### PR TITLE
feat(claim): claim link preview + add getNoPubKey api

### DIFF
--- a/src/app/(mobile-ui)/claim/page.tsx
+++ b/src/app/(mobile-ui)/claim/page.tsx
@@ -33,12 +33,12 @@ export async function generateMetadata({
                 }
             })
             const url = `${siteUrl}/claim?${queryParams.toString()}`
-            
+
             const [linkDetailsResult, txDetailsResult] = await Promise.allSettled([
                 getLinkDetails(url),
-                sendLinksApi.getNoPubKey(url)
+                sendLinksApi.getNoPubKey(url),
             ])
-            
+
             linkDetails = linkDetailsResult.status === 'fulfilled' ? linkDetailsResult.value : undefined
             txDetails = txDetailsResult.status === 'fulfilled' ? txDetailsResult.value : undefined
 
@@ -58,13 +58,12 @@ export async function generateMetadata({
         }
     }
 
-
-    let previewUrl;
+    let previewUrl
     if (linkDetails && !linkDetails.claimed) {
         const ogUrl = new URL(`${siteUrl}/api/og`)
         ogUrl.searchParams.set('type', 'send')
         ogUrl.searchParams.set('username', txDetails!.sender.username)
-        ogUrl.searchParams.set('amount', Math.floor(Number(linkDetails.tokenAmount)).toString()) // @bozzi ALWAYS ROUNDING DOWN JUST IN CASE (also, design looked like it didn't accept decimals) 
+        ogUrl.searchParams.set('amount', Math.floor(Number(linkDetails.tokenAmount)).toString()) // @bozzi ALWAYS ROUNDING DOWN JUST IN CASE (also, design looked like it didn't accept decimals)
         previewUrl = ogUrl.toString()
     }
 

--- a/src/app/(mobile-ui)/claim/page.tsx
+++ b/src/app/(mobile-ui)/claim/page.tsx
@@ -33,12 +33,12 @@ export async function generateMetadata({
                 }
             })
             const url = `${siteUrl}/claim?${queryParams.toString()}`
-            
+
             const [linkDetailsResult, txDetailsResult] = await Promise.allSettled([
                 getLinkDetails(url),
-                sendLinksApi.getNoPubKey(url)
+                sendLinksApi.getNoPubKey(url),
             ])
-            
+
             linkDetails = linkDetailsResult.status === 'fulfilled' ? linkDetailsResult.value : undefined
             txDetails = txDetailsResult.status === 'fulfilled' ? txDetailsResult.value : undefined
 
@@ -58,13 +58,12 @@ export async function generateMetadata({
         }
     }
 
-
-    let previewUrl;
+    let previewUrl
     if (linkDetails && !linkDetails.claimed) {
         const ogUrl = new URL(`${siteUrl}/api/og`)
         ogUrl.searchParams.set('type', 'send')
-        ogUrl.searchParams.set('username', txDetails!.sender.username)
-        ogUrl.searchParams.set('amount', Math.floor(Number(linkDetails.tokenAmount)).toString()) // @bozzi ALWAYS ROUNDING DOWN JUST IN CASE (also, design looked like it didn't accept decimals) 
+        ogUrl.searchParams.set('username', txDetails?.sender?.username || 'Anonymous')
+        ogUrl.searchParams.set('amount', Math.floor(Number(linkDetails.tokenAmount)).toString()) // @bozzi ALWAYS ROUNDING DOWN JUST IN CASE (also, design looked like it didn't accept decimals)
         previewUrl = ogUrl.toString()
     }
 
@@ -73,19 +72,21 @@ export async function generateMetadata({
         description: 'Receive this payment to your Peanut account, or directly to your bank account.',
         icons: { icon: '/favicon.ico' },
         openGraph: {
-            images: [
-                {
-                    url: previewUrl!,
-                    width: 1200,
-                    height: 630,
-                },
-            ],
+            images: previewUrl
+                ? [
+                      {
+                          url: previewUrl,
+                          width: 1200,
+                          height: 630,
+                      },
+                  ]
+                : [],
         },
         twitter: {
             card: 'summary_large_image',
             title,
             description: 'Claim your tokens using Peanut Protocol',
-            images: [previewUrl!],
+            images: previewUrl ? [previewUrl] : [],
         },
     }
 }

--- a/src/components/Global/WalletNavigation/index.tsx
+++ b/src/components/Global/WalletNavigation/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { PEANUT_LOGO } from '@/assets'
 import DirectSendQr from '@/components/Global/DirectSendQR'
 import { Icon, IconName, Icon as NavIcon } from '@/components/Global/Icons/Icon'
@@ -32,10 +33,9 @@ type NavSectionProps = {
 const NavSection: React.FC<NavSectionProps> = ({ paths, pathName }) => (
     <>
         {paths.map(({ name, href, icon, size }, index) => (
-            <>
+            <React.Fragment key={`${name}-${index}`}>
                 <Link
                     href={href}
-                    key={`${name}-${index}`}
                     className={classNames(
                         'flex items-center gap-3 text-white hover:cursor-pointer hover:text-white/80',
                         {
@@ -52,7 +52,7 @@ const NavSection: React.FC<NavSectionProps> = ({ paths, pathName }) => (
                     <span className="block w-fit pt-0.5 text-center text-base font-semibold">{name}</span>
                 </Link>
                 {index === 3 && <div className="w-full border-b border-grey-1" />}
-            </>
+            </React.Fragment>
         ))}
     </>
 )

--- a/src/services/sendLinks.ts
+++ b/src/services/sendLinks.ts
@@ -175,6 +175,7 @@ export const sendLinksApi = {
         return data
     },
 
+    // like the get function, but no public key needed to get TX details
     getNoPubKey: async (link: string): Promise<SendLink> => {
         const params = getParamsFromLink(link)
         const url = `${PEANUT_API_URL}/send-links?c=${params.chainId}&v=${params.contractVersion}&i=${params.depositIdx}`

--- a/src/services/sendLinks.ts
+++ b/src/services/sendLinks.ts
@@ -175,6 +175,19 @@ export const sendLinksApi = {
         return data
     },
 
+    getNoPubKey: async (link: string): Promise<SendLink> => {
+        const params = getParamsFromLink(link)
+        const url = `${PEANUT_API_URL}/send-links?c=${params.chainId}&v=${params.contractVersion}&i=${params.depositIdx}`
+        const response = await fetchWithSentry(url, {
+            method: 'GET',
+        })
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`)
+        }
+        const data: SendLink = jsonParse(await response.text())
+        return data
+    },
+
     getByPubKey: async (pubKey: string): Promise<SendLink> => {
         const url = `${PEANUT_API_URL}/send-links/${pubKey}`
         const response = await fetchWithSentry(url, {


### PR DESCRIPTION
Last Social Preview PR. This time for claim links.

Ex: peanut.me/claim?c=42161&v=v4.3&i=4123#p=08ElxE4TpCKSj1ym
Sending that URL in Whatsapp will load a dynamically generated social preview with the design made by Manu.

Tested using ngrok to expose the URL and they were generated correctly.

- Add new getNoPubKey method to sendLinks service
- Improve claim page metadata generation with parallel requests
- Update OG image generation to use new endpoint and parameters
- Fix React key warning in WalletNavigation component