### PR TITLE
feat: Add support for whitelisted parent frame origins - Cashout

### DIFF
--- a/src/utils/cashout.utils.ts
+++ b/src/utils/cashout.utils.ts
@@ -13,15 +13,11 @@ const isInAllowedFrame = (): boolean => {
 
     // Check ancestor origins (modern browsers)
     if (window.location.ancestorOrigins?.length) {
-        return ALLOWED_PARENT_DOMAINS.some((domain) =>
-            window.location.ancestorOrigins[0].includes(domain)
-        )
+        return ALLOWED_PARENT_DOMAINS.some((domain) => window.location.ancestorOrigins[0].includes(domain))
     }
 
     // Fallback to referrer check
-    return ALLOWED_PARENT_DOMAINS.some((domain) =>
-        document.referrer.includes(domain)
-    )
+    return ALLOWED_PARENT_DOMAINS.some((domain) => document.referrer.includes(domain))
 }
 
 export const convertPersonaUrl = (url: string) => {
@@ -33,11 +29,7 @@ export const convertPersonaUrl = (url: string) => {
     const referenceId = parsedUrl.searchParams.get('reference-id')
 
     // Use parent frame origin if in allowed iframe, otherwise use current origin
-    const origin = encodeURIComponent(
-        isInAllowedFrame()
-            ? new URL(document.referrer).origin
-            : window.location.origin
-    )
+    const origin = encodeURIComponent(isInAllowedFrame() ? new URL(document.referrer).origin : window.location.origin)
 
     return `https://bridge.withpersona.com/widget?environment=production&inquiry-template-id=${templateId}&fields[iqt_token=${iqtToken}&iframe-origin=${origin}&redirect-uri=${origin}&fields[developer_id]=${developerId}&reference-id=${referenceId}`
 }

--- a/src/utils/cashout.utils.ts
+++ b/src/utils/cashout.utils.ts
@@ -5,6 +5,25 @@ import countries from 'i18n-iso-countries'
 import { generateKeysFromString } from '@squirrel-labs/peanut-sdk'
 import { getSquidRouteRaw } from '@squirrel-labs/peanut-sdk'
 
+const ALLOWED_PARENT_DOMAINS = ['intersend.io', 'app.intersend.io'];
+
+// Helper function to check if the app is running within an allowed iframe
+const isInAllowedFrame = (): boolean => {
+    if (window.location === window.parent.location) return false;
+    
+    // Check ancestor origins (modern browsers)
+    if (window.location.ancestorOrigins?.length) {
+      return ALLOWED_PARENT_DOMAINS.some(domain => 
+        window.location.ancestorOrigins[0].includes(domain)
+      );
+    }
+    
+    // Fallback to referrer check
+    return ALLOWED_PARENT_DOMAINS.some(domain => 
+      document.referrer.includes(domain)
+    );
+  };
+
 export const convertPersonaUrl = (url: string) => {
     const parsedUrl = new URL(url)
 
@@ -12,10 +31,16 @@ export const convertPersonaUrl = (url: string) => {
     const iqtToken = parsedUrl.searchParams.get('fields[iqt_token]')
     const developerId = parsedUrl.searchParams.get('fields[developer_id]')
     const referenceId = parsedUrl.searchParams.get('reference-id')
-    const origin = encodeURIComponent(window.location.origin)
 
-    return `https://bridge.withpersona.com/widget?environment=production&inquiry-template-id=${templateId}&fields[iqt_token=${iqtToken}&iframe-origin=${origin}&redirect-uri=${origin}&fields[developer_id]=${developerId}&reference-id=${referenceId}`
-}
+    // Use parent frame origin if in allowed iframe, otherwise use current origin
+    const origin = encodeURIComponent(
+        isInAllowedFrame() 
+          ? new URL(document.referrer).origin 
+          : window.location.origin
+      );
+
+      return `https://bridge.withpersona.com/widget?environment=production&inquiry-template-id=${templateId}&fields[iqt_token=${iqtToken}&iframe-origin=${origin}&redirect-uri=${origin}&fields[developer_id]=${developerId}&reference-id=${referenceId}`;
+    };
 const fetchUser = async (accountIdentifier: string): Promise<any> => {
     const response = await fetch(`/api/peanut/user/fetch-user?accountIdentifier=${accountIdentifier}`, {
         method: 'GET',

--- a/src/utils/cashout.utils.ts
+++ b/src/utils/cashout.utils.ts
@@ -5,7 +5,6 @@ import countries from 'i18n-iso-countries'
 import { generateKeysFromString } from '@squirrel-labs/peanut-sdk'
 import { getSquidRouteRaw } from '@squirrel-labs/peanut-sdk'
 
-// Add this at the top of the file or in a separate constants file
 const ALLOWED_PARENT_DOMAINS = ['intersend.io', 'app.intersend.io']
 
 // Helper function to check if the app is running within an allowed iframe

--- a/src/utils/cashout.utils.ts
+++ b/src/utils/cashout.utils.ts
@@ -5,24 +5,25 @@ import countries from 'i18n-iso-countries'
 import { generateKeysFromString } from '@squirrel-labs/peanut-sdk'
 import { getSquidRouteRaw } from '@squirrel-labs/peanut-sdk'
 
-const ALLOWED_PARENT_DOMAINS = ['intersend.io', 'app.intersend.io'];
+// Add this at the top of the file or in a separate constants file
+const ALLOWED_PARENT_DOMAINS = ['intersend.io', 'app.intersend.io']
 
 // Helper function to check if the app is running within an allowed iframe
 const isInAllowedFrame = (): boolean => {
-    if (window.location === window.parent.location) return false;
-    
+    if (window.location === window.parent.location) return false
+
     // Check ancestor origins (modern browsers)
     if (window.location.ancestorOrigins?.length) {
-      return ALLOWED_PARENT_DOMAINS.some(domain => 
-        window.location.ancestorOrigins[0].includes(domain)
-      );
+        return ALLOWED_PARENT_DOMAINS.some((domain) =>
+            window.location.ancestorOrigins[0].includes(domain)
+        )
     }
-    
+
     // Fallback to referrer check
-    return ALLOWED_PARENT_DOMAINS.some(domain => 
-      document.referrer.includes(domain)
-    );
-  };
+    return ALLOWED_PARENT_DOMAINS.some((domain) =>
+        document.referrer.includes(domain)
+    )
+}
 
 export const convertPersonaUrl = (url: string) => {
     const parsedUrl = new URL(url)
@@ -34,13 +35,14 @@ export const convertPersonaUrl = (url: string) => {
 
     // Use parent frame origin if in allowed iframe, otherwise use current origin
     const origin = encodeURIComponent(
-        isInAllowedFrame() 
-          ? new URL(document.referrer).origin 
-          : window.location.origin
-      );
+        isInAllowedFrame()
+            ? new URL(document.referrer).origin
+            : window.location.origin
+    )
 
-      return `https://bridge.withpersona.com/widget?environment=production&inquiry-template-id=${templateId}&fields[iqt_token=${iqtToken}&iframe-origin=${origin}&redirect-uri=${origin}&fields[developer_id]=${developerId}&reference-id=${referenceId}`;
-    };
+    return `https://bridge.withpersona.com/widget?environment=production&inquiry-template-id=${templateId}&fields[iqt_token=${iqtToken}&iframe-origin=${origin}&redirect-uri=${origin}&fields[developer_id]=${developerId}&reference-id=${referenceId}`
+}
+
 const fetchUser = async (accountIdentifier: string): Promise<any> => {
     const response = await fetch(`/api/peanut/user/fetch-user?accountIdentifier=${accountIdentifier}`, {
         method: 'GET',


### PR DESCRIPTION
## Description
This PR adds support for handling iframe integration with whitelisted parent domains. When the application is embedded within an allowed parent frame, it will properly use the parent's origin for Bridge widget integration.

## Changes
- Added `ALLOWED_PARENT_DOMAINS` constant to maintain a list of trusted parent domains
- Added `isInAllowedFrame` helper function to safely detect if running within an allowed iframe
- Modified `convertPersonaUrl` to use parent origin when appropriate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new constant for allowed iframe domains.
	- Added a helper function to check if the application is running within an allowed iframe.
- **Improvements**
	- Updated URL construction logic to utilize the iframe context for better origin handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->