### PR TITLE
[TASK-18810] fix: restrict send flow to supported countries + validate country par…

### DIFF
--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -23,11 +23,12 @@ import { useEffect, useState } from 'react'
 import PaymentSuccessView from '@/features/payments/shared/components/PaymentSuccessView'
 import { ErrorHandler } from '@/utils/sdkErrorHandler.utils'
 import { getBridgeChainName } from '@/utils/bridge-accounts.utils'
-import { getOfframpCurrencyConfig } from '@/utils/bridge.utils'
+import { getOfframpCurrencyConfig, getCountryFromPath } from '@/utils/bridge.utils'
 import { createOfframp, confirmOfframp } from '@/app/actions/offramp'
 import { useAuth } from '@/context/authContext'
 import ExchangeRate from '@/components/ExchangeRate'
 import countryCurrencyMappings, { isNonEuroSepaCountry } from '@/constants/countryCurrencyMapping'
+import { useIdentityVerification } from '@/hooks/useIdentityVerification'
 import { PointsAction } from '@/services/services.types'
 import { usePointsCalculation } from '@/hooks/usePointsCalculation'
 import { useSearchParams } from 'next/navigation'
@@ -56,6 +57,17 @@ export default function WithdrawBankPage() {
     const country = params.country as string
     const [balanceErrorMessage, setBalanceErrorMessage] = useState<string | null>(null)
     const { hasPendingTransactions } = usePendingTransactions()
+    const { isBridgeSupportedCountry } = useIdentityVerification()
+
+    // validate country is supported for bank withdrawals
+    useEffect(() => {
+        if (country) {
+            const countryInfo = getCountryFromPath(country)
+            if (!countryInfo || !isBridgeSupportedCountry(countryInfo.id)) {
+                router.replace('/withdraw')
+            }
+        }
+    }, [country, isBridgeSupportedCountry, router])
 
     // check if we came from send flow - using method param to detect (only bank goes through this page)
     const methodParam = searchParams.get('method')

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -432,7 +432,7 @@ export default function MantecaWithdrawFlow() {
 
     // redirect to withdraw page if country is not supported by manteca
     useEffect(() => {
-        if (selectedCountry && !MANTECA_COUNTRIES_CONFIG[selectedCountry.id]) {
+        if (!selectedCountry || !MANTECA_COUNTRIES_CONFIG[selectedCountry.id]) {
             router.replace('/withdraw')
         }
     }, [selectedCountry, router])

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -430,7 +430,14 @@ export default function MantecaWithdrawFlow() {
         }
     }, [step, queryClient])
 
-    if (isCurrencyLoading || !currencyPrice || !selectedCountry) {
+    // redirect to withdraw page if country is not supported by manteca
+    useEffect(() => {
+        if (selectedCountry && !MANTECA_COUNTRIES_CONFIG[selectedCountry.id]) {
+            router.replace('/withdraw')
+        }
+    }, [selectedCountry, router])
+
+    if (isCurrencyLoading || !currencyPrice || !selectedCountry || !countryConfig) {
         return <PeanutLoading />
     }
 

--- a/src/components/AddWithdraw/AddWithdrawRouterView.tsx
+++ b/src/components/AddWithdraw/AddWithdrawRouterView.tsx
@@ -309,6 +309,7 @@ export const AddWithdrawRouterView: FC<AddWithdrawRouterViewProps> = ({
             <CountryList
                 inputTitle={mainHeading}
                 viewMode="add-withdraw"
+                enforceSupportedCountries={isBankFromSend}
                 onCountryClick={(country) => {
                     if (flow === 'add') {
                         posthog.capture(ANALYTICS_EVENTS.DEPOSIT_METHOD_SELECTED, {


### PR DESCRIPTION
…am on withdraw

- Pass enforceSupportedCountries to CountryList when coming from send flow (unsupported countries show 'Soon' badge and are disabled)
- Validate country param on withdraw/[country]/bank — redirect to /withdraw if country is not bridge-supported
- Validate country param on withdraw/manteca — redirect to /withdraw if country is not in MANTECA_COUNTRIES_CONFIG