### PR TITLE
fix: use peanut.me as rpId on all *.peanut.me subdomains

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,12 +2,52 @@
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { getAuthToken } from '@/utils/auth-token'
+import { isCapacitor } from '@/utils/capacitor'
+import { Suspense } from 'react'
+import { LandingPageShell } from '@/components/LandingPage/LandingPageShell'
+import { LandingPageClient } from '@/components/LandingPage/LandingPageClient'
+import Manteca from '@/components/LandingPage/Manteca'
+import { RegulatedRails } from '@/components/LandingPage/RegulatedRails'
+import { YourMoney } from '@/components/LandingPage/yourMoney'
+import { SecurityBuiltIn } from '@/components/LandingPage/securityBuiltIn'
+import { SendInSeconds } from '@/components/LandingPage/sendInSeconds'
+import Footer from '@/components/LandingPage/Footer'
+import { faqSchema } from '@/lib/seo/schemas'
+import { JsonLd } from '@/components/Marketing/JsonLd'
+import { heroConfig, faqData, marqueeMessages } from '@/components/LandingPage/landingPageData'
 
-export default function RootRedirect() {
+export default function RootPage() {
     const router = useRouter()
+
     useEffect(() => {
-        const token = getAuthToken()
-        router.replace(token ? '/home' : '/setup')
+        // native app has no landing page — go straight to home or setup
+        if (isCapacitor()) {
+            const token = getAuthToken()
+            router.replace(token ? '/home' : '/setup')
+        }
     }, [router])
-    return null
+
+    // native app: render nothing while redirecting
+    if (isCapacitor()) return null
+
+    const faqJsonLd = faqSchema(faqData.questions.map((q) => ({ question: q.question, answer: q.answer })))
+
+    return (
+        <LandingPageShell>
+            {faqJsonLd && <JsonLd data={faqJsonLd} />}
+            <Suspense>
+                <LandingPageClient
+                    heroConfig={heroConfig}
+                    faqData={faqData}
+                    marqueeMessages={marqueeMessages}
+                    mantecaSlot={<Manteca />}
+                    regulatedRailsSlot={<RegulatedRails />}
+                    yourMoneySlot={<YourMoney />}
+                    securitySlot={<SecurityBuiltIn />}
+                    sendInSecondsSlot={<SendInSeconds />}
+                    footerSlot={<Footer />}
+                />
+            </Suspense>
+        </LandingPageShell>
+    )
 }

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -15,7 +15,7 @@ import { captureException } from '@sentry/nextjs'
 import { invitesApi } from '@/services/invites'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
-import { isCapacitor, getNativeRpId } from '@/utils/capacitor'
+import { isCapacitor, getNativeRpId, getWebRpId } from '@/utils/capacitor'
 
 // types
 type UserOpEncodedParams = {
@@ -73,7 +73,7 @@ export const useZeroDev = () => {
 
         dispatch(zerodevActions.setIsRegistering(true))
         try {
-            const rpId = isCapacitor() ? getNativeRpId() : window.location.hostname.replace(/^www\./, '')
+            const rpId = isCapacitor() ? getNativeRpId() : getWebRpId()
 
             // @capgo/capacitor-passkey shim patches navigator.credentials on native,
             // so toWebAuthnKey works on all platforms (web, android, ios).
@@ -146,7 +146,7 @@ export const useZeroDev = () => {
                 passkeyServerHeaders['x-username'] = user.user.username
             }
 
-            const rpId = isCapacitor() ? getNativeRpId() : window.location.hostname.replace(/^www\./, '')
+            const rpId = isCapacitor() ? getNativeRpId() : getWebRpId()
 
             const webAuthnKey = await toWebAuthnKey({
                 passkeyName: '[]',

--- a/src/utils/capacitor.ts
+++ b/src/utils/capacitor.ts
@@ -89,6 +89,20 @@ export function getNativeRpId(): string {
 }
 
 /**
+ * returns the rpId for web passkey operations.
+ * on *.peanut.me subdomains (staging, dev), uses 'peanut.me' so production
+ * passkeys work across all environments. on other domains (localhost, vercel
+ * previews), uses the hostname directly.
+ */
+export function getWebRpId(): string {
+    const hostname = window.location.hostname.replace(/^www\./, '')
+    if (hostname === 'peanut.me' || hostname.endsWith('.peanut.me')) {
+        return 'peanut.me'
+    }
+    return hostname
+}
+
+/**
  * opens a url in the appropriate way for the current platform
  * - on web: window.open with _blank
  * - in capacitor: uses @capacitor/browser plugin


### PR DESCRIPTION
## Summary

- On staging (`staging.peanut.me`), the `isCapacitor()` fix from #1899 changed rpId from `peanut.me` to `staging.peanut.me`
- Existing passkeys were registered with rpId=`peanut.me` → login fails because rpId doesn't match
- New `getWebRpId()` uses `peanut.me` on all `*.peanut.me` subdomains so production passkeys work on staging/dev
- On other domains (localhost, vercel previews) uses hostname directly for separate passkey scopes

## Test plan

- [ ] Login on staging.peanut.me with existing production passkey
- [ ] Login on localhost with local passkey
- [ ] Native app login still works