### PR TITLE
feat: self-heal UI for provider-rejected users

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -397,7 +397,7 @@ export default function OnrampBankPage() {
                     visible={showKycModal}
                     onClose={() => setShowKycModal(false)}
                     onVerify={async () => {
-                        const hasRejection = bridgeRejection.state === 'fixable' || bridgeRejection.state === 'blocked'
+                        const hasRejection = bridgeRejection.state === 'fixable'
                         if (hasRejection) {
                             await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                         } else {

--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -11,6 +11,7 @@ import { formatAmount } from '@/utils/general.utils'
 import { countryData } from '@/components/AddMoney/consts'
 import { useAuth } from '@/context/authContext'
 import useKycStatus from '@/hooks/useKycStatus'
+import useProviderRejectionStatus from '@/hooks/useProviderRejectionStatus'
 import { useCreateOnramp } from '@/hooks/useCreateOnramp'
 import { useRouter, useParams } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -94,6 +95,7 @@ export default function OnrampBankPage() {
     const isUK = isUKCountry(selectedCountryPath)
 
     const { isUserKycApproved } = useKycStatus()
+    const { bridge: bridgeRejection } = useProviderRejectionStatus()
     const { guardWithTos, showBridgeTos, hideTos } = useBridgeTosGuard()
 
     useEffect(() => {
@@ -194,7 +196,7 @@ export default function OnrampBankPage() {
     const handleAmountContinue = () => {
         if (!validateAmount(rawTokenAmount)) return
 
-        if (!isUserKycApproved) {
+        if (!isUserKycApproved || bridgeRejection.state === 'fixable' || bridgeRejection.state === 'blocked') {
             setShowKycModal(true)
             return
         }
@@ -395,10 +397,21 @@ export default function OnrampBankPage() {
                     visible={showKycModal}
                     onClose={() => setShowKycModal(false)}
                     onVerify={async () => {
-                        await sumsubFlow.handleInitiateKyc('STANDARD')
+                        const hasRejection = bridgeRejection.state === 'fixable' || bridgeRejection.state === 'blocked'
+                        if (hasRejection) {
+                            await sumsubFlow.handleSelfHealResubmit('BRIDGE')
+                        } else {
+                            await sumsubFlow.handleInitiateKyc('STANDARD')
+                        }
                         setShowKycModal(false)
                     }}
                     isLoading={sumsubFlow.isLoading}
+                    variant={
+                        bridgeRejection.state === 'fixable' || bridgeRejection.state === 'blocked'
+                            ? 'provider_rejection'
+                            : 'default'
+                    }
+                    providerMessage={bridgeRejection.userMessage ?? undefined}
                 />
 
                 <SumsubKycModals flow={sumsubFlow} autoStartSdk />

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -1076,10 +1076,59 @@ export default function QRPayPage() {
     const needsKycVerification =
         kycGateState === QrKycState.REQUIRES_IDENTITY_VERIFICATION ||
         kycGateState === QrKycState.IDENTITY_VERIFICATION_IN_PROGRESS
+    const hasProviderRejection =
+        kycGateState === QrKycState.PROVIDER_REJECTION_FIXABLE || kycGateState === QrKycState.PROVIDER_REJECTION_BLOCKED
 
     // show loading while KYC state is being determined
     if (isLoadingKycState) {
         return <PeanutLoading />
+    }
+
+    // provider rejection: user is sumsub-approved but manteca rejected
+    if (hasProviderRejection) {
+        const isFixable = kycGateState === QrKycState.PROVIDER_REJECTION_FIXABLE
+        return (
+            <div className="flex min-h-[inherit] flex-col gap-8">
+                <NavHeader title="Pay" />
+                <ActionModal
+                    visible
+                    onClose={() => router.back()}
+                    title={isFixable ? 'We need an updated document' : 'QR payments are not available'}
+                    description={
+                        isFixable
+                            ? 'We need an updated document to enable QR payments. Please upload a clearer photo of your ID.'
+                            : 'QR payments are not available for your account. Contact support for help.'
+                    }
+                    icon={
+                        methodIcon ? (
+                            <Image src={methodIcon} alt="Payment method" width={48} height={48} priority />
+                        ) : undefined
+                    }
+                    ctas={[
+                        isFixable
+                            ? {
+                                  text: 'Upload document',
+                                  onClick: () => {
+                                      saveRedirectUrl()
+                                      router.push('/profile/identity-verification')
+                                  },
+                                  variant: 'purple' as const,
+                                  shadowSize: '4' as const,
+                                  icon: 'upload',
+                              }
+                            : {
+                                  text: 'Contact support',
+                                  onClick: () => {
+                                      if (typeof window !== 'undefined' && (window as any).$crisp) {
+                                          ;(window as any).$crisp.push(['do', 'chat:open'])
+                                      }
+                                  },
+                                  variant: 'stroke' as const,
+                              },
+                    ]}
+                />
+            </div>
+        )
     }
 
     // show KYC screens before any error screens - user needs to verify first

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -532,7 +532,7 @@ export default function MantecaWithdrawFlow() {
                 visible={showKycModal}
                 onClose={() => setShowKycModal(false)}
                 onVerify={async () => {
-                    const hasRejection = mantecaRejection.state === 'fixable' || mantecaRejection.state === 'blocked'
+                    const hasRejection = mantecaRejection.state === 'fixable'
                     if (hasRejection) {
                         await sumsubFlow.handleSelfHealResubmit('MANTECA')
                     } else {

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -34,6 +34,7 @@ import { SoundPlayer } from '@/components/Global/SoundPlayer'
 import { useQueryClient } from '@tanstack/react-query'
 import { captureException } from '@sentry/nextjs'
 import useKycStatus from '@/hooks/useKycStatus'
+import useProviderRejectionStatus from '@/hooks/useProviderRejectionStatus'
 import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
@@ -91,6 +92,7 @@ export default function MantecaWithdrawFlow() {
     const { setIsSupportModalOpen, openSupportWithMessage } = useModalsContext()
     const queryClient = useQueryClient()
     const { isUserMantecaKycApproved } = useKycStatus()
+    const { manteca: mantecaRejection } = useProviderRejectionStatus()
     const { hasPendingTransactions } = usePendingTransactions()
 
     // inline sumsub kyc flow for manteca users who need LATAM verification
@@ -530,10 +532,21 @@ export default function MantecaWithdrawFlow() {
                 visible={showKycModal}
                 onClose={() => setShowKycModal(false)}
                 onVerify={async () => {
-                    await sumsubFlow.handleInitiateKyc('LATAM')
+                    const hasRejection = mantecaRejection.state === 'fixable' || mantecaRejection.state === 'blocked'
+                    if (hasRejection) {
+                        await sumsubFlow.handleSelfHealResubmit('MANTECA')
+                    } else {
+                        await sumsubFlow.handleInitiateKyc('LATAM')
+                    }
                     setShowKycModal(false)
                 }}
                 isLoading={sumsubFlow.isLoading}
+                variant={
+                    mantecaRejection.state === 'fixable' || mantecaRejection.state === 'blocked'
+                        ? 'provider_rejection'
+                        : 'default'
+                }
+                providerMessage={mantecaRejection.userMessage ?? undefined}
             />
             <SumsubKycModals flow={sumsubFlow} />
             <SumsubKycWrapper

--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -55,3 +55,50 @@ export const initiateSumsubKyc = async (params?: {
         return { error: message }
     }
 }
+
+export interface SelfHealResubmissionResponse {
+    token: string
+    applicantId: string
+    actionId: string
+    externalActionId: string
+    requiredAction: 'REUPLOAD_ID' | 'REUPLOAD_ADDRESS_PROOF' | 'CONTACT_SUPPORT'
+    userMessage: string
+    attempt: number
+    maxAttempts: number
+}
+
+// initiate self-heal document resubmission for a provider-rejected user
+export const initiateSelfHealResubmission = async (
+    provider: 'BRIDGE' | 'MANTECA'
+): Promise<{ data?: SelfHealResubmissionResponse; error?: string }> => {
+    const jwtToken = (await getJWTCookie())?.value
+
+    if (!jwtToken) {
+        return { error: 'Authentication required' }
+    }
+
+    try {
+        const response = await fetchWithSentry(`${PEANUT_API_URL}/users/identity/resubmit`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${jwtToken}`,
+                'api-key': API_KEY,
+            },
+            body: JSON.stringify({ provider }),
+        })
+
+        const responseJson = await response.json()
+
+        if (!response.ok) {
+            return {
+                error: responseJson.userMessage || responseJson.error || 'Failed to initiate document resubmission',
+            }
+        }
+
+        return { data: responseJson }
+    } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'An unexpected error occurred'
+        return { error: message }
+    }
+}

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -223,8 +223,7 @@ const MantecaAddMoney: FC = () => {
                     visible={showKycModal}
                     onClose={() => setShowKycModal(false)}
                     onVerify={async () => {
-                        const hasRejection =
-                            mantecaRejection.state === 'fixable'
+                        const hasRejection = mantecaRejection.state === 'fixable'
                         if (hasRejection) {
                             await sumsubFlow.handleSelfHealResubmit('MANTECA')
                         } else {

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -224,7 +224,7 @@ const MantecaAddMoney: FC = () => {
                     onClose={() => setShowKycModal(false)}
                     onVerify={async () => {
                         const hasRejection =
-                            mantecaRejection.state === 'fixable' || mantecaRejection.state === 'blocked'
+                            mantecaRejection.state === 'fixable'
                         if (hasRejection) {
                             await sumsubFlow.handleSelfHealResubmit('MANTECA')
                         } else {

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -11,6 +11,7 @@ import { mantecaApi } from '@/services/manteca'
 import { parseUnits } from 'viem'
 import { useQueryClient } from '@tanstack/react-query'
 import useKycStatus from '@/hooks/useKycStatus'
+import useProviderRejectionStatus from '@/hooks/useProviderRejectionStatus'
 import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
@@ -64,6 +65,7 @@ const MantecaAddMoney: FC = () => {
         return countryData.find((country) => country.type === 'country' && country.path === selectedCountryPath)
     }, [selectedCountryPath])
     const { isUserMantecaKycApproved } = useKycStatus()
+    const { manteca: mantecaRejection } = useProviderRejectionStatus()
     const currencyData = useCurrency(selectedCountry?.currency ?? 'ARS')
     const { user } = useAuth()
 
@@ -221,10 +223,22 @@ const MantecaAddMoney: FC = () => {
                     visible={showKycModal}
                     onClose={() => setShowKycModal(false)}
                     onVerify={async () => {
-                        await sumsubFlow.handleInitiateKyc('LATAM')
+                        const hasRejection =
+                            mantecaRejection.state === 'fixable' || mantecaRejection.state === 'blocked'
+                        if (hasRejection) {
+                            await sumsubFlow.handleSelfHealResubmit('MANTECA')
+                        } else {
+                            await sumsubFlow.handleInitiateKyc('LATAM')
+                        }
                         setShowKycModal(false)
                     }}
                     isLoading={sumsubFlow.isLoading}
+                    variant={
+                        mantecaRejection.state === 'fixable' || mantecaRejection.state === 'blocked'
+                            ? 'provider_rejection'
+                            : 'default'
+                    }
+                    providerMessage={mantecaRejection.userMessage ?? undefined}
                 />
                 <SumsubKycModals flow={sumsubFlow} />
                 <InputAmountStep

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -21,6 +21,7 @@ import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { useAppDispatch } from '@/redux/hooks'
 import { bankFormActions } from '@/redux/slices/bank-form-slice'
 import useKycStatus from '@/hooks/useKycStatus'
+import useProviderRejectionStatus from '@/hooks/useProviderRejectionStatus'
 import KycVerifiedOrReviewModal from '../Global/KycVerifiedOrReviewModal'
 import { ActionListCard } from '@/components/ActionListCard'
 import TokenAndNetworkConfirmationModal from '../Global/TokenAndNetworkConfirmationModal'
@@ -65,6 +66,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
     const [isSupportedTokensModalOpen, setIsSupportedTokensModalOpen] = useState(false)
 
     const { isUserKycApproved, isUserBridgeKycUnderReview } = useKycStatus()
+    const { bridge: bridgeRejection } = useProviderRejectionStatus()
     const [showKycStatusModal, setShowKycStatusModal] = useState(false)
 
     const countryPathParts = Array.isArray(params.country) ? params.country : [params.country]
@@ -82,6 +84,12 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
         // re-fetch user to ensure we have the latest KYC status
         // (the multi-phase flow may have completed but websocket/state not yet propagated)
         await fetchUser()
+
+        // block users with bridge provider rejection — they need to resubmit docs first
+        if (bridgeRejection.state === 'fixable' || bridgeRejection.state === 'blocked') {
+            await sumsubFlow.handleSelfHealResubmit('BRIDGE')
+            return {}
+        }
 
         // scenario (1): happy path: if the user has already completed kyc, we can add the bank account directly
         // email and name are now collected by sumsub — no need to check them here

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -85,10 +85,13 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
         // (the multi-phase flow may have completed but websocket/state not yet propagated)
         await fetchUser()
 
-        // block users with bridge provider rejection — they need to resubmit docs first
-        if (bridgeRejection.state === 'fixable' || bridgeRejection.state === 'blocked') {
+        // block users with bridge provider rejection
+        if (bridgeRejection.state === 'fixable') {
             await sumsubFlow.handleSelfHealResubmit('BRIDGE')
             return {}
+        }
+        if (bridgeRejection.state === 'blocked') {
+            return { error: 'Bank transfers are not available for your account. Please contact support.' }
         }
 
         // scenario (1): happy path: if the user has already completed kyc, we can add the bank account directly

--- a/src/components/Claim/Link/MantecaFlowManager.tsx
+++ b/src/components/Claim/Link/MantecaFlowManager.tsx
@@ -122,7 +122,7 @@ const MantecaFlowManager: FC<MantecaFlowManagerProps> = ({ claimLinkData, amount
                 visible={showKycModal}
                 onClose={() => setShowKycModal(false)}
                 onVerify={async () => {
-                    const hasRejection = mantecaRejection.state === 'fixable' || mantecaRejection.state === 'blocked'
+                    const hasRejection = mantecaRejection.state === 'fixable'
                     if (hasRejection) {
                         await sumsubFlow.handleSelfHealResubmit('MANTECA')
                     } else {

--- a/src/components/Claim/Link/MantecaFlowManager.tsx
+++ b/src/components/Claim/Link/MantecaFlowManager.tsx
@@ -12,6 +12,7 @@ import MantecaReviewStep from './views/MantecaReviewStep'
 import { Button } from '@/components/0_Bruddle/Button'
 import { useRouter } from 'next/navigation'
 import useKycStatus from '@/hooks/useKycStatus'
+import useProviderRejectionStatus from '@/hooks/useProviderRejectionStatus'
 import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
@@ -28,6 +29,7 @@ const MantecaFlowManager: FC<MantecaFlowManagerProps> = ({ claimLinkData, amount
     const router = useRouter()
     const [destinationAddress, setDestinationAddress] = useState('')
     const { isUserMantecaKycApproved } = useKycStatus()
+    const { manteca: mantecaRejection } = useProviderRejectionStatus()
 
     // inline sumsub kyc flow for manteca users who need LATAM verification
     // regionIntent is NOT passed here to avoid creating a backend record on mount.
@@ -120,10 +122,21 @@ const MantecaFlowManager: FC<MantecaFlowManagerProps> = ({ claimLinkData, amount
                 visible={showKycModal}
                 onClose={() => setShowKycModal(false)}
                 onVerify={async () => {
-                    await sumsubFlow.handleInitiateKyc('LATAM')
+                    const hasRejection = mantecaRejection.state === 'fixable' || mantecaRejection.state === 'blocked'
+                    if (hasRejection) {
+                        await sumsubFlow.handleSelfHealResubmit('MANTECA')
+                    } else {
+                        await sumsubFlow.handleInitiateKyc('LATAM')
+                    }
                     setShowKycModal(false)
                 }}
                 isLoading={sumsubFlow.isLoading}
+                variant={
+                    mantecaRejection.state === 'fixable' || mantecaRejection.state === 'blocked'
+                        ? 'provider_rejection'
+                        : 'default'
+                }
+                providerMessage={mantecaRejection.userMessage ?? undefined}
             />
             <SumsubKycModals flow={sumsubFlow} />
         </div>

--- a/src/components/Home/ActivationCTAs.tsx
+++ b/src/components/Home/ActivationCTAs.tsx
@@ -6,18 +6,24 @@ import { Icon, type IconName } from '@/components/Global/Icons/Icon'
 import { useRouter } from 'next/navigation'
 import { useModalsContext } from '@/context/ModalsContext'
 import Card from '../Global/Card'
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import useProviderRejectionStatus from '@/hooks/useProviderRejectionStatus'
 
 interface ActivationCTAsProps {
     activationStep: ActivationStep
 }
 
-const STEPS: Record<
-    Exclude<ActivationStep, 'completed'>,
-    { icon: IconName; title: string; description: string; ctaLabel: string; href: string }
-> = {
+interface StepConfig {
+    icon: IconName
+    title: string
+    description: string
+    ctaLabel: string
+    href: string
+}
+
+const STEPS: Record<Exclude<ActivationStep, 'completed'>, StepConfig> = {
     verify: {
         icon: 'globe-lock',
         title: 'Verify to get started',
@@ -44,10 +50,13 @@ const STEPS: Record<
 /**
  * single activation CTA for non-activated users on the home screen.
  * shows only the current step the user needs to complete.
+ * when sumsub is approved but a provider rejected the user, overrides
+ * the deposit/outbound step with a "complete your setup" message.
  */
 export default function ActivationCTAs({ activationStep }: ActivationCTAsProps) {
     const router = useRouter()
     const { setIsQRScannerOpen } = useModalsContext()
+    const { hasFixableRejection, hasBlockedRejection, primaryRejection } = useProviderRejectionStatus()
 
     const lastTrackedStep = useRef<ActivationStep | null>(null)
     useEffect(() => {
@@ -59,9 +68,38 @@ export default function ActivationCTAs({ activationStep }: ActivationCTAsProps) 
         }
     }, [activationStep])
 
-    if (activationStep === 'completed') return null
+    // provider rejection overrides the step copy when user is past the verify step
+    // (sumsub approved but provider rejected — deposit/outbound CTAs are useless)
+    const hasProviderRejection = activationStep !== 'verify' && (hasFixableRejection || hasBlockedRejection)
 
-    const step = STEPS[activationStep]
+    const step: StepConfig | null = useMemo(() => {
+        if (activationStep === 'completed' && !hasProviderRejection) return null
+
+        if (hasProviderRejection) {
+            if (hasFixableRejection) {
+                return {
+                    icon: 'globe-lock',
+                    title: 'Complete your setup',
+                    description:
+                        primaryRejection?.userMessage || 'We need an updated document before you can add money.',
+                    ctaLabel: 'Upload document',
+                    href: '/profile/identity-verification',
+                }
+            }
+            // blocked
+            return {
+                icon: 'globe-lock',
+                title: 'Verification issue',
+                description: 'Contact support for help with your verification.',
+                ctaLabel: 'Contact support',
+                href: '', // handled in onClick
+            }
+        }
+
+        return STEPS[activationStep as Exclude<ActivationStep, 'completed'>]
+    }, [activationStep, hasProviderRejection, hasFixableRejection, primaryRejection])
+
+    if (!step) return null
 
     return (
         <Card position="single" className="p-0">
@@ -78,7 +116,11 @@ export default function ActivationCTAs({ activationStep }: ActivationCTAsProps) 
                     shadowSize="4"
                     className="mt-2 w-full"
                     onClick={() => {
-                        if (activationStep === 'outbound') {
+                        if (hasProviderRejection && hasBlockedRejection && !hasFixableRejection) {
+                            if (typeof window !== 'undefined' && (window as any).$crisp) {
+                                ;(window as any).$crisp.push(['do', 'chat:open'])
+                            }
+                        } else if (activationStep === 'outbound' && !hasProviderRejection) {
                             setIsQRScannerOpen(true)
                         } else {
                             router.push(step.href)

--- a/src/components/Kyc/InitiateKycModal.tsx
+++ b/src/components/Kyc/InitiateKycModal.tsx
@@ -7,32 +7,52 @@ interface InitiateKycModalProps {
     onClose: () => void
     onVerify: () => void
     isLoading?: boolean
+    /** when set, shows provider-specific messaging instead of generic "verify your identity" */
+    variant?: 'default' | 'provider_rejection'
+    providerMessage?: string
 }
 
-// confirmation modal shown before starting KYC.
-// user must click "Start Verification" to proceed to the sumsub SDK.
-export const InitiateKycModal = ({ visible, onClose, onVerify, isLoading }: InitiateKycModalProps) => {
+// confirmation modal shown before starting KYC or provider resubmission.
+// for fresh KYC: "Verify your identity" — for provider rejections: "We need extra documents"
+export const InitiateKycModal = ({
+    visible,
+    onClose,
+    onVerify,
+    isLoading,
+    variant = 'default',
+    providerMessage,
+}: InitiateKycModalProps) => {
+    const isProviderRejection = variant === 'provider_rejection'
+
     return (
         <ActionModal
             visible={visible}
             onClose={onClose}
-            title="Verify your identity"
-            description="To continue, you need to complete identity verification. This usually takes just a few minutes."
+            title={isProviderRejection ? 'We need extra documents' : 'Verify your identity'}
+            description={
+                isProviderRejection
+                    ? providerMessage || 'Please upload a clearer photo of your ID to continue.'
+                    : 'To continue, you need to complete identity verification. This usually takes just a few minutes.'
+            }
             icon={'badge' as IconName}
             modalPanelClassName="max-w-full m-2"
             ctaClassName="grid grid-cols-1 gap-3"
             ctas={[
                 {
-                    text: isLoading ? 'Loading...' : 'Start Verification',
+                    text: isLoading ? 'Loading...' : isProviderRejection ? 'Upload document' : 'Start Verification',
                     onClick: onVerify,
                     variant: 'purple',
                     disabled: isLoading,
                     shadowSize: '4',
-                    icon: 'check-circle',
+                    icon: isProviderRejection ? 'upload' : 'check-circle',
                     className: 'h-11',
                 },
             ]}
-            footer={<PeanutDoesntStoreAnyPersonalInformation className="w-full justify-center" />}
+            footer={
+                isProviderRejection ? undefined : (
+                    <PeanutDoesntStoreAnyPersonalInformation className="w-full justify-center" />
+                )
+            }
         />
     )
 }

--- a/src/components/Kyc/KycStatusDrawer.tsx
+++ b/src/components/Kyc/KycStatusDrawer.tsx
@@ -4,6 +4,7 @@ import { KycFailed } from './states/KycFailed'
 import { KycNotStarted } from './states/KycNotStarted'
 import { KycProcessing } from './states/KycProcessing'
 import { KycRequiresDocuments } from './states/KycRequiresDocuments'
+import { KycProviderRejection } from './states/KycProviderRejection'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { Drawer, DrawerContent, DrawerTitle } from '../Global/Drawer'
 import { type BridgeKycStatus } from '@/utils/bridge-accounts.utils'
@@ -13,6 +14,7 @@ import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { getKycStatusCategory, isKycStatusNotStarted } from '@/constants/kyc.consts'
 import { type KYCRegionIntent } from '@/app/actions/types/sumsub.types'
 import { useCallback } from 'react'
+import useProviderRejectionStatus from '@/hooks/useProviderRejectionStatus'
 
 interface KycStatusDrawerProps {
     isOpen: boolean
@@ -101,11 +103,33 @@ export const KycStatusDrawer = ({
         [closeAndStartKyc]
     )
 
+    // provider rejection status
+    const { bridge: bridgeRejection, manteca: mantecaRejection, hasAnyRejection } = useProviderRejectionStatus()
+
     const renderContent = () => {
         // user initiated kyc but abandoned before submitting — close drawer visually
         // but keep component mounted so SumsubKycModals persists for the SDK flow
         if (verification && isKycStatusNotStarted(status)) {
             return <KycNotStarted onResume={closeAndStartKyc} />
+        }
+
+        // provider rejection: sumsub approved but bridge/manteca rejected
+        // show two-level status: identity verified + provider-specific rejection
+        if (statusCategory === 'completed' && hasAnyRejection) {
+            const rejection =
+                bridgeRejection.state === 'fixable' || bridgeRejection.state === 'blocked'
+                    ? bridgeRejection
+                    : mantecaRejection
+            return (
+                <KycProviderRejection
+                    rejection={rejection}
+                    onStartResubmission={() => {
+                        onKeepMounted?.(true)
+                        onClose()
+                        sumsubFlow.handleSelfHealResubmit(rejection.provider)
+                    }}
+                />
+            )
         }
 
         // bridge additional document requirement — but don't mask terminal kyc states

--- a/src/components/Kyc/KycStatusDrawer.tsx
+++ b/src/components/Kyc/KycStatusDrawer.tsx
@@ -126,9 +126,9 @@ export const KycStatusDrawer = ({
                     onStartResubmission={async () => {
                         onKeepMounted?.(true)
                         onClose()
-                        try {
-                            await sumsubFlow.handleSelfHealResubmit(rejection.provider)
-                        } catch (e) {
+                        await sumsubFlow.handleSelfHealResubmit(rejection.provider)
+                        // release keep-mounted if SDK didn't open (error path)
+                        if (!sumsubFlow.showWrapper) {
                             onKeepMounted?.(false)
                         }
                     }}

--- a/src/components/Kyc/KycStatusDrawer.tsx
+++ b/src/components/Kyc/KycStatusDrawer.tsx
@@ -123,10 +123,14 @@ export const KycStatusDrawer = ({
             return (
                 <KycProviderRejection
                     rejection={rejection}
-                    onStartResubmission={() => {
+                    onStartResubmission={async () => {
                         onKeepMounted?.(true)
                         onClose()
-                        sumsubFlow.handleSelfHealResubmit(rejection.provider)
+                        try {
+                            await sumsubFlow.handleSelfHealResubmit(rejection.provider)
+                        } catch (e) {
+                            onKeepMounted?.(false)
+                        }
                     }}
                 />
             )

--- a/src/components/Kyc/KycStatusItem.tsx
+++ b/src/components/Kyc/KycStatusItem.tsx
@@ -17,6 +17,7 @@ import {
     isKycStatusNotStarted,
     isKycStatusActionRequired,
 } from '@/constants/kyc.consts'
+import useProviderRejectionStatus from '@/hooks/useProviderRejectionStatus'
 
 // kyc history entry type + type guard — used by HomeHistory and history page
 export interface KycHistoryEntry {
@@ -80,6 +81,9 @@ export const KycStatusItem = ({
         [user?.rails]
     )
 
+    // provider rejection status (bridge/manteca)
+    const { hasFixableRejection, hasBlockedRejection } = useProviderRejectionStatus()
+
     const isApproved = isKycStatusApproved(kycStatus)
     const isPending = isKycStatusPending(kycStatus)
     const isRejected = isKycStatusFailed(kycStatus)
@@ -89,6 +93,9 @@ export const KycStatusItem = ({
     const isInitiatedButNotStarted = !!verification && isKycStatusNotStarted(kycStatus)
 
     const subtitle = useMemo(() => {
+        // provider rejection takes priority when sumsub is approved
+        if (isApproved && hasFixableRejection) return 'Action needed'
+        if (isApproved && hasBlockedRejection) return 'Verification issue'
         if (hasBridgeDocsNeeded) return 'Action needed'
         if (isInitiatedButNotStarted) return 'Not completed'
         if (isActionRequired) return 'Action needed'
@@ -96,7 +103,16 @@ export const KycStatusItem = ({
         if (isApproved) return 'Verified'
         if (isRejected) return 'Failed'
         return 'Unknown'
-    }, [hasBridgeDocsNeeded, isInitiatedButNotStarted, isActionRequired, isPending, isApproved, isRejected])
+    }, [
+        hasBridgeDocsNeeded,
+        isInitiatedButNotStarted,
+        isActionRequired,
+        isPending,
+        isApproved,
+        isRejected,
+        hasFixableRejection,
+        hasBlockedRejection,
+    ])
 
     // only hide for bridge's default "not_started" state.
     // if a verification record exists, the user has initiated KYC — show it.
@@ -122,9 +138,13 @@ export const KycStatusItem = ({
                                 <p className="text-sm text-grey-1">{subtitle}</p>
                                 <StatusPill
                                     status={
-                                        hasBridgeDocsNeeded || isInitiatedButNotStarted || isActionRequired || isPending
+                                        hasBridgeDocsNeeded ||
+                                        isInitiatedButNotStarted ||
+                                        isActionRequired ||
+                                        isPending ||
+                                        (isApproved && hasFixableRejection)
                                             ? 'pending'
-                                            : isRejected
+                                            : isRejected || (isApproved && hasBlockedRejection)
                                               ? 'cancelled'
                                               : 'completed'
                                     }

--- a/src/components/Kyc/states/KycFailed.tsx
+++ b/src/components/Kyc/states/KycFailed.tsx
@@ -27,7 +27,7 @@ export const KycFailed = ({
     rejectLabels?: string[] | null
     bridgeReason?: string | null
     isSumsub?: boolean
-    rejectType?: 'RETRY' | 'FINAL' | null
+    rejectType?: 'RETRY' | 'FINAL' | 'PROVIDER_FIXABLE' | 'PROVIDER_FINAL' | null
     failureCount?: number
     bridgeKycRejectedAt?: string
     countryCode?: string | null

--- a/src/components/Kyc/states/KycProviderRejection.tsx
+++ b/src/components/Kyc/states/KycProviderRejection.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { KYCStatusDrawerItem } from '../KYCStatusDrawerItem'
+import { Button } from '@/components/0_Bruddle/Button'
+import { Icon } from '@/components/Global/Icons/Icon'
+import type { ProviderRejectionInfo } from '@/hooks/useProviderRejectionStatus'
+
+/**
+ * shown when a user is sumsub-approved but a provider (bridge/manteca) rejected their documents.
+ * displays two-level status: identity verified + provider-specific rejection with action.
+ * onStartResubmission is called when user clicks "Upload document" — the parent (KycStatusDrawer)
+ * handles the actual API call + SDK opening via sumsubFlow.handleSelfHealResubmit.
+ */
+export const KycProviderRejection = ({
+    rejection,
+    onStartResubmission,
+}: {
+    rejection: ProviderRejectionInfo
+    onStartResubmission?: () => void
+}) => {
+    const providerLabel = rejection.provider === 'BRIDGE' ? 'Bank transfers' : 'QR payments'
+    const isFixable = rejection.state === 'fixable'
+
+    return (
+        <div className="space-y-4 p-1">
+            {/* identity verified status */}
+            <KYCStatusDrawerItem status="completed" customText="Identity verified" />
+
+            {/* provider-specific status */}
+            <div className="rounded-sm border border-n-1 p-4">
+                <div className="flex items-center gap-3">
+                    <div
+                        className={`flex size-8 shrink-0 items-center justify-center rounded-full ${
+                            isFixable ? 'bg-yellow-1' : 'bg-red-1'
+                        }`}
+                    >
+                        <Icon name={isFixable ? 'alert' : 'failed'} size={16} />
+                    </div>
+                    <div>
+                        <p className="font-semibold">
+                            {providerLabel}: {isFixable ? 'action needed' : 'unavailable'}
+                        </p>
+                        <p className="text-sm text-grey-1">
+                            {rejection.userMessage ||
+                                (isFixable ? 'We need an updated document.' : 'Contact support for help.')}
+                        </p>
+                    </div>
+                </div>
+
+                {isFixable && rejection.selfHealAttempt > 0 && (
+                    <p className="mt-2 text-xs text-grey-1">
+                        Attempt {rejection.selfHealAttempt} of {rejection.maxAttempts}
+                    </p>
+                )}
+            </div>
+
+            {isFixable ? (
+                <Button variant="purple" shadowSize="4" className="w-full" onClick={onStartResubmission}>
+                    Upload document
+                </Button>
+            ) : (
+                <Button
+                    variant="stroke"
+                    className="w-full"
+                    onClick={() => {
+                        if (typeof window !== 'undefined' && (window as any).$crisp) {
+                            ;(window as any).$crisp.push(['do', 'chat:open'])
+                        }
+                    }}
+                >
+                    Contact support
+                </Button>
+            )}
+        </div>
+    )
+}

--- a/src/components/Profile/views/RegionsVerification.view.tsx
+++ b/src/components/Profile/views/RegionsVerification.view.tsx
@@ -10,8 +10,10 @@ import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { KycProcessingModal } from '@/components/Kyc/modals/KycProcessingModal'
 import { KycActionRequiredModal } from '@/components/Kyc/modals/KycActionRequiredModal'
 import { KycFailedModal } from '@/components/Kyc/modals/KycFailedModal'
+import ActionModal from '@/components/Global/ActionModal'
 import { useIdentityVerification, getRegionIntent, type Region } from '@/hooks/useIdentityVerification'
 import useUnifiedKycStatus from '@/hooks/useUnifiedKycStatus'
+import useProviderRejectionStatus from '@/hooks/useProviderRejectionStatus'
 import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { useAuth } from '@/context/authContext'
 import Image from 'next/image'
@@ -51,7 +53,9 @@ const RegionsVerification = () => {
     const router = useRouter()
     const { user } = useAuth()
     const { unlockedRegions, lockedRegions } = useIdentityVerification()
-    const { sumsubStatus, sumsubRejectLabels, sumsubRejectType, sumsubVerificationRegionIntent } = useUnifiedKycStatus()
+    const { sumsubStatus, sumsubRejectLabels, sumsubRejectType, sumsubVerificationRegionIntent, isSumsubApproved } =
+        useUnifiedKycStatus()
+    const { bridge: bridgeRejection, manteca: mantecaRejection, hasAnyRejection } = useProviderRejectionStatus()
     const [selectedRegion, setSelectedRegion] = useState<Region | null>(null)
     // keeps the region display stable during modal close animation
     const displayRegionRef = useRef<Region | null>(null)
@@ -69,9 +73,18 @@ const RegionsVerification = () => {
     )
 
     const clickedRegionIntent = selectedRegion ? getRegionIntent(selectedRegion.path) : undefined
-    const modalVariant = selectedRegion
+    const baseModalVariant = selectedRegion
         ? getModalVariant(sumsubStatus, clickedRegionIntent, sumsubVerificationRegionIntent)
         : null
+
+    // override modal variant when sumsub is approved but a provider rejected the user
+    // determines which provider is relevant based on the clicked region
+    const providerRejectionForRegion = clickedRegionIntent === 'LATAM' ? mantecaRejection : bridgeRejection
+    const hasProviderRejectionForRegion =
+        !!selectedRegion &&
+        isSumsubApproved &&
+        (providerRejectionForRegion.state === 'fixable' || providerRejectionForRegion.state === 'blocked')
+    const modalVariant = hasProviderRejectionForRegion ? ('provider_rejection' as const) : baseModalVariant
 
     const handleFinalKycSuccess = useCallback(() => {
         setSelectedRegion(null)
@@ -173,6 +186,47 @@ const RegionsVerification = () => {
                 rejectLabels={sumsubRejectLabels}
                 rejectType={sumsubRejectType}
                 failureCount={sumsubFailureCount}
+            />
+
+            <ActionModal
+                visible={modalVariant === 'provider_rejection'}
+                onClose={handleModalClose}
+                title={
+                    providerRejectionForRegion.state === 'fixable'
+                        ? 'We need an updated document'
+                        : 'Region unavailable'
+                }
+                description={
+                    providerRejectionForRegion.state === 'fixable'
+                        ? providerRejectionForRegion.userMessage ||
+                          'Please upload a clearer photo of your ID to unlock this region.'
+                        : 'This region is not available for your account. Contact support for help.'
+                }
+                icon="alert"
+                iconContainerClassName="bg-yellow-1"
+                ctas={[
+                    providerRejectionForRegion.state === 'fixable'
+                        ? {
+                              text: 'Upload document',
+                              onClick: () => {
+                                  handleModalClose()
+                                  flow.handleSelfHealResubmit(providerRejectionForRegion.provider)
+                              },
+                              variant: 'purple' as const,
+                              shadowSize: '4' as const,
+                          }
+                        : {
+                              text: 'Contact support',
+                              onClick: () => {
+                                  if (typeof window !== 'undefined' && (window as any).$crisp) {
+                                      ;(window as any).$crisp.push(['do', 'chat:open'])
+                                  }
+                                  handleModalClose()
+                              },
+                              variant: 'purple' as const,
+                              shadowSize: '4' as const,
+                          },
+                ]}
             />
 
             {flow.error && <p className="text-red-500 mt-2 text-sm">{flow.error}</p>}

--- a/src/constants/sumsub-reject-labels.consts.ts
+++ b/src/constants/sumsub-reject-labels.consts.ts
@@ -322,11 +322,11 @@ export const isTerminalRejection = ({
     failureCount,
     rejectLabels,
 }: {
-    rejectType?: 'RETRY' | 'FINAL' | null
+    rejectType?: 'RETRY' | 'FINAL' | 'PROVIDER_FIXABLE' | 'PROVIDER_FINAL' | null
     failureCount?: number
     rejectLabels?: string[] | null
 }): boolean => {
-    if (rejectType === 'FINAL') return true
+    if (rejectType === 'FINAL' || rejectType === 'PROVIDER_FINAL') return true
     if (failureCount && failureCount >= MAX_RETRY_COUNT) return true
     if (rejectLabels?.length && hasTerminalRejectLabel(rejectLabels)) return true
     return false

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -143,6 +143,7 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
         accessToken,
         liveKycStatus,
         handleInitiateKyc: originalHandleInitiateKyc,
+        handleSelfHealResubmit,
         handleSdkComplete: originalHandleSdkComplete,
         handleClose,
         refreshToken,
@@ -321,6 +322,7 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
     return {
         // initiation
         handleInitiateKyc,
+        handleSelfHealResubmit,
         isLoading,
         error,
         liveKycStatus,

--- a/src/hooks/useProviderRejectionStatus.ts
+++ b/src/hooks/useProviderRejectionStatus.ts
@@ -142,7 +142,7 @@ export default function useProviderRejectionStatus() {
     const hasAnyRejection = hasFixableRejection || hasBlockedRejection
 
     // the provider that needs attention first (fixable takes priority)
-    const primaryRejection = bridge.state === 'fixable' ? bridge : manteca.state === 'fixable' ? manteca : null
+    const primaryRejection = bridge.state === 'fixable' ? bridge : manteca.state === 'fixable' ? manteca : bridge.state === 'blocked' ? bridge : manteca.state === 'blocked' ? manteca : null
 
     return {
         bridge,

--- a/src/hooks/useProviderRejectionStatus.ts
+++ b/src/hooks/useProviderRejectionStatus.ts
@@ -92,8 +92,7 @@ export default function useProviderRejectionStatus() {
                     userMessage = first?.reason || first?.developer_reason || null
                 } else if (Array.isArray(endorsementIssues) && endorsementIssues.length > 0) {
                     // bridge endorsement issues: plain strings like 'government_id_verification_failed'
-                    const issue = String(endorsementIssues[0]).replace(/_/g, ' ')
-                    userMessage = `ID verification failed. Please upload a clearer photo.`
+                                        userMessage = `ID verification failed. Please upload a clearer photo.`
                 }
 
                 return {

--- a/src/hooks/useProviderRejectionStatus.ts
+++ b/src/hooks/useProviderRejectionStatus.ts
@@ -1,0 +1,155 @@
+'use client'
+
+import { useAuth } from '@/context/authContext'
+import { useMemo } from 'react'
+import type { IUserRail, IUserKycVerification } from '@/interfaces/interfaces'
+
+export type ProviderRejectionState = 'happy' | 'processing' | 'fixable' | 'blocked'
+
+export interface ProviderRejectionInfo {
+    provider: 'BRIDGE' | 'MANTECA'
+    state: ProviderRejectionState
+    userMessage: string | null
+    rejectedRails: IUserRail[]
+    kycVerification: IUserKycVerification | null
+    selfHealAttempt: number
+    maxAttempts: number
+}
+
+const MAX_SELF_HEAL_ATTEMPTS = 3
+
+/**
+ * derives per-provider fixable/blocked/processing state from rails + kycVerifications.
+ * shared by ActivationCTAs and KycStatusItem (DRY — hugo's comment #11).
+ */
+export default function useProviderRejectionStatus() {
+    const { user } = useAuth()
+
+    const rails = user?.rails ?? []
+    const kycVerifications = user?.user?.kycVerifications ?? []
+
+    const getProviderState = useMemo(() => {
+        return (providerCode: 'BRIDGE' | 'MANTECA'): ProviderRejectionInfo => {
+            const providerRails = rails.filter((r) => r.rail.provider.code === providerCode)
+            const rejectedRails = providerRails.filter((r) => r.status === 'REJECTED')
+            const pendingRails = providerRails.filter((r) => r.status === 'PENDING')
+            const enabledRails = providerRails.filter((r) => r.status === 'ENABLED')
+
+            // find the most recent kyc verification for this provider
+            const kycVerification =
+                kycVerifications
+                    .filter((v) => v.provider === providerCode)
+                    .sort((a, b) => new Date(b.updatedAt ?? 0).getTime() - new Date(a.updatedAt ?? 0).getTime())[0] ??
+                null
+
+            const metadata = (kycVerification?.metadata ?? {}) as Record<string, unknown>
+            const selfHealAttempt = (metadata.selfHealAttempt as number) || 0
+
+            // no rails for this provider — not submitted
+            if (providerRails.length === 0) {
+                return {
+                    provider: providerCode,
+                    state: 'happy',
+                    userMessage: null,
+                    rejectedRails: [],
+                    kycVerification,
+                    selfHealAttempt,
+                    maxAttempts: MAX_SELF_HEAL_ATTEMPTS,
+                }
+            }
+
+            // all enabled — happy
+            if (enabledRails.length > 0 && rejectedRails.length === 0) {
+                return {
+                    provider: providerCode,
+                    state: 'happy',
+                    userMessage: null,
+                    rejectedRails: [],
+                    kycVerification,
+                    selfHealAttempt,
+                    maxAttempts: MAX_SELF_HEAL_ATTEMPTS,
+                }
+            }
+
+            // has rejected rails
+            if (rejectedRails.length > 0) {
+                const firstRejectedMetadata = (rejectedRails[0].metadata ?? {}) as Record<string, unknown>
+                const isSelfHealable = firstRejectedMetadata.selfHealable === true
+                const rejectType = kycVerification?.rejectType
+
+                // check if fixable: selfHealable flag on rail + rejectType + attempt limit
+                const isFixable =
+                    isSelfHealable && rejectType !== 'PROVIDER_FINAL' && selfHealAttempt < MAX_SELF_HEAL_ATTEMPTS
+
+                // extract user-facing message from rejection reasons or endorsement issues
+                let userMessage: string | null = null
+                const reasons = firstRejectedMetadata.rejectionReasons
+                const endorsementIssues = firstRejectedMetadata.endorsementIssues
+                if (Array.isArray(reasons) && reasons.length > 0) {
+                    // bridge format: { reason: string, developer_reason: string }
+                    // manteca format: { task: string, reason: string }
+                    const first = reasons[0]
+                    userMessage = first?.reason || first?.developer_reason || null
+                } else if (Array.isArray(endorsementIssues) && endorsementIssues.length > 0) {
+                    // bridge endorsement issues: plain strings like 'government_id_verification_failed'
+                    const issue = String(endorsementIssues[0]).replace(/_/g, ' ')
+                    userMessage = `ID verification failed. Please upload a clearer photo.`
+                }
+
+                return {
+                    provider: providerCode,
+                    state: isFixable ? 'fixable' : 'blocked',
+                    userMessage,
+                    rejectedRails,
+                    kycVerification,
+                    selfHealAttempt,
+                    maxAttempts: MAX_SELF_HEAL_ATTEMPTS,
+                }
+            }
+
+            // has pending rails (submitted but not yet reviewed)
+            if (pendingRails.length > 0) {
+                return {
+                    provider: providerCode,
+                    state: 'processing',
+                    userMessage: null,
+                    rejectedRails: [],
+                    kycVerification,
+                    selfHealAttempt,
+                    maxAttempts: MAX_SELF_HEAL_ATTEMPTS,
+                }
+            }
+
+            // default: processing (REQUIRES_INFORMATION, REQUIRES_EXTRA_INFORMATION, etc.)
+            return {
+                provider: providerCode,
+                state: 'processing',
+                userMessage: null,
+                rejectedRails: [],
+                kycVerification,
+                selfHealAttempt,
+                maxAttempts: MAX_SELF_HEAL_ATTEMPTS,
+            }
+        }
+    }, [rails, kycVerifications])
+
+    const bridge = useMemo(() => getProviderState('BRIDGE'), [getProviderState])
+    const manteca = useMemo(() => getProviderState('MANTECA'), [getProviderState])
+
+    // overall: has any fixable rejection across providers
+    const hasFixableRejection = bridge.state === 'fixable' || manteca.state === 'fixable'
+    const hasBlockedRejection = bridge.state === 'blocked' || manteca.state === 'blocked'
+    const hasAnyRejection = hasFixableRejection || hasBlockedRejection
+
+    // the provider that needs attention first (fixable takes priority)
+    const primaryRejection = bridge.state === 'fixable' ? bridge : manteca.state === 'fixable' ? manteca : null
+
+    return {
+        bridge,
+        manteca,
+        hasFixableRejection,
+        hasBlockedRejection,
+        hasAnyRejection,
+        primaryRejection,
+    }
+}

--- a/src/hooks/useProviderRejectionStatus.ts
+++ b/src/hooks/useProviderRejectionStatus.ts
@@ -92,7 +92,7 @@ export default function useProviderRejectionStatus() {
                     userMessage = first?.reason || first?.developer_reason || null
                 } else if (Array.isArray(endorsementIssues) && endorsementIssues.length > 0) {
                     // bridge endorsement issues: plain strings like 'government_id_verification_failed'
-                                        userMessage = `ID verification failed. Please upload a clearer photo.`
+                    userMessage = `ID verification failed. Please upload a clearer photo.`
                 }
 
                 return {
@@ -141,7 +141,16 @@ export default function useProviderRejectionStatus() {
     const hasAnyRejection = hasFixableRejection || hasBlockedRejection
 
     // the provider that needs attention first (fixable takes priority)
-    const primaryRejection = bridge.state === 'fixable' ? bridge : manteca.state === 'fixable' ? manteca : bridge.state === 'blocked' ? bridge : manteca.state === 'blocked' ? manteca : null
+    const primaryRejection =
+        bridge.state === 'fixable'
+            ? bridge
+            : manteca.state === 'fixable'
+              ? manteca
+              : bridge.state === 'blocked'
+                ? bridge
+                : manteca.state === 'blocked'
+                  ? manteca
+                  : null
 
     return {
         bridge,

--- a/src/hooks/useQrKycGate.ts
+++ b/src/hooks/useQrKycGate.ts
@@ -5,6 +5,8 @@ import { useAuth } from '@/context/authContext'
 import { MantecaKycStatus } from '@/interfaces'
 import { isKycStatusApproved, isSumsubStatusInProgress } from '@/constants/kyc.consts'
 
+const MAX_SELF_HEAL_ATTEMPTS = 3
+
 export enum QrKycState {
     LOADING = 'loading',
     PROCEED_TO_PAY = 'proceed_to_pay',
@@ -81,7 +83,7 @@ export function useQrKycGate(paymentProcessor?: 'MANTECA' | 'SIMPLEFI' | null): 
                 const isFixable =
                     railMeta.selfHealable === true &&
                     mantecaKyc?.rejectType !== 'PROVIDER_FINAL' &&
-                    ((kycMeta.selfHealAttempt as number) || 0) < 3
+                    ((kycMeta.selfHealAttempt as number) || 0) < MAX_SELF_HEAL_ATTEMPTS
                 setKycGateState(
                     isFixable ? QrKycState.PROVIDER_REJECTION_FIXABLE : QrKycState.PROVIDER_REJECTION_BLOCKED
                 )

--- a/src/hooks/useQrKycGate.ts
+++ b/src/hooks/useQrKycGate.ts
@@ -74,7 +74,9 @@ export function useQrKycGate(paymentProcessor?: 'MANTECA' | 'SIMPLEFI' | null): 
             )
             if (rejectedMantecaRails.length > 0) {
                 const railMeta = (rejectedMantecaRails[0].metadata ?? {}) as Record<string, unknown>
-                const mantecaKyc = currentUser.kycVerifications?.find((v) => v.provider === 'MANTECA')
+                const mantecaKyc = currentUser.kycVerifications
+                    ?.filter((v) => v.provider === 'MANTECA')
+                    .sort((a, b) => new Date(b.updatedAt ?? 0).getTime() - new Date(a.updatedAt ?? 0).getTime())[0]
                 const kycMeta = (mantecaKyc?.metadata ?? {}) as Record<string, unknown>
                 const isFixable =
                     railMeta.selfHealable === true &&

--- a/src/hooks/useQrKycGate.ts
+++ b/src/hooks/useQrKycGate.ts
@@ -10,6 +10,8 @@ export enum QrKycState {
     PROCEED_TO_PAY = 'proceed_to_pay',
     REQUIRES_IDENTITY_VERIFICATION = 'requires_identity_verification',
     IDENTITY_VERIFICATION_IN_PROGRESS = 'identity_verification_in_progress',
+    PROVIDER_REJECTION_FIXABLE = 'provider_rejection_fixable',
+    PROVIDER_REJECTION_BLOCKED = 'provider_rejection_blocked',
 }
 
 export interface QrKycGateResult {
@@ -61,12 +63,28 @@ export function useQrKycGate(paymentProcessor?: 'MANTECA' | 'SIMPLEFI' | null): 
             return
         }
 
-        // sumsub approved users (including foreign users) can proceed to qr pay.
-        // note: backend enforces per-rail access separately — frontend gate only checks identity verification.
+        // sumsub approved users can proceed to qr pay, unless manteca rejected them
         const hasSumsubApproved = currentUser.kycVerifications?.some(
             (v) => v.provider === 'SUMSUB' && isKycStatusApproved(v.status)
         )
         if (hasSumsubApproved) {
+            // check if manteca has rejected rails (qr payments use manteca)
+            const rejectedMantecaRails = (user?.rails ?? []).filter(
+                (r) => r.rail.provider.code === 'MANTECA' && r.status === 'REJECTED'
+            )
+            if (rejectedMantecaRails.length > 0) {
+                const railMeta = (rejectedMantecaRails[0].metadata ?? {}) as Record<string, unknown>
+                const mantecaKyc = currentUser.kycVerifications?.find((v) => v.provider === 'MANTECA')
+                const kycMeta = (mantecaKyc?.metadata ?? {}) as Record<string, unknown>
+                const isFixable =
+                    railMeta.selfHealable === true &&
+                    mantecaKyc?.rejectType !== 'PROVIDER_FINAL' &&
+                    ((kycMeta.selfHealAttempt as number) || 0) < 3
+                setKycGateState(
+                    isFixable ? QrKycState.PROVIDER_REJECTION_FIXABLE : QrKycState.PROVIDER_REJECTION_BLOCKED
+                )
+                return
+            }
             setKycGateState(QrKycState.PROCEED_TO_PAY)
             return
         }
@@ -121,6 +139,8 @@ export function useQrKycGate(paymentProcessor?: 'MANTECA' | 'SIMPLEFI' | null): 
         shouldBlockPay:
             kycGateState === QrKycState.REQUIRES_IDENTITY_VERIFICATION ||
             kycGateState === QrKycState.IDENTITY_VERIFICATION_IN_PROGRESS ||
+            kycGateState === QrKycState.PROVIDER_REJECTION_FIXABLE ||
+            kycGateState === QrKycState.PROVIDER_REJECTION_BLOCKED ||
             kycGateState === QrKycState.LOADING,
     }
 

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -209,6 +209,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     // called when sdk signals applicant submitted
     const handleSdkComplete = useCallback(() => {
         userInitiatedRef.current = true
+        selfHealProviderRef.current = null
         setShowWrapper(false)
         setIsActionFlow(false)
         setIsVerificationProgressModalOpen(true)

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import { useWebSocket } from '@/hooks/useWebSocket'
 import { useUserStore } from '@/redux/hooks'
-import { initiateSumsubKyc } from '@/app/actions/sumsub'
+import { initiateSumsubKyc, initiateSelfHealResubmission } from '@/app/actions/sumsub'
 import { type KYCRegionIntent, type SumsubKycStatus } from '@/app/actions/types/sumsub.types'
 
 interface UseSumsubKycFlowOptions {
@@ -36,6 +36,8 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     // guard: only fire onKycSuccess when the user initiated a kyc flow in this session.
     // prevents stale websocket events or mount-time fetches from auto-closing the drawer.
     const userInitiatedRef = useRef(false)
+    // tracks self-heal provider for token refresh — null when in regular KYC flow
+    const selfHealProviderRef = useRef<'BRIDGE' | 'MANTECA' | null>(null)
 
     useEffect(() => {
         regionIntentRef.current = regionIntent
@@ -129,6 +131,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         async (overrideIntent?: KYCRegionIntent, levelName?: string, crossRegion?: boolean) => {
             userInitiatedRef.current = true
             initiatingRef.current = true
+            selfHealProviderRef.current = null
             setIsLoading(true)
             setError(null)
 
@@ -219,8 +222,17 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     }, [onManualClose])
 
     // token refresh function passed to the sdk for when the token expires.
-    // uses regionIntentRef + levelNameRef so refresh always matches the template used during initiation.
+    // uses self-heal provider ref when in self-heal mode, otherwise regular KYC endpoint.
     const refreshToken = useCallback(async (): Promise<string> => {
+        if (selfHealProviderRef.current) {
+            const response = await initiateSelfHealResubmission(selfHealProviderRef.current)
+            if (response.error || !response.data?.token) {
+                throw new Error(response.error || 'Failed to refresh self-heal token')
+            }
+            setAccessToken(response.data.token)
+            return response.data.token
+        }
+
         const response = await initiateSumsubKyc({
             regionIntent: regionIntentRef.current,
             levelName: levelNameRef.current,
@@ -247,6 +259,36 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         setError(null)
     }, [])
 
+    // initiate self-heal document resubmission: calls the resubmit API
+    // and opens the sumsub SDK with the action token
+    const handleSelfHealResubmit = useCallback(async (provider: 'BRIDGE' | 'MANTECA') => {
+        setIsLoading(true)
+        setError(null)
+        userInitiatedRef.current = true
+        selfHealProviderRef.current = provider
+
+        try {
+            const response = await initiateSelfHealResubmission(provider)
+
+            if (response.error) {
+                setError(response.error)
+                return
+            }
+
+            if (response.data?.token) {
+                setAccessToken(response.data.token)
+                setShowWrapper(true)
+            } else {
+                setError('Could not initiate document resubmission. Please try again.')
+            }
+        } catch (e: unknown) {
+            const message = e instanceof Error ? e.message : 'An unexpected error occurred'
+            setError(message)
+        } finally {
+            setIsLoading(false)
+        }
+    }, [])
+
     return {
         isLoading,
         error,
@@ -255,6 +297,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         liveKycStatus,
         rejectLabels,
         handleInitiateKyc,
+        handleSelfHealResubmit,
         handleSdkComplete,
         handleClose,
         refreshToken,

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -271,6 +271,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
             const response = await initiateSelfHealResubmission(provider)
 
             if (response.error) {
+                selfHealProviderRef.current = null
                 setError(response.error)
                 return
             }
@@ -282,6 +283,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 setError('Could not initiate document resubmission. Please try again.')
             }
         } catch (e: unknown) {
+            selfHealProviderRef.current = null
             const message = e instanceof Error ? e.message : 'An unexpected error occurred'
             setError(message)
         } finally {

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -280,6 +280,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 setAccessToken(response.data.token)
                 setShowWrapper(true)
             } else {
+                selfHealProviderRef.current = null
                 setError('Could not initiate document resubmission. Please try again.')
             }
         } catch (e: unknown) {

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -254,7 +254,7 @@ export interface IUserKycVerification {
     providerRawStatus?: string | null
     sumsubApplicantId?: string | null
     rejectLabels?: string[] | null
-    rejectType?: 'RETRY' | 'FINAL' | null
+    rejectType?: 'RETRY' | 'FINAL' | 'PROVIDER_FIXABLE' | 'PROVIDER_FINAL' | null
     metadata?: { regionIntent?: string; [key: string]: unknown } | null
     createdAt: string
     updatedAt: string


### PR DESCRIPTION
## Summary

- Add `useProviderRejectionStatus` hook: derives per-provider fixable/blocked state from rails + kycVerifications (shared by all components)
- Add `KycProviderRejection` component: two-level status (identity verified + provider rejection) with resubmission CTA
- Add `handleSelfHealResubmit` to sumsub flow: calls resubmit API + opens SDK with action token
- Fix "verify your identity" bug: all 10 flows now show "We need extra documents" for provider-rejected users
- Fix activation CTA: shows "Complete your setup" instead of misleading "Deposit" for rejected users
- Add provider rejection states to QR payment gate
- Fix regions verification page: provider rejection modal only appears on region click, not on page load
- Token refresh uses correct endpoint during self-heal (selfHealProviderRef)

## Depends on

- Backend PR: peanutprotocol/peanut-api-ts#667

## Test plan

- [ ] Home page: provider-rejected user at deposit step sees "Complete your setup" (not "Deposit")
- [ ] KycStatusDrawer: shows two-level status with "Upload document" CTA
- [ ] "Upload document" → Sumsub SDK opens with action token → SDK closes after upload
- [ ] All in-flow modals (deposit/withdraw/claim) call handleSelfHealResubmit (not handleInitiateKyc)
- [ ] Regions page: modal only shows on region click, not on load
- [ ] QR payment: manteca-rejected shows "We need an updated document"
- [ ] Token refresh during self-heal calls resubmit API
- [ ] Existing approved users see normal flows (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)