### PR TITLE
fix: add google play signing key to assetlinks.json

### DIFF
--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -19,6 +19,7 @@
             "namespace": "android_app",
             "package_name": "com.peanut_dev.app",
             "sha256_cert_fingerprints": [
+                "42:E1:F7:7F:2B:2F:C7:26:26:19:4A:15:D3:07:BC:41:62:26:12:6F:7F:C9:0A:54:C3:7A:F5:E2:2D:42:6A:D0",
                 "93:5F:2F:BD:0B:5F:F0:6A:D3:4D:FD:03:5E:8C:B9:E7:AE:11:E0:20:8A:6C:DB:70:B3:B1:39:4F:9C:79:29:78",
                 "11:94:75:B7:2F:74:28:DC:D8:B2:FF:FF:A9:A0:6B:2D:78:13:17:F1:15:F6:24:BD:BE:F3:C8:16:38:92:0E:98",
                 "29:10:BA:ED:60:53:6D:60:A9:B2:D5:DB:7D:AD:9B:04:A5:49:FE:17:6E:89:CF:A4:85:17:19:D1:14:99:F1:EB"


### PR DESCRIPTION
## Summary
- Adds Google Play's app signing key SHA-256 fingerprint to `assetlinks.json`
- Google Play re-signs the app with their own key — passkey verification fails without this fingerprint
- `42:E1:F7:7F:2B:2F:C7:26:26:19:4A:15:D3:07:BC:41:62:26:12:6F:7F:C9:0A:54:C3:7A:F5:E2:2D:42:6A:D0`

## Test plan
- [ ] Merge and wait for staging deploy
- [ ] Verify passkey signup works in the Play Store internal testing build