### PR TITLE
feat: hide rewards wallet on non-pinta flow

### DIFF
--- a/src/components/Global/FlowHeader/index.tsx
+++ b/src/components/Global/FlowHeader/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/0_Bruddle'
+import { usePathname } from 'next/navigation'
 import Icon from '../Icon'
 import WalletHeader from '../WalletHeader'
 
@@ -7,6 +8,7 @@ interface FlowHeaderProps {
     disableBackBtn?: boolean
     disableWalletHeader?: boolean
     hideWalletHeader?: boolean
+    isPintaReq?: boolean
 }
 
 const FlowHeader = ({
@@ -14,7 +16,14 @@ const FlowHeader = ({
     disableBackBtn,
     disableWalletHeader = false,
     hideWalletHeader = false,
+    isPintaReq = false,
 }: FlowHeaderProps) => {
+    const pathname = usePathname()
+    const isSendPage = pathname === '/send'
+    const isCashoutPage = pathname === '/cashout'
+    const isCreateReqPage = pathname === '/request/create'
+    const hideRewardsWallet = isSendPage || isCashoutPage || isCreateReqPage || !isPintaReq
+
     return (
         <div className="flex w-full flex-row items-center justify-between pb-3">
             {onPrev && (
@@ -23,7 +32,11 @@ const FlowHeader = ({
                 </Button>
             )}
             {!hideWalletHeader && (
-                <WalletHeader disabled={disableWalletHeader} className={onPrev ? 'w-fit' : 'w-full'} />
+                <WalletHeader
+                    disabled={disableWalletHeader}
+                    className={onPrev ? 'w-fit' : 'w-full'}
+                    hideRewardsWallet={hideRewardsWallet}
+                />
             )}
         </div>
     )

--- a/src/components/Global/RewardsModal/index.tsx
+++ b/src/components/Global/RewardsModal/index.tsx
@@ -23,7 +23,13 @@ export const RewardDetails = () => {
 
 export const PartnerBarLocation = () => {
     return (
-        <Link href={'#'} rel="noreferrer noopenner" target="_blank" className="font-semibold underline">
+        <Link
+            // casa temple location
+            href={'https://maps.app.goo.gl/DmHaJzjKuCQLSRD27'}
+            rel="noreferrer noopenner"
+            target="_blank"
+            className="font-semibold underline"
+        >
             partner bar.
         </Link>
     )

--- a/src/components/Global/WalletHeader/index.tsx
+++ b/src/components/Global/WalletHeader/index.tsx
@@ -31,6 +31,7 @@ interface WalletEntryCardProps {
     wallet: IWallet
     isActive?: boolean
     onClick: () => void
+    hasConnectedExternalWallets: boolean
 }
 
 interface WalletIconContainerProps {
@@ -253,6 +254,7 @@ const WalletHeader = ({ className, disabled, hideRewardsWallet = false }: Wallet
                                 wallet={wallet}
                                 isActive={wallet.id === selectedWallet?.id}
                                 onClick={() => handleWalletSelection(wallet)}
+                                hasConnectedExternalWallets={hasConnectedExternalWallets}
                             />
                         ))}
                         <AddNewWallet
@@ -268,10 +270,16 @@ const WalletHeader = ({ className, disabled, hideRewardsWallet = false }: Wallet
 }
 
 // individual wallet card component
-const WalletEntryCard: React.FC<WalletEntryCardProps> = ({ wallet, isActive, onClick }) => {
+const WalletEntryCard: React.FC<WalletEntryCardProps> = ({
+    wallet,
+    isActive,
+    onClick,
+    hasConnectedExternalWallets,
+}) => {
     const { username } = useAuth()
     const { isWalletConnected } = useWallet()
     const [showConfirmationModal, setShowConfirmationModal] = useState(false)
+    const { connectWallet } = useWalletConnection()
 
     const isExternalWallet = useMemo(() => wallet.walletProviderType !== WalletProviderType.PEANUT, [wallet])
     const isPeanutWallet = useMemo(() => wallet.walletProviderType === WalletProviderType.PEANUT, [wallet])
@@ -297,8 +305,15 @@ const WalletEntryCard: React.FC<WalletEntryCardProps> = ({ wallet, isActive, onC
     })
 
     const handleCardClick = () => {
+        // for external wallets that are not connected
         if (isExternalWallet && !isConnected) {
-            setShowConfirmationModal(true)
+            // if there's already a connected external wallet, show confirmation modal
+            if (hasConnectedExternalWallets) {
+                setShowConfirmationModal(true)
+            } else {
+                // show reown modal directly
+                connectWallet()
+            }
         } else {
             onClick()
         }

--- a/src/components/Home/WalletCard.tsx
+++ b/src/components/Home/WalletCard.tsx
@@ -11,10 +11,10 @@ import { usePrimaryName } from '@justaname.id/react'
 import classNames from 'classnames'
 import { motion } from 'framer-motion'
 import Image from 'next/image'
-import Link from 'next/link'
 import { useMemo } from 'react'
 import { twMerge } from 'tailwind-merge'
 import CopyToClipboard from '../Global/CopyToClipboard'
+import { PartnerBarLocation } from '../Global/RewardsModal'
 
 const WALLET_CARD_WIDTH = 'w-[300px]'
 const WALLET_COLORS = ['bg-secondary-3', 'bg-secondary-1', 'bg-primary-1']
@@ -297,9 +297,9 @@ function WalletIdentifier({
         return (
             <p>
                 Claim at{' '}
-                <Link href={'#'} rel="noreferrer noopenner" className="underline" target="_blank">
-                    partners bars
-                </Link>
+                <span onClick={(e) => e.stopPropagation()}>
+                    <PartnerBarLocation />
+                </span>
             </p>
         )
     }

--- a/src/components/Payment/PaymentForm/index.tsx
+++ b/src/components/Payment/PaymentForm/index.tsx
@@ -396,13 +396,13 @@ export const PaymentForm = ({ recipient, amount, token, chain }: ParsedURL) => {
                                     className="flex items-center gap-0.5 text-sm font-semibold hover:underline"
                                 >
                                     <span>Download</span>
-                                    <Icon name="download" className="fill-grey-1 h-4" />
+                                    <Icon name="download" className="h-4 fill-grey-1" />
                                 </a>
                             }
                         />
                     )}
                 </div>
-                <div className="text-grey-1 mt-4 text-xs">
+                <div className="mt-4 text-xs text-grey-1">
                     You can choose to pay with any token on any network. The payment will be automatically converted to
                     the requested token.
                 </div>
@@ -507,7 +507,7 @@ export const PaymentForm = ({ recipient, amount, token, chain }: ParsedURL) => {
             )}
 
             {!isPeanutWallet && !requestId && (
-                <div className="text-grey-1 mt-4 text-xs">
+                <div className="mt-4 text-xs text-grey-1">
                     You can choose to pay with any token on any network. The payment will be automatically converted to
                     the requested token.
                 </div>

--- a/src/components/Payment/PaymentForm/index.tsx
+++ b/src/components/Payment/PaymentForm/index.tsx
@@ -11,11 +11,12 @@ import TokenSelector from '@/components/Global/TokenSelector/TokenSelector'
 import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants'
 import * as context from '@/context'
 import { useWallet } from '@/hooks/wallet/useWallet'
-import { AccountType } from '@/interfaces'
+import { AccountType, WalletProviderType } from '@/interfaces'
 import { ParsedURL } from '@/lib/url-parser/types/payment'
 import { getReadableChainName } from '@/lib/validation/resolvers/chain-resolver'
 import { useAppDispatch, usePaymentStore } from '@/redux/hooks'
 import { paymentActions } from '@/redux/slices/payment-slice'
+import { walletActions } from '@/redux/slices/wallet-slice'
 import { chargesApi } from '@/services/charges'
 import { requestsApi } from '@/services/requests'
 import { CreateChargeRequest } from '@/services/services.types'
@@ -36,7 +37,7 @@ import { PaymentInfoRow } from '../PaymentInfoRow'
 export const PaymentForm = ({ recipient, amount, token, chain }: ParsedURL) => {
     const dispatch = useAppDispatch()
     const { attachmentOptions, requestDetails, error, chargeDetails } = usePaymentStore()
-    const { signInModal, isPeanutWallet, selectedWallet, isExternalWallet, isWalletConnected } = useWallet()
+    const { signInModal, isPeanutWallet, selectedWallet, isExternalWallet, isWalletConnected, wallets } = useWallet()
     const [initialSetupDone, setInitialSetupDone] = useState(false)
     const [isSubmitting, setIsSubmitting] = useState(false)
     const [displayTokenAmount, setDisplayTokenAmount] = useState<string>(
@@ -454,9 +455,20 @@ export const PaymentForm = ({ recipient, amount, token, chain }: ParsedURL) => {
         }
     }, [chargeDetails, resetTokenAndChain])
 
+    // handle auto-selection of rewards wallet if token is PNT
+    useEffect(() => {
+        if (token?.symbol === 'PNT' && wallets) {
+            const rewardsWallet = wallets.find((wallet) => wallet.walletProviderType === WalletProviderType.REWARDS)
+
+            if (rewardsWallet) {
+                dispatch(walletActions.setSelectedWalletId(rewardsWallet.id))
+            }
+        }
+    }, [token?.symbol, wallets, dispatch])
+
     return (
         <div className="space-y-4">
-            <FlowHeader hideWalletHeader={!isConnected} />
+            <FlowHeader hideWalletHeader={!isConnected} isPintaReq={token?.symbol === 'PNT'} />
 
             {/* Show recipient from parsed data */}
             <div className="text-h6 font-bold">


### PR DESCRIPTION
- contributes to TASK-9504 : hide rewards wallet on other flows
- contributes to TASK-9284 : close wallet header on wallet selction 
- contributes to TASK-9349 : auto select pinta wallet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced wallet display: Wallet headers now dynamically adjust rewards visibility based on the current page and the new `isPintaReq` context.
	- Streamlined payment experience: For "PNT" tokens, the system automatically selects the appropriate rewards wallet.
	- Improved wallet selection: The wallet modal now automatically closes after a wallet is chosen.
	- Updated external link for the partner location in the rewards modal.
	- New visual representation for the partner location in the wallet card.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->