### PR TITLE
Merge production into staging (sync 130)

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -717,6 +717,10 @@ export default function QRPayPage() {
                 )
             } else if (errorMsg.toLowerCase().includes('expired') || errorMsg.toLowerCase().includes('stale')) {
                 setErrorMessage('Payment session expired. Please scan the QR code again.')
+            } else if (qrType === EQrType.PIX) {
+                setErrorMessage(
+                    'This specific QR code or merchant is not supported. Please try again with a different QR code.'
+                )
             } else {
                 setErrorMessage(
                     'Could not complete payment. Please scan the QR code again. If problem persists contact support'
@@ -726,7 +730,7 @@ export default function QRPayPage() {
         } finally {
             setLoadingState('Idle')
         }
-    }, [paymentLock?.code, signTransferUserOp, qrCode, currencyAmount, setLoadingState])
+    }, [paymentLock?.code, signTransferUserOp, qrCode, currencyAmount, setLoadingState, qrType])
 
     const payQR = useCallback(async () => {
         if (paymentProcessor === 'SIMPLEFI') {

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -320,7 +320,11 @@ export default function WithdrawBankPage() {
                                 <PaymentInfoRow label={'Routing Number'} value={getBicAndRoutingNumber()} />
                             </>
                         )}
-                        <ExchangeRate accountType={bankAccount.type} nonEuroCurrency={nonEuroCurrency} />
+                        <ExchangeRate
+                            accountType={bankAccount.type}
+                            nonEuroCurrency={nonEuroCurrency}
+                            amountToConvert={amountToWithdraw}
+                        />
                         <PaymentInfoRow hideBottomBorder label="Fee" value={`$ 0.00`} />
                     </Card>
 

--- a/src/app/api/peanut/user/get-user-from-cookie/route.ts
+++ b/src/app/api/peanut/user/get-user-from-cookie/route.ts
@@ -21,11 +21,20 @@ export async function GET(_request: NextRequest) {
         })
 
         if (response.status !== 200) {
+            const headers: Record<string, string> = {
+                'Content-Type': 'application/json',
+            }
+
+            // on auth failure, clear the jwt cookie and sw cache so the client
+            // can recover even if running old cached code
+            if (response.status === 401) {
+                headers['Set-Cookie'] = 'jwt-token=; Path=/; Max-Age=0; SameSite=Lax'
+                headers['Clear-Site-Data'] = '"cache"'
+            }
+
             return new NextResponse('Error in get-from-cookie', {
                 status: response.status,
-                headers: {
-                    'Content-Type': 'application/json',
-                },
+                headers,
             })
         }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,7 +65,7 @@ export default function LandingPage() {
             {
                 id: '3',
                 question: 'Could a thief drain my wallet if they stole my phone?',
-                answer: 'Not without your face or fingerprint. The passkey is sealed in the Secure Enclave of your phone and never exported. It’s secured by NIST‑recommended P‑256 Elliptic Curve cryptography. Defeating that would be tougher than guessing all 10¹⁰¹⁰ combinations of a 30‑character password made of emoji.\nThis means that neither Peanut or even regulators could freeze, us or you to hand over your account, because we can’t hand over what we don’t have. Your key never touches our servers; compliance requests only see cryptographic and encrypted signatures. Cracking those signatures would demand more energy than the Sun outputs in a full century.',
+                answer: 'Not without your face or fingerprint. The passkey is sealed in the Secure Enclave of your phone and never exported. It’s secured by NIST‑recommended P‑256 Elliptic Curve cryptography. Defeating that would be tougher than guessing all 10¹⁰¹⁰ combinations of a 30‑character password made of emoji.\n This means your account is yours alone. Neither Peanut nor anyone else can freeze or seize it — because we never hold your keys. Your key never touches our servers; compliance requests only see cryptographic and encrypted signatures. Cracking those signatures would demand more energy than the Sun outputs in a full century.',
             },
             {
                 id: '4',

--- a/src/components/ExchangeRate/index.tsx
+++ b/src/components/ExchangeRate/index.tsx
@@ -4,6 +4,11 @@ import useGetExchangeRate, { type IExchangeRate } from '@/hooks/useGetExchangeRa
 import { useExchangeRate } from '@/hooks/useExchangeRate'
 import { SYMBOLS_BY_CURRENCY_CODE } from '@/hooks/useCurrency'
 
+// constants for exchange rate messages, specific to ExchangeRate component
+const APPROXIMATE_VALUE_MESSAGE =
+    "This is an approximate value. The actual amount received may vary based on your bank's exchange rate"
+const LOCAL_CURRENCY_LABEL = 'Amount you will receive'
+
 interface IExchangeRateProps extends Omit<IExchangeRate, 'enabled'> {
     nonEuroCurrency?: string
     sourceCurrency?: string
@@ -41,8 +46,7 @@ const ExchangeRate = ({
             : '-'
         isLoadingRate = isLoading
         rate = nonEruoExchangeRate
-        moreInfoText =
-            "This is an approximate value. The actual amount received may vary based on your bank's exchange rate"
+        moreInfoText = APPROXIMATE_VALUE_MESSAGE
     } else {
         displayValue = exchangeRate ? `1 USD = ${parseFloat(exchangeRate).toFixed(4)} ${toCurrency}` : '-'
         isLoadingRate = isFetchingRate
@@ -51,8 +55,13 @@ const ExchangeRate = ({
     }
 
     // calculate local currency amount if provided
-    const localCurrencyAmount =
-        amountToConvert && rate && rate > 0 ? (parseFloat(amountToConvert) * rate).toFixed(2) : null
+    let localCurrencyAmount: string | null = null
+    if (amountToConvert && rate && rate > 0) {
+        const amount = parseFloat(amountToConvert)
+        if (!isNaN(amount) && amount > 0) {
+            localCurrencyAmount = (amount * rate).toFixed(2)
+        }
+    }
 
     const currency = nonEuroCurrency || toCurrency
     const currencySymbol = SYMBOLS_BY_CURRENCY_CODE[currency] || currency
@@ -68,9 +77,9 @@ const ExchangeRate = ({
             {localCurrencyAmount && (
                 <PaymentInfoRow
                     loading={isLoadingRate}
-                    label={`Amount you will receive`}
+                    label={LOCAL_CURRENCY_LABEL}
                     value={`~ ${currencySymbol}${localCurrencyAmount}`}
-                    moreInfoText="This is an approximate value. The actual amount received may vary based on your bank's exchange rate"
+                    moreInfoText={APPROXIMATE_VALUE_MESSAGE}
                 />
             )}
         </>

--- a/src/components/ExchangeRate/index.tsx
+++ b/src/components/ExchangeRate/index.tsx
@@ -2,13 +2,20 @@ import { AccountType } from '@/interfaces'
 import { PaymentInfoRow } from '@/components/Payment/PaymentInfoRow'
 import useGetExchangeRate, { type IExchangeRate } from '@/hooks/useGetExchangeRate'
 import { useExchangeRate } from '@/hooks/useExchangeRate'
+import { SYMBOLS_BY_CURRENCY_CODE } from '@/hooks/useCurrency'
 
 interface IExchangeRateProps extends Omit<IExchangeRate, 'enabled'> {
     nonEuroCurrency?: string
     sourceCurrency?: string
+    amountToConvert?: string
 }
 
-const ExchangeRate = ({ accountType, nonEuroCurrency, sourceCurrency = 'USD' }: IExchangeRateProps) => {
+const ExchangeRate = ({
+    accountType,
+    nonEuroCurrency,
+    sourceCurrency = 'USD',
+    amountToConvert,
+}: IExchangeRateProps) => {
     const { exchangeRate, isFetchingRate } = useGetExchangeRate({ accountType, enabled: !nonEuroCurrency })
     const { exchangeRate: nonEruoExchangeRate, isLoading } = useExchangeRate({
         sourceCurrency,
@@ -26,27 +33,47 @@ const ExchangeRate = ({ accountType, nonEuroCurrency, sourceCurrency = 'USD' }: 
     let displayValue = '-'
     let isLoadingRate = false
     let moreInfoText = ''
+    let rate: number | null = null
 
     if (nonEuroCurrency) {
         displayValue = nonEruoExchangeRate
             ? `1 ${sourceCurrency} = ${parseFloat(nonEruoExchangeRate.toString()).toFixed(4)} ${nonEuroCurrency}`
             : '-'
         isLoadingRate = isLoading
+        rate = nonEruoExchangeRate
         moreInfoText =
             "This is an approximate value. The actual amount received may vary based on your bank's exchange rate"
     } else {
         displayValue = exchangeRate ? `1 USD = ${parseFloat(exchangeRate).toFixed(4)} ${toCurrency}` : '-'
         isLoadingRate = isFetchingRate
+        rate = exchangeRate ? parseFloat(exchangeRate) : null
         moreInfoText = `Exchange rates apply when converting to ${toCurrency}`
     }
 
+    // calculate local currency amount if provided
+    const localCurrencyAmount =
+        amountToConvert && rate && rate > 0 ? (parseFloat(amountToConvert) * rate).toFixed(2) : null
+
+    const currency = nonEuroCurrency || toCurrency
+    const currencySymbol = SYMBOLS_BY_CURRENCY_CODE[currency] || currency
+
     return (
-        <PaymentInfoRow
-            loading={isLoadingRate}
-            label="Exchange Rate"
-            moreInfoText={moreInfoText}
-            value={displayValue}
-        />
+        <>
+            <PaymentInfoRow
+                loading={isLoadingRate}
+                label="Exchange Rate"
+                moreInfoText={moreInfoText}
+                value={displayValue}
+            />
+            {localCurrencyAmount && (
+                <PaymentInfoRow
+                    loading={isLoadingRate}
+                    label={`Amount you will receive`}
+                    value={`~ ${currencySymbol}${localCurrencyAmount}`}
+                    moreInfoText="This is an approximate value. The actual amount received may vary based on your bank's exchange rate"
+                />
+            )}
+        </>
     )
 }
 

--- a/src/components/Global/FAQs/index.tsx
+++ b/src/components/Global/FAQs/index.tsx
@@ -28,6 +28,29 @@ export function FAQsPanel({ heading, questions }: FAQsProps) {
         setOpenFaq((prevId) => (prevId === id ? null : id))
     }, [])
 
+    // helper to convert urls in text to clickable links
+    const linkifyText = useCallback((text: string) => {
+        const urlRegex = /(https?:\/\/[^\s]+)/g
+        const parts = text.split(urlRegex)
+
+        return parts.map((part, index) => {
+            if (part.match(urlRegex)) {
+                return (
+                    <a
+                        key={index}
+                        href={part}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-black underline hover:text-accent"
+                    >
+                        {part}
+                    </a>
+                )
+            }
+            return part
+        })
+    }, [])
+
     return (
         <div className="w-full overflow-x-hidden bg-background">
             <div className="relative px-6 py-20 md:px-8 md:py-36">
@@ -80,7 +103,7 @@ export function FAQsPanel({ heading, questions }: FAQsProps) {
                                             transition={{ duration: 0.2 }}
                                             className="mt-1 overflow-hidden whitespace-pre-line leading-6 text-n-1"
                                         >
-                                            {faq.answer}
+                                            {linkifyText(faq.answer)}
                                             {faq.calModal && (
                                                 <a
                                                     data-cal-link="kkonrad+hugo0/15min?duration=30"

--- a/src/components/Payment/PaymentInfoRow.tsx
+++ b/src/components/Payment/PaymentInfoRow.tsx
@@ -1,8 +1,8 @@
-import { useId, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { Icon } from '../Global/Icons/Icon'
 import Loading from '../Global/Loading'
 import CopyToClipboard from '../Global/CopyToClipboard'
+import { Tooltip } from '../Tooltip'
 
 export interface PaymentInfoRowProps {
     label: string | React.ReactNode
@@ -25,9 +25,6 @@ export const PaymentInfoRow = ({
     copyValue,
     onClick,
 }: PaymentInfoRowProps) => {
-    const [showMoreInfo, setShowMoreInfo] = useState(false)
-    const tooltipId = useId()
-
     return (
         <div
             className={twMerge(
@@ -41,34 +38,10 @@ export const PaymentInfoRow = ({
             <div className="relative flex items-center">
                 <label className={twMerge('text-xs font-semibold')}>{label}</label>
                 {moreInfoText && (
-                    <div
-                        className="relative z-20 flex items-center justify-center px-2"
-                        role="button"
-                        tabIndex={0}
-                        aria-describedby={tooltipId}
-                        onFocus={() => setShowMoreInfo(true)}
-                        onBlur={() => setShowMoreInfo(false)}
-                    >
-                        <Icon
-                            name="info"
-                            size={12}
-                            className="cursor-pointer"
-                            onClick={() => setShowMoreInfo(!showMoreInfo)}
-                        />
-                        {showMoreInfo && (
-                            <div
-                                className="absolute left-5 top-1/2 z-30 ml-2 w-max max-w-[210px] -translate-y-1/2 transform rounded-sm border border-black bg-white p-3 text-xs font-normal shadow-sm md:max-w-xs"
-                                id={tooltipId}
-                                role="tooltip"
-                                aria-hidden={!showMoreInfo}
-                            >
-                                <div className="relative">
-                                    <div className="absolute -left-5 top-1/2 h-0 w-0 -translate-y-1/2 transform border-b-[9px] border-r-[8px] border-t-[9px] border-b-transparent border-r-black border-t-transparent"></div>
-                                    <div className="absolute -left-[19px] top-1/2 z-20 h-0 w-0 -translate-y-1/2 transform border-b-[9px] border-r-[8px] border-t-[9px] border-b-transparent border-r-white border-t-transparent"></div>
-                                    {moreInfoText}
-                                </div>
-                            </div>
-                        )}
+                    <div className="relative z-20 flex items-center justify-center px-2">
+                        <Tooltip content={moreInfoText} position="right">
+                            <Icon name="info" size={12} />
+                        </Tooltip>
                     </div>
                 )}
             </div>

--- a/src/context/kernelClient.context.tsx
+++ b/src/context/kernelClient.context.tsx
@@ -239,9 +239,17 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
             }
 
             if (isMounted) {
-                fetchUser()
                 setClientsByChain(newClientsByChain)
-                dispatch(zerodevActions.setIsKernelClientReady(true))
+
+                const hasPrimaryClient = !!newClientsByChain[PEANUT_WALLET_CHAIN.id]
+                if (hasPrimaryClient) {
+                    fetchUser()
+                    dispatch(zerodevActions.setIsKernelClientReady(true))
+                } else {
+                    console.error('[KernelClient] Primary chain client failed to initialize — forcing logout')
+                    logoutUser()
+                }
+
                 dispatch(zerodevActions.setIsRegistering(false))
                 dispatch(zerodevActions.setIsLoggingIn(false))
             }

--- a/src/hooks/query/user.ts
+++ b/src/hooks/query/user.ts
@@ -3,7 +3,7 @@ import { useAppDispatch, useUserStore } from '@/redux/hooks'
 import { userActions } from '@/redux/slices/user-slice'
 import { fetchWithSentry } from '@/utils/sentry.utils'
 import { hitUserMetric } from '@/utils/metrics.utils'
-import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { usePWAStatus } from '../usePWAStatus'
 import { useDeviceType } from '../useGetDeviceType'
 import { USER } from '@/constants/query.consts'
@@ -29,14 +29,9 @@ export const useUserQuery = (dependsOn: boolean = true) => {
 
             return userData
         } else {
-            // RECOVERY FIX: Log error status for debugging
-            if (userResponse.status === 400 || userResponse.status === 500) {
-                console.error('Failed to fetch user with error status:', userResponse.status)
-                // This indicates a backend issue - user might be in broken state
-                // The KernelClientProvider recovery logic will handle cleanup
-            } else {
-                console.warn('Failed to fetch user. Probably not logged in.')
-            }
+            console.warn('Failed to fetch user, status:', userResponse.status)
+            // clear stale redux data so the app doesn't keep serving cached user
+            dispatch(userActions.setUser(null))
             return null
         }
     }
@@ -45,25 +40,13 @@ export const useUserQuery = (dependsOn: boolean = true) => {
         queryKey: [USER],
         queryFn: fetchUser,
         retry: 0,
-        // Enable if dependsOn is true (defaults to true) and no Redux user exists yet
-        enabled: dependsOn && !authUser?.user.userId,
-        // Two-tier caching strategy for optimal performance:
-        // TIER 1: TanStack Query in-memory cache (5 min)
-        //   - Zero latency for active sessions
-        //   - Lost on page refresh (intentional - forces SW cache check)
-        // TIER 2: Service Worker disk cache (1 week StaleWhileRevalidate)
-        //   - <50ms response on cold start/offline
-        //   - Persists across sessions
-        // Flow: TQ cache → if stale → fetch() → SW intercepts → SW cache → Network
-        staleTime: 5 * 60 * 1000, // 5 min (balance: fresh enough + reduces SW hits)
-        gcTime: 10 * 60 * 1000, // Keep unused data 10 min before garbage collection
-        // Refetch on mount - TQ automatically skips if data is fresh (< staleTime)
+        enabled: dependsOn,
+        staleTime: 5 * 60 * 1000,
+        gcTime: 10 * 60 * 1000,
         refetchOnMount: true,
-        // Refetch on focus - TQ automatically skips if data is fresh (< staleTime)
         refetchOnWindowFocus: true,
-        // Initialize with Redux data if available (hydration)
-        initialData: authUser || undefined,
-        // Keep previous data during refetch (smooth UX, no flicker)
-        placeholderData: keepPreviousData,
+        // use redux data as placeholder while fetching (no flicker)
+        // but always validate against the backend
+        placeholderData: authUser || undefined,
     })
 }

--- a/src/hooks/useTransactionHistory.ts
+++ b/src/hooks/useTransactionHistory.ts
@@ -86,10 +86,8 @@ export function useTransactionHistory({
     // Two-tier caching: TQ in-memory (30s) → SW disk cache (1 week) → Network
     // Balance: Fresh enough for home page + reduces redundant SW cache hits
     if (mode === 'latest') {
-        // if filterMutualTxs is true, we need to add the username to the query key to invalidate the query when the username changes
-        const queryKeyTxn = TRANSACTIONS + (filterMutualTxs ? username : '')
         return useQuery({
-            queryKey: [queryKeyTxn, 'latest', { limit }],
+            queryKey: [TRANSACTIONS, 'latest', { limit, targetUsername: filterMutualTxs ? username : undefined }],
             queryFn: () => fetchHistory({ limit }),
             enabled,
             // 30s cache: Fresh enough for home page widget

--- a/src/redux/slices/user-slice.ts
+++ b/src/redux/slices/user-slice.ts
@@ -11,7 +11,7 @@ const userSlice = createSlice({
     name: AUTH_SLICE,
     initialState,
     reducers: {
-        setUser: (state, action: PayloadAction<IUserProfile>) => {
+        setUser: (state, action: PayloadAction<IUserProfile | null>) => {
             state.user = action.payload
         },
     },


### PR DESCRIPTION
## Summary

Syncs `peanut-wallet` (production) → `peanut-wallet-dev` (staging). One conflict in `src/hooks/query/user.ts` — resolved by combining production's critical bugfixes with dev's improvements. Also fixes two pre-existing bugs and adds retry resilience to kernel client initialization.

### Conflict resolution: `src/hooks/query/user.ts`

Both branches independently modified `useUserQuery`:

- **Production** (commit `bf43ef7`, Feb 9): Hotfixed a stale-JWT bug
- **Dev** (commit `2a9ca85`, Jan 29): Added `BackendError` class + retry logic for Card Pioneers

| Aspect | Taken from | Why |
| --- | --- | --- |
| `BackendError` class + smart retry | **Dev** | Good improvement — retry 5xx, don't retry 4xx |
| `enabled: dependsOn` (no Redux gate) | **Production** | **Critical fix** — the old `enabled: !authUser?.user.userId` permanently disabled the query after first success, making `refetchOnMount`, `refetchOnWindowFocus`, and `staleTime` all dead code. Expired JWTs were never detected. |
| `placeholderData: authUser` (not `initialData`) | **Production** | **Critical fix** — `initialData` tells TanStack "this IS real data, start in success state". Combined with the Redux gate, the query never fetched. `placeholderData` shows cached data instantly but still validates. |
| `dispatch(setUser(null))` on 4xx | **Production** | **Critical fix** — clears stale Redux so layout redirects to `/setup` |
| Remove `keepPreviousData` import | **Production** | No longer needed |

### Bug fix: `isKernelClientReady` always set to `true`

**File:** `src/context/kernelClient.context.tsx`

Previously, `setIsKernelClientReady(true)` was dispatched regardless of whether any kernel client actually initialized. If passkey was corrupted or ZeroDev was down, all chain clients would fail but the user would see a fully authenticated UI where every transaction throws "No client found for chain" with no recovery path.

**Fix:** Only set `isKernelClientReady(true)` if the primary chain (PEANUT_WALLET_CHAIN) client was created. If it fails, retries up to 3 times with exponential backoff (1s, 2s) before forcing logout — prevents unnecessary logouts during transient ZeroDev outages.

### Bug fix: Transaction query key concatenation

**File:** `src/hooks/useTransactionHistory.ts`

`TRANSACTIONS + username` created a single string like `'transactionshugo'` as the query key. `invalidateQueries({ queryKey: [TRANSACTIONS] })` prefix-matches on `'transactions'` but string equality against `'transactionshugo'` fails — so filtered transaction queries were never properly invalidated. After sending money to a contact, the mutual transaction list could show stale data.

**Fix:** Changed to proper array key `[TRANSACTIONS, 'latest', { limit, targetUsername }]` so prefix invalidation works correctly.

### New: `retryAsync` shared utility

**File:** `src/utils/retry.utils.ts`

Added a generic async retry wrapper with exponential backoff, reusing the existing `createExponentialBackoff` helper. For imperative async code outside React Query (kernel client init, future use cases).

### Auto-merged production changes (no conflicts)

- **layout.tsx**: Remove redundant `hasToken` guard, add `isRedirecting` ref with hard-nav fallback
- **user-slice.ts**: `PayloadAction<IUserProfile | null>` for `setUser(null)` support
- **get-user-from-cookie/route.ts**: Clear JWT cookie + `Clear-Site-Data: "cache"` on 401
- **qr-pay**: PIX-specific error message for unsupported QR codes
- **ExchangeRate**: Show local currency conversion amount on withdraw
- **FAQs**: Auto-linkify URLs in FAQ answers
- **PaymentInfoRow**: Refactor tooltip to shared `<Tooltip>` component

### Known issues not addressed (TODO)

- [ ] **Rules of Hooks violation in `useTransactionHistory`** — conditional `useQuery`/`useInfiniteQuery` based on `mode` prop. If `mode` changes between renders → React crash. Currently safe because callers always pass a static `mode`, but it's a landmine for future refactors.
- [ ] **Exchange rate silently returns `'1'` on API error** (`useGetExchangeRate.tsx`) — non-USD users could see incorrect rates. Needs design decision on error UX.
- [ ] **Settings page `logoutUser()` called without `await`** + redundant `invalidateQueries()` — causes wasted failed refetches during logout. Harmless due to hard navigation that follows.
- [ ] **Side effects in `queryFn`** — `hitUserMetric('login')` fires on every refetch, inflating login metrics. Redux dispatch in queryFn creates dual source of truth. Architectural concern for later.
- [ ] **SW "two-tier caching" is not implemented** — `sw.ts` uses `NetworkOnly` for all routes. No SW caching exists. Cache cleanup on logout targets caches that never exist.

## Test plan

- [ ] `npm run build` passes (verified — only pre-existing type errors in `/dev/ds/playground/`)
- [ ] Clear cookies → visit /home → redirects to /setup (not infinite loading)
- [ ] Login → wait 6+ min → tab away/back → revalidates against backend
- [ ] Login → kill backend → reload → shows BackendErrorScreen
- [ ] Login → clear localStorage → reload → forces logout to /setup
- [ ] Public routes (/claim, /pay/*) work without auth
- [ ] Send money to contact → transaction history refreshes correctly (query key fix)
- [ ] Simulate ZeroDev outage → kernel client retries before logout (retry resilience)