### PR TITLE
feat(card): handle main-kyc-required response from /rain/cards

### DIFF
--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -100,6 +100,15 @@ const CardPage: FC = () => {
                     posthog.capture(ANALYTICS_EVENTS.CARD_SUMSUB_OPENED)
                     return
                 }
+                // Main applicant is missing a doc Rain requires (e.g. SELFIE
+                // after liveness was added to the level). Open WebSDK at the
+                // MAIN level — Sumsub asks only for the missing step. Same
+                // wrapper handles both action and main-level tokens.
+                if (res.status === 'main-kyc-required' && 'sumsubAccessToken' in res) {
+                    setSumsubToken(res.sumsubAccessToken)
+                    posthog.capture(ANALYTICS_EVENTS.CARD_SUMSUB_OPENED)
+                    return
+                }
                 if (res.status === 'terms-required' && 'isUsResident' in res) {
                     setPendingTerms({ isUsResident: res.isUsResident })
                     return
@@ -187,7 +196,7 @@ const CardPage: FC = () => {
 
     const handleSumsubRefreshToken = useCallback(async () => {
         const res = await rainApi.applyForCard({ termsAccepted: false })
-        if (res.status === 'incomplete' && 'sumsubAccessToken' in res) {
+        if ((res.status === 'incomplete' || res.status === 'main-kyc-required') && 'sumsubAccessToken' in res) {
             return res.sumsubAccessToken
         }
         // Edge case: the user became "ready" between initial apply and the

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -122,7 +122,8 @@ export const ANALYTICS_EVENTS = {
     // ── Card: acquisition funnel (Rain virtual card) ──
     // State observed on /card mount or transition. `state` matches CardTopLevelState.
     CARD_STATE_VIEWED: 'card_state_viewed',
-    // POST /rain/cards lifecycle. `outcome` ∈ pending|terms-required|incomplete|enabled|error|already-applied.
+    // POST /rain/cards lifecycle. `outcome` ∈
+    // pending|terms-required|incomplete|main-kyc-required|enabled|error|already-applied.
     CARD_APPLY_ATTEMPTED: 'card_apply_attempted',
     CARD_APPLY_SUCCEEDED: 'card_apply_succeeded',
     CARD_APPLY_FAILED: 'card_apply_failed',

--- a/src/services/rain.ts
+++ b/src/services/rain.ts
@@ -148,8 +148,11 @@ export class RainCardRateLimitError extends Error {
 
 /**
  * Response shapes for `POST /rain/cards` — apply for a Rain card.
- * - `incomplete`: user's Sumsub profile is missing data; returned token opens
- *   the card-application Applicant Action so the user can fill it in.
+ * - `incomplete`: card-application action is missing data; returned token
+ *   opens the card-application Applicant Action.
+ * - `main-kyc-required`: main applicant is missing a doc Rain requires
+ *   (e.g. SELFIE after liveness was added to the level). Token opens the
+ *   WebSDK at the MAIN level so the user supplies just the missing step.
  * - `pending`: application submitted to Rain; wait for webhook to approve.
  * - any other string: existing application in that state (ENABLED / REJECTED / …).
  */
@@ -158,6 +161,11 @@ export type ApplyForCardResponse =
           status: 'incomplete'
           missing: string[]
           questionnaireComplete: boolean
+          sumsubAccessToken: string
+      }
+    | {
+          status: 'main-kyc-required'
+          missingDocTypes: string[]
           sumsubAccessToken: string
       }
     | {


### PR DESCRIPTION
## Summary

Companion to peanutprotocol/peanut-api-ts#684. The backend now returns a new `main-kyc-required` status when the user's **main** Sumsub applicant is missing a doc Rain reads from the share token (e.g. `SELFIE` after liveness was added to the level). The accompanying token is bound to the **main level** (not the card-application action), so opening the WebSDK with it lets Sumsub ask for just the missing step — everything that's already GREEN stays GREEN.

This PR teaches the FE to recognize and route the new status. The same `SumsubKycWrapper` component handles it: it's just an access token, level-agnostic.

## Files

- `src/services/rain.ts` — `ApplyForCardResponse` adds the `main-kyc-required` variant.
- `src/app/(mobile-ui)/card/page.tsx` — handler routes `main-kyc-required` through the same SumsubKycWrapper as `incomplete`. Refresh-token path also accepts it.
- `src/constants/analytics.consts.ts` — outcome-enum comment updated.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm prettier --check` clean
- [x] `pnpm test` — only pre-existing failure is `add-money-states.test.tsx` (line 919), unrelated and present on `dev`
- [ ] Manual: with backend PR #684 deployed and Sumsub level config requiring SELFIE, an existing approved user (no SELFIE on main applicant) hits "Get your card" → expect WebSDK opens at main level → expect Sumsub asks for SELFIE → user submits → modal closes → next call to `/rain/cards` proceeds through the action flow
- [ ] Manual: brand-new user goes through main KYC at the updated level → main applicant has SELFIE from the start → first `/rain/cards` doesn't return `main-kyc-required`, runs action flow normally

## Why no new wrapper / state

The same `SumsubKycWrapper` component works for both action and main-level tokens — it consumes whatever token it's given. No new modal or screen needed. The FE state machine doesn't need a new top-level state either: from the user's POV, this is "verification step inside the apply flow," same UX shape as the existing `incomplete` branch.

## Related

- peanutprotocol/peanut-api-ts#684 — backend doc-presence gate (this PR is its FE companion).
- peanutprotocol/peanut-api-ts#680, #683 — earlier action-state-machine fixes.
- peanutprotocol/peanut-ui#1917 — earlier wrapper fix to keep WebSDK open on RED+RETRY.