### PR TITLE
fix: install in the app cta

### DIFF
--- a/src/components/Setup/Views/InstallPWA.tsx
+++ b/src/components/Setup/Views/InstallPWA.tsx
@@ -237,7 +237,7 @@ const InstallPWA = ({
                 className="w-full"
                 shadowSize="4"
             >
-                {isUnsupportedBrowser ? 'Open in Main Browser' : installComplete ? 'Done' : 'Install App'}
+                {isUnsupportedBrowser ? 'Open in Main Browser' : installComplete ? 'Open in the App' : 'Install App'}
             </Button>
 
             <Modal


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the installation button label to guide users more clearly. After installation is complete, the button now reads "Open in the App," while other conditions retain their previous messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->