### PR TITLE
[TASK-8125] feat: refetch balances on link claim

### DIFF
--- a/src/components/Claim/Link/Initial.view.tsx
+++ b/src/components/Claim/Link/Initial.view.tsx
@@ -82,7 +82,8 @@ export const InitialClaimLinkView = ({
         supportedSquidChainsAndTokens,
     } = useContext(context.tokenSelectorContext)
     const { claimLink } = useClaimLink()
-    const { isConnected, address, signInModal, isExternalWallet, isPeanutWallet, selectedWallet } = useWallet()
+    const { isConnected, address, signInModal, isExternalWallet, isPeanutWallet, selectedWallet, refetchBalances } =
+        useWallet()
     const { user } = useAuth()
 
     const resetSelectedToken = useCallback(() => {
@@ -142,6 +143,7 @@ export const InitialClaimLinkView = ({
                 setClaimType('claim')
                 setTransactionHash(claimTxHash)
                 onCustom('SUCCESS')
+                refetchBalances(address ?? '')
             } else {
                 throw new Error('Error claiming link')
             }

--- a/src/components/Claim/Link/Onchain/Success.view.tsx
+++ b/src/components/Claim/Link/Onchain/Success.view.tsx
@@ -11,7 +11,7 @@ import * as _consts from '../../Claim.consts'
 
 export const SuccessClaimLinkView = ({ transactionHash, claimLinkData, type }: _consts.IClaimScreenProps) => {
     const connections = useConnections()
-    const { isConnected, address, chain: currentChain } = useWallet()
+    const { isConnected, address, chain: currentChain, isPeanutWallet } = useWallet()
     const { switchChainAsync } = useSwitchChain()
 
     const { resetTokenContextProvider, selectedChainID } = useContext(context.tokenSelectorContext)
@@ -45,11 +45,11 @@ export const SuccessClaimLinkView = ({ transactionHash, claimLinkData, type }: _
     }
 
     useEffect(() => {
-        resetTokenContextProvider()
+        if (!isPeanutWallet) resetTokenContextProvider()
         if (transactionHash && type === 'claimxchain') {
             fetchDestinationChain(transactionHash, setExplorerUrlDestChainWithTxHash)
         }
-    }, [])
+    }, [isPeanutWallet, transactionHash, type])
 
     useEffect(() => {
         if (isw3mEmailWallet && isConnected) {

--- a/src/components/Create/Create.tsx
+++ b/src/components/Create/Create.tsx
@@ -53,7 +53,7 @@ export const Create = () => {
         }[]
     >([])
 
-    const { address } = useWallet()
+    const { address, isPeanutWallet } = useWallet()
 
     const { resetTokenContextProvider } = useContext(context.tokenSelectorContext)
 
@@ -105,9 +105,11 @@ export const Create = () => {
     }
 
     useEffect(() => {
-        resetTokenContextProvider()
-        fetchAndSetCrossChainDetails()
-    }, [])
+        if (!isPeanutWallet) {
+            resetTokenContextProvider()
+            fetchAndSetCrossChainDetails()
+        }
+    }, [isPeanutWallet])
 
     useEffect(() => {
         if (address) {

--- a/src/components/Create/Link/Input.view.tsx
+++ b/src/components/Create/Link/Input.view.tsx
@@ -80,9 +80,6 @@ export const CreateLinkInputView = ({
 
     const { open } = useAppKit()
 
-    const handleConnectWallet = async () => {
-        open()
-    }
     const { selectedWallet, signInModal, isConnected, address, isExternalWallet, isPeanutWallet } = useWallet()
 
     const handleOnNext = async () => {

--- a/src/context/contextProvider.tsx
+++ b/src/context/contextProvider.tsx
@@ -3,15 +3,18 @@ import { AuthProvider } from './authContext'
 import { LoadingStateContextProvider } from './loadingStates.context'
 import { PushProvider } from './pushProvider'
 import { TokenContextProvider } from './tokenSelector.context'
+import { KernelClientProvider } from './kernelClient.context'
 
 export const ContextProvider = ({ children }: { children: React.ReactNode }) => {
     return (
         <ToastProvider>
             <AuthProvider>
                 <PushProvider>
-                    <TokenContextProvider>
-                        <LoadingStateContextProvider>{children}</LoadingStateContextProvider>
-                    </TokenContextProvider>
+                    <KernelClientProvider>
+                        <TokenContextProvider>
+                            <LoadingStateContextProvider>{children}</LoadingStateContextProvider>
+                        </TokenContextProvider>
+                    </KernelClientProvider>
                 </PushProvider>
             </AuthProvider>
         </ToastProvider>

--- a/src/context/kernelClient.context.tsx
+++ b/src/context/kernelClient.context.tsx
@@ -138,7 +138,7 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
 export const useKernelClient = (): KernelClientContextType => {
     const context = useContext(KernelClientContext)
     if (context === undefined) {
-        throw new Error('useAuth must be used within an AuthProvider')
+        throw new Error('useKernelClient must be used within a KernelClientProvider')
     }
     return context
 }

--- a/src/context/kernelClient.context.tsx
+++ b/src/context/kernelClient.context.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import { peanutPublicClient } from '@/constants/viem.consts'
+import * as consts from '@/constants/zerodev.consts'
+import { useAuth } from '@/context/authContext'
+import { useAppDispatch } from '@/redux/hooks'
+import { zerodevActions } from '@/redux/slices/zerodev-slice'
+import { getFromLocalStorage } from '@/utils'
+import { PasskeyValidatorContractVersion, toPasskeyValidator, toWebAuthnKey } from '@zerodev/passkey-validator'
+import {
+    createKernelAccount,
+    createKernelAccountClient,
+    createZeroDevPaymasterClient,
+    KernelAccountClient,
+} from '@zerodev/sdk'
+import { KERNEL_V3_1 } from '@zerodev/sdk/constants'
+import { createContext, useEffect, useState, useContext, ReactNode } from 'react'
+import { http, Transport } from 'viem'
+
+interface KernelClientContextType {
+    kernelClient: AppSmartAccountClient | undefined
+    setWebAuthnKey: (webAuthnKey: WebAuthnKey) => void
+}
+
+// types
+type AppSmartAccountClient = KernelAccountClient<Transport, typeof consts.PEANUT_WALLET_CHAIN>
+
+type WebAuthnKey = Awaited<ReturnType<typeof toWebAuthnKey>>
+
+const LOCAL_STORAGE_WEB_AUTHN_KEY = 'web-authn-key'
+
+const KernelClientContext = createContext<KernelClientContextType | undefined>(undefined)
+
+const createKernelClient = async (passkeyValidator: any) => {
+    console.log('Creating new kernel client...')
+    const kernelAccount = await createKernelAccount(peanutPublicClient, {
+        plugins: {
+            sudo: passkeyValidator,
+        },
+        entryPoint: consts.USER_OP_ENTRY_POINT,
+        kernelVersion: KERNEL_V3_1,
+    })
+
+    const kernelClient = createKernelAccountClient({
+        account: kernelAccount,
+        chain: consts.PEANUT_WALLET_CHAIN,
+        bundlerTransport: http(consts.BUNDLER_URL),
+        paymaster: {
+            getPaymasterData: async (userOperation) => {
+                const zerodevPaymaster = createZeroDevPaymasterClient({
+                    chain: consts.PEANUT_WALLET_CHAIN,
+                    transport: http(consts.PAYMASTER_URL),
+                })
+
+                try {
+                    return await zerodevPaymaster.sponsorUserOperation({
+                        userOperation,
+                        shouldOverrideFee: true,
+                    })
+                } catch (error) {
+                    console.error('Paymaster error:', error)
+                    throw error
+                }
+            },
+        },
+    })
+
+    return kernelClient
+}
+
+export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
+    const [kernelClient, setKernelClient] = useState<AppSmartAccountClient>()
+    const [webAuthnKey, setWebAuthnKey] = useState<WebAuthnKey | undefined>(undefined)
+    const dispatch = useAppDispatch()
+    const { fetchUser } = useAuth()
+
+    // lifecycle hooks
+    useEffect(() => {
+        const storedWebAuthnKey = getFromLocalStorage(LOCAL_STORAGE_WEB_AUTHN_KEY)
+        if (storedWebAuthnKey) {
+            setWebAuthnKey(storedWebAuthnKey)
+        }
+    }, [])
+
+    useEffect(() => {
+        let isMounted = true
+
+        if (!webAuthnKey) {
+            return () => {
+                isMounted = false
+            }
+        }
+
+        const initializeClient = async () => {
+            try {
+                const validator = await toPasskeyValidator(peanutPublicClient, {
+                    webAuthnKey,
+                    entryPoint: consts.USER_OP_ENTRY_POINT,
+                    kernelVersion: KERNEL_V3_1,
+                    validatorContractVersion: PasskeyValidatorContractVersion.V0_0_2,
+                })
+
+                const client = await createKernelClient(validator)
+
+                if (isMounted) {
+                    fetchUser()
+                    setKernelClient(client)
+                    dispatch(zerodevActions.setAddress(client.account!.address))
+                    dispatch(zerodevActions.setIsKernelClientReady(true))
+                    dispatch(zerodevActions.setIsRegistering(false))
+                    dispatch(zerodevActions.setIsLoggingIn(false))
+                }
+            } catch (error) {
+                console.error('Error initializing kernel client:', error)
+                dispatch(zerodevActions.setIsKernelClientReady(false))
+            }
+        }
+
+        initializeClient()
+
+        return () => {
+            isMounted = false
+        }
+    }, [webAuthnKey])
+
+    return (
+        <KernelClientContext.Provider
+            value={{
+                kernelClient,
+                setWebAuthnKey,
+            }}
+        >
+            {children}
+        </KernelClientContext.Provider>
+    )
+}
+
+export const useKernelClient = (): KernelClientContextType => {
+    const context = useContext(KernelClientContext)
+    if (context === undefined) {
+        throw new Error('useAuth must be used within an AuthProvider')
+    }
+    return context
+}

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -126,6 +126,8 @@ export const useWallet = () => {
             dispatch(walletActions.setWallets(processedWallets))
             return processedWallets
         },
+        staleTime: 30 * 1000, // 30 seconds
+        gcTime: 1 * 60 * 1000, // 1 minute
     })
 
     const selectedWallet = useMemo(() => {
@@ -224,7 +226,7 @@ export const useWallet = () => {
                 console.error('Error refetching balance:', error)
             }
         },
-        [wallets, dispatch]
+        [wallets]
     )
 
     const selectExternalWallet = useCallback(() => {


### PR DESCRIPTION
When claiming a link now we refetch the balances to show the cards with the latest information. Also added cache to the wallets query because it is being used in a hook that gets called from different components so we where fetching them every time. Now we have it cached for 30 seconds so we avoid unnecessary calls with normal navigation. This may be too little  and need to be increased but I'm not sure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added support for Peanut wallet type detection
  - Introduced Kernel Client Provider for enhanced wallet management

- **Improvements**
  - Optimized wallet balance fetching and caching
  - Refined wallet connection and initialization logic

- **Changes**
  - Updated wallet connection and context handling
  - Removed deprecated wallet connection methods

- **Technical Updates**
  - Introduced new context for managing kernel client state
  - Enhanced wallet hook with more robust state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->