### PR TITLE
Chore/latam cashback cta

### DIFF
--- a/src/hooks/useHomeCarouselCTAs.tsx
+++ b/src/hooks/useHomeCarouselCTAs.tsx
@@ -93,17 +93,24 @@ export const useHomeCarouselCTAs = () => {
     const generateCarouselCTAs = useCallback(() => {
         const _carouselCTAs: CarouselCTA[] = []
 
-        _carouselCTAs.push({
-            id: 'invite-friends',
-            title: 'Invite friends. Get cashback',
-            description: "Your friends' activity earns you badges, perks & rewards.",
-            icon: 'invite-heart',
-            logo: STAR_STRAIGHT_ICON,
-            logoSize: 30,
-            onClick: () => {
-                router.push('/points')
-            },
-        })
+        // DRY: Check KYC approval status once
+        const hasKycApproval = isUserKycApproved || isUserMantecaKycApproved
+        const isLatamUser = userCountryCode === 'AR' || userCountryCode === 'BR'
+
+        // Generic invite CTA for non-LATAM users
+        if (!isLatamUser) {
+            _carouselCTAs.push({
+                id: 'invite-friends',
+                title: 'Invite friends. Get cashback',
+                description: "Your friends' activity earns you badges, perks & rewards.",
+                icon: 'invite-heart',
+                logo: STAR_STRAIGHT_ICON,
+                logoSize: 30,
+                onClick: () => {
+                    router.push('/points')
+                },
+            })
+        }
 
         // show notification cta only in pwa when notifications are not granted
         // clicking it triggers native prompt (or shows reinstall modal if denied)
@@ -137,7 +144,7 @@ export const useHomeCarouselCTAs = () => {
         }
 
         // Show QR code payment prompt if user's Bridge or Manteca KYC is approved.
-        if (isUserKycApproved || isUserMantecaKycApproved) {
+        if (hasKycApproval) {
             _carouselCTAs.push({
                 id: 'qr-payment',
                 title: (
@@ -160,10 +167,9 @@ export const useHomeCarouselCTAs = () => {
         }
 
         // ------------------------------------------------------------------------------------------------
-        // LATAM Cashback CTA - show only to users in Argentina or Brazil
-        // Encourage them to invite friends to earn more cashback
-        const isLatamUser = userCountryCode === 'AR' || userCountryCode === 'BR'
-        if (isLatamUser && (isUserKycApproved || isUserMantecaKycApproved)) {
+        // LATAM Cashback CTA - show to all users in Argentina or Brazil
+        // Encourage them to invite friends to earn more cashback (and complete KYC if needed)
+        if (isLatamUser) {
             _carouselCTAs.push({
                 id: 'latam-cashback-invite',
                 title: (
@@ -179,7 +185,7 @@ export const useHomeCarouselCTAs = () => {
                 iconContainerClassName: 'bg-secondary-1',
                 icon: 'gift',
                 onClick: () => {
-                    router.push('/profile/referral')
+                    router.push('/points')
                 },
                 iconSize: 16,
             })
@@ -213,7 +219,7 @@ export const useHomeCarouselCTAs = () => {
         }
         // --------------------------------------------------------------------------------------------------
 
-        if (!isUserKycApproved && !isUserBridgeKycUnderReview) {
+        if (!hasKycApproval && !isUserBridgeKycUnderReview) {
             _carouselCTAs.push({
                 id: 'kyc-prompt',
                 title: (

--- a/src/hooks/useHomeCarouselCTAs.tsx
+++ b/src/hooks/useHomeCarouselCTAs.tsx
@@ -14,6 +14,7 @@ import { DEVCONNECT_INTENT_EXPIRY_MS } from '@/constants'
 import { DeviceType, useDeviceType } from './useGetDeviceType'
 import { usePWAStatus } from './usePWAStatus'
 import { useModalsContext } from '@/context/ModalsContext'
+import { useGeoLocation } from './useGeoLocation'
 
 export type CarouselCTA = {
     id: string
@@ -42,6 +43,7 @@ export const useHomeCarouselCTAs = () => {
     const { setIsIosPwaInstallModalOpen } = useModalsContext()
 
     const { setIsQRScannerOpen } = useQrCodeContext()
+    const { countryCode: userCountryCode } = useGeoLocation()
 
     // --------------------------------------------------------------------------------------------------
     /**
@@ -158,6 +160,33 @@ export const useHomeCarouselCTAs = () => {
         }
 
         // ------------------------------------------------------------------------------------------------
+        // LATAM Cashback CTA - show only to users in Argentina or Brazil
+        // Encourage them to invite friends to earn more cashback
+        const isLatamUser = userCountryCode === 'AR' || userCountryCode === 'BR'
+        if (isLatamUser && (isUserKycApproved || isUserMantecaKycApproved)) {
+            _carouselCTAs.push({
+                id: 'latam-cashback-invite',
+                title: (
+                    <p>
+                        Earn <b>20% cashback</b> on QR payments
+                    </p>
+                ),
+                description: (
+                    <p>
+                        Invite friends to <b>unlock more rewards</b>. The more they use, the more you earn!
+                    </p>
+                ),
+                iconContainerClassName: 'bg-secondary-1',
+                icon: 'gift',
+                onClick: () => {
+                    router.push('/profile/referral')
+                },
+                iconSize: 16,
+            })
+        }
+        // ------------------------------------------------------------------------------------------------
+
+        // ------------------------------------------------------------------------------------------------
         // add devconnect payment cta if there's a pending intent
         // @dev: note, this code needs to be deleted post devconnect, this is just to temporarily support onramp to devconnect wallet using bank accounts
         if (pendingDevConnectIntent) {
@@ -220,6 +249,7 @@ export const useHomeCarouselCTAs = () => {
         setIsQRScannerOpen,
         deviceType,
         isPwa,
+        userCountryCode,
     ])
 
     useEffect(() => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds geolocation-aware carousel CTAs, introducing a LATAM cashback invite for AR/BR users, restricting the generic invite to others, and consolidating KYC checks.
> 
> - **Hooks (`src/hooks/useHomeCarouselCTAs.tsx`)**:
>   - **Geolocation**: Import `useGeoLocation`; derive `userCountryCode` and `isLatamUser`.
>   - **CTAs**:
>     - Add `latam-cashback-invite` CTA for AR/BR users.
>     - Show `invite-friends` CTA only for non-LATAM users.
>     - Reuse existing CTAs (notifications, iOS PWA install, QR payment, DevConnect, KYC prompt) with updated conditions.
>   - **KYC Refactor**: Introduce `hasKycApproval` and use it for `qr-payment` visibility and `kyc-prompt` gating.
>   - **Deps**: Update hook dependencies to include `userCountryCode`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee8a2d8c862df908eada29c9a97bf2933a9f6170. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->