### PR TITLE
fix: error state when amount exceed wallet balance

### DIFF
--- a/src/components/Create/Link/Input.view.tsx
+++ b/src/components/Create/Link/Input.view.tsx
@@ -175,6 +175,18 @@ export const CreateLinkInputView = ({
                             preparedTx: prepareDepositTxsResponse?.unsignedTxs[0],
                         })
 
+                        // if the total amount (tokenValue + estimated gas fees) exceeds the wallet balance set error
+                        const totalAmount = parseFloat(tokenValue ?? '0') + (transactionCostUSD ?? 0)
+                        const walletBalance = parseFloat(maxValue ?? '0')
+                        if (totalAmount > walletBalance) {
+                            setErrorState({
+                                showError: true,
+                                errorMessage:
+                                    'You do not have enough balance to cover the transaction fees, try again with a lower amount',
+                            })
+                            return
+                        }
+
                         _feeOptions = feeOptions
                         setFeeOptions(feeOptions)
                         setTransactionCostUSD(transactionCostUSD)
@@ -200,7 +212,7 @@ export const CreateLinkInputView = ({
                             setErrorState({
                                 showError: true,
                                 errorMessage:
-                                    'You do not have enough balance to cover the transaction fees, try again with suggested amount',
+                                    'You do not have enough balance to cover the transaction fees, try again with a lower amount',
                             })
                             return
                         }

--- a/src/utils/sdkErrorHandler.utils.tsx
+++ b/src/utils/sdkErrorHandler.utils.tsx
@@ -97,6 +97,8 @@ export const ErrorHandler = (error: any) => {
             return 'Error sending the transaction.'
         } else if (error.toString().includes('Error getting the link with transactionHash')) {
             return error.message
+        } else if (error.toString().includes('transfer amount exceeds balance')) {
+            return 'You do not have enough balance to cover the transaction fees, try again with a lower amount'
         } else {
             return 'Something failed. Please try again.'
         }


### PR DESCRIPTION
- updated the error state if `send amount + gas` exceeds wallet balance
- now preventing going to confirm send view if balance is not there for gas

fixes TASK-8303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for transactions with insufficient wallet balance
	- Enhanced user feedback when transaction fees exceed available funds
	- Clarified error message to guide users on resolving balance-related transaction issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->