### PR TITLE
refactor: migrate InviteFriendsModal to unified modal tracking

### DIFF
--- a/src/components/Global/InviteFriendsModal/index.tsx
+++ b/src/components/Global/InviteFriendsModal/index.tsx
@@ -5,9 +5,9 @@ import Card from '@/components/Global/Card'
 import CopyToClipboard from '@/components/Global/CopyToClipboard'
 import ShareButton from '@/components/Global/ShareButton'
 import { generateInviteCodeLink, generateInvitesShareText } from '@/utils/general.utils'
-import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
 import posthog from 'posthog-js'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import QRCode from 'react-qr-code'
 
 interface InviteFriendsModalProps {
@@ -26,14 +26,16 @@ interface InviteFriendsModalProps {
 export default function InviteFriendsModal({ visible, onClose, username, source }: InviteFriendsModalProps) {
     const { inviteCode, inviteLink } = generateInviteCodeLink(username)
 
+    const hasTrackedShow = useRef(false)
     useEffect(() => {
-        if (visible) {
-            posthog.capture(ANALYTICS_EVENTS.INVITE_MODAL_OPENED, { source })
+        if (visible && !hasTrackedShow.current) {
+            hasTrackedShow.current = true
+            posthog.capture(ANALYTICS_EVENTS.MODAL_SHOWN, { modal_type: MODAL_TYPES.INVITE, source })
         }
     }, [visible, source])
 
     const handleClose = () => {
-        posthog.capture(ANALYTICS_EVENTS.INVITE_MODAL_DISMISSED, { source })
+        posthog.capture(ANALYTICS_EVENTS.MODAL_DISMISSED, { modal_type: MODAL_TYPES.INVITE, source })
         onClose()
     }
 

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -70,8 +70,6 @@ export const ANALYTICS_EVENTS = {
     INVITE_CLAIM_CLICKED: 'invite_claim_clicked',
     INVITE_ACCEPTED: 'invite_accepted',
     INVITE_ACCEPT_FAILED: 'invite_accept_failed',
-    INVITE_MODAL_OPENED: 'invite_modal_opened',
-    INVITE_MODAL_DISMISSED: 'invite_modal_dismissed',
 
     // ── Points / Cashback ──
     POINTS_PAGE_VIEWED: 'points_page_viewed',
@@ -110,6 +108,7 @@ export const MODAL_TYPES = {
     BALANCE_WARNING: 'balance_warning',
     CARD_PIONEER: 'card_pioneer',
     KYC_COMPLETED: 'kyc_completed',
+    INVITE: 'invite',
 } as const
 
 export type AnalyticsEvent = (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS]


### PR DESCRIPTION
## Summary

- Migrate `InviteFriendsModal` from specific `invite_modal_opened` / `invite_modal_dismissed` events to generic `modal_shown` / `modal_dismissed` with `modal_type: 'invite'`
- Add `INVITE` to `MODAL_TYPES` constants for type safety
- Add `useRef` dedup guard to prevent duplicate `modal_shown` fires
- Remove dead `INVITE_MODAL_OPENED` / `INVITE_MODAL_DISMISSED` constants
- Update PostHog "Invite Modal Engagement" dashboard insight to use new event names

## Test plan

- [ ] Open invite modal from profile/points/card success — verify `modal_shown` with `modal_type=invite` fires once
- [ ] Dismiss modal — verify `modal_dismissed` with `modal_type=invite` fires
- [ ] Check PostHog Invite Loop dashboard loads correctly