### PR TITLE
[TASK-6243] feat: social preview on request links

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "@headlessui/tailwindcss": "^0.2.1",
         "@safe-global/safe-apps-sdk": "^9.1.0",
         "@sentry/nextjs": "^8.30.0",
-        "@squirrel-labs/peanut-sdk": "^0.5.5",
+        "@squirrel-labs/peanut-sdk": "^0.5.6",
         "@tanstack/react-query": "^5.56.2",
         "@typeform/embed-react": "^3.20.0",
         "@vercel/analytics": "^1.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^8.30.0
         version: 8.30.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@14.2.13(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.94.0)
       '@squirrel-labs/peanut-sdk':
-        specifier: ^0.5.5
-        version: 0.5.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        specifier: ^0.5.6
+        version: 0.5.6(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@tanstack/react-query':
         specifier: ^5.56.2
         version: 5.56.2(react@18.3.1)
@@ -2778,8 +2778,8 @@ packages:
   '@spruceid/siwe-parser@2.1.2':
     resolution: {integrity: sha512-d/r3S1LwJyMaRAKQ0awmo9whfXeE88Qt00vRj91q5uv5ATtWIQEGJ67Yr5eSZw5zp1/fZCXZYuEckt8lSkereQ==}
 
-  '@squirrel-labs/peanut-sdk@0.5.5':
-    resolution: {integrity: sha512-+fjO1RNQKu/WAxN6wmi/I6SQri35hFDxYHuo0k9AU4Ne+KnQPlUmwBxTZTn7gy4LBgx6qUuQwHuXYpDzGZWwNQ==}
+  '@squirrel-labs/peanut-sdk@0.5.6':
+    resolution: {integrity: sha512-et2/GxIi67hSugQ3wNFkzAvGphelVs1Yw56k8wAlSpSzNQNEwbEbjidAimKeRvZ3zx0zsd9j/OomuqQ/AA90og==}
 
   '@stablelib/aead@1.0.1':
     resolution: {integrity: sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg==}
@@ -4709,6 +4709,7 @@ packages:
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   esniff@2.0.1:
@@ -12383,7 +12384,7 @@ snapshots:
       uri-js: 4.4.1
       valid-url: 1.0.9
 
-  '@squirrel-labs/peanut-sdk@0.5.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+  '@squirrel-labs/peanut-sdk@0.5.6(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
       ethersv5: ethers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       jest-summary-reporter: 0.0.2

--- a/src/app/api/preview-image/route.tsx
+++ b/src/app/api/preview-image/route.tsx
@@ -14,13 +14,13 @@ export async function GET(request: Request) {
     const chainId = searchParams.get('chainId') ?? ''
     const tokenAddress = searchParams.get('tokenAddress') ?? ''
     const tokenSymbol = searchParams.get('tokenSymbol') ?? ''
-    const senderAddress = searchParams.get('senderAddress') ?? ''
+    const address = searchParams.get('address') ?? ''
     const previewType =
         PreviewType[(searchParams.get('previewType')?.toUpperCase() ?? 'claim') as keyof typeof PreviewType] ??
         PreviewType.CLAIM
 
     return new ImageResponse(
-        <LinkPreviewImg {...{ amount, chainId, tokenAddress, tokenSymbol, senderAddress, previewType }} />,
+        <LinkPreviewImg {...{ amount, chainId, tokenAddress, tokenSymbol, address, previewType }} />,
         {
             width: 400,
             height: 200,

--- a/src/app/api/preview-image/route.tsx
+++ b/src/app/api/preview-image/route.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @next/next/no-img-element */
 import { ImageResponse } from 'next/og'
 
-import { LinkPreviewImg } from '@/components/Global/ImageGeneration/LinkPreview'
+import { LinkPreviewImg, PreviewType } from '@/components/Global/ImageGeneration/LinkPreview'
 
 export const runtime = 'edge'
 
@@ -15,9 +15,15 @@ export async function GET(request: Request) {
     const tokenAddress = searchParams.get('tokenAddress') ?? ''
     const tokenSymbol = searchParams.get('tokenSymbol') ?? ''
     const senderAddress = searchParams.get('senderAddress') ?? ''
+    const previewType =
+        PreviewType[(searchParams.get('previewType')?.toUpperCase() ?? 'claim') as keyof typeof PreviewType] ??
+        PreviewType.CLAIM
 
-    return new ImageResponse(<LinkPreviewImg {...{ amount, chainId, tokenAddress, tokenSymbol, senderAddress }} />, {
-        width: 400,
-        height: 200,
-    })
+    return new ImageResponse(
+        <LinkPreviewImg {...{ amount, chainId, tokenAddress, tokenSymbol, senderAddress, previewType }} />,
+        {
+            width: 400,
+            height: 200,
+        }
+    )
 }

--- a/src/app/api/preview-image/route.tsx
+++ b/src/app/api/preview-image/route.tsx
@@ -15,14 +15,9 @@ export async function GET(request: Request) {
     const tokenAddress = searchParams.get('tokenAddress') ?? ''
     const tokenSymbol = searchParams.get('tokenSymbol') ?? ''
     const senderAddress = searchParams.get('senderAddress') ?? ''
-    // const tokenPrice = parseFloat(searchParams.get('tokenPrice') ?? '')
-    const tokenPrice = undefined
 
-    return new ImageResponse(
-        <LinkPreviewImg {...{ amount, chainId, tokenAddress, tokenSymbol, senderAddress, tokenPrice }} />,
-        {
-            width: 400,
-            height: 200,
-        }
-    )
+    return new ImageResponse(<LinkPreviewImg {...{ amount, chainId, tokenAddress, tokenSymbol, senderAddress }} />, {
+        width: 400,
+        height: 200,
+    })
 }

--- a/src/app/claim/page.tsx
+++ b/src/app/claim/page.tsx
@@ -55,7 +55,7 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
 
     let previewUrl = '/claim-metadata-img.jpg'
     if (linkDetails) {
-        previewUrl = `${host}/api/preview-image?amount=${linkDetails.tokenAmount}&chainId=${linkDetails.chainId}&tokenAddress=${linkDetails.tokenAddress}&tokenSymbol=${linkDetails.tokenSymbol}&senderAddress=${linkDetails.senderAddress}`
+        previewUrl = `${host}/api/preview-image?amount=${linkDetails.tokenAmount}&chainId=${linkDetails.chainId}&tokenAddress=${linkDetails.tokenAddress}&tokenSymbol=${linkDetails.tokenSymbol}&address=${linkDetails.senderAddress}`
     }
     return {
         title: title,

--- a/src/app/claim/page.tsx
+++ b/src/app/claim/page.tsx
@@ -55,7 +55,7 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
 
     let previewUrl = '/claim-metadata-img.jpg'
     if (linkDetails) {
-        previewUrl = `${host}/api/preview-image?amount=${linkDetails.tokenAmount}&chainId=${linkDetails.chainId}&tokenAddress=${linkDetails.tokenAddress}&tokenSymbol=${linkDetails.tokenSymbol}&senderAddress=${linkDetails.senderAddress}&tokenPrice=${undefined}`
+        previewUrl = `${host}/api/preview-image?amount=${linkDetails.tokenAmount}&chainId=${linkDetails.chainId}&tokenAddress=${linkDetails.tokenAddress}&tokenSymbol=${linkDetails.tokenSymbol}&senderAddress=${linkDetails.senderAddress}`
     }
     return {
         title: title,

--- a/src/app/request/pay/page.tsx
+++ b/src/app/request/pay/page.tsx
@@ -1,28 +1,71 @@
 import { Metadata } from 'next'
 import Layout from '@/components/Global/Layout'
-import * as components from '@/components'
+import { PayRequestLink } from '@/components'
+import { headers } from 'next/headers'
+import { PreviewType } from '@/components/Global/ImageGeneration/LinkPreview'
+import { IRequestLinkData } from '@/components/Request/Pay/Pay.consts'
+import { formatAmount } from '@/utils'
 
-export const metadata: Metadata = {
-    // TODO: make metadata dynamic and change title based on if payment completed or not
-    // see claim/page.tsx
-    title: 'Peanut Protocol - Payment Request',
-    description: 'Text Tokens',
-    metadataBase: new URL('https://peanut.to'),
-    icons: {
-        icon: '/logo-favicon.png',
-    },
-    openGraph: {
-        images: [
-            {
-                url: '/metadata-img.png',
-            },
-        ],
-    },
+export const dynamic = 'force-dynamic'
+
+type Props = {
+    params: { id: string }
+    searchParams: { [key: string]: string | string[] | undefined }
 }
+
+function getPreviewUrl(host: string, data: IRequestLinkData): string {
+    const url = new URL('/api/preview-image', host)
+
+    const params = new URLSearchParams({
+        amount: data.tokenAmount,
+        chainId: data.chainId,
+        tokenAddress: data.tokenAddress,
+        tokenSymbol: data.tokenSymbol ?? '',
+        senderAddress: data.recipientAddress,
+        previewType: PreviewType.REQUEST,
+    })
+
+    url.search = params.toString()
+    return url.toString()
+}
+
+export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
+    let title = 'Request Payment'
+    let previewUrl = '/metadata-img.jpg'
+    let host = headers().get('host') || 'peanut.to'
+    host = `${process.env.NODE_ENV === 'development' ? 'http://' : 'https://'}${host}`
+    try {
+        const linkRes = await fetch(`${host}/api/proxy/get/request-links/${searchParams.id}`, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        })
+        if (linkRes.ok) {
+            const linkDetails: IRequestLinkData = await linkRes.json()
+            title = `${linkDetails.recipientAddress} is requesting ${formatAmount(Number(linkDetails.tokenAmount))} ${linkDetails.tokenSymbol}`
+            previewUrl = getPreviewUrl(host, linkDetails)
+        }
+    } catch (e) {}
+    return {
+        title,
+        icons: {
+            icon: '/logo-favicon.png',
+        },
+        openGraph: {
+            images: [
+                {
+                    url: previewUrl,
+                },
+            ],
+        },
+    }
+}
+
 export default function RequestPay() {
     return (
         <Layout className="!mx-0 w-full !px-0 !pt-0 ">
-            <components.PayRequestLink />
+            <PayRequestLink />
         </Layout>
     )
 }

--- a/src/app/request/pay/page.tsx
+++ b/src/app/request/pay/page.tsx
@@ -46,7 +46,9 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
             title = `${linkDetails.recipientAddress} is requesting ${formatAmount(Number(linkDetails.tokenAmount))} ${linkDetails.tokenSymbol}`
             previewUrl = getPreviewUrl(host, linkDetails)
         }
-    } catch (e) {}
+    } catch (e) {
+        console.error('Error fetching request link details:', e)
+    }
     return {
         title,
         icons: {

--- a/src/app/request/pay/page.tsx
+++ b/src/app/request/pay/page.tsx
@@ -21,7 +21,7 @@ function getPreviewUrl(host: string, data: IRequestLinkData): string {
         chainId: data.chainId,
         tokenAddress: data.tokenAddress,
         tokenSymbol: data.tokenSymbol ?? '',
-        senderAddress: data.recipientAddress,
+        address: data.recipientAddress,
         previewType: PreviewType.REQUEST,
     })
 

--- a/src/components/Global/ImageGeneration/LinkPreview.tsx
+++ b/src/components/Global/ImageGeneration/LinkPreview.tsx
@@ -21,14 +21,14 @@ export function LinkPreviewImg({
     chainId,
     tokenAddress,
     tokenSymbol,
-    senderAddress,
+    address,
     previewType,
 }: {
     amount: string
     chainId: string
     tokenAddress: string
     tokenSymbol: string
-    senderAddress: string
+    address: string
     previewType: PreviewType
 }) {
     const tokenImage = consts.peanutTokenDetails
@@ -75,7 +75,7 @@ export function LinkPreviewImg({
                 }}
             >
                 <label style={{ fontSize: '16px', fontWeight: 'bold', color: 'black' }}>
-                    {utils.printableAddress(senderAddress)} {PREVIEW_TYPES[previewType].message}
+                    {utils.printableAddress(address)} {PREVIEW_TYPES[previewType].message}
                 </label>
                 <div
                     style={{

--- a/src/components/Global/ImageGeneration/LinkPreview.tsx
+++ b/src/components/Global/ImageGeneration/LinkPreview.tsx
@@ -2,18 +2,34 @@ import * as consts from '@/constants'
 import * as utils from '@/utils'
 import { headers } from 'next/headers'
 
+export enum PreviewType {
+    CLAIM = 'claim',
+    REQUEST = 'request',
+}
+
+type PreviewTypeData = {
+    message: string
+}
+
+const PREVIEW_TYPES: Record<PreviewType, PreviewTypeData> = {
+    [PreviewType.CLAIM]: { message: 'sent you' },
+    [PreviewType.REQUEST]: { message: 'is requesting' },
+}
+
 export function LinkPreviewImg({
     amount,
     chainId,
     tokenAddress,
     tokenSymbol,
     senderAddress,
+    previewType,
 }: {
     amount: string
     chainId: string
     tokenAddress: string
     tokenSymbol: string
     senderAddress: string
+    previewType: PreviewType
 }) {
     const tokenImage = consts.peanutTokenDetails
         .find((detail) => detail.chainId === chainId)
@@ -59,7 +75,7 @@ export function LinkPreviewImg({
                 }}
             >
                 <label style={{ fontSize: '16px', fontWeight: 'bold', color: 'black' }}>
-                    {utils.printableAddress(senderAddress)} sent you
+                    {utils.printableAddress(senderAddress)} {PREVIEW_TYPES[previewType].message}
                 </label>
                 <div
                     style={{

--- a/src/components/Global/ImageGeneration/LinkPreview.tsx
+++ b/src/components/Global/ImageGeneration/LinkPreview.tsx
@@ -115,8 +115,8 @@ export function LinkPreviewImg({
                             <img
                                 src={chainImage ?? ''}
                                 alt="Chain Image"
-                                height="32px"
-                                width="32px"
+                                height="37px"
+                                width="37px"
                                 style={{
                                     position: 'absolute',
                                     right: '-12px',

--- a/src/components/Global/ImageGeneration/LinkPreview.tsx
+++ b/src/components/Global/ImageGeneration/LinkPreview.tsx
@@ -8,14 +8,12 @@ export function LinkPreviewImg({
     tokenAddress,
     tokenSymbol,
     senderAddress,
-    tokenPrice,
 }: {
     amount: string
     chainId: string
     tokenAddress: string
     tokenSymbol: string
     senderAddress: string
-    tokenPrice?: number
 }) {
     const tokenImage = consts.peanutTokenDetails
         .find((detail) => detail.chainId === chainId)
@@ -121,12 +119,6 @@ export function LinkPreviewImg({
                         {utils.formatTokenAmount(parseFloat(amount), 2)} {tokenSymbol}
                     </label>
                 </div>
-
-                {tokenPrice && (
-                    <label style={{ fontSize: '16px', color: 'black' }}>
-                        ${utils.formatTokenAmount(parseFloat(amount) * tokenPrice, 2)}
-                    </label>
-                )}
             </div>
         </div>
     )

--- a/src/components/Global/ImageGeneration/LinkPreview.tsx
+++ b/src/components/Global/ImageGeneration/LinkPreview.tsx
@@ -98,7 +98,9 @@ export function LinkPreviewImg({
                         {tokenImage && (
                             <img
                                 src={tokenImage ?? ''}
-                                alt="Chain Image"
+                                alt="Token Image"
+                                height="50px"
+                                width="50px"
                                 style={{
                                     height: '50px',
                                     width: '50px',
@@ -112,7 +114,9 @@ export function LinkPreviewImg({
                         {chainImage && (
                             <img
                                 src={chainImage ?? ''}
-                                alt="Token Image"
+                                alt="Chain Image"
+                                height="32px"
+                                width="32px"
                                 style={{
                                     position: 'absolute',
                                     right: '-12px',


### PR DESCRIPTION
This pr adds a dynamic social preview for request links, informing the token, chain, amount and requester address.

Note: The token symbol may not be fetched, this is known and being addressed [here](https://www.notion.so/peanutprotocol/Request-data-is-not-stored-properly-in-every-case-eg-tokenSymbol-c6f6fa0909f84d4b85263c92a3b98faf?pvs=4)