### PR TITLE
fix: refetch wallet balance after claim/req-pay/send flow completion

### DIFF
--- a/src/components/Claim/useClaimLink.tsx
+++ b/src/components/Claim/useClaimLink.tsx
@@ -11,7 +11,7 @@ import { useWallet } from '@/hooks/wallet/useWallet'
 import * as utils from '@/utils'
 
 export const useClaimLink = () => {
-    const { chain: currentChain } = useWallet()
+    const { chain: currentChain, refetchBalances } = useWallet()
     const { switchChainAsync } = useSwitchChain()
 
     const { setLoadingState } = useContext(context.loadingStateContext)
@@ -25,6 +25,9 @@ export const useClaimLink = () => {
                 baseUrl: `${consts.next_proxy_url}/claim-v2`,
                 APIKey: 'doesnt-matter',
             })
+
+            // refetch wallet balance after successful claim
+            await refetchBalances(address)
 
             return claimTx.transactionHash ?? claimTx.txHash ?? claimTx.hash ?? claimTx.tx_hash ?? ''
         } catch (error) {

--- a/src/components/Claim/useClaimLink.tsx
+++ b/src/components/Claim/useClaimLink.tsx
@@ -27,7 +27,7 @@ export const useClaimLink = () => {
             })
 
             // refetch wallet balance after successful claim
-            await refetchBalances(address)
+            refetchBalances(address)
 
             return claimTx.transactionHash ?? claimTx.txHash ?? claimTx.hash ?? claimTx.tx_hash ?? ''
         } catch (error) {

--- a/src/components/Create/useCreateLink.tsx
+++ b/src/components/Create/useCreateLink.tsx
@@ -761,7 +761,8 @@ export const useCreateLink = () => {
                 transaction: type === 'deposit' ? response && response.unsignedTxs[0] : undefined,
             })
 
-            await refetchBalances(address ?? '')
+            // refetch wallet balance after successful link creation
+            await refetchBalances(selectedWallet?.address || '')
 
             return link[0]
         } catch (error) {

--- a/src/components/Create/useCreateLink.tsx
+++ b/src/components/Create/useCreateLink.tsx
@@ -762,7 +762,7 @@ export const useCreateLink = () => {
             })
 
             // refetch wallet balance after successful link creation
-            await refetchBalances(selectedWallet?.address || '')
+            refetchBalances(selectedWallet?.address || '')
 
             return link[0]
         } catch (error) {

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -335,7 +335,7 @@ export const InitialView = ({
                 onNext()
 
                 // update wallet balance after successful req payment
-                await refetchBalances(address)
+                refetchBalances(address)
             } else {
                 if (!xChainUnsignedTxs) {
                     throw new Error('Cross-chain transaction data not ready')

--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -32,7 +32,6 @@ import {
     switchNetwork as switchNetworkUtil,
 } from '@/utils/general.utils'
 import { checkTokenSupportsXChain } from '@/utils/token.utils'
-import { useAppKit } from '@reown/appkit/react'
 import { interfaces, peanut } from '@squirrel-labs/peanut-sdk'
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { useAccount, useSwitchChain } from 'wagmi'
@@ -81,7 +80,7 @@ export const InitialView = ({
     estimatedPoints,
 }: _consts.IPayScreenProps) => {
     const { sendTransactions, checkUserHasEnoughBalance } = useCreateLink()
-    const { address, signInModal, selectedWallet, chain: currentChain, isPeanutWallet } = useWallet()
+    const { address, signInModal, selectedWallet, chain: currentChain, isPeanutWallet, refetchBalances } = useWallet()
     const { isConnected: isExternalWalletConnected } = useAccount()
     const { handleLogin } = useZeroDev()
     const toast = useToast()
@@ -89,8 +88,7 @@ export const InitialView = ({
     const isConnected = isExternalWalletConnected || isPeanutWallet
 
     const { switchChainAsync } = useSwitchChain()
-    const { open } = useAppKit()
-    const { setLoadingState, loadingState, isLoading } = useContext(context.loadingStateContext)
+    const { setLoadingState, isLoading } = useContext(context.loadingStateContext)
     const {
         selectedTokenData,
         selectedChainID,
@@ -335,6 +333,9 @@ export const InitialView = ({
 
                 setTransactionHash(hash ?? '')
                 onNext()
+
+                // update wallet balance after successful req payment
+                await refetchBalances(address)
             } else {
                 if (!xChainUnsignedTxs) {
                     throw new Error('Cross-chain transaction data not ready')

--- a/src/components/Request/Pay/Views/Success.view.tsx
+++ b/src/components/Request/Pay/Views/Success.view.tsx
@@ -1,4 +1,3 @@
-import * as assets from '@/assets'
 import { Card } from '@/components/0_Bruddle'
 import AddressLink from '@/components/Global/AddressLink'
 import { PaymentsFooter } from '@/components/Global/PaymentsFooter'
@@ -79,20 +78,22 @@ export const SuccessView = ({ transactionHash, requestLinkData, tokenPriceData }
             fetchDestinationChain(transactionHash, setExplorerUrlDestChainWithTxHash)
         }
     }, [])
-    if (isLoading) {
-        return (
-            <div className="flex flex-col items-center justify-center gap-4">
-                <div className="animate-spin">
-                    <img src={assets.PEANUTMAN_LOGO.src} alt="logo" className="h-6 sm:h-10" />
-                    <span className="sr-only">{loadingState}</span>
-                </div>
 
-                <label className="text-h8 font-bold ">
-                    Funds are on their way to <AddressLink address={requestLinkData.recipientAddress} />!
-                </label>
-            </div>
-        )
-    }
+    // todo: manage loading state properly, currently it keeps loading forever
+    // if (isLoading) {
+    //     return (
+    //         <div className="flex flex-col items-center justify-center gap-4">
+    //             <div className="animate-spin">
+    //                 <img src={assets.PEANUTMAN_LOGO.src} alt="logo" className="h-6 sm:h-10" />
+    //                 <span className="sr-only">{loadingState}</span>
+    //             </div>
+
+    //             <label className="text-h8 font-bold ">
+    //                 Funds are on their way to <AddressLink address={requestLinkData.recipientAddress} />!
+    //             </label>
+    //         </div>
+    //     )
+    // }
 
     return (
         <Card className="w-full shadow-none sm:shadow-primary-4">


### PR DESCRIPTION
- fixes TASK-8586
- request pay, claim funds and send funds flow now properly updates wallet balances

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Wallet balance now refreshes automatically after completing transactions (claims, link creation, and payments), ensuring your account always shows the latest information.

- **Bug Fixes**
	- Improved how the correct wallet address is used during balance updates.
	- Removed an unnecessary loading screen in the payment success view for a smoother transaction experience.
	- Adjusted loading state management in the InitialView component for better user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->