### PR TITLE
feat(card): hard-deny screen for Rain rejections

### DIFF
--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -271,10 +271,13 @@ const CardPage: FC = () => {
             case 'manual-review':
                 return <ApplicationStatusScreen variant="manual-review" onPrev={() => router.back()} />
             case 'rejected':
+                // No retry CTA: Rain denials are terminal on our side. The only
+                // path forward is support reviewing the case manually (PEP /
+                // sanctions / fraud-pattern flags need a human in the loop on
+                // Rain's end). The CTA is "Contact support" only.
                 return (
                     <ApplicationStatusScreen
                         variant="rejected"
-                        onRetry={() => handleApply(false)}
                         onContactSupport={() => router.push('/support')}
                         onPrev={() => router.back()}
                     />

--- a/src/components/Card/ApplicationStatusScreen.tsx
+++ b/src/components/Card/ApplicationStatusScreen.tsx
@@ -1,14 +1,14 @@
 'use client'
 import type { FC } from 'react'
-import { Button } from '@/components/0_Bruddle/Button'
+import Image from 'next/image'
 import NavHeader from '@/components/Global/NavHeader'
 import Loading from '@/components/Global/Loading'
+import { PEANUTMAN_SAD } from '@/assets/peanut'
 
 type Variant = 'pending' | 'manual-review' | 'rejected'
 
 interface Props {
     variant: Variant
-    onRetry?: () => void
     onContactSupport?: () => void
     onPrev?: () => void
 }
@@ -24,26 +24,31 @@ const COPY: Record<Variant, { title: string; body: string }> = {
     },
     rejected: {
         title: "We couldn't verify your identity",
-        body: "Your card application wasn't approved. This might be because of incomplete documents, information mismatch, or regional restrictions.",
+        body: "Your card application wasn't approved. This might be because of incomplete documents, information mismatch, or regional restrictions. Our support team can help you sort it out.",
     },
 }
 
-const ApplicationStatusScreen: FC<Props> = ({ variant, onRetry, onContactSupport, onPrev }) => {
+const ApplicationStatusScreen: FC<Props> = ({ variant, onContactSupport, onPrev }) => {
     const copy = COPY[variant]
     return (
         <div className="flex min-h-[inherit] flex-col gap-8">
             <NavHeader title="Add card" onPrev={onPrev} />
             <div className="my-auto flex flex-col items-center gap-6 text-center">
                 {variant === 'pending' && <Loading />}
+                {variant === 'rejected' && (
+                    <Image
+                        src={PEANUTMAN_SAD}
+                        alt="Sad peanut"
+                        width={122}
+                        height={152}
+                        className="select-none"
+                        priority
+                    />
+                )}
                 <div className="flex flex-col gap-3">
                     <h1 className="text-2xl font-extrabold text-n-1">{copy.title}</h1>
                     <p className="text-grey-1">{copy.body}</p>
                 </div>
-                {variant === 'rejected' && onRetry && (
-                    <Button onClick={onRetry} variant="purple" shadowSize="4" className="w-full">
-                        Try again
-                    </Button>
-                )}
                 {variant === 'rejected' && onContactSupport && (
                     <button type="button" onClick={onContactSupport} className="text-black underline">
                         Contact support


### PR DESCRIPTION
## Summary

Rain denials (PEP, sanctions, fraud-pattern flags) are terminal on our side — they require Rain's compliance team / human review to unwind. The previous rejected screen offered a "Try again" CTA, which is misleading: re-applying with the same data hits the same Rain decision tree and gets denied again.

This PR refines the rejected variant of `ApplicationStatusScreen`:
- Removes the "Try again" CTA
- Adds the sad-peanut illustration above the heading (per [Figma node 17198:7171](https://www.figma.com/design/IBevOyWuFyP3KcEYuQufi1/Peanut-UI?node-id=17198-7171))
- Slightly tightens the body copy to point users to support directly

The component's now-unused `onRetry` prop is dropped, and the `case 'rejected'` branch in `card/page.tsx` no longer passes it.

## Files

- `src/components/Card/ApplicationStatusScreen.tsx` — drop `onRetry`, add `<Image src={PEANUTMAN_SAD} … />` for rejected variant
- `src/app/(mobile-ui)/card/page.tsx` — `case 'rejected'` no longer passes `onRetry`

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm prettier --check` clean
- [x] `pnpm test --testPathPattern=card` — 26/26 pass (existing `cardState.utils` mapping unchanged)
- [ ] Manual: with a user whose UserRail status is REJECTED (e.g. after Rain `applicationStatus: denied` webhook), navigate to /card → expect sad-peanut illustration + "We couldn't verify your identity" heading + only Contact-support link, no Try-again button

## Why no separate state for hard vs soft deny

For now, Rain's `denied` is treated uniformly — based on the failure modes seen so far (PEP, fraud, etc.), all denials need human review. If Rain later exposes a softer denial subtype that's user-recoverable, we can branch on `metadata.denialReason` and add a recoverable variant then.

## Related

- Companion to peanutprotocol/peanut-api-ts#684 and peanutprotocol/peanut-ui#1918 — the broader card-flow polish thread.
- Backend already maps Rain `applicationStatus: denied` → `RailStatus.REJECTED` and stores `denialReason` in metadata, so this PR is FE-only.