### PR TITLE
fix: cross-region KYC locks previously unlocked regions

### DIFF
--- a/src/hooks/useIdentityVerification.tsx
+++ b/src/hooks/useIdentityVerification.tsx
@@ -176,20 +176,21 @@ export const useIdentityVerification = () => {
 
         // helper to check if a region should be unlocked
         const isRegionUnlocked = (regionName: string) => {
-            // sumsub approval scoped by the regionIntent used during verification.
-            // 'LATAM' intent → unlocks LATAM. 'STANDARD' intent → unlocks Bridge regions.
-            // rest of world is always unlocked with any sumsub approval (crypto features).
-            // provider-specific regions require the provider rails to be functional
-            // (not still PENDING from submission or FAILED).
             if (isSumsubApproved) {
                 if (regionName === 'Rest of the world') return true
-                if (sumsubVerificationRegionIntent === 'LATAM') {
-                    // LATAM is always unlocked for LATAM-intent sumsub users
-                    // (QR payments work without manteca rails via superuser fallback)
-                    if (MANTECA_SUPPORTED_REGIONS.includes(regionName)) return true
-                    return false
+
+                // bridge regions: check provider rails regardless of sumsub regionIntent
+                if (BRIDGE_SUPPORTED_REGIONS.includes(regionName)) {
+                    return hasProviderAccess('BRIDGE')
                 }
-                return hasProviderAccess('BRIDGE') && BRIDGE_SUPPORTED_REGIONS.includes(regionName)
+
+                // latam: unlocked when sumsub intent is LATAM (manteca submission
+                // happens after sumsub approval, rails may still be pending)
+                if (MANTECA_SUPPORTED_REGIONS.includes(regionName)) {
+                    return sumsubVerificationRegionIntent === 'LATAM' || isMantecaApproved
+                }
+
+                return false
             }
             return (
                 (isBridgeApproved && BRIDGE_SUPPORTED_REGIONS.includes(regionName)) ||


### PR DESCRIPTION
## problem

after PR [#641](https://github.com/peanutprotocol/peanut-api-ts/pull/641) (moveToLevel for cross-region KYC), users who complete verification for a second region lose access to their first region. this affected users

**root cause:** `isRegionUnlocked` in `useIdentityVerification.tsx` scoped region access by `sumsubVerificationRegionIntent`. when the intent was `LATAM`, it returned `false` for bridge regions without checking `hasProviderAccess('BRIDGE')` — even when bridge rails were `ENABLED`. same issue in reverse: `STANDARD` intent never checked manteca for LATAM regions.

```typescript
// before (broken)
if (sumsubVerificationRegionIntent === 'LATAM') {
    if (MANTECA_SUPPORTED_REGIONS.includes(regionName)) return true
    return false  // ← locks bridge regions even if rails are ENABLED
}
return hasProviderAccess('BRIDGE') && BRIDGE_SUPPORTED_REGIONS.includes(regionName)
// ← never checks manteca for LATAM regions
```

## fix

check provider access independently of sumsub regionIntent:

- bridge regions: unlock based on `hasProviderAccess('BRIDGE')` regardless of intent
- latam: unlock if `sumsubVerificationRegionIntent === 'LATAM'` (immediate, while manteca rails still pending) OR `isMantecaApproved` (after manteca submission completes)
- rest of world: always unlocked with any sumsub approval

existing affected users will auto-fix on deploy — their bridge/manteca rails are already ENABLED.

## test scenarios

- user with SUMSUB APPROVED (LATAM) + bridge rails ENABLED → europe unlocked ✓
- user with SUMSUB APPROVED (STANDARD) + manteca ACTIVE → latam unlocked ✓
- first-time user with SUMSUB APPROVED (STANDARD) + no manteca → latam locked ✓
- first-time user with SUMSUB APPROVED (LATAM) + no bridge rails → europe locked ✓