### PR TITLE
revert: remove aggressive dark mode disabling

### DIFF
--- a/src/components/Global/Modal/index.tsx
+++ b/src/components/Global/Modal/index.tsx
@@ -77,7 +77,7 @@ const Modal = ({
                 >
                     <Dialog.Panel
                         className={twMerge(
-                            `relative bottom-0 z-10 mx-0 max-h-[] w-full max-w-[26rem] self-end rounded-md border-0 bg-white outline-none sm:m-auto sm:self-auto dark:bg-n-1 ${
+                            `relative bottom-0 z-10 mx-0 max-h-[] w-full max-w-[26rem] self-end rounded-md border-0 bg-white outline-none dark:bg-n-1 sm:m-auto sm:self-auto ${
                                 video
                                     ? 'static aspect-video max-w-[64rem] overflow-hidden bg-n-1 shadow-[0_2.5rem_8rem_rgba(0,0,0,0.5)] dark:border-transparent'
                                     : ''

--- a/src/components/Global/ValidatedInput/index.tsx
+++ b/src/components/Global/ValidatedInput/index.tsx
@@ -211,7 +211,7 @@ const ValidatedInput = ({
                                     e.preventDefault()
                                     onUpdate({ value: '', isValid: false, isChanging: false })
                                 }}
-                                className="flex h-full w-6 items-center justify-center pr-2 md:w-8 md:pr-0 dark:bg-n-1"
+                                className="flex h-full w-6 items-center justify-center pr-2 dark:bg-n-1 md:w-8 md:pr-0"
                             >
                                 <Icon className="h-6 w-6 dark:fill-white" name="cancel" />
                             </button>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,27 +3,11 @@
 @tailwind utilities;
 
 @layer base {
-    /* Force light mode - prevent browser dark mode */
-    :root {
-        color-scheme: light only;
-    }
-
     body {
         /* disable text selection */
         @apply select-none;
         /* disable tap highlight */
         -webkit-tap-highlight-color: transparent;
-    }
-
-    /* Aggressive light mode enforcement for Android/Brave dark mode override */
-    @media (prefers-color-scheme: dark) {
-        :root,
-        html,
-        body {
-            color-scheme: light !important;
-            background-color: white !important;
-            color: black !important;
-        }
     }
 }
 
@@ -401,7 +385,7 @@ Firefox input[type='number'] {
 
 /* Panel styling */
 .panel {
-    @apply rounded-md border-2 border-n-1 bg-white shadow-lg shadow-md ring-2 ring-white;
+    @apply rounded-md border-2 border-n-1 bg-white shadow-lg shadow-md ring-2 ring-white dark:border-white dark:bg-n-1 dark:ring-n-1;
 }
 
 .panel-sm {
@@ -427,7 +411,7 @@ Firefox input[type='number'] {
 
 /* Form styling */
 .input-text {
-    @apply h-12 w-full border border-n-1 bg-white px-3 font-medium outline-none ring-2 ring-white transition-colors focus:border-primary-1;
+    @apply h-12 w-full border border-n-1 bg-white px-3 font-medium outline-none ring-2 ring-white transition-colors focus:border-primary-1 dark:border-white dark:bg-n-1 dark:text-white dark:placeholder:text-white/75 dark:focus:border-primary-1;
 }
 
 .input-text-inset {
@@ -436,11 +420,11 @@ Firefox input[type='number'] {
 
 /* Decoration */
 .border-rounded {
-    @apply rounded-md border-2 border-n-1;
+    @apply rounded-md border-2 border-n-1 dark:border-white;
 }
 
 .ring-sm {
-    @apply shadow-md ring-2 ring-white;
+    @apply shadow-md ring-2 ring-white dark:ring-n-1;
 }
 
 .font-roboto-400-50 {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,7 @@ const plugin = require('tailwindcss/plugin')
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-    darkMode: false, // Disable dark mode completely
+    darkMode: ['class', '[data-theme="dark"]'],
     content: [
         './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
         './src/components/**/*.{js,ts,jsx,tsx,mdx}',


### PR DESCRIPTION
- Restore darkMode to class-based: ['class', '[data-theme="dark"]']
- Remove forced light-only color-scheme and !important overrides
- Restore dark: variants to panel, input-text, border-rounded, ring-sm
- Fix dark mode class ordering in Modal and ValidatedInput

This reverts the aggressive dark mode removal from PR #1431 that was breaking modals. Dark mode now only activates with explicit class/attribute.