### PR TITLE
fix: remove network cost loading dep from req pay

### DIFF
--- a/src/components/Request/Pay/Views/Initial.view.tsx
+++ b/src/components/Request/Pay/Views/Initial.view.tsx
@@ -444,11 +444,7 @@ export const InitialView = ({
                 {!isFeeEstimationError && (
                     <>
                         <FeeDescription
-                            loading={
-                                Number(feeCalculations.estimatedFee) === 0 ||
-                                Number(feeCalculations.networkFee.expected) === 0 ||
-                                (!isPayInitiatedByUser && isLoading)
-                            }
+                            loading={Number(feeCalculations.estimatedFee) === 0 || (!isPayInitiatedByUser && isLoading)}
                             estimatedFee={feeCalculations.estimatedFee}
                             networkFee={feeCalculations.networkFee.max}
                             maxSlippage={


### PR DESCRIPTION
fixes TASK-8841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the display of loading indicators during payment processing. The loading cues in fee details now activate only when appropriate, ensuring more consistent and accurate feedback for users during transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->