### PR TITLE
feat: instrument core money flows with PostHog analytics

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -31,6 +31,8 @@ import { useLimitsValidation } from '@/features/limits/hooks/useLimitsValidation
 import LimitsWarningCard from '@/features/limits/components/LimitsWarningCard'
 import { getLimitsWarningCardProps } from '@/features/limits/utils'
 import { useExchangeRate } from '@/hooks/useExchangeRate'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 // Step type for URL state
 type BridgeBankStep = 'inputAmount' | 'kyc' | 'collectUserDetails' | 'showDetails'
@@ -216,6 +218,11 @@ export default function OnrampBankPage() {
 
     const handleAmountContinue = () => {
         if (validateAmount(rawTokenAmount)) {
+            posthog.capture(ANALYTICS_EVENTS.DEPOSIT_AMOUNT_ENTERED, {
+                amount_usd: usdEquivalent,
+                method_type: 'bank',
+                country: selectedCountryPath,
+            })
             setShowWarningModal(true)
         }
     }
@@ -238,6 +245,11 @@ export default function OnrampBankPage() {
             setOnrampData(onrampDataResponse)
 
             if (onrampDataResponse.transferId) {
+                posthog.capture(ANALYTICS_EVENTS.DEPOSIT_CONFIRMED, {
+                    amount_usd: usdEquivalent,
+                    method_type: 'bank',
+                    country: selectedCountryPath,
+                })
                 setUrlState({ step: 'showDetails' })
             } else {
                 setError({
@@ -247,6 +259,10 @@ export default function OnrampBankPage() {
             }
         } catch (error) {
             setShowWarningModal(false)
+            posthog.capture(ANALYTICS_EVENTS.DEPOSIT_FAILED, {
+                method_type: 'bank',
+                error_message: onrampError || 'Unknown error',
+            })
             if (onrampError) {
                 setError({
                     showError: true,

--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -259,9 +259,10 @@ export default function OnrampBankPage() {
             }
         } catch (error) {
             setShowWarningModal(false)
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error'
             posthog.capture(ANALYTICS_EVENTS.DEPOSIT_FAILED, {
                 method_type: 'bank',
-                error_message: onrampError || 'Unknown error',
+                error_message: errorMessage,
             })
             if (onrampError) {
                 setError({

--- a/src/app/(mobile-ui)/add-money/crypto/page.tsx
+++ b/src/app/(mobile-ui)/add-money/crypto/page.tsx
@@ -8,6 +8,8 @@ import type { RhinoChainType } from '@/services/services.types'
 import { useQuery } from '@tanstack/react-query'
 import { useRouter } from 'next/navigation'
 import { useCallback, useState } from 'react'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 const AddMoneyCryptoPage = () => {
     const { user } = useAuth()
@@ -25,10 +27,18 @@ const AddMoneyCryptoPage = () => {
         staleTime: 1000 * 60 * 60 * 24, // 24 hours
     })
 
-    const handleSuccess = useCallback((amount: number) => {
-        setDepositedAmount(amount)
-        setShowSuccessView(true)
-    }, [])
+    const handleSuccess = useCallback(
+        (amount: number) => {
+            posthog.capture(ANALYTICS_EVENTS.DEPOSIT_COMPLETED, {
+                amount,
+                chain_type: chainType,
+                method_type: 'crypto',
+            })
+            setDepositedAmount(amount)
+            setShowSuccessView(true)
+        },
+        [chainType]
+    )
 
     if (showSuccessView) {
         return <PaymentSuccessView type="DEPOSIT" amount={depositedAmount.toString()} />

--- a/src/app/(mobile-ui)/points/page.tsx
+++ b/src/app/(mobile-ui)/points/page.tsx
@@ -20,6 +20,8 @@ import { pointsApi } from '@/services/points'
 import EmptyState from '@/components/Global/EmptyStates/EmptyState'
 import { type PointsInvite } from '@/services/services.types'
 import { useEffect, useRef, useState } from 'react'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import InvitesGraph from '@/components/Global/InvitesGraph'
 import { CashCard } from '@/components/Points/CashCard'
 import InviteFriendsModal from '@/components/Global/InviteFriendsModal'
@@ -84,6 +86,10 @@ const PointsPage = () => {
         duration: 1.8,
         enabled: !!tierInfo?.data,
     })
+
+    useEffect(() => {
+        posthog.capture(ANALYTICS_EVENTS.POINTS_PAGE_VIEWED)
+    }, [])
 
     useEffect(() => {
         // re-fetch user to get the latest invitees list for showing heart icon
@@ -303,6 +309,7 @@ const PointsPage = () => {
                     visible={isInviteModalOpen}
                     onClose={() => setIsInviteModalOpen(false)}
                     username={username ?? ''}
+                    source="points_page"
                 />
             </section>
         </PageContainer>

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -32,6 +32,8 @@ import { PointsAction } from '@/services/services.types'
 import { usePointsCalculation } from '@/hooks/usePointsCalculation'
 import { useSearchParams } from 'next/navigation'
 import { parseUnits } from 'viem'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 type View = 'INITIAL' | 'SUCCESS'
 
@@ -153,6 +155,12 @@ export default function WithdrawBankPage() {
             return
         }
 
+        posthog.capture(ANALYTICS_EVENTS.WITHDRAW_CONFIRMED, {
+            amount_usd: amountToWithdraw,
+            method_type: 'bridge',
+            country,
+        })
+
         try {
             // Step 1: create the transfer to get deposit instructions
             const destination = destinationDetails(bankAccount)
@@ -213,8 +221,17 @@ export default function WithdrawBankPage() {
             }
 
             setView('SUCCESS')
+            posthog.capture(ANALYTICS_EVENTS.WITHDRAW_COMPLETED, {
+                amount_usd: amountToWithdraw,
+                method_type: 'bridge',
+                country,
+            })
         } catch (e: any) {
             const error = ErrorHandler(e)
+            posthog.capture(ANALYTICS_EVENTS.WITHDRAW_FAILED, {
+                method_type: 'bridge',
+                error_message: error,
+            })
             if (error.includes('Something failed. Please try again.')) {
                 setError({ showError: true, errorMessage: e.message })
             } else {

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -31,6 +31,8 @@ import { useRouteCalculation } from '@/features/payments/shared/hooks/useRouteCa
 import { usePaymentRecorder } from '@/features/payments/shared/hooks/usePaymentRecorder'
 import { isTxReverted } from '@/utils/general.utils'
 import { ErrorHandler } from '@/utils/sdkErrorHandler.utils'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 export default function WithdrawCryptoPage() {
     const router = useRouter()
@@ -254,6 +256,11 @@ export default function WithdrawCryptoPage() {
         clearErrors()
         setIsSendingTx(true)
 
+        posthog.capture(ANALYTICS_EVENTS.WITHDRAW_CONFIRMED, {
+            amount_usd: usdAmount,
+            method_type: 'crypto',
+        })
+
         try {
             // send transactions via peanut wallet
             const txResult = await sendTransactions(transactions, PEANUT_WALLET_CHAIN.id.toString())
@@ -281,9 +288,17 @@ export default function WithdrawCryptoPage() {
             setPaymentDetails(payment)
             triggerHaptic()
             setCurrentView('STATUS')
+            posthog.capture(ANALYTICS_EVENTS.WITHDRAW_COMPLETED, {
+                amount_usd: usdAmount,
+                method_type: 'crypto',
+            })
         } catch (err) {
             console.error('Withdrawal execution failed:', err)
             const errMsg = ErrorHandler(err)
+            posthog.capture(ANALYTICS_EVENTS.WITHDRAW_FAILED, {
+                method_type: 'crypto',
+                error_message: errMsg,
+            })
             setError(errMsg)
         } finally {
             setIsSendingTx(false)

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -48,6 +48,8 @@ import { PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
 import { TRANSACTIONS } from '@/constants/query.consts'
 import { useLimitsValidation } from '@/features/limits/hooks/useLimitsValidation'
 import { MIN_MANTECA_WITHDRAW_AMOUNT } from '@/constants/payment.consts'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import LimitsWarningCard from '@/features/limits/components/LimitsWarningCard'
 import { getLimitsWarningCardProps } from '@/features/limits/utils'
 
@@ -257,6 +259,12 @@ export default function MantecaWithdrawFlow() {
     const handleWithdraw = async () => {
         if (!destinationAddress || !usdAmount || !currencyCode || !priceLock) return
 
+        posthog.capture(ANALYTICS_EVENTS.WITHDRAW_CONFIRMED, {
+            amount_usd: usdAmount,
+            method_type: 'manteca',
+            country: countryPath,
+        })
+
         try {
             setLoadingState('Preparing transaction')
 
@@ -311,6 +319,11 @@ export default function MantecaWithdrawFlow() {
             })
 
             if (result.error) {
+                posthog.capture(ANALYTICS_EVENTS.WITHDRAW_FAILED, {
+                    method_type: 'manteca',
+                    error_message: result.error,
+                })
+
                 // handle third-party account error with user-friendly message
                 if (result.error === 'TAX_ID_MISMATCH' || result.error === 'CUIT_MISMATCH') {
                     setErrorMessage('You can only withdraw to accounts under your name.')
@@ -324,8 +337,17 @@ export default function MantecaWithdrawFlow() {
             }
 
             setStep('success')
+            posthog.capture(ANALYTICS_EVENTS.WITHDRAW_COMPLETED, {
+                amount_usd: usdAmount,
+                method_type: 'manteca',
+                country: countryPath,
+            })
         } catch (error) {
             console.error('Manteca withdraw error:', error)
+            posthog.capture(ANALYTICS_EVENTS.WITHDRAW_FAILED, {
+                method_type: 'manteca',
+                error_message: 'Withdraw failed unexpectedly',
+            })
             setErrorMessage('Withdraw failed unexpectedly. If problem persists contact support')
             setStep('failure')
         } finally {

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -19,6 +19,8 @@ import { PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
 import { TRANSACTIONS } from '@/constants/query.consts'
 import { useQueryStates, parseAsString, parseAsStringEnum } from 'nuqs'
 import { useLimitsValidation } from '@/features/limits/hooks/useLimitsValidation'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 // Step type for URL state
 type MantecaStep = 'inputAmount' | 'depositDetails'
@@ -170,6 +172,14 @@ const MantecaAddMoney: FC = () => {
         try {
             setError(null)
             setIsCreatingDeposit(true)
+
+            posthog.capture(ANALYTICS_EVENTS.DEPOSIT_AMOUNT_ENTERED, {
+                amount_usd: usdAmount,
+                method_type: 'manteca',
+                country: selectedCountryPath,
+                denomination: currentDenomination,
+            })
+
             const isUsdDenominated = currentDenomination === 'USD'
             // Use the displayed amount for the API call
             const amount = displayedAmount
@@ -183,11 +193,21 @@ const MantecaAddMoney: FC = () => {
                 return
             }
             setDepositDetails(depositData.data)
+            posthog.capture(ANALYTICS_EVENTS.DEPOSIT_CONFIRMED, {
+                amount_usd: usdAmount,
+                method_type: 'manteca',
+                country: selectedCountryPath,
+            })
             // Update URL state to show deposit details step
             setUrlState({ step: 'depositDetails' })
         } catch (error) {
             console.log(error)
-            setError(error instanceof Error ? error.message : String(error))
+            const errorMessage = error instanceof Error ? error.message : String(error)
+            posthog.capture(ANALYTICS_EVENTS.DEPOSIT_FAILED, {
+                method_type: 'manteca',
+                error_message: errorMessage,
+            })
+            setError(errorMessage)
         } finally {
             setIsCreatingDeposit(false)
         }

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -189,6 +189,11 @@ const MantecaAddMoney: FC = () => {
                 currency: selectedCountry.currency,
             })
             if (depositData.error) {
+                posthog.capture(ANALYTICS_EVENTS.DEPOSIT_FAILED, {
+                    method_type: 'manteca',
+                    country: selectedCountryPath,
+                    error_message: depositData.error,
+                })
                 setError(depositData.error)
                 return
             }
@@ -211,7 +216,16 @@ const MantecaAddMoney: FC = () => {
         } finally {
             setIsCreatingDeposit(false)
         }
-    }, [currentDenomination, selectedCountry, displayedAmount, isMantecaKycRequired, isCreatingDeposit, setUrlState])
+    }, [
+        currentDenomination,
+        selectedCountry,
+        displayedAmount,
+        isMantecaKycRequired,
+        isCreatingDeposit,
+        setUrlState,
+        usdAmount,
+        selectedCountryPath,
+    ])
 
     // handle verification modal opening
     useEffect(() => {

--- a/src/components/AddWithdraw/AddWithdrawRouterView.tsx
+++ b/src/components/AddWithdraw/AddWithdrawRouterView.tsx
@@ -21,6 +21,8 @@ import { CountryList } from '../Common/CountryList'
 import PeanutLoading from '../Global/PeanutLoading'
 import SavedAccountsView from '../Common/SavedAccountsView'
 import TokenAndNetworkConfirmationModal from '../Global/TokenAndNetworkConfirmationModal'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 interface AddWithdrawRouterViewProps {
     flow: 'add' | 'withdraw'
@@ -126,6 +128,10 @@ export const AddWithdrawRouterView: FC<AddWithdrawRouterViewProps> = ({
         (method: DepositMethod) => {
             if (flow === 'add' && user) {
                 saveRecentMethod(user.user.userId, method)
+                posthog.capture(ANALYTICS_EVENTS.DEPOSIT_METHOD_SELECTED, {
+                    method_type: method.type === 'crypto' ? 'crypto' : 'bank',
+                    country: method.path,
+                })
             }
 
             // Handle "From Bank" specially for add flow
@@ -143,6 +149,11 @@ export const AddWithdrawRouterView: FC<AddWithdrawRouterViewProps> = ({
             if (flow === 'withdraw') {
                 const methodType =
                     method.type === 'crypto' ? 'crypto' : isMantecaCountry(method.path) ? 'manteca' : 'bridge'
+
+                posthog.capture(ANALYTICS_EVENTS.WITHDRAW_METHOD_SELECTED, {
+                    method_type: methodType,
+                    country: method.path,
+                })
 
                 setSelectedMethod({
                     type: methodType,
@@ -299,6 +310,18 @@ export const AddWithdrawRouterView: FC<AddWithdrawRouterViewProps> = ({
                 inputTitle={mainHeading}
                 viewMode="add-withdraw"
                 onCountryClick={(country) => {
+                    if (flow === 'add') {
+                        posthog.capture(ANALYTICS_EVENTS.DEPOSIT_METHOD_SELECTED, {
+                            method_type: 'bank',
+                            country: country.path,
+                        })
+                    } else {
+                        posthog.capture(ANALYTICS_EVENTS.WITHDRAW_METHOD_SELECTED, {
+                            method_type: isMantecaCountry(country.path) ? 'manteca' : 'bridge',
+                            country: country.path,
+                        })
+                    }
+
                     // from send flow (bank): set method in context and stay on /withdraw?method=bank
                     if (flow === 'withdraw' && isBankFromSend) {
                         if (isMantecaCountry(country.path)) {
@@ -333,8 +356,16 @@ export const AddWithdrawRouterView: FC<AddWithdrawRouterViewProps> = ({
                 }}
                 onCryptoClick={() => {
                     if (flow === 'add') {
+                        posthog.capture(ANALYTICS_EVENTS.DEPOSIT_METHOD_SELECTED, {
+                            method_type: 'crypto',
+                            country: 'crypto',
+                        })
                         setIsSupportedTokensModalOpen(true)
                     } else {
+                        posthog.capture(ANALYTICS_EVENTS.WITHDRAW_METHOD_SELECTED, {
+                            method_type: 'crypto',
+                            country: 'crypto',
+                        })
                         // preserve method param if coming from send flow (though crypto shouldn't show this screen)
                         const queryParams = methodParam ? `?method=${methodParam}` : ''
                         const cryptoPath = `${baseRoute}/crypto${queryParams}`

--- a/src/components/AddWithdraw/AddWithdrawRouterView.tsx
+++ b/src/components/AddWithdraw/AddWithdrawRouterView.tsx
@@ -130,7 +130,7 @@ export const AddWithdrawRouterView: FC<AddWithdrawRouterViewProps> = ({
                 saveRecentMethod(user.user.userId, method)
                 posthog.capture(ANALYTICS_EVENTS.DEPOSIT_METHOD_SELECTED, {
                     method_type: method.type === 'crypto' ? 'crypto' : 'bank',
-                    country: method.path,
+                    country: method.path?.split('?')[0].split('/').filter(Boolean).at(-1),
                 })
             }
 
@@ -152,7 +152,7 @@ export const AddWithdrawRouterView: FC<AddWithdrawRouterViewProps> = ({
 
                 posthog.capture(ANALYTICS_EVENTS.WITHDRAW_METHOD_SELECTED, {
                     method_type: methodType,
-                    country: method.path,
+                    country: method.path?.split('?')[0].split('/').filter(Boolean).at(-1),
                 })
 
                 setSelectedMethod({

--- a/src/components/Card/CardSuccessScreen.tsx
+++ b/src/components/Card/CardSuccessScreen.tsx
@@ -136,6 +136,7 @@ const CardSuccessScreen = ({ onViewBadges }: CardSuccessScreenProps) => {
                 visible={isInviteModalOpen}
                 onClose={() => setIsInviteModalOpen(false)}
                 username={user?.user?.username ?? ''}
+                source="card_deposit_success"
             />
         </>
     )

--- a/src/components/Claim/Link/Initial.view.tsx
+++ b/src/components/Claim/Link/Initial.view.tsx
@@ -181,15 +181,17 @@ export const InitialClaimLinkView = (props: IClaimScreenProps) => {
         prevUser.current = user
     }, [user, resetClaimBankFlow])
 
+    const hasTrackedClaimView = useRef(false)
     useEffect(() => {
-        if (claimLinkData) {
+        if (claimLinkData && !hasTrackedClaimView.current) {
+            hasTrackedClaimView.current = true
             posthog.capture(ANALYTICS_EVENTS.CLAIM_LINK_VIEWED, {
                 amount: formatUnits(claimLinkData.amount, claimLinkData.tokenDecimals),
                 token_symbol: claimLinkData.tokenSymbol,
                 chain_id: claimLinkData.chainId,
             })
         }
-    }, [])
+    }, [claimLinkData])
 
     const resetSelectedToken = useCallback(() => {
         if (isPeanutWallet) {

--- a/src/components/Claim/Link/Initial.view.tsx
+++ b/src/components/Claim/Link/Initial.view.tsx
@@ -45,6 +45,8 @@ import { invitesApi } from '@/services/invites'
 import { EInviteType } from '@/services/services.types'
 import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants/zerodev.consts'
 import { ROUTE_NOT_FOUND_ERROR } from '@/constants/general.consts'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 export const InitialClaimLinkView = (props: IClaimScreenProps) => {
     // get campaign tag from claim link url
@@ -178,6 +180,16 @@ export const InitialClaimLinkView = (props: IClaimScreenProps) => {
         }
         prevUser.current = user
     }, [user, resetClaimBankFlow])
+
+    useEffect(() => {
+        if (claimLinkData) {
+            posthog.capture(ANALYTICS_EVENTS.CLAIM_LINK_VIEWED, {
+                amount: formatUnits(claimLinkData.amount, claimLinkData.tokenDecimals),
+                token_symbol: claimLinkData.tokenSymbol,
+                chain_id: claimLinkData.chainId,
+            })
+        }
+    }, [])
 
     const resetSelectedToken = useCallback(() => {
         if (isPeanutWallet) {
@@ -950,6 +962,11 @@ export const InitialClaimLinkView = (props: IClaimScreenProps) => {
                                     })
                                 } else {
                                     setRecipientType(update.type)
+                                    if (update.isValid && !update.isChanging) {
+                                        posthog.capture(ANALYTICS_EVENTS.CLAIM_RECIPIENT_SELECTED, {
+                                            recipient_type: update.type,
+                                        })
+                                    }
                                 }
                                 setIsValidRecipient(update.isValid)
                                 setErrorState({

--- a/src/components/Claim/Link/Onchain/Confirm.view.tsx
+++ b/src/components/Claim/Link/Onchain/Confirm.view.tsx
@@ -19,6 +19,8 @@ import useClaimLink from '../../useClaimLink'
 import { useAuth } from '@/context/authContext'
 import { sendLinksApi } from '@/services/sendLinks'
 import { useSearchParams } from 'next/navigation'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 export const ConfirmClaimLinkView = ({
     onNext,
@@ -83,6 +85,15 @@ export const ConfirmClaimLinkView = ({
             errorMessage: '',
         })
 
+        const formattedAmount = formatUnits(claimLinkData.amount, claimLinkData.tokenDecimals)
+
+        posthog.capture(ANALYTICS_EVENTS.CLAIM_LINK_STARTED, {
+            amount: formattedAmount,
+            token_symbol: claimLinkData.tokenSymbol,
+            chain_id: claimLinkData.chainId,
+            is_xchain: !!selectedRoute,
+        })
+
         try {
             let claimTxHash: string | undefined = ''
             if (selectedRoute) {
@@ -119,6 +130,12 @@ export const ConfirmClaimLinkView = ({
                 }
             }
             setTransactionHash(claimTxHash)
+            posthog.capture(ANALYTICS_EVENTS.CLAIM_LINK_COMPLETED, {
+                amount: formattedAmount,
+                token_symbol: claimLinkData.tokenSymbol,
+                chain_id: claimLinkData.chainId,
+                is_xchain: !!selectedRoute,
+            })
             onNext()
             // Note: Balance/transaction refresh handled by mutation or SUCCESS view
         } catch (error) {
@@ -126,6 +143,11 @@ export const ConfirmClaimLinkView = ({
             setErrorState({
                 showError: true,
                 errorMessage: errorString,
+            })
+            posthog.capture(ANALYTICS_EVENTS.CLAIM_LINK_FAILED, {
+                amount: formattedAmount,
+                error_message: errorString,
+                is_xchain: !!selectedRoute,
             })
             Sentry.captureException(error)
         } finally {

--- a/src/components/Global/CopyToClipboard/index.tsx
+++ b/src/components/Global/CopyToClipboard/index.tsx
@@ -14,18 +14,20 @@ interface Props {
     iconSize?: '2' | '3' | '4' | '6' | '8'
     type?: 'button' | 'icon'
     buttonSize?: ButtonSize
+    onCopy?: () => void
 }
 
 const CopyToClipboard = forwardRef<CopyToClipboardRef, Props>(
-    ({ textToCopy, fill = 'black', className, iconSize = '6', type = 'icon', buttonSize }, ref) => {
+    ({ textToCopy, fill = 'black', className, iconSize = '6', type = 'icon', buttonSize, onCopy }, ref) => {
         const [copied, setCopied] = useState(false)
 
         const copy = useCallback(() => {
             navigator.clipboard.writeText(textToCopy).then(() => {
                 setCopied(true)
                 setTimeout(() => setCopied(false), 2000)
+                onCopy?.()
             })
-        }, [textToCopy])
+        }, [textToCopy, onCopy])
 
         useImperativeHandle(ref, () => ({ copy }), [copy])
 

--- a/src/components/Global/InviteFriendsModal/index.tsx
+++ b/src/components/Global/InviteFriendsModal/index.tsx
@@ -5,12 +5,16 @@ import Card from '@/components/Global/Card'
 import CopyToClipboard from '@/components/Global/CopyToClipboard'
 import ShareButton from '@/components/Global/ShareButton'
 import { generateInviteCodeLink, generateInvitesShareText } from '@/utils/general.utils'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import posthog from 'posthog-js'
+import { useEffect } from 'react'
 import QRCode from 'react-qr-code'
 
 interface InviteFriendsModalProps {
     visible: boolean
     onClose: () => void
     username: string
+    source?: string
 }
 
 /**
@@ -19,13 +23,24 @@ interface InviteFriendsModalProps {
  *
  * Used in: CardSuccessScreen, Profile, PointsPage
  */
-export default function InviteFriendsModal({ visible, onClose, username }: InviteFriendsModalProps) {
+export default function InviteFriendsModal({ visible, onClose, username, source }: InviteFriendsModalProps) {
     const { inviteCode, inviteLink } = generateInviteCodeLink(username)
+
+    useEffect(() => {
+        if (visible) {
+            posthog.capture(ANALYTICS_EVENTS.INVITE_MODAL_OPENED, { source })
+        }
+    }, [visible, source])
+
+    const handleClose = () => {
+        posthog.capture(ANALYTICS_EVENTS.INVITE_MODAL_DISMISSED, { source })
+        onClose()
+    }
 
     return (
         <ActionModal
             visible={visible}
-            onClose={onClose}
+            onClose={handleClose}
             title="Invite friends!"
             description="Invite friends to Peanut and help them skip ahead on the waitlist. Once they're onboarded and start using the app, you'll earn rewards from their activity too."
             icon="user-plus"
@@ -47,12 +62,17 @@ export default function InviteFriendsModal({ visible, onClose, username }: Invit
                             <p className="overflow-hidden text-ellipsis whitespace-nowrap text-sm font-bold">
                                 {inviteCode}
                             </p>
-                            <CopyToClipboard textToCopy={inviteCode} iconSize="4" />
+                            <CopyToClipboard
+                                textToCopy={inviteCode}
+                                iconSize="4"
+                                onCopy={() => posthog.capture(ANALYTICS_EVENTS.INVITE_LINK_COPIED, { source })}
+                            />
                         </Card>
                     </div>
                     <ShareButton
                         generateText={() => Promise.resolve(generateInvitesShareText(inviteLink))}
                         title="Share your invite link"
+                        onSuccess={() => posthog.capture(ANALYTICS_EVENTS.INVITE_LINK_SHARED, { source })}
                     >
                         Share Invite Link
                     </ShareButton>

--- a/src/components/Invites/InvitesPage.tsx
+++ b/src/components/Invites/InvitesPage.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { Suspense, useEffect, useRef, useState } from 'react'
+import { Suspense, useEffect, useRef, useState, useCallback } from 'react'
 import PeanutLoading from '../Global/PeanutLoading'
 import ValidationErrorView from '../Payment/Views/Error.validation.view'
 import InvitesPageLayout from './InvitesPageLayout'
@@ -16,6 +16,8 @@ import { EInviteType } from '@/services/services.types'
 import { saveToCookie } from '@/utils/general.utils'
 import { useLogin } from '@/hooks/useLogin'
 import UnsupportedBrowserModal from '../Global/UnsupportedBrowserModal'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 // mapping of special invite codes to their campaign tags
 // when these invite codes are used, the corresponding campaign tag is automatically applied
@@ -54,6 +56,18 @@ function InvitePageContent() {
         queryFn: () => invitesApi.validateInviteCode(inviteCode!),
         enabled: !!inviteCode,
     })
+
+    // track invite page view (ref guard prevents duplicate fires when shouldShowContent toggles)
+    const hasTrackedPageView = useRef(false)
+    useEffect(() => {
+        if (shouldShowContent && inviteCodeData?.success && !hasTrackedPageView.current) {
+            hasTrackedPageView.current = true
+            posthog.capture(ANALYTICS_EVENTS.INVITE_PAGE_VIEWED, {
+                invite_code: inviteCode,
+                inviter_username: inviteCodeData.username,
+            })
+        }
+    }, [shouldShowContent, inviteCodeData, inviteCode])
 
     // determine if we should show content based on user state
     useEffect(() => {
@@ -123,6 +137,9 @@ function InvitePageContent() {
 
     const handleClaimInvite = async () => {
         if (inviteCode) {
+            posthog.capture(ANALYTICS_EVENTS.INVITE_CLAIM_CLICKED, {
+                invite_code: inviteCode,
+            })
             dispatch(setupActions.setInviteCode(inviteCode))
             dispatch(setupActions.setInviteType(EInviteType.PAYMENT_LINK))
             saveToCookie('inviteCode', inviteCode) // Save to cookies as well, so that if user installs PWA, they can still use the invite code

--- a/src/components/Invites/JoinWaitlistPage.tsx
+++ b/src/components/Invites/JoinWaitlistPage.tsx
@@ -19,6 +19,8 @@ import { updateUserById } from '@/app/actions/users'
 import { useQueryState, parseAsStringEnum } from 'nuqs'
 import { isValidEmail } from '@/utils/format.utils'
 import { BaseInput } from '@/components/0_Bruddle/BaseInput'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 type WaitlistStep = 'email' | 'notifications' | 'jail'
 
@@ -153,12 +155,26 @@ const JoinWaitlistPage = () => {
         try {
             const res = await invitesApi.acceptInvite(inviteCode, inviteType)
             if (res.success) {
+                posthog.capture(ANALYTICS_EVENTS.INVITE_ACCEPTED, {
+                    invite_code: inviteCode,
+                    source: 'waitlist_page',
+                })
                 sessionStorage.setItem('showNoMoreJailModal', 'true')
                 fetchUser()
             } else {
+                posthog.capture(ANALYTICS_EVENTS.INVITE_ACCEPT_FAILED, {
+                    invite_code: inviteCode,
+                    error_message: 'API returned unsuccessful',
+                    source: 'waitlist_page',
+                })
                 setError('Something went wrong. Please try again or contact support.')
             }
         } catch {
+            posthog.capture(ANALYTICS_EVENTS.INVITE_ACCEPT_FAILED, {
+                invite_code: inviteCode,
+                error_message: 'Exception during invite acceptance',
+                source: 'waitlist_page',
+            })
             setError('Something went wrong. Please try again or contact support.')
         } finally {
             setIsAccepting(false)

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -145,6 +145,7 @@ export const Profile = () => {
                 visible={isInviteFriendsModalOpen}
                 onClose={() => setIsInviteFriendsModalOpen(false)}
                 username={user?.user.username ?? ''}
+                source="profile"
             />
         </div>
     )

--- a/src/components/Send/link/views/Initial.link.send.view.tsx
+++ b/src/components/Send/link/views/Initial.link.send.view.tsx
@@ -19,6 +19,8 @@ import { Button } from '@/components/0_Bruddle/Button'
 import FileUploadInput from '../../../Global/FileUploadInput'
 import AmountInput from '../../../Global/AmountInput'
 import { usePendingTransactions } from '@/hooks/wallet/usePendingTransactions'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 const LinkSendInitialView = () => {
     const {
@@ -56,6 +58,13 @@ const LinkSendInitialView = () => {
             const { link, pubKey, chainId, contractVersion, depositIdx, txHash, amount, tokenAddress } =
                 await createLink(parseUnits(tokenValue!, PEANUT_WALLET_TOKEN_DECIMALS))
 
+            posthog.capture(ANALYTICS_EVENTS.SEND_LINK_CREATED, {
+                amount: tokenValue,
+                chain_id: chainId,
+                token_address: tokenAddress,
+                has_attachment: !!attachmentOptions?.rawFile,
+            })
+
             setLink(link)
             setView('SUCCESS')
             fetchBalance()
@@ -89,6 +98,10 @@ const LinkSendInitialView = () => {
             // handle errors
             const errorString = ErrorHandler(error)
             setErrorState({ showError: true, errorMessage: errorString })
+            posthog.capture(ANALYTICS_EVENTS.SEND_LINK_FAILED, {
+                amount: tokenValue,
+                error_message: errorString,
+            })
             captureException(error)
         } finally {
             setLoadingState('Idle')

--- a/src/components/Send/link/views/Success.link.send.view.tsx
+++ b/src/components/Send/link/views/Success.link.send.view.tsx
@@ -17,6 +17,8 @@ import { useEffect, useState } from 'react'
 import useClaimLink from '@/components/Claim/useClaimLink'
 import { useToast } from '@/components/0_Bruddle/Toast'
 import { TRANSACTIONS } from '@/constants/query.consts'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 const LinkSendSuccessView = () => {
     const router = useRouter()
@@ -62,7 +64,15 @@ const LinkSendSuccessView = () => {
 
                 {link && (
                     <div className="flex w-full flex-col items-center justify-center gap-4">
-                        <ShareButton url={link} title="Share link">
+                        <ShareButton
+                            url={link}
+                            title="Share link"
+                            onSuccess={() => {
+                                posthog.capture(ANALYTICS_EVENTS.SEND_LINK_SHARED, {
+                                    amount: tokenValue,
+                                })
+                            }}
+                        >
                             Share link
                         </ShareButton>
                         <Button

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -77,6 +77,14 @@ export const ANALYTICS_EVENTS = {
     POINTS_PAGE_VIEWED: 'points_page_viewed',
     POINTS_EARNED: 'points_earned',
 
+    // ── Notifications ──
+    NOTIFICATION_PERMISSION_REQUESTED: 'notification_permission_requested',
+    NOTIFICATION_PERMISSION_GRANTED: 'notification_permission_granted',
+    NOTIFICATION_PERMISSION_DENIED: 'notification_permission_denied',
+    NOTIFICATION_MODAL_SHOWN: 'notification_modal_shown',
+    NOTIFICATION_MODAL_DISMISSED: 'notification_modal_dismissed',
+    NOTIFICATION_SUBSCRIBED: 'notification_subscribed',
+
     // ── QR ──
     QR_SCANNED: 'qr_scanned',
 

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -37,8 +37,31 @@ export const ANALYTICS_EVENTS = {
     // ── Send ──
     SEND_METHOD_SELECTED: 'send_method_selected',
 
+    // ── Send Link ──
+    SEND_LINK_CREATED: 'send_link_created',
+    SEND_LINK_FAILED: 'send_link_failed',
+    SEND_LINK_SHARED: 'send_link_shared',
+
+    // ── Claim Link ──
+    CLAIM_LINK_VIEWED: 'claim_link_viewed',
+    CLAIM_LINK_STARTED: 'claim_link_started',
+    CLAIM_LINK_COMPLETED: 'claim_link_completed',
+    CLAIM_LINK_FAILED: 'claim_link_failed',
+    CLAIM_RECIPIENT_SELECTED: 'claim_recipient_selected',
+
+    // ── Deposit / Onramp ──
+    DEPOSIT_METHOD_SELECTED: 'deposit_method_selected',
+    DEPOSIT_AMOUNT_ENTERED: 'deposit_amount_entered',
+    DEPOSIT_CONFIRMED: 'deposit_confirmed',
+    DEPOSIT_COMPLETED: 'deposit_completed',
+    DEPOSIT_FAILED: 'deposit_failed',
+
     // ── Withdraw ──
     WITHDRAW_AMOUNT_ENTERED: 'withdraw_amount_entered',
+    WITHDRAW_METHOD_SELECTED: 'withdraw_method_selected',
+    WITHDRAW_CONFIRMED: 'withdraw_confirmed',
+    WITHDRAW_COMPLETED: 'withdraw_completed',
+    WITHDRAW_FAILED: 'withdraw_failed',
 
     // ── QR ──
     QR_SCANNED: 'qr_scanned',

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -63,6 +63,20 @@ export const ANALYTICS_EVENTS = {
     WITHDRAW_COMPLETED: 'withdraw_completed',
     WITHDRAW_FAILED: 'withdraw_failed',
 
+    // ── Invites / Referrals ──
+    INVITE_LINK_SHARED: 'invite_link_shared',
+    INVITE_LINK_COPIED: 'invite_link_copied',
+    INVITE_PAGE_VIEWED: 'invite_page_viewed',
+    INVITE_CLAIM_CLICKED: 'invite_claim_clicked',
+    INVITE_ACCEPTED: 'invite_accepted',
+    INVITE_ACCEPT_FAILED: 'invite_accept_failed',
+    INVITE_MODAL_OPENED: 'invite_modal_opened',
+    INVITE_MODAL_DISMISSED: 'invite_modal_dismissed',
+
+    // ── Points / Cashback ──
+    POINTS_PAGE_VIEWED: 'points_page_viewed',
+    POINTS_EARNED: 'points_earned',
+
     // ── QR ──
     QR_SCANNED: 'qr_scanned',
 

--- a/src/features/payments/shared/components/PaymentSuccessView.tsx
+++ b/src/features/payments/shared/components/PaymentSuccessView.tsx
@@ -37,6 +37,8 @@ import { type ReactNode, useEffect, useMemo, useRef } from 'react'
 import { usePointsConfetti } from '@/hooks/usePointsConfetti'
 import chillPeanutAnim from '@/animations/GIF_ALPHA_BACKGORUND/512X512_ALPHA_GIF_konradurban_01.gif'
 import { useHaptic } from 'use-haptic'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import PointsCard from '@/components/Common/PointsCard'
 import { BASE_URL } from '@/constants/general.consts'
 import { TRANSACTIONS } from '@/constants/query.consts'
@@ -193,6 +195,15 @@ const PaymentSuccessView = ({
 
     const pointsDivRef = useRef<HTMLDivElement>(null)
     usePointsConfetti(points, pointsDivRef)
+
+    useEffect(() => {
+        if (points) {
+            posthog.capture(ANALYTICS_EVENTS.POINTS_EARNED, {
+                points,
+                flow_type: isWithdrawFlow ? 'withdraw' : type?.toLowerCase(),
+            })
+        }
+    }, [points, isWithdrawFlow, type])
 
     useEffect(() => {
         // invalidate queries to refetch history

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import OneSignal from 'react-onesignal'
 import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils'
 import { useUserStore } from '@/redux/hooks'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 export function useNotifications() {
     const { user } = useUserStore()
@@ -102,6 +104,7 @@ export function useNotifications() {
         // show modal only if user hasn't closed it yet
         if (!modalClosed) {
             setShowPermissionModal(true)
+            posthog.capture(ANALYTICS_EVENTS.NOTIFICATION_MODAL_SHOWN)
         } else {
             setShowPermissionModal(false)
         }
@@ -186,6 +189,16 @@ export function useNotifications() {
                         // update local permission state and immediately re-evaluate ui visibility
                         refreshPermissionState()
                         evaluateVisibility()
+
+                        // track the resulting permission state
+                        if (typeof Notification !== 'undefined') {
+                            const perm = Notification.permission
+                            if (perm === 'granted') {
+                                posthog.capture(ANALYTICS_EVENTS.NOTIFICATION_PERMISSION_GRANTED)
+                            } else if (perm === 'denied') {
+                                posthog.capture(ANALYTICS_EVENTS.NOTIFICATION_PERMISSION_DENIED)
+                            }
+                        }
                     })
 
                     type PushSubscriptionChangeEvent = { current?: { optedIn?: boolean } | null }
@@ -214,6 +227,7 @@ export function useNotifications() {
 
                             // hide modal when user opts in
                             if (event.current?.optedIn) {
+                                posthog.capture(ANALYTICS_EVENTS.NOTIFICATION_SUBSCRIBED)
                                 setShowPermissionModal(false)
                             }
                         }
@@ -237,6 +251,7 @@ export function useNotifications() {
         if (typeof window === 'undefined' || !oneSignalInitialized) return 'default'
 
         setIsRequestingPermission(true)
+        posthog.capture(ANALYTICS_EVENTS.NOTIFICATION_PERMISSION_REQUESTED)
 
         try {
             // always use the native browser permission dialog, avoid onesignal slidedown ui
@@ -315,6 +330,7 @@ export function useNotifications() {
     const closePermissionModal = useCallback(() => {
         setShowPermissionModal(false)
         updateUserPreferences(user?.user.userId, { notifModalClosed: true })
+        posthog.capture(ANALYTICS_EVENTS.NOTIFICATION_MODAL_DISMISSED)
     }, [user?.user.userId])
 
     // update permission state after user interacts with permission prompt

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -13,6 +13,8 @@ import { useCallback, useContext } from 'react'
 import type { TransactionReceipt, Hex, Hash } from 'viem'
 import { captureException } from '@sentry/nextjs'
 import { invitesApi } from '@/services/invites'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 // types
 type UserOpEncodedParams = {
@@ -87,7 +89,17 @@ export const useZeroDev = () => {
             if (userInviteCode?.trim().length > 0) {
                 try {
                     const result = await invitesApi.acceptInvite(userInviteCode, inviteType, campaignTag)
-                    if (!result.success) {
+                    if (result.success) {
+                        posthog.capture(ANALYTICS_EVENTS.INVITE_ACCEPTED, {
+                            invite_code: userInviteCode,
+                            invite_type: inviteType,
+                            campaign_tag: campaignTag,
+                        })
+                    } else {
+                        posthog.capture(ANALYTICS_EVENTS.INVITE_ACCEPT_FAILED, {
+                            invite_code: userInviteCode,
+                            error_message: 'API returned unsuccessful',
+                        })
                         console.error('Error accepting invite', result)
                     }
                     if (inviteCodeFromCookie) {
@@ -97,6 +109,10 @@ export const useZeroDev = () => {
                         removeFromCookie('campaignTag')
                     }
                 } catch (e) {
+                    posthog.capture(ANALYTICS_EVENTS.INVITE_ACCEPT_FAILED, {
+                        invite_code: userInviteCode,
+                        error_message: String(e),
+                    })
                     console.error('Error accepting invite', e)
                 }
             }


### PR DESCRIPTION
## Summary

Instruments **core money flows** and **invite/referral + points engagement** with PostHog analytics — two batches in one PR.

### Batch 1: Money Flows (17 events)
- **Send Link**: created, failed, shared
- **Claim Link**: viewed, started, completed, failed, recipient selected
- **Deposit/Onramp**: method selected, amount entered, confirmed, completed, failed
- **Withdraw/Offramp**: method selected, confirmed, completed, failed

### Batch 2: Invites & Points (10 events)
- **Invite Modal**: opened, dismissed, link shared, link copied (with `source` attribution)
- **Invite Page**: viewed, claim clicked
- **Invite Accept**: accepted, accept failed (both signup and waitlist paths)
- **Points**: page viewed, points earned (with `flow_type` discrimination)

### Improvements
- Added `onCopy` callback prop to `CopyToClipboard` component for clean analytics integration
- Ref guard on `INVITE_PAGE_VIEWED` to prevent duplicate fires from `shouldShowContent` toggling
- All events use centralized `ANALYTICS_EVENTS` constants

## Key Funnels Enabled
1. **Invite virality**: modal_opened → link_shared/copied → page_viewed → claim_clicked → accepted
2. **Share frequency**: invite_link_shared count by user and source
3. **Deposit funnel**: method_selected → amount_entered → confirmed → completed
4. **Claim funnel**: viewed → started → completed

## Test plan
- [x] prettier passes
- [x] typecheck passes (only pre-existing useSendMoney.test.tsx error)
- [x] all 200 tests pass
- [ ] Deploy to staging and verify events appear in PostHog
- [ ] Verify invite modal analytics fire with correct source from Profile, Points, CardSuccess