### PR TITLE
[TASK-12855] fix: correct approval owner and base rpc

### DIFF
--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -26,12 +26,13 @@ import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useMemo } from 'react'
 import { captureMessage } from '@sentry/nextjs'
+import type { Address } from 'viem'
 
 export default function WithdrawCryptoPage() {
     const router = useRouter()
     const dispatch = useAppDispatch()
     const { chargeDetails: activeChargeDetailsFromStore } = usePaymentStore()
-    const { isConnected: isPeanutWallet } = useWallet()
+    const { isConnected: isPeanutWallet, address } = useWallet()
     const {
         amountToWithdraw,
         setAmountToWithdraw,
@@ -97,13 +98,14 @@ export default function WithdrawCryptoPage() {
             prepareTransactionDetails({
                 chargeDetails: activeChargeDetailsFromStore,
                 from: {
+                    address: address as Address,
                     tokenAddress: PEANUT_WALLET_TOKEN,
                     chainId: PEANUT_WALLET_CHAIN.id.toString(),
                 },
                 usdAmount: amountToWithdraw,
             })
         }
-    }, [currentView, activeChargeDetailsFromStore, withdrawData, prepareTransactionDetails, amountToWithdraw])
+    }, [currentView, activeChargeDetailsFromStore, withdrawData, prepareTransactionDetails, amountToWithdraw, address])
 
     const handleSetupReview = useCallback(
         async (data: Omit<WithdrawData, 'amount'>) => {
@@ -237,12 +239,13 @@ export default function WithdrawCryptoPage() {
         await prepareTransactionDetails({
             chargeDetails: activeChargeDetailsFromStore,
             from: {
+                address: address as Address,
                 tokenAddress: PEANUT_WALLET_TOKEN,
                 chainId: PEANUT_WALLET_CHAIN.id.toString(),
             },
             usdAmount: amountToWithdraw,
         })
-    }, [activeChargeDetailsFromStore, prepareTransactionDetails, amountToWithdraw])
+    }, [activeChargeDetailsFromStore, prepareTransactionDetails, amountToWithdraw, address])
 
     const handleBackFromConfirm = useCallback(() => {
         setCurrentView('INITIAL')

--- a/src/components/AddWithdraw/AddWithdrawRouterView.tsx
+++ b/src/components/AddWithdraw/AddWithdrawRouterView.tsx
@@ -9,7 +9,13 @@ import {
 import EmptyState from '@/components/Global/EmptyStates/EmptyState'
 import NavHeader from '@/components/Global/NavHeader'
 import { SearchInput } from '@/components/SearchUsers/SearchInput'
-import { RecentMethod, getUserPreferences, updateUserPreferences, shortenAddressLong, formatIban } from '@/utils/general.utils'
+import {
+    RecentMethod,
+    getUserPreferences,
+    updateUserPreferences,
+    shortenAddressLong,
+    formatIban,
+} from '@/utils/general.utils'
 import { useRouter } from 'next/navigation'
 import { FC, useEffect, useMemo, useState } from 'react'
 import { useUserStore } from '@/redux/hooks'

--- a/src/components/Payment/Views/Confirm.payment.view.tsx
+++ b/src/components/Payment/Views/Confirm.payment.view.tsx
@@ -83,7 +83,7 @@ export default function ConfirmPaymentView({
         xChainRoute,
     } = usePaymentInitiator()
     const { selectedTokenData, selectedChainID } = useContext(tokenSelectorContext)
-    const { isConnected: isPeanutWallet, fetchBalance } = useWallet()
+    const { isConnected: isPeanutWallet, fetchBalance, address: peanutWalletAddress } = useWallet()
     const { isConnected: isWagmiConnected, address: wagmiAddress } = useAccount()
     const { rewardWalletBalance } = useWalletStore()
     const queryClient = useQueryClient()
@@ -171,9 +171,11 @@ export default function ConfirmPaymentView({
                 isDirectUsdPayment && chargeDetails.currencyCode.toLowerCase() === 'usd'
                     ? chargeDetails.currencyAmount
                     : undefined
+            const senderAddress = isUsingExternalWallet ? wagmiAddress : peanutWalletAddress
             await prepareTransactionDetails({
                 chargeDetails,
                 from: {
+                    address: senderAddress as Address,
                     tokenAddress: fromTokenAddress as Address,
                     chainId: fromChainId,
                 },
@@ -187,6 +189,8 @@ export default function ConfirmPaymentView({
         prepareTransactionDetails,
         isDirectUsdPayment,
         isUsingExternalWallet,
+        wagmiAddress,
+        peanutWalletAddress,
     ])
 
     useEffect(() => {

--- a/src/components/TransactionDetails/TransactionDetailsDrawer.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsDrawer.tsx
@@ -440,16 +440,16 @@ export const TransactionDetailsReceipt = ({
                                                     value={
                                                         <div className="flex items-center gap-2">
                                                             <span>
-                                                                {
-                                                                    formatIban(transaction.extraDataForDrawer.depositInstructions
-                                                                        .iban)
-                                                                }
+                                                                {formatIban(
+                                                                    transaction.extraDataForDrawer.depositInstructions
+                                                                        .iban
+                                                                )}
                                                             </span>
                                                             <CopyToClipboard
-                                                                textToCopy={
-                                                                    formatIban(transaction.extraDataForDrawer.depositInstructions
-                                                                        .iban)
-                                                                }
+                                                                textToCopy={formatIban(
+                                                                    transaction.extraDataForDrawer.depositInstructions
+                                                                        .iban
+                                                                )}
                                                                 iconSize="4"
                                                             />
                                                         </div>

--- a/src/constants/general.consts.ts
+++ b/src/constants/general.consts.ts
@@ -15,7 +15,7 @@ export const infuraRpcUrls: Record<number, string> = {
     [arbitrumSepolia.id]: `https://arbitrum-sepolia.infura.io/v3/${INFURA_API_KEY}`,
     [polygon.id]: `https://polygon-mainnet.infura.io/v3/${INFURA_API_KEY}`,
     [optimism.id]: `https://optimism-mainnet.infura.io/v3/${INFURA_API_KEY}`,
-    [base.id]: `https://base-sepolia.infura.io/v3/${INFURA_API_KEY}`,
+    [base.id]: `https://base-mainnet.infura.io/v3/${INFURA_API_KEY}`,
     // Infura is returning weird estimations for BSC @2025-05-14
     //[bsc.id]: `https://bsc-mainnet.infura.io/v3/${INFURA_API_KEY}`,
     [bsc.id]: 'https://bsc-dataseed.bnbchain.org',

--- a/src/hooks/usePaymentInitiator.ts
+++ b/src/hooks/usePaymentInitiator.ts
@@ -165,16 +165,12 @@ export const usePaymentInitiator = () => {
         }: {
             chargeDetails: TRequestChargeResponse
             from: {
+                address: Address
                 tokenAddress: Address
                 chainId: string
             }
             usdAmount?: string
         }) => {
-            if (!peanutWalletAddress && !wagmiAddress) {
-                console.warn('Missing data for transaction preparation')
-                return
-            }
-
             setError(null)
             setIsFeeEstimationError(false)
             setUnsignedTx(null)
@@ -192,7 +188,6 @@ export const usePaymentInitiator = () => {
 
                 if (_isXChain || _diffTokens) {
                     setLoadingStep('Preparing Transaction')
-                    const senderAddress = isPeanutWallet ? peanutWalletAddress : wagmiAddress
                     setIsCalculatingFees(true)
                     const amount = usdAmount
                         ? {
@@ -202,10 +197,7 @@ export const usePaymentInitiator = () => {
                               toAmount: parseUnits(chargeDetails.tokenAmount, chargeDetails.tokenDecimals),
                           }
                     const xChainRoute = await getRoute({
-                        from: {
-                            address: senderAddress as Address,
-                            ...from,
-                        },
+                        from,
                         to: {
                             address: chargeDetails.requestLink.recipientAddress as Address,
                             tokenAddress: chargeDetails.tokenAddress as Address,
@@ -273,7 +265,7 @@ export const usePaymentInitiator = () => {
                 setIsPreparingTx(false)
             }
         },
-        [peanutWalletAddress, wagmiAddress, setIsXChain, isPeanutWallet]
+        [setIsXChain, isPeanutWallet]
     )
 
     // helper function: determine charge details (fetch or create)


### PR DESCRIPTION
Two things here:

1. We were using the peanut address for approval checking on deposits, this didn't affect because if the approval call failed we just continued with the deposit
2. The base rpc url was the sepolia one, not the mainnet. Big oversight
   there