### PR TITLE
Chore/ethlatam perk

### DIFF
--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -581,11 +581,10 @@ export const TransactionDetailsReceipt = ({
 
                                     // If user hit their campaign cap, show special message
                                     if (isCapped && campaignCap) {
-                                        const amountText =
-                                            amount !== undefined && amount !== null
-                                                ? `You received $${amount.toFixed(2)} cashback! `
-                                                : ''
-                                        return `${amountText}You've reached your $${campaignCap.toFixed(0)} campaign limit 🎉`
+                                        if (amount !== undefined && amount !== null) {
+                                            return `$${amount.toFixed(2)} cashback — campaign limit reached! 🎉`
+                                        }
+                                        return `Campaign limit reached! 🎉`
                                     }
 
                                     // For non-capped messages, use amountStr

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -576,14 +576,21 @@ export const TransactionDetailsReceipt = ({
                                     const perk = transaction.extraDataForDrawer.perk
                                     const percentage = perk.discountPercentage
                                     const amount = perk.amountSponsored
-                                    const amountStr = amount ? `$${amount.toFixed(2)}` : ''
                                     const isCapped = perk.isCapped
                                     const campaignCap = perk.campaignCapUsd
 
                                     // If user hit their campaign cap, show special message
                                     if (isCapped && campaignCap) {
-                                        return `You received ${amountStr} cashback! You've reached your $${campaignCap.toFixed(0)} campaign limit for now 🎉`
+                                        const amountText =
+                                            amount !== undefined && amount !== null
+                                                ? `You received $${amount.toFixed(2)} cashback! `
+                                                : ''
+                                        return `${amountText}You've reached your $${campaignCap.toFixed(0)} campaign limit 🎉`
                                     }
+
+                                    // For non-capped messages, use amountStr
+                                    const amountStr =
+                                        amount !== undefined && amount !== null ? `$${amount.toFixed(2)}` : ''
 
                                     if (percentage === 100) {
                                         return `You received a full refund${amount ? ` (${amountStr})` : ''} as a Peanut Perk.`

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -573,9 +573,17 @@ export const TransactionDetailsReceipt = ({
                             <span className="font-semibold text-gray-900">Eligible for a Peanut Perk!</span>
                             <span className="text-sm text-gray-600">
                                 {(() => {
-                                    const percentage = transaction.extraDataForDrawer.perk.discountPercentage
-                                    const amount = transaction.extraDataForDrawer.perk.amountSponsored
+                                    const perk = transaction.extraDataForDrawer.perk
+                                    const percentage = perk.discountPercentage
+                                    const amount = perk.amountSponsored
                                     const amountStr = amount ? `$${amount.toFixed(2)}` : ''
+                                    const isCapped = perk.isCapped
+                                    const campaignCap = perk.campaignCapUsd
+
+                                    // If user hit their campaign cap, show special message
+                                    if (isCapped && campaignCap) {
+                                        return `You received ${amountStr} cashback! You've reached your $${campaignCap.toFixed(0)} campaign limit for now 🎉`
+                                    }
 
                                     if (percentage === 100) {
                                         return `You received a full refund${amount ? ` (${amountStr})` : ''} as a Peanut Perk.`

--- a/src/components/TransactionDetails/transactionTransformer.ts
+++ b/src/components/TransactionDetails/transactionTransformer.ts
@@ -76,6 +76,9 @@ export interface TransactionDetails {
             merchantInfo?: {
                 promoDescription?: string
             }
+            isCapped?: boolean
+            campaignCapUsd?: number
+            remainingCapUsd?: number
         }
         depositInstructions?: {
             amount: string
@@ -524,6 +527,9 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
                       amountSponsored?: number
                       txHash?: string
                       merchantInfo?: { promoDescription?: string }
+                      isCapped?: boolean
+                      campaignCapUsd?: number
+                      remainingCapUsd?: number
                   }
                 | undefined,
             depositInstructions:


### PR DESCRIPTION
only the perk related changes are relevant. rest are pulls from prod/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show campaign-cap reached messaging in the perk banner and plumb cap fields through the transaction transformer.
> 
> - **Perks UI (receipt)**:
>   - Update perk banner logic in `src/components/TransactionDetails/TransactionDetailsReceipt.tsx` to handle capped campaigns using `perk.isCapped` and `perk.campaignCapUsd`, showing a “campaign limit reached” message and safe amount formatting.
> - **Data model / transformer**:
>   - Extend `extraDataForDrawer.perk` in `src/components/TransactionDetails/transactionTransformer.ts` with `isCapped`, `campaignCapUsd`, and `remainingCapUsd` and propagate these fields when mapping `entry.extraData.perk`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 880dfeaec3be71503de95430822f4fde5b688c8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->