### PR TITLE
fix: remove httpOnly from JWT cookie to unblock client-side services

### DIFF
--- a/src/app/api/peanut/user/get-jwt-token/route.ts
+++ b/src/app/api/peanut/user/get-jwt-token/route.ts
@@ -39,10 +39,10 @@ export async function POST(request: NextRequest) {
         // Set the JWT token in a cookie, nextjs requires to do this serverside
         const cookieStore = await cookies()
         cookieStore.set('jwt-token', token, {
-            httpOnly: true,
-            secure: process.env.NODE_ENV === 'production', // consistent with other auth routes
+            httpOnly: false, // Required for client-side services to read token (see cookie-migration.utils.ts for TODO)
+            secure: process.env.NODE_ENV === 'production',
             path: '/',
-            sameSite: 'lax', // 'lax' allows cookies on top-level navigation while still preventing CSRF
+            sameSite: 'lax',
         })
 
         return new NextResponse(JSON.stringify(data), {

--- a/src/app/api/peanut/user/login-user/route.ts
+++ b/src/app/api/peanut/user/login-user/route.ts
@@ -36,10 +36,10 @@ export async function POST(request: NextRequest) {
 
         const cookieStore = await cookies()
         cookieStore.set('jwt-token', token, {
-            httpOnly: true,
-            secure: process.env.NODE_ENV === 'production', // in production, only send cookies over HTTPS
+            httpOnly: false, // Required for client-side services to read token (see cookie-migration.utils.ts for TODO)
+            secure: process.env.NODE_ENV === 'production',
             path: '/',
-            sameSite: 'lax', // 'lax' allows cookies on top-level navigation while still preventing CSRF
+            sameSite: 'lax',
         })
 
         return new NextResponse(JSON.stringify(data), {

--- a/src/app/api/peanut/user/register-user/route.ts
+++ b/src/app/api/peanut/user/register-user/route.ts
@@ -42,10 +42,10 @@ export async function POST(request: NextRequest) {
         // Set the JWT token in a cookie, nextjs requires to do this serverside
         const cookieStore = await cookies()
         cookieStore.set('jwt-token', token, {
-            httpOnly: true,
+            httpOnly: false, // Required for client-side services to read token (see cookie-migration.utils.ts for TODO)
             secure: process.env.NODE_ENV === 'production',
             path: '/',
-            sameSite: 'lax', // 'lax' allows cookies on top-level navigation while still preventing CSRF
+            sameSite: 'lax',
         })
         return new NextResponse(JSON.stringify(data), {
             status: 200,

--- a/src/utils/cookie-migration.utils.ts
+++ b/src/utils/cookie-migration.utils.ts
@@ -1,5 +1,12 @@
 import { cookies } from 'next/headers'
 
+// TODO: Consider migrating to a more secure cookie architecture:
+// 1. Set cookie with `domain: '.peanut.me'` so it's sent to all subdomains
+// 2. Use `credentials: 'include'` in fetch calls instead of manual Authorization headers
+// 3. Update backend CORS to allow credentials + read JWT from Cookie header
+// 4. Re-enable httpOnly once client-side code no longer needs to read the token
+// This would eliminate the need for js-cookie reads while maintaining httpOnly security.
+
 export async function getJWTCookie() {
     const cookieStore = await cookies()
     const cookie = cookieStore.get('jwt-token')
@@ -7,7 +14,7 @@ export async function getJWTCookie() {
     if (cookie?.value) {
         try {
             cookieStore.set('jwt-token', cookie.value, {
-                httpOnly: true,
+                httpOnly: false, // Required for client-side services to read token (see TODO above)
                 secure: process.env.NODE_ENV === 'production',
                 path: '/',
                 sameSite: 'lax',


### PR DESCRIPTION
## Summary
Removes `httpOnly` flag from JWT cookies to allow client-side services to read the token.

## Problem
After PR #1627 merged with `httpOnly: true`, client-side services (manteca, points, history, notifications, etc.) using `Cookies.get('jwt-token')` get `undefined`, causing 401 errors across the app.

## Solution
- Set `httpOnly: false` in 4 cookie-setting locations
- Added comprehensive TODO comment documenting future migration to domain cookies + credentials mode for better security

## Files Changed
- `src/app/api/peanut/user/login-user/route.ts`
- `src/app/api/peanut/user/register-user/route.ts`
- `src/app/api/peanut/user/get-jwt-token/route.ts`
- `src/utils/cookie-migration.utils.ts`

## Backend Companion
Corresponding backend changes already merged to `peanut-wallet-dev` in peanut-api-ts (commit 9b1e0638).

## Trade-offs
**Pros:** Unblocks all client-side authenticated features immediately
**Cons:** JWT readable by JavaScript (XSS risk, mitigated by existing CSP headers)

## Future Work
TODO added for cleaner architecture using domain cookies + credentials mode (see cookie-migration.utils.ts)