### PR TITLE
fix: remove points from profile section on home page

### DIFF
--- a/src/components/Profile/Components/ProfileSection.tsx
+++ b/src/components/Profile/Components/ProfileSection.tsx
@@ -17,7 +17,7 @@ const ProfileSection = ({}: ProfileSectionProps) => {
     }
 
     return (
-        <div className="space-y-4">
+        <div className="space-y-4 py-2">
             <div className="flex items-center justify-between gap-4">
                 <div className="flex items-center gap-4">
                     <Image
@@ -45,7 +45,8 @@ const ProfileSection = ({}: ProfileSectionProps) => {
                     <CopyToClipboard fill="black" textToCopy={`https://peanut.me/${user?.user.username}`} />
                 </div>
             </div>
-            <div className="border-t border-dashed border-black">
+            {/* todo: revisit later, commenting out for now */}
+            {/* <div className="border-t border-dashed border-black">
                 {
                     <div className="flex justify-between py-2">
                         {Object.entries(points).map(([key, value]) => (
@@ -56,7 +57,7 @@ const ProfileSection = ({}: ProfileSectionProps) => {
                         ))}
                     </div>
                 }
-            </div>
+            </div> */}
         </div>
     )
 }


### PR DESCRIPTION
fixes TASK-8964 - removed points from profile section in home page

preview:
<img width="657" alt="image" src="https://github.com/user-attachments/assets/d8adb582-628d-41dd-9317-53cd73509335" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the profile layout with enhanced vertical spacing for a cleaner look.

- **Refactor**
  - Temporarily removed the display of user rewards points and invitation details from the profile view, while maintaining core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->