### PR TITLE
[ISSUE-249] fix: locked validated input

### DIFF
--- a/src/components/Global/ValidatedInput/index.tsx
+++ b/src/components/Global/ValidatedInput/index.tsx
@@ -29,7 +29,7 @@ const ValidatedInput = ({
     const previousValueRef = useRef(value)
 
     useEffect(() => {
-        if ('' === debouncedValue || debouncedValue === previousValueRef.current) {
+        if ('' === debouncedValue) {
             return
         }
         let isStale = false


### PR DESCRIPTION
We were previousley checking previousValueRef.current to see if the value was the same as the debounced value. This was causing issues and is no longer necessary, because it was introduced when the state was not handled correctly