### PR TITLE
hotfix: switch blog rendering from marked to MDX

### DIFF
--- a/src/app/[locale]/(marketing)/blog/[slug]/page.tsx
+++ b/src/app/[locale]/(marketing)/blog/[slug]/page.tsx
@@ -134,10 +134,9 @@ export default async function BlogPostPageLocalized({ params }: PageProps) {
                     <p className="mt-2 text-gray-600">{post.frontmatter.description}</p>
                     <time className="mt-3 block text-sm text-gray-400">{post.frontmatter.date}</time>
                 </header>
-                <article
-                    className="prose prose-lg prose-headings:font-bold prose-a:text-black prose-a:underline prose-pre:border prose-pre:border-n-1 prose-pre:bg-white max-w-none"
-                    dangerouslySetInnerHTML={{ __html: post.html }}
-                />
+                <article className="prose prose-lg prose-headings:font-bold prose-a:text-black prose-a:underline prose-pre:border prose-pre:border-n-1 prose-pre:bg-white max-w-none">
+                    {post.content}
+                </article>
             </MarketingShell>
         </>
     )

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,10 +1,10 @@
 import matter from 'gray-matter'
-import { marked } from 'marked'
-import { createHighlighter, type Highlighter } from 'shiki'
 import fs from 'fs'
 import path from 'path'
+import { renderContent } from '@/lib/mdx'
 
 import type { Locale } from '@/i18n/types'
+import type { ReactNode } from 'react'
 
 /** Blog content lives in the peanut-content submodule at src/content/content/blog/.
  *  Structure: content/blog/{slug}/{locale}.md  (e.g. content/blog/pay-in-argentina/en.md)
@@ -26,23 +26,15 @@ export interface BlogPost {
     content: string
 }
 
-// Singleton highlighter — created once, reused across all posts
-let _highlighter: Highlighter | null = null
-
-async function getHighlighter(): Promise<Highlighter> {
-    if (_highlighter) return _highlighter
-    _highlighter = await createHighlighter({
-        themes: ['github-light'],
-        langs: ['javascript', 'typescript', 'bash', 'json', 'yaml', 'html', 'css', 'python', 'solidity'],
-    })
-    return _highlighter
+function coerceDate(date: unknown): string {
+    if (date instanceof Date) return date.toISOString().split('T')[0]
+    return String(date ?? '')
 }
 
 export function getAllPosts(locale: Locale = 'en'): BlogPost[] {
     const blogDir = getBlogDir()
     if (!fs.existsSync(blogDir)) return []
 
-    // Each subfolder is a slug, each file inside is {locale}.md
     const slugDirs = fs.readdirSync(blogDir).filter((f) => fs.statSync(path.join(blogDir, f)).isDirectory())
 
     return slugDirs
@@ -54,11 +46,7 @@ export function getAllPosts(locale: Locale = 'en'): BlogPost[] {
             const { data, content } = matter(raw)
             return {
                 slug,
-                frontmatter: {
-                    ...data,
-                    // gray-matter parses YAML dates as Date objects, but we need strings for React rendering
-                    date: data.date instanceof Date ? data.date.toISOString().split('T')[0] : String(data.date ?? ''),
-                } as BlogPost['frontmatter'],
+                frontmatter: { ...data, date: coerceDate(data.date) } as BlogPost['frontmatter'],
                 content,
             }
         })
@@ -69,43 +57,18 @@ export function getAllPosts(locale: Locale = 'en'): BlogPost[] {
 export async function getPostBySlug(
     slug: string,
     locale: Locale = 'en'
-): Promise<{ frontmatter: BlogPost['frontmatter']; html: string } | null> {
+): Promise<{ frontmatter: BlogPost['frontmatter']; content: ReactNode } | null> {
     const filePath = path.join(getBlogDir(), slug, `${locale}.md`)
     if (!fs.existsSync(filePath)) return null
 
     const raw = fs.readFileSync(filePath, 'utf8')
-    const { data, content } = matter(raw)
+    const { data, content: body } = matter(raw)
 
-    const highlighter = await getHighlighter()
+    const { content } = await renderContent(body)
 
-    // Custom renderer for code blocks with shiki syntax highlighting
-    const renderer = new marked.Renderer()
-    renderer.code = ({ text, lang }: { text: string; lang?: string }) => {
-        const language = lang || 'text'
-        try {
-            return highlighter.codeToHtml(text, {
-                lang: language,
-                theme: 'github-light',
-            })
-        } catch {
-            // Fallback for unsupported languages — escape HTML to prevent XSS
-            const escaped = text
-                .replace(/&/g, '&amp;')
-                .replace(/</g, '&lt;')
-                .replace(/>/g, '&gt;')
-                .replace(/"/g, '&quot;')
-            return `<pre><code class="language-${language}">${escaped}</code></pre>`
-        }
-    }
+    const frontmatter = { ...data, date: coerceDate(data.date) } as BlogPost['frontmatter']
 
-    const html = (await marked(content, { renderer })) as string
-
-    const frontmatter = {
-        ...data,
-        date: data.date instanceof Date ? data.date.toISOString().split('T')[0] : String(data.date ?? ''),
-    } as BlogPost['frontmatter']
-
-    return { frontmatter, html }
+    return { frontmatter, content }
 }
 
 export function getPostsByCategory(category: string, locale: Locale = 'en'): BlogPost[] {


### PR DESCRIPTION
## Summary
Blog pages render headings and MDX components as plain text because `lib/blog.ts` uses `marked` (plain markdown) while the content uses MDX components (`<Hero>`, `<Steps>`, `<CTA>`, etc.).

Every other marketing page uses `renderContent()` from `lib/mdx.ts` (next-mdx-remote). The blog was the only outlier.

## Fix
- Replace `marked` + `shiki` with `renderContent()` in `lib/blog.ts`
- Change blog page from `dangerouslySetInnerHTML={{ __html }}` to rendering the MDX React element
- Remove ~40 lines of dead marked/shiki code

## Test plan
- [ ] `/en/blog/earn-with-peanut-passive-income` — headings, Hero, Steps, CTA components should render properly
- [ ] `/en/blog` — listing page still works
- [ ] Other marketing pages unaffected (they already use renderContent)