### PR TITLE
feat: fix manteca (mercado pago/pix) add-money on native app

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "me.peanut.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 3
-        versionName "1.0.2"
+        versionCode 4
+        versionName "1.0.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/scripts/native-build.js
+++ b/scripts/native-build.js
@@ -190,6 +190,10 @@ const COMPONENT_COPIES = [
         dest: '(mobile-ui)/add-money/_onramp-bank.tsx',
     },
     {
+        src: '(mobile-ui)/add-money/[country]/[regional-method]/page.tsx',
+        dest: '(mobile-ui)/add-money/_onramp-manteca.tsx',
+    },
+    {
         src: '(mobile-ui)/withdraw/[country]/bank/page.tsx',
         dest: '(mobile-ui)/withdraw/_withdraw-bank.tsx',
     },

--- a/src/app/(mobile-ui)/add-money/[country]/[regional-method]/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/[regional-method]/page.tsx
@@ -2,12 +2,14 @@
 import MantecaAddMoney from '@/components/AddMoney/components/MantecaAddMoney'
 import { type CountryData, countryData } from '@/components/AddMoney/consts'
 import { MantecaSupportedExchanges } from '@/components/AddMoney/consts'
-import { useParams } from 'next/navigation'
+import { useParams, useSearchParams } from 'next/navigation'
 
 export default function AddMoneyRegionalMethodPage() {
     const params = useParams()
-    const country = params.country as string
-    const method = params['regional-method'] as string
+    const searchParams = useSearchParams()
+    // path params (web) or query params (native static export)
+    const country = (params.country as string) || searchParams.get('country') || ''
+    const method = (params['regional-method'] as string) || searchParams.get('view') || ''
 
     const countryDetails: CountryData | undefined = countryData.find((c) => c.path === country)
 

--- a/src/app/(mobile-ui)/add-money/_onramp-manteca.tsx
+++ b/src/app/(mobile-ui)/add-money/_onramp-manteca.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+// stub for web build — real component is injected by scripts/native-build.js during native builds.
+// on web, this code path is never reached (dynamic route /add-money/[country]/[regional-method] handles it).
+export default function Stub() {
+    return null
+}

--- a/src/app/(mobile-ui)/add-money/page.tsx
+++ b/src/app/(mobile-ui)/add-money/page.tsx
@@ -4,8 +4,9 @@ import AddMoneyMethodSelection from '@/components/AddMoney/views/AddMoneyMethodS
 import AddWithdrawCountriesList from '@/components/AddWithdraw/AddWithdrawCountriesList'
 import dynamic from 'next/dynamic'
 
-// stub exists for web build; real component is injected by native build script.
+// stubs exist for web build; real components are injected by native build script.
 const OnrampBankPage = dynamic(() => import('./_onramp-bank'), { ssr: false })
+const OnrampMantecaPage = dynamic(() => import('./_onramp-manteca'), { ssr: false })
 import { CountryList } from '@/components/Common/CountryList'
 import type { CountryData } from '@/components/AddMoney/consts'
 import NavHeader from '@/components/Global/NavHeader'
@@ -73,8 +74,10 @@ export default function AddMoneyPage() {
     // native app: render sub-views based on query params
     const viewFromQuery = searchParams.get('view')
     if (countryFromQuery && viewFromQuery === 'bank') {
-        // bank form: /add-money?country=austria&view=bank
         return <OnrampBankPage />
+    }
+    if (countryFromQuery && viewFromQuery === 'manteca') {
+        return <OnrampMantecaPage />
     }
     if (countryFromQuery) {
         // country method selection: /add-money?country=austria

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -2,7 +2,7 @@
 import { type FC, useEffect, useMemo, useState, useCallback } from 'react'
 import MantecaDepositShareDetails from '@/components/AddMoney/components/MantecaDepositShareDetails'
 import InputAmountStep from '@/components/AddMoney/components/InputAmountStep'
-import { useParams } from 'next/navigation'
+import { useParams, useSearchParams } from 'next/navigation'
 import { type CountryData, countryData } from '@/components/AddMoney/consts'
 import { type MantecaDepositResponseData } from '@/types/manteca.types'
 import { useCurrency } from '@/hooks/useCurrency'
@@ -30,6 +30,7 @@ type CurrencyDenomination = 'USD' | 'ARS' | 'BRL' | 'MXN' | 'EUR'
 
 const MantecaAddMoney: FC = () => {
     const params = useParams()
+    const searchParams = useSearchParams()
     const queryClient = useQueryClient()
 
     // URL state - persisted in query params
@@ -59,7 +60,8 @@ const MantecaAddMoney: FC = () => {
     const [error, setError] = useState<string | null>(null)
     const [depositDetails, setDepositDetails] = useState<MantecaDepositResponseData>()
 
-    const selectedCountryPath = params.country as string
+    // path params (web) or query params (native static export)
+    const selectedCountryPath = (params.country as string) || searchParams.get('country') || ''
     const selectedCountry = useMemo(() => {
         return countryData.find((country) => country.type === 'country' && country.path === selectedCountryPath)
     }, [selectedCountryPath])

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -9,6 +9,7 @@ import { getColorForUsername } from '@/utils/color.utils'
 import Image, { type StaticImageData } from 'next/image'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import { withdrawBankUrl, rewriteMethodPath } from '@/utils/native-routes'
+import { isCapacitor } from '@/utils/capacitor'
 import EmptyState from '../Global/EmptyStates/EmptyState'
 import { useAuth } from '@/context/authContext'
 import { useMemo, useRef, useState } from 'react'
@@ -190,7 +191,14 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                 return
             }
 
-            router.push(rewriteMethodPath(method.path))
+            const target = rewriteMethodPath(method.path)
+            // force full navigation in capacitor — router.push to same page with
+            // different query params doesn't trigger useSearchParams re-render in static export
+            if (isCapacitor() && target.startsWith(window.location.pathname)) {
+                window.location.href = target
+            } else {
+                router.push(target)
+            }
         }
     }
 

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -74,14 +74,6 @@ export const useZeroDev = () => {
         dispatch(zerodevActions.setIsRegistering(true))
         try {
             const rpId = isCapacitor() ? getNativeRpId() : window.location.hostname.replace(/^www\./, '')
-            console.log(
-                '[useZeroDev] register rpId:',
-                rpId,
-                'isCapacitor:',
-                isCapacitor(),
-                'serverUrl:',
-                consts.PASSKEY_SERVER_URL
-            )
 
             // @capgo/capacitor-passkey shim patches navigator.credentials on native,
             // so toWebAuthnKey works on all platforms (web, android, ios).


### PR DESCRIPTION
## Summary
- Fix add-money flow for Argentina (Mercado Pago) and Brazil (Pix) on native app
- The `[country]/[regional-method]` dynamic route was disabled by native build but had no stub/handler like the bank route did
- Use `window.location.href` for same-page query param navigation in Capacitor (router.push doesn't trigger useSearchParams re-render in static export)

## Changes
- New stub `_onramp-manteca.tsx` for web build
- Added manteca to `COMPONENT_COPIES` in native-build.js
- Parent page handles `view=manteca` query param
- `[regional-method]/page.tsx` reads country/method from searchParams fallback
- `AddWithdrawCountriesList` uses `window.location.href` for same-page Capacitor navigation

## Test plan
- [ ] Web: add-money flows unchanged
- [ ] Native: Add Money → Argentina → Mercado Pago renders form
- [ ] Native: Add Money → Brazil → Pix renders form
- [ ] Native: Add Money → Austria → Bank still works