### PR TITLE
Peanut wallet

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,12 +1,15 @@
 # peanut-ui Development Rules
 
-**Version:** 0.0.1 | **Updated:** October 17, 2025
+**Version:** 0.0.2 | **Updated:** December 16, 2025
 
 ## 🚫 Random
 
 - **Never open SVG files** - it crashes you. Only read jpeg, png, gif, or webp.
 - **Never run jq command** - it crashes you.
 - **Never run sleep** from command line - it hibernates pc.
+- **Do not generate .md files** unless explicity told to do so.
+- **Comments** should always be made in all lowercase and simple english
+- **Error messages**, any error being shown in the ui should be user friendly and easy to understand, and any error being logged in consoles and sentry should be descriptive for developers to help with debugging
 
 ## 💻 Code Quality
 
@@ -14,12 +17,27 @@
 - **DRY** - do not repeat yourself. Reuse existing code and abstract shared functionality. Less code is better code.
 - this also means to use shared consts (e.g. check src/constants)
 - **Separate business logic from interface** - this is important for readability, debugging and testability.
-- **Use explicit imports** where possible.
 - **Reuse existing components and functions** - don't hardcode hacky solutions.
 - **Warn about breaking changes** - when making changes, ensure you're not breaking existing functionality, and if there's a risk, explicitly WARN about it.
 - **Mention refactor opportunities** - if you notice an opportunity to refactor or improve existing code, mention it. DO NOT make any changes you were not explicitly told to do. Only mention the potential change to the user.
 - **Performance is important** - cache where possible, make sure to not make unnecessary re-renders or data fetching.
 - **Flag breaking changes** - always flag if changes done in Frontend are breaking and require action on Backend (or viceversa)
