### PR TITLE
[TASK-12677] fix: update payment form for crosschain add money

### DIFF
--- a/src/components/AddMoney/components/AddMoneyBankDetails.tsx
+++ b/src/components/AddMoney/components/AddMoneyBankDetails.tsx
@@ -139,7 +139,7 @@ Please use these details to complete your bank transfer.`
             <div className="my-auto flex h-full w-full flex-col justify-center space-y-4 pb-5">
                 <PeanutActionDetailsCard
                     avatarSize="small"
-                    transactionType={'ADD_MONEY'}
+                    transactionType={'ADD_MONEY_BANK_ACCOUNT'}
                     recipientType={'BANK_ACCOUNT'}
                     recipientName={'Your Bank Account'}
                     amount={amountToOnramp}

--- a/src/components/Global/PeanutActionDetailsCard/index.tsx
+++ b/src/components/Global/PeanutActionDetailsCard/index.tsx
@@ -20,6 +20,7 @@ interface PeanutActionDetailsCardProps {
         | 'ADD_MONEY'
         | 'WITHDRAW'
         | 'WITHDRAW_BANK_ACCOUNT'
+        | 'ADD_MONEY_BANK_ACCOUNT'
     recipientType: RecipientType | 'BANK_ACCOUNT'
     recipientName: string
     message?: string
@@ -97,7 +98,7 @@ export default function PeanutActionDetailsCard({
 
     const getAvatarIcon = useCallback((): IconName | undefined => {
         if (viewType === 'SUCCESS') return 'check'
-        if (transactionType === 'WITHDRAW_BANK_ACCOUNT') return 'bank'
+        if (transactionType === 'WITHDRAW_BANK_ACCOUNT' || transactionType === 'ADD_MONEY_BANK_ACCOUNT') return 'bank'
         if (recipientType !== 'USERNAME' || transactionType === 'ADD_MONEY' || transactionType === 'WITHDRAW')
             return 'wallet-outline'
         return undefined
@@ -131,7 +132,7 @@ export default function PeanutActionDetailsCard({
     }
 
     const isWithdrawBankAccount = transactionType === 'WITHDRAW_BANK_ACCOUNT' && recipientType === 'BANK_ACCOUNT'
-    const isAddBankAccount = transactionType === 'ADD_MONEY'
+    const isAddBankAccount = transactionType === 'ADD_MONEY_BANK_ACCOUNT'
 
     const withdrawBankIcon = () => {
         if (isWithdrawBankAccount || isAddBankAccount)

--- a/src/components/Payment/Views/Confirm.payment.view.tsx
+++ b/src/components/Payment/Views/Confirm.payment.view.tsx
@@ -150,8 +150,8 @@ export default function ConfirmPaymentView({
 
     const handleRouteRefresh = useCallback(async () => {
         if (chargeDetails && selectedTokenData && selectedChainID) {
-            const fromTokenAddress = isPeanutWallet ? PEANUT_WALLET_TOKEN : selectedTokenData.address
-            const fromChainId = isPeanutWallet ? PEANUT_WALLET_CHAIN.id.toString() : selectedChainID
+            const fromTokenAddress = !isAddMoneyFlow && isPeanutWallet ? PEANUT_WALLET_TOKEN : selectedTokenData.address
+            const fromChainId = !isAddMoneyFlow && isPeanutWallet ? PEANUT_WALLET_CHAIN.id.toString() : selectedChainID
             const usdAmount =
                 isDirectUsdPayment && chargeDetails.currencyCode.toLowerCase() === 'usd'
                     ? chargeDetails.currencyAmount
@@ -165,6 +165,7 @@ export default function ConfirmPaymentView({
         prepareTransactionDetails,
         isDirectUsdPayment,
         isPeanutWallet,
+        isAddMoneyFlow,
     ])
 
     useEffect(() => {
@@ -326,19 +327,19 @@ export default function ConfirmPaymentView({
 
     const isCrossChainPayment = useMemo((): boolean => {
         if (!chargeDetails) return false
-        if (isPeanutWallet) {
+        if (!isAddMoneyFlow && isPeanutWallet) {
             return (
                 !areEvmAddressesEqual(chargeDetails.tokenAddress, PEANUT_WALLET_TOKEN) ||
                 chargeDetails.chainId !== PEANUT_WALLET_CHAIN.id.toString()
             )
         } else if (selectedTokenData && selectedChainID) {
             return (
-                areEvmAddressesEqual(chargeDetails.tokenAddress, selectedTokenData.address) &&
+                !areEvmAddressesEqual(chargeDetails.tokenAddress, selectedTokenData.address) ||
                 chargeDetails.chainId !== selectedChainID
             )
         }
         return false
-    }, [chargeDetails, selectedTokenData, selectedChainID])
+    }, [chargeDetails, selectedTokenData, selectedChainID, isPeanutWallet, isAddMoneyFlow])
 
     const routeTypeError = useMemo((): string | null => {
         if (!isCrossChainPayment || !xChainRoute || !isPeanutWallet) return null
@@ -423,7 +424,7 @@ export default function ConfirmPaymentView({
                             }
                         />
                     )}
-                    {isCrossChainPayment !== isPeanutWallet && (
+                    {isCrossChainPayment !== (isPeanutWallet && !isAddMoneyFlow) && (
                         <PaymentInfoRow
                             label={isCrossChainPayment ? `Sending` : 'Token and network'}
                             value={


### PR DESCRIPTION
Two bugs here
- When adding onramp, we did not differentiante between normal deposit and bank deposit, but this was only a UI error (showed wrong icon)
- The second bug is a little more worrysome because it was due to modyfing the PaymentForm for other use in the app (Paying to a semantic request xchain from peanut wallet) and that broke the deposit one. The bad part is that the developer that did both flows for xchain was the same (me) PaymentForm is complex enough that the same developer working on the same functionallity for two different flows can fall into pitfalls.
