### PR TITLE
fix: wrong balance warning showing when it shouldnt be

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -761,7 +761,8 @@ export default function QRPayPage() {
         }
 
         // Skip balance check if transaction is being processed
-        if (hasPendingTransactions || isWaitingForWebSocket) {
+        // isLoading covers the gap between sendMoney completing and completeQrPayment finishing
+        if (hasPendingTransactions || isWaitingForWebSocket || isLoading) {
             return
         }
 
@@ -777,7 +778,7 @@ export default function QRPayPage() {
         } else {
             setBalanceErrorMessage(null)
         }
-    }, [usdAmount, balance, hasPendingTransactions, isWaitingForWebSocket, isSuccess])
+    }, [usdAmount, balance, hasPendingTransactions, isWaitingForWebSocket, isSuccess, isLoading])
 
     // Use points confetti hook for animation - must be called unconditionally
     usePointsConfetti(isSuccess && pointsData?.estimatedPoints ? pointsData.estimatedPoints : undefined, pointsDivRef)

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -230,7 +230,8 @@ export default function WithdrawBankPage() {
     // Balance validation
     useEffect(() => {
         // Skip balance check if transaction is pending
-        if (hasPendingTransactions) {
+        // isLoading covers the gap between sendMoney completing and confirmOfframp completing
+        if (hasPendingTransactions || isLoading) {
             return
         }
 
@@ -245,7 +246,7 @@ export default function WithdrawBankPage() {
         } else {
             setBalanceErrorMessage(null)
         }
-    }, [amountToWithdraw, balance, hasPendingTransactions])
+    }, [amountToWithdraw, balance, hasPendingTransactions, isLoading])
 
     if (!bankAccount) {
         return null

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -305,7 +305,8 @@ export default function MantecaWithdrawFlow() {
     useEffect(() => {
         // Skip balance check if transaction is being processed
         // Use hasPendingTransactions to prevent race condition with optimistic updates
-        if (hasPendingTransactions) {
+        // isLoading covers the gap between sendMoney completing and API withdraw completing
+        if (hasPendingTransactions || isLoading) {
             return
         }
 
@@ -323,7 +324,7 @@ export default function MantecaWithdrawFlow() {
         } else {
             setBalanceErrorMessage(null)
         }
-    }, [usdAmount, balance, hasPendingTransactions])
+    }, [usdAmount, balance, hasPendingTransactions, isLoading])
 
     // Fetch points early to avoid latency penalty - fetch as soon as we have usdAmount
     // Use flowId as uniqueId to prevent cache collisions between different withdrawal flows

--- a/src/components/Send/link/views/Initial.link.send.view.tsx
+++ b/src/components/Send/link/views/Initial.link.send.view.tsx
@@ -100,7 +100,8 @@ const LinkSendInitialView = () => {
     useEffect(() => {
         // Skip balance check if transaction is pending
         // (balance may be optimistically updated during transaction)
-        if (hasPendingTransactions) {
+        // isLoading covers the createLink operation which directly uses handleSendUserOpEncoded
+        if (hasPendingTransactions || isLoading) {
             return
         }
 
@@ -132,7 +133,7 @@ const LinkSendInitialView = () => {
                 })
             )
         }
-    }, [peanutWalletBalance, tokenValue, dispatch, hasPendingTransactions])
+    }, [peanutWalletBalance, tokenValue, dispatch, hasPendingTransactions, isLoading])
 
     return (
         <div className="w-full space-y-4">


### PR DESCRIPTION
## Fix: Balance validation race condition during payments

**Problem:** "Not enough funds" warning flashed during QR payments and withdrawals after transaction completed but before API call finished.

**Root Cause:** Balance check effects only checked `hasPendingTransactions` (mutation state), missing the gap between transaction completion and API completion.

**Solution:** Added `isLoading` check to balance validation in 4 payment flows:
- QR payment
- Manteca withdraw  
- Bank withdraw
- Send link

**Result:** Balance validation now skips checks during the entire payment lifecycle (transaction + API calls), preventing premature warnings.

```typescript
// Before
if (hasPendingTransactions) return

// After  
if (hasPendingTransactions || isLoading) return
```