### PR TITLE
fix: pass crossRegion to manteca KYC flows + surface region errors

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -94,7 +94,8 @@ export default function OnrampBankPage() {
     // uk-specific check
     const isUK = isUKCountry(selectedCountryPath)
 
-    const { isUserKycApproved } = useKycStatus()
+    const { isUserKycApproved, isUserSumsubKycApproved, isUserBridgeKycApproved, isUserBridgeKycUnderReview } =
+        useKycStatus()
     const { bridge: bridgeRejection } = useProviderRejectionStatus()
     const { guardWithTos, showBridgeTos, hideTos } = useBridgeTosGuard()
 
@@ -193,10 +194,17 @@ export default function OnrampBankPage() {
         }
     }, [rawTokenAmount, validateAmount, setError])
 
+    const needsBridgeEnrollment = isUserSumsubKycApproved && !isUserBridgeKycApproved && !isUserBridgeKycUnderReview
+
     const handleAmountContinue = () => {
         if (!validateAmount(rawTokenAmount)) return
 
-        if (!isUserKycApproved || bridgeRejection.state === 'fixable' || bridgeRejection.state === 'blocked') {
+        if (
+            needsBridgeEnrollment ||
+            !isUserKycApproved ||
+            bridgeRejection.state === 'fixable' ||
+            bridgeRejection.state === 'blocked'
+        ) {
             setShowKycModal(true)
             return
         }
@@ -401,7 +409,7 @@ export default function OnrampBankPage() {
                         if (hasRejection) {
                             await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                         } else {
-                            await sumsubFlow.handleInitiateKyc('STANDARD')
+                            await sumsubFlow.handleInitiateKyc('STANDARD', undefined, needsBridgeEnrollment || undefined)
                         }
                         setShowKycModal(false)
                     }}
@@ -409,9 +417,12 @@ export default function OnrampBankPage() {
                     variant={
                         bridgeRejection.state === 'fixable' || bridgeRejection.state === 'blocked'
                             ? 'provider_rejection'
-                            : 'default'
+                            : needsBridgeEnrollment
+                              ? 'cross_region'
+                              : 'default'
                     }
                     providerMessage={bridgeRejection.userMessage ?? undefined}
+                    regionName={selectedCountry?.title}
                 />
 
                 <SumsubKycModals flow={sumsubFlow} autoStartSdk />

--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -405,8 +405,9 @@ export default function OnrampBankPage() {
                     visible={showKycModal}
                     onClose={() => setShowKycModal(false)}
                     onVerify={async () => {
-                        const hasRejection = bridgeRejection.state === 'fixable'
-                        if (hasRejection) {
+                        // needsBridgeEnrollment takes priority: user has no bridge customer,
+                        // so rejection state from a stale/deleted customer is irrelevant
+                        if (!needsBridgeEnrollment && bridgeRejection.state === 'fixable') {
                             await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                         } else {
                             await sumsubFlow.handleInitiateKyc('STANDARD', undefined, needsBridgeEnrollment || undefined)
@@ -415,10 +416,10 @@ export default function OnrampBankPage() {
                     }}
                     isLoading={sumsubFlow.isLoading}
                     variant={
-                        bridgeRejection.state === 'fixable' || bridgeRejection.state === 'blocked'
-                            ? 'provider_rejection'
-                            : needsBridgeEnrollment
-                              ? 'cross_region'
+                        needsBridgeEnrollment
+                            ? 'cross_region'
+                            : bridgeRejection.state === 'fixable' || bridgeRejection.state === 'blocked'
+                              ? 'provider_rejection'
                               : 'default'
                     }
                     providerMessage={bridgeRejection.userMessage ?? undefined}

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -28,6 +28,10 @@ import { createOfframp, confirmOfframp } from '@/app/actions/offramp'
 import { useAuth } from '@/context/authContext'
 import { useBridgeTosGuard } from '@/hooks/useBridgeTosGuard'
 import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
+import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
+import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
+import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
+import useKycStatus from '@/hooks/useKycStatus'
 import ExchangeRate from '@/components/ExchangeRate'
 import countryCurrencyMappings, { isNonEuroSepaCountry } from '@/constants/countryCurrencyMapping'
 import { useIdentityVerification } from '@/hooks/useIdentityVerification'
@@ -61,6 +65,10 @@ export default function WithdrawBankPage() {
     const [balanceErrorMessage, setBalanceErrorMessage] = useState<string | null>(null)
     const { hasPendingTransactions } = usePendingTransactions()
     const { isBridgeSupportedCountry } = useIdentityVerification()
+    const { isUserSumsubKycApproved, isUserBridgeKycApproved } = useKycStatus()
+    const sumsubFlow = useMultiPhaseKycFlow({})
+    const [showKycModal, setShowKycModal] = useState(false)
+    const needsBridgeEnrollment = isUserSumsubKycApproved && !isUserBridgeKycApproved && !user?.user.bridgeCustomerId
 
     // validate country is supported for bank withdrawals
     useEffect(() => {
@@ -155,6 +163,11 @@ export default function WithdrawBankPage() {
     }
 
     const handleCreateAndInitiateOfframp = async () => {
+        if (needsBridgeEnrollment) {
+            setShowKycModal(true)
+            return
+        }
+
         if (guardWithTos()) return
 
         setIsLoading(true)
@@ -428,6 +441,19 @@ export default function WithdrawBankPage() {
                 }}
                 onSkip={hideTos}
             />
+
+            <InitiateKycModal
+                visible={showKycModal}
+                onClose={() => setShowKycModal(false)}
+                onVerify={async () => {
+                    await sumsubFlow.handleInitiateKyc('STANDARD', undefined, true)
+                    setShowKycModal(false)
+                }}
+                isLoading={sumsubFlow.isLoading}
+                variant="cross_region"
+                regionName={getCountryFromPath(country)?.title}
+            />
+            <SumsubKycModals flow={sumsubFlow} />
         </div>
     )
 }

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -101,6 +101,7 @@ export default function MantecaWithdrawFlow() {
     const sumsubFlow = useMultiPhaseKycFlow({})
     const [showKycModal, setShowKycModal] = useState(false)
     const [isRedirectingToOnboarding, setIsRedirectingToOnboarding] = useState(false)
+
     // Get method and country from URL parameters
     const selectedMethodType = searchParams.get('method') // mercadopago, pix, bank-transfer, etc.
     const countryFromUrl = searchParams.get('country') // argentina, brazil, etc.
@@ -536,7 +537,7 @@ export default function MantecaWithdrawFlow() {
                     if (hasRejection) {
                         await sumsubFlow.handleSelfHealResubmit('MANTECA')
                     } else {
-                        await sumsubFlow.handleInitiateKyc('LATAM')
+                        await sumsubFlow.handleInitiateKyc('LATAM', undefined, true)
                     }
                     setShowKycModal(false)
                 }}
@@ -758,7 +759,7 @@ export default function MantecaWithdrawFlow() {
                                   : 'Review'}
                         </Button>
 
-                        {errorMessage && <ErrorAlert description={errorMessage} />}
+                        {(errorMessage || sumsubFlow.error) && <ErrorAlert description={(errorMessage || sumsubFlow.error)!} />}
                     </div>
                 </div>
             )}
@@ -815,7 +816,7 @@ export default function MantecaWithdrawFlow() {
                     >
                         {isLoading ? loadingState : 'Withdraw'}
                     </Button>
-                    {errorMessage && <ErrorAlert description={errorMessage} />}
+                    {(errorMessage || sumsubFlow.error) && <ErrorAlert description={(errorMessage || sumsubFlow.error)!} />}
                 </div>
             )}
         </div>

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -91,7 +91,7 @@ export default function MantecaWithdrawFlow() {
     const { user } = useAuth()
     const { setIsSupportModalOpen, openSupportWithMessage } = useModalsContext()
     const queryClient = useQueryClient()
-    const { isUserMantecaKycApproved } = useKycStatus()
+    const { isUserMantecaKycApproved, isUserSumsubKycApproved } = useKycStatus()
     const { manteca: mantecaRejection } = useProviderRejectionStatus()
     const { hasPendingTransactions } = usePendingTransactions()
 
@@ -545,9 +545,12 @@ export default function MantecaWithdrawFlow() {
                 variant={
                     mantecaRejection.state === 'fixable' || mantecaRejection.state === 'blocked'
                         ? 'provider_rejection'
-                        : 'default'
+                        : isUserSumsubKycApproved
+                          ? 'cross_region'
+                          : 'default'
                 }
                 providerMessage={mantecaRejection.userMessage ?? undefined}
+                regionName={selectedCountry?.title}
             />
             <SumsubKycModals flow={sumsubFlow} />
             <SumsubKycWrapper

--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -39,7 +39,13 @@ export const initiateSumsubKyc = async (params?: {
         const responseJson = await response.json()
 
         if (!response.ok) {
-            return { error: responseJson.message || responseJson.error || 'Failed to initiate identity verification' }
+            return {
+                error:
+                    responseJson.userMessage ||
+                    responseJson.message ||
+                    responseJson.error ||
+                    'Failed to initiate identity verification',
+            }
         }
 
         return {

--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -42,7 +42,6 @@ export const initiateSumsubKyc = async (params?: {
             return {
                 error:
                     responseJson.userMessage ||
-                    responseJson.message ||
                     responseJson.error ||
                     'Failed to initiate identity verification',
             }

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -227,7 +227,7 @@ const MantecaAddMoney: FC = () => {
                         if (hasRejection) {
                             await sumsubFlow.handleSelfHealResubmit('MANTECA')
                         } else {
-                            await sumsubFlow.handleInitiateKyc('LATAM')
+                            await sumsubFlow.handleInitiateKyc('LATAM', undefined, true)
                         }
                         setShowKycModal(false)
                     }}
@@ -245,7 +245,7 @@ const MantecaAddMoney: FC = () => {
                     setTokenAmount={handleUsdAmountChange}
                     onSubmit={handleAmountSubmit}
                     isLoading={isCreatingDeposit}
-                    error={error}
+                    error={error || sumsubFlow.error}
                     currencyData={currencyData}
                     setCurrencyAmount={handleLocalCurrencyAmountChange}
                     setCurrentDenomination={handleDenominationChange}

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -64,7 +64,7 @@ const MantecaAddMoney: FC = () => {
     const selectedCountry = useMemo(() => {
         return countryData.find((country) => country.type === 'country' && country.path === selectedCountryPath)
     }, [selectedCountryPath])
-    const { isUserMantecaKycApproved } = useKycStatus()
+    const { isUserMantecaKycApproved, isUserSumsubKycApproved } = useKycStatus()
     const { manteca: mantecaRejection } = useProviderRejectionStatus()
     const currencyData = useCurrency(selectedCountry?.currency ?? 'ARS')
     const { user } = useAuth()
@@ -235,9 +235,12 @@ const MantecaAddMoney: FC = () => {
                     variant={
                         mantecaRejection.state === 'fixable' || mantecaRejection.state === 'blocked'
                             ? 'provider_rejection'
-                            : 'default'
+                            : isUserSumsubKycApproved
+                              ? 'cross_region'
+                              : 'default'
                     }
                     providerMessage={mantecaRejection.userMessage ?? undefined}
+                    regionName={selectedCountry?.title}
                 />
                 <SumsubKycModals flow={sumsubFlow} />
                 <InputAmountStep

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -27,6 +27,7 @@ import { ActionListCard } from '@/components/ActionListCard'
 import TokenAndNetworkConfirmationModal from '../Global/TokenAndNetworkConfirmationModal'
 import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
+import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
 
 interface AddWithdrawCountriesListProps {
     flow: 'add' | 'withdraw'
@@ -65,7 +66,8 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
     const formRef = useRef<{ handleSubmit: () => void }>(null)
     const [isSupportedTokensModalOpen, setIsSupportedTokensModalOpen] = useState(false)
 
-    const { isUserKycApproved, isUserBridgeKycUnderReview } = useKycStatus()
+    const { isUserKycApproved, isUserBridgeKycUnderReview, isUserSumsubKycApproved, isUserBridgeKycApproved } =
+        useKycStatus()
     const { bridge: bridgeRejection } = useProviderRejectionStatus()
     const [showKycStatusModal, setShowKycStatusModal] = useState(false)
 
@@ -92,6 +94,13 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
         }
         if (bridgeRejection.state === 'blocked') {
             return { error: 'Bank transfers are not available for your account. Please contact support.' }
+        }
+
+        // JIT bridge enrollment: user is sumsub-approved but no bridge customer yet
+        // show the KYC modal — enrollment happens when user clicks "Start Verification"
+        if (isUserSumsubKycApproved && !isUserBridgeKycApproved && !user?.user.bridgeCustomerId) {
+            setIsKycModalOpen(true)
+            return {}
         }
 
         // scenario (1): happy path: if the user has already completed kyc, we can add the bank account directly
@@ -275,6 +284,17 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                     onSuccess={handleFormSubmit}
                     initialData={{}}
                     error={null}
+                />
+                <InitiateKycModal
+                    visible={isKycModalOpen}
+                    onClose={() => setIsKycModalOpen(false)}
+                    onVerify={async () => {
+                        await sumsubFlow.handleInitiateKyc('STANDARD', undefined, true)
+                        setIsKycModalOpen(false)
+                    }}
+                    isLoading={sumsubFlow.isLoading}
+                    variant="cross_region"
+                    regionName={currentCountry?.title}
                 />
                 <SumsubKycModals flow={sumsubFlow} />
             </div>

--- a/src/components/Claim/Link/MantecaFlowManager.tsx
+++ b/src/components/Claim/Link/MantecaFlowManager.tsx
@@ -29,7 +29,7 @@ const MantecaFlowManager: FC<MantecaFlowManagerProps> = ({ claimLinkData, amount
     const [currentStep, setCurrentStep] = useState<MercadoPagoStep>(MercadoPagoStep.DETAILS)
     const router = useRouter()
     const [destinationAddress, setDestinationAddress] = useState('')
-    const { isUserMantecaKycApproved } = useKycStatus()
+    const { isUserMantecaKycApproved, isUserSumsubKycApproved } = useKycStatus()
     const { manteca: mantecaRejection } = useProviderRejectionStatus()
 
     // inline sumsub kyc flow for manteca users who need LATAM verification
@@ -136,9 +136,12 @@ const MantecaFlowManager: FC<MantecaFlowManagerProps> = ({ claimLinkData, amount
                 variant={
                     mantecaRejection.state === 'fixable' || mantecaRejection.state === 'blocked'
                         ? 'provider_rejection'
-                        : 'default'
+                        : isUserSumsubKycApproved
+                          ? 'cross_region'
+                          : 'default'
                 }
                 providerMessage={mantecaRejection.userMessage ?? undefined}
+                regionName={selectedCountry?.title}
             />
             <SumsubKycModals flow={sumsubFlow} />
         </div>

--- a/src/components/Claim/Link/MantecaFlowManager.tsx
+++ b/src/components/Claim/Link/MantecaFlowManager.tsx
@@ -10,6 +10,7 @@ import MantecaDetailsStep from './views/MantecaDetailsStep.view'
 import { MercadoPagoStep } from '@/types/manteca.types'
 import MantecaReviewStep from './views/MantecaReviewStep'
 import { Button } from '@/components/0_Bruddle/Button'
+import ErrorAlert from '@/components/Global/ErrorAlert'
 import { useRouter } from 'next/navigation'
 import useKycStatus from '@/hooks/useKycStatus'
 import useProviderRejectionStatus from '@/hooks/useProviderRejectionStatus'
@@ -139,9 +140,7 @@ const MantecaFlowManager: FC<MantecaFlowManagerProps> = ({ claimLinkData, amount
                 providerMessage={mantecaRejection.userMessage ?? undefined}
             />
             <SumsubKycModals flow={sumsubFlow} />
-            {sumsubFlow.error && (
-                <p className="text-center text-sm text-red-500">{sumsubFlow.error}</p>
-            )}
+            {sumsubFlow.error && <ErrorAlert description={sumsubFlow.error} />}
         </div>
     )
 }

--- a/src/components/Claim/Link/MantecaFlowManager.tsx
+++ b/src/components/Claim/Link/MantecaFlowManager.tsx
@@ -118,6 +118,7 @@ const MantecaFlowManager: FC<MantecaFlowManagerProps> = ({ claimLinkData, amount
                 />
 
                 {renderStepDetails()}
+                {sumsubFlow.error && <ErrorAlert description={sumsubFlow.error} />}
             </div>
             <InitiateKycModal
                 visible={showKycModal}
@@ -140,7 +141,6 @@ const MantecaFlowManager: FC<MantecaFlowManagerProps> = ({ claimLinkData, amount
                 providerMessage={mantecaRejection.userMessage ?? undefined}
             />
             <SumsubKycModals flow={sumsubFlow} />
-            {sumsubFlow.error && <ErrorAlert description={sumsubFlow.error} />}
         </div>
     )
 }

--- a/src/components/Claim/Link/MantecaFlowManager.tsx
+++ b/src/components/Claim/Link/MantecaFlowManager.tsx
@@ -126,7 +126,7 @@ const MantecaFlowManager: FC<MantecaFlowManagerProps> = ({ claimLinkData, amount
                     if (hasRejection) {
                         await sumsubFlow.handleSelfHealResubmit('MANTECA')
                     } else {
-                        await sumsubFlow.handleInitiateKyc('LATAM')
+                        await sumsubFlow.handleInitiateKyc('LATAM', undefined, true)
                     }
                     setShowKycModal(false)
                 }}
@@ -139,6 +139,9 @@ const MantecaFlowManager: FC<MantecaFlowManagerProps> = ({ claimLinkData, amount
                 providerMessage={mantecaRejection.userMessage ?? undefined}
             />
             <SumsubKycModals flow={sumsubFlow} />
+            {sumsubFlow.error && (
+                <p className="text-center text-sm text-red-500">{sumsubFlow.error}</p>
+            )}
         </div>
     )
 }

--- a/src/components/Kyc/InitiateKycModal.tsx
+++ b/src/components/Kyc/InitiateKycModal.tsx
@@ -45,6 +45,7 @@ export const InitiateKycModal = ({
             onClose={onClose}
             title={isProviderRejection ? 'We need extra documents' : 'Verify your identity'}
             description={getDescription()}
+            preventClose
             icon={'badge' as IconName}
             modalPanelClassName="max-w-full m-2"
             ctaClassName="grid grid-cols-1 gap-3"

--- a/src/components/Kyc/InitiateKycModal.tsx
+++ b/src/components/Kyc/InitiateKycModal.tsx
@@ -8,12 +8,16 @@ interface InitiateKycModalProps {
     onVerify: () => void
     isLoading?: boolean
     /** when set, shows provider-specific messaging instead of generic "verify your identity" */
-    variant?: 'default' | 'provider_rejection'
+    variant?: 'default' | 'provider_rejection' | 'cross_region'
     providerMessage?: string
+    /** country name shown in cross_region variant (e.g. "Brazil", "Argentina") */
+    regionName?: string
 }
 
 // confirmation modal shown before starting KYC or provider resubmission.
-// for fresh KYC: "Verify your identity" — for provider rejections: "We need extra documents"
+// for fresh KYC: "Verify your identity"
+// for provider rejections: "We need extra documents"
+// for cross-region: "Your identity is verified, we need a local ID"
 export const InitiateKycModal = ({
     visible,
     onClose,
@@ -21,19 +25,26 @@ export const InitiateKycModal = ({
     isLoading,
     variant = 'default',
     providerMessage,
+    regionName,
 }: InitiateKycModalProps) => {
     const isProviderRejection = variant === 'provider_rejection'
+    const isCrossRegion = variant === 'cross_region'
+
+    const getDescription = () => {
+        if (isProviderRejection) return providerMessage || 'Please upload a clearer photo of your ID to continue.'
+        if (isCrossRegion) {
+            const region = regionName ? ` from ${regionName}` : ''
+            return `Your identity is already verified. To enable payments in this region, we need a valid ID${region}.`
+        }
+        return 'To continue, you need to complete identity verification. This usually takes just a few minutes.'
+    }
 
     return (
         <ActionModal
             visible={visible}
             onClose={onClose}
             title={isProviderRejection ? 'We need extra documents' : 'Verify your identity'}
-            description={
-                isProviderRejection
-                    ? providerMessage || 'Please upload a clearer photo of your ID to continue.'
-                    : 'To continue, you need to complete identity verification. This usually takes just a few minutes.'
-            }
+            description={getDescription()}
             icon={'badge' as IconName}
             modalPanelClassName="max-w-full m-2"
             ctaClassName="grid grid-cols-1 gap-3"

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -174,7 +174,12 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
         posthog.capture(ANALYTICS_EVENTS.KYC_SUBMITTED, { region_intent: regionIntent })
         isRealtimeFlowRef.current = true
         originalHandleSdkComplete()
-    }, [originalHandleSdkComplete, regionIntent])
+        // for action flows (manteca, self-heal), the base status is already APPROVED
+        // and won't transition — directly start the preparing/tracking phase
+        if (isActionFlow) {
+            handleSumsubApproved()
+        }
+    }, [originalHandleSdkComplete, handleSumsubApproved, isActionFlow, regionIntent])
 
     // wrap handleInitiateKyc to reset state for new attempts
     const handleInitiateKyc = useCallback(


### PR DESCRIPTION
## Summary

- Passes `crossRegion: true` in all 3 `handleInitiateKyc('LATAM')` callsites (MantecaAddMoney, withdraw/manteca, MantecaFlowManager) so the backend creates the manteca applicant action for already-approved users
- Prefers `userMessage` from API error responses in `initiateSumsubKyc` server action for user-friendly error text
- Renders `sumsubFlow.error` directly in JSX for `region_not_supported` errors
- Adds `cross_region` variant to `InitiateKycModal` — shows "Your identity is already verified. To enable payments in this region, we need a valid ID from [Country]."
- Adds `preventClose` to `InitiateKycModal` to fix headlessui Dialog focus conflict (modal closing on first attempt)
- Fixes post-action progress modal for manteca/self-heal flows (calls `handleSumsubApproved` directly since base status is already APPROVED)
- JIT Bridge enrollment in deposit (`add-money/[country]/bank`) and withdraw (`AddWithdrawCountriesList`) — shows cross_region modal when Sumsub-approved user without Bridge tries to use Bridge flows

## Context

When a Sumsub-approved user tried to use Manteca flows (deposit, withdraw, claim), the KYC modal silently closed because `handleInitiateKyc('LATAM')` was called without `crossRegion: true`. The backend returned `{ token: null, status: 'APPROVED' }` without creating the manteca action.

Additionally, LATAM-first users trying Bridge flows (SEPA, ACH) would get transfer failures because `bridgeCustomerId` was null — JIT enrollment now handles this via the cross_region modal + bridge-direct backend path.

## Tests performed

### Manteca flows (tested with prod Manteca env)
- [x] Sumsub+Bridge approved user → Manteca deposit (`/add-money/brazil/manteca`) → cross_region modal shown → "Start Verification" → Manteca action SDK opens
- [x] Same flow for Manteca withdraw (`/withdraw/manteca?country=brazil`) → works
- [x] Same flow for Argentina → works
- [x] Already Manteca-approved user → deposit proceeds directly (no modal)

### Bridge JIT enrollment (LATAM user without Bridge)
- [x] `/add-money/germany/bank` → enter amount → Continue → cross_region modal: "Your identity is already verified. To enable payments in this region, we need a valid ID from Germany."
- [x] Click "Start Verification" → progress modal "Setting up your account" → Bridge ToS iframe → "All set!"
- [x] After enrollment, Continue again → proceeds directly (Bridge now ready)
- [x] Withdraw flow → enter bank details → submit → cross_region modal → enrollment → bank account saves

### Regression
- [x] Already Bridge-approved user → Bridge deposit works normally (no modal)
- [x] Home page activation CTA shows correct step (not "verify your identity" for verified users)
- [x] Unverified user → Bridge withdraw → full Sumsub KYC flow (existing behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Backend companion PR:** peanutprotocol/peanut-api-ts#688