### PR TITLE
[TASK-16734] feat: add PIX key to BR Code conversion for QR payments

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "jsqr": "^1.4.0",
         "next": "16.0.10",
         "nuqs": "^2.8.6",
+        "pix-utils": "^2.8.2",
         "pulltorefreshjs": "^0.1.22",
         "qr-scanner": "^1.4.2",
         "react": "^19.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
       nuqs:
         specifier: ^2.8.6
         version: 2.8.6(next@16.0.10(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+      pix-utils:
+        specifier: ^2.8.2
+        version: 2.8.2
       pulltorefreshjs:
         specifier: ^0.1.22
         version: 0.1.22
@@ -4546,6 +4549,9 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-text-encoding@1.0.6:
+    resolution: {integrity: sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -5853,6 +5859,10 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
+  pix-utils@2.8.2:
+    resolution: {integrity: sha512-PXkuvFJzFkcxlFCotVQJGZAhz6uruOdjUaW1RsBbx5DC5dzfFCYjtVdhb65a0YMG1BScdM5fLBu3udEchyRk4Q==}
+    engines: {node: '>=12', npm: '>=6'}
+
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
@@ -6069,6 +6079,11 @@ packages:
 
   qrcode@1.5.3:
     resolution: {integrity: sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
     engines: {node: '>=10.13.0'}
     hasBin: true
 
@@ -13623,6 +13638,8 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-text-encoding@1.0.6: {}
+
   fast-uri@3.1.0: {}
 
   fastq@1.19.1:
@@ -15301,6 +15318,14 @@ snapshots:
 
   pirates@4.0.7: {}
 
+  pix-utils@2.8.2:
+    dependencies:
+      axios: 1.11.0
+      fast-text-encoding: 1.0.6
+      qrcode: 1.5.4
+    transitivePeerDependencies:
+      - debug
+
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
@@ -15473,6 +15498,12 @@ snapshots:
     dependencies:
       dijkstrajs: 1.0.3
       encode-utf8: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
+
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
       pngjs: 5.0.0
       yargs: 15.4.1
 

--- a/src/components/Global/DirectSendQR/index.tsx
+++ b/src/components/Global/DirectSendQR/index.tsx
@@ -17,6 +17,7 @@ import { twMerge } from 'tailwind-merge'
 import ActionModal from '../ActionModal'
 import { Icon, type IconName } from '../Icons/Icon'
 import { EQrType, NAME_BY_QR_TYPE, parseEip681, recognizeQr } from './utils'
+import { pixKeyToBRCode } from '@/utils/pix.utils'
 import { useHaptic } from 'use-haptic'
 import { useModalsContext } from '@/context/ModalsContext'
 
@@ -326,6 +327,21 @@ export default function DirectSendQr({
                     const timestamp = Date.now()
                     // Casing matters, so send original instead of normalized
                     redirectUrl = `/qr-pay?qrCode=${encodeURIComponent(originalData)}&t=${timestamp}&type=${qrType}`
+                }
+                break
+            case EQrType.PIX_KEY:
+                {
+                    const brCode = pixKeyToBRCode(originalData)
+                    if (brCode) {
+                        const timestamp = Date.now()
+                        redirectUrl = `/qr-pay?qrCode=${encodeURIComponent(brCode)}&t=${timestamp}&type=${EQrType.PIX}`
+                    } else {
+                        // Invalid PIX key - show unrecognized modal
+                        setModalContent(EModalType.UNRECOGNIZED)
+                        setIsModalOpen(true)
+                        setIsQRScannerOpen(false)
+                        return { success: true }
+                    }
                 }
                 break
             case EQrType.BITCOIN_ONCHAIN:

--- a/src/utils/__tests__/pix.utils.test.ts
+++ b/src/utils/__tests__/pix.utils.test.ts
@@ -1,0 +1,94 @@
+import { pixKeyToBRCode } from '@/utils/pix.utils'
+
+jest.mock('@/assets', () => ({}))
+
+describe('PIX Utilities', () => {
+    describe('pixKeyToBRCode', () => {
+        describe('Valid PIX keys should generate BR Codes', () => {
+            it.each([
+                // Email
+                ['user@example.com', 'email'],
+                ['test.user@domain.com.br', 'email with subdomain'],
+                // CPF (11 digits)
+                ['12345678901', 'CPF'],
+                ['98765432100', 'another CPF'],
+                // CNPJ (14 digits)
+                ['12345678901234', 'CNPJ'],
+                // Phone numbers
+                ['+5511999999999', 'phone with +'],
+                ['5511999999999', 'phone without +'],
+                // UUID (random key)
+                ['123e4567-e89b-12d3-a456-426614174000', 'UUID'],
+            ])('should generate BR Code for %s (%s)', (pixKey, _description) => {
+                const result = pixKeyToBRCode(pixKey)
+                expect(result).not.toBeNull()
+                expect(result).toContain('000201')
+                expect(result).toContain('br.gov.bcb.pix')
+                expect(result).toContain('5802BR')
+                expect(result).toContain('5303986')
+            })
+        })
+
+        describe('BR Codes should be returned as-is', () => {
+            it.each([
+                [
+                    '00020126580014br.gov.bcb.pix0136123e4567-e12b-12d1-a456-4266554400005204000053039865802BR5913Fulano de Tal6008BRASILIA62070503***63041D3D',
+                    'standard PIX QR',
+                ],
+                [
+                    '00020126850014br.gov.bcb.pix2563pix.voluti.com.br/qr/v3/at/c75d8412-3935-49d1-9d80-6435716962665204000053039865802BR5925SMARTPAY_SERVICOS_DIGITAI6013FLORIANOPOLIS62070503***6304575A',
+                    'dynamic PIX QR',
+                ],
+            ])('should return existing BR Code as-is: %s', (brCode, _description) => {
+                const result = pixKeyToBRCode(brCode)
+                expect(result).toBe(brCode)
+            })
+        })
+
+        describe('Invalid PIX keys should return null', () => {
+            it.each([
+                ['', 'empty string'],
+                ['   ', 'whitespace only'],
+                ['invalid', 'random text'],
+                ['123456', 'too short number'],
+                ['11111111111', 'all same digits CPF'],
+                ['00000000000000', 'all zeros CNPJ'],
+                ['not-a-valid-email', 'invalid email'],
+                ['123e4567-e89b-12d3-a456', 'incomplete UUID'],
+                ['+5511', 'too short phone'],
+            ])('should return null for %s (%s)', (pixKey, _description) => {
+                const result = pixKeyToBRCode(pixKey)
+                expect(result).toBeNull()
+            })
+        })
+
+        describe('Merchant name truncation', () => {
+            it('should handle long PIX keys by truncating merchant name', () => {
+                const longEmail = 'verylongemailaddress@verylongdomain.com.br'
+                const result = pixKeyToBRCode(longEmail)
+                expect(result).not.toBeNull()
+                // The BR Code should still be valid even with truncated merchant name
+                expect(result).toContain('000201')
+                expect(result).toContain('br.gov.bcb.pix')
+            })
+        })
+
+        describe('Case preservation', () => {
+            it('should preserve email case in the PIX key', () => {
+                const email = 'User.Name@Example.COM'
+                const result = pixKeyToBRCode(email)
+                expect(result).not.toBeNull()
+                // The email should be preserved in the BR Code
+                expect(result).toContain('User.Name@Example.COM')
+            })
+        })
+
+        describe('Whitespace handling', () => {
+            it('should trim leading/trailing whitespace', () => {
+                const result = pixKeyToBRCode('  user@example.com  ')
+                expect(result).not.toBeNull()
+                expect(result).toContain('user@example.com')
+            })
+        })
+    })
+})

--- a/src/utils/pix.utils.ts
+++ b/src/utils/pix.utils.ts
@@ -1,0 +1,40 @@
+import { createStaticPix, hasError } from 'pix-utils'
+import { validatePixKey, isPixEmvcoQr } from './withdraw.utils'
+
+/**
+ * Converts a raw PIX key into an EMVCo BR Code string.
+ * If the input is already a BR Code, returns it as-is.
+ * Returns null if the PIX key is invalid.
+ *
+ * @param pixKey - The PIX key (email, CPF, CNPJ, phone, UUID) or BR Code
+ * @returns The EMVCo BR Code string, or null if invalid
+ */
+export const pixKeyToBRCode = (pixKey: string): string | null => {
+    const trimmed = pixKey.trim()
+
+    // Already a BR Code? Return as-is
+    if (isPixEmvcoQr(trimmed)) {
+        return trimmed
+    }
+
+    // Validate the PIX key first
+    const validation = validatePixKey(trimmed)
+    if (!validation.valid) {
+        return null
+    }
+
+    // Generate BR Code using pix-utils
+    // merchantName is the PIX key itself (truncated to 25 chars per EMVCo spec)
+    // Note: transactionAmount is optional at runtime despite TypeScript types
+    const pix = createStaticPix({
+        merchantName: trimmed.substring(0, 25),
+        merchantCity: 'Sao Paulo',
+        pixKey: trimmed,
+    } as Parameters<typeof createStaticPix>[0])
+
+    if (hasError(pix)) {
+        return null
+    }
+
+    return pix.toBRCode()
+}


### PR DESCRIPTION
When users scan or paste a raw PIX key (email, CPF, phone, UUID), it's now automatically converted to EMVCo BR Code format using pix-utils, enabling the existing PIX payment flow.