+
+## 🔗 URL as State (Critical for UX)
+
+- **URL is source of truth** - use query parameters for user-facing state that should survive navigation, refresh, or sharing (step indicators, amounts, filters, view modes, selected items)
+- **Use nuqs library** - always use `useQueryStates` from [nuqs](https://nuqs.dev) for type-safe URL state management. never manually parse/set query params with router.push or URLSearchParams
+- **Enable deep-linking** - users should be able to share or bookmark URLs mid-flow (e.g. `?step=inputAmount&amount=500&currency=ARS`)
+- **Proper navigation** - URL state enables correct back/forward browser button behavior
+- **Multi-step flows** - the URL should always reflect current step and relevant data, making the app behave like a proper web app, not a trapped SPA
+- **Reserve useState for ephemeral UI** - only use React useState for truly transient state:
+    - loading spinners and skeleton states
+    - modal open/close state
+    - form validation errors (unless they should persist)
+    - hover/focus states
+    - temporary UI animations
+- **Don't URL-ify everything** - API responses, user authentication state, and internal component state generally shouldn't be in the URL unless they're user-facing and shareable
+- **Type safety** - define parsers for query params (e.g. `parseAsInteger`, `parseAsStringEnum`) to ensure type safety and validation
 
 ## 🚫 Import Rules (critical for build performance)
 
@@ -27,6 +45,14 @@
 - **No circular dependencies** - before adding imports, check if the target file imports from the current file. circular deps cause `Cannot access X before initialization` errors. move shared types to `interfaces.ts` if needed.
 - **No node.js packages in client components** - packages like `web-push`, `fs`, `crypto` (node) can't be used in `'use client'` files. use server actions or api routes instead.
 - **Check for legacy code** - before importing from a file, check if it has TODO comments marking it as legacy/deprecated. prefer newer implementations.
+
+## 🚫 Export Rules (critical for build performance)
+
+- **Do not export multiple stuff from same component**:
+    - never export types or other utility methods from a component or a hook
+    - for types always use a separate file if they need to be reused
+    - and for utility/helper functions use a separate utils file to export them and use if they need to be reused
+    - same for files with multiple components exported, do not export multiple components from same file and if you see this done anywhere in the code, abstract it to other file
 
 ## 🧪 Testing
 

--- a/src/app/(mobile-ui)/dev/full-graph/page.tsx
+++ b/src/app/(mobile-ui)/dev/full-graph/page.tsx
@@ -481,8 +481,8 @@ export default function FullGraphPage() {
                                             <div className="space-y-0.5">
                                                 <div className="flex items-center justify-between">
                                                     <span className="text-[9px] text-gray-500">Min users:</span>
-                                                    <div className="flex gap-1">
-                                                        {[1, 2, 3, 5, 10].map((val) => (
+                                                    <div className="flex flex-wrap gap-1">
+                                                        {[1, 2, 3, 5, 10, 20, 50].map((val) => (
                                                             <button
                                                                 key={val}
                                                                 onClick={() =>

--- a/src/app/(mobile-ui)/dev/full-graph/page.tsx
+++ b/src/app/(mobile-ui)/dev/full-graph/page.tsx
@@ -11,7 +11,7 @@ import InvitesGraph, {
 } from '@/components/Global/InvitesGraph'
 
 // Allowed users for full graph access (frontend check - backend also validates)
-const ALLOWED_USERNAMES = ['squirrel', 'konrad', 'hugo']
+const ALLOWED_USERNAMES = ['squirrel', 'kkonrad', 'hugo']
 
 export default function FullGraphPage() {
     const { user, isFetchingUser } = useAuth()

--- a/src/app/(mobile-ui)/dev/invite-graph/page.tsx
+++ b/src/app/(mobile-ui)/dev/invite-graph/page.tsx
@@ -433,27 +433,31 @@ export default function InviteGraphPage() {
                                     )}
                                     {!externalNodesError && externalNodesConfig.enabled && (
                                         <div className="space-y-1.5 pl-4">
-                                            {/* Min connections slider - show only external addresses used by N+ users */}
+                                            {/* Min connections - discrete options */}
                                             <div className="space-y-0.5">
                                                 <div className="flex items-center justify-between">
-                                                    <span className="text-[9px] text-gray-500">
-                                                        Show if ≥{externalNodesConfig.minConnections} users
-                                                    </span>
+                                                    <span className="text-[9px] text-gray-500">Min users:</span>
+                                                    <div className="flex gap-1">
+                                                        {[1, 2, 3, 5, 10].map((val) => (
+                                                            <button
+                                                                key={val}
+                                                                onClick={() =>
+                                                                    setExternalNodesConfig({
+                                                                        ...externalNodesConfig,
+                                                                        minConnections: val,
+                                                                    })
+                                                                }
+                                                                className={`rounded px-1.5 py-0.5 text-[9px] transition-colors ${
+                                                                    externalNodesConfig.minConnections === val
+                                                                        ? 'bg-orange-600 text-white'
+                                                                        : 'bg-gray-200 text-gray-600 hover:bg-gray-300'
+                                                                }`}
+                                                            >
+                                                                {val}
+                                                            </button>
+                                                        ))}
+                                                    </div>
                                                 </div>
-                                                <input
-                                                    type="range"
-                                                    min="2"
-                                                    max="20"
-                                                    step="1"
-                                                    value={externalNodesConfig.minConnections}
-                                                    onChange={(e) =>
-                                                        setExternalNodesConfig({
-                                                            ...externalNodesConfig,
-                                                            minConnections: parseInt(e.target.value),
-                                                        })
-                                                    }
-                                                    className="h-1 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 accent-orange-600"
-                                                />
                                             </div>
                                             {/* Type filters */}
                                             <div className="flex gap-2 text-[9px]">

--- a/src/app/(mobile-ui)/dev/invite-graph/page.tsx
+++ b/src/app/(mobile-ui)/dev/invite-graph/page.tsx
@@ -681,6 +681,10 @@ export default function InviteGraphPage() {
                                     {/* Nodes */}
                                     <div className="flex flex-wrap gap-x-2 gap-y-0.5 text-gray-500">
                                         <span className="flex items-center gap-0.5">
+                                            <span className="inline-block h-2 w-2 rounded-full bg-green-500"></span>
+                                            New
+                                        </span>
+                                        <span className="flex items-center gap-0.5">
                                             <span className="inline-block h-2 w-2 rounded-full bg-purple-500"></span>
                                             Active
                                         </span>

--- a/src/app/(mobile-ui)/dev/layout.tsx
+++ b/src/app/(mobile-ui)/dev/layout.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { notFound } from 'next/navigation'
+import { IS_DEV } from '@/constants/general.consts'
+
+// Routes that are allowed in production (protected by API key / user check)
+const PRODUCTION_ALLOWED_ROUTES = ['/dev/full-graph', '/dev/payment-graph']
+
+export default function DevLayout({ children }: { children: React.ReactNode }) {
+    const pathname = usePathname()
+
+    // In production, only allow specific routes (full-graph, payment-graph)
+    // Other dev tools (leaderboard, shake-test, dev index) are dev-only
+    if (!IS_DEV) {
+        const isAllowedInProd = PRODUCTION_ALLOWED_ROUTES.some((route) => pathname?.startsWith(route))
+        if (!isAllowedInProd) {
+            notFound()
+        }
+    }
+
+    return <>{children}</>
+}

--- a/src/app/(mobile-ui)/dev/page.tsx
+++ b/src/app/(mobile-ui)/dev/page.tsx
@@ -15,10 +15,18 @@ export default function DevToolsPage() {
             status: 'active',
         },
         {
-            name: 'Invite Graph',
-            description: 'Interactive force-directed graph visualization of all user invites (admin only)',
-            path: '/dev/invite-graph',
+            name: 'Full Graph',
+            description:
+                'Interactive force-directed graph visualization of all users, invites, and P2P activity (admin only)',
+            path: '/dev/full-graph',
             icon: '🕸️',
+            status: 'active',
+        },
+        {
+            name: 'Payment Graph',
+            description: 'P2P payment flow visualization (120-day window, no invites)',
+            path: '/dev/payment-graph',
+            icon: '💸',
             status: 'active',
         },
         {
@@ -70,7 +78,7 @@ export default function DevToolsPage() {
                 <Card className="space-y-2 bg-blue-50 p-4">
                     <h3 className="font-bold text-blue-900">ℹ️ Info</h3>
                     <ul className="space-y-1 text-sm text-blue-800">
-                        <li>• These tools are publicly accessible (no login required)</li>
+                        <li>• These tools are only available in development mode</li>
                         <li>• Perfect for testing on multiple devices</li>
                         <li>• Share the URL with team members for testing</li>
                     </ul>

--- a/src/app/(mobile-ui)/dev/page.tsx
+++ b/src/app/(mobile-ui)/dev/page.tsx
@@ -24,7 +24,7 @@ export default function DevToolsPage() {
         },
         {
             name: 'Payment Graph',
-            description: 'P2P payment flow visualization (120-day window, no invites)',
+            description: 'P2P payment flow visualization',
             path: '/dev/payment-graph',
             icon: '💸',
             status: 'active',

--- a/src/app/(mobile-ui)/dev/payment-graph/page.tsx
+++ b/src/app/(mobile-ui)/dev/payment-graph/page.tsx
@@ -65,10 +65,10 @@ export default function PaymentGraphPage() {
     return (
         <div className="fixed inset-0 z-50 flex flex-col bg-gray-50">
             <InvitesGraph
-                key={`payment-graph-${performanceMode ? 'perf' : 'full'}`}
                 apiKey={apiKey}
                 mode="payment"
-                topNodes={performanceMode ? 1000 : 0}
+                topNodes={5000}
+                performanceMode={performanceMode}
                 onClose={handleClose}
                 width={typeof window !== 'undefined' ? window.innerWidth : 1200}
                 height={typeof window !== 'undefined' ? window.innerHeight - 120 : 800}

--- a/src/app/(mobile-ui)/dev/payment-graph/page.tsx
+++ b/src/app/(mobile-ui)/dev/payment-graph/page.tsx
@@ -8,6 +8,8 @@ export default function PaymentGraphPage() {
     const [apiKey, setApiKey] = useState('')
     const [apiKeySubmitted, setApiKeySubmitted] = useState(false)
     const [error, setError] = useState<string | null>(null)
+    // Performance mode: limit to 1000 top nodes
+    const [performanceMode, setPerformanceMode] = useState(false)
 
     const handleApiKeySubmit = useCallback(() => {
         if (!apiKey.trim()) {
@@ -30,9 +32,7 @@ export default function PaymentGraphPage() {
                     <div className="text-center">
                         <div className="mb-4 text-6xl">💸</div>
                         <h2 className="mb-2 text-2xl font-bold text-gray-900">Payment Graph</h2>
-                        <p className="text-sm text-gray-600">
-                            P2P payment flow visualization (120-day window, no invites)
-                        </p>
+                        <p className="text-sm text-gray-600">P2P payment flow visualization</p>
                     </div>
                     {error && (
                         <div className="bg-red-50 text-red-800 rounded-lg p-3 text-sm">
@@ -65,8 +65,10 @@ export default function PaymentGraphPage() {
     return (
         <div className="fixed inset-0 z-50 flex flex-col bg-gray-50">
             <InvitesGraph
+                key={`payment-graph-${performanceMode ? 'perf' : 'full'}`}
                 apiKey={apiKey}
                 mode="payment"
+                topNodes={performanceMode ? 1000 : 0}
                 onClose={handleClose}
                 width={typeof window !== 'undefined' ? window.innerWidth : 1200}
                 height={typeof window !== 'undefined' ? window.innerHeight - 120 : 800}
@@ -267,7 +269,7 @@ export default function PaymentGraphPage() {
                                 {/* Divider */}
                                 <div className="my-1 border-t border-gray-200"></div>
 
-                                {/* Merchants Section */}
+                                {/* External Nodes Section */}
                                 <div className="space-y-1">
                                     <div className="flex items-center gap-1.5">
                                         <input
@@ -283,11 +285,11 @@ export default function PaymentGraphPage() {
                                                         : externalNodesConfig.types,
                                                 })
                                             }
-                                            className="h-3 w-3 rounded border-gray-300 text-green-600"
+                                            className="h-3 w-3 rounded border-gray-300 text-orange-600"
                                         />
-                                        <span className="text-gray-700">Merchants</span>
+                                        <span className="text-gray-700">External Nodes</span>
                                         {externalNodesLoading && (
-                                            <span className="ml-auto animate-pulse text-[9px] text-green-500">
+                                            <span className="ml-auto animate-pulse text-[9px] text-orange-500">
                                                 loading...
                                             </span>
                                         )}
@@ -309,13 +311,65 @@ export default function PaymentGraphPage() {
                                     </div>
                                     {externalNodesConfig.enabled && !externalNodesError && (
                                         <div className="space-y-1.5 pl-4">
+                                            {/* Type filters - emoji only */}
+                                            <div className="flex gap-2 text-[9px]">
+                                                <label className="flex cursor-pointer items-center gap-0.5">
+                                                    <input
+                                                        type="checkbox"
+                                                        checked={externalNodesConfig.types.WALLET}
+                                                        onChange={(e) =>
+                                                            setExternalNodesConfig({
+                                                                ...externalNodesConfig,
+                                                                types: {
+                                                                    ...externalNodesConfig.types,
+                                                                    WALLET: e.target.checked,
+                                                                },
+                                                            })
+                                                        }
+                                                        className="h-2.5 w-2.5 rounded border-gray-300 text-orange-500"
+                                                    />
+                                                    <span className="text-orange-600">₿</span>
+                                                </label>
+                                                <label className="flex cursor-pointer items-center gap-0.5">
+                                                    <input
+                                                        type="checkbox"
+                                                        checked={externalNodesConfig.types.BANK}
+                                                        onChange={(e) =>
+                                                            setExternalNodesConfig({
+                                                                ...externalNodesConfig,
+                                                                types: {
+                                                                    ...externalNodesConfig.types,
+                                                                    BANK: e.target.checked,
+                                                                },
+                                                            })
+                                                        }
+                                                        className="h-2.5 w-2.5 rounded border-gray-300 text-blue-500"
+                                                    />
+                                                    <span className="text-blue-600">🏦</span>
+                                                </label>
+                                                <label className="flex cursor-pointer items-center gap-0.5">
+                                                    <input
+                                                        type="checkbox"
+                                                        checked={externalNodesConfig.types.MERCHANT}
+                                                        onChange={(e) =>
+                                                            setExternalNodesConfig({
+                                                                ...externalNodesConfig,
+                                                                types: {
+                                                                    ...externalNodesConfig.types,
+                                                                    MERCHANT: e.target.checked,
+                                                                },
+                                                            })
+                                                        }
+                                                        className="h-2.5 w-2.5 rounded border-gray-300 text-green-500"
+                                                    />
+                                                    <span className="text-green-600">🏪</span>
+                                                </label>
+                                            </div>
                                             {/* Min connections */}
                                             <div className="space-y-1">
-                                                <span className="text-[9px] text-gray-500">
-                                                    Min users to show merchant:
-                                                </span>
-                                                <div className="flex gap-0.5">
-                                                    {[1, 2, 3, 5, 10].map((val) => (
+                                                <span className="text-[9px] text-gray-500">Min users:</span>
+                                                <div className="flex flex-wrap gap-0.5">
+                                                    {[1, 2, 3, 5, 10, 20, 50].map((val) => (
                                                         <button
                                                             key={val}
                                                             onClick={() =>
@@ -326,7 +380,7 @@ export default function PaymentGraphPage() {
                                                             }
                                                             className={`rounded px-1 py-0.5 text-[9px] transition-colors ${
                                                                 externalNodesConfig.minConnections === val
-                                                                    ? 'bg-green-600 text-white'
+                                                                    ? 'bg-orange-600 text-white'
                                                                     : 'bg-gray-200 text-gray-600 hover:bg-gray-300'
                                                             }`}
                                                         >
@@ -355,7 +409,7 @@ export default function PaymentGraphPage() {
                                                                     },
                                                                 })
                                                             }
-                                                            className="h-2.5 w-2.5 rounded border-gray-300 text-green-500"
+                                                            className="h-2.5 w-2.5 rounded border-gray-300 text-orange-500"
                                                         />
                                                         <span className="text-[9px] text-gray-600">Link Force</span>
                                                     </div>
@@ -395,7 +449,7 @@ export default function PaymentGraphPage() {
                                                                 },
                                                             })
                                                         }
-                                                        className="h-1 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 accent-green-500"
+                                                        className="h-1 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 accent-orange-500"
                                                     />
                                                 )}
                                             </div>
@@ -417,6 +471,21 @@ export default function PaymentGraphPage() {
                                         />
                                         <span className="text-gray-600">Names</span>
                                     </label>
+                                </div>
+
+                                {/* Performance mode toggle */}
+                                <div className="flex items-center gap-2">
+                                    <button
+                                        onClick={() => setPerformanceMode(!performanceMode)}
+                                        className={`flex-1 rounded border px-2 py-1 text-[10px] transition-colors ${
+                                            performanceMode
+                                                ? 'border-green-500 bg-green-50 text-green-700'
+                                                : 'border-gray-200 text-gray-500 hover:bg-gray-50'
+                                        }`}
+                                        title="Limit to top 1000 nodes for better performance"
+                                    >
+                                        ⚡ Performance {performanceMode ? 'ON' : 'OFF'}
+                                    </button>
                                 </div>
 
                                 {/* Action buttons */}
@@ -455,16 +524,30 @@ export default function PaymentGraphPage() {
                                     {/* External nodes */}
                                     {externalNodesConfig.enabled && (
                                         <div className="flex flex-wrap gap-x-2 gap-y-0.5 text-gray-500">
-                                            <span className="flex items-center gap-0.5">
-                                                <span
-                                                    className="inline-block h-2 w-2 bg-green-500"
-                                                    style={{
-                                                        clipPath:
-                                                            'polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)',
-                                                    }}
-                                                ></span>
-                                                Merchant
-                                            </span>
+                                            {externalNodesConfig.types.WALLET && (
+                                                <span className="flex items-center gap-0.5">
+                                                    <span className="inline-block h-2 w-2 rotate-45 bg-orange-500"></span>
+                                                    ₿
+                                                </span>
+                                            )}
+                                            {externalNodesConfig.types.BANK && (
+                                                <span className="flex items-center gap-0.5">
+                                                    <span className="inline-block h-2 w-2 bg-blue-500"></span>
+                                                    Bank
+                                                </span>
+                                            )}
+                                            {externalNodesConfig.types.MERCHANT && (
+                                                <span className="flex items-center gap-0.5">
+                                                    <span
+                                                        className="inline-block h-2 w-2 bg-green-500"
+                                                        style={{
+                                                            clipPath:
+                                                                'polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)',
+                                                        }}
+                                                    ></span>
+                                                    Merchant
+                                                </span>
+                                            )}
                                         </div>
                                     )}
                                     {/* Edges */}
@@ -474,7 +557,9 @@ export default function PaymentGraphPage() {
                                         </span>
                                     </div>
                                     <p className="text-gray-400">Click → Grafana | Right-click → Focus</p>
-                                    <p className="text-gray-400">Limited to 5000 nodes for performance</p>
+                                    <p className="text-gray-400">
+                                        {performanceMode ? 'Limited to 1000 nodes' : 'Limited to 5000 nodes'}
+                                    </p>
                                 </div>
                             </div>
                         </div>

--- a/src/app/(mobile-ui)/dev/payment-graph/page.tsx
+++ b/src/app/(mobile-ui)/dev/payment-graph/page.tsx
@@ -1,31 +1,42 @@
 'use client'
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
+import { useSearchParams } from 'next/navigation'
 import { Button } from '@/components/0_Bruddle/Button'
 import InvitesGraph, { DEFAULT_FORCE_CONFIG } from '@/components/Global/InvitesGraph'
 
 export default function PaymentGraphPage() {
-    const [apiKey, setApiKey] = useState('')
-    const [apiKeySubmitted, setApiKeySubmitted] = useState(false)
+    const searchParams = useSearchParams()
+    const [password, setPassword] = useState('')
+    const [passwordSubmitted, setPasswordSubmitted] = useState(false)
     const [error, setError] = useState<string | null>(null)
     // Performance mode: limit to 1000 top nodes
     const [performanceMode, setPerformanceMode] = useState(false)
 
-    const handleApiKeySubmit = useCallback(() => {
-        if (!apiKey.trim()) {
-            setError('Please enter an API key')
+    // Check for password in URL on mount
+    useEffect(() => {
+        const urlPassword = searchParams.get('password')
+        if (urlPassword) {
+            setPassword(urlPassword)
+            setPasswordSubmitted(true)
+        }
+    }, [searchParams])
+
+    const handlePasswordSubmit = useCallback(() => {
+        if (!password.trim()) {
+            setError('Please enter a password')
             return
         }
         setError(null)
-        setApiKeySubmitted(true)
-    }, [apiKey])
+        setPasswordSubmitted(true)
+    }, [password])
 
     const handleClose = useCallback(() => {
         window.location.href = '/dev'
     }, [])
 
-    // API key input screen
-    if (!apiKeySubmitted) {
+    // Password input screen (only shown if not provided in URL)
+    if (!passwordSubmitted) {
         return (
             <div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900">
                 <div className="w-full max-w-md space-y-6 rounded-2xl bg-white p-8 shadow-2xl">
@@ -42,13 +53,13 @@ export default function PaymentGraphPage() {
                     )}
                     <input
                         type="password"
-                        value={apiKey}
-                        onChange={(e) => setApiKey(e.target.value)}
-                        onKeyDown={(e) => e.key === 'Enter' && handleApiKeySubmit()}
-                        placeholder="Admin API Key"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        onKeyDown={(e) => e.key === 'Enter' && handlePasswordSubmit()}
+                        placeholder="Password"
                         className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm transition-colors focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-500/20"
                     />
-                    <Button onClick={handleApiKeySubmit} className="w-full">
+                    <Button onClick={handlePasswordSubmit} className="w-full">
                         Enter Graph
                     </Button>
                     <button
@@ -65,7 +76,8 @@ export default function PaymentGraphPage() {
     return (
         <div className="fixed inset-0 z-50 flex flex-col bg-gray-50">
             <InvitesGraph
-                apiKey={apiKey}
+                apiKey=""
+                password={password}
                 mode="payment"
                 topNodes={5000}
                 performanceMode={performanceMode}

--- a/src/app/(mobile-ui)/dev/payment-graph/page.tsx
+++ b/src/app/(mobile-ui)/dev/payment-graph/page.tsx
@@ -1,0 +1,486 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { Button } from '@/components/0_Bruddle/Button'
+import InvitesGraph, { DEFAULT_FORCE_CONFIG } from '@/components/Global/InvitesGraph'
+
+export default function PaymentGraphPage() {
+    const [apiKey, setApiKey] = useState('')
+    const [apiKeySubmitted, setApiKeySubmitted] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+
+    const handleApiKeySubmit = useCallback(() => {
+        if (!apiKey.trim()) {
+            setError('Please enter an API key')
+            return
+        }
+        setError(null)
+        setApiKeySubmitted(true)
+    }, [apiKey])
+
+    const handleClose = useCallback(() => {
+        window.location.href = '/dev'
+    }, [])
+
+    // API key input screen
+    if (!apiKeySubmitted) {
+        return (
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900">
+                <div className="w-full max-w-md space-y-6 rounded-2xl bg-white p-8 shadow-2xl">
+                    <div className="text-center">
+                        <div className="mb-4 text-6xl">💸</div>
+                        <h2 className="mb-2 text-2xl font-bold text-gray-900">Payment Graph</h2>
+                        <p className="text-sm text-gray-600">
+                            P2P payment flow visualization (120-day window, no invites)
+                        </p>
+                    </div>
+                    {error && (
+                        <div className="bg-red-50 text-red-800 rounded-lg p-3 text-sm">
+                            <div className="font-semibold">Error</div>
+                            <div>{error}</div>
+                        </div>
+                    )}
+                    <input
+                        type="password"
+                        value={apiKey}
+                        onChange={(e) => setApiKey(e.target.value)}
+                        onKeyDown={(e) => e.key === 'Enter' && handleApiKeySubmit()}
+                        placeholder="Admin API Key"
+                        className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm transition-colors focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-500/20"
+                    />
+                    <Button onClick={handleApiKeySubmit} className="w-full">
+                        Enter Graph
+                    </Button>
+                    <button
+                        onClick={() => (window.location.href = '/dev')}
+                        className="w-full text-sm text-gray-500 hover:text-gray-700"
+                    >
+                        ← Back to Dev Tools
+                    </button>
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <div className="fixed inset-0 z-50 flex flex-col bg-gray-50">
+            <InvitesGraph
+                apiKey={apiKey}
+                mode="payment"
+                onClose={handleClose}
+                width={typeof window !== 'undefined' ? window.innerWidth : 1200}
+                height={typeof window !== 'undefined' ? window.innerHeight - 120 : 800}
+                renderOverlays={({
+                    showUsernames,
+                    setShowUsernames,
+                    forceConfig,
+                    setForceConfig,
+                    externalNodesConfig,
+                    setExternalNodesConfig,
+                    externalNodes,
+                    externalNodesLoading,
+                    externalNodesError,
+                    handleReset,
+                    handleRecalculate,
+                }) => (
+                    <>
+                        {/* Controls Panel - Top Right */}
+                        <div className="absolute right-4 top-4 max-h-[calc(100vh-140px)] w-[200px] overflow-y-auto rounded-xl bg-white/95 p-3 shadow-lg backdrop-blur-sm">
+                            <h3 className="mb-2 text-xs font-bold text-gray-900">Display & Forces</h3>
+
+                            <div className="space-y-2 text-[11px]">
+                                {/* Scale indicator */}
+                                <div className="-mb-1 flex justify-between text-[8px] text-gray-400">
+                                    <span>0.1×</span>
+                                    <span>1×</span>
+                                    <span>10×</span>
+                                </div>
+
+                                {/* Repulsion Force */}
+                                <div className="space-y-0.5">
+                                    <label className="flex cursor-pointer items-center justify-between">
+                                        <div className="flex items-center gap-1.5">
+                                            <input
+                                                type="checkbox"
+                                                checked={forceConfig.charge.enabled}
+                                                onChange={(e) =>
+                                                    setForceConfig({
+                                                        ...forceConfig,
+                                                        charge: { ...forceConfig.charge, enabled: e.target.checked },
+                                                    })
+                                                }
+                                                className="h-3 w-3 rounded border-gray-300 text-cyan-600"
+                                            />
+                                            <span className="text-gray-700">Repulsion Force</span>
+                                        </div>
+                                        {forceConfig.charge.enabled && (
+                                            <span className="text-[9px] text-gray-500">
+                                                {(
+                                                    forceConfig.charge.strength / DEFAULT_FORCE_CONFIG.charge.strength
+                                                ).toFixed(1)}
+                                                x
+                                            </span>
+                                        )}
+                                    </label>
+                                    {forceConfig.charge.enabled && (
+                                        <input
+                                            type="range"
+                                            min="-1"
+                                            max="1"
+                                            step="0.05"
+                                            value={Math.log10(
+                                                forceConfig.charge.strength / DEFAULT_FORCE_CONFIG.charge.strength
+                                            )}
+                                            onChange={(e) =>
+                                                setForceConfig({
+                                                    ...forceConfig,
+                                                    charge: {
+                                                        ...forceConfig.charge,
+                                                        strength:
+                                                            DEFAULT_FORCE_CONFIG.charge.strength *
+                                                            Math.pow(10, parseFloat(e.target.value)),
+                                                    },
+                                                })
+                                            }
+                                            className="h-1 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 accent-cyan-600"
+                                        />
+                                    )}
+                                </div>
+
+                                {/* P2P Force */}
+                                <div className="space-y-0.5">
+                                    <label className="flex cursor-pointer items-center justify-between">
+                                        <div className="flex items-center gap-1.5">
+                                            <input
+                                                type="checkbox"
+                                                checked={forceConfig.p2pLinks.enabled}
+                                                onChange={(e) => {
+                                                    setForceConfig({
+                                                        ...forceConfig,
+                                                        p2pLinks: {
+                                                            ...forceConfig.p2pLinks,
+                                                            enabled: e.target.checked,
+                                                        },
+                                                    })
+                                                }}
+                                                className="h-3 w-3 rounded border-gray-300 text-cyan-600"
+                                            />
+                                            <span className="text-gray-700">P2P Force</span>
+                                        </div>
+                                        {forceConfig.p2pLinks.enabled && (
+                                            <span className="text-[9px] text-gray-500">
+                                                {(
+                                                    forceConfig.p2pLinks.strength /
+                                                    DEFAULT_FORCE_CONFIG.p2pLinks.strength
+                                                ).toFixed(1)}
+                                                x
+                                            </span>
+                                        )}
+                                    </label>
+                                    {forceConfig.p2pLinks.enabled && (
+                                        <input
+                                            type="range"
+                                            min="-1"
+                                            max="1"
+                                            step="0.05"
+                                            value={Math.log10(
+                                                forceConfig.p2pLinks.strength / DEFAULT_FORCE_CONFIG.p2pLinks.strength
+                                            )}
+                                            onChange={(e) =>
+                                                setForceConfig({
+                                                    ...forceConfig,
+                                                    p2pLinks: {
+                                                        ...forceConfig.p2pLinks,
+                                                        strength:
+                                                            DEFAULT_FORCE_CONFIG.p2pLinks.strength *
+                                                            Math.pow(10, parseFloat(e.target.value)),
+                                                    },
+                                                })
+                                            }
+                                            className="h-1 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 accent-cyan-600"
+                                        />
+                                    )}
+                                </div>
+
+                                {/* Center Force */}
+                                <div className="space-y-1">
+                                    <label className="flex cursor-pointer items-center justify-between">
+                                        <div className="flex items-center gap-1.5">
+                                            <input
+                                                type="checkbox"
+                                                checked={
+                                                    forceConfig.center?.enabled ?? DEFAULT_FORCE_CONFIG.center.enabled
+                                                }
+                                                onChange={(e) =>
+                                                    setForceConfig({
+                                                        ...forceConfig,
+                                                        center: {
+                                                            ...(forceConfig.center || DEFAULT_FORCE_CONFIG.center),
+                                                            enabled: e.target.checked,
+                                                        },
+                                                    })
+                                                }
+                                                className="h-3 w-3 rounded border-gray-300 text-amber-600"
+                                            />
+                                            <span className="text-gray-700">Center Force</span>
+                                        </div>
+                                        {(forceConfig.center?.enabled ?? DEFAULT_FORCE_CONFIG.center.enabled) && (
+                                            <span className="text-[9px] text-gray-500">
+                                                {(
+                                                    (forceConfig.center?.strength ??
+                                                        DEFAULT_FORCE_CONFIG.center.strength) /
+                                                    DEFAULT_FORCE_CONFIG.center.strength
+                                                ).toFixed(1)}
+                                                x
+                                            </span>
+                                        )}
+                                    </label>
+                                    {(forceConfig.center?.enabled ?? DEFAULT_FORCE_CONFIG.center.enabled) && (
+                                        <div className="space-y-0.5 pl-4">
+                                            <input
+                                                type="range"
+                                                min="-1"
+                                                max="1"
+                                                step="0.05"
+                                                value={Math.log10(
+                                                    (forceConfig.center?.strength ??
+                                                        DEFAULT_FORCE_CONFIG.center.strength) /
+                                                        DEFAULT_FORCE_CONFIG.center.strength
+                                                )}
+                                                onChange={(e) =>
+                                                    setForceConfig({
+                                                        ...forceConfig,
+                                                        center: {
+                                                            ...(forceConfig.center || DEFAULT_FORCE_CONFIG.center),
+                                                            strength:
+                                                                DEFAULT_FORCE_CONFIG.center.strength *
+                                                                Math.pow(10, parseFloat(e.target.value)),
+                                                        },
+                                                    })
+                                                }
+                                                className="h-1 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 accent-amber-600"
+                                            />
+                                        </div>
+                                    )}
+                                </div>
+
+                                {/* Divider */}
+                                <div className="my-1 border-t border-gray-200"></div>
+
+                                {/* Merchants Section */}
+                                <div className="space-y-1">
+                                    <div className="flex items-center gap-1.5">
+                                        <input
+                                            type="checkbox"
+                                            checked={externalNodesConfig.enabled}
+                                            onChange={(e) =>
+                                                setExternalNodesConfig({
+                                                    ...externalNodesConfig,
+                                                    enabled: e.target.checked,
+                                                    // When enabling, default to merchants only
+                                                    types: e.target.checked
+                                                        ? { WALLET: false, BANK: false, MERCHANT: true }
+                                                        : externalNodesConfig.types,
+                                                })
+                                            }
+                                            className="h-3 w-3 rounded border-gray-300 text-green-600"
+                                        />
+                                        <span className="text-gray-700">Merchants</span>
+                                        {externalNodesLoading && (
+                                            <span className="ml-auto animate-pulse text-[9px] text-green-500">
+                                                loading...
+                                            </span>
+                                        )}
+                                        {externalNodesError && (
+                                            <span
+                                                className="text-red-500 ml-auto text-[9px]"
+                                                title={externalNodesError}
+                                            >
+                                                ❌
+                                            </span>
+                                        )}
+                                        {!externalNodesLoading &&
+                                            !externalNodesError &&
+                                            externalNodesConfig.enabled && (
+                                                <span className="ml-auto text-[9px] text-gray-400">
+                                                    {externalNodes.length}
+                                                </span>
+                                            )}
+                                    </div>
+                                    {externalNodesConfig.enabled && !externalNodesError && (
+                                        <div className="space-y-1.5 pl-4">
+                                            {/* Min connections */}
+                                            <div className="space-y-1">
+                                                <span className="text-[9px] text-gray-500">
+                                                    Min users to show merchant:
+                                                </span>
+                                                <div className="flex gap-0.5">
+                                                    {[1, 2, 3, 5, 10].map((val) => (
+                                                        <button
+                                                            key={val}
+                                                            onClick={() =>
+                                                                setExternalNodesConfig({
+                                                                    ...externalNodesConfig,
+                                                                    minConnections: val,
+                                                                })
+                                                            }
+                                                            className={`rounded px-1 py-0.5 text-[9px] transition-colors ${
+                                                                externalNodesConfig.minConnections === val
+                                                                    ? 'bg-green-600 text-white'
+                                                                    : 'bg-gray-200 text-gray-600 hover:bg-gray-300'
+                                                            }`}
+                                                        >
+                                                            {val}
+                                                        </button>
+                                                    ))}
+                                                </div>
+                                            </div>
+                                            {/* External link force strength */}
+                                            <div className="space-y-0.5">
+                                                <label className="flex cursor-pointer items-center justify-between">
+                                                    <div className="flex items-center gap-1">
+                                                        <input
+                                                            type="checkbox"
+                                                            checked={
+                                                                forceConfig.externalLinks?.enabled ??
+                                                                DEFAULT_FORCE_CONFIG.externalLinks.enabled
+                                                            }
+                                                            onChange={(e) =>
+                                                                setForceConfig({
+                                                                    ...forceConfig,
+                                                                    externalLinks: {
+                                                                        ...(forceConfig.externalLinks ||
+                                                                            DEFAULT_FORCE_CONFIG.externalLinks),
+                                                                        enabled: e.target.checked,
+                                                                    },
+                                                                })
+                                                            }
+                                                            className="h-2.5 w-2.5 rounded border-gray-300 text-green-500"
+                                                        />
+                                                        <span className="text-[9px] text-gray-600">Link Force</span>
+                                                    </div>
+                                                    {(forceConfig.externalLinks?.enabled ??
+                                                        DEFAULT_FORCE_CONFIG.externalLinks.enabled) && (
+                                                        <span className="text-[9px] text-gray-500">
+                                                            {(
+                                                                (forceConfig.externalLinks?.strength ??
+                                                                    DEFAULT_FORCE_CONFIG.externalLinks.strength) /
+                                                                DEFAULT_FORCE_CONFIG.externalLinks.strength
+                                                            ).toFixed(1)}
+                                                            x
+                                                        </span>
+                                                    )}
+                                                </label>
+                                                {(forceConfig.externalLinks?.enabled ??
+                                                    DEFAULT_FORCE_CONFIG.externalLinks.enabled) && (
+                                                    <input
+                                                        type="range"
+                                                        min="-1"
+                                                        max="1"
+                                                        step="0.05"
+                                                        value={Math.log10(
+                                                            (forceConfig.externalLinks?.strength ??
+                                                                DEFAULT_FORCE_CONFIG.externalLinks.strength) /
+                                                                DEFAULT_FORCE_CONFIG.externalLinks.strength
+                                                        )}
+                                                        onChange={(e) =>
+                                                            setForceConfig({
+                                                                ...forceConfig,
+                                                                externalLinks: {
+                                                                    ...(forceConfig.externalLinks ||
+                                                                        DEFAULT_FORCE_CONFIG.externalLinks),
+                                                                    strength:
+                                                                        DEFAULT_FORCE_CONFIG.externalLinks.strength *
+                                                                        Math.pow(10, parseFloat(e.target.value)),
+                                                                },
+                                                            })
+                                                        }
+                                                        className="h-1 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 accent-green-500"
+                                                    />
+                                                )}
+                                            </div>
+                                        </div>
+                                    )}
+                                </div>
+
+                                {/* Divider */}
+                                <div className="my-1 border-t border-gray-200"></div>
+
+                                {/* Other options */}
+                                <div className="flex gap-3">
+                                    <label className="flex cursor-pointer items-center gap-1">
+                                        <input
+                                            type="checkbox"
+                                            checked={showUsernames}
+                                            onChange={(e) => setShowUsernames(e.target.checked)}
+                                            className="h-3 w-3 rounded border-gray-300 text-cyan-600"
+                                        />
+                                        <span className="text-gray-600">Names</span>
+                                    </label>
+                                </div>
+
+                                {/* Action buttons */}
+                                <div className="flex gap-1">
+                                    <button
+                                        onClick={handleRecalculate}
+                                        className="flex-1 rounded border border-cyan-200 px-2 py-0.5 text-[9px] text-cyan-600 hover:bg-cyan-50 hover:text-cyan-800"
+                                        title="Recalculate layout with current settings"
+                                    >
+                                        🔄 Recalc
+                                    </button>
+                                    <button
+                                        onClick={handleReset}
+                                        className="flex-1 rounded border border-gray-200 px-2 py-0.5 text-[9px] text-gray-500 hover:bg-gray-50 hover:text-gray-700"
+                                        title="Reset all settings to defaults"
+                                    >
+                                        ↺ Defaults
+                                    </button>
+                                </div>
+                            </div>
+
+                            {/* Compact Legend */}
+                            <div className="mt-3 border-t border-gray-200 pt-2">
+                                <div className="space-y-1 text-[9px]">
+                                    {/* Nodes - by P2P activity */}
+                                    <div className="flex flex-wrap gap-x-2 gap-y-0.5 text-gray-500">
+                                        <span className="flex items-center gap-0.5">
+                                            <span className="inline-block h-2 w-2 rounded-full bg-purple-500"></span>
+                                            P2P Active
+                                        </span>
+                                        <span className="flex items-center gap-0.5">
+                                            <span className="inline-block h-2 w-2 rounded-full bg-gray-400 opacity-50"></span>
+                                            No P2P
+                                        </span>
+                                    </div>
+                                    {/* External nodes */}
+                                    {externalNodesConfig.enabled && (
+                                        <div className="flex flex-wrap gap-x-2 gap-y-0.5 text-gray-500">
+                                            <span className="flex items-center gap-0.5">
+                                                <span
+                                                    className="inline-block h-2 w-2 bg-green-500"
+                                                    style={{
+                                                        clipPath:
+                                                            'polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)',
+                                                    }}
+                                                ></span>
+                                                Merchant
+                                            </span>
+                                        </div>
+                                    )}
+                                    {/* Edges */}
+                                    <div className="flex flex-wrap gap-x-2 gap-y-0.5 text-gray-500">
+                                        <span className="flex items-center gap-0.5">
+                                            <span className="inline-block h-0.5 w-3 bg-cyan-500/50"></span>P2P
+                                        </span>
+                                    </div>
+                                    <p className="text-gray-400">Click → Grafana | Right-click → Focus</p>
+                                    <p className="text-gray-400">Limited to 5000 nodes for performance</p>
+                                </div>
+                            </div>
+                        </div>
+                    </>
+                )}
+            />
+        </div>
+    )
+}

--- a/src/app/(mobile-ui)/points/page.tsx
+++ b/src/app/(mobile-ui)/points/page.tsx
@@ -22,6 +22,7 @@ import EmptyState from '@/components/Global/EmptyStates/EmptyState'
 import { type PointsInvite } from '@/services/services.types'
 import { useEffect } from 'react'
 import InvitesGraph from '@/components/Global/InvitesGraph'
+import { IS_DEV } from '@/constants/general.consts'
 
 const PointsPage = () => {
     const router = useRouter()
@@ -53,11 +54,12 @@ const PointsPage = () => {
         enabled: !!user?.user.userId,
     })
 
+    // In dev mode, show graph for all users. In production, only for Seedling badge holders.
+    const hasSeedlingBadge = user?.user?.badges?.some((badge) => badge.code === 'SEEDLING_DEVCONNECT_BA_2025')
     const { data: myGraphResult } = useQuery({
         queryKey: ['myInviteGraph', user?.user.userId],
         queryFn: () => pointsApi.getUserInvitesGraph(),
-        enabled:
-            !!user?.user.userId && user?.user?.badges?.some((badge) => badge.code === 'SEEDLING_DEVCONNECT_BA_2025'),
+        enabled: !!user?.user.userId && (IS_DEV || hasSeedlingBadge),
     })
     const username = user?.user.username
     const { inviteCode, inviteLink } = generateInviteCodeLink(username ?? '')
@@ -171,6 +173,29 @@ const PointsPage = () => {
                     </Card>
                 </div>
 
+                {/* User Graph - shows user, their inviter, and points flow regardless of invites */}
+                {myGraphResult?.data && (
+                    <>
+                        <Card className="overflow-hidden p-0">
+                            <InvitesGraph
+                                minimal
+                                data={myGraphResult.data}
+                                height={250}
+                                backgroundColor="#ffffff"
+                                showUsernames
+                            />
+                        </Card>
+                        <div className="flex items-center gap-2">
+                            <Icon name="info" className="size-4 flex-shrink-0 text-black" />
+                            <p className="text-sm text-black">
+                                {IS_DEV
+                                    ? 'Experimental. Enabled for all users in dev mode.'
+                                    : 'Experimental. Only available for Seedlings badge holders.'}
+                            </p>
+                        </div>
+                    </>
+                )}
+
                 {invites && invites?.invitees && invites.invitees.length > 0 && (
                     <>
                         <ShareButton
@@ -186,27 +211,6 @@ const PointsPage = () => {
                             <h2 className="font-bold">People you invited</h2>
                             <NavigationArrow className="text-black" />
                         </div>
-
-                        {/* Invite Graph */}
-                        {myGraphResult?.data && (
-                            <>
-                                <Card className="overflow-hidden p-0">
-                                    <InvitesGraph
-                                        minimal
-                                        data={myGraphResult.data}
-                                        height={250}
-                                        backgroundColor="#ffffff"
-                                        showUsernames
-                                    />
-                                </Card>
-                                <div className="flex items-center gap-2">
-                                    <Icon name="info" className="size-4 flex-shrink-0 text-black" />
-                                    <p className="text-sm text-black">
-                                        Experimental. Only available for Seedlings badge holders.
-                                    </p>
-                                </div>
-                            </>
-                        )}
 
                         <div>
                             {invites.invitees?.map((invite: PointsInvite, i: number) => {

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -12,7 +12,7 @@ import EmptyState from '../Global/EmptyStates/EmptyState'
 import { useAuth } from '@/context/authContext'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { DynamicBankAccountForm, type IBankAccountDetails } from './DynamicBankAccountForm'
-import { addBankAccount } from '@/app/actions/users'
+import { addBankAccount, updateUserById } from '@/app/actions/users'
 import { type BridgeKycStatus } from '@/utils/bridge-accounts.utils'
 import { type AddBankAccountPayload } from '@/app/actions/types/users.types'
 import { useWebSocket } from '@/hooks/useWebSocket'
@@ -136,6 +136,24 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
 
         // scenario (2): if the user hasn't completed kyc yet
         if (!isUserKycVerified) {
+            // update user's name and email if they are not present
+            const hasNameOnLoad = !!user?.user.fullName
+            const hasEmailOnLoad = !!user?.user.email
+
+            if (!hasNameOnLoad || !hasEmailOnLoad) {
+                if (user?.user.userId && rawData.accountOwnerName && rawData.email) {
+                    const result = await updateUserById({
+                        userId: user.user.userId,
+                        fullName: rawData.accountOwnerName.trim(),
+                        email: rawData.email,
+                    })
+                    if (result.error) {
+                        return { error: result.error }
+                    }
+                    await fetchUser()
+                }
+            }
+
             setIsKycModalOpen(true)
         }
 

--- a/src/components/Global/InvitesGraph/index.tsx
+++ b/src/components/Global/InvitesGraph/index.tsx
@@ -1005,6 +1005,7 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                     limit: externalNodesConfig.limit, // User-configurable limit
                     types: ['WALLET', 'BANK', 'MERCHANT'], // Fetch all types, filter client-side
                     topNodes: topNodes > 0 ? topNodes : undefined, // Match graph's top-N filter
+                    password: apiMode === 'payment' ? props.password : undefined, // Password for payment mode
                 })
 
                 if (result.success && result.data) {

--- a/src/components/Global/InvitesGraph/index.tsx
+++ b/src/components/Global/InvitesGraph/index.tsx
@@ -288,6 +288,8 @@ interface BaseProps {
 interface FullModeProps extends BaseProps {
     /** Admin API key to fetch full graph */
     apiKey: string
+    /** Password for payment mode authentication */
+    password?: string
     /** Graph mode: 'full' shows all features, 'payment' shows P2P only (no invites, fixed 120-day window) */
     mode?: GraphMode
     /** Close/back button handler */
@@ -960,9 +962,11 @@ export default function InvitesGraph(props: InvitesGraphProps) {
             // API only supports 'full' | 'payment' modes (user mode uses different endpoint)
             const apiMode = mode === 'payment' ? 'payment' : 'full'
             // Pass topNodes for both modes - payment mode now supports it via Performance button
+            // Pass password for payment mode authentication
             const result = await pointsApi.getInvitesGraph(props.apiKey, {
                 mode: apiMode,
                 topNodes: topNodes > 0 ? topNodes : undefined,
+                password: mode === 'payment' ? props.password : undefined,
             })
 
             if (result.success && result.data) {

--- a/src/components/Global/InvitesGraph/index.tsx
+++ b/src/components/Global/InvitesGraph/index.tsx
@@ -1154,7 +1154,8 @@ export default function InvitesGraph(props: InvitesGraphProps) {
             // User node → Select (camera follows) - click again to open Grafana
             if (selectedUserId === node.id) {
                 // Already selected - open Grafana
-                window.open(`https://peanut.grafana.net/d/user-details/user-details?var-user_id=${node.id}`, '_blank')
+                const username = node.username || node.id
+                window.open(`https://teampeanut.grafana.net/d/ad31f645-81ca-4779-bfb2-bff8e03d9057/explore-peanut-wallet-user?orgId=1&var-GRAFANA_VAR_Username=${encodeURIComponent(username)}`, '_blank')
             } else {
                 // Select node
                 setSelectedUserId(node.id)

--- a/src/components/Global/InvitesGraph/index.tsx
+++ b/src/components/Global/InvitesGraph/index.tsx
@@ -14,7 +14,7 @@
  *   - visibilityConfig: Remove nodes/edges from simulation
  *     - activeNodes / inactiveNodes: Filter by activity status
  *     - inviteEdges / p2pEdges: Filter edge types
- *   - showAllNodes: Toggle 5000 node limit
+ *   - topNodes: Limit to top N nodes by points (0 = all, default 5000)
  *   - externalNodesConfig: Add/remove external nodes
  *
  * REINSERTION STRATEGY (when toggling nodes/edges back ON):
@@ -72,15 +72,21 @@ export interface GraphEdge {
     createdAt: string
 }
 
-/** P2P payment edge between users (for clustering) */
+/** P2P payment edge between users (for clustering)
+ * Supports both full mode (with exact count/totalUsd) and anonymized mode (with frequency/volume labels)
+ */
 export interface P2PEdge {
     source: string
     target: string
     type: 'SEND_LINK' | 'REQUEST_PAYMENT' | 'DIRECT_TRANSFER'
-    count: number
-    totalUsd: number
     /** True if payments went both ways between these users */
     bidirectional: boolean
+    // Full mode fields (exact values)
+    count?: number
+    totalUsd?: number
+    // Anonymized mode fields (qualitative labels)
+    frequency?: 'rare' | 'occasional' | 'regular' | 'frequent'
+    volume?: 'small' | 'medium' | 'large' | 'whale'
 }
 
 export interface GraphData {
@@ -116,7 +122,7 @@ export type ForceConfig = {
     /** Node repulsion (charge) - prevents overlap */
     charge: { enabled: boolean; strength: number }
     /** Invite link attraction - tree clustering (force only, use visibilityConfig to hide edges) */
-    inviteLinks: { enabled: boolean; strength: number }
+    inviteLinks: { enabled: boolean; strength: number; distance?: number }
     /** P2P link attraction - clusters transacting users (force only, use visibilityConfig to hide edges) */
     p2pLinks: { enabled: boolean; strength: number }
     /** External link attraction - clusters users with shared wallets/banks/merchants */
@@ -127,7 +133,7 @@ export type ForceConfig = {
 
 export const DEFAULT_FORCE_CONFIG: ForceConfig = {
     charge: { enabled: true, strength: 80 },
-    inviteLinks: { enabled: true, strength: 0.4 },
+    inviteLinks: { enabled: true, strength: 0.4, distance: 50 },
     p2pLinks: { enabled: true, strength: 0.3 },
     externalLinks: { enabled: true, strength: 0.2 }, // Weaker than P2P - external connections are looser
     center: { enabled: true, strength: 0.03, sizeBias: 0.5 },
@@ -188,14 +194,17 @@ export const DEFAULT_EXTERNAL_NODES_CONFIG: ExternalNodesConfig = {
 /** Re-export ExternalNode type for convenience */
 export type { ExternalNode, ExternalNodeType }
 
+/** Graph mode determines which features are enabled */
+export type GraphMode = 'full' | 'payment' | 'user'
+
 interface BaseProps {
     width?: number
     height?: number
     backgroundColor?: string
     /** Show usernames on nodes */
     showUsernames?: boolean
-    /** Show all nodes (no 5000 limit) - can be slow */
-    showAllNodes?: boolean
+    /** Limit to top N nodes by points (0 = all nodes, default 5000). Backend filtering. */
+    topNodes?: number
     /** Activity filter for highlighting active/inactive/new users */
     activityFilter?: ActivityFilter
     /** Force configuration for layout tuning */
@@ -206,8 +215,9 @@ interface BaseProps {
     renderOverlays?: (props: {
         showUsernames: boolean
         setShowUsernames: (v: boolean) => void
-        showAllNodes: boolean
-        setShowAllNodes: (v: boolean) => void
+        /** Top N nodes limit (0 = all). Changing triggers backend refetch. */
+        topNodes: number
+        setTopNodes: (v: number) => void
         activityFilter: ActivityFilter
         setActivityFilter: (v: ActivityFilter) => void
         forceConfig: ForceConfig
@@ -228,6 +238,8 @@ interface BaseProps {
 interface FullModeProps extends BaseProps {
     /** Admin API key to fetch full graph */
     apiKey: string
+    /** Graph mode: 'full' shows all features, 'payment' shows P2P only (no invites, fixed 120-day window) */
+    mode?: GraphMode
     /** Close/back button handler */
     onClose?: () => void
     /** Minimal mode disabled */
@@ -260,57 +272,8 @@ export const DEFAULT_ACTIVITY_FILTER: ActivityFilter = {
     hideInactive: false, // Default: show inactive as greyed out
 }
 
-// Performance limit - max nodes to render
-const MAX_NODES = 5000
-
-/**
- * Prune graph to MAX_NODES by removing oldest inactive users first
- * Keeps all edges between remaining nodes
- */
-function pruneGraphData(graphData: GraphData | null): GraphData | null {
-    if (!graphData || graphData.nodes.length <= MAX_NODES) {
-        return graphData
-    }
-
-    // Sort nodes: active users first (by lastActiveAt desc), then inactive (by createdAt desc)
-    const sortedNodes = [...graphData.nodes].sort((a, b) => {
-        // Both have lastActiveAt - sort by most recent first
-        if (a.lastActiveAt && b.lastActiveAt) {
-            return new Date(b.lastActiveAt).getTime() - new Date(a.lastActiveAt).getTime()
-        }
-        // Only a has activity - a comes first
-        if (a.lastActiveAt && !b.lastActiveAt) return -1
-        // Only b has activity - b comes first
-        if (!a.lastActiveAt && b.lastActiveAt) return 1
-        // Neither has activity - sort by createdAt (most recent first)
-        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-    })
-
-    // Take top MAX_NODES
-    const keptNodes = sortedNodes.slice(0, MAX_NODES)
-    const keptNodeIds = new Set(keptNodes.map((n) => n.id))
-
-    // Filter edges to only include those between kept nodes
-    const keptEdges = graphData.edges.filter((edge) => keptNodeIds.has(edge.source) && keptNodeIds.has(edge.target))
-
-    // Filter P2P edges to only include those between kept nodes
-    const keptP2PEdges = (graphData.p2pEdges || []).filter(
-        (edge) => keptNodeIds.has(edge.source) && keptNodeIds.has(edge.target)
-    )
-
-    return {
-        nodes: keptNodes,
-        edges: keptEdges,
-        p2pEdges: keptP2PEdges,
-        stats: {
-            totalNodes: keptNodes.length,
-            totalEdges: keptEdges.length,
-            totalP2PEdges: keptP2PEdges.length,
-            usersWithAccess: keptNodes.filter((n) => n.hasAppAccess).length,
-            orphans: keptNodes.filter((n) => !n.hasAppAccess).length,
-        },
-    }
-}
+// Default top nodes limit (0 = all nodes, backend-filtered)
+const DEFAULT_TOP_NODES = 5000
 
 export default function InvitesGraph(props: InvitesGraphProps) {
     const {
@@ -318,7 +281,7 @@ export default function InvitesGraph(props: InvitesGraphProps) {
         height,
         backgroundColor = '#f9fafb',
         showUsernames: initialShowUsernames = true,
-        showAllNodes: initialShowAllNodes = false,
+        topNodes: initialTopNodes = DEFAULT_TOP_NODES,
         activityFilter: initialActivityFilter = DEFAULT_ACTIVITY_FILTER,
         forceConfig: initialForceConfig = DEFAULT_FORCE_CONFIG,
         visibilityConfig: initialVisibilityConfig = DEFAULT_VISIBILITY_CONFIG,
@@ -326,6 +289,54 @@ export default function InvitesGraph(props: InvitesGraphProps) {
     } = props
 
     const isMinimal = props.minimal === true
+    // Get mode from props - defaults to 'full' for non-minimal, 'user' for minimal
+    const mode: GraphMode = isMinimal ? 'user' : (props.mode ?? 'full')
+
+    // Mode-specific defaults
+    // Payment mode: 120-day fixed window, no invite edges
+    // User mode: invite edges only (no P2P), used for points animation
+    const modeActivityFilter: ActivityFilter =
+        mode === 'payment' ? { ...initialActivityFilter, activityDays: 120 } : initialActivityFilter
+    const modeVisibilityConfig: VisibilityConfig =
+        mode === 'payment'
+            ? { ...initialVisibilityConfig, inviteEdges: false }
+            : mode === 'user'
+              ? { ...initialVisibilityConfig, p2pEdges: false }
+              : initialVisibilityConfig
+    const modeForceConfig: ForceConfig =
+        mode === 'payment'
+            ? { ...initialForceConfig, inviteLinks: { ...initialForceConfig.inviteLinks, enabled: false } }
+            : mode === 'user'
+              ? {
+                    ...initialForceConfig,
+                    p2pLinks: { ...initialForceConfig.p2pLinks, enabled: false },
+                    // Stronger repulsion for user graph to prevent overlap in small space
+                    charge: { ...initialForceConfig.charge, strength: initialForceConfig.charge.strength * 3 },
+                    // Longer link distance for clearer separation
+                    inviteLinks: { ...initialForceConfig.inviteLinks, distance: 80 },
+                }
+              : initialForceConfig
+    // Payment mode: merchants enabled by default with minConnections=10, weaker link force (0.1x)
+    const modeExternalNodesConfig: ExternalNodesConfig =
+        mode === 'payment'
+            ? {
+                  enabled: true,
+                  minConnections: 10,
+                  limit: 5000,
+                  types: { WALLET: false, BANK: false, MERCHANT: true },
+              }
+            : DEFAULT_EXTERNAL_NODES_CONFIG
+    // Apply payment mode external link force adjustment (0.1x default)
+    const finalModeForceConfig: ForceConfig =
+        mode === 'payment'
+            ? {
+                  ...modeForceConfig,
+                  externalLinks: {
+                      ...DEFAULT_FORCE_CONFIG.externalLinks,
+                      strength: DEFAULT_FORCE_CONFIG.externalLinks.strength * 0.1,
+                  },
+              }
+            : modeForceConfig
 
     // Data state
     const [fetchedGraphData, setFetchedGraphData] = useState<GraphData | null>(null)
@@ -334,16 +345,12 @@ export default function InvitesGraph(props: InvitesGraphProps) {
 
     // UI state (declare early so they can be used in data processing)
     const [showUsernames, setShowUsernames] = useState(initialShowUsernames)
-    const [showAllNodes, setShowAllNodes] = useState(initialShowAllNodes)
+    // topNodes: limit to top N by points (0 = all). Backend-filtered, triggers refetch.
+    const [topNodes, setTopNodes] = useState(initialTopNodes)
 
     // Use passed data in minimal mode, fetched data otherwise
+    // Note: topNodes filtering is now done by backend, no client-side pruning needed
     const rawGraphData = isMinimal ? props.data : fetchedGraphData
-
-    // Prune to MAX_NODES for performance (keeps most active users) unless showAllNodes is enabled
-    const prunedGraphData = useMemo(() => {
-        if (showAllNodes) return rawGraphData
-        return pruneGraphData(rawGraphData)
-    }, [rawGraphData, showAllNodes])
 
     // Helper to check if node is active based on activityDays threshold
     // Used for both coloring and visibility filtering
@@ -363,15 +370,15 @@ export default function InvitesGraph(props: InvitesGraphProps) {
 
         return false
     }, [])
-    const [activityFilter, setActivityFilter] = useState<ActivityFilter>(initialActivityFilter)
-    const [forceConfig, setForceConfig] = useState<ForceConfig>(initialForceConfig)
-    const [visibilityConfig, setVisibilityConfig] = useState<VisibilityConfig>(initialVisibilityConfig)
+    const [activityFilter, setActivityFilter] = useState<ActivityFilter>(modeActivityFilter)
+    const [forceConfig, setForceConfig] = useState<ForceConfig>(finalModeForceConfig)
+    const [visibilityConfig, setVisibilityConfig] = useState<VisibilityConfig>(modeVisibilityConfig)
     const [selectedUserId, setSelectedUserId] = useState<string | null>(null)
     const [searchQuery, setSearchQuery] = useState('')
     const [searchResults, setSearchResults] = useState<GraphNode[]>([])
 
     // External nodes state (wallets, banks, merchants)
-    const [externalNodesConfig, setExternalNodesConfig] = useState<ExternalNodesConfig>(DEFAULT_EXTERNAL_NODES_CONFIG)
+    const [externalNodesConfig, setExternalNodesConfig] = useState<ExternalNodesConfig>(modeExternalNodesConfig)
     const [externalNodesData, setExternalNodesData] = useState<ExternalNode[]>([])
     const [externalNodesLoading, setExternalNodesLoading] = useState(false)
     const [externalNodesError, setExternalNodesError] = useState<string | null>(null)
@@ -431,7 +438,7 @@ export default function InvitesGraph(props: InvitesGraphProps) {
         if (preferences.activityFilter) setActivityFilter(preferences.activityFilter)
         if (preferences.externalNodesConfig) setExternalNodesConfig(preferences.externalNodesConfig)
         if (preferences.showUsernames !== undefined) setShowUsernames(preferences.showUsernames)
-        if (preferences.showAllNodes !== undefined) setShowAllNodes(preferences.showAllNodes)
+        if (preferences.topNodes !== undefined) setTopNodes(preferences.topNodes)
 
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [preferencesLoaded, isMinimal]) // Only depend on preferencesLoaded, not preferences
@@ -448,7 +455,7 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                 activityFilter,
                 externalNodesConfig,
                 showUsernames,
-                showAllNodes,
+                topNodes,
             })
         }, 1000) // Debounce 1 second
 
@@ -459,7 +466,7 @@ export default function InvitesGraph(props: InvitesGraphProps) {
         activityFilter,
         externalNodesConfig,
         showUsernames,
-        showAllNodes,
+        topNodes,
         isMinimal,
         savePreferences,
     ])
@@ -467,10 +474,10 @@ export default function InvitesGraph(props: InvitesGraphProps) {
     // Filter nodes/edges based on visibility settings (DELETE approach)
     // All visibility toggles remove data from simulation for better performance and accurate layout
     const graphData = useMemo(() => {
-        if (!prunedGraphData) return null
+        if (!rawGraphData) return null
 
         // Start with all nodes
-        let filteredNodes = prunedGraphData.nodes
+        let filteredNodes = rawGraphData.nodes
 
         // Filter by activity time window AND active/inactive checkboxes
         // activityDays defines the time window (e.g., 30 days)
@@ -488,12 +495,12 @@ export default function InvitesGraph(props: InvitesGraphProps) {
         const nodeIds = new Set(filteredNodes.map((n) => n.id))
 
         // Filter edges based on visibility settings AND whether both nodes exist
-        let filteredEdges = prunedGraphData.edges.filter((edge) => nodeIds.has(edge.source) && nodeIds.has(edge.target))
+        let filteredEdges = rawGraphData.edges.filter((edge) => nodeIds.has(edge.source) && nodeIds.has(edge.target))
         if (!visibilityConfig.inviteEdges) {
             filteredEdges = []
         }
 
-        let filteredP2PEdges = (prunedGraphData.p2pEdges || []).filter(
+        let filteredP2PEdges = (rawGraphData.p2pEdges || []).filter(
             (edge) => nodeIds.has(edge.source) && nodeIds.has(edge.target)
         )
         if (!visibilityConfig.p2pEdges) {
@@ -512,7 +519,7 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                 orphans: filteredNodes.filter((n) => !n.hasAppAccess).length,
             },
         }
-    }, [prunedGraphData, activityFilter.activityDays, visibilityConfig, isNodeActive])
+    }, [rawGraphData, activityFilter.activityDays, visibilityConfig, isNodeActive])
 
     const graphRef = useRef<any>(null)
     const containerRef = useRef<HTMLDivElement>(null)
@@ -568,6 +575,18 @@ export default function InvitesGraph(props: InvitesGraphProps) {
         return map
     }, [filteredGraphData])
 
+    // Build set of node IDs that participate in P2P (for payment mode coloring)
+    // A node is "P2P active" if it's the source or target of any P2P edge
+    const p2pActiveNodes = useMemo(() => {
+        if (!rawGraphData) return new Set<string>()
+        const set = new Set<string>()
+        ;(rawGraphData.p2pEdges || []).forEach((edge) => {
+            set.add(edge.source)
+            set.add(edge.target)
+        })
+        return set
+    }, [rawGraphData])
+
     // Filter external nodes based on config (client-side for fast UI updates)
     const filteredExternalNodes = useMemo(() => {
         if (!externalNodesConfig.enabled) return []
@@ -580,9 +599,11 @@ export default function InvitesGraph(props: InvitesGraphProps) {
             if (node.uniqueUsers < externalNodesConfig.minConnections) return false
             // Filter by type
             if (!externalNodesConfig.types[node.type]) return false
-            // Filter by activity window (only show nodes with recent transactions)
-            const lastTxMs = new Date(node.lastTxDate).getTime()
-            if (lastTxMs < activityCutoff) return false
+            // Filter by activity window (only in full mode where lastTxDate exists)
+            if (node.lastTxDate) {
+                const lastTxMs = new Date(node.lastTxDate).getTime()
+                if (lastTxMs < activityCutoff) return false
+            }
             return true
         })
     }, [externalNodesData, externalNodesConfig, activityFilter.activityDays])
@@ -604,50 +625,110 @@ export default function InvitesGraph(props: InvitesGraphProps) {
         // Get set of user IDs in the graph for filtering links
         const userIdsInGraph = new Set(filteredGraphData.nodes.map((n) => n.id))
 
+        // Helper to extract userId from userTxData keys
+        // Keys can be: `${userId}_${direction}` (new format) or just `${userId}` (old format)
+        // User IDs may contain underscores, so we use lastIndexOf to find the direction suffix
+        const extractUserIdFromKey = (key: string): string => {
+            if (key.endsWith('_INCOMING') || key.endsWith('_OUTGOING')) {
+                return key.substring(0, key.lastIndexOf('_'))
+            }
+            return key // Old format: key is just the userId
+        }
+
         // Add external nodes with position hint (start them at edges)
         // x, y will be populated by force simulation at runtime
         const externalNodes = filteredExternalNodes
-            .filter((ext) => ext.userIds.some((uid) => userIdsInGraph.has(uid))) // Only show if connected to visible users
-            .map((ext) => ({
-                id: `ext_${ext.id}`,
-                label: ext.label,
-                externalType: ext.type,
-                uniqueUsers: ext.uniqueUsers,
-                txCount: ext.txCount,
-                totalUsd: ext.totalUsd,
-                userIds: ext.userIds.filter((uid) => userIdsInGraph.has(uid)), // Only connected users in graph
-                isExternal: true as const,
-                x: undefined as number | undefined,
-                y: undefined as number | undefined,
-            }))
+            .filter((ext) => {
+                // Only show if connected to visible users
+                // In anonymized mode, check userTxData keys for user IDs
+                const connectedUserIds = ext.userIds || Object.keys(ext.userTxData || {}).map(extractUserIdFromKey)
+                return connectedUserIds.some((uid: string) => userIdsInGraph.has(uid))
+            })
+            .map((ext) => {
+                const connectedUserIds = ext.userIds || Object.keys(ext.userTxData || {}).map(extractUserIdFromKey)
+                return {
+                    id: `ext_${ext.id}`,
+                    label: ext.label,
+                    externalType: ext.type,
+                    uniqueUsers: ext.uniqueUsers,
+                    txCount: ext.txCount,
+                    totalUsd: ext.totalUsd,
+                    frequency: ext.frequency,
+                    volume: ext.volume,
+                    userIds: connectedUserIds.filter((uid: string) => userIdsInGraph.has(uid)),
+                    isExternal: true as const,
+                    x: undefined as number | undefined,
+                    y: undefined as number | undefined,
+                }
+            })
 
         return [...userNodes, ...externalNodes]
     }, [filteredGraphData, filteredExternalNodes, externalNodesConfig.enabled])
 
-    // Build links to external nodes with per-user transaction data
+    // Build links to external nodes with per-user transaction data and direction
+    // Creates separate links for INCOMING and OUTGOING to enable correct particle flow
+    // Supports both full mode (txCount, totalUsd) and anonymized mode (frequency, volume)
     const externalLinks = useMemo(() => {
         if (!externalNodesConfig.enabled || filteredExternalNodes.length === 0 || !filteredGraphData) {
             return []
         }
 
         const userIdsInGraph = new Set(filteredGraphData.nodes.map((n) => n.id))
-        const links: { source: string; target: string; isExternal: true; txCount: number; totalUsd: number }[] = []
+        type ExternalLink = {
+            source: string
+            target: string
+            isExternal: true
+            direction: 'INCOMING' | 'OUTGOING'
+        } & ({ txCount: number; totalUsd: number } | { frequency: string; volume: string })
+
+        const links: ExternalLink[] = []
 
         filteredExternalNodes.forEach((ext) => {
             const extNodeId = `ext_${ext.id}`
-            ext.userIds.forEach((userId) => {
-                if (userIdsInGraph.has(userId)) {
-                    // Use per-user data if available, otherwise fall back to node totals
-                    const userData = ext.userTxData?.[userId] || {
-                        txCount: ext.txCount,
-                        totalUsd: ext.totalUsd,
-                    }
+
+            // userTxData keys can be in two formats:
+            // - New format: `${userId}_${direction}` (e.g., "abc123_INCOMING", "abc123_OUTGOING")
+            // - Old format: just `${userId}` (e.g., "abc123") - backwards compatibility
+            Object.entries(ext.userTxData || {}).forEach(([key, data]) => {
+                // Check if key ends with _INCOMING or _OUTGOING (new format)
+                const isNewFormat = key.endsWith('_INCOMING') || key.endsWith('_OUTGOING')
+
+                let userId: string
+                let direction: 'INCOMING' | 'OUTGOING'
+
+                if (isNewFormat) {
+                    // New format: parse userId and direction from key
+                    const lastUnderscoreIdx = key.lastIndexOf('_')
+                    userId = key.substring(0, lastUnderscoreIdx)
+                    direction = key.substring(lastUnderscoreIdx + 1) as 'INCOMING' | 'OUTGOING'
+                } else {
+                    // Old format: key is just userId, default to OUTGOING (original behavior)
+                    userId = key
+                    direction = data.direction || 'OUTGOING'
+                }
+
+                if (!userIdsInGraph.has(userId)) return
+
+                // Handle both full and anonymized data formats
+                if (data.txCount !== undefined && data.totalUsd !== undefined) {
+                    // Full mode: use exact values
                     links.push({
                         source: userId,
                         target: extNodeId,
                         isExternal: true,
-                        txCount: userData.txCount,
-                        totalUsd: userData.totalUsd,
+                        txCount: data.txCount,
+                        totalUsd: data.totalUsd,
+                        direction: direction,
+                    })
+                } else if (data.frequency && data.volume) {
+                    // Anonymized mode: use labels
+                    links.push({
+                        source: userId,
+                        target: extNodeId,
+                        isExternal: true,
+                        frequency: data.frequency,
+                        volume: data.volume,
+                        direction: direction,
                     })
                 }
             })
@@ -656,7 +737,8 @@ export default function InvitesGraph(props: InvitesGraphProps) {
         return links
     }, [filteredExternalNodes, filteredGraphData, externalNodesConfig.enabled])
 
-    // Fetch graph data on mount (only in full mode)
+    // Fetch graph data on mount and when topNodes changes (only in full mode)
+    // Note: topNodes filtering only applies to full mode (payment mode has fixed 5000 limit in backend)
     useEffect(() => {
         if (isMinimal) return
 
@@ -664,7 +746,13 @@ export default function InvitesGraph(props: InvitesGraphProps) {
             setLoading(true)
             setError(null)
 
-            const result = await pointsApi.getInvitesGraph(props.apiKey)
+            // API only supports 'full' | 'payment' modes (user mode uses different endpoint)
+            const apiMode = props.mode === 'payment' ? 'payment' : 'full'
+            // Only pass topNodes for full mode (payment mode ignores it, has its own limit)
+            const result = await pointsApi.getInvitesGraph(props.apiKey, {
+                mode: apiMode,
+                topNodes: apiMode === 'full' ? topNodes : undefined,
+            })
 
             if (result.success && result.data) {
                 setFetchedGraphData(result.data)
@@ -675,7 +763,8 @@ export default function InvitesGraph(props: InvitesGraphProps) {
         }
 
         fetchData()
-    }, [isMinimal, props.apiKey])
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isMinimal, !isMinimal && props.apiKey, mode, topNodes])
 
     // Fetch external nodes when enabled (lazy load on first enable)
     useEffect(() => {
@@ -688,7 +777,10 @@ export default function InvitesGraph(props: InvitesGraphProps) {
             setExternalNodesError(null)
 
             try {
+                // API only supports 'full' | 'payment' modes
+                const apiMode = props.mode === 'payment' ? 'payment' : 'full'
                 const result = await pointsApi.getExternalNodes(props.apiKey, {
+                    mode: apiMode,
                     minConnections: 1, // Fetch all, filter client-side for flexibility
                     limit: externalNodesConfig.limit, // User-configurable limit
                 })
@@ -720,25 +812,42 @@ export default function InvitesGraph(props: InvitesGraphProps) {
         showUsernames,
         selectedUserId,
         isMinimal,
+        mode,
         activityFilter,
         visibilityConfig,
         externalNodesConfig,
+        p2pActiveNodes,
     })
     useEffect(() => {
         displaySettingsRef.current = {
             showUsernames,
             selectedUserId,
             isMinimal,
+            mode,
             activityFilter,
             visibilityConfig,
             externalNodesConfig,
+            p2pActiveNodes,
         }
-    }, [showUsernames, selectedUserId, isMinimal, activityFilter, visibilityConfig, externalNodesConfig])
+    }, [
+        showUsernames,
+        selectedUserId,
+        isMinimal,
+        mode,
+        activityFilter,
+        visibilityConfig,
+        externalNodesConfig,
+        p2pActiveNodes,
+    ])
 
     // Helper to determine user activity status
     const getUserActivityStatus = useCallback(
         (node: GraphNode, filter: ActivityFilter): 'new' | 'active' | 'inactive' => {
             if (!filter.enabled) return 'active' // No filtering, show all as active
+
+            // In payment mode, all nodes shown as active (no inactive differentiation)
+            // Backend already sets lastActiveAt to now, but check mode to be safe
+            if (mode === 'payment') return 'active'
 
             const now = Date.now()
             const activityCutoff = now - filter.activityDays * 24 * 60 * 60 * 1000
@@ -757,7 +866,7 @@ export default function InvitesGraph(props: InvitesGraphProps) {
             if (hasRecentActivity) return 'active'
             return 'inactive'
         },
-        []
+        [mode]
     )
 
     // Node styling
@@ -845,21 +954,29 @@ export default function InvitesGraph(props: InvitesGraphProps) {
             // ============================================
             const isSelected = node.id === selId
             const hasAccess = node.hasAppAccess
+            const { mode: currentMode } = displaySettingsRef.current
 
             // Determine activity status for coloring
             // Note: Visibility filtering is done at data level, so hidden nodes never reach here
             const activityStatus = getUserActivityStatus(node, filter)
 
-            const baseSize = hasAccess ? 6 : 3
-            const pointsMultiplier = Math.sqrt(node.totalPoints) / 10
-            const size = baseSize + Math.min(pointsMultiplier, 25)
+            // In user mode: all nodes same size (larger for cleaner display)
+            // In other modes: size based on points
+            let size: number
+            if (currentMode === 'user') {
+                size = 12 // Fixed size for user graph - all nodes equal
+            } else {
+                const baseSize = hasAccess ? 6 : 3
+                const pointsMultiplier = Math.sqrt(node.totalPoints) / 10
+                size = baseSize + Math.min(pointsMultiplier, 25)
+            }
 
             // ===========================================
             // NODE STYLING: Fill + Outline are separate
             // ===========================================
-            // FILL: Based on activity status
-            //   - Active (signup or tx within window): purple (#8b5cf6)
-            //   - Inactive: gray, semi-transparent
+            // In USER mode: All nodes same purple color (unified appearance)
+            // In PAYMENT mode: Color by P2P activity (purple = has P2P, grey = no P2P)
+            // In FULL mode: Color based on activity status
             // OUTLINE: Based on access/selection
             //   - Jailed (no app access): black (#000000)
             //   - Selected: golden (#fbbf24)
@@ -867,8 +984,18 @@ export default function InvitesGraph(props: InvitesGraphProps) {
             // ===========================================
 
             let fillColor: string
+            const { p2pActiveNodes: p2pNodes } = displaySettingsRef.current
 
-            if (!filter.enabled) {
+            if (currentMode === 'user') {
+                // User mode: all nodes same pleasant purple
+                fillColor = 'rgba(139, 92, 246, 0.9)' // Solid purple for all
+            } else if (currentMode === 'payment') {
+                // Payment mode: color by P2P participation (sending or receiving)
+                const hasP2PActivity = p2pNodes.has(node.id)
+                fillColor = hasP2PActivity
+                    ? 'rgba(139, 92, 246, 0.85)' // Purple for P2P active
+                    : 'rgba(156, 163, 175, 0.5)' // Grey for no P2P
+            } else if (!filter.enabled) {
                 // No filter - simple active/inactive by access
                 fillColor = hasAccess ? 'rgba(139, 92, 246, 0.85)' : 'rgba(156, 163, 175, 0.85)'
             } else {
@@ -884,25 +1011,25 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                     const lastActiveMs = node.lastActiveAt ? new Date(node.lastActiveAt).getTime() : 0
                     const lastActivityMs = Math.max(createdAtMs, lastActiveMs)
                     const daysSinceActivity = (now - lastActivityMs) / (24 * 60 * 60 * 1000)
-                    
+
                     // Exponential time bands: 1w, 2w, 4w, 8w, 16w, 32w, 64w+
                     // Each band gets progressively lighter gray
                     if (daysSinceActivity < 7) {
-                        fillColor = 'rgba(80, 80, 80, 0.9)'    // Very dark gray - <1 week
+                        fillColor = 'rgba(80, 80, 80, 0.9)' // Very dark gray - <1 week
                     } else if (daysSinceActivity < 14) {
                         fillColor = 'rgba(100, 100, 100, 0.85)' // Dark gray - 1-2 weeks
                     } else if (daysSinceActivity < 28) {
-                        fillColor = 'rgba(120, 120, 120, 0.8)'  // Medium-dark - 2-4 weeks
+                        fillColor = 'rgba(120, 120, 120, 0.8)' // Medium-dark - 2-4 weeks
                     } else if (daysSinceActivity < 56) {
-                        fillColor = 'rgba(145, 145, 145, 0.7)'  // Medium gray - 4-8 weeks
+                        fillColor = 'rgba(145, 145, 145, 0.7)' // Medium gray - 4-8 weeks
                     } else if (daysSinceActivity < 112) {
-                        fillColor = 'rgba(170, 170, 170, 0.6)'  // Medium-light - 8-16 weeks
+                        fillColor = 'rgba(170, 170, 170, 0.6)' // Medium-light - 8-16 weeks
                     } else if (daysSinceActivity < 224) {
-                        fillColor = 'rgba(195, 195, 195, 0.5)'  // Light gray - 16-32 weeks
+                        fillColor = 'rgba(195, 195, 195, 0.5)' // Light gray - 16-32 weeks
                     } else if (daysSinceActivity < 448) {
-                        fillColor = 'rgba(215, 215, 215, 0.4)'  // Very light - 32-64 weeks
+                        fillColor = 'rgba(215, 215, 215, 0.4)' // Very light - 32-64 weeks
                     } else {
-                        fillColor = 'rgba(235, 235, 235, 0.3)'  // Almost invisible - 64+ weeks
+                        fillColor = 'rgba(235, 235, 235, 0.3)' // Almost invisible - 64+ weeks
                     }
                 }
             }
@@ -1018,8 +1145,16 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                     MERCHANT: 'rgba(16, 185, 129, 0.8)', // Green
                 }
 
+                // Convert frequency/volume labels to numeric values for rendering
+                // Full mode: use actual values; Anonymized mode: map labels to ranges
+                const frequencyMap = { rare: 1, occasional: 3, regular: 10, frequent: 30 }
+                const volumeMap = { small: 50, medium: 500, large: 5000, whale: 50000 }
+
+                const txCount = link.txCount ?? frequencyMap[link.frequency as keyof typeof frequencyMap] ?? 1
+                const usdVolume = link.totalUsd ?? volumeMap[link.volume as keyof typeof volumeMap] ?? 50
+
                 // Scale line width by transaction count (same formula as P2P)
-                const lineWidth = Math.min(0.4 + (link.txCount || 1) * 0.25, 3.0)
+                const lineWidth = Math.min(0.4 + txCount * 0.25, 3.0)
 
                 // Draw base line
                 ctx.strokeStyle = lineColors[extType] || 'rgba(107, 114, 128, 0.25)'
@@ -1029,17 +1164,16 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                 ctx.lineTo(target.x, target.y)
                 ctx.stroke()
 
-                // Animated particles flowing user → external (scaled by activity, slightly slower than P2P)
+                // Animated particles with direction based on actual fund flow
                 const time = performance.now()
-                // Logarithmic scaling for better visual distinction (1 tx vs 10 tx vs 100 tx)
-                const logTxCount = Math.log10(Math.max(link.txCount || 1, 1) + 1) // log10(2) to log10(101) = 0.3 to 2.0
-                const logUsd = Math.log10(Math.max(link.totalUsd || 1, 1) + 1) // Similar range
-                
+                // Logarithmic scaling for better visual distinction
+                const logTxCount = Math.log10(Math.max(txCount, 1) + 1)
+                const logUsd = Math.log10(Math.max(usdVolume, 1) + 1)
+
                 // Speed: 0.0002 (1tx) → 0.0008 (100tx) using log scale
                 const baseSpeed = 0.0002 + logTxCount * 0.0003
-                // Only normalize by length when simulation is stable (avoid jitter)
                 const speed = baseSpeed
-                
+
                 // Particle count: 1 → 4 particles, log-scaled
                 const particleCount = Math.min(1 + Math.floor(logTxCount * 1.5), 4)
                 // Size: 1.5 (small) → 6.0 (large), log-scaled by USD volume
@@ -1047,11 +1181,17 @@ export default function InvitesGraph(props: InvitesGraphProps) {
 
                 ctx.fillStyle = particleColors[extType] || 'rgba(107, 114, 128, 0.8)'
 
+                // Determine particle direction based on fund flow
+                const isIncoming = link.direction === 'INCOMING'
+
                 // Draw particles along the edge
                 for (let i = 0; i < particleCount; i++) {
                     const t = (time * speed + i / particleCount) % 1
-                    const px = source.x + dx * t
-                    const py = source.y + dy * t
+                    // OUTGOING: flow from source (user) to target (external) → t goes 0→1
+                    // INCOMING: flow from target (external) to source (user) → t goes 1→0 (use 1-t)
+                    const progress = isIncoming ? 1 - t : t
+                    const px = source.x + dx * progress
+                    const py = source.y + dy * progress
                     ctx.beginPath()
                     ctx.arc(px, py, particleSize, 0, 2 * Math.PI)
                     ctx.fill()
@@ -1062,10 +1202,20 @@ export default function InvitesGraph(props: InvitesGraphProps) {
 
             if (link.isP2P) {
                 // P2P: Draw line with animated particles (scaled by activity & volume)
+                // Supports both full mode (count/totalUsd) and anonymized mode (frequency/volume labels)
                 const baseAlpha = inactive ? 0.08 : 0.25
                 ctx.strokeStyle = `rgba(6, 182, 212, ${baseAlpha})`
+
+                // Convert frequency/volume labels to numeric values for rendering
+                // Full mode: use actual values; Anonymized mode: map labels to ranges
+                const frequencyMap = { rare: 1, occasional: 3, regular: 10, frequent: 30 }
+                const volumeMap = { small: 50, medium: 500, large: 5000, whale: 50000 }
+
+                const txCount = link.count ?? frequencyMap[link.frequency as keyof typeof frequencyMap] ?? 1
+                const usdVolume = link.totalUsd ?? volumeMap[link.volume as keyof typeof volumeMap] ?? 50
+
                 // Line width: 0.4 (min) → 3.0 (max) based on tx count
-                ctx.lineWidth = Math.min(0.4 + (link.count || 1) * 0.25, 3.0)
+                ctx.lineWidth = Math.min(0.4 + txCount * 0.25, 3.0)
                 ctx.beginPath()
                 ctx.moveTo(source.x, source.y)
                 ctx.lineTo(target.x, target.y)
@@ -1074,16 +1224,16 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                 // Animated particles for P2P
                 if (!inactive) {
                     const time = performance.now()
-                    // Logarithmic scaling for better visual distinction (1 tx vs 10 tx vs 100 tx)
-                    const logTxCount = Math.log10(Math.max(link.count || 1, 1) + 1) // log10(2) to log10(101) = 0.3 to 2.0
-                    const logUsd = Math.log10(Math.max(link.totalUsd || 1, 1) + 1)
-                    
+                    // Logarithmic scaling for better visual distinction
+                    const logTxCount = Math.log10(Math.max(txCount, 1) + 1)
+                    const logUsd = Math.log10(Math.max(usdVolume, 1) + 1)
+
                     // Particle count: 1 → 5 particles, log-scaled
                     const particleCount = Math.min(1 + Math.floor(logTxCount * 2), 5)
                     // Speed: 0.0003 (1tx) → 0.001 (100tx) using log scale
                     const baseSpeed = 0.0003 + logTxCount * 0.00035
                     const speed = baseSpeed
-                    
+
                     // Size: 1.5 (small) → 6.0 (large), log-scaled by USD volume
                     const particleSize = 1.5 + logUsd * 2.25
                     const isBidirectional = link.bidirectional === true
@@ -1116,6 +1266,7 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                 const baseColor = isDirect ? [139, 92, 246] : [236, 72, 153]
                 const alpha = inactive ? 0.12 : 0.35
                 const arrowAlpha = inactive ? 0.2 : 0.6
+                const { mode: currentMode } = displaySettingsRef.current
 
                 // Draw main line
                 ctx.strokeStyle = `rgba(${baseColor.join(',')}, ${alpha})`
@@ -1125,34 +1276,60 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                 ctx.lineTo(target.x, target.y)
                 ctx.stroke()
 
-                // Draw arrows along the line (every ~60px, minimum 2)
-                // Skip the last arrow to prevent bunching near target node
-                const arrowSpacing = 60
-                const numArrows = Math.max(2, Math.floor(len / arrowSpacing))
-                const arrowSize = inactive ? 3 : 5
+                // In user mode: Draw animated points flowing UP the tree (invitee → inviter)
+                // This visualizes "points flowing to the inviter"
+                if (currentMode === 'user' && !inactive) {
+                    const time = performance.now()
+                    // Slow, pulsing animation - slower than P2P
+                    const baseSpeed = 0.00015
+                    const particleCount = 3
+                    const particleSize = 3
 
-                ctx.fillStyle = `rgba(${baseColor.join(',')}, ${arrowAlpha})`
+                    // Gold color for points
+                    ctx.fillStyle = 'rgba(251, 191, 36, 0.9)' // #fbbf24 with alpha
 
-                // Draw arrows from source toward target, but skip the last one (closest to target)
-                for (let i = 1; i < numArrows; i++) {
-                    // Changed: i < numArrows instead of i <= numArrows
-                    const t = i / (numArrows + 1)
-                    const ax = source.x + dx * t
-                    const ay = source.y + dy * t
+                    for (let i = 0; i < particleCount; i++) {
+                        // Flow direction: source → target (invitee → inviter)
+                        // Note: Edges are REVERSED for graph rendering (see graphData mapping)
+                        // After reversal: link.source = invitee, link.target = inviter
+                        // So particles flow from source (invitee) to target (inviter)
+                        const t = (time * baseSpeed + i / particleCount) % 1
+                        const px = source.x + (target.x - source.x) * t
+                        const py = source.y + (target.y - source.y) * t
+                        ctx.beginPath()
+                        ctx.arc(px, py, particleSize, 0, 2 * Math.PI)
+                        ctx.fill()
+                    }
+                } else {
+                    // Full/Payment mode: Draw arrows along the line (every ~60px, minimum 2)
+                    // Skip the last arrow to prevent bunching near target node
+                    const arrowSpacing = 60
+                    const numArrows = Math.max(2, Math.floor(len / arrowSpacing))
+                    const arrowSize = inactive ? 3 : 5
 
-                    // Draw arrow head pointing in direction of edge
-                    ctx.beginPath()
-                    ctx.moveTo(ax + ux * arrowSize, ay + uy * arrowSize)
-                    ctx.lineTo(
-                        ax - ux * arrowSize * 0.5 - uy * arrowSize * 0.6,
-                        ay - uy * arrowSize * 0.5 + ux * arrowSize * 0.6
-                    )
-                    ctx.lineTo(
-                        ax - ux * arrowSize * 0.5 + uy * arrowSize * 0.6,
-                        ay - uy * arrowSize * 0.5 - ux * arrowSize * 0.6
-                    )
-                    ctx.closePath()
-                    ctx.fill()
+                    ctx.fillStyle = `rgba(${baseColor.join(',')}, ${arrowAlpha})`
+
+                    // Draw arrows from source toward target, but skip the last one (closest to target)
+                    for (let i = 1; i < numArrows; i++) {
+                        // Changed: i < numArrows instead of i <= numArrows
+                        const t = i / (numArrows + 1)
+                        const ax = source.x + dx * t
+                        const ay = source.y + dy * t
+
+                        // Draw arrow head pointing in direction of edge
+                        ctx.beginPath()
+                        ctx.moveTo(ax + ux * arrowSize, ay + uy * arrowSize)
+                        ctx.lineTo(
+                            ax - ux * arrowSize * 0.5 - uy * arrowSize * 0.6,
+                            ay - uy * arrowSize * 0.5 + ux * arrowSize * 0.6
+                        )
+                        ctx.lineTo(
+                            ax - ux * arrowSize * 0.5 + uy * arrowSize * 0.6,
+                            ay - uy * arrowSize * 0.5 - ux * arrowSize * 0.6
+                        )
+                        ctx.closePath()
+                        ctx.fill()
+                    }
                 }
             }
         },
@@ -1216,7 +1393,10 @@ export default function InvitesGraph(props: InvitesGraphProps) {
             if (selectedUserId === node.id) {
                 // Already selected - open Grafana
                 const username = node.username || node.id
-                window.open(`https://teampeanut.grafana.net/d/ad31f645-81ca-4779-bfb2-bff8e03d9057/explore-peanut-wallet-user?orgId=1&var-GRAFANA_VAR_Username=${encodeURIComponent(username)}`, '_blank')
+                window.open(
+                    `https://teampeanut.grafana.net/d/ad31f645-81ca-4779-bfb2-bff8e03d9057/explore-peanut-wallet-user?orgId=1&var-GRAFANA_VAR_Username=${encodeURIComponent(username)}`,
+                    '_blank'
+                )
             } else {
                 // Select node
                 setSelectedUserId(node.id)
@@ -1261,7 +1441,7 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                 clearTimeout(searchTimeoutRef.current)
             }
 
-            if (!prunedGraphData || !query.trim()) {
+            if (!rawGraphData || !query.trim()) {
                 setSearchResults([])
                 return
             }
@@ -1272,21 +1452,18 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                 const results: any[] = []
 
                 // Search user nodes
-                if (prunedGraphData) {
-                    const userResults = prunedGraphData.nodes.filter(
+                if (rawGraphData) {
+                    const userResults = rawGraphData.nodes.filter(
                         (node) => node.username && node.username.toLowerCase().includes(lowerQuery)
                     )
-                    results.push(
-                        ...userResults.map((n) => ({ ...n, isExternal: false, displayName: n.username }))
-                    )
+                    results.push(...userResults.map((n) => ({ ...n, isExternal: false, displayName: n.username })))
                 }
 
                 // Search external nodes (by label and ID)
                 if (externalNodesConfig.enabled && filteredExternalNodes.length > 0) {
                     const externalResults = filteredExternalNodes.filter(
                         (node) =>
-                            node.label.toLowerCase().includes(lowerQuery) ||
-                            node.id.toLowerCase().includes(lowerQuery)
+                            node.label.toLowerCase().includes(lowerQuery) || node.id.toLowerCase().includes(lowerQuery)
                     )
                     results.push(
                         ...externalResults.map((n) => ({
@@ -1307,7 +1484,7 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                 }
             }, 150)
         },
-        [prunedGraphData, filteredExternalNodes, externalNodesConfig.enabled]
+        [rawGraphData, filteredExternalNodes, externalNodesConfig.enabled]
     )
 
     const handleClearSearch = useCallback(() => {
@@ -1689,6 +1866,8 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                                         isP2P: false,
                                     })),
                                     // P2P payment edges (for clustering visualization)
+                                    // P2P payment edges (for clustering visualization)
+                                    // Include both full mode (count/totalUsd) and anonymized mode (frequency/volume) fields
                                     ...(filteredGraphData.p2pEdges || []).map((edge, i) => ({
                                         id: `p2p-${i}`,
                                         source: edge.source,
@@ -1696,6 +1875,9 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                                         type: edge.type,
                                         count: edge.count,
                                         totalUsd: edge.totalUsd,
+                                        frequency: edge.frequency,
+                                        volume: edge.volume,
+                                        bidirectional: edge.bidirectional,
                                         isP2P: true,
                                     })),
                                 ],
@@ -1703,10 +1885,8 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                             nodeId="id"
                             nodePointerAreaPaint={(node: any, color: string, ctx: CanvasRenderingContext2D) => {
                                 // Draw hit detection area matching actual rendered node size
-                                const hasAccess = node.hasAppAccess
-                                const baseSize = hasAccess ? 6 : 3
-                                const pointsMultiplier = Math.sqrt(node.totalPoints || 0) / 10
-                                const nodeRadius = baseSize + Math.min(pointsMultiplier, 25)
+                                // In user mode (minimal): fixed size of 12
+                                const nodeRadius = 12
                                 ctx.fillStyle = color
                                 ctx.beginPath()
                                 ctx.arc(node.x, node.y, nodeRadius + 2, 0, 2 * Math.PI) // +2 for easier hover
@@ -1749,8 +1929,8 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                     {renderOverlays?.({
                         showUsernames,
                         setShowUsernames,
-                        showAllNodes,
-                        setShowAllNodes,
+                        topNodes,
+                        setTopNodes,
                         activityFilter,
                         setActivityFilter,
                         forceConfig,
@@ -1800,7 +1980,9 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                                 <div className="h-6 w-px bg-gray-300"></div>
                             </>
                         )}
-                        <h1 className="text-lg font-bold text-gray-900">Invite Network</h1>
+                        <h1 className="text-lg font-bold text-gray-900">
+                            {mode === 'payment' ? 'Payment Network' : 'Invite Network'}
+                        </h1>
                         <div className="flex gap-3 text-xs font-medium">
                             <span className="rounded-full bg-purple-100 px-2 py-1 text-purple-700">
                                 {combinedGraphNodes.length} nodes
@@ -1812,7 +1994,11 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                                     )}
                             </span>
                             <span className="rounded-full bg-blue-100 px-2 py-1 text-blue-700">
-                                {filteredGraphData.stats.totalEdges + externalLinks.length} edges
+                                {/* In payment mode, show P2P edges; in other modes, show invite edges */}
+                                {(mode === 'payment'
+                                    ? filteredGraphData.stats.totalP2PEdges
+                                    : filteredGraphData.stats.totalEdges) + externalLinks.length}{' '}
+                                edges
                                 {externalNodesConfig.enabled && externalLinks.length > 0 && (
                                     <span className="ml-1 text-orange-600">(+{externalLinks.length} ext)</span>
                                 )}
@@ -1823,73 +2009,77 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                     {/* Right side - empty, controls are in sidebar overlay */}
                 </div>
 
-                {/* Second Row: Search */}
-                <div className="border-t border-gray-100 px-4 py-2">
-                    <div className="flex items-center gap-2">
-                        <div className="relative flex-1">
-                            <input
-                                type="text"
-                                value={searchQuery}
-                                onChange={(e) => handleSearch(e.target.value)}
-                                placeholder="Search username..."
-                                className="w-full rounded-lg border border-gray-300 py-1.5 pl-9 pr-9 text-sm transition-colors focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-500/20"
-                            />
-                            <Icon
-                                name="search"
-                                size={16}
-                                className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
-                            />
-                            {searchQuery && (
-                                <button
-                                    onClick={handleClearSearch}
-                                    className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
-                                >
-                                    <Icon name="cancel" size={14} />
-                                </button>
+                {/* Second Row: Search (hidden in payment mode - no usernames) */}
+                {mode !== 'payment' && (
+                    <div className="border-t border-gray-100 px-4 py-2">
+                        <div className="flex items-center gap-2">
+                            <div className="relative flex-1">
+                                <input
+                                    type="text"
+                                    value={searchQuery}
+                                    onChange={(e) => handleSearch(e.target.value)}
+                                    placeholder="Search username..."
+                                    className="w-full rounded-lg border border-gray-300 py-1.5 pl-9 pr-9 text-sm transition-colors focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-500/20"
+                                />
+                                <Icon
+                                    name="search"
+                                    size={16}
+                                    className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+                                />
+                                {searchQuery && (
+                                    <button
+                                        onClick={handleClearSearch}
+                                        className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                                    >
+                                        <Icon name="cancel" size={14} />
+                                    </button>
+                                )}
+                            </div>
+                            {searchResults.length > 0 && (
+                                <span className="text-xs text-gray-600">
+                                    {searchResults.length} {searchResults.length === 1 ? 'match' : 'matches'}
+                                </span>
                             )}
                         </div>
-                        {searchResults.length > 0 && (
-                            <span className="text-xs text-gray-600">
-                                {searchResults.length} {searchResults.length === 1 ? 'match' : 'matches'}
-                            </span>
+                        {/* Search Results Dropdown */}
+                        {searchQuery && searchResults.length > 1 && (
+                            <div className="mt-2 max-h-48 overflow-y-auto rounded-lg border border-gray-200 bg-white shadow-lg">
+                                {searchResults.map((node: any) => (
+                                    <button
+                                        key={node.id}
+                                        onClick={() => {
+                                            setSelectedUserId(node.id)
+                                            handleClearSearch()
+                                        }}
+                                        className={`flex w-full items-center justify-between px-3 py-2 text-sm transition-colors ${
+                                            node.isExternal ? 'hover:bg-orange-50' : 'hover:bg-purple-50'
+                                        }`}
+                                    >
+                                        <div className="flex items-center gap-2">
+                                            {node.isExternal && (
+                                                <span className="text-xs">
+                                                    {node.externalType === 'WALLET'
+                                                        ? '💳'
+                                                        : node.externalType === 'BANK'
+                                                          ? '🏦'
+                                                          : '🏪'}
+                                                </span>
+                                            )}
+                                            <span className="font-medium text-gray-900">{node.displayName}</span>
+                                        </div>
+                                        <span className="text-xs text-gray-500">
+                                            {node.isExternal
+                                                ? node.totalUsd
+                                                    ? `${node.uniqueUsers} users, $${node.totalUsd.toFixed(0)}`
+                                                    : `${node.uniqueUsers} users, ${node.volume || 'N/A'}`
+                                                : `${node.totalPoints?.toLocaleString() || 0} pts`}
+                                        </span>
+                                    </button>
+                                ))}
+                            </div>
                         )}
                     </div>
-                    {/* Search Results Dropdown */}
-                    {searchQuery && searchResults.length > 1 && (
-                        <div className="mt-2 max-h-48 overflow-y-auto rounded-lg border border-gray-200 bg-white shadow-lg">
-                            {searchResults.map((node: any) => (
-                                <button
-                                    key={node.id}
-                                    onClick={() => {
-                                        setSelectedUserId(node.id)
-                                        handleClearSearch()
-                                    }}
-                                    className={`flex w-full items-center justify-between px-3 py-2 text-sm transition-colors ${
-                                        node.isExternal ? 'hover:bg-orange-50' : 'hover:bg-purple-50'
-                                    }`}
-                                >
-                                    <div className="flex items-center gap-2">
-                                        {node.isExternal && (
-                                            <span className="text-xs">
-                                                {node.externalType === 'WALLET'
-                                                    ? '💳'
-                                                    : node.externalType === 'BANK'
-                                                      ? '🏦'
-                                                      : '🏪'}
-                                            </span>
-                                        )}
-                                        <span className="font-medium text-gray-900">{node.displayName}</span>
-                                    </div>
-                                    <span className="text-xs text-gray-500">
-                                        {node.isExternal
-                                            ? `${node.uniqueUsers} users, $${node.totalUsd.toFixed(0)}`
-                                            : `${node.totalPoints?.toLocaleString() || 0} pts`}
-                                    </span>
-                                </button>
-                            ))}
-                        </div>
-                    )}
-                </div>
+                )}
 
                 {/* Selected User/Node Banner */}
                 {selectedUserId && (
@@ -1900,9 +2090,7 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                                 : 'border-purple-100 bg-purple-50'
                         }`}
                     >
-                        <span
-                            className={selectedUserId.startsWith('ext_') ? 'text-orange-700' : 'text-purple-700'}
-                        >
+                        <span className={selectedUserId.startsWith('ext_') ? 'text-orange-700' : 'text-purple-700'}>
                             Focused on:{' '}
                             <span className="font-bold">
                                 {selectedUserId.startsWith('ext_')
@@ -1935,6 +2123,7 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                                 isExternal: false,
                             })),
                             // P2P payment edges (for clustering visualization)
+                            // Include both full mode (count/totalUsd) and anonymized mode (frequency/volume) fields
                             ...(filteredGraphData.p2pEdges || []).map((edge, i) => ({
                                 id: `p2p-${i}`,
                                 source: edge.source,
@@ -1942,6 +2131,9 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                                 type: edge.type,
                                 count: edge.count,
                                 totalUsd: edge.totalUsd,
+                                frequency: edge.frequency,
+                                volume: edge.volume,
+                                bidirectional: edge.bidirectional,
                                 isP2P: true,
                                 isExternal: false,
                             })),
@@ -1967,6 +2159,9 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                         ctx.fill()
                     }}
                     nodeLabel={(node: any) => {
+                        const currentMode = displaySettingsRef.current.mode
+                        const isAnonymized = currentMode === 'payment'
+
                         // External node tooltip
                         if (node.isExternal) {
                             const fullId = node.id.replace('ext_', '')
@@ -1976,9 +2171,22 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                                     : node.externalType === 'BANK'
                                       ? `🏦 ${inferBankAccountType(fullId)}`
                                       : '🏪 Merchant'
-                            
+
                             // Show only masked labels for all types
                             const displayLabel = node.externalType === 'BANK' ? 'Account' : 'ID'
+
+                            // Anonymized mode: show qualitative labels instead of exact values
+                            if (isAnonymized) {
+                                return `<div style="background: white; border-radius: 8px; border: 1px solid #e5e7eb; font-family: Inter, system-ui, sans-serif; max-width: 280px; padding: 12px 14px;">
+                                    <div style="font-weight: 700; margin-bottom: 8px; font-size: 14px; color: #1f2937;">${typeLabel}</div>
+                                    <div style="font-size: 12px; line-height: 1.6; color: #6b7280;">
+                                        <div style="margin-bottom: 4px; word-break: break-all;">🏷️ ${displayLabel}: <span style="color: #374151; font-weight: 600;">${node.label}</span></div>
+                                        <div style="margin-bottom: 4px;">👥 Users: <span style="color: #374151;">${node.uniqueUsers}</span></div>
+                                        <div style="margin-bottom: 4px;">📊 Activity: <span style="color: #374151;">${node.frequency || 'N/A'}</span></div>
+                                        <div>💵 Volume: <span style="color: #374151;">${node.volume || 'N/A'}</span></div>
+                                    </div>
+                                </div>`
+                            }
 
                             return `<div style="background: white; border-radius: 8px; border: 1px solid #e5e7eb; font-family: Inter, system-ui, sans-serif; max-width: 280px; padding: 12px 14px;">
                                 <div style="font-weight: 700; margin-bottom: 8px; font-size: 14px; color: #1f2937;">${typeLabel}</div>
@@ -1990,7 +2198,18 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                                 </div>
                             </div>`
                         }
-                        // User node tooltip
+
+                        // User node tooltip - anonymized in payment mode
+                        if (isAnonymized) {
+                            return `<div style="background: white; border-radius: 8px; border: 1px solid #e5e7eb; font-family: Inter, system-ui, sans-serif; max-width: 240px; padding: 12px 14px; box-shadow: none;">
+                                <div style="font-weight: 700; margin-bottom: 8px; font-size: 14px; color: #1f2937; font-family: monospace;">${node.username || 'User'}</div>
+                                <div style="font-size: 12px; line-height: 1.6; color: #6b7280;">
+                                    <div style="margin-bottom: 4px;">${node.hasAppAccess ? '<span style="color: #10b981;">✓ Active User</span>' : '<span style="color: #f59e0b;">⏳ Inactive</span>'}</div>
+                                </div>
+                            </div>`
+                        }
+
+                        // Full mode: show all details
                         const signupDate = node.createdAt ? new Date(node.createdAt).toLocaleDateString() : 'Unknown'
                         const lastActive = node.lastActiveAt
                             ? new Date(node.lastActiveAt).toLocaleDateString()
@@ -2023,9 +2242,17 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                     nodeCanvasObjectMode={() => 'replace'}
                     linkLabel={(link: any) => {
                         if (link.isP2P) {
+                            // Handle both full (count/totalUsd) and anonymized (frequency/volume) modes
+                            if (link.frequency && link.volume) {
+                                return `P2P: ${link.frequency} activity, ${link.volume} volume`
+                            }
                             return `P2P: ${link.count} txs ($${link.totalUsd?.toFixed(2) ?? '0'})`
                         }
                         if (link.isExternal) {
+                            // Handle both full and anonymized modes
+                            if (link.frequency && link.volume) {
+                                return `Merchant: ${link.frequency} activity, ${link.volume} volume`
+                            }
                             return `External: ${link.txCount} txs ($${link.totalUsd?.toFixed(2) ?? '0'})`
                         }
                         return `${link.type} - ${new Date(link.createdAt).toLocaleDateString()}`
@@ -2056,8 +2283,8 @@ export default function InvitesGraph(props: InvitesGraphProps) {
                 {renderOverlays?.({
                     showUsernames,
                     setShowUsernames,
-                    showAllNodes,
-                    setShowAllNodes,
+                    topNodes,
+                    setTopNodes,
                     activityFilter,
                     setActivityFilter,
                     forceConfig,

--- a/src/components/Global/InvitesGraph/index.tsx
+++ b/src/components/Global/InvitesGraph/index.tsx
@@ -497,9 +497,11 @@ export default function InvitesGraph(props: InvitesGraphProps) {
 
     // Graph preferences persistence (separate storage for payment vs full mode)
     const isPaymentMode = mode === 'payment'
-    const { preferences, savePreferences, isLoaded: preferencesLoaded } = useGraphPreferences(
-        isPaymentMode ? 'payment' : 'full'
-    )
+    const {
+        preferences,
+        savePreferences,
+        isLoaded: preferencesLoaded,
+    } = useGraphPreferences(isPaymentMode ? 'payment' : 'full')
     const preferencesRestoredRef = useRef(false)
 
     // Load preferences ONCE on mount (not in minimal mode)
@@ -2091,8 +2093,8 @@ export default function InvitesGraph(props: InvitesGraphProps) {
         const allLinks = [...inviteLinks, ...p2pLinks, ...externalLinks]
 
         // Debug logging
-        const externalLinksInFinal = allLinks.filter(l => l.isExternal)
-        const carrefourLinks = externalLinksInFinal.filter(l => (l.target as string).includes('ext_CARREF'))
+        const externalLinksInFinal = allLinks.filter((l) => l.isExternal)
+        const carrefourLinks = externalLinksInFinal.filter((l) => (l.target as string).includes('ext_CARREF'))
 
         console.log('[CombinedLinks] Final links passed to ForceGraph2D:', {
             totalLinks: allLinks.length,
@@ -2100,11 +2102,11 @@ export default function InvitesGraph(props: InvitesGraphProps) {
             p2pLinks: p2pLinks.length,
             externalLinks: externalLinksInFinal.length,
             carrefourLinks: carrefourLinks.length,
-            sampleCarrefourLinks: carrefourLinks.slice(0, 3).map(l => ({
+            sampleCarrefourLinks: carrefourLinks.slice(0, 3).map((l) => ({
                 source: l.source,
                 target: l.target,
-                isExternal: l.isExternal
-            }))
+                isExternal: l.isExternal,
+            })),
         })
 
         return allLinks

--- a/src/components/Global/NavHeader/index.tsx
+++ b/src/components/Global/NavHeader/index.tsx
@@ -65,10 +65,9 @@ const NavHeader = ({
                     onClick={logoutUser}
                     loading={isLoggingOut}
                     variant="stroke"
+                    icon="logout"
                     className={twMerge('h-7 w-7 p-0 md:hidden', isLoggingOut && 'pl-3')}
-                >
-                    <Icon name="logout" size={32} className="size-8" />
-                </Button>
+                />
             )}
         </div>
     )

--- a/src/components/Kyc/InitiateBridgeKYCModal.tsx
+++ b/src/components/Kyc/InitiateBridgeKYCModal.tsx
@@ -5,6 +5,7 @@ import { KycVerificationInProgressModal } from './KycVerificationInProgressModal
 import { type IconName } from '@/components/Global/Icons/Icon'
 import { saveRedirectUrl } from '@/utils/general.utils'
 import useClaimLink from '../Claim/useClaimLink'
+import { useEffect } from 'react'
 
 interface BridgeKycModalFlowProps {
     isOpen: boolean
@@ -29,8 +30,14 @@ export const InitiateBridgeKYCModal = ({
         handleInitiateKyc,
         handleIframeClose,
         closeVerificationProgressModal,
+        resetError,
     } = useBridgeKycFlow({ onKycSuccess, flow, onManualClose })
     const { addParamStep } = useClaimLink()
+
+    // Reset error whenever modal open state changes to ensure clean state
+    useEffect(() => {
+        resetError()
+    }, [isOpen, resetError])
 
     const handleVerifyClick = async () => {
         addParamStep('bank')
@@ -61,14 +68,17 @@ export const InitiateBridgeKYCModal = ({
                         icon: 'check-circle',
                         className: 'h-11',
                     },
-                    {
-                        hidden: !error,
-                        text: error ?? 'Retry',
-                        onClick: onClose,
-                        variant: 'transparent',
-                        className:
-                            'underline text-xs md:text-sm !font-normal w-full !transform-none !pt-2 text-error-3 px-0',
-                    },
+                    ...(error
+                        ? [
+                              {
+                                  text: error,
+                                  onClick: onClose,
+                                  variant: 'transparent' as const,
+                                  className:
+                                      'underline text-xs md:text-sm !font-normal w-full !transform-none !pt-2 text-error-3 px-0',
+                              },
+                          ]
+                        : []),
                 ]}
             />
             <IframeWrapper {...iframeOptions} onClose={handleIframeClose} />

--- a/src/components/Kyc/InitiateBridgeKYCModal.tsx
+++ b/src/components/Kyc/InitiateBridgeKYCModal.tsx
@@ -34,9 +34,11 @@ export const InitiateBridgeKYCModal = ({
     } = useBridgeKycFlow({ onKycSuccess, flow, onManualClose })
     const { addParamStep } = useClaimLink()
 
-    // Reset error whenever modal open state changes to ensure clean state
+    // Reset error when modal opens to ensure clean state
     useEffect(() => {
-        resetError()
+        if (isOpen) {
+            resetError()
+        }
     }, [isOpen, resetError])
 
     const handleVerifyClick = async () => {

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -32,7 +32,6 @@ export const Profile = () => {
         await logoutUser()
     }
 
-    const fullName = user?.user.fullName || user?.user?.username || 'Anonymous User'
     const username = user?.user.username || 'anonymous'
     // respect user's showFullName preference: use fullName only if showFullName is true, otherwise use username
     const displayName = user?.user.showFullName && user?.user.fullName ? user.user.fullName : username

--- a/src/config/underMaintenance.config.ts
+++ b/src/config/underMaintenance.config.ts
@@ -17,6 +17,11 @@
  *    - shows clear error message to users about provider outage
  *    - other providers continue to work normally
  *
+ * 4. disableSquidWithdraw: disables cross-chain withdrawals via Squid
+ *    - restricts withdraw token selector to only USDC on Arbitrum
+ *    - shows info message explaining cross-chain is temporarily unavailable
+ *    - same-chain withdrawals (USDC on Arbitrum) continue to work
+ *
  * note: if either mode is enabled, the maintenance banner will show everywhere
  *
  * I HOPE WE NEVER NEED TO USE THIS...
@@ -29,12 +34,14 @@ interface MaintenanceConfig {
     enableFullMaintenance: boolean
     enableMaintenanceBanner: boolean
     disabledPaymentProviders: PaymentProvider[]
+    disableSquidWithdraw: boolean
 }
 
 const underMaintenanceConfig: MaintenanceConfig = {
     enableFullMaintenance: false, // set to true to redirect all pages to /maintenance
     enableMaintenanceBanner: false, // set to true to show maintenance banner on all pages
     disabledPaymentProviders: [], // set to ['MANTECA'] to disable Manteca QR payments
+    disableSquidWithdraw: true, // set to true to disable cross-chain withdrawals (only allows USDC on Arbitrum)
 }
 
 export default underMaintenanceConfig

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -51,17 +51,19 @@ export const RESERVED_ROUTES: readonly string[] = [...DEDICATED_ROUTES, ...STATI
  * Routes accessible without authentication
  * These paths can be accessed by non-logged-in users
  *
- * Note: 'dev' routes require authentication and specific user authorization (not public)
+ * Note: Most 'dev' routes require authentication and specific user authorization
+ * Exception: /dev/payment-graph is public (uses API key instead of user auth)
  */
-export const PUBLIC_ROUTES = ['request/pay', 'claim', 'pay', 'support', 'invite', 'qr'] as const
+export const PUBLIC_ROUTES = ['request/pay', 'claim', 'pay', 'support', 'invite', 'qr', 'dev/payment-graph'] as const
 
 /**
  * Regex pattern for public routes (used in layout.tsx)
  * Matches paths that don't require authentication
  *
- * Note: Dev tools routes are NOT public - they require both authentication and specific user authorization
+ * Note: Most dev tools routes are NOT public - they require both authentication and specific user authorization
+ * Exception: /dev/payment-graph is public (uses API key instead of user auth)
  */
-export const PUBLIC_ROUTES_REGEX = /^\/(request\/pay|claim|pay\/.+|support|invite|qr)/
+export const PUBLIC_ROUTES_REGEX = /^\/(request\/pay|claim|pay\/.+|support|invite|qr|dev\/payment-graph)/
 
 /**
  * Routes where middleware should run

--- a/src/hooks/useBridgeKycFlow.ts
+++ b/src/hooks/useBridgeKycFlow.ts
@@ -170,6 +170,10 @@ export const useBridgeKycFlow = ({ onKycSuccess, flow, onManualClose }: UseKycFl
         router.push('/home')
     }
 
+    const resetError = useCallback(() => {
+        setError(null)
+    }, [])
+
     return {
         isLoading,
         error,
@@ -179,5 +183,6 @@ export const useBridgeKycFlow = ({ onKycSuccess, flow, onManualClose }: UseKycFl
         handleIframeClose,
         closeVerificationProgressModal,
         closeVerificationModalAndGoHome,
+        resetError,
     }
 }

--- a/src/hooks/useGraphPreferences.ts
+++ b/src/hooks/useGraphPreferences.ts
@@ -15,7 +15,8 @@ export interface GraphPreferences {
     activityFilter?: ActivityFilter
     externalNodesConfig?: ExternalNodesConfig
     showUsernames?: boolean
-    showAllNodes?: boolean
+    /** Top N nodes limit (0 = all nodes). Backend-filtered. */
+    topNodes?: number
 }
 
 /**

--- a/src/hooks/useGraphPreferences.ts
+++ b/src/hooks/useGraphPreferences.ts
@@ -8,6 +8,7 @@ import type {
 } from '@/components/Global/InvitesGraph'
 
 const GRAPH_PREFS_KEY = 'invite-graph-preferences'
+const PAYMENT_GRAPH_PREFS_KEY = 'payment-graph-preferences'
 
 export interface GraphPreferences {
     forceConfig?: ForceConfig
@@ -26,36 +27,43 @@ export interface GraphPreferences {
  *
  * IMPORTANT: savePreferences does NOT update state to avoid infinite loops
  * It only writes to localStorage. preferences state is only set on initial load.
+ *
+ * @param mode - 'full' for full-graph, 'payment' for payment-graph (separate storage keys)
  */
-export function useGraphPreferences() {
+export function useGraphPreferences(mode: 'full' | 'payment' = 'full') {
     const [preferences, setPreferences] = useState<GraphPreferences | null>(null)
     const [isLoaded, setIsLoaded] = useState(false)
     const initialPrefsRef = useRef<GraphPreferences | null>(null)
 
+    const storageKey = mode === 'payment' ? PAYMENT_GRAPH_PREFS_KEY : GRAPH_PREFS_KEY
+
     // Load preferences on mount
     useEffect(() => {
-        const saved = getFromLocalStorage(GRAPH_PREFS_KEY) as GraphPreferences | null
+        const saved = getFromLocalStorage(storageKey) as GraphPreferences | null
         if (saved) {
             setPreferences(saved)
             initialPrefsRef.current = saved
         }
         setIsLoaded(true)
-    }, [])
+    }, [storageKey])
 
     // Save preferences to localStorage ONLY - does NOT update state to avoid loops
-    const savePreferences = useCallback((prefs: GraphPreferences) => {
-        saveToLocalStorage(GRAPH_PREFS_KEY, prefs)
-        // Don't call setPreferences here - it causes infinite loops
-    }, [])
+    const savePreferences = useCallback(
+        (prefs: GraphPreferences) => {
+            saveToLocalStorage(storageKey, prefs)
+            // Don't call setPreferences here - it causes infinite loops
+        },
+        [storageKey]
+    )
 
     // Clear all preferences
     const clearPreferences = useCallback(() => {
         setPreferences(null)
         initialPrefsRef.current = null
         if (typeof localStorage !== 'undefined') {
-            localStorage.removeItem(GRAPH_PREFS_KEY)
+            localStorage.removeItem(storageKey)
         }
-    }, [])
+    }, [storageKey])
 
     return {
         preferences,

--- a/src/services/points.ts
+++ b/src/services/points.ts
@@ -6,6 +6,7 @@ import { PEANUT_API_URL } from '@/constants/general.consts'
 /** Qualitative labels for anonymized data */
 export type FrequencyLabel = 'rare' | 'occasional' | 'regular' | 'frequent'
 export type VolumeLabel = 'small' | 'medium' | 'large' | 'whale'
+export type SizeLabel = 'tiny' | 'small' | 'medium' | 'large' | 'huge'
 
 /** P2P edge - can be full (with counts) or anonymized (with labels) */
 export type P2PEdge = {
@@ -28,11 +29,14 @@ type InvitesGraphResponse = {
             id: string
             username: string
             hasAppAccess: boolean
-            directPoints: number
-            transitivePoints: number
-            totalPoints: number
-            createdAt: string
-            lastActiveAt: string | null
+            // Full mode fields - optional in payment mode
+            directPoints?: number
+            transitivePoints?: number
+            totalPoints?: number
+            createdAt?: string
+            lastActiveAt?: string | null
+            // Payment mode fields - optional in full mode
+            size?: SizeLabel
             kycRegions: string[] | null
         }>
         edges: Array<{
@@ -80,14 +84,15 @@ export type ExternalNode = {
     id: string
     type: ExternalNodeType
     label: string
-    uniqueUsers: number
     userTxData: Record<string, UserTxDataEntry>
     // Full mode fields - optional in anonymized mode
+    uniqueUsers?: number
     userIds?: string[]
     txCount?: number
     totalUsd?: number
     lastTxDate?: string
     // Anonymized mode fields - optional in full mode
+    size?: SizeLabel
     frequency?: FrequencyLabel
     volume?: VolumeLabel
 }
@@ -336,6 +341,7 @@ export const pointsApi = {
             minConnections?: number
             types?: ExternalNodeType[]
             limit?: number
+            topNodes?: number
         }
     ): Promise<ExternalNodesResponse> => {
         try {
@@ -359,6 +365,9 @@ export const pointsApi = {
             }
             if (options?.limit) {
                 params.set('limit', options.limit.toString())
+            }
+            if (options?.topNodes && options.topNodes > 0) {
+                params.set('topNodes', options.topNodes.toString())
             }
 
             const url = `${PEANUT_API_URL}/invites/graph/external${params.toString() ? `?${params}` : ''}`

--- a/src/services/points.ts
+++ b/src/services/points.ts
@@ -56,6 +56,7 @@ export type ExternalNode = {
     totalUsd: number
     label: string
     userTxData: Record<string, { txCount: number; totalUsd: number }> // Per-user breakdown for edge weights
+    lastTxDate: string // ISO date of most recent transaction (for activity filtering)
 }
 
 type ExternalNodesResponse = {

--- a/src/services/points.ts
+++ b/src/services/points.ts
@@ -55,6 +55,7 @@ export type ExternalNode = {
     txCount: number
     totalUsd: number
     label: string
+    userTxData: Record<string, { txCount: number; totalUsd: number }> // Per-user breakdown for edge weights
 }
 
 type ExternalNodesResponse = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a new payment graph and refactors the invites graph to support multiple modes and scalable filtering, plus maintenance-based withdraw restrictions.
> 
> - Adds `/dev/payment-graph` page with password access, performance mode, and P2P-focused overlays; marks it public in routes while backend/password-gated
> - Replaces invite graph page with auth-gated `/dev/full-graph`; adds `(mobile-ui)/dev/layout` to restrict dev routes in prod and updates dev tools index
> - Major `InvitesGraph` overhaul: new `mode` (`full`/`payment`/`user`), backend-driven `topNodes` limit (replaces `showAllNodes`), payment-safe anonymized data (size/frequency/volume), improved external node linking/direction, new force defaults, search for external nodes, revised legends/labels, and separate saved preferences per mode
> - Points page: show minimal personal graph in dev for all users; badge-gated in prod
> - KYC flow: prefill missing `fullName`/`email` from bank form before KYC; KYC modal now resets errors on open
> - Token selector: honors `underMaintenance.disableSquidWithdraw` to limit withdraws to USDC on Arbitrum with UI notice
> - Misc: simplify logout button rendering; expose `resetError` in `useBridgeKycFlow`; extend public routes regex
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bb7377a2ab374d323b53e9032c259ee1ff5aff3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->