### PR TITLE
Bypass gas estimation for Safe wallet connector

### DIFF
--- a/src/components/Create/useCreateLink.tsx
+++ b/src/components/Create/useCreateLink.tsx
@@ -22,7 +22,7 @@ export const useCreateLink = () => {
     const { selectedChainID, selectedTokenData, selectedTokenAddress } = useContext(tokenSelectorContext)
     const { balances, refetchBalances, balanceByToken } = useBalance()
 
-    const { chain: currentChain, address } = useAccount()
+    const { chain: currentChain, address, connector } = useAccount()
     const { switchChainAsync } = useSwitchChain()
     const { signTypedDataAsync } = useSignTypedData()
     const { sendTransactionAsync } = useSendTransaction()
@@ -190,7 +190,6 @@ export const useCreateLink = () => {
         if (!name) return false
         return name.toLowerCase().includes('safe')
     }
-    const { connector } = useAccount()
     const estimateGasFee = useCallback(async ({ chainId, preparedTx }: { chainId: string; preparedTx: any }) => {
         // Return early with default values for Safe connector
         if (isSafeConnector({ name: connector?.name })) {

--- a/src/components/Create/useCreateLink.tsx
+++ b/src/components/Create/useCreateLink.tsx
@@ -185,7 +185,22 @@ export const useCreateLink = () => {
             console.error('Failed to switch network:', error)
         }
     }
+    const isSafeConnector = (connector?: string) => {
+        return connector?.toLowerCase() === 'safe'
+    }
     const estimateGasFee = useCallback(async ({ chainId, preparedTx }: { chainId: string; preparedTx: any }) => {
+        const { connector } = useAccount()
+        // Return early with default values for Safe connector
+        if (isSafeConnector(connector?.name)) {
+            return {
+                feeOptions: {
+                    gasLimit: BigNumber.from(0),
+                    maxFeePerGas: BigNumber.from(0),
+                    gasPrice: BigNumber.from(0)
+                },
+                transactionCostUSD: 0
+            }
+        }
         try {
             const feeOptions = await peanut.setFeeOptions({
                 chainId: chainId,

--- a/src/components/Create/useCreateLink.tsx
+++ b/src/components/Create/useCreateLink.tsx
@@ -185,18 +185,20 @@ export const useCreateLink = () => {
             console.error('Failed to switch network:', error)
         }
     }
-    const isSafeConnector = (connector?: string) => {
-        return connector?.toLowerCase() === 'safe'
+    const isSafeConnector = (connector?: { name?: string }): boolean => {
+        const name = connector?.name
+        if (!name) return false
+        return name.toLowerCase().includes('safe')
     }
+    const { connector } = useAccount()
     const estimateGasFee = useCallback(async ({ chainId, preparedTx }: { chainId: string; preparedTx: any }) => {
-        const { connector } = useAccount()
         // Return early with default values for Safe connector
-        if (isSafeConnector(connector?.name)) {
+        if (isSafeConnector({ name: connector?.name })) {
             return {
                 feeOptions: {
-                    gasLimit: BigNumber.from(0),
-                    maxFeePerGas: BigNumber.from(0),
-                    gasPrice: BigNumber.from(0)
+                    gasLimit: BigInt(0),
+                    maxFeePerGas: BigInt(0),
+                    gasPrice: BigInt(0)
                 },
                 transactionCostUSD: 0
             }


### PR DESCRIPTION
- Added Safe wallet detection to skip gas estimation
- Safe uses Account Abstraction (AA) wallet where gas is sponsored/handled by Safe
- AA wallets don't need to hold native tokens for gas, making standard gas estimation irrelevant
- Returns default gas values (0) when Safe detected to prevent estimation errors
- Normal gas estimation flow maintained for regular wallets