### PR TITLE
fix: apply Peanut dev fee to ExchangeRateWidget destination amount

### DIFF
--- a/src/components/Global/ExchangeRateWidget/index.tsx
+++ b/src/components/Global/ExchangeRateWidget/index.tsx
@@ -1,12 +1,29 @@
 import CurrencySelect from '@/components/LandingPage/CurrencySelect'
 import countryCurrencyMappings from '@/constants/countryCurrencyMapping'
+import { BRIDGE_DEVELOPER_FEE_RATE } from '@/constants/payment.consts'
 import { useDebounce } from '@/hooks/useDebounce'
 import { useExchangeRate } from '@/hooks/useExchangeRate'
+import { applyBridgeCrossCurrencyFee } from '@/utils/bridge.utils'
 import Image from 'next/image'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Icon, type IconName } from '../Icons/Icon'
 import { Button } from '@/components/0_Bruddle/Button'
+
+/**
+ * Gross up a net destination amount by the Bridge cross-currency fee.
+ * Inverse of applyBridgeCrossCurrencyFee — used when the user types a
+ * "Recipient Gets" (net) value and we need the gross equivalent to
+ * feed back into rate math. USD pairs pass through unchanged.
+ */
+const reverseBridgeCrossCurrencyFee = (netAmount: number, srcCurrency: string, dstCurrency: string): number => {
+    const src = (srcCurrency ?? '').toLowerCase()
+    const dst = (dstCurrency ?? '').toLowerCase()
+    if (src === 'usd' || dst === 'usd') {
+        return netAmount
+    }
+    return netAmount / (1 - BRIDGE_DEVELOPER_FEE_RATE)
+}
 
 interface IExchangeRateWidgetProps {
     ctaLabel: string
@@ -42,6 +59,24 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
     })
 
     const debouncedSourceAmount = useDebounce(sourceAmount, 500)
+
+    // Bridge charges a 0.5% developer fee on cross-currency transfers (non-USD ↔ non-USD).
+    // The hook returns gross `source × rate`; we display net so "Recipient Gets" matches
+    // what Bridge actually delivers. USD pairs pass through unchanged.
+    const netDestinationAmount = useMemo<number | ''>(() => {
+        if (typeof destinationAmount !== 'number') return destinationAmount
+        return applyBridgeCrossCurrencyFee(destinationAmount, sourceCurrency, destinationCurrency)
+    }, [destinationAmount, sourceCurrency, destinationCurrency])
+
+    // Track whether the user is actively typing in the destination field so we can
+    // echo their input verbatim instead of formatting a net value over it.
+    const [isEditingDestination, setIsEditingDestination] = useState(false)
+
+    const netDestinationDisplayValue = useMemo<string>(() => {
+        if (isEditingDestination) return getDestinationDisplayValue()
+        if (netDestinationAmount === '' || typeof netDestinationAmount !== 'number') return ''
+        return netDestinationAmount.toFixed(2)
+    }, [isEditingDestination, getDestinationDisplayValue, netDestinationAmount])
 
     // Function to update URL parameters
     const updateUrlParams = useCallback(
@@ -95,13 +130,16 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
 
     const swapCurrencies = useCallback(() => {
         setIsSwapping(true)
+        setIsEditingDestination(false)
         skipNextDebounceSyncRef.current = true
+        // Use the displayed net amount as the new source so post-swap values match
+        // what the user saw in "Recipient Gets" before swapping.
         const newAmount =
-            typeof destinationAmount === 'number' && destinationAmount > 0
-                ? Math.round(destinationAmount * 100) / 100
+            typeof netDestinationAmount === 'number' && netDestinationAmount > 0
+                ? Math.round(netDestinationAmount * 100) / 100
                 : undefined
         updateUrlParams({ from: destinationCurrency, to: sourceCurrency, amount: newAmount })
-    }, [sourceCurrency, destinationCurrency, destinationAmount, updateUrlParams])
+    }, [sourceCurrency, destinationCurrency, netDestinationAmount, updateUrlParams])
 
     // clear swapping state once exchange rate hook finishes recalculating
     useEffect(() => {
@@ -162,6 +200,7 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
                             value={sourceAmount === '' ? '' : sourceAmount}
                             onChange={(e) => {
                                 const inputValue = e.target.value
+                                setIsEditingDestination(false)
                                 if (inputValue === '') {
                                     handleSourceAmountChange('')
                                 } else {
@@ -212,14 +251,21 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
                         <input
                             min={0}
                             placeholder="0"
-                            value={getDestinationDisplayValue()}
+                            value={netDestinationDisplayValue}
                             onChange={(e) => {
                                 const inputValue = e.target.value
+                                setIsEditingDestination(true)
                                 if (inputValue === '') {
                                     handleDestinationAmountChange('', '')
                                 } else {
                                     const value = parseFloat(inputValue)
-                                    handleDestinationAmountChange(inputValue, isNaN(value) ? '' : value)
+                                    // User typed a net "Recipient Gets" value — gross it up
+                                    // before handing to the hook so the source amount is
+                                    // computed from the gross equivalent (net / (1 - fee) / rate).
+                                    const grossValue = isNaN(value)
+                                        ? ''
+                                        : reverseBridgeCrossCurrencyFee(value, sourceCurrency, destinationCurrency)
+                                    handleDestinationAmountChange(inputValue, grossValue)
                                 }
                             }}
                             type="number"


### PR DESCRIPTION
## Summary

Follow-up to #1889. The landing-page `ExchangeRateWidget` calculator was showing "Recipient Gets" amounts using the raw exchange rate without deducting Peanut's 0.5% developer fee. Users planning a deposit based on the widget would receive less than shown.

## Scope

- `src/components/Global/ExchangeRateWidget/index.tsx` only
- Cross-currency pairs (EUR/GBP/MXN ↔ other non-USD). USD pairs pass through unchanged.

## Fix

Apply `applyBridgeCrossCurrencyFee()` (shared helper from #1889) to the destination amount before display. Reuses the same constant and logic as the onramp/offramp quote fix.

Bidirectional editing handled with an inverse helper (`reverseBridgeCrossCurrencyFee`): when the user types a net "Recipient Gets" value, we gross it up before computing the source amount, so source = (net / (1 - fee)) / rate.

Swap-currencies button uses the displayed (net) amount as the new source so the post-swap value matches what the user saw.

## Test plan

- [ ] Landing page widget: USD → EUR shows net amount (rate × 0.995)
- [ ] Landing page widget: EUR → MXN shows net amount (rate × 0.995)
- [ ] USD → USDC unchanged (no fee applied)
- [ ] Bidirectional editing stays consistent (gross/net math reverses correctly)