### PR TITLE
fix: open in pwa after install

### DIFF
--- a/src/components/Setup/Views/InstallPWA.tsx
+++ b/src/components/Setup/Views/InstallPWA.tsx
@@ -118,7 +118,6 @@ const InstallPWA = ({
         } else if (outcome === 'accepted') {
             setTimeout(() => {
                 setInstallComplete(true)
-                window.location.href = window.location.origin + '/setup'
                 dispatch(setupActions.setLoading(false))
             }, 5000)
         }
@@ -226,7 +225,7 @@ const InstallPWA = ({
                 loading={isLoading}
                 disabled={isLoading}
                 onClick={() => {
-                    if (isUnsupportedBrowser) {
+                    if (isUnsupportedBrowser || installComplete) {
                         // Open in default browser
                         window.open(window.location.origin + '/setup', '_blank')
                     } else if (canInstall) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the installation experience: After installation or when a browser is unsupported, users can now click the button to open the setup page in a new tab instead of being automatically redirected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->