### PR TITLE
[TASK-12653] removed white spaces before processing to BIC

### DIFF
--- a/src/app/actions/ibanToBic.ts
+++ b/src/app/actions/ibanToBic.ts
@@ -9,7 +9,7 @@ import { ibanToBic } from 'iban-to-bic'
  */
 export async function getBicFromIban(iban: string): Promise<string> {
     try {
-        return ibanToBic(iban)
+        return ibanToBic(iban.replace(/\s+/g, '').trim())
     } catch (err) {
         console.error('IBAN→BIC conversion failed', err)
         throw new Error('Unable to derive BIC from IBAN')


### PR DESCRIPTION
couldnt reproduce Hugo's error to be honest but maybe it was due to the fact that the IBAN's blank spaces were not removed before processing (like the package's example, so this should be merged since its a proper implementation of the library)

works good for me (tried multiple countries) but maybe this fixes it for Hugo. Let's do QA and see if its solved, otherwise Hugo and Konrad will have to provide more details on how to reproduce