### PR TITLE
[TASK-18201] fix: use correct timestamp for Bridge KYC history entry

### DIFF
--- a/src/app/(mobile-ui)/history/page.tsx
+++ b/src/app/(mobile-ui)/history/page.tsx
@@ -167,9 +167,16 @@ const HistoryPage = () => {
 
         if (user) {
             if (user.user?.bridgeKycStatus && user.user.bridgeKycStatus !== 'not_started') {
+                // Use appropriate timestamp based on KYC status
+                const bridgeKycTimestamp = (() => {
+                    const status = user.user.bridgeKycStatus
+                    if (status === 'approved') return user.user.bridgeKycApprovedAt
+                    if (status === 'rejected') return user.user.bridgeKycRejectedAt
+                    return user.user.bridgeKycStartedAt
+                })()
                 entries.push({
                     isKyc: true,
-                    timestamp: user.user.bridgeKycStartedAt ?? user.user.createdAt ?? new Date().toISOString(),
+                    timestamp: bridgeKycTimestamp ?? user.user.createdAt ?? new Date().toISOString(),
                     uuid: 'bridge-kyc-status-item',
                     bridgeKycStatus: user.user.bridgeKycStatus,
                 })

--- a/src/components/Home/HomeHistory.tsx
+++ b/src/components/Home/HomeHistory.tsx
@@ -181,9 +181,16 @@ const HomeHistory = ({ username, hideTxnAmount = false }: { username?: string; h
                 // viewing their own history
                 if (isViewingOwnHistory) {
                     if (user?.user?.bridgeKycStatus && user.user.bridgeKycStatus !== 'not_started') {
+                        // Use appropriate timestamp based on KYC status
+                        const bridgeKycTimestamp = (() => {
+                            const status = user.user.bridgeKycStatus
+                            if (status === 'approved') return user.user.bridgeKycApprovedAt
+                            if (status === 'rejected') return user.user.bridgeKycRejectedAt
+                            return user.user.bridgeKycStartedAt
+                        })()
                         entries.push({
                             isKyc: true,
-                            timestamp: user.user.bridgeKycStartedAt ?? user.user.createdAt ?? new Date().toISOString(),
+                            timestamp: bridgeKycTimestamp ?? user.user.createdAt ?? new Date().toISOString(),
                             uuid: 'bridge-kyc-status-item',
                             bridgeKycStatus: user.user.bridgeKycStatus,
                         })


### PR DESCRIPTION
Bridge KYC was using bridgeKycStartedAt for sorting, which could be recent if the user tested another KYC flow. Now uses the appropriate timestamp based on status:
- approved: bridgeKycApprovedAt
- rejected: bridgeKycRejectedAt
- pending: bridgeKycStartedAt

Applied to both HistoryPage and HomeHistory components.