### PR TITLE
[TASK-7191] [TASK-7155] [TASK-7093] Receive to peanut wallet

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ node_modules/
 .out/
 pnpm-lock.yaml
 **.md
+src/assets/

--- a/src/app/(mobile-ui)/home/page.tsx
+++ b/src/app/(mobile-ui)/home/page.tsx
@@ -95,7 +95,7 @@ export default function Home() {
                                         key={wallet.address}
                                         type="wallet"
                                         wallet={wallet}
-                                        username={username}
+                                        username={username ?? ''}
                                         selected={selectedWalletIndex === index}
                                         onClick={() => handleCardClick(index)}
                                     />

--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -3,7 +3,7 @@
 import '../../styles/globals.bruddle.css'
 import { Button, NavIcons, NavIconsName } from '@/components/0_Bruddle'
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import Modal from '@/components/Global/Modal'
 import { useWallet } from '@/context/walletContext'
 import { useZeroDev } from '@/context/walletContext/zeroDevContext.context'
@@ -103,29 +103,30 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
     const { back } = useRouter()
     const [isReady, setIsReady] = useState(false)
     const { signInModal } = useWallet()
-    const { username } = useAuth()
+    const { username, user } = useAuth()
     const { handleLogin, isLoggingIn } = useZeroDev()
 
     useEffect(() => {
         setIsReady(true)
     }, [])
 
-    if (!isReady) return null
-
     const isHome = pathName === '/home'
     const pageDefinition = pages.find((page) => page.href === pathName)
+    const showFullPeanutWallet = useMemo(() => {
+        return (user?.user.hasPwAccess ?? false) || !peanutWalletIsInPreview
+    }, [user])
 
+    if (!isReady) return null
     return (
         <div
             className="flex h-screen flex-col"
             style={{
                 backgroundColor: colorMap.lavender,
                 height: '100vh',
-                paddingBottom: '60px',
             }}
         >
             <CloudsBackground />
-            {!(isHome || peanutWalletIsInPreview) && (
+            {showFullPeanutWallet && !isHome && (
                 <div className="flex min-h-[64px] flex-row items-center border-b-2 border-black p-4">
                     <div
                         className="absolute left-2"
@@ -145,10 +146,10 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
                     'p-4': !isHome,
                 })}
             >
-                {peanutWalletIsInPreview ? <HomeWaitlist /> : children}
+                {showFullPeanutWallet ? children : <HomeWaitlist />}
             </div>
-            {!peanutWalletIsInPreview && (
-                <div className="grid grid-cols-5 border-t-2 border-black p-2">
+            {showFullPeanutWallet && (
+                <div className="z-1 grid grid-cols-5 border-t-2 border-black p-2">
                     {tabs.map((tab) => {
                         if (tab.icon === 'wallet') {
                             return <WalletToggleButton />

--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -17,6 +17,7 @@ import HomeWaitlist from '@/components/Home/HomeWaitlist'
 import { peanutWalletIsInPreview } from '@/constants'
 import CloudsBackground from '@/components/0_Bruddle/CloudsBackground'
 import { colorMap } from '@/utils'
+import { useWeb3Modal } from '@web3modal/wagmi/react'
 
 type ScreenProps = {
     name: string
@@ -104,8 +105,9 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
     const pathName = usePathname()
     const { back } = useRouter()
     const [isReady, setIsReady] = useState(false)
-    const { signInModal } = useWallet()
-    const { username, user } = useAuth()
+    const { signInModal, isConnected } = useWallet()
+    const web3Modal = useWeb3Modal()
+    const { user } = useAuth()
     const { handleLogin, isLoggingIn } = useZeroDev()
 
     useEffect(() => {
@@ -179,20 +181,38 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
                 }}
                 title={'Sign In with your Peanut Wallet'}
             >
-                <div className="flex flex-col gap-2 p-5">
-                    {/* TODO: Explicit by something else than username */}
-                    <p>
-                        Selected Wallet: <span className="font-bold">{username}.peanut.wallet</span>
-                    </p>
+                <div className="flex flex-col items-center gap-2 p-5">
                     <Button
                         loading={isLoggingIn}
                         disabled={isLoggingIn}
                         onClick={() => {
-                            if (!username) return
                             handleLogin()
                         }}
                     >
                         Sign In
+                    </Button>
+                    <Link href={'/setup'} className="text-h8 hover:underline">
+                        Don't have a penanut wallet? Get one now.
+                    </Link>
+                    <div className="my-2 flex w-full items-center gap-4">
+                        <div className="h-px flex-1 bg-gray-200" />
+                        <span className="text-sm text-gray-500">or</span>
+                        <div className="h-px flex-1 bg-gray-200" />
+                    </div>
+                    <Button
+                        loading={isLoggingIn}
+                        disabled={isLoggingIn}
+                        variant="dark"
+                        shadowType="secondary"
+                        onClick={() => {
+                            web3Modal.open().finally(() => {
+                                if (isConnected) {
+                                    signInModal.close()
+                                }
+                            })
+                        }}
+                    >
+                        Connect External Wallet
                     </Button>
                 </div>
             </Modal>

--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -98,6 +98,8 @@ const tabs: NavTabProps[] = [
     },
 ]
 
+const publicPathRegex = /^\/(request\/pay|claim)/
+
 const Layout = ({ children }: { children: React.ReactNode }) => {
     const pathName = usePathname()
     const { back } = useRouter()
@@ -113,8 +115,9 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
     const isHome = pathName === '/home'
     const pageDefinition = pages.find((page) => page.href === pathName)
     const showFullPeanutWallet = useMemo(() => {
-        return (user?.user.hasPwAccess ?? false) || !peanutWalletIsInPreview
-    }, [user])
+        const isPublicPath = publicPathRegex.test(pathName)
+        return isPublicPath || (user?.user.hasPwAccess ?? false) || !peanutWalletIsInPreview
+    }, [user, pathName])
 
     if (!isReady) return null
     return (

--- a/src/app/api/peanut/user/get-user-from-cookie/route.ts
+++ b/src/app/api/peanut/user/get-user-from-cookie/route.ts
@@ -9,8 +9,7 @@ export async function GET(request: NextRequest) {
         return new NextResponse('Bad Request: missing required parameters', { status: 400 })
     }
     try {
-        const { protocol, hostname, port } = new URL(request.url)
-        const apiUrl = `${protocol}//${hostname}:${port}/api/peanut/user/get-user`
+        const apiUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/api/peanut/user/get-user`
 
         const response = await fetch(apiUrl, {
             method: 'POST',

--- a/src/components/Global/PaymentsFooter/index.tsx
+++ b/src/components/Global/PaymentsFooter/index.tsx
@@ -1,5 +1,6 @@
 import Icon, { type IconNameType } from '@/components/Global/Icon'
 import Link from 'next/link'
+import { Button } from '@/components/0_Bruddle'
 
 interface PaymentsFooterProps {
     href?: string
@@ -13,14 +14,13 @@ export const PaymentsFooter = ({
     icon = 'profile',
 }: PaymentsFooterProps) => {
     return (
-        <Link
-            className="absolute bottom-0 flex h-20 w-[27rem] w-full flex-row items-center justify-start gap-2 border-t-[1px] border-black bg-purple-3 px-4.5 dark:text-black"
-            href={href}
-        >
-            <div className="border border-n-1 p-0 px-1">
-                <Icon name={icon} className="-mt-0.5" />
-            </div>
-            {text}
+        <Link href={href}>
+            <Button variant="stroke" className="flex flex-row justify-between text-nowrap">
+                <div className="border border-n-1 p-0 px-1">
+                    <Icon name={icon} className="-mt-0.5" />
+                </div>
+                {text}
+            </Button>
         </Link>
     )
 }

--- a/src/components/Home/WalletCard.tsx
+++ b/src/components/Home/WalletCard.tsx
@@ -9,15 +9,25 @@ import Icon from '@/components/Global/Icon'
 import { shortenAddressLong } from '@/utils'
 import { IWallet } from '@/interfaces'
 
-interface WalletCardProps {
-    type: 'wallet' | 'add'
-    wallet?: IWallet
-    username?: string
-    selected?: boolean
+type BaseWalletCardProps = {
     onClick?: () => void
+    type: 'add' | 'wallet'
 }
 
-export function WalletCard({ type, wallet, username, selected = false, onClick }: WalletCardProps) {
+type WalletCardAdd = BaseWalletCardProps & {
+    type: 'add'
+}
+
+type WalletCardWallet = BaseWalletCardProps & {
+    type: 'wallet'
+    wallet: IWallet
+    username: string
+    selected?: boolean
+}
+
+type WalletCardProps = WalletCardAdd | WalletCardWallet
+
+export function WalletCard({ type, onClick, ...props }: WalletCardProps) {
     if (type === 'add') {
         return (
             <motion.div className="h-full">
@@ -40,7 +50,7 @@ export function WalletCard({ type, wallet, username, selected = false, onClick }
         )
     }
 
-    if (!wallet) return null
+    const { wallet, username, selected = false } = props as WalletCardWallet
 
     return (
         <motion.div

--- a/src/components/Home/WalletCard.tsx
+++ b/src/components/Home/WalletCard.tsx
@@ -1,0 +1,82 @@
+import { Card } from '@/components/0_Bruddle'
+import Image from 'next/image'
+import { motion } from 'framer-motion'
+import classNames from 'classnames'
+import Link from 'next/link'
+import { formatUnits } from 'viem'
+import PeanutWalletIcon from '@/assets/icons/peanut-wallet.png'
+import Icon from '@/components/Global/Icon'
+import { shortenAddressLong } from '@/utils'
+import { IWallet } from '@/interfaces'
+
+interface WalletCardProps {
+    type: 'wallet' | 'add'
+    wallet?: IWallet
+    username?: string
+    selected?: boolean
+    onClick?: () => void
+}
+
+export function WalletCard({ type, wallet, username, selected = false, onClick }: WalletCardProps) {
+    if (type === 'add') {
+        return (
+            <motion.div className="h-full">
+                <Card
+                    className="h-full min-w-[300px] rounded-md text-black hover:cursor-pointer"
+                    shadowSize="6"
+                    onClick={onClick}
+                >
+                    <Link href="/setup" className="h-full">
+                        <Card.Content className="flex h-full flex-col items-center justify-center gap-6 p-6">
+                            <p className="text-center text-xl font-bold">Add your own ETH wallet</p>
+                            <div className="flex flex-row items-center gap-3">
+                                <Icon name="plus-circle" className="h-6 w-6" />
+                                <span className="text-base">Add BYOW wallet</span>
+                            </div>
+                        </Card.Content>
+                    </Link>
+                </Card>
+            </motion.div>
+        )
+    }
+
+    if (!wallet) return null
+
+    return (
+        <motion.div
+            className={classNames('mr-4 h-full', {
+                'opacity-40': !selected,
+            })}
+            onClick={onClick}
+            transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+        >
+            <Card
+                className={classNames(
+                    'flex h-full w-[300px] flex-col gap-4 rounded-md text-white hover:cursor-pointer',
+                    {
+                        'bg-green-1': wallet.connected,
+                        'bg-purple-1': !wallet.connected,
+                    }
+                )}
+                shadowSize="6"
+            >
+                <Card.Content className="flex h-full flex-col justify-between gap-2">
+                    <div className="flex flex-row items-center gap-4">
+                        <Image src={PeanutWalletIcon} alt="" />
+                        <p className="text-md">
+                            peanut.me/<span className="font-bold">{username}</span>
+                        </p>
+                    </div>
+                    <p className="text-4xl font-black sm:text-5xl">
+                        $ {Number(formatUnits(wallet.balance, 6)).toFixed(2)}
+                    </p>
+                    <div>
+                        <div className="flex flex-col">
+                            <p className="text-xl font-black sm:text-2xl">{shortenAddressLong(wallet.address)}</p>
+                        </div>
+                    </div>
+                </Card.Content>
+            </Card>
+        </motion.div>
+    )
+}

--- a/src/components/Request/Pay/Views/GeneralViews/AlreadyPaid.view.tsx
+++ b/src/components/Request/Pay/Views/GeneralViews/AlreadyPaid.view.tsx
@@ -101,7 +101,6 @@ export const AlreadyPaidLinkView = ({ requestLinkData }: { requestLinkData: _con
                         Discord!
                     </a>
                 </label>
-                <PaymentsFooter />
             </Card.Content>
         </Card>
     )

--- a/src/components/Request/Pay/Views/GeneralViews/AlreadyPaid.view.tsx
+++ b/src/components/Request/Pay/Views/GeneralViews/AlreadyPaid.view.tsx
@@ -1,10 +1,8 @@
 'use client'
 
-import Icon from '@/components/Global/Icon'
 import * as consts from '@/constants'
 import * as _consts from '../../Pay.consts'
-import Link from 'next/link'
-import { Button, Card } from '@/components/0_Bruddle'
+import { Card } from '@/components/0_Bruddle'
 import { ReferenceAndAttachment } from '@/components/Request/Components/ReferenceAndAttachment'
 import { PaymentsFooter } from '@/components/Global/PaymentsFooter'
 import AddressLink from '@/components/Global/AddressLink'
@@ -83,14 +81,7 @@ export const AlreadyPaidLinkView = ({ requestLinkData }: { requestLinkData: _con
                         )}
                     </div>
                 )}
-                <Link href={'/request/create'}>
-                    <Button variant="stroke" className="flex flex-row justify-between text-nowrap">
-                        <div className=" border border-n-1 p-0 px-1">
-                            <Icon name="send" className="-mt-0.5" />
-                        </div>
-                        Request a payment yourself!
-                    </Button>
-                </Link>
+                <PaymentsFooter href={'/request/create'} text="Request a payment yourself!" icon="send" />
                 <label className="text-h9 font-normal">
                     We would like to hear from your experience. Hit us up on{' '}
                     <a

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -20,7 +20,7 @@ import { useCreateLink } from '@/components/Create/useCreateLink'
 import { peanut, interfaces } from '@squirrel-labs/peanut-sdk'
 import TokenSelector from '@/components/Global/TokenSelector/TokenSelector'
 import { switchNetwork as switchNetworkUtil } from '@/utils/general.utils'
-import { Card } from '@/components/0_Bruddle'
+import { Card, Button } from '@/components/0_Bruddle'
 import { useWallet } from '@/context/walletContext'
 import { type ITokenPriceData } from '@/interfaces'
 import { ReferenceAndAttachment } from '@/components/Request/Components/ReferenceAndAttachment'
@@ -461,24 +461,16 @@ export const InitialView = ({
                     </>
                 )}
                 <div className="flex w-full flex-col items-center justify-center gap-3">
-                    <button
-                        className="wc-disable-mf btn-purple btn-xl "
+                    <Button
                         disabled={isButtonDisabled}
                         onClick={() => {
                             if (!isConnected) handleConnectWallet()
                             else if (ViewState.READY_TO_PAY === viewState) handleOnNext()
                         }}
+                        loading={viewState === ViewState.LOADING}
                     >
-                        {viewState === ViewState.LOADING ? (
-                            <div className="flex w-full flex-row items-center justify-center gap-2">
-                                <Loading /> {loadingState}
-                            </div>
-                        ) : !isConnected ? (
-                            'Connect Wallet'
-                        ) : (
-                            'Pay'
-                        )}
-                    </button>
+                        {!isConnected ? 'Connect Wallet' : 'Pay'}
+                    </Button>
                     {errorState.showError && (
                         <div className="text-center">
                             <label className=" text-h8 font-normal text-red ">{errorState.errorMessage}</label>

--- a/src/constants/general.consts.ts
+++ b/src/constants/general.consts.ts
@@ -11,6 +11,8 @@ export const infuraRpcUrls: Record<number, string> = {
     [arbitrumSepolia.id]: `https://arbitrum-sepolia.infura.io/v3/${infuraApiKey}`,
 }
 
+export const USDC_ARBITRUM_ADDRESS = '0xaf88d065e77c8cc2239327c5edb3a432268e5831'
+
 export const ipfsProviderArray = [
     'https://ipfs.io/ipfs/',
     'https://cloudflare-ipfs.com/ipfs/',

--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -237,7 +237,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
                 console.error('Failed to update user')
             }
         } catch (error) {
-            console.error('Error updating user', error)
+            console.error('Error in addAccount', error)
+            throw error
         }
     }
 

--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -5,7 +5,7 @@ import { useToast, ToastId } from '@chakra-ui/react'
 import { useWeb3Modal } from '@web3modal/wagmi/react'
 import { useQuery } from '@tanstack/react-query'
 import { hitUserMetric } from '@/utils/metrics.utils'
-import { isPwa } from '@/utils'
+import { usePWAStatus } from '@/hooks/usePWAStatus'
 
 interface AuthContextType {
     user: interfaces.IUserProfile | null
@@ -37,6 +37,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined)
  */
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const { open: web3modalOpen } = useWeb3Modal()
+    const isPwa = usePWAStatus()
     const {
         data: user,
         isFetching: isFetchingUser,
@@ -50,7 +51,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
                 const userData: interfaces.IUserProfile | null = await userResponse.json()
                 if (userData) {
                     // no await, log metric async
-                    hitUserMetric(userData.user.userId, 'login', { isPwa: isPwa() })
+                    hitUserMetric(userData.user.userId, 'login', { isPwa: isPwa })
                 }
 
                 return userData

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -351,6 +351,7 @@ interface User {
     bridge_customer_id: string | null
     full_name: string
     telegram: string | null
+    hasPwAccess: boolean
 }
 
 // based on the API's AccountType

--- a/src/interfaces/wallet.interfaces.ts
+++ b/src/interfaces/wallet.interfaces.ts
@@ -28,6 +28,7 @@ export interface IWallet extends IDBWallet {
     // and the user is logged in. That is because there is only one PW per user,
     // and the provider will always be connected to that.
     connected: boolean
+    balance: bigint
 }
 
 export enum WalletErrorType {

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -1010,7 +1010,3 @@ export async function fetchTokenSymbol(tokenAddress: string, chainId: string): P
     }
     return tokenSymbol
 }
-
-export function isPwa(): boolean {
-    return window.matchMedia('(display-mode: standalone)').matches || (window.navigator as any).standalone === true
-}


### PR DESCRIPTION
This PR does the following

- Enables peanut wallet functionality per user flag
- Opens the /request/pay and /claim pages to non users
- Allows a user with a Peanut wallet to generate a request to the peanut wallet
- Shows the correct balance on the user home

Still missing:
- Send money
- Wallet page
- Automatically choose token/chain for peanut wallet users