### PR TITLE
Web3inbox fix 500

### DIFF
--- a/src/app/api/notify/route.ts
+++ b/src/app/api/notify/route.ts
@@ -27,12 +27,18 @@ export async function POST(request: NextRequest, response: NextResponse) {
             },
             body: JSON.stringify(notificationPayload),
         })
+
+        return NextResponse.json({
+            status: 200,
+        })
     } catch (error: any) {
         console.error('Error occured while sending notification:', error)
-        throw new Error('Error occured while sending notification')
-    }
 
-    return NextResponse.json({
-        status: 200,
-    })
+        return NextResponse.json({
+            status: 500,
+            body: {
+                error: 'Error occured while sending notification',
+            },
+        })
+    }
 }

--- a/src/app/api/notify/route.ts
+++ b/src/app/api/notify/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 const projectId = process.env.WC_PROJECT_ID
 if (!projectId) {
-    throw new Error('You need to provide NEXT_PUBLIC_PROJECT_ID env variable')
+    throw new Error('You need to provide WC_PROJECT_ID env variable')
 }
 
 export async function POST(request: NextRequest, response: NextResponse) {
@@ -28,6 +28,11 @@ export async function POST(request: NextRequest, response: NextResponse) {
             body: JSON.stringify(notificationPayload),
         })
     } catch (error: any) {
+        console.error('Error occured while sending notification:', error)
         throw new Error('Error occured while sending notification')
     }
+
+    return NextResponse.json({
+        status: 200,
+    })
 }

--- a/src/components/claim/multilinkViews/multilinkSuccess.view.tsx
+++ b/src/components/claim/multilinkViews/multilinkSuccess.view.tsx
@@ -7,9 +7,11 @@ import * as global_components from '@/components/global'
 import * as utils from '@/utils'
 import dropdown_svg from '@/assets/dropdown.svg'
 import { useRouter } from 'next/navigation'
+import { useAccount } from 'wagmi'
 
