### PR TITLE
Import & Export feature

### DIFF
--- a/src/components/dashboard/dashboard.tsx
+++ b/src/components/dashboard/dashboard.tsx
@@ -23,67 +23,101 @@ export function Dashboard() {
         }
         router.prefetch('/')
     }, [])
+
+
+    const createButton = (
+        <button
+            type="button"
+            className="brutalborder inline-flex cursor-pointer items-center justify-center bg-black px-4 py-2 text-sm font-medium text-white hover:bg-white hover:text-black sm:w-auto"
+            onClick={() => {
+                router.push('/')
+            }}
+        >
+            CREATE
+            <svg
+                className="-mr-0.5 ml-2 h-4 w-4"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 -2 15 20"
+                fill="currentColor"
+                aria-hidden="true"
+            >
+                <path
+                    // fill-rule="evenodd"
+                    d="M10 3a1 1 0 011 1v4h4a1 1 0 110 2h-4v4a1 1 0 11-2 0v-4H5a1 1 0 110-2h4V4a1 1 0 011-1z"
+                    // clip-rule="evenodd"
+                />
+            </svg>
+        </button>
+    )
+
     return (
         <global_components.CardWrapper>
             <div className="flex flex-col gap-2">
-                <div className="align-center flex w-full justify-between">
-                    <div className="text-center text-xl font-bold">A list of all the links you have created.</div>
-                    <div className="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
-                        <button
-                            type="button"
-                            className="brutalborder inline-flex cursor-pointer items-center justify-center bg-black px-4 py-2 text-sm font-medium text-white hover:bg-white hover:text-black sm:w-auto"
-                            onClick={() => {
-                                router.push('/')
-                            }}
-                        >
-                            CREATE
-                            <svg
-                                className="-mr-0.5 ml-2 h-4 w-4"
-                                xmlns="http://www.w3.org/2000/svg"
-                                viewBox="0 -2 15 20"
-                                fill="currentColor"
-                                aria-hidden="true"
-                            >
-                                <path
-                                    fill-rule="evenodd"
-                                    d="M10 3a1 1 0 011 1v4h4a1 1 0 110 2h-4v4a1 1 0 11-2 0v-4H5a1 1 0 110-2h4V4a1 1 0 011-1z"
-                                    clip-rule="evenodd"
-                                />
-                            </svg>
-                        </button>
+                {localStorageData.length && (
+                    <div className="align-center flex w-full justify-between">
+                        <div className="text-center text-xl font-bold">A list of all the links you have created.</div>
+                        <div className="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
+                            { createButton }
+                        </div>
                     </div>
-                </div>
+                ) || null}
                 {isConnected ? (
-                    <table className=" w-full table-fixed border-separate border-spacing-y-4 border-2 border-white ">
-                        <thead className="bg-black text-white ">
-                            <tr>
-                                <th className="w-1/4 py-2">Chain</th>
-                                <th className="w-3/4 py-2">Link</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {localStorageData.map((item) => (
-                                <tr key={item.hash}>
-                                    <td className="brutalborder-bottom h-8 cursor-pointer overflow-hidden overflow-ellipsis whitespace-nowrap break-all">
-                                        {
-                                            chainDetails.find(
-                                                (chain) => chain.chainId.toString() === item.link.match(/c=(\d+)/)?.[1]
-                                            )?.name
-                                        }
-                                    </td>
+                    localStorageData.length ? (
+                        <table className=" w-full table-fixed border-separate border-spacing-y-4 border-2 border-white ">
+                            <thead className="bg-black text-white ">
+                                <tr>
+                                    <th className="w-1/4 py-2">Chain</th>
+                                    <th className="w-3/4 py-2">Link</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {localStorageData.map((item) => (
+                                    <tr key={item.hash}>
+                                        <td className="brutalborder-bottom h-8 cursor-pointer overflow-hidden overflow-ellipsis whitespace-nowrap break-all">
+                                            {
+                                                chainDetails.find(
+                                                    (chain) => chain.chainId.toString() === item.link.match(/c=(\d+)/)?.[1]
+                                                )?.name
+                                            }
+                                        </td>
 
-                                    <td
-                                        className="brutalborder-bottom h-8 cursor-pointer overflow-hidden overflow-ellipsis whitespace-nowrap break-all"
+                                        <td
+                                            className="brutalborder-bottom h-8 cursor-pointer overflow-hidden overflow-ellipsis whitespace-nowrap break-all"
+                                            onClick={() => {
+                                                navigator.clipboard.writeText(item.link)
+                                            }}
+                                        >
+                                            {item.link}
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    ):(
+                        <div>
+                            <div className="text-center">You have not created any links yet</div>
+                            <div className="flex justify-center align-center mt-4">
+                                <div>
+                                    { createButton }
+                                </div>
+                                <div className="px-8 leading-10 font-normal">OR</div>
+                                <div>
+                                        <button
+                                        type="button"
+                                        className="brutalborder inline-flex cursor-pointer items-center justify-center bg-black px-4 py-2 text-sm font-medium text-white hover:bg-white hover:text-black sm:w-auto"
                                         onClick={() => {
-                                            navigator.clipboard.writeText(item.link)
+                                            router.push('/')
                                         }}
                                     >
-                                        {item.link}
-                                    </td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
+                                        IMPORT BACKUP
+                                        <svg className="-mr-0.5 ml-2 h-4 w-4" width="16" height="14" viewBox="0 0 16 14" fill="currentcolor" xmlns="http://www.w3.org/2000/svg">
+                                            <path fill-rule="evenodd" clip-rule="evenodd" d="M14.9333 8.60002C14.3445 8.60002 13.8667 9.07789 13.8667 9.66669V11.8H2.13333V9.66669C2.13333 9.07789 1.65547 8.60002 1.06667 8.60002C0.477867 8.60002 0 9.07789 0 9.66669V13.4C0 13.6555 0.277867 13.9334 0.533333 13.9334H15.4667C15.7888 13.9334 16 13.6891 16 13.4V9.66669C16 9.07789 15.5221 8.60002 14.9333 8.60002ZM5.86667 4.33335H6.93333V9.13335C6.93333 9.72215 7.4112 10.2 8 10.2C8.5888 10.2 9.06667 9.72215 9.06667 9.13335V4.33335H10.1333C10.5088 4.33335 10.8405 4.38403 11.0501 4.17336C11.2587 3.96376 11.2587 3.62295 11.0501 3.41281L8.41387 0.217631C8.30187 0.105631 8.15413 0.0576123 8.00853 0.0656123C7.8624 0.0576123 7.71466 0.105631 7.60319 0.217631L4.96693 3.41281C4.75786 3.62295 4.75786 3.96376 4.96693 4.17336C5.17599 4.38403 5.6576 4.33335 5.86667 4.33335Z"/>
+                                        </svg>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    )
                 ) : (
                     'Connect your wallet to view your deposits'
                 )}

--- a/src/components/dashboard/dashboard.tsx
+++ b/src/components/dashboard/dashboard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useAccount } from 'wagmi'
-
+import DashboardLogin from './login';
 import * as global_components from '@/components/global'
 import * as utils from '@/utils'
 import * as interfaces from '@/interfaces'
@@ -9,21 +9,45 @@ import { useAtom } from 'jotai'
 import { useRouter } from 'next/navigation'
 
 export function Dashboard() {
+
+    const syncLinks = (address): void => {
+        if(!address)
+            return;
+
+        // to keep previously saved links
+        // we need to re-save them in new json format
+        utils.migrateAllLinksFromLocalStorageV2({
+            address: address.toString(),
+        })
+
+        const data = utils.getAllLinksFromLocalStorage({
+            address: address.toString(),
+        })
+
+        data && setLocalStorageData(data)
+    }
+
+    const { address, isConnected } = useAccount({
+        onConnect({address}: { address?: string }) {
+            // onConnect we need to load links using a new (or just assigned) address
+            syncLinks(address)
+        },
+    })
+
     const [chainDetails] = useAtom(store.defaultChainDetailsAtom)
-    const { address, isConnected } = useAccount()
     const router = useRouter()
     const [localStorageData, setLocalStorageData] = useState<interfaces.ILocalStorageItem[]>([])
 
     useEffect(() => {
-        if (address) {
-            const data = utils.getAllLinksFromLocalStorage({
-                address: address.toString(),
-            })
-            data && setLocalStorageData(data)
-        }
+        syncLinks(address)
         router.prefetch('/')
     }, [])
 
+    if(!isConnected) {
+        return (
+            <DashboardLogin />
+        )
+    }
 
     const createButton = (
         <button
@@ -42,84 +66,126 @@ export function Dashboard() {
                 aria-hidden="true"
             >
                 <path
-                    // fill-rule="evenodd"
                     d="M10 3a1 1 0 011 1v4h4a1 1 0 110 2h-4v4a1 1 0 11-2 0v-4H5a1 1 0 110-2h4V4a1 1 0 011-1z"
-                    // clip-rule="evenodd"
                 />
             </svg>
         </button>
+    )
+
+    const importBackup = (event) => {
+        const reader = new FileReader();
+        reader.onload = (event) => {
+            // reads a JSON file and saves all links to localStorage
+            utils.saveLinksToLocalStorage({ address: address.toString(), links: JSON.parse(event.target.result.toString())})
+            syncLinks(address);
+        };
+        reader.readAsText(event.target.files[0]);
+    }
+
+    const importButton = (
+        <div className="inline-block">
+            <input className="hidden" id="upload-backup" type="file" onChange={importBackup}/>
+            <label
+                htmlFor="upload-backup"
+                className="brutalborder inline-flex cursor-pointer items-center justify-center px-4 py-2 text-sm font-medium bg-white hover:bg-white hover:text-black sm:w-auto"
+            >
+                IMPORT
+                <svg className="-mr-0.5 ml-2 h-4 w-4" width="16" height="14" viewBox="0 0 16 14" fill="currentcolor" xmlns="http://www.w3.org/2000/svg">
+                    <path fillRule="evenodd" clipRule="evenodd" d="M14.9333 8.60002C14.3445 8.60002 13.8667 9.07789 13.8667 9.66669V11.8H2.13333V9.66669C2.13333 9.07789 1.65547 8.60002 1.06667 8.60002C0.477867 8.60002 0 9.07789 0 9.66669V13.4C0 13.6555 0.277867 13.9334 0.533333 13.9334H15.4667C15.7888 13.9334 16 13.6891 16 13.4V9.66669C16 9.07789 15.5221 8.60002 14.9333 8.60002ZM5.86667 4.33335H6.93333V9.13335C6.93333 9.72215 7.4112 10.2 8 10.2C8.5888 10.2 9.06667 9.72215 9.06667 9.13335V4.33335H10.1333C10.5088 4.33335 10.8405 4.38403 11.0501 4.17336C11.2587 3.96376 11.2587 3.62295 11.0501 3.41281L8.41387 0.217631C8.30187 0.105631 8.15413 0.0576123 8.00853 0.0656123C7.8624 0.0576123 7.71466 0.105631 7.60319 0.217631L4.96693 3.41281C4.75786 3.62295 4.75786 3.96376 4.96693 4.17336C5.17599 4.38403 5.6576 4.33335 5.86667 4.33335Z"/>
+                </svg>
+            </label>
+        </div>
+    )
+
+    // data-url to generate a downloadable backup.json
+    const backupData = "text/json;charset=utf-8," + encodeURIComponent(localStorage.getItem(address.toString()) || '');
+
+    const backupButton = (
+        <a href={`data:${backupData}`} download="backup.json">
+            <button
+                type="button"
+                className="brutalborder inline-flex cursor-pointer items-center justify-center px-4 py-2 text-sm font-medium bg-white text-black hover:bg-white hover:text-black sm:w-auto"
+            >
+                BACKUP
+                <svg className="-mr-0.5 ml-2 h-4 w-4" width="16" height="16" viewBox="0 0 16 16" fill="currentcolor" xmlns="http://www.w3.org/2000/svg">
+                    <path fillRule="evenodd" clipRule="evenodd" d="M15.4667 1.06668H0.533333C0.277867 1.06668 0 1.34455 0 1.60001V5.33335C0 5.92215 0.477867 6.40001 1.06667 6.40001C1.65547 6.40001 2.13333 5.92215 2.13333 5.33335V3.20001H13.8667V5.33335C13.8667 5.92215 14.3445 6.40001 14.9333 6.40001C15.5221 6.40001 16 5.92215 16 5.33335V1.60001C16 1.31095 15.7888 1.06668 15.4667 1.06668ZM10.1333 10.6667H9.06667V5.86668C9.06667 5.27788 8.5888 4.80001 8 4.80001C7.4112 4.80001 6.93333 5.27788 6.93333 5.86668V10.6667H5.86667C5.6576 10.6667 5.176 10.616 4.96694 10.8267C4.75787 11.0363 4.75787 11.3771 4.96694 11.5872L7.60267 14.7824C7.71413 14.8944 7.8624 14.9424 8.00853 14.9344C8.15467 14.9424 8.3024 14.8944 8.41387 14.7824L11.0496 11.5872C11.2587 11.3771 11.2587 11.0363 11.0496 10.8267C10.8405 10.616 10.5093 10.6667 10.1333 10.6667Z"/>
+                </svg>
+            </button>
+        </a>
     )
 
     return (
         <global_components.CardWrapper>
             <div className="flex flex-col gap-2">
                 {localStorageData.length && (
-                    <div className="align-center flex w-full justify-between">
-                        <div className="text-center text-xl font-bold">A list of all the links you have created.</div>
-                        <div className="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
-                            { createButton }
+                    <div className="align-center flex flex-col sm:flex-row w-full justify-between">
+                        <div className="text-center text-xl font-bold">All your links</div>
+                        <div className="flex mt-4 md:mt-0 gap-0 md:gap-4 items-center justify-center">
+                            <div>
+                                { importButton }
+                            </div>
+                            <div>
+                                { backupButton }
+                            </div>
+                            <div>
+                                { createButton }
+                            </div>
                         </div>
                     </div>
                 ) || null}
-                {isConnected ? (
-                    localStorageData.length ? (
-                        <table className=" w-full table-fixed border-separate border-spacing-y-4 border-2 border-white ">
-                            <thead className="bg-black text-white ">
-                                <tr>
-                                    <th className="w-1/4 py-2">Chain</th>
-                                    <th className="w-3/4 py-2">Link</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {localStorageData.map((item) => (
-                                    <tr key={item.hash}>
-                                        <td className="brutalborder-bottom h-8 cursor-pointer overflow-hidden overflow-ellipsis whitespace-nowrap break-all">
-                                            {
-                                                chainDetails.find(
-                                                    (chain) => chain.chainId.toString() === item.link.match(/c=(\d+)/)?.[1]
-                                                )?.name
-                                            }
-                                        </td>
 
-                                        <td
-                                            className="brutalborder-bottom h-8 cursor-pointer overflow-hidden overflow-ellipsis whitespace-nowrap break-all"
-                                            onClick={() => {
-                                                navigator.clipboard.writeText(item.link)
-                                            }}
-                                        >
-                                            {item.link}
-                                        </td>
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </table>
-                    ):(
-                        <div>
-                            <div className="text-center">You have not created any links yet</div>
-                            <div className="flex justify-center align-center mt-4">
-                                <div>
-                                    { createButton }
-                                </div>
-                                <div className="px-8 leading-10 font-normal">OR</div>
-                                <div>
-                                        <button
-                                        type="button"
-                                        className="brutalborder inline-flex cursor-pointer items-center justify-center bg-black px-4 py-2 text-sm font-medium text-white hover:bg-white hover:text-black sm:w-auto"
+                {localStorageData.length ? (
+                    <table className=" w-full table-fixed border-separate border-spacing-y-4 border-2 border-white ">
+                        <thead className="bg-black text-white ">
+                            <tr>
+                                <th className="w-1/4 py-2">Chain</th>
+                                <th className="py-2">Link</th>
+                                <th className="w-6"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {localStorageData.map((item) => (
+                                <tr key={item.hash}>
+                                    <td className="brutalborder-bottom h-8 cursor-pointer overflow-hidden overflow-ellipsis whitespace-nowrap break-all">
+                                        {
+                                            chainDetails.find(
+                                                (chain) => chain.chainId.toString() === item.link.match(/c=(\d+)/)?.[1]
+                                            )?.name
+                                        }
+                                    </td>
+
+                                    <td
+                                        className="brutalborder-bottom h-8 overflow-hidden overflow-ellipsis whitespace-nowrap break-all"
                                         onClick={() => {
-                                            router.push('/')
+                                            navigator.clipboard.writeText(item.link)
                                         }}
                                     >
-                                        IMPORT BACKUP
-                                        <svg className="-mr-0.5 ml-2 h-4 w-4" width="16" height="14" viewBox="0 0 16 14" fill="currentcolor" xmlns="http://www.w3.org/2000/svg">
-                                            <path fill-rule="evenodd" clip-rule="evenodd" d="M14.9333 8.60002C14.3445 8.60002 13.8667 9.07789 13.8667 9.66669V11.8H2.13333V9.66669C2.13333 9.07789 1.65547 8.60002 1.06667 8.60002C0.477867 8.60002 0 9.07789 0 9.66669V13.4C0 13.6555 0.277867 13.9334 0.533333 13.9334H15.4667C15.7888 13.9334 16 13.6891 16 13.4V9.66669C16 9.07789 15.5221 8.60002 14.9333 8.60002ZM5.86667 4.33335H6.93333V9.13335C6.93333 9.72215 7.4112 10.2 8 10.2C8.5888 10.2 9.06667 9.72215 9.06667 9.13335V4.33335H10.1333C10.5088 4.33335 10.8405 4.38403 11.0501 4.17336C11.2587 3.96376 11.2587 3.62295 11.0501 3.41281L8.41387 0.217631C8.30187 0.105631 8.15413 0.0576123 8.00853 0.0656123C7.8624 0.0576123 7.71466 0.105631 7.60319 0.217631L4.96693 3.41281C4.75786 3.62295 4.75786 3.96376 4.96693 4.17336C5.17599 4.38403 5.6576 4.33335 5.86667 4.33335Z"/>
+
+                                        <a href={item.link} target="_blank" className="text-black">{item.link}</a>
+                                    </td>
+                                    <td>
+                                        <svg className="cursor-pointer transition duration-75 active:text-green-400" width="24" height="24" viewBox="0 0 24 24" fill="currentcolor" xmlns="http://www.w3.org/2000/svg">
+                                            <path d="M20.235 4.50001L16.11 0.555014C15.9386 0.378522 15.7334 0.238407 15.5066 0.143047C15.2798 0.0476865 15.0361 -0.00096041 14.79 1.43642e-05H8.79002C8.30058 0.0117643 7.83515 0.214484 7.49319 0.564849C7.15124 0.915214 6.95988 1.38543 6.96002 1.87501V18.375C6.96002 18.8723 7.15757 19.3492 7.5092 19.7008C7.86083 20.0525 8.33774 20.25 8.83502 20.25H18.915C19.4123 20.25 19.8892 20.0525 20.2408 19.7008C20.5925 19.3492 20.79 18.8723 20.79 18.375V5.82001C20.791 5.57398 20.7424 5.33028 20.647 5.10348C20.5516 4.87667 20.4115 4.67143 20.235 4.50001ZM18.915 18.375H8.83502V1.87501H12.915V5.82001C12.915 6.3173 13.1126 6.79421 13.4642 7.14584C13.8158 7.49747 14.2927 7.69502 14.79 7.69502H18.915V18.375ZM18.915 5.82001H14.79V1.87501L18.915 5.82001Z"/>
+                                            <path d="M15.165 22.125H5.08502V5.625H6.00002V3.75H5.08502C4.58774 3.75 4.11083 3.94754 3.7592 4.29917C3.40757 4.65081 3.21002 5.12772 3.21002 5.625V22.125C3.21002 22.6223 3.40757 23.0992 3.7592 23.4508C4.11083 23.8025 4.58774 24 5.08502 24H15.165C15.6623 24 16.1392 23.8025 16.4908 23.4508C16.8425 23.0992 17.04 22.6223 17.04 22.125V21.18H15.165V22.125Z"/>
                                         </svg>
-                                    </button>
-                                </div>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                ):(
+                    <div>
+                        <div className="text-center">You have not created any links yet</div>
+                        <div className="flex flex-col items-center justify-center align-center mt-4 lg:flex-row">
+                            <div>
+                                { createButton }
+                            </div>
+                            <div className="px-8 leading-10 font-normal">OR</div>
+                            <div>
+                                { importButton }
                             </div>
                         </div>
-                    )
-                ) : (
-                    'Connect your wallet to view your deposits'
+                    </div>
                 )}
             </div>
         </global_components.CardWrapper>

--- a/src/components/dashboard/login.tsx
+++ b/src/components/dashboard/login.tsx
@@ -1,0 +1,16 @@
+import {useWeb3Modal} from "@web3modal/react";
+import * as global_components from '@/components/global'
+
+export default function DashboardLogin() {
+    const {open} = useWeb3Modal()
+    return (
+        <global_components.CardWrapper>
+            <div className="flex flex-col gap-2">
+                <div className="text-center">
+                    <span onClick={open} className="underline decoration-solid cursor-pointer">Connect</span> your
+                    wallet to view your deposits
+                </div>
+            </div>
+        </global_components.CardWrapper>
+    )
+}

--- a/src/components/send/views/initial.view.tsx
+++ b/src/components/send/views/initial.view.tsx
@@ -264,7 +264,7 @@ export function SendInitialView({ onNextScreen, setClaimLink, setTxReceipt, setC
                     baseUrl: window.location.origin + '/claim',
                 })
                 console.log('Created link:', link)
-                utils.saveToLocalStorage(address + ' - ' + txReceipt.hash, link)
+                utils.saveLinkToLocalStorage({ address, hash: txReceipt.transactionHash, link});
 
                 setClaimLink(link)
                 setTxReceipt(txReceipt)


### PR DESCRIPTION
During my onboarding before the hackathon, I discovered a few things I would be happy to fix/add to your UI. 
This PR has a one feature, few bug fixes & some minor improvements 

## Changes List

### UI/UX improvements 
Now, when you access a Dashboard being unlogged in, you can see only a login message with a clickable **Connect** button. Previously, I had to find that button in the top right corner. 

_Before_

<img width="1008" alt="Screenshot 2023-08-24 at 00 23 30" src="https://github.com/ProphetFund/peanut-ui/assets/7770343/52cd852d-fa37-4de7-a7a5-321fd79f712a">

_After_

<img width="1011" alt="Screenshot 2023-08-24 at 00 23 13" src="https://github.com/ProphetFund/peanut-ui/assets/7770343/87685195-7f3d-4c1f-abb0-30f77abe7bf0">

----

The empty list also has minor improvements. It informs you about no links and proposes to create them or import the backup

_Before_

<img width="982" alt="Screenshot 2023-08-24 at 00 26 17" src="https://github.com/ProphetFund/peanut-ui/assets/7770343/5beb044b-9281-4e91-86ad-46265765b2bd">


_After_

<img width="996" alt="Screenshot 2023-08-24 at 00 26 09" src="https://github.com/ProphetFund/peanut-ui/assets/7770343/8b3785de-6a45-483a-99ad-4d2aa5258007">

----

The main list of links has the following improvements:
- Short title
- Import/Backup buttons
- Copy button (As a user, I didn't know that a click on a link copies it. Now it has a button that becomes green when clicking on it.)
- Link is clickable (First my idea was to add a "check status" icon next to the copy icon. However, I realized that the user may be confused about each link value when he has 10+ links (because we display only the link & network but don't display the balance locked). So I decided to let the user quickly jump to the link page to check its status and data. But talking about the links list stored in a localStorage, we can store a sum as well and add it to the table.   

_Before_

<img width="1000" alt="Screenshot 2023-08-24 at 00 30 19" src="https://github.com/ProphetFund/peanut-ui/assets/7770343/75970817-9389-4b7f-b653-51af8df5947a">

_After_

<img width="991" alt="Screenshot 2023-08-24 at 00 30 09" src="https://github.com/ProphetFund/peanut-ui/assets/7770343/c9bc8ac8-3746-4f54-8ada-ac50f65cbd96">

### Bug Fixes

1. If you try to create multiple links you will see that you can store only one link. It happens because the previous approach was to store `{address}-{hash}` but `hash` was undefined. Now I changed the way we store links and made it like an array of objects: `{address}: array[{hash, link}]` 

2. If your wallet was disconnected for some reason but you have links stored in localStorage, during your login on a dashboard page - you will see an empty list and you need to reload the page to see them (fixed)

![login-empty](https://github.com/ProphetFund/peanut-ui/assets/7770343/e8b8d595-ab2e-4b28-9b52-0f07b8333aa6)

### Import/Export backup 

It stores the links in JSON file in the following format:
```
[{"hash":"0x5e280d1ac30f66906d0e06d57a4e30dd4b81127507d324e020a702cb16348625","link":"http://localhost:3000/claim#?c=5&v=v3&i=467&p=QuWMGwZsEhMfRhPA&t=sdk"}]
```

You can import a list of links for any wallet (just because it doesn't make sense what wallet you use to create a link, the main goal is to be able to track the link and claim money back to whatever account you want)

When you import a list of links - it extends the current one, avoiding duplicates. The idea behind this is if you created a link, then go to the dashboard and realized that all your links are gone and only a newly created one here (for e.g. because user tried to hide your porn views from the browser history and accidentally cleared all websites data) - you can go to import the list and all new links will be added. 

Also, you can see something called `migrateAllLinksFromLocalStorageV2` - (oh, it had to be `ToLocalStoragev2` but nevermind :))) - the idea behind, is to keep all the links we stored in the old format `{address}-{hash}` and resave them into a new format to be able to export in `backup.json` 

---- 

UPD:  I made it responsive. I tested it on multiple screen devices and it looks pretty good 

<img width="496" alt="Screenshot 2023-08-24 at 00 51 30" src="https://github.com/ProphetFund/peanut-ui/assets/7770343/2e55bb38-2f0a-47a5-b621-2cf1da9cf160">

----

Time spent: ~ 3h excluding onboarding (clicking on your website and tasting it). 
