### PR TITLE
revert: use window.location.hostname for web rpId

### DIFF
--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -15,7 +15,7 @@ import { captureException } from '@sentry/nextjs'
 import { invitesApi } from '@/services/invites'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
-import { isCapacitor, getNativeRpId, getWebRpId } from '@/utils/capacitor'
+import { isCapacitor, getNativeRpId } from '@/utils/capacitor'
 
 // types
 type UserOpEncodedParams = {
@@ -73,7 +73,7 @@ export const useZeroDev = () => {
 
         dispatch(zerodevActions.setIsRegistering(true))
         try {
-            const rpId = isCapacitor() ? getNativeRpId() : getWebRpId()
+            const rpId = isCapacitor() ? getNativeRpId() : window.location.hostname.replace(/^www\./, '')
 
             // @capgo/capacitor-passkey shim patches navigator.credentials on native,
             // so toWebAuthnKey works on all platforms (web, android, ios).
@@ -146,7 +146,7 @@ export const useZeroDev = () => {
                 passkeyServerHeaders['x-username'] = user.user.username
             }
 
-            const rpId = isCapacitor() ? getNativeRpId() : getWebRpId()
+            const rpId = isCapacitor() ? getNativeRpId() : window.location.hostname.replace(/^www\./, '')
 
             const webAuthnKey = await toWebAuthnKey({
                 passkeyName: '[]',

--- a/src/utils/capacitor.ts
+++ b/src/utils/capacitor.ts
@@ -88,19 +88,6 @@ export function getNativeRpId(): string {
     return process.env.NEXT_PUBLIC_NATIVE_RP_ID || 'peanut.me'
 }
 
-/**
- * returns the rpId for web passkey operations.
- * on *.peanut.me subdomains (staging, dev), uses 'peanut.me' so production
- * passkeys work across all environments. on other domains (localhost, vercel
- * previews), uses the hostname directly.
- */
-export function getWebRpId(): string {
-    const hostname = window.location.hostname.replace(/^www\./, '')
-    if (hostname === 'peanut.me' || hostname.endsWith('.peanut.me')) {
-        return 'peanut.me'
-    }
-    return hostname
-}
 
 /**
  * opens a url in the appropriate way for the current platform


### PR DESCRIPTION
## Summary

Reverts `getWebRpId()` from PR #1900. That function forced `peanut.me` as rpId on all `*.peanut.me` subdomains, but staging users registered their passkeys with rpId=`staging.peanut.me` — so login on staging was searching for the wrong passkeys.

Restores the original `main` branch behavior: each domain uses its own hostname as rpId.

## Test plan

- [ ] Login on staging.peanut.me with staging passkey
- [ ] Login on peanut.me with production passkey
- [ ] Signup on localhost with new passkey