### PR TITLE
[TASK-6944] fix: disable autocorrect on address input

### DIFF
--- a/src/components/Global/RecipientInput/index.tsx
+++ b/src/components/Global/RecipientInput/index.tsx
@@ -20,6 +20,9 @@ const RecipientInput = ({ placeholder, value, setValue, onEnter }: RecipientInpu
                 type="text"
                 placeholder={placeholder}
                 spellCheck="false"
+                autoCorrect="off"
+                autoCapitalize="off"
+                autoComplete="off"
                 value={value}
                 onChange={(e) => setValue(e.target.value)}
                 onKeyDown={(e) => {

--- a/src/components/Global/ValidatedInput/index.tsx
+++ b/src/components/Global/ValidatedInput/index.tsx
@@ -85,6 +85,9 @@ const ValidatedInput = ({
                 bg-white px-4 pl-8 text-h8 font-medium outline-none placeholder:text-sm focus:border-purple-1 dark:border-white dark:bg-n-1 dark:text-white dark:placeholder:text-white/75 dark:focus:border-purple-1`}
                 placeholder={placeholder}
                 spellCheck="false"
+                autoCorrect="off"
+                autoCapitalize="off"
+                autoComplete="off"
             />
             {value &&
                 (isValidating ? (


### PR DESCRIPTION
Having autocorrect and autocapitalize in address inputs can lead to wrong (but valid) addresses being used and loss of funds for the users