### PR TITLE
Fix: KYC modal close navigation on withdraw flow

### DIFF
--- a/src/hooks/useKycFlow.ts
+++ b/src/hooks/useKycFlow.ts
@@ -143,7 +143,7 @@ export const useKycFlow = ({ onKycSuccess, flow }: UseKycFlowOptions = {}) => {
             }
             // if user is in withdraw flow, and they close on the ToS acceptance page
             else {
-                router.push('/withdraw')
+                setIframeOptions((prev) => ({ ...prev, visible: false }))
             }
         },
         [iframeOptions.src, apiResponse, flow, router]


### PR DESCRIPTION
Current flow
- User closes the KYC modal (without completing the KYC) they get redirected to `/withdraw` route

Updated flow - 
-User closes the KYC modal (without completing the KYC) they stay on the same screen only the popup is closed
