### PR TITLE
fix: skip SW reload on first-ever install

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -184,14 +184,18 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                                 });
 
                                 // Reload when new SW takes control (more reliable than statechange).
-                                // Guard prevents double-reloads. Skip in standalone PWA mode because
+                                // Guards: (1) refreshing prevents double-reloads, (2) hadController
+                                // skips first-ever install (no previous SW = initial registration, not
+                                // an update — reloading on first visit would flash/reload for every new
+                                // user and SEO crawler), (3) isStandalone skips PWA mode because
                                 // window.location.reload() in Android PWA standalone context can break
                                 // the standalone session and bounce the user back to Chrome — causing
                                 // a PWA ↔ Chrome redirect loop (the new SW still activates via
                                 // skipWaiting + clientsClaim, so the user gets new code on next navigation).
                                 let refreshing = false;
+                                const hadController = !!navigator.serviceWorker.controller;
                                 navigator.serviceWorker.addEventListener('controllerchange', () => {
-                                    if (refreshing) return;
+                                    if (refreshing || !hadController) return;
                                     const isStandalone = window.matchMedia('(display-mode: standalone)').matches
                                         || navigator.standalone === true;
                                     if (!isStandalone) {


### PR DESCRIPTION
## Summary

Follow-up to #1810. The `controllerchange` handler introduced in that PR fires on **first-ever SW install** too (via `clientsClaim`), not just on updates. Without a guard, every first-time visitor and SEO crawler sees an unnecessary page reload.

### What changed

Added `hadController` guard — captures `navigator.serviceWorker.controller` at script execution time (null on first visit, set on subsequent visits). Skips reload when there was no previous controller.

```js
const hadController = !!navigator.serviceWorker.controller;
navigator.serviceWorker.addEventListener('controllerchange', () => {
    if (refreshing || !hadController) return;
    // ...
});
```

This replicates the semantics of the old `statechange` handler which checked `navigator.serviceWorker.controller` before triggering reload.

### Regression this prevents

Without this fix: user visits peanut.me for the first time → SW registers → `clientsClaim` → `controllerchange` fires → `reload()` → unnecessary flash/double page load for every new user.

## Test plan

- [ ] First visit in incognito (no SW) → page should load once, no reload flash
- [ ] Subsequent visit after deploy (SW update) → should reload in browser, skip in PWA