### PR TITLE
Bugfix/receipts previews

### DIFF
--- a/src/app/(mobile-ui)/request/pay/page.tsx
+++ b/src/app/(mobile-ui)/request/pay/page.tsx
@@ -1,4 +1,3 @@
-import { PreviewType } from '@/components/Global/ImageGeneration/LinkPreview'
 import { PayRequestLink } from '@/components/Request/Pay/Pay'
 import { chargesApi } from '@/services/charges'
 import { formatAmount, printableAddress } from '@/utils'
@@ -19,15 +18,13 @@ function getPreviewUrl(
         recipientAddress: string
     }
 ) {
-    const url = new URL('/api/preview-image', host)
+    const url = new URL('/api/og', host)
 
     const params = new URLSearchParams({
+        type: 'request',
+        username: data.recipientAddress ?? '',
         amount: data.tokenAmount,
-        chainId: data.chainId,
-        tokenAddress: data.tokenAddress,
-        tokenSymbol: data.tokenSymbol ?? '',
-        address: data.recipientAddress ?? '',
-        previewType: PreviewType.REQUEST,
+        token: data.tokenSymbol ?? '',
     })
 
     url.search = params.toString()

--- a/src/app/[...recipient]/page.tsx
+++ b/src/app/[...recipient]/page.tsx
@@ -15,8 +15,9 @@ export async function generateMetadata({ params, searchParams }: any) {
     let title = 'Request Payment | Peanut'
     const siteUrl: string = (await getOrigin()) || BASE_URL // getOrigin for getting the origin of the site regardless of its a vercel preview or not
     const resolvedSearchParams = await searchParams
+    const resolvedParams = await params
 
-    let recipient = params.recipient[0]
+    let recipient = resolvedParams.recipient[0]
 
     if (recipient.includes('%40') || recipient.includes('@')) {
         // split on @ or %40
@@ -25,72 +26,97 @@ export async function generateMetadata({ params, searchParams }: any) {
 
     const chargeId = resolvedSearchParams.chargeId
 
+    // Parse amount/token from URL for request links
+    let amount, token
+    if (resolvedParams.recipient[1]) {
+        const amountToken = resolvedParams.recipient[1]
+        const match = amountToken.match(/^(\d*\.?\d*)(.*)$/)
+        if (match) {
+            amount = match[1]
+            token = match[2]
+        }
+    }
+
+    // Check if recipient is ETH address or ENS name
+    const isEthAddress = isAddress(recipient)
+    const isEnsName = recipient.endsWith('.eth')
+    const isAddressOrEns = isEthAddress || isEnsName
+
+    // Determine if we should generate custom OG image
+    const shouldGenerateCustomOG = amount || isAddressOrEns
+
     let isPaid = false
+    let ogImageUrl = '/metadata-img.png' // Default fallback
+
+    // Only check charge status if there's a chargeId
     if (chargeId) {
         try {
-            //get charge details to determine status
             const chargeDetails = await chargesApi.get(chargeId)
             console.log('chargeDetails', chargeDetails)
-
-            // determine status based on charge data
             isPaid = chargeDetails?.fulfillmentPayment?.status === 'SUCCESSFUL'
         } catch (error) {
             console.error('Failed to fetch charge details:', error)
         }
+    }
 
-        let amount, token
-        if (params.recipient[1]) {
-            const amountToken = params.recipient[1]
-            const match = amountToken.match(/^(\d*\.?\d*)(.*)$/)
-            if (match) {
-                amount = match[1]
-                token = match[2]
-            }
-        }
-
-        const ogUrl = new URL(`${siteUrl}/api/og`)
-        ogUrl.searchParams.set('type', 'request')
-        ogUrl.searchParams.set('username', recipient)
-        if (amount) {
-            // if its amount, make request/claim social preview, otherwise make receipt social preview
-            ogUrl.searchParams.set('amount', String(amount))
-        }
-        if (isPaid) {
-            // if its paid, make receipt social preview
-            ogUrl.searchParams.set('isReceipt', 'true')
-        }
-
+    // Generate custom OG image only for addresses/ENS or when there's an amount
+    if (shouldGenerateCustomOG) {
         if (!siteUrl) {
             console.error('Error: Unable to determine site origin')
-            return { title }
-        }
-
-        if (amount && token) {
-            title = `${isAddress(recipient) ? printableAddress(recipient) : recipient} is requesting ${amount} ${token.toUpperCase()}`
-        } else if (amount) {
-            title = `${isAddress(recipient) ? printableAddress(recipient) : recipient} is requesting $${amount}`
         } else {
-            title = `${isAddress(recipient) ? printableAddress(recipient) : recipient} | Peanut`
-        }
+            const ogUrl = new URL(`${siteUrl}/api/og`)
+            ogUrl.searchParams.set('type', 'request')
+            ogUrl.searchParams.set('username', recipient)
 
-        return {
+            if (amount) {
+                ogUrl.searchParams.set('amount', String(amount))
+                if (token) {
+                    ogUrl.searchParams.set('token', token.toUpperCase())
+                }
+            } else {
+                // For ETH addresses/ENS without amount, set to 0 to show "is requesting funds"
+                ogUrl.searchParams.set('amount', '0')
+            }
+
+            // Only show as receipt if there's both a chargeId AND it's paid
+            if (chargeId && isPaid) {
+                ogUrl.searchParams.set('isReceipt', 'true')
+            }
+
+            ogImageUrl = ogUrl.toString()
+        }
+    }
+
+    // Generate appropriate title
+    if (amount && token) {
+        title = `${isEthAddress ? printableAddress(recipient) : recipient} is requesting ${amount} ${token.toUpperCase()}`
+    } else if (amount) {
+        title = `${isEthAddress ? printableAddress(recipient) : recipient} is requesting $${amount}`
+    } else if (isAddressOrEns) {
+        title = `${isEthAddress ? printableAddress(recipient) : recipient} is requesting funds`
+    } else {
+        // For Peanut usernames without amounts, use generic title
+        title = `${recipient} | Peanut`
+    }
+
+    return {
+        title,
+        description: 'Send cryptocurrency to friends, family, or anyone else using Peanut on any chain.',
+        ...(siteUrl ? { metadataBase: new URL(siteUrl) } : {}),
+        icons: {
+            icon: '/logo-favicon.png',
+        },
+        openGraph: {
+            title,
+            description: 'Seamless payment infrastructure for sending and receiving digital assets.',
+            images: [{ url: ogImageUrl, width: 1200, height: 630 }],
+        },
+        twitter: {
+            card: 'summary_large_image',
             title,
             description: 'Send cryptocurrency to friends, family, or anyone else using Peanut on any chain.',
-            icons: {
-                icon: '/logo-favicon.png',
-            },
-            openGraph: {
-                title,
-                description: 'Seamless payment infrastructure for sending and receiving digital assets.',
-                images: [{ url: ogUrl.toString(), width: 1200, height: 630 }],
-            },
-            twitter: {
-                card: 'summary_large_image',
-                title,
-                description: 'Send cryptocurrency to friends, family, or anyone else using Peanut on any chain.',
-                images: [ogUrl.toString()],
-            },
-        }
+            images: [ogImageUrl],
+        },
     }
 }
 

--- a/src/app/[...recipient]/page.tsx
+++ b/src/app/[...recipient]/page.tsx
@@ -6,6 +6,7 @@ import { BASE_URL } from '@/constants'
 import { isAddress } from 'viem'
 import { printableAddress } from '@/utils'
 import { chargesApi } from '@/services/charges'
+import { parseAmountAndToken } from '@/lib/url-parser/parser'
 
 type PageProps = {
     params: Promise<{ recipient?: string[] }>
@@ -27,6 +28,7 @@ export async function generateMetadata({ params, searchParams }: any) {
     const chargeId = resolvedSearchParams.chargeId
 
     // Parse amount/token from URL for request links
+    // @dev TODO: use parseAmountAndToken instead
     let amount, token
     if (resolvedParams.recipient[1]) {
         const amountToken = resolvedParams.recipient[1]

--- a/src/app/[...recipient]/page.tsx
+++ b/src/app/[...recipient]/page.tsx
@@ -28,15 +28,12 @@ export async function generateMetadata({ params, searchParams }: any) {
     const chargeId = resolvedSearchParams.chargeId
 
     // Parse amount/token from URL for request links
-    // @dev TODO: use parseAmountAndToken instead
     let amount, token
     if (resolvedParams.recipient[1]) {
         const amountToken = resolvedParams.recipient[1]
-        const match = amountToken.match(/^(\d*\.?\d*)(.*)$/)
-        if (match) {
-            amount = match[1]
-            token = match[2]
-        }
+        const parsed = parseAmountAndToken(amountToken)
+        amount = parsed.amount
+        token = parsed.token
     }
 
     // Check if recipient is ETH address or ENS name

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -8,8 +8,61 @@ import { BASE_URL } from '@/constants'
 import getOrigin from '@/lib/hosting/get-origin'
 import { ReceiptCardOG } from '@/components/og/ReceiptCardOG'
 import { printableAddress } from '@/utils'
+import { isAddress } from 'viem'
 
 export const runtime = 'nodejs' //node.js instead of edge!
+
+// utility function to resolve ENS name from an address
+async function resolveAddressToENS(address: string): Promise<string | null> {
+    if (!isAddress(address)) return null
+
+    try {
+        const response = await fetch(`https://api.justaname.id/ens/v1/subname/address?address=${address}&chainId=1`, {
+            headers: {
+                Accept: '*/*',
+            },
+        })
+
+        if (!response.ok) {
+            return null
+        }
+
+        const data = await response.json()
+
+        // handle response from justaname
+        if (
+            data?.result?.data?.subnames &&
+            Array.isArray(data.result.data.subnames) &&
+            data.result.data.subnames.length > 0
+        ) {
+            // get the first subname
+            const firstSubname = data.result.data.subnames[0]
+            if (firstSubname.ens) {
+                return firstSubname.ens
+            }
+        }
+
+        return null
+    } catch (error) {
+        console.error('Error resolving ENS name:', error)
+        return null
+    }
+}
+
+// utility function to clean up username display
+function formatUsernameForDisplay(username: string): string {
+    // if it's an ENS name ending with .peanut.me, strip that part
+    if (username.endsWith('.peanut.me')) {
+        return username.replace('.peanut.me', '')
+    }
+
+    // if it's too long and looks like an address, make it printable
+    if (username.length > 12) {
+        return printableAddress(username)
+    }
+
+    return username
+}
 
 // loads a font once and keeps it cached in the module
 const fontDir = path.join(process.cwd(), 'src', 'assets', 'fonts')
@@ -45,10 +98,8 @@ export async function GET(req: NextRequest) {
     const type = ['send', 'request', 'generic'].includes(typeParam)
         ? (typeParam as 'send' | 'request' | 'generic')
         : 'generic'
-    const username =
-        searchParams.get('username')!.length > 12
-            ? printableAddress(searchParams.get('username')!)
-            : searchParams.get('username')! // username will always exist. If it doesn't, page will 404 + format the length if its too long/an ethereum address
+
+    let username = searchParams.get('username') || 'someone'
     const amount = Number(searchParams.get('amount') ?? 0)
     const token = searchParams.get('token') || null
     const isReceipt = searchParams.get('isReceipt') || 'false'
@@ -60,6 +111,17 @@ export async function GET(req: NextRequest) {
             fonts: [{ name: 'Montserrat', data: montserratMedium, style: 'normal' }],
         })
     }
+
+    // for send/claim links, try to resolve ENS name if username is an address
+    if (type === 'send' && isAddress(username)) {
+        const ensName = await resolveAddressToENS(username)
+        if (ensName) {
+            username = ensName // Use the resolved ENS name
+        }
+    }
+
+    // format username for display (handles .peanut.me cleanup and address formatting)
+    username = formatUsernameForDisplay(username)
 
     if (isReceipt === 'true') {
         const link: PaymentLink & { token?: string } = {

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -50,6 +50,7 @@ export async function GET(req: NextRequest) {
             ? printableAddress(searchParams.get('username')!)
             : searchParams.get('username')! // username will always exist. If it doesn't, page will 404 + format the length if its too long/an ethereum address
     const amount = Number(searchParams.get('amount') ?? 0)
+    const token = searchParams.get('token') || null
     const isReceipt = searchParams.get('isReceipt') || 'false'
 
     if (type === 'generic') {
@@ -61,7 +62,13 @@ export async function GET(req: NextRequest) {
     }
 
     if (isReceipt === 'true') {
-        const link: PaymentLink = { type, username, amount, status: 'unclaimed' }
+        const link: PaymentLink & { token?: string } = {
+            type,
+            username,
+            amount,
+            status: 'unclaimed',
+            token: token || undefined,
+        }
         return new ImageResponse(
             (
                 <ReceiptCardOG
@@ -92,7 +99,13 @@ export async function GET(req: NextRequest) {
         bottomRight: `${origin}/arrows/bottom-right-arrow.svg`,
     }
 
-    const link: PaymentLink = { type, username, amount, status: 'unclaimed' }
+    const link: PaymentLink & { token?: string } = {
+        type,
+        username,
+        amount,
+        status: 'unclaimed',
+        token: token || undefined,
+    }
     return new ImageResponse(
         (
             <PaymentCardOG

--- a/src/app/api/preview-image/route.tsx
+++ b/src/app/api/preview-image/route.tsx
@@ -2,74 +2,38 @@
 import { LinkPreviewImg, PreviewType } from '@/components/Global/ImageGeneration/LinkPreview'
 import { ImageResponse } from 'next/og'
 import { isAddress } from 'viem'
+import { NextResponse } from 'next/server'
 
 export const runtime = 'edge'
 
-// utility function to resolve ENS name of an address
-async function resolveAddress(address: string): Promise<string | null> {
-    if (!isAddress(address)) return null
-
-    try {
-        const response = await fetch(`https://api.justaname.id/ens/v1/subname/address?address=${address}&chainId=1`, {
-            headers: {
-                Accept: '*/*',
-            },
-        })
-
-        if (!response.ok) {
-            return null
-        }
-
-        const data = await response.json()
-
-        // handle response from justaname
-        if (
-            data?.result?.data?.subnames &&
-            Array.isArray(data.result.data.subnames) &&
-            data.result.data.subnames.length > 0
-        ) {
-            // get the first subname
-            const firstSubname = data.result.data.subnames[0]
-            if (firstSubname.ens) {
-                return firstSubname.ens
-            }
-        }
-
-        return null
-    } catch (error) {
-        console.error('Error resolving ENS name:', error)
-        return null
-    }
-}
-
-// Generate link preview image
-// Note that a lot of usual CSS is unsupported, including tailwind.
+// DEPRECATED: This endpoint is deprecated. Use /api/og instead.
+// This endpoint will be removed in a future version.
 export async function GET(request: Request) {
     const { searchParams } = new URL(request.url)
 
+    // Log deprecation warning
+    console.warn('DEPRECATED: /api/preview-image endpoint is deprecated. Use /api/og instead.')
+
+    // Extract parameters from the old format
     const amount = searchParams.get('amount') ?? ''
     const tokenSymbol = searchParams.get('tokenSymbol') ?? ''
     const address = searchParams.get('address') ?? ''
+    const previewType = searchParams.get('previewType')?.toLowerCase() ?? 'claim'
 
-    const previewType =
-        PreviewType[(searchParams.get('previewType')?.toUpperCase() ?? 'claim') as keyof typeof PreviewType] ??
-        PreviewType.CLAIM
+    // Redirect to new og endpoint with proper parameters
+    const baseUrl = new URL(request.url).origin
+    const ogUrl = new URL('/api/og', baseUrl)
 
-    // resolve to ENS name if possible
-    const ensName = await resolveAddress(address)
+    // Map old parameters to new format
+    ogUrl.searchParams.set('type', previewType === 'request' ? 'request' : 'send')
+    ogUrl.searchParams.set('username', address)
+    if (amount) {
+        ogUrl.searchParams.set('amount', amount)
+    }
+    if (tokenSymbol) {
+        ogUrl.searchParams.set('token', tokenSymbol)
+    }
 
-    return new ImageResponse(
-        (
-            <LinkPreviewImg
-                amount={amount}
-                tokenSymbol={tokenSymbol}
-                address={ensName || address}
-                previewType={previewType}
-            />
-        ),
-        {
-            width: 400,
-            height: 200,
-        }
-    )
+    // Return a redirect response to the new endpoint
+    return NextResponse.redirect(ogUrl.toString(), 301)
 }

--- a/src/components/og/PaymentCardOG.tsx
+++ b/src/components/og/PaymentCardOG.tsx
@@ -178,7 +178,9 @@ export function PaymentCardOG({
                                     letterSpacing: '-0.08em',
                                 }}
                             >
-                                {link.token ? `${link.amount} ${link.token}` : `$${link.amount}`}
+                                {link.token && link.token.toLowerCase() !== 'usdc'
+                                    ? `${link.amount} ${link.token}`
+                                    : `$${link.amount}`}
                             </span>
 
                             {/* 2) black outline — absolutely positioned, painted *after* → on top */}
@@ -196,7 +198,9 @@ export function PaymentCardOG({
                                     letterSpacing: '-0.08em',
                                 }}
                             >
-                                {link.token ? `${link.amount} ${link.token}` : `$${link.amount}`}
+                                {link.token && link.token.toLowerCase() !== 'usdc'
+                                    ? `${link.amount} ${link.token}`
+                                    : `$${link.amount}`}
                             </span>
 
                             {/* Bottom-left arrow */}

--- a/src/components/og/PaymentCardOG.tsx
+++ b/src/components/og/PaymentCardOG.tsx
@@ -12,7 +12,7 @@ export function PaymentCardOG({
     scribbleSrc,
     arrowSrcs,
 }: {
-    link: PaymentLink
+    link: PaymentLink & { token?: string }
     iconSrc: string
     logoSrc: string
     scribbleSrc: string
@@ -115,112 +115,121 @@ export function PaymentCardOG({
                         fontWeight: 500,
                         fontSize: 46,
                         margin: 0,
-                        marginTop: -12,
+                        marginTop: link.type === 'request' && link.amount === 0 ? 100 : -12,
                         letterSpacing: '-0.03em',
                     }}
                 >
-                    {link.type === 'send' ? 'is sending you' : 'is requesting'}
+                    {link.type === 'send'
+                        ? 'is sending you'
+                        : link.amount === 0
+                          ? 'is requesting funds'
+                          : 'is requesting'}
                 </p>
 
-                {/*  big outlined amount  */}
-                {/* $ amount — white fill first, outline absolute & on top */}
-                <p
-                    style={{
-                        position: 'relative',
-                        display: 'block', // only flex | block | none | -webkit-box are allowed
-                        fontSize: 250, // px
-                        lineHeight: 1,
-                        margin: 0,
-                        marginTop: 30,
-                    }}
-                >
-                    {/* Top-left arrow */}
-                    <img
-                        src={arrowSrcs.topLeft}
-                        width={100}
-                        height={100}
-                        alt=""
-                        style={{
-                            position: 'absolute',
-                            top: -110,
-                            left: -60,
-                            pointerEvents: 'none',
-                        }}
-                    />
+                {/* Only show amount display when amount > 0 */}
+                {link.amount > 0 && (
+                    <>
+                        {/*  big outlined amount  */}
+                        {/* $ amount — white fill first, outline absolute & on top */}
+                        <p
+                            style={{
+                                position: 'relative',
+                                display: 'block', // only flex | block | none | -webkit-box are allowed
+                                fontSize: 250, // px
+                                lineHeight: 1,
+                                margin: 0,
+                                marginTop: 30,
+                            }}
+                        >
+                            {/* Top-left arrow */}
+                            <img
+                                src={arrowSrcs.topLeft}
+                                width={100}
+                                height={100}
+                                alt=""
+                                style={{
+                                    position: 'absolute',
+                                    top: -110,
+                                    left: -60,
+                                    pointerEvents: 'none',
+                                }}
+                            />
 
-                    {/* Top-right arrow */}
-                    <img
-                        src={arrowSrcs.topRight}
-                        width={130}
-                        height={80}
-                        alt=""
-                        style={{
-                            position: 'absolute',
-                            top: -90,
-                            right: -100,
-                            pointerEvents: 'none',
-                            transform: 'rotate(5deg)',
-                        }}
-                    />
+                            {/* Top-right arrow */}
+                            <img
+                                src={arrowSrcs.topRight}
+                                width={130}
+                                height={80}
+                                alt=""
+                                style={{
+                                    position: 'absolute',
+                                    top: -90,
+                                    right: -100,
+                                    pointerEvents: 'none',
+                                    transform: 'rotate(5deg)',
+                                }}
+                            />
 
-                    {/* 1) white fill — stays in normal flow */}
-                    <span
-                        style={{
-                            fontFamily: 'Knerd Filled',
-                            color: '#fff',
-                            letterSpacing: '-0.08em',
-                        }}
-                    >
-                        ${link.amount}
-                    </span>
+                            {/* 1) white fill — stays in normal flow */}
+                            <span
+                                style={{
+                                    fontFamily: 'Knerd Filled',
+                                    color: '#fff',
+                                    letterSpacing: '-0.08em',
+                                }}
+                            >
+                                {link.token ? `${link.amount} ${link.token}` : `$${link.amount}`}
+                            </span>
 
-                    {/* 2) black outline — absolutely positioned, painted *after* → on top */}
-                    <span
-                        aria-hidden="true"
-                        style={{
-                            position: 'absolute',
-                            top: 3, // positive offset → outline shows down-right
-                            left: 3,
-                            fontFamily: 'Knerd Outline',
-                            color: '#000',
-                            pointerEvents: 'none', // just in case
-                            transformOrigin: 'top left',
-                            transform: 'scaleX(1.01) scaleY(1.01)',
-                            letterSpacing: '-0.08em',
-                        }}
-                    >
-                        ${link.amount}
-                    </span>
+                            {/* 2) black outline — absolutely positioned, painted *after* → on top */}
+                            <span
+                                aria-hidden="true"
+                                style={{
+                                    position: 'absolute',
+                                    top: 3, // positive offset → outline shows down-right
+                                    left: 3,
+                                    fontFamily: 'Knerd Outline',
+                                    color: '#000',
+                                    pointerEvents: 'none', // just in case
+                                    transformOrigin: 'top left',
+                                    transform: 'scaleX(1.01) scaleY(1.01)',
+                                    letterSpacing: '-0.08em',
+                                }}
+                            >
+                                {link.token ? `${link.amount} ${link.token}` : `$${link.amount}`}
+                            </span>
 
-                    {/* Bottom-left arrow */}
-                    <img
-                        src={arrowSrcs.bottomLeft}
-                        width={64}
-                        height={96}
-                        alt=""
-                        style={{
-                            position: 'absolute',
-                            bottom: 10,
-                            left: -20,
-                            pointerEvents: 'none',
-                        }}
-                    />
+                            {/* Bottom-left arrow */}
+                            <img
+                                src={arrowSrcs.bottomLeft}
+                                width={64}
+                                height={96}
+                                alt=""
+                                style={{
+                                    position: 'absolute',
+                                    bottom: 10,
+                                    left: -20,
+                                    pointerEvents: 'none',
+                                }}
+                            />
 
-                    {/* Bottom-right arrow */}
-                    <img
-                        src={arrowSrcs.bottomRight}
-                        width={40}
-                        height={60}
-                        alt=""
-                        style={{
-                            position: 'absolute',
-                            bottom: 10,
-                            right: -20,
-                            pointerEvents: 'none',
-                            transform: 'rotate(-15deg)',
-                        }}
-                    />
-                </p>
+                            {/* Bottom-right arrow */}
+                            <img
+                                src={arrowSrcs.bottomRight}
+                                width={40}
+                                height={60}
+                                alt=""
+                                style={{
+                                    position: 'absolute',
+                                    bottom: 10,
+                                    right: -20,
+                                    pointerEvents: 'none',
+                                    transform: 'rotate(-15deg)',
+                                }}
+                            />
+                        </p>
+                    </>
+                )}
             </div>
         </div>
     )

--- a/src/components/og/PaymentCardOG.tsx
+++ b/src/components/og/PaymentCardOG.tsx
@@ -116,13 +116,14 @@ export function PaymentCardOG({
                         fontSize: 46,
                         margin: 0,
                         marginTop: link.type === 'request' && link.amount === 0 ? 100 : -12,
+                        marginBottom: link.amount > 0 ? 16 : 0, // Add padding when amount is shown
                         letterSpacing: '-0.03em',
                     }}
                 >
                     {link.type === 'send'
                         ? 'is sending you'
                         : link.amount === 0
-                          ? 'is requesting funds'
+                          ? 'is requesting funds!'
                           : 'is requesting'}
                 </p>
 

--- a/src/components/og/ReceiptCardOG.tsx
+++ b/src/components/og/ReceiptCardOG.tsx
@@ -11,7 +11,7 @@ export function ReceiptCardOG({
     logoSrc,
     scribbleSrc,
 }: {
-    link: PaymentLink
+    link: PaymentLink & { token?: string }
     iconSrc: string
     logoSrc: string
     scribbleSrc: string


### PR DESCRIPTION
What this PR does:
-if URL is just a generic peanut username (ex: [peanut.me/jota](http://peanut.me/jota)), fallback social preview to static default “buttery smooth” image 
-if URL is a generic raw eth address (ex: [peanut.me/0xasas232](http://peanut.me/0xasas232)), same request link social preview but it should say “requesting funds” instead of “requesting ${amount}”
-semantic links should show token type

What this PR does NOT do:
-send links should show peanut username, not raw address (these links dont have the username in the URL, so this is happening under the hood) 

THIS HAS BEEN PUSHED TO THE NEXT SPRINT IN A NEW TICKET

HUGO EDIT: (i didnt know I could edit PRs???) - fix send link previews