### PR TITLE
feat: PostHog reverse proxy to bypass ad blockers

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -2,7 +2,8 @@ import posthog from 'posthog-js'
 
 if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'development') {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-        api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+        api_host: '/ingest',
+        ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
         person_profiles: 'identified_only',
         capture_pageview: true,
         capture_pageleave: true,

--- a/next.config.js
+++ b/next.config.js
@@ -95,6 +95,7 @@ let nextConfig = {
         return config
     },
     reactStrictMode: false,
+    skipTrailingSlashRedirect: true,
     async rewrites() {
         return {
             beforeFiles: [
@@ -109,6 +110,17 @@ let nextConfig = {
                 {
                     source: '/.well-known/assetLinks.json',
                     destination: '/api/assetLinks',
+                },
+            ],
+            afterFiles: [
+                // PostHog reverse proxy — bypasses ad blockers
+                {
+                    source: '/ingest/static/:path*',
+                    destination: 'https://eu-assets.i.posthog.com/static/:path*',
+                },
+                {
+                    source: '/ingest/:path*',
+                    destination: 'https://eu.i.posthog.com/:path*',
                 },
             ],
         }


### PR DESCRIPTION
## Summary
- Routes PostHog analytics requests through `/ingest/*` Next.js rewrites instead of directly to `eu.i.posthog.com`
- Ad blockers typically block requests to known analytics domains — this proxy makes events appear as first-party traffic, recovering ~30-40% of lost events
- Adds `skipTrailingSlashRedirect` to prevent Next.js from breaking proxy paths
- Sets `ui_host` so the PostHog toolbar/session replay still connects correctly

## Changes
- **`next.config.js`**: Added `afterFiles` rewrites for `/ingest/static/*` → `eu-assets.i.posthog.com` and `/ingest/*` → `eu.i.posthog.com`, plus `skipTrailingSlashRedirect: true`
- **`instrumentation-client.ts`**: Changed `api_host` from env var to `/ingest`, added `ui_host` pointing to the original PostHog host

## Risk
- Low — rewrites are additive, no existing routes affected
- `skipTrailingSlashRedirect` is a global setting but should not affect existing routes (our app doesn't rely on trailing slash redirects)

## Test plan
- [ ] Deploy to preview, open DevTools Network tab
- [ ] Verify PostHog requests go to `/ingest/*` instead of `eu.i.posthog.com`
- [ ] Verify events still appear in PostHog dashboard
- [ ] Test with an ad blocker enabled — events should still flow