-export function multilinkSuccessView({ txHash, claimDetails }: _consts.IClaimScreenProps) {
+export function multilinkSuccessView({ txHash, claimDetails, senderAddress }: _consts.IClaimScreenProps) {
     const router = useRouter()
+    const { address } = useAccount()
 
     const [isDropdownOpen, setIsDropdownOpen] = useState(false)
     const [chainDetails] = useAtom(store.defaultChainDetailsAtom)
@@ -23,7 +25,13 @@ export function multilinkSuccessView({ txHash, claimDetails }: _consts.IClaimScr
 
     useEffect(() => {
         router.prefetch('/send')
+        sendNotification()
     }, [])
+
+    const sendNotification = async () => {
+        const chainName = chainDetails.find((detail) => detail.chainId === claimDetails[0].chainId)?.name
+        utils.sendNotification(senderAddress, address, chainName)
+    }
 
     return (
         <>

--- a/src/components/claim/views/success.view.tsx
+++ b/src/components/claim/views/success.view.tsx
@@ -39,9 +39,7 @@ export function ClaimSuccessView({ txHash, claimDetails, senderAddress }: _const
     }, [])
 
     const sendNotification = async () => {
-        const chainName = chainDetails.find(
-            (detail) => detail.chainId === claimDetails[0].chainId
-        )?.name
+        const chainName = chainDetails.find((detail) => detail.chainId === claimDetails[0].chainId)?.name
         utils.sendNotification(senderAddress, address, chainName)
     }
 

--- a/src/components/claim/views/success.view.tsx
+++ b/src/components/claim/views/success.view.tsx
@@ -35,25 +35,14 @@ export function ClaimSuccessView({ txHash, claimDetails, senderAddress }: _const
     useEffect(() => {
         router.prefetch('/send')
         gaEventTracker('peanut-claimed', 'success')
-        sendNotification(claimDetails[0])
+        sendNotification()
     }, [])
 
-    const sendNotification = async (linkDetails: interfaces.ILinkDetails) => {
-        console.log('sendNotification', senderAddress)
-        const accounts = [`eip155:1:${senderAddress}` ?? '']
+    const sendNotification = async () => {
         const chainName = chainDetails.find(
-            (detail) => detail.chainId.toString() === linkDetails.chainId.toString()
+            (detail) => detail.chainId === claimDetails[0].chainId
         )?.name
-        const notification = {
-            title: 'Peanut Protocol',
-            body: `Your link has been claimed on ${chainName} by ${address ?? ''}`,
-            url: undefined,
-            type: '2aee6e5f-091d-444e-96cd-868ba2ddd0e7',
-        }
-        utils.sendNotification({
-            notification,
-            accounts,
-        })
+        utils.sendNotification(senderAddress, address, chainName)
     }
 
     return (

--- a/src/components/claim/xchainViews/xchainSucces.view.tsx
+++ b/src/components/claim/xchainViews/xchainSucces.view.tsx
@@ -11,9 +11,11 @@ import * as utils from '@/utils'
 import { peanut } from '@squirrel-labs/peanut-sdk'
 import axios from 'axios'
 import checkbox from '@/assets/checkbox.svg'
+import { useAccount } from 'wagmi'
 
-export function xchainSuccesView({ txHash, crossChainSuccess, claimDetails }: _consts.IClaimScreenProps) {
+export function xchainSuccesView({ txHash, crossChainSuccess, claimDetails, senderAddress }: _consts.IClaimScreenProps) {
     const router = useRouter()
+    const { address } = useAccount()
     const gaEventTracker = hooks.useAnalyticsEventTracker('claim-component')
 
     const [isDropdownOpen, setIsDropdownOpen] = useState(true)
@@ -83,10 +85,17 @@ export function xchainSuccesView({ txHash, crossChainSuccess, claimDetails }: _c
     useEffect(() => {
         router.prefetch('/send')
         gaEventTracker('peanut-x-chain-claimed', 'success')
+        sendNotification()
         if (txHash && crossChainSuccess) {
             loopUntilSuccess(txHash[0])
         }
     }, [])
+
+    const sendNotification = async () => {
+        const destinationChainId = crossChainSuccess?.chainId || claimDetails[0].chainId
+        const chainName = chainDetails.find((detail) => detail.chainId === destinationChainId)?.name
+        utils.sendNotification(senderAddress, address, chainName)
+    }
 
     return (
         <>

--- a/src/components/claim/xchainViews/xchainSucces.view.tsx
+++ b/src/components/claim/xchainViews/xchainSucces.view.tsx
@@ -13,7 +13,12 @@ import axios from 'axios'
 import checkbox from '@/assets/checkbox.svg'
 import { useAccount } from 'wagmi'
 
-export function xchainSuccesView({ txHash, crossChainSuccess, claimDetails, senderAddress }: _consts.IClaimScreenProps) {
+export function xchainSuccesView({
+    txHash,
+    crossChainSuccess,
+    claimDetails,
+    senderAddress,
+}: _consts.IClaimScreenProps) {
     const router = useRouter()
     const { address } = useAccount()
     const gaEventTracker = hooks.useAnalyticsEventTracker('claim-component')

--- a/src/utils/notifications.utils.ts
+++ b/src/utils/notifications.utils.ts
@@ -5,7 +5,11 @@ interface INotification {
     type: string
 }
 
-export const sendNotification = async (senderAddress: string, recipientAddress: string | undefined, chainName: string) => {
+export const sendNotification = async (
+    senderAddress: string,
+    recipientAddress: string | undefined,
+    chainName: string
+) => {
     console.log('sendNotification', senderAddress)
     const accounts = [`eip155:1:${senderAddress}` ?? '']
     const notification: INotification = {

--- a/src/utils/notifications.utils.ts
+++ b/src/utils/notifications.utils.ts
@@ -5,8 +5,22 @@ interface INotification {
     type: string
 }
 
-export const sendNotification = async (notificationPayload: { accounts: string[]; notification: INotification }) => {
+export const sendNotification = async (senderAddress: string, recipientAddress: string | undefined, chainName: string) => {
+    console.log('sendNotification', senderAddress)
+    const accounts = [`eip155:1:${senderAddress}` ?? '']
+    const notification: INotification = {
+        title: 'Peanut Protocol',
+        body: `Your link has been claimed on ${chainName} by ${recipientAddress ?? ''}`,
+        url: undefined,
+        type: '2aee6e5f-091d-444e-96cd-868ba2ddd0e7',
+    }
+
+    const notificationPayload = {
+        notification,
+        accounts,
+    }
     console.log({ notificationPayload })
+
     await fetch('/api/notify', {
         method: 'POST',
         headers: {


### PR DESCRIPTION
1. Don't return 500 error in all calls to the frontend's /api/notify
2. Send web3inbox notifications on x-chain & multilink claiming