### PR TITLE
fix: success view for request and claim

### DIFF
--- a/src/components/Claim/Link/Onchain/Success.view.tsx
+++ b/src/components/Claim/Link/Onchain/Success.view.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useContext, useEffect, useMemo, useState } from 'react'
 import { useAccount, useConnections, useSwitchChain } from 'wagmi'
-import { loopUntilSuccess } from '@/components/utils/utils'
+import { fetchDestinationChain } from '@/components/utils/utils'
 
 export const SuccessClaimLinkView = ({ transactionHash, claimLinkData, type }: _consts.IClaimScreenProps) => {
     const connections = useConnections()
@@ -46,7 +46,7 @@ export const SuccessClaimLinkView = ({ transactionHash, claimLinkData, type }: _
     useEffect(() => {
         resetTokenContextProvider()
         if (transactionHash && type === 'claimxchain') {
-            loopUntilSuccess(transactionHash, setExplorerUrlDestChainWithTxHash)
+            fetchDestinationChain(transactionHash, setExplorerUrlDestChainWithTxHash)
         }
     }, [])
 

--- a/src/components/Request/Pay/Views/Success.view.tsx
+++ b/src/components/Request/Pay/Views/Success.view.tsx
@@ -7,16 +7,16 @@ import { fetchDestinationChain } from '@/components/utils/utils'
 import * as context from '@/context'
 
 export const SuccessView = ({ transactionHash, requestLinkData }: _consts.IPayScreenProps) => {
-    const explorerUrlWithTx = useMemo(
-        () => `${utils.getExplorerUrl(requestLinkData.chainId)}/tx/${transactionHash}`,
-        [transactionHash, requestLinkData.chainId]
+    const { selectedChainID } = useContext(context.tokenSelectorContext)
+    const sourceUrlWithTx = useMemo(
+        () => `${utils.getExplorerUrl(selectedChainID)}/tx/${transactionHash}`,
+        [transactionHash, selectedChainID]
     )
     const [explorerUrlDestChainWithTxHash, setExplorerUrlDestChainWithTxHash] = useState<
         { transactionId: string; transactionUrl: string } | undefined
     >(undefined)
     const explorerUrlAxelarWithTx = 'https://axelarscan.io/gmp/' + transactionHash
 
-    const { selectedChainID } = useContext(context.tokenSelectorContext)
 
     useEffect(() => {
         if (transactionHash) {
@@ -37,7 +37,7 @@ export const SuccessView = ({ transactionHash, requestLinkData }: _consts.IPaySc
                 <label className="text-h8 font-normal text-gray-1">Transaction details</label>
                 <div className="flex w-full flex-row items-center justify-start gap-1">
                     <label className="">Source chain:</label>
-                    <Link className="cursor-pointer underline" href={explorerUrlWithTx}>
+                    <Link className="cursor-pointer underline" href={sourceUrlWithTx}>
                         {utils.shortenAddressLong(transactionHash ?? '')}
                     </Link>
                 </div>

--- a/src/components/Request/Pay/Views/Success.view.tsx
+++ b/src/components/Request/Pay/Views/Success.view.tsx
@@ -3,7 +3,7 @@ import * as _consts from '../Pay.consts'
 import Icon from '@/components/Global/Icon'
 import * as utils from '@/utils'
 import { useContext, useEffect, useMemo, useState } from 'react'
-import { loopUntilSuccess } from '@/components/utils/utils'
+import { fetchDestinationChain } from '@/components/utils/utils'
 import * as context from '@/context'
 
 export const SuccessView = ({ transactionHash, requestLinkData }: _consts.IPayScreenProps) => {
@@ -20,7 +20,7 @@ export const SuccessView = ({ transactionHash, requestLinkData }: _consts.IPaySc
 
     useEffect(() => {
         if (transactionHash) {
-            loopUntilSuccess(transactionHash, setExplorerUrlDestChainWithTxHash)
+            fetchDestinationChain(transactionHash, setExplorerUrlDestChainWithTxHash)
         }
     }, [])
     return (

--- a/src/components/utils/utils.ts
+++ b/src/components/utils/utils.ts
@@ -2,7 +2,75 @@ import axios from 'axios'
 import * as consts from '@/constants'
 import * as utils from '@/utils'
 
-export async function checkTransactionStatus(txHash: string): Promise<void> {
+type ISquidChainData = {
+  id: string,
+  chainId: string,
+  networkIdentifier: string,
+  chainName: string,
+  axelarChainName: string,
+  type: string,
+  networkName: string,
+  nativeCurrency: {
+    name: string,
+    symbol: string,
+    decimals: number,
+    icon: string,
+  },
+  chainIconURI: string,
+  blockExplorerUrls: string[],
+  swapAmountForGas: string,
+  sameChainSwapsSupported: boolean,
+  compliance: {
+    trmIdentifier: string,
+  },
+  boostSupported: boolean,
+  enableBoostByDefault: boolean,
+  rpcList: string[],
+  chainNativeContracts: {
+    wrappedNativeToken: string,
+    ensRegistry: string,
+    multicall: string,
+    usdcToken: string,
+  },
+  feeCurrencies: any[],
+  currencies: any[],
+  features: any[],
+}
+
+type ISquidStatusResponse = {
+  id: string,
+  status: string,
+  gasStatus: string,
+  isGMPTransaction: boolean,
+  axelarTransactionUrl: string,
+  fromChain: {
+    transactionId: string,
+    blockNumber: number,
+    callEventStatus: string,
+    callEventLog: any[],
+    chainData: ISquidChainData,
+    transactionUrl: string,
+  },
+  toChain: {
+    transactionId: string,
+    blockNumber: number,
+    callEventStatus: string,
+    callEventLog: any[],
+    chainData: ISquidChainData,
+    transactionUrl: string,
+  },
+  timeSpent: {
+    call_express_executed: number,
+    total: number,
+  },
+  routeStatus: any[],
+  error: any,
+  squidTransactionStatus: string,
+}
+
+export async function checkTransactionStatus(
+  txHash: string
+): Promise<ISquidStatusResponse> {
     try {
         const response = await axios.get('https://apiplus.squidrouter.com/v2/status', {
             params: { transactionId: txHash },
@@ -22,22 +90,16 @@ export async function fetchDestinationChain(
     let intervalId = setInterval(async () => {
         const result = await checkTransactionStatus(txHash)
 
-        //@ts-ignore
         if (result.squidTransactionStatus === 'success') {
-            //@ts-ignore
             const explorerUrl = utils.getExplorerUrl(result.toChain.chainData.chainId.toString())
             if (explorerUrl) {
                 setExplorerUrlDestChainWithTxHash({
-                    //@ts-ignore
                     transactionUrl: explorerUrl + '/tx/' + result.toChain.transactionId,
-                    //@ts-ignore
                     transactionId: result.toChain.transactionId,
                 })
             } else {
                 setExplorerUrlDestChainWithTxHash({
-                    //@ts-ignore
                     transactionUrl: result.toChain.transactionUrl,
-                    //@ts-ignore
                     transactionId: result.toChain.transactionId,
                 })
             }

--- a/src/components/utils/utils.ts
+++ b/src/components/utils/utils.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import * as consts from '@/constants'
+import * as utils from '@/utils'
 
 export async function checkTransactionStatus(txHash: string): Promise<void> {
     try {

--- a/src/components/utils/utils.ts
+++ b/src/components/utils/utils.ts
@@ -15,7 +15,7 @@ export async function checkTransactionStatus(txHash: string): Promise<void> {
     }
 }
 
-export async function loopUntilSuccess(
+export async function fetchDestinationChain(
     txHash: string,
     setExplorerUrlDestChainWithTxHash: (value: { transactionId: string; transactionUrl: string }) => void
 ) {


### PR DESCRIPTION
## Fixes
1. For both claim and request, the destination address was not being fetched because utils was not being imported. This fixes that by importing it
2. For request view, the source chain was wrong, now it uses the selected one (because when paying a request the selected chain is the source one)

## Chores
- Remove some ts-ignore
- Rename `loopUntilSuccessful` to more self-explaining `fetchDestinationChain`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved transaction handling in the SuccessClaimLinkView and SuccessView components, enhancing the fetching of destination chain transaction details.
	- Introduced new structured types for better handling of blockchain data and transaction statuses.

- **Bug Fixes**
	- Updated logic for fetching transaction URLs to ensure accurate linking based on the current context.

- **Refactor**
	- Replaced outdated methods with more efficient alternatives for fetching transaction data.
	- Streamlined component logic for better performance and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->