### PR TITLE
[TASK-6611] feat: add max button to token amount input

### DIFF
--- a/src/components/Cashout/Components/Initial.view.tsx
+++ b/src/components/Cashout/Components/Initial.view.tsx
@@ -194,6 +194,7 @@ export const InitialCashoutView = ({
     const maxValue = useMemo(() => {
         const balance = balanceByToken(selectedChainID, selectedTokenAddress)
         if (!balance) return ''
+        // 6 decimal places, prettier
         return floorFixed(balance.amount, 6)
     }, [selectedChainID, selectedTokenAddress, balanceByToken])
 

--- a/src/components/Cashout/Components/Initial.view.tsx
+++ b/src/components/Cashout/Components/Initial.view.tsx
@@ -14,7 +14,7 @@ import { useAuth } from '@/context/authContext'
 import { useCreateLink } from '@/components/Create/useCreateLink'
 import { Icon as ChakraIcon } from '@chakra-ui/react'
 import * as assets from '@/assets'
-import { formatIban, validateBankAccount } from '@/utils'
+import { formatIban, validateBankAccount, floorFixed } from '@/utils'
 import { FAQComponent } from './Faq.comp'
 import { RecipientInfoComponent } from './RecipientInfo.comp'
 import Icon from '@/components/Global/Icon'
@@ -32,9 +32,11 @@ export const InitialCashoutView = ({
     setOfframpForm,
     crossChainDetails,
 }: _consts.ICashoutScreenProps) => {
-    const { selectedTokenPrice, inputDenomination, selectedChainID } = useContext(context.tokenSelectorContext)
+    const { selectedTokenPrice, inputDenomination, selectedChainID, selectedTokenAddress } = useContext(
+        context.tokenSelectorContext
+    )
 
-    const { balances, hasFetchedBalances } = useBalance()
+    const { balances, hasFetchedBalances, balanceByToken } = useBalance()
     const { user, fetchUser, isFetchingUser } = useAuth()
     const [, setUserType] = useState<'NEW' | 'EXISTING' | undefined>(undefined)
 
@@ -189,6 +191,12 @@ export const InitialCashoutView = ({
         }
     }
 
+    const maxValue = useMemo(() => {
+        const balance = balanceByToken(selectedChainID, selectedTokenAddress)
+        if (!balance) return ''
+        return floorFixed(balance.amount, 6)
+    }, [selectedChainID, selectedTokenAddress, balanceByToken])
+
     useEffect(() => {
         if (!_tokenValue) return
         if (inputDenomination === 'TOKEN') {
@@ -219,6 +227,7 @@ export const InitialCashoutView = ({
                     className="w-full max-w-[100%]"
                     tokenValue={_tokenValue}
                     setTokenValue={_setTokenValue}
+                    maxValue={maxValue}
                     onSubmit={() => {
                         if (!isConnected) handleConnectWallet()
                         else handleOnNext()

--- a/src/components/Create/Link/Input.view.tsx
+++ b/src/components/Create/Link/Input.view.tsx
@@ -8,17 +8,17 @@ import { useState, useContext, useEffect } from 'react'
 import { useCreateLink } from '../useCreateLink'
 
 import * as _consts from '../Create.consts'
-import * as _utils from '../Create.utils'
+import { isGaslessDepositPossible } from '../Create.utils'
 import * as context from '@/context'
-import * as utils from '@/utils'
+import { isNativeCurrency, ErrorHandler, shortenAddressLong } from '@/utils'
 import Loading from '@/components/Global/Loading'
 import FileUploadInput from '@/components/Global/FileUploadInput'
 import { interfaces } from '@squirrel-labs/peanut-sdk'
-import SafeAppsSDK from '@safe-global/safe-apps-sdk'
 import Icon from '@/components/Global/Icon'
 import MoreInfo from '@/components/Global/MoreInfo'
 import { useWalletType } from '@/hooks/useWalletType'
 import { useBalance } from '@/hooks/useBalance'
+import { formatEther } from 'viem'
 
 export const CreateLinkInputView = ({
     onNext,
@@ -104,11 +104,11 @@ export const CreateLinkInputView = ({
                 setLoadingState('Preparing transaction')
 
                 let prepareDepositTxsResponse: interfaces.IPrepareDepositTxsResponse | undefined
-                const isGaslessDepositPossible = _utils.isGaslessDepositPossible({
+                const _isGaslessDepositPossible = isGaslessDepositPossible({
                     chainId: selectedChainID,
                     tokenAddress: selectedTokenAddress,
                 })
-                if (isGaslessDepositPossible) {
+                if (_isGaslessDepositPossible) {
                     setTransactionType('gasless')
 
                     const makeGaslessDepositResponse = await makeGaslessDepositPayload({
@@ -137,12 +137,15 @@ export const CreateLinkInputView = ({
 
                     setPreparedDepositTxs(prepareDepositTxsResponse)
 
+                    let _feeOptions = undefined
+
                     try {
                         const { feeOptions, transactionCostUSD } = await estimateGasFee({
                             chainId: selectedChainID,
                             preparedTx: prepareDepositTxsResponse?.unsignedTxs[0],
                         })
 
+                        _feeOptions = feeOptions
                         setFeeOptions(feeOptions)
                         setTransactionCostUSD(transactionCostUSD)
                     } catch (error) {
@@ -150,13 +153,24 @@ export const CreateLinkInputView = ({
                         setFeeOptions(undefined)
                         setTransactionCostUSD(undefined)
                     }
+                    // If the selected token is native currency, we need to check
+                    // the user's balance to ensure they have enough to cover the
+                    // gas fees.
+                    if (undefined !== _feeOptions && isNativeCurrency(selectedTokenAddress)) {
+                        const maxGasAmount = Number(
+                            formatEther(_feeOptions.gasLimit.mul(_feeOptions.maxFeePerGas || _feeOptions.gasPrice))
+                        )
+                        await checkUserHasEnoughBalance({
+                            tokenValue: String(Number(tokenValue) + maxGasAmount),
+                        })
+                    }
                 }
 
                 const estimatedPoints = await estimatePoints({
                     chainId: selectedChainID,
                     address: address ?? '',
                     amountUSD: parseFloat(usdValue ?? '0'),
-                    preparedTx: isGaslessDepositPossible
+                    preparedTx: _isGaslessDepositPossible
                         ? undefined
                         : prepareDepositTxsResponse &&
                           prepareDepositTxsResponse?.unsignedTxs[prepareDepositTxsResponse?.unsignedTxs.length - 1],
@@ -207,7 +221,7 @@ export const CreateLinkInputView = ({
             await switchNetwork(selectedChainID)
             onNext()
         } catch (error) {
-            const errorString = utils.ErrorHandler(error)
+            const errorString = ErrorHandler(error)
             setErrorState({
                 showError: true,
                 errorMessage: errorString,
@@ -242,7 +256,7 @@ export const CreateLinkInputView = ({
                     {createType === 'link'
                         ? 'Text Tokens'
                         : createType === 'direct'
-                          ? `Send to ${recipient.name?.endsWith('.eth') ? recipient.name : utils.shortenAddressLong(recipient.address ?? '')}`
+                          ? `Send to ${recipient.name?.endsWith('.eth') ? recipient.name : shortenAddressLong(recipient.address ?? '')}`
                           : `Send to ${recipient.name}`}
                 </h2>
                 <div className="max-w-96 text-center">

--- a/src/components/Create/Link/Input.view.tsx
+++ b/src/components/Create/Link/Input.view.tsx
@@ -165,6 +165,7 @@ export const CreateLinkInputView = ({
                                 tokenValue: String(Number(tokenValue) + maxGasAmount),
                             })
                         } catch (error) {
+                            // 6 decimal places, prettier
                             _setTokenValue((Number(tokenValue) - maxGasAmount * 1.3).toFixed(6))
                             setErrorState({
                                 showError: true,
@@ -244,6 +245,7 @@ export const CreateLinkInputView = ({
     const maxValue = useMemo(() => {
         const balance = balanceByToken(selectedChainID, selectedTokenAddress)
         if (!balance) return ''
+        // 6 decimal places, prettier
         return floorFixed(balance.amount, 6)
     }, [selectedChainID, selectedTokenAddress, balanceByToken])
 

--- a/src/components/Create/useCreateLink.tsx
+++ b/src/components/Create/useCreateLink.tsx
@@ -33,7 +33,7 @@ export const useCreateLink = () => {
     const checkUserHasEnoughBalance = useCallback(
         async ({ tokenValue }: ICheckUserHasEnoughBalanceProps) => {
             // the selectedChainID and selectedTokenAddress have to be defined
-            if (!selectedChainID && !selectedTokenAddress) {
+            if (!selectedChainID || !selectedTokenAddress) {
                 throw new Error('Please ensure that the correct token and chain are defined')
             }
             // if the userbalances are know, the user must have a balance of the selected token

--- a/src/components/Global/TokenAmountInput/index.tsx
+++ b/src/components/Global/TokenAmountInput/index.tsx
@@ -96,7 +96,7 @@ const TokenAmountInput = ({ className, tokenValue, setTokenValue, onSubmit, maxV
                 {maxValue && maxValue !== tokenValue && (
                     <button
                         onClick={handleMaxClick}
-                        className="absolute right-1 ml-1 border border-n-1 px-3 py-2 text-h7 uppercase hover:bg-n-3/10"
+                        className="absolute right-1 ml-1 bg-gray-200 px-2 py-1 text-h7 uppercase transition-colors hover:bg-black hover:text-white"
                     >
                         Max
                     </button>

--- a/src/components/Global/TokenAmountInput/index.tsx
+++ b/src/components/Global/TokenAmountInput/index.tsx
@@ -8,15 +8,25 @@ interface TokenAmountInputProps {
     tokenValue: string | undefined
     setTokenValue: (tokenvalue: string | undefined) => void
     onSubmit?: () => void
+    maxValue?: string
 }
 
-const TokenAmountInput = ({ className, tokenValue, setTokenValue, onSubmit }: TokenAmountInputProps) => {
+const TokenAmountInput = ({ className, tokenValue, setTokenValue, onSubmit, maxValue }: TokenAmountInputProps) => {
     const { inputDenomination, setInputDenomination, selectedTokenData } = useContext(context.tokenSelectorContext)
     const inputRef = useRef<HTMLInputElement>(null)
     const inputType = useMemo(() => (window.innerWidth < 640 ? 'text' : 'number'), [])
 
     const onChange = (tokenvalue: string) => {
         setTokenValue(tokenvalue)
+    }
+
+    const handleMaxClick = (e: React.MouseEvent) => {
+        e.preventDefault()
+        e.stopPropagation() // Prevent container click handler from firing
+        if (maxValue) {
+            setInputDenomination('TOKEN')
+            setTokenValue(maxValue)
+        }
     }
 
     useEffect(() => {
@@ -52,15 +62,14 @@ const TokenAmountInput = ({ className, tokenValue, setTokenValue, onSubmit }: To
             onClick={handleContainerClick}
         >
             <div className="flex h-14 w-full flex-row items-center justify-center gap-1">
-                {}
                 {selectedTokenData?.price &&
                     (inputDenomination === 'USD' || utils.estimateStableCoin(selectedTokenData.price) ? (
-                        <label className={` text-h1 ${tokenValue ? 'text-black' : 'text-gray-2'}`}>$</label>
+                        <label className={`text-h1 ${tokenValue ? 'text-black' : 'text-gray-2'}`}>$</label>
                     ) : (
-                        <label className={`sr-only text-h1 `}>$</label>
+                        <label className="sr-only text-h1">$</label>
                     ))}
                 <input
-                    className={`h-12 w-[4ch] max-w-80 bg-transparent text-center text-h1 outline-none transition-colors placeholder:text-h1 focus:border-purple-1 dark:border-white dark:bg-n-1 dark:text-white  dark:placeholder:text-white/75 dark:focus:border-purple-1`}
+                    className={`h-12 w-[4ch] max-w-80 bg-transparent text-center text-h1 outline-none transition-colors placeholder:text-h1 focus:border-purple-1 dark:border-white dark:bg-n-1 dark:text-white dark:placeholder:text-white/75 dark:focus:border-purple-1`}
                     placeholder={'0.00'}
                     onChange={(e) => {
                         const value = utils.formatAmountWithoutComma(e.target.value)
@@ -84,6 +93,14 @@ const TokenAmountInput = ({ className, tokenValue, setTokenValue, onSubmit }: To
                     }}
                     style={{ maxWidth: `${parentWidth}px` }}
                 />
+                {maxValue && maxValue !== tokenValue && (
+                    <button
+                        onClick={handleMaxClick}
+                        className="absolute right-1 ml-1 border border-n-1 px-3 py-2 text-h7 uppercase hover:bg-n-3/10"
+                    >
+                        Max
+                    </button>
+                )}
             </div>
             {selectedTokenData?.price && !utils.estimateStableCoin(selectedTokenData.price) && (
                 <div className="flex w-full flex-row items-center justify-center gap-1">

--- a/src/components/Global/TokenAmountInput/index.tsx
+++ b/src/components/Global/TokenAmountInput/index.tsx
@@ -96,7 +96,7 @@ const TokenAmountInput = ({ className, tokenValue, setTokenValue, onSubmit, maxV
                 {maxValue && maxValue !== tokenValue && (
                     <button
                         onClick={handleMaxClick}
-                        className="absolute right-1 ml-1 bg-gray-200 px-2 py-1 text-h7 uppercase transition-colors hover:bg-black hover:text-white"
+                        className="absolute right-1 ml-1 px-2 py-1 text-h7 uppercase text-gray-1 transition-colors hover:text-black"
                     >
                         Max
                     </button>

--- a/src/hooks/useBalance.tsx
+++ b/src/hooks/useBalance.tsx
@@ -1,7 +1,7 @@
 import { useAccount } from 'wagmi'
 import * as interfaces from '@/interfaces'
-import { useEffect, useState, useRef } from 'react'
-import * as utils from '@/utils'
+import { useEffect, useState, useRef, useCallback } from 'react'
+import { areTokenAddressesEqual, isAddressZero } from '@/utils'
 
 /**
  * Custom React hook to fetch and manage user's wallet balances across multiple chains,
@@ -123,10 +123,8 @@ export const useBalance = () => {
                                 const valueB = parseFloat(b.value)
 
                                 if (valueA === valueB) {
-                                    if (utils.isAddressZero(a.address))
-                                        return -1
-                                    if (utils.isAddressZero(b.address))
-                                        return 1
+                                    if (isAddressZero(a.address)) return -1
+                                    if (isAddressZero(b.address)) return 1
 
                                     return b.amount - a.amount
                                 } else {
@@ -166,5 +164,15 @@ export const useBalance = () => {
         }
     }
 
-    return { balances, fetchBalances, valuePerChain, refetchBalances, hasFetchedBalances }
+    const balanceByToken = useCallback(
+        (chainId: string, tokenAddress: string) => {
+            if (!chainId || !tokenAddress) return undefined
+            return balances.find(
+                (balance) => balance.chainId === chainId && areTokenAddressesEqual(balance.address, tokenAddress)
+            )
+        },
+        [balances]
+    )
+
+    return { balances, fetchBalances, valuePerChain, refetchBalances, hasFetchedBalances, balanceByToken }
 }

--- a/src/hooks/useBalance.tsx
+++ b/src/hooks/useBalance.tsx
@@ -1,5 +1,5 @@
 import { useAccount } from 'wagmi'
-import * as interfaces from '@/interfaces'
+import { IUserBalance, ChainValue } from '@/interfaces'
 import { useEffect, useState, useRef, useCallback } from 'react'
 import { areTokenAddressesEqual, isAddressZero } from '@/utils'
 
@@ -8,9 +8,9 @@ import { areTokenAddressesEqual, isAddressZero } from '@/utils'
  * convert API response to a structured format, and calculate total value per chain.
  */
 export const useBalance = () => {
-    const [balances, setBalances] = useState<interfaces.IUserBalance[]>([])
+    const [balances, setBalances] = useState<IUserBalance[]>([])
     const [hasFetchedBalances, setHasFetchedBalances] = useState<boolean>(false)
-    const [valuePerChain, setValuePerChain] = useState<interfaces.ChainValue[]>([])
+    const [valuePerChain, setValuePerChain] = useState<ChainValue[]>([])
     const { address } = useAccount()
     const prevAddressRef = useRef<string | undefined>(undefined)
 
@@ -33,7 +33,7 @@ export const useBalance = () => {
             iconUrl: string
             address?: string
         }>
-    ): interfaces.IUserBalance[] {
+    ): IUserBalance[] {
         return data.map((item) => ({
             chainId: item?.chainId ? item.chainId.split(':')[1] : '1',
             address: item?.address ? item.address.split(':')[2] : '0x0000000000000000000000000000000000000000',
@@ -59,8 +59,8 @@ export const useBalance = () => {
             iconUrl: string
             address?: string
         }[]
-    ): interfaces.ChainValue[] {
-        let result: interfaces.ChainValue[] = []
+    ): ChainValue[] {
+        let result: ChainValue[] = []
 
         try {
             const chainValueMap: { [key: string]: number } = {}
@@ -89,7 +89,7 @@ export const useBalance = () => {
             let attempts = 0
             const maxAttempts = 3
             let success = false
-            let userBalances: interfaces.IUserBalance[] = []
+            let userBalances: IUserBalance[] = []
 
             while (!success && attempts < maxAttempts) {
                 try {
@@ -165,7 +165,7 @@ export const useBalance = () => {
     }
 
     const balanceByToken = useCallback(
-        (chainId: string, tokenAddress: string) => {
+        (chainId: string, tokenAddress: string): IUserBalance | undefined => {
             if (!chainId || !tokenAddress) return undefined
             return balances.find(
                 (balance) => balance.chainId === chainId && areTokenAddressesEqual(balance.address, tokenAddress)

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -235,6 +235,10 @@ export function formatAmount(amount: number) {
     return amount.toFixed(2)
 }
 
+export function floorFixed(value: number, decimals: number) {
+    return (Math.floor(value * 10 ** decimals) / 10 ** decimals).toFixed(decimals)
+}
+
 export function formatAmountWithSignificantDigits(amount: number, significantDigits: number): string {
     let fractionDigits = Math.floor(Math.log10(1 / amount)) + significantDigits
     fractionDigits = fractionDigits < 0 ? 0 : fractionDigits


### PR DESCRIPTION
This PR does the following

- Adds a max button to the claim and cashout flows where the user can select their balance for that token as input
- Adds check of value+gas before trying transaction both in claim and cashout for native tokens
- In claim suggest a new value for a native token that didn't pass previous check (in cashout is needed a bigger refactor for being able to do that, still with the previous check users should not be able to try to send more than they have)