### PR TITLE
[TASK-18199] feat: disable crosschain send everywhere

### DIFF
--- a/src/components/Global/TokenSelector/TokenSelector.tsx
+++ b/src/components/Global/TokenSelector/TokenSelector.tsx
@@ -439,7 +439,7 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
                                     </>
                                 )}
 
-                                {/* Hide search when squid withdraw is disabled - only one option available */}
+                                {/* Hide search when cross-chain functionality is disabled (withdraw or send) - only one option available */}
                                 {!isCrossChainDisabled && (
                                     <div className="sticky -top-1 z-10 space-y-2 bg-background py-3">
                                         <SearchInput

--- a/src/config/underMaintenance.config.ts
+++ b/src/config/underMaintenance.config.ts
@@ -22,6 +22,11 @@
  *    - shows info message explaining cross-chain is temporarily unavailable
  *    - same-chain withdrawals (USDC on Arbitrum) continue to work
  *
+ * 5. disableSquidSend: disables cross-chain sends via Squid (claim, request payments)
+ *    - restricts token selector to only USDC on Arbitrum for claim and req_pay flows
+ *    - shows info message explaining cross-chain is temporarily unavailable
+ *    - same-chain operations continue to work
+ *
  * note: if either mode is enabled, the maintenance banner will show everywhere
  *
  * I HOPE WE NEVER NEED TO USE THIS...
@@ -35,6 +40,7 @@ interface MaintenanceConfig {
     enableMaintenanceBanner: boolean
     disabledPaymentProviders: PaymentProvider[]
     disableSquidWithdraw: boolean
+    disableSquidSend: boolean
 }
 
 const underMaintenanceConfig: MaintenanceConfig = {
@@ -42,6 +48,7 @@ const underMaintenanceConfig: MaintenanceConfig = {
     enableMaintenanceBanner: false, // set to true to show maintenance banner on all pages
     disabledPaymentProviders: [], // set to ['MANTECA'] to disable Manteca QR payments
     disableSquidWithdraw: true, // set to true to disable cross-chain withdrawals (only allows USDC on Arbitrum)
+    disableSquidSend: true, // set to true to disable cross-chain sends (claim, request payments - only allows USDC on Arbitrum)
 }
 
 export default underMaintenanceConfig


### PR DESCRIPTION
- Added disableSquidSend config flag in underMaintenance.config.ts
- Extended TokenSelector to check for crosschain disabled state on claim and req_pay viewTypes
- Shows info banner when crosschain is disabled for any supported flow
- Restricts to USDC on Arbitrum when crosschain is disabled