### PR TITLE
[TASK-18801] fix: refresh balance on all balance-affecting websocket history entries

### DIFF
--- a/src/components/Home/HomeHistory.tsx
+++ b/src/components/Home/HomeHistory.tsx
@@ -53,11 +53,23 @@ const HomeHistory = ({ username, hideTxnAmount = false }: { username?: string; h
         username, // Pass the username to the WebSocket hook
         onHistoryEntry: useCallback(
             (entry: HistoryEntry) => {
-                // for direct send and completed requests, fetch the balance
-                if (
-                    entry.type === EHistoryEntryType.DIRECT_SEND ||
-                    (entry.type === EHistoryEntryType.REQUEST && entry.status.toUpperCase() === 'COMPLETED')
-                ) {
+                // refresh balance for transaction types that affect the user's wallet
+                const BALANCE_AFFECTING_TYPES: string[] = [
+                    EHistoryEntryType.DIRECT_SEND,
+                    EHistoryEntryType.DEPOSIT,
+                    EHistoryEntryType.WITHDRAW,
+                    EHistoryEntryType.BRIDGE_OFFRAMP,
+                    EHistoryEntryType.BRIDGE_ONRAMP,
+                    EHistoryEntryType.MANTECA_OFFRAMP,
+                    EHistoryEntryType.MANTECA_ONRAMP,
+                    EHistoryEntryType.SEND_LINK,
+                    EHistoryEntryType.BANK_SEND_LINK_CLAIM,
+                    EHistoryEntryType.PERK_REWARD,
+                ]
+                const isCompleted = !entry.status || entry.status.toUpperCase() === 'COMPLETED'
+                const isBalanceAffecting = BALANCE_AFFECTING_TYPES.includes(entry.type)
+
+                if (isBalanceAffecting || (entry.type === EHistoryEntryType.REQUEST && isCompleted)) {
                     fetchBalance()
                 }
             },

--- a/src/components/Home/HomeHistory.tsx
+++ b/src/components/Home/HomeHistory.tsx
@@ -25,6 +25,21 @@ import { useHaptic } from 'use-haptic'
 import { PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
 import { Icon } from '../Global/Icons/Icon'
 
+/** Transaction types that affect the user's wallet balance. Hoisted to module scope to avoid re-allocation. */
+const BALANCE_AFFECTING_TYPES: EHistoryEntryType[] = [
+    EHistoryEntryType.DIRECT_SEND,
+    EHistoryEntryType.DEPOSIT,
+    EHistoryEntryType.WITHDRAW,
+    EHistoryEntryType.BRIDGE_OFFRAMP,
+    EHistoryEntryType.BRIDGE_ONRAMP,
+    EHistoryEntryType.BRIDGE_GUEST_OFFRAMP,
+    EHistoryEntryType.MANTECA_OFFRAMP,
+    EHistoryEntryType.MANTECA_ONRAMP,
+    EHistoryEntryType.SEND_LINK,
+    EHistoryEntryType.BANK_SEND_LINK_CLAIM,
+    EHistoryEntryType.PERK_REWARD,
+]
+
 /**
  * component to display a preview of the most recent transactions on the home page.
  */
@@ -53,21 +68,9 @@ const HomeHistory = ({ username, hideTxnAmount = false }: { username?: string; h
         username, // Pass the username to the WebSocket hook
         onHistoryEntry: useCallback(
             (entry: HistoryEntry) => {
-                // refresh balance for transaction types that affect the user's wallet
-                const BALANCE_AFFECTING_TYPES: string[] = [
-                    EHistoryEntryType.DIRECT_SEND,
-                    EHistoryEntryType.DEPOSIT,
-                    EHistoryEntryType.WITHDRAW,
-                    EHistoryEntryType.BRIDGE_OFFRAMP,
-                    EHistoryEntryType.BRIDGE_ONRAMP,
-                    EHistoryEntryType.MANTECA_OFFRAMP,
-                    EHistoryEntryType.MANTECA_ONRAMP,
-                    EHistoryEntryType.SEND_LINK,
-                    EHistoryEntryType.BANK_SEND_LINK_CLAIM,
-                    EHistoryEntryType.PERK_REWARD,
-                ]
-                const isCompleted = !entry.status || entry.status.toUpperCase() === 'COMPLETED'
-                const isBalanceAffecting = BALANCE_AFFECTING_TYPES.includes(entry.type)
+                const isCompleted = entry.status?.toUpperCase() === 'COMPLETED'
+                const isBalanceAffecting =
+                    BALANCE_AFFECTING_TYPES.includes(entry.type as EHistoryEntryType) && isCompleted
 
                 if (isBalanceAffecting || (entry.type === EHistoryEntryType.REQUEST && isCompleted)) {
                     fetchBalance()


### PR DESCRIPTION
Previously only DIRECT_SEND and completed REQUEST triggered a balance refetch. Added explicit list of balance-affecting transaction types: DEPOSIT, WITHDRAW, BRIDGE_OFFRAMP/ONRAMP, MANTECA_OFFRAMP/ONRAMP, SEND_LINK, BANK_SEND_LINK_CLAIM, and PERK_REWARD.

Non-balance-affecting types (e.g. CASHOUT, QR payments with separate flows) are excluded. REQUEST still requires COMPLETED status.