### PR TITLE
[TASK-18804] fix: replace technical timeout/network errors with user-friendly mess…

### DIFF
--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -142,7 +142,10 @@ export const fetchWithSentry = async (
                 })
             })
 
-            throw timeoutError
+            const userError = new Error('Service temporarily unavailable. Please try again.')
+            userError.name = 'ServiceUnavailableError'
+            userError.cause = timeoutError
+            throw userError
         }
 
         let errorMessage: string
@@ -175,6 +178,9 @@ export const fetchWithSentry = async (
             })
         })
 
-        throw error
+        const userError = new Error('Something went wrong. Please try again.')
+        userError.name = 'ServiceUnavailableError'
+        userError.cause = error
+        throw userError
     }
 }


### PR DESCRIPTION
…ages

- Timeout errors now throw 'Service temporarily unavailable' instead of raw URL + ms
- Network errors throw 'Something went wrong' instead of technical details
- Original errors preserved in .cause for debugging
- Sentry reporting unchanged