### PR TITLE
feat: PostHog analytics — money flows, invites, notifications & modal fatigue

### DIFF
--- a/src/components/Card/CardPioneerModal.tsx
+++ b/src/components/Card/CardPioneerModal.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/0_Bruddle/Button'
 import BaseModal from '@/components/Global/Modal'
@@ -44,17 +46,23 @@ const CardPioneerModal = ({ hasPurchased }: CardPioneerModalProps) => {
         // Show modal with a small delay for better UX
         const timer = setTimeout(() => {
             setIsVisible(true)
+            posthog.capture(ANALYTICS_EVENTS.MODAL_SHOWN, { modal_type: MODAL_TYPES.CARD_PIONEER })
         }, 1000)
 
         return () => clearTimeout(timer)
     }, [hasPurchased])
 
     const handleDismiss = () => {
+        posthog.capture(ANALYTICS_EVENTS.MODAL_DISMISSED, { modal_type: MODAL_TYPES.CARD_PIONEER })
         localStorage.setItem(STORAGE_KEY, new Date().toISOString())
         setIsVisible(false)
     }
 
     const handleJoinNow = () => {
+        posthog.capture(ANALYTICS_EVENTS.MODAL_CTA_CLICKED, {
+            modal_type: MODAL_TYPES.CARD_PIONEER,
+            cta: 'get_early_access',
+        })
         setIsVisible(false)
         router.push('/card')
     }

--- a/src/components/Global/BalanceWarningModal/index.tsx
+++ b/src/components/Global/BalanceWarningModal/index.tsx
@@ -2,8 +2,10 @@
 
 import { Icon } from '@/components/Global/Icons/Icon'
 import Modal from '@/components/Global/Modal'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { Slider } from '@/components/Slider'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
 
 enum Platform {
     IOS = 'ios',
@@ -74,6 +76,14 @@ export default function BalanceWarningModal({ visible, onCloseAction }: BalanceW
         const platform = detectPlatform()
         return PLATFORM_INFO[platform]
     }, [])
+
+    const hasTrackedShow = useRef(false)
+    useEffect(() => {
+        if (visible && !hasTrackedShow.current) {
+            hasTrackedShow.current = true
+            posthog.capture(ANALYTICS_EVENTS.MODAL_SHOWN, { modal_type: MODAL_TYPES.BALANCE_WARNING })
+        }
+    }, [visible])
     return (
         <Modal
             visible={visible}
@@ -118,7 +128,16 @@ export default function BalanceWarningModal({ visible, onCloseAction }: BalanceW
                     </div>
                 </div>
 
-                <Slider onAccepted={onCloseAction} title="Slide to Continue" />
+                <Slider
+                    onAccepted={() => {
+                        posthog.capture(ANALYTICS_EVENTS.MODAL_CTA_CLICKED, {
+                            modal_type: MODAL_TYPES.BALANCE_WARNING,
+                            cta: 'slide_to_continue',
+                        })
+                        onCloseAction()
+                    }}
+                    title="Slide to Continue"
+                />
             </div>
         </Modal>
     )

--- a/src/components/Global/EarlyUserModal/index.tsx
+++ b/src/components/Global/EarlyUserModal/index.tsx
@@ -1,23 +1,31 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import ActionModal from '../ActionModal'
 import ShareButton from '../ShareButton'
 import { generateInviteCodeLink, generateInvitesShareText } from '@/utils/general.utils'
 import { useAuth } from '@/context/authContext'
 import { updateUserById } from '@/app/actions/users'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
 
 const EarlyUserModal = () => {
     const { user, fetchUser } = useAuth()
     const inviteLink = generateInviteCodeLink(user?.user.username ?? '').inviteLink
     const [showModal, setShowModal] = useState(false)
+    const hasTrackedShow = useRef(false)
 
     useEffect(() => {
         if (user && user.showEarlyUserModal) {
             setShowModal(true)
+            if (!hasTrackedShow.current) {
+                hasTrackedShow.current = true
+                posthog.capture(ANALYTICS_EVENTS.MODAL_SHOWN, { modal_type: MODAL_TYPES.EARLY_USER })
+            }
         }
     }, [user])
 
     const handleCloseModal = async () => {
+        posthog.capture(ANALYTICS_EVENTS.MODAL_DISMISSED, { modal_type: MODAL_TYPES.EARLY_USER })
         setShowModal(false)
         await updateUserById({ userId: user?.user.userId, hasSeenEarlyUserModal: true })
         fetchUser()

--- a/src/components/Global/NoMoreJailModal/index.tsx
+++ b/src/components/Global/NoMoreJailModal/index.tsx
@@ -1,5 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
 import Image from 'next/image'
 import { PEANUT_LOGO_BLACK, PEANUTMAN_LOGO } from '@/assets'
 import Modal from '../Modal'
@@ -10,6 +12,7 @@ const NoMoreJailModal = () => {
     const [isOpen, setisOpen] = useState(false)
 
     const onClose = () => {
+        posthog.capture(ANALYTICS_EVENTS.MODAL_CTA_CLICKED, { modal_type: MODAL_TYPES.POST_SIGNUP, cta: 'start_using' })
         setisOpen(false)
         sessionStorage.removeItem('showNoMoreJailModal')
     }
@@ -18,6 +21,7 @@ const NoMoreJailModal = () => {
         const showNoMoreJailModal = sessionStorage.getItem('showNoMoreJailModal')
         if (showNoMoreJailModal === 'true') {
             setisOpen(true)
+            posthog.capture(ANALYTICS_EVENTS.MODAL_SHOWN, { modal_type: MODAL_TYPES.POST_SIGNUP })
         }
     }, [])
 

--- a/src/components/Home/KycCompletedModal/index.tsx
+++ b/src/components/Home/KycCompletedModal/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import ActionModal from '@/components/Global/ActionModal'
 import type { IconName } from '@/components/Global/Icons/Icon'
 import InfoCard from '@/components/Global/InfoCard'
@@ -8,10 +8,20 @@ import { MantecaKycStatus } from '@/interfaces'
 import { countryData, MantecaSupportedExchanges, type CountryData } from '@/components/AddMoney/consts'
 import useKycStatus from '@/hooks/useKycStatus'
 import { useIdentityVerification } from '@/hooks/useIdentityVerification'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
 
 const KycCompletedModal = ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) => {
     const { user } = useAuth()
     const [approvedCountryData, setApprovedCountryData] = useState<CountryData | null>(null)
+
+    const hasTrackedShow = useRef(false)
+    useEffect(() => {
+        if (isOpen && !hasTrackedShow.current) {
+            hasTrackedShow.current = true
+            posthog.capture(ANALYTICS_EVENTS.MODAL_SHOWN, { modal_type: MODAL_TYPES.KYC_COMPLETED })
+        }
+    }, [isOpen])
 
     const { isUserBridgeKycApproved, isUserMantecaKycApproved } = useKycStatus()
     const { getVerificationUnlockItems } = useIdentityVerification()
@@ -70,7 +80,13 @@ const KycCompletedModal = ({ isOpen, onClose }: { isOpen: boolean; onClose: () =
             ctas={[
                 {
                     text: 'Start sending money',
-                    onClick: onClose,
+                    onClick: () => {
+                        posthog.capture(ANALYTICS_EVENTS.MODAL_CTA_CLICKED, {
+                            modal_type: MODAL_TYPES.KYC_COMPLETED,
+                            cta: 'start_sending',
+                        })
+                        onClose()
+                    },
                     variant: 'purple',
                     className: 'w-full',
                     shadowSize: '4',

--- a/src/components/Notifications/SetupNotificationsModal.tsx
+++ b/src/components/Notifications/SetupNotificationsModal.tsx
@@ -1,6 +1,8 @@
 'use client'
 import { useNotifications } from '@/hooks/useNotifications'
 import ActionModal from '../Global/ActionModal'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
 
 export default function SetupNotificationsModal() {
     const {
@@ -15,6 +17,8 @@ export default function SetupNotificationsModal() {
         // prevent event bubbling to avoid double-triggering
         e?.preventDefault()
         e?.stopPropagation()
+
+        posthog.capture(ANALYTICS_EVENTS.MODAL_CTA_CLICKED, { modal_type: MODAL_TYPES.NOTIFICATIONS, cta: 'enable' })
 
         try {
             // request permission - this shows the native dialog

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -81,9 +81,12 @@ export const ANALYTICS_EVENTS = {
     NOTIFICATION_PERMISSION_REQUESTED: 'notification_permission_requested',
     NOTIFICATION_PERMISSION_GRANTED: 'notification_permission_granted',
     NOTIFICATION_PERMISSION_DENIED: 'notification_permission_denied',
-    NOTIFICATION_MODAL_SHOWN: 'notification_modal_shown',
-    NOTIFICATION_MODAL_DISMISSED: 'notification_modal_dismissed',
     NOTIFICATION_SUBSCRIBED: 'notification_subscribed',
+
+    // ── Modal Fatigue ──
+    MODAL_SHOWN: 'modal_shown',
+    MODAL_DISMISSED: 'modal_dismissed',
+    MODAL_CTA_CLICKED: 'modal_cta_clicked',
 
     // ── QR ──
     QR_SCANNED: 'qr_scanned',
@@ -95,6 +98,18 @@ export const ANALYTICS_EVENTS = {
     BACKEND_ERROR_SHOWN: 'backend_error_shown',
     BACKEND_ERROR_RETRY: 'backend_error_retry',
     BACKEND_ERROR_LOGOUT: 'backend_error_logout',
+} as const
+
+/**
+ * Valid modal_type values for MODAL_SHOWN / MODAL_DISMISSED / MODAL_CTA_CLICKED events.
+ */
+export const MODAL_TYPES = {
+    NOTIFICATIONS: 'notifications',
+    EARLY_USER: 'early_user',
+    POST_SIGNUP: 'post_signup',
+    BALANCE_WARNING: 'balance_warning',
+    CARD_PIONEER: 'card_pioneer',
+    KYC_COMPLETED: 'kyc_completed',
 } as const
 
 export type AnalyticsEvent = (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS]

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -5,7 +5,7 @@ import OneSignal from 'react-onesignal'
 import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils'
 import { useUserStore } from '@/redux/hooks'
 import posthog from 'posthog-js'
-import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
 
 export function useNotifications() {
     const { user } = useUserStore()
@@ -15,6 +15,7 @@ export function useNotifications() {
     const externalIdRef = useRef<string | null>(null)
     const lastLinkedExternalIdRef = useRef<string | null>(null)
     const disableExternalIdLoginRef = useRef<boolean>(false)
+    const hasTrackedModalShown = useRef(false)
 
     // ui state for permission modal (shown once on login)
     const [showPermissionModal, setShowPermissionModal] = useState(false)
@@ -104,7 +105,10 @@ export function useNotifications() {
         // show modal only if user hasn't closed it yet
         if (!modalClosed) {
             setShowPermissionModal(true)
-            posthog.capture(ANALYTICS_EVENTS.NOTIFICATION_MODAL_SHOWN)
+            if (!hasTrackedModalShown.current) {
+                hasTrackedModalShown.current = true
+                posthog.capture(ANALYTICS_EVENTS.MODAL_SHOWN, { modal_type: MODAL_TYPES.NOTIFICATIONS })
+            }
         } else {
             setShowPermissionModal(false)
         }
@@ -330,7 +334,7 @@ export function useNotifications() {
     const closePermissionModal = useCallback(() => {
         setShowPermissionModal(false)
         updateUserPreferences(user?.user.userId, { notifModalClosed: true })
-        posthog.capture(ANALYTICS_EVENTS.NOTIFICATION_MODAL_DISMISSED)
+        posthog.capture(ANALYTICS_EVENTS.MODAL_DISMISSED, { modal_type: MODAL_TYPES.NOTIFICATIONS })
     }, [user?.user.userId])
 
     // update permission state after user interacts with permission prompt


### PR DESCRIPTION
## Summary

- **Core money flow tracking**: deposit, withdraw, and send/claim link funnels with method type and country properties
- **Invite/referral tracking**: invite page views, link shares/copies, acceptance funnel
- **Notification permission tracking**: permission requested/granted/denied, subscription events
- **Modal fatigue tracking**: unified `modal_shown` / `modal_dismissed` / `modal_cta_clicked` events across all 6 auto-shown modals (notifications, early_user, post_signup, balance_warning, card_pioneer, kyc_completed)
- **Type-safe `MODAL_TYPES` constants** to prevent typos in `modal_type` property values
- **Dedup guards** (`useRef`) on all prop-driven modals to prevent duplicate `modal_shown` fires

All events use centralized `ANALYTICS_EVENTS` constants from `src/constants/analytics.consts.ts`.

## Test plan

- [ ] Verify `modal_shown` fires exactly once per modal appearance (check PostHog live events)
- [ ] Verify `modal_dismissed` / `modal_cta_clicked` fire on user interaction
- [ ] Verify deposit/withdraw/send flows capture events at each step
- [ ] Verify notification permission flow captures correct events
- [ ] Verify no duplicate events on re-renders (especially EarlyUserModal with user object changes)
- [ ] Run `npm run typecheck` — passes (pre-existing test error only)