### PR TITLE
feat: add Chainstack RPCs for Polygon, Base, and BSC

### DIFF
--- a/src/constants/general.consts.ts
+++ b/src/constants/general.consts.ts
@@ -38,6 +38,7 @@ export const rpcUrls: Record<number, string[]> = {
         'https://sepolia-rollup.arbitrum.io/rpc', // Official Arbitrum Sepolia
     ].filter(Boolean) as string[],
     [polygon.id]: [
+        'https://polygon-mainnet.core.chainstack.com/e8d733c7341e28d98e4cf66c61c42aa6', // Chainstack (primary)
         infuraUrl('polygon-mainnet'),
         alchemyUrl('polygon-mainnet'),
         'https://polygon-rpc.com', // Official public RPC
@@ -48,11 +49,13 @@ export const rpcUrls: Record<number, string[]> = {
         'https://mainnet.optimism.io', // Official Optimism RPC
     ].filter(Boolean) as string[],
     [base.id]: [
+        'https://base-mainnet.core.chainstack.com/01f0761d79d1b6e9d234d7ab69a90b19', // Chainstack (primary)
         infuraUrl('base-mainnet'),
         alchemyUrl('base-mainnet'),
         'https://mainnet.base.org', // Official Base RPC
     ].filter(Boolean) as string[],
     [bsc.id]: [
+        'https://bsc-mainnet.core.chainstack.com/2d9b1537fa4555562f8e15fd08bf8ed5', // Chainstack (primary)
         'https://bsc-dataseed.bnbchain.org', // Official BSC RPC
         infuraUrl('bsc-mainnet'),
         alchemyUrl('bsc-mainnet'),


### PR DESCRIPTION
## Summary
- Adds Chainstack as primary RPC provider for **Polygon**, **Base**, and **BSC** (Chainstack was already primary for Ethereum and Arbitrum)
- Reduces dependency on Infura/Alchemy which are both near quota limits (Infura at 93%, Alchemy maxed out)
- Directly addresses the Polygon RPC health check failures — Chainstack is now first in the fallback chain

## Changes
- `src/constants/general.consts.ts`: Added Chainstack URLs as first entry for Polygon (137), Base (8453), and BSC (56)

## Risks
- **LOW**: If Chainstack is down, falls back to Infura → Alchemy → public RPCs (existing behavior, just with an extra layer)
- Chainstack quota: all chains share the same 20M request pool (currently at 93% with 12 days left). Adding 3 more chains as primary will increase usage — monitor quota

## Deploy notes
- No env vars needed — Chainstack URLs are hardcoded (same pattern as existing Ethereum/Arbitrum Chainstack URLs)
- Companion backend PR: peanutprotocol/peanut-api-ts#612 (requires env vars to be set)