### PR TITLE
fix: api calls for web/pwa affected by native app changes

### DIFF
--- a/src/app/(mobile-ui)/qr/[code]/page.tsx
+++ b/src/app/(mobile-ui)/qr/[code]/page.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import { getAuthToken } from '@/utils/auth-token'
 import { Button } from '@/components/0_Bruddle/Button'
 import Card from '@/components/Global/Card'
 import NavHeader from '@/components/Global/NavHeader'
-import { PEANUT_API_URL } from '@/constants/general.consts'
+import { serverFetch } from '@/utils/api-fetch'
 import { useAuth } from '@/context/authContext'
 import { useRouter, useParams, useSearchParams } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
@@ -89,12 +88,8 @@ export default function RedirectQrClaimPage() {
 
             const { inviteLink } = generateInviteCodeLink(username)
 
-            const response = await fetch(`${PEANUT_API_URL}/qr/${code}/claim`, {
+            const response = await serverFetch(`/qr/${code}/claim`, {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    Authorization: `Bearer ${getAuthToken()}`,
-                },
                 body: JSON.stringify({
                     targetUrl: inviteLink, // Pass the correctly formatted invite link
                 }),

--- a/src/app/actions/__tests__/api-headers.test.ts
+++ b/src/app/actions/__tests__/api-headers.test.ts
@@ -1,6 +1,7 @@
-// integration test: all action functions that make POST requests include Content-Type header
+// integration test: action functions include Content-Type headers and route correctly
 
 import { fetchWithSentry } from '@/utils/sentry.utils'
+import { isCapacitor } from '@/utils/capacitor'
 
 jest.mock('@/utils/sentry.utils', () => ({
     fetchWithSentry: jest.fn(() =>
@@ -39,12 +40,19 @@ jest.mock('@/utils/bridge.utils', () => ({
 }))
 
 const mockFetchWithSentry = fetchWithSentry as jest.MockedFunction<typeof fetchWithSentry>
+const mockIsCapacitor = isCapacitor as jest.MockedFunction<typeof isCapacitor>
 
 // helper to extract headers from the most recent fetchWithSentry call
 function getLastCallHeaders(): Record<string, string> {
     const calls = mockFetchWithSentry.mock.calls
     const lastCall = calls[calls.length - 1]
     return (lastCall[1]?.headers as Record<string, string>) ?? {}
+}
+
+// helper to extract the url from the most recent fetchWithSentry call
+function getLastCallUrl(): string {
+    const calls = mockFetchWithSentry.mock.calls
+    return calls[calls.length - 1][0] as string
 }
 
 describe('action functions Content-Type headers', () => {
@@ -172,5 +180,66 @@ describe('action functions Content-Type headers', () => {
 
         const headers = getLastCallHeaders()
         expect(headers['Content-Type']).toBe('application/json')
+    })
+})
+
+describe('action functions route through proxy on web', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockIsCapacitor.mockReturnValue(false)
+    })
+
+    it('should route POST actions through /api/proxy/', async () => {
+        const { validateInviteCode } = require('@/app/actions/invites')
+        await validateInviteCode('TEST-CODE')
+        expect(getLastCallUrl()).toBe('/api/proxy/invites/validate')
+    })
+
+    it('should route GET actions through /api/proxy/get/', async () => {
+        const { getCardInfo } = require('@/app/actions/card')
+        await getCardInfo()
+        expect(getLastCallUrl()).toBe('/api/proxy/get/card')
+    })
+
+    it('should route DELETE actions through /api/proxy/delete/', async () => {
+        const { cancelOnramp } = require('@/app/actions/onramp')
+        await cancelOnramp('transfer-123')
+        expect(getLastCallUrl()).toBe('/api/proxy/delete/bridge/onramp/transfer-123/cancel')
+    })
+})
+
+describe('action functions call backend directly on native', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockIsCapacitor.mockReturnValue(true)
+    })
+
+    afterEach(() => {
+        mockIsCapacitor.mockReturnValue(false)
+    })
+
+    it('should call PEANUT_API_URL directly for POST actions', async () => {
+        const { validateInviteCode } = require('@/app/actions/invites')
+        await validateInviteCode('TEST-CODE')
+        expect(getLastCallUrl()).toBe('https://api.test.com/invites/validate')
+    })
+
+    it('should call PEANUT_API_URL directly for GET actions', async () => {
+        const { getCardInfo } = require('@/app/actions/card')
+        await getCardInfo()
+        expect(getLastCallUrl()).toBe('https://api.test.com/card')
+    })
+
+    it('should call PEANUT_API_URL directly for DELETE actions', async () => {
+        const { cancelOnramp } = require('@/app/actions/onramp')
+        await cancelOnramp('transfer-123')
+        expect(getLastCallUrl()).toBe('https://api.test.com/bridge/onramp/transfer-123/cancel')
+    })
+
+    it('should include auth headers in native mode', async () => {
+        const { getCardInfo } = require('@/app/actions/card')
+        await getCardInfo()
+        const headers = getLastCallHeaders()
+        expect(headers['Authorization']).toBe('Bearer test-token')
     })
 })

--- a/src/app/actions/bridge/get-customer.ts
+++ b/src/app/actions/bridge/get-customer.ts
@@ -1,7 +1,6 @@
 import { unstable_cache } from '@/utils/no-cache'
 import { countryData } from '@/components/AddMoney/consts'
-import { PEANUT_API_URL } from '@/constants/general.consts'
-import { getAuthHeaders } from '@/utils/auth-token'
+import { serverFetch } from '@/utils/api-fetch'
 
 type BridgeCustomer = {
     id: string
@@ -39,9 +38,8 @@ export const getBridgeCustomerCountry = async (
 ): Promise<{ countryCode: string | null; rawCountry: string | null }> => {
     const runner = unstable_cache(
         async () => {
-            const response = await fetch(`${PEANUT_API_URL}/bridge/customers/${bridgeCustomerId}` as string, {
-                headers: getAuthHeaders(),
-                cache: 'no-store',
+            const response = await serverFetch(`/bridge/customers/${bridgeCustomerId}`, {
+                method: 'GET',
             })
 
             if (!response.ok) {

--- a/src/app/actions/card.ts
+++ b/src/app/actions/card.ts
@@ -1,9 +1,6 @@
-// card api calls — works in both web (server action) and native (client-side)
-// migrated from 'use server' to support capacitor static export
+// card api calls — works in both web (via proxy) and native (direct backend)
 
-import { PEANUT_API_URL } from '@/constants/general.consts'
-import { fetchWithSentry } from '@/utils/sentry.utils'
-import { getAuthHeaders } from '@/utils/auth-token'
+import { serverFetch } from '@/utils/api-fetch'
 
 export interface CardInfoResponse {
     hasPurchased: boolean
@@ -40,9 +37,8 @@ export interface CardErrorResponse {
  */
 export const getCardInfo = async (): Promise<{ data?: CardInfoResponse; error?: string }> => {
     try {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/card`, {
+        const response = await serverFetch('/card', {
             method: 'GET',
-            headers: getAuthHeaders(),
         })
 
         if (!response.ok) {
@@ -62,9 +58,8 @@ export const getCardInfo = async (): Promise<{ data?: CardInfoResponse; error?: 
  */
 export const purchaseCard = async (): Promise<{ data?: CardPurchaseResponse; error?: string; errorCode?: string }> => {
     try {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/card/purchase`, {
+        const response = await serverFetch('/card/purchase', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
             body: JSON.stringify({}),
         })
 

--- a/src/app/actions/ens.ts
+++ b/src/app/actions/ens.ts
@@ -1,12 +1,10 @@
 import { unstable_cache } from '@/utils/no-cache'
-import { fetchWithSentry } from '@/utils/sentry.utils'
-import { PEANUT_API_URL } from '@/constants/general.consts'
-import { getAuthHeaders } from '@/utils/auth-token'
+import { serverFetch } from '@/utils/api-fetch'
 
 export const resolveEns = unstable_cache(
     async (ensName: string): Promise<string | undefined> => {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/ens/${ensName}`, {
-            headers: getAuthHeaders(),
+        const response = await serverFetch(`/ens/${ensName}`, {
+            method: 'GET',
         })
         if (response.status === 404) return undefined
 

--- a/src/app/actions/ens.ts
+++ b/src/app/actions/ens.ts
@@ -3,7 +3,7 @@ import { serverFetch } from '@/utils/api-fetch'
 
 export const resolveEns = unstable_cache(
     async (ensName: string): Promise<string | undefined> => {
-        const response = await serverFetch(`/ens/${ensName}`, {
+        const response = await serverFetch(`/ens/${encodeURIComponent(ensName)}`, {
             method: 'GET',
         })
         if (response.status === 404) return undefined

--- a/src/app/actions/exchange-rate.ts
+++ b/src/app/actions/exchange-rate.ts
@@ -1,7 +1,5 @@
-import { fetchWithSentry } from '@/utils/sentry.utils'
 import { AccountType } from '@/interfaces'
-import { PEANUT_API_URL } from '@/constants/general.consts'
-import { getAuthHeaders } from '@/utils/auth-token'
+import { serverFetch } from '@/utils/api-fetch'
 
 export interface ExchangeRateResponse {
     from: string
@@ -24,12 +22,8 @@ export async function getExchangeRate(
     accountType: AccountType
 ): Promise<{ data?: ExchangeRateResponse; error?: string }> {
     try {
-        const url = new URL(`${PEANUT_API_URL}/bridge/exchange-rate`)
-        url.searchParams.append('accountType', accountType)
-
-        const response = await fetchWithSentry(url.toString(), {
+        const response = await serverFetch(`/bridge/exchange-rate?accountType=${accountType}`, {
             method: 'GET',
-            headers: getAuthHeaders(),
         })
 
         const data = await response.json()

--- a/src/app/actions/external-accounts.ts
+++ b/src/app/actions/external-accounts.ts
@@ -1,17 +1,14 @@
-import { fetchWithSentry } from '@/utils/sentry.utils'
 import { type AddBankAccountPayload } from './types/users.types'
 import { type IBridgeAccount } from '@/interfaces'
-import { PEANUT_API_URL } from '@/constants/general.consts'
-import { getAuthHeaders } from '@/utils/auth-token'
+import { serverFetch } from '@/utils/api-fetch'
 
 export async function createBridgeExternalAccountForGuest(
     customerId: string,
     accountDetails: AddBankAccountPayload
 ): Promise<IBridgeAccount | { error: string; source?: string }> {
     try {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/bridge/customers/${customerId}/external-accounts`, {
+        const response = await serverFetch(`/bridge/customers/${customerId}/external-accounts`, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
             body: JSON.stringify({ ...accountDetails, reuseOnError: true }), // note: reuseOnError is used to avoid showing errors for duplicate accounts on guest flow
         })
 

--- a/src/app/actions/history.ts
+++ b/src/app/actions/history.ts
@@ -1,7 +1,6 @@
 import { EHistoryEntryType, completeHistoryEntry } from '@/utils/history.utils'
 import type { HistoryEntry } from '@/utils/history.utils'
-import { PEANUT_API_URL } from '@/constants/general.consts'
-import { fetchWithSentry } from '@/utils/sentry.utils'
+import { serverFetch } from '@/utils/api-fetch'
 
 /**
  * Fetches a single history entry from the API. This is used for receipts
@@ -16,9 +15,9 @@ import { fetchWithSentry } from '@/utils/sentry.utils'
  * @returns The fetched history entry
  */
 export async function getHistoryEntry(entryId: string, entryType: EHistoryEntryType): Promise<HistoryEntry | null> {
-    let response: Awaited<ReturnType<typeof fetchWithSentry>>
+    let response: Response
     try {
-        response = await fetchWithSentry(`${PEANUT_API_URL}/history/${entryId}?entryType=${entryType}`)
+        response = await serverFetch(`/history/${entryId}?entryType=${entryType}`)
     } catch (error) {
         throw new Error(`Unexpected error fetching history entry: ${error}`)
     }

--- a/src/app/actions/increase-limits.ts
+++ b/src/app/actions/increase-limits.ts
@@ -1,6 +1,4 @@
-import { fetchWithSentry } from '@/utils/sentry.utils'
-import { PEANUT_API_URL } from '@/constants/general.consts'
-import { getAuthHeaders } from '@/utils/auth-token'
+import { serverFetch } from '@/utils/api-fetch'
 
 export interface IncreaseLimitsResponse {
     token: string | null
@@ -11,9 +9,9 @@ export interface IncreaseLimitsResponse {
 
 export const initiateIncreaseLimits = async (): Promise<{ data?: IncreaseLimitsResponse; error?: string }> => {
     try {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/users/increase-limits`, {
+        const response = await serverFetch('/users/increase-limits', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+            body: JSON.stringify({}),
         })
 
         const responseJson = await response.json()

--- a/src/app/actions/invites.ts
+++ b/src/app/actions/invites.ts
@@ -1,17 +1,11 @@
-import { fetchWithSentry } from '@/utils/sentry.utils'
-import { PEANUT_API_URL } from '@/constants/general.consts'
-import { getAuthHeaders } from '@/utils/auth-token'
+import { serverFetch } from '@/utils/api-fetch'
 
 export async function validateInviteCode(
     inviteCode: string
 ): Promise<{ data?: { success: boolean; username: string }; error?: string }> {
     try {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/invites/validate`, {
+        const response = await serverFetch('/invites/validate', {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                ...getAuthHeaders(),
-            },
             body: JSON.stringify({ inviteCode }),
         })
 

--- a/src/app/actions/offramp.ts
+++ b/src/app/actions/offramp.ts
@@ -1,7 +1,5 @@
 import { type TCreateOfframpRequest } from '../../services/services.types'
-import { fetchWithSentry } from '@/utils/sentry.utils'
-import { PEANUT_API_URL } from '@/constants/general.consts'
-import { getAuthHeaders } from '@/utils/auth-token'
+import { serverFetch } from '@/utils/api-fetch'
 
 export type CreateOfframpSuccessResponse = {
     transferId: string
@@ -24,9 +22,8 @@ export async function createOfframp(
     params: TCreateOfframpRequest
 ): Promise<{ data?: CreateOfframpSuccessResponse; error?: string }> {
     try {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/bridge/offramp/create`, {
+        const response = await serverFetch('/bridge/offramp/create', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
             body: JSON.stringify({
                 ...params,
                 provider: 'bridge', // note: bridge is currently the only provider
@@ -53,9 +50,8 @@ export async function createOfframpForGuest(
     params: TCreateOfframpRequest
 ): Promise<{ data?: CreateOfframpSuccessResponse; error?: string }> {
     try {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/bridge/offramp/create-for-guest`, {
+        const response = await serverFetch('/bridge/offramp/create-for-guest', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
             body: JSON.stringify({
                 ...params,
                 provider: 'bridge',
@@ -93,9 +89,8 @@ export async function confirmOfframp(
     txHash: string
 ): Promise<{ data?: { success: boolean }; error?: string }> {
     try {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/bridge/transfers/${transferId}/confirm`, {
+        const response = await serverFetch(`/bridge/transfers/${transferId}/confirm`, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
             body: JSON.stringify({ txHash }),
         })
 

--- a/src/app/actions/onramp.ts
+++ b/src/app/actions/onramp.ts
@@ -1,9 +1,7 @@
-import { fetchWithSentry } from '@/utils/sentry.utils'
 import { type CountryData } from '@/components/AddMoney/consts'
 import { getCurrencyConfig } from '@/utils/bridge.utils'
 import { getCurrencyPrice } from '@/app/actions/currency'
-import { PEANUT_API_URL } from '@/constants/general.consts'
-import { getAuthHeaders } from '@/utils/auth-token'
+import { serverFetch } from '@/utils/api-fetch'
 
 export interface CreateOnrampGuestParams {
     amount: string
@@ -23,9 +21,8 @@ export interface CreateOnrampGuestParams {
  */
 export async function cancelOnramp(transferId: string): Promise<{ data?: { success: boolean }; error?: string }> {
     try {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/bridge/onramp/${transferId}/cancel`, {
+        const response = await serverFetch(`/bridge/onramp/${transferId}/cancel`, {
             method: 'DELETE',
-            headers: getAuthHeaders(),
         })
 
         if (!response.ok) {
@@ -51,9 +48,8 @@ export async function createOnrampForGuest(
         const price = await getCurrencyPrice(currency)
         const amount = (Number(params.amount) * price.buy).toFixed(2)
 
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/bridge/onramp/create-for-guest`, {
+        const response = await serverFetch('/bridge/onramp/create-for-guest', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
             body: JSON.stringify({
                 amount,
                 userId: params.userId,

--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -1,7 +1,5 @@
 import { type InitiateSumsubKycResponse, type KYCRegionIntent } from './types/sumsub.types'
-import { fetchWithSentry } from '@/utils/sentry.utils'
-import { PEANUT_API_URL } from '@/constants/general.consts'
-import { getAuthHeaders } from '@/utils/auth-token'
+import { serverFetch } from '@/utils/api-fetch'
 
 // initiate kyc flow (using sumsub) and get websdk access token
 export const initiateSumsubKyc = async (params?: {
@@ -16,9 +14,8 @@ export const initiateSumsubKyc = async (params?: {
     }
 
     try {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/users/identity`, {
+        const response = await serverFetch('/users/identity', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
             body: JSON.stringify(body),
         })
 

--- a/src/app/actions/users.ts
+++ b/src/app/actions/users.ts
@@ -1,16 +1,13 @@
 import { type ApiUser } from '@/services/users'
-import { fetchWithSentry } from '@/utils/sentry.utils'
 import { type AddBankAccountPayload, BridgeEndorsementType, type InitiateKycResponse } from './types/users.types'
 import { type User } from '@/interfaces'
 import { type ContactsResponse } from '@/interfaces'
-import { PEANUT_API_URL } from '@/constants/general.consts'
-import { getAuthHeaders } from '@/utils/auth-token'
+import { serverFetch } from '@/utils/api-fetch'
 
 export const updateUserById = async (payload: Record<string, any>): Promise<{ data?: ApiUser; error?: string }> => {
     try {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/update-user`, {
+        const response = await serverFetch('/update-user', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
             body: JSON.stringify(payload),
         })
 
@@ -29,9 +26,8 @@ export const getKycDetails = async (params?: {
     endorsements: BridgeEndorsementType[]
 }): Promise<{ data?: InitiateKycResponse; error?: string }> => {
     try {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/users/initiate-kyc`, {
+        const response = await serverFetch('/users/initiate-kyc', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
             body: JSON.stringify(params || {}),
         })
 
@@ -52,9 +48,8 @@ export const getKycDetails = async (params?: {
 
 export const addBankAccount = async (payload: AddBankAccountPayload): Promise<{ data?: any; error?: string }> => {
     try {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/users/accounts`, {
+        const response = await serverFetch('/users/accounts', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
             body: JSON.stringify(payload),
         })
 
@@ -75,9 +70,8 @@ export const addBankAccount = async (payload: AddBankAccountPayload): Promise<{ 
 
 export async function getUserById(userId: string): Promise<User | null> {
     try {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/users/${userId}`, {
+        const response = await serverFetch(`/users/${userId}`, {
             method: 'GET',
-            headers: getAuthHeaders(),
         })
 
         if (!response.ok) {
@@ -110,9 +104,8 @@ export async function getContacts(params: {
             queryParams.append('search', params.search.trim())
         }
 
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/users/contacts?${queryParams}`, {
+        const response = await serverFetch(`/users/contacts?${queryParams}`, {
             method: 'GET',
-            headers: getAuthHeaders(),
         })
 
         if (!response.ok) {
@@ -130,9 +123,8 @@ export async function getContacts(params: {
 // fetch bridge ToS acceptance link for users with pending ToS
 export const getBridgeTosLink = async (): Promise<{ data?: { tosLink: string }; error?: string }> => {
     try {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/users/bridge-tos-link`, {
+        const response = await serverFetch('/users/bridge-tos-link', {
             method: 'GET',
-            headers: getAuthHeaders(),
         })
         const responseJson = await response.json()
         if (!response.ok) {
@@ -147,9 +139,8 @@ export const getBridgeTosLink = async (): Promise<{ data?: { tosLink: string }; 
 // confirm bridge ToS acceptance after user closes the ToS iframe
 export const confirmBridgeTos = async (): Promise<{ data?: { accepted: boolean }; error?: string }> => {
     try {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/users/bridge-tos-confirm`, {
+        const response = await serverFetch('/users/bridge-tos-confirm', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
             body: JSON.stringify({}),
         })
         const responseJson = await response.json()

--- a/src/app/api/proxy/[...slug]/route.ts
+++ b/src/app/api/proxy/[...slug]/route.ts
@@ -16,14 +16,11 @@ export async function POST(request: NextRequest) {
     const endpointToCall = request.url.substring(indexOfSeparator + separator.length)
     const fullAPIUrl = `${PEANUT_API_URL}/${endpointToCall}`
 
-    let jsonToPass
+    let jsonToPass = {}
     try {
         jsonToPass = await request.json()
-    } catch (error: any) {
-        console.error('Error while parsing json:', error)
-        return NextResponse.json('Pass a valid json', {
-            status: 400,
-        })
+    } catch {
+        // no body or invalid json — proceed with empty object
     }
 
     const userIp = request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip')

--- a/src/app/api/proxy/[...slug]/route.ts
+++ b/src/app/api/proxy/[...slug]/route.ts
@@ -17,10 +17,13 @@ export async function POST(request: NextRequest) {
     const fullAPIUrl = `${PEANUT_API_URL}/${endpointToCall}`
 
     let jsonToPass = {}
-    try {
-        jsonToPass = await request.json()
-    } catch {
-        // no body or invalid json — proceed with empty object
+    const rawBody = await request.text()
+    if (rawBody.length > 0) {
+        try {
+            jsonToPass = JSON.parse(rawBody)
+        } catch (error) {
+            console.warn('proxy POST: malformed JSON body, proceeding with {}', error)
+        }
     }
 
     const userIp = request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip')

--- a/src/app/api/proxy/delete/[...slug]/route.ts
+++ b/src/app/api/proxy/delete/[...slug]/route.ts
@@ -2,29 +2,15 @@ import { fetchWithSentry } from '@/utils/sentry.utils'
 import { NextRequest, NextResponse } from 'next/server'
 import { PEANUT_API_URL } from '@/constants/general.consts'
 
-export async function PATCH(request: NextRequest) {
-    const separator = '/api/proxy/patch/'
+export async function DELETE(request: NextRequest) {
+    const separator = '/api/proxy/delete/'
     const indexOfSeparator = request.url.indexOf(separator)
     const endpointToCall = request.url.substring(indexOfSeparator + separator.length)
     const fullAPIUrl = `${PEANUT_API_URL}/${endpointToCall}`
 
-    let jsonToPass
-    try {
-        jsonToPass = await request.json()
-    } catch (error: any) {
-        console.error('Error while parsing json:', error)
-        return NextResponse.json('Pass a valid json', {
-            status: 400,
-        })
-    }
-
-    jsonToPass.apiKey = process.env.PEANUT_API_KEY!
-
     const userIp = request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip')
     const headersToPass = {
-        'Content-Type': 'application/json',
         'x-forwarded-for': userIp,
-        'Accept-Encoding': 'gzip', // Explicitly accept gzip encoding
         'Api-Key': process.env.PEANUT_API_KEY!,
     } as any
 
@@ -34,12 +20,10 @@ export async function PATCH(request: NextRequest) {
     }
 
     const apiResponse = await fetchWithSentry(fullAPIUrl, {
-        method: 'PATCH',
+        method: 'DELETE',
         headers: headersToPass,
-        body: JSON.stringify(jsonToPass),
     })
 
-    // render returns in gzip format - turn to string and let next handle it
     const apiResponseString = await apiResponse.text()
 
     return new NextResponse(apiResponseString, {

--- a/src/app/api/proxy/get/[...slug]/route.ts
+++ b/src/app/api/proxy/get/[...slug]/route.ts
@@ -16,6 +16,11 @@ export async function GET(request: NextRequest) {
         'Api-Key': process.env.PEANUT_API_KEY!,
     } as any
 
+    const authHeader = request.headers.get('authorization')
+    if (authHeader) {
+        headersToPass['authorization'] = authHeader
+    }
+
     const apiResponse = await fetchWithSentry(fullAPIUrl, {
         method: 'GET',
         headers: headersToPass,
@@ -41,6 +46,11 @@ export async function HEAD(request: NextRequest) {
         'x-forwarded-for': userIp,
         'Api-Key': process.env.PEANUT_API_KEY!,
     } as any
+
+    const authHeader = request.headers.get('authorization')
+    if (authHeader) {
+        headersToPass['authorization'] = authHeader
+    }
 
     const apiResponse = await fetchWithSentry(fullAPIUrl, {
         method: 'HEAD',

--- a/src/components/Global/DirectSendQR/index.tsx
+++ b/src/components/Global/DirectSendQR/index.tsx
@@ -248,9 +248,10 @@ export default function DirectSendQr({
 
                         // Check redirect QR status (single endpoint for speed)
                         try {
-                            const response = await fetch(
-                                `${process.env.NEXT_PUBLIC_PEANUT_API_URL}/qr/${redirectQrCode}`
-                            )
+                            const { serverFetch } = await import('@/utils/api-fetch')
+                            const response = await serverFetch(`/qr/${redirectQrCode}`, {
+                                method: 'GET',
+                            })
                             const data = await response.json()
 
                             if (data.claimed && data.redirectUrl) {

--- a/src/constants/general.consts.ts
+++ b/src/constants/general.consts.ts
@@ -1,3 +1,4 @@
+import { isCapacitor } from '@/utils/capacitor'
 import * as interfaces from '@/interfaces'
 import { CHAIN_DETAILS, TOKEN_DETAILS } from '@squirrel-labs/peanut-sdk'
 import { mainnet, arbitrum, arbitrumSepolia, polygon, optimism, base, bsc, scroll } from 'viem/chains'
@@ -94,11 +95,7 @@ export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://peanut.me'
 // URL for the frontend to call its own Next.js API routes (like /api/health/*)
 export const SELF_URL = IS_DEV ? 'http://localhost:3000' : BASE_URL
 // in capacitor (static export), /api/proxy doesn't exist — call backend directly.
-// checks both window.Capacitor and NEXT_PUBLIC_CAPACITOR_BUILD env var for consistency with isCapacitor()
-export const next_proxy_url =
-    typeof window !== 'undefined' && ((window as any).Capacitor || process.env.NEXT_PUBLIC_CAPACITOR_BUILD === 'true')
-        ? process.env.NEXT_PUBLIC_PEANUT_API_URL || 'https://api.peanut.me'
-        : '/api/proxy'
+export const next_proxy_url = isCapacitor() ? PEANUT_API_URL : '/api/proxy'
 
 // Git commit hash - injected at build time
 export const GIT_COMMIT_HASH = process.env.NEXT_PUBLIC_GIT_COMMIT_HASH || 'unknown'

--- a/src/hooks/query/user.ts
+++ b/src/hooks/query/user.ts
@@ -7,7 +7,9 @@ import { useQuery } from '@tanstack/react-query'
 import { usePWAStatus } from '../usePWAStatus'
 import { useDeviceType } from '../useGetDeviceType'
 import { USER } from '@/constants/query.consts'
-import { apiFetch } from '@/utils/api-fetch'
+import { isCapacitor } from '@/utils/capacitor'
+import { PEANUT_API_URL } from '@/constants/general.consts'
+import { getAuthHeaders } from '@/utils/auth-token'
 
 // custom error class for backend errors (5xx) that should trigger retry
 export class BackendError extends Error {
@@ -26,10 +28,16 @@ export const useUserQuery = (dependsOn: boolean = true) => {
     const { user: authUser } = useUserStore()
 
     const fetchUser = async (): Promise<IUserProfile | null> => {
-        const userResponse = await apiFetch('/get-user', '/api/peanut/user/get-user-from-cookie', {
-            method: 'POST',
-            body: JSON.stringify({}),
-        })
+        // web and native have different flows for "get current user":
+        // web: GET to Next.js server route that reads the jwt cookie server-side
+        // native: POST to backend directly with auth token from localStorage
+        const userResponse = isCapacitor()
+            ? await fetchWithSentry(`${PEANUT_API_URL}/get-user`, {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+                  body: JSON.stringify({}),
+              })
+            : await fetchWithSentry('/api/peanut/user/get-user-from-cookie')
         if (userResponse.ok) {
             const userData: IUserProfile | null = await userResponse.json()
             if (userData) {

--- a/src/hooks/useLimits.ts
+++ b/src/hooks/useLimits.ts
@@ -2,10 +2,9 @@
 
 import { getAuthToken } from '@/utils/auth-token'
 import { useQuery } from '@tanstack/react-query'
-import { fetchWithSentry } from '@/utils/sentry.utils'
-import { PEANUT_API_URL } from '@/constants/general.consts'
 import type { UserLimitsResponse } from '@/interfaces'
 import { LIMITS } from '@/constants/query.consts'
+import { serverFetch } from '@/utils/api-fetch'
 
 interface UseLimitsOptions {
     enabled?: boolean
@@ -25,13 +24,7 @@ export function useLimits(options: UseLimitsOptions = {}) {
             return { manteca: null, bridge: null }
         }
 
-        const url = `${PEANUT_API_URL}/users/limits`
-        const headers: Record<string, string> = {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-        }
-
-        const response = await fetchWithSentry(url, { method: 'GET', headers })
+        const response = await serverFetch('/users/limits', { method: 'GET' })
 
         // 400 means user has no kyc - return empty limits
         if (response.status === 400) {

--- a/src/hooks/useRedirectQrStatus.ts
+++ b/src/hooks/useRedirectQrStatus.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { PEANUT_API_URL } from '@/constants/general.consts'
+import { serverFetch } from '@/utils/api-fetch'
 
 interface RedirectQrStatusData {
     claimed: boolean
@@ -9,7 +9,9 @@ interface RedirectQrStatusData {
 }
 
 async function fetchRedirectQrStatus(code: string): Promise<RedirectQrStatusData> {
-    const response = await fetch(`${PEANUT_API_URL}/qr/${code}`)
+    const response = await serverFetch(`/qr/${code}`, {
+        method: 'GET',
+    })
     const result = await response.json()
 
     if (!response.ok) {

--- a/src/hooks/useTransactionHistory.ts
+++ b/src/hooks/useTransactionHistory.ts
@@ -1,11 +1,9 @@
-import { getAuthToken } from '@/utils/auth-token'
 import { TRANSACTIONS } from '@/constants/query.consts'
-import { fetchWithSentry } from '@/utils/sentry.utils'
+import { serverFetch } from '@/utils/api-fetch'
 import type { InfiniteData, InfiniteQueryObserverResult, QueryObserverResult } from '@tanstack/react-query'
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import { completeHistoryEntry } from '@/utils/history.utils'
 import type { HistoryEntry } from '@/utils/history.utils'
-import { PEANUT_API_URL } from '@/constants/general.consts'
 
 //TODO: remove and import all from utils everywhere
 export { EHistoryEntryType, EHistoryUserRole } from '@/utils/history.utils'
@@ -62,11 +60,8 @@ export function useTransactionHistory({
         // append targetUsername to the query params if filterMutualTxs is true and username is provided
         if (filterMutualTxs && username) queryParams.append('targetUsername', username)
 
-        const url = `${PEANUT_API_URL}/users/history?${queryParams.toString()}`
-
-        const response = await fetchWithSentry(url, {
+        const response = await serverFetch(`/users/history?${queryParams.toString()}`, {
             method: 'GET',
-            headers: { Authorization: `Bearer ${getAuthToken()}` },
         })
 
         if (!response.ok) {

--- a/src/lib/validation/recipient.ts
+++ b/src/lib/validation/recipient.ts
@@ -4,11 +4,10 @@ import { resolveEns } from '@/app/actions/ens'
 
 import { AccountType } from '@/interfaces'
 import { usersApi } from '@/services/users'
-import { fetchWithSentry } from '@/utils/sentry.utils'
+import { serverFetch } from '@/utils/api-fetch'
 import * as Sentry from '@sentry/nextjs'
 import { RecipientValidationError } from '../url-parser/errors'
 import { type RecipientType } from '../url-parser/types/payment'
-import { PEANUT_API_URL } from '@/constants/general.consts'
 
 export async function validateAndResolveRecipient(
     recipient: string,
@@ -81,8 +80,7 @@ export const getRecipientType = (recipient: string, isWithdrawal: boolean = fals
 // utility function to check if a handle is a valid peanut username
 export const verifyPeanutUsername = async (username: string): Promise<boolean> => {
     try {
-        // we are in server, call the api directly
-        const res = await fetchWithSentry(`${PEANUT_API_URL}/users/username/${username}`, {
+        const res = await serverFetch(`/users/username/${username}`, {
             method: 'HEAD',
         })
         const isValidPeanutUsername = res.status === 200

--- a/src/services/charges.ts
+++ b/src/services/charges.ts
@@ -8,8 +8,8 @@ import {
 } from './services.types'
 import { PEANUT_API_URL } from '@/constants/general.consts'
 import { isCapacitor } from '@/utils/capacitor'
-import { getAuthHeaders, getAuthToken } from '@/utils/auth-token'
-import { apiFetch } from '@/utils/api-fetch'
+import { getAuthToken } from '@/utils/auth-token'
+import { apiFetch, serverFetch } from '@/utils/api-fetch'
 
 export const chargesApi = {
     create: async (data: CreateChargeRequest): Promise<TCharge> => {
@@ -44,11 +44,8 @@ export const chargesApi = {
     },
 
     get: async (id: string): Promise<TRequestChargeResponse> => {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/request-charges/${id}`, {
+        const response = await serverFetch(`/request-charges/${id}`, {
             method: 'GET',
-            headers: {
-                'Content-Type': 'application/json',
-            },
         })
 
         if (!response.ok) {
@@ -59,9 +56,8 @@ export const chargesApi = {
     },
 
     cancel: async (id: string): Promise<void> => {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/charges/${id}`, {
+        const response = await serverFetch(`/charges/${id}`, {
             method: 'DELETE',
-            headers: getAuthHeaders(),
         })
 
         if (!response.ok) {

--- a/src/services/invites.ts
+++ b/src/services/invites.ts
@@ -1,8 +1,6 @@
-import { getAuthToken } from '@/utils/auth-token'
 import { validateInviteCode } from '@/app/actions/invites'
-import { fetchWithSentry } from '@/utils/sentry.utils'
+import { serverFetch } from '@/utils/api-fetch'
 import { EInviteType, type PointsInvitesResponse } from './services.types'
-import { PEANUT_API_URL } from '@/constants/general.consts'
 
 export const invitesApi = {
     acceptInvite: async (
@@ -11,13 +9,8 @@ export const invitesApi = {
         campaignTag?: string
     ): Promise<{ success: boolean }> => {
         try {
-            const jwtToken = getAuthToken()
-            const response = await fetchWithSentry(`${PEANUT_API_URL}/invites/accept`, {
+            const response = await serverFetch('/invites/accept', {
                 method: 'POST',
-                headers: {
-                    Authorization: `Bearer ${jwtToken}`,
-                    'Content-Type': 'application/json',
-                },
                 body: JSON.stringify({ inviteCode, type, campaignTag }),
             })
             if (!response.ok) {
@@ -31,17 +24,8 @@ export const invitesApi = {
 
     getInvites: async (): Promise<PointsInvitesResponse> => {
         try {
-            const jwtToken = getAuthToken()
-            if (!jwtToken) {
-                throw new Error('No JWT token found')
-            }
-
-            const response = await fetchWithSentry(`${PEANUT_API_URL}/points/invites`, {
+            const response = await serverFetch('/points/invites', {
                 method: 'GET',
-                headers: {
-                    Authorization: `Bearer ${jwtToken}`,
-                    'Content-Type': 'application/json',
-                },
             })
             if (!response.ok) {
                 throw new Error('Failed to fetch invites')
@@ -69,14 +53,8 @@ export const invitesApi = {
 
     getWaitlistQueuePosition: async (): Promise<{ success: boolean; position: number }> => {
         try {
-            const token = getAuthToken()
-            if (!token) return { success: false, position: 0 }
-
-            const response = await fetchWithSentry(`${PEANUT_API_URL}/invites/waitlist-position`, {
+            const response = await serverFetch('/invites/waitlist-position', {
                 method: 'GET',
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                },
             })
 
             if (!response.ok) {
@@ -93,12 +71,8 @@ export const invitesApi = {
 
     awardBadge: async (campaignTag: string): Promise<{ success: boolean }> => {
         try {
-            const response = await fetchWithSentry(`${PEANUT_API_URL}/badge/award`, {
+            const response = await serverFetch('/badge/award', {
                 method: 'POST',
-                headers: {
-                    Authorization: `Bearer ${getAuthToken()}`,
-                    'Content-Type': 'application/json',
-                },
                 body: JSON.stringify({ campaignTag }),
             })
             if (!response.ok) {

--- a/src/services/manteca.ts
+++ b/src/services/manteca.ts
@@ -1,12 +1,10 @@
-import { PEANUT_API_URL } from '@/constants/general.consts'
-import { getAuthHeaders, getAuthToken } from '@/utils/auth-token'
 import {
     type MantecaDepositResponseData,
     type MantecaWithdrawData,
     type MantecaWithdrawResponse,
     type CreateMantecaOnrampParams,
 } from '@/types/manteca.types'
-import { fetchWithSentry } from '@/utils/sentry.utils'
+import { serverFetch } from '@/utils/api-fetch'
 import { jsonStringify } from '@/utils/general.utils'
 import type { Address } from 'viem'
 import type { SignUserOperationReturnType } from '@zerodev/sdk/actions'
@@ -114,12 +112,8 @@ export type WithdrawPriceLock = {
 
 export const mantecaApi = {
     initiateQrPayment: async (data: QrPaymentRequest): Promise<QrPaymentLock> => {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/manteca/qr-payment/init`, {
+        const response = await serverFetch('/manteca/qr-payment/init', {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${getAuthToken()}`,
-            },
             body: jsonStringify(data),
         })
 
@@ -172,24 +166,23 @@ export const mantecaApi = {
         chainId: string
         entryPointAddress: Address
     }): Promise<QrPayment> => {
-        const response = await fetchWithSentry(
-            `${PEANUT_API_URL}/manteca/qr-payment/complete-with-signed-tx`,
-            {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    Authorization: `Bearer ${getAuthToken()}`,
-                },
-                body: jsonStringify({
-                    paymentLockCode,
-                    signedUserOp,
-                    chainId,
-                    entryPointAddress,
-                    qrType,
-                }),
-            },
-            120000
-        )
+        // 120s timeout for this long-running operation
+        const controller = new AbortController()
+        const timeoutId = setTimeout(() => controller.abort(), 120000)
+
+        const response = await serverFetch('/manteca/qr-payment/complete-with-signed-tx', {
+            method: 'POST',
+            body: jsonStringify({
+                paymentLockCode,
+                signedUserOp,
+                chainId,
+                entryPointAddress,
+                qrType,
+            }),
+            signal: controller.signal,
+        })
+
+        clearTimeout(timeoutId)
 
         if (!response.ok) {
             const errorData = await response.json().catch(() => ({}))
@@ -204,12 +197,8 @@ export const mantecaApi = {
         success: boolean
         perk: { sponsored: boolean; amountSponsored: number; discountPercentage: number; txHash?: string }
     }> => {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/perks/claim`, {
+        const response = await serverFetch('/perks/claim', {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${getAuthToken()}`,
-            },
             body: jsonStringify({ mantecaTransferId }),
         })
 
@@ -221,8 +210,8 @@ export const mantecaApi = {
         return response.json()
     },
     getPrices: async ({ asset, against }: { asset: string; against: string }): Promise<MantecaPrice> => {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/manteca/prices?asset=${asset}&against=${against}`, {
-            headers: getAuthHeaders(),
+        const response = await serverFetch(`/manteca/prices?asset=${asset}&against=${against}`, {
+            method: 'GET',
         })
 
         if (!response.ok) {
@@ -237,12 +226,8 @@ export const mantecaApi = {
         failureUrl?: string
         exchange?: string
     }): Promise<{ url: string }> => {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/manteca/initiate-onboarding`, {
+        const response = await serverFetch('/manteca/initiate-onboarding', {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${getAuthToken()}`,
-            },
             body: jsonStringify(params),
         })
 
@@ -258,12 +243,8 @@ export const mantecaApi = {
         params: CreateMantecaOnrampParams
     ): Promise<{ data?: MantecaDepositResponseData; error?: string }> => {
         try {
-            const response = await fetchWithSentry(`${PEANUT_API_URL}/manteca/deposit`, {
+            const response = await serverFetch('/manteca/deposit', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    Authorization: `Bearer ${getAuthToken()}`,
-                },
                 body: jsonStringify({
                     amount: params.amount,
                     isUsdDenominated: params.isUsdDenominated,
@@ -292,11 +273,8 @@ export const mantecaApi = {
 
     cancelDeposit: async (depositId: string): Promise<{ data?: MantecaDepositResponseData; error?: string }> => {
         try {
-            const response = await fetchWithSentry(`${PEANUT_API_URL}/manteca/deposit/${depositId}/cancel`, {
+            const response = await serverFetch(`/manteca/deposit/${depositId}/cancel`, {
                 method: 'PATCH',
-                headers: {
-                    Authorization: `Bearer ${getAuthToken()}`,
-                },
             })
 
             const data = await response.json()
@@ -319,12 +297,8 @@ export const mantecaApi = {
 
     withdraw: async (data: MantecaWithdrawData): Promise<MantecaWithdrawResponse> => {
         try {
-            const response = await fetchWithSentry(`${PEANUT_API_URL}/manteca/withdraw`, {
+            const response = await serverFetch('/manteca/withdraw', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    Authorization: `Bearer ${getAuthToken()}`,
-                },
                 body: jsonStringify(data),
             })
 
@@ -357,12 +331,8 @@ export const mantecaApi = {
         currency: string
     }): Promise<{ data?: WithdrawPriceLock; error?: string }> => {
         try {
-            const response = await fetchWithSentry(`${PEANUT_API_URL}/manteca/withdraw/init`, {
+            const response = await serverFetch('/manteca/withdraw/init', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    Authorization: `Bearer ${getAuthToken()}`,
-                },
                 body: jsonStringify(params),
             })
 
@@ -415,12 +385,8 @@ export const mantecaApi = {
         entryPointAddress: string
     }): Promise<MantecaWithdrawResponse> => {
         try {
-            const response = await fetchWithSentry(`${PEANUT_API_URL}/manteca/withdraw/complete-with-signed-tx`, {
+            const response = await serverFetch('/manteca/withdraw/complete-with-signed-tx', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    Authorization: `Bearer ${getAuthToken()}`,
-                },
                 body: jsonStringify(params),
             })
 

--- a/src/services/manteca.ts
+++ b/src/services/manteca.ts
@@ -166,10 +166,6 @@ export const mantecaApi = {
         chainId: string
         entryPointAddress: Address
     }): Promise<QrPayment> => {
-        // 120s timeout for this long-running operation
-        const controller = new AbortController()
-        const timeoutId = setTimeout(() => controller.abort(), 120000)
-
         const response = await serverFetch('/manteca/qr-payment/complete-with-signed-tx', {
             method: 'POST',
             body: jsonStringify({
@@ -179,10 +175,8 @@ export const mantecaApi = {
                 entryPointAddress,
                 qrType,
             }),
-            signal: controller.signal,
+            timeoutMs: 120_000, // long-running signed userop submission
         })
-
-        clearTimeout(timeoutId)
 
         if (!response.ok) {
             const errorData = await response.json().catch(() => ({}))

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -1,5 +1,4 @@
-import { getAuthToken } from '@/utils/auth-token'
-import { PEANUT_API_URL } from '@/constants/general.consts'
+import { serverFetch } from '@/utils/api-fetch'
 
 export type InAppItem = {
     id: string
@@ -26,15 +25,9 @@ export const notificationsApi = {
         if (cursor) search.set('cursor', cursor)
         if (category) search.set('category', category)
 
-        const token = getAuthToken()
-        const url = `${PEANUT_API_URL}/notifications?${search.toString()}`
-
         try {
-            const response = await fetch(url, {
-                headers: {
-                    'Content-Type': 'application/json',
-                    Authorization: `Bearer ${token}`,
-                },
+            const response = await serverFetch(`/notifications?${search.toString()}`, {
+                method: 'GET',
             })
             if (!response.ok) throw new Error('failed to fetch notifications')
             return (await response.json()) as ListResponse
@@ -44,23 +37,16 @@ export const notificationsApi = {
     },
 
     async unreadCount(): Promise<{ count: number }> {
-        const response = await fetch(`${PEANUT_API_URL}/notifications/unread-count`, {
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${getAuthToken()}`,
-            },
+        const response = await serverFetch('/notifications/unread-count', {
+            method: 'GET',
         })
         if (!response.ok) throw new Error('failed to fetch unread count')
         return await response.json()
     },
 
     async markRead(ids: string[]) {
-        const response = await fetch(`${PEANUT_API_URL}/notifications/mark-read`, {
+        const response = await serverFetch('/notifications/mark-read', {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${getAuthToken()}`,
-            },
             body: JSON.stringify({ ids }),
         })
         if (!response.ok) throw new Error('failed to mark read')

--- a/src/services/perks.ts
+++ b/src/services/perks.ts
@@ -1,6 +1,4 @@
-import { getAuthToken } from '@/utils/auth-token'
-import { fetchWithSentry } from '@/utils/sentry.utils'
-import { PEANUT_API_URL } from '@/constants/general.consts'
+import { serverFetch } from '@/utils/api-fetch'
 
 export type PendingPerk = {
     id: string
@@ -37,18 +35,8 @@ export const perksApi = {
      */
     getPendingPerks: async (): Promise<PendingPerksResponse> => {
         try {
-            const jwtToken = getAuthToken()
-            if (!jwtToken) {
-                console.error('getPendingPerks: No JWT token found')
-                return { success: false, perks: [], error: 'Not authenticated' }
-            }
-
-            const response = await fetchWithSentry(`${PEANUT_API_URL}/perks/pending`, {
+            const response = await serverFetch('/perks/pending', {
                 method: 'GET',
-                headers: {
-                    Authorization: `Bearer ${jwtToken}`,
-                    'Content-Type': 'application/json',
-                },
             })
 
             if (!response.ok) {
@@ -69,18 +57,8 @@ export const perksApi = {
      */
     claimPerk: async (usageId: string): Promise<ClaimPerkResponse> => {
         try {
-            const jwtToken = getAuthToken()
-            if (!jwtToken) {
-                console.error('claimPerk: No JWT token found')
-                return { success: false, error: 'NOT_AUTHENTICATED', message: 'Not authenticated' }
-            }
-
-            const response = await fetchWithSentry(`${PEANUT_API_URL}/perks/claim`, {
+            const response = await serverFetch('/perks/claim', {
                 method: 'POST',
-                headers: {
-                    Authorization: `Bearer ${jwtToken}`,
-                    'Content-Type': 'application/json',
-                },
                 body: JSON.stringify({ usageId }),
             })
 

--- a/src/services/points.ts
+++ b/src/services/points.ts
@@ -119,17 +119,11 @@ async function fetchInvitesGraph(
     handleStatusError?: (status: number) => string | null
 ): Promise<InvitesGraphResponse> {
     try {
-        // Add 30s timeout for large graph data
-        const controller = new AbortController()
-        const timeoutId = setTimeout(() => controller.abort(), 30000)
-
         const response = await serverFetch(endpoint, {
             method: 'GET',
             headers: extraHeaders,
-            signal: controller.signal,
+            timeoutMs: 30_000, // large graph data can be slow
         })
-
-        clearTimeout(timeoutId)
 
         if (!response.ok) {
             console.error('getInvitesGraph: API request failed', response.status, response.statusText)

--- a/src/services/points.ts
+++ b/src/services/points.ts
@@ -1,7 +1,5 @@
-import { getAuthToken } from '@/utils/auth-token'
 import { type CalculatePointsRequest, PointsAction, type TierInfo } from './services.types'
-import { fetchWithSentry } from '@/utils/sentry.utils'
-import { PEANUT_API_URL } from '@/constants/general.consts'
+import { serverFetch } from '@/utils/api-fetch'
 
 /** Qualitative labels for anonymized data */
 export type FrequencyLabel = 'rare' | 'occasional' | 'regular' | 'frequent'
@@ -118,33 +116,16 @@ type ExternalNodesResponse = {
 async function fetchInvitesGraph(
     endpoint: string,
     extraHeaders?: Record<string, string>,
-    handleStatusError?: (status: number) => string | null,
-    requiresAuth: boolean = true
+    handleStatusError?: (status: number) => string | null
 ): Promise<InvitesGraphResponse> {
     try {
-        // Get JWT token for user authentication (optional in payment mode)
-        const jwtToken = getAuthToken()
-        if (requiresAuth && !jwtToken) {
-            console.error('getInvitesGraph: No JWT token found')
-            return { success: false, data: null, error: 'Not authenticated. Please log in.' }
-        }
-
         // Add 30s timeout for large graph data
         const controller = new AbortController()
         const timeoutId = setTimeout(() => controller.abort(), 30000)
 
-        // Build headers - JWT is optional when requiresAuth is false
-        const headers: Record<string, string> = {
-            'Content-Type': 'application/json',
-            ...extraHeaders,
-        }
-        if (jwtToken) {
-            headers['Authorization'] = `Bearer ${jwtToken}`
-        }
-
-        const response = await fetchWithSentry(`${PEANUT_API_URL}${endpoint}`, {
+        const response = await serverFetch(endpoint, {
             method: 'GET',
-            headers,
+            headers: extraHeaders,
             signal: controller.signal,
         })
 
@@ -178,18 +159,8 @@ async function fetchInvitesGraph(
 export const pointsApi = {
     getTierInfo: async (): Promise<{ success: boolean; data: TierInfo | null }> => {
         try {
-            const jwtToken = getAuthToken()
-            if (!jwtToken) {
-                console.error('getTierInfo: No JWT token found')
-                return { success: false, data: null }
-            }
-
-            const response = await fetchWithSentry(`${PEANUT_API_URL}/points`, {
+            const response = await serverFetch('/points', {
                 method: 'GET',
-                headers: {
-                    Authorization: `Bearer ${jwtToken}`,
-                    'Content-Type': 'application/json',
-                },
             })
             if (!response.ok) {
                 console.error('getTierInfo: API request failed', response.status, response.statusText)
@@ -210,14 +181,6 @@ export const pointsApi = {
         otherUserId,
     }: CalculatePointsRequest): Promise<{ estimatedPoints: number }> => {
         try {
-            const jwtToken = getAuthToken()
-
-            if (!jwtToken) {
-                const error = new Error('No JWT token found')
-                console.error('calculatePoints: No JWT token found')
-                throw error
-            }
-
             const body: { actionType: PointsAction; usdAmount: number; otherUserId?: string } = {
                 actionType,
                 usdAmount,
@@ -227,12 +190,8 @@ export const pointsApi = {
                 body.otherUserId = otherUserId
             }
 
-            const response = await fetchWithSentry(`${PEANUT_API_URL}/points/calculate`, {
+            const response = await serverFetch('/points/calculate', {
                 method: 'POST',
-                headers: {
-                    Authorization: `Bearer ${jwtToken}`,
-                    'Content-Type': 'application/json',
-                },
                 body: JSON.stringify(body),
             })
 
@@ -278,15 +237,9 @@ export const pointsApi = {
             if (params?.limit) queryParams.append('limit', params.limit.toString())
             if (params?.since) queryParams.append('since', params.since)
 
-            const response = await fetchWithSentry(
-                `${PEANUT_API_URL}/points/time-leaderboard?${queryParams.toString()}`,
-                {
-                    method: 'GET',
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
-                }
-            )
+            const response = await serverFetch(`/points/time-leaderboard?${queryParams.toString()}`, {
+                method: 'GET',
+            })
 
             if (!response.ok) {
                 console.error('getTimeLeaderboard: API request failed', response.status, response.statusText)
@@ -322,19 +275,14 @@ export const pointsApi = {
         const endpoint = `/invites/graph${params.toString() ? `?${params}` : ''}`
         // Payment mode uses password auth (no API key needed), full mode requires API key + JWT
         const headers: Record<string, string> = isPaymentMode ? {} : { 'api-key': apiKey }
-        return fetchInvitesGraph(
-            endpoint,
-            headers,
-            (status) => {
-                if (status === 403) {
-                    return 'Access denied. Only authorized users can access this tool.'
-                } else if (status === 401) {
-                    return isPaymentMode ? 'Invalid or missing password.' : 'Invalid API key or authentication token.'
-                }
-                return null
-            },
-            !isPaymentMode // requiresAuth = false for payment mode
-        )
+        return fetchInvitesGraph(endpoint, headers, (status) => {
+            if (status === 403) {
+                return 'Access denied. Only authorized users can access this tool.'
+            } else if (status === 401) {
+                return isPaymentMode ? 'Invalid or missing password.' : 'Invalid API key or authentication token.'
+            }
+            return null
+        })
     },
 
     getUserInvitesGraph: async (): Promise<InvitesGraphResponse> => {
@@ -361,18 +309,8 @@ export const pointsApi = {
         } | null
     }> => {
         try {
-            const jwtToken = getAuthToken()
-            if (!jwtToken) {
-                console.error('getCashStatus: No JWT token found')
-                return { success: false, data: null }
-            }
-
-            const response = await fetchWithSentry(`${PEANUT_API_URL}/points/cash-status`, {
+            const response = await serverFetch('/points/cash-status', {
                 method: 'GET',
-                headers: {
-                    Authorization: `Bearer ${jwtToken}`,
-                    'Content-Type': 'application/json',
-                },
             })
             if (!response.ok) {
                 console.error('getCashStatus: API request failed', response.status, response.statusText)
@@ -399,12 +337,7 @@ export const pointsApi = {
         }
     ): Promise<ExternalNodesResponse> => {
         try {
-            const jwtToken = getAuthToken()
-            // Payment mode uses password auth, full mode requires JWT
             const isPaymentMode = options?.mode === 'payment'
-            if (!isPaymentMode && !jwtToken) {
-                return { success: false, data: null, error: 'Not authenticated. Please log in.' }
-            }
 
             // Build query params
             const params = new URLSearchParams()
@@ -428,22 +361,17 @@ export const pointsApi = {
                 params.set('password', options.password)
             }
 
-            const url = `${PEANUT_API_URL}/invites/graph/external${params.toString() ? `?${params}` : ''}`
+            const path = `/invites/graph/external${params.toString() ? `?${params}` : ''}`
 
-            // Build headers:
+            // Build custom headers:
             // - Payment mode: no API key required (uses password auth)
-            // - Full mode: API key + JWT required
-            const headers: Record<string, string> = {
-                'Content-Type': 'application/json',
-            }
+            // - Full mode: API key required
+            const headers: Record<string, string> = {}
             if (!isPaymentMode) {
                 headers['api-key'] = apiKey
             }
-            if (jwtToken) {
-                headers['Authorization'] = `Bearer ${jwtToken}`
-            }
 
-            const response = await fetchWithSentry(url, {
+            const response = await serverFetch(path, {
                 method: 'GET',
                 headers,
             })

--- a/src/services/quests.ts
+++ b/src/services/quests.ts
@@ -3,10 +3,8 @@
  * Handles all quest-related API calls
  */
 
-import { getAuthToken } from '@/utils/auth-token'
-import { fetchWithSentry } from '@/utils/sentry.utils'
 import type { QuestLeaderboardData, AllQuestsLeaderboardData } from '@/app/quests/types'
-import { PEANUT_API_URL } from '@/constants/general.consts'
+import { serverFetch } from '@/utils/api-fetch'
 
 export const questsApi = {
     /**
@@ -19,23 +17,15 @@ export const questsApi = {
         error?: string
     }> {
         try {
-            const jwtToken = getAuthToken()
             const limit = params?.limit || 3
             const useTestTimePeriod = params?.useTestTimePeriod ? 'true' : 'false'
-            const url = `${PEANUT_API_URL}/quests/leaderboards?limit=${limit}&useTestTimePeriod=${useTestTimePeriod}`
 
-            const headers: HeadersInit = {
-                'Content-Type': 'application/json',
-            }
-
-            if (jwtToken) {
-                headers['Authorization'] = `Bearer ${jwtToken}`
-            }
-
-            const response = await fetchWithSentry(url, {
-                method: 'GET',
-                headers,
-            })
+            const response = await serverFetch(
+                `/quests/leaderboards?limit=${limit}&useTestTimePeriod=${useTestTimePeriod}`,
+                {
+                    method: 'GET',
+                }
+            )
 
             if (!response.ok) {
                 throw new Error(`Failed to fetch leaderboards: ${response.statusText}`)
@@ -65,23 +55,15 @@ export const questsApi = {
         error?: string
     }> {
         try {
-            const jwtToken = getAuthToken()
             const limit = params?.limit || 10
             const useTestTimePeriod = params?.useTestTimePeriod ? 'true' : 'false'
-            const url = `${PEANUT_API_URL}/quests/${questId}/leaderboard?limit=${limit}&useTestTimePeriod=${useTestTimePeriod}`
 
-            const headers: HeadersInit = {
-                'Content-Type': 'application/json',
-            }
-
-            if (jwtToken) {
-                headers['Authorization'] = `Bearer ${jwtToken}`
-            }
-
-            const response = await fetchWithSentry(url, {
-                method: 'GET',
-                headers,
-            })
+            const response = await serverFetch(
+                `/quests/${questId}/leaderboard?limit=${limit}&useTestTimePeriod=${useTestTimePeriod}`,
+                {
+                    method: 'GET',
+                }
+            )
 
             if (!response.ok) {
                 throw new Error(`Failed to fetch ${questId} leaderboard: ${response.statusText}`)

--- a/src/services/requests.ts
+++ b/src/services/requests.ts
@@ -1,21 +1,11 @@
-import { getAuthToken } from '@/utils/auth-token'
 import { type CreateRequestRequest, type TRequestResponse } from './services.types'
-import { fetchWithSentry } from '@/utils/sentry.utils'
+import { serverFetch } from '@/utils/api-fetch'
 import { jsonStringify } from '@/utils/general.utils'
-import { PEANUT_API_URL } from '@/constants/general.consts'
 
 export const requestsApi = {
     create: async (data: CreateRequestRequest): Promise<TRequestResponse> => {
-        const token = getAuthToken()
-        if (!token) {
-            throw new Error('Authentication token not found. Please log in again.')
-        }
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/requests`, {
+        const response = await serverFetch('/requests', {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${token}`,
-            },
             body: jsonStringify(data),
         })
 
@@ -39,16 +29,8 @@ export const requestsApi = {
     },
 
     update: async (id: string, data: Partial<CreateRequestRequest>): Promise<TRequestResponse> => {
-        const token = getAuthToken()
-        if (!token) {
-            throw new Error('Authentication token not found. Please log in again.')
-        }
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/requests/${id}`, {
+        const response = await serverFetch(`/requests/${id}`, {
             method: 'PATCH',
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${token}`,
-            },
             body: jsonStringify(data),
         })
 
@@ -60,7 +42,9 @@ export const requestsApi = {
     },
 
     get: async (uuid: string): Promise<TRequestResponse> => {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/requests/${uuid}`)
+        const response = await serverFetch(`/requests/${uuid}`, {
+            method: 'GET',
+        })
         if (!response.ok) {
             throw new Error(`Failed to fetch request: ${response.statusText}`)
         }
@@ -78,7 +62,9 @@ export const requestsApi = {
             if (value) queryParams.append(key, value)
         })
 
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/requests?${queryParams.toString()}`)
+        const response = await serverFetch(`/requests?${queryParams.toString()}`, {
+            method: 'GET',
+        })
         if (!response.ok) {
             if (response.status === 404) {
                 return null
@@ -89,15 +75,8 @@ export const requestsApi = {
     },
 
     close: async (uuid: string): Promise<TRequestResponse> => {
-        const token = getAuthToken()
-        if (!token) {
-            throw new Error('Authentication token not found. Please log in again.')
-        }
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/requests/${uuid}`, {
+        const response = await serverFetch(`/requests/${uuid}`, {
             method: 'DELETE',
-            headers: {
-                Authorization: `Bearer ${token}`,
-            },
         })
         if (!response.ok) {
             throw new Error(`Failed to close request: ${response.statusText}`)

--- a/src/services/rewards.ts
+++ b/src/services/rewards.ts
@@ -1,16 +1,10 @@
-import { getAuthToken } from '@/utils/auth-token'
-import { fetchWithSentry } from '@/utils/sentry.utils'
+import { serverFetch } from '@/utils/api-fetch'
 import { type RewardLink } from './services.types'
-import { PEANUT_API_URL } from '@/constants/general.consts'
 
 export const rewardsApi = {
     getByUser: async (userId: string): Promise<RewardLink[]> => {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/users/${userId}/rewards`, {
+        const response = await serverFetch(`/users/${userId}/rewards`, {
             method: 'GET',
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${getAuthToken()}`,
-            },
         })
         if (!response.ok) {
             throw new Error(`Failed to fetch rewards: ${response.statusText}`)

--- a/src/services/rhino.ts
+++ b/src/services/rhino.ts
@@ -1,6 +1,5 @@
-import { getAuthToken } from '@/utils/auth-token'
+import { serverFetch } from '@/utils/api-fetch'
 import type { CreateDepositAddressResponse, DepositAddressStatusResponse, RhinoChainType } from './services.types'
-import { PEANUT_API_URL } from '@/constants/general.consts'
 
 export const rhinoApi = {
     createDepositAddress: async (
@@ -8,17 +7,8 @@ export const rhinoApi = {
         chainType: RhinoChainType,
         identifier: string
     ): Promise<CreateDepositAddressResponse> => {
-        const token = getAuthToken()
-        if (!token) {
-            throw new Error('Authentication required')
-        }
-
-        const response = await fetch(`${PEANUT_API_URL}/rhino/deposit`, {
+        const response = await serverFetch('/rhino/deposit', {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${token}`,
-            },
             body: JSON.stringify({ destinationAddress, type: chainType, addressNote: identifier }),
         })
         if (!response.ok) {
@@ -29,11 +19,8 @@ export const rhinoApi = {
     },
 
     getDepositAddressStatus: async (depositAddress: string): Promise<DepositAddressStatusResponse> => {
-        const response = await fetch(`${PEANUT_API_URL}/rhino/status/${depositAddress}`, {
+        const response = await serverFetch(`/rhino/status/${depositAddress}`, {
             method: 'GET',
-            headers: {
-                'Content-Type': 'application/json',
-            },
         })
 
         if (!response.ok) {
@@ -45,16 +32,8 @@ export const rhinoApi = {
     },
 
     resetDepositAddressStatus: async (depositAddress: string): Promise<boolean> => {
-        const token = getAuthToken()
-        if (!token) {
-            throw new Error('Authentication required')
-        }
-        const response = await fetch(`${PEANUT_API_URL}/rhino/reset-status/${depositAddress}`, {
+        const response = await serverFetch(`/rhino/reset-status/${depositAddress}`, {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${token}`,
-            },
         })
 
         if (!response.ok) {
@@ -69,11 +48,8 @@ export const rhinoApi = {
         chargeId: string,
         peanutWalletAddress?: string
     ): Promise<CreateDepositAddressResponse> => {
-        const response = await fetch(`${PEANUT_API_URL}/rhino/request-fulfilment`, {
+        const response = await serverFetch('/rhino/request-fulfilment', {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
             body: JSON.stringify({
                 type: chainType,
                 chargeId,

--- a/src/services/sendLinks.ts
+++ b/src/services/sendLinks.ts
@@ -1,9 +1,11 @@
 // Removed claimSendLink import - no longer used (was insecure)
-import { getAuthToken } from '@/utils/auth-token'
-import { fetchWithSentry } from '@/utils/sentry.utils'
 import { jsonParse, jsonStringify } from '@/utils/general.utils'
 import { generateKeysFromString, getParamsFromLink } from '@squirrel-labs/peanut-sdk'
 import type { SendLink } from '@/services/services.types'
+import { serverFetch } from '@/utils/api-fetch'
+import { isCapacitor } from '@/utils/capacitor'
+import { getAuthHeaders } from '@/utils/auth-token'
+import { fetchWithSentry } from '@/utils/sentry.utils'
 import { PEANUT_API_URL } from '@/constants/general.consts'
 
 export { ESendLinkStatus } from '@/services/services.types'
@@ -39,9 +41,7 @@ type UpdateLinkBody = {
 export const sendLinksApi = {
     create: async (sendLink: CreateLinkBody): Promise<SendLink> => {
         let requestBody: FormData | string
-        const headers: HeadersInit = {
-            Authorization: `Bearer ${getAuthToken()}`,
-        }
+        const headers: Record<string, string> = {}
 
         // check if attachment is a File or Blob object
         if (sendLink.attachment && (sendLink.attachment instanceof File || sendLink.attachment instanceof Blob)) {
@@ -70,15 +70,21 @@ export const sendLinksApi = {
             }
         } else {
             // no file, or attachment is not a File/Blob, send as JSON
-            // if attachment exists but is not a file (e.g. just a reference string), it will be stringified.
             requestBody = jsonStringify(sendLink)
             headers['Content-Type'] = 'application/json'
         }
 
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/send-links`, {
+        // formdata needs the withFormData proxy on web; json goes through regular proxy
+        const url = isCapacitor()
+            ? `${PEANUT_API_URL}/send-links`
+            : requestBody instanceof FormData
+              ? '/api/proxy/withFormData/send-links'
+              : '/api/proxy/send-links'
+        Object.assign(headers, getAuthHeaders())
+        const response = await fetchWithSentry(url, {
             method: 'POST',
             body: requestBody,
-            headers: headers,
+            headers,
         })
 
         if (!response.ok) {
@@ -102,13 +108,9 @@ export const sendLinksApi = {
     },
 
     update: async (sendLink: UpdateLinkBody): Promise<SendLink> => {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/send-links/${sendLink.pubKey}`, {
+        const response = await serverFetch(`/send-links/${sendLink.pubKey}`, {
             method: 'PATCH',
             body: jsonStringify(sendLink),
-            headers: {
-                Authorization: `Bearer ${getAuthToken()}`,
-                'Content-Type': 'application/json',
-            },
         })
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`)
@@ -122,11 +124,12 @@ export const sendLinksApi = {
         const pubKey = generateKeysFromString(params.password).address
         // Add timestamp to prevent caching of 404s during DB replication lag
         const cacheBuster = Date.now()
-        const url = `${PEANUT_API_URL}/send-links/${pubKey}?c=${params.chainId}&v=${params.contractVersion}&i=${params.depositIdx}&_=${cacheBuster}`
-        const response = await fetchWithSentry(url, {
-            method: 'GET',
-            cache: 'no-store', // Prevent browser from caching responses
-        })
+        const response = await serverFetch(
+            `/send-links/${pubKey}?c=${params.chainId}&v=${params.contractVersion}&i=${params.depositIdx}&_=${cacheBuster}`,
+            {
+                method: 'GET',
+            }
+        )
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`)
         }
@@ -144,10 +147,12 @@ export const sendLinksApi = {
         depositIdx: number | string
         contractVersion: string
     }): Promise<SendLink> => {
-        const url = `${PEANUT_API_URL}/send-links?c=${params.chainId}&v=${params.contractVersion}&i=${params.depositIdx}`
-        const response = await fetchWithSentry(url, {
-            method: 'GET',
-        })
+        const response = await serverFetch(
+            `/send-links?c=${params.chainId}&v=${params.contractVersion}&i=${params.depositIdx}`,
+            {
+                method: 'GET',
+            }
+        )
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`)
         }
@@ -156,8 +161,7 @@ export const sendLinksApi = {
     },
 
     getByPubKey: async (pubKey: string): Promise<SendLink> => {
-        const url = `${PEANUT_API_URL}/send-links/${pubKey}`
-        const response = await fetchWithSentry(url, {
+        const response = await serverFetch(`/send-links/${pubKey}`, {
             method: 'GET',
         })
         if (!response.ok) {
@@ -179,11 +183,8 @@ export const sendLinksApi = {
      * @param txhash - the transaction hash of the successful claim.
      */
     associateClaim: async (txHash: string): Promise<void> => {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/send-links/claim/${txHash}/associate-user`, {
+        const response = await serverFetch(`/send-links/claim/${txHash}/associate-user`, {
             method: 'PATCH',
-            headers: {
-                Authorization: `Bearer ${getAuthToken()}`,
-            },
         })
 
         if (!response.ok) {

--- a/src/services/simplefi.ts
+++ b/src/services/simplefi.ts
@@ -1,7 +1,5 @@
-import { getAuthToken } from '@/utils/auth-token'
-import { fetchWithSentry } from '@/utils/sentry.utils'
+import { serverFetch } from '@/utils/api-fetch'
 import type { Address } from 'viem'
-import { PEANUT_API_URL } from '@/constants/general.consts'
 
 export type QrPaymentType = 'STATIC' | 'DYNAMIC' | 'USER_SPECIFIED'
 
@@ -52,12 +50,8 @@ const ERROR_MESSAGES: Record<SimpleFiErrorCode, string> = {
 
 export const simplefiApi = {
     initiateQrPayment: async (data: SimpleFiQrPaymentRequest): Promise<SimpleFiQrPaymentResponse> => {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/simplefi/qr-pay`, {
+        const response = await serverFetch('/simplefi/qr-pay', {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${getAuthToken()}`,
-            },
             body: JSON.stringify(data),
         })
 

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -1,4 +1,3 @@
-import { getAuthToken } from '@/utils/auth-token'
 import {
     PEANUT_WALLET_CHAIN,
     PEANUT_WALLET_TOKEN,
@@ -7,11 +6,11 @@ import {
 } from '@/constants/zerodev.consts'
 import { AccountType, type IUserKycVerification } from '@/interfaces'
 import { type IAttachmentOptions } from '@/interfaces/attachment'
-import { fetchWithSentry } from '@/utils/sentry.utils'
+import { serverFetch } from '@/utils/api-fetch'
 import { interfaces as peanutInterfaces } from '@squirrel-labs/peanut-sdk'
 import { chargesApi } from './charges'
 import { type TCharge } from './services.types'
-import { PEANUT_API_URL, BASE_URL } from '@/constants/general.consts'
+import { BASE_URL } from '@/constants/general.consts'
 
 type ApiAccount = {
     identifier: string
@@ -48,23 +47,16 @@ export interface UserSearchResponse {
 
 export const usersApi = {
     getByUsername: async (username: string): Promise<ApiUser> => {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/users/username/${username}`, {
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${getAuthToken()}`,
-            },
+        const response = await serverFetch(`/users/username/${username}`, {
+            method: 'GET',
         })
         return await response.json()
     },
 
     getInteractionStatus: async (userIds: string[]): Promise<Record<string, boolean>> => {
         // returns a map of userIds to booleans indicating if the current user has sent money to them
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/users/interaction-status`, {
+        const response = await serverFetch('/users/interaction-status', {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${getAuthToken()}`,
-            },
             body: JSON.stringify({ userIds }),
         })
         return await response.json()

--- a/src/utils/__tests__/api-fetch.test.ts
+++ b/src/utils/__tests__/api-fetch.test.ts
@@ -1,6 +1,6 @@
-// tests for apiFetch routing between capacitor (direct backend) and web (proxy)
+// tests for apiFetch and serverFetch routing between capacitor (direct backend) and web (proxy)
 
-import { apiFetch } from '../api-fetch'
+import { apiFetch, serverFetch } from '../api-fetch'
 import { fetchWithSentry } from '@/utils/sentry.utils'
 import { isCapacitor } from '@/utils/capacitor'
 import { getAuthHeaders } from '@/utils/auth-token'
@@ -133,6 +133,130 @@ describe('apiFetch', () => {
             })
 
             expect(getAuthHeaders).toHaveBeenCalledWith({ 'X-Custom': 'value' })
+        })
+    })
+})
+
+describe('serverFetch', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockIsCapacitor.mockReturnValue(false)
+    })
+
+    describe('web mode — proxy url routing by method', () => {
+        it('should route GET to /api/proxy/get/', async () => {
+            await serverFetch('/users/history', { method: 'GET' })
+            expect(mockFetchWithSentry).toHaveBeenCalledWith('/api/proxy/get/users/history', expect.any(Object))
+        })
+
+        it('should route HEAD to /api/proxy/get/', async () => {
+            await serverFetch('/users/username/test', { method: 'HEAD' })
+            expect(mockFetchWithSentry).toHaveBeenCalledWith('/api/proxy/get/users/username/test', expect.any(Object))
+        })
+
+        it('should route POST to /api/proxy/', async () => {
+            await serverFetch('/invites/validate', { method: 'POST', body: JSON.stringify({ code: 'x' }) })
+            expect(mockFetchWithSentry).toHaveBeenCalledWith('/api/proxy/invites/validate', expect.any(Object))
+        })
+
+        it('should route PATCH to /api/proxy/patch/', async () => {
+            await serverFetch('/send-links/key', { method: 'PATCH', body: JSON.stringify({}) })
+            expect(mockFetchWithSentry).toHaveBeenCalledWith('/api/proxy/patch/send-links/key', expect.any(Object))
+        })
+
+        it('should route DELETE to /api/proxy/delete/', async () => {
+            await serverFetch('/bridge/onramp/123/cancel', { method: 'DELETE' })
+            expect(mockFetchWithSentry).toHaveBeenCalledWith(
+                '/api/proxy/delete/bridge/onramp/123/cancel',
+                expect.any(Object)
+            )
+        })
+
+        it('should default to GET when no method specified', async () => {
+            await serverFetch('/history/entry-1')
+            expect(mockFetchWithSentry).toHaveBeenCalledWith('/api/proxy/get/history/entry-1', expect.any(Object))
+        })
+
+        it('should preserve query params', async () => {
+            await serverFetch('/users/history?cursor=abc&limit=10', { method: 'GET' })
+            expect(mockFetchWithSentry).toHaveBeenCalledWith(
+                '/api/proxy/get/users/history?cursor=abc&limit=10',
+                expect.any(Object)
+            )
+        })
+    })
+
+    describe('native mode — direct backend urls', () => {
+        beforeEach(() => {
+            mockIsCapacitor.mockReturnValue(true)
+        })
+
+        it('should call PEANUT_API_URL directly for GET', async () => {
+            await serverFetch('/users/history', { method: 'GET' })
+            expect(mockFetchWithSentry).toHaveBeenCalledWith('https://api.test.com/users/history', expect.any(Object))
+        })
+
+        it('should call PEANUT_API_URL directly for POST', async () => {
+            await serverFetch('/invites/validate', { method: 'POST', body: JSON.stringify({}) })
+            expect(mockFetchWithSentry).toHaveBeenCalledWith(
+                'https://api.test.com/invites/validate',
+                expect.any(Object)
+            )
+        })
+
+        it('should call PEANUT_API_URL directly for DELETE', async () => {
+            await serverFetch('/bridge/onramp/123/cancel', { method: 'DELETE' })
+            expect(mockFetchWithSentry).toHaveBeenCalledWith(
+                'https://api.test.com/bridge/onramp/123/cancel',
+                expect.any(Object)
+            )
+        })
+    })
+
+    describe('auth headers', () => {
+        it('should include auth headers via getAuthHeaders in native mode', async () => {
+            mockIsCapacitor.mockReturnValue(true)
+            await serverFetch('/users/me', { method: 'GET' })
+
+            expect(getAuthHeaders).toHaveBeenCalled()
+            const callArgs = mockFetchWithSentry.mock.calls[0][1]
+            expect((callArgs?.headers as Record<string, string>)['Authorization']).toBe('Bearer test-token')
+        })
+
+        it('should forward auth headers on web for proxy relay', async () => {
+            mockIsCapacitor.mockReturnValue(false)
+            await serverFetch('/users/me', { method: 'GET' })
+
+            // serverFetch calls getAuthHeaders() on web too, to forward to proxy
+            const callArgs = mockFetchWithSentry.mock.calls[0][1]
+            expect((callArgs?.headers as Record<string, string>)['Authorization']).toBe('Bearer test-token')
+        })
+    })
+
+    describe('content-type header', () => {
+        it('should auto-add Content-Type for POST with body', async () => {
+            await serverFetch('/update', { method: 'POST', body: JSON.stringify({ x: 1 }) })
+
+            const callArgs = mockFetchWithSentry.mock.calls[0][1]
+            expect((callArgs?.headers as Record<string, string>)['Content-Type']).toBe('application/json')
+        })
+
+        it('should not add Content-Type for GET without body', async () => {
+            await serverFetch('/data', { method: 'GET' })
+
+            const callArgs = mockFetchWithSentry.mock.calls[0][1]
+            expect((callArgs?.headers as Record<string, string>)['Content-Type']).toBeUndefined()
+        })
+
+        it('should respect caller-provided Content-Type', async () => {
+            await serverFetch('/upload', {
+                method: 'POST',
+                body: 'raw data',
+                headers: { 'Content-Type': 'text/plain' },
+            })
+
+            const callArgs = mockFetchWithSentry.mock.calls[0][1]
+            expect((callArgs?.headers as Record<string, string>)['Content-Type']).toBe('text/plain')
         })
     })
 })

--- a/src/utils/__tests__/capacitor.test.ts
+++ b/src/utils/__tests__/capacitor.test.ts
@@ -28,8 +28,8 @@ describe('capacitor utils', () => {
             expect(isCapacitor()).toBe(false)
         })
 
-        it('should return true when window.Capacitor exists', () => {
-            ;(window as any).Capacitor = { getPlatform: () => 'ios' }
+        it('should return true when running on a native platform', () => {
+            ;(window as any).Capacitor = { getPlatform: () => 'ios', isNativePlatform: () => true }
             ;({ isCapacitor } = require('../capacitor'))
             expect(isCapacitor()).toBe(true)
         })
@@ -172,14 +172,14 @@ describe('capacitor utils', () => {
     describe('getApiBaseUrl', () => {
         it('should return NEXT_PUBLIC_BASE_URL in capacitor mode', () => {
             process.env.NEXT_PUBLIC_BASE_URL = 'https://api.staging.peanut.me'
-            ;(window as any).Capacitor = { getPlatform: () => 'ios' }
+            ;(window as any).Capacitor = { getPlatform: () => 'ios', isNativePlatform: () => true }
             ;({ getApiBaseUrl } = require('../capacitor'))
             expect(getApiBaseUrl()).toBe('https://api.staging.peanut.me')
         })
 
         it('should return fallback url when NEXT_PUBLIC_BASE_URL is not set in capacitor mode', () => {
             delete process.env.NEXT_PUBLIC_BASE_URL
-            ;(window as any).Capacitor = { getPlatform: () => 'ios' }
+            ;(window as any).Capacitor = { getPlatform: () => 'ios', isNativePlatform: () => true }
             ;({ getApiBaseUrl } = require('../capacitor'))
             expect(getApiBaseUrl()).toBe('https://peanut.me')
         })

--- a/src/utils/api-fetch.ts
+++ b/src/utils/api-fetch.ts
@@ -40,20 +40,24 @@ export function apiFetch(backendPath: string, proxyPath: string, options?: Reque
  *   DELETE    -> /api/proxy/delete/...
  *   POST/etc  -> /api/proxy/...
  */
-export function serverFetch(path: string, options?: RequestInit): Promise<Response> {
-    const method = (options?.method ?? 'GET').toUpperCase()
-    const callerHeaders = (options?.headers as Record<string, string>) ?? {}
+export function serverFetch(path: string, options?: RequestInit & { timeoutMs?: number }): Promise<Response> {
+    const { timeoutMs, ...fetchOptions } = options ?? {}
+    const method = (fetchOptions.method ?? 'GET').toUpperCase()
+    const callerHeaders = (fetchOptions.headers as Record<string, string>) ?? {}
     const headers: Record<string, string> = {}
 
-    // default json content-type for body-bearing requests
-    if (options?.body && !callerHeaders['Content-Type']) {
+    // default json content-type for body-bearing requests (case-insensitive check)
+    const hasContentType = Object.keys(callerHeaders).some((k) => k.toLowerCase() === 'content-type')
+    if (fetchOptions.body && !hasContentType) {
         headers['Content-Type'] = 'application/json'
     }
 
     if (isCapacitor()) {
         // native: direct backend call with auth
         Object.assign(headers, getAuthHeaders(callerHeaders))
-        return fetchWithSentry(`${PEANUT_API_URL}${path}`, { ...options, headers })
+        const args: Parameters<typeof fetchWithSentry> = [`${PEANUT_API_URL}${path}`, { ...fetchOptions, headers }]
+        if (timeoutMs !== undefined) args[2] = timeoutMs
+        return fetchWithSentry(...args)
     }
 
     // web: route through proxy — forward auth header so proxy can relay it
@@ -77,5 +81,7 @@ export function serverFetch(path: string, options?: RequestInit): Promise<Respon
             break
     }
 
-    return fetchWithSentry(`${proxyPrefix}${path}`, { ...options, headers })
+    const args: Parameters<typeof fetchWithSentry> = [`${proxyPrefix}${path}`, { ...fetchOptions, headers }]
+    if (timeoutMs !== undefined) args[2] = timeoutMs
+    return fetchWithSentry(...args)
 }

--- a/src/utils/api-fetch.ts
+++ b/src/utils/api-fetch.ts
@@ -7,6 +7,7 @@ import { PEANUT_API_URL } from '@/constants/general.consts'
 
 /**
  * makes an api call that works in both web (via next.js proxy) and capacitor (direct backend).
+ * caller provides both backend and proxy paths explicitly.
  */
 export function apiFetch(backendPath: string, proxyPath: string, options?: RequestInit): Promise<Response> {
     const url = isCapacitor() ? `${PEANUT_API_URL}${backendPath}` : proxyPath
@@ -26,4 +27,55 @@ export function apiFetch(backendPath: string, proxyPath: string, options?: Reque
     }
 
     return fetchWithSentry(url, { ...options, headers })
+}
+
+/**
+ * replaces direct PEANUT_API_URL calls in former server action files.
+ * web: routes through next.js proxy (bypasses CORS, injects api-key server-side).
+ * native: calls backend directly with auth token from localStorage.
+ *
+ * proxy routing by method:
+ *   GET/HEAD  -> /api/proxy/get/...
+ *   PATCH     -> /api/proxy/patch/...
+ *   DELETE    -> /api/proxy/delete/...
+ *   POST/etc  -> /api/proxy/...
+ */
+export function serverFetch(path: string, options?: RequestInit): Promise<Response> {
+    const method = (options?.method ?? 'GET').toUpperCase()
+    const callerHeaders = (options?.headers as Record<string, string>) ?? {}
+    const headers: Record<string, string> = {}
+
+    // default json content-type for body-bearing requests
+    if (options?.body && !callerHeaders['Content-Type']) {
+        headers['Content-Type'] = 'application/json'
+    }
+
+    if (isCapacitor()) {
+        // native: direct backend call with auth
+        Object.assign(headers, getAuthHeaders(callerHeaders))
+        return fetchWithSentry(`${PEANUT_API_URL}${path}`, { ...options, headers })
+    }
+
+    // web: route through proxy — forward auth header so proxy can relay it
+    const authHeaders = getAuthHeaders()
+    Object.assign(headers, authHeaders, callerHeaders)
+
+    let proxyPrefix: string
+    switch (method) {
+        case 'GET':
+        case 'HEAD':
+            proxyPrefix = '/api/proxy/get'
+            break
+        case 'PATCH':
+            proxyPrefix = '/api/proxy/patch'
+            break
+        case 'DELETE':
+            proxyPrefix = '/api/proxy/delete'
+            break
+        default:
+            proxyPrefix = '/api/proxy'
+            break
+    }
+
+    return fetchWithSentry(`${proxyPrefix}${path}`, { ...options, headers })
 }

--- a/src/utils/capacitor.ts
+++ b/src/utils/capacitor.ts
@@ -12,7 +12,11 @@ const IS_CAPACITOR_BUILD = process.env.NEXT_PUBLIC_CAPACITOR_BUILD === 'true'
  */
 export function isCapacitor(): boolean {
     if (typeof window === 'undefined') return false
-    if ((window as any).Capacitor) return true
+    // check isNativePlatform() — not just window.Capacitor existence.
+    // @capacitor/core sets window.Capacitor on ALL platforms (including web) when bundled.
+    // only return true if the native bridge is actually active.
+    const cap = (window as any).Capacitor
+    if (cap?.isNativePlatform?.()) return true
     if (IS_CAPACITOR_BUILD) return true
     return false
 }

--- a/src/utils/metrics.utils.ts
+++ b/src/utils/metrics.utils.ts
@@ -1,16 +1,10 @@
-import { getAuthToken } from '@/utils/auth-token'
 import { type JSONObject } from '@/interfaces'
-import { fetchWithSentry } from '@/utils/sentry.utils'
-import { PEANUT_API_URL } from '@/constants/general.consts'
+import { serverFetch } from '@/utils/api-fetch'
 
 export async function hitUserMetric(userId: string, name: string, value: JSONObject = {}): Promise<void> {
     try {
-        await fetchWithSentry(`${PEANUT_API_URL}/users/${userId}/metrics/${name}`, {
+        await serverFetch(`/users/${userId}/metrics/${name}`, {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${getAuthToken()}`,
-            },
             body: JSON.stringify(value),
         })
     } catch (error) {


### PR DESCRIPTION
## Summary

The native app (Capacitor) implementation removed `'use server'` from all action files and changed backend CORS from `origin: true` to a restrictive allowlist. This broke all web/PWA API calls — CORS errors on signup, login, history, invite validation, and every other backend call.

**Root causes:**
- `isCapacitor()` checked `window.Capacitor` existence, which `@capacitor/core` sets on ALL platforms including browsers — so web took the native code path everywhere
- Action files lost `'use server'` → now run client-side → direct browser-to-backend calls → CORS failures
- Service files and hooks always called backend directly, but relied on `origin: true` CORS which was removed

**Fix:** `serverFetch(path, options)` — a unified API call utility that:
- **Web**: routes through Next.js proxy (no CORS, api-key injected server-side)
- **Native**: calls backend directly with auth token from localStorage

This makes all three environments work:
| Environment | How it works |
|---|---|
| Native app | `serverFetch` → direct to `PEANUT_API_URL` with JWT |
| Web staging/prod | `serverFetch` → proxy → backend (same-origin, no CORS) |
| Local dev | `serverFetch` → proxy at localhost → staging backend (no CORS) |

## Changes

- **`isCapacitor()` fix** — use `isNativePlatform()` instead of `window.Capacitor` check
- **`serverFetch` utility** — auto-routes by HTTP method: GET→`/api/proxy/get/`, POST→`/api/proxy/`, DELETE→`/api/proxy/delete/`, PATCH→`/api/proxy/patch/`
- **New DELETE proxy** — `src/app/api/proxy/delete/[...slug]/route.ts`
- **POST proxy fix** — handles empty body gracefully (was returning 400)
- **Auth forwarding** — GET/HEAD/PATCH proxies now forward `Authorization` header
- **31 files migrated** — 12 action files, 13 services, 4 hooks, 2 utils converted to `serverFetch`
- **Tests** — 55 tests covering proxy routing on web and direct calls on native

## Files changed (41 total)

**Infrastructure (5):** `api-fetch.ts`, proxy routes (GET, POST, PATCH, DELETE)
**Actions (12):** invites, users, history, exchange-rate, external-accounts, offramp, onramp, sumsub, bridge/get-customer, card, increase-limits, ens
**Services (13):** invites, manteca, notifications, perks, points, quests, requests, rewards, rhino, sendLinks, simplefi, users, charges
**Hooks (4):** useTransactionHistory, useLimits, useRedirectQrStatus, query/user
**Utils (3):** capacitor, metrics.utils, general.consts
**Tests (4):** api-fetch, api-headers, api-headers-extended, capacitor

## Companion BE change needed

Backend CORS (`peanut-api-ts` `src/app.ts`) needs `http://localhost:*` added to the allowlist — for service files and hooks that still call the backend directly (they always did, even pre-native-app, but relied on `origin: true`).

## Test plan

- [ ] `npm test` — 55 API routing tests pass (web proxy + native direct)
- [ ] Local dev: signup flow (username validation, invite code)
- [ ] Local dev: history page loads
- [ ] Local dev: login → get-user-from-cookie works
- [ ] Verify native app still works (passkeys, history, all routes)
- [ ] Verify web staging/prod deployment works