### PR TITLE
fix: CodeRabbit review followups for ping-indexnow

### DIFF
--- a/scripts/ping-indexnow.ts
+++ b/scripts/ping-indexnow.ts
@@ -2,7 +2,7 @@
  * Pings IndexNow (Bing, Yandex, etc.) with all sitemap URLs.
  *
  * Usage:
- *   INDEXNOW_KEY=054e10e6239a45cb2d06e92d669f5b6f tsx scripts/ping-indexnow.ts
+ *   INDEXNOW_KEY=your-key-here tsx scripts/ping-indexnow.ts
  *
  * Or pass specific paths:
  *   INDEXNOW_KEY=xxx tsx scripts/ping-indexnow.ts /en/argentina /en/brazil
@@ -78,11 +78,14 @@ async function main() {
             urlList: batch,
         }
 
+        const controller = new AbortController()
+        const timeout = setTimeout(() => controller.abort(), 30_000)
         const res = await fetch(INDEXNOW_ENDPOINT, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json; charset=utf-8' },
             body: JSON.stringify(payload),
-        })
+            signal: controller.signal,
+        }).finally(() => clearTimeout(timeout))
 
         console.log(`Batch ${Math.floor(i / batchSize) + 1}: ${res.status} ${res.statusText} (${batch.length} URLs)`)
 


### PR DESCRIPTION
## Summary
- Replace real IndexNow key in script usage comment with placeholder (avoids secret scanner false positives)
- Add 30s `AbortController` timeout to `fetch` call to prevent CI workflow hangs on network stalls

Addresses CodeRabbit findings from #1702.

## Not addressed (over-engineering)
- **Clamp title/subtitle length in OG route**: We control all inputs from our own metadata — not user-generated
- **Try/catch wrapper for font/SVG reads in OG route**: Stack trace already identifies the missing file clearly