### PR TITLE
feat: payment graph with password auth and UI improvements

### DIFF
--- a/src/app/(mobile-ui)/dev/payment-graph/page.tsx
+++ b/src/app/(mobile-ui)/dev/payment-graph/page.tsx
@@ -1,31 +1,42 @@
 'use client'
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
+import { useSearchParams } from 'next/navigation'
 import { Button } from '@/components/0_Bruddle/Button'
 import InvitesGraph, { DEFAULT_FORCE_CONFIG } from '@/components/Global/InvitesGraph'
 
 export default function PaymentGraphPage() {
-    const [apiKey, setApiKey] = useState('')
-    const [apiKeySubmitted, setApiKeySubmitted] = useState(false)
+    const searchParams = useSearchParams()
+    const [password, setPassword] = useState('')
+    const [passwordSubmitted, setPasswordSubmitted] = useState(false)
     const [error, setError] = useState<string | null>(null)
     // Performance mode: limit to 1000 top nodes
     const [performanceMode, setPerformanceMode] = useState(false)
 
-    const handleApiKeySubmit = useCallback(() => {
-        if (!apiKey.trim()) {
-            setError('Please enter an API key')
+    // Check for password in URL on mount
+    useEffect(() => {
+        const urlPassword = searchParams.get('password')
+        if (urlPassword) {
+            setPassword(urlPassword)
+            setPasswordSubmitted(true)
+        }
+    }, [searchParams])
+
+    const handlePasswordSubmit = useCallback(() => {
+        if (!password.trim()) {
+            setError('Please enter a password')
             return
         }
         setError(null)
-        setApiKeySubmitted(true)
-    }, [apiKey])
+        setPasswordSubmitted(true)
+    }, [password])
 
     const handleClose = useCallback(() => {
         window.location.href = '/dev'
     }, [])
 
-    // API key input screen
-    if (!apiKeySubmitted) {
+    // Password input screen (only shown if not provided in URL)
+    if (!passwordSubmitted) {
         return (
             <div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900">
                 <div className="w-full max-w-md space-y-6 rounded-2xl bg-white p-8 shadow-2xl">
@@ -42,13 +53,13 @@ export default function PaymentGraphPage() {
                     )}
                     <input
                         type="password"
-                        value={apiKey}
-                        onChange={(e) => setApiKey(e.target.value)}
-                        onKeyDown={(e) => e.key === 'Enter' && handleApiKeySubmit()}
-                        placeholder="Admin API Key"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        onKeyDown={(e) => e.key === 'Enter' && handlePasswordSubmit()}
+                        placeholder="Password"
                         className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm transition-colors focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-500/20"
                     />
-                    <Button onClick={handleApiKeySubmit} className="w-full">
+                    <Button onClick={handlePasswordSubmit} className="w-full">
                         Enter Graph
                     </Button>
                     <button
@@ -65,7 +76,8 @@ export default function PaymentGraphPage() {
     return (
         <div className="fixed inset-0 z-50 flex flex-col bg-gray-50">
             <InvitesGraph
-                apiKey={apiKey}
+                apiKey=""
+                password={password}
                 mode="payment"
                 topNodes={5000}
                 performanceMode={performanceMode}

--- a/src/components/Global/InvitesGraph/index.tsx
+++ b/src/components/Global/InvitesGraph/index.tsx
@@ -288,6 +288,8 @@ interface BaseProps {
 interface FullModeProps extends BaseProps {
     /** Admin API key to fetch full graph */
     apiKey: string
+    /** Password for payment mode authentication */
+    password?: string
     /** Graph mode: 'full' shows all features, 'payment' shows P2P only (no invites, fixed 120-day window) */
     mode?: GraphMode
     /** Close/back button handler */
@@ -960,9 +962,11 @@ export default function InvitesGraph(props: InvitesGraphProps) {
             // API only supports 'full' | 'payment' modes (user mode uses different endpoint)
             const apiMode = mode === 'payment' ? 'payment' : 'full'
             // Pass topNodes for both modes - payment mode now supports it via Performance button
+            // Pass password for payment mode authentication
             const result = await pointsApi.getInvitesGraph(props.apiKey, {
                 mode: apiMode,
                 topNodes: topNodes > 0 ? topNodes : undefined,
+                password: mode === 'payment' ? props.password : undefined,
             })
 
             if (result.success && result.data) {


### PR DESCRIPTION
## Summary
- Add password-based authentication for payment graph
- Support direct URL access with password query param
- Remove verbose debug logging, add safety assertions
- Add SizeLabel type and optional fields for payment mode

## Changes
- **Password auth**: Read from URL `?password=xxx` or show input form
- **Direct URL**: `https://peanut.me/dev/payment-graph?password=xxx` works
- **Debug cleanup**: Remove 9 verbose console.log statements
- **Safety nets**: Add console.assert for duplicate ID detection
- **Types**: Add SizeLabel export, make node fields optional for payment mode

## Auth Flow
| Mode | Authentication |
|------|----------------|
| Full | API key + JWT |
| Payment | Password (URL or input form) |

## Test plan
- [ ] Test `/dev/payment-graph?password=xxx` loads graph directly
- [ ] Test password input form works when no URL param
- [ ] Test invalid password shows error message
- [ ] Verify no console.log spam in production
- [ ] Test full-graph still works with API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)