### PR TITLE
feat(request): pre-load requested pair on pay

### DIFF
--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -144,6 +144,10 @@ export const InitialView = ({
         }
     }, [requestLinkData, tokenPriceData])
 
+    useEffect(() => {
+        resetTokenAndChain()
+    }, [])
+
     const handleConnectWallet = async () => {
         open().finally(() => {
             if (isConnected) setLinkState(RequestStatus.LOADING)


### PR DESCRIPTION
Now when accessing a request link to pay, the selected token/chain pair will be the one that the requester set. The payer can pay directly in this or change it to use cross-chain