### PR TITLE
Bugfix/receipt timestamp

### DIFF
--- a/src/app/[...recipient]/client.tsx
+++ b/src/app/[...recipient]/client.tsx
@@ -264,7 +264,7 @@ export default function PaymentPage({ recipient, flow = 'request_pay' }: Props) 
             id: chargeDetails.uuid,
             status,
             amount: Number(chargeDetails.tokenAmount),
-            date: new Date(chargeDetails.createdAt),
+            date: new Date(chargeDetails?.fulfillmentPayment?.createdAt || chargeDetails.createdAt),
             tokenSymbol: chargeDetails.tokenSymbol,
             initials: getInitialsFromName(username ?? ''),
             memo: chargeDetails.requestLink.reference ?? undefined,

--- a/src/app/[...recipient]/client.tsx
+++ b/src/app/[...recipient]/client.tsx
@@ -34,7 +34,7 @@ export default function PaymentPage({ recipient, flow = 'request_pay' }: Props) 
     const isDirectPay = flow === 'direct_pay'
     const isAddMoneyFlow = flow === 'add_money'
     const dispatch = useAppDispatch()
-    const { currentView, parsedPaymentData, chargeDetails } = usePaymentStore()
+    const { currentView, parsedPaymentData, chargeDetails, paymentDetails } = usePaymentStore()
     const [error, setError] = useState<ValidationErrorViewProps | null>(null)
     const [isUrlParsed, setIsUrlParsed] = useState(false)
     const [isRequestDetailsFetching, setIsRequestDetailsFetching] = useState(false)
@@ -264,7 +264,7 @@ export default function PaymentPage({ recipient, flow = 'request_pay' }: Props) 
             id: chargeDetails.uuid,
             status,
             amount: Number(chargeDetails.tokenAmount),
-            date: new Date(chargeDetails?.fulfillmentPayment?.createdAt || chargeDetails.createdAt),
+            date: new Date(paymentDetails?.createdAt ?? chargeDetails.createdAt),
             tokenSymbol: chargeDetails.tokenSymbol,
             initials: getInitialsFromName(username ?? ''),
             memo: chargeDetails.requestLink.reference ?? undefined,
@@ -295,7 +295,7 @@ export default function PaymentPage({ recipient, flow = 'request_pay' }: Props) 
         }
 
         return details as TransactionDetails
-    }, [chargeDetails, user?.user.userId, isAddMoneyFlow, user?.user.username])
+    }, [chargeDetails, user?.user.userId, isAddMoneyFlow, user?.user.username, paymentDetails])
 
     useEffect(() => {
         if (!transactionForDrawer) return

--- a/src/components/Payment/Views/Status.payment.view.tsx
+++ b/src/components/Payment/Views/Status.payment.view.tsx
@@ -47,7 +47,7 @@ const DirectSuccessView = ({
     redirectTo = '/home',
 }: DirectSuccessViewProps) => {
     const router = useRouter()
-    const { chargeDetails, parsedPaymentData } = usePaymentStore()
+    const { chargeDetails, parsedPaymentData, paymentDetails } = usePaymentStore()
     const dispatch = useDispatch()
     const { isDrawerOpen, selectedTransaction, openTransactionDetails, closeTransactionDetails } =
         useTransactionDetailsDrawer()
@@ -86,19 +86,14 @@ const DirectSuccessView = ({
     const transactionForDrawer: TransactionDetails | null = useMemo(() => {
         if (!chargeDetails) return null
 
-        const firstPayment =
-            chargeDetails.payments && chargeDetails.payments.length > 0 ? chargeDetails.payments[0] : null
-
-        const txTimestamp = firstPayment?.createdAt || chargeDetails.createdAt
-
         const networkFeeDisplayValue = '$ 0.00' // fee is zero for peanut wallet txns
         const peanutFeeDisplayValue = '$ 0.00' // peanut doesn't charge fees yet
 
         let details: Partial<TransactionDetails> = {
-            id: firstPayment?.payerTransactionHash,
+            id: paymentDetails?.payerTransactionHash,
             status: 'completed' as StatusType,
             amount: parseFloat(amountValue),
-            date: new Date(txTimestamp),
+            date: new Date(paymentDetails?.createdAt ?? chargeDetails.createdAt),
             tokenSymbol: chargeDetails.tokenSymbol,
             direction: 'send', // only showing receipt for send txns
             initials: getInitialsFromName(recipientName),
@@ -140,6 +135,7 @@ const DirectSuccessView = ({
         chainIconUrl,
         resolvedChainName,
         resolvedTokenSymbol,
+        paymentDetails,
     ])
 
     useEffect(() => {

--- a/src/services/services.types.ts
+++ b/src/services/services.types.ts
@@ -154,6 +154,7 @@ export interface PaymentCreationResponse {
     paidTokenAddress: string
     payerChainId: string
     payerTransactionHash: string
+    createdAt: string
     requestCharge: {
         uuid: string
         chainId: string


### PR DESCRIPTION
When a user created a request, the transaction was timestamped with the date and time of the request creation. However, when the payer completed the payment, the receipt showed the original request timestamp instead of the actual date and time of the payment.

This PR updates the receipt to display the actual date and time when the payment is made, not when the request was created. Both on normal receipts and in the box drawer receipt when the payment is accepted.