### PR TITLE
feat: funnel analytics — signup→activated + activated→referrer

### DIFF
--- a/src/app/(mobile-ui)/add-money/crypto/page.tsx
+++ b/src/app/(mobile-ui)/add-money/crypto/page.tsx
@@ -46,6 +46,7 @@ const AddMoneyCryptoPage = () => {
                 amount,
                 chain_type: network,
                 method_type: 'crypto',
+                acquisition_source: user?.invitedBy ? 'referred' : 'organic',
             })
             setDepositResult(statusData ?? { status: 'completed', amount })
             setShowSuccessView(true)

--- a/src/app/(mobile-ui)/add-money/crypto/page.tsx
+++ b/src/app/(mobile-ui)/add-money/crypto/page.tsx
@@ -51,7 +51,7 @@ const AddMoneyCryptoPage = () => {
             setDepositResult(statusData ?? { status: 'completed', amount })
             setShowSuccessView(true)
         },
-        [network]
+        [network, user?.invitedBy]
     )
 
     // build minimal transaction details for the receipt drawer

--- a/src/components/Global/InviteFriendsModal/index.tsx
+++ b/src/components/Global/InviteFriendsModal/index.tsx
@@ -76,7 +76,12 @@ export default function InviteFriendsModal({ visible, onClose, username, source 
                     <ShareButton
                         generateText={() => Promise.resolve(generateInvitesShareText(inviteLink))}
                         title="Share your invite link"
-                        onSuccess={() => posthog.capture(ANALYTICS_EVENTS.INVITE_LINK_SHARED, { source })}
+                        onSuccess={() => {
+                            posthog.capture(ANALYTICS_EVENTS.INVITE_LINK_SHARED, { source })
+                            posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_CLICKED, {
+                                source: source ?? 'invite_modal',
+                            })
+                        }}
                     >
                         Share Invite Link
                     </ShareButton>

--- a/src/components/Global/InviteFriendsModal/index.tsx
+++ b/src/components/Global/InviteFriendsModal/index.tsx
@@ -5,7 +5,7 @@ import Card from '@/components/Global/Card'
 import CopyToClipboard from '@/components/Global/CopyToClipboard'
 import ShareButton from '@/components/Global/ShareButton'
 import { generateInviteCodeLink, generateInvitesShareText } from '@/utils/general.utils'
-import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
+import { ANALYTICS_EVENTS, MODAL_TYPES, REFERRAL_SOURCES } from '@/constants/analytics.consts'
 import posthog from 'posthog-js'
 import { useEffect, useRef } from 'react'
 import QRCode from 'react-qr-code'
@@ -32,7 +32,7 @@ export default function InviteFriendsModal({ visible, onClose, username, source 
         if (visible && !hasTrackedShow.current) {
             hasTrackedShow.current = true
             posthog.capture(ANALYTICS_EVENTS.MODAL_SHOWN, { modal_type: MODAL_TYPES.INVITE, source })
-            posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_SHOWN, { source: source ?? 'invite_modal' })
+            posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_SHOWN, { source: source ?? REFERRAL_SOURCES.INVITE_MODAL })
         }
     }, [visible, source])
 
@@ -79,7 +79,7 @@ export default function InviteFriendsModal({ visible, onClose, username, source 
                         onSuccess={() => {
                             posthog.capture(ANALYTICS_EVENTS.INVITE_LINK_SHARED, { source })
                             posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_CLICKED, {
-                                source: source ?? 'invite_modal',
+                                source: source ?? REFERRAL_SOURCES.INVITE_MODAL,
                             })
                         }}
                     >

--- a/src/components/Global/InviteFriendsModal/index.tsx
+++ b/src/components/Global/InviteFriendsModal/index.tsx
@@ -32,6 +32,7 @@ export default function InviteFriendsModal({ visible, onClose, username, source 
         if (visible && !hasTrackedShow.current) {
             hasTrackedShow.current = true
             posthog.capture(ANALYTICS_EVENTS.MODAL_SHOWN, { modal_type: MODAL_TYPES.INVITE, source })
+            posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_SHOWN, { source: source ?? 'invite_modal' })
         }
     }, [visible, source])
 

--- a/src/components/Home/ActivationCTAs.tsx
+++ b/src/components/Home/ActivationCTAs.tsx
@@ -7,7 +7,7 @@ import { Icon, type IconName } from '@/components/Global/Icons/Icon'
 import { useRouter } from 'next/navigation'
 import { useModalsContext } from '@/context/ModalsContext'
 import Card from '../Global/Card'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
@@ -60,8 +60,10 @@ export default function ActivationCTAs({ activationStep }: ActivationCTAsProps) 
     const router = useRouter()
     const { setIsQRScannerOpen } = useModalsContext()
 
+    const lastTrackedStep = useRef<ActivationStep | null>(null)
     useEffect(() => {
-        if (activationStep !== 'completed') {
+        if (activationStep !== 'completed' && activationStep !== lastTrackedStep.current) {
+            lastTrackedStep.current = activationStep
             posthog.capture(ANALYTICS_EVENTS.ACTIVATION_STEP_VIEWED, {
                 step: activationStep,
             })

--- a/src/components/Home/ActivationCTAs.tsx
+++ b/src/components/Home/ActivationCTAs.tsx
@@ -7,6 +7,9 @@ import { Icon, type IconName } from '@/components/Global/Icons/Icon'
 import { useRouter } from 'next/navigation'
 import { useModalsContext } from '@/context/ModalsContext'
 import Card from '../Global/Card'
+import { useEffect } from 'react'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 interface ActivationCTAsProps {
     activationStep: ActivationStep
@@ -56,6 +59,14 @@ const STEP_ORDER: ActivationStep[] = ['verify', 'deposit', 'outbound']
 export default function ActivationCTAs({ activationStep }: ActivationCTAsProps) {
     const router = useRouter()
     const { setIsQRScannerOpen } = useModalsContext()
+
+    useEffect(() => {
+        if (activationStep !== 'completed') {
+            posthog.capture(ANALYTICS_EVENTS.ACTIVATION_STEP_VIEWED, {
+                step: activationStep,
+            })
+        }
+    }, [activationStep])
 
     if (activationStep === 'completed') return null
 

--- a/src/components/Home/FloatingReferralButton/index.tsx
+++ b/src/components/Home/FloatingReferralButton/index.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from 'react'
 import posthog from 'posthog-js'
-import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { ANALYTICS_EVENTS, REFERRAL_SOURCES } from '@/constants/analytics.consts'
 
 interface FloatingReferralButtonProps {
     onClick: () => void
@@ -14,14 +14,14 @@ const FloatingReferralButton: React.FC<FloatingReferralButtonProps> = ({ onClick
     useEffect(() => {
         if (!hasTrackedShow.current) {
             hasTrackedShow.current = true
-            posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_SHOWN, { source: 'floating_button' })
+            posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_SHOWN, { source: REFERRAL_SOURCES.FLOATING_BUTTON })
         }
     }, [])
 
     return (
         <button
             onClick={() => {
-                posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_CLICKED, { source: 'floating_button' })
+                posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_CLICKED, { source: REFERRAL_SOURCES.FLOATING_BUTTON })
                 onClick()
             }}
             className="absolute right-1 top-20 z-50 !w-12 animate-pulse cursor-pointer text-4xl transition-all duration-300 hover:scale-110 hover:animate-none md:hidden"

--- a/src/components/Home/FloatingReferralButton/index.tsx
+++ b/src/components/Home/FloatingReferralButton/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
@@ -9,8 +9,13 @@ interface FloatingReferralButtonProps {
 }
 
 const FloatingReferralButton: React.FC<FloatingReferralButtonProps> = ({ onClick }) => {
+    const hasTrackedShow = useRef(false)
+
     useEffect(() => {
-        posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_SHOWN, { source: 'floating_button' })
+        if (!hasTrackedShow.current) {
+            hasTrackedShow.current = true
+            posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_SHOWN, { source: 'floating_button' })
+        }
     }, [])
 
     return (

--- a/src/components/Home/FloatingReferralButton/index.tsx
+++ b/src/components/Home/FloatingReferralButton/index.tsx
@@ -1,13 +1,24 @@
 'use client'
 
+import { useEffect } from 'react'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+
 interface FloatingReferralButtonProps {
     onClick: () => void
 }
 
 const FloatingReferralButton: React.FC<FloatingReferralButtonProps> = ({ onClick }) => {
+    useEffect(() => {
+        posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_SHOWN, { source: 'floating_button' })
+    }, [])
+
     return (
         <button
-            onClick={onClick}
+            onClick={() => {
+                posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_CLICKED, { source: 'floating_button' })
+                onClick()
+            }}
             className="absolute right-1 top-20 z-50 !w-12 animate-pulse cursor-pointer text-4xl transition-all duration-300 hover:scale-110 hover:animate-none md:hidden"
             aria-label="Open referral campaign"
         >

--- a/src/components/Home/HomeCarouselCTA/index.tsx
+++ b/src/components/Home/HomeCarouselCTA/index.tsx
@@ -45,9 +45,7 @@ const HomeCarouselCTA = () => {
     // Referral rewards and surprise moments are claimed inline after QR payment, not from home.
     const claimablePerks = useMemo(() => {
         return (
-            pendingPerksData?.perks?.filter(
-                (p) => !claimedPerkIds.has(p.id) && p.name?.includes('Card Pioneer')
-            ) || []
+            pendingPerksData?.perks?.filter((p) => !claimedPerkIds.has(p.id) && p.name?.includes('Card Pioneer')) || []
         )
     }, [pendingPerksData?.perks, claimedPerkIds])
 

--- a/src/components/Home/PerkClaimModal.tsx
+++ b/src/components/Home/PerkClaimModal.tsx
@@ -17,7 +17,7 @@ import { useRouter } from 'next/navigation'
 import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils'
 import { useAuth } from '@/context/authContext'
 import posthog from 'posthog-js'
-import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { ANALYTICS_EVENTS, REFERRAL_SOURCES } from '@/constants/analytics.consts'
 
 type ClaimPhase = 'idle' | 'holding' | 'opening' | 'revealed' | 'exiting'
 
@@ -262,7 +262,7 @@ function SuccessModal({ perk, claimPhase, onClose, onDismiss }: SuccessModalProp
                                             className="w-full"
                                             onClick={() => {
                                                 posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_CLICKED, {
-                                                    source: 'surprise_moment',
+                                                    source: REFERRAL_SOURCES.SURPRISE_MOMENT,
                                                 })
                                                 onDismiss()
                                                 setIsInviteModalOpen(true)

--- a/src/components/Home/PerkClaimModal.tsx
+++ b/src/components/Home/PerkClaimModal.tsx
@@ -16,6 +16,8 @@ import InviteFriendsModal from '@/components/Global/InviteFriendsModal'
 import { useRouter } from 'next/navigation'
 import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils'
 import { useAuth } from '@/context/authContext'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 type ClaimPhase = 'idle' | 'holding' | 'opening' | 'revealed' | 'exiting'
 
@@ -47,6 +49,7 @@ interface PerkClaimModalProps {
  */
 export function PerkClaimModal({ perk, visible, onClose, onClaimed }: PerkClaimModalProps) {
     const queryClient = useQueryClient()
+    const { user } = useAuth()
     const [claimPhase, setClaimPhase] = useState<ClaimPhase>('idle')
     const [lastClaimedPerk, setLastClaimedPerk] = useState<PendingPerk | null>(null)
     const apiCallRef = useRef<Promise<void> | null>(null)
@@ -66,8 +69,21 @@ export function PerkClaimModal({ perk, visible, onClose, onClaimed }: PerkClaimM
         if (visible) {
             setClaimPhase('idle')
             setLastClaimedPerk(null)
+
+            const prefs = getUserPreferences(perk.id) // just need any stable key for claim count
+            const eventProps = { amount_usd: perk.amountUsd, perk_name: perk.name }
+            posthog.capture(ANALYTICS_EVENTS.REWARD_CLAIM_SHOWN, eventProps)
+
+            // Read claim count from user prefs to determine if this is a surprise moment
+            const claimCount = getUserPreferences(user?.user.userId ?? '')?.[SURPRISE_CLAIM_COUNT_KEY] ?? 0
+            if (claimCount < 2) {
+                posthog.capture(ANALYTICS_EVENTS.SURPRISE_MOMENT_SHOWN, {
+                    ...eventProps,
+                    claim_number: claimCount + 1,
+                })
+            }
         }
-    }, [visible, perk.id])
+    }, [visible, perk.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
     // Optimistic claim: trigger animation immediately, API call in background
     const handleHoldComplete = useCallback(async () => {
@@ -79,6 +95,11 @@ export function PerkClaimModal({ perk, visible, onClose, onClaimed }: PerkClaimM
             try {
                 const result = await perksApi.claimPerk(perk.id)
                 if (result.success) {
+                    posthog.capture(ANALYTICS_EVENTS.REWARD_CLAIMED, {
+                        amount_usd: perk.amountUsd,
+                        perk_name: perk.name,
+                        invitee_name: perk.inviteeName ?? extractInviteeName(perk.reason),
+                    })
                     onClaimed(perk.id)
                     queryClient.invalidateQueries({ queryKey: ['pendingPerks'] })
                     queryClient.invalidateQueries({ queryKey: ['transactions'] })
@@ -117,10 +138,14 @@ export function PerkClaimModal({ perk, visible, onClose, onClaimed }: PerkClaimM
         if (claimPhase === 'revealed') {
             handleDismissSuccess()
         } else if (claimPhase === 'idle') {
+            posthog.capture(ANALYTICS_EVENTS.REWARD_CLAIM_DISMISSED, {
+                amount_usd: perk.amountUsd,
+                perk_name: perk.name,
+            })
             onClose()
         }
         // Don't allow closing during opening/exiting phases
-    }, [claimPhase, handleDismissSuccess, onClose])
+    }, [claimPhase, handleDismissSuccess, onClose, perk])
 
     if (!visible) return null
 
@@ -235,6 +260,9 @@ function SuccessModal({ perk, claimPhase, onClose, onDismiss }: SuccessModalProp
                                             shadowSize="4"
                                             className="w-full"
                                             onClick={() => {
+                                                posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_CLICKED, {
+                                                    source: 'surprise_moment',
+                                                })
                                                 onDismiss()
                                                 setIsInviteModalOpen(true)
                                             }}

--- a/src/components/Home/PerkClaimModal.tsx
+++ b/src/components/Home/PerkClaimModal.tsx
@@ -70,12 +70,12 @@ export function PerkClaimModal({ perk, visible, onClose, onClaimed }: PerkClaimM
             setClaimPhase('idle')
             setLastClaimedPerk(null)
 
-            const prefs = getUserPreferences(perk.id) // just need any stable key for claim count
             const eventProps = { amount_usd: perk.amountUsd, perk_name: perk.name }
             posthog.capture(ANALYTICS_EVENTS.REWARD_CLAIM_SHOWN, eventProps)
 
             // Read claim count from user prefs to determine if this is a surprise moment
-            const claimCount = getUserPreferences(user?.user.userId ?? '')?.[SURPRISE_CLAIM_COUNT_KEY] ?? 0
+            const userId = user?.user.userId ?? ''
+            const claimCount = getUserPreferences(userId)?.[SURPRISE_CLAIM_COUNT_KEY] ?? 0
             if (claimCount < 2) {
                 posthog.capture(ANALYTICS_EVENTS.SURPRISE_MOMENT_SHOWN, {
                     ...eventProps,
@@ -83,7 +83,8 @@ export function PerkClaimModal({ perk, visible, onClose, onClaimed }: PerkClaimM
                 })
             }
         }
-    }, [visible, perk.id]) // eslint-disable-line react-hooks/exhaustive-deps
+        // perk props and user are stable while modal is open — deps kept minimal to fire once per open
+    }, [visible, perk.id, perk.amountUsd, perk.name, user?.user.userId])
 
     // Optimistic claim: trigger animation immediately, API call in background
     const handleHoldComplete = useCallback(async () => {

--- a/src/components/Home/ReferralCampaignModal/index.tsx
+++ b/src/components/Home/ReferralCampaignModal/index.tsx
@@ -4,9 +4,9 @@ import { PEANUTMAN_WAVING } from '@/assets'
 import ActionModal, { type ActionModalButtonProps } from '@/components/Global/ActionModal'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import posthog from 'posthog-js'
-import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { ANALYTICS_EVENTS, REFERRAL_SOURCES } from '@/constants/analytics.consts'
 
 interface ReferralCampaignModalProps {
     visible: boolean
@@ -16,14 +16,16 @@ interface ReferralCampaignModalProps {
 const ReferralCampaignModal: React.FC<ReferralCampaignModalProps> = ({ visible, onClose }) => {
     const router = useRouter()
 
+    const hasTrackedShow = useRef(false)
     useEffect(() => {
-        if (visible) {
-            posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_SHOWN, { source: 'campaign_modal' })
+        if (visible && !hasTrackedShow.current) {
+            hasTrackedShow.current = true
+            posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_SHOWN, { source: REFERRAL_SOURCES.CAMPAIGN_MODAL })
         }
     }, [visible])
 
     const handleInviteFriends = () => {
-        posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_CLICKED, { source: 'campaign_modal' })
+        posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_CLICKED, { source: REFERRAL_SOURCES.CAMPAIGN_MODAL })
         router.push('/send?createLink=true')
         onClose()
     }

--- a/src/components/Home/ReferralCampaignModal/index.tsx
+++ b/src/components/Home/ReferralCampaignModal/index.tsx
@@ -4,6 +4,9 @@ import { PEANUTMAN_WAVING } from '@/assets'
 import ActionModal, { type ActionModalButtonProps } from '@/components/Global/ActionModal'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 interface ReferralCampaignModalProps {
     visible: boolean
@@ -13,7 +16,14 @@ interface ReferralCampaignModalProps {
 const ReferralCampaignModal: React.FC<ReferralCampaignModalProps> = ({ visible, onClose }) => {
     const router = useRouter()
 
+    useEffect(() => {
+        if (visible) {
+            posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_SHOWN, { source: 'campaign_modal' })
+        }
+    }, [visible])
+
     const handleInviteFriends = () => {
+        posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_CLICKED, { source: 'campaign_modal' })
         router.push('/send?createLink=true')
         onClose()
     }

--- a/src/components/Setup/Views/SignTestTransaction.tsx
+++ b/src/components/Setup/Views/SignTestTransaction.tsx
@@ -12,6 +12,7 @@ import { capturePasskeyDebugInfo } from '@/utils/passkeyDebug'
 import * as Sentry from '@sentry/nextjs'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { getFromCookie } from '@/utils/general.utils'
 import { twMerge } from 'tailwind-merge'
 
 const SignTestTransaction = () => {
@@ -131,7 +132,11 @@ const SignTestTransaction = () => {
 
                 // account setup complete - addAccount() already fetched and verified user data
                 console.log('[SignTestTransaction] Account setup complete, redirecting to the app')
-                posthog.capture(ANALYTICS_EVENTS.SIGNUP_COMPLETED)
+                const inviteCode = getFromCookie('inviteCode')
+                posthog.capture(ANALYTICS_EVENTS.SIGNUP_COMPLETED, {
+                    acquisition_source: inviteCode ? 'referred' : 'organic',
+                    invite_code: inviteCode || undefined,
+                })
 
                 // keep loading state active until redirect completes
             } else {

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -75,6 +75,21 @@ export const ANALYTICS_EVENTS = {
     POINTS_PAGE_VIEWED: 'points_page_viewed',
     POINTS_EARNED: 'points_earned',
 
+    // ── Activation Funnel ──
+    ACTIVATION_STEP_VIEWED: 'activation_step_viewed',
+
+    // ── Surprise Moment (funnel handoff) ──
+    SURPRISE_MOMENT_SHOWN: 'surprise_moment_shown',
+
+    // ── Reward Claim Lifecycle ──
+    REWARD_CLAIM_SHOWN: 'reward_claim_shown',
+    REWARD_CLAIMED: 'reward_claimed',
+    REWARD_CLAIM_DISMISSED: 'reward_claim_dismissed',
+
+    // ── Referral Funnel ──
+    REFERRAL_CTA_SHOWN: 'referral_cta_shown',
+    REFERRAL_CTA_CLICKED: 'referral_cta_clicked',
+
     // ── Notifications ──
     NOTIFICATION_PERMISSION_REQUESTED: 'notification_permission_requested',
     NOTIFICATION_PERMISSION_GRANTED: 'notification_permission_granted',

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -126,4 +126,14 @@ export const MODAL_TYPES = {
     INVITE: 'invite',
 } as const
 
+/**
+ * Valid source values for REFERRAL_CTA_SHOWN / REFERRAL_CTA_CLICKED events.
+ */
+export const REFERRAL_SOURCES = {
+    FLOATING_BUTTON: 'floating_button',
+    CAMPAIGN_MODAL: 'campaign_modal',
+    INVITE_MODAL: 'invite_modal',
+    SURPRISE_MOMENT: 'surprise_moment',
+} as const
+
 export type AnalyticsEvent = (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS]

--- a/src/features/payments/shared/components/PaymentSuccessView.tsx
+++ b/src/features/payments/shared/components/PaymentSuccessView.tsx
@@ -207,7 +207,7 @@ const PaymentSuccessView = ({
                 acquisition_source: authUser?.invitedBy ? 'referred' : 'organic',
             })
         }
-    }, [points, isWithdrawFlow, type])
+    }, [points, isWithdrawFlow, type, authUser?.invitedBy])
 
     useEffect(() => {
         // invalidate queries to refetch history

--- a/src/features/payments/shared/components/PaymentSuccessView.tsx
+++ b/src/features/payments/shared/components/PaymentSuccessView.tsx
@@ -204,6 +204,7 @@ const PaymentSuccessView = ({
             posthog.capture(ANALYTICS_EVENTS.POINTS_EARNED, {
                 points,
                 flow_type: isWithdrawFlow ? 'withdraw' : type?.toLowerCase(),
+                acquisition_source: authUser?.invitedBy ? 'referred' : 'organic',
             })
         }
     }, [points, isWithdrawFlow, type])

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -46,7 +46,8 @@ interface UseMultiPhaseKycFlowOptions {
  * for the modal rendering.
  */
 export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: UseMultiPhaseKycFlowOptions) => {
-    const { fetchUser } = useAuth()
+    const { fetchUser, user } = useAuth()
+    const acquisitionSource = user?.invitedBy ? 'referred' : 'organic'
 
     // multi-phase modal state
     const [modalPhase, setModalPhase] = useState<KycModalPhase>('verifying')
@@ -78,7 +79,7 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
     const completeFlow = useCallback(() => {
         posthog.capture(
             regionIntent === 'LATAM' ? ANALYTICS_EVENTS.MANTECA_KYC_COMPLETED : ANALYTICS_EVENTS.KYC_APPROVED,
-            { region_intent: regionIntent }
+            { region_intent: regionIntent, acquisition_source: acquisitionSource }
         )
         isRealtimeFlowRef.current = false
         setForceShowModal(false)
@@ -173,7 +174,7 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
             const intent = overrideIntent ?? regionIntent
             posthog.capture(
                 intent === 'LATAM' ? ANALYTICS_EVENTS.MANTECA_KYC_INITIATED : ANALYTICS_EVENTS.KYC_INITIATED,
-                { region_intent: intent }
+                { region_intent: intent, acquisition_source: acquisitionSource }
             )
 
             setModalPhase('verifying')

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -92,7 +92,7 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
         stopTracking()
         closeVerificationModalRef.current()
         onKycSuccess?.()
-    }, [onKycSuccess, clearPreparingTimer, stopTracking, regionIntent])
+    }, [onKycSuccess, clearPreparingTimer, stopTracking, regionIntent, acquisitionSource])
 
     // called when sumsub status transitions to APPROVED
     const handleSumsubApproved = useCallback(async () => {
@@ -188,7 +188,7 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
 
             await originalHandleInitiateKyc(overrideIntent, levelName)
         },
-        [originalHandleInitiateKyc, clearPreparingTimer, regionIntent]
+        [originalHandleInitiateKyc, clearPreparingTimer, regionIntent, acquisitionSource]
     )
 
     // 30s timeout for preparing phase


### PR DESCRIPTION
## Summary

Instruments the two-funnel analytics methodology for Peanut:

**Funnel 1: Signup → Activated** — tracks acquisition through registration, verification, funding, and first spend. Segments organic vs referred users.

**Funnel 2: Activated → Referrer** — tracks the viral loop from surprise moment through referral CTA exposure, link sharing, and reward claiming.

### New PostHog Events (7)
| Event | Component | Purpose |
|-------|-----------|---------|
| `activation_step_viewed` | ActivationCTAs | Which activation step users see |
| `surprise_moment_shown` | PerkClaimModal | Handoff between funnels (first 2 claims) |
| `reward_claim_shown` | PerkClaimModal | Any perk claim modal opens |
| `reward_claimed` | PerkClaimModal | Perk successfully claimed |
| `reward_claim_dismissed` | PerkClaimModal | Modal closed without claiming |
| `referral_cta_shown` | FloatingButton, InviteModal, CampaignModal | Any referral prompt surfaced |
| `referral_cta_clicked` | FloatingButton, CampaignModal, SurpriseModal | User taps referral CTA |

### Enriched Properties
`acquisition_source` (`organic` | `referred`) added to: `signup_completed`, `kyc_initiated`, `kyc_approved`, `deposit_completed`, `points_earned`

`invite_code` added to: `signup_completed`

### PostHog Dashboard Specs (to create manually)

**Dashboard 1: Signup → Activated**
- Funnel: signup_completed → kyc_initiated → kyc_approved → deposit_completed → surprise_moment_shown
- Breakdown by: acquisition_source

**Dashboard 2: Activated → Referrer**
- Funnel: surprise_moment_shown → referral_cta_shown → invite_link_shared → reward_claimed
- Trends: referral_cta_shown, invite_link_shared, reward_claimed over time

### Grafana Dashboard (needs admin to create)

SQL queries for a "Funnel Analytics" dashboard are ready — could not create via MCP (missing write permissions). Panels:
1. Acquisition funnel bar chart (all users + organic vs referred split)
2. Referral funnel conversion
3. K-Factor per time period (K0 invites, K1 active invitees)
4. Reward economics (claim rate, pending USD, drain rate by campaign)
5. Second-order virality + max referral depth + invite→activation rate

## Test plan
- [ ] Verify `activation_step_viewed` fires on home screen for non-activated users
- [ ] Verify `surprise_moment_shown` fires on first 2 perk claims
- [ ] Verify `reward_claim_shown` / `reward_claimed` / `reward_claim_dismissed` fire correctly
- [ ] Verify `referral_cta_shown` fires from floating button, invite modal, campaign modal
- [ ] Verify `acquisition_source` appears on signup_completed, kyc, deposit, points_earned events
- [ ] Verify no regressions in existing analytics events
- [ ] Create PostHog dashboards from specs above
- [ ] Create Grafana dashboard from SQL queries (needs admin access)