### PR TITLE
Fix refund page connect wallet button

### DIFF
--- a/src/components/Refund/index.tsx
+++ b/src/components/Refund/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useForm } from 'react-hook-form'
 import { useAccount, useConfig, useSendTransaction, useSwitchChain } from 'wagmi'
+import { useWeb3Modal } from '@web3modal/wagmi/react'
 import peanut from '@squirrel-labs/peanut-sdk'
 
 import * as consts from '@/constants'
@@ -15,6 +16,7 @@ export const Refund = () => {
     const { isConnected, chain: currentChain } = useAccount()
     const { sendTransactionAsync } = useSendTransaction()
     const config = useConfig()
+    const { open } = useWeb3Modal()
 
     const [errorState, setErrorState] = useState<{
         showError: boolean


### PR DESCRIPTION
Refund page (`https://peanut.to/refund`) is missing a `useWeb3Modal` import, so instead of opening wallet connect modal "Create or Connect Wallet" button just opens a blank page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated web3 modal capabilities into the Refund component for enhanced user interaction with blockchain networks.
	- Users can now open a web3 modal for account connections or transactions directly from the Refund component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->