### PR TITLE
fix: prevent PWA ↔ Chrome redirect loop and stale SW issues

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -164,28 +164,39 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                             if ('serviceWorker' in navigator) {
                                 window.addEventListener('load', async () => {
                                     try {
-                                        // Register service worker - skipWaiting & clientsClaim handle updates
                                         const registration = await navigator.serviceWorker.register('/sw.js', {
                                             scope: '/',
                                             updateViaCache: 'none'
                                         });
                                         console.log('SW registered:', registration.scope);
-                                        
-                                        // Handle updates: reload page when new SW is waiting
-                                        registration.addEventListener('updatefound', () => {
-                                            const newWorker = registration.installing;
-                                            if (newWorker) {
-                                                newWorker.addEventListener('statechange', () => {
-                                                    if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-                                                        // New SW installed, reload to activate
-                                                        console.log('New SW available, reloading...');
-                                                        window.location.reload();
-                                                    }
-                                                });
+
+                                        // Check for SW updates when user returns to app/tab.
+                                        // Without this, PWA users can stay on stale SWs indefinitely
+                                        // (browser's 24h auto-check is unreliable for backgrounded PWAs).
+                                        document.addEventListener('visibilitychange', () => {
+                                            if (!document.hidden) {
+                                                registration.update();
                                             }
                                         });
                                     } catch (error) {
                                         console.error('SW registration failed:', error);
+                                    }
+                                });
+
+                                // Reload when new SW takes control (more reliable than statechange).
+                                // Guard prevents double-reloads. Skip in standalone PWA mode because
+                                // window.location.reload() in Android PWA standalone context can break
+                                // the standalone session and bounce the user back to Chrome — causing
+                                // a PWA ↔ Chrome redirect loop (the new SW still activates via
+                                // skipWaiting + clientsClaim, so the user gets new code on next navigation).
+                                let refreshing = false;
+                                navigator.serviceWorker.addEventListener('controllerchange', () => {
+                                    if (refreshing) return;
+                                    const isStandalone = window.matchMedia('(display-mode: standalone)').matches
+                                        || navigator.standalone === true;
+                                    if (!isStandalone) {
+                                        refreshing = true;
+                                        window.location.reload();
                                     }
                                 });
                             }

--- a/src/hooks/useAccountSetupRedirect.ts
+++ b/src/hooks/useAccountSetupRedirect.ts
@@ -28,6 +28,13 @@ export const useAccountSetupRedirect = () => {
                 '[useAccountSetupRedirect] User logged in without peanut wallet account, redirecting to /setup/finish'
             )
             router.push('/setup/finish')
+            // Hard navigation fallback in case soft navigation silently fails.
+            // Without this, needsRedirect stays true and the loading gate in
+            // layout.tsx blocks rendering indefinitely.
+            const fallback = setTimeout(() => {
+                window.location.replace('/setup/finish')
+            }, 3000)
+            return () => clearTimeout(fallback)
         }
     }, [needsRedirect, router])
 

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -40,7 +40,11 @@ export const usePullToRefresh = (options: UsePullToRefreshOptions = {}) => {
             mainElement: 'body',
             onRefresh: () => {
                 window.location.reload()
-                return Promise.resolve()
+                // Don't return a resolved promise — it resets the library's internal
+                // state to 'pending' before the reload completes, which on Android
+                // allows a new pull gesture to trigger immediately (infinite loop).
+                // Returning nothing lets the library's refreshTimeout handle cleanup,
+                // but the page will be gone by then anyway.
             },
             instructionsPullToRefresh: 'Pull down to refresh',
             instructionsReleaseToRefresh: 'Release to refresh',


### PR DESCRIPTION
## Summary

Fixes a critical production issue where Android PWA users get stuck in a redirect loop between Chrome and the PWA, causing "infinite loading" and inability to access their account.

### Root cause analysis

Three deployments today triggered SW updates. When the PWA opens, the SW update handler calls `window.location.reload()`. On Android Chrome, `reload()` in PWA standalone mode breaks the standalone context and bounces the user back to Chrome. Chrome shows the "Open Peanut app" button, which reopens the PWA — creating an infinite loop.

Confirmed via Sentry: 16 consecutive auth failures (400 on get-user-from-cookie) from the affected user across 3+ hours, matching the reported symptoms exactly.

### Changes

**1. SW update handler rewrite** (`layout.tsx`)
- **Problem**: `window.location.reload()` on SW `statechange` breaks Android PWA standalone context, bouncing users back to Chrome in a loop.
- **Fix**: Switch to `controllerchange` event (fires after new SW takes control, more reliable than `statechange`). Skip reload entirely in standalone PWA mode — the new SW still activates via `skipWaiting` + `clientsClaim`, so PWA users get new code on their next navigation without the context-breaking reload.
- **Added**: `visibilitychange` listener that calls `registration.update()` when the user returns to the app. This catches deployments within seconds of the user foregrounding the app, instead of relying on the browser's unreliable 24h auto-check.
- **Confidence**: High. `controllerchange` + standalone skip is the standard pattern recommended by Google's Workbox docs. The `visibilitychange` update check is used by most production PWAs.
- **Regression risk**: Low. In standalone mode, the SW still updates (skipWaiting + clientsClaim handle this), users just don't get a forced reload. In browser mode, behavior is improved (controllerchange is more correct than statechange). The refreshing guard prevents double-reloads.

**2. Pull-to-refresh infinite animation fix** (`usePullToRefresh.ts`)
- **Problem**: `onRefresh` returns `Promise.resolve()`, which immediately resets the pulltorefreshjs library's internal state to 'pending' before `window.location.reload()` completes. On Android (where reload can be delayed in PWA/WebView), this allows a new pull gesture to trigger immediately, creating an infinite animation loop.
- **Fix**: Don't return a value from `onRefresh`. The library handles this case via its `refreshTimeout` (500ms default), but the page will be gone by then anyway due to the reload.
- **Confidence**: High. The pulltorefreshjs library (v0.1.22) explicitly supports both return styles — returning a thenable triggers immediate reset, returning nothing uses the timeout path. The `Promise.resolve()` was unnecessary.
- **Regression risk**: Very low. The only behavioral change is that the library's internal state isn't reset instantly — but the page is reloading anyway. iOS and Android both handle this correctly.

**3. Account setup redirect fallback** (`useAccountSetupRedirect.ts`)
- **Problem**: If `router.push('/setup/finish')` silently fails (e.g., chunk load error after deployment), `needsRedirect` stays `true` and the loading gate in `layout.tsx` blocks rendering **indefinitely**. The `/setup` redirect already has a 3-second `window.location.replace` fallback, but this redirect did not.
- **Fix**: Add the same 3-second hard navigation fallback pattern.
- **Confidence**: High. This is the exact same pattern already used for the /setup redirect in layout.tsx (line 89-97), proven to work.
- **Regression risk**: Very low. The fallback only fires if soft navigation doesn't complete within 3 seconds. The cleanup function prevents the timeout from firing if the component unmounts (successful navigation).

## Not included (separate PR needed)

- **JWT refresh for passkey flow**: The JWT hard-expires after 30 days even though the cookie sliding window keeps extending. This is the root cause of WHY the user's cookie was gone — but it requires backend changes and is a larger architectural fix.

## Test plan

- [ ] Android PWA: Install PWA → deploy a new version → reopen PWA → should load normally without bouncing to Chrome
- [ ] Android Chrome: Same deploy scenario in browser tab → should reload to pick up new SW
- [ ] iOS PWA: Verify no regression in iOS standalone behavior
- [ ] Pull-to-refresh on Android: Pull down on any page → should refresh once, not loop
- [ ] Pull-to-refresh on iOS: Same test → should work as before
- [ ] Account without PEANUT_WALLET: Verify redirect to /setup/finish works (and fallback fires if route fails)
- [ ] Normal auth flow: Login → home → verify no unexpected reloads