### PR TITLE
[TASK-9019] fix: dont trim handle with space

### DIFF
--- a/src/components/Setup/Views/Signup.tsx
+++ b/src/components/Setup/Views/Signup.tsx
@@ -77,7 +77,7 @@ const SignupStep = () => {
         isChanging: boolean
         isValid: boolean
     }) => {
-        dispatch(setupActions.setHandle(value.trim().toLowerCase()))
+        dispatch(setupActions.setHandle(value.toLowerCase()))
         setIsValid(isValid)
         setIsChanging(isChanging)
 


### PR DESCRIPTION
This was causing the validator to hang because the change in value was not being registered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the signup input handling so that user entries are now converted to lowercase without trimming whitespace. This change affects how handles are processed during sign-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->