### PR TITLE
Track AI tool symlinks in git

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CONTRIBUTING.md

--- a/.gitignore
+++ b/.gitignore
@@ -78,8 +78,5 @@ public/swe-worker*
 android/
 .claude/
 
-# AI tool symlinks (source of truth: CONTRIBUTING.md)
-CLAUDE.md
-AGENTS.md
-.cursorrules
-.windsurfrules
+# AI tool worktrees
+.claude/worktrees/

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,0 +1,1 @@
+CONTRIBUTING.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CONTRIBUTING.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+CONTRIBUTING.md


### PR DESCRIPTION
## Summary
- Remove CLAUDE.md, AGENTS.md, .cursorrules, .windsurfrules from .gitignore
- Track them as symlinks so every dev gets them on clone
- Add .github/copilot-instructions.md symlink for GitHub Copilot

All 5 symlinks point to CONTRIBUTING.md — one file to maintain, every AI tool picks it up.