### PR TITLE
[TASK-18246] fix: add beforeSend filters to reduce Sentry noise

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -22,30 +22,6 @@ const IGNORED_ERRORS = {
         'The operation was aborted',
     ],
 
-    // Network issues (transient, client-side)
-    network: [
-        'NetworkError',
-        'Failed to fetch',
-        'network error',
-        'Network request failed',
-        'ETIMEDOUT',
-        'ECONNREFUSED',
-        'ECONNRESET',
-        'ENOTFOUND',
-        'Load failed',
-        'fetch failed',
-        'Network Error',
-    ],
-
-    // Chunk loading (usually network/cache issues)
-    chunkLoading: [
-        'ChunkLoadError',
-        'Loading chunk',
-        'Loading CSS chunk',
-        'Failed to load script',
-        'Importing a module script failed',
-    ],
-
     // Browser/extension noise
     browserNoise: [
         'ResizeObserver loop',

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -4,6 +4,99 @@
 
 import * as Sentry from '@sentry/nextjs'
 
+/**
+ * Patterns to filter out from Sentry reporting.
+ * These are generally noise that doesn't require action.
+ */
+const IGNORED_ERRORS = {
+    // User-initiated cancellations (not bugs)
+    userRejected: [
+        'User rejected',
+        'user rejected',
+        'User denied',
+        'not allowed by the user',
+        'User cancelled',
+        'user cancelled',
+        'Request rejected',
+        'AbortError',
+        'The operation was aborted',
+    ],
+
+    // Network issues (transient, client-side)
+    network: [
+        'NetworkError',
+        'Failed to fetch',
+        'network error',
+        'Network request failed',
+        'ETIMEDOUT',
+        'ECONNREFUSED',
+        'ECONNRESET',
+        'ENOTFOUND',
+        'Load failed',
+        'fetch failed',
+        'Network Error',
+    ],
+
+    // Chunk loading (usually network/cache issues)
+    chunkLoading: [
+        'ChunkLoadError',
+        'Loading chunk',
+        'Loading CSS chunk',
+        'Failed to load script',
+        'Importing a module script failed',
+    ],
+
+    // Browser/extension noise
+    browserNoise: [
+        'ResizeObserver loop',
+        'ResizeObserver loop limit exceeded',
+        'Script error.',
+        // Extension interference
+        'chrome-extension://',
+        'moz-extension://',
+        'safari-extension://',
+    ],
+
+    // Third-party scripts we don't control
+    thirdParty: ['googletagmanager', 'gtag', 'analytics', 'hotjar', 'clarity', 'intercom', 'crisp'],
+}
+
+/**
+ * Check if error message matches any ignored pattern
+ */
+function shouldIgnoreError(event: Sentry.ErrorEvent): boolean {
+    const message = event.message || ''
+    const exceptionValue = event.exception?.values?.[0]?.value || ''
+    const exceptionType = event.exception?.values?.[0]?.type || ''
+    const culprit = (event as any).culprit || ''
+
+    const searchText = `${message} ${exceptionValue} ${exceptionType} ${culprit}`.toLowerCase()
+
+    // Check all ignore patterns
+    for (const patterns of Object.values(IGNORED_ERRORS)) {
+        for (const pattern of patterns) {
+            if (searchText.includes(pattern.toLowerCase())) {
+                return true
+            }
+        }
+    }
+
+    // Ignore errors from browser extensions
+    const frames = event.exception?.values?.[0]?.stacktrace?.frames || []
+    for (const frame of frames) {
+        const filename = frame.filename || ''
+        if (
+            filename.includes('chrome-extension://') ||
+            filename.includes('moz-extension://') ||
+            filename.includes('safari-extension://')
+        ) {
+            return true
+        }
+    }
+
+    return false
+}
+
 if (process.env.NODE_ENV !== 'development') {
     Sentry.init({
         dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -12,11 +105,18 @@ if (process.env.NODE_ENV !== 'development') {
         debug: false,
 
         beforeSend(event) {
-            // Clean client-side events
+            // Filter out noise
+            if (shouldIgnoreError(event)) {
+                return null
+            }
+
+            // Clean sensitive headers from client-side events
             if (event.request?.headers) {
                 delete event.request.headers['Authorization']
                 delete event.request.headers['api-key']
+                delete event.request.headers['cookie']
             }
+
             return event
         },
 

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -2,6 +2,30 @@ import * as Sentry from '@sentry/nextjs'
 
 import { type JSONValue } from '../interfaces/interfaces'
 
+/**
+ * Endpoint + status combinations to skip reporting.
+ * These are expected responses, not errors.
+ * Pattern can be a string (exact match) or regex.
+ */
+const SKIP_REPORTING: Array<{ pattern: string | RegExp; statuses: number[] }> = [
+    // 400 on get-user-from-cookie is expected when no valid session
+    { pattern: /get-user-from-cookie/, statuses: [400] },
+]
+
+/**
+ * Check if this endpoint + status combo should skip Sentry reporting
+ */
+function shouldSkipReporting(url: string, status: number): boolean {
+    for (const rule of SKIP_REPORTING) {
+        const matches = typeof rule.pattern === 'string' ? url.includes(rule.pattern) : rule.pattern.test(url)
+
+        if (matches && rule.statuses.includes(status)) {
+            return true
+        }
+    }
+    return false
+}
+
 /** Use configured fetch timeout or default to 10s
  * We use 10s because vercel function timout is 15s and this function
  * can be called in that context, and we preffer to have control over
@@ -64,29 +88,33 @@ export const fetchWithSentry = async (
 
         if (!response.ok) {
             console.warn(`Request to ${url} failed with status ${response.status}`)
-            let errorContent: JSONValue
-            try {
-                errorContent = await response.clone().json()
-            } catch {
-                errorContent = await response.clone().text()
-            }
-            const method = options.method || 'GET'
-            Sentry.withScope((scope) => {
-                // Set fingerprint to group similar errors
-                scope.setFingerprint([method, sanitizeUrl(url), String(response.status)])
 
-                Sentry.captureMessage(`${method} to ${url} failed with status ${response.status}`, {
-                    level: getErrorLevelFromStatus(response.status),
-                    extra: {
-                        url,
-                        method,
-                        requestHeaders: sanitizeHeaders(options.headers || {}),
-                        requestBody: options.body || null,
-                        status: response.status,
-                        response: errorContent,
-                    },
+            // Skip Sentry reporting for expected error responses
+            if (!shouldSkipReporting(url, response.status)) {
+                let errorContent: JSONValue
+                try {
+                    errorContent = await response.clone().json()
+                } catch {
+                    errorContent = await response.clone().text()
+                }
+                const method = options.method || 'GET'
+                Sentry.withScope((scope) => {
+                    // Set fingerprint to group similar errors
+                    scope.setFingerprint([method, sanitizeUrl(url), String(response.status)])
+
+                    Sentry.captureMessage(`${method} to ${url} failed with status ${response.status}`, {
+                        level: getErrorLevelFromStatus(response.status),
+                        extra: {
+                            url,
+                            method,
+                            requestHeaders: sanitizeHeaders(options.headers || {}),
+                            requestBody: options.body || null,
+                            status: response.status,
+                            response: errorContent,
+                        },
+                    })
                 })
-            })
+            }
         }
 
         return response


### PR DESCRIPTION
Filter out non-actionable errors:
- User rejections/cancellations (wallet, AbortError)
- Browser noise (ResizeObserver, extensions)
- Third-party script errors (analytics, etc)