### PR TITLE
fix: post-signup claim redirect + passkey retry for Samsung

### DIFF
--- a/src/components/Global/PostSignupActionManager/index.tsx
+++ b/src/components/Global/PostSignupActionManager/index.tsx
@@ -6,8 +6,6 @@ import { useEffect, useState } from 'react'
 import ActionModal from '../ActionModal'
 import { POST_SIGNUP_ACTIONS } from './post-signup-action.consts'
 import { type IconName } from '../Icons/Icon'
-import { useAuth } from '@/context/authContext'
-import { isUserKycVerified } from '@/constants/kyc.consts'
 
 export const PostSignupActionManager = ({
     onActionModalVisibilityChange,
@@ -23,11 +21,10 @@ export const PostSignupActionManager = ({
         action: () => void
     } | null>(null)
     const router = useRouter()
-    const { user } = useAuth()
 
-    const checkClaimModalAfterKYC = () => {
+    const checkForPostSignupAction = () => {
         const redirectUrl = getRedirectUrl()
-        if (isUserKycVerified(user?.user) && redirectUrl) {
+        if (redirectUrl) {
             const matchedAction = POST_SIGNUP_ACTIONS.find((action) => action.pathPattern.test(redirectUrl))
             if (matchedAction) {
                 setActionConfig({
@@ -44,8 +41,8 @@ export const PostSignupActionManager = ({
     }
 
     useEffect(() => {
-        checkClaimModalAfterKYC()
-    }, [router, user])
+        checkForPostSignupAction()
+    }, [router])
 
     useEffect(() => {
         onActionModalVisibilityChange(showModal)

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -134,34 +134,47 @@ export const useZeroDev = () => {
     // dual passkey providers (Google Credential Manager + Samsung Pass). Conditional mediation
     // surfaces passkeys from ALL providers in the autofill UI, bypassing provider priority issues.
     // See: https://web.dev/articles/passkey-form-autofill
+    const _attemptLogin = async () => {
+        const passkeyServerHeaders: Record<string, string> = {}
+
+        if (user?.user?.username) {
+            passkeyServerHeaders['x-username'] = user.user.username
+        }
+
+        const webAuthnKey = await toWebAuthnKey({
+            passkeyName: '[]',
+            passkeyServerUrl: consts.PASSKEY_SERVER_URL as string,
+            mode: WebAuthnMode.Login,
+            passkeyServerHeaders,
+            rpID: window.location.hostname.replace(/^www\./, ''),
+        })
+
+        setWebAuthnKey(webAuthnKey)
+        saveToCookie(WEB_AUTHN_COOKIE_KEY, webAuthnKey, 90)
+    }
+
     const handleLogin = async () => {
         dispatch(zerodevActions.setIsLoggingIn(true))
         try {
-            const passkeyServerHeaders: Record<string, string> = {}
-
-            if (user?.user?.username) {
-                passkeyServerHeaders['x-username'] = user.user.username
-            }
-
-            const webAuthnKey = await toWebAuthnKey({
-                passkeyName: '[]',
-                passkeyServerUrl: consts.PASSKEY_SERVER_URL as string,
-                mode: WebAuthnMode.Login,
-                passkeyServerHeaders,
-                rpID: window.location.hostname.replace(/^www\./, ''),
-            })
-
-            setWebAuthnKey(webAuthnKey)
-            saveToCookie(WEB_AUTHN_COOKIE_KEY, webAuthnKey, 90)
+            await _attemptLogin()
         } catch (e) {
             const error = e as Error
             if (error.name === 'NotAllowedError') {
-                // User cancelled - no state was saved, just let them retry
-                dispatch(zerodevActions.setIsLoggingIn(false))
-                throw new PasskeyError(
-                    'Login was canceled or no passkey found. Please try again or register.',
-                    'LOGIN_CANCELED'
-                )
+                // On devices with multiple passkey providers (e.g. Samsung with Google + Samsung Pass),
+                // the first provider may intercept and report "no passkeys" while the actual passkey
+                // lives in the other provider. Auto-retry once to give the second provider a chance.
+                console.warn('[useZeroDev] Login NotAllowedError, retrying once for multi-provider devices')
+                try {
+                    await _attemptLogin()
+                    return // retry succeeded
+                } catch (retryError) {
+                    // retry also failed — throw user-facing error
+                    dispatch(zerodevActions.setIsLoggingIn(false))
+                    throw new PasskeyError(
+                        'Login was canceled or no passkey found. Please try again or register.',
+                        'LOGIN_CANCELED'
+                    )
+                }
             }
 
             // Other login errors - clear any stale state

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -129,7 +129,11 @@ export const useZeroDev = () => {
         }
     }
 
-    // login function
+    // TODO: Consider implementing conditional mediation (WebAuthn autofill) for login.
+    // Currently, discoverable credential requests cause conflicts on Samsung devices with
+    // dual passkey providers (Google Credential Manager + Samsung Pass). Conditional mediation
+    // surfaces passkeys from ALL providers in the autofill UI, bypassing provider priority issues.
+    // See: https://web.dev/articles/passkey-form-autofill
     const handleLogin = async () => {
         dispatch(zerodevActions.setIsLoggingIn(true))
         try {


### PR DESCRIPTION
## Summary
- **Bug 1 — Claim redirect:** Remove KYC verification check from `PostSignupActionManager` — new users arriving via claim links were blocked from seeing the claim modal because they aren't KYC verified yet. KYC is only needed for bank/offramp claims, and the claim page itself handles that gating.
- **Bug 2 — Passkey login:** Auto-retry passkey login once on `NotAllowedError` for devices with multiple passkey providers (Google Credential Manager + Samsung Pass). The first provider may intercept and report "no passkeys" while the actual passkey lives in the other provider.
- Add TODO for future WebAuthn conditional mediation as the longer-term fix for the Samsung issue.

## Bug 1 details
- **User report:** new user arrives via claim QR/link → signs up → completes passkey setup → lands on home with $0
- **Root cause:** `PostSignupActionManager` gated the claim modal on `isUserKycVerified()`, which is always `false` for new signups
- **Fix:** Remove the KYC gate — the redirect URL in localStorage is now picked up immediately on `/home`

## Bug 2 details
- **User report:** Samsung S22 Ultra user taps "Log In" → Google Credential Manager shows "No passkeys available" → has to dismiss and retry multiple times before Samsung Pass responds
- **Sentry:** ~3,900 events across 400 users for LOGIN_CANCELED (PEANUT-UI-6T2/A9W/6T7), many likely from this dual-provider conflict
- **Fix:** Extract login attempt to `_attemptLogin()`, auto-retry once on `NotAllowedError` before throwing to the UI
- **Future:** TODO added for conditional mediation (WebAuthn autofill) which surfaces passkeys from ALL providers

## Test plan
- [ ] New user signup via claim link → should see claim modal on home page immediately after setup
- [ ] New user signup via request link → should see "Send it!" modal on home page
- [ ] Normal signup without claim link → no modal shown (no regression)
- [ ] Claim to bank still requires KYC at the claim page level (not at the modal level)
- [ ] Login on Android device → should work normally, auto-retry is transparent
- [ ] Login canceled by user → still shows appropriate error after retry attempt
- [ ] Login on Samsung with dual passkey providers → should succeed on auto-retry