### PR TITLE
fix: should be clearer for US users how to enter their bank account

### DIFF
--- a/src/components/Cashout/Components/Initial.view.tsx
+++ b/src/components/Cashout/Components/Initial.view.tsx
@@ -324,7 +324,7 @@ export const InitialCashoutView = ({
                                         setErrorState({
                                             showError: true,
                                             errorMessage:
-                                                'Invalid bank account. Please make sure your account is supported',
+                                                'Invalid bank account. For US bank accounts, enter your bank routing number followed by your account number.',
                                         })
                                     } else {
                                         setErrorState({

--- a/src/components/Cashout/Components/Initial.view.tsx
+++ b/src/components/Cashout/Components/Initial.view.tsx
@@ -324,7 +324,8 @@ export const InitialCashoutView = ({
                                         setErrorState({
                                             showError: true,
                                             errorMessage:
-                                                'Invalid bank account. For US bank accounts, enter your bank routing number followed by your account number.',
+                                                'Invalid bank account. For US bank accounts, enter your bank routing number (9 digits) followed by your account number \
+                                                (example: 1112223330001234567 where routing number is: 111222333 and account number: 0001234567)',
                                         })
                                     } else {
                                         setErrorState({

--- a/src/components/Cashout/Components/RecipientInfo.comp.tsx
+++ b/src/components/Cashout/Components/RecipientInfo.comp.tsx
@@ -21,15 +21,17 @@ export const RecipientInfoComponent = ({ className }: { className?: string }) =>
                         {/* TODO: these need to be standardized. It's dumb to have 10000 tw classes in here but also in Faq.comp.tsx etc... */}
                         <Menu.Items className="shadow-primary-4 absolute bottom-full left-0 z-[999] mb-1 mr-1 w-64 border border-n-1 bg-white px-4 py-2 md:left-0 md:right-auto">
                             <Menu.Item as={'label'} className={'text-h8 font-normal'}>
-                                You can claim directly to your IBAN OR US bank account. Click{' '}
+                                You can claim directly to your IBAN OR US bank account. For US bank accounts, enter your
+                                bank routing number and account number together.
+                                <br />
+                                <br />
                                 <a
                                     href="https://docs.peanut.to/app/cashout/supported-geographies"
                                     target="_blank"
                                     className="underline"
                                 >
-                                    here
-                                </a>{' '}
-                                to see if your region is supported.
+                                    Supported regions
+                                </a>
                             </Menu.Item>
                         </Menu.Items>
                     </Transition>

--- a/src/components/Cashout/Components/RecipientInfo.comp.tsx
+++ b/src/components/Cashout/Components/RecipientInfo.comp.tsx
@@ -21,8 +21,18 @@ export const RecipientInfoComponent = ({ className }: { className?: string }) =>
                         {/* TODO: these need to be standardized. It's dumb to have 10000 tw classes in here but also in Faq.comp.tsx etc... */}
                         <Menu.Items className="shadow-primary-4 absolute bottom-full left-0 z-[999] mb-1 mr-1 w-64 border border-n-1 bg-white px-4 py-2 md:left-0 md:right-auto">
                             <Menu.Item as={'label'} className={'text-h8 font-normal'}>
-                                You can claim directly to your IBAN OR US bank account. For US bank accounts, enter your
-                                bank routing number and account number together.
+                                You can claim directly to your IBAN OR US bank account.
+                                <br />
+                                <br />
+                                For US bank accounts, enter your
+                                bank routing number (9 digits) and account number together.
+                                <br />
+                                <br />
+                                Example US bank account: 1112223330001234567, with:
+                                <br />
+                                Routing number (9 digits): 111222333
+                                <br />
+                                Account number: 0001234567
                                 <br />
                                 <br />
                                 <a

--- a/src/components/Global/GeneralRecipientInput/index.tsx
+++ b/src/components/Global/GeneralRecipientInput/index.tsx
@@ -34,7 +34,9 @@ const GeneralRecipientInput = ({ placeholder, recipient, onUpdate, className }: 
                 type = 'iban'
                 isValid = await utils.validateBankAccount(recipient)
                 if (!isValid) errorMessage.current = 'Invalid IBAN, country not supported'
-            } else if (/^[0-9]{6,17}$/.test(recipient)) {
+            } else if (/^[0-9]{6,26}$/.test(recipient)) {
+                // routing number: 9 digits
+                // account number: 8-12 digits (can go up to 17)
                 type = 'us'
                 isValid = await utils.validateBankAccount(recipient)
                 if (!isValid) errorMessage.current = 'Invalid US account number'

--- a/src/components/Global/LinkAccountComponent/index.tsx
+++ b/src/components/Global/LinkAccountComponent/index.tsx
@@ -98,7 +98,8 @@ export const GlobaLinkAccountComponent = ({ accountNumber, onCompleted }: IGloba
 
             if (isIBAN(sanitizedAccountNumber)) {
                 setAccountDetailsValue('type', 'iban')
-            } else if (/^[0-9]{6,17}$/.test(sanitizedAccountNumber)) {
+                // this code is also repeated in GeneralRecipientInput.tsx
+            } else if (/^[0-9]{6,26}$/.test(sanitizedAccountNumber)) {
                 setAccountDetailsValue('type', 'us')
             } else {
                 setIbanFormError('accountNumber', { message: 'Invalid account number' })


### PR DESCRIPTION
US bank accounts have 9 digit routing number and then account number. This isn;t clear for users currently and we had 5 complaints