### PR TITLE
fix: use justaname batch api call for resolving to ens

### DIFF
--- a/src/app/(mobile-ui)/home/page.tsx
+++ b/src/app/(mobile-ui)/home/page.tsx
@@ -18,6 +18,7 @@ import { WalletProviderType } from '@/interfaces'
 import { useAppDispatch, useWalletStore } from '@/redux/hooks'
 import { walletActions } from '@/redux/slices/wallet-slice'
 import { getUserPreferences, updateUserPreferences } from '@/utils'
+import { usePrimaryNameBatch } from '@justaname.id/react'
 import classNames from 'classnames'
 import { motion, useAnimation } from 'framer-motion'
 import Image from 'next/image'
@@ -45,6 +46,13 @@ export default function Home() {
     const { focusedWallet: focusedWalletId } = useWalletStore()
 
     const [focusedIndex, setFocusedIndex] = useState(0)
+
+    // Fetch ENS names for all wallet addresses
+    const walletAddresses = useMemo(() => wallets.map((wallet) => wallet.address), [wallets])
+    const { allPrimaryNames } = usePrimaryNameBatch({
+        addresses: walletAddresses,
+        enabled: !!walletAddresses.length,
+    })
 
     // update focusedIndex and focused wallet when selectedWallet changes
     useEffect(() => {
@@ -224,6 +232,7 @@ export default function Home() {
                                                 type="wallet"
                                                 wallet={wallet}
                                                 username={username ?? ''}
+                                                primaryName={allPrimaryNames?.[wallet.address] || wallet.address}
                                                 selected={selectedWallet?.id === wallet.id}
                                                 onClick={() => handleCardClick(index)}
                                                 index={index}

--- a/src/app/(mobile-ui)/wallet/page.tsx
+++ b/src/app/(mobile-ui)/wallet/page.tsx
@@ -17,6 +17,7 @@ import { useWalletConnection } from '@/hooks/wallet/useWalletConnection'
 import { IWallet, WalletProviderType } from '@/interfaces'
 import { useWalletStore } from '@/redux/hooks'
 import { formatAmount, getChainName, getHeaderTitle, getUserPreferences, updateUserPreferences } from '@/utils'
+import { usePrimaryName } from '@justaname.id/react'
 import { useDisconnect } from '@reown/appkit/react'
 import { usePathname } from 'next/navigation'
 import { useState } from 'react'
@@ -37,6 +38,11 @@ const WalletDetailsPage = () => {
     const walletDetails = wallets.find((wallet) => wallet.id === focusedWalletId)
     const isPeanutWallet = walletDetails?.walletProviderType === WalletProviderType.PEANUT
     const isRewardsWallet = walletDetails?.walletProviderType === WalletProviderType.REWARDS
+
+    const { primaryName } = usePrimaryName({
+        address: walletDetails?.address,
+        priority: 'onChain',
+    })
 
     const isConnected = isWalletConnected(walletDetails as IWallet)
 
@@ -140,6 +146,7 @@ const WalletDetailsPage = () => {
                         type="wallet"
                         wallet={walletDetails}
                         username={username ?? ''}
+                        primaryName={primaryName ?? walletDetails.address}
                         selected
                         onClick={() => {}}
                         index={0}

--- a/src/components/Global/ImageGeneration/LinkPreview.tsx
+++ b/src/components/Global/ImageGeneration/LinkPreview.tsx
@@ -1,4 +1,5 @@
 import { formatAmount, printableAddress } from '@/utils'
+import { usePrimaryName } from '@justaname.id/react'
 import { isAddress } from 'viem'
 
 export enum PreviewType {
@@ -17,6 +18,15 @@ const PREVIEW_TYPES: Record<PreviewType, PreviewTypeData> = {
 }
 
 function formatDisplayAddress(address: string): string {
+    const { primaryName } = usePrimaryName({
+        address,
+        priority: 'onChain',
+    })
+
+    if (primaryName) {
+        return primaryName
+    }
+
     if (address.startsWith('0x')) {
         if (isAddress(address)) {
             return printableAddress(address)

--- a/src/components/Home/WalletCard.tsx
+++ b/src/components/Home/WalletCard.tsx
@@ -7,7 +7,6 @@ import { useWalletStore } from '@/redux/hooks'
 import { formatExtendedNumber, printableUsdc, shortenAddressLong } from '@/utils'
 import { identicon } from '@dicebear/collection'
 import { createAvatar } from '@dicebear/core'
-import { usePrimaryName } from '@justaname.id/react'
 import classNames from 'classnames'
 import { motion } from 'framer-motion'
 import Image from 'next/image'
@@ -33,6 +32,7 @@ type WalletCardWallet = BaseWalletCardProps & {
     type: 'wallet'
     wallet: IWallet
     username: string
+    primaryName: string
     selected?: boolean
     isConnected?: boolean
     isUsable?: boolean
@@ -74,6 +74,7 @@ function AddWalletCard({ onClick }: { onClick?: () => void }) {
 function ExistingWalletCard({
     wallet,
     username,
+    primaryName,
     index,
     isBalanceHidden,
     onToggleBalanceVisibility,
@@ -81,12 +82,6 @@ function ExistingWalletCard({
     onClick,
 }: WalletCardWallet) {
     const { isWalletConnected } = useWallet()
-
-    // exceptionally we don't use AddressLink here because the whole card is clickable
-    const { primaryName } = usePrimaryName({
-        address: wallet.address,
-        priority: 'onChain',
-    })
 
     const isExternalWallet = wallet.walletProviderType !== WalletProviderType.PEANUT
     const isRewardsWallet = wallet.walletProviderType === WalletProviderType.REWARDS
@@ -339,12 +334,7 @@ function WalletIdentifier({
     )
 }
 
-function getWalletDisplayInfo(
-    wallet: IWallet,
-    username: string,
-    primaryName: string | null | undefined,
-    isRewardsWallet: boolean
-) {
+function getWalletDisplayInfo(wallet: IWallet, username: string, primaryName: string, isRewardsWallet: boolean) {
     if (isRewardsWallet) {
         return {
             displayName: 'Rewards',


### PR DESCRIPTION
- now using justaname's batch `usePrimaryNameBatch` hook to resolve to ens names
- contributes to TASK-10131
- also fixes TASK-9912 : address resolution in link previews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Wallet displays now show more recognizable names by retrieving and displaying ENS names for wallet addresses. Users will see a primary name when available, with the address serving as a fallback.
  
- **Refactor**
  - Updated the wallet display components to streamline data flow and consistently pass the primary name to wallet cards.
  - Simplified logic for retrieving primary names in the wallet display components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->