### PR TITLE
feat: reset button for going back to request link token on pay

### DIFF
--- a/src/components/Global/TokenSelector/Components/AdvancedButton.tsx
+++ b/src/components/Global/TokenSelector/Components/AdvancedButton.tsx
@@ -20,6 +20,7 @@ interface IAdvancedTokenSelectorButtonProps {
     classNameButton?: string
     isStatic?: boolean
     type?: 'xchain' | 'send'
+    onReset?: () => void
 }
 
 export const AdvancedTokenSelectorButton = ({
@@ -35,6 +36,7 @@ export const AdvancedTokenSelectorButton = ({
     classNameButton,
     isStatic = false,
     type = 'send',
+    onReset,
 }: IAdvancedTokenSelectorButtonProps) => {
     const { selectedChainID, selectedTokenAddress } = useContext(context.tokenSelectorContext)
     const { address } = useAccount()
@@ -131,16 +133,32 @@ export const AdvancedTokenSelectorButton = ({
                     )}
                 </div>
             </div>
-            <div className="flex flex-row items-center justify-center gap-2">
-                <div className="block">
-                    {!isStatic && (
-                        <Icon
-                            name={'arrow-bottom'}
-                            className={`h-12 w-12 transition-transform dark:fill-white ${isVisible ? 'rotate-180 ' : ''}`}
-                        />
-                    )}
+            {!isStatic && (
+                <div className="flex flex-row items-center justify-center gap-2">
+                    {'send' === type &&
+                        <div className="block">
+                                <Icon
+                                    name={'arrow-bottom'}
+                                    className={`h-12 w-12 transition-transform dark:fill-white ${isVisible ? 'rotate-180 ' : ''}`}
+                                />
+                        </div>
+                    }
+                    {'xchain' === type &&
+                        <div
+                            className="block"
+                            onClick={(e) => {
+                                e.stopPropagation()  //don't open modal
+                                onReset && onReset()
+                            }}
+                        >
+                            <Icon
+                                name={'close'}
+                                className={`h-10 w-10 transition-transform dark:fill-white`}
+                            />
+                        </div>
+                    }
                 </div>
-            </div>
+            )}
         </div>
     )
 }

--- a/src/components/Global/TokenSelector/Components/AdvancedButton.tsx
+++ b/src/components/Global/TokenSelector/Components/AdvancedButton.tsx
@@ -91,9 +91,16 @@ export const AdvancedTokenSelectorButton = ({
         //         <div className="">{chainName}</div>
         //     </div>
         // </div>
-        <div
+        <section
+            role="button"
+            tabIndex={0}
+            aria-label="Open token selector"
             className={`flex w-full max-w-96 ${!isStatic && ' cursor-pointer '} h-18 flex-row items-center justify-between border border-n-1 px-4 py-2 hover:bg-n-3/10 dark:border-white  ${classNameButton}`}
             onClick={() => {
+                !isStatic && onClick()
+            }}
+            onKeyDown={(e) => {
+                if (e.key !== 'Enter' && e.key !== ' ') return
                 !isStatic && onClick()
             }}
         >
@@ -136,29 +143,38 @@ export const AdvancedTokenSelectorButton = ({
             {!isStatic && (
                 <div className="flex flex-row items-center justify-center gap-2">
                     {'send' === type &&
-                        <div className="block">
+                        <button
+                            aria-label="Open token selector"
+                            className="block"
+                        >
                                 <Icon
                                     name={'arrow-bottom'}
                                     className={`h-12 w-12 transition-transform dark:fill-white ${isVisible ? 'rotate-180 ' : ''}`}
                                 />
-                        </div>
+                        </button>
                     }
                     {'xchain' === type &&
-                        <div
+                        <button
+                            aria-label="Reset token selection"
                             className="block"
                             onClick={(e) => {
                                 e.stopPropagation()  //don't open modal
-                                onReset && onReset()
+                                onReset?.()
+                            }}
+                            onKeyDown={(e) => {
+                                if (e.key !== 'Enter') return
+                                e.stopPropagation()
+                                onReset?.()
                             }}
                         >
                             <Icon
                                 name={'close'}
                                 className={`h-10 w-10 transition-transform dark:fill-white`}
                             />
-                        </div>
+                        </button>
                     }
                 </div>
             )}
-        </div>
+        </section>
     )
 }

--- a/src/components/Global/TokenSelector/TokenSelector.consts.ts
+++ b/src/components/Global/TokenSelector/TokenSelector.consts.ts
@@ -7,6 +7,7 @@ export interface CombinedType extends interfaces.IPeanutChainDetails {
 export interface TokenSelectorProps {
     classNameButton?: string
     shouldBeConnected?: boolean
+    onReset?: () => void
 }
 
 export interface TokenSelectorXChainProps extends TokenSelectorProps {

--- a/src/components/Global/TokenSelector/TokenSelector.tsx
+++ b/src/components/Global/TokenSelector/TokenSelector.tsx
@@ -18,7 +18,11 @@ import { useWalletType } from '@/hooks/useWalletType'
 import Icon from '../Icon'
 import { CrispButton } from '@/components/CrispChat'
 
-const TokenSelector = ({ classNameButton, shouldBeConnected = true }: _consts.TokenSelectorProps) => {
+const TokenSelector = ({
+    classNameButton,
+    shouldBeConnected = true,
+    onReset,
+}: _consts.TokenSelectorProps) => {
     const [visible, setVisible] = useState(false)
     const [filterValue, setFilterValue] = useState('')
     const focusButtonRef = useRef<HTMLButtonElement>(null)
@@ -29,7 +33,13 @@ const TokenSelector = ({ classNameButton, shouldBeConnected = true }: _consts.To
     const [showFallback, setShowFallback] = useState(!shouldBeConnected)
 
     const { balances, hasFetchedBalances } = useBalance()
-    const { selectedChainID, selectedTokenAddress, setSelectedTokenAddress, setSelectedChainID } = useContext(
+    const {
+        selectedChainID,
+        selectedTokenAddress,
+        setSelectedTokenAddress,
+        setSelectedChainID,
+        isXChain,
+    } = useContext(
         context.tokenSelectorContext
     )
     const { isConnected } = useAccount()
@@ -140,6 +150,8 @@ const TokenSelector = ({ classNameButton, shouldBeConnected = true }: _consts.To
                 chainIconUri={(IconPlaceholderChecker(selectedChainID) as string) ?? displayedChain?.icon.url}
                 chainName={displayedChain?.name ?? ''}
                 classNameButton={classNameButton}
+                type={isXChain ? 'xchain' : 'send'}
+                onReset={onReset}
             />
 
             <Modal

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -30,9 +30,12 @@ export const InitialView = ({
     const { setLoadingState, loadingState, isLoading } = useContext(context.loadingStateContext)
     const {
         selectedChainID,
+        setSelectedChainID,
         selectedTokenAddress,
+        setSelectedTokenAddress,
         selectedTokenDecimals,
-        isTokenPriceFetchingComplete
+        isTokenPriceFetchingComplete,
+        setIsXChain,
     } = useContext(context.tokenSelectorContext)
     const [errorState, setErrorState] = useState<{
         showError: boolean
@@ -92,10 +95,17 @@ export const InitialView = ({
             }
         }
 
+        const isXChain = selectedChainID !== requestLinkData.chainId
+            || !utils.areTokenAddressesEqual(
+                selectedTokenAddress,
+                requestLinkData.tokenAddress
+                )
+        setIsXChain(isXChain)
+
         // wait for token selector to fetch token price, both effects depend on
         // selectedTokenAddress and selectedChainID, but we depend on that
         // effect being completed first
-        if (!isConnected || !isTokenPriceFetchingComplete) return
+        if (!isConnected || (isXChain && !isTokenPriceFetchingComplete)) return
 
         estimateTxFee()
     }, [
@@ -219,6 +229,11 @@ export const InitialView = ({
         }
     }
 
+    const resetTokenAndChain = () => {
+        setSelectedChainID(requestLinkData.chainId)
+        setSelectedTokenAddress(requestLinkData.tokenAddress)
+    }
+
     const chainDetails = consts.peanutTokenDetails.find((chain) => chain.chainId === requestLinkData.chainId)
 
     const tokenRequestedLogoURI = chainDetails?.tokens.find((token) =>
@@ -299,7 +314,10 @@ export const InitialView = ({
                     want to fulfill this request with.
                 </label>
             </div>
-            <TokenSelector classNameButton="w-full" />
+            <TokenSelector
+                classNameButton="w-full"
+                onReset={resetTokenAndChain}
+            />
             <div className="flex w-full flex-col items-center justify-center gap-2">
                 {!isFeeEstimationError && (
                     <>

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -14,6 +14,8 @@ import TokenSelector from '@/components/Global/TokenSelector/TokenSelector'
 import { switchNetwork as switchNetworkUtil } from '@/utils/general.utils'
 import { ADDRESS_ZERO, EPeanutLinkType, RequestStatus } from '../utils'
 
+const ERR_NO_ROUTE = 'No route found to pay in this chain and token'
+
 export const InitialView = ({
     onNext,
     requestLinkData,
@@ -82,13 +84,13 @@ export const InitialView = ({
                     setTxFee(Number(feeEstimation).toFixed(2))
                     setLinkState(RequestStatus.CLAIM)
                 } else {
-                    setErrorState({ showError: true, errorMessage: 'No route found' })
+                    setErrorState({ showError: true, errorMessage: ERR_NO_ROUTE })
                     setIsFeeEstimationError(true)
                     setTxFee('0')
                     setLinkState(RequestStatus.NOT_FOUND)
                 }
             } catch (error) {
-                setErrorState({ showError: true, errorMessage: 'No route found' })
+                setErrorState({ showError: true, errorMessage: ERR_NO_ROUTE })
                 setLinkState(RequestStatus.NOT_FOUND)
                 setIsFeeEstimationError(true)
                 setTxFee('0')

--- a/src/context/tokenSelector.context.tsx
+++ b/src/context/tokenSelector.context.tsx
@@ -22,6 +22,8 @@ export const tokenSelectorContext = createContext({
     setRefetchXchainRoute: (value: boolean) => {},
     resetTokenContextProvider: () => {},
     isTokenPriceFetchingComplete: false as boolean,
+    isXChain: false as boolean,
+    setIsXChain: (value: boolean) => {},
 })
 
 /**
@@ -36,6 +38,7 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
     const [refetchXchainRoute, setRefetchXchainRoute] = useState<boolean>(false)
     const [selectedTokenDecimals, setSelectedTokenDecimals] = useState<number | undefined>(18)
     const [isTokenPriceFetchingComplete, setTokenPriceFetchingComplete] = useState<boolean>(false)
+    const [isXChain, setIsXChain] = useState<boolean>(false)
 
 
     const { isConnected } = useAccount()
@@ -139,6 +142,8 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
                 setRefetchXchainRoute,
                 resetTokenContextProvider,
                 isTokenPriceFetchingComplete,
+                isXChain,
+                setIsXChain,
             }}
         >
             {children}


### PR DESCRIPTION
On the pay view for the request flow, when the selected token-chain pair is different from the combination on the request link, the token selector has a "X" which can be used to select the pair from the request link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an optional reset functionality for the token selector component.
	- Enhanced the `InitialView` component to manage selected chain and token states effectively, improving cross-chain transaction handling.

- **Bug Fixes**
	- Improved fee estimation logic to ensure it accounts for cross-chain scenarios.

- **Documentation**
	- Updated context management to include new state variables related to cross-chain functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->