### PR TITLE
🐛 fix: clear stale redux user on auth failure

### DIFF
--- a/src/hooks/query/user.ts
+++ b/src/hooks/query/user.ts
@@ -3,7 +3,7 @@ import { useAppDispatch, useUserStore } from '@/redux/hooks'
 import { userActions } from '@/redux/slices/user-slice'
 import { fetchWithSentry } from '@/utils/sentry.utils'
 import { hitUserMetric } from '@/utils/metrics.utils'
-import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { usePWAStatus } from '../usePWAStatus'
 import { useDeviceType } from '../useGetDeviceType'
 import { USER } from '@/constants/query.consts'
@@ -29,14 +29,9 @@ export const useUserQuery = (dependsOn: boolean = true) => {
 
             return userData
         } else {
-            // RECOVERY FIX: Log error status for debugging
-            if (userResponse.status === 400 || userResponse.status === 500) {
-                console.error('Failed to fetch user with error status:', userResponse.status)
-                // This indicates a backend issue - user might be in broken state
-                // The KernelClientProvider recovery logic will handle cleanup
-            } else {
-                console.warn('Failed to fetch user. Probably not logged in.')
-            }
+            console.warn('Failed to fetch user, status:', userResponse.status)
+            // clear stale redux data so the app doesn't keep serving cached user
+            dispatch(userActions.setUser(null))
             return null
         }
     }
@@ -45,25 +40,13 @@ export const useUserQuery = (dependsOn: boolean = true) => {
         queryKey: [USER],
         queryFn: fetchUser,
         retry: 0,
-        // Enable if dependsOn is true (defaults to true) and no Redux user exists yet
-        enabled: dependsOn && !authUser?.user.userId,
-        // Two-tier caching strategy for optimal performance:
-        // TIER 1: TanStack Query in-memory cache (5 min)
-        //   - Zero latency for active sessions
-        //   - Lost on page refresh (intentional - forces SW cache check)
-        // TIER 2: Service Worker disk cache (1 week StaleWhileRevalidate)
-        //   - <50ms response on cold start/offline
-        //   - Persists across sessions
-        // Flow: TQ cache → if stale → fetch() → SW intercepts → SW cache → Network
-        staleTime: 5 * 60 * 1000, // 5 min (balance: fresh enough + reduces SW hits)
-        gcTime: 10 * 60 * 1000, // Keep unused data 10 min before garbage collection
-        // Refetch on mount - TQ automatically skips if data is fresh (< staleTime)
+        enabled: dependsOn,
+        staleTime: 5 * 60 * 1000,
+        gcTime: 10 * 60 * 1000,
         refetchOnMount: true,
-        // Refetch on focus - TQ automatically skips if data is fresh (< staleTime)
         refetchOnWindowFocus: true,
-        // Initialize with Redux data if available (hydration)
-        initialData: authUser || undefined,
-        // Keep previous data during refetch (smooth UX, no flicker)
-        placeholderData: keepPreviousData,
+        // use redux data as placeholder while fetching (no flicker)
+        // but always validate against the backend
+        placeholderData: authUser || undefined,
     })
 }

--- a/src/redux/slices/user-slice.ts
+++ b/src/redux/slices/user-slice.ts
@@ -11,7 +11,7 @@ const userSlice = createSlice({
     name: AUTH_SLICE,
     initialState,
     reducers: {
-        setUser: (state, action: PayloadAction<IUserProfile>) => {
+        setUser: (state, action: PayloadAction<IUserProfile | null>) => {
             state.user = action.payload
         },
     },


### PR DESCRIPTION
## Summary
- Always validate user against backend on mount (remove redux gate from `enabled`)
- Use `placeholderData` instead of `initialData` (show cached UI instantly, but don't skip fetch)
- Clear redux user on fetch failure so layout redirect to `/setup` triggers

## Problem
Redux persists user data to localStorage. On app boot, the query had `enabled: !authUser?.user.userId` — if Redux had a user, the query never fired. Expired JWTs were never detected. App rendered with stale cached data while all API calls failed.

## Risks
- One extra `/get-user-from-cookie` call on mount (skipped if data < 5min stale)
- No visual change for healthy sessions (placeholderData shows cached UI while validating)

## QA
- User with expired JWT should redirect to /setup after app boot
- User with valid JWT should see no difference (instant load, no flicker)