### PR TITLE
[TASK-15937] fix: restore service worker generation in production builds

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -213,8 +213,6 @@ if (process.env.NODE_ENV !== 'development' && !Boolean(process.env.LOCAL_BUILD))
             deleteSourcemapsAfterUpload: true,
         },
     })
-} else {
-    module.exports = nextConfig
 }
 
 if (process.env.NODE_ENV !== 'development') {
@@ -225,8 +223,8 @@ if (process.env.NODE_ENV !== 'development') {
             // explicitly include offline screen assets in precache
             additionalPrecacheEntries: ['/icons/peanut-icon.svg'],
         })
-        return withSerwist(nextConfig)
+        return withBundleAnalyzer(withSerwist(nextConfig))
     }
+} else {
+    module.exports = nextConfig
 }
-
-module.exports = withBundleAnalyzer(nextConfig)


### PR DESCRIPTION
### Problem
Since Sprint 124 (Jan 7), the service worker (sw.js) was not being generated in production builds. This broke:
- Offline support
- PWA asset caching
- Runtime caching strategies

Users saw SW registration failed errors in console as the app tried to register a non-existent /sw.js.

## Root cause
The next.config.js export logic was broken:

1. The Sentry block had a dead else { module.exports = nextConfig } branch that always got overwritten
2. The Serwist block set module.exports correctly for production
3. But a dangling module.exports = withBundleAnalyzer(nextConfig) line ran unconditionally after, overwriting the Serwist export

### Fix
- Remove dead Sentry else branch (it was always overwritten anyway)
- Remove dangling module.exports line
- Add proper if/else: production exports Serwist + BundleAnalyzer wrapped config, development exports plain config