### PR TITLE
[TASK-12561] fix: always show the bottom border for the deposit message 

### DIFF
--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -516,7 +516,7 @@ export const TransactionDetailsReceipt = ({
                                         />
                                     </div>
                                 }
-                                hideBottomBorder={shouldHideBorder('depositInstructions')}
+                                hideBottomBorder={false} // Always show the border for the deposit message
                             />
 
                             {/* Toggle button for bank details */}


### PR DESCRIPTION
<img width="342" height="752" alt="image" src="https://github.com/user-attachments/assets/5ddb2089-c1d4-475b-89f2-41bdd178d42e" />