### PR TITLE
fix(qr-pay): send qr type on user specified amount

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -633,7 +633,7 @@ export default function QRPayPage() {
         if (finalPaymentLock.code === '') {
             setLoadingState('Fetching details')
             try {
-                finalPaymentLock = await mantecaApi.initiateQrPayment({ qrCode, amount: currencyAmount })
+                finalPaymentLock = await mantecaApi.initiateQrPayment({ qrCode, amount: currencyAmount, qrType: qrType ?? undefined })
                 setPaymentLock(finalPaymentLock)
             } catch (error) {
                 captureException(error)

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -633,7 +633,11 @@ export default function QRPayPage() {
         if (finalPaymentLock.code === '') {
             setLoadingState('Fetching details')
             try {
-                finalPaymentLock = await mantecaApi.initiateQrPayment({ qrCode, amount: currencyAmount, qrType: qrType ?? undefined })
+                finalPaymentLock = await mantecaApi.initiateQrPayment({
+                    qrCode,
+                    amount: currencyAmount,
+                    qrType: qrType ?? undefined,
+                })
                 setPaymentLock(finalPaymentLock)
             } catch (error) {
                 captureException(error)


### PR DESCRIPTION
Was missing in this case, caused issues for foreigners paying pix