### PR TITLE
fix: prefered token in localStorage doesn't match any currently fetched tokens

### DIFF
--- a/src/components/Global/TokenSelector/TokenSelector.tsx
+++ b/src/components/Global/TokenSelector/TokenSelector.tsx
@@ -16,6 +16,7 @@ import { useAccount } from 'wagmi'
 import { useWeb3Modal } from '@web3modal/wagmi/react'
 import { useWalletType } from '@/hooks/useWalletType'
 import Icon from '../Icon'
+import { ethers } from 'ethers'
 
 const TokenSelector = ({ classNameButton }: _consts.TokenSelectorProps) => {
     const [visible, setVisible] = useState(false)
@@ -107,6 +108,21 @@ const TokenSelector = ({ classNameButton }: _consts.TokenSelectorProps) => {
         }
     }, [visible])
 
+    const displayedToken = _tokensToDisplay.find((token) =>
+        utils.compareTokenAddresses(token.address, selectedTokenAddress)
+    )
+    const displayedChain = supportedPeanutChains.find((chain) => chain.chainId === selectedChainID)
+    const displayedTokenBalance = balances.find(
+        (balance) =>
+            utils.compareTokenAddresses(balance.address, selectedTokenAddress) && balance.chainId === selectedChainID
+    )
+
+    useEffect(() => {
+        if (displayedToken === undefined && _tokensToDisplay[0]) {
+            setSelectedTokenAddress(_tokensToDisplay[0].address)
+        }
+    }, [displayedToken])
+
     return (
         <>
             <components.AdvancedTokenSelectorButton
@@ -114,27 +130,11 @@ const TokenSelector = ({ classNameButton }: _consts.TokenSelectorProps) => {
                     setVisible(!visible)
                 }}
                 isVisible={visible}
-                tokenLogoUri={
-                    (IconPlaceholderChecker(selectedChainID) as string) ??
-                    _tokensToDisplay.find((token) => utils.compareTokenAddresses(token.address, selectedTokenAddress))
-                        ?.logoURI
-                }
-                tokenSymbol={
-                    _tokensToDisplay.find((token) => utils.compareTokenAddresses(token.address, selectedTokenAddress))
-                        ?.symbol ?? ''
-                }
-                tokenBalance={
-                    balances.find(
-                        (balance) =>
-                            utils.compareTokenAddresses(balance.address, selectedTokenAddress) &&
-                            balance.chainId === selectedChainID
-                    )?.amount ?? 0
-                }
-                chainIconUri={
-                    (IconPlaceholderChecker(selectedChainID) as string) ??
-                    consts.supportedPeanutChains.find((chain) => chain.chainId === selectedChainID)?.icon.url
-                }
-                chainName={supportedPeanutChains.find((chain) => chain.chainId === selectedChainID)?.name ?? ''}
+                tokenLogoUri={(IconPlaceholderChecker(selectedChainID) as string) ?? displayedToken?.logoURI}
+                tokenSymbol={displayedToken?.symbol ?? ''}
+                tokenBalance={displayedTokenBalance?.amount ?? 0}
+                chainIconUri={(IconPlaceholderChecker(selectedChainID) as string) ?? displayedChain?.icon.url}
+                chainName={displayedChain?.name ?? ''}
                 classNameButton={classNameButton}
             />
 

--- a/src/components/Global/TokenSelector/TokenSelector.tsx
+++ b/src/components/Global/TokenSelector/TokenSelector.tsx
@@ -16,7 +16,6 @@ import { useAccount } from 'wagmi'
 import { useWeb3Modal } from '@web3modal/wagmi/react'
 import { useWalletType } from '@/hooks/useWalletType'
 import Icon from '../Icon'
-import { ethers } from 'ethers'
 
 const TokenSelector = ({ classNameButton }: _consts.TokenSelectorProps) => {
     const [visible, setVisible] = useState(false)


### PR DESCRIPTION
Making sure the UI for the currently selected token doesn't break if a previously preferedToken that is in local storage isn't in the fetched list of tokens. Picking top of the list token as newly selected token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced token selection functionality with improved display of tokens and balances.
	- Simplified rendering logic for better clarity in token selection.

- **Bug Fixes**
	- Resolved issues with displaying undefined tokens by defaulting to the first token in the list.

- **Refactor**
	- Streamlined state management and filtering logic for tokens and balances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->