### PR TITLE
fix(cashout): remove old validation

### DIFF
--- a/src/components/Cashout/Components/Initial.view.tsx
+++ b/src/components/Cashout/Components/Initial.view.tsx
@@ -111,18 +111,6 @@ export const InitialCashoutView = ({
             }
             if (!_tokenValue) return
 
-            const recipientBankAccount = selectedBankAccount || newBankAccount
-
-            const validAccount = await utils.validateBankAccount(recipientBankAccount)
-            if (!validAccount) {
-                console.error('Invalid bank account')
-                setErrorState({
-                    showError: true,
-                    errorMessage: 'Invalid bank account. Reach out to support if you need help.',
-                })
-                return
-            }
-        
             if (!user) {
                 await fetchUser()
             }


### PR DESCRIPTION
Was reintroduced by a merge and caused build fails, is obsolete because now we are using ValidatedInput