### PR TITLE
[TASK-6249] Store token symbol when creating a request link

### DIFF
--- a/src/components/Dashboard/useDashboard.tsx
+++ b/src/components/Dashboard/useDashboard.tsx
@@ -2,7 +2,17 @@ import { getLinkDetails, peanut } from '@squirrel-labs/peanut-sdk'
 
 import * as interfaces from '@/interfaces'
 import * as consts from '@/constants'
-import * as utils from '@/utils'
+import {
+    getTokenSymbol,
+    getClaimedLinksFromLocalStorage,
+    getCreatedLinksFromLocalStorage,
+    getDirectSendFromLocalStorage,
+    getOfframpClaimsFromLocalStorage,
+    getRequestLinkFulfillmentsFromLocalStorage,
+    getRequestLinksFromLocalStorage,
+    getCashoutStatus,
+    setRequestLinksToLocalStorage,
+} from '@/utils'
 
 export const useDashboard = () => {
     const fetchLinkDetailsAsync = async (visibleData: interfaces.IDashboardItem[]) => {
@@ -49,7 +59,7 @@ export const useDashboard = () => {
             await Promise.all(
                 _data3.map(async (item) => {
                     try {
-                        const offrampStatus = await utils.getCashoutStatus(item.link ?? '')
+                        const offrampStatus = await getCashoutStatus(item.link ?? '')
                         item.status = offrampStatus.status
                     } catch (error) {
                         item.status = 'claimed'
@@ -67,18 +77,18 @@ export const useDashboard = () => {
     }
 
     const removeRequestLinkFromLocalStorage = (link: string) => {
-        const requestLinks = utils.getRequestLinksFromLocalStorage()!
+        const requestLinks = getRequestLinksFromLocalStorage()!
         const updatedRequestLinks = requestLinks.filter((item) => item.link !== link)
-        utils.setRequestLinksToLocalStorage(updatedRequestLinks)
+        setRequestLinksToLocalStorage(updatedRequestLinks)
     }
 
     const composeLinkDataArray = (address: string) => {
-        const claimedLinks = utils.getClaimedLinksFromLocalStorage({ address: address })!
-        const createdLinks = utils.getCreatedLinksFromLocalStorage({ address: address })!
-        const directSends = utils.getDirectSendFromLocalStorage({ address: address })!
-        const offrampClaims = utils.getOfframpClaimsFromLocalStorage()!
-        const requestLinks = utils.getRequestLinksFromLocalStorage()!
-        const requestLinkFulfillments = utils.getRequestLinkFulfillmentsFromLocalStorage()!
+        const claimedLinks = getClaimedLinksFromLocalStorage({ address: address })!
+        const createdLinks = getCreatedLinksFromLocalStorage({ address: address })!
+        const directSends = getDirectSendFromLocalStorage({ address: address })!
+        const offrampClaims = getOfframpClaimsFromLocalStorage()!
+        const requestLinks = getRequestLinksFromLocalStorage()!
+        const requestLinkFulfillments = getRequestLinkFulfillmentsFromLocalStorage()!
 
         let linkData: interfaces.IDashboardItem[] = []
 
@@ -121,11 +131,7 @@ export const useDashboard = () => {
                 link: link.link,
                 type: 'Link Sent',
                 amount: link.tokenAmount.toString(),
-                tokenSymbol:
-                    consts.peanutTokenDetails
-                        .find((token) => token.chainId === link.chainId)
-                        ?.tokens.find((token) => utils.areTokenAddressesEqual(token.address, link.tokenAddress ?? ''))
-                        ?.symbol ?? '',
+                tokenSymbol: getTokenSymbol(link.tokenAddress ?? '', link.chainId) ?? '',
                 chain: consts.supportedPeanutChains.find((chain) => chain.chainId === link.chainId)?.name ?? '',
                 date: link.depositDate.toString(),
                 address: undefined,
@@ -142,11 +148,7 @@ export const useDashboard = () => {
                 link: undefined,
                 type: 'Direct Sent',
                 amount: link.tokenAmount.toString(),
-                tokenSymbol:
-                    consts.peanutTokenDetails
-                        .find((token) => token.chainId === link.chainId)
-                        ?.tokens.find((token) => utils.areTokenAddressesEqual(token.address, link.tokenAddress))
-                        ?.symbol ?? '',
+                tokenSymbol: getTokenSymbol(link.tokenAddress ?? '', link.chainId) ?? '',
                 chain: consts.supportedPeanutChains.find((chain) => chain.chainId === link.chainId)?.name ?? '',
                 date: link.date.toString(),
                 address: undefined,
@@ -163,11 +165,7 @@ export const useDashboard = () => {
                 link: link.link,
                 type: 'Request Link',
                 amount: link.tokenAmount.toString(),
-                tokenSymbol:
-                    consts.peanutTokenDetails
-                        .find((token) => token.chainId === link.chainId)
-                        ?.tokens.find((token) => utils.areTokenAddressesEqual(token.address, link.tokenAddress))
-                        ?.symbol ?? '',
+                tokenSymbol: getTokenSymbol(link.tokenAddress ?? '', link.chainId) ?? '',
                 chain: consts.supportedPeanutChains.find((chain) => chain.chainId === link.chainId)?.name ?? '',
                 date: link.createdAt.toString(),
                 address: link.recipientAddress,
@@ -184,11 +182,7 @@ export const useDashboard = () => {
                 link: link.link,
                 type: 'Request Link Fulfillment',
                 amount: link.tokenAmount.toString(),
-                tokenSymbol:
-                    consts.peanutTokenDetails
-                        .find((token) => token.chainId === link.chainId)
-                        ?.tokens.find((token) => utils.areTokenAddressesEqual(token.address, link.tokenAddress))
-                        ?.symbol ?? '',
+                tokenSymbol: getTokenSymbol(link.tokenAddress ?? '', link.chainId) ?? '',
                 chain: consts.supportedPeanutChains.find((chain) => chain.chainId === link.chainId)?.name ?? '',
                 date: link.createdAt.toString(),
                 address: link.recipientAddress,

--- a/src/components/Global/ConfirmDetails/Index.tsx
+++ b/src/components/Global/ConfirmDetails/Index.tsx
@@ -1,5 +1,5 @@
 import * as consts from '@/constants'
-import * as utils from '@/utils'
+import { getTokenSymbol, formatTokenAmount, areTokenAddressesEqual } from '@/utils'
 
 interface IConfirmDetailsProps {
     selectedChainID: string
@@ -29,34 +29,30 @@ export const ConfirmDetails = ({
                                 ? data
                                       .find((chain: any) => chain.chainId === selectedChainID)
                                       ?.tokens.find((token: any) =>
-                                          utils.areTokenAddressesEqual(token.address, selectedTokenAddress)
+                                          areTokenAddressesEqual(token.address, selectedTokenAddress)
                                       )?.logoURI
                                 : consts.peanutTokenDetails
                                       .find((detail) => detail.chainId === selectedChainID)
                                       ?.tokens.find((token) =>
-                                          utils.areTokenAddressesEqual(token.address, selectedTokenAddress)
+                                          areTokenAddressesEqual(token.address, selectedTokenAddress)
                                       )?.logoURI
                         }
                         className="h-6 w-6"
                     />
                     <label className="text-h5 sm:text-h3">
-                        {utils.formatTokenAmount(Number(tokenAmount))}{' '}
+                        {formatTokenAmount(Number(tokenAmount))}{' '}
                         {data
                             ? data
                                   .find((chain: any) => chain.chainId === selectedChainID)
                                   ?.tokens.find((token: any) =>
-                                      utils.areTokenAddressesEqual(token.address, selectedTokenAddress)
+                                      areTokenAddressesEqual(token.address, selectedTokenAddress)
                                   )?.symbol
-                            : consts.peanutTokenDetails
-                                  .find((detail) => detail.chainId === selectedChainID)
-                                  ?.tokens.find((token) =>
-                                      utils.areTokenAddressesEqual(token.address, selectedTokenAddress)
-                                  )?.symbol}
+                            : getTokenSymbol(selectedTokenAddress, selectedChainID)}
                     </label>
                 </div>
                 {tokenPrice && (
                     <label className="text-h7 font-bold text-gray-1">
-                        $ {utils.formatTokenAmount(Number(tokenAmount) * tokenPrice)}
+                        $ {formatTokenAmount(Number(tokenAmount) * tokenPrice)}
                     </label>
                 )}
             </div>

--- a/src/components/Request/Create/Views/Initial.view.tsx
+++ b/src/components/Request/Create/Views/Initial.view.tsx
@@ -10,7 +10,7 @@ import AddressInput from '@/components/Global/AddressInput'
 import { InputUpdate } from '@/components/Global/ValidatedInput'
 import { getTokenDetails } from '@/components/Create/Create.utils'
 import { useBalance } from '@/hooks/useBalance'
-import { getTokenSymbol, saveRequestLinkToLocalStorage, isNativeCurrency } from '@/utils'
+import { fetchTokenSymbol, saveRequestLinkToLocalStorage, isNativeCurrency } from '@/utils'
 import { IUserBalance, IToken } from '@/interfaces'
 
 export const InitialView = ({
@@ -83,7 +83,7 @@ export const InitialView = ({
                 tokenData = {
                     address: tokenAddress,
                     chainId,
-                    symbol: (await getTokenSymbol(tokenAddress, chainId)) ?? '',
+                    symbol: (await fetchTokenSymbol(tokenAddress, chainId)) ?? '',
                     decimals: tokenDetails.tokenDecimals,
                 }
             }

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -956,11 +956,15 @@ export function getTokenSymbol(tokenAddress: string, chainId: string): string | 
 export async function fetchTokenSymbol(tokenAddress: string, chainId: string): Promise<string | undefined> {
     let tokenSymbol = getTokenSymbol(tokenAddress, chainId)
     if (!tokenSymbol) {
-        const contract = await peanut.getTokenContractDetails({
-            address: tokenAddress,
-            provider: await peanut.getDefaultProvider(chainId),
-        })
-        tokenSymbol = contract?.symbol?.toUpperCase()
+        try {
+            const contract = await peanut.getTokenContractDetails({
+                address: tokenAddress,
+                provider: await peanut.getDefaultProvider(chainId),
+            })
+            tokenSymbol = contract?.symbol?.toUpperCase()
+        } catch (error) {
+            console.error('Error fetching token symbol:', error)
+        }
     }
     if (!tokenSymbol) {
         console.error(`Failed to get token symbol for token ${tokenAddress} on chain ${chainId}`)

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -927,3 +927,21 @@ export const switchNetwork = async ({
         }
     }
 }
+
+export async function getTokenSymbol(tokenAddress: string, chainId: string): Promise<string | undefined> {
+    let tokenSymbol = consts.peanutTokenDetails
+        .find((chain) => chain.chainId === chainId)
+        ?.tokens.find((token) => areTokenAddressesEqual(token.address, tokenAddress))
+        ?.symbol?.toUpperCase()
+    if (!tokenSymbol) {
+        const contract = await peanut.getTokenContractDetails({
+            address: tokenAddress,
+            provider: await peanut.getDefaultProvider(chainId),
+        })
+        tokenSymbol = contract?.symbol?.toUpperCase()
+    }
+    if (!tokenSymbol) {
+        console.error(`Failed to get token symbol for token ${tokenAddress} on chain ${chainId}`)
+    }
+    return tokenSymbol
+}

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -928,6 +928,14 @@ export const switchNetwork = async ({
     }
 }
 
+/**
+ * Gets the token symbol for a given token address and chain ID.
+ *
+ * From the sdk token list, if you need to be sure to get a token symbol you
+ * should use the {@link fetchTokenSymbol} function.
+ *
+ * @returns The token symbol, or undefined if not found.
+ */
 export function getTokenSymbol(tokenAddress: string, chainId: string): string | undefined {
     return consts.peanutTokenDetails
         .find((chain) => chain.chainId === chainId)
@@ -935,6 +943,16 @@ export function getTokenSymbol(tokenAddress: string, chainId: string): string | 
         ?.symbol?.toUpperCase()
 }
 
+/**
+ * Fetches the token symbol for a given token address and chain ID.
+ *
+ * This function first checks the sdk token list, and if the token is not found
+ * it fetches the token contract details and tries to get the symbol from the
+ * contract. If you are ok with only checking the sdk token list, and don't want
+ * to await you can use the {@link getTokenSymbol} function.
+ *
+ * @returns The token symbol, or undefined if not found.
+ */
 export async function fetchTokenSymbol(tokenAddress: string, chainId: string): Promise<string | undefined> {
     let tokenSymbol = getTokenSymbol(tokenAddress, chainId)
     if (!tokenSymbol) {

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -928,11 +928,15 @@ export const switchNetwork = async ({
     }
 }
 
-export async function getTokenSymbol(tokenAddress: string, chainId: string): Promise<string | undefined> {
-    let tokenSymbol = consts.peanutTokenDetails
+export function getTokenSymbol(tokenAddress: string, chainId: string): string | undefined {
+    return consts.peanutTokenDetails
         .find((chain) => chain.chainId === chainId)
         ?.tokens.find((token) => areTokenAddressesEqual(token.address, tokenAddress))
         ?.symbol?.toUpperCase()
+}
+
+export async function fetchTokenSymbol(tokenAddress: string, chainId: string): Promise<string | undefined> {
+    let tokenSymbol = getTokenSymbol(tokenAddress, chainId)
     if (!tokenSymbol) {
         const contract = await peanut.getTokenContractDetails({
             address: tokenAddress,


### PR DESCRIPTION
- Now we send token symbol when creating a request link on the backend
- Created the getTokenSymbol and fetchTokenSymbol functions
- Use the functions where we currently search for token symbol

QA Note: this should fix the token symbol not showing on the success pay page and on the preview links of requests