### PR TITLE
fix: close IFrameWrapper closing feat

### DIFF
--- a/src/components/Global/IframeWrapper/index.tsx
+++ b/src/components/Global/IframeWrapper/index.tsx
@@ -32,22 +32,32 @@ const IframeWrapper = ({
         <Modal
             visible={visible}
             onClose={onClose}
-            classWrap="w-full max-w-2xl"
+            classWrap="w-full max-w-2xl border-none sm:border"
             classOverlay="bg-black bg-opacity-50"
             video={false}
+            /**
+             * Making sure the Iframe showing on top of the Crisp Chat widget
+             * which has z-index of 1000000
+             */
+            className="z-[1000001]"
             classButtonClose="hidden"
         >
-            <div className="flex flex-col gap-2 p-2 sm:p-5">
-                <div className="overflow-hidden rounded-sm border border-black">
+            <div className="flex flex-col gap-2 p-0 sm:p-5">
+                <div className="w-full sm:hidden">
+                    <button className="btn-purple w-full rounded-none" onClick={onClose}>
+                        CLOSE
+                    </button>
+                </div>
+                <div className="h-[550px] overflow-hidden rounded-sm sm:h-[500px] sm:border sm:border-black">
                     <iframe
                         src={src}
                         allow="camera;"
-                        style={style}
-                        className="rounded-md border border-black"
+                        style={{ ...style, width: '100%', height: '100%', border: 'none' }}
+                        className="rounded-md"
                         sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-modals allow-top-navigation-by-user-activation"
                     />
                 </div>
-                <div className="w-full">
+                <div className="hidden w-full sm:flex">
                     <button className="btn-purple w-full" onClick={onClose}>
                         Close
                     </button>

--- a/src/components/Global/IframeWrapper/index.tsx
+++ b/src/components/Global/IframeWrapper/index.tsx
@@ -4,13 +4,11 @@ import Modal from '../Modal'
 const IframeWrapper = ({
     src,
     style,
-    modalTitle,
     visible,
     onClose,
 }: {
     src: string
     style?: React.CSSProperties
-    modalTitle?: string
     visible: boolean
     onClose: () => void
 }) => {
@@ -39,12 +37,22 @@ const IframeWrapper = ({
             video={false}
             classButtonClose="hidden"
         >
-            <iframe
-                src={src}
-                allow="camera;"
-                style={style}
-                sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-modals allow-top-navigation-by-user-activation"
-            />
+            <div className="flex flex-col gap-2 p-2 sm:p-5">
+                <div className="overflow-hidden rounded-sm border border-black">
+                    <iframe
+                        src={src}
+                        allow="camera;"
+                        style={style}
+                        className="rounded-md border border-black"
+                        sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-modals allow-top-navigation-by-user-activation"
+                    />
+                </div>
+                <div className="w-full">
+                    <button className="btn-purple w-full" onClick={onClose}>
+                        Close
+                    </button>
+                </div>
+            </div>
         </Modal>
     )
 }


### PR DESCRIPTION
The IFrame own closing button was clashing with the modal closing button, that's probably why it was set to "hidden". But there was no way clear way to close it other than clicking out. Added a close button at the bottom
<img width="209" alt="Screenshot 2024-10-05 at 10 33 16" src="https://github.com/user-attachments/assets/000a4b43-b0e3-4a8e-a80b-27c7335288de">
<img width="823" alt="Screenshot 2024-10-05 at 10 33 36" src="https://github.com/user-attachments/assets/09e67340-ea0c-4905-b795-a554ffed5ad3">
