### PR TITLE
fix(request): allow route even if fees are less that a cent

### DIFF
--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -134,15 +134,9 @@ export const InitialView = ({
                 })
                 const { feeEstimation, estimatedFromAmount } = txData
                 setEstimatedFromValue(estimatedFromAmount)
-                if (Number(feeEstimation) > 0) {
-                    clearError()
-                    setTxFee(Number(feeEstimation).toFixed(2))
-                    setViewState(ViewState.READY_TO_PAY)
-                } else {
-                    setErrorState({ showError: true, errorMessage: ERR_NO_ROUTE })
-                    setIsFeeEstimationError(true)
-                    setTxFee('0')
-                }
+                clearError()
+                setTxFee(Number(feeEstimation).toFixed(2))
+                setViewState(ViewState.READY_TO_PAY)
             } catch (error) {
                 setErrorState({ showError: true, errorMessage: ERR_NO_ROUTE })
                 setIsFeeEstimationError(true)


### PR DESCRIPTION
If we are at this point we have a route, the feeEstimation is only to show and in this case is less than a cent. Removing unneeded check that was causing to reject a valid route