### PR TITLE
Fix: Ios force pwa install screen not visible

### DIFF
--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -18,6 +18,8 @@ import JoinWaitlistPage from '@/components/Invites/JoinWaitlistPage'
 import { useRouter } from 'next/navigation'
 import { Banner } from '@/components/Global/Banner'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
+import { useSetupStore } from '@/redux/hooks'
+import ForceIOSPWAInstall from '@/components/ForceIOSPWAInstall'
 
 // Allow access to some public paths without authentication
 const publicPathRegex = /^\/(request\/pay|claim|pay\/.+$|support|invite|dev)/
@@ -34,6 +36,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
     const alignStart = isHome || isHistory || isSupport
     const router = useRouter()
     const { deviceType: detectedDeviceType } = useDeviceType()
+    const { showIosPwaInstallScreen } = useSetupStore()
 
     useEffect(() => {
         // check for JWT token
@@ -89,6 +92,11 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
                 <PeanutLoading />
             </div>
         )
+    }
+
+    // After setup flow is completed, show ios pwa install screen if not in pwa
+    if (!isPublicPath && showIosPwaInstallScreen) {
+        return <ForceIOSPWAInstall />
     }
 
     // Show waitlist page if user doesn't have app access

--- a/src/app/(setup)/layout.tsx
+++ b/src/app/(setup)/layout.tsx
@@ -21,12 +21,14 @@ function SetupLayoutContent({ children }: { children?: React.ReactNode }) {
             // Filter out pwa-install if already in PWA
             if (step.screenId === 'pwa-install' && isPWA) return false
 
-            // Filter out ios-initial-pwa-install if not iOS or already in PWA
-            if (step.screenId === 'ios-initial-pwa-install' && (deviceType !== DeviceType.IOS || isPWA)) return false
-
             return true
         })
         dispatch(setupActions.setSteps(filteredSteps))
+
+        // if ios and not in pwa, show ios pwa install screen after setup flow is completed
+        if (deviceType === DeviceType.IOS && !isPWA) {
+            dispatch(setupActions.setShowIosPwaInstallScreen(true))
+        }
     }, [isPWA, deviceType])
 
     return (

--- a/src/app/(setup)/setup/page.tsx
+++ b/src/app/(setup)/setup/page.tsx
@@ -107,11 +107,11 @@ function SetupPageContent() {
             }
 
             if (localDeviceType === 'android') {
-                determinedSetupInitialStepId = isStandalonePWA ? 'welcome' : 'android-initial-pwa-install'
+                determinedSetupInitialStepId = isStandalonePWA ? 'landing' : 'android-initial-pwa-install'
             }
-            // if ios, show welcome screen
+            // if ios, show landing screen
             else if (localDeviceType === 'ios') {
-                determinedSetupInitialStepId = 'welcome'
+                determinedSetupInitialStepId = 'landing'
             } else {
                 determinedSetupInitialStepId = 'pwa-install'
             }

--- a/src/components/Setup/Setup.consts.tsx
+++ b/src/components/Setup/Setup.consts.tsx
@@ -99,17 +99,4 @@ export const setupSteps: ISetupStep[] = [
         showSkipButton: false,
         contentClassName: 'flex flex-col items-center justify-center gap-5',
     },
-    {
-        screenId: 'ios-initial-pwa-install',
-        layoutType: 'ios-initial-pwa-install',
-        title: '',
-        description: '',
-        image: PEANUTMAN_MOBILE,
-        component: ForceIOSPWAInstall,
-        showBackButton: false,
-        showSkipButton: false,
-        imageClassName: 'hidden',
-        titleClassName: 'text-2xl',
-        contentClassName: 'flex flex-col p-0 items-center justify-center gap-5 bg-secondary-3',
-    },
 ]

--- a/src/components/Setup/Setup.types.ts
+++ b/src/components/Setup/Setup.types.ts
@@ -12,9 +12,8 @@ export type ScreenId =
     | 'unsupported-browser'
     | 'join-beta'
     | 'collect-email'
-    | 'ios-initial-pwa-install'
 
-export type LayoutType = 'signup' | 'standard' | 'android-initial-pwa-install' | 'ios-initial-pwa-install'
+export type LayoutType = 'signup' | 'standard' | 'android-initial-pwa-install'
 
 export type ScreenProps = {
     landing: undefined
@@ -33,7 +32,6 @@ export type ScreenProps = {
     'unsupported-browser': undefined
     'join-beta': undefined
     'collect-email': undefined
-    'ios-initial-pwa-install': undefined
 }
 
 export interface StepComponentProps {

--- a/src/components/Setup/components/SetupWrapper.tsx
+++ b/src/components/Setup/components/SetupWrapper.tsx
@@ -40,7 +40,6 @@ const IMAGE_CONTAINER_CLASSES: Record<LayoutType, string> = {
     signup: 'min-h-[55dvh] md:min-h-full', // signup view has larger container height
     standard: 'min-h-[50dvh] md:min-h-full', // rest all views has medium container height
     'android-initial-pwa-install': 'min-h-[60dvh] md:min-h-full',
-    'ios-initial-pwa-install': 'hidden',
 }
 
 // define animated star decorations positions and sizes
@@ -99,7 +98,6 @@ const ImageSection = ({
     if (!image) return null
 
     const isSignup = layoutType === 'signup'
-    const isIosInitialPwaInstall = layoutType === 'ios-initial-pwa-install'
     const containerClass = IMAGE_CONTAINER_CLASSES[layoutType]
     const imageClass = !!imageClassName
         ? imageClassName
@@ -139,9 +137,6 @@ const ImageSection = ({
                 />
             </div>
         )
-    }
-    if (isIosInitialPwaInstall) {
-        return null
     }
 
     // standard layout rendering without decorations

--- a/src/redux/slices/setup-slice.ts
+++ b/src/redux/slices/setup-slice.ts
@@ -13,6 +13,7 @@ const initialState: ISetupState = {
     steps: [],
     inviteCode: '',
     inviteType: EInviteType.DIRECT,
+    showIosPwaInstallScreen: false,
 }
 
 const setupSlice = createSlice({
@@ -58,6 +59,9 @@ const setupSlice = createSlice({
         },
         setInviteType: (state, action: PayloadAction<EInviteType>) => {
             state.inviteType = action.payload
+        },
+        setShowIosPwaInstallScreen: (state, action: PayloadAction<boolean>) => {
+            state.showIosPwaInstallScreen = action.payload
         },
     },
 })

--- a/src/redux/types/setup.types.ts
+++ b/src/redux/types/setup.types.ts
@@ -10,4 +10,5 @@ export interface ISetupState {
     telegramHandle: string
     inviteCode: string
     inviteType: EInviteType
+    showIosPwaInstallScreen: boolean
 }


### PR DESCRIPTION
- Fix Force PWA install screen on IOS when logging in or signing up with invite code
- Setup landing screen not visible on android and IOS