### PR TITLE
feat(analytics): detect Brave browser in PostHog

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -9,4 +9,14 @@ if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'development') {
         capture_pageleave: true,
         autocapture: true,
     })
+
+    // Brave identifies as Chrome in User-Agent — detect it and set a person property
+    // so we can accurately measure our crypto-native Brave audience in PostHog
+    if (navigator.brave) {
+        navigator.brave.isBrave().then((isBrave) => {
+            if (isBrave) {
+                posthog.setPersonProperties({ browser_override: 'Brave' })
+            }
+        })
+    }
 }

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -4,3 +4,9 @@ interface Window {
     CRISP_TOKEN_ID?: string | null
     CRISP_WEBSITE_ID?: string
 }
+
+interface Navigator {
+    brave?: {
+        isBrave: () => Promise<boolean>
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Brave browser detection using `navigator.brave.isBrave()` API
- Sets `browser_override` PostHog person property for Brave users
- Adds TypeScript declaration for the Brave Navigator API

Brave identifies as Chrome in User-Agent, making it invisible in analytics. Given our crypto-native audience, Brave is likely 5-15% of traffic.

Ref: TASK-19060

## Test plan
- [ ] Open app in Brave — verify `browser_override: "Brave"` appears on the user's PostHog person profile
- [ ] Open app in Chrome — verify no `browser_override` property is set
- [ ] Verify no errors in console for browsers without `navigator.brave`