### PR TITLE
fix: instrument reward analytics on QR payment page

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -136,6 +136,10 @@ export default function QRPayPage() {
     const [waitingForMerchantAmount, setWaitingForMerchantAmount] = useState(false)
     const retryCount = useRef(0)
 
+    // Analytics tracking refs (declared before resetState so it can clear them)
+    const hasTrackedPerkShown = useRef(false)
+    const perkClaimedRef = useRef(false)
+
     const resetState = () => {
         setIsSuccess(false)
         setErrorMessage(null)
@@ -167,6 +171,9 @@ export default function QRPayPage() {
         // reset perk states
         setIsClaimingPerk(false)
         setPerkClaimed(false)
+        // reset analytics tracking refs so a new QR flow gets fresh tracking
+        hasTrackedPerkShown.current = false
+        perkClaimedRef.current = false
     }
 
     // Cleanup timers on unmount
@@ -180,8 +187,6 @@ export default function QRPayPage() {
     }, [])
 
     // Track reward claim shown + surprise moment when perk UI appears after payment
-    const hasTrackedPerkShown = useRef(false)
-    const perkClaimedRef = useRef(false)
     useEffect(() => {
         perkClaimedRef.current = perkClaimed
     }, [perkClaimed])

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -34,6 +34,8 @@ import { loadingStateContext } from '@/context'
 import { getCurrencyPrice } from '@/app/actions/currency'
 import { PaymentInfoRow } from '@/components/Payment/PaymentInfoRow'
 import { captureException } from '@sentry/nextjs'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import {
     isPaymentProcessorQR,
     parseSimpleFiQr,
@@ -174,6 +176,35 @@ export default function QRPayPage() {
             if (progressIntervalRef.current) clearInterval(progressIntervalRef.current)
             if (payingStateTimerRef.current) clearTimeout(payingStateTimerRef.current)
             holdStartTimeRef.current = null
+        }
+    }, [])
+
+    // Track reward claim shown + surprise moment when perk UI appears after payment
+    const hasTrackedPerkShown = useRef(false)
+    const perkClaimedRef = useRef(false)
+    useEffect(() => {
+        perkClaimedRef.current = perkClaimed
+    }, [perkClaimed])
+
+    useEffect(() => {
+        if (isSuccess && qrPayment?.perk?.eligible && !perkClaimed && !hasTrackedPerkShown.current) {
+            hasTrackedPerkShown.current = true
+            const eventProps = {
+                amount_usd: qrPayment.perk.amountSponsored,
+                discount_pct: qrPayment.perk.discountPercentage,
+                merchant: qrPayment.details?.merchant?.name,
+            }
+            posthog.capture(ANALYTICS_EVENTS.REWARD_CLAIM_SHOWN, eventProps)
+            posthog.capture(ANALYTICS_EVENTS.SURPRISE_MOMENT_SHOWN, eventProps)
+        }
+    }, [isSuccess, qrPayment?.perk?.eligible, perkClaimed, qrPayment])
+
+    // Track dismiss: user navigated away after seeing perk but without claiming
+    useEffect(() => {
+        return () => {
+            if (hasTrackedPerkShown.current && !perkClaimedRef.current) {
+                posthog.capture(ANALYTICS_EVENTS.REWARD_CLAIM_DISMISSED)
+            }
         }
     }, [])
 
@@ -784,6 +815,10 @@ export default function QRPayPage() {
         try {
             const result = await mantecaApi.claimPerk(qrPayment.externalId)
             if (result.success) {
+                posthog.capture(ANALYTICS_EVENTS.REWARD_CLAIMED, {
+                    amount_usd: result.perk.amountSponsored,
+                    discount_pct: result.perk.discountPercentage,
+                })
                 // Update qrPayment with actual claimed perk info from backend
                 setQrPayment({
                     ...qrPayment,


### PR DESCRIPTION
## Summary
- 4 PostHog events (`surprise_moment_shown`, `reward_claim_shown`, `reward_claimed`, `reward_claim_dismissed`) fire 0 times in prod despite being in the codebase
- **Root cause**: events were instrumented on `PerkClaimModal` (HomeCarouselCTA), but that component only renders for "Card Pioneer" perks. The Rewards v2 surprise perks are claimed inline on the **QR payment success screen** (`qr-pay/page.tsx`), which had zero PostHog instrumentation
- Added the 4 capture calls to the QR payment flow

## What was broken
```
PerkClaimModal (has analytics) → only shows "Card Pioneer" perks → never shows surprise perks
QR payment page (no analytics) → shows surprise perks → events never fire
```

## Fix
- `REWARD_CLAIM_SHOWN` + `SURPRISE_MOMENT_SHOWN`: fire once when perk UI appears after QR payment (useEffect + hasTrackedShow ref to prevent double-fire)
- `REWARD_CLAIMED`: fires after successful `mantecaApi.claimPerk()`
- `REWARD_CLAIM_DISMISSED`: fires on unmount if perk was shown but not claimed

## Impact
- Unblocks Rewards v2 KR2 measurement ("10% of activated users make first referral within 14d of surprise moment")
- Currently 93 users received surprise perks since Mar 31; after this ships, new surprise moments will generate events

## Test plan
- [ ] Make a QR payment on staging with an account eligible for Rewards v2 surprise perk
- [ ] Verify `surprise_moment_shown` and `reward_claim_shown` appear in PostHog live events
- [ ] Hold to claim → verify `reward_claimed` fires
- [ ] Make another payment, see perk UI, navigate away without claiming → verify `reward_claim_dismissed` fires
- [ ] Verify no double-firing on re-renders (check hasTrackedShow ref behavior)

Closes TASK-19172 (Instrument surprise_moment_shown for KR2 measurability)