### PR TITLE
[ISSUE-169] fix: us link account form

### DIFF
--- a/src/app/api/bridge/external-account/create-external-account/route.ts
+++ b/src/app/api/bridge/external-account/create-external-account/route.ts
@@ -65,31 +65,40 @@ export async function POST(request: NextRequest) {
             body: JSON.stringify(body),
         })
 
-        const data = await response.json()
-
         if (!response.ok) {
-            if (data.code && data.code == 'duplicate_external_account') {
-                // in case the bridge account already exists
-                //
-                // sending back error responses is not currently common across app 
-                // in how we deliver errors from backend -> frontend
-                // sends back an object like:
-                // {
-                //     id: '4c537540-80bf-41dd-a528-dbe39a4',
-                //     code: 'duplicate_external_account',
-                //     message: 'An external account with the same information has already been added for this customer'
-                //   }
-                //
-                // TODO: standardize error responses across backend
-                return new NextResponse(JSON.stringify(data), {
-                    status: response.status,
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
-                })
+            try {
+                const data = await response.json()
+                if (data.code && data.code == 'duplicate_external_account') {
+                    // in case the bridge account already exists
+                    //
+                    // sending back error responses is not currently common across app
+                    // in how we deliver errors from backend -> frontend
+                    // sends back an object like:
+                    // {
+                    //     id: '4c537540-80bf-41dd-a528-dbe39a4',
+                    //     code: 'duplicate_external_account',
+                    //     message: 'An external account with the same information has already been added for this customer'
+                    //   }
+                    //
+                    // TODO: standardize error responses across backend
+                    return new NextResponse(JSON.stringify(data), {
+                        status: response.status,
+                        headers: {
+                            'Content-Type': 'application/json',
+                        },
+                    })
+                }
+            } catch (e) {
+                console.error('Error creating external account', e)
             }
-            throw new Error(`HTTP error! status: ${response.status}`)
+            return new NextResponse('', {
+                status: response.status,
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+            })
         }
+        const data = await response.json()
 
         return new NextResponse(JSON.stringify(data), {
             status: 200,

--- a/src/components/Global/LinkAccountComponent/index.tsx
+++ b/src/components/Global/LinkAccountComponent/index.tsx
@@ -54,6 +54,7 @@ export const GlobaLinkAccountComponent = ({ accountNumber, onCompleted }: IGloba
         setValue: setAccountDetailsValue,
         getValues: getAccountDetailsValue,
         setError: setAccountDetailsError,
+        clearErrors: clearAccountDetailsErrors,
         handleSubmit: handleAccountDetailsSubmit,
     } = useForm<IRegisterAccountDetails>({
         mode: 'onChange',
@@ -368,7 +369,7 @@ export const GlobaLinkAccountComponent = ({ accountNumber, onCompleted }: IGloba
                                             value={accountDetailsWatch('country')}
                                             onChange={(value: any) => {
                                                 setAccountDetailsValue('country', value, { shouldValidate: true })
-                                                setAccountDetailsError('country', { message: undefined })
+                                                clearAccountDetailsErrors('country')
                                             }}
                                             error={accountDetailsErrors.country?.message}
                                         />

--- a/src/utils/cashout.utils.ts
+++ b/src/utils/cashout.utils.ts
@@ -187,31 +187,35 @@ export async function createExternalAccount(
             }),
         })
 
-        const data = await response.json()
-
         if (!response.ok) {
-            if (data.code && data.code == 'duplicate_external_account') {
-                // if bridge account already exists for this iban
-                // but somehow not stored in our DB (this should never happen in
-                // prod, but can happen if same email used in prod & staging)
-                //
-                // returns:  not interfaces.IBridgeAccount type, but
-                // a currently undefined error type on the data field of interfaces.IResponse
-                // of format:
-                // {
-                //     id: '4c537540-80bf-41dd-a528-d79a4',
-                //     code: 'duplicate_external_account',
-                //     message: 'An external account with the same information has already been added for this customer'
-                // }
-                //
-                // TODO: HTTP responses need to be standardized client wide
-                return {
-                    success: false,
-                    data,
-                } as interfaces.IResponse
+            try {
+                const data = await response.json()
+                if (data.code && data.code == 'duplicate_external_account') {
+                    // if bridge account already exists for this iban
+                    // but somehow not stored in our DB (this should never happen in
+                    // prod, but can happen if same email used in prod & staging)
+                    //
+                    // returns:  not interfaces.IBridgeAccount type, but
+                    // a currently undefined error type on the data field of interfaces.IResponse
+                    // of format:
+                    // {
+                    //     id: '4c537540-80bf-41dd-a528-d79a4',
+                    //     code: 'duplicate_external_account',
+                    //     message: 'An external account with the same information has already been added for this customer'
+                    // }
+                    //
+                    // TODO: HTTP responses need to be standardized client wide
+                    return {
+                        success: false,
+                        data,
+                    } as interfaces.IResponse
+                }
+            } catch (error) {
+                console.error('Error creating external account', response)
+                throw new Error('Unexpected error')
             }
-            throw new Error('Failed to create external account (duplicate account)')
         }
+        const data = await response.json()
 
         return {
             success: true,


### PR DESCRIPTION
US account details form was impossible to advance due to wrong error handling and clearing, this is now fixed. Also modified a little the handling of errors for create-external-account, because on error the API doesn't return a json so it was always failing when trying to parse it