### PR TITLE
fix(request): store correct destination hash for xchain

### DIFF
--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -252,26 +252,6 @@ export const InitialView = ({
                     feeOptions: undefined,
                 })
                 setLoadingState('Executing transaction')
-
-                await peanut.submitRequestLinkFulfillment({
-                    chainId: requestLinkData.chainId,
-                    hash: hash ?? '',
-                    payerAddress: address ?? '',
-                    link: requestLinkData.link,
-                    apiUrl: '/api/proxy/patch/',
-                    amountUsd,
-                })
-
-                const currentDate = new Date().toISOString()
-                utils.saveRequestLinkFulfillmentToLocalStorage({
-                    details: {
-                        ...requestLinkData,
-                        destinationChainFulfillmentHash: hash ?? '',
-                        createdAt: currentDate,
-                    },
-                    link: requestLinkData.link,
-                })
-
                 setTransactionHash(hash ?? '')
                 onNext()
             }


### PR DESCRIPTION
We only have the destination hash after we fetch it from squid. We were incorrectly storing the origin hash as destination hash