### PR TITLE
feat: add gentle light mode nudge

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,6 +3,11 @@
 @tailwind utilities;
 
 @layer base {
+    /* Nudge browser to prefer light mode for native controls (scrollbars, inputs, etc) */
+    :root {
+        color-scheme: light;
+    }
+
     body {
         /* disable text selection */
         @apply select-none;


### PR DESCRIPTION
- Add color-scheme: light to :root (without 'only')
- Nudges browser to prefer light mode for native controls
- Doesn't override app styles or break components
- Keep class-based dark mode functional for explicit use

This gentle nudge affects only browser native elements (scrollbars, form controls) without forcing colors that could break styling.