### PR TITLE
[TASK-18200] fix: show peso amount in manteca withdraw activity item

### DIFF
--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -284,13 +284,14 @@ export async function completeHistoryEntry(entry: HistoryEntry): Promise<History
         }
         case EHistoryEntryType.BRIDGE_OFFRAMP:
         case EHistoryEntryType.BRIDGE_GUEST_OFFRAMP:
-        case EHistoryEntryType.BANK_SEND_LINK_CLAIM: {
+        case EHistoryEntryType.BANK_SEND_LINK_CLAIM:
+        case EHistoryEntryType.MANTECA_OFFRAMP: {
             tokenSymbol = entry.tokenSymbol
             usdAmount = entry.amount
             if (entry.currency?.code) {
                 entry.currency.code = entry.currency.code.toUpperCase()
             }
-            // when bridge returns non-usd currency on pending states, it may mirror the usd amount.
+            // when bridge/manteca returns non-usd currency on pending states, it may mirror the usd amount.
             // convert it using current fx rate if it looks unconverted (missing or ~equal to usd amount).
             if (entry.currency?.code && entry.currency.code !== 'USD') {
                 const usdNum = Number(usdAmount)


### PR DESCRIPTION
Added MANTECA_OFFRAMP to the switch case in completeHistoryEntry that handles currency conversion for offramp transactions. This ensures the local currency amount (e.g., ARS) is properly calculated and displayed in the activity list.