### PR TITLE
[TASK-18633] fix: setup flow bugs - install copy, notification stuck state, PWA loop

### DIFF
--- a/src/components/Invites/JoinWaitlistPage.tsx
+++ b/src/components/Invites/JoinWaitlistPage.tsx
@@ -28,6 +28,7 @@ const JoinWaitlistPage = () => {
     const [inviteCode, setInviteCode] = useState(setupInviteCode)
 
     const { requestPermission, afterPermissionAttempt, isPermissionGranted } = useNotifications()
+    const [notificationSkipped, setNotificationSkipped] = useState(false)
 
     const { data, isLoading: isLoadingWaitlistPosition } = useQuery({
         queryKey: ['waitlist-position'],
@@ -85,7 +86,7 @@ const JoinWaitlistPage = () => {
                 )}
             >
                 <div className="mx-auto w-full md:max-w-xs">
-                    {!isPermissionGranted && (
+                    {!isPermissionGranted && !notificationSkipped && (
                         <div className="flex h-full flex-col justify-between gap-4 md:gap-10 md:pt-5">
                             <h1 className="text-xl font-extrabold">Enable notifications</h1>
                             <p className="text-base font-medium">We'll send you an update as soon as you get access.</p>
@@ -99,10 +100,16 @@ const JoinWaitlistPage = () => {
                             >
                                 Yes, notify me
                             </Button>
+                            <button
+                                onClick={() => setNotificationSkipped(true)}
+                                className="text-sm underline"
+                            >
+                                Not now
+                            </button>
                         </div>
                     )}
 
-                    {isPermissionGranted && (
+                    {(isPermissionGranted || notificationSkipped) && (
                         <div className="flex h-full flex-col justify-between gap-4 md:gap-10 md:pt-5">
                             <h1 className="text-xl font-extrabold">You&apos;re still in Peanut jail</h1>
 

--- a/src/components/Setup/Views/InstallPWA.tsx
+++ b/src/components/Setup/Views/InstallPWA.tsx
@@ -162,23 +162,20 @@ const InstallPWA = ({
                 return null
             }
 
-            // for other browsers, try to open the pwa in a new tab
+            // for other browsers, prompt user to open the installed PWA from home screen
+            // (opening /setup in a new tab causes a redirect loop between browser and PWA)
             return (
                 <div className="flex flex-col gap-4">
+                    <p className="text-center text-sm text-grey-1">
+                        Peanut has been installed! Open it from your Home Screen to continue.
+                    </p>
                     <Button
-                        onClick={() => {
-                            const link = document.createElement('a')
-                            link.href = '/setup'
-                            link.target = '_blank'
-                            document.body.appendChild(link)
-                            link.click()
-                            document.body.removeChild(link)
-                        }}
+                        onClick={() => handleNext()}
                         className="w-full"
                         shadowSize="4"
-                        loading={isSetupFlowLoading}
+                        variant="purple"
                     >
-                        Open Peanut app
+                        Continue here instead
                     </Button>
                 </div>
             )
@@ -209,12 +206,13 @@ const InstallPWA = ({
             )
         }
 
-        // Scenario 4: Fallback (cannot initiate automatic install)
+        // Scenario 4: Fallback (manual install instructions)
         return (
-            <div className="space-y-2 text-center">
-                <p className="text-sm text-grey-1">Could not initiate automatic installation.</p>
-                <p className="text-sm text-grey-1">Please try adding to Home Screen manually via your browser menu.</p>
-                <Button onClick={() => handleNext()} className="mt-4 w-full" shadowSize="4" variant="purple">
+            <div className="space-y-4 text-center">
+                <p className="text-sm text-grey-1">
+                    To install the app, please add it to your Home Screen from your browser menu.
+                </p>
+                <Button onClick={() => handleNext()} className="w-full" shadowSize="4" variant="purple">
                     Continue
                 </Button>
             </div>


### PR DESCRIPTION
1. Install screen: Replace tech-speak fallback with user-friendly copy
2. Waitlist notification: Add 'Not now' skip so users without invite codes don't get stuck on 'Enable Notifications' forever
3. PWA install loop: Remove target=_blank /setup link that causes redirect loop between browser and PWA; show instruction to open from Home Screen with fallback 'Continue here instead' button