### PR TITLE
fix: kernel client stuck loading screen + retry logic

### DIFF
--- a/src/context/kernelClient.context.tsx
+++ b/src/context/kernelClient.context.tsx
@@ -16,6 +16,7 @@ import { createContext, type ReactNode, useCallback, useContext, useEffect, useS
 import { type Chain, http, type PublicClient, type Transport } from 'viem'
 import type { Address } from 'viem'
 import { captureException } from '@sentry/nextjs'
+import { retryAsync } from '@/utils/retry.utils'
 import { PUBLIC_CLIENTS_BY_CHAIN } from '@/app/actions/clients'
 
 interface KernelClientContextType {
@@ -231,16 +232,29 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
                 }
             }
 
+            if (!newClientsByChain[PEANUT_WALLET_CHAIN.id]) {
+                throw new Error('Primary chain client failed to initialize')
+            }
+
+            // only update state after primary client check passes —
+            // avoids UI flicker (registering→not registering→registering) between retries
             if (isMounted) {
-                fetchUser()
                 setClientsByChain(newClientsByChain)
+                fetchUser()
                 dispatch(zerodevActions.setIsKernelClientReady(true))
                 dispatch(zerodevActions.setIsRegistering(false))
                 dispatch(zerodevActions.setIsLoggingIn(false))
             }
         }
 
-        initializeClients()
+        retryAsync(initializeClients, { maxRetries: 2, baseDelay: 1000, maxDelay: 5000 }).catch(() => {
+            if (isMounted) {
+                console.error('[KernelClient] Primary chain client failed after retries — forcing logout')
+                dispatch(zerodevActions.setIsRegistering(false))
+                dispatch(zerodevActions.setIsLoggingIn(false))
+                logoutUser()
+            }
+        })
 
         return () => {
             isMounted = false

--- a/src/hooks/useTransactionHistory.ts
+++ b/src/hooks/useTransactionHistory.ts
@@ -86,10 +86,8 @@ export function useTransactionHistory({
     // Two-tier caching: TQ in-memory (30s) → SW disk cache (1 week) → Network
     // Balance: Fresh enough for home page + reduces redundant SW cache hits
     if (mode === 'latest') {
-        // if filterMutualTxs is true, we need to add the username to the query key to invalidate the query when the username changes
-        const queryKeyTxn = TRANSACTIONS + (filterMutualTxs ? username : '')
         return useQuery({
-            queryKey: [queryKeyTxn, 'latest', { limit }],
+            queryKey: [TRANSACTIONS, 'latest', { limit, targetUsername: filterMutualTxs ? username : undefined }],
             queryFn: () => fetchHistory({ limit }),
             enabled,
             // 30s cache: Fresh enough for home page widget


### PR DESCRIPTION
Cherry-picked from peanut-wallet-dev:
- 71fe5d3: fix kernel client ready state + transaction query key bug
- f24d698: add retry logic before kernel client logout
- 79e5c6f: move state updates after primary client check to prevent UI flicker