### PR TITLE
Feat/move liquidation address earlier

### DIFF
--- a/src/components/Claim/Link/Initial.view.tsx
+++ b/src/components/Claim/Link/Initial.view.tsx
@@ -20,7 +20,12 @@ import { Popover } from '@headlessui/react'
 import { useAuth } from '@/context/authContext'
 import { ActionType, estimatePoints } from '@/components/utils/utils'
 import { CrispButton } from '@/components/CrispChat'
-import { MAX_CASHOUT_LIMIT, MIN_CASHOUT_LIMIT, optimismChainId, usdcAddressOptimism } from '@/components/Offramp/Offramp.consts'
+import {
+    MAX_CASHOUT_LIMIT,
+    MIN_CASHOUT_LIMIT,
+    optimismChainId,
+    usdcAddressOptimism,
+} from '@/components/Offramp/Offramp.consts'
 
 export const InitialClaimLinkView = ({
     onNext,
@@ -296,6 +301,7 @@ export const InitialClaimLinkView = ({
                     Number(claimLinkData.tokenAmount) * Math.pow(10, claimLinkData.tokenDecimals)
                 ).toString()
 
+                // TODO: this is duplicate with src/utils/fetchRouteRaw
                 const route = await getSquidRouteRaw({
                     squidRouterUrl: 'https://apiplus.squidrouter.com/v2/route',
                     fromChain: claimLinkData.chainId.toString(),
@@ -634,8 +640,9 @@ export const InitialClaimLinkView = ({
                                 <>
                                     {errorState.errorMessage === 'No route found for the given token pair.' && (
                                         <>
-                                            <label className=" text-h8 font-normal text-red ">{errorState.errorMessage}</label>
-                                            {' '}
+                                            <label className=" text-h8 font-normal text-red ">
+                                                {errorState.errorMessage}
+                                            </label>{' '}
                                             <span
                                                 className="cursor-pointer text-h8 font-normal text-red underline"
                                                 onClick={() => {
@@ -654,14 +661,16 @@ export const InitialClaimLinkView = ({
                                     {errorState.errorMessage === 'offramp_lt_minimum' && (
                                         <>
                                             <label className=" text-h8 font-normal text-red ">
-                                                You can not claim links with less than ${MIN_CASHOUT_LIMIT} to your bank account.{' '}
+                                                You can not claim links with less than ${MIN_CASHOUT_LIMIT} to your bank
+                                                account.{' '}
                                             </label>
                                         </>
                                     )}
                                     {errorState.errorMessage === 'offramp_mt_maximum' && (
                                         <>
                                             <label className=" text-h8 font-normal text-red ">
-                                                You can not claim links with more than ${MAX_CASHOUT_LIMIT} to your bank account.{' '}
+                                                You can not claim links with more than ${MAX_CASHOUT_LIMIT} to your bank
+                                                account.{' '}
                                             </label>
                                         </>
                                     )}

--- a/src/components/Offramp/Confirm.view.tsx
+++ b/src/components/Offramp/Confirm.view.tsx
@@ -279,13 +279,13 @@ export const OfframpConfirmView = ({
         }
 
         const route = await utils.fetchRouteRaw(
-            claimLinkData.tokenAddress,
-            claimLinkData.chainId.toString(),
+            claimLinkData.tokenAddress!,
+            claimLinkData.chainId!.toString(),
             usdcAddressOptimism,
             optimismChainId,
-            claimLinkData.tokenDecimals,
-            claimLinkData.tokenAmount,
-            claimLinkData.senderAddress
+            claimLinkData.tokenDecimals!,
+            claimLinkData.tokenAmount!,
+            claimLinkData.senderAddress ?? '0x9647BB6a598c2675310c512e0566B60a5aEE6261'
         )
 
         if (route === undefined) {

--- a/src/components/Offramp/Confirm.view.tsx
+++ b/src/components/Offramp/Confirm.view.tsx
@@ -191,12 +191,20 @@ export const OfframpConfirmView = ({
 
             const claimLinkData = await getLinkDetails({ link: link })
 
+            const srcChainId = claimLinkData.chainId
+            const destChainId = chainId
+            const isSameChain = srcChainId === destChainId
             const { sourceTxHash, destinationTxHash } = await claimAndProcessLink(
                 xchainNeeded,
                 liquidationAddress.address,
                 claimLinkData,
                 chainId,
-                tokenAddress
+                tokenAddress,
+                isSameChain
+            )
+
+            console.log(
+                `finalized claimAndProcessLink, sourceTxHash: ${sourceTxHash}, destinationTxHash: ${destinationTxHash}`
             )
 
             localStorage.removeItem(tempKey)
@@ -217,7 +225,6 @@ export const OfframpConfirmView = ({
             console.log('Transaction hash:', destinationTxHash)
 
             onNext()
-            setLoadingState('Idle')
         } catch (error) {
             handleError(error)
         } finally {
@@ -303,8 +310,9 @@ export const OfframpConfirmView = ({
         address: string,
         claimLinkData: any, // TODO: fix type
         chainId: string,
-        tokenAddress: string
-    ) => {
+        tokenAddress: string,
+        isSameChain?: boolean // e.g. for opt ETH -> opt USDC
+    ): Promise<{ sourceTxHash: string; destinationTxHash: string }> => {
         if (xchainNeeded) {
             const sourceTxHash = await claimLinkXchain({
                 address,
@@ -312,34 +320,48 @@ export const OfframpConfirmView = ({
                 destinationChainId: chainId,
                 destinationToken: tokenAddress,
             })
+            setLoadingState('Executing transaction') // claimLinkXchain sets loading state to idle after it finishes. pls no.
 
-            // Wait for the destination transaction
-            const destinationTxHash = await new Promise<string>((resolve) => {
-                let retryCount = 0
-                let intervalId = setInterval(async () => {
-                    if (retryCount >= 10) {
-                        clearInterval(intervalId)
-                        resolve(sourceTxHash)
-                        return
-                    }
+            if (isSameChain) {
+                return {
+                    sourceTxHash,
+                    destinationTxHash: sourceTxHash,
+                }
+            }
+
+            const maxAttempts = 15
+            let attempts = 0
+
+            while (attempts < maxAttempts) {
+                try {
                     const status = await checkTransactionStatus(sourceTxHash)
                     if (status.squidTransactionStatus === 'success') {
-                        clearInterval(intervalId)
-                        resolve(status.toChain.transactionId)
+                        return {
+                            sourceTxHash,
+                            destinationTxHash: status.toChain.transactionId,
+                        }
                     }
-                    retryCount++
-                }, 1000)
-            })
+                } catch (error) {
+                    console.warn('Error checking transaction status:', error)
+                }
 
+                attempts++
+                if (attempts < maxAttempts) {
+                    await new Promise((resolve) => setTimeout(resolve, 2000))
+                }
+            }
+
+            console.warn('Transaction status check timed out. Using sourceTxHash as destinationTxHash.')
             return {
                 sourceTxHash,
-                destinationTxHash: destinationTxHash,
+                destinationTxHash: sourceTxHash,
             }
         } else {
             const txHash = await claimLink({
                 address,
                 link: claimLinkData.link,
             })
+            setLoadingState('Executing transaction') // claimLink
             return { sourceTxHash: txHash, destinationTxHash: txHash }
         }
     }

--- a/src/components/utils/utils.ts
+++ b/src/components/utils/utils.ts
@@ -76,7 +76,7 @@ export async function checkTransactionStatus(txHash: string): Promise<ISquidStat
         })
         return response.data
     } catch (error) {
-        console.error('Error fetching transaction status:', error)
+        console.warn('Error fetching transaction status:', error)
         throw error
     }
 }

--- a/src/utils/cashout.utils.ts
+++ b/src/utils/cashout.utils.ts
@@ -448,6 +448,7 @@ export type CashoutStatus =
     | 'REFUNDED'
     | 'READY'
     | 'AWAITING_TX'
+    | 'AWAITING_FIAT'
     | 'FUNDS_IN_BRIDGE'
     | 'FUNDS_MOVED_AWAY'
     | 'FUNDS_IN_BANK'
@@ -480,6 +481,7 @@ export const CashoutStatusDescriptions: { [key in CashoutStatus]: string } = {
     REFUNDED: 'The funds will be refunded to your address.',
     READY: 'The cashout is ready and can be processed.',
     AWAITING_TX: 'Awaiting the transaction to be broadcast on the blockchain.',
+    AWAITING_FIAT: 'Awaiting the funds to be moved to FIAT.',
     FUNDS_IN_BRIDGE: 'Funds are currently in the bridge, moving to the destination chain.',
     FUNDS_MOVED_AWAY: 'Funds have been moved from the bridge to another chain.',
     FUNDS_IN_BANK: 'Funds have been deposited into your bank account.',

--- a/src/utils/cashout.utils.ts
+++ b/src/utils/cashout.utils.ts
@@ -194,7 +194,7 @@ export async function createExternalAccount(
                 // if bridge account already exists for this iban
                 // but somehow not stored in our DB (this should never happen in
                 // prod, but can happen if same email used in prod & staging)
-                // 
+                //
                 // returns:  not interfaces.IBridgeAccount type, but
                 // a currently undefined error type on the data field of interfaces.IResponse
                 // of format:
@@ -207,7 +207,7 @@ export async function createExternalAccount(
                 // TODO: HTTP responses need to be standardized client wide
                 return {
                     success: false,
-                    data
+                    data,
                 } as interfaces.IResponse
             }
             throw new Error('Failed to create external account')
@@ -215,7 +215,7 @@ export async function createExternalAccount(
 
         return {
             success: true,
-            data: data as interfaces.IBridgeAccount
+            data: data as interfaces.IBridgeAccount,
         } as interfaces.IResponse
     } catch (error) {
         console.error('Error:', error)
@@ -527,7 +527,7 @@ export const fetchRouteRaw = async (
     toChain: string,
     tokenDecimals: number,
     tokenAmount: string,
-    senderAddress: string
+    fromAddress?: string
 ) => {
     try {
         const _tokenAmount = BigInt(Math.floor(Number(tokenAmount) * Math.pow(10, tokenDecimals))).toString()
@@ -537,12 +537,11 @@ export const fetchRouteRaw = async (
             fromChain: fromChain,
             fromToken: fromToken.toLowerCase(),
             fromAmount: _tokenAmount,
+            fromAddress: fromAddress ?? '0x9647BB6a598c2675310c512e0566B60a5aEE6261', // placeholder address just to get a route sample
+            toAddress: '0x04B5f21facD2ef7c7dbdEe7EbCFBC68616adC45C', // placeholder address just to get a route sample
             toChain: toChain,
             toToken: toToken,
             slippage: 1,
-            fromAddress: senderAddress,
-
-            toAddress: '0x04B5f21facD2ef7c7dbdEe7EbCFBC68616adC45C',
         })
         return route
     } catch (error) {


### PR DESCRIPTION
Problem: liquidation address creation could fail. Sucks if user pays and THEN gets error.

Moved logic earlier.

@panosfilianos the type safety is a mess here - please take a look and lmk if this refactor seems reasonable to you 

EDIT: did some debugging and QA and seems fine now