### PR TITLE
Fix container breaking for link input view

### DIFF
--- a/src/components/Create/Create.tsx
+++ b/src/components/Create/Create.tsx
@@ -121,7 +121,7 @@ export const Create = () => {
     }, [address])
 
     return (
-        <div className="card">
+        <div className="card max-w-lg">
             {createElement(_consts.CREATE_SCREEN_MAP[step.screen].comp, {
                 onPrev: handleOnPrev,
                 onNext: handleOnNext,

--- a/src/components/Create/Link/Input.view.tsx
+++ b/src/components/Create/Link/Input.view.tsx
@@ -277,7 +277,7 @@ export const CreateLinkInputView = ({
                           ? `Send to ${recipient.name?.endsWith('.eth') ? recipient.name : shortenAddressLong(recipient.address ?? '')}`
                           : `Send to ${recipient.name}`}
                 </h2>
-                <div className="max-w-96 text-center">
+                <div className="max-w-96 mx-auto text-center">
                     {createType === 'link' &&
                         'Deposit some crypto to the link, no need for wallet addresses. Send the link to the recipient. They will be able to claim the funds in any token on any chain from the link.'}
                     {createType === 'email_link' &&

--- a/src/components/Create/Link/Input.view.tsx
+++ b/src/components/Create/Link/Input.view.tsx
@@ -265,7 +265,7 @@ export const CreateLinkInputView = ({
     }, [_tokenValue, inputDenomination])
 
     return (
-        <div className="flex w-full flex-col items-center justify-center gap-6 text-center">
+          <div className="space-y-6 text-center">
             <div className="space-y-2">
                 <h2
                     className="max-h-[92px] w-full overflow-hidden text-h2"


### PR DESCRIPTION
hey @Hugo0 I overrode the `max-width` class for the create component since the card class was being used on other places too and fixing it directly in `tailwind config` declaration would affect the ui on other places too.

For reference the below two screenshots show the current fix implementation

The first screenshot shows how a normal email will look like
<img width="1512" alt="Screenshot 2024-12-04 at 10 33 00 PM" src="https://github.com/user-attachments/assets/eb7d6939-e0fd-4c4c-9260-f33663ec35a1">

The second screenshot shows how it would look if the email is comparatively bigger, so it will be truncated 
<img width="1512" alt="Screenshot 2024-12-04 at 10 33 14 PM" src="https://github.com/user-attachments/assets/e8002241-90f8-4ca3-acfa-d255268063d8">


Thoughts?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced styling for the Create component, improving visual appeal.
	- Simplified layout and structure for the CreateLinkInputView component, enhancing readability.
- **Bug Fixes**
	- Adjusted error message display for improved clarity.
- **Chores**
	- Minor adjustments to the conditional rendering for better responsiveness to different transaction types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->