### PR TITLE
[TASK-18880] feat: BR self-service limit increase UI

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -9,4 +9,14 @@ if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'development') {
         capture_pageleave: true,
         autocapture: true,
     })
+
+    // Brave identifies as Chrome in User-Agent — detect it and set a person property
+    // so we can accurately measure our crypto-native Brave audience in PostHog
+    if (navigator.brave) {
+        navigator.brave.isBrave().then((isBrave) => {
+            if (isBrave) {
+                posthog.setPersonProperties({ browser_override: 'Brave' })
+            }
+        })
+    }
 }

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -136,6 +136,10 @@ export default function QRPayPage() {
     const [waitingForMerchantAmount, setWaitingForMerchantAmount] = useState(false)
     const retryCount = useRef(0)
 
+    // Analytics tracking refs (declared before resetState so it can clear them)
+    const hasTrackedPerkShown = useRef(false)
+    const perkClaimedRef = useRef(false)
+
     const resetState = () => {
         setIsSuccess(false)
         setErrorMessage(null)
@@ -167,6 +171,9 @@ export default function QRPayPage() {
         // reset perk states
         setIsClaimingPerk(false)
         setPerkClaimed(false)
+        // reset analytics tracking refs so a new QR flow gets fresh tracking
+        hasTrackedPerkShown.current = false
+        perkClaimedRef.current = false
     }
 
     // Cleanup timers on unmount
@@ -180,8 +187,6 @@ export default function QRPayPage() {
     }, [])
 
     // Track reward claim shown + surprise moment when perk UI appears after payment
-    const hasTrackedPerkShown = useRef(false)
-    const perkClaimedRef = useRef(false)
     useEffect(() => {
         perkClaimedRef.current = perkClaimed
     }, [perkClaimed])

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -34,6 +34,8 @@ import { loadingStateContext } from '@/context'
 import { getCurrencyPrice } from '@/app/actions/currency'
 import { PaymentInfoRow } from '@/components/Payment/PaymentInfoRow'
 import { captureException } from '@sentry/nextjs'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import {
     isPaymentProcessorQR,
     parseSimpleFiQr,
@@ -174,6 +176,35 @@ export default function QRPayPage() {
             if (progressIntervalRef.current) clearInterval(progressIntervalRef.current)
             if (payingStateTimerRef.current) clearTimeout(payingStateTimerRef.current)
             holdStartTimeRef.current = null
+        }
+    }, [])
+
+    // Track reward claim shown + surprise moment when perk UI appears after payment
+    const hasTrackedPerkShown = useRef(false)
+    const perkClaimedRef = useRef(false)
+    useEffect(() => {
+        perkClaimedRef.current = perkClaimed
+    }, [perkClaimed])
+
+    useEffect(() => {
+        if (isSuccess && qrPayment?.perk?.eligible && !perkClaimed && !hasTrackedPerkShown.current) {
+            hasTrackedPerkShown.current = true
+            const eventProps = {
+                amount_usd: qrPayment.perk.amountSponsored,
+                discount_pct: qrPayment.perk.discountPercentage,
+                merchant: qrPayment.details?.merchant?.name,
+            }
+            posthog.capture(ANALYTICS_EVENTS.REWARD_CLAIM_SHOWN, eventProps)
+            posthog.capture(ANALYTICS_EVENTS.SURPRISE_MOMENT_SHOWN, eventProps)
+        }
+    }, [isSuccess, qrPayment?.perk?.eligible, perkClaimed, qrPayment])
+
+    // Track dismiss: user navigated away after seeing perk but without claiming
+    useEffect(() => {
+        return () => {
+            if (hasTrackedPerkShown.current && !perkClaimedRef.current) {
+                posthog.capture(ANALYTICS_EVENTS.REWARD_CLAIM_DISMISSED)
+            }
         }
     }, [])
 
@@ -784,6 +815,10 @@ export default function QRPayPage() {
         try {
             const result = await mantecaApi.claimPerk(qrPayment.externalId)
             if (result.success) {
+                posthog.capture(ANALYTICS_EVENTS.REWARD_CLAIMED, {
+                    amount_usd: result.perk.amountSponsored,
+                    discount_pct: result.perk.discountPercentage,
+                })
                 // Update qrPayment with actual claimed perk info from backend
                 setQrPayment({
                     ...qrPayment,

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -61,8 +61,12 @@ import PointsCard from '@/components/Common/PointsCard'
 import { TRANSACTIONS } from '@/constants/query.consts'
 import { useLimitsValidation } from '@/features/limits/hooks/useLimitsValidation'
 import LimitsWarningCard from '@/features/limits/components/LimitsWarningCard'
-import { getLimitsWarningCardProps } from '@/features/limits/utils'
+import { getLimitsWarningCardProps, isBrUserEligibleForLimitIncrease } from '@/features/limits/utils'
 import useKycStatus from '@/hooks/useKycStatus'
+import { useSumsubActionFlow } from '@/hooks/useSumsubActionFlow'
+import { initiateIncreaseLimits } from '@/app/actions/increase-limits'
+import { SumsubKycWrapper } from '@/components/Kyc/SumsubKycWrapper'
+import { useLimits } from '@/hooks/useLimits'
 
 const MAX_QR_PAYMENT_AMOUNT = '2000'
 const MIN_QR_PAYMENT_AMOUNT = '0.1'
@@ -130,7 +134,7 @@ export default function QRPayPage() {
     const [pendingSimpleFiPaymentId, setPendingSimpleFiPaymentId] = useState<string | null>(null)
     const [isWaitingForWebSocket, setIsWaitingForWebSocket] = useState(false)
     const [shouldRetry, setShouldRetry] = useState(true)
-    const { setIsSupportModalOpen } = useModalsContext()
+    const { setIsSupportModalOpen, openSupportWithMessage: openSupportForLimits } = useModalsContext()
     const [waitingForMerchantAmount, setWaitingForMerchantAmount] = useState(false)
     const retryCount = useRef(0)
 
@@ -387,6 +391,15 @@ export default function QRPayPage() {
         flowType: 'qr-payment',
         amount: usdAmount,
         currency: currency?.code,
+    })
+
+    // BR self-service limit increase flow
+    const { mantecaLimits: qrMantecaLimits, refetch: refetchQrLimits } = useLimits()
+    const isBrQrEligible = isBrUserEligibleForLimitIncrease(qrMantecaLimits)
+    const qrLimitIncreaseFlow = useSumsubActionFlow({
+        fetchToken: initiateIncreaseLimits,
+        onSuccess: refetchQrLimits,
+        onNeedsSupport: () => openSupportForLimits('Hi, I would like to increase my payment limits.'),
     })
 
     // Fetch points early to avoid latency penalty - fetch as soon as we have usdAmount
@@ -1503,6 +1516,15 @@ export default function QRPayPage() {
 
     return (
         <>
+            <SumsubKycWrapper
+                visible={qrLimitIncreaseFlow.showWrapper}
+                accessToken={qrLimitIncreaseFlow.accessToken}
+                onClose={qrLimitIncreaseFlow.handleClose}
+                onComplete={qrLimitIncreaseFlow.handleSdkComplete}
+                onRefreshToken={qrLimitIncreaseFlow.refreshToken}
+                autoStart
+                isMultiLevel
+            />
             <div className={`flex min-h-[inherit] flex-col gap-8 ${getShakeClass(isShaking, shakeIntensity)}`}>
                 <NavHeader title="Pay" />
 
@@ -1569,7 +1591,18 @@ export default function QRPayPage() {
                             flowType: 'qr-payment',
                             currency: limitsValidation.currency,
                         })
-                        return limitsCardProps ? <LimitsWarningCard {...limitsCardProps} /> : null
+                        if (!limitsCardProps) return null
+                        return (
+                            <LimitsWarningCard
+                                {...limitsCardProps}
+                                onIncreaseLimits={
+                                    isBrQrEligible && limitsValidation.isBlocking
+                                        ? qrLimitIncreaseFlow.handleInitiate
+                                        : undefined
+                                }
+                                isIncreaseLimitsLoading={qrLimitIncreaseFlow.isLoading}
+                            />
+                        )
                     })()}
 
                     {/* Information Card */}

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -55,7 +55,11 @@ import { MIN_MANTECA_WITHDRAW_AMOUNT } from '@/constants/payment.consts'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import LimitsWarningCard from '@/features/limits/components/LimitsWarningCard'
-import { getLimitsWarningCardProps } from '@/features/limits/utils'
+import { getLimitsWarningCardProps, isBrUserEligibleForLimitIncrease } from '@/features/limits/utils'
+import { useSumsubActionFlow } from '@/hooks/useSumsubActionFlow'
+import { initiateIncreaseLimits } from '@/app/actions/increase-limits'
+import { SumsubKycWrapper } from '@/components/Kyc/SumsubKycWrapper'
+import { useLimits } from '@/hooks/useLimits'
 
 type MantecaWithdrawStep = 'amountInput' | 'bankDetails' | 'review' | 'success' | 'failure'
 
@@ -84,7 +88,7 @@ export default function MantecaWithdrawFlow() {
     const { signTransferUserOp } = useSignUserOp()
     const { isLoading, loadingState, setLoadingState } = useContext(loadingStateContext)
     const { user } = useAuth()
-    const { setIsSupportModalOpen } = useModalsContext()
+    const { setIsSupportModalOpen, openSupportWithMessage } = useModalsContext()
     const queryClient = useQueryClient()
     const { isUserMantecaKycApproved } = useKycStatus()
     const { hasPendingTransactions } = usePendingTransactions()
@@ -124,6 +128,15 @@ export default function MantecaWithdrawFlow() {
         flowType: 'offramp',
         amount: usdAmount,
         currency: selectedCountry?.currency,
+    })
+
+    // BR self-service limit increase flow
+    const { mantecaLimits, refetch: refetchLimits } = useLimits()
+    const isBrEligible = isBrUserEligibleForLimitIncrease(mantecaLimits)
+    const limitIncreaseFlow = useSumsubActionFlow({
+        fetchToken: initiateIncreaseLimits,
+        onSuccess: refetchLimits,
+        onNeedsSupport: () => openSupportWithMessage('Hi, I would like to increase my payment limits.'),
     })
 
     // Get country flag code
@@ -523,6 +536,15 @@ export default function MantecaWithdrawFlow() {
                 isLoading={sumsubFlow.isLoading}
             />
             <SumsubKycModals flow={sumsubFlow} />
+            <SumsubKycWrapper
+                visible={limitIncreaseFlow.showWrapper}
+                accessToken={limitIncreaseFlow.accessToken}
+                onClose={limitIncreaseFlow.handleClose}
+                onComplete={limitIncreaseFlow.handleSdkComplete}
+                onRefreshToken={limitIncreaseFlow.refreshToken}
+                autoStart
+                isMultiLevel
+            />
             <NavHeader
                 title="Withdraw"
                 onPrev={() => {
@@ -574,7 +596,18 @@ export default function MantecaWithdrawFlow() {
                             flowType: 'offramp',
                             currency: limitsValidation.currency,
                         })
-                        return limitsCardProps ? <LimitsWarningCard {...limitsCardProps} /> : null
+                        if (!limitsCardProps) return null
+                        return (
+                            <LimitsWarningCard
+                                {...limitsCardProps}
+                                onIncreaseLimits={
+                                    isBrEligible && limitsValidation.isBlocking
+                                        ? limitIncreaseFlow.handleInitiate
+                                        : undefined
+                                }
+                                isIncreaseLimitsLoading={limitIncreaseFlow.isLoading}
+                            />
+                        )
                     })()}
 
                     <Button

--- a/src/app/actions/increase-limits.ts
+++ b/src/app/actions/increase-limits.ts
@@ -8,7 +8,7 @@ const API_KEY = process.env.PEANUT_API_KEY!
 
 export interface IncreaseLimitsResponse {
     token: string | null
-    actionId: string | null
+    applicantId?: string | null
     status: string
     message?: string
 }

--- a/src/app/actions/increase-limits.ts
+++ b/src/app/actions/increase-limits.ts
@@ -1,0 +1,44 @@
+'use server'
+
+import { fetchWithSentry } from '@/utils/sentry.utils'
+import { PEANUT_API_URL } from '@/constants/general.consts'
+import { getJWTCookie } from '@/utils/cookie-migration.utils'
+
+const API_KEY = process.env.PEANUT_API_KEY!
+
+export interface IncreaseLimitsResponse {
+    token: string | null
+    actionId: string | null
+    status: string
+    message?: string
+}
+
+export const initiateIncreaseLimits = async (): Promise<{ data?: IncreaseLimitsResponse; error?: string }> => {
+    const jwtToken = (await getJWTCookie())?.value
+
+    if (!jwtToken) {
+        return { error: 'Authentication required' }
+    }
+
+    try {
+        const response = await fetchWithSentry(`${PEANUT_API_URL}/users/increase-limits`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${jwtToken}`,
+                'api-key': API_KEY,
+            },
+        })
+
+        const responseJson = await response.json()
+
+        if (!response.ok) {
+            return { error: responseJson.message || responseJson.error || 'Failed to initiate limit increase' }
+        }
+
+        return { data: responseJson }
+    } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'An unexpected error occurred'
+        return { error: message }
+    }
+}

--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -11,6 +11,7 @@ const API_KEY = process.env.PEANUT_API_KEY!
 export const initiateSumsubKyc = async (params?: {
     regionIntent?: KYCRegionIntent
     levelName?: string
+    crossRegion?: boolean
 }): Promise<{ data?: InitiateSumsubKycResponse; error?: string }> => {
     const jwtToken = (await getJWTCookie())?.value
 
@@ -18,9 +19,10 @@ export const initiateSumsubKyc = async (params?: {
         return { error: 'Authentication required' }
     }
 
-    const body: Record<string, string | undefined> = {
+    const body: Record<string, string | boolean | undefined> = {
         regionIntent: params?.regionIntent,
         levelName: params?.levelName,
+        crossRegion: params?.crossRegion,
     }
 
     try {

--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -47,6 +47,7 @@ export const initiateSumsubKyc = async (params?: {
                 token: responseJson.token,
                 applicantId: responseJson.applicantId,
                 status: responseJson.status,
+                actionType: responseJson.actionType,
             },
         }
     } catch (e: unknown) {

--- a/src/app/actions/types/sumsub.types.ts
+++ b/src/app/actions/types/sumsub.types.ts
@@ -1,7 +1,10 @@
+export type KycActionType = 'manteca' | 'bridge-direct'
+
 export interface InitiateSumsubKycResponse {
-    token: string | null // null when user is already APPROVED
+    token: string | null // null when user is already APPROVED or bridge-direct
     applicantId: string | null
     status: SumsubKycStatus
+    actionType?: KycActionType // present for cross-region responses
 }
 
 export type SumsubKycStatus =

--- a/src/app/actions/types/sumsub.types.ts
+++ b/src/app/actions/types/sumsub.types.ts
@@ -4,6 +4,13 @@ export interface InitiateSumsubKycResponse {
     status: SumsubKycStatus
 }
 
-export type SumsubKycStatus = 'NOT_STARTED' | 'PENDING' | 'IN_REVIEW' | 'APPROVED' | 'REJECTED' | 'ACTION_REQUIRED'
+export type SumsubKycStatus =
+    | 'NOT_STARTED'
+    | 'PENDING'
+    | 'IN_REVIEW'
+    | 'APPROVED'
+    | 'REJECTED'
+    | 'ACTION_REQUIRED'
+    | 'REVERIFYING'
 
 export type KYCRegionIntent = 'STANDARD' | 'LATAM'

--- a/src/components/Kyc/SumsubKycWrapper.tsx
+++ b/src/components/Kyc/SumsubKycWrapper.tsx
@@ -135,10 +135,16 @@ export const SumsubKycWrapper = ({
                 }
             }
 
-            // for applicant actions, the SDK may fire action-specific events
-            const handleActionCompleted = (payload: unknown) => {
+            // for applicant actions, the SDK fires action-specific events.
+            // only close on terminal status to avoid premature SDK closure.
+            const handleActionCompleted = (payload: {
+                reviewStatus?: string
+                reviewResult?: { reviewAnswer?: string }
+            }) => {
                 console.log('[sumsub] onApplicantActionStatusChanged fired', payload)
-                stableOnComplete()
+                if (payload?.reviewStatus === 'completed') {
+                    stableOnComplete()
+                }
             }
 
             const sdk = window.snsWebSdk

--- a/src/components/Kyc/SumsubKycWrapper.tsx
+++ b/src/components/Kyc/SumsubKycWrapper.tsx
@@ -135,6 +135,12 @@ export const SumsubKycWrapper = ({
                 }
             }
 
+            // for applicant actions, the SDK may fire action-specific events
+            const handleActionCompleted = (payload: unknown) => {
+                console.log('[sumsub] onApplicantActionStatusChanged fired', payload)
+                stableOnComplete()
+            }
+
             const sdk = window.snsWebSdk
                 .init(accessToken, stableOnRefreshToken)
                 .withConf({ lang: 'en', theme: 'light' })
@@ -142,10 +148,12 @@ export const SumsubKycWrapper = ({
                 .on('onApplicantSubmitted', handleSubmitted)
                 .on('onApplicantResubmitted', handleResubmitted)
                 .on('onApplicantStatusChanged', handleStatusChanged)
+                .on('onApplicantActionStatusChanged', handleActionCompleted)
                 // also listen for idCheck-prefixed events (some sdk versions use these)
                 .on('idCheck.onApplicantSubmitted', handleSubmitted)
                 .on('idCheck.onApplicantResubmitted', handleResubmitted)
                 .on('idCheck.onApplicantStatusChanged', handleStatusChanged)
+                .on('idCheck.onApplicantActionStatusChanged', handleActionCompleted)
                 .on('onError', (error: unknown) => {
                     console.error('[sumsub] sdk error', error)
                     stableOnError(error)

--- a/src/components/Profile/views/RegionsVerification.view.tsx
+++ b/src/components/Profile/views/RegionsVerification.view.tsx
@@ -100,10 +100,11 @@ const RegionsVerification = () => {
     const handleStartKyc = useCallback(async () => {
         const intent = selectedRegion ? getRegionIntent(selectedRegion.path) : undefined
         if (intent) setActiveRegionIntent(intent)
-        // detect cross-region: user is approved for a different region and wants to unlock a new one
-        const isCrossRegion = !!sumsubVerificationRegionIntent && !!intent && intent !== sumsubVerificationRegionIntent
+        // only signal cross-region when user is switching to a different region
+        const crossRegion =
+            sumsubVerificationRegionIntent && intent && intent !== sumsubVerificationRegionIntent ? true : undefined
         setSelectedRegion(null)
-        await flow.handleInitiateKyc(intent, undefined, isCrossRegion)
+        await flow.handleInitiateKyc(intent, undefined, crossRegion)
     }, [flow.handleInitiateKyc, selectedRegion, sumsubVerificationRegionIntent])
 
     // re-submission: skip StartVerificationView since user already consented

--- a/src/components/Profile/views/RegionsVerification.view.tsx
+++ b/src/components/Profile/views/RegionsVerification.view.tsx
@@ -100,9 +100,11 @@ const RegionsVerification = () => {
     const handleStartKyc = useCallback(async () => {
         const intent = selectedRegion ? getRegionIntent(selectedRegion.path) : undefined
         if (intent) setActiveRegionIntent(intent)
+        // detect cross-region: user is approved for a different region and wants to unlock a new one
+        const isCrossRegion = !!sumsubVerificationRegionIntent && !!intent && intent !== sumsubVerificationRegionIntent
         setSelectedRegion(null)
-        await flow.handleInitiateKyc(intent)
-    }, [flow.handleInitiateKyc, selectedRegion])
+        await flow.handleInitiateKyc(intent, undefined, isCrossRegion)
+    }, [flow.handleInitiateKyc, selectedRegion, sumsubVerificationRegionIntent])
 
     // re-submission: skip StartVerificationView since user already consented
     const handleResubmitKyc = useCallback(async () => {

--- a/src/constants/kyc.consts.ts
+++ b/src/constants/kyc.consts.ts
@@ -10,7 +10,9 @@ export type KycVerificationStatus = MantecaKycStatus | SumsubKycStatus | string
 export type KycStatusCategory = 'completed' | 'processing' | 'failed' | 'action_required'
 
 // sets of status values by category — single source of truth
-const APPROVED_STATUSES: ReadonlySet<string> = new Set(['approved', 'ACTIVE', 'APPROVED'])
+// REVERIFYING = user is approved but re-verifying for a new region (cross-region KYC).
+// treated as approved for access checks — user retains existing provider access.
+const APPROVED_STATUSES: ReadonlySet<string> = new Set(['approved', 'ACTIVE', 'APPROVED', 'REVERIFYING'])
 const FAILED_STATUSES: ReadonlySet<string> = new Set(['rejected', 'INACTIVE', 'REJECTED'])
 const PENDING_STATUSES: ReadonlySet<string> = new Set([
     'under_review',

--- a/src/features/limits/components/IncreaseLimitsButton.tsx
+++ b/src/features/limits/components/IncreaseLimitsButton.tsx
@@ -25,13 +25,9 @@ export default function IncreaseLimitsButton() {
 
     const actionFlow = useSumsubActionFlow({
         fetchToken: initiateIncreaseLimits,
-        onSuccess: refetchLimits,
+        onSuccess: refetch,
         onNeedsSupport: () => openSupportWithMessage(INCREASE_LIMITS_MESSAGE),
     })
-
-    function refetchLimits() {
-        refetch()
-    }
 
     const handleClick = useCallback(() => {
         if (isEligibleForSelfService) {

--- a/src/features/limits/components/IncreaseLimitsButton.tsx
+++ b/src/features/limits/components/IncreaseLimitsButton.tsx
@@ -1,19 +1,77 @@
 'use client'
 
+import { useCallback } from 'react'
 import { Button } from '@/components/0_Bruddle/Button'
 import { useModalsContext } from '@/context/ModalsContext'
+import { useLimits } from '@/hooks/useLimits'
+import { useSumsubActionFlow } from '@/hooks/useSumsubActionFlow'
+import { initiateIncreaseLimits } from '@/app/actions/increase-limits'
+import { SumsubKycWrapper } from '@/components/Kyc/SumsubKycWrapper'
+import { isBrUserEligibleForLimitIncrease } from '../utils'
 
 const INCREASE_LIMITS_MESSAGE = 'Hi, I would like to increase my payment limits.'
 
 /**
- * button that opens support drawer with prefilled message to request limit increase
+ * Button to increase payment limits.
+ * - BR users with ≤1000 USDT monthly limit: self-service document upload
+ *   (either auto-uploaded from Sumsub or collected via LATAM KYC SDK)
+ * - Everyone else: opens support chat with prefilled message
  */
 export default function IncreaseLimitsButton() {
     const { openSupportWithMessage } = useModalsContext()
+    const { mantecaLimits, refetch } = useLimits()
+
+    const isEligibleForSelfService = isBrUserEligibleForLimitIncrease(mantecaLimits)
+
+    const actionFlow = useSumsubActionFlow({
+        fetchToken: initiateIncreaseLimits,
+        onSuccess: refetchLimits,
+        onNeedsSupport: () => openSupportWithMessage(INCREASE_LIMITS_MESSAGE),
+    })
+
+    function refetchLimits() {
+        refetch()
+    }
+
+    const handleClick = useCallback(() => {
+        if (isEligibleForSelfService) {
+            actionFlow.handleInitiate()
+        } else {
+            openSupportWithMessage(INCREASE_LIMITS_MESSAGE)
+        }
+    }, [isEligibleForSelfService, actionFlow.handleInitiate, openSupportWithMessage])
+
+    if (actionFlow.isComplete) {
+        return (
+            <div className="rounded-sm border border-n-1 bg-success-3 p-4 text-center text-sm font-medium">
+                Document submitted! Your limits will be updated shortly.
+            </div>
+        )
+    }
 
     return (
-        <Button className="w-full" shadowSize="4" onClick={() => openSupportWithMessage(INCREASE_LIMITS_MESSAGE)}>
-            Increase my limits
-        </Button>
+        <>
+            <Button
+                className="w-full"
+                shadowSize="4"
+                onClick={handleClick}
+                loading={actionFlow.isLoading}
+                disabled={actionFlow.isLoading}
+            >
+                Increase my limits
+            </Button>
+
+            {actionFlow.error && <p className="text-center text-xs text-error">{actionFlow.error}</p>}
+
+            <SumsubKycWrapper
+                visible={actionFlow.showWrapper}
+                accessToken={actionFlow.accessToken}
+                onClose={actionFlow.handleClose}
+                onComplete={actionFlow.handleSdkComplete}
+                onRefreshToken={actionFlow.refreshToken}
+                autoStart
+                isMultiLevel
+            />
+        </>
     )
 }

--- a/src/features/limits/components/IncreaseLimitsButton.tsx
+++ b/src/features/limits/components/IncreaseLimitsButton.tsx
@@ -19,7 +19,7 @@ const INCREASE_LIMITS_MESSAGE = 'Hi, I would like to increase my payment limits.
  */
 export default function IncreaseLimitsButton() {
     const { openSupportWithMessage } = useModalsContext()
-    const { mantecaLimits, refetch } = useLimits()
+    const { mantecaLimits, isLoading: isLimitsLoading, refetch } = useLimits()
 
     const isEligibleForSelfService = isBrUserEligibleForLimitIncrease(mantecaLimits)
 
@@ -51,8 +51,8 @@ export default function IncreaseLimitsButton() {
                 className="w-full"
                 shadowSize="4"
                 onClick={handleClick}
-                loading={actionFlow.isLoading}
-                disabled={actionFlow.isLoading}
+                loading={actionFlow.isLoading || isLimitsLoading}
+                disabled={actionFlow.isLoading || isLimitsLoading}
             >
                 Increase my limits
             </Button>

--- a/src/features/limits/components/LimitsWarningCard.tsx
+++ b/src/features/limits/components/LimitsWarningCard.tsx
@@ -14,6 +14,10 @@ export interface LimitsWarningCardProps {
     title: string
     items: LimitsWarningItem[]
     showSupportLink?: boolean
+    /** when set, shows an "Increase my limits" button instead of the support link */
+    onIncreaseLimits?: () => void
+    /** loading state for the increase limits action */
+    isIncreaseLimitsLoading?: boolean
     className?: string
 }
 
@@ -26,6 +30,8 @@ export default function LimitsWarningCard({
     title,
     items,
     showSupportLink = true,
+    onIncreaseLimits,
+    isIncreaseLimitsLoading,
     className,
 }: LimitsWarningCardProps) {
     const { openSupportWithMessage } = useModalsContext()
@@ -56,7 +62,21 @@ export default function LimitsWarningCard({
                             </li>
                         ))}
                     </ul>
-                    {showSupportLink && (
+                    {onIncreaseLimits ? (
+                        <>
+                            <div className="my-1 border-t border-yellow-9" />
+                            <button
+                                onClick={onIncreaseLimits}
+                                disabled={isIncreaseLimitsLoading}
+                                className="flex items-center gap-1 text-xs md:text-sm"
+                            >
+                                <Icon name="plus-circle" className="text-yellow-11" size={12} />
+                                <span className="font-semibold text-yellow-11 underline">
+                                    {isIncreaseLimitsLoading ? 'Loading...' : 'Increase my limits'}
+                                </span>
+                            </button>
+                        </>
+                    ) : showSupportLink ? (
                         <>
                             <div className="my-1 border-t border-yellow-9" />
                             <button
@@ -69,7 +89,7 @@ export default function LimitsWarningCard({
                                 </span>
                             </button>
                         </>
-                    )}
+                    ) : null}
                 </div>
             }
         />

--- a/src/features/limits/utils.ts
+++ b/src/features/limits/utils.ts
@@ -140,7 +140,7 @@ export interface LimitsWarningItem {
     icon?: IconName
 }
 
-interface LimitsWarningCardPropsResult {
+export interface LimitsWarningCardPropsResult {
     type: 'warning' | 'error'
     title: string
     items: LimitsWarningItem[]
@@ -206,4 +206,28 @@ export function getLimitsWarningCardProps({
         items,
         showSupportLink: validation.isMantecaUser ?? false,
     }
+}
+
+// ─── BR Limit Increase Eligibility ─────────────────────────────────────────
+
+/** monthly limit threshold (in USDT-equivalent BRL limit) below which BR users can self-increase */
+const BR_SELF_INCREASE_MONTHLY_LIMIT_USD = 1000
+
+/**
+ * determines if the user is a Brazilian Manteca user eligible for
+ * self-service limit increase (legacy users without document photos).
+ * eligible = has BRL limits with monthly limit ≤ 1000 USD equivalent.
+ */
+export function isBrUserEligibleForLimitIncrease(mantecaLimits: MantecaLimit[] | null): boolean {
+    if (!mantecaLimits || mantecaLimits.length === 0) return false
+
+    const brlLimit = mantecaLimits.find((l) => l.asset === 'BRL' && l.exchangeCountry === 'BRA')
+    if (!brlLimit) return false
+
+    // manteca returns limits in local currency (BRL), but the threshold
+    // is defined in USD. since we're comparing against a round tier boundary
+    // (1000 USDT = ~5000 BRL), we use the raw monthly limit value.
+    // manteca's lowest BR tier is ~5000 BRL monthly ≈ 1000 USD.
+    const monthlyLimit = parseFloat(brlLimit.monthlyLimit)
+    return monthlyLimit > 0 && monthlyLimit <= BR_SELF_INCREASE_MONTHLY_LIMIT_USD
 }

--- a/src/features/limits/utils.ts
+++ b/src/features/limits/utils.ts
@@ -210,13 +210,13 @@ export function getLimitsWarningCardProps({
 
 // ─── BR Limit Increase Eligibility ─────────────────────────────────────────
 
-/** monthly limit threshold (in USDT-equivalent BRL limit) below which BR users can self-increase */
-const BR_SELF_INCREASE_MONTHLY_LIMIT_USD = 1000
+/** monthly limit threshold — Manteca returns BR limits denominated in USDT */
+const BR_SELF_INCREASE_MONTHLY_LIMIT_USDT = 1000
 
 /**
  * determines if the user is a Brazilian Manteca user eligible for
  * self-service limit increase (legacy users without document photos).
- * eligible = has BRL limits with monthly limit ≤ 1000 USD equivalent.
+ * eligible = has BRL limits with monthly limit ≤ 1000 USDT.
  */
 export function isBrUserEligibleForLimitIncrease(mantecaLimits: MantecaLimit[] | null): boolean {
     if (!mantecaLimits || mantecaLimits.length === 0) return false
@@ -224,10 +224,6 @@ export function isBrUserEligibleForLimitIncrease(mantecaLimits: MantecaLimit[] |
     const brlLimit = mantecaLimits.find((l) => l.asset === 'BRL' && l.exchangeCountry === 'BRA')
     if (!brlLimit) return false
 
-    // manteca returns limits in local currency (BRL), but the threshold
-    // is defined in USD. since we're comparing against a round tier boundary
-    // (1000 USDT = ~5000 BRL), we use the raw monthly limit value.
-    // manteca's lowest BR tier is ~5000 BRL monthly ≈ 1000 USD.
     const monthlyLimit = parseFloat(brlLimit.monthlyLimit)
-    return monthlyLimit > 0 && monthlyLimit <= BR_SELF_INCREASE_MONTHLY_LIMIT_USD
+    return monthlyLimit > 0 && monthlyLimit <= BR_SELF_INCREASE_MONTHLY_LIMIT_USDT
 }

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -148,6 +148,7 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
         refreshToken,
         isVerificationProgressModalOpen,
         closeVerificationProgressModal,
+        isActionFlow,
     } = useSumsubKycFlow({ onKycSuccess: handleSumsubApproved, onManualClose, regionIntent })
 
     // keep ref in sync
@@ -306,7 +307,9 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
 
     const isModalOpen = isVerificationProgressModalOpen || forceShowModal
 
-    const isMultiLevel = regionIntent === 'LATAM'
+    // multi-level only for first-time LATAM (workflow with conditional questionnaire).
+    // cross-region LATAM uses an applicant action (single level, not multi-level).
+    const isMultiLevel = regionIntent === 'LATAM' && !isActionFlow
 
     // Derive preparing stage from elapsed time for progressive copy
     const preparingStage = useMemo<'initial' | 'configuring' | 'slow'>(() => {

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -176,7 +176,7 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
 
     // wrap handleInitiateKyc to reset state for new attempts
     const handleInitiateKyc = useCallback(
-        async (overrideIntent?: KYCRegionIntent, levelName?: string) => {
+        async (overrideIntent?: KYCRegionIntent, levelName?: string, crossRegion?: boolean) => {
             const intent = overrideIntent ?? regionIntent
             posthog.capture(
                 intent === 'LATAM' ? ANALYTICS_EVENTS.MANTECA_KYC_INITIATED : ANALYTICS_EVENTS.KYC_INITIATED,
@@ -192,7 +192,7 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
             isRealtimeFlowRef.current = false
             clearPreparingTimer()
 
-            await originalHandleInitiateKyc(overrideIntent, levelName)
+            await originalHandleInitiateKyc(overrideIntent, levelName, crossRegion)
         },
         [originalHandleInitiateKyc, clearPreparingTimer, regionIntent, acquisitionSource]
     )

--- a/src/hooks/useSumsubActionFlow.ts
+++ b/src/hooks/useSumsubActionFlow.ts
@@ -1,0 +1,127 @@
+import { useState, useCallback, useRef } from 'react'
+
+export interface ActionFlowResponse {
+    token: string | null
+    status: string
+    message?: string
+    applicantId?: string | null
+}
+
+interface ActionTokenFetcher {
+    (): Promise<{ data?: ActionFlowResponse; error?: string }>
+}
+
+interface UseSumsubActionFlowOptions {
+    /** server action that returns { token, status, message? } */
+    fetchToken: ActionTokenFetcher
+    onSuccess?: () => void
+    /** called when the backend says the user should contact support instead */
+    onNeedsSupport?: () => void
+}
+
+/**
+ * Hook for Sumsub verification flows triggered outside the main KYC path.
+ * Used for BR limit increase (LATAM KYC level) and reusable for future
+ * flows like Rain card application.
+ *
+ * Handles three backend response states:
+ * - completed: documents were found and uploaded server-side, no SDK needed
+ * - pending: SDK token returned, user needs to complete verification
+ * - needs_support: edge case requiring manual support
+ */
+export function useSumsubActionFlow({ fetchToken, onSuccess, onNeedsSupport }: UseSumsubActionFlowOptions) {
+    const [accessToken, setAccessToken] = useState<string | null>(null)
+    const [showWrapper, setShowWrapper] = useState(false)
+    const [isLoading, setIsLoading] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+    const [isComplete, setIsComplete] = useState(false)
+
+    const fetchTokenRef = useRef(fetchToken)
+    fetchTokenRef.current = fetchToken
+    const onSuccessRef = useRef(onSuccess)
+    onSuccessRef.current = onSuccess
+    const onNeedsSupportRef = useRef(onNeedsSupport)
+    onNeedsSupportRef.current = onNeedsSupport
+
+    const handleInitiate = useCallback(async () => {
+        setIsLoading(true)
+        setError(null)
+
+        try {
+            const response = await fetchTokenRef.current()
+
+            if (response.error) {
+                setError(response.error)
+                return
+            }
+
+            const { status, token, message } = response.data ?? {}
+
+            if (status === 'completed') {
+                // backend found documents and uploaded them — no SDK needed
+                setIsComplete(true)
+                onSuccessRef.current?.()
+                return
+            }
+
+            if (status === 'needs_support') {
+                // edge case: user needs to contact support
+                onNeedsSupportRef.current?.()
+                setError(message || 'Please contact support to increase your limits.')
+                return
+            }
+
+            if (token) {
+                setAccessToken(token)
+                setShowWrapper(true)
+            } else {
+                setError('Could not start document verification. Please try again.')
+            }
+        } catch (e: unknown) {
+            const message = e instanceof Error ? e.message : 'An unexpected error occurred'
+            setError(message)
+        } finally {
+            setIsLoading(false)
+        }
+    }, [])
+
+    // called when SDK signals verification was submitted
+    const handleSdkComplete = useCallback(() => {
+        setShowWrapper(false)
+        setIsComplete(true)
+        onSuccessRef.current?.()
+    }, [])
+
+    const handleClose = useCallback(() => {
+        setShowWrapper(false)
+    }, [])
+
+    // token refresh for the SDK
+    const refreshToken = useCallback(async (): Promise<string> => {
+        const response = await fetchTokenRef.current()
+
+        if (response.error || !response.data?.token) {
+            throw new Error(response.error || 'Failed to refresh token')
+        }
+
+        setAccessToken(response.data.token)
+        return response.data.token
+    }, [])
+
+    const resetError = useCallback(() => {
+        setError(null)
+    }, [])
+
+    return {
+        isLoading,
+        error,
+        showWrapper,
+        accessToken,
+        isComplete,
+        handleInitiate,
+        handleSdkComplete,
+        handleClose,
+        refreshToken,
+        resetError,
+    }
+}

--- a/src/hooks/useSumsubActionFlow.ts
+++ b/src/hooks/useSumsubActionFlow.ts
@@ -46,6 +46,7 @@ export function useSumsubActionFlow({ fetchToken, onSuccess, onNeedsSupport }: U
     const handleInitiate = useCallback(async () => {
         setIsLoading(true)
         setError(null)
+        setIsComplete(false)
 
         try {
             const response = await fetchTokenRef.current()
@@ -55,7 +56,12 @@ export function useSumsubActionFlow({ fetchToken, onSuccess, onNeedsSupport }: U
                 return
             }
 
-            const { status, token, message } = response.data ?? {}
+            if (!response.data) {
+                setError('No response from server. Please try again.')
+                return
+            }
+
+            const { status, token, message } = response.data
 
             if (status === 'completed') {
                 // backend found documents and uploaded them — no SDK needed
@@ -65,9 +71,8 @@ export function useSumsubActionFlow({ fetchToken, onSuccess, onNeedsSupport }: U
             }
 
             if (status === 'needs_support') {
-                // edge case: user needs to contact support
+                // edge case: user needs to contact support — open support modal only
                 onNeedsSupportRef.current?.()
-                setError(message || 'Please contact support to increase your limits.')
                 return
             }
 
@@ -75,7 +80,7 @@ export function useSumsubActionFlow({ fetchToken, onSuccess, onNeedsSupport }: U
                 setAccessToken(token)
                 setShowWrapper(true)
             } else {
-                setError('Could not start document verification. Please try again.')
+                setError(message || 'Could not start document verification. Please try again.')
             }
         } catch (e: unknown) {
             const message = e instanceof Error ? e.message : 'An unexpected error occurred'
@@ -92,8 +97,13 @@ export function useSumsubActionFlow({ fetchToken, onSuccess, onNeedsSupport }: U
         onSuccessRef.current?.()
     }, [])
 
+    // called when user manually closes the SDK — reset state and refetch
+    // in case they completed a multi-level flow before closing
     const handleClose = useCallback(() => {
         setShowWrapper(false)
+        setAccessToken(null)
+        setError(null)
+        onSuccessRef.current?.()
     }, [])
 
     // token refresh for the SDK
@@ -108,10 +118,6 @@ export function useSumsubActionFlow({ fetchToken, onSuccess, onNeedsSupport }: U
         return response.data.token
     }, [])
 
-    const resetError = useCallback(() => {
-        setError(null)
-    }, [])
-
     return {
         isLoading,
         error,
@@ -122,6 +128,5 @@ export function useSumsubActionFlow({ fetchToken, onSuccess, onNeedsSupport }: U
         handleSdkComplete,
         handleClose,
         refreshToken,
-        resetError,
     }
 }

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -127,6 +127,13 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
             setIsLoading(true)
             setError(null)
 
+            // for cross-region: pre-set prevStatusRef to APPROVED so the fetchCurrentStatus
+            // effect (which also fires when regionIntent changes) doesn't trigger onKycSuccess
+            // when it sees the existing APPROVED status.
+            if (crossRegion) {
+                prevStatusRef.current = 'APPROVED'
+            }
+
             try {
                 const response = await initiateSumsubKyc({
                     regionIntent: overrideIntent ?? regionIntent,

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -22,6 +22,8 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     const [isVerificationProgressModalOpen, setIsVerificationProgressModalOpen] = useState(false)
     const [liveKycStatus, setLiveKycStatus] = useState<SumsubKycStatus | undefined>(undefined)
     const [rejectLabels, setRejectLabels] = useState<string[] | undefined>(undefined)
+    // true when the SDK is showing an applicant action (not a standard level)
+    const [isActionFlow, setIsActionFlow] = useState(false)
     const prevStatusRef = useRef(liveKycStatus)
     const showWrapperRef = useRef(showWrapper)
     showWrapperRef.current = showWrapper
@@ -150,9 +152,19 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 if (effectiveIntent) regionIntentRef.current = effectiveIntent
                 levelNameRef.current = levelName
 
+                // cross-region: bridge-direct means no SDK needed — backend is handling
+                // rail enrollment + submission. go straight to the post-approval flow.
+                if (response.data?.actionType === 'bridge-direct') {
+                    prevStatusRef.current = 'APPROVED'
+                    userInitiatedRef.current = true
+                    setIsVerificationProgressModalOpen(true)
+                    onKycSuccess?.()
+                    return
+                }
+
                 // if already approved (or reverifying) and no token returned, kyc is done.
                 // set prevStatusRef so the transition effect doesn't fire onKycSuccess a second time.
-                // when a token IS returned (e.g. cross-region or additional-docs flow), we still need to show the SDK.
+                // when a token IS returned (e.g. cross-region action or additional-docs), we still need to show the SDK.
                 const status = response.data?.status
                 if ((status === 'APPROVED' || status === 'REVERIFYING') && !response.data?.token) {
                     prevStatusRef.current = status
@@ -162,6 +174,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
 
                 if (response.data?.token) {
                     setAccessToken(response.data.token)
+                    setIsActionFlow(!!response.data.actionType)
                     setShowWrapper(true)
                 } else {
                     setError('Could not initiate verification. Please try again.')
@@ -233,5 +246,6 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         closeVerificationProgressModal,
         closeVerificationModalAndGoHome,
         resetError,
+        isActionFlow,
     }
 }

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -157,6 +157,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 if (response.data?.actionType === 'bridge-direct') {
                     prevStatusRef.current = 'APPROVED'
                     userInitiatedRef.current = true
+                    setIsActionFlow(false)
                     setIsVerificationProgressModalOpen(true)
                     onKycSuccess?.()
                     return

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -193,12 +193,14 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     const handleSdkComplete = useCallback(() => {
         userInitiatedRef.current = true
         setShowWrapper(false)
+        setIsActionFlow(false)
         setIsVerificationProgressModalOpen(true)
     }, [])
 
     // called when user manually closes the sdk modal
     const handleClose = useCallback(() => {
         setShowWrapper(false)
+        setIsActionFlow(false)
         onManualClose?.()
     }, [onManualClose])
 

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -67,7 +67,8 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
             liveKycStatus &&
             liveKycStatus !== prevStatus &&
             liveKycStatus !== 'APPROVED' &&
-            liveKycStatus !== 'PENDING'
+            liveKycStatus !== 'PENDING' &&
+            liveKycStatus !== 'REVERIFYING'
         ) {
             // close modal for any non-success terminal state (REJECTED, ACTION_REQUIRED, FAILED, etc.)
             setIsVerificationProgressModalOpen(false)
@@ -149,11 +150,12 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 if (effectiveIntent) regionIntentRef.current = effectiveIntent
                 levelNameRef.current = levelName
 
-                // if already approved and no token returned, kyc is done.
+                // if already approved (or reverifying) and no token returned, kyc is done.
                 // set prevStatusRef so the transition effect doesn't fire onKycSuccess a second time.
-                // when a token IS returned (e.g. additional-docs flow), we still need to show the SDK.
-                if (response.data?.status === 'APPROVED' && !response.data?.token) {
-                    prevStatusRef.current = 'APPROVED'
+                // when a token IS returned (e.g. cross-region or additional-docs flow), we still need to show the SDK.
+                const status = response.data?.status
+                if ((status === 'APPROVED' || status === 'REVERIFYING') && !response.data?.token) {
+                    prevStatusRef.current = status
                     onKycSuccess?.()
                     return
                 }

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -119,7 +119,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     }, [isVerificationProgressModalOpen])
 
     const handleInitiateKyc = useCallback(
-        async (overrideIntent?: KYCRegionIntent, levelName?: string) => {
+        async (overrideIntent?: KYCRegionIntent, levelName?: string, crossRegion?: boolean) => {
             userInitiatedRef.current = true
             setIsLoading(true)
             setError(null)
@@ -128,6 +128,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 const response = await initiateSumsubKyc({
                     regionIntent: overrideIntent ?? regionIntent,
                     levelName,
+                    crossRegion,
                 })
 
                 if (response.error) {

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -31,6 +31,8 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     const regionIntentRef = useRef<KYCRegionIntent | undefined>(regionIntent)
     // tracks the level name across initiate + refresh (e.g. 'peanut-additional-docs')
     const levelNameRef = useRef<string | undefined>(undefined)
+    // guards fetchCurrentStatus from running while handleInitiateKyc is in progress
+    const initiatingRef = useRef(false)
     // guard: only fire onKycSuccess when the user initiated a kyc flow in this session.
     // prevents stale websocket events or mount-time fetches from auto-closing the drawer.
     const userInitiatedRef = useRef(false)
@@ -82,11 +84,13 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     // (e.g. RegionsVerification mounts with no region selected yet).
     useEffect(() => {
         if (!regionIntent) return
+        // skip if handleInitiateKyc is already in progress — it handles status sync itself
+        if (initiatingRef.current) return
 
         const fetchCurrentStatus = async () => {
             try {
                 const response = await initiateSumsubKyc({ regionIntent })
-                if (response.data?.status) {
+                if (response.data?.status && !initiatingRef.current) {
                     setLiveKycStatus(response.data.status)
                 }
             } catch {
@@ -124,6 +128,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     const handleInitiateKyc = useCallback(
         async (overrideIntent?: KYCRegionIntent, levelName?: string, crossRegion?: boolean) => {
             userInitiatedRef.current = true
+            initiatingRef.current = true
             setIsLoading(true)
             setError(null)
 
@@ -192,6 +197,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 setError(message)
             } finally {
                 setIsLoading(false)
+                initiatingRef.current = false
             }
         },
         [regionIntent, onKycSuccess]

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -4,3 +4,9 @@ interface Window {
     CRISP_TOKEN_ID?: string | null
     CRISP_WEBSITE_ID?: string
 }
+
+interface Navigator {
+    brave?: {
+        isBrave: () => Promise<boolean>
+    }
+}


### PR DESCRIPTION
Replace support-only "Increase my limits" with a self-service flow for BR users with ≤1000 USDT monthly limit. Adds useSumsubActionFlow hook, wires Sumsub SDK into IncreaseLimitsButton, and shows inline "Increase my limits" action in LimitsWarningCard when blocking on withdraw and QR/PIX payment flows. Non-eligible users still get the support chat fallback.