### PR TITLE
Specify allowed nodejs versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
     "name": "peanut-ui",
     "version": "0.2.0",
     "private": true,
+    "engines": {
+        "node": ">=21.1.0 <22.0.0 || ^18.18.0 || ^20.9.0"
+    },
     "scripts": {
         "dev": "next dev",
         "build": "next build",


### PR DESCRIPTION
Added a rule to limit node.js versions allowed to run the app.

Why `">=21.1.0 <22.0.0 || ^18.18.0 || ^20.9.0"`?
1. During package installation, @typescript-eslint/eslint-plugin@8.7.0 is expecting these versions: `^18.18.0 || ^20.9.0 || >=21.1.0"`, otherwise it throws an error and package installation fails
2. As learned from discord, node v22+ breaks the build and throws `ReferenceError: document is not defined`, so I've capped the allowed versions below v22.0.0

I was able to start the app using `next dev` locally on 3 node versions: 21.7.3, 18.18.2, 20.12.0 (which implies that other node versions that are limited by the rule should work as well  ¯\\_(ツ)_/¯). Also, anything that's not in the specified range, correctly throws an error (tested on node 16.13.0 and 22.9.0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated project configuration to specify compatible Node.js versions, ensuring better compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->