### PR TITLE
[TASK-6288] refactor(request): avoid multiple calls to getLinkDetails

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "@headlessui/tailwindcss": "^0.2.1",
         "@safe-global/safe-apps-sdk": "^9.1.0",
         "@sentry/nextjs": "^8.30.0",
-        "@squirrel-labs/peanut-sdk": "^0.5.4",
+        "@squirrel-labs/peanut-sdk": "^0.5.5",
         "@tanstack/react-query": "^5.56.2",
         "@typeform/embed-react": "^3.20.0",
         "@vercel/analytics": "^1.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^8.30.0
         version: 8.30.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@14.2.13(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.94.0)
       '@squirrel-labs/peanut-sdk':
-        specifier: ^0.5.4
-        version: 0.5.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        specifier: ^0.5.5
+        version: 0.5.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@tanstack/react-query':
         specifier: ^5.56.2
         version: 5.56.2(react@18.3.1)
@@ -2790,8 +2790,8 @@ packages:
   '@spruceid/siwe-parser@2.1.2':
     resolution: {integrity: sha512-d/r3S1LwJyMaRAKQ0awmo9whfXeE88Qt00vRj91q5uv5ATtWIQEGJ67Yr5eSZw5zp1/fZCXZYuEckt8lSkereQ==}
 
-  '@squirrel-labs/peanut-sdk@0.5.4':
-    resolution: {integrity: sha512-qJHNv4zFcaWOlX1JZVac9taP1cKiklNZU7sUNHawGRNa+F9+h0YsMYLm2ieZaXOctTyaZbHWleIdaE+aY3GZGQ==}
+  '@squirrel-labs/peanut-sdk@0.5.5':
+    resolution: {integrity: sha512-+fjO1RNQKu/WAxN6wmi/I6SQri35hFDxYHuo0k9AU4Ne+KnQPlUmwBxTZTn7gy4LBgx6qUuQwHuXYpDzGZWwNQ==}
 
   '@stablelib/aead@1.0.1':
     resolution: {integrity: sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg==}
@@ -12458,7 +12458,7 @@ snapshots:
       uri-js: 4.4.1
       valid-url: 1.0.9
 
-  '@squirrel-labs/peanut-sdk@0.5.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+  '@squirrel-labs/peanut-sdk@0.5.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
       ethersv5: ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       jest-summary-reporter: 0.0.2

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -37,14 +37,13 @@ async function createXChainUnsignedTx({
         fromToken: tokenData.address,
         fromChainId: tokenData.chainId,
         senderAddress,
-        link: requestLink.link,
         squidRouterUrl: 'https://apiplus.squidrouter.com/v2/route',
-        apiUrl: '/api/proxy/get',
         provider: await peanut.getDefaultProvider(tokenData.chainId),
         tokenType: utils.isAddressZero(tokenData.address)
             ? interfaces.EPeanutLinkType.native
             : interfaces.EPeanutLinkType.erc20,
         fromTokenDecimals: tokenData.decimals as number,
+        linkDetails: requestLink,
     })
     return xchainUnsignedTxs
 }


### PR DESCRIPTION
This PR uses newest sdk version that reuses previously fetched linkDetails when preparing xchain transactions on request