### PR TITLE
fix: content submodule update workflow

### DIFF
--- a/.github/workflows/update-content.yml
+++ b/.github/workflows/update-content.yml
@@ -40,21 +40,12 @@ jobs:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   BRANCH="auto/update-content-$(date -u +%Y%m%d-%H%M%S)"
+                  git config user.name "github-actions[bot]"
+                  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                  git checkout -b "$BRANCH"
                   git add src/content
-                  TREE=$(git write-tree)
-                  PARENT=$(git rev-parse HEAD)
-                  # create signed commit via GitHub API (verified signature)
-                  COMMIT_SHA=$(gh api repos/${{ github.repository }}/git/commits \
-                    --method POST \
-                    -f message="Update content submodule to latest main" \
-                    -f "tree=$TREE" \
-                    -f "parents[]=$PARENT" \
-                    --jq '.sha')
-                  # create branch pointing to signed commit
-                  gh api repos/${{ github.repository }}/git/refs \
-                    --method POST \
-                    -f "ref=refs/heads/$BRANCH" \
-                    -f "sha=$COMMIT_SHA"
+                  git commit -m "Update content submodule to latest main"
+                  git push origin "$BRANCH"
                   gh pr create \
                     --head "$BRANCH" \
                     --title "Update content submodule" \


### PR DESCRIPTION
## Summary
The update-content workflow was broken — `git write-tree` + GitHub API approach fails with "Tree SHA does not exist" because the tree references a submodule commit SHA that only exists in peanut-content's remote.

Switches to standard `git commit` + `git push` which handles submodule pointers correctly.

## Note
If `git push` fails due to branch protection, we may need to add a `SUBMODULE_TOKEN` (PAT) for the push step instead of `GITHUB_TOKEN`.