### PR TITLE
fix: req charge amount display + external address input

### DIFF
--- a/src/config/underMaintenance.config.ts
+++ b/src/config/underMaintenance.config.ts
@@ -33,8 +33,8 @@ interface MaintenanceConfig {
 
 const underMaintenanceConfig: MaintenanceConfig = {
     enableFullMaintenance: false, // set to true to redirect all pages to /maintenance
-    enableMaintenanceBanner: false, // set to true to show maintenance banner on all pages
-    disabledPaymentProviders: [], // set to ['MANTECA'] to disable Manteca QR payments
+    enableMaintenanceBanner: true, // set to true to show maintenance banner on all pages
+    disabledPaymentProviders: ['MANTECA', 'SIMPLEFI'], // set to ['MANTECA'] to disable Manteca QR payments
 }
 
 export default underMaintenanceConfig


### PR DESCRIPTION
smoke tested these flows:
- request pot slider
- request pot input enter amount
- request pot charge amount display in input
- peanut user direct send
- peanut user semantic request send
- external address semantic send
- external address semantic send without amount in url
- add money swap currency toggle in manteca flow
- add money enter amount in input
- add money non manteca countries flows input