### PR TITLE
[TASK-7729] fix: remove allowedDomains from safe connector

### DIFF
--- a/src/config/wagmi.config.tsx
+++ b/src/config/wagmi.config.tsx
@@ -28,7 +28,6 @@ const transports = Object.fromEntries(consts.chains.map((chain) => [chain.id, ht
 const connectors: CreateConnectorFn[] = [
     injected({ shimDisconnect: true }),
     safe({
-        allowedDomains: [/app.safe.global$/, /.*\.blockscout\.com$/, /^(.*\.)?intersend\.io$/],
         shimDisconnect: true,
     }),
     walletConnect({


### PR DESCRIPTION
- fixed the safe wallet connection issue by removing allowedDomains configuration from safe-connector



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified domain restrictions for the `safe` connector, potentially broadening its applicability. 

- **Bug Fixes**
	- Removed the regex pattern that matched `intersend.io` from the `allowedDomains` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->