### PR TITLE
fix(manteca): handle TAX_ID_MISMATCH error code for Brazil CPF

### DIFF
--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -241,16 +241,23 @@ export default function MantecaWithdrawFlow() {
 
             if (result.error) {
                 // Handle specific error types with user-friendly messages
-                if (result.error === 'CUIT_MISMATCH') {
+                // TAX_ID_MISMATCH covers both Argentina (CUIT) and Brazil (CPF)
+                if (result.error === 'TAX_ID_MISMATCH' || result.error === 'CUIT_MISMATCH') {
+                    // Country-specific message based on currency (Manteca countries have this restriction)
+                    const countryName =
+                        currencyCode === 'ARS' ? 'Argentina' : currencyCode === 'BRL' ? 'Brazil' : 'your country'
                     setErrorMessage(
                         result.message ??
-                            'The bank account you entered is not registered under your name. In Argentina, you can only withdraw to accounts linked to your identity. Please contact support to request a refund.'
+                            `The bank account you entered is not registered under your name. Due to local regulations in ${countryName}, you can only withdraw to accounts linked to your identity. Please contact support to request a refund.`
                     )
                     setStep('failure')
                 } else if (result.error === 'Unexpected error') {
                     setErrorMessage('Withdraw failed unexpectedly. If problem persists contact support')
                     setStep('failure')
                 } else {
+                    // @dev TODO: Should this call setStep('failure')? Currently user sees error on review
+                    // screen but withdraw button is disabled and there's no "Contact Support" option.
+                    // Funds are already at Manteca's address at this point.
                     setErrorMessage(result.message ?? result.error)
                 }
                 return


### PR DESCRIPTION
## Problem

Brazilian users withdrawing via Manteca get a generic error instead of a user-friendly message when their bank account CPF doesn't match their identity.

## Root Cause

**Backend PR #533** only added CUIT (Argentina) mismatch detection. Brazil uses CPF, which wasn't handled. The backend is being updated to return `TAX_ID_MISMATCH` for both countries.

## Changes

Update withdraw error handling to support both error codes:
- `TAX_ID_MISMATCH` (new - covers Argentina CUIT + Brazil CPF)
- `CUIT_MISMATCH` (old - backwards compatibility)

Also removed "In Argentina" from fallback message since it now applies to multiple countries.

## Testing
- Brazilian users should see user-friendly error for CPF mismatches
- Argentine users continue to work as before
- Old cached responses with `CUIT_MISMATCH` still handled correctly

## Related
- **Backend PR:** https://github.com/peanutprotocol/peanut-api-ts/pull/536
- **Original issue caused by:** Backend PR #533