### PR TITLE
[TASK-6259] chore: redirect claim to main version

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -54,6 +54,11 @@ const nextConfig = {
                 destination: '/raffle/create',
                 permanent: true,
             },
+            {
+                source: '/claim',
+                destination: 'https://peanut.to/claim',
+                permanent: true,
+            },
         ]
     },
     async headers() {


### PR DESCRIPTION
No reason to use legacy claim (that also has less features)