### PR TITLE
[TASK-7669] feat: implement rpc fallback mechanism

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -14,3 +14,6 @@ global.console = {
     // warn: jest.fn(),
     // error: jest.fn(),
 }
+
+// mock console.warn
+global.console.warn = jest.fn()

--- a/src/components/Create/useCreateLink.tsx
+++ b/src/components/Create/useCreateLink.tsx
@@ -588,7 +588,7 @@ export const useCreateLink = () => {
         walletType: 'blockscout' | undefined
     }) => {
         try {
-            const provider = getChainProvider(linkDetails.chainId)
+            const provider = await getChainProvider(linkDetails.chainId)
             const getLinksFromTxResponse = await peanut.getLinksFromTx({
                 linkDetails,
                 txHash: hash,

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -43,7 +43,7 @@ async function createXChainUnsignedTx({
     requestLink: Awaited<ReturnType<typeof peanut.getRequestLinkDetails>>
     senderAddress: string
 }) {
-    const provider = getChainProvider(tokenData.chainId) || (await peanut.getDefaultProvider(tokenData.chainId))
+    const provider = (await getChainProvider(tokenData.chainId)) || (await peanut.getDefaultProvider(tokenData.chainId))
     const xchainUnsignedTxs = await peanut.prepareXchainRequestFulfillmentTransaction({
         fromToken: tokenData.address,
         fromChainId: tokenData.chainId,

--- a/src/utils/__tests__/chains.utils.test.ts
+++ b/src/utils/__tests__/chains.utils.test.ts
@@ -1,0 +1,93 @@
+import { chains } from '@/constants/chains.consts'
+import peanut from '@squirrel-labs/peanut-sdk'
+import { getChainProvider } from '../chains.utils'
+
+// mock the chains array
+jest.mock('@/constants/chains.consts', () => ({
+    chains: [
+        {
+            id: 1,
+            name: 'Ethereum',
+            rpcUrls: {
+                default: { http: ['https://eth-mainnet.infura.io/v3/your-key'] },
+                public: { http: ['https://ethereum-rpc.publicnode.com'] },
+            },
+        },
+    ],
+}))
+
+// mock the peanut SDK
+jest.mock('@squirrel-labs/peanut-sdk', () => ({
+    getDefaultProvider: jest.fn(),
+}))
+
+describe('Chain Utilities', () => {
+    // mock provider with required methods
+    const mockProvider = {
+        getNetwork: jest.fn(),
+    }
+
+    beforeEach(() => {
+        // clear all mocks before each test
+        jest.clearAllMocks()
+        // reset the mock implementation
+        mockProvider.getNetwork.mockReset()
+    })
+
+    it('should successfully return provider when Infura RPC works', async () => {
+        // setup successful infura response
+        mockProvider.getNetwork.mockResolvedValueOnce({ chainId: 1 })
+        ;(peanut.getDefaultProvider as jest.Mock).mockResolvedValueOnce(mockProvider)
+
+        const provider = await getChainProvider('1')
+
+        expect(provider).toBe(mockProvider)
+        expect(peanut.getDefaultProvider).toHaveBeenCalledWith('1')
+        expect(mockProvider.getNetwork).toHaveBeenCalled()
+    })
+
+    it('should fall back to public RPC when Infura fails', async () => {
+        // setup failed Infura response but successful public RPC
+        const failingProvider = {
+            getNetwork: jest.fn().mockRejectedValueOnce(new Error('Infura failed')),
+        }
+        const successfulPublicProvider = {
+            getNetwork: jest.fn().mockResolvedValueOnce({ chainId: 1 }),
+        }
+
+        // first call fails (Infura), second call succeeds (public RPC)
+        ;(peanut.getDefaultProvider as jest.Mock)
+            .mockResolvedValueOnce(failingProvider)
+            .mockResolvedValueOnce(successfulPublicProvider)
+
+        const provider = await getChainProvider('1')
+
+        expect(provider).toBe(successfulPublicProvider)
+        expect(peanut.getDefaultProvider).toHaveBeenCalledTimes(2)
+        expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Default RPC failed for chain 1'))
+    })
+
+    it('should throw error when chain is not found', async () => {
+        await expect(getChainProvider('999999')).rejects.toThrow('Chain 999999 not found')
+    })
+
+    it('should throw error when no public RPC is available', async () => {
+        // mock a chain without public RPC
+        const chainWithoutPublicRpc = {
+            ...chains[0],
+            rpcUrls: {
+                public: { http: [] },
+                default: { http: ['some-url'] },
+            },
+        }
+        jest.spyOn(chains, 'find').mockReturnValueOnce(chainWithoutPublicRpc)
+
+        // setup failed Infura response
+        const failingProvider = {
+            getNetwork: jest.fn().mockRejectedValueOnce(new Error('Infura failed')),
+        }
+        ;(peanut.getDefaultProvider as jest.Mock).mockResolvedValueOnce(failingProvider)
+
+        await expect(getChainProvider('1')).rejects.toThrow('No public RPC URL found for chain 1')
+    })
+})


### PR DESCRIPTION
implements an automatic fallback mechanism for RPC providers
when the default infura rpc fails, automatically tries to use public rpc endpoints

- added fallback logic to `getChainProvider` fn
- add test coverage for RPC fallback
- mock necessary dependencies for testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced blockchain chain provider retrieval with improved error handling and fallback mechanisms.

- **Bug Fixes**
	- Improved provider selection logic for different blockchain networks.

- **Tests**
	- Added comprehensive unit tests for the chain provider utility function.
	- Implemented mock setup for console warnings during testing.

- **Refactor**
	- Migrated chain provider implementation from the ethers library to the peanut SDK.
	- Updated `getChainProvider` function to be asynchronous.
	- Adjusted provider retrieval in related components to ensure proper asynchronous handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->