### PR TITLE
fix: BackendErrorScreen resilience to transient network failures

### DIFF
--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -103,9 +103,11 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
         return <OfflineScreen />
     }
 
-    // show backend error screen when user fetch fails after retries
-    // user can retry or force logout to clear stale state
-    if (userFetchError && !isFetchingUser && !isPublicPath) {
+    // show backend error screen only when user fetch fails AND there's no cached user data
+    // previously, a transient background refetch failure (e.g. refetchOnWindowFocus hitting
+    // a network blip) would replace the entire app with the error screen even though
+    // valid user data was still in the cache
+    if (userFetchError && !isFetchingUser && !isPublicPath && !user) {
         return <BackendErrorScreen />
     }
 

--- a/src/hooks/query/user.ts
+++ b/src/hooks/query/user.ts
@@ -53,9 +53,11 @@ export const useUserQuery = (dependsOn: boolean = true) => {
     return useQuery({
         queryKey: [USER],
         queryFn: fetchUser,
-        retry: (failureCount, error) => {
-            if (error instanceof BackendError && failureCount < 2) return true
-            return false
+        retry: (failureCount, _error) => {
+            // retry all errors (5xx, network timeouts, connection failures) up to 2 times
+            // previously only BackendError (5xx) was retried, meaning a single network
+            // blip would instantly show the BackendErrorScreen with zero retries
+            return failureCount < 2
         },
         retryDelay: 1000,
         enabled: dependsOn,


### PR DESCRIPTION
## Summary
- **Retry all errors in useUserQuery**: Previously only `BackendError` (5xx) was retried. Network timeouts, connection failures, and DNS errors got zero retries — a single network blip instantly showed "Something went wrong". Now all errors retry up to 2 times with 1s delay.
- **Don't show error screen when cached user data exists**: Added `&& !user` to the layout check. Previously, a background refetch failure (e.g. `refetchOnWindowFocus` after tabbing back) replaced the entire app with the error screen even though valid user data was still in the TanStack Query cache.

## Root cause
Users reported seeing "Something went wrong" intermittently. The `BackendErrorScreen` was too aggressive — it treated any transient error (even on background refetches with valid cached data) as a fatal error requiring a full-screen takeover.

## Files changed
- `src/hooks/query/user.ts` — retry logic now covers all error types
- `src/app/(mobile-ui)/layout.tsx` — error screen only shows when no cached user data

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Existing tests pass (`get-user-from-cookie` route tests)
- [ ] Manual: kill network briefly while logged in → app should NOT show error screen
- [ ] Manual: stop backend entirely with no cached user → error screen should still appear
- [ ] Manual: tab away and back with flaky network → app should keep working