### PR TITLE
feat(request): simpler create success screen

### DIFF
--- a/src/components/Request/Create/Views/Success.view.tsx
+++ b/src/components/Request/Create/Views/Success.view.tsx
@@ -3,33 +3,15 @@ import * as _consts from '../Create.consts'
 import CopyField from '@/components/Global/CopyField'
 import Link from 'next/link'
 import Icon from '@/components/Global/Icon'
-import * as context from '@/context'
-import * as consts from '@/constants'
-import * as utils from '@/utils'
-import { useContext } from 'react'
 
-export const SuccessView = ({ onNext, onPrev, tokenValue, recipientAddress, link }: _consts.ICreateScreenProps) => {
-    const { selectedTokenPrice, inputDenomination, selectedChainID, selectedTokenAddress } = useContext(
-        context.tokenSelectorContext
-    )
+export const SuccessView = ({ link }: _consts.ICreateScreenProps) => {
     return (
         <div className={`flex w-full flex-col items-center justify-center gap-6 py-2 pb-20 text-center`}>
-            <label className="text-h2">Request a payment</label>
-            <label className="w-full max-w-96 text-h8 font-light">
-                You are requesting {utils.formatTokenAmount(parseFloat(tokenValue ?? ''), 4)}{' '}
-                {
-                    consts.peanutTokenDetails
-                        .find((chain) => chain.chainId === selectedChainID)
-                        ?.tokens.find((token) => token.address === selectedTokenAddress)?.symbol
-                }{' '}
-                on {consts.supportedPeanutChains.find((chain) => chain.chainId === selectedChainID)?.name} to{' '}
-                {recipientAddress}
-            </label>
+            <label className="text-h2">Yay!</label>
 
             <QRCodeWrapper url={link} />
             <label className="text-h8 ">
-                Share this link or QR with anyone. They will be able to pay you
-                from any chain in any token.
+                Share this link or QR with anyone. They will be able to pay you from any chain in any token.
             </label>
 
             <CopyField text={link} />


### PR DESCRIPTION
The info is already in the previous screen and in the link itself, also changed "Request a paymet" to more on brand "Yay!"