### PR TITLE
refactor: Change linkState types in enums for more robust checking

### DIFF
--- a/src/components/Claim/Claim.consts.ts
+++ b/src/components/Claim/Claim.consts.ts
@@ -66,5 +66,3 @@ export enum claimLinkStateType {
     NOT_FOUND = 'NOT_FOUND',
     CLAIM_SENDER = 'CLAIM_SENDER'
 }
-
-// export type claimLinkState = 'LOADING' | 'CLAIM' | 'ALREADY_CLAIMED' | 'NOT_FOUND' | 'CLAIM_SENDER'

--- a/src/components/Claim/Claim.consts.ts
+++ b/src/components/Claim/Claim.consts.ts
@@ -59,4 +59,12 @@ export interface IClaimScreenProps {
     setInitialKYCStep: (step: number) => void
 }
 
-export type claimLinkState = 'LOADING' | 'CLAIM' | 'ALREADY_CLAIMED' | 'NOT_FOUND' | 'CLAIM_SENDER'
+export enum claimLinkStateType {
+    LOADING = 'LOADING',
+    CLAIM = 'CLAIM',
+    ALREADY_CLAIMED = 'ALREADY_CLAIMED',
+    NOT_FOUND = 'NOT_FOUND',
+    CLAIM_SENDER = 'CLAIM_SENDER'
+}
+
+// export type claimLinkState = 'LOADING' | 'CLAIM' | 'ALREADY_CLAIMED' | 'NOT_FOUND' | 'CLAIM_SENDER'

--- a/src/components/Claim/Claim.tsx
+++ b/src/components/Claim/Claim.tsx
@@ -17,7 +17,7 @@ import { ActionType, estimatePoints } from '../utils/utils'
 
 export const Claim = ({}) => {
     const [step, setStep] = useState<_consts.IClaimScreenState>(_consts.INIT_VIEW_STATE)
-    const [linkState, setLinkState] = useState<_consts.claimLinkState>('LOADING')
+    const [linkState, setLinkState] = useState<_consts.claimLinkStateType>(_consts.claimLinkStateType.LOADING)
     const [claimLinkData, setClaimLinkData] = useState<interfaces.ILinkDetails | undefined>(undefined)
     const [crossChainDetails, setCrossChainDetails] = useState<
         Array<peanutInterfaces.ISquidChain & { tokens: peanutInterfaces.ISquidToken[] }> | undefined
@@ -134,7 +134,7 @@ export const Claim = ({}) => {
 
             setClaimLinkData(linkDetails)
             if (linkDetails.claimed) {
-                setLinkState('ALREADY_CLAIMED')
+                setLinkState(_consts.claimLinkStateType.ALREADY_CLAIMED)
             } else {
                 const crossChainDetails = await getCrossChainDetails(linkDetails)
                 setCrossChainDetails(crossChainDetails)
@@ -157,13 +157,13 @@ export const Claim = ({}) => {
                 }
 
                 if (address && linkDetails.senderAddress === address) {
-                    setLinkState('CLAIM_SENDER')
+                    setLinkState(_consts.claimLinkStateType.CLAIM_SENDER)
                 } else {
-                    setLinkState('CLAIM')
+                    setLinkState(_consts.claimLinkStateType.CLAIM)
                 }
             }
         } catch (error) {
-            setLinkState('NOT_FOUND')
+            setLinkState(_consts.claimLinkStateType.NOT_FOUND)
         }
     }
 
@@ -176,7 +176,7 @@ export const Claim = ({}) => {
 
     return (
         <div className="card">
-            {linkState === 'LOADING' && (
+            {linkState === _consts.claimLinkStateType.LOADING && (
                 <div className="relative flex w-full items-center justify-center">
                     <div className="animate-spin">
                         <img src={assets.PEANUTMAN_LOGO.src} alt="logo" className="h-6 sm:h-10" />
@@ -184,7 +184,7 @@ export const Claim = ({}) => {
                     </div>
                 </div>
             )}
-            {linkState === 'CLAIM' && (
+            {linkState === _consts.claimLinkStateType.CLAIM && (
                 <FlowManager
                     recipientType={recipientType}
                     step={step}
@@ -226,12 +226,12 @@ export const Claim = ({}) => {
                 />
             )}
 
-            {linkState === 'ALREADY_CLAIMED' && <genericViews.AlreadyClaimedLinkView claimLinkData={claimLinkData} />}
-            {linkState === 'NOT_FOUND' && <genericViews.NotFoundClaimLink />}
-            {linkState === 'CLAIM_SENDER' && (
+            {linkState === _consts.claimLinkStateType.ALREADY_CLAIMED && <genericViews.AlreadyClaimedLinkView claimLinkData={claimLinkData} />}
+            {linkState === _consts.claimLinkStateType.NOT_FOUND && <genericViews.NotFoundClaimLink />}
+            {linkState === _consts.claimLinkStateType.CLAIM_SENDER && (
                 <genericViews.SenderClaimLinkView
                     changeToRecipientView={() => {
-                        setLinkState('CLAIM')
+                        setLinkState(_consts.claimLinkStateType.CLAIM)
                     }}
                     claimLinkData={claimLinkData}
                     setTransactionHash={setTransactionHash}

--- a/src/components/Request/Pay/Pay.consts.ts
+++ b/src/components/Request/Pay/Pay.consts.ts
@@ -9,7 +9,13 @@ export interface IPayScreenState {
     idx: number
 }
 
-export type IRequestLinkState = 'LOADING' | 'READY_TO_PAY' | 'ALREADY_PAID' | 'ERROR' | 'CANCELED'
+export enum IRequestLinkState {
+    LOADING = 'LOADING',
+    READY_TO_PAY = 'READY_TO_PAY',
+    ALREADY_PAID = 'ALREADY_PAID',
+    ERROR = 'ERROR',
+    CANCELED = 'CANCELED'
+}
 
 export const INIT_VIEW_STATE: IPayScreenState = {
     screen: 'INITIAL',

--- a/src/components/Request/Pay/Pay.tsx
+++ b/src/components/Request/Pay/Pay.tsx
@@ -13,7 +13,7 @@ import { type ITokenPriceData } from '@/interfaces'
 
 export const PayRequestLink = () => {
     const [step, setStep] = useState<_consts.IPayScreenState>(_consts.INIT_VIEW_STATE)
-    const [linkState, setLinkState] = useState<_consts.IRequestLinkState>('LOADING')
+    const [linkState, setLinkState] = useState<_consts.IRequestLinkState>(_consts.IRequestLinkState.LOADING)
     const [tokenPriceData, setTokenPriceData] = useState<ITokenPriceData | undefined>(undefined)
     const [requestLinkData, setRequestLinkData] = useState<_consts.IRequestLinkData | undefined>(undefined)
     const { estimateGasFee } = useCreateLink()
@@ -78,7 +78,7 @@ export const PayRequestLink = () => {
             // Check if request link is not found
             if (requestLinkDetails.error === 'Request link not found') {
                 setErrorMessage('This request could not be found. Are you sure your link is correct?')
-                setLinkState('ERROR')
+                setLinkState(_consts.IRequestLinkState.ERROR)
                 return
             }
 
@@ -86,14 +86,14 @@ export const PayRequestLink = () => {
 
             // Check if request link is already paid
             if (requestLinkDetails.status === 'PAID') {
-                setLinkState('ALREADY_PAID')
+                setLinkState(_consts.IRequestLinkState.ALREADY_PAID)
                 return
             }
-            setLinkState('READY_TO_PAY')
+            setLinkState(_consts.IRequestLinkState.READY_TO_PAY)
         } catch (error) {
             console.error('Failed to fetch request link details:', error)
             setErrorMessage('This request could not be found. Are you sure your link is correct?')
-            setLinkState('ERROR')
+            setLinkState(_consts.IRequestLinkState.ERROR)
         }
     }
 
@@ -115,7 +115,7 @@ export const PayRequestLink = () => {
                     setTokenPriceData(tokenPriceData)
                 } else {
                     setErrorMessage('Failed to fetch token price, please try again later')
-                    setLinkState('ERROR')
+                    setLinkState(_consts.IRequestLinkState.ERROR)
                 }
             })
 
@@ -134,7 +134,7 @@ export const PayRequestLink = () => {
             .catch((error) => {
                 console.log('error fetching recipient address:', error)
                 setErrorMessage('Failed to fetch recipient address, please try again later')
-                setLinkState('ERROR')
+                setLinkState(_consts.IRequestLinkState.ERROR)
             })
 
         // Prepare request link fulfillment transaction
@@ -158,13 +158,13 @@ export const PayRequestLink = () => {
             .catch((error) => {
                 console.log('error calculating transaction cost:', error)
                 setErrorMessage('Failed to estimate gas fee, please try again later')
-                setLinkState('ERROR')
+                setLinkState(_consts.IRequestLinkState.ERROR)
             })
     }, [unsignedTx, requestLinkData])
 
     return (
         <div className="card">
-            {linkState === 'LOADING' && (
+            {linkState === _consts.IRequestLinkState.ERROR && (
                 <div className="relative flex w-full items-center justify-center">
                     <div className="animate-spin">
                         <img src={assets.PEANUTMAN_LOGO.src} alt="logo" className="h-6 sm:h-10" />
@@ -172,7 +172,7 @@ export const PayRequestLink = () => {
                     </div>
                 </div>
             )}
-            {linkState === 'READY_TO_PAY' &&
+            {linkState === _consts.IRequestLinkState.READY_TO_PAY &&
                 createElement(_consts.PAY_SCREEN_MAP[step.screen].comp, {
                     onNext: handleOnNext,
                     onPrev: handleOnPrev,
@@ -184,9 +184,9 @@ export const PayRequestLink = () => {
                     estimatedGasCost,
                     unsignedTx,
                 } as _consts.IPayScreenProps)}
-            {linkState === 'ERROR' && <generalViews.ErrorView errorMessage={errorMessage} />}
-            {linkState === 'CANCELED' && <generalViews.CanceledClaimLink />}
-            {linkState === 'ALREADY_PAID' && <generalViews.AlreadyPaidLinkView requestLinkData={requestLinkData} />}
+            {linkState === _consts.IRequestLinkState.ERROR && <generalViews.ErrorView errorMessage={errorMessage} />}
+            {linkState === _consts.IRequestLinkState.CANCELED && <generalViews.CanceledClaimLink />}
+            {linkState === _consts.IRequestLinkState.ALREADY_PAID && <generalViews.AlreadyPaidLinkView requestLinkData={requestLinkData} />}
         </div>
     )
 }


### PR DESCRIPTION
- Changes linkState types from string choice to enum
- This allows for type checking with enum members vs simple strings which to not have unexpected values we need to thoroughly typecheck everywhere