### PR TITLE
fix: persist cta carousel dismissals to localstorage

### DIFF
--- a/src/components/Home/HomeCarouselCTA/index.tsx
+++ b/src/components/Home/HomeCarouselCTA/index.tsx
@@ -13,7 +13,7 @@ import { extractInviteeName } from '@/utils/general.utils'
 import PerkClaimModal from '../PerkClaimModal'
 
 const HomeCarouselCTA = () => {
-    const { carouselCTAs, setCarouselCTAs } = useHomeCarouselCTAs()
+    const { carouselCTAs, dismissCTA } = useHomeCarouselCTAs()
     const { user } = useAuth()
     const queryClient = useQueryClient()
 
@@ -103,12 +103,8 @@ const HomeCarouselCTA = () => {
                         description={cta.description}
                         icon={cta.icon as IconName}
                         onClose={() => {
-                            // Use cta.onClose if provided (for notification prompt), otherwise filter from list
-                            if (cta.onClose) {
-                                cta.onClose()
-                            } else {
-                                setCarouselCTAs((prev) => prev.filter((c) => c.id !== cta.id))
-                            }
+                            cta.onClose?.()
+                            dismissCTA(cta.id)
                         }}
                         onClick={cta.onClick}
                         logo={cta.logo}

--- a/src/hooks/useHomeCarouselCTAs.tsx
+++ b/src/hooks/useHomeCarouselCTAs.tsx
@@ -60,12 +60,17 @@ export const useHomeCarouselCTAs = () => {
     } = useCardPioneerInfo()
     const { isActivated } = useActivationStatus()
 
+    // ctas gated by conditions that can change (e.g. permission state) should not be permanently dismissed
+    const TRANSIENT_CTA_IDS = new Set(['notification-prompt'])
+
     const dismissCTA = useCallback(
         (ctaId: string) => {
             dismissedRef.current.add(ctaId)
-            updateUserPreferences(user?.user?.userId, {
-                dismissedCarouselCTAs: Array.from(dismissedRef.current),
-            })
+            if (!TRANSIENT_CTA_IDS.has(ctaId)) {
+                updateUserPreferences(user?.user?.userId, {
+                    dismissedCarouselCTAs: Array.from(dismissedRef.current),
+                })
+            }
             setCarouselCTAs((prev) => prev.filter((c) => c.id !== ctaId))
         },
         [user?.user?.userId]

--- a/src/hooks/useHomeCarouselCTAs.tsx
+++ b/src/hooks/useHomeCarouselCTAs.tsx
@@ -68,9 +68,7 @@ export const useHomeCarouselCTAs = () => {
             dismissedRef.current.add(ctaId)
             if (!TRANSIENT_CTA_IDS.has(ctaId)) {
                 updateUserPreferences(user?.user?.userId, {
-                    dismissedCarouselCTAs: Array.from(dismissedRef.current).filter(
-                        (id) => !TRANSIENT_CTA_IDS.has(id)
-                    ),
+                    dismissedCarouselCTAs: Array.from(dismissedRef.current).filter((id) => !TRANSIENT_CTA_IDS.has(id)),
                 })
             }
             setCarouselCTAs((prev) => prev.filter((c) => c.id !== ctaId))

--- a/src/hooks/useHomeCarouselCTAs.tsx
+++ b/src/hooks/useHomeCarouselCTAs.tsx
@@ -2,7 +2,8 @@
 
 import { type IconName } from '@/components/Global/Icons/Icon'
 import { useAuth } from '@/context/authContext'
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
+import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils'
 import { useNotifications } from './useNotifications'
 import { useRouter } from 'next/navigation'
 import useKycStatus from './useKycStatus'
@@ -34,9 +35,15 @@ export type CarouselCTA = {
     isPerkClaim?: boolean
 }
 
+const getDismissedCTAs = (userId: string | undefined): Set<string> => {
+    const dismissed = getUserPreferences(userId)?.dismissedCarouselCTAs
+    return new Set(dismissed ?? [])
+}
+
 export const useHomeCarouselCTAs = () => {
     const [carouselCTAs, setCarouselCTAs] = useState<CarouselCTA[]>([])
     const { user } = useAuth()
+    const dismissedRef = useRef<Set<string>>(new Set())
     const { requestPermission, afterPermissionAttempt, isPermissionDenied, isPermissionGranted } = useNotifications()
     const router = useRouter()
     const { isUserKycApproved, isUserBridgeKycUnderReview, isUserMantecaKycApproved } = useKycStatus()
@@ -52,6 +59,17 @@ export const useHomeCarouselCTAs = () => {
         isLoading: isCardPioneerLoading,
     } = useCardPioneerInfo()
     const { isActivated } = useActivationStatus()
+
+    const dismissCTA = useCallback(
+        (ctaId: string) => {
+            dismissedRef.current.add(ctaId)
+            updateUserPreferences(user?.user?.userId, {
+                dismissedCarouselCTAs: Array.from(dismissedRef.current),
+            })
+            setCarouselCTAs((prev) => prev.filter((c) => c.id !== ctaId))
+        },
+        [user?.user?.userId]
+    )
 
     const generateCarouselCTAs = useCallback(() => {
         const _carouselCTAs: CarouselCTA[] = []
@@ -199,7 +217,7 @@ export const useHomeCarouselCTAs = () => {
             })
         }
 
-        setCarouselCTAs(_carouselCTAs)
+        setCarouselCTAs(_carouselCTAs.filter((cta) => !dismissedRef.current.has(cta.id)))
     }, [
         user?.user?.userId,
         isPermissionGranted,
@@ -223,11 +241,13 @@ export const useHomeCarouselCTAs = () => {
     useEffect(() => {
         if (!user) {
             setCarouselCTAs([])
+            dismissedRef.current = new Set()
             return
         }
 
+        dismissedRef.current = getDismissedCTAs(user.user.userId)
         generateCarouselCTAs()
     }, [user, generateCarouselCTAs, isPermissionGranted])
 
-    return { carouselCTAs, setCarouselCTAs }
+    return { carouselCTAs, dismissCTA }
 }

--- a/src/hooks/useHomeCarouselCTAs.tsx
+++ b/src/hooks/useHomeCarouselCTAs.tsx
@@ -68,7 +68,9 @@ export const useHomeCarouselCTAs = () => {
             dismissedRef.current.add(ctaId)
             if (!TRANSIENT_CTA_IDS.has(ctaId)) {
                 updateUserPreferences(user?.user?.userId, {
-                    dismissedCarouselCTAs: Array.from(dismissedRef.current),
+                    dismissedCarouselCTAs: Array.from(dismissedRef.current).filter(
+                        (id) => !TRANSIENT_CTA_IDS.has(id)
+                    ),
                 })
             }
             setCarouselCTAs((prev) => prev.filter((c) => c.id !== ctaId))

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -495,6 +495,7 @@ export type UserPreferences = {
     hasSeenBalanceWarning?: { value: boolean; expiry: number }
     /** tracks surprise moment claim count for referral CTA copy (rewards v2). 0=first, 1=second, 2+=normal */
     rewards_surprise_claim_count?: number
+    dismissedCarouselCTAs?: string[]
 }
 
 export const updateUserPreferences = (


### PR DESCRIPTION
- fixes TASK-19059 : dismissed ctas now survive page refresh via user preferences