### PR TITLE
🐛 fix: clear expired jwt cookie and sw cache on 401

### DIFF
--- a/src/app/api/peanut/user/get-user-from-cookie/route.ts
+++ b/src/app/api/peanut/user/get-user-from-cookie/route.ts
@@ -21,11 +21,20 @@ export async function GET(_request: NextRequest) {
         })
 
         if (response.status !== 200) {
+            const headers: Record<string, string> = {
+                'Content-Type': 'application/json',
+            }
+
+            // on auth failure, clear the jwt cookie and sw cache so the client
+            // can recover even if running old cached code
+            if (response.status === 401) {
+                headers['Set-Cookie'] = 'jwt-token=; Path=/; Max-Age=0; SameSite=Lax'
+                headers['Clear-Site-Data'] = '"cache"'
+            }
+
             return new NextResponse('Error in get-from-cookie', {
                 status: response.status,
-                headers: {
-                    'Content-Type': 'application/json',
-                },
+                headers,
             })
         }
 


### PR DESCRIPTION
## Summary
- On 401 from `/get-user`, clear the jwt cookie and send `Clear-Site-Data: "cache"` header
- This nukes the stale cookie and service worker cache so the client redirects to `/setup` for re-authentication

## Context
Users with expired JWTs (30-day expiry) or corrupted cookies (from the Jan 20 httpOnly/sameSite changes) get stuck because the browser keeps sending the invalid cookie. This fix ensures the client can recover automatically.

## Risks
- `Clear-Site-Data: "cache"` will clear the SW cache on 401, forcing a fresh download of app assets on next load. This is intentional — stale cached code was part of the problem.

## QA
- User with expired JWT should be redirected to /setup instead of infinite spinner
- After re-authenticating, app should work normally

@coderabbitai review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auth failure handling in a user bootstrap endpoint and adds cache-clearing headers, which can impact session behavior and force asset re-downloads, but is scoped to `401` responses only.
> 
> **Overview**
> When `/api/peanut/user/get-user-from-cookie` receives a non-`200` response, it now conditionally adds recovery headers.
> 
> On `401`, the route clears the `jwt-token` cookie via `Set-Cookie` and instructs the browser to clear cached assets via `Clear-Site-Data: "cache"`, so clients stuck with expired/invalid tokens or stale service-worker code can re-authenticate cleanly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 578071be31b0ba22741e9362109d2227320bdae2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->