### PR TITLE
feat: Fetch wallets from accounts

### DIFF
--- a/src/app/(mobile-ui)/home/page.tsx
+++ b/src/app/(mobile-ui)/home/page.tsx
@@ -16,6 +16,7 @@ import { shortenAddressLong } from '@/utils'
 import PointsBanner from '@/components/Home/PointsBanner'
 import { useRouter } from 'next/navigation'
 import HomeHeader from '@/components/Home/HomeHeader'
+import { useAuth } from '@/context/authContext'
 
 const cardWidth = 300
 const cardMargin = 16
@@ -28,6 +29,7 @@ const Home = () => {
     const rawIndex = wallets.findIndex((wallet) => wallet.address === selectedWallet?.address)
     const selectedWalletIndex = rawIndex === -1 ? 0 : rawIndex
     const hasWallets = wallets.length > 0
+    const { username } = useAuth()
 
     useEffect(() => {
         controls.start({
@@ -109,7 +111,7 @@ const Home = () => {
                                                     <div className="flex flex-row items-center gap-4">
                                                         <Image src={PeanutWalletIcon} alt="" />
                                                         <p className="text-md">
-                                                            peanut.me/<span className="font-bold">{'username'}</span>
+                                                            peanut.me/<span className="font-bold">{username}</span>
                                                         </p>
                                                     </div>
                                                     <p className="text-4xl font-black sm:text-5xl">$ 0.00</p>

--- a/src/app/(mobile-ui)/home/page.tsx
+++ b/src/app/(mobile-ui)/home/page.tsx
@@ -109,7 +109,7 @@ const Home = () => {
                                                     <div className="flex flex-row items-center gap-4">
                                                         <Image src={PeanutWalletIcon} alt="" />
                                                         <p className="text-md">
-                                                            peanut.me/<span className="font-bold">{wallet.handle}</span>
+                                                            peanut.me/<span className="font-bold">{'username'}</span>
                                                         </p>
                                                     </div>
                                                     <p className="text-4xl font-black sm:text-5xl">$ 0.00</p>

--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -98,8 +98,8 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
     const pathName = usePathname()
     const { back } = useRouter()
     const [isReady, setIsReady] = useState(false)
-    const { signInModal, selectedWallet, walletColor } = useWallet()
-    const { user } = useAuth()
+    const { signInModal, walletColor } = useWallet()
+    const { username } = useAuth()
     const { handleLogin, isLoggingIn } = useZeroDev()
 
     useEffect(() => {
@@ -167,14 +167,14 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
                 <div className="flex flex-col gap-2 p-5">
                     {/* TODO: Explicit by something else than username */}
                     <p>
-                        Selected Wallet: <span className="font-bold">{'username'}.peanut.wallet</span>
+                        Selected Wallet: <span className="font-bold">{username}.peanut.wallet</span>
                     </p>
                     <Button
                         loading={isLoggingIn}
                         disabled={isLoggingIn}
                         onClick={() => {
-                            if (!user?.user?.username) return
-                            handleLogin(user?.user?.username)
+                            if (!username) return
+                            handleLogin(username)
                         }}
                     >
                         Sign In

--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -12,6 +12,7 @@ import classNames from 'classnames'
 import Icon from '@/components/Global/Icon'
 import { useRouter } from 'next/navigation'
 import WalletToggleButton from '@/components/Home/WalletToggleButton'
+import { useAuth } from '@/context/authContext'
 
 type ScreenProps = {
     name: string
@@ -98,6 +99,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
     const { back } = useRouter()
     const [isReady, setIsReady] = useState(false)
     const { signInModal, selectedWallet, walletColor } = useWallet()
+    const { user } = useAuth()
     const { handleLogin, isLoggingIn } = useZeroDev()
 
     useEffect(() => {
@@ -163,16 +165,16 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
                 title={'Sign In with your Peanut Wallet'}
             >
                 <div className="flex flex-col gap-2 p-5">
+                    {/* TODO: Explicit by something else than username */}
                     <p>
-                        Selected Wallet: <span className="font-bold">{selectedWallet?.handle}.peanut.wallet</span>
+                        Selected Wallet: <span className="font-bold">{'username'}.peanut.wallet</span>
                     </p>
                     <Button
                         loading={isLoggingIn}
                         disabled={isLoggingIn}
                         onClick={() => {
-                            if (!selectedWallet) return
-                            const { handle } = selectedWallet
-                            handleLogin(handle)
+                            if (!user?.user?.username) return
+                            handleLogin(user?.user?.username)
                         }}
                     >
                         Sign In

--- a/src/app/(mobile-ui)/wallet/page.tsx
+++ b/src/app/(mobile-ui)/wallet/page.tsx
@@ -7,21 +7,36 @@ import smallPeanut from '@/assets/icons/small-peanut.png'
 import Link from 'next/link'
 import { motion } from 'framer-motion'
 import { HomeLink } from '@/components/Home/HomeLink'
+import { useAuth } from '@/context/authContext'
+import { WalletProviderType } from '@/interfaces'
 
 const WalletDetailsPage = () => {
     const { selectedWallet } = useWallet()
+    const { user } = useAuth()
+    const isActiveWalletPW = selectedWallet?.walletProviderType === WalletProviderType.PEANUT
+    const isActiveWalletBYOW = selectedWallet?.walletProviderType === WalletProviderType.BYOW
 
     return (
         <div className="flex w-full flex-row justify-center gap-2">
             <div className="flex w-[100%] flex-col gap-4 sm:w-[90%] sm:gap-2 md:w-[70%] lg:w-[35%]">
-                <Card shadowSize="4" className="w-full rounded-md py-5">
-                    <Card.Content className="flex h-full flex-row items-center justify-evenly">
-                        <img src={smallPeanut.src} className="h-15 w-15 object-contain" />
-                        <p className="text-xl sm:text-2xl">
-                            <span className="font-bold">{selectedWallet?.handle}</span>.peanut.wallet
-                        </p>
-                    </Card.Content>
-                </Card>
+                {selectedWallet && (
+                    <Card shadowSize="4" className="w-full rounded-md py-5">
+                        <Card.Content className="flex h-full flex-row items-center justify-evenly">
+                            <img src={smallPeanut.src} className="h-15 w-15 object-contain" />
+                            {isActiveWalletPW && (
+                                <p className="text-xl sm:text-2xl">
+                                    <span className="font-bold">{user?.user.username}</span>.peanut.wallet
+                                </p>
+                            )}
+                            {isActiveWalletBYOW && (
+                                <p className="text-xl sm:text-2xl">
+                                    <span className="font-bold">{selectedWallet.address}</span>.peanut.wallet
+                                </p>
+                            )}
+                        </Card.Content>
+                    </Card>
+                )}
+
                 <Card shadowSize="4" className="w-full rounded-md py-10">
                     <Card.Content className="flex h-full flex-row items-center justify-center">
                         <div className="text-5xl">{'$ 420.69'}</div>

--- a/src/components/Home/HomeHeader.tsx
+++ b/src/components/Home/HomeHeader.tsx
@@ -2,8 +2,10 @@ import { useWallet } from '@/context/walletContext'
 import useAvatar from '@/hooks/useAvatar'
 import { Button } from '../0_Bruddle'
 import { useZeroDev } from '@/context/walletContext/zeroDevContext.context'
+import { useAuth } from '@/context/authContext'
 
 const HomeHeader = () => {
+    const { username } = useAuth()
     const { selectedWallet, wallets } = useWallet()
     const hasWallets = wallets.length > 0
     const { handleLogin, isLoggingIn } = useZeroDev()
@@ -23,7 +25,7 @@ const HomeHeader = () => {
                 </div>
                 <div className="">
                     <p>www.peanute.me/</p>
-                    <p className="text-h4">{selectedWallet?.handle}</p>
+                    <p className="text-h4">{username}</p>
                 </div>
                 {hasWallets && (
                     <div>
@@ -34,8 +36,8 @@ const HomeHeader = () => {
                             variant={isConnectWallet ? 'green' : 'purple'}
                             size="small"
                             onClick={() => {
-                                if (!selectedWallet?.handle) return
-                                handleLogin(selectedWallet?.handle)
+                                if (!username) return
+                                handleLogin(username)
                             }}
                         >
                             {isConnectWallet ? 'Connected' : 'Sign In'}

--- a/src/components/Home/HomeHeader.tsx
+++ b/src/components/Home/HomeHeader.tsx
@@ -24,7 +24,7 @@ const HomeHeader = () => {
                     />
                 </div>
                 <div className="">
-                    <p>www.peanute.me/</p>
+                    <p>www.peanut.me/</p>
                     <p className="text-h4">{username}</p>
                 </div>
                 {hasWallets && (

--- a/src/components/Setup/Views/SetupPasskey.tsx
+++ b/src/components/Setup/Views/SetupPasskey.tsx
@@ -5,11 +5,12 @@ import { useSetupFlow } from '@/components/Setup/context/SetupFlowContext'
 import { useZeroDev } from '@/context/walletContext/zeroDevContext.context'
 import { PasskeyStorage } from '../Setup.helpers'
 import { useAuth } from '@/context/authContext'
+import { WalletProviderType } from '@/interfaces'
 
 const SetupPasskey = () => {
     const { handleNext, handleBack, isLoading, screenProps = { handle: '' } } = useSetupFlow()
     const { handleRegister } = useZeroDev()
-    const { fetchUser } = useAuth()
+    const { fetchUser, addAccount } = useAuth()
     const toast = useToast()
 
     const { handle } = screenProps
@@ -23,13 +24,20 @@ const SetupPasskey = () => {
 
             // once register is set, provider is setup,
             // all calls get a response and
-            // cookies are set properly, then get the user
+            // cookies are set properly, then get add the new PW
+            // as an account (calls fetchUser() interanlly on success)
             //
             // note: this was tested to ensure jwt will be set in Cookies
             // by the time we arive to fetchUser()
             //
             // TODO: ensure getUser() is properly called on reload
-            fetchUser()
+            // TODO: on login -> this will need to be just fetchUser() instead of, also, addAccount()
+            const fetchedUser = await fetchUser()
+            await addAccount({
+                accountIdentifier: account.address,
+                accountType: WalletProviderType.PEANUT,
+                userId: fetchedUser?.user.userId as string,
+            })
 
             const smartAccountAddress = account.address
 

--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -1,12 +1,12 @@
 'use client'
-import { createContext, useContext, useEffect, useState, ReactNode, useRef } from 'react'
+import { createContext, useContext, ReactNode, useRef } from 'react'
 import * as interfaces from '@/interfaces'
 import { useToast, ToastId } from '@chakra-ui/react'
-import { useZeroDev } from './walletContext/zeroDevContext.context'
+import { useQuery } from '@tanstack/react-query'
 
 interface AuthContextType {
     user: interfaces.IUserProfile | null
-    setUser: (user: interfaces.IUserProfile | null) => void
+    username: string | undefined
     fetchUser: () => Promise<interfaces.IUserProfile | null>
     updateUserName: (username: string) => Promise<void>
     submitProfilePhoto: (file: File) => Promise<void>
@@ -31,9 +31,31 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined)
  * adding accounts and logging out. It also provides hooks for child components to access user data and auth-related functions.
  */
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
-    // TODO: add handle
-    const [user, setUser] = useState<interfaces.IUserProfile | null>(null)
-    const [isFetchingUser, setIsFetchingUser] = useState(true)
+    const {
+        data: user,
+        isLoading: isFetchingUser,
+        refetch: fetchUser,
+    } = useQuery<interfaces.IUserProfile | null>({
+        queryKey: ['user'],
+        initialData: null,
+        queryFn: async () => {
+            const userResponse = await fetch('/api/peanut/user/get-user-from-cookie')
+            if (userResponse.ok) {
+                const userData: interfaces.IUserProfile | null = await userResponse.json()
+
+                return userData
+            } else {
+                console.warn('Failed to fetch user. Probably not logged in.')
+                return null
+            }
+        },
+    })
+
+    const legacy_fetchUser = async () => {
+        const { data: fetchedUser } = await fetchUser()
+        return fetchedUser ?? null
+    }
+
     const toast = useToast({
         position: 'bottom-right',
         duration: 5000,
@@ -41,40 +63,6 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         icon: '🥜',
     })
     const toastIdRef = useRef<ToastId | undefined>(undefined)
-
-    useEffect(() => {
-        fetchUser()
-    }, [])
-
-    const fetchUser = async (): Promise<interfaces.IUserProfile | null> => {
-        // @Hugo0: this logic seems a bit duplicated. We should rework with passkeys login.
-        try {
-            // const tokenAddressResponse = await fetch('/api/peanut/user/get-decoded-token')
-            // const { address: tokenAddress } = await tokenAddressResponse.json()
-            // if (address && tokenAddress && tokenAddress.toLowerCase() !== address.toLowerCase()) {
-            //     setIsFetchingUser(false)
-            //     setUser(null)
-            //     return null
-            // }
-
-            const userResponse = await fetch('/api/peanut/user/get-user-from-cookie')
-            if (userResponse.ok) {
-                const userData: interfaces.IUserProfile | null = await userResponse.json()
-                setUser(userData)
-                return userData
-            } else {
-                console.warn('Failed to fetch user. Probably not logged in.')
-                return null
-            }
-        } catch (error) {
-            console.error('ERROR WHEN FETCHING USER', error)
-            return null
-        } finally {
-            setTimeout(() => {
-                setIsFetchingUser(false)
-            }, 500)
-        }
-    }
 
     const updateUserName = async (username: string) => {
         if (!user) return
@@ -246,7 +234,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
             })
 
             if (response.ok) {
-                setUser(null)
+                fetchUser()
             } else {
                 console.error('Failed to log out user')
             }
@@ -261,9 +249,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         <AuthContext.Provider
             value={{
                 user,
-                setUser,
+                username: user?.user?.username ?? undefined,
                 updateBridgeCustomerId,
-                fetchUser,
+                fetchUser: legacy_fetchUser,
                 updateUserName,
                 submitProfilePhoto,
                 addAccount,

--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -212,8 +212,6 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         userId: string
         bridgeAccountId?: string
     }) => {
-        if (!user) return
-
         try {
             const response = await fetch('/api/peanut/user/add-account', {
                 method: 'POST',
@@ -229,10 +227,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
             })
 
             if (response.ok) {
-                const updatedUserData: any = await response.json()
-                if (updatedUserData.success) {
-                    fetchUser()
-                }
+                fetchUser()
             } else {
                 console.error('Failed to update user')
             }

--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -7,7 +7,6 @@ import { useZeroDev } from './walletContext/zeroDevContext.context'
 interface AuthContextType {
     user: interfaces.IUserProfile | null
     setUser: (user: interfaces.IUserProfile | null) => void
-    isAuthed: boolean
     fetchUser: () => Promise<interfaces.IUserProfile | null>
     updateUserName: (username: string) => Promise<void>
     submitProfilePhoto: (file: File) => Promise<void>
@@ -32,11 +31,8 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined)
  * adding accounts and logging out. It also provides hooks for child components to access user data and auth-related functions.
  */
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
-    const { address, handleLogin } = useZeroDev()
-
     // TODO: add handle
     const [user, setUser] = useState<interfaces.IUserProfile | null>(null)
-    const [isAuthed, setIsAuthed] = useState<boolean>(false)
     const [isFetchingUser, setIsFetchingUser] = useState(true)
     const toast = useToast({
         position: 'bottom-right',
@@ -47,41 +43,19 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const toastIdRef = useRef<ToastId | undefined>(undefined)
 
     useEffect(() => {
-        if (user != null) {
-            afterLoginUserSetup()
-        } else {
-            setIsAuthed(false)
-        }
-    }, [user])
-
-
-    // TODO: document better
-    // used after register too (there is a login event then too)
-    const afterLoginUserSetup = async (): Promise<undefined> => {
-        // set isAuthed
-        setIsAuthed(true)
-
-        //TODO: REMOVE THIS - ONLY FOR TESTING
-        await handleLogin('hey2')
-
-        // // fetch user wallets
-        // // set PW as active wallet
-        // setupWalletsAfterLogin()
-
-
-    }
-
+        fetchUser()
+    }, [])
 
     const fetchUser = async (): Promise<interfaces.IUserProfile | null> => {
         // @Hugo0: this logic seems a bit duplicated. We should rework with passkeys login.
         try {
-            const tokenAddressResponse = await fetch('/api/peanut/user/get-decoded-token')
-            const { address: tokenAddress } = await tokenAddressResponse.json()
-            if (address && tokenAddress && tokenAddress.toLowerCase() !== address.toLowerCase()) {
-                setIsFetchingUser(false)
-                setUser(null)
-                return null
-            }
+            // const tokenAddressResponse = await fetch('/api/peanut/user/get-decoded-token')
+            // const { address: tokenAddress } = await tokenAddressResponse.json()
+            // if (address && tokenAddress && tokenAddress.toLowerCase() !== address.toLowerCase()) {
+            //     setIsFetchingUser(false)
+            //     setUser(null)
+            //     return null
+            // }
 
             const userResponse = await fetch('/api/peanut/user/get-user-from-cookie')
             if (userResponse.ok) {
@@ -286,12 +260,13 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         }
     }
 
+    console.log({ user })
+
     return (
         <AuthContext.Provider
             value={{
                 user,
                 setUser,
-                isAuthed,
                 updateBridgeCustomerId,
                 fetchUser,
                 updateUserName,

--- a/src/context/walletContext/walletContext.tsx
+++ b/src/context/walletContext/walletContext.tsx
@@ -67,8 +67,8 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
 
     ////// Wallets
     const { data: wallets } = useQuery<interfaces.IWallet[]>({
-        queryKey: ['wallets', user?.user.userId],
-        queryFn: () => {
+        queryKey: ['wallets', user?.accounts],
+        queryFn: async () => {
             const processedWallets = user?.accounts
                 .filter((account) => Object.values(interfaces.WalletProviderType).includes(account.account_type))
                 .map((account) => ({

--- a/src/context/walletContext/walletContext.tsx
+++ b/src/context/walletContext/walletContext.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, useContext, useEffect, useState, ReactNode, useMemo, useCallback } from 'react'
+import { createContext, useContext, useEffect, useState, ReactNode, useCallback } from 'react'
 import * as interfaces from '@/interfaces'
 import { useAccount } from 'wagmi'
 
@@ -10,7 +10,6 @@ import { PasskeyStorage } from '@/components/Setup/Setup.helpers'
 import { useQuery } from '@tanstack/react-query'
 import { PEANUT_WALLET_CHAIN } from '@/constants'
 import { Chain } from 'viem'
-import { useRouter } from 'next/navigation'
 import { backgroundColorFromAddress } from '@/utils'
 import { useAuth } from '../authContext'
 
@@ -39,7 +38,7 @@ const WalletContext = createContext<WalletContextType | undefined>(undefined)
  */
 export const WalletProvider = ({ children }: { children: ReactNode }) => {
     const [promptWalletSigninOpen, setPromptWalletSigninOpen] = useState(false)
-    const { push } = useRouter()
+
     ////// ZeroDev props
     const { address: kernelClientAddress, isKernelClientReady } = useZeroDev()
 
@@ -70,14 +69,18 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
         queryKey: ['wallets', user?.accounts],
         queryFn: async () => {
             const processedWallets = user?.accounts
-                .filter((account) => Object.values(interfaces.WalletProviderType).includes(account.account_type))
+                .filter((account) =>
+                    Object.values(interfaces.WalletProviderType).includes(
+                        account.account_type as unknown as interfaces.WalletProviderType
+                    )
+                )
                 .map((account) => ({
-                    walletProviderType: account.account_type,
+                    walletProviderType: account.account_type as unknown as interfaces.WalletProviderType,
                     protocolType: interfaces.WalletProtocolType.EVM,
                     address: account.account_identifier,
                     connected: false,
                 }))
-            return processedWallets ? processedWallets : []
+            return (processedWallets ? processedWallets : []).concat(legacy_getLocalPWs())
         },
     })
 

--- a/src/context/walletContext/walletContext.tsx
+++ b/src/context/walletContext/walletContext.tsx
@@ -80,7 +80,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
                     address: account.account_identifier,
                     connected: false,
                 }))
-            return (processedWallets ? processedWallets : []).concat(legacy_getLocalPWs())
+            return processedWallets ? processedWallets : []
         },
     })
 

--- a/src/context/walletContext/walletContext.tsx
+++ b/src/context/walletContext/walletContext.tsx
@@ -73,7 +73,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
                 .filter((account) => Object.values(interfaces.WalletProviderType).includes(account.account_type))
                 .map((account) => ({
                     walletProviderType: account.account_type,
-                    protocolType: account.chain,
+                    protocolType: interfaces.WalletProtocolType.EVM,
                     address: account.account_identifier,
                     connected: false,
                 }))

--- a/src/context/walletContext/walletContext.tsx
+++ b/src/context/walletContext/walletContext.tsx
@@ -12,6 +12,7 @@ import { PEANUT_WALLET_CHAIN } from '@/constants'
 import { Chain } from 'viem'
 import { useRouter } from 'next/navigation'
 import { backgroundColorFromAddress } from '@/utils'
+import { useAuth } from '../authContext'
 
 interface WalletContextType {
     selectedWallet: interfaces.IWallet | undefined
@@ -45,43 +46,38 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
     ////// BYOW props
     const { address: wagmiAddress, isConnected: isWagmiConnected } = useAccount()
 
+    ////// User props
+    const { user } = useAuth()
+
     ////// Selected Wallet
     const [selectedWallet, setSelectedWallet] = useState<interfaces.IWallet | undefined>(undefined) // TODO: this is the var that should be exposed for the app to consume, instead of const { address } = useWallet() anywhere
 
+    const legacy_getLocalPWs = () => {
+        const localPasskeys = PasskeyStorage.list()
+        return [
+            ...localPasskeys.map(({ handle, account }) => ({
+                walletProviderType: interfaces.WalletProviderType.PEANUT,
+                protocolType: interfaces.WalletProtocolType.EVM,
+                connected: false,
+                address: account,
+                handle,
+            })),
+        ]
+    }
+
     ////// Wallets
-    const { data: wallets } = useQuery({
-        queryKey: ['wallets', kernelClientAddress, wagmiAddress],
-        queryFn: async () => {
-            /**
-             * TODO: fetch wallets from backend
-             * TODO: 2: Remove fetch & pass user?.account ?
-             */
-            const localPasskeys = PasskeyStorage.list()
-            // const walletsResponse = await fetch('/api/peanut/user/get-wallets')
-            // if (walletsResponse.ok) {
-            //     // receive in backend format
-            //     const { dbWallets }: { dbWallets: interfaces.IDBWallet[] } = await walletsResponse.json()
-            //     // manipulate to frontend format (add connected attribute)
-            //     const wallets: interfaces.IWallet[] = dbWallets.map((dbWallet: interfaces.IDBWallet) => ({
-            //         ...dbWallet,
-            //         connected: false    // this property will be processed into accurate values later in the flow
-            //     }))
-            // }
-            return [
-                // {
-                //     walletProviderType: interfaces.WalletProviderType.BYOW,
-                //     protocolType: interfaces.WalletProtocolType.EVM,
-                //     connected: false,
-                //     address: '0x7D4c7063E003CeB8B9413f63569e7AB968AF3714'
-                // },
-                ...localPasskeys.map(({ handle, account }) => ({
-                    walletProviderType: interfaces.WalletProviderType.PEANUT,
-                    protocolType: interfaces.WalletProtocolType.EVM,
+    const { data: wallets } = useQuery<interfaces.IWallet[]>({
+        queryKey: ['wallets', user?.user.userId],
+        queryFn: () => {
+            const processedWallets = user?.accounts
+                .filter((account) => Object.values(interfaces.WalletProviderType).includes(account.account_type))
+                .map((account) => ({
+                    walletProviderType: account.account_type,
+                    protocolType: account.chain,
+                    address: account.account_identifier,
                     connected: false,
-                    address: account,
-                    handle,
-                })),
-            ]
+                }))
+            return processedWallets ? processedWallets : []
         },
     })
 

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -352,11 +352,21 @@ interface User {
     full_name: string
 }
 
+// based on the API's AccountType
+// https://github.com/peanutprotocol/peanut-api-ts/blob/b32570b7bd366efed7879f607040c511fa036a57/src/db/interfaces/account.ts
+export enum AccountType {
+	IBAN = 'iban',
+	US = 'us',
+	EVM_ADDRESS = 'evm-address',
+	PEANUT_WALLET = 'peanut-wallet',
+	BRIDGE = 'bridgeBankAccount',
+}
+
 interface Account {
     account_id: string
     user_id: string
     bridge_account_id: string
-    account_type: string
+    account_type: AccountType
     account_identifier: string
     account_details: string
     created_at: string
@@ -365,7 +375,6 @@ interface Account {
     referrer: string | null
     referred_users_points: number
     totalReferralPoints: number
-    chain: string
 }
 
 export interface IUserProfile {

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -365,6 +365,7 @@ interface Account {
     referrer: string | null
     referred_users_points: number
     totalReferralPoints: number
+    chain: string
 }
 
 export interface IUserProfile {

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -362,6 +362,27 @@ export enum AccountType {
 	BRIDGE = 'bridgeBankAccount',
 }
 
+// these types should always be the same as ChainId defined in
+// src/constants/general.consts.ts -> supportedWalletconnectChains
+// previously defined here:
+// https://github.com/peanutprotocol/peanut-ui/blob/195c4a71111389b50034842e3a150fc82d827ef3/src/constants/general.consts.ts#L18
+export type ChainIdType =
+| '1'
+| '10'
+| '56'
+| '100'
+| '137'
+| '324'
+| '1101'
+| '5000'
+| '8217'
+| '8453'
+| '42161'
+| '42220'
+| '43114'
+| '7777777'
+| '1313161554';
+
 interface Account {
     account_id: string
     user_id: string
@@ -375,6 +396,7 @@ interface Account {
     referrer: string | null
     referred_users_points: number
     totalReferralPoints: number
+    chain_id: ChainIdType
 }
 
 export interface IUserProfile {

--- a/src/interfaces/wallet.interfaces.ts
+++ b/src/interfaces/wallet.interfaces.ts
@@ -1,8 +1,12 @@
 import { Address } from 'viem'
+import * as interfaces from '@/interfaces'
 
+
+// based on API AccountType
+// https://github.com/peanutprotocol/peanut-api-ts/blob/b32570b7bd366efed7879f607040c511fa036a57/src/db/interfaces/account.ts
 export enum WalletProviderType {
-    PEANUT = 'PEANUT',
-    BYOW = 'BYOW',
+    PEANUT = interfaces.AccountType.PEANUT_WALLET,
+    BYOW = interfaces.AccountType.EVM_ADDRESS,
 }
 
 export enum WalletProtocolType {
@@ -25,7 +29,6 @@ export interface IWallet extends IDBWallet {
     // and the user is logged in. That is because there is only one PW per user,
     // and the provider will always be connected to that.
     connected: boolean
-    handle: string
 }
 
 export enum WalletErrorType {


### PR DESCRIPTION
## Adds
- Logic to properly auth after register (note: does **not** work on reload)
- Logic to add PW to user accounts
- Logic to get wallets from accounts (refreshes on `user.accounts` refresh)
- `AccountType` from backend to frontend
- `ChainType` newly created here
- Update Account type with `chain` and `AccountType`

## Removes
- `handle` from `IWallet` (using `user.user.username` from `useAuth()` context)