### PR TITLE
fix: only show token and network field when its not peanut token/chain

### DIFF
--- a/src/components/Payment/PaymentForm/index.tsx
+++ b/src/components/Payment/PaymentForm/index.tsx
@@ -22,7 +22,7 @@ import { ParsedURL } from '@/lib/url-parser/types/payment'
 import { useAppDispatch, usePaymentStore } from '@/redux/hooks'
 import { paymentActions } from '@/redux/slices/payment-slice'
 import { walletActions } from '@/redux/slices/wallet-slice'
-import { areEvmAddressesEqual, ErrorHandler, formatAmount } from '@/utils'
+import { areEvmAddressesEqual, ErrorHandler, formatAmount, formatCurrency } from '@/utils'
 import { useAppKit, useDisconnect } from '@reown/appkit/react'
 import Image from 'next/image'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -102,7 +102,7 @@ export const PaymentForm = ({
     const { initiatePayment, isProcessing, error: initiatorError } = usePaymentInitiator()
 
     const peanutWalletBalance = useMemo(() => {
-        return balance !== undefined ? parseFloat(formatUnits(balance, PEANUT_WALLET_TOKEN_DECIMALS)).toFixed(4) : ''
+        return balance !== undefined ? formatCurrency(formatUnits(balance, PEANUT_WALLET_TOKEN_DECIMALS)) : ''
     }, [balance])
 
     const error = useMemo(() => {

--- a/src/components/Payment/PaymentForm/index.tsx
+++ b/src/components/Payment/PaymentForm/index.tsx
@@ -102,7 +102,7 @@ export const PaymentForm = ({
     const { initiatePayment, isProcessing, error: initiatorError } = usePaymentInitiator()
 
     const peanutWalletBalance = useMemo(() => {
-        return balance !== undefined ? formatAmount(formatUnits(balance, PEANUT_WALLET_TOKEN_DECIMALS)) : ''
+        return balance !== undefined ? parseFloat(formatUnits(balance, PEANUT_WALLET_TOKEN_DECIMALS)).toFixed(4) : ''
     }, [balance])
 
     const error = useMemo(() => {

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/constants/manteca.consts'
 import { mantecaApi } from '@/services/manteca'
 import { getReceiptUrl } from '@/utils/history.utils'
+import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN_SYMBOL } from '@/constants'
 
 export const TransactionDetailsReceipt = ({
     transaction,
@@ -221,6 +222,14 @@ export const TransactionDetailsReceipt = ({
         return false
     }, [transaction, isPendingSentLink, isPendingRequester, isPendingRequestee])
 
+    // check if token is usdc on arbitrum to hide token/network section
+    const isPeanutWalletToken = useMemo(() => {
+        if (!transaction) return false
+        const tokenSymbol = transaction.tokenSymbol?.toUpperCase()
+        const chainName = transaction.tokenDisplayDetails?.chainName?.toLowerCase()
+        return tokenSymbol === PEANUT_WALLET_TOKEN_SYMBOL && chainName === PEANUT_WALLET_CHAIN.name.toLowerCase()
+    }, [transaction])
+
     useEffect(() => {
         const getTokenDetails = async () => {
             if (!transaction) {
@@ -346,7 +355,8 @@ export const TransactionDetailsReceipt = ({
                     {rowVisibilityConfig.tokenAndNetwork &&
                         transaction.tokenDisplayDetails &&
                         tokenData?.icon &&
-                        tokenData?.symbol && (
+                        tokenData?.symbol &&
+                        !isPeanutWalletToken && (
                             <>
                                 {!isStableCoin(transaction.tokenSymbol ?? 'USDC') && (
                                     <PaymentInfoRow label="Token amount" value={transaction.amount} />


### PR DESCRIPTION
- contributes to TASK-14498 :  only show token and network field in receipt when its not peanut token/chain
- also fixes TASK-15141 : format token balance in send flow