### PR TITLE
hot-fix: skip coral route fetching for add-money flow and use default squid route fetching

### DIFF
--- a/src/components/Payment/Views/Confirm.payment.view.tsx
+++ b/src/components/Payment/Views/Confirm.payment.view.tsx
@@ -187,6 +187,7 @@ export default function ConfirmPaymentView({
                     chainId: fromChainId,
                 },
                 usdAmount,
+                disableCoral: isAddMoneyFlow && isUsingExternalWallet,
             })
         }
     }, [
@@ -197,6 +198,8 @@ export default function ConfirmPaymentView({
         isDirectUsdPayment,
         wagmiAddress,
         peanutWalletAddress,
+        isAddMoneyFlow,
+        isUsingExternalWallet,
     ])
 
     useEffect(() => {
@@ -232,7 +235,8 @@ export default function ConfirmPaymentView({
     }, [chargeDetails, selectedTokenData, selectedChainID])
 
     const routeTypeError = useMemo((): string | null => {
-        if (!isCrossChainPayment || !xChainRoute || !isPeanutWallet) return null
+        // error only applies to peanut wallet flows (not external wallet) where cross-chain swap route is RFQ-required.
+        if (!isCrossChainPayment || !xChainRoute || isUsingExternalWallet || !isPeanutWallet) return null
 
         // For peanut wallet flows, only RFQ routes are allowed
         if (xChainRoute.type === 'swap') {
@@ -247,7 +251,7 @@ export default function ConfirmPaymentView({
         }
 
         return null
-    }, [isCrossChainPayment, xChainRoute, isPeanutWallet])
+    }, [isCrossChainPayment, xChainRoute, isUsingExternalWallet, isPeanutWallet])
 
     const errorMessage = useMemo((): string | undefined => {
         if (isRouteExpired) return 'This quoute has expired. Please retry to fetch latest quote.'
@@ -424,7 +428,7 @@ export default function ConfirmPaymentView({
                         tokenSymbol={symbolForDisplay}
                         message={chargeDetails?.requestLink?.reference ?? ''}
                         fileUrl={chargeDetails?.requestLink?.attachmentUrl ?? ''}
-                        showTimer={isCrossChainPayment}
+                        showTimer={isCrossChainPayment && xChainRoute?.type === 'rfq'}
                         timerExpiry={xChainRoute?.expiry}
                         isTimerLoading={isCalculatingFees || isPreparingTx}
                         onTimerNearExpiry={handleRouteRefresh}

--- a/src/components/Payment/Views/Confirm.payment.view.tsx
+++ b/src/components/Payment/Views/Confirm.payment.view.tsx
@@ -489,12 +489,13 @@ export default function ConfirmPaymentView({
                             }
                         />
                     )}
-
+                    {/* note: @dev temp hide gas fee, estimation is way off */}
+                    {/* 
                     <PaymentInfoRow
                         loading={isCalculatingFees || isEstimatingGas || isPreparingTx}
                         label={'Network fee'}
                         value={networkFee}
-                    />
+                    /> */}
 
                     <PaymentInfoRow hideBottomBorder label="Peanut fee" value={`$ 0.00`} />
                 </Card>

--- a/src/constants/general.consts.ts
+++ b/src/constants/general.consts.ts
@@ -1,6 +1,6 @@
 import * as interfaces from '@/interfaces'
 import { CHAIN_DETAILS, TOKEN_DETAILS } from '@squirrel-labs/peanut-sdk'
-import { mainnet, arbitrum, arbitrumSepolia, polygon, optimism, base, bsc, scroll, baseSepolia } from 'viem/chains'
+import { mainnet, arbitrum, arbitrumSepolia, polygon, optimism, base, bsc, scroll } from 'viem/chains'
 
 export const peanutWalletIsInPreview = true
 
@@ -8,7 +8,9 @@ export const INFURA_API_KEY = process.env.NEXT_PUBLIC_INFURA_API_KEY
 export const ALCHEMY_API_KEY = process.env.NEXT_PUBLIC_ALCHEMY_API_KEY
 
 export const SQUID_INTEGRATOR_ID = process.env.SQUID_INTEGRATOR_ID!
-export const SQUID_API_URL = process.env.SQUID_API_URL
+export const DEFAULT_SQUID_INTEGRATOR_ID =
+    process.env.DEFAULT_SQUID_INTEGRATOR_ID || process.env.NEXT_PUBLIC_DEFAULT_SQUID_INTEGRATOR_ID
+export const SQUID_API_URL = process.env.NEXT_PUBLIC_SQUID_API_URL
 
 const infuraUrl = (subdomain: string) => (INFURA_API_KEY ? `https://${subdomain}.infura.io/v3/${INFURA_API_KEY}` : null)
 const alchemyUrl = (subdomain: string) =>

--- a/src/hooks/usePaymentInitiator.ts
+++ b/src/hooks/usePaymentInitiator.ts
@@ -501,7 +501,6 @@ export const usePaymentInitiator = () => {
                 chainId: PEANUT_WALLET_CHAIN.id.toString(),
                 hash: receipt.transactionHash,
                 tokenAddress: PEANUT_WALLET_TOKEN,
-                payerAddress: peanutWalletAddress ?? '',
             })
             console.log('Backend payment creation response:', payment)
 
@@ -609,7 +608,6 @@ export const usePaymentInitiator = () => {
                 chainId: sourceChainId.toString(),
                 hash: txHash,
                 tokenAddress: selectedTokenData?.address || chargeDetails.tokenAddress,
-                payerAddress: wagmiAddress ?? '',
             })
             console.log('Backend payment creation response:', payment)
 

--- a/src/services/charges.ts
+++ b/src/services/charges.ts
@@ -64,13 +64,11 @@ export const chargesApi = {
         chainId,
         hash,
         tokenAddress,
-        payerAddress,
     }: {
         chargeId: string
         chainId: string
         hash: string
         tokenAddress: string
-        payerAddress: string
     }): Promise<PaymentCreationResponse> => {
         const response = await fetchWithSentry(`/api/proxy/charges/${chargeId}/payments`, {
             method: 'POST',
@@ -81,7 +79,6 @@ export const chargesApi = {
                 chainId,
                 hash,
                 tokenAddress,
-                payerAddress,
             }),
         })
 

--- a/src/services/charges.ts
+++ b/src/services/charges.ts
@@ -64,11 +64,13 @@ export const chargesApi = {
         chainId,
         hash,
         tokenAddress,
+        payerAddress,
     }: {
         chargeId: string
         chainId: string
         hash: string
         tokenAddress: string
+        payerAddress: string
     }): Promise<PaymentCreationResponse> => {
         const response = await fetchWithSentry(`/api/proxy/charges/${chargeId}/payments`, {
             method: 'POST',
@@ -79,6 +81,7 @@ export const chargesApi = {
                 chainId,
                 hash,
                 tokenAddress,
+                payerAddress,
             }),
         })
 


### PR DESCRIPTION
fixes TASK-13364