### PR TITLE
feat: bridge additional document collection UI

### DIFF
--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -10,6 +10,7 @@ const API_KEY = process.env.PEANUT_API_KEY!
 // initiate kyc flow (using sumsub) and get websdk access token
 export const initiateSumsubKyc = async (params?: {
     regionIntent?: KYCRegionIntent
+    levelName?: string
 }): Promise<{ data?: InitiateSumsubKycResponse; error?: string }> => {
     const jwtToken = (await getJWTCookie())?.value
 
@@ -19,6 +20,7 @@ export const initiateSumsubKyc = async (params?: {
 
     const body: Record<string, string | undefined> = {
         regionIntent: params?.regionIntent,
+        levelName: params?.levelName,
     }
 
     try {

--- a/src/components/Kyc/KycStatusDrawer.tsx
+++ b/src/components/Kyc/KycStatusDrawer.tsx
@@ -88,11 +88,10 @@ export const KycStatusDrawer = ({ isOpen, onClose, verification, bridgeKycStatus
     const bridgeRailsNeedingDocs = (user?.rails ?? []).filter(
         (r) => r.status === 'REQUIRES_EXTRA_INFORMATION' && r.rail.provider.code === 'BRIDGE'
     )
-    const additionalRequirements: string[] =
-        bridgeRailsNeedingDocs.length > 0
-            ? ((bridgeRailsNeedingDocs[0].metadata?.additionalRequirements as string[]) ?? [])
-            : []
-    const needsAdditionalDocs = additionalRequirements.length > 0
+    const needsAdditionalDocs = bridgeRailsNeedingDocs.length > 0
+    const additionalRequirements: string[] = needsAdditionalDocs
+        ? (bridgeRailsNeedingDocs[0].metadata?.additionalRequirements ?? [])
+        : []
 
     // count sumsub rejections for failure lockout.
     // counts total REJECTED entries — accurate if backend creates a new row per attempt.

--- a/src/components/Kyc/states/KycRequiresDocuments.tsx
+++ b/src/components/Kyc/states/KycRequiresDocuments.tsx
@@ -19,15 +19,13 @@ export const KycRequiresDocuments = ({
             <KYCStatusDrawerItem status="pending" customText="Additional documents needed" />
 
             <div className="space-y-3">
-                <p className="text-sm text-gray-1">
-                    Your payment provider requires additional verification documents.
-                </p>
+                <p className="text-sm text-gray-1">Your payment provider requires additional verification documents.</p>
                 {requirements.map((req) => {
                     const label = getRequirementLabel(req)
                     return (
                         <div key={req} className="border border-n-1 p-3">
                             <p className="text-sm font-bold">{label.title}</p>
-                            <p className="text-xs text-gray-1 mt-1">{label.description}</p>
+                            <p className="mt-1 text-xs text-gray-1">{label.description}</p>
                         </div>
                     )
                 })}

--- a/src/components/Kyc/states/KycRequiresDocuments.tsx
+++ b/src/components/Kyc/states/KycRequiresDocuments.tsx
@@ -1,7 +1,6 @@
 import { KYCStatusDrawerItem } from '../KYCStatusDrawerItem'
 import { Button } from '@/components/0_Bruddle/Button'
 import { getRequirementLabel } from '@/constants/bridge-requirements.consts'
-import type { IconName } from '@/components/Global/Icons/Icon'
 
 // shows when a payment provider (bridge) needs additional documents from the user.
 // displays the specific requirements with human-readable descriptions.
@@ -20,19 +19,26 @@ export const KycRequiresDocuments = ({
 
             <div className="space-y-3">
                 <p className="text-sm text-gray-1">Your payment provider requires additional verification documents.</p>
-                {requirements.map((req) => {
-                    const label = getRequirementLabel(req)
-                    return (
-                        <div key={req} className="border border-n-1 p-3">
-                            <p className="text-sm font-bold">{label.title}</p>
-                            <p className="mt-1 text-xs text-gray-1">{label.description}</p>
-                        </div>
-                    )
-                })}
+                {requirements.length > 0 ? (
+                    requirements.map((req) => {
+                        const label = getRequirementLabel(req)
+                        return (
+                            <div key={req} className="border border-n-1 p-3">
+                                <p className="text-sm font-bold">{label.title}</p>
+                                <p className="mt-1 text-xs text-gray-1">{label.description}</p>
+                            </div>
+                        )
+                    })
+                ) : (
+                    <div className="border border-n-1 p-3">
+                        <p className="text-sm font-bold">Additional Document</p>
+                        <p className="mt-1 text-xs text-gray-1">Please provide the requested document.</p>
+                    </div>
+                )}
             </div>
 
             <Button
-                icon={'document' as IconName}
+                icon="docs"
                 className="w-full"
                 shadowSize="4"
                 onClick={onSubmitDocuments}

--- a/src/components/Kyc/states/KycRequiresDocuments.tsx
+++ b/src/components/Kyc/states/KycRequiresDocuments.tsx
@@ -1,0 +1,47 @@
+import { KYCStatusDrawerItem } from '../KYCStatusDrawerItem'
+import { Button } from '@/components/0_Bruddle/Button'
+import { getRequirementLabel } from '@/constants/bridge-requirements.consts'
+import type { IconName } from '@/components/Global/Icons/Icon'
+
+// shows when a payment provider (bridge) needs additional documents from the user.
+// displays the specific requirements with human-readable descriptions.
+export const KycRequiresDocuments = ({
+    requirements,
+    onSubmitDocuments,
+    isLoading,
+}: {
+    requirements: string[]
+    onSubmitDocuments: () => void
+    isLoading?: boolean
+}) => {
+    return (
+        <div className="space-y-4 p-1">
+            <KYCStatusDrawerItem status="pending" customText="Additional documents needed" />
+
+            <div className="space-y-3">
+                <p className="text-sm text-gray-1">
+                    Your payment provider requires additional verification documents.
+                </p>
+                {requirements.map((req) => {
+                    const label = getRequirementLabel(req)
+                    return (
+                        <div key={req} className="border border-n-1 p-3">
+                            <p className="text-sm font-bold">{label.title}</p>
+                            <p className="text-xs text-gray-1 mt-1">{label.description}</p>
+                        </div>
+                    )
+                })}
+            </div>
+
+            <Button
+                icon={'document' as IconName}
+                className="w-full"
+                shadowSize="4"
+                onClick={onSubmitDocuments}
+                disabled={isLoading}
+            >
+                {isLoading ? 'Loading...' : 'Submit documents'}
+            </Button>
+        </div>
+    )
+}

--- a/src/components/Kyc/states/KycRequiresDocuments.tsx
+++ b/src/components/Kyc/states/KycRequiresDocuments.tsx
@@ -37,13 +37,7 @@ export const KycRequiresDocuments = ({
                 )}
             </div>
 
-            <Button
-                icon="docs"
-                className="w-full"
-                shadowSize="4"
-                onClick={onSubmitDocuments}
-                disabled={isLoading}
-            >
+            <Button icon="docs" className="w-full" shadowSize="4" onClick={onSubmitDocuments} disabled={isLoading}>
                 {isLoading ? 'Loading...' : 'Submit documents'}
             </Button>
         </div>

--- a/src/constants/bridge-requirements.consts.ts
+++ b/src/constants/bridge-requirements.consts.ts
@@ -1,0 +1,41 @@
+interface RequirementLabelInfo {
+    title: string
+    description: string
+}
+
+// map of bridge additional_requirements to user-friendly labels
+const BRIDGE_REQUIREMENT_LABELS: Record<string, RequirementLabelInfo> = {
+    proof_of_address: {
+        title: 'Proof of Address',
+        description:
+            'Upload a utility bill, bank statement, or government letter showing your current address (dated within 3 months).',
+    },
+    additional_identity_document: {
+        title: 'Additional Identity Document',
+        description: 'Upload an additional government-issued ID document.',
+    },
+    proof_of_source_of_funds: {
+        title: 'Proof of Source of Funds',
+        description: 'Upload documentation showing the origin of your funds (e.g. pay stub, tax return).',
+    },
+    proof_of_tax_identification: {
+        title: 'Tax Identification',
+        description: 'Upload a document showing your tax identification number.',
+    },
+}
+
+const FALLBACK_LABEL: RequirementLabelInfo = {
+    title: 'Additional Document',
+    description: 'Please provide the requested document.',
+}
+
+/** get human-readable label for a bridge additional requirement */
+export function getRequirementLabel(requirement: string): RequirementLabelInfo {
+    return BRIDGE_REQUIREMENT_LABELS[requirement] ?? {
+        // auto-format unknown requirement codes as title case
+        title: requirement
+            .replace(/_/g, ' ')
+            .replace(/\b\w/g, (c) => c.toUpperCase()),
+        description: FALLBACK_LABEL.description,
+    }
+}

--- a/src/constants/bridge-requirements.consts.ts
+++ b/src/constants/bridge-requirements.consts.ts
@@ -31,11 +31,11 @@ const FALLBACK_LABEL: RequirementLabelInfo = {
 
 /** get human-readable label for a bridge additional requirement */
 export function getRequirementLabel(requirement: string): RequirementLabelInfo {
-    return BRIDGE_REQUIREMENT_LABELS[requirement] ?? {
-        // auto-format unknown requirement codes as title case
-        title: requirement
-            .replace(/_/g, ' ')
-            .replace(/\b\w/g, (c) => c.toUpperCase()),
-        description: FALLBACK_LABEL.description,
-    }
+    return (
+        BRIDGE_REQUIREMENT_LABELS[requirement] ?? {
+            // auto-format unknown requirement codes as title case
+            title: requirement.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
+            description: FALLBACK_LABEL.description,
+        }
+    )
 }

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -79,12 +79,15 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     }, [regionIntent])
 
     const handleInitiateKyc = useCallback(
-        async (overrideIntent?: KYCRegionIntent) => {
+        async (overrideIntent?: KYCRegionIntent, levelName?: string) => {
             setIsLoading(true)
             setError(null)
 
             try {
-                const response = await initiateSumsubKyc({ regionIntent: overrideIntent ?? regionIntent })
+                const response = await initiateSumsubKyc({
+                    regionIntent: overrideIntent ?? regionIntent,
+                    levelName,
+                })
 
                 if (response.error) {
                     setError(response.error)

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -7,7 +7,7 @@ export type RecipientType = 'address' | 'ens' | 'iban' | 'us' | 'username'
 export type KycModalPhase = 'verifying' | 'preparing' | 'bridge_tos' | 'complete'
 
 // per-provider rail status for tracking after kyc approval
-export type ProviderDisplayStatus = 'setting_up' | 'requires_tos' | 'enabled' | 'failed'
+export type ProviderDisplayStatus = 'setting_up' | 'requires_tos' | 'requires_documents' | 'enabled' | 'failed'
 
 export interface ProviderStatus {
     providerCode: string

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -348,7 +348,7 @@ export interface IUserRail {
     id: string
     railId: string
     status: UserRailStatus
-    metadata?: { bridgeCustomerId?: string; [key: string]: unknown } | null
+    metadata?: { bridgeCustomerId?: string; additionalRequirements?: string[]; [key: string]: unknown } | null
     rail: {
         id: string
         provider: { code: string; name: string }


### PR DESCRIPTION
adds requires_documents display status to rail tracking so bridge rails needing extra documents are distinguished from those needing ToS acceptance.

new KycRequiresDocuments component shows human-readable requirement descriptions and a submit button that opens the sumsub SDK with the peanut-additional-docs level.

wires into KycStatusDrawer to show the additional docs UI when bridge rails have REQUIRES_EXTRA_INFORMATION status, and extends initiateSumsubKyc to accept a levelName parameter.