### PR TITLE
fix: claim flow state updates lead to claiming funds on xChain in peanut wallet

### DIFF
--- a/src/components/Claim/Link/Initial.view.tsx
+++ b/src/components/Claim/Link/Initial.view.tsx
@@ -629,9 +629,14 @@ export const InitialClaimLinkView = ({
                                     // force cross-chain route for Peanut Wallet if chain doesn't match
                                     setRefetchXchainRoute(true)
                                     onNext()
+                                } else if (recipientType === 'iban' || recipientType === 'us') {
+                                    // handle IBAN/US bank account claims
+                                    handleIbanRecipient()
                                 } else if (hasFetchedRoute && selectedRoute) {
+                                    // handle  cross-chain claims
                                     onNext()
                                 } else {
+                                    // handle direct claims
                                     handleClaimLink()
                                 }
                             }}


### PR DESCRIPTION
fixes TASK-8881, where on the claim flow, switching wallets back and forth using wallet header would lead to claiming funds on sent network in peanut wallet even tho should only have happened with USDC on Arb

also fixes state update issue in the recipient input when requesting funds and switching from peanut wallet to external wallet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Wallet and recipient handling has been improved. Now, when the wallet connection or type changes, related selections and validations reset automatically.
	- Button labels and error messages have been refined, offering clearer instructions and feedback to ensure a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->