### PR TITLE
[TASK-6438] feat: avoid loading tokens that wont be used

### DIFF
--- a/src/components/Global/TokenSelector/Components/AdvancedButton.tsx
+++ b/src/components/Global/TokenSelector/Components/AdvancedButton.tsx
@@ -1,6 +1,5 @@
 import { tokenSelectorContext } from '@/context'
-import { formatTokenAmount } from '@/utils'
-import { fetchTokenSymbol } from '@/utils'
+import { formatTokenAmount, fetchTokenSymbol, getTokenLogo } from '@/utils'
 import { useContext, useEffect, useState } from 'react'
 import Icon from '../../Icon'
 
@@ -39,6 +38,7 @@ export const AdvancedTokenSelectorButton = ({
 }: IAdvancedTokenSelectorButtonProps) => {
     const { selectedChainID, selectedTokenAddress } = useContext(tokenSelectorContext)
     const [_tokenSymbol, _setTokenSymbol] = useState<string | undefined>(tokenSymbol)
+    const [_tokenLogoUri, _setTokenLogoUri] = useState<string | undefined>(tokenLogoUri)
 
     useEffect(() => {
         let isMounted = true
@@ -56,6 +56,12 @@ export const AdvancedTokenSelectorButton = ({
         }
     }, [tokenSymbol, selectedTokenAddress, selectedChainID])
 
+    useEffect(() => {
+        if (!_tokenLogoUri && _tokenSymbol && selectedTokenAddress) {
+            _setTokenLogoUri(getTokenLogo(_tokenSymbol))
+        }
+    }, [_tokenLogoUri, _tokenSymbol, selectedTokenAddress])
+
     return (
         <section
             role="button"
@@ -72,8 +78,8 @@ export const AdvancedTokenSelectorButton = ({
         >
             <div className={'flex flex-row items-center justify-center gap-4'}>
                 <div className="relative h-8 w-8">
-                    {tokenLogoUri ? (
-                        <img src={tokenLogoUri} className="absolute left-0 top-0 h-8 w-8" alt="logo" />
+                    {_tokenLogoUri ? (
+                        <img src={_tokenLogoUri} className="absolute left-0 top-0 h-8 w-8" alt="logo" />
                     ) : (
                         <Icon name="token_placeholder" className="absolute left-0 top-0 h-8 w-8" fill="#999" />
                     )}


### PR DESCRIPTION
For flows where the user needs to be connected (most of them), only show the tokens that the user has a balance in. This will improve user experience and also reduce the amount of tokens (and their logos) that will be loaded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced performance and responsiveness of the token selector modal.
  - Tokens are now hidden when a user connection is required.
  - The chain selector is hidden when the user is expected to be connected.
  - Improved state reset and filter clearing when closing the modal for a smoother user experience.
  - Token logos dynamically update based on the selected token, improving visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->