### PR TITLE
fix(kyc): keep WebSDK open on RED+RETRY action launch

### DIFF
--- a/src/components/Kyc/SumsubKycWrapper.tsx
+++ b/src/components/Kyc/SumsubKycWrapper.tsx
@@ -152,14 +152,31 @@ export const SumsubKycWrapper = ({
                 }
             }
 
-            // for applicant actions, the SDK fires action-specific events.
-            // only close on terminal status to avoid premature SDK closure.
+            // For applicant actions (rain-card-application, additional-docs):
+            // the SDK fires onApplicantActionStatusChanged with the action's
+            // CURRENT state on launch — including for actions that are already
+            // `completed + RED + RETRY` from a prior attempt. If we close on
+            // any `completed`, the modal disappears before the WebSDK can
+            // render its "data mismatch / retry" UI for RETRY-able actions,
+            // and the user is permanently stuck.
+            //
+            // Mirror handleStatusChanged: ignore events within 3s of SDK init
+            // (those reflect pre-existing state, not a new submission), and
+            // only close on success (completed + GREEN). RED stays open so
+            // the user can resubmit; the resubmission path emits
+            // onApplicantActionSubmitted, which `handleActionSubmitted` closes.
             const handleActionCompleted = (payload: {
                 reviewStatus?: string
                 reviewResult?: { reviewAnswer?: string }
             }) => {
                 console.log('[sumsub] onApplicantActionStatusChanged fired', payload)
-                if (payload?.reviewStatus === 'completed') {
+                if (Date.now() - sdkInitTime < 3000) {
+                    console.log('[sumsub] ignoring early onApplicantActionStatusChanged (pre-existing state)')
+                    return
+                }
+                if (isMultiLevelRef.current) return
+                if (payload?.reviewStatus === 'completed' && payload?.reviewResult?.reviewAnswer === 'GREEN') {
+                    hasSubmittedRef.current = true
                     stableOnComplete()
                 }
             }


### PR DESCRIPTION
## Summary

Companion to peanutprotocol/peanut-api-ts#680. The backend now correctly reuses an existing RED+RETRY Applicant Action (Sumsub's design — the WebSDK is supposed to render the rejection feedback + retry buttons natively). But the wrapper closed the modal on **any** `completed` status, including the action's pre-existing state on launch, so the SDK flashed open and immediately disappeared. User permanently stuck.

`handleActionCompleted` in `SumsubKycWrapper.tsx` was missing the same two safeguards `handleStatusChanged` already had:

1. **Ignore status events within 3s of SDK init** — those reflect pre-existing state (the RED+RETRY action that already exists), not new work the user just did.
2. **Only close on `completed + GREEN`** — RED needs to stay open so the user can resubmit; the resubmission emits `onApplicantActionSubmitted`, which `handleActionSubmitted` already handles.

## Files

- `src/components/Kyc/SumsubKycWrapper.tsx` — single handler change, ~20 line diff including comment.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm prettier --check` clean
- [x] `pnpm test` — only failure is `add-money-states.test.tsx` line 919, pre-existing on `dev` (verified by stash + retest)
- [ ] Manual: with peanut-api-ts#680 deployed, reject a card-apply Applicant Action with RED+RETRY in the Sumsub dashboard, then re-open the card flow. Expect: WebSDK stays open and shows Sumsub's rejection / retry UI ("data mismatch — fix details") instead of closing immediately.
- [ ] Manual sanity: standard KYC flow (non-action) still auto-closes on success.

## Why now

We saw this live during card-issuance testing — once the backend stopped rebinding tokens to dead actions, the FE's behavior on RED+RETRY became the next blocker. Doesn't strictly require the backend PR to merge first (FE-only change), but the user-visible bug only manifests when the backend correctly reuses the action.