### PR TITLE
[TASK-13525] fix(semantic-send): fix history for payments

### DIFF
--- a/src/components/Payment/PaymentForm/index.tsx
+++ b/src/components/Payment/PaymentForm/index.tsx
@@ -403,7 +403,7 @@ export const PaymentForm = ({
             currency,
             currencyAmount,
             isAddMoneyFlow: !!isAddMoneyFlow,
-            transactionType: isAddMoneyFlow ? 'DEPOSIT' : isDirectUsdPayment ? 'DIRECT_SEND' : 'REQUEST',
+            transactionType: isAddMoneyFlow ? 'DEPOSIT' : isDirectUsdPayment || !requestId ? 'DIRECT_SEND' : 'REQUEST',
             attachmentOptions: attachmentOptions,
         }
 

--- a/src/services/swap.ts
+++ b/src/services/swap.ts
@@ -267,6 +267,8 @@ async function getSquidRouteRaw(params: SquidGetRouteParams, options: RouteOptio
     })
 
     if (!response.ok) {
+        console.error(`Failed to get route: ${response.status}`)
+        console.dir(await response.json())
         throw new Error(`Failed to get route: ${response.status}`)
     }
 


### PR DESCRIPTION
Treat as a direct send if there is no request id