### PR TITLE
fix: thread crossRegion flag for cross-region KYC

### DIFF
--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -11,6 +11,7 @@ const API_KEY = process.env.PEANUT_API_KEY!
 export const initiateSumsubKyc = async (params?: {
     regionIntent?: KYCRegionIntent
     levelName?: string
+    crossRegion?: boolean
 }): Promise<{ data?: InitiateSumsubKycResponse; error?: string }> => {
     const jwtToken = (await getJWTCookie())?.value
 
@@ -18,9 +19,10 @@ export const initiateSumsubKyc = async (params?: {
         return { error: 'Authentication required' }
     }
 
-    const body: Record<string, string | undefined> = {
+    const body: Record<string, string | boolean | undefined> = {
         regionIntent: params?.regionIntent,
         levelName: params?.levelName,
+        crossRegion: params?.crossRegion,
     }
 
     try {

--- a/src/app/actions/types/sumsub.types.ts
+++ b/src/app/actions/types/sumsub.types.ts
@@ -4,6 +4,13 @@ export interface InitiateSumsubKycResponse {
     status: SumsubKycStatus
 }
 
-export type SumsubKycStatus = 'NOT_STARTED' | 'PENDING' | 'IN_REVIEW' | 'APPROVED' | 'REJECTED' | 'ACTION_REQUIRED'
+export type SumsubKycStatus =
+    | 'NOT_STARTED'
+    | 'PENDING'
+    | 'IN_REVIEW'
+    | 'APPROVED'
+    | 'REJECTED'
+    | 'ACTION_REQUIRED'
+    | 'REVERIFYING'
 
 export type KYCRegionIntent = 'STANDARD' | 'LATAM'

--- a/src/components/Profile/views/RegionsVerification.view.tsx
+++ b/src/components/Profile/views/RegionsVerification.view.tsx
@@ -100,10 +100,11 @@ const RegionsVerification = () => {
     const handleStartKyc = useCallback(async () => {
         const intent = selectedRegion ? getRegionIntent(selectedRegion.path) : undefined
         if (intent) setActiveRegionIntent(intent)
-        // detect cross-region: user is approved for a different region and wants to unlock a new one
-        const isCrossRegion = !!sumsubVerificationRegionIntent && !!intent && intent !== sumsubVerificationRegionIntent
+        // only signal cross-region when user is switching to a different region
+        const crossRegion =
+            sumsubVerificationRegionIntent && intent && intent !== sumsubVerificationRegionIntent ? true : undefined
         setSelectedRegion(null)
-        await flow.handleInitiateKyc(intent, undefined, isCrossRegion)
+        await flow.handleInitiateKyc(intent, undefined, crossRegion)
     }, [flow.handleInitiateKyc, selectedRegion, sumsubVerificationRegionIntent])
 
     // re-submission: skip StartVerificationView since user already consented

--- a/src/components/Profile/views/RegionsVerification.view.tsx
+++ b/src/components/Profile/views/RegionsVerification.view.tsx
@@ -100,9 +100,11 @@ const RegionsVerification = () => {
     const handleStartKyc = useCallback(async () => {
         const intent = selectedRegion ? getRegionIntent(selectedRegion.path) : undefined
         if (intent) setActiveRegionIntent(intent)
+        // detect cross-region: user is approved for a different region and wants to unlock a new one
+        const isCrossRegion = !!sumsubVerificationRegionIntent && !!intent && intent !== sumsubVerificationRegionIntent
         setSelectedRegion(null)
-        await flow.handleInitiateKyc(intent)
-    }, [flow.handleInitiateKyc, selectedRegion])
+        await flow.handleInitiateKyc(intent, undefined, isCrossRegion)
+    }, [flow.handleInitiateKyc, selectedRegion, sumsubVerificationRegionIntent])
 
     // re-submission: skip StartVerificationView since user already consented
     const handleResubmitKyc = useCallback(async () => {

--- a/src/constants/kyc.consts.ts
+++ b/src/constants/kyc.consts.ts
@@ -10,7 +10,9 @@ export type KycVerificationStatus = MantecaKycStatus | SumsubKycStatus | string
 export type KycStatusCategory = 'completed' | 'processing' | 'failed' | 'action_required'
 
 // sets of status values by category — single source of truth
-const APPROVED_STATUSES: ReadonlySet<string> = new Set(['approved', 'ACTIVE', 'APPROVED'])
+// REVERIFYING = user is approved but re-verifying for a new region (cross-region KYC).
+// treated as approved for access checks — user retains existing provider access.
+const APPROVED_STATUSES: ReadonlySet<string> = new Set(['approved', 'ACTIVE', 'APPROVED', 'REVERIFYING'])
 const FAILED_STATUSES: ReadonlySet<string> = new Set(['rejected', 'INACTIVE', 'REJECTED'])
 const PENDING_STATUSES: ReadonlySet<string> = new Set([
     'under_review',

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -176,7 +176,7 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
 
     // wrap handleInitiateKyc to reset state for new attempts
     const handleInitiateKyc = useCallback(
-        async (overrideIntent?: KYCRegionIntent, levelName?: string) => {
+        async (overrideIntent?: KYCRegionIntent, levelName?: string, crossRegion?: boolean) => {
             const intent = overrideIntent ?? regionIntent
             posthog.capture(
                 intent === 'LATAM' ? ANALYTICS_EVENTS.MANTECA_KYC_INITIATED : ANALYTICS_EVENTS.KYC_INITIATED,
@@ -192,7 +192,7 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
             isRealtimeFlowRef.current = false
             clearPreparingTimer()
 
-            await originalHandleInitiateKyc(overrideIntent, levelName)
+            await originalHandleInitiateKyc(overrideIntent, levelName, crossRegion)
         },
         [originalHandleInitiateKyc, clearPreparingTimer, regionIntent, acquisitionSource]
     )

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -67,7 +67,8 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
             liveKycStatus &&
             liveKycStatus !== prevStatus &&
             liveKycStatus !== 'APPROVED' &&
-            liveKycStatus !== 'PENDING'
+            liveKycStatus !== 'PENDING' &&
+            liveKycStatus !== 'REVERIFYING'
         ) {
             // close modal for any non-success terminal state (REJECTED, ACTION_REQUIRED, FAILED, etc.)
             setIsVerificationProgressModalOpen(false)
@@ -149,11 +150,12 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 if (effectiveIntent) regionIntentRef.current = effectiveIntent
                 levelNameRef.current = levelName
 
-                // if already approved and no token returned, kyc is done.
+                // if already approved (or reverifying) and no token returned, kyc is done.
                 // set prevStatusRef so the transition effect doesn't fire onKycSuccess a second time.
-                // when a token IS returned (e.g. additional-docs flow), we still need to show the SDK.
-                if (response.data?.status === 'APPROVED' && !response.data?.token) {
-                    prevStatusRef.current = 'APPROVED'
+                // when a token IS returned (e.g. cross-region or additional-docs flow), we still need to show the SDK.
+                const status = response.data?.status
+                if ((status === 'APPROVED' || status === 'REVERIFYING') && !response.data?.token) {
+                    prevStatusRef.current = status
                     onKycSuccess?.()
                     return
                 }

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -119,7 +119,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     }, [isVerificationProgressModalOpen])
 
     const handleInitiateKyc = useCallback(
-        async (overrideIntent?: KYCRegionIntent, levelName?: string) => {
+        async (overrideIntent?: KYCRegionIntent, levelName?: string, crossRegion?: boolean) => {
             userInitiatedRef.current = true
             setIsLoading(true)
             setError(null)
@@ -128,6 +128,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 const response = await initiateSumsubKyc({
                     regionIntent: overrideIntent ?? regionIntent,
                     levelName,
+                    crossRegion,
                 })
 
                 if (response.error) {


### PR DESCRIPTION
- fixes TASK-19021
- fixes TASK-19137

## context

pairs with backend PR peanutprotocol/peanut-api-ts#643. must be deployed together.

## changes

### 1. crossRegion flag threading
threads `crossRegion` boolean through the KYC initiation chain:
- `initiateSumsubKyc` server action → backend `POST /users/identity`
- `useSumsubKycFlow.handleInitiateKyc` → accepts `crossRegion` param
- `useMultiPhaseKycFlow.handleInitiateKyc` → passes through
- `RegionsVerification.handleStartKyc` → detects cross-region (clicked intent differs from existing) and passes `crossRegion: true` (omitted when same-region)

automatic calls (fetchCurrentStatus, polling, component mounts) never set this flag, so they can't trigger moveToLevel or stale rail enrollment on the backend.

### 2. REVERIFYING status support
- added `REVERIFYING` to `SumsubKycStatus` type union
- added `REVERIFYING` to `APPROVED_STATUSES` set in `kyc.consts.ts` (single source of truth)
- all downstream readers automatically treat REVERIFYING as approved: `isKycStatusApproved`, `getKycStatusCategory`, `useKycStatus`, `useQrKycGate`, `useIdentityVerification`, `KycStatusItem`, etc.
- user retains existing provider access (QR pay, deposits, withdrawals) while re-verifying for a new region

## test plan

| test | expected |
|------|----------|
| first-time KYC | no crossRegion flag sent, works as before |
| cross-region click on regions page | crossRegion=true sent, moveToLevel triggered |
| navigate to deposit/withdraw after approval | no crossRegion, no side effects |
| during REVERIFYING: QR pay gate | PROCEED_TO_PAY (treated as approved) |
| during REVERIFYING: regions page | all previously unlocked regions stay unlocked |
| during REVERIFYING: "Rest of World" | stays unlocked |