### PR TITLE
[TASK-6773] fix: hide points estimation on consumer pages

### DIFF
--- a/src/components/Claim/Link/Initial.view.tsx
+++ b/src/components/Claim/Link/Initial.view.tsx
@@ -493,17 +493,15 @@ export const InitialClaimLinkView = ({
                                                         ]?.axelarChainName
                                                     }
                                                     <MoreInfo
-                                                        text={`You are bridging ${claimLinkData.tokenSymbol.toLowerCase()} on ${
-                                                            consts.supportedPeanutChains.find(
-                                                                (chain) =>
-                                                                    chain.chainId ===
-                                                                    selectedRoute.route.params.fromChain
-                                                            )?.name
-                                                        } to ${selectedRoute.route.estimate.toToken.symbol.toLowerCase()} on  ${
-                                                            supportedSquidChainsAndTokens[
+                                                        text={`You are bridging ${claimLinkData.tokenSymbol.toLowerCase()} on ${consts.supportedPeanutChains.find(
+                                                            (chain) =>
+                                                                chain.chainId ===
+                                                                selectedRoute.route.params.fromChain
+                                                        )?.name
+                                                            } to ${selectedRoute.route.estimate.toToken.symbol.toLowerCase()} on  ${supportedSquidChainsAndTokens[
                                                                 selectedRoute.route.params.toChain
                                                             ]?.axelarChainName
-                                                        }.`}
+                                                            }.`}
                                                     />
                                                 </>
                                             )
@@ -528,12 +526,12 @@ export const InitialClaimLinkView = ({
                                 </span>
                             </div>
 
+                            {/* TODO: correct points estimation
                             <div className="flex w-full flex-row items-center justify-between px-2 text-h8 text-gray-1">
                                 <div className="flex w-max flex-row items-center justify-center gap-1">
                                     <Icon name={'plus-circle'} className="h-4 fill-gray-1" />
                                     <label className="font-bold">Points</label>
                                 </div>
-                                {/* TODO: correct points estimation
                                 <span className="flex flex-row items-center justify-center gap-1 text-center text-sm font-normal leading-4">
                                     {estimatedPoints < 0 ? estimatedPoints : `+${estimatedPoints}`}
                                     <MoreInfo
@@ -546,8 +544,8 @@ export const InitialClaimLinkView = ({
                                         }
                                     />
                                 </span>
-                                */}
                             </div>
+                                */}
                         </div>
                     )}
                 </div>{' '}
@@ -645,10 +643,10 @@ export const InitialClaimLinkView = ({
                                         'offramp_mt_maximum',
                                         'No route found for the given token pair.',
                                     ].includes(errorState.errorMessage) && (
-                                        <label className="text-h8 font-normal text-red">
-                                            {errorState.errorMessage}
-                                        </label>
-                                    )}
+                                            <label className="text-h8 font-normal text-red">
+                                                {errorState.errorMessage}
+                                            </label>
+                                        )}
                                 </>
                             )}
                         </div>

--- a/src/components/Claim/Link/Initial.view.tsx
+++ b/src/components/Claim/Link/Initial.view.tsx
@@ -493,15 +493,17 @@ export const InitialClaimLinkView = ({
                                                         ]?.axelarChainName
                                                     }
                                                     <MoreInfo
-                                                        text={`You are bridging ${claimLinkData.tokenSymbol.toLowerCase()} on ${consts.supportedPeanutChains.find(
-                                                            (chain) =>
-                                                                chain.chainId ===
-                                                                selectedRoute.route.params.fromChain
-                                                        )?.name
-                                                            } to ${selectedRoute.route.estimate.toToken.symbol.toLowerCase()} on  ${supportedSquidChainsAndTokens[
+                                                        text={`You are bridging ${claimLinkData.tokenSymbol.toLowerCase()} on ${
+                                                            consts.supportedPeanutChains.find(
+                                                                (chain) =>
+                                                                    chain.chainId ===
+                                                                    selectedRoute.route.params.fromChain
+                                                            )?.name
+                                                        } to ${selectedRoute.route.estimate.toToken.symbol.toLowerCase()} on  ${
+                                                            supportedSquidChainsAndTokens[
                                                                 selectedRoute.route.params.toChain
                                                             ]?.axelarChainName
-                                                            }.`}
+                                                        }.`}
                                                     />
                                                 </>
                                             )
@@ -643,10 +645,10 @@ export const InitialClaimLinkView = ({
                                         'offramp_mt_maximum',
                                         'No route found for the given token pair.',
                                     ].includes(errorState.errorMessage) && (
-                                            <label className="text-h8 font-normal text-red">
-                                                {errorState.errorMessage}
-                                            </label>
-                                        )}
+                                        <label className="text-h8 font-normal text-red">
+                                            {errorState.errorMessage}
+                                        </label>
+                                    )}
                                 </>
                             )}
                         </div>

--- a/src/components/Claim/Link/Onchain/Confirm.view.tsx
+++ b/src/components/Claim/Link/Onchain/Confirm.view.tsx
@@ -195,12 +195,14 @@ export const ConfirmClaimLinkView = ({
                                     <Icon name={'arrow-next'} className="h-4 fill-gray-1" />{' '}
                                     {supportedSquidChainsAndTokens[selectedRoute.route.params.toChain]?.axelarChainName}
                                     <MoreInfo
-                                        text={`You are bridging ${claimLinkData.tokenSymbol.toLowerCase()} on ${consts.supportedPeanutChains.find(
-                                            (chain) => chain.chainId === selectedRoute.route.params.fromChain
-                                        )?.name
-                                            } to ${selectedRoute.route.estimate.toToken.symbol.toLowerCase()} on  ${supportedSquidChainsAndTokens[selectedRoute.route.params.toChain]
+                                        text={`You are bridging ${claimLinkData.tokenSymbol.toLowerCase()} on ${
+                                            consts.supportedPeanutChains.find(
+                                                (chain) => chain.chainId === selectedRoute.route.params.fromChain
+                                            )?.name
+                                        } to ${selectedRoute.route.estimate.toToken.symbol.toLowerCase()} on  ${
+                                            supportedSquidChainsAndTokens[selectedRoute.route.params.toChain]
                                                 ?.axelarChainName
-                                            }.`}
+                                        }.`}
                                     />
                                 </>
                             )}

--- a/src/components/Claim/Link/Onchain/Confirm.view.tsx
+++ b/src/components/Claim/Link/Onchain/Confirm.view.tsx
@@ -195,14 +195,12 @@ export const ConfirmClaimLinkView = ({
                                     <Icon name={'arrow-next'} className="h-4 fill-gray-1" />{' '}
                                     {supportedSquidChainsAndTokens[selectedRoute.route.params.toChain]?.axelarChainName}
                                     <MoreInfo
-                                        text={`You are bridging ${claimLinkData.tokenSymbol.toLowerCase()} on ${
-                                            consts.supportedPeanutChains.find(
-                                                (chain) => chain.chainId === selectedRoute.route.params.fromChain
-                                            )?.name
-                                        } to ${selectedRoute.route.estimate.toToken.symbol.toLowerCase()} on  ${
-                                            supportedSquidChainsAndTokens[selectedRoute.route.params.toChain]
+                                        text={`You are bridging ${claimLinkData.tokenSymbol.toLowerCase()} on ${consts.supportedPeanutChains.find(
+                                            (chain) => chain.chainId === selectedRoute.route.params.fromChain
+                                        )?.name
+                                            } to ${selectedRoute.route.estimate.toToken.symbol.toLowerCase()} on  ${supportedSquidChainsAndTokens[selectedRoute.route.params.toChain]
                                                 ?.axelarChainName
-                                        }.`}
+                                            }.`}
                                     />
                                 </>
                             )}
@@ -220,12 +218,12 @@ export const ConfirmClaimLinkView = ({
                     </span>
                 </div>
 
+                {/* TODO: correct points estimation
                 <div className="flex w-full flex-row items-center justify-between px-2 text-h8 text-gray-1">
                     <div className="flex w-max flex-row items-center justify-center gap-1">
                         <Icon name={'plus-circle'} className="h-4 fill-gray-1" />
                         <label className="font-bold">Points</label>
                     </div>
-                    {/* TODO: correct points estimation
                     <span className="flex flex-row items-center justify-center gap-1 text-center text-sm font-normal leading-4">
                         {estimatedPoints < 0 ? estimatedPoints : `+${estimatedPoints}`}
                         <MoreInfo
@@ -238,8 +236,8 @@ export const ConfirmClaimLinkView = ({
                             }
                         />
                     </span>
-                    */}
                 </div>
+                    */}
             </div>
 
             <div className="flex w-full flex-col items-center justify-center gap-2">

--- a/src/components/Create/Link/Confirm.view.tsx
+++ b/src/components/Create/Link/Confirm.view.tsx
@@ -315,12 +315,12 @@ export const CreateLinkConfirmView = ({
                         </label>
                     </div>
                 )}
+                {/* TODO: correct points estimation
                 <div className="flex w-full flex-row items-center justify-between px-2 text-h8 text-gray-1">
                     <div className="flex w-max flex-row items-center justify-center gap-1">
                         <Icon name={'plus-circle'} className="h-4 fill-gray-1" />
                         <label className="font-bold">Points</label>
                     </div>
-                    {/* TODO: correct points estimation
                     <span className="flex flex-row items-center justify-center gap-1 text-center text-sm font-normal leading-4">
                         {estimatedPoints && estimatedPoints < 0 ? estimatedPoints : `+${estimatedPoints}`}
                         <MoreInfo
@@ -335,8 +335,8 @@ export const CreateLinkConfirmView = ({
                             }
                         />
                     </span>
-                    */}
                 </div>
+                    */}
             </div>
 
             <div className="flex w-full flex-col items-center justify-center gap-2">

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -433,7 +433,7 @@ export const InitialView = ({
                             </div>
                         )}
 
-                            {/* TODO: correct points estimation
+                        {/* TODO: correct points estimation
                         <div className="flex w-full flex-row items-center justify-between px-2 text-h8 text-gray-1">
                             <div className="flex w-max flex-row items-center justify-center gap-1">
                                 <Icon name={'plus-circle'} className="h-4 fill-gray-1" />

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -433,12 +433,12 @@ export const InitialView = ({
                             </div>
                         )}
 
+                            {/* TODO: correct points estimation
                         <div className="flex w-full flex-row items-center justify-between px-2 text-h8 text-gray-1">
                             <div className="flex w-max flex-row items-center justify-center gap-1">
                                 <Icon name={'plus-circle'} className="h-4 fill-gray-1" />
                                 <label className="font-bold">Points</label>
                             </div>
-                            {/* TODO: correct points estimation
                             <span className="flex flex-row items-center justify-center gap-1 text-center text-sm font-normal leading-4">
                                 {estimatedPoints ? (
                                     `${estimatedPoints > 0 ? '+' : ''}${estimatedPoints}`
@@ -455,8 +455,8 @@ export const InitialView = ({
                                     }
                                 />
                             </span>
-                            */}
                         </div>
+                            */}
                     </>
                 )}
             </div>


### PR DESCRIPTION
hides the points estimation calculation from ui on the consumer facing pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling across multiple components for improved user feedback.
	- Conditional rendering for attachments.

- **Bug Fixes**
	- Improved logic for handling transaction errors and cross-chain transaction states.

- **Chores**
	- Removed outdated points estimation sections from user interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->