### PR TITLE
[TASK-18690] hotfix: pass qrType to backend for PIX QR payment fallback

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -490,7 +490,7 @@ export default function QRPayPage() {
             if (paymentProcessor !== 'MANTECA' || !qrCode || !isPaymentProcessorQR(qrCode)) {
                 return null
             }
-            return mantecaApi.initiateQrPayment({ qrCode })
+            return mantecaApi.initiateQrPayment({ qrCode, qrType: qrType ?? undefined })
         },
         enabled: paymentProcessor === 'MANTECA' && !!qrCode && isPaymentProcessorQR(qrCode) && !paymentLock,
         retry: (failureCount, error: any) => {
@@ -693,6 +693,7 @@ export default function QRPayPage() {
                 signedUserOp,
                 chainId: signedUserOpData.chainId,
                 entryPointAddress: signedUserOpData.entryPointAddress,
+                qrType: qrType ?? undefined,
             })
             // clear the timer since we got a response
             if (payingStateTimerRef.current) {

--- a/src/services/manteca.ts
+++ b/src/services/manteca.ts
@@ -14,6 +14,7 @@ import type { SignUserOperationReturnType } from '@zerodev/sdk/actions'
 export interface QrPaymentRequest {
     qrCode: string
     amount?: string
+    qrType?: string
 }
 
 export type QrPayment = {
@@ -146,8 +147,10 @@ export const mantecaApi = {
         signedUserOp,
         chainId,
         entryPointAddress,
+        qrType,
     }: {
         paymentLockCode: string
+        qrType?: string
         signedUserOp: Pick<
             SignUserOperationReturnType,
             | 'sender'
@@ -182,6 +185,7 @@ export const mantecaApi = {
                     signedUserOp,
                     chainId,
                     entryPointAddress,
+                    qrType,
                 }),
             },
             120000


### PR DESCRIPTION
Passes qrType from URL search params to /manteca/qr-payment/init and /manteca/qr-payment/complete-with-signed-tx