### PR TITLE
fix: add microphone perms headers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -141,7 +141,7 @@ let nextConfig = {
                 headers: [
                     {
                         key: 'Permissions-Policy',
-                        value: 'camera=(self), clipboard-read=(self), clipboard-write=(self)',
+                        value: 'camera=(self "*"), microphone=(self "*"), clipboard-read=(self), clipboard-write=(self)',
                     },
                 ],
             },

--- a/src/components/Global/IframeWrapper/index.tsx
+++ b/src/components/Global/IframeWrapper/index.tsx
@@ -139,7 +139,7 @@ const IframeWrapper = ({ src, visible, onClose, closeConfirmMessage }: IFrameWra
                         <iframe
                             key={src}
                             src={src}
-                            allow="camera *; fullscreen *"
+                            allow="camera *; microphone *; fullscreen *"
                             style={{ width: '100%', height: '85%', border: 'none' }}
                             className="rounded-md"
                             sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-modals allow-top-navigation-by-user-activation allow-media-devices"


### PR DESCRIPTION
- fixes camera issue in bridge iframe, was due to microphone restrictions, bridge iframe required microphone access (even tho its not needed), and browser policies now are strict so it blocks the camera standalone to be opened within the iframe