### PR TITLE
[TASK-17182] Fix: Request pots not working for amount greater than 999

### DIFF
--- a/src/components/Payment/PaymentForm/index.tsx
+++ b/src/components/Payment/PaymentForm/index.tsx
@@ -777,6 +777,7 @@ export const PaymentForm = ({
         // Cap at 100% max
         return { percentage: Math.min(percentage, 100), suggestedAmount }
     }, [requestDetails?.charges, requestDetails?.tokenAmount, totalAmountCollected])
+    console.log('inputTokenAmount', inputTokenAmount)
 
     return (
         <div className="flex min-h-[inherit] flex-col justify-between gap-8">
@@ -825,7 +826,7 @@ export const PaymentForm = ({
                 {/* use TokenAmountInput for direct usd payments, request pot payments, and external address payments to avoid typing issues */}
                 {isDirectUsdPayment || shouldUseTokenAmountInput ? (
                     <TokenAmountInput
-                        tokenValue={inputTokenAmount}
+                        tokenValue={inputTokenAmount.replace(/,/g, '')}
                         setTokenValue={(value: string | undefined) => setInputTokenAmount(value || '')}
                         setUsdValue={(value: string) => {
                             setInputUsdValue(value)


### PR DESCRIPTION
Reason - for amount greater than 999, we format at and show like 1,780 this was creating the bug because 1,780 cant be converted to `Number`
Fix- format the amount back to 1780 before passing it in `TokenAmountInput`