### PR TITLE
fix(request): show some request info on already paid view

### DIFF
--- a/src/components/Request/Pay/Pay.tsx
+++ b/src/components/Request/Pay/Pay.tsx
@@ -67,6 +67,9 @@ export const PayRequestLink = () => {
                 setLinkState('NOT_FOUND')
                 return
             }
+
+            setRequestLinkData(requestLinkDetails)
+
             // Check if request link is already paid
             if (requestLinkDetails.status === 'PAID') {
                 setLinkState('ALREADY_PAID')
@@ -110,7 +113,6 @@ export const PayRequestLink = () => {
                 console.log('error calculating transaction cost:', error)
             }
 
-            setRequestLinkData(requestLinkDetails)
             setLinkState('PAY')
         } catch (error) {
             console.error('Failed to fetch request link details:', error)

--- a/src/components/Request/Pay/Views/GeneralViews/AlreadyPaid.view.tsx
+++ b/src/components/Request/Pay/Views/GeneralViews/AlreadyPaid.view.tsx
@@ -3,13 +3,10 @@
 import Icon from '@/components/Global/Icon'
 import * as consts from '@/constants'
 import * as _consts from '../../Pay.consts'
-import * as interfaces from '@/interfaces'
 import * as utils from '@/utils'
-import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 
 export const AlreadyPaidLinkView = ({ requestLinkData }: { requestLinkData: _consts.IRequestLinkData | undefined }) => {
-    const router = useRouter()
     return (
         <div className="flex w-full flex-col items-center justify-center gap-6 py-2 pb-20 text-center">
             <label className="text-h2">Sorry, this link has already been paid.</label>
@@ -20,7 +17,7 @@ export const AlreadyPaidLinkView = ({ requestLinkData }: { requestLinkData: _con
                         .find((chain) => chain.chainId === requestLinkData?.chainId)
                         ?.tokens.find((token) =>
                             utils.areTokenAddressesEqual(token.address, requestLinkData?.tokenAddress ?? '')
-                        )?.symbol}{' '}
+                        )?.symbol ?? requestLinkData?.tokenAddress}{' '}
                 on{' '}
                 {consts.supportedPeanutChains &&
                     consts.supportedPeanutChains.find((chain) => chain.chainId == requestLinkData?.chainId)?.name}
@@ -37,12 +34,12 @@ export const AlreadyPaidLinkView = ({ requestLinkData }: { requestLinkData: _con
             </label>
             <Link
                 className="absolute bottom-0 flex h-20 w-[27rem] w-full flex-row items-center justify-start gap-2 border-t-[1px] border-black bg-purple-3  px-4.5 dark:text-black"
-                href={'/send'}
+                href={'/request/create'}
             >
                 <div className=" border border-n-1 p-0 px-1">
                     <Icon name="send" className="-mt-0.5" />
                 </div>
-                Make a payment yourself!
+                Request a payment yourself!
             </Link>
         </div>
     )


### PR DESCRIPTION
We were moving the state before setting the link data, this commit sets the link data before moving the state in case of an already paid link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved navigation within the payment request flow by updating links and prompts.
	- Enhanced display logic for token symbols to ensure accurate information is shown.

- **Bug Fixes**
	- Updated the timing of data retrieval for request link details to improve user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->