### PR TITLE
fix: disable non-euro sepa onramps and offramps 

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -15,6 +15,7 @@ import { useAuth } from '@/context/authContext'
 import { useCreateOnramp } from '@/hooks/useCreateOnramp'
 import { useRouter, useParams } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useNonEurSepaRedirect } from '@/hooks/useNonEurSepaRedirect'
 import { formatUnits } from 'viem'
 import PeanutLoading from '@/components/Global/PeanutLoading'
 import EmptyState from '@/components/Global/EmptyStates/EmptyState'
@@ -52,6 +53,14 @@ export default function OnrampBankPage() {
     const { parsedPaymentData } = usePaymentStore()
 
     const selectedCountryPath = params.country as string
+
+    // redirect to add-money if this is a non-eur sepa country (blocked)
+    useNonEurSepaRedirect({
+        countryIdentifier: selectedCountryPath,
+        redirectPath: '/add-money',
+        shouldRedirect: true,
+    })
+
     const selectedCountry = useMemo(() => {
         if (!selectedCountryPath) return null
         return countryData.find((country) => country.type === 'country' && country.path === selectedCountryPath)

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -26,6 +26,7 @@ import { PointsAction } from '@/services/services.types'
 import { usePointsCalculation } from '@/hooks/usePointsCalculation'
 import { useSearchParams } from 'next/navigation'
 import { parseUnits } from 'viem'
+import { useNonEurSepaRedirect } from '@/hooks/useNonEurSepaRedirect'
 
 type View = 'INITIAL' | 'SUCCESS'
 
@@ -48,6 +49,13 @@ export default function WithdrawBankPage() {
     const country = params.country as string
     const [balanceErrorMessage, setBalanceErrorMessage] = useState<string | null>(null)
     const { hasPendingTransactions } = usePendingTransactions()
+
+    // redirect to withdraw if this is a non-eur sepa country (blocked)
+    useNonEurSepaRedirect({
+        countryIdentifier: country,
+        redirectPath: '/withdraw',
+        shouldRedirect: true,
+    })
 
     // check if we came from send flow - using method param to detect (only bank goes through this page)
     const methodParam = searchParams.get('method')

--- a/src/components/AddMoney/components/AddMoneyBankDetails.tsx
+++ b/src/components/AddMoney/components/AddMoneyBankDetails.tsx
@@ -7,14 +7,13 @@ import { PaymentInfoRow } from '@/components/Payment/PaymentInfoRow'
 import { useOnrampFlow } from '@/context/OnrampFlowContext'
 import { useRouter, useParams } from 'next/navigation'
 import { useCallback, useEffect, useMemo } from 'react'
-import { type CountryData, countryData } from '@/components/AddMoney/consts'
+import { countryData } from '@/components/AddMoney/consts'
 import { formatCurrencyAmount } from '@/utils/currency'
 import { formatBankAccountDisplay } from '@/utils/format.utils'
 import { getCurrencyConfig, getCurrencySymbol } from '@/utils/bridge.utils'
 import { RequestFulfillmentBankFlowStep, useRequestFulfillmentFlow } from '@/context/RequestFulfillmentFlowContext'
 import { usePaymentStore } from '@/redux/hooks'
 import { formatAmount } from '@/utils'
-import { AccountType } from '@/interfaces'
 import InfoCard from '@/components/Global/InfoCard'
 import CopyToClipboard from '@/components/Global/CopyToClipboard'
 import { Button } from '@/components/0_Bruddle'
@@ -22,13 +21,6 @@ import { useExchangeRate } from '@/hooks/useExchangeRate'
 
 interface IAddMoneyBankDetails {
     flow?: 'add-money' | 'request-fulfillment'
-}
-
-const getAccountTypeFromCountry = (country: CountryData | null): AccountType => {
-    if (!country) return AccountType.US
-    if (country.currency === 'MXN') return AccountType.CLABE
-    if (country.currency === 'EUR') return AccountType.IBAN
-    return AccountType.US
 }
 
 export default function AddMoneyBankDetails({ flow = 'add-money' }: IAddMoneyBankDetails) {

--- a/src/components/AddMoney/consts/index.ts
+++ b/src/components/AddMoney/consts/index.ts
@@ -1,4 +1,4 @@
-import { APPLE_PAY, GOOGLE_PAY, MERCADO_PAGO, SOLANA_ICON, TRON_ICON, PIX } from '@/assets'
+import { MERCADO_PAGO, SOLANA_ICON, TRON_ICON, PIX } from '@/assets'
 import { BINANCE_LOGO, LEMON_LOGO, RIPIO_LOGO } from '@/assets/exchanges'
 import { METAMASK_LOGO, RAINBOW_LOGO, TRUST_WALLET_LOGO } from '@/assets/wallets'
 import { type IconName } from '@/components/Global/Icons/Icon'
@@ -2817,7 +2817,10 @@ const enabledBankWithdrawCountries = new Set(
     [...Object.values(BRIDGE_ALPHA3_TO_ALPHA2), 'US', 'MX', 'AR'].filter((code) => !NON_EUR_SEPA_ALPHA2.has(code))
 )
 
-const enabledBankDepositCountries = new Set([...Object.values(BRIDGE_ALPHA3_TO_ALPHA2), 'US', 'MX', 'AR'])
+// exclude non-euro sepa countries from bank deposits, same as withdrawals
+const enabledBankDepositCountries = new Set(
+    [...Object.values(BRIDGE_ALPHA3_TO_ALPHA2), 'US', 'MX', 'AR'].filter((code) => !NON_EUR_SEPA_ALPHA2.has(code))
+)
 
 // Helper function to check if a country code is enabled for bank transfers
 // Handles both 2-letter and 3-letter country codes

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -30,6 +30,7 @@ import { getCountryCodeForWithdraw } from '@/utils/withdraw.utils'
 import { useAppDispatch } from '@/redux/hooks'
 import { bankFormActions } from '@/redux/slices/bank-form-slice'
 import { sendLinksApi } from '@/services/sendLinks'
+import { useNonEurSepaRedirect } from '@/hooks/useNonEurSepaRedirect'
 import { InitiateBridgeKYCModal } from '@/components/Kyc/InitiateBridgeKYCModal'
 import { useSearchParams } from 'next/navigation'
 
@@ -86,6 +87,12 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
     const [isProcessingKycSuccess, setIsProcessingKycSuccess] = useState(false)
     const [offrampData, setOfframpData] = useState<TCreateOfframpResponse | null>(null)
 
+    // redirect back to country list if selected country is a non-eur sepa country (blocked)
+    const { isBlocked: isCountryBlocked } = useNonEurSepaRedirect({
+        countryIdentifier: selectedCountry?.id || selectedCountry?.path,
+        shouldRedirect: false, // we handle redirect manually in useEffect
+    })
+
     // websocket for real-time KYC status updates
     useWebSocket({
         username: user?.user.username ?? undefined,
@@ -101,6 +108,17 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
             setLiveKycStatus(user.user.bridgeKycStatus as BridgeKycStatus)
         }
     }, [user?.user.bridgeKycStatus])
+
+    // redirect back to country list if trying to access a blocked non-eur sepa country
+    useEffect(() => {
+        if (
+            isCountryBlocked &&
+            (claimBankFlowStep === ClaimBankFlowStep.BankDetailsForm ||
+                claimBankFlowStep === ClaimBankFlowStep.BankConfirmClaim)
+        ) {
+            setClaimBankFlowStep(ClaimBankFlowStep.BankCountryList)
+        }
+    }, [isCountryBlocked, claimBankFlowStep, setClaimBankFlowStep])
 
     /**
      * @name handleConfirmClaim

--- a/src/hooks/useNonEurSepaRedirect.ts
+++ b/src/hooks/useNonEurSepaRedirect.ts
@@ -1,0 +1,115 @@
+import { useEffect, useMemo } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+    countryData,
+    NON_EUR_SEPA_ALPHA2,
+    ALL_COUNTRIES_ALPHA3_TO_ALPHA2,
+    type CountryData,
+} from '@/components/AddMoney/consts'
+import countryCurrencyMappings from '@/constants/countryCurrencyMapping'
+
+interface UseNonEurSepaRedirectOptions {
+    countryIdentifier?: string // the country path or code (e.g., 'united-kingdom' or 'GB')
+    redirectPath?: string // redirect path on failure (e.g., '/add-money' or '/withdraw')
+    shouldRedirect?: boolean // whether to actually redirect or just return the status
+}
+
+interface UseNonEurSepaRedirectResult {
+    isBlocked: boolean // true if the country is a non-eur sepa country and bank operations should be blocked
+    country: CountryData | null // the detected country object
+}
+
+/**
+ * hook to check if a country is a non-eur sepa country and optionally redirect
+ * non-eur sepa countries are those that use sepa but don't have eur as their currency
+ * (e.g., poland with pln, hungary with huf, etc.)
+ */
+export function useNonEurSepaRedirect({
+    countryIdentifier,
+    redirectPath,
+    shouldRedirect = true,
+}: UseNonEurSepaRedirectOptions = {}): UseNonEurSepaRedirectResult {
+    const router = useRouter()
+
+    // find the country from the identifier (could be path, iso2, or iso3)
+    const country = useMemo(() => {
+        if (!countryIdentifier) return null
+
+        // try to find by path first
+        let found = countryData.find((c) => c.type === 'country' && c.path === countryIdentifier.toLowerCase())
+
+        // if not found, try by iso2
+        if (!found) {
+            found = countryData.find(
+                (c) => c.type === 'country' && c.iso2?.toLowerCase() === countryIdentifier.toLowerCase()
+            )
+        }
+
+        // if not found, try by iso3
+        if (!found) {
+            found = countryData.find(
+                (c) => c.type === 'country' && c.iso3?.toLowerCase() === countryIdentifier.toLowerCase()
+            )
+        }
+
+        return found || null
+    }, [countryIdentifier])
+
+    // determine if the country should be blocked for bank operations
+    const isBlocked = useMemo(() => {
+        if (!country || country.type !== 'country') return false
+
+        // get the 2-letter country code for the check
+        let countryCode: string | undefined
+
+        // try to get from iso2 first
+        if (country.iso2) {
+            countryCode = country.iso2
+        }
+        // otherwise try to map from iso3
+        else if (country.iso3 && ALL_COUNTRIES_ALPHA3_TO_ALPHA2[country.iso3]) {
+            countryCode = ALL_COUNTRIES_ALPHA3_TO_ALPHA2[country.iso3]
+        }
+        // fallback to id
+        else {
+            countryCode = country.id
+        }
+
+        if (!countryCode) return false
+
+        // check if it's in the non-eur sepa set
+        if (NON_EUR_SEPA_ALPHA2.has(countryCode)) {
+            return true
+        }
+
+        // additional check using currency mappings
+        // this catches countries where currency is not usd/eur/mxn
+        const currencyMapping = countryCurrencyMappings.find(
+            (currency) =>
+                countryCode?.toLowerCase() === currency.country.toLowerCase() ||
+                currency.path?.toLowerCase() === country.path?.toLowerCase()
+        )
+
+        const isNonStandardCurrency = !!(
+            currencyMapping &&
+            currencyMapping.currencyCode &&
+            currencyMapping.currencyCode !== 'EUR' &&
+            currencyMapping.currencyCode !== 'USD' &&
+            currencyMapping.currencyCode !== 'MXN'
+        )
+
+        return isNonStandardCurrency
+    }, [country])
+
+    // redirect if needed
+    useEffect(() => {
+        if (isBlocked && shouldRedirect && redirectPath) {
+            router.replace(redirectPath)
+        }
+    }, [isBlocked, shouldRedirect, redirectPath, router])
+
+    return {
+        isBlocked,
+        country,
+    }
+}


### PR DESCRIPTION
- contributes to TASK-16982 : added new hook to check for non-euro sepa countries in withdraw, claim and deposit flow and redirect to previous page if condition matches