### PR TITLE
fix(request): two bugs when preparing pay transaction

### DIFF
--- a/src/components/Claim/Link/Initial.view.tsx
+++ b/src/components/Claim/Link/Initial.view.tsx
@@ -272,7 +272,7 @@ export const InitialClaimLinkView = ({
                     route.fromChain === claimLinkData.chainId &&
                     route.fromToken.toLowerCase() === claimLinkData.tokenAddress.toLowerCase() &&
                     route.toChain === selectedChainID &&
-                    utils.compareTokenAddresses(route.toToken, selectedTokenAddress)
+                    utils.areTokenAddressesEqual(route.toToken, selectedTokenAddress)
             )
             if (existingRoute) {
                 setSelectedRoute(existingRoute)
@@ -382,7 +382,7 @@ export const InitialClaimLinkView = ({
                                     : mappedData
                                           .find((data) => data.chainId === selectedChainID)
                                           ?.tokens?.find((token) =>
-                                              utils.compareTokenAddresses(token.address, selectedTokenAddress)
+                                              utils.areTokenAddressesEqual(token.address, selectedTokenAddress)
                                           )?.symbol
                                 : claimLinkData.tokenSymbol
                         }
@@ -393,12 +393,12 @@ export const InitialClaimLinkView = ({
                                     : mappedData
                                           .find((data) => data.chainId === selectedChainID)
                                           ?.tokens?.find((token) =>
-                                              utils.compareTokenAddresses(token.address, selectedTokenAddress)
+                                              utils.areTokenAddressesEqual(token.address, selectedTokenAddress)
                                           )?.logoURI
                                 : consts.peanutTokenDetails
                                       .find((chain) => chain.chainId === claimLinkData.chainId)
                                       ?.tokens.find((token) =>
-                                          utils.compareTokenAddresses(token.address, claimLinkData.tokenAddress)
+                                          utils.areTokenAddressesEqual(token.address, claimLinkData.tokenAddress)
                                       )?.logoURI
                         }
                         chainLogoUrl={

--- a/src/components/Create/Create.utils.ts
+++ b/src/components/Create/Create.utils.ts
@@ -52,18 +52,18 @@ export const getTokenDetails = (tokenAddress: string, chainId: string, userBalan
     let tokenDecimals: number = 18
     if (
         userBalances.some(
-            (balance) => utils.compareTokenAddresses(balance.address, tokenAddress) && balance.chainId == chainId
+            (balance) => utils.areTokenAddressesEqual(balance.address, tokenAddress) && balance.chainId == chainId
         )
     ) {
         tokenDecimals =
             userBalances.find(
-                (balance) => balance.chainId == chainId && utils.compareTokenAddresses(balance.address, tokenAddress)
+                (balance) => balance.chainId == chainId && utils.areTokenAddressesEqual(balance.address, tokenAddress)
             )?.decimals ?? 18
     } else {
         tokenDecimals =
             consts.peanutTokenDetails
                 .find((detail) => detail.chainId.toString() == chainId)
-                ?.tokens.find((token) => utils.compareTokenAddresses(token.address, tokenAddress))?.decimals ?? 18
+                ?.tokens.find((token) => utils.areTokenAddressesEqual(token.address, tokenAddress))?.decimals ?? 18
     }
     const tokenType = utils.isNativeCurrency(tokenAddress) ? 0 : 1
 

--- a/src/components/Create/useCreateLink.tsx
+++ b/src/components/Create/useCreateLink.tsx
@@ -74,7 +74,7 @@ export const useCreateLink = () => {
         if (balances.length > 0) {
             let balance = balances.find(
                 (balance) =>
-                    utils.compareTokenAddresses(balance.address, selectedTokenAddress) &&
+                    utils.areTokenAddressesEqual(balance.address, selectedTokenAddress) &&
                     balance.chainId === selectedChainID
             )?.amount
             if (!balance) {

--- a/src/components/Dashboard/useDashboard.tsx
+++ b/src/components/Dashboard/useDashboard.tsx
@@ -124,7 +124,7 @@ export const useDashboard = () => {
                 tokenSymbol:
                     consts.peanutTokenDetails
                         .find((token) => token.chainId === link.chainId)
-                        ?.tokens.find((token) => utils.compareTokenAddresses(token.address, link.tokenAddress ?? ''))
+                        ?.tokens.find((token) => utils.areTokenAddressesEqual(token.address, link.tokenAddress ?? ''))
                         ?.symbol ?? '',
                 chain: consts.supportedPeanutChains.find((chain) => chain.chainId === link.chainId)?.name ?? '',
                 date: link.depositDate.toString(),
@@ -145,7 +145,7 @@ export const useDashboard = () => {
                 tokenSymbol:
                     consts.peanutTokenDetails
                         .find((token) => token.chainId === link.chainId)
-                        ?.tokens.find((token) => utils.compareTokenAddresses(token.address, link.tokenAddress))
+                        ?.tokens.find((token) => utils.areTokenAddressesEqual(token.address, link.tokenAddress))
                         ?.symbol ?? '',
                 chain: consts.supportedPeanutChains.find((chain) => chain.chainId === link.chainId)?.name ?? '',
                 date: link.date.toString(),
@@ -166,7 +166,7 @@ export const useDashboard = () => {
                 tokenSymbol:
                     consts.peanutTokenDetails
                         .find((token) => token.chainId === link.chainId)
-                        ?.tokens.find((token) => utils.compareTokenAddresses(token.address, link.tokenAddress))
+                        ?.tokens.find((token) => utils.areTokenAddressesEqual(token.address, link.tokenAddress))
                         ?.symbol ?? '',
                 chain: consts.supportedPeanutChains.find((chain) => chain.chainId === link.chainId)?.name ?? '',
                 date: link.createdAt.toString(),
@@ -187,7 +187,7 @@ export const useDashboard = () => {
                 tokenSymbol:
                     consts.peanutTokenDetails
                         .find((token) => token.chainId === link.chainId)
-                        ?.tokens.find((token) => utils.compareTokenAddresses(token.address, link.tokenAddress))
+                        ?.tokens.find((token) => utils.areTokenAddressesEqual(token.address, link.tokenAddress))
                         ?.symbol ?? '',
                 chain: consts.supportedPeanutChains.find((chain) => chain.chainId === link.chainId)?.name ?? '',
                 date: link.createdAt.toString(),

--- a/src/components/Global/ConfirmDetails/Index.tsx
+++ b/src/components/Global/ConfirmDetails/Index.tsx
@@ -29,12 +29,12 @@ export const ConfirmDetails = ({
                                 ? data
                                       .find((chain: any) => chain.chainId === selectedChainID)
                                       ?.tokens.find((token: any) =>
-                                          utils.compareTokenAddresses(token.address, selectedTokenAddress)
+                                          utils.areTokenAddressesEqual(token.address, selectedTokenAddress)
                                       )?.logoURI
                                 : consts.peanutTokenDetails
                                       .find((detail) => detail.chainId === selectedChainID)
                                       ?.tokens.find((token) =>
-                                          utils.compareTokenAddresses(token.address, selectedTokenAddress)
+                                          utils.areTokenAddressesEqual(token.address, selectedTokenAddress)
                                       )?.logoURI
                         }
                         className="h-6 w-6"
@@ -45,12 +45,12 @@ export const ConfirmDetails = ({
                             ? data
                                   .find((chain: any) => chain.chainId === selectedChainID)
                                   ?.tokens.find((token: any) =>
-                                      utils.compareTokenAddresses(token.address, selectedTokenAddress)
+                                      utils.areTokenAddressesEqual(token.address, selectedTokenAddress)
                                   )?.symbol
                             : consts.peanutTokenDetails
                                   .find((detail) => detail.chainId === selectedChainID)
                                   ?.tokens.find((token) =>
-                                      utils.compareTokenAddresses(token.address, selectedTokenAddress)
+                                      utils.areTokenAddressesEqual(token.address, selectedTokenAddress)
                                   )?.symbol}
                     </label>
                 </div>

--- a/src/components/Global/ImageGeneration/LinkPreview.tsx
+++ b/src/components/Global/ImageGeneration/LinkPreview.tsx
@@ -18,7 +18,7 @@ export function LinkPreviewImg({
 }) {
     const tokenImage = consts.peanutTokenDetails
         .find((detail) => detail.chainId === chainId)
-        ?.tokens.find((token) => utils.compareTokenAddresses(token.address, tokenAddress))?.logoURI
+        ?.tokens.find((token) => utils.areTokenAddressesEqual(token.address, tokenAddress))?.logoURI
     const chainImage = consts.supportedPeanutChains.find((chain) => chain.chainId === chainId)?.icon.url
 
     const bgImageUrl = `https://peanut.to/bg.svg`

--- a/src/components/Global/TokenSelector/TokenSelector.tsx
+++ b/src/components/Global/TokenSelector/TokenSelector.tsx
@@ -113,12 +113,12 @@ const TokenSelector = ({ classNameButton, shouldBeConnected = true }: _consts.To
     }, [visible])
 
     const displayedToken = _tokensToDisplay.find((token) =>
-        utils.compareTokenAddresses(token.address, selectedTokenAddress)
+        utils.areTokenAddressesEqual(token.address, selectedTokenAddress)
     )
     const displayedChain = supportedPeanutChains.find((chain) => chain.chainId === selectedChainID)
     const displayedTokenBalance = balances.find(
         (balance) =>
-            utils.compareTokenAddresses(balance.address, selectedTokenAddress) && balance.chainId === selectedChainID
+            utils.areTokenAddressesEqual(balance.address, selectedTokenAddress) && balance.chainId === selectedChainID
     )
 
     useEffect(() => {

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -569,7 +569,7 @@ export const Profile = () => {
                                             <label className="w-[30%] text-right text-h8">
                                                 {Math.floor(
                                                     user.pointsPerReferral?.find((ref) =>
-                                                        utils.compareTokenAddresses(ref.address, referral.address)
+                                                        utils.areTokenAddressesEqual(ref.address, referral.address)
                                                     )?.points ?? 0
                                                 )}
                                             </label>

--- a/src/components/Request/Pay/Views/GeneralViews/AlreadyPaid.view.tsx
+++ b/src/components/Request/Pay/Views/GeneralViews/AlreadyPaid.view.tsx
@@ -19,7 +19,7 @@ export const AlreadyPaidLinkView = ({ requestLinkData }: { requestLinkData: _con
                     consts.peanutTokenDetails
                         .find((chain) => chain.chainId === requestLinkData?.chainId)
                         ?.tokens.find((token) =>
-                            utils.compareTokenAddresses(token.address, requestLinkData?.tokenAddress ?? '')
+                            utils.areTokenAddressesEqual(token.address, requestLinkData?.tokenAddress ?? '')
                         )?.symbol}{' '}
                 on{' '}
                 {consts.supportedPeanutChains &&

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -28,7 +28,12 @@ export const InitialView = ({
     const { switchChainAsync } = useSwitchChain()
     const { open } = useWeb3Modal()
     const { setLoadingState, loadingState, isLoading } = useContext(context.loadingStateContext)
-    const { selectedChainID, selectedTokenAddress, selectedTokenDecimals } = useContext(context.tokenSelectorContext)
+    const {
+        selectedChainID,
+        selectedTokenAddress,
+        selectedTokenDecimals,
+        tokenPriceCompleted
+    } = useContext(context.tokenSelectorContext)
     const [errorState, setErrorState] = useState<{
         showError: boolean
         errorMessage: string
@@ -86,8 +91,19 @@ export const InitialView = ({
                 setTxFee('0')
             }
         }
+
+        // wait for token selector to fetch token price, both effects depend on
+        // selectedTokenAddress and selectedChainID, but we depend on that
+        // effect being completed first
+        if (!tokenPriceCompleted) return
+
         estimateTxFee()
-    }, [selectedTokenAddress, selectedChainID])
+    }, [
+        selectedTokenAddress,
+        selectedChainID,
+        selectedTokenDecimals,
+        tokenPriceCompleted
+    ])
 
     const handleConnectWallet = async () => {
         open()

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -55,7 +55,10 @@ export const InitialView = ({
     useEffect(() => {
         const estimateTxFee = async () => {
             setLinkState(RequestStatus.LOADING)
-            if (selectedChainID === requestLinkData.chainId && selectedTokenAddress === requestLinkData.tokenAddress) {
+            if (
+                selectedChainID === requestLinkData.chainId
+                && utils.compareTokenAddresses(selectedTokenAddress, requestLinkData.tokenAddress)
+            ) {
                 setErrorState({ showError: false, errorMessage: '' })
                 setIsFeeEstimationError(false)
                 setLinkState(RequestStatus.CLAIM)
@@ -111,7 +114,10 @@ export const InitialView = ({
         try {
             setErrorState({ showError: false, errorMessage: '' })
             if (!unsignedTx) return
-            if (selectedChainID === requestLinkData.chainId && selectedTokenAddress === requestLinkData.tokenAddress) {
+            if (
+                selectedChainID === requestLinkData.chainId
+                && utils.compareTokenAddresses(selectedTokenAddress, requestLinkData.tokenAddress)
+            ){
                 await checkUserHasEnoughBalance({ tokenValue: requestLinkData.tokenAmount })
                 if (selectedChainID !== String(currentChain?.id)) {
                     await switchNetwork(selectedChainID)

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -40,7 +40,7 @@ export const InitialView = ({
     }>({ showError: false, errorMessage: '' })
     const [txFee, setTxFee] = useState<string>('0')
     const [isFeeEstimationError, setIsFeeEstimationError] = useState<boolean>(false)
-    const [linkState, setLinkState] = useState<RequestStatus>(RequestStatus.LOADING)
+    const [linkState, setLinkState] = useState<RequestStatus>(RequestStatus.NOT_CONNECTED)
     const [estimatedFromValue, setEstimatedFromValue] = useState<string>('0')
     const createXChainUnsignedTx = async () => {
         const xchainUnsignedTxs = await peanut.prepareXchainRequestFulfillmentTransaction({
@@ -95,7 +95,7 @@ export const InitialView = ({
         // wait for token selector to fetch token price, both effects depend on
         // selectedTokenAddress and selectedChainID, but we depend on that
         // effect being completed first
-        if (!isTokenPriceFetchingComplete) return
+        if (!isConnected || !isTokenPriceFetchingComplete) return
 
         estimateTxFee()
     }, [
@@ -107,7 +107,9 @@ export const InitialView = ({
     ])
 
     const handleConnectWallet = async () => {
-        open()
+        open().finally(() => {
+            if (isConnected) setLinkState(RequestStatus.LOADING)
+        })
     }
 
     const switchNetwork = async (chainId: string) => {
@@ -356,7 +358,7 @@ export const InitialView = ({
                     disabled={linkState === RequestStatus.LOADING || linkState === RequestStatus.NOT_FOUND || isLoading}
                     onClick={() => {
                         if (!isConnected) handleConnectWallet()
-                        else handleOnNext()
+                        else if (RequestStatus.CLAIM === linkState) handleOnNext()
                     }}
                 >
                     {linkState === RequestStatus.LOADING ? (

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -103,6 +103,7 @@ export const InitialView = ({
         selectedChainID,
         selectedTokenDecimals,
         isTokenPriceFetchingComplete,
+        requestLinkData
     ])
 
     const handleConnectWallet = async () => {

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -62,7 +62,7 @@ export const InitialView = ({
             setLinkState(RequestStatus.LOADING)
             if (
                 selectedChainID === requestLinkData.chainId
-                && utils.compareTokenAddresses(selectedTokenAddress, requestLinkData.tokenAddress)
+                && utils.areTokenAddressesEqual(selectedTokenAddress, requestLinkData.tokenAddress)
             ) {
                 setErrorState({ showError: false, errorMessage: '' })
                 setIsFeeEstimationError(false)
@@ -133,7 +133,7 @@ export const InitialView = ({
             if (!unsignedTx) return
             if (
                 selectedChainID === requestLinkData.chainId
-                && utils.compareTokenAddresses(selectedTokenAddress, requestLinkData.tokenAddress)
+                && utils.areTokenAddressesEqual(selectedTokenAddress, requestLinkData.tokenAddress)
             ){
                 await checkUserHasEnoughBalance({ tokenValue: requestLinkData.tokenAmount })
                 if (selectedChainID !== String(currentChain?.id)) {
@@ -220,7 +220,7 @@ export const InitialView = ({
     const chainDetails = consts.peanutTokenDetails.find((chain) => chain.chainId === requestLinkData.chainId)
 
     const tokenRequestedLogoURI = chainDetails?.tokens.find((token) =>
-        utils.compareTokenAddresses(token.address, requestLinkData.tokenAddress)
+        utils.areTokenAddressesEqual(token.address, requestLinkData.tokenAddress)
     )?.logoURI
 
     return (
@@ -285,7 +285,7 @@ export const InitialView = ({
                             consts.peanutTokenDetails
                                 .find((chain) => chain.chainId === requestLinkData.chainId)
                                 ?.tokens.find((token) =>
-                                    utils.compareTokenAddresses(token.address, requestLinkData.tokenAddress)
+                                    utils.areTokenAddressesEqual(token.address, requestLinkData.tokenAddress)
                                 )
                                 ?.symbol.toUpperCase()}{' '}
                         on{' '}

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -32,7 +32,7 @@ export const InitialView = ({
         selectedChainID,
         selectedTokenAddress,
         selectedTokenDecimals,
-        tokenPriceCompleted
+        isTokenPriceFetchingComplete
     } = useContext(context.tokenSelectorContext)
     const [errorState, setErrorState] = useState<{
         showError: boolean
@@ -95,14 +95,14 @@ export const InitialView = ({
         // wait for token selector to fetch token price, both effects depend on
         // selectedTokenAddress and selectedChainID, but we depend on that
         // effect being completed first
-        if (!tokenPriceCompleted) return
+        if (!isTokenPriceFetchingComplete) return
 
         estimateTxFee()
     }, [
         selectedTokenAddress,
         selectedChainID,
         selectedTokenDecimals,
-        tokenPriceCompleted
+        isTokenPriceFetchingComplete,
     ])
 
     const handleConnectWallet = async () => {

--- a/src/components/Request/Pay/utils.ts
+++ b/src/components/Request/Pay/utils.ts
@@ -14,5 +14,6 @@ export enum EPeanutLinkType {
 export enum RequestStatus {
     LOADING = 'LOADING',
     CLAIM = 'CLAIM',
+    NOT_CONNECTED = 'NOT_CONNECTED',
     NOT_FOUND = 'NOT_FOUND',
 }

--- a/src/context/tokenSelector.context.tsx
+++ b/src/context/tokenSelector.context.tsx
@@ -21,7 +21,7 @@ export const tokenSelectorContext = createContext({
     refetchXchainRoute: false as boolean,
     setRefetchXchainRoute: (value: boolean) => {},
     resetTokenContextProvider: () => {},
-    tokenPriceCompleted: false as boolean,
+    isTokenPriceFetchingComplete: false as boolean,
 })
 
 /**
@@ -35,7 +35,7 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
     const [inputDenomination, setInputDenomination] = useState<inputDenominationType>('TOKEN')
     const [refetchXchainRoute, setRefetchXchainRoute] = useState<boolean>(false)
     const [selectedTokenDecimals, setSelectedTokenDecimals] = useState<number | undefined>(18)
-    const [tokenPriceCompleted, setTokenPriceCompleted] = useState<boolean>(false)
+    const [isTokenPriceFetchingComplete, setTokenPriceFetchingComplete] = useState<boolean>(false)
 
 
     const { isConnected } = useAccount()
@@ -75,7 +75,7 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
                     if (tokenPriceResponse?.price) {
                         setSelectedTokenPrice(tokenPriceResponse.price)
                         setSelectedTokenDecimals(tokenPriceResponse.decimals)
-                        setTokenPriceCompleted(true)
+                        setTokenPriceFetchingComplete(true)
                         if (tokenPriceResponse.price === 1) {
                             setInputDenomination('TOKEN')
                         } else {
@@ -98,7 +98,7 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
             setSelectedTokenDecimals(undefined)
             setInputDenomination('TOKEN')
             return () => {
-                setTokenPriceCompleted(false)
+                setTokenPriceFetchingComplete(false)
             }
         } else if (selectedTokenAddress && selectedChainID) {
             setSelectedTokenPrice(undefined)
@@ -107,7 +107,7 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
             fetchAndSetTokenPrice(selectedTokenAddress, selectedChainID)
             return () => {
                 isCurrent = false
-                setTokenPriceCompleted(false)
+                setTokenPriceFetchingComplete(false)
             }
         }
     }, [selectedTokenAddress, selectedChainID, isConnected])
@@ -118,7 +118,7 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
             setSelectedTokenAddress(prefs.tokenAddress)
             setSelectedChainID(prefs.chainId)
             setSelectedTokenDecimals(prefs.decimals)
-            setTokenPriceCompleted(true)
+            setTokenPriceFetchingComplete(true)
         }
     }, [])
 
@@ -138,7 +138,7 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
                 refetchXchainRoute,
                 setRefetchXchainRoute,
                 resetTokenContextProvider,
-                tokenPriceCompleted,
+                isTokenPriceFetchingComplete,
             }}
         >
             {children}

--- a/src/context/tokenSelector.context.tsx
+++ b/src/context/tokenSelector.context.tsx
@@ -21,6 +21,7 @@ export const tokenSelectorContext = createContext({
     refetchXchainRoute: false as boolean,
     setRefetchXchainRoute: (value: boolean) => {},
     resetTokenContextProvider: () => {},
+    tokenPriceCompleted: false as boolean,
 })
 
 /**
@@ -34,6 +35,8 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
     const [inputDenomination, setInputDenomination] = useState<inputDenominationType>('TOKEN')
     const [refetchXchainRoute, setRefetchXchainRoute] = useState<boolean>(false)
     const [selectedTokenDecimals, setSelectedTokenDecimals] = useState<number | undefined>(18)
+    const [tokenPriceCompleted, setTokenPriceCompleted] = useState<boolean>(false)
+
 
     const { isConnected } = useAccount()
     const preferences = utils.getPeanutPreferences()
@@ -72,6 +75,7 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
                     if (tokenPriceResponse?.price) {
                         setSelectedTokenPrice(tokenPriceResponse.price)
                         setSelectedTokenDecimals(tokenPriceResponse.decimals)
+                        setTokenPriceCompleted(true)
                         if (tokenPriceResponse.price === 1) {
                             setInputDenomination('TOKEN')
                         } else {
@@ -88,10 +92,14 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
             }
         }
 
+
         if (!isConnected) {
             setSelectedTokenPrice(undefined)
             setSelectedTokenDecimals(undefined)
             setInputDenomination('TOKEN')
+            return () => {
+                setTokenPriceCompleted(false)
+            }
         } else if (selectedTokenAddress && selectedChainID) {
             setSelectedTokenPrice(undefined)
             setSelectedTokenDecimals(undefined)
@@ -99,6 +107,7 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
             fetchAndSetTokenPrice(selectedTokenAddress, selectedChainID)
             return () => {
                 isCurrent = false
+                setTokenPriceCompleted(false)
             }
         }
     }, [selectedTokenAddress, selectedChainID, isConnected])
@@ -109,6 +118,7 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
             setSelectedTokenAddress(prefs.tokenAddress)
             setSelectedChainID(prefs.chainId)
             setSelectedTokenDecimals(prefs.decimals)
+            setTokenPriceCompleted(true)
         }
     }, [])
 
@@ -128,6 +138,7 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
                 refetchXchainRoute,
                 setRefetchXchainRoute,
                 resetTokenContextProvider,
+                tokenPriceCompleted,
             }}
         >
             {children}

--- a/src/utils/cashout.utils.ts
+++ b/src/utils/cashout.utils.ts
@@ -326,7 +326,7 @@ export function getThreeCharCountryCodeFromIban(iban: string): string {
 export function getBridgeTokenName(chainId: string, tokenAddress: string): string | undefined {
     const token = consts.supportedBridgeTokensDictionary
         .find((chain) => chain.chainId === chainId)
-        ?.tokens.find((token) => utils.compareTokenAddresses(token.address, tokenAddress))
+        ?.tokens.find((token) => utils.areTokenAddressesEqual(token.address, tokenAddress))
         ?.token.toLowerCase()
 
     return token ?? undefined

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -2,6 +2,7 @@ import * as interfaces from '@/interfaces'
 import * as consts from '@/constants'
 import peanut, { interfaces as peanutInterfaces } from '@squirrel-labs/peanut-sdk'
 import { exportTraceState } from 'next/dist/trace'
+import { ethers } from 'ethers'
 
 export const shortenAddress = (address: string) => {
     const firstBit = address.substring(0, 6)
@@ -319,12 +320,14 @@ export const isTestnetChain = (chainId: string) => {
     return isTestnet
 }
 
-export const compareTokenAddresses = (address1: string, address2: string) => {
+export const compareTokenAddresses = (address1: string, address2: string): boolean => {
     if (address1.toLowerCase() === '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'.toLocaleLowerCase())
         address1 = '0x0000000000000000000000000000000000000000'
     if (address2.toLowerCase() === '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'.toLocaleLowerCase())
         address2 = '0x0000000000000000000000000000000000000000'
-    return address1.toLowerCase() === address2.toLowerCase()
+    // By using ethers.getAddress we are safe from different cases
+    // and other address formatting
+    return ethers.utils.getAddress(address1) === ethers.utils.getAddress(address2)
 }
 
 export const isNativeCurrency = (address: string) => {

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -320,7 +320,7 @@ export const isTestnetChain = (chainId: string) => {
     return isTestnet
 }
 
-export const compareTokenAddresses = (address1: string, address2: string): boolean => {
+export const areTokenAddressesEqual = (address1: string, address2: string): boolean => {
     if (address1.toLowerCase() === '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'.toLocaleLowerCase())
         address1 = '0x0000000000000000000000000000000000000000'
     if (address2.toLowerCase() === '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'.toLocaleLowerCase())


### PR DESCRIPTION
1. Because a case sensitive comparison two token addresses were treated as different when they should be equal

2. Because the token selector and the request component both depend on
selectedTokenAddress and selectedChainID, they will try to execute
their effects at the same time. This causes the request component to use
incorrect token price data. This commit fixes that by adding a
tokenPriceCompleted state to the token selector context, which is set to
true once the token price has been fetched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new property, `isTokenPriceFetchingComplete`, to improve token price fetching and transaction fee estimation.
	- Enhanced address comparison logic by replacing `compareTokenAddresses` with `areTokenAddressesEqual` for improved accuracy in token selection across multiple components.

- **Bug Fixes**
	- Improved error messages for clearer user feedback during the claim process and token selection.

- **Documentation**
	- Updated utility functions for managing Ethereum address validation and local storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->