### PR TITLE
fix: send links history ui for senders pov when claimed to bank accounts

### DIFF
--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -1,11 +1,6 @@
 'use client'
 
-import {
-    COUNTRY_SPECIFIC_METHODS,
-    countryCodeMap,
-    countryData,
-    SpecificPaymentMethod,
-} from '@/components/AddMoney/consts'
+import { COUNTRY_SPECIFIC_METHODS, countryData, SpecificPaymentMethod } from '@/components/AddMoney/consts'
 import StatusBadge from '@/components/Global/Badges/StatusBadge'
 import { IconName } from '@/components/Global/Icons/Icon'
 import NavHeader from '@/components/Global/NavHeader'

--- a/src/components/Common/ActionList.tsx
+++ b/src/components/Common/ActionList.tsx
@@ -118,6 +118,18 @@ export default function ActionList({ claimLinkData, isLoggedIn, flow, requestLin
         return false
     }, [claimType, requestType, flow])
 
+    const sortedActionMethods = useMemo(() => {
+        return [...ACTION_METHODS].sort((a, b) => {
+            const aIsUnavailable = a.soon || (a.id === 'bank' && requiresVerification)
+            const bIsUnavailable = b.soon || (b.id === 'bank' && requiresVerification)
+
+            if (aIsUnavailable === bIsUnavailable) {
+                return 0
+            }
+            return aIsUnavailable ? 1 : -1
+        })
+    }, [requiresVerification])
+
     return (
         <div className="space-y-2">
             {!isLoggedIn && (
@@ -142,7 +154,7 @@ export default function ActionList({ claimLinkData, isLoggedIn, flow, requestLin
             )}
             <Divider text="or" />
             <div className="space-y-2">
-                {ACTION_METHODS.map((method) => {
+                {sortedActionMethods.map((method) => {
                     if (flow === 'request' && method.id === 'exchange-or-wallet') {
                         return <ActionListDaimoPayButton key={method.id} />
                     }

--- a/src/components/TransactionDetails/TransactionAvatarBadge.tsx
+++ b/src/components/TransactionDetails/TransactionAvatarBadge.tsx
@@ -53,6 +53,7 @@ const TransactionAvatarBadge: React.FC<TransactionAvatarBadgeProps> = ({
         case 'bank_withdraw':
         case 'bank_deposit':
         case 'bank_request_fulfillment':
+        case 'bank_claim':
             displayIconName = 'bank'
             displayInitials = undefined
             calculatedBgColor = AVATAR_TEXT_DARK

--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -26,6 +26,7 @@ export type TransactionType =
     | 'bank_deposit'
     | 'bank_request_fulfillment'
     | 'claim_external'
+    | 'bank_claim'
 
 interface TransactionCardProps {
     type: TransactionType
@@ -235,6 +236,7 @@ function getActionIcon(type: TransactionType, direction: TransactionDirection): 
         case 'bank_withdraw':
         case 'cashout':
         case 'claim_external':
+        case 'bank_claim':
             iconName = 'arrow-up'
             iconSize = 8
             break
@@ -258,6 +260,7 @@ function getActionText(type: TransactionType): string {
         case 'bank_withdraw':
             actionText = 'Withdraw'
             break
+        case 'bank_claim':
         case 'claim_external':
             actionText = 'Claim'
             break

--- a/src/constants/actionlist.consts.ts
+++ b/src/constants/actionlist.consts.ts
@@ -1,4 +1,4 @@
-import { MERCADO_PAGO_ICON } from '@/assets'
+import { MERCADO_PAGO } from '@/assets'
 import { METAMASK_LOGO, TRUST_WALLET_SMALL_LOGO } from '@/assets/wallets'
 import binanceIcon from '@/assets/exchanges/binance.svg'
 
@@ -26,7 +26,7 @@ export const ACTION_METHODS: PaymentMethod[] = [
         id: 'mercadopago',
         title: 'Mercado Pago',
         description: 'Instant transfers',
-        icons: [MERCADO_PAGO_ICON],
+        icons: [MERCADO_PAGO],
         soon: true,
     },
     {


### PR DESCRIPTION
- fixes TASK-14407 : send links claimed to bank accounts showing incorrect history for sender's pov

### receiver is a **non-kyced** peanut user, claiming on behalf of sender
- sender : testk01 (history looks like this)
    - initial history when link is not claimed
    - <img width="397" height="627" alt="Screenshot 2025-09-01 at 11 08 26 PM" src="https://github.com/user-attachments/assets/0ab1774f-9c13-4c9c-bc62-1d3dc6c79c9b" />
 
- history when link is claimed on sender’s pov
    - <img width="603" height="743" alt="Screenshot 2025-09-01 at 11 09 41 PM" src="https://github.com/user-attachments/assets/00c10cf4-d0a7-41a6-a8ee-993fee9c9c45" />
            
- receiver : testk02 (history looks like this)
    - history when link is claimed on receiver's pov
    - <img width="760" height="749" alt="Screenshot 2025-09-01 at 11 10 08 PM" src="https://github.com/user-attachments/assets/7b5346e8-007c-4168-9813-8713a2309bc5" />

### receiver is a **kyced** peanut user

- sender : testk02 (history looks like this)
    - initial history when link is not claimed
    - <img width="472" height="710" alt="image" src="https://github.com/user-attachments/assets/bf699fc0-8fa6-4d84-9197-db714156a469" />

- history when link is claimed to bank account, shown as direct send to the user
    - <img width="584" height="684" alt="Screenshot 2025-09-01 at 11 12 14 PM" src="https://github.com/user-attachments/assets/e352256a-f5ba-4d8c-812a-7910f9d1c6c3" />

- receiver : testk01 (history looks like this)
    - <img width="691" height="682" alt="Screenshot 2025-09-01 at 11 12 42 PM" src="https://github.com/user-attachments/assets/bf1aa406-96dc-444d-9431-8a9d2e8f66ba" />
            
### receiver is a **guest** user claiming on senders kyc, sender is kyced

- sender : testk01 (history looks like this)
    - initial history when link is not claimed
    - <img width="408" height="610" alt="Screenshot 2025-09-01 at 11 14 13 PM" src="https://github.com/user-attachments/assets/41fa1642-1f66-4c3c-b45c-a90ca6af8f20" />

    - history when link is claimed by a guest (logged out) user
    - <img width="564" height="586" alt="Screenshot 2025-09-01 at 11 14 21 PM" src="https://github.com/user-attachments/assets/519475ba-30d0-4136-89fd-8f1064be32fa" />

            
- receiver : guest
    - NO HISTORY IN THIS CASE