### PR TITLE
[refactor]: discovery into moving queries in claim flow into refactored queries w/ useQuery

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,5 +85,6 @@
         "prettier-plugin-tailwindcss": "^0.5.14",
         "tailwindcss": "^3.4.12",
         "typescript": "^5.6.2"
-    }
+    },
+    "packageManager": "pnpm@9.9.0+sha256.7a4261e50d9a44d9240baf6c9d6e10089dcf0a79d0007f2a26985a6927324177"
 }

--- a/src/app/claim/page.tsx
+++ b/src/app/claim/page.tsx
@@ -3,8 +3,12 @@ import Layout from '@/components/Global/Layout'
 import { Metadata, ResolvingMetadata } from 'next'
 import { getLinkDetails } from '@squirrel-labs/peanut-sdk'
 import * as utils from '@/utils'
+import { getQueryClient } from '@/query'
+import { getClaimQuery } from '@/components/Claim/services/query'
 
 export const dynamic = 'force-dynamic'
+
+const host = 'https://peanut.to'
 
 type Props = {
     params: { id: string }
@@ -28,11 +32,10 @@ function createURL(host: string, searchParams: { [key: string]: string | string[
     return `${host}?${queryParams.toString()}`
 }
 
-export async function generateMetadata({ params, searchParams }: Props, parent: ResolvingMetadata): Promise<Metadata> {
+export async function generateMetadata({ searchParams }: Props, parent: ResolvingMetadata): Promise<Metadata> {
     let title = 'Claim your tokens!'
 
     // const host = headers().get('host') || ''
-    const host = 'https://peanut.to'
     let linkDetails = undefined
     try {
         const url = createURL(host, searchParams)
@@ -72,7 +75,10 @@ export async function generateMetadata({ params, searchParams }: Props, parent: 
     }
 }
 
-export default function ClaimPage() {
+export default function ClaimPage({ searchParams }: Props) {
+    const queryClient = getQueryClient()
+    void queryClient.prefetchQuery(getClaimQuery(createURL(host, searchParams)))
+
     return (
         <Layout>
             <components.Claim />

--- a/src/components/Claim/Claim.tsx
+++ b/src/components/Claim/Claim.tsx
@@ -22,10 +22,11 @@ import { Attachement, CheckLinkReturnType } from './types'
 export const Claim = ({}) => {
     const { address } = useAccount()
     const { data, error, isLoading } = useQuery<CheckLinkReturnType>({
-        enabled: typeof window !== 'undefined' && address !== undefined,
+        enabled: typeof window !== 'undefined',
         queryKey: [address, '-claiming-', window.location.href],
+        refetchOnWindowFocus: false,
         queryFn: async ({ queryKey }) => {
-            const address = queryKey[0] as string
+            const address = queryKey[0] as string | undefined
             const link = typeof window !== 'undefined' ? window.location.href : ''
             let linkState: _consts.claimLinkState = 'ALREADY_CLAIMED'
             let crossChainDetails: CrossChainDetails | undefined = undefined
@@ -46,7 +47,7 @@ export const Claim = ({}) => {
                     (await utils.fetchTokenPrice(linkDetails.tokenAddress.toLowerCase(), linkDetails.chainId))?.price ??
                     0
                 estimatedPoints = await estimatePoints({
-                    address,
+                    address: address ?? '',
                     chainId: linkDetails.chainId,
                     amountUSD: Number(linkDetails.tokenAmount) * tokenPrice,
                     actionType: ActionType.CLAIM,

--- a/src/components/Claim/Link/Onchain/Confirm.view.tsx
+++ b/src/components/Claim/Link/Onchain/Confirm.view.tsx
@@ -51,7 +51,7 @@ export const ConfirmClaimLinkView = ({
         })
 
         try {
-            let claimTxHash = ''
+            let claimTxHash: string | undefined = ''
             if (selectedRoute) {
                 claimTxHash = await claimLinkXchain({
                     address: recipient ? recipient.address : (address ?? ''),

--- a/src/components/Claim/services/cross-chain.ts
+++ b/src/components/Claim/services/cross-chain.ts
@@ -1,0 +1,52 @@
+import peanut, { interfaces as peanutInterfaces } from "@squirrel-labs/peanut-sdk"
+import * as _consts from "../Claim.consts";
+import * as utils from '@/utils'
+import * as _utils from '../Claim.utils'
+import * as consts from '@/constants'
+import * as interfaces from '@/interfaces'
+
+export type CrossChainDetails = Array<peanutInterfaces.ISquidChain & { tokens: peanutInterfaces.ISquidToken[] }>;
+
+export const getCrossChainDetails = async (linkDetails: interfaces.ILinkDetails): Promise<CrossChainDetails | undefined> => {
+    // xchain is only available for native and erc20
+    if (linkDetails.tokenType != 0 && linkDetails.tokenType != 1) {
+        return undefined
+    }
+
+    try {
+        const crossChainDetails = await peanut.getXChainOptionsForLink({
+            isTestnet: utils.isTestnetChain(linkDetails.chainId.toString()),
+            sourceChainId: linkDetails.chainId.toString(),
+            tokenType: linkDetails.tokenType,
+        })
+
+        const contractVersionCheck = peanut.compareVersions('v4.2', linkDetails.contractVersion, 'v') // v4.2 is the minimum version required for cross chain
+        if (crossChainDetails.length > 0 && contractVersionCheck) {
+            const xchainDetails = _utils.sortCrossChainDetails(
+                crossChainDetails.filter((chain: any) => chain.chainId != '1'),
+                consts.supportedPeanutChains,
+                linkDetails.chainId
+            )
+            const filteredXchainDetails = xchainDetails.map((chain) => {
+                if (chain.chainId === linkDetails?.chainId) {
+                    const filteredTokens = chain.tokens.filter(
+                        (token: any) => token.address.toLowerCase() !== linkDetails?.tokenAddress.toLowerCase()
+                    )
+
+                    return {
+                        ...chain,
+                        tokens: filteredTokens,
+                    }
+                }
+                return chain
+            })
+
+            return filteredXchainDetails
+        } else {
+            return undefined
+        }
+    } catch (error) {
+        console.log('error fetching cross chain details: ' + error)
+        return undefined
+    }
+}

--- a/src/components/Claim/services/query.ts
+++ b/src/components/Claim/services/query.ts
@@ -1,0 +1,65 @@
+import peanut from '@squirrel-labs/peanut-sdk'
+import * as _consts from '../Claim.consts'
+import * as interfaces from '@/interfaces'
+import * as utils from '@/utils'
+import { PeanutAPI } from '@/services/peanut-api'
+import { CrossChainDetails, getCrossChainDetails } from './cross-chain'
+import { FetchQueryOptions } from '@tanstack/react-query'
+import { CheckLinkReturnType } from '../types'
+
+export const fetchClaim = async (link: string) => {
+    let linkState: _consts.claimLinkState = 'ALREADY_CLAIMED'
+    let crossChainDetails: CrossChainDetails | undefined = undefined
+    let tokenPrice: number = 0
+    let estimatedPoints: number = 0
+    let recipient: { name: string | undefined; address: string } = { name: undefined, address: '' }
+
+    const linkDetails: interfaces.ILinkDetails = await peanut.getLinkDetails({
+        link,
+    })
+    const attachmentInfo = await new PeanutAPI().getAttachmentInfo(linkDetails.link)
+
+    if (linkDetails.claimed) {
+        linkState = 'ALREADY_CLAIMED'
+    } else {
+        crossChainDetails = await getCrossChainDetails(linkDetails)
+        tokenPrice =
+            (await utils.fetchTokenPrice(linkDetails.tokenAddress.toLowerCase(), linkDetails.chainId))?.price ?? 0
+
+        // NOTE: Let client estimate points
+        // estimatedPoints = await estimatePoints({
+        //     address: address ?? '',
+        //     chainId: linkDetails.chainId,
+        //     amountUSD: Number(linkDetails.tokenAmount) * tokenPrice,
+        //     actionType: ActionType.CLAIM,
+        // })
+
+        linkState = 'CLAIM'
+    }
+    return {
+        linkDetails,
+        attachmentInfo: {
+            message: attachmentInfo?.message,
+            attachmentUrl: attachmentInfo?.fileUrl,
+        },
+        crossChainDetails,
+        tokenPrice,
+        estimatedPoints,
+        recipient,
+        linkState,
+    }
+}
+
+export const getClaimQuery = (link: string): FetchQueryOptions<CheckLinkReturnType> => {
+    const params = new URLSearchParams(link.split('?')[1]).toString()
+
+    return {
+        queryKey: ['claiming-', params],
+        queryFn: ({ queryKey }) => {
+            console.log('queryKey: ', queryKey)
+            const searchParams = queryKey[1]
+            const link = `https://peanut.to/claim?${searchParams}`
+            return fetchClaim(link)
+        },
+    }
+}

--- a/src/components/Claim/types.ts
+++ b/src/components/Claim/types.ts
@@ -1,0 +1,15 @@
+import * as interfaces from '@/interfaces'
+import { CrossChainDetails } from './services/cross-chain';
+import * as _consts from './Claim.consts'
+
+export type Attachement = { message: string | undefined; attachmentUrl: string | undefined }
+
+export type CheckLinkReturnType = {
+    linkDetails: interfaces.ILinkDetails | undefined
+    attachmentInfo: Attachement
+    crossChainDetails?: CrossChainDetails
+    tokenPrice: number
+    estimatedPoints: number
+    recipient: { name: string | undefined; address: string }
+    linkState: _consts.claimLinkState
+}

--- a/src/components/Claim/useClaimLink.tsx
+++ b/src/components/Claim/useClaimLink.tsx
@@ -14,7 +14,7 @@ export const useClaimLink = () => {
 
     const { loadingState, setLoadingState } = useContext(context.loadingStateContext)
 
-    const claimLink = async ({ address, link }: { address: string; link: string }) => {
+    const claimLink = async ({ address, link }: { address: string; link: string }): Promise<string | undefined> => {
         setLoadingState('Executing transaction')
         try {
             const claimTx = await claimLinkGasless({

--- a/src/components/Global/TokenSelector/TokenSelectorXChain.tsx
+++ b/src/components/Global/TokenSelector/TokenSelectorXChain.tsx
@@ -5,12 +5,10 @@ import Modal from '../Modal'
 import Search from '../Search'
 import ChainSelector from '../ChainSelector'
 import { useBalance } from '@/hooks/useBalance'
-import { peanutTokenDetails, supportedPeanutChains } from '@/constants'
+import { peanutTokenDetails } from '@/constants'
 import * as context from '@/context'
-import * as utils from '@/utils'
 import * as components from './Components'
 import * as _consts from './TokenSelector.consts'
-import * as consts from '@/constants'
 import Icon from '../Icon'
 
 const TokenSelectorXChain = ({

--- a/src/components/utils/utils.ts
+++ b/src/components/utils/utils.ts
@@ -3,74 +3,72 @@ import * as consts from '@/constants'
 import * as utils from '@/utils'
 
 type ISquidChainData = {
-  id: string,
-  chainId: string,
-  networkIdentifier: string,
-  chainName: string,
-  axelarChainName: string,
-  type: string,
-  networkName: string,
-  nativeCurrency: {
-    name: string,
-    symbol: string,
-    decimals: number,
-    icon: string,
-  },
-  chainIconURI: string,
-  blockExplorerUrls: string[],
-  swapAmountForGas: string,
-  sameChainSwapsSupported: boolean,
-  compliance: {
-    trmIdentifier: string,
-  },
-  boostSupported: boolean,
-  enableBoostByDefault: boolean,
-  rpcList: string[],
-  chainNativeContracts: {
-    wrappedNativeToken: string,
-    ensRegistry: string,
-    multicall: string,
-    usdcToken: string,
-  },
-  feeCurrencies: any[],
-  currencies: any[],
-  features: any[],
+    id: string
+    chainId: string
+    networkIdentifier: string
+    chainName: string
+    axelarChainName: string
+    type: string
+    networkName: string
+    nativeCurrency: {
+        name: string
+        symbol: string
+        decimals: number
+        icon: string
+    }
+    chainIconURI: string
+    blockExplorerUrls: string[]
+    swapAmountForGas: string
+    sameChainSwapsSupported: boolean
+    compliance: {
+        trmIdentifier: string
+    }
+    boostSupported: boolean
+    enableBoostByDefault: boolean
+    rpcList: string[]
+    chainNativeContracts: {
+        wrappedNativeToken: string
+        ensRegistry: string
+        multicall: string
+        usdcToken: string
+    }
+    feeCurrencies: any[]
+    currencies: any[]
+    features: any[]
 }
 
 type ISquidStatusResponse = {
-  id: string,
-  status: string,
-  gasStatus: string,
-  isGMPTransaction: boolean,
-  axelarTransactionUrl: string,
-  fromChain: {
-    transactionId: string,
-    blockNumber: number,
-    callEventStatus: string,
-    callEventLog: any[],
-    chainData: ISquidChainData,
-    transactionUrl: string,
-  },
-  toChain: {
-    transactionId: string,
-    blockNumber: number,
-    callEventStatus: string,
-    callEventLog: any[],
-    chainData: ISquidChainData,
-    transactionUrl: string,
-  },
-  timeSpent: {
-    call_express_executed: number,
-    total: number,
-  },
-  routeStatus: any[],
-  error: any,
-  squidTransactionStatus: string,
+    id: string
+    status: string
+    gasStatus: string
+    isGMPTransaction: boolean
+    axelarTransactionUrl: string
+    fromChain: {
+        transactionId: string
+        blockNumber: number
+        callEventStatus: string
+        callEventLog: any[]
+        chainData: ISquidChainData
+        transactionUrl: string
+    }
+    toChain: {
+        transactionId: string
+        blockNumber: number
+        callEventStatus: string
+        callEventLog: any[]
+        chainData: ISquidChainData
+        transactionUrl: string
+    }
+    timeSpent: {
+        call_express_executed: number
+        total: number
+    }
+    routeStatus: any[]
+    error: any
+    squidTransactionStatus: string
 }
 
-export async function checkTransactionStatus(
-  txHash: string
-): Promise<ISquidStatusResponse> {
+export async function checkTransactionStatus(txHash: string): Promise<ISquidStatusResponse> {
     try {
         const response = await axios.get('https://apiplus.squidrouter.com/v2/status', {
             params: { transactionId: txHash },

--- a/src/config/wagmi.config.tsx
+++ b/src/config/wagmi.config.tsx
@@ -6,12 +6,10 @@ import { createWeb3Modal } from '@web3modal/wagmi/react'
 
 import { WagmiProvider, createConfig, http } from 'wagmi'
 import { coinbaseWallet, injected, safe, walletConnect } from 'wagmi/connectors'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClientProvider } from '@tanstack/react-query'
 import { createClient } from 'viem'
 import { authConnector } from '@web3modal/wagmi'
-
-// 0. Setup queryClient
-const queryClient = new QueryClient()
+import { getQueryClient } from '@/query'
 
 // 1. Get projectId at https://cloud.walletconnect.com
 const projectId = process.env.NEXT_PUBLIC_WC_PROJECT_ID ?? ''
@@ -71,6 +69,8 @@ createWeb3Modal({
 console.log('Created Web3modal')
 
 export function ContextProvider({ children }: { children: React.ReactNode }) {
+    const queryClient = getQueryClient()
+
     return (
         <WagmiProvider config={config}>
             <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,0 +1,27 @@
+import { QueryClient, defaultShouldDehydrateQuery, isServer } from '@tanstack/react-query'
+
+function makeQueryClient() {
+    return new QueryClient({
+        defaultOptions: {
+            queries: {
+                staleTime: 0,
+                refetchInterval: 5 * 60 * 1000,
+                refetchIntervalInBackground: true,
+            },
+            dehydrate: {
+                shouldDehydrateQuery: (query) => defaultShouldDehydrateQuery(query) || query.state.status === 'pending',
+            },
+        },
+    })
+}
+
+let browserQueryClient: QueryClient | undefined = undefined
+
+export function getQueryClient() {
+    if (isServer) {
+        return makeQueryClient()
+    } else {
+        if (!browserQueryClient) browserQueryClient = makeQueryClient()
+        return browserQueryClient
+    }
+}

--- a/src/services/app-api.ts
+++ b/src/services/app-api.ts
@@ -1,0 +1,13 @@
+export class AppAPI {
+    static getUserById(id: string) {
+        return fetch('/api/peanut/user/get-user-id', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                accountIdentifier: id,
+            }),
+        }).then((res) => res.json())
+    }
+}

--- a/src/services/peanut-api.ts
+++ b/src/services/peanut-api.ts
@@ -1,5 +1,7 @@
 import { ActionType } from '@/components/utils/utils'
 import { PEANUT_API_URL } from '@/constants'
+import { ILinkDetails } from '@/interfaces'
+import { getSquidRouteRaw, interfaces } from '@squirrel-labs/peanut-sdk'
 
 export type EstimatePointsArgs = {
     address: string
@@ -8,10 +10,45 @@ export type EstimatePointsArgs = {
     actionType: ActionType
 }
 
+export type GetSquidRouteRawArgs = {
+    linkDetails: ILinkDetails
+    toToken: string
+    toChain: string
+    toAddress: string
+}
+
 export class PeanutAPI {
     baseURL: string = PEANUT_API_URL
+    squidRouterUrl: string = 'https://apiplus.squidrouter.com/v2/route'
 
-    estimatePoints = async ({ address, actionType, amountUSD, chainId }: EstimatePointsArgs) => {
+    getSquidRouteRaw = async ({ linkDetails, toChain, toToken, toAddress }: GetSquidRouteRawArgs) => {
+        const { squidRouterUrl } = this
+        const {
+            chainId: fromChain,
+            tokenAddress: fromToken,
+            tokenAmount,
+            tokenDecimals,
+            senderAddress: fromAddress,
+        } = linkDetails
+        const fromAmount = Math.floor(Number(tokenAmount) * Math.pow(10, tokenDecimals)).toString()
+        return getSquidRouteRaw({
+            squidRouterUrl,
+            fromChain,
+            fromToken,
+            fromAmount,
+            slippage: 1,
+            fromAddress,
+            toToken,
+            toChain,
+            toAddress,
+        })
+    }
+
+    estimatePoints = async (args: EstimatePointsArgs) => {
+        const { address, actionType, amountUSD, chainId } = args
+
+        console.log('estimatePoints', { args })
+
         return this.post('/calculate-pts-for-action', {
             actionType: actionType,
             userAddress: address,
@@ -29,6 +66,21 @@ export class PeanutAPI {
             })
             .catch(() => {
                 return 0
+            })
+    }
+
+    getAttachmentInfo = async (link: string) => {
+        return this.post('/get-attachment-info', {
+            link,
+        })
+            .then(({ fileUrl, message }) => {
+                return {
+                    fileUrl,
+                    message,
+                }
+            })
+            .catch(() => {
+                return undefined
             })
     }
 

--- a/src/services/peanut-api.ts
+++ b/src/services/peanut-api.ts
@@ -1,0 +1,49 @@
+import { ActionType } from '@/components/utils/utils'
+import { PEANUT_API_URL } from '@/constants'
+
+export type EstimatePointsArgs = {
+    address: string
+    chainId: string
+    amountUSD: number
+    actionType: ActionType
+}
+
+export class PeanutAPI {
+    baseURL: string = PEANUT_API_URL
+
+    estimatePoints = async ({ address, actionType, amountUSD, chainId }: EstimatePointsArgs) => {
+        return this.post('/calculate-pts-for-action', {
+            actionType: actionType,
+            userAddress: address,
+            chainId: chainId,
+            amountUsd: amountUSD,
+            transaction: {
+                from: address,
+                to: address,
+                data: '',
+                value: '',
+            },
+        })
+            .then((res) => {
+                return Math.round(res.points)
+            })
+            .catch(() => {
+                return 0
+            })
+    }
+
+    post = async (url: string, body: any) => {
+        return fetch(this.baseURL + url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(body),
+        }).then((res) => {
+            if (!res.ok) {
+                throw new Error('HTTP error! status: ' + res.status)
+            }
+            return res.json()
+        })
+    }
+}


### PR DESCRIPTION
## Summary

The aim was to deep dive into the page and flow structure while leaning on react-query for data fetching, storage, and handling in-app side effects (instead of relying on useEffect/useState).

## Changes

- prefetch claim before initial page load (no more peanut loader... 😢)
- move queries into useQuery/useSuspense
  -  Claim.tsx
     - getClaim (linkDetails, attachement, tokenPrice)
  -  InitialView.tsx
     - crossChainRoute
     - pointsEstimate
     - claiming (mutation)

## Why ?

This helps minimize the potential for React bugs and boosts team efficiency. Relying too much on side effects from server data can lead to unexpected and hard-to-debug issues. We reduce data duplication previously stored in React state and benefit from react-query's built-in loading and error states, driving more predictable behaviors. Lastly, simple refactors like exporting calls into separate services help improve clarity.

## Impact

Leaving this work here for review and feedback. Unfinished and could include bugs, It’s not intended for production at this time.
