### PR TITLE
chore(landing): reframe Manteca QR-pay section to lead with ease/access

### DIFF
--- a/src/components/LandingPage/Manteca.tsx
+++ b/src/components/LandingPage/Manteca.tsx
@@ -39,17 +39,15 @@ const Manteca = () => {
 
             <div className="relative flex flex-col items-center justify-center px-4">
                 <h1 className="font-roboto-flex-extrabold text-center text-[4rem] font-extraBlack md:text-left lg:text-headingMedium">
-                    GET PAID. PAY. DONE.
+                    PAY LIKE A LOCAL.
                 </h1>
 
                 <h2 className="font-roboto-flex mt-6 text-center text-xl md:text-5xl">
                     RECEIVE FROM ANYWHERE. NO LOCAL ID NEEDED.
                 </h2>
 
-                <h2 className="font-roboto-flex mt-6 text-center text-xl md:text-4xl">Get best exchange rate.</h2>
-
-                <h3 className="font-roboto-flex mt-6 text-center text-xl md:text-xl">
-                    up to <b>~15% cheaper</b> than Visa & Mastercard.
+                <h3 className="font-roboto-flex mt-6 text-center text-xl md:text-2xl">
+                    Pay MercadoPago QR in Argentina. Send PIX in Brazil. Just your passport.
                 </h3>
             </div>
 
@@ -69,6 +67,10 @@ const Manteca = () => {
                 <Image src={mantecaIphone} alt="Mercado pago payment" width={250} height={250} />
                 <Image src={PIX_BRZ_LOGO} alt="Pix Brazil" width={170} height={170} />
             </div>
+
+            <p className="font-roboto-flex relative mt-12 text-center text-sm opacity-70 md:absolute md:bottom-4 md:left-1/2 md:mt-0 md:-translate-x-1/2">
+                Settles in digital dollars at the real exchange rate.
+            </p>
         </section>
     )
 }

--- a/src/components/LandingPage/Manteca.tsx
+++ b/src/components/LandingPage/Manteca.tsx
@@ -16,7 +16,7 @@ const Manteca = () => {
     return (
         <section
             id="qr-pay"
-            className="relative overflow-hidden py-20 text-n-1 md:h-[850px] lg:h-[750px]"
+            className="relative overflow-hidden py-20 text-n-1 md:min-h-[850px] lg:min-h-[750px]"
             style={{ backgroundColor: '#F9F4F0' }}
         >
             <div className="hidden md:block">

--- a/src/components/LandingPage/Manteca.tsx
+++ b/src/components/LandingPage/Manteca.tsx
@@ -62,13 +62,19 @@ const Manteca = () => {
             </div>
 
             {/* Desktop layout */}
-            <div className="absolute -bottom-24 left-1/2 mx-auto hidden -translate-x-1/2 items-center justify-center gap-20 md:flex lg:gap-36">
-                <Image src={MEPA_ARGENTINA_LOGO} alt="Mepa Argentina" width={170} height={170} />
-                <Image src={mantecaIphone} alt="Mercado pago payment" width={250} height={250} />
-                <Image src={PIX_BRZ_LOGO} alt="Pix Brazil" width={170} height={170} />
+            <div className="mx-auto mt-12 hidden flex-col items-center justify-center gap-8 md:flex">
+                <div className="flex items-center justify-center gap-20 lg:gap-36">
+                    <Image src={MEPA_ARGENTINA_LOGO} alt="Mepa Argentina" width={170} height={170} />
+                    <Image src={mantecaIphone} alt="Mercado pago payment" width={250} height={250} />
+                    <Image src={PIX_BRZ_LOGO} alt="Pix Brazil" width={170} height={170} />
+                </div>
+
+                <p className="font-roboto-flex text-center text-sm opacity-70">
+                    Settles in digital dollars at the real exchange rate.
+                </p>
             </div>
 
-            <p className="font-roboto-flex relative mt-12 text-center text-sm opacity-70 md:absolute md:bottom-4 md:left-1/2 md:mt-0 md:-translate-x-1/2">
+            <p className="font-roboto-flex relative mt-12 text-center text-sm opacity-70 md:hidden">
                 Settles in digital dollars at the real exchange rate.
             </p>
         </section>


### PR DESCRIPTION
## Summary
- Removes the savings-lead heading stack ("Get best exchange rate." / "up to ~15% cheaper than Visa & Mastercard.") from the `#qr-pay` landing section.
- Replaces with access-led copy: H1 **"PAY LIKE A LOCAL."**, retained H2 **"RECEIVE FROM ANYWHERE. NO LOCAL ID NEEDED."**, and a concrete-action H3 **"Pay MercadoPago QR in Argentina. Send PIX in Brazil. Just your passport."**
- Demotes the rate claim to a small caption below the phone+logos: *"Settles in digital dollars at the real exchange rate."* — no %, no Visa/MC comparison.

## Why
Savings are a post-purchase trust-and-delight payoff, never a headline (per product rule). A baked-in "~15%" creates a trust liability when the cripto dólar rate moves — the "we currently lie about the rate" issue from the parent task. Wording also aligns with `messaging.md` guardrails (no "stablecoin" → "digital dollars"; no provider names; no %/spread).

## Test plan
- [ ] Visual check on dev: `pnpm dev` in `peanut-ui/`, scroll to `#qr-pay` section
- [ ] Verify hero is access-led on **mobile** breakpoint (separate layout block)
- [ ] Verify hero is access-led on **desktop** breakpoint (separate layout block, with `-bottom-24` logo overhang — confirm caption doesn't collide)
- [ ] Confirm caption "Settles in digital dollars at the real exchange rate." renders below the phone+logos, not in heading hierarchy
- [ ] Confirm no `%`, `Visa`, or `Mastercard` strings appear in the section

🤖 Generated with [Claude Code](https://claude.com/claude-code)