### PR TITLE
Replace formatAmountWithDecimals with formatUnits of viem

### DIFF
--- a/src/components/Claim/Link/Initial.view.tsx
+++ b/src/components/Claim/Link/Initial.view.tsx
@@ -3,7 +3,6 @@ import AddressInput from '@/components/Global/AddressInput'
 import * as _consts from '../Claim.consts'
 import { useContext, useEffect, useState } from 'react'
 import Icon from '@/components/Global/Icon'
-import * as assets from '@/assets'
 import { useAccount } from 'wagmi'
 import { useWeb3Modal } from '@web3modal/wagmi/react'
 import useClaimLink from '../useClaimLink'
@@ -18,7 +17,7 @@ import { getSquidRouteRaw } from '@squirrel-labs/peanut-sdk'
 import * as _interfaces from '../Claim.interfaces'
 import * as _utils from '../Claim.utils'
 import { Popover } from '@headlessui/react'
-import { PopupButton } from '@typeform/embed-react'
+import { formatUnits } from 'viem'
 export const InitialClaimLinkView = ({
     onNext,
     claimLinkData,
@@ -302,7 +301,7 @@ export const InitialClaimLinkView = ({
                             ? '0x04B5f21facD2ef7c7dbdEe7EbCFBC68616adC45C'
                             : recipient.address
                               ? recipient.address
-                              : (address ?? '0x04B5f21facD2ef7c7dbdEe7EbCFBC68616adC45C'),
+                              : address ?? '0x04B5f21facD2ef7c7dbdEe7EbCFBC68616adC45C',
                 })
                 setRoutes([...routes, route])
                 !toToken && !toChain && setSelectedRoute(route)
@@ -421,10 +420,12 @@ export const InitialClaimLinkView = ({
                             hasFetchedRoute
                                 ? selectedRoute
                                     ? utils.formatTokenAmount(
-                                          utils.formatAmountWithDecimals({
-                                              amount: selectedRoute.route.estimate.toAmountMin,
-                                              decimals: selectedRoute.route.estimate.toToken.decimals,
-                                          }),
+                                          Number(
+                                              formatUnits(
+                                                  selectedRoute.route.estimate.toAmountMin,
+                                                  selectedRoute.route.estimate.toToken.decimals
+                                              )
+                                          ),
                                           4
                                       )
                                     : undefined
@@ -448,7 +449,7 @@ export const InitialClaimLinkView = ({
                     <AddressInput
                         className="px-1"
                         placeholder="wallet address / ENS / IBAN / US account number"
-                        value={recipient.name ? recipient.name : (recipient.address ?? '')}
+                        value={recipient.name ? recipient.name : recipient.address ?? ''}
                         onSubmit={(name: string, address: string) => {
                             setRecipient({ name, address })
                             setInputChanging(false)

--- a/src/components/Claim/Link/Onchain/Confirm.view.tsx
+++ b/src/components/Claim/Link/Onchain/Confirm.view.tsx
@@ -6,13 +6,14 @@ import * as _consts from '../../Claim.consts'
 import * as utils from '@/utils'
 import useClaimLink from '../../useClaimLink'
 import * as context from '@/context'
-import { useContext, useEffect, useState } from 'react'
+import { useContext, useState } from 'react'
 import Loading from '@/components/Global/Loading'
 import MoreInfo from '@/components/Global/MoreInfo'
 import * as _interfaces from '../../Claim.interfaces'
 import * as _utils from '../../Claim.utils'
 import * as consts from '@/constants'
 import { useBalance } from '@/hooks/useBalance'
+import { formatUnits } from 'viem'
 
 export const ConfirmClaimLinkView = ({
     onNext,
@@ -57,7 +58,7 @@ export const ConfirmClaimLinkView = ({
             let claimTxHash = ''
             if (selectedRoute) {
                 claimTxHash = await claimLinkXchain({
-                    address: recipient ? recipient.address : (address ?? ''),
+                    address: recipient ? recipient.address : address ?? '',
                     link: claimLinkData.link,
                     destinationChainId: selectedChainID,
                     destinationToken: selectedTokenAddress,
@@ -65,14 +66,14 @@ export const ConfirmClaimLinkView = ({
                 setClaimType('claimxchain')
             } else {
                 claimTxHash = await claimLink({
-                    address: recipient ? recipient.address : (address ?? ''),
+                    address: recipient ? recipient.address : address ?? '',
                     link: claimLinkData.link,
                 })
                 setClaimType('claim')
             }
             if (claimTxHash) {
                 utils.saveClaimedLinkToLocalStorage({
-                    address: recipient ? recipient.address : (address ?? ''),
+                    address: recipient ? recipient.address : address ?? '',
                     data: {
                         ...claimLinkData,
                         depositDate: new Date(),
@@ -148,10 +149,12 @@ export const ConfirmClaimLinkView = ({
                         <label className="text-h2">
                             ${' '}
                             {utils.formatTokenAmount(
-                                utils.formatAmountWithDecimals({
-                                    amount: selectedRoute.route.estimate.toAmountMin,
-                                    decimals: selectedRoute.route.estimate.toToken.decimals,
-                                }) * selectedRoute.route.estimate.toToken.usdPrice
+                                Number(
+                                    formatUnits(
+                                        selectedRoute.route.estimate.toAmountMin,
+                                        selectedRoute.route.estimate.toToken.decimals
+                                    )
+                                ) * selectedRoute.route.estimate.toToken.usdPrice
                             )}
                         </label>
                     ) : (
@@ -167,10 +170,12 @@ export const ConfirmClaimLinkView = ({
                 {selectedRoute ? (
                     <div className="flex w-full flex-row items-start justify-center gap-1 text-h7">
                         {utils.formatTokenAmount(
-                            utils.formatAmountWithDecimals({
-                                amount: selectedRoute.route.estimate.toAmountMin,
-                                decimals: selectedRoute.route.estimate.toToken.decimals,
-                            })
+                            Number(
+                                formatUnits(
+                                    selectedRoute.route.estimate.toAmountMin,
+                                    selectedRoute.route.estimate.toToken.decimals
+                                )
+                            )
                         )}{' '}
                         {selectedRoute.route.estimate.toToken.symbol} on{' '}
                         {mappedData.find((chain) => chain.chainId === selectedRoute.route.params.toChain)?.name}

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -222,12 +222,6 @@ export const getAllGigalinksFromLocalstorage = ({ address }: { address: string }
     }
 }
 
-export function formatAmountWithDecimals({ amount, decimals }: { amount: number; decimals: number }) {
-    const divider = 10 ** decimals
-    const formattedAmount = amount / divider
-    return formattedAmount
-}
-
 export function formatAmount(amount: number) {
     return amount.toFixed(2)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced token amount formatting using the new `formatUnits` function for improved precision.
	- Streamlined address handling in the `InitialClaimLinkView` and `Confirm.view` components.

- **Bug Fixes**
	- Improved clarity and readability of address handling logic, ensuring consistent functionality.

- **Chores**
	- Removed the outdated `formatAmountWithDecimals` utility function to simplify the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->