### PR TITLE
chore: add alternative url to under maintenance

### DIFF
--- a/src/app/(mobile-ui)/cashout/page.tsx
+++ b/src/app/(mobile-ui)/cashout/page.tsx
@@ -18,6 +18,7 @@ export default function CashoutPage() {
             <UnderMaintenance
                 title="Cashout Temporarily Unavailable"
                 message="We're improving our cashout service. Please check back soon!"
+                alternativeUrl="https://peanut.to/cashout"
             />
         )
     }

--- a/src/components/Global/UnderMaintenance/index.tsx
+++ b/src/components/Global/UnderMaintenance/index.tsx
@@ -30,7 +30,7 @@ export function UnderMaintenance({
                     <p className="text-gray-600 dark:text-gray-400">{message}</p>
                     {alternativeUrl && (
                         <div>
-                            <p className="text-gray-600 dark:text-gray-400">In the meantime, you can try:</p>
+                            <p className="text-gray-600 dark:text-gray-400">In the meantime, you can use: </p>
                             <Link href={alternativeUrl} target="_system">
                                 {alternativeUrl}
                             </Link>

--- a/src/components/Global/UnderMaintenance/index.tsx
+++ b/src/components/Global/UnderMaintenance/index.tsx
@@ -1,18 +1,21 @@
 import React from 'react'
 import { Card } from '@/components/0_Bruddle/Card'
 import Image from 'next/image'
+import Link from 'next/link'
 import { PeanutGuyGIF } from '@/assets'
 
 interface UnderMaintenanceProps {
     title?: string
     message?: string
     showImage?: boolean
+    alternativeUrl?: string
 }
 
 export function UnderMaintenance({
     title = 'Under Maintenance',
     message = 'This feature is currently undergoing maintenance. Please check back later.',
     showImage = true,
+    alternativeUrl,
 }: UnderMaintenanceProps) {
     return (
         <div className="flex h-full w-full flex-col items-center justify-center p-4">
@@ -25,6 +28,14 @@ export function UnderMaintenance({
                     )}
                     <h2 className="text-xl font-bold">{title}</h2>
                     <p className="text-gray-600 dark:text-gray-400">{message}</p>
+                    {alternativeUrl && (
+                        <div>
+                            <p className="text-gray-600 dark:text-gray-400">In the meantime, you can try:</p>
+                            <Link href={alternativeUrl} target="_system">
+                                {alternativeUrl}
+                            </Link>
+                        </div>
+                    )}
                 </div>
             </Card>
         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - When the cashout service is under maintenance, users are now shown an alternative link to access the service on a different site.
- **User Interface**
  - The maintenance message now includes a clickable link if an alternative URL is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->