### PR TITLE
fix: show dollar amounts instead of misleading percentages in cashback banners

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -1256,13 +1256,10 @@ export default function QRPayPage() {
                                             parseFloat(qrPayment?.details?.paymentAgainstAmount || '0') || 0
 
                                         // Always show actual dollar amount — never percentage (misleading due to dynamic caps)
-                                        // Tone scales with amount: small = factual + growth nudge, large = celebratory
+                                        // Note: perks <$0.50 are auto-claimed and skip this banner entirely
                                         if (amountSponsored && typeof amountSponsored === 'number') {
                                             if (transactionUsd > 0 && amountSponsored >= transactionUsd) {
                                                 return `This bill can be covered by Peanut! $${amountSponsored.toFixed(2)} back. Claim it now.`
-                                            }
-                                            if (amountSponsored < 0.5) {
-                                                return `You earned $${amountSponsored.toFixed(2)} back. Invite friends to unlock bigger cashback!`
                                             }
                                             return `Peanut's got you! $${amountSponsored.toFixed(2)} back on this payment. Claim it now.`
                                         }

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -700,7 +700,24 @@ export default function QRPayPage() {
                 clearTimeout(payingStateTimerRef.current)
                 payingStateTimerRef.current = null
             }
+            // Map backend field name (sponsoredUsd) to frontend field name (amountSponsored)
+            const perkResponse = qrPayment.perk as Record<string, unknown> | undefined
+            if (qrPayment.perk && perkResponse?.sponsoredUsd !== undefined) {
+                qrPayment.perk.amountSponsored = perkResponse.sponsoredUsd as number
+            }
+
             setQrPayment(qrPayment)
+
+            // Auto-claim small perks (<$0.50) — skip the hold-to-claim ceremony.
+            // The backend already claimed the perk at payment time, so this is just a UI shortcut.
+            if (
+                qrPayment.perk?.eligible &&
+                qrPayment.perk.amountSponsored !== undefined &&
+                qrPayment.perk.amountSponsored < 0.5
+            ) {
+                setPerkClaimed(true)
+            }
+
             setIsSuccess(true)
         } catch (error) {
             // clear the timer on error to prevent race condition

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -1239,9 +1239,13 @@ export default function QRPayPage() {
                                             parseFloat(qrPayment?.details?.paymentAgainstAmount || '0') || 0
 
                                         // Always show actual dollar amount — never percentage (misleading due to dynamic caps)
+                                        // Tone scales with amount: small = factual + growth nudge, large = celebratory
                                         if (amountSponsored && typeof amountSponsored === 'number') {
                                             if (transactionUsd > 0 && amountSponsored >= transactionUsd) {
                                                 return `This bill can be covered by Peanut! $${amountSponsored.toFixed(2)} back. Claim it now.`
+                                            }
+                                            if (amountSponsored < 0.5) {
+                                                return `You earned $${amountSponsored.toFixed(2)} back. Invite friends to unlock bigger cashback!`
                                             }
                                             return `Peanut's got you! $${amountSponsored.toFixed(2)} back on this payment. Claim it now.`
                                         }
@@ -1268,10 +1272,16 @@ export default function QRPayPage() {
                                         const transactionUsd =
                                             parseFloat(qrPayment?.details?.paymentAgainstAmount || '0') || 0
 
-                                        // Always show actual dollar amount
+                                        // Tone scales with amount: small = growth nudge, large = celebratory
                                         if (amountSponsored && typeof amountSponsored === 'number') {
                                             if (transactionUsd > 0 && amountSponsored >= transactionUsd) {
                                                 return 'We paid for this bill! Earn points, climb tiers and unlock even better perks.'
+                                            }
+                                            if (amountSponsored < 0.5) {
+                                                return `You got $${amountSponsored.toFixed(2)} back. The more friends you invite, the more you earn!`
+                                            }
+                                            if (amountSponsored >= 5) {
+                                                return `We gave you $${amountSponsored.toFixed(2)} back! Your points are paying off.`
                                             }
                                             return `We gave you $${amountSponsored.toFixed(2)} back! Invite friends to unlock bigger rewards.`
                                         }

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -1235,13 +1235,12 @@ export default function QRPayPage() {
                                 <p className="text-sm text-gray-600">
                                     {(() => {
                                         const amountSponsored = qrPayment?.perk?.amountSponsored
-                                        const percentage = qrPayment?.perk?.discountPercentage || 100
                                         const transactionUsd =
                                             parseFloat(qrPayment?.details?.paymentAgainstAmount || '0') || 0
 
-                                        // Always prefer showing the actual dollar amount
+                                        // Always show actual dollar amount — never percentage (misleading due to dynamic caps)
                                         if (amountSponsored && typeof amountSponsored === 'number') {
-                                            if (percentage >= 100 && transactionUsd > 0 && amountSponsored >= transactionUsd) {
+                                            if (transactionUsd > 0 && amountSponsored >= transactionUsd) {
                                                 return `This bill can be covered by Peanut! $${amountSponsored.toFixed(2)} back. Claim it now.`
                                             }
                                             return `Peanut's got you! $${amountSponsored.toFixed(2)} back on this payment. Claim it now.`

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -702,8 +702,8 @@ export default function QRPayPage() {
             }
             // Map backend field name (sponsoredUsd) to frontend field name (amountSponsored)
             const perkResponse = qrPayment.perk as Record<string, unknown> | undefined
-            if (qrPayment.perk && perkResponse?.sponsoredUsd !== undefined) {
-                qrPayment.perk.amountSponsored = perkResponse.sponsoredUsd as number
+            if (qrPayment.perk && typeof perkResponse?.sponsoredUsd === 'number') {
+                qrPayment.perk.amountSponsored = perkResponse.sponsoredUsd
             }
 
             setQrPayment(qrPayment)
@@ -712,7 +712,7 @@ export default function QRPayPage() {
             // The backend already claimed the perk at payment time, so this is just a UI shortcut.
             if (
                 qrPayment.perk?.eligible &&
-                qrPayment.perk.amountSponsored !== undefined &&
+                typeof qrPayment.perk.amountSponsored === 'number' &&
                 qrPayment.perk.amountSponsored < 0.5
             ) {
                 setPerkClaimed(true)

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -1234,31 +1234,21 @@ export default function QRPayPage() {
                                 <h2 className="text-lg font-bold">Eligible for a Peanut Perk!</h2>
                                 <p className="text-sm text-gray-600">
                                     {(() => {
-                                        const percentage = qrPayment?.perk?.discountPercentage || 100
                                         const amountSponsored = qrPayment?.perk?.amountSponsored
+                                        const percentage = qrPayment?.perk?.discountPercentage || 100
                                         const transactionUsd =
                                             parseFloat(qrPayment?.details?.paymentAgainstAmount || '0') || 0
 
-                                        // Check if percentage matches the actual math (within 1% tolerance)
-                                        let percentageMatches = false
-                                        if (amountSponsored && transactionUsd > 0) {
-                                            const actualPercentage = (amountSponsored / transactionUsd) * 100
-                                            percentageMatches = Math.abs(actualPercentage - percentage) < 1
-                                        }
-
-                                        if (percentageMatches) {
-                                            if (percentage === 100) {
-                                                return 'This bill can be covered by Peanut. Claim it now to unlock your reward.'
-                                            } else if (percentage > 100) {
-                                                return `You're getting ${percentage}% back — that's more than you paid! Claim it now.`
-                                            } else {
-                                                return `You're getting ${percentage}% cashback! Claim it now to unlock your reward.`
+                                        // Always prefer showing the actual dollar amount
+                                        if (amountSponsored && typeof amountSponsored === 'number') {
+                                            if (percentage >= 100 && transactionUsd > 0 && amountSponsored >= transactionUsd) {
+                                                return `This bill can be covered by Peanut! $${amountSponsored.toFixed(2)} back. Claim it now.`
                                             }
+                                            return `Peanut's got you! $${amountSponsored.toFixed(2)} back on this payment. Claim it now.`
                                         }
 
-                                        return amountSponsored && typeof amountSponsored === 'number'
-                                            ? `Get $${amountSponsored.toFixed(2)} back!`
-                                            : 'Claim it now to unlock your reward.'
+                                        // Fallback: no amount available yet
+                                        return 'You earned a Peanut Perk! Claim it now to unlock your reward.'
                                     })()}
                                 </p>
                             </div>
@@ -1278,17 +1268,16 @@ export default function QRPayPage() {
                                         const amountSponsored = qrPayment?.perk?.amountSponsored
                                         const transactionUsd =
                                             parseFloat(qrPayment?.details?.paymentAgainstAmount || '0') || 0
-                                        const percentage =
-                                            amountSponsored && transactionUsd > 0
-                                                ? Math.round((amountSponsored / transactionUsd) * 100)
-                                                : qrPayment?.perk?.discountPercentage || 100
-                                        if (percentage === 100) {
-                                            return 'We paid for this bill! Earn points, climb tiers and unlock even better perks.'
-                                        } else if (percentage > 100) {
-                                            return `We gave you ${percentage}% back — that's more than you paid! Earn points, climb tiers and unlock even better perks.`
-                                        } else {
-                                            return `We gave you ${percentage}% cashback! Earn points, climb tiers and unlock even better perks.`
+
+                                        // Always show actual dollar amount
+                                        if (amountSponsored && typeof amountSponsored === 'number') {
+                                            if (transactionUsd > 0 && amountSponsored >= transactionUsd) {
+                                                return 'We paid for this bill! Earn points, climb tiers and unlock even better perks.'
+                                            }
+                                            return `We gave you $${amountSponsored.toFixed(2)} back! Invite friends to unlock bigger rewards.`
                                         }
+
+                                        return 'We gave you cashback! Earn points, climb tiers and unlock even better perks.'
                                     })()}
                                 </p>
                             </div>

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -610,30 +610,17 @@ export const TransactionDetailsReceipt = ({
                             <span className="text-sm text-gray-600">
                                 {(() => {
                                     const perk = transaction.extraDataForDrawer.perk
-                                    const percentage = perk.discountPercentage
                                     const amount = perk.amountSponsored
-                                    const isCapped = perk.isCapped
-                                    const campaignCap = perk.campaignCapUsd
 
-                                    // If user hit their campaign cap, show special message
-                                    if (isCapped && campaignCap) {
-                                        if (amount !== undefined && amount !== null) {
-                                            return `$${amount.toFixed(2)} cashback — campaign limit reached! 🎉`
+                                    // Always show actual dollar amount — never percentage (misleading due to dynamic caps)
+                                    if (amount !== undefined && amount !== null) {
+                                        if (perk.isCapped && perk.campaignCapUsd) {
+                                            return `$${amount.toFixed(2)} cashback — campaign limit reached!`
                                         }
-                                        return `Campaign limit reached! 🎉`
+                                        return `You received $${amount.toFixed(2)} cashback!`
                                     }
 
-                                    // For non-capped messages, use amountStr
-                                    const amountStr =
-                                        amount !== undefined && amount !== null ? `$${amount.toFixed(2)}` : ''
-
-                                    if (percentage === 100) {
-                                        return `You received a full refund${amount ? ` (${amountStr})` : ''} as a Peanut Perk.`
-                                    } else if (percentage > 100) {
-                                        return `You received back${amount ? ` (${amountStr})` : ''} — that's more than you paid!`
-                                    } else {
-                                        return `You received a Peanut Perk! ${amount ? ` ${amountStr}` : ''} cashback.`
-                                    }
+                                    return 'You received a Peanut Perk!'
                                 })()}
                             </span>
                         </div>


### PR DESCRIPTION
## Summary
- Show actual dollar amounts instead of misleading percentages in cashback banners
- Users were seeing "10% cashback" but getting far less due to dynamic point-based caps, causing confusion and support tickets (~10% of Crisp tickets last week)
- Updated both `qr-pay/page.tsx` (pre-claim and post-claim banners) and `TransactionDetailsReceipt.tsx` for consistency
- Removed unused `percentage` variable and aligned full-coverage detection logic between banners

## Test plan
- [ ] Make a QR payment with an eligible perk — pre-claim banner should show "$X.XX back" not "10% cashback"
- [ ] Claim the perk — post-claim banner should show "$X.XX back" not "10% cashback"
- [ ] Check transaction details for a claimed perk — should show "$X.XX cashback" not percentage
- [ ] Test with 100%+ coverage perk — should show "This bill can be covered by Peanut!"
- [ ] Test with campaign-capped perk — should show "campaign limit reached"