### PR TITLE
feat: handle applicant action responses for cross-region KYC

### DIFF
--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -47,6 +47,7 @@ export const initiateSumsubKyc = async (params?: {
                 token: responseJson.token,
                 applicantId: responseJson.applicantId,
                 status: responseJson.status,
+                actionType: responseJson.actionType,
             },
         }
     } catch (e: unknown) {

--- a/src/app/actions/types/sumsub.types.ts
+++ b/src/app/actions/types/sumsub.types.ts
@@ -1,7 +1,10 @@
+export type KycActionType = 'manteca' | 'bridge-direct'
+
 export interface InitiateSumsubKycResponse {
-    token: string | null // null when user is already APPROVED
+    token: string | null // null when user is already APPROVED or bridge-direct
     applicantId: string | null
     status: SumsubKycStatus
+    actionType?: KycActionType // present for cross-region responses
 }
 
 export type SumsubKycStatus =

--- a/src/components/Kyc/SumsubKycWrapper.tsx
+++ b/src/components/Kyc/SumsubKycWrapper.tsx
@@ -135,10 +135,16 @@ export const SumsubKycWrapper = ({
                 }
             }
 
-            // for applicant actions, the SDK may fire action-specific events
-            const handleActionCompleted = (payload: unknown) => {
+            // for applicant actions, the SDK fires action-specific events.
+            // only close on terminal status to avoid premature SDK closure.
+            const handleActionCompleted = (payload: {
+                reviewStatus?: string
+                reviewResult?: { reviewAnswer?: string }
+            }) => {
                 console.log('[sumsub] onApplicantActionStatusChanged fired', payload)
-                stableOnComplete()
+                if (payload?.reviewStatus === 'completed') {
+                    stableOnComplete()
+                }
             }
 
             const sdk = window.snsWebSdk

--- a/src/components/Kyc/SumsubKycWrapper.tsx
+++ b/src/components/Kyc/SumsubKycWrapper.tsx
@@ -135,6 +135,12 @@ export const SumsubKycWrapper = ({
                 }
             }
 
+            // for applicant actions, the SDK may fire action-specific events
+            const handleActionCompleted = (payload: unknown) => {
+                console.log('[sumsub] onApplicantActionStatusChanged fired', payload)
+                stableOnComplete()
+            }
+
             const sdk = window.snsWebSdk
                 .init(accessToken, stableOnRefreshToken)
                 .withConf({ lang: 'en', theme: 'light' })
@@ -142,10 +148,12 @@ export const SumsubKycWrapper = ({
                 .on('onApplicantSubmitted', handleSubmitted)
                 .on('onApplicantResubmitted', handleResubmitted)
                 .on('onApplicantStatusChanged', handleStatusChanged)
+                .on('onApplicantActionStatusChanged', handleActionCompleted)
                 // also listen for idCheck-prefixed events (some sdk versions use these)
                 .on('idCheck.onApplicantSubmitted', handleSubmitted)
                 .on('idCheck.onApplicantResubmitted', handleResubmitted)
                 .on('idCheck.onApplicantStatusChanged', handleStatusChanged)
+                .on('idCheck.onApplicantActionStatusChanged', handleActionCompleted)
                 .on('onError', (error: unknown) => {
                     console.error('[sumsub] sdk error', error)
                     stableOnError(error)

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -148,6 +148,7 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
         refreshToken,
         isVerificationProgressModalOpen,
         closeVerificationProgressModal,
+        isActionFlow,
     } = useSumsubKycFlow({ onKycSuccess: handleSumsubApproved, onManualClose, regionIntent })
 
     // keep ref in sync
@@ -306,7 +307,9 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
 
     const isModalOpen = isVerificationProgressModalOpen || forceShowModal
 
-    const isMultiLevel = regionIntent === 'LATAM'
+    // multi-level only for first-time LATAM (workflow with conditional questionnaire).
+    // cross-region LATAM uses an applicant action (single level, not multi-level).
+    const isMultiLevel = regionIntent === 'LATAM' && !isActionFlow
 
     // Derive preparing stage from elapsed time for progressive copy
     const preparingStage = useMemo<'initial' | 'configuring' | 'slow'>(() => {

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -127,6 +127,13 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
             setIsLoading(true)
             setError(null)
 
+            // for cross-region: pre-set prevStatusRef to APPROVED so the fetchCurrentStatus
+            // effect (which also fires when regionIntent changes) doesn't trigger onKycSuccess
+            // when it sees the existing APPROVED status.
+            if (crossRegion) {
+                prevStatusRef.current = 'APPROVED'
+            }
+
             try {
                 const response = await initiateSumsubKyc({
                     regionIntent: overrideIntent ?? regionIntent,

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -22,6 +22,8 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     const [isVerificationProgressModalOpen, setIsVerificationProgressModalOpen] = useState(false)
     const [liveKycStatus, setLiveKycStatus] = useState<SumsubKycStatus | undefined>(undefined)
     const [rejectLabels, setRejectLabels] = useState<string[] | undefined>(undefined)
+    // true when the SDK is showing an applicant action (not a standard level)
+    const [isActionFlow, setIsActionFlow] = useState(false)
     const prevStatusRef = useRef(liveKycStatus)
     const showWrapperRef = useRef(showWrapper)
     showWrapperRef.current = showWrapper
@@ -150,9 +152,19 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 if (effectiveIntent) regionIntentRef.current = effectiveIntent
                 levelNameRef.current = levelName
 
+                // cross-region: bridge-direct means no SDK needed — backend is handling
+                // rail enrollment + submission. go straight to the post-approval flow.
+                if (response.data?.actionType === 'bridge-direct') {
+                    prevStatusRef.current = 'APPROVED'
+                    userInitiatedRef.current = true
+                    setIsVerificationProgressModalOpen(true)
+                    onKycSuccess?.()
+                    return
+                }
+
                 // if already approved (or reverifying) and no token returned, kyc is done.
                 // set prevStatusRef so the transition effect doesn't fire onKycSuccess a second time.
-                // when a token IS returned (e.g. cross-region or additional-docs flow), we still need to show the SDK.
+                // when a token IS returned (e.g. cross-region action or additional-docs), we still need to show the SDK.
                 const status = response.data?.status
                 if ((status === 'APPROVED' || status === 'REVERIFYING') && !response.data?.token) {
                     prevStatusRef.current = status
@@ -162,6 +174,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
 
                 if (response.data?.token) {
                     setAccessToken(response.data.token)
+                    setIsActionFlow(!!response.data.actionType)
                     setShowWrapper(true)
                 } else {
                     setError('Could not initiate verification. Please try again.')
@@ -233,5 +246,6 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         closeVerificationProgressModal,
         closeVerificationModalAndGoHome,
         resetError,
+        isActionFlow,
     }
 }

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -157,6 +157,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 if (response.data?.actionType === 'bridge-direct') {
                     prevStatusRef.current = 'APPROVED'
                     userInitiatedRef.current = true
+                    setIsActionFlow(false)
                     setIsVerificationProgressModalOpen(true)
                     onKycSuccess?.()
                     return

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -193,12 +193,14 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     const handleSdkComplete = useCallback(() => {
         userInitiatedRef.current = true
         setShowWrapper(false)
+        setIsActionFlow(false)
         setIsVerificationProgressModalOpen(true)
     }, [])
 
     // called when user manually closes the sdk modal
     const handleClose = useCallback(() => {
         setShowWrapper(false)
+        setIsActionFlow(false)
         onManualClose?.()
     }, [onManualClose])
 

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -31,6 +31,8 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     const regionIntentRef = useRef<KYCRegionIntent | undefined>(regionIntent)
     // tracks the level name across initiate + refresh (e.g. 'peanut-additional-docs')
     const levelNameRef = useRef<string | undefined>(undefined)
+    // guards fetchCurrentStatus from running while handleInitiateKyc is in progress
+    const initiatingRef = useRef(false)
     // guard: only fire onKycSuccess when the user initiated a kyc flow in this session.
     // prevents stale websocket events or mount-time fetches from auto-closing the drawer.
     const userInitiatedRef = useRef(false)
@@ -82,11 +84,13 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     // (e.g. RegionsVerification mounts with no region selected yet).
     useEffect(() => {
         if (!regionIntent) return
+        // skip if handleInitiateKyc is already in progress — it handles status sync itself
+        if (initiatingRef.current) return
 
         const fetchCurrentStatus = async () => {
             try {
                 const response = await initiateSumsubKyc({ regionIntent })
-                if (response.data?.status) {
+                if (response.data?.status && !initiatingRef.current) {
                     setLiveKycStatus(response.data.status)
                 }
             } catch {
@@ -124,6 +128,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     const handleInitiateKyc = useCallback(
         async (overrideIntent?: KYCRegionIntent, levelName?: string, crossRegion?: boolean) => {
             userInitiatedRef.current = true
+            initiatingRef.current = true
             setIsLoading(true)
             setError(null)
 
@@ -192,6 +197,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 setError(message)
             } finally {
                 setIsLoading(false)
+                initiatingRef.current = false
             }
         },
         [regionIntent, onKycSuccess]


### PR DESCRIPTION
- fixes TASK-19197

## context

pairs with backend PR peanutprotocol/peanut-api-ts#646. must be deployed together.

## changes

- `sumsub.types.ts` — added `KycActionType` and `actionType` to `InitiateSumsubKycResponse`
- `sumsub.ts` — passes `actionType` through from backend response
- `useSumsubKycFlow.ts`:
  - handles `actionType: 'bridge-direct'`: skips SDK, shows preparing modal, backend handles submission
  - handles `actionType: 'manteca'`: opens SDK with action token (questionnaire only)
  - `isActionFlow` state: tracks whether SDK is showing an action (not standard level)
  - resets `isActionFlow` in `handleSdkComplete` and `handleClose`
- `useMultiPhaseKycFlow.ts`: `isMultiLevel` is false for action flows (actions don't have multi-level workflows)

## test plan

| test | expected |
|------|----------|
| first-time KYC | no actionType, works as before |
| cross-region LATAM | actionType=manteca, SDK opens for questionnaire, isMultiLevel=false |
| cross-region STANDARD | actionType=bridge-direct, no SDK, preparing modal shown |
| action SDK close/complete | isActionFlow resets to false |
| existing provider access during cross-region | not affected (base APPROVED) |