### PR TITLE
fix: request pay issues

### DIFF
--- a/src/components/Claim/Link/Onchain/Confirm.view.tsx
+++ b/src/components/Claim/Link/Onchain/Confirm.view.tsx
@@ -1,5 +1,6 @@
 'use client'
 import Icon from '@/components/Global/Icon'
+import AddressLink from '@/components/Global/AddressLink'
 import { useAccount } from 'wagmi'
 
 import * as _consts from '../../Claim.consts'
@@ -184,7 +185,7 @@ export const ConfirmClaimLinkView = ({
                 <label className="text-h7 font-normal">Claiming to:</label>
                 <span className="flex items-center gap-1 ">
                     <label className="text-h7">
-                        {recipient.name ? recipient.name : utils.printableAddress(recipient.address ?? '')}
+                        <AddressLink address={recipient.name ?? recipient.address ?? ''} />
                     </label>
                     {recipient.name && <MoreInfo text={`You will be claiming to ${recipient.address}`} />}
                 </span>

--- a/src/components/Dashboard/components/MobileComponent.tsx
+++ b/src/components/Dashboard/components/MobileComponent.tsx
@@ -1,4 +1,5 @@
 import Modal from '@/components/Global/Modal'
+import AddressLink from '@/components/Global/AddressLink'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import * as utils from '@/utils'
@@ -44,7 +45,9 @@ export const MobileItemComponent = ({
                         {linkDetail.chain}]
                     </label>
 
-                    <label>From: {utils.printableAddress(linkDetail.address ?? address)}</label>
+                    <label>
+                        From: <AddressLink address={linkDetail.address ?? address} />
+                    </label>
                 </div>
                 <div className="flex flex-col items-end justify-end gap-2 text-end">
                     <div>

--- a/src/components/Dashboard/index.tsx
+++ b/src/components/Dashboard/index.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import Icon from '../Global/Icon'
 import Sorting from '../Global/Sorting'
 import TablePagination from '../Global/TablePagination'
+import AddressLink from '../Global/AddressLink'
 import { useAccount } from 'wagmi'
 import Loading from '../Global/Loading'
 import { useRouter } from 'next/navigation'
@@ -184,7 +185,7 @@ export const Dashboard = () => {
                                                 <td className="td-custom font-bold">{link.chain}</td>
                                                 <td className="td-custom">{utils.formatDate(new Date(link.date))}</td>
                                                 <td className="td-custom">
-                                                    {utils.printableAddress(link.address ?? address ?? '')}
+                                                    <AddressLink address={link.address ?? address ?? ''} />
                                                 </td>
                                                 <td className="td-custom max-w-32">
                                                     <span

--- a/src/components/Global/AddressLink/index.tsx
+++ b/src/components/Global/AddressLink/index.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+
+import * as utils from '@/utils'
+
+const AddressLink = ({ address }: { address: string }) => {
+    const [url, setUrl] = useState<string>('')
+    useEffect(() => {
+        if (!address) return
+        if (address.endsWith('.eth')) {
+            utils.resolveFromEnsName(address).then((resolvedAddress) => {
+                if (!resolvedAddress) return
+                setUrl(`https://debank.com/profile/${resolvedAddress}`)
+            })
+            return
+        }
+        setUrl(`https://debank.com/profile/${address}`)
+    }, [address])
+    return url ? (
+        <Link className="cursor-pointer underline" href={url} target="_blank">
+            {utils.printableAddress(address)}
+        </Link>
+    ) : (
+        <span>{utils.printableAddress(address)}</span>
+    )
+}
+
+export default AddressLink

--- a/src/components/Profile/Components/TableComponent.tsx
+++ b/src/components/Profile/Components/TableComponent.tsx
@@ -3,6 +3,7 @@ import * as utils from '@/utils'
 import * as interfaces from '@/interfaces'
 import Sorting from '@/components/Global/Sorting'
 import Loading from '@/components/Global/Loading'
+import AddressLink from '@/components/Global/AddressLink'
 import { OptionsComponent } from './OptionsComponent'
 import * as consts from '@/constants'
 import { useCallback } from 'react'
@@ -108,7 +109,7 @@ export const TableComponent = ({
                                     <td className="td-custom font-bold">{data.dashboardItem.chain}</td>
                                     <td className="td-custom">{utils.formatDate(new Date(data.dashboardItem.date))}</td>
                                     <td className="td-custom">
-                                        {utils.printableAddress(data.dashboardItem.address ?? '')}
+                                        <AddressLink address={data.dashboardItem.address ?? ''} />
                                     </td>
                                     <td className="td-custom max-w-32">
                                         <span

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Icon from '../Global/Icon'
+import AddressLink from '../Global/AddressLink'
 import * as consts from '@/constants'
 import { createAvatar } from '@dicebear/core'
 import { identicon } from '@dicebear/collection'
@@ -561,7 +562,7 @@ export const Profile = () => {
                                                         )
                                                     }}
                                                 />
-                                                {utils.printableAddress(referral.address)}
+                                                <AddressLink address={referral.address} />
                                             </label>
                                             <label className="w-[30%] text-center text-h8">
                                                 {referral?.totalReferrals ?? 0}

--- a/src/components/Request/Pay/Pay.tsx
+++ b/src/components/Request/Pay/Pay.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { createElement, useEffect, useState } from 'react'
+import { createElement, useEffect, useState, useContext } from 'react'
 import * as _consts from './Pay.consts'
 import * as assets from '@/assets'
 import { peanut, interfaces as peanutInterfaces } from '@squirrel-labs/peanut-sdk'
 
 import * as generalViews from './Views/GeneralViews'
 import * as utils from '@/utils'
+import * as context from '@/context'
 import { useCreateLink } from '@/components/Create/useCreateLink'
 import { ActionType, estimatePoints } from '@/components/utils/utils'
 import { type ITokenPriceData } from '@/interfaces'
@@ -21,6 +22,7 @@ export const PayRequestLink = () => {
     const [estimatedGasCost, setEstimatedGasCost] = useState<number | undefined>(undefined)
     const [transactionHash, setTransactionHash] = useState<string>('')
     const [unsignedTx, setUnsignedTx] = useState<peanutInterfaces.IPeanutUnsignedTransaction | undefined>(undefined)
+    const { setLoadingState } = useContext(context.loadingStateContext)
     const [errorMessage, setErrorMessage] = useState<string>('')
 
     const fetchPointsEstimation = async (
@@ -55,6 +57,7 @@ export const PayRequestLink = () => {
             screen: _consts.PAY_SCREEN_FLOW[newIdx],
             idx: newIdx,
         }))
+        setLoadingState('Idle')
     }
 
     const handleOnPrev = () => {
@@ -64,6 +67,7 @@ export const PayRequestLink = () => {
             screen: _consts.PAY_SCREEN_FLOW[newIdx],
             idx: newIdx,
         }))
+        setLoadingState('Idle')
     }
 
     const checkRequestLink = async (pageUrl: string) => {

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -70,6 +70,7 @@ export const InitialView = ({
         setSelectedTokenAddress,
         isXChain,
         setIsXChain,
+        isFetchingTokenData,
     } = useContext(context.tokenSelectorContext)
     const [errorState, setErrorState] = useState<{
         showError: boolean
@@ -139,14 +140,16 @@ export const InitialView = ({
         if (!isConnected || !address) return
 
         if (isXChain && !selectedTokenData) {
-            setErrorState({ showError: true, errorMessage: ERR_NO_ROUTE })
-            setIsFeeEstimationError(true)
-            setTxFee('0')
+            if (!isFetchingTokenData) {
+                setErrorState({ showError: true, errorMessage: ERR_NO_ROUTE })
+                setIsFeeEstimationError(true)
+                setTxFee('0')
+            }
             return
         }
 
         estimateTxFee()
-    }, [isConnected, address, selectedTokenData, requestLinkData, isXChain])
+    }, [isConnected, address, selectedTokenData, requestLinkData, isXChain, isFetchingTokenData])
 
     useEffect(() => {
         setLoadingState('Loading')

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -4,6 +4,7 @@ import { useWeb3Modal } from '@web3modal/wagmi/react'
 import { useContext, useEffect, useState, useMemo } from 'react'
 import * as context from '@/context'
 import Loading from '@/components/Global/Loading'
+import AddressLink from '@/components/Global/AddressLink'
 import * as utils from '@/utils'
 import Icon from '@/components/Global/Icon'
 import MoreInfo from '@/components/Global/MoreInfo'
@@ -94,6 +95,18 @@ export const InitialView = ({
             (viewState === ViewState.READY_TO_PAY && !calculatedFee)
         )
     }, [viewState, isLoading, calculatedFee])
+
+    const requestedAmount = useMemo(() => {
+        const amount = tokenPriceData
+            ? Number(requestLinkData.tokenAmount) * tokenPriceData.price
+            : Number(requestLinkData.tokenAmount)
+
+        if (tokenPriceData) {
+            return `$ ${utils.formatAmountWithSignificantDigits(amount, 3)}`
+        } else {
+            return `${utils.formatAmountWithSignificantDigits(amount, 3)} ${tokenRequestedSymbol}`
+        }
+    }, [tokenPriceData, requestLinkData.tokenAmount, tokenRequestedSymbol])
 
     const fetchTokenSymbol = async (chainId: string, address: string) => {
         const provider = await peanut.getDefaultProvider(chainId)
@@ -335,21 +348,10 @@ export const InitialView = ({
 
             <div className="flex w-full flex-col items-center justify-center gap-2">
                 <label className="text-h4">
-                    {requestLinkData.recipientAddress.endsWith('.eth')
-                        ? requestLinkData.recipientAddress
-                        : utils.shortenAddress(requestLinkData.recipientAddress)}{' '}
-                    is requesting
+                    <AddressLink address={requestLinkData.recipientAddress} /> is requesting
                 </label>
 
-                {tokenPriceData ? (
-                    <label className="text-h2">
-                        $ {utils.formatTokenAmount(Number(requestLinkData.tokenAmount) * tokenPriceData.price)}
-                    </label>
-                ) : (
-                    <label className="text-h2 ">
-                        {requestLinkData.tokenAmount} {tokenRequestedSymbol}
-                    </label>
-                )}
+                <label className="text-h2">{requestedAmount}</label>
                 <div>
                     <div className="flex flex-row items-center justify-center gap-2 pl-1 text-h7">
                         <div className="relative h-6 w-6">
@@ -364,7 +366,8 @@ export const InitialView = ({
                                 alt="logo"
                             />
                         </div>
-                        {requestLinkData.tokenAmount} {tokenRequestedSymbol} on{' '}
+                        {utils.formatAmountWithSignificantDigits(Number(requestLinkData.tokenAmount), 3)}{' '}
+                        {tokenRequestedSymbol} on{' '}
                         {consts.supportedPeanutChains.find((chain) => chain.chainId === requestLinkData.chainId)?.name}
                     </div>
                 </div>

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -106,7 +106,6 @@ export const InitialView = ({
 
     useEffect(() => {
         const estimateTxFee = async () => {
-            setLoadingState('Preparing transaction')
             if (!isXChain) {
                 clearError()
                 setViewState(ViewState.READY_TO_PAY)
@@ -114,6 +113,7 @@ export const InitialView = ({
             }
             try {
                 clearError()
+                setLoadingState('Preparing transaction')
                 const txData = await createXChainUnsignedTx({
                     tokenData: selectedTokenData!,
                     requestLink: requestLinkData,

--- a/src/components/Request/Pay/Views/Success.view.tsx
+++ b/src/components/Request/Pay/Views/Success.view.tsx
@@ -2,12 +2,12 @@ import Link from 'next/link'
 import * as _consts from '../Pay.consts'
 import * as assets from '@/assets'
 import Icon from '@/components/Global/Icon'
+import AddressLink from '@/components/Global/AddressLink'
 import * as utils from '@/utils'
 import { useContext, useEffect, useMemo, useState } from 'react'
 import { fetchDestinationChain } from '@/components/utils/utils'
 import * as context from '@/context'
 import { peanut } from '@squirrel-labs/peanut-sdk'
-import Loading from '@/components/Global/Loading'
 import { useAccount } from 'wagmi'
 
 export const SuccessView = ({ transactionHash, requestLinkData, tokenPriceData }: _consts.IPayScreenProps) => {
@@ -87,14 +87,14 @@ export const SuccessView = ({ transactionHash, requestLinkData, tokenPriceData }
                         <span className="sr-only">{loadingState}</span>
                     </div>
                     <label className="text-h8 font-bold ">
-                        Funds are on their way to {utils.printableAddress(requestLinkData.recipientAddress)}!
+                        Funds are on their way to <AddressLink address={requestLinkData.recipientAddress} />!
                     </label>
                 </>
             ) : (
                 <>
                     <label className="text-h2">Yay!</label>
                     <label className="text-h8 font-bold ">
-                        You have successfully paid {utils.printableAddress(requestLinkData.recipientAddress)}!
+                        You have successfully paid <AddressLink address={requestLinkData.recipientAddress} />!
                     </label>
                 </>
             )}

--- a/src/constants/loadingStates.consts.ts
+++ b/src/constants/loadingStates.consts.ts
@@ -8,6 +8,7 @@ export type LoadingStates =
     | 'Creating link'
     | 'Switching network'
     | 'Fetching route'
+    | 'Awaiting route fulfillment'
     | 'Asserting values'
     | 'Generating details'
     | 'Estimating points'

--- a/src/context/tokenSelector.context.tsx
+++ b/src/context/tokenSelector.context.tsx
@@ -25,6 +25,7 @@ export const tokenSelectorContext = createContext({
     isXChain: false as boolean,
     setIsXChain: (value: boolean) => {},
     selectedTokenData: undefined as ITokenPriceData | undefined,
+    isFetchingTokenData: false as boolean,
 })
 
 /**
@@ -39,6 +40,7 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
     const [refetchXchainRoute, setRefetchXchainRoute] = useState<boolean>(false)
     const [selectedTokenDecimals, setSelectedTokenDecimals] = useState<number | undefined>(18)
     const [isXChain, setIsXChain] = useState<boolean>(false)
+    const [isFetchingTokenData, setIsFetchingTokenData] = useState<boolean>(false)
     const [selectedTokenData, setSelectedTokenData] = useState<ITokenPriceData | undefined>(undefined)
 
     const { isConnected } = useAccount()
@@ -64,6 +66,7 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
         let isCurrent = true
 
         async function fetchAndSetTokenPrice(tokenAddress: string, chainId: string) {
+            setIsFetchingTokenData(true)
             try {
                 if (!consts.supportedMobulaChains.some((chain) => chain.chainId == chainId)) {
                     setSelectedTokenData(undefined)
@@ -94,6 +97,8 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
                 }
             } catch (error) {
                 console.log('error fetching tokenPrice, falling back to tokenDenomination')
+            } finally {
+                setIsFetchingTokenData(false)
             }
         }
 
@@ -103,6 +108,7 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
             setSelectedTokenDecimals(undefined)
             setInputDenomination('TOKEN')
         } else if (selectedTokenAddress && selectedChainID) {
+            setIsFetchingTokenData(true)
             setSelectedTokenData(undefined)
             setSelectedTokenPrice(undefined)
             setSelectedTokenDecimals(undefined)
@@ -142,6 +148,7 @@ export const TokenContextProvider = ({ children }: { children: React.ReactNode }
                 isXChain,
                 setIsXChain,
                 selectedTokenData,
+                isFetchingTokenData,
             }}
         >
             {children}

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -235,6 +235,12 @@ export function formatAmount(amount: number) {
     return amount.toFixed(2)
 }
 
+export function formatAmountWithSignificantDigits(amount: number, significantDigits: number): string {
+    let fractionDigits = Math.floor(Math.log10(1 / amount)) + significantDigits
+    fractionDigits = fractionDigits < 0 ? 0 : fractionDigits
+    return amount.toFixed(fractionDigits)
+}
+
 export function formatTokenAmount(amount?: number, maxFractionDigits?: number) {
     if (amount === undefined) return undefined
     maxFractionDigits = maxFractionDigits ?? 6


### PR DESCRIPTION
- Added a spinner to the request pay success view when doing cross chain payments to show that the payment is on route. Resolve when we have the txHash for the destination chain
- "No route found" error no longer flashes before fetching route when changing token/chain
- No longer trying to get axelar tx for same chain swaps
- Added link for shortened addresses
- In request pay, now showing amounts better formated

Also
- Refactored the state handling and flow of the request pay which helped on implementing the above