### PR TITLE
[TASK-19063] fix(qr-pay): block PIX payments below 1 BRL in send flow

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -24,7 +24,7 @@ import ErrorAlert from '@/components/Global/ErrorAlert'
 import { PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
 import { PERK_HOLD_DURATION_MS } from '@/constants/general.consts'
 import { MANTECA_DEPOSIT_ADDRESS } from '@/constants/manteca.consts'
-import { MIN_MANTECA_QR_PAYMENT_AMOUNT } from '@/constants/payment.consts'
+import { MIN_MANTECA_QR_PAYMENT_AMOUNT, MIN_PIX_AMOUNT_BRL } from '@/constants/payment.consts'
 import { formatUnits, parseUnits } from 'viem'
 import type { TransactionReceipt, Hash } from 'viem'
 import { useTransactionDetailsDrawer } from '@/hooks/useTransactionDetailsDrawer'
@@ -982,6 +982,11 @@ export default function QRPayPage() {
                 setBalanceErrorMessage(`Payment amount must be at least $${MIN_MANTECA_QR_PAYMENT_AMOUNT}`)
                 return
             }
+            // PIX rail enforces a 1 BRL minimum, stricter than the USD floor above
+            if (currency?.code === 'BRL' && currencyAmount && parseFloat(currencyAmount) < MIN_PIX_AMOUNT_BRL) {
+                setBalanceErrorMessage(`Minimum PIX amount is ${MIN_PIX_AMOUNT_BRL} BRL`)
+                return
+            }
         }
 
         // Common validations for all payment processors
@@ -994,7 +999,7 @@ export default function QRPayPage() {
         } else {
             setBalanceErrorMessage(null)
         }
-    }, [usdAmount, balance, paymentProcessor])
+    }, [usdAmount, balance, paymentProcessor, currency?.code, currencyAmount])
 
     // Use points confetti hook for animation - must be called unconditionally
     usePointsConfetti(isSuccess && pointsData?.estimatedPoints ? pointsData.estimatedPoints : undefined, pointsDivRef)

--- a/src/constants/payment.consts.ts
+++ b/src/constants/payment.consts.ts
@@ -19,6 +19,9 @@ export const MIN_MANTECA_WITHDRAW_AMOUNT = 1
 export const MIN_MANTECA_QR_PAYMENT_AMOUNT = 0.1 // Manteca provider minimum
 export const MAX_QR_PAYMENT_AMOUNT_FOREIGN = 2000 // max per transaction for foreign users
 
+// PIX network minimum payment amount (in BRL, not USD)
+export const MIN_PIX_AMOUNT_BRL = 1
+
 // Bridge developer fee applied to cross-currency (non-USD) transfers.
 // Must match backend BRIDGE_DEVELOPER_FEE_PERCENT in peanut-api-ts/src/bridge/consts.ts
 export const BRIDGE_DEVELOPER_FEE_RATE = 0.005


### PR DESCRIPTION
PIX has a 1 BRL network minimum that's stricter than our existing $0.10 USD Manteca floor. Previously a 0.55–0.99 BRL payment would pass the UI and only fail once Manteca rejected it mid-flow.

TASK-19063