### PR TITLE
feat: take 0.25% peanut fee in account for cashout

### DIFF
--- a/src/components/Global/FeeDescription/index.tsx
+++ b/src/components/Global/FeeDescription/index.tsx
@@ -141,9 +141,10 @@ const FeeDescription = ({
                             moreInfoText={
                                 isPromoApplied
                                     ? 'Fees waived with promo code!'
-                                    : accountType === 'iban'
-                                      ? 'For SEPA transactions a fee of $1 is charged. For ACH transactions a fee of $0.50 is charged.'
-                                      : 'For ACH transactions a fee of $0.50 is charged. For SEPA transactions a fee of $1 is charged.'
+                                    : (accountType === 'iban'
+                                          ? 'For SEPA transactions a fee of $1 is charged. For ACH transactions a fee of $0.50 is charged.'
+                                          : 'For ACH transactions a fee of $0.50 is charged. For SEPA transactions a fee of $1 is charged.') +
+                                      ' Peanut fees are 0.25% of the cashout amount.'
                             }
                             loading={loading}
                         />

--- a/src/components/Global/FeeDescription/index.tsx
+++ b/src/components/Global/FeeDescription/index.tsx
@@ -142,8 +142,8 @@ const FeeDescription = ({
                                 isPromoApplied
                                     ? 'Fees waived with promo code!'
                                     : (accountType === 'iban'
-                                          ? 'For SEPA transactions a fee of $1 is charged. For ACH transactions a fee of $0.50 is charged.'
-                                          : 'For ACH transactions a fee of $0.50 is charged. For SEPA transactions a fee of $1 is charged.') +
+                                          ? 'For SEPA transactions a flat fee of $1 is charged. For ACH transactions a flat fee of $0.50 is charged.'
+                                          : 'For ACH transactions a flat fee of $0.50 is charged. For SEPA transactions a flat fee of $1 is charged.') +
                                       ' Peanut fees are 0.25% of the cashout amount.'
                             }
                             loading={loading}

--- a/src/components/Offramp/Success.view.tsx
+++ b/src/components/Offramp/Success.view.tsx
@@ -1,10 +1,10 @@
 'use client'
 import Icon from '@/components/Global/Icon'
-import Link from 'next/link'
-import * as _consts from './Offramp.consts'
 import MoreInfo from '@/components/Global/MoreInfo'
 import { useAuth } from '@/context/authContext'
 import * as utils from '@/utils'
+import Link from 'next/link'
+import * as _consts from './Offramp.consts'
 
 export const OfframpSuccessView = ({
     offrampForm, // available on all offramps
@@ -61,7 +61,7 @@ export const OfframpSuccessView = ({
                                 text={
                                     appliedPromoCode
                                         ? `Fees waived with promo code ${appliedPromoCode}`
-                                        : `For ${accountType === 'iban' ? 'SEPA' : 'ACH'} transactions a fee of ${
+                                        : `For ${accountType === 'iban' ? 'SEPA' : 'ACH'} transactions a flat fee of ${
                                               accountType === 'iban' ? '$1' : '$0.50'
                                           } is charged.`
                                 }

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -451,7 +451,9 @@ export const InitialView = ({
                             }
                             estimatedFee={feeCalculations.estimatedFee}
                             networkFee={feeCalculations.networkFee.max}
-                            maxSlippage={feeCalculations.slippage ? feeCalculations.slippage.max.toString() : undefined}
+                            maxSlippage={
+                                feeCalculations.slippage ? formatAmount(feeCalculations.slippage.max) : undefined
+                            }
                         />
 
                         <InfoRow


### PR DESCRIPTION
fixes TASK-8571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced fee details now include additional information on banking charges, such as a 0.25% fee on cashout amounts.
  - Improved display of fee-related values for clearer user understanding.
  - Clarified fee descriptions by specifying "flat fee" for SEPA and ACH transactions.

- **Refactor**
  - Updated fee computation to ensure consistent calculations across the payment and confirmation screens.
  - Enhanced formatting of slippage values for improved presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->