### PR TITLE
Fix/simplefi

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -78,7 +78,23 @@ export default function QRPayPage() {
     const { openTransactionDetails, selectedTransaction, isDrawerOpen, closeTransactionDetails } =
         useTransactionDetailsDrawer()
     const { isLoading, loadingState, setLoadingState } = useContext(loadingStateContext)
-    const { shouldBlockPay, kycGateState } = useQrKycGate()
+
+    const paymentProcessor: PaymentProcessor | null = useMemo(() => {
+        switch (qrType) {
+            case EQrType.SIMPLEFI_STATIC:
+            case EQrType.SIMPLEFI_DYNAMIC:
+            case EQrType.SIMPLEFI_USER_SPECIFIED:
+                return 'SIMPLEFI'
+            case EQrType.MERCADO_PAGO:
+            case EQrType.ARGENTINA_QR3:
+            case EQrType.PIX:
+                return 'MANTECA'
+            default:
+                return null
+        }
+    }, [qrType])
+
+    const { shouldBlockPay, kycGateState } = useQrKycGate(paymentProcessor)
     const queryClient = useQueryClient()
     const { hasPendingTransactions } = usePendingTransactions()
     const [isShaking, setIsShaking] = useState(false)
@@ -96,21 +112,6 @@ export default function QRPayPage() {
     const { setIsSupportModalOpen } = useSupportModalContext()
     const [waitingForMerchantAmount, setWaitingForMerchantAmount] = useState(false)
     const retryCount = useRef(0)
-
-    const paymentProcessor: PaymentProcessor | null = useMemo(() => {
-        switch (qrType) {
-            case EQrType.SIMPLEFI_STATIC:
-            case EQrType.SIMPLEFI_DYNAMIC:
-            case EQrType.SIMPLEFI_USER_SPECIFIED:
-                return 'SIMPLEFI'
-            case EQrType.MERCADO_PAGO:
-            case EQrType.ARGENTINA_QR3:
-            case EQrType.PIX:
-                return 'MANTECA'
-            default:
-                return null
-        }
-    }, [qrType])
 
     const resetState = () => {
         setIsSuccess(false)

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -302,6 +302,22 @@ export default function QRPayPage() {
         getCurrencyObject().then(setCurrency)
     }, [paymentLock?.code, paymentProcessor])
 
+    // Set default currency for SimpleFi USER_SPECIFIED (user will enter amount)
+    useEffect(() => {
+        if (paymentProcessor !== 'SIMPLEFI') return
+        if (simpleFiQrData?.type !== 'SIMPLEFI_USER_SPECIFIED') return
+        if (currency) return // Already set
+
+        // Default to ARS for SimpleFi payments
+        getCurrencyPrice('ARS').then((priceData) => {
+            setCurrency({
+                code: 'ARS',
+                symbol: 'ARS',
+                price: priceData.sell,
+            })
+        })
+    }, [paymentProcessor, simpleFiQrData?.type, currency])
+
     const isBlockingError = useMemo(() => {
         return !!errorMessage && errorMessage !== 'Please confirm the transaction.'
     }, [errorMessage])

--- a/src/components/Global/DirectSendQR/utils.ts
+++ b/src/components/Global/DirectSendQR/utils.ts
@@ -68,12 +68,15 @@ const PIX_REGEX = /^.*000201.*0014br\.gov\.bcb\.pix.*5303986.*5802BR.*$/i
  * infer the flow type and merchant slug.
  *
  * The flow type is static, dynamic or user_specified.
+ * Supports both pagar.simplefi.tech (legacy) and pay.simplefi.tech (new) URLs.
+ * Dynamic URLs support both old format (/merchant/payment/123) and new format (/merchant/123).
  */
 export const SIMPLEFI_STATIC_REGEX =
-    /^(?:https?:\/\/)?(?:www\.)?pagar\.simplefi\.tech\/(?<merchantSlug>[^\/]*)(\/static|\/?\?.*static\=true.*)/
-export const SIMPLEFI_USER_SPECIFIED_REGEX = /^(?:https?:\/\/)?(?:www\.)?pagar\.simplefi\.tech\/(?<merchantSlug>[^\/]*)/
+    /^(?:https?:\/\/)?(?:www\.)?(?:pagar|pay)\.simplefi\.tech\/(?<merchantSlug>[^\/]*)(\/static|\/?\?.*static\=true.*)/
+export const SIMPLEFI_USER_SPECIFIED_REGEX =
+    /^(?:https?:\/\/)?(?:www\.)?(?:pagar|pay)\.simplefi\.tech\/(?<merchantSlug>[^\/\?]*)(?:\/)?(?:\?.*)?$/
 export const SIMPLEFI_DYNAMIC_REGEX =
-    /^(?:https?:\/\/)?(?:www\.)?pagar\.simplefi\.tech\/(?<merchantId>[^\/]*)\/payment\/(?<paymentId>[^\/]*)/
+    /^(?:https?:\/\/)?(?:www\.)?(?:pagar|pay)\.simplefi\.tech\/(?<merchantId>[^\/]*)\/(?:payment\/)?(?<paymentId>[^\/\?]+)(?:\/)?(?:\?.*)?$/
 
 export const PAYMENT_PROCESSOR_REGEXES: { [key in QrType]?: RegExp } = {
     [EQrType.MERCADO_PAGO]: MP_AR_REGEX,

--- a/src/hooks/useQrKycGate.ts
+++ b/src/hooks/useQrKycGate.ts
@@ -23,7 +23,7 @@ export interface QrKycGateResult {
  * It checks the user's KYC status and the country of the QR code to determine the appropriate action.
  * @param paymentProcessor - The payment processor type ('MANTECA' | 'SIMPLEFI' | null)
  * @returns {QrKycGateResult} An object with the KYC gate state and a boolean indicating if the user should be blocked from paying.
- * 
+ *
  * Note: KYC is only required for MANTECA payments. SimpleFi payments do not require KYC.
  */
 export function useQrKycGate(paymentProcessor?: 'MANTECA' | 'SIMPLEFI' | null): QrKycGateResult {

--- a/src/hooks/useQrKycGate.ts
+++ b/src/hooks/useQrKycGate.ts
@@ -21,13 +21,22 @@ export interface QrKycGateResult {
 /**
  * This hook determines the KYC gate state for the QR pay page.
  * It checks the user's KYC status and the country of the QR code to determine the appropriate action.
+ * @param paymentProcessor - The payment processor type ('MANTECA' | 'SIMPLEFI' | null)
  * @returns {QrKycGateResult} An object with the KYC gate state and a boolean indicating if the user should be blocked from paying.
+ * 
+ * Note: KYC is only required for MANTECA payments. SimpleFi payments do not require KYC.
  */
-export function useQrKycGate(): QrKycGateResult {
+export function useQrKycGate(paymentProcessor?: 'MANTECA' | 'SIMPLEFI' | null): QrKycGateResult {
     const { user } = useAuth()
     const [kycGateState, setKycGateState] = useState<QrKycState>(QrKycState.LOADING)
 
     const determineKycGateState = useCallback(async () => {
+        // SimpleFi payments do not require KYC - allow payment immediately
+        if (paymentProcessor === 'SIMPLEFI') {
+            setKycGateState(QrKycState.PROCEED_TO_PAY)
+            return
+        }
+
         const currentUser = user?.user
         if (!currentUser) {
             setKycGateState(QrKycState.REQUIRES_IDENTITY_VERIFICATION)
@@ -68,7 +77,7 @@ export function useQrKycGate(): QrKycGateResult {
         }
 
         setKycGateState(QrKycState.REQUIRES_IDENTITY_VERIFICATION)
-    }, [user?.user])
+    }, [user?.user, paymentProcessor])
 
     useEffect(() => {
         determineKycGateState()


### PR DESCRIPTION
## Support SimpleFi URL changes & Fix KYC requirement

### Problem
1. **SimpleFi changed their URLs:**
   - Domain: `pagar.simplefi.tech` → `pay.simplefi.tech`
   - Dynamic format: `/merchant/payment/123` → `/merchant/123` (removed "payment" from path)
   
2. **SimpleFi payments incorrectly required KYC:**
   - The `useQrKycGate` hook was applying identity verification checks to all QR payment types
   - SimpleFi payments don't require KYC but were being blocked

### Solution
**URL Support Changes:**
- Updated regex patterns to support both `pagar.simplefi.tech` (legacy) and `pay.simplefi.tech` (new)
- Updated dynamic URL regex to match both `/merchant/payment/123` (old) and `/merchant/123` (new)
- Maintains backward compatibility - all old URLs continue to work

**KYC Fix:**
- Updated `useQrKycGate` hook to accept `paymentProcessor` parameter
- Added early return that bypasses KYC checks when `paymentProcessor === 'SIMPLEFI'`
- SimpleFi payments now proceed without identity verification modal

### Changes
- `peanut-ui/src/components/Global/DirectSendQR/utils.ts`: Updated 3 SimpleFi regex patterns
- `peanut-ui/src/components/Global/DirectSendQR/__tests__/recognizeQr.test.ts`: Added 27 new test cases
- `peanut-ui/src/hooks/useQrKycGate.ts`: Added payment processor awareness
- `peanut-ui/src/app/(mobile-ui)/qr-pay/page.tsx`: Pass payment processor to KYC gate
- `peanut-api-ts/src/depositWatchService.ts`: Fixed null check for `log.args.from`
- `peanut-api-ts/src/requestPaymentValidator.ts`: Added debug log for ongoing Squid transactions

### Risks
**Low Risk - Fully Backward Compatible:**
- ✅ Old SimpleFi URLs (`pagar.simplefi.tech`, `/payment/` format) continue to work
- ✅ Manteca payments (PIX, Mercado Pago, QR3) still properly require KYC
- ✅ No changes to core payment logic, only URL recognition and KYC gating
- ✅ 224 tests passing (up from 213)

### Testing
- Verified both `pagar` and `pay` subdomains work
- Verified both old and new dynamic URL formats work
- Verified SimpleFi QR codes work without KYC modal
- Verified Manteca QR codes still show KYC modal when appropriate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for pay.simplefi.tech (incl. new dynamic format) and makes KYC gating apply only to MANTECA, not SimpleFi.
> 
> - **QR recognition (utils)**:
>   - Update `SIMPLEFI_*` regexes to support both `pagar.simplefi.tech` and `pay.simplefi.tech`, and handle dynamic URLs with/without `/payment/`.
> - **KYC gating (hooks/ui)**:
>   - Make `useQrKycGate(paymentProcessor)` processor-aware; bypass KYC when `paymentProcessor === 'SIMPLEFI'`.
>   - In `app/(mobile-ui)/qr-pay/page.tsx`, derive `paymentProcessor` from `qrType` and pass to `useQrKycGate`.
>   - Default currency to `ARS` for `SIMPLEFI_USER_SPECIFIED` flows.
> - **Tests**:
>   - Expand `recognizeQr.test.ts` with cases for `pay.simplefi.tech`, new dynamic format, and precedence rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45ee0527f2873d34febcfdf139fb9de0afb95fcd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->