### PR TITLE
fix: associate a external wallet claim to user if logged in

### DIFF
--- a/src/components/Claim/Link/Initial.view.tsx
+++ b/src/components/Claim/Link/Initial.view.tsx
@@ -196,8 +196,7 @@ export const InitialClaimLinkView = (props: IClaimScreenProps) => {
                         setClaimType('claim')
                     }
 
-                    // if a user is logged in, we tell the backend to link this claim to their account so it shows up in their activity
-                    // this is only for external claims, as internal claims are already associated with the user.
+                    // associate the claim with the user so it shows up in their activity
                     if (user && claimTxHash) {
                         try {
                             await sendLinksApi.associateClaim(claimTxHash)

--- a/src/components/Claim/Link/Initial.view.tsx
+++ b/src/components/Claim/Link/Initial.view.tsx
@@ -196,6 +196,17 @@ export const InitialClaimLinkView = (props: IClaimScreenProps) => {
                         setClaimType('claim')
                     }
 
+                    // if a user is logged in, we tell the backend to link this claim to their account so it shows up in their activity
+                    // this is only for external claims, as internal claims are already associated with the user.
+                    if (user && claimTxHash) {
+                        try {
+                            await sendLinksApi.associateClaim(claimTxHash)
+                        } catch (e) {
+                            Sentry.captureException(e)
+                            console.error('Failed to associate claim', e)
+                        }
+                    }
+
                     setTransactionHash(claimTxHash)
                     onCustom('SUCCESS')
                     queryClient.invalidateQueries({ queryKey: [TRANSACTIONS] })

--- a/src/components/Claim/Link/Onchain/Confirm.view.tsx
+++ b/src/components/Claim/Link/Onchain/Confirm.view.tsx
@@ -103,8 +103,7 @@ export const ConfirmClaimLinkView = ({
                 setClaimType('claim')
             }
             if (claimTxHash) {
-                // if a user is logged in, we tell the backend to link this claim to their account so it shows up in their activity
-                // this is only for external claims, as internal claims are already associated with the user.
+                // associate the claim with the user so it shows up in their activity
                 if (user) {
                     try {
                         await sendLinksApi.associateClaim(claimTxHash)

--- a/src/services/sendLinks.ts
+++ b/src/services/sendLinks.ts
@@ -199,4 +199,25 @@ export const sendLinksApi = {
         const pubKey = generateKeysFromString(params.password).address
         return await claimSendLink(pubKey, recipient, params.password)
     },
+
+    /**
+     * associates a logged-in user with a claim transaction.
+     * this is called after an external wallet claim is successful.
+     * it helps the backend link the claim to the user's history.
+     * @param txhash - the transaction hash of the successful claim.
+     */
+    associateClaim: async (txHash: string): Promise<void> => {
+        const response = await fetchWithSentry(`${PEANUT_API_URL}/send-links/claim/${txHash}/associate-user`, {
+            method: 'PATCH',
+            headers: {
+                Authorization: `Bearer ${Cookies.get('jwt-token')}`,
+            },
+        })
+
+        if (!response.ok) {
+            const errorText = await response.text()
+            console.error('Failed to associate user with claim:', errorText)
+            // not throwing error because the claim itself was successful.
+        }
+    },
 }


### PR DESCRIPTION
- fixes TASK-14058 :  associate a claim link to logged in user if claimed to external wallets
