### PR TITLE
fix: resolve to ens names of an address if available in link previews

### DIFF
--- a/src/app/api/preview-image/route.tsx
+++ b/src/app/api/preview-image/route.tsx
@@ -1,9 +1,46 @@
 /* eslint-disable @next/next/no-img-element */
-import { ImageResponse } from 'next/og'
-
 import { LinkPreviewImg, PreviewType } from '@/components/Global/ImageGeneration/LinkPreview'
+import { ImageResponse } from 'next/og'
+import { isAddress } from 'viem'
 
 export const runtime = 'edge'
+
+// utility function to resolve ENS name of an address
+async function resolveAddress(address: string): Promise<string | null> {
+    if (!isAddress(address)) return null
+
+    try {
+        const response = await fetch(`https://api.justaname.id/ens/v1/subname/address?address=${address}&chainId=1`, {
+            headers: {
+                Accept: '*/*',
+            },
+        })
+
+        if (!response.ok) {
+            return null
+        }
+
+        const data = await response.json()
+
+        // handle response from justaname
+        if (
+            data?.result?.data?.subnames &&
+            Array.isArray(data.result.data.subnames) &&
+            data.result.data.subnames.length > 0
+        ) {
+            // get the first subname
+            const firstSubname = data.result.data.subnames[0]
+            if (firstSubname.ens) {
+                return firstSubname.ens
+            }
+        }
+
+        return null
+    } catch (error) {
+        console.error('Error resolving ENS name:', error)
+        return null
+    }
+}
 
 // Generate link preview image
 // Note that a lot of usual CSS is unsupported, including tailwind.
@@ -13,12 +50,26 @@ export async function GET(request: Request) {
     const amount = searchParams.get('amount') ?? ''
     const tokenSymbol = searchParams.get('tokenSymbol') ?? ''
     const address = searchParams.get('address') ?? ''
+
     const previewType =
         PreviewType[(searchParams.get('previewType')?.toUpperCase() ?? 'claim') as keyof typeof PreviewType] ??
         PreviewType.CLAIM
 
-    return new ImageResponse(<LinkPreviewImg {...{ amount, tokenSymbol, address, previewType }} />, {
-        width: 400,
-        height: 200,
-    })
+    // resolve to ENS name if possible
+    const ensName = await resolveAddress(address)
+
+    return new ImageResponse(
+        (
+            <LinkPreviewImg
+                amount={amount}
+                tokenSymbol={tokenSymbol}
+                address={ensName || address}
+                previewType={previewType}
+            />
+        ),
+        {
+            width: 400,
+            height: 200,
+        }
+    )
 }

--- a/src/components/Global/TransactionBadge/index.tsx
+++ b/src/components/Global/TransactionBadge/index.tsx
@@ -29,7 +29,7 @@ export const TransactionBadge = ({ status, className }: BadgeProps) => {
 
     return (
         <div className={twMerge('border p-0.5 text-center text-xs font-semibold capitalize', statusStyles, className)}>
-            {status?.toLowerCase() ?? ''} 
+            {status?.toLowerCase() ?? ''}
         </div>
     )
 }


### PR DESCRIPTION
fixes TASK-9912

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - ENS names are now displayed in link preview images when available, providing a more user-friendly identifier instead of raw Ethereum addresses.

- **Style**
  - Minor adjustment to the TransactionBadge component to remove an unnecessary trailing space after the status text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->