### PR TITLE
[TASK-18832] fix(qr-pay): navigate home on stale app resume

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -190,6 +190,28 @@ export default function QRPayPage() {
         }
     }, [])
 
+    // Reopening the app onto a past QR URL (last merchant, expired lock) is stale —
+    // after a real absence, drop the user on home so they can start fresh.
+    useEffect(() => {
+        const STALE_THRESHOLD_MS = 30_000
+        let hiddenAt: number | null = null
+
+        const onVisibility = () => {
+            if (document.hidden) {
+                hiddenAt = Date.now()
+                return
+            }
+            if (hiddenAt === null) return
+            const elapsed = Date.now() - hiddenAt
+            hiddenAt = null
+            if (elapsed > STALE_THRESHOLD_MS) {
+                router.push('/home')
+            }
+        }
+        document.addEventListener('visibilitychange', onVisibility)
+        return () => document.removeEventListener('visibilitychange', onVisibility)
+    }, [router])
+
     // Track reward claim shown + surprise moment when perk UI appears after payment
     useEffect(() => {
         perkClaimedRef.current = perkClaimed


### PR DESCRIPTION
When the user backgrounds the app on /qr-pay and returns after a real absence, the URL itself points at a past scan: merchant info, rate lock, and qrCode param are no longer what they want. Reopening to "Pay this old merchant" or "QR not recognized" is confusing.

On visibilitychange back to visible, if the page was hidden for more than 30s, push to /home so the next session starts fresh. Threshold avoids booting users who just glanced at a notification.

TASK-18832