### PR TITLE
fix: fetchRouteRaw containing scientific notion string number

### DIFF
--- a/src/utils/cashout.utils.ts
+++ b/src/utils/cashout.utils.ts
@@ -515,7 +515,7 @@ export const fetchRouteRaw = async (
     senderAddress: string
 ) => {
     try {
-        const _tokenAmount = Math.floor(Number(tokenAmount) * Math.pow(10, tokenDecimals)).toString()
+        const _tokenAmount = BigInt(Math.floor(Number(tokenAmount) * Math.pow(10, tokenDecimals))).toString()
 
         const route = await getSquidRouteRaw({
             squidRouterUrl: 'https://apiplus.squidrouter.com/v2/route',


### PR DESCRIPTION
A scientific number breaks the cashout flow. Using BigInt to make sure the Number is being formatted correctly to be sent to the SDK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved precision in token amount calculations by switching to `BigInt`.
	- Enhanced error handling with clearer console messages for route fetching issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->