### PR TITLE
fix: full-graph new users render green + debounce topNodes slider

### DIFF
--- a/src/components/Global/InvitesGraph/index.tsx
+++ b/src/components/Global/InvitesGraph/index.tsx
@@ -859,7 +859,7 @@ export default function InvitesGraph(props: InvitesGraphProps) {
             const result = await pointsApi.getInvitesGraph(props.apiKey, {
                 mode: apiMode,
                 topNodes: topNodes > 0 ? topNodes : undefined,
-                includeNewDays: activityFilter.activityDays,
+                includeNewDays: displaySettingsRef.current.activityFilter.activityDays,
                 password: mode === 'payment' ? props.password : undefined,
             })
 

--- a/src/components/Global/InvitesGraph/index.tsx
+++ b/src/components/Global/InvitesGraph/index.tsx
@@ -841,6 +841,9 @@ export default function InvitesGraph(props: InvitesGraphProps) {
 
     // Fetch graph data on mount and when topNodes changes (only in full mode)
     // Note: topNodes filtering only applies to full mode (payment mode has fixed 5000 limit in backend)
+    // topNodes is debounced so the slider doesn't trigger a refetch on every tick
+    const topNodesDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+    const isInitialFetchRef = useRef(true)
     useEffect(() => {
         if (isMinimal) return
 
@@ -852,9 +855,11 @@ export default function InvitesGraph(props: InvitesGraphProps) {
             const apiMode = mode === 'payment' ? 'payment' : 'full'
             // Pass topNodes for both modes - payment mode now supports it via Performance button
             // Pass password for payment mode authentication
+            // Pass includeNewDays so backend always includes recent signups regardless of topNodes
             const result = await pointsApi.getInvitesGraph(props.apiKey, {
                 mode: apiMode,
                 topNodes: topNodes > 0 ? topNodes : undefined,
+                includeNewDays: activityFilter.activityDays,
                 password: mode === 'payment' ? props.password : undefined,
             })
 
@@ -866,7 +871,18 @@ export default function InvitesGraph(props: InvitesGraphProps) {
             setLoading(false)
         }
 
-        fetchData()
+        // First fetch is immediate, subsequent topNodes changes are debounced (500ms)
+        if (isInitialFetchRef.current) {
+            isInitialFetchRef.current = false
+            fetchData()
+        } else {
+            if (topNodesDebounceRef.current) clearTimeout(topNodesDebounceRef.current)
+            topNodesDebounceRef.current = setTimeout(fetchData, 500)
+        }
+
+        return () => {
+            if (topNodesDebounceRef.current) clearTimeout(topNodesDebounceRef.current)
+        }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isMinimal, !isMinimal && props.apiKey, mode, topNodes])
 
@@ -1118,7 +1134,7 @@ export default function InvitesGraph(props: InvitesGraphProps) {
             } else {
                 // Activity filter enabled - three states
                 if (activityStatus === 'new') {
-                    fillColor = 'rgba(144, 168, 237, 0.85)' // secondary-3 #90A8ED for new signups
+                    fillColor = 'rgba(74, 222, 128, 0.85)' // green-400 for new signups
                 } else if (activityStatus === 'active') {
                     fillColor = 'rgba(255, 144, 232, 0.85)' // primary-1 for active
                 } else {

--- a/src/services/points.ts
+++ b/src/services/points.ts
@@ -303,7 +303,7 @@ export const pointsApi = {
 
     getInvitesGraph: async (
         apiKey: string,
-        options?: { mode?: 'full' | 'payment'; topNodes?: number; password?: string }
+        options?: { mode?: 'full' | 'payment'; topNodes?: number; includeNewDays?: number; password?: string }
     ): Promise<InvitesGraphResponse> => {
         const isPaymentMode = options?.mode === 'payment'
         const params = new URLSearchParams()
@@ -312,6 +312,9 @@ export const pointsApi = {
         }
         if (options?.topNodes && options.topNodes > 0) {
             params.set('topNodes', options.topNodes.toString())
+        }
+        if (options?.includeNewDays && options.includeNewDays > 0) {
+            params.set('includeNewDays', options.includeNewDays.toString())
         }
         if (options?.password) {
             params.set('password', options.password)


### PR DESCRIPTION
## Summary
- **Green new users**: Changed new user node color from blue (`rgba(144, 168, 237)`) to green (`rgba(74, 222, 128)`) to match the existing legend which already shows green for "New"
- **Debounced topNodes slider**: Slider no longer triggers API refetch on every tick — debounced by 500ms so you can drag freely
- **Always show new users**: Passes `includeNewDays` param to backend so new users appear in the graph regardless of topNodes point ranking

## Safety
- **Payment graph**: Unaffected — payment mode returns `'active'` for all nodes, never hits the green color path
- **User invite graph (points page)**: Unaffected — uses `minimal` mode (all-pink) and different API endpoint (`getUserInvitesGraph`)
- Color change only applies to full-graph with activity filter enabled

## Companion PR
Backend: peanutprotocol/peanut-api-ts — `fix/graph-createdAt-null-safety` (adds `includeNewDays` backend support + null safety)

## Test plan
- [ ] Open `/dev/full-graph`, verify new users (within activity window) show as green circles
- [ ] Verify legend matches (green dot = New)
- [ ] Drag the topNodes slider — should not spam-reload, only fetches after stopping
- [ ] Set topNodes to a low number — new users should still appear
- [ ] Check `/dev/payment-graph` still works normally (no green nodes)
- [ ] Check points page invite graph still works (all pink nodes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches graph data fetching cadence and the invites-graph API query contract (`includeNewDays`), which could affect load behavior if the backend handling differs; UI-only color change is low risk.
> 
> **Overview**
> Improves the full invites graph fetch behavior by **debouncing `topNodes`-driven refetches (500ms)** to avoid API spam while dragging the slider.
> 
> Extends `pointsApi.getInvitesGraph` and the graph request to send a new `includeNewDays` query param so **recent signups remain included even when `topNodes` limits results**, and updates the activity-filter rendering so **"new" users render green** instead of blue.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d42b9559fb006245a217bc4a6ae89fc84a2442b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->