### PR TITLE
chore: remove residual Squid naming + dead types after Rhino SDA cutover

### DIFF
--- a/src/app/actions/supported-chains.ts
+++ b/src/app/actions/supported-chains.ts
@@ -1,12 +1,7 @@
-/** Pre-decomplexify this hit a third-party API for chain + token metadata.
- *  Post-decomplexify (Rhino SDA cutover) the data is local — same shape,
- *  same callsites, no live API call. The legacy `Squid` naming —
- *  see decomplexify TODO #46 for the rename. */
-
-import * as interfaces from '@/interfaces/peanut-sdk-types'
+import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
 import { supportedPeanutChains, peanutTokenDetails } from '@/constants/general.consts'
 
-type ChainWithTokens = interfaces.IChainMeta & { networkName: string; tokens: interfaces.ITokenMeta[] }
+type ChainWithTokens = ChainMeta & { networkName: string; tokens: TokenMeta[] }
 
 export async function getSupportedChainsAndTokens(): Promise<Record<string, ChainWithTokens>> {
     const result: Record<string, ChainWithTokens> = {}
@@ -14,8 +9,6 @@ export async function getSupportedChainsAndTokens(): Promise<Record<string, Chai
         if (!chain.mainnet) continue
         result[chain.chainId] = {
             chainId: chain.chainId,
-            axelarChainName: chain.shortName ?? chain.name,
-            chainType: 'evm',
             chainIconURI: chain.icon?.url ?? '',
             networkName: chain.name,
             tokens: [],
@@ -26,7 +19,6 @@ export async function getSupportedChainsAndTokens(): Promise<Record<string, Chai
         if (!bucket) continue
         for (const token of chainTokens.tokens) {
             bucket.tokens.push({
-                active: true,
                 chainId: chainTokens.chainId,
                 address: token.address,
                 decimals: token.decimals,

--- a/src/app/actions/supported-chains.ts
+++ b/src/app/actions/supported-chains.ts
@@ -1,7 +1,5 @@
-import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
+import type { ChainWithTokens } from '@/interfaces/chain-meta'
 import { supportedPeanutChains, peanutTokenDetails } from '@/constants/general.consts'
-
-type ChainWithTokens = ChainMeta & { networkName: string; tokens: TokenMeta[] }
 
 export async function getSupportedChainsAndTokens(): Promise<Record<string, ChainWithTokens>> {
     const result: Record<string, ChainWithTokens> = {}

--- a/src/components/Offramp/Offramp.consts.ts
+++ b/src/components/Offramp/Offramp.consts.ts
@@ -1,5 +1,6 @@
 import type { ILinkDetails, RecipientType } from '@/interfaces/interfaces'
 import * as peanutInterfaces from '@/interfaces/peanut-sdk-types'
+import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
 import type { IOfframpForm } from '@/constants/cashout.consts'
 
 export enum OfframpType {
@@ -38,7 +39,7 @@ export interface IOfframpConfirmScreenProps {
 
     // available in claim link offramps
     claimLinkData?: ILinkDetails
-    crossChainDetails?: Array<peanutInterfaces.IChainMeta & { tokens: peanutInterfaces.ITokenMeta[] }> | undefined
+    crossChainDetails?: Array<ChainMeta & { tokens: TokenMeta[] }> | undefined
     tokenPrice?: number
     estimatedPoints?: number
     attachment?: { message: string | undefined; attachmentUrl: string | undefined }

--- a/src/components/Offramp/Offramp.consts.ts
+++ b/src/components/Offramp/Offramp.consts.ts
@@ -1,6 +1,6 @@
 import type { ILinkDetails, RecipientType } from '@/interfaces/interfaces'
 import * as peanutInterfaces from '@/interfaces/peanut-sdk-types'
-import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
+import type { ChainWithTokens } from '@/interfaces/chain-meta'
 import type { IOfframpForm } from '@/constants/cashout.consts'
 
 export enum OfframpType {
@@ -39,7 +39,7 @@ export interface IOfframpConfirmScreenProps {
 
     // available in claim link offramps
     claimLinkData?: ILinkDetails
-    crossChainDetails?: Array<ChainMeta & { tokens: TokenMeta[] }> | undefined
+    crossChainDetails?: Array<ChainWithTokens> | undefined
     tokenPrice?: number
     estimatedPoints?: number
     attachment?: { message: string | undefined; attachmentUrl: string | undefined }

--- a/src/components/Withdraw/views/Confirm.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Confirm.withdraw.view.tsx
@@ -11,14 +11,14 @@ import { PaymentInfoRow } from '@/components/Payment/PaymentInfoRow'
 import { useTokenChainIcons } from '@/hooks/useTokenChainIcons'
 import { type ITokenPriceData } from '@/interfaces'
 import { formatAmount, isStableCoin } from '@/utils/general.utils'
-import * as interfaces from '@/interfaces/peanut-sdk-types'
+import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
 import { useMemo } from 'react'
 import { ROUTE_NOT_FOUND_ERROR } from '@/constants/general.consts'
 
 interface WithdrawConfirmViewProps {
     amount: string
     token: ITokenPriceData
-    chain: interfaces.IChainMeta & { networkName: string; tokens: interfaces.ITokenMeta[] }
+    chain: ChainMeta & { networkName: string; tokens: TokenMeta[] }
     toAddress: string
     networkFee?: number
     peanutFee?: string

--- a/src/components/Withdraw/views/Confirm.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Confirm.withdraw.view.tsx
@@ -11,14 +11,14 @@ import { PaymentInfoRow } from '@/components/Payment/PaymentInfoRow'
 import { useTokenChainIcons } from '@/hooks/useTokenChainIcons'
 import { type ITokenPriceData } from '@/interfaces'
 import { formatAmount, isStableCoin } from '@/utils/general.utils'
-import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
+import type { ChainWithTokens } from '@/interfaces/chain-meta'
 import { useMemo } from 'react'
 import { ROUTE_NOT_FOUND_ERROR } from '@/constants/general.consts'
 
 interface WithdrawConfirmViewProps {
     amount: string
     token: ITokenPriceData
-    chain: ChainMeta & { networkName: string; tokens: TokenMeta[] }
+    chain: ChainWithTokens
     toAddress: string
     networkFee?: number
     peanutFee?: string

--- a/src/components/Withdraw/views/Initial.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Initial.withdraw.view.tsx
@@ -17,11 +17,7 @@ import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants/zerodev.co
 
 interface InitialWithdrawViewProps {
     amount: string
-    onReview: (data: {
-        token: ITokenPriceData
-        chain: ChainWithTokens
-        address: string
-    }) => void
+    onReview: (data: { token: ITokenPriceData; chain: ChainWithTokens; address: string }) => void
     onBack?: () => void
     isProcessing?: boolean
 }

--- a/src/components/Withdraw/views/Initial.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Initial.withdraw.view.tsx
@@ -8,8 +8,8 @@ import PeanutActionDetailsCard from '@/components/Global/PeanutActionDetailsCard
 import { useWithdrawFlow } from '@/context/WithdrawFlowContext'
 import { tokenSelectorContext } from '@/context/tokenSelector.context'
 import { type ITokenPriceData } from '@/interfaces'
+import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
 import { formatAmount } from '@/utils/general.utils'
-import * as interfaces from '@/interfaces/peanut-sdk-types'
 import { useRouter } from 'next/navigation'
 import { useContext, useEffect } from 'react'
 import TokenSelector from '@/components/Global/TokenSelector/TokenSelector'
@@ -19,7 +19,7 @@ interface InitialWithdrawViewProps {
     amount: string
     onReview: (data: {
         token: ITokenPriceData
-        chain: interfaces.IChainMeta & { networkName: string; tokens: interfaces.ITokenMeta[] }
+        chain: ChainMeta & { networkName: string; tokens: TokenMeta[] }
         address: string
     }) => void
     onBack?: () => void
@@ -50,31 +50,18 @@ export default function InitialWithdrawView({ amount, onReview, onBack, isProces
 
     const handleReview = () => {
         const xchainChainData = supportedChainsAndTokens[selectedChainID]
-        // When the user is withdrawing on the Peanut wallet chain (same-chain,
-        // no Rhino bridge needed), supportedChainsAndTokens may not list that chain — especially
-        // on testnets or env-configured chains. Synthesize a chain object
-        // in that case so the flow can proceed. Downstream code only reads
-        // `chainId` and `networkName` off this object — but the type
-        // requires the legacy Squid IChainMeta fields (axelarChainName,
-        // chainType, chainIconURI). Populate them with safe placeholders so
-        // we don't fall through `as unknown as` and silently mask missing
-        // shape (CR-flagged). Once the cross-chain surface fully migrates
-        // off the Squid types, the narrower-callback alternative is to
-        // tighten `onReview` to only the fields it actually reads.
+        // supportedChainsAndTokens may not list the Peanut wallet chain on
+        // testnets / env-configured chains. Synthesize a minimal entry so the
+        // same-chain (no-bridge) path can proceed.
         const isPeanutWalletChain = selectedChainID === PEANUT_WALLET_CHAIN.id.toString()
         const fallbackChainData =
             isPeanutWalletChain && !xchainChainData
                 ? ({
                       chainId: PEANUT_WALLET_CHAIN.id.toString(),
                       networkName: PEANUT_WALLET_CHAIN.name,
-                      axelarChainName: PEANUT_WALLET_CHAIN.name,
-                      chainType: 'evm',
                       chainIconURI: '',
                       tokens: [],
-                  } satisfies interfaces.IChainMeta & {
-                      networkName: string
-                      tokens: interfaces.ITokenMeta[]
-                  })
+                  } satisfies ChainMeta & { networkName: string; tokens: TokenMeta[] })
                 : undefined
         const selectedChainData = xchainChainData ?? fallbackChainData
 

--- a/src/components/Withdraw/views/Initial.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Initial.withdraw.view.tsx
@@ -8,7 +8,7 @@ import PeanutActionDetailsCard from '@/components/Global/PeanutActionDetailsCard
 import { useWithdrawFlow } from '@/context/WithdrawFlowContext'
 import { tokenSelectorContext } from '@/context/tokenSelector.context'
 import { type ITokenPriceData } from '@/interfaces'
-import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
+import type { ChainWithTokens } from '@/interfaces/chain-meta'
 import { formatAmount } from '@/utils/general.utils'
 import { useRouter } from 'next/navigation'
 import { useContext, useEffect } from 'react'
@@ -19,7 +19,7 @@ interface InitialWithdrawViewProps {
     amount: string
     onReview: (data: {
         token: ITokenPriceData
-        chain: ChainMeta & { networkName: string; tokens: TokenMeta[] }
+        chain: ChainWithTokens
         address: string
     }) => void
     onBack?: () => void
@@ -61,7 +61,7 @@ export default function InitialWithdrawView({ amount, onReview, onBack, isProces
                       networkName: PEANUT_WALLET_CHAIN.name,
                       chainIconURI: '',
                       tokens: [],
-                  } satisfies ChainMeta & { networkName: string; tokens: TokenMeta[] })
+                  } satisfies ChainWithTokens)
                 : undefined
         const selectedChainData = xchainChainData ?? fallbackChainData
 

--- a/src/context/WithdrawFlowContext.tsx
+++ b/src/context/WithdrawFlowContext.tsx
@@ -2,7 +2,7 @@
 
 import { type ITokenPriceData, type Account } from '@/interfaces'
 import { type TRequestChargeResponse, type PaymentCreationResponse } from '@/services/services.types'
-import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
+import type { ChainWithTokens } from '@/interfaces/chain-meta'
 import React, { createContext, type ReactNode, useContext, useMemo, useState, useCallback } from 'react'
 
 export interface WithdrawMethod {
@@ -18,7 +18,7 @@ export type WithdrawView = 'INITIAL' | 'CONFIRM' | 'STATUS'
 
 export interface WithdrawData {
     token: ITokenPriceData
-    chain: ChainMeta & { networkName: string; tokens: TokenMeta[] }
+    chain: ChainWithTokens
     address: string
     amount: string
 }

--- a/src/context/WithdrawFlowContext.tsx
+++ b/src/context/WithdrawFlowContext.tsx
@@ -2,7 +2,7 @@
 
 import { type ITokenPriceData, type Account } from '@/interfaces'
 import { type TRequestChargeResponse, type PaymentCreationResponse } from '@/services/services.types'
-import * as peanutInterfaces from '@/interfaces/peanut-sdk-types'
+import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
 import React, { createContext, type ReactNode, useContext, useMemo, useState, useCallback } from 'react'
 
 export interface WithdrawMethod {
@@ -18,7 +18,7 @@ export type WithdrawView = 'INITIAL' | 'CONFIRM' | 'STATUS'
 
 export interface WithdrawData {
     token: ITokenPriceData
-    chain: peanutInterfaces.IChainMeta & { networkName: string; tokens: peanutInterfaces.ITokenMeta[] }
+    chain: ChainMeta & { networkName: string; tokens: TokenMeta[] }
     address: string
     amount: string
 }

--- a/src/context/tokenSelector.context.tsx
+++ b/src/context/tokenSelector.context.tsx
@@ -14,7 +14,7 @@ import { useSupportedChainsAndTokens } from '@/hooks/useSupportedChainsAndTokens
 import { useTokenPrice } from '@/hooks/useTokenPrice'
 import { type ITokenPriceData } from '@/interfaces'
 import { NATIVE_TOKEN_ADDRESS } from '@/utils/token.utils'
-import * as interfaces from '@/interfaces/peanut-sdk-types'
+import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
 
 export const tokenSelectorContext = createContext({
     selectedTokenAddress: '',
@@ -35,10 +35,7 @@ export const tokenSelectorContext = createContext({
     setIsXChain: (value: boolean) => {},
     selectedTokenData: undefined as ITokenPriceData | null | undefined,
     isFetchingTokenData: false as boolean,
-    supportedChainsAndTokens: {} as Record<
-        string,
-        interfaces.IChainMeta & { networkName: string; tokens: interfaces.ITokenMeta[] }
-    >,
+    supportedChainsAndTokens: {} as Record<string, ChainMeta & { networkName: string; tokens: TokenMeta[] }>,
     selectedTokenBalance: undefined as string | undefined,
     setSelectedTokenBalance: (balance: string | undefined) => {},
 })

--- a/src/context/tokenSelector.context.tsx
+++ b/src/context/tokenSelector.context.tsx
@@ -14,7 +14,7 @@ import { useSupportedChainsAndTokens } from '@/hooks/useSupportedChainsAndTokens
 import { useTokenPrice } from '@/hooks/useTokenPrice'
 import { type ITokenPriceData } from '@/interfaces'
 import { NATIVE_TOKEN_ADDRESS } from '@/utils/token.utils'
-import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
+import type { ChainWithTokens } from '@/interfaces/chain-meta'
 
 export const tokenSelectorContext = createContext({
     selectedTokenAddress: '',
@@ -35,7 +35,7 @@ export const tokenSelectorContext = createContext({
     setIsXChain: (value: boolean) => {},
     selectedTokenData: undefined as ITokenPriceData | null | undefined,
     isFetchingTokenData: false as boolean,
-    supportedChainsAndTokens: {} as Record<string, ChainMeta & { networkName: string; tokens: TokenMeta[] }>,
+    supportedChainsAndTokens: {} as Record<string, ChainWithTokens>,
     selectedTokenBalance: undefined as string | undefined,
     setSelectedTokenBalance: (balance: string | undefined) => {},
 })

--- a/src/features/payments/flows/semantic-request/SemanticRequestFlowContext.tsx
+++ b/src/features/payments/flows/semantic-request/SemanticRequestFlowContext.tsx
@@ -19,7 +19,7 @@ import { createContext, useContext, useState, useMemo, useCallback, type ReactNo
 import { type Address, type Hash } from 'viem'
 import { type TRequestChargeResponse, type PaymentCreationResponse } from '@/services/services.types'
 import { type ParsedURL, type RecipientType } from '@/lib/url-parser/types/payment'
-import * as interfaces from '@/interfaces/peanut-sdk-types'
+import type { TokenMeta } from '@/interfaces/chain-meta'
 import { isStableCoin } from '@/utils/general.utils'
 
 // view states for semantic request flow
@@ -72,7 +72,7 @@ interface SemanticRequestFlowContextValue {
 
     // token denomination from url (e.g., ETH when url is /address/0.0001eth)
     // when set, amounts should be displayed in this token rather than USD
-    urlToken: interfaces.ITokenMeta | undefined
+    urlToken: TokenMeta | undefined
 
     // whether the url specified a non-stablecoin token (e.g., eth, not usdc)
     // when true, amounts are displayed in token units rather than USD

--- a/src/features/payments/flows/semantic-request/useSemanticRequestFlow.ts
+++ b/src/features/payments/flows/semantic-request/useSemanticRequestFlow.ts
@@ -450,8 +450,7 @@ export function useSemanticRequestFlow() {
         }
     }, [currentView, charge, prepareRoute])
 
-    // SDA flow has no route expiry — deposit address is valid forever, so the
-    // expired/near-expiry handlers that existed under the old Squid path are unnecessary.
+    // SDA deposit addresses don't expire — no route-expiry handlers needed.
 
     // execute payment from confirm view (handles both same-chain and cross-chain)
     const executePayment = useCallback(async () => {

--- a/src/features/payments/shared/hooks/useCrossChainTransfer.ts
+++ b/src/features/payments/shared/hooks/useCrossChainTransfer.ts
@@ -3,19 +3,18 @@
 /**
  * Unified cross-chain transfer hook — Rhino SDA flow.
  *
- * Replaces useRouteCalculation (the legacy Squid route hook). Same three consumers:
+ * Three consumers:
  *   - Withdraw flow   (user's kernel wallet → external chain)
  *   - Pay-request     (payer's kernel wallet → merchant's chain)
  *   - Claim-link      (relayer EOA → claimer's chain, via /claim)
  *
- * Same-chain same-token fallback uses Peanut SDK's
- * `prepareRequestLinkFulfillmentTransaction` — unchanged vs the old hook.
+ * Same-chain same-token: uses Peanut SDK's `prepareRequestLinkFulfillmentTransaction`.
  *
- * For cross-chain: provisions (or reuses) an SDA on the source chain via
- * the unified /rhino/sda-transfer endpoint and returns a single ERC20
- * transfer() tx the smart account signs. Rhino's BRIDGE_EXECUTED webhook
- * advances downstream state (charge paid, claim settled, etc.) — the UI
- * does NOT call recordPayment for cross-chain; the webhook does it.
+ * Cross-chain: provisions (or reuses) an SDA on the source chain via the unified
+ * /rhino/sda-transfer endpoint and returns a single ERC20 transfer() tx the smart
+ * account signs. Rhino's BRIDGE_EXECUTED webhook advances downstream state
+ * (charge paid, claim settled, etc.) — the UI does NOT call recordPayment for
+ * cross-chain; the webhook does it.
  *
  * @example
  * const { transactions, receiveAmount, sdaAddress, calculate, isCalculating } = useCrossChainTransfer()

--- a/src/hooks/useSupportedChainsAndTokens.ts
+++ b/src/hooks/useSupportedChainsAndTokens.ts
@@ -2,10 +2,9 @@ import { useQuery } from '@tanstack/react-query'
 import { getSupportedChainsAndTokens } from '@/app/actions/supported-chains'
 
 /**
- * Hook to fetch and cache Squid chains and tokens configuration
+ * Hook to fetch and cache supported chains and tokens configuration.
  *
- * This data is static and rarely changes, so we cache it for one day.
- * This prevents redundant API calls on every component mount.
+ * Sourced locally (no live API call); cached for 24h since the data is static.
  *
  * @returns TanStack Query result with chains and tokens data
  *
@@ -16,7 +15,7 @@ import { getSupportedChainsAndTokens } from '@/app/actions/supported-chains'
  */
 export const useSupportedChainsAndTokens = () => {
     return useQuery({
-        queryKey: ['squidChainsAndTokens'],
+        queryKey: ['supportedChainsAndTokens'],
         queryFn: getSupportedChainsAndTokens,
         staleTime: 24 * 60 * 60 * 1000, // 1 day in milliseconds
         gcTime: 24 * 60 * 60 * 1000, // 1 day in milliseconds

--- a/src/hooks/useTokenChainIcons.ts
+++ b/src/hooks/useTokenChainIcons.ts
@@ -1,5 +1,5 @@
 import { tokenSelectorContext } from '@/context/tokenSelector.context'
-import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
+import type { ChainWithTokens, TokenMeta } from '@/interfaces/chain-meta'
 import { useContext } from 'react'
 
 interface TokenChainIconInputs {
@@ -15,7 +15,7 @@ export interface TokenChainIconData {
     resolvedTokenSymbol?: string
     chainFound: boolean
     tokenFound: boolean
-    chainDetails?: ChainMeta & { tokens: TokenMeta[] }
+    chainDetails?: ChainWithTokens
     tokenDetails?: TokenMeta
 }
 

--- a/src/hooks/useTokenChainIcons.ts
+++ b/src/hooks/useTokenChainIcons.ts
@@ -1,5 +1,5 @@
 import { tokenSelectorContext } from '@/context/tokenSelector.context'
-import * as interfaces from '@/interfaces/peanut-sdk-types'
+import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
 import { useContext } from 'react'
 
 interface TokenChainIconInputs {
@@ -15,8 +15,8 @@ export interface TokenChainIconData {
     resolvedTokenSymbol?: string
     chainFound: boolean
     tokenFound: boolean
-    chainDetails?: interfaces.IChainMeta & { tokens: interfaces.ITokenMeta[] }
-    tokenDetails?: interfaces.ITokenMeta
+    chainDetails?: ChainMeta & { tokens: TokenMeta[] }
+    tokenDetails?: TokenMeta
 }
 
 export const useTokenChainIcons = ({
@@ -46,7 +46,7 @@ export const useTokenChainIcons = ({
 
     // use networkName if available, otherwise fallback to simple CHAIN
     const resolvedChainName = chainInfo.networkName ? chainInfo.networkName : `CHAIN`
-    let tokenInfo: interfaces.ITokenMeta | undefined = undefined
+    let tokenInfo: TokenMeta | undefined = undefined
 
     if (tokenAddress) {
         tokenInfo = chainInfo.tokens.find((t) => t.address.toLowerCase() === tokenAddress.toLowerCase())

--- a/src/hooks/useTokenPrice.ts
+++ b/src/hooks/useTokenPrice.ts
@@ -10,16 +10,13 @@ import {
 } from '@/constants/zerodev.consts'
 import { type ITokenPriceData } from '@/interfaces'
 import * as Sentry from '@sentry/nextjs'
-import * as interfaces from '@/interfaces/peanut-sdk-types'
+import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
 import { STABLE_COINS, supportedMobulaChains } from '@/constants/general.consts'
 
 interface UseTokenPriceParams {
     tokenAddress: string | undefined
     chainId: string | undefined
-    supportedChainsAndTokens: Record<
-        string,
-        interfaces.IChainMeta & { networkName: string; tokens: interfaces.ITokenMeta[] }
-    >
+    supportedChainsAndTokens: Record<string, ChainMeta & { networkName: string; tokens: TokenMeta[] }>
     isPeanutWallet: boolean
 }
 

--- a/src/hooks/useTokenPrice.ts
+++ b/src/hooks/useTokenPrice.ts
@@ -10,13 +10,13 @@ import {
 } from '@/constants/zerodev.consts'
 import { type ITokenPriceData } from '@/interfaces'
 import * as Sentry from '@sentry/nextjs'
-import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
+import type { ChainWithTokens } from '@/interfaces/chain-meta'
 import { STABLE_COINS, supportedMobulaChains } from '@/constants/general.consts'
 
 interface UseTokenPriceParams {
     tokenAddress: string | undefined
     chainId: string | undefined
-    supportedChainsAndTokens: Record<string, ChainMeta & { networkName: string; tokens: TokenMeta[] }>
+    supportedChainsAndTokens: Record<string, ChainWithTokens>
     isPeanutWallet: boolean
 }
 

--- a/src/interfaces/chain-meta.ts
+++ b/src/interfaces/chain-meta.ts
@@ -1,0 +1,20 @@
+/**
+ * Chain + token metadata shapes used by the token selector, validation,
+ * and url-parser surfaces. Sourced locally from `app/actions/supported-chains.ts`
+ * (no live third-party API call) since cross-chain settlement moved to Rhino SDA.
+ */
+
+export interface ChainMeta {
+    chainId: string
+    chainIconURI: string
+}
+
+export interface TokenMeta {
+    chainId: string
+    address: string
+    decimals: number
+    name: string
+    symbol: string
+    logoURI: string
+    usdPrice: number
+}

--- a/src/interfaces/chain-meta.ts
+++ b/src/interfaces/chain-meta.ts
@@ -18,3 +18,7 @@ export interface TokenMeta {
     logoURI: string
     usdPrice: number
 }
+
+/** Canonical chain record as returned by `getSupportedChainsAndTokens` —
+ *  every consumer that reads chains-with-tokens expects this shape. */
+export type ChainWithTokens = ChainMeta & { networkName: string; tokens: TokenMeta[] }

--- a/src/interfaces/peanut-sdk-types.ts
+++ b/src/interfaces/peanut-sdk-types.ts
@@ -1,8 +1,6 @@
 /** Local replacements for `@squirrel-labs/peanut-sdk`'s `interfaces` namespace.
  *  Lifted byte-for-byte from the SDK's `dist/index.d.ts` so consumers swap
- *  imports without behaviour change. New code should not extend these — the
- *  Squid-shaped pieces are kept only so the cross-chain UI surface compiles
- *  while it's being migrated to Rhino. */
+ *  imports without behaviour change. */
 
 export interface IPeanutLinkDetails {
     chainId: string
@@ -66,23 +64,4 @@ export enum ESignAndSubmitTx {
 export interface SDKStatus {
     code: number
     extraInfo?: unknown
-}
-
-/** Squid types — kept until the cross-chain UI surface is migrated to Rhino. */
-export interface IChainMeta {
-    chainId: string
-    axelarChainName: string
-    chainType: string
-    chainIconURI: string
-}
-
-export interface ITokenMeta {
-    active: boolean
-    chainId: string
-    address: string
-    decimals: number
-    name: string
-    symbol: string
-    logoURI: string
-    usdPrice: number
 }

--- a/src/lib/url-parser/parser.ts
+++ b/src/lib/url-parser/parser.ts
@@ -1,6 +1,6 @@
 import { getSupportedChainsAndTokens } from '@/app/actions/supported-chains'
 import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants/zerodev.consts'
-import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
+import type { ChainWithTokens, TokenMeta } from '@/interfaces/chain-meta'
 import { validateAmount } from '../validation/amount'
 import { validateAndResolveRecipient } from '../validation/recipient'
 import { getChainDetails, getTokenAndChainDetails } from '../validation/token'
@@ -103,7 +103,7 @@ export async function parsePaymentURL(
     const isPeanutRecipient = recipientDetails.recipientType === 'USERNAME'
 
     // 4. Resolve chain details
-    let chainDetails: (ChainMeta & { tokens: TokenMeta[] }) | undefined = undefined
+    let chainDetails: ChainWithTokens | undefined = undefined
     if (chainId) {
         try {
             chainDetails = getChainDetails(chainId, supportedChainsAndTokens)
@@ -144,7 +144,7 @@ export async function parsePaymentURL(
 
             // Update chain details for non-USERNAME recipients if needed
             if (!chainDetails && !isPeanutRecipient && tokenAndChainData.chain) {
-                chainDetails = tokenAndChainData.chain as ChainMeta & { tokens: TokenMeta[] }
+                chainDetails = tokenAndChainData.chain as ChainWithTokens
             }
         } else if (isPeanutRecipient) {
             tokenDetails = chainDetails?.tokens.find(

--- a/src/lib/url-parser/parser.ts
+++ b/src/lib/url-parser/parser.ts
@@ -1,6 +1,6 @@
 import { getSupportedChainsAndTokens } from '@/app/actions/supported-chains'
 import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants/zerodev.consts'
-import * as interfaces from '@/interfaces/peanut-sdk-types'
+import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
 import { validateAmount } from '../validation/amount'
 import { validateAndResolveRecipient } from '../validation/recipient'
 import { getChainDetails, getTokenAndChainDetails } from '../validation/token'
@@ -88,25 +88,25 @@ export async function parsePaymentURL(
     }
 
     // 3. Fetch and validate recipient and chains/tokens data
-    const [recipientResult, squidChainsResult] = await Promise.allSettled([
+    const [recipientResult, chainsAndTokensResult] = await Promise.allSettled([
         validateAndResolveRecipient(recipient),
         getSupportedChainsAndTokens(),
     ])
     if (recipientResult.status === 'rejected') {
         return { parsedUrl: null, error: { message: EParseUrlError.INVALID_RECIPIENT, recipient } }
     }
-    if (squidChainsResult.status === 'rejected') {
+    if (chainsAndTokensResult.status === 'rejected') {
         return { parsedUrl: null, error: { message: EParseUrlError.INVALID_URL_FORMAT } }
     }
     const recipientDetails = recipientResult.value
-    const squidChainsAndTokens = squidChainsResult.value
+    const supportedChainsAndTokens = chainsAndTokensResult.value
     const isPeanutRecipient = recipientDetails.recipientType === 'USERNAME'
 
     // 4. Resolve chain details
-    let chainDetails: (interfaces.IChainMeta & { tokens: interfaces.ITokenMeta[] }) | undefined = undefined
+    let chainDetails: (ChainMeta & { tokens: TokenMeta[] }) | undefined = undefined
     if (chainId) {
         try {
-            chainDetails = getChainDetails(chainId, squidChainsAndTokens)
+            chainDetails = getChainDetails(chainId, supportedChainsAndTokens)
             if (isPeanutRecipient && PEANUT_WALLET_CHAIN.id.toString() !== chainDetails.chainId) {
                 throw new Error('Invalid chain')
             }
@@ -115,12 +115,12 @@ export async function parsePaymentURL(
         }
     } else if (isPeanutRecipient) {
         // If no chain specified, use peanut wallet chain for username types
-        chainDetails = squidChainsAndTokens[PEANUT_WALLET_CHAIN.id]
+        chainDetails = supportedChainsAndTokens[PEANUT_WALLET_CHAIN.id]
     }
 
     // 5. Handle amount and token parsing from second segment
     let parsedAmount: { amount: string } | undefined = undefined
-    let tokenDetails: interfaces.ITokenMeta | undefined = undefined
+    let tokenDetails: TokenMeta | undefined = undefined
     if (segments.length > 1) {
         const { amount, token } = parseAmountAndToken(segments[1])
         if (amount) {
@@ -133,7 +133,7 @@ export async function parsePaymentURL(
         if (token) {
             if (!chainDetails && !isPeanutRecipient) {
                 // default to arb even for non-USERNAME recipients if no chain is specified
-                chainDetails = squidChainsAndTokens[PEANUT_WALLET_CHAIN.id]
+                chainDetails = supportedChainsAndTokens[PEANUT_WALLET_CHAIN.id]
             }
             const tokenAndChainData = await getTokenAndChainDetails(token, chainId)
             tokenDetails = tokenAndChainData?.token
@@ -144,7 +144,7 @@ export async function parsePaymentURL(
 
             // Update chain details for non-USERNAME recipients if needed
             if (!chainDetails && !isPeanutRecipient && tokenAndChainData.chain) {
-                chainDetails = tokenAndChainData.chain as interfaces.IChainMeta & { tokens: interfaces.ITokenMeta[] }
+                chainDetails = tokenAndChainData.chain as ChainMeta & { tokens: TokenMeta[] }
             }
         } else if (isPeanutRecipient) {
             tokenDetails = chainDetails?.tokens.find(

--- a/src/lib/url-parser/types/payment.ts
+++ b/src/lib/url-parser/types/payment.ts
@@ -1,4 +1,4 @@
-import * as interfaces from '@/interfaces/peanut-sdk-types'
+import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
 import { type Chain } from 'viem'
 
 export type RecipientType = 'ENS' | 'ADDRESS' | 'USERNAME'
@@ -11,6 +11,6 @@ export interface ParsedURL {
         resolvedAddress: string
     } | null
     amount?: string
-    token?: interfaces.ITokenMeta
-    chain?: interfaces.IChainMeta & { tokens: interfaces.ITokenMeta[] }
+    token?: TokenMeta
+    chain?: ChainMeta & { tokens: TokenMeta[] }
 }

--- a/src/lib/url-parser/types/payment.ts
+++ b/src/lib/url-parser/types/payment.ts
@@ -1,4 +1,4 @@
-import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
+import type { ChainWithTokens, TokenMeta } from '@/interfaces/chain-meta'
 import { type Chain } from 'viem'
 
 export type RecipientType = 'ENS' | 'ADDRESS' | 'USERNAME'
@@ -12,5 +12,5 @@ export interface ParsedURL {
     } | null
     amount?: string
     token?: TokenMeta
-    chain?: ChainMeta & { tokens: TokenMeta[] }
+    chain?: ChainWithTokens
 }

--- a/src/lib/validation/token.test.ts
+++ b/src/lib/validation/token.test.ts
@@ -1,17 +1,12 @@
 import { ChainValidationError } from '@/lib/url-parser/errors'
 import { getChainDetails, getTokenAndChainDetails } from '@/lib/validation/token'
-import * as interfaces from '@/interfaces/peanut-sdk-types'
+import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
 
-const mockSquidChains: Record<
-    string,
-    interfaces.IChainMeta & { networkName: string; tokens: interfaces.ITokenMeta[] }
-> = {
+const mockChainsAndTokens: Record<string, ChainMeta & { networkName: string; tokens: TokenMeta[] }> = {
     '1': {
         chainId: '1',
-        axelarChainName: 'Ethereum',
         networkName: 'Ethereum',
-        chainType: 'evm',
-        chainIconURI: 'https://raw.githubusercontent.com/0xsquid/assets/main/images/webp128/chains/ethereum.webp',
+        chainIconURI: 'https://example.test/chains/ethereum.webp',
         tokens: [
             {
                 symbol: 'ETH',
@@ -20,8 +15,7 @@ const mockSquidChains: Record<
                 name: 'ETH',
                 decimals: 18,
                 usdPrice: 2094.96,
-                logoURI: 'https://raw.githubusercontent.com/0xsquid/assets/main/images/tokens/eth.svg',
-                active: true,
+                logoURI: 'https://example.test/tokens/eth.svg',
             },
             {
                 symbol: 'USDC',
@@ -30,17 +24,14 @@ const mockSquidChains: Record<
                 name: 'USD Coin',
                 decimals: 6,
                 usdPrice: 1,
-                logoURI: 'https://raw.githubusercontent.com/0xsquid/assets/main/images/tokens/usdc.svg',
-                active: true,
+                logoURI: 'https://example.test/tokens/usdc.svg',
             },
         ],
     },
     '10': {
         chainId: '10',
-        axelarChainName: 'optimism',
         networkName: 'optimism',
-        chainType: 'evm',
-        chainIconURI: 'https://raw.githubusercontent.com/0xsquid/assets/main/images/webp128/chains/optimism.webp',
+        chainIconURI: 'https://example.test/chains/optimism.webp',
         tokens: [
             {
                 symbol: 'ETH',
@@ -49,8 +40,7 @@ const mockSquidChains: Record<
                 name: 'ETH',
                 decimals: 18,
                 usdPrice: 2093.52,
-                logoURI: 'https://raw.githubusercontent.com/0xsquid/assets/main/images/tokens/eth.svg',
-                active: true,
+                logoURI: 'https://example.test/tokens/eth.svg',
             },
             {
                 symbol: 'USDC',
@@ -59,17 +49,14 @@ const mockSquidChains: Record<
                 name: 'USD Coin',
                 decimals: 6,
                 usdPrice: 1,
-                logoURI: 'https://raw.githubusercontent.com/0xsquid/assets/main/images/tokens/usdc.svg',
-                active: true,
+                logoURI: 'https://example.test/tokens/usdc.svg',
             },
         ],
     },
     '8453': {
         chainId: '8453',
-        axelarChainName: 'base',
         networkName: 'base',
-        chainType: 'evm',
-        chainIconURI: 'https://raw.githubusercontent.com/0xsquid/assets/main/images/chains/base.svg',
+        chainIconURI: 'https://example.test/chains/base.svg',
         tokens: [
             {
                 symbol: 'ETH',
@@ -78,8 +65,7 @@ const mockSquidChains: Record<
                 name: 'ETH',
                 decimals: 18,
                 usdPrice: 2094.96,
-                logoURI: 'https://raw.githubusercontent.com/0xsquid/assets/main/images/tokens/eth.svg',
-                active: true,
+                logoURI: 'https://example.test/tokens/eth.svg',
             },
             {
                 symbol: 'USDC',
@@ -88,8 +74,7 @@ const mockSquidChains: Record<
                 name: 'USD Coin',
                 decimals: 6,
                 usdPrice: 1,
-                logoURI: 'https://raw.githubusercontent.com/0xsquid/assets/main/images/tokens/usdc.svg',
-                active: true,
+                logoURI: 'https://example.test/tokens/usdc.svg',
             },
         ],
     },
@@ -104,43 +89,43 @@ jest.mock('@/constants/zerodev.consts', () => ({
 }))
 
 jest.mock('@/app/actions/supported-chains', () => ({
-    getSupportedChainsAndTokens: () => Promise.resolve(mockSquidChains),
+    getSupportedChainsAndTokens: () => Promise.resolve(mockChainsAndTokens),
 }))
 
 describe('Token Validation', () => {
     describe('getChainDetails', () => {
         it('should resolve chain by name', () => {
-            expect(getChainDetails('ethereum', mockSquidChains)).toEqual(mockSquidChains['1'])
+            expect(getChainDetails('ethereum', mockChainsAndTokens)).toEqual(mockChainsAndTokens['1'])
         })
 
         it('should resolve chain by decimal ID', () => {
-            expect(getChainDetails('1', mockSquidChains)).toEqual(mockSquidChains['1'])
-            expect(getChainDetails(1, mockSquidChains)).toEqual(mockSquidChains['1'])
+            expect(getChainDetails('1', mockChainsAndTokens)).toEqual(mockChainsAndTokens['1'])
+            expect(getChainDetails(1, mockChainsAndTokens)).toEqual(mockChainsAndTokens['1'])
         })
 
         it('should resolve chain by hex ID', () => {
-            expect(getChainDetails('0x1', mockSquidChains)).toEqual(mockSquidChains['1'])
+            expect(getChainDetails('0x1', mockChainsAndTokens)).toEqual(mockChainsAndTokens['1'])
         })
 
         it('should throw for unsupported chains', () => {
-            expect(() => getChainDetails('invalid', mockSquidChains)).toThrow(ChainValidationError)
-            expect(() => getChainDetails('999', mockSquidChains)).toThrow(ChainValidationError)
+            expect(() => getChainDetails('invalid', mockChainsAndTokens)).toThrow(ChainValidationError)
+            expect(() => getChainDetails('999', mockChainsAndTokens)).toThrow(ChainValidationError)
         })
 
         it('should be case insensitive for chain names', () => {
-            expect(getChainDetails('ETHEREUM', mockSquidChains)).toEqual(mockSquidChains['1'])
-            expect(getChainDetails('EthereUM', mockSquidChains)).toEqual(mockSquidChains['1'])
+            expect(getChainDetails('ETHEREUM', mockChainsAndTokens)).toEqual(mockChainsAndTokens['1'])
+            expect(getChainDetails('EthereUM', mockChainsAndTokens)).toEqual(mockChainsAndTokens['1'])
         })
 
         it('should resolve optimism chain variants', () => {
-            expect(getChainDetails('optimism', mockSquidChains)).toEqual(mockSquidChains['10'])
-            expect(getChainDetails('op', mockSquidChains)).toEqual(mockSquidChains['10'])
-            expect(getChainDetails('10', mockSquidChains)).toEqual(mockSquidChains['10'])
+            expect(getChainDetails('optimism', mockChainsAndTokens)).toEqual(mockChainsAndTokens['10'])
+            expect(getChainDetails('op', mockChainsAndTokens)).toEqual(mockChainsAndTokens['10'])
+            expect(getChainDetails('10', mockChainsAndTokens)).toEqual(mockChainsAndTokens['10'])
         })
 
         it('should resolve base chain variants', () => {
-            expect(getChainDetails('base', mockSquidChains)).toEqual(mockSquidChains['8453'])
-            expect(getChainDetails('8453', mockSquidChains)).toEqual(mockSquidChains['8453'])
+            expect(getChainDetails('base', mockChainsAndTokens)).toEqual(mockChainsAndTokens['8453'])
+            expect(getChainDetails('8453', mockChainsAndTokens)).toEqual(mockChainsAndTokens['8453'])
         })
     })
 
@@ -148,8 +133,8 @@ describe('Token Validation', () => {
         it('should resolve token with specified chain', async () => {
             const result = await getTokenAndChainDetails('ETH', '1')
             expect(result).toEqual({
-                chain: mockSquidChains['1'],
-                token: mockSquidChains['1'].tokens[0],
+                chain: mockChainsAndTokens['1'],
+                token: mockChainsAndTokens['1'].tokens[0],
             })
         })
 
@@ -157,23 +142,23 @@ describe('Token Validation', () => {
             const result = await getTokenAndChainDetails('USDC')
             expect(result).toEqual({
                 chain: null,
-                token: mockSquidChains['1'].tokens[1],
+                token: mockChainsAndTokens['1'].tokens[1],
             })
         })
 
         it('should handle case insensitive token symbols', async () => {
             const result = await getTokenAndChainDetails('eth', '1')
             expect(result).toEqual({
-                chain: mockSquidChains['1'],
-                token: mockSquidChains['1'].tokens[0],
+                chain: mockChainsAndTokens['1'],
+                token: mockChainsAndTokens['1'].tokens[0],
             })
         })
 
         it('should return default token when no token specified', async () => {
             const result = await getTokenAndChainDetails('')
             expect(result).toEqual({
-                chain: mockSquidChains['1'],
-                token: mockSquidChains['1'].tokens[1], // USDC
+                chain: mockChainsAndTokens['1'],
+                token: mockChainsAndTokens['1'].tokens[1], // USDC
             })
         })
 

--- a/src/lib/validation/token.test.ts
+++ b/src/lib/validation/token.test.ts
@@ -1,8 +1,8 @@
 import { ChainValidationError } from '@/lib/url-parser/errors'
 import { getChainDetails, getTokenAndChainDetails } from '@/lib/validation/token'
-import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
+import type { ChainWithTokens } from '@/interfaces/chain-meta'
 
-const mockChainsAndTokens: Record<string, ChainMeta & { networkName: string; tokens: TokenMeta[] }> = {
+const mockChainsAndTokens: Record<string, ChainWithTokens> = {
     '1': {
         chainId: '1',
         networkName: 'Ethereum',

--- a/src/lib/validation/token.ts
+++ b/src/lib/validation/token.ts
@@ -1,6 +1,6 @@
 import { getSupportedChainsAndTokens } from '@/app/actions/supported-chains'
 import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants/zerodev.consts'
-import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
+import type { ChainMeta, ChainWithTokens, TokenMeta } from '@/interfaces/chain-meta'
 import { ChainValidationError } from '../url-parser/errors'
 import { POPULAR_CHAIN_NAME_VARIANTS } from '../url-parser/parser.consts'
 
@@ -55,9 +55,9 @@ export async function getTokenAndChainDetails(
 // utility to get human-readable chain name
 export function getChainDetails(
     chain: string | number,
-    supportedChainsAndTokens: Record<string, ChainMeta & { tokens: TokenMeta[] }>
-): ChainMeta & { tokens: TokenMeta[] } {
-    let chainDetails: ChainMeta & { tokens: TokenMeta[] }
+    supportedChainsAndTokens: Record<string, ChainWithTokens>
+): ChainWithTokens {
+    let chainDetails: ChainWithTokens
 
     // resolve chain by name
     if (typeof chain === 'string') {

--- a/src/lib/validation/token.ts
+++ b/src/lib/validation/token.ts
@@ -1,25 +1,23 @@
 import { getSupportedChainsAndTokens } from '@/app/actions/supported-chains'
 import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants/zerodev.consts'
-import * as interfaces from '@/interfaces/peanut-sdk-types'
+import type { ChainMeta, TokenMeta } from '@/interfaces/chain-meta'
 import { ChainValidationError } from '../url-parser/errors'
 import { POPULAR_CHAIN_NAME_VARIANTS } from '../url-parser/parser.consts'
 
 // This is used to support other tokens, specifically for reward tokens for
 // example, it was used to support beer token in polygon in early versions of the app
 // We keep the mapping for future configuration
-const EXTRA_TOKENS_BY_CHAIN: Record<string, interfaces.ITokenMeta[]> = {}
+const EXTRA_TOKENS_BY_CHAIN: Record<string, TokenMeta[]> = {}
 
 export async function getTokenAndChainDetails(
     tokenSymbol: string,
     chain?: string | number
-): Promise<{ chain: interfaces.IChainMeta | null; token?: interfaces.ITokenMeta }> {
+): Promise<{ chain: ChainMeta | null; token?: TokenMeta }> {
     const normalizeTokenSymbol = tokenSymbol.toLowerCase()
-    const squidChainsAndTokens = await getSupportedChainsAndTokens()
+    const supportedChainsAndTokens = await getSupportedChainsAndTokens()
 
     if (chain) {
-        //TODO what about chains and tokens that are not supported by squid? we should
-        //support direct token transfers for those chains
-        const chainDetails = getChainDetails(chain, squidChainsAndTokens)
+        const chainDetails = getChainDetails(chain, supportedChainsAndTokens)
         let tokenDetails = chainDetails.tokens.find((token) => token.symbol.toLowerCase() === normalizeTokenSymbol)
         if (!tokenDetails) {
             tokenDetails = EXTRA_TOKENS_BY_CHAIN[chainDetails.chainId]?.find(
@@ -33,7 +31,7 @@ export async function getTokenAndChainDetails(
     }
 
     if (tokenSymbol) {
-        const arbitrumChainDetails = squidChainsAndTokens[PEANUT_WALLET_CHAIN.id]
+        const arbitrumChainDetails = supportedChainsAndTokens[PEANUT_WALLET_CHAIN.id]
         const tokenDetails = arbitrumChainDetails.tokens.find(
             (token) => token.symbol.toLowerCase() === normalizeTokenSymbol
         )
@@ -43,7 +41,7 @@ export async function getTokenAndChainDetails(
         }
     }
 
-    const arbitrumChainDetails = squidChainsAndTokens[PEANUT_WALLET_CHAIN.id]
+    const arbitrumChainDetails = supportedChainsAndTokens[PEANUT_WALLET_CHAIN.id]
     const usdcArbTokenDetails = arbitrumChainDetails.tokens.find(
         (token) => token.address.toLowerCase() === PEANUT_WALLET_TOKEN.toLowerCase()
     )
@@ -57,15 +55,15 @@ export async function getTokenAndChainDetails(
 // utility to get human-readable chain name
 export function getChainDetails(
     chain: string | number,
-    squidChainsAndTokens: Record<string, interfaces.IChainMeta & { tokens: interfaces.ITokenMeta[] }>
-): interfaces.IChainMeta & { tokens: interfaces.ITokenMeta[] } {
-    let chainDetails: interfaces.IChainMeta & { tokens: interfaces.ITokenMeta[] }
+    supportedChainsAndTokens: Record<string, ChainMeta & { tokens: TokenMeta[] }>
+): ChainMeta & { tokens: TokenMeta[] } {
+    let chainDetails: ChainMeta & { tokens: TokenMeta[] }
 
     // resolve chain by name
     if (typeof chain === 'string') {
         for (const [_chainID, variants] of Object.entries(POPULAR_CHAIN_NAME_VARIANTS)) {
             if (variants.includes(chain.toLowerCase())) {
-                chainDetails = squidChainsAndTokens[_chainID]
+                chainDetails = supportedChainsAndTokens[_chainID]
                 if (chainDetails) return chainDetails
             }
         }
@@ -73,7 +71,7 @@ export function getChainDetails(
         // try hex chain IDs
         if (chain.startsWith('0x')) {
             const decimalChainId = parseInt(chain, 16).toString()
-            chainDetails = squidChainsAndTokens[decimalChainId]
+            chainDetails = supportedChainsAndTokens[decimalChainId]
             if (chainDetails) return chainDetails
         }
     }
@@ -81,7 +79,7 @@ export function getChainDetails(
     // handle numeric chain IDs
     const numericChainId = typeof chain === 'string' ? parseInt(chain) : chain
     if (!isNaN(numericChainId)) {
-        chainDetails = squidChainsAndTokens[numericChainId.toString()]
+        chainDetails = supportedChainsAndTokens[numericChainId.toString()]
         if (chainDetails) return chainDetails
     }
 

--- a/src/services/rhino-sda.ts
+++ b/src/services/rhino-sda.ts
@@ -3,9 +3,8 @@
 /**
  * Client-side wrappers around the unified Rhino SDA-transfer backend.
  *
- * Replaces the legacy Squid primitive under Option A (SDA for
- * every cross-chain flow). Three consumers: withdraw, pay-request-x-chain,
- * claim-link-x-chain — all route through these two calls.
+ * Three consumers: withdraw, pay-request-x-chain, claim-link-x-chain —
+ * all route through these two calls.
  */
 
 import { apiFetch } from '@/utils/api-fetch'

--- a/src/utils/__tests__/url-parser.test.ts
+++ b/src/utils/__tests__/url-parser.test.ts
@@ -35,7 +35,7 @@ jest.mock('@/lib/validation/recipient', () => {
     }
 })
 
-// mock Squid data
+// mock chain + token data
 jest.mock('@/app/actions/supported-chains', () => ({
     getSupportedChainsAndTokens: () => ({
         '1': {
@@ -57,10 +57,6 @@ jest.mock('@/app/actions/supported-chains', () => ({
         '8453': {
             chainId: '8453',
             name: 'Base',
-            networkIdentifier: 'base',
-            chainName: 'Chain 8453',
-            axelarChainName: 'base',
-            type: 'evm',
             networkName: 'Base',
             tokens: [
                 {
@@ -69,7 +65,6 @@ jest.mock('@/app/actions/supported-chains', () => ({
                     chainId: '8453',
                     name: 'ETH',
                     decimals: 18,
-                    active: true,
                 },
                 {
                     symbol: 'USDC',
@@ -77,7 +72,6 @@ jest.mock('@/app/actions/supported-chains', () => ({
                     chainId: '8453',
                     name: 'USDC',
                     decimals: 6,
-                    active: true,
                 },
             ],
         },

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -16,7 +16,7 @@ import { type ChargeEntry } from '@/services/services.types'
 import { NATIVE_TOKEN_ADDRESS, NATIVE_TOKEN_PROXY_ADDRESS } from '@/constants/tokens.consts'
 import { toWebAuthnKey } from '@zerodev/passkey-validator'
 import { USER_OPERATION_REVERT_REASON_TOPIC } from '@/constants/zerodev.consts'
-import { CHAIN_LOGOS, type ChainName } from '@/constants/rhino.consts'
+import { CHAIN_LOGOS, TOKEN_LOGOS, type ChainName, type TokenName } from '@/constants/rhino.consts'
 import { isUserKycVerified } from '@/constants/kyc.consts'
 
 export const shortenAddress = (address?: string, chars?: number) => {
@@ -753,9 +753,8 @@ export function getRequestLink(
     return link
 }
 
-// for now it works
 export function getTokenLogo(tokenSymbol: string): string {
-    return `https://raw.githubusercontent.com/0xsquid/assets/main/images/tokens/${tokenSymbol.toLowerCase()}.svg`
+    return TOKEN_LOGOS[tokenSymbol.toUpperCase() as TokenName] ?? ''
 }
 
 export function getChainLogo(chainName: string): string {
@@ -772,13 +771,7 @@ export function getChainLogo(chainName: string): string {
             name = chainName.toLowerCase()
     }
 
-    const chainLogo = CHAIN_LOGOS[name.toUpperCase() as ChainName]
-
-    if (chainLogo) {
-        return chainLogo
-    }
-
-    return `https://raw.githubusercontent.com/0xsquid/assets/main/images/webp128/chains/${name}.webp`
+    return CHAIN_LOGOS[name.toUpperCase() as ChainName] ?? ''
 }
 
 export function isStableCoin(tokenSymbol: string): boolean {


### PR DESCRIPTION
## Summary

Cross-chain withdraw + claim already settle through Rhino SDA on `dev` (PRs #1916 / api-ts #682 etc.) — only the **naming and a few dead fields** remained from the Squid-shaped surface. This PR finishes the cleanup.

- New `ChainMeta` / `TokenMeta` in `src/interfaces/chain-meta.ts` — drops dead fields `axelarChainName`, `chainType`, `active` (verified zero readers across the repo before removal)
- Old `IChainMeta` / `ITokenMeta` removed from `peanut-sdk-types.ts`
- Synthetic `IChainMeta` fallback in `Initial.withdraw.view.tsx` collapses to the fields actually read (chainId, networkName, chainIconURI, tokens)
- queryKey `'squidChainsAndTokens'` → `'supportedChainsAndTokens'` (cache namespace clarity)
- `getTokenLogo` / `getChainLogo` no longer fall back to `raw.githubusercontent.com/0xsquid/assets` — local `CHAIN_LOGOS` / `TOKEN_LOGOS` only, `''` otherwise (img consumers already gate on truthy URL)
- Stale "this replaces Squid" comments cleaned up

Closes decomplexify TODO #44 + #45.

**Diff**: 21 files, −181/+120. peanut-ui only — peanut-api-ts has no remaining Squid references that need touching (the 4 mentions on `dev` are intentional historical refs in the reaper rules + README).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `npm test` — 960 pass / 1 unrelated locale-dependent failure (`add-money-states.test.tsx:919` expects `10,000 USD` but renders `10.000 USD` under es-ES locale; test file untouched by this PR, pre-existing on `dev`)
- [x] `git grep -niE 'squid|IChainMeta|ITokenMeta' src/` returns 0 matches
- [ ] Smoke withdraw + cross-chain claim flows in sandbox
- [ ] Verify TanStack Query cache invalidates correctly after the queryKey rename (one-time stale-cache miss expected on first load post-deploy; data is regenerated locally so no API impact)