### PR TITLE
Fix PIX key validation failing when pasted with whitespace

### DIFF
--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -17,7 +17,13 @@ import { loadingStateContext } from '@/context'
 import { countryData } from '@/components/AddMoney/consts'
 import Image from 'next/image'
 import { formatAmount, formatNumberForDisplay } from '@/utils/general.utils'
-import { validateCbuCvuAlias, validatePixKey, normalizePixPhoneNumber, isPixPhoneNumber } from '@/utils/withdraw.utils'
+import {
+    validateCbuCvuAlias,
+    validatePixKey,
+    normalizePixPhoneNumber,
+    isPixPhoneNumber,
+    isPixEmvcoQr,
+} from '@/utils/withdraw.utils'
 import ValidatedInput from '@/components/Global/ValidatedInput'
 import AmountInput from '@/components/Global/AmountInput'
 import { formatUnits, parseUnits } from 'viem'
@@ -153,7 +159,7 @@ export default function MantecaWithdrawFlow() {
                 }
                 break
             case 'brazil':
-                value = value.replace(/\s/g, '')
+                value = isPixEmvcoQr(value.trim()) ? value.trim() : value.replace(/\s/g, '')
                 const pixResult = validatePixKey(value)
                 isValid = pixResult.valid
                 if (!pixResult.valid) {
@@ -582,7 +588,9 @@ export default function MantecaWithdrawFlow() {
                                     // Auto-normalize PIX keys for Brazil: strip whitespace and normalize phone numbers
                                     let normalizedValue = update.value
                                     if (countryPath === 'brazil') {
-                                        normalizedValue = normalizedValue.replace(/\s/g, '')
+                                        normalizedValue = isPixEmvcoQr(normalizedValue.trim())
+                                            ? normalizedValue.trim()
+                                            : normalizedValue.replace(/\s/g, '')
                                         if (isPixPhoneNumber(normalizedValue)) {
                                             normalizedValue = normalizePixPhoneNumber(normalizedValue)
                                         }

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -153,6 +153,7 @@ export default function MantecaWithdrawFlow() {
                 }
                 break
             case 'brazil':
+                value = value.replace(/\s/g, '')
                 const pixResult = validatePixKey(value)
                 isValid = pixResult.valid
                 if (!pixResult.valid) {
@@ -578,10 +579,13 @@ export default function MantecaWithdrawFlow() {
                                 value={destinationAddress}
                                 placeholder={countryConfig!.accountNumberLabel}
                                 onUpdate={(update) => {
-                                    // Auto-normalize PIX phone numbers for Brazil
+                                    // Auto-normalize PIX keys for Brazil: strip whitespace and normalize phone numbers
                                     let normalizedValue = update.value
-                                    if (countryPath === 'brazil' && isPixPhoneNumber(update.value)) {
-                                        normalizedValue = normalizePixPhoneNumber(update.value)
+                                    if (countryPath === 'brazil') {
+                                        normalizedValue = normalizedValue.replace(/\s/g, '')
+                                        if (isPixPhoneNumber(normalizedValue)) {
+                                            normalizedValue = normalizePixPhoneNumber(normalizedValue)
+                                        }
                                     }
                                     setDestinationAddress(normalizedValue)
                                     setIsDestinationAddressValid(update.isValid)

--- a/src/utils/__tests__/withdraw.utils.test.ts
+++ b/src/utils/__tests__/withdraw.utils.test.ts
@@ -276,5 +276,25 @@ describe('Withdraw Utilities', () => {
                 }
             })
         })
+
+        describe('Pasted values with whitespace (stripped before validation)', () => {
+            // The withdraw page strips all whitespace from PIX keys before validation.
+            // These tests verify that after stripping, the values validate correctly.
+            const stripWhitespace = (value: string) => value.replace(/\s/g, '')
+
+            it.each([
+                { raw: ' +5511999999999 ', desc: 'phone with leading/trailing spaces' },
+                { raw: '+55 11 999999999', desc: 'phone with internal spaces' },
+                { raw: '  5511999999999  ', desc: 'phone without + with spaces' },
+                { raw: '123 456 789 01', desc: 'CPF with spaces' },
+                { raw: ' 12345678901234 ', desc: 'CNPJ with spaces' },
+                { raw: ' user@example.com ', desc: 'email with spaces' },
+                { raw: ' 123e4567-e89b-12d3-a456-426614174000 ', desc: 'UUID with spaces' },
+            ])('should accept $desc after whitespace stripping', ({ raw }) => {
+                const cleaned = stripWhitespace(raw)
+                const result = validatePixKey(cleaned)
+                expect(result.valid).toBe(true)
+            })
+        })
     })
 })


### PR DESCRIPTION
Strip all whitespace from PIX keys at the input level in the withdraw flow so spaces from copy-paste don't cause Manteca API errors.