### PR TITLE
[TASK-12678] fix: coral withdraw fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,10 @@ export WC_PROJECT_ID=""
 export GA_KEY=""
 export SOCKET_API_KEY=""
 
+# SQUID
+export SQUID_API_URL=""
+export SQUID_INTEGRATOR_ID=""
+
 # Passkey envs
 export NEXT_PUBLIC_ZERO_DEV_PASSKEY_PROJECT_ID=""
 export NEXT_PUBLIC_ZERO_DEV_BUNDLER_URL=""

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -75,10 +75,9 @@ export default function WithdrawCryptoPage() {
             router.push('/withdraw')
             return
         }
-        dispatch(paymentActions.setChargeDetails(null))
         clearErrors()
-        setCurrentView('INITIAL')
-    }, [amountToWithdraw, router, dispatch, setAmountToWithdraw, setCurrentView])
+        dispatch(paymentActions.setChargeDetails(null))
+    }, [amountToWithdraw])
 
     useEffect(() => {
         setPaymentError(paymentErrorFromHook)
@@ -205,19 +204,6 @@ export default function WithdrawCryptoPage() {
 
         if (result.success && result.txHash) {
             setCurrentView('STATUS')
-
-            // reset the entire withdraw flow after successful payment
-            setTimeout(() => {
-                setAmountToWithdraw('')
-                setWithdrawData(null)
-                setCurrentView('INITIAL')
-
-                // clear any errors
-                clearErrors()
-
-                // clear charge details
-                dispatch(paymentActions.setChargeDetails(null))
-            }, 3000) // wait 3 seconds to show success status before resetting
         } else {
             console.error('Withdrawal execution failed:', result.error)
             const errMsg = result.error || 'Withdrawal processing failed.'

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -25,6 +25,7 @@ import { interfaces as peanutInterfaces } from '@squirrel-labs/peanut-sdk'
 import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useMemo } from 'react'
+import { captureMessage } from '@sentry/nextjs'
 
 export default function WithdrawCryptoPage() {
     const router = useRouter()
@@ -265,7 +266,14 @@ export default function WithdrawCryptoPage() {
 
         // For peanut wallet flows, only RFQ routes are allowed
         if (xChainRoute.type === 'swap') {
-            return 'This token pair is not available for withdraw.'
+            captureMessage('No RFQ route found for this token pair', {
+                level: 'warning',
+                extra: {
+                    flow: 'withdraw',
+                    routeObject: xChainRoute,
+                },
+            })
+            return 'No route found for this token pair. You can try with a different token pair, or try again later'
         }
 
         return null

--- a/src/app/(mobile-ui)/withdraw/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/page.tsx
@@ -25,6 +25,7 @@ export default function WithdrawPage() {
         setError,
         error,
         resetWithdrawFlow,
+        setWithdrawData,
     } = useWithdrawFlow()
 
     const { balance } = useWallet()
@@ -92,6 +93,12 @@ export default function WithdrawPage() {
         },
         [setRawTokenAmount]
     )
+
+    // Clean state
+    useEffect(() => {
+        setAmountToWithdraw('')
+        setWithdrawData(null)
+    }, [])
 
     useEffect(() => {
         if (rawTokenAmount === '') {

--- a/src/components/Payment/Views/Confirm.payment.view.tsx
+++ b/src/components/Payment/Views/Confirm.payment.view.tsx
@@ -29,6 +29,7 @@ import { useAccount } from 'wagmi'
 import { PaymentInfoRow } from '../PaymentInfoRow'
 import { formatUnits } from 'viem'
 import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants'
+import { captureMessage } from '@sentry/nextjs'
 
 type ConfirmPaymentViewProps = {
     isPintaReq?: boolean
@@ -344,7 +345,14 @@ export default function ConfirmPaymentView({
 
         // For peanut wallet flows, only RFQ routes are allowed
         if (xChainRoute.type === 'swap') {
-            return 'This token pair is not supported'
+            captureMessage('No RFQ route found for this token pair', {
+                level: 'warning',
+                extra: {
+                    flow: 'payment',
+                    routeObject: xChainRoute,
+                },
+            })
+            return 'No route found for this token pair. You can try with a different token pair, or try again later'
         }
 
         return null

--- a/src/components/Payment/Views/Confirm.payment.view.tsx
+++ b/src/components/Payment/Views/Confirm.payment.view.tsx
@@ -344,7 +344,7 @@ export default function ConfirmPaymentView({
 
         // For peanut wallet flows, only RFQ routes are allowed
         if (xChainRoute.type === 'swap') {
-            return 'This route requires external wallet payment. Peanut Wallet only supports RFQ (Request for Quote) routes.'
+            return 'This token pair is not supported'
         }
 
         return null

--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -108,6 +108,9 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
                 : transaction.currencySymbol || getDisplayCurrencySymbol(actualCurrencyCode) // Use provided sign+symbol or derive symbol
 
         let amountString = Math.abs(amount).toString()
+        if (transaction.currency?.code === 'USD') {
+            amountString = transaction.currency?.amount
+        }
         // If it's a token and not USD/ARS, transaction.tokenSymbol should be displayed after amount.
         // And `displayDecimals` might need to come from token itself if available, else default.
         const decimalsForDisplay = actualCurrencyCode // If it's a known currency (USD, ARS)

--- a/src/constants/general.consts.ts
+++ b/src/constants/general.consts.ts
@@ -6,7 +6,7 @@ export const peanutWalletIsInPreview = true
 
 export const INFURA_API_KEY = process.env.NEXT_PUBLIC_INFURA_API_KEY
 
-export const SQUID_INTEGRATOR_ID = '11CBA45B-5EE9-4331-B146-48CCD7ED4C7C'
+export const SQUID_INTEGRATOR_ID = process.env.SQUID_INTEGRATOR_ID!
 export const SQUID_API_URL = process.env.SQUID_API_URL
 
 export const infuraRpcUrls: Record<number, string> = {

--- a/src/hooks/usePaymentInitiator.ts
+++ b/src/hooks/usePaymentInitiator.ts
@@ -250,12 +250,14 @@ export const usePaymentInitiator = () => {
 
                     setIsCalculatingFees(true)
                     setEstimatedGasCost(
-                        await estimateTransactionCostUsd(
-                            tx.unsignedTx.from! as Address,
-                            tx.unsignedTx.to! as Address,
-                            tx.unsignedTx.data! as Hex,
-                            selectedChainID
-                        )
+                        isPeanutWallet
+                            ? 0
+                            : await estimateTransactionCostUsd(
+                                  tx.unsignedTx.from! as Address,
+                                  tx.unsignedTx.to! as Address,
+                                  tx.unsignedTx.data! as Hex,
+                                  selectedChainID
+                              )
                     )
                     setIsCalculatingFees(false)
                     setUnsignedTx(tx.unsignedTx)


### PR DESCRIPTION
- Stop refreshing the page after successful payment
- Better error message for unsupported token pairs