### PR TITLE
Routes error on request pay

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
         "dev": "next dev",
         "build": "next build",
         "start": "next start",
-        "lint": "next lint"
+        "lint": "next lint",
+        "format": "prettier --write ."
     },
     "dependencies": {
         "@calcom/embed-react": "^1.5.1",

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -30,13 +30,9 @@ export const InitialView = ({
     const { switchChainAsync } = useSwitchChain()
     const { open } = useWeb3Modal()
     const { setLoadingState, loadingState, isLoading } = useContext(context.loadingStateContext)
-    const {
-        selectedTokenData,
-        setSelectedChainID,
-        setSelectedTokenAddress,
-        isXChain,
-        setIsXChain,
-    } = useContext(context.tokenSelectorContext)
+    const { selectedTokenData, setSelectedChainID, setSelectedTokenAddress, isXChain, setIsXChain } = useContext(
+        context.tokenSelectorContext
+    )
     const [errorState, setErrorState] = useState<{
         showError: boolean
         errorMessage: string
@@ -49,7 +45,7 @@ export const InitialView = ({
         // This function is only makes sense if selectedTokenData is defined
         // Check that it is defined before calling this function
         if (!selectedTokenData) {
-          throw new Error('selectedTokenData must be defined before estimating tx fee');
+            throw new Error('selectedTokenData must be defined before estimating tx fee')
         }
 
         const xchainUnsignedTxs = await peanut.prepareXchainRequestFulfillmentTransaction({
@@ -60,7 +56,8 @@ export const InitialView = ({
             squidRouterUrl: 'https://apiplus.squidrouter.com/v2/route',
             apiUrl: '/api/proxy/get',
             provider: await peanut.getDefaultProvider(selectedTokenData!.chainId),
-            tokenType: selectedTokenData!.tokenAddress === ADDRESS_ZERO ? EPeanutLinkType.native : EPeanutLinkType.erc20,
+            tokenType:
+                selectedTokenData!.tokenAddress === ADDRESS_ZERO ? EPeanutLinkType.native : EPeanutLinkType.erc20,
             fromTokenDecimals: selectedTokenData!.decimals as number,
         })
         return xchainUnsignedTxs
@@ -68,7 +65,6 @@ export const InitialView = ({
 
     useEffect(() => {
         const estimateTxFee = async () => {
-
             setLinkState(RequestStatus.LOADING)
             if (!isXChain) {
                 setErrorState({ showError: false, errorMessage: '' })
@@ -100,11 +96,9 @@ export const InitialView = ({
             }
         }
 
-        const isXChain = selectedTokenData?.chainId !== requestLinkData.chainId
-            || !utils.areTokenAddressesEqual(
-                selectedTokenData?.tokenAddress,
-                requestLinkData.tokenAddress
-                )
+        const isXChain =
+            selectedTokenData?.chainId !== requestLinkData.chainId ||
+            !utils.areTokenAddressesEqual(selectedTokenData?.tokenAddress, requestLinkData.tokenAddress)
         setIsXChain(isXChain)
 
         // wait for token selector to fetch token price, both effects depend on
@@ -142,7 +136,7 @@ export const InitialView = ({
         try {
             setErrorState({ showError: false, errorMessage: '' })
             if (!unsignedTx) return
-            if (!isXChain){
+            if (!isXChain) {
                 await checkUserHasEnoughBalance({ tokenValue: requestLinkData.tokenAmount })
                 if (selectedTokenData?.chainId !== String(currentChain?.id)) {
                     await switchNetwork(selectedTokenData!.chainId)
@@ -310,10 +304,7 @@ export const InitialView = ({
                     want to fulfill this request with.
                 </label>
             </div>
-            <TokenSelector
-                classNameButton="w-full"
-                onReset={resetTokenAndChain}
-            />
+            <TokenSelector classNameButton="w-full" onReset={resetTokenAndChain} />
             <div className="flex w-full flex-col items-center justify-center gap-2">
                 {!isFeeEstimationError && (
                     <>
@@ -323,9 +314,7 @@ export const InitialView = ({
                                 <label className="font-bold">Network cost</label>
                             </div>
                             <label className="flex flex-row items-center justify-center gap-1 text-center text-sm font-normal leading-4">
-                                {!isXChain
-                                    ? `$${utils.formatTokenAmount(estimatedGasCost, 3) ?? 0}`
-                                    : `$${txFee}`}
+                                {!isXChain ? `$${utils.formatTokenAmount(estimatedGasCost, 3) ?? 0}` : `$${txFee}`}
                                 {!isXChain ? (
                                     <MoreInfo
                                         text={

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -34,6 +34,7 @@ export const InitialView = ({
         selectedTokenData,
         setSelectedChainID,
         setSelectedTokenAddress,
+        isXChain,
         setIsXChain,
     } = useContext(context.tokenSelectorContext)
     const [errorState, setErrorState] = useState<{
@@ -69,10 +70,7 @@ export const InitialView = ({
         const estimateTxFee = async () => {
 
             setLinkState(RequestStatus.LOADING)
-            if (
-                selectedTokenData!.chainId === requestLinkData.chainId
-                && utils.areTokenAddressesEqual(selectedTokenData!.tokenAddress, requestLinkData.tokenAddress)
-            ) {
+            if (!isXChain) {
                 setErrorState({ showError: false, errorMessage: '' })
                 setIsFeeEstimationError(false)
                 setLinkState(RequestStatus.CLAIM)
@@ -144,10 +142,7 @@ export const InitialView = ({
         try {
             setErrorState({ showError: false, errorMessage: '' })
             if (!unsignedTx) return
-            if (
-                selectedTokenData!.chainId === requestLinkData.chainId
-                && utils.areTokenAddressesEqual(selectedTokenData!.tokenAddress, requestLinkData.tokenAddress)
-            ){
+            if (!isXChain){
                 await checkUserHasEnoughBalance({ tokenValue: requestLinkData.tokenAmount })
                 if (selectedTokenData?.chainId !== String(currentChain?.id)) {
                     await switchNetwork(selectedTokenData!.chainId)
@@ -328,12 +323,10 @@ export const InitialView = ({
                                 <label className="font-bold">Network cost</label>
                             </div>
                             <label className="flex flex-row items-center justify-center gap-1 text-center text-sm font-normal leading-4">
-                                {requestLinkData.chainId === selectedTokenData?.chainId &&
-                                requestLinkData.tokenAddress === selectedTokenData?.tokenAddress
+                                {!isXChain
                                     ? `$${utils.formatTokenAmount(estimatedGasCost, 3) ?? 0}`
                                     : `$${txFee}`}
-                                {requestLinkData.chainId === selectedTokenData?.chainId &&
-                                requestLinkData.tokenAddress === selectedTokenData?.tokenAddress ? (
+                                {!isXChain ? (
                                     <MoreInfo
                                         text={
                                             estimatedGasCost && estimatedGasCost > 0

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -46,8 +46,10 @@ export const InitialView = ({
     const [estimatedFromValue, setEstimatedFromValue] = useState<string>('0')
     const createXChainUnsignedTx = async () => {
         // This function is only makes sense if selectedTokenData is defined
-        // Chack that it is defined before calling this function
-        console.assert(selectedTokenData, 'selectedTokenData must be defined before estimating tx fee')
+        // Check that it is defined before calling this function
+        if (!selectedTokenData) {
+          throw new Error('selectedTokenData must be defined before estimating tx fee');
+        }
 
         const xchainUnsignedTxs = await peanut.prepareXchainRequestFulfillmentTransaction({
             fromToken: selectedTokenData!.tokenAddress,

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -115,7 +115,7 @@ export const InitialView = ({
         if (!isConnected || (isXChain && !selectedTokenData)) return
 
         estimateTxFee()
-    }, [selectedTokenData, requestLinkData])
+    }, [isConnected, address, selectedTokenData, requestLinkData])
 
     const handleConnectWallet = async () => {
         open().finally(() => {

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -80,6 +80,7 @@ export const InitialView = ({
                 const { feeEstimation, estimatedFromAmount } = txData
                 setEstimatedFromValue(estimatedFromAmount)
                 if (Number(feeEstimation) > 0) {
+                    setErrorState({ showError: false, errorMessage: '' })
                     setIsFeeEstimationError(false)
                     setTxFee(Number(feeEstimation).toFixed(2))
                     setLinkState(RequestStatus.CLAIM)

--- a/src/context/tokenSelector.context.tsx
+++ b/src/context/tokenSelector.context.tsx
@@ -47,7 +47,6 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
     const [isXChain, setIsXChain] = useState<boolean>(false)
     const [selectedTokenData, setSelectedTokenData] = useState<ITokenData | undefined>(undefined)
 
-
     const { isConnected } = useAccount()
     const preferences = utils.getPeanutPreferences()
 
@@ -87,10 +86,10 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
                         setSelectedTokenPrice(tokenPriceResponse.price)
                         setSelectedTokenDecimals(tokenPriceResponse.decimals)
                         setSelectedTokenData({
-                          tokenAddress,
-                          chainId,
-                          decimals: tokenPriceResponse.decimals,
-                          price: tokenPriceResponse.price,
+                            tokenAddress,
+                            chainId,
+                            decimals: tokenPriceResponse.decimals,
+                            price: tokenPriceResponse.price,
                         })
                         if (tokenPriceResponse.price === 1) {
                             setInputDenomination('TOKEN')

--- a/src/context/tokenSelector.context.tsx
+++ b/src/context/tokenSelector.context.tsx
@@ -21,10 +21,17 @@ export const tokenSelectorContext = createContext({
     refetchXchainRoute: false as boolean,
     setRefetchXchainRoute: (value: boolean) => {},
     resetTokenContextProvider: () => {},
-    isTokenPriceFetchingComplete: false as boolean,
     isXChain: false as boolean,
     setIsXChain: (value: boolean) => {},
+    selectedTokenData: undefined as ITokenData | undefined,
 })
+
+type ITokenData = {
+    tokenAddress: string
+    chainId: string
+    decimals: number
+    price: number
+}
 
 /**
  * Context provider to manage the selected token and chain ID set in the tokenSelector. Token price is fetched here and input denomination can be set here too.
@@ -37,8 +44,8 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
     const [inputDenomination, setInputDenomination] = useState<inputDenominationType>('TOKEN')
     const [refetchXchainRoute, setRefetchXchainRoute] = useState<boolean>(false)
     const [selectedTokenDecimals, setSelectedTokenDecimals] = useState<number | undefined>(18)
-    const [isTokenPriceFetchingComplete, setTokenPriceFetchingComplete] = useState<boolean>(false)
     const [isXChain, setIsXChain] = useState<boolean>(false)
+    const [selectedTokenData, setSelectedTokenData] = useState<ITokenData | undefined>(undefined)
 
 
     const { isConnected } = useAccount()
@@ -66,6 +73,7 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
         async function fetchAndSetTokenPrice(tokenAddress: string, chainId: string) {
             try {
                 if (!consts.supportedMobulaChains.some((chain) => chain.chainId == chainId)) {
+                    setSelectedTokenData(undefined)
                     setSelectedTokenPrice(undefined)
                     setSelectedTokenDecimals(undefined)
                     setInputDenomination('TOKEN')
@@ -78,13 +86,19 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
                     if (tokenPriceResponse?.price) {
                         setSelectedTokenPrice(tokenPriceResponse.price)
                         setSelectedTokenDecimals(tokenPriceResponse.decimals)
-                        setTokenPriceFetchingComplete(true)
+                        setSelectedTokenData({
+                          tokenAddress,
+                          chainId,
+                          decimals: tokenPriceResponse.decimals,
+                          price: tokenPriceResponse.price,
+                        })
                         if (tokenPriceResponse.price === 1) {
                             setInputDenomination('TOKEN')
                         } else {
                             setInputDenomination('USD')
                         }
                     } else {
+                        setSelectedTokenData(undefined)
                         setSelectedTokenPrice(undefined)
                         setSelectedTokenDecimals(undefined)
                         setInputDenomination('TOKEN')
@@ -95,22 +109,19 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
             }
         }
 
-
         if (!isConnected) {
+            setSelectedTokenData(undefined)
             setSelectedTokenPrice(undefined)
             setSelectedTokenDecimals(undefined)
             setInputDenomination('TOKEN')
-            return () => {
-                setTokenPriceFetchingComplete(false)
-            }
         } else if (selectedTokenAddress && selectedChainID) {
+            setSelectedTokenData(undefined)
             setSelectedTokenPrice(undefined)
             setSelectedTokenDecimals(undefined)
             setInputDenomination('TOKEN')
             fetchAndSetTokenPrice(selectedTokenAddress, selectedChainID)
             return () => {
                 isCurrent = false
-                setTokenPriceFetchingComplete(false)
             }
         }
     }, [selectedTokenAddress, selectedChainID, isConnected])
@@ -121,7 +132,6 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
             setSelectedTokenAddress(prefs.tokenAddress)
             setSelectedChainID(prefs.chainId)
             setSelectedTokenDecimals(prefs.decimals)
-            setTokenPriceFetchingComplete(true)
         }
     }, [])
 
@@ -141,9 +151,9 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
                 refetchXchainRoute,
                 setRefetchXchainRoute,
                 resetTokenContextProvider,
-                isTokenPriceFetchingComplete,
                 isXChain,
                 setIsXChain,
+                selectedTokenData,
             }}
         >
             {children}


### PR DESCRIPTION
This PR addresses two issues

1. The route error was shown alongside with an enabled pay button. Now we properly clean the error message when we "recover" from an error
2. The routes error we were experiencing in the first place were due to calling squid with bad params (specifically we used the decimals from the previous token to calculate the amount of the current token). This was due to a race condition between the token selector and the effect that calls squid, they both depending on the selected token changing so they executed alongside. Now the effect depends on "selectedTokenData" and not the selected address, selectedTokenData is modified by the selector after fetching the price and decimal data