### PR TITLE
chore: add android app to assetlinks.json

### DIFF
--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -12,5 +12,17 @@
             "namespace": "web",
             "site": "https://peanut.me"
         }
+    },
+    {
+        "relation": ["delegate_permission/common.handle_all_urls", "delegate_permission/common.get_login_creds"],
+        "target": {
+            "namespace": "android_app",
+            "package_name": "com.peanut.app",
+            "sha256_cert_fingerprints": [
+                "93:5F:2F:BD:0B:5F:F0:6A:D3:4D:FD:03:5E:8C:B9:E7:AE:11:E0:20:8A:6C:DB:70:B3:B1:39:4F:9C:79:29:78",
+                "11:94:75:B7:2F:74:28:DC:D8:B2:FF:FF:A9:A0:6B:2D:78:13:17:F1:15:F6:24:BD:BE:F3:C8:16:38:92:0E:98",
+                "29:10:BA:ED:60:53:6D:60:A9:B2:D5:DB:7D:AD:9B:04:A5:49:FE:17:6E:89:CF:A4:85:17:19:D1:14:99:F1:EB"
+            ]
+        }
     }
 ]


### PR DESCRIPTION
## Summary
- Adds `com.peanut_dev.app` android_app entry to `assetlinks.json` with signing key SHA-256 fingerprints
- Required for Android passkey (WebAuthn) credential creation and login via Digital Asset Links
- Keeps existing web/TWA entries unchanged

**Note:** Package name is `com.peanut_dev.app` (personal dev account for internal testing). Will change to production package name when moving to company account.

## Test plan
- [ ] Verify `staging.peanut.me/.well-known/assetlinks.json` serves the updated file after deploy
- [ ] Verify Android passkey registration works against staging