### PR TITLE
fix(tokens): fetch token price + wallet balances via api-ts backend

### DIFF
--- a/src/app/(mobile-ui)/recover-funds/page.tsx
+++ b/src/app/(mobile-ui)/recover-funds/page.tsx
@@ -6,7 +6,7 @@ import TokenListItem from '@/components/Global/TokenSelector/Components/TokenLis
 import { type IUserBalance } from '@/interfaces'
 import { useState, useEffect, useCallback, useContext } from 'react'
 import { useWallet } from '@/hooks/wallet/useWallet'
-import { fetchWalletBalances } from '@/app/actions/tokens'
+import { fetchWalletBalances } from '@/services/tokens-price'
 import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants/zerodev.consts'
 import { nativeCurrencyAddresses } from '@/constants/general.consts'
 import { areEvmAddressesEqual, isTxReverted, getExplorerUrl, getChainName, getTokenLogo } from '@/utils/general.utils'

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -165,7 +165,17 @@ export default function WithdrawCryptoPage() {
             setIsPreparingReview(true)
 
             try {
-                const completeWithdrawData = { ...data, amount: amountToWithdraw }
+                // AmountInput's primary denomination is USD ($), so amountToWithdraw
+                // is the USD value the user typed. Convert to destination token
+                // units before persisting the request/charge — otherwise meta
+                // ends up with `tokenAmount: "1"` + `tokenSymbol: "ETH"` and
+                // history renders "1 ETH" for what was actually a $1 withdraw.
+                const usdValue = parseFloat(amountToWithdraw)
+                const tokenPrice = data.token.price ?? 0
+                const destinationTokenAmount =
+                    tokenPrice > 0 ? (usdValue / tokenPrice).toFixed(Number(data.token.decimals)) : amountToWithdraw
+
+                const completeWithdrawData = { ...data, amount: destinationTokenAmount }
                 setWithdrawData(completeWithdrawData)
                 const apiRequestPayload: CreateRequestPayloadServices = {
                     recipientAddress: completeWithdrawData.address,
@@ -176,7 +186,7 @@ export default function WithdrawCryptoPage() {
                             ? peanutInterfaces.EPeanutLinkType.native
                             : peanutInterfaces.EPeanutLinkType.erc20
                     ),
-                    tokenAmount: amountToWithdraw,
+                    tokenAmount: destinationTokenAmount,
                     tokenDecimals: completeWithdrawData.token.decimals.toString(),
                     tokenSymbol: completeWithdrawData.token.symbol,
                 }
@@ -188,12 +198,12 @@ export default function WithdrawCryptoPage() {
 
                 const chargePayload: CreateChargeRequest = {
                     pricing_type: 'fixed_price',
-                    local_price: { amount: completeWithdrawData.amount || amountToWithdraw, currency: 'USD' },
+                    local_price: { amount: usdValue.toString(), currency: 'USD' },
                     baseUrl: window.location.origin,
                     requestId: newRequest.uuid,
                     requestProps: {
                         chainId: completeWithdrawData.chain.chainId.toString(),
-                        tokenAmount: completeWithdrawData.amount,
+                        tokenAmount: destinationTokenAmount,
                         tokenAddress: completeWithdrawData.token.address,
                         tokenType:
                             completeWithdrawData.token.address.toLowerCase() === NATIVE_TOKEN_ADDRESS.toLowerCase()

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -68,6 +68,8 @@ export default function WithdrawCryptoPage() {
         receiveAmount,
         feeUsd,
         isCalculating,
+        isXChain,
+        isDiffToken,
         error: routeError,
         calculate: calculateRoute,
         reset: resetRouteCalculation,
@@ -242,17 +244,15 @@ export default function WithdrawCryptoPage() {
         }
     }, [chargeDetails, withdrawData, setCurrentView, setShowCompatibilityModal, setError])
 
-    // check if this is a cross-chain withdrawal — determines whether we can
-    // route same-chain spends through the direct collateral-only path.
+    // True when the withdraw needs a Rhino path (SDA or bridge swap) rather
+    // than a direct USDC transfer. Crosses a chain boundary OR a token
+    // boundary — `isCrossChainWithdrawal` historically only checked chains,
+    // which silently downgraded cross-token same-chain (USDC → ETH on Arb)
+    // to a plain USDC.transfer to the recipient.
     const isCrossChainWithdrawal = useMemo<boolean>(() => {
         if (!withdrawData || !chargeDetails) return false
-
-        // in withdraw flow, we're moving from Peanut Wallet to the selected chain
-        const fromChainId = isPeanutWallet ? PEANUT_WALLET_CHAIN.id.toString() : withdrawData.chain.chainId
-        const toChainId = chargeDetails.chainId
-
-        return fromChainId !== toChainId
-    }, [withdrawData, chargeDetails, isPeanutWallet])
+        return isXChain || isDiffToken
+    }, [withdrawData, chargeDetails, isXChain, isDiffToken])
 
     const handleConfirmWithdrawal = useCallback(async () => {
         if (!chargeDetails || !withdrawData || !amountToWithdraw || !address) {

--- a/src/app/actions/tokens.ts
+++ b/src/app/actions/tokens.ts
@@ -1,158 +1,16 @@
 import { unstable_cache } from '@/utils/no-cache'
-import {
-    isAddressZero,
-    estimateIfIsStableCoinFromPrice,
-    getTokenDetails,
-    isStableCoin,
-    areEvmAddressesEqual,
-} from '@/utils/general.utils'
-import { fetchWithSentry } from '@/utils/sentry.utils'
+import { getTokenDetails } from '@/utils/general.utils'
 import { NATIVE_TOKEN_ADDRESS } from '@/utils/token.utils'
-import { type ITokenPriceData } from '@/interfaces'
+import { fetchTokenPrice } from '@/services/tokens-price'
 import { parseAbi, formatUnits } from 'viem'
 import { type ChainId, getPublicClient } from '@/app/actions/clients'
 import type { Address, Hex } from 'viem'
-import { type IUserBalance } from '@/interfaces'
-
-type IMobulaMarketData = {
-    id: number
-    market_cap: number
-    market_cap_diluted: number
-    liquidity: number
-    price: number
-    off_chain_volume: number
-    volume: number
-    volume_change_24h: number
-    volume_7d: number
-    is_listed: boolean
-    price_change_24h: number
-    price_change_1h: number
-    price_change_7d: number
-    price_change_1m: number
-    price_change_1y: number
-    ath: number
-    atl: number
-    name: string
-    symbol: string
-    logo: string
-    rank: number
-    contracts: {
-        address: string
-        blockchain: string
-        blockchainId: string
-        decimals: number
-    }[]
-    total_supply: string
-    circulating_supply: string
-    decimals?: number
-    priceNative: number
-    native: {
-        name: string
-        address: string
-        decimals: number
-        symbol: string
-        type: string
-        logo: string
-        id: number
-    }
-}
-
-type IMobulaContractBalanceData = {
-    address: string //of the contract
-    balance: number
-    balanceRaw: string
-    chainId: string // this chainId is og the type evm:<chainId>
-    decimals: number
-}
-
-type IMobulaCrossChainBalanceData = {
-    balance: number
-    balanceRaw: string
-    chainId: string
-    address: string //of the token
-}
-
-type IMobulaAsset = {
-    id: number
-    name: string
-    symbol: string
-    logo: string
-    decimals: string[]
-    contracts: string[]
-    blockchains: string[]
-}
-
-type IMobulaAssetData = {
-    contracts_balances: IMobulaContractBalanceData[]
-    cross_chain_balances: Record<string, IMobulaCrossChainBalanceData> // key is the same as in asset.blockchains    price_change_24h: number
-    estimated_balance: number
-    price: number
-    token_balance: number
-    allocation: number
-    asset: IMobulaAsset
-    wallets: string[]
-}
-
-type IMobulaPortfolioData = {
-    total_wallet_balance: number
-    wallets: string[]
-    assets: IMobulaAssetData[]
-    balances_length: number
-}
 
 const ERC20_DATA_ABI = parseAbi([
     'function symbol() view returns (string)',
     'function name() view returns (string)',
     'function decimals() view returns (uint8)',
 ])
-
-const MOBULA_API_URL = process.env.MOBULA_API_URL!
-const MOBULA_API_KEY = process.env.MOBULA_API_KEY!
-
-export const fetchTokenPrice = unstable_cache(
-    async (tokenAddress: string, chainId: string): Promise<ITokenPriceData | undefined> => {
-        try {
-            tokenAddress = isAddressZero(tokenAddress) ? '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' : tokenAddress
-
-            const mobulaResponse = await fetchWithSentry(
-                `${MOBULA_API_URL}/api/1/market/data?asset=${tokenAddress}&blockchain=${chainId}`,
-                {
-                    headers: {
-                        'Content-Type': 'application/json',
-                        authorization: MOBULA_API_KEY,
-                    },
-                }
-            )
-            const json: { data: IMobulaMarketData } = await mobulaResponse.json()
-
-            if (mobulaResponse.ok) {
-                const decimals = json.data.contracts.find((contract) => contract.blockchainId === chainId)!.decimals
-                let data = {
-                    price: json.data.price,
-                    chainId: chainId,
-                    address: tokenAddress,
-                    name: json.data.name,
-                    symbol: json.data.symbol,
-                    decimals,
-                    logoURI: json.data.logo,
-                }
-                if (isStableCoin(data.symbol) || estimateIfIsStableCoinFromPrice(json.data.price)) {
-                    data.price = 1
-                }
-                return data
-            } else {
-                return undefined
-            }
-        } catch (error) {
-            console.log('error fetching token price for token ' + tokenAddress + ' on chain ' + chainId)
-            return undefined
-        }
-    },
-    ['fetchTokenPrice'],
-    {
-        revalidate: 5 * 60, // 5 minutes
-    }
-)
 
 export const fetchTokenDetails = unstable_cache(
     async (
@@ -163,11 +21,9 @@ export const fetchTokenDetails = unstable_cache(
         name: string
         decimals: number
     }> => {
-        console.log('chain id', chainId)
         const tokenDetails = getTokenDetails({ tokenAddress: tokenAddress as Address, chainId: chainId! })
         if (tokenDetails) return tokenDetails
         const client = getPublicClient(Number(chainId) as ChainId)
-        console.log('token address', tokenAddress)
         const [symbol, name, decimals] = await Promise.all([
             client.readContract({
                 address: tokenAddress as Address,
@@ -263,70 +119,3 @@ export async function estimateTransactionCostUsd(
         return 0.01
     }
 }
-
-export const fetchWalletBalances = unstable_cache(
-    async (address: string): Promise<{ balances: IUserBalance[]; totalBalance: number }> => {
-        const mobulaResponse = await fetchWithSentry(`${MOBULA_API_URL}/api/1/wallet/portfolio?wallet=${address}`, {
-            headers: {
-                'Content-Type': 'application/json',
-                authorization: MOBULA_API_KEY,
-            },
-        })
-
-        if (!mobulaResponse.ok) throw new Error('Failed to fetch wallet balances')
-
-        const json: { data: IMobulaPortfolioData } = await mobulaResponse.json()
-        const assets = json.data.assets
-            .filter((a: IMobulaAssetData) => !!a.price)
-            .filter((a: IMobulaAssetData) => !!a.token_balance)
-        const balances: IUserBalance[] = []
-        for (const asset of assets) {
-            const symbol = asset.asset.symbol
-            const price = isStableCoin(symbol) || estimateIfIsStableCoinFromPrice(asset.price) ? 1 : asset.price
-            /*
-           Mobula returns balances per asset, IE: USDC on arbitrum, mainnet
-           and optimism are all part of the same "asset", here we need to
-           divide it
-          */
-            for (const chain of asset.asset.blockchains) {
-                const crossChainBalance = asset.cross_chain_balances[chain]
-                if (!crossChainBalance || crossChainBalance.balance === 0) continue
-                const address =
-                    symbol === 'ETH' ? '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' : crossChainBalance.address
-                const contractInfo = asset.contracts_balances.find((c) => areEvmAddressesEqual(c.address, address))
-                if (
-                    balances.find(
-                        (b) => areEvmAddressesEqual(b.address, address) && b.chainId === crossChainBalance.chainId
-                    )
-                )
-                    continue
-                balances.push({
-                    chainId: crossChainBalance.chainId,
-                    address,
-                    name: asset.asset.name,
-                    symbol,
-                    decimals: contractInfo!.decimals,
-                    price,
-                    amount: crossChainBalance.balance,
-                    currency: 'usd',
-                    logoURI: asset.asset.logo,
-                    value: (crossChainBalance.balance * price).toString(),
-                })
-            }
-        }
-        const totalBalance = balances.reduce(
-            (acc: number, balance: IUserBalance) => acc + balance.amount * balance.price,
-            0
-        )
-        balances.sort((a, b) => Number(b.value) - Number(a.value))
-        return {
-            balances,
-            totalBalance,
-        }
-    },
-    ['fetchWalletBalances'],
-    {
-        tags: ['fetchWalletBalances'],
-        revalidate: 5, // 5 seconds
-    }
-)

--- a/src/app/api/proxy/withFormData/[...slug]/route.ts
+++ b/src/app/api/proxy/withFormData/[...slug]/route.ts
@@ -21,12 +21,21 @@ async function handleFormDataRequest(request: NextRequest, method: string) {
         return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
     }
 
+    const headers: Record<string, string> = {
+        // Don't set Content-Type header, let it be automatically set as multipart/form-data
+        'api-key': apiKey,
+    }
+    // Forward Authorization so backend routes can read the user's JWT.
+    // Parity with /api/proxy/[...slug] (POST). Without this, the backend's
+    // soft-auth path on /charges sees no user — withdraws to external
+    // addresses then FK-violate on transaction_intents_user_id_fkey when
+    // the recipient isn't a known Peanut account.
+    const authHeader = request.headers.get('authorization')
+    if (authHeader) headers['authorization'] = authHeader
+
     const response = await fetchWithSentry(fullAPIUrl, {
         method,
-        headers: {
-            // Don't set Content-Type header, let it be automatically set as multipart/form-data
-            'api-key': apiKey,
-        },
+        headers,
         body: apiFormData,
     })
 

--- a/src/components/Claim/Claim.tsx
+++ b/src/components/Claim/Claim.tsx
@@ -2,7 +2,8 @@
 import { generateKeysFromString } from '@/utils/peanut-link.utils'
 import { useContext, useEffect, useMemo, useState } from 'react'
 
-import { fetchTokenDetails, fetchTokenPrice } from '@/app/actions/tokens'
+import { fetchTokenDetails } from '@/app/actions/tokens'
+import { fetchTokenPrice } from '@/services/tokens-price'
 import { type StatusType } from '@/components/Global/Badges/StatusBadge'
 import { TransactionDetailsReceipt } from '@/components/TransactionDetails/TransactionDetailsReceipt'
 import { type TransactionDetails, REWARD_TOKENS } from '@/components/TransactionDetails/transactionTransformer'

--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -124,12 +124,23 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
     }
 
     let currencyDisplayAmount: string | undefined
-    // Skip the secondary "≈ <CCY> <amount>" line when the currency is USD or a
-    // USD-pegged stablecoin — `$0.10` next to `≈ USDC 0.10` is just noise.
+    // Secondary line preference:
+    //   1. Local fiat (e.g. ARS for Manteca off-ramp) via currency.code/amount
+    //   2. Destination token (e.g. ETH for cross-token withdraw) via amount + tokenSymbol
+    // Skip both for USD / USD-pegged stablecoins to avoid `$0.10 / ≈ USDC 0.10` noise.
     const ccyCode = transaction.currency?.code.toUpperCase()
+    const tokenSymbolUpper = (transaction.tokenSymbol ?? '').toUpperCase()
     if (transaction.currency && ccyCode && ccyCode !== 'USD' && !isStableCoin(ccyCode)) {
         const formattedCurrencyAmount = formatNumberForDisplay(transaction.currency.amount, { maxDecimals: 2 })
         currencyDisplayAmount = `≈ ${ccyCode} ${formattedCurrencyAmount}`
+    } else if (
+        tokenSymbolUpper &&
+        tokenSymbolUpper !== 'USD' &&
+        !isStableCoin(tokenSymbolUpper) &&
+        transaction.tokenAmount
+    ) {
+        const formattedTokenAmount = formatNumberForDisplay(transaction.tokenAmount, { maxDecimals: 6 })
+        currencyDisplayAmount = `≈ ${formattedTokenAmount} ${tokenSymbolUpper}`
     }
 
     // Spec §4.4: declined card transactions stay in the feed but are visually

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -173,20 +173,24 @@ export const TransactionDetailsReceipt = ({
 
     const convertedAmount = useMemo(() => {
         if (!transaction) return null
+        // Preference order:
+        //   1. Local fiat (e.g. ARS for Manteca on/off-ramps) via currency.code/amount
+        //   2. Destination token (e.g. ETH for cross-token withdraw) via amount + tokenSymbol
+        //      — full decimals here, not truncated, so the receipt is auditable.
+        // USD-pegged stablecoins are skipped (same rule as TransactionCard).
         const code = transaction.currency?.code
         const amount = transaction.currency?.amount
-        // Show the converted amount under the primary for any non-USD fiat
-        // leg (on/offramps, bank claims). The amount already carries the
-        // effective conversion (fees baked in), so the rate isn't rendered
-        // separately. Don't gate on `receipt.exchange_rate` — Bridge sandbox
-        // only populates it on true settlement, hiding the row through
-        // PAYMENT_PROCESSED; currency + amount alone suffice.
-        if (!code || !amount) return null
-        const upper = code.toUpperCase()
-        // USD-pegged stablecoins read like USD to the user — don't render
-        // `≈ USDC 0.10` under `$0.10`. (Same rule as TransactionCard.)
-        if (upper === 'USD' || isStableCoin(upper)) return null
-        return `${upper} ${formatCurrency(amount)}`
+        if (code && amount) {
+            const upper = code.toUpperCase()
+            if (upper !== 'USD' && !isStableCoin(upper)) {
+                return `${upper} ${formatCurrency(amount)}`
+            }
+        }
+        const tokenSymbol = transaction.tokenSymbol?.toUpperCase()
+        if (tokenSymbol && tokenSymbol !== 'USD' && !isStableCoin(tokenSymbol) && transaction.tokenAmount) {
+            return `${transaction.tokenAmount} ${tokenSymbol}`
+        }
+        return null
     }, [transaction])
 
     if (!transaction) return null

--- a/src/components/TransactionDetails/transactionTransformer.ts
+++ b/src/components/TransactionDetails/transactionTransformer.ts
@@ -218,6 +218,10 @@ export interface TransactionDetails {
     fullName: string
     showFullName?: boolean
     amount: number | bigint
+    /** Raw destination-token amount string from the BE (e.g. "0.000416666"
+     *  for a $1 ETH withdraw). Preserves full decimals for receipt rendering;
+     *  feed cards still truncate via formatNumberForDisplay. */
+    tokenAmount?: string
     currency?: {
         amount: string
         code: string
@@ -435,6 +439,7 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
         direction: direction,
         userName: nameForDetails,
         amount,
+        tokenAmount: entry.amount,
         fullName,
         showFullName,
         currency: rewardData ? undefined : entry.currency,

--- a/src/components/Withdraw/views/Initial.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Initial.withdraw.view.tsx
@@ -148,6 +148,18 @@ export default function InitialWithdrawView({ amount, onReview, onBack, isProces
                     Review
                 </Button>
 
+                {/* TEMP DEBUG — remove once we find which gate is blocking Review on ETH select */}
+                <div className="rounded-sm border border-dashed border-error bg-error/10 p-2 font-mono text-xs">
+                    <div>tokenData? {selectedTokenData ? `yes (${selectedTokenData.symbol})` : 'NO ⛔'}</div>
+                    <div>chainID? {selectedChainID || 'NO ⛔'}</div>
+                    <div>recipient.address? {recipient.address ? `yes (${recipient.address.slice(0, 12)}…)` : 'NO ⛔'}</div>
+                    <div>isValidRecipient? {String(isValidRecipient)}{!isValidRecipient && ' ⛔'}</div>
+                    <div>error.showError? {String(error.showError)}{error.showError && ' ⛔'}</div>
+                    <div>error.errorMessage: {error.errorMessage || '(none)'}</div>
+                    <div>inputChanging? {String(inputChanging)}{inputChanging && ' ⛔'}</div>
+                    <div>isProcessing? {String(isProcessing)}{isProcessing && ' ⛔'}</div>
+                </div>
+
                 {error.showError && !!error.errorMessage && <ErrorAlert description={error.errorMessage} />}
             </div>
         </div>

--- a/src/components/Withdraw/views/Initial.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Initial.withdraw.view.tsx
@@ -148,7 +148,6 @@ export default function InitialWithdrawView({ amount, onReview, onBack, isProces
                     Review
                 </Button>
 
-
                 {error.showError && !!error.errorMessage && <ErrorAlert description={error.errorMessage} />}
             </div>
         </div>

--- a/src/components/Withdraw/views/Initial.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Initial.withdraw.view.tsx
@@ -148,17 +148,6 @@ export default function InitialWithdrawView({ amount, onReview, onBack, isProces
                     Review
                 </Button>
 
-                {/* TEMP DEBUG — remove once we find which gate is blocking Review on ETH select */}
-                <div className="rounded-sm border border-dashed border-error bg-error/10 p-2 font-mono text-xs">
-                    <div>tokenData? {selectedTokenData ? `yes (${selectedTokenData.symbol})` : 'NO ⛔'}</div>
-                    <div>chainID? {selectedChainID || 'NO ⛔'}</div>
-                    <div>recipient.address? {recipient.address ? `yes (${recipient.address.slice(0, 12)}…)` : 'NO ⛔'}</div>
-                    <div>isValidRecipient? {String(isValidRecipient)}{!isValidRecipient && ' ⛔'}</div>
-                    <div>error.showError? {String(error.showError)}{error.showError && ' ⛔'}</div>
-                    <div>error.errorMessage: {error.errorMessage || '(none)'}</div>
-                    <div>inputChanging? {String(inputChanging)}{inputChanging && ' ⛔'}</div>
-                    <div>isProcessing? {String(isProcessing)}{isProcessing && ' ⛔'}</div>
-                </div>
 
                 {error.showError && !!error.errorMessage && <ErrorAlert description={error.errorMessage} />}
             </div>

--- a/src/features/payments/shared/hooks/useCrossChainTransfer.ts
+++ b/src/features/payments/shared/hooks/useCrossChainTransfer.ts
@@ -391,7 +391,25 @@ async function runBridgePath({
         throw new Error('Rhino did not return a bridge contract address — cannot construct tx')
     }
 
+    // Rhino's bridge contract pulls USDC via transferFrom — the kernel SA
+    // must approve it first. Prepend USDC.approve(bridgeContract, amount)
+    // to the batch so it's atomic with the bridge call (same userOp).
+    // USDC source amount in base units — quote.amountIn is the decimal pay
+    // amount; our source token is always USDC (6 decimals).
+    const STABLECOIN_DECIMALS = 6
+    const approveAmount = parseUnits(quote.amountIn, STABLECOIN_DECIMALS)
+    const approveData = encodeFunctionData({
+        abi: erc20Abi,
+        functionName: 'approve',
+        args: [commit.calldata.to as Address, approveAmount],
+    })
+
     setTransactions([
+        {
+            to: source.tokenAddress,
+            data: approveData,
+            value: undefined,
+        },
         {
             to: commit.calldata.to as Address,
             data: commit.calldata.data as Hex,

--- a/src/features/payments/shared/hooks/useCrossChainTransfer.ts
+++ b/src/features/payments/shared/hooks/useCrossChainTransfer.ts
@@ -374,6 +374,16 @@ async function runBridgePath({
     // Source is always USDC from the Peanut wallet — symbol-only is enough
     // for Rhino (it resolves the address from its bridge config). For cross-
     // token withdraw, tokenIn=USDC, tokenOut=destination token.
+    //
+    // Mode selection:
+    //   - Same-chain swap → 'receive' (Rhino accepts it; user-friendly UX
+    //     "merchant gets X")
+    //   - Cross-chain swap → 'pay' (Rhino rejects 'receive' for cross-chain
+    //     swap routes with `InvalidRequest: Receive mode is not supported
+    //     for the selected tokens`). With 'pay', the input amount is the
+    //     source USDC the user spends; Rhino computes the destination output.
+    const isCrossChain = sourceRhinoChain !== destRhinoChain
+    const mode: 'pay' | 'receive' = isCrossChain ? 'pay' : 'receive'
     const quote: BridgeQuoteResponse = await getBridgeQuote({
         amount: destination.tokenAmount,
         tokenIn: 'USDC',
@@ -381,9 +391,8 @@ async function runBridgePath({
         chainOut: destRhinoChain,
         recipient: destination.recipientAddress,
         depositor: source.address,
-        mode: 'receive', // UI always asks "merchant gets X" — user pays X + fee
+        mode,
     })
-    void sourceRhinoChain // chainIn is fixed to ARBITRUM on backend
 
     const commit: BridgeCommitResponse = await commitBridgeQuote(quote.quoteId, quote.isSwap)
 

--- a/src/features/payments/shared/hooks/useCrossChainTransfer.ts
+++ b/src/features/payments/shared/hooks/useCrossChainTransfer.ts
@@ -91,8 +91,12 @@ interface CalculateInput {
 }
 
 function inferTokenSymbol(chainId: string, tokenAddress: Address): RhinoSupportedToken | undefined {
-    const symbol = getTokenSymbol(tokenAddress, chainId)?.toUpperCase()
-    return symbol === 'USDC' || symbol === 'USDT' ? symbol : undefined
+    // Whatever the curated FE list calls the token (USDC, USDT, ETH, WETH, …);
+    // backend forwards it to Rhino, which validates against its own per-route
+    // supported-tokens map. Native ETH on EVM uses the SAME 'ETH' symbol —
+    // address differs by chain (proxy 0xeee… or zero), but Rhino keys on the
+    // symbol.
+    return getTokenSymbol(tokenAddress, chainId)?.toUpperCase()
 }
 
 export function useCrossChainTransfer(): UseCrossChainTransferReturn {

--- a/src/features/payments/shared/hooks/useCrossChainTransfer.ts
+++ b/src/features/payments/shared/hooks/useCrossChainTransfer.ts
@@ -51,6 +51,23 @@ import { areEvmAddressesEqual, getTokenSymbol } from '@/utils/general.utils'
  *  through the bridge quote/commit flow which supports the wider token set. */
 const SDA_SUPPORTED_TOKENS = new Set(['USDC', 'USDT'])
 
+/** Minimal fragment of Rhino's DVFDepositContract used for cross-chain
+ *  bridge / cross-chain swap deposits. Source: rhino.fi SDK
+ *  (adapters/evm/abis/DVFDepositContract). */
+const DVF_DEPOSIT_WITH_ID_ABI = [
+    {
+        type: 'function',
+        name: 'depositWithId',
+        stateMutability: 'nonpayable',
+        inputs: [
+            { name: 'tokenAddress', type: 'address' },
+            { name: 'amount', type: 'uint256' },
+            { name: 'commitmentId', type: 'uint256' },
+        ],
+        outputs: [],
+    },
+] as const
+
 export interface CrossChainSourceInfo {
     address: Address
     tokenAddress: Address
@@ -382,8 +399,8 @@ async function runBridgePath({
     //     swap routes with `InvalidRequest: Receive mode is not supported
     //     for the selected tokens`). With 'pay', the input amount is the
     //     source USDC the user spends; Rhino computes the destination output.
-    const isCrossChain = sourceRhinoChain !== destRhinoChain
-    const mode: 'pay' | 'receive' = isCrossChain ? 'pay' : 'receive'
+    const isSameChainSwap = sourceRhinoChain === destRhinoChain
+    const mode: 'pay' | 'receive' = isSameChainSwap ? 'receive' : 'pay'
     const quote: BridgeQuoteResponse = await getBridgeQuote({
         amount: destination.tokenAmount,
         tokenIn: 'USDC',
@@ -394,24 +411,46 @@ async function runBridgePath({
         mode,
     })
 
-    const commit: BridgeCommitResponse = await commitBridgeQuote(quote.quoteId, quote.isSwap)
+    const commit: BridgeCommitResponse = await commitBridgeQuote(quote.quoteId, quote.isSwap, isSameChainSwap)
 
     if (!commit.contractAddress) {
         throw new Error('Rhino did not return a bridge contract address — cannot construct tx')
     }
 
-    // Rhino's bridge contract pulls USDC via transferFrom — the kernel SA
-    // must approve it first. Prepend USDC.approve(bridgeContract, amount)
-    // to the batch so it's atomic with the bridge call (same userOp).
-    // USDC source amount in base units — quote.amountIn is the decimal pay
-    // amount; our source token is always USDC (6 decimals).
     const STABLECOIN_DECIMALS = 6
     const approveAmount = parseUnits(quote.amountIn, STABLECOIN_DECIMALS)
+    // Approve USDC for Rhino's bridge contract — required for both same-chain
+    // swap (the swap contract does transferFrom) and cross-chain depositWithId.
     const approveData = encodeFunctionData({
         abi: erc20Abi,
         functionName: 'approve',
-        args: [commit.calldata.to as Address, approveAmount],
+        args: [commit.contractAddress as Address, approveAmount],
     })
+
+    let bridgeCall: PreparedTransaction
+    if (commit.kind === 'swap-calldata') {
+        // Same-chain atomic swap: user signs Rhino's swap-contract calldata.
+        bridgeCall = {
+            to: commit.calldata.to as Address,
+            data: commit.calldata.data as Hex,
+            value: commit.calldata.value ? BigInt(commit.calldata.value) : undefined,
+        }
+    } else {
+        // Cross-chain: encode depositWithId(tokenAddress, amount, commitmentId)
+        // ourselves. Rhino's API doesn't return calldata for this path — the
+        // SDK constructs it client-side via DVFDepositContract__factory.
+        // commitmentId is hex-encoded BigInt of the quoteId.
+        const depositData = encodeFunctionData({
+            abi: DVF_DEPOSIT_WITH_ID_ABI,
+            functionName: 'depositWithId',
+            args: [source.tokenAddress, approveAmount, BigInt(`0x${commit.commitmentId}`)],
+        })
+        bridgeCall = {
+            to: commit.contractAddress as Address,
+            data: depositData,
+            value: undefined,
+        }
+    }
 
     setTransactions([
         {
@@ -419,11 +458,7 @@ async function runBridgePath({
             data: approveData,
             value: undefined,
         },
-        {
-            to: commit.calldata.to as Address,
-            data: commit.calldata.data as Hex,
-            value: commit.calldata.value ? BigInt(commit.calldata.value) : undefined,
-        },
+        bridgeCall,
     ])
     setReceiveAmount(quote.amountOut)
     setFeeUsd(quote.feeUsd + quote.gasFeeUsd)

--- a/src/features/payments/shared/hooks/useCrossChainTransfer.ts
+++ b/src/features/payments/shared/hooks/useCrossChainTransfer.ts
@@ -35,8 +35,21 @@ import {
     type SdaPreviewResult,
     type SdaTransferResult,
 } from '@/services/rhino-sda'
+import {
+    getBridgeQuote,
+    commitBridgeQuote,
+    getBridgeStatus,
+    isQuoteNearExpiry,
+    type BridgeQuoteResponse,
+    type BridgeCommitResponse,
+    type BridgeStatusResponse,
+} from '@/services/rhino-bridge'
 import { evmChainIdToRhinoName } from '@/constants/rhino.consts'
 import { areEvmAddressesEqual, getTokenSymbol } from '@/utils/general.utils'
+
+/** Tokens Rhino's SDA primitive accepts as `tokenOut`. Anything else routes
+ *  through the bridge quote/commit flow which supports the wider token set. */
+const SDA_SUPPORTED_TOKENS = new Set(['USDC', 'USDT'])
 
 export interface CrossChainSourceInfo {
     address: Address
@@ -61,6 +74,12 @@ export interface PreparedTransaction {
     value?: bigint
 }
 
+/** Indicates which Rhino primitive backed the calculate result.
+ *  - `sda`         → user does ERC20.transfer(sdaAddress, amount); webhook settles
+ *  - `bridge`      → user signs calldata against Rhino's bridge contract directly
+ *  - `same-chain`  → no Rhino; Peanut SDK request-link fulfillment */
+export type CrossChainPath = 'sda' | 'bridge' | 'same-chain'
+
 export interface UseCrossChainTransferReturn {
     transactions: PreparedTransaction[] | null
     sdaAddress: Address | null
@@ -74,6 +93,15 @@ export interface UseCrossChainTransferReturn {
     isCalculating: boolean
     isFeeEstimationError: boolean
     error: string | null
+    /** Which path produced the current `transactions` (null before calculate). */
+    path: CrossChainPath | null
+    /** Bridge-only: ISO expiry on Rhino quote. SDA / same-chain don't expire. */
+    quoteExpiresAt: string | null
+    /** Bridge-only: commitment id (for status polling after the user signs). */
+    commitmentId: string | null
+    isQuoteExpired: boolean
+    /** Poll `/rhino/bridge/status/:id` until COMPLETED/FAILED/EXPIRED. Bridge only. */
+    pollBridgeStatus: (commitmentId: string, opts?: { timeoutMs?: number }) => Promise<BridgeStatusResponse>
     calculate: (params: CalculateInput) => Promise<void>
     reset: () => void
 }
@@ -112,6 +140,9 @@ export function useCrossChainTransfer(): UseCrossChainTransferReturn {
     const [isCalculating, setIsCalculating] = useState(false)
     const [isFeeEstimationError, setIsFeeEstimationError] = useState(false)
     const [error, setError] = useState<string | null>(null)
+    const [path, setPath] = useState<CrossChainPath | null>(null)
+    const [quoteExpiresAt, setQuoteExpiresAt] = useState<string | null>(null)
+    const [commitmentId, setCommitmentId] = useState<string | null>(null)
 
     const reset = useCallback(() => {
         setTransactions(null)
@@ -126,7 +157,33 @@ export function useCrossChainTransfer(): UseCrossChainTransferReturn {
         setIsCalculating(false)
         setIsFeeEstimationError(false)
         setError(null)
+        setPath(null)
+        setQuoteExpiresAt(null)
+        setCommitmentId(null)
     }, [])
+
+    const isQuoteExpired = quoteExpiresAt ? isQuoteNearExpiry(quoteExpiresAt, 0) : false
+
+    /** Poll `/rhino/bridge/status/:id` at 3s intervals until terminal or timeout. */
+    const pollBridgeStatus = useCallback(
+        async (id: string, opts: { timeoutMs?: number } = {}): Promise<BridgeStatusResponse> => {
+            const timeoutMs = opts.timeoutMs ?? 5 * 60 * 1000 // 5 min — covers normal Rhino bridge ETA
+            const intervalMs = 3000
+            const deadline = Date.now() + timeoutMs
+            // Treat anything with the substring as terminal — Rhino's status enum
+            // capitalisation has shifted between versions; substring keeps us
+            // resilient to that.
+            const isTerminal = (s: string) => /COMPLETED|FAILED|EXPIRED/i.test(s)
+
+            while (Date.now() < deadline) {
+                const status = await getBridgeStatus(id)
+                if (isTerminal(status.status)) return status
+                await new Promise((r) => setTimeout(r, intervalMs))
+            }
+            throw new Error(`Bridge status poll timed out after ${timeoutMs}ms (id=${id})`)
+        },
+        []
+    )
 
     const calculate = useCallback(
         async ({
@@ -145,6 +202,9 @@ export function useCrossChainTransfer(): UseCrossChainTransferReturn {
             setReceiveAmount(null)
             setFeeUsd(undefined)
             setEstimatedGasCostUsd(undefined)
+            setPath(null)
+            setQuoteExpiresAt(null)
+            setCommitmentId(null)
 
             try {
                 const _isXChain = source.chainId !== destination.chainId
@@ -163,10 +223,10 @@ export function useCrossChainTransfer(): UseCrossChainTransferReturn {
                         setReceiveAmount,
                         skipGasEstimate,
                     })
+                    setPath('same-chain')
                     return
                 }
 
-                // Cross-chain via Rhino SDA
                 const sourceRhinoChain = evmChainIdToRhinoName(source.chainId)
                 const destRhinoChain = evmChainIdToRhinoName(destination.chainId)
                 if (!sourceRhinoChain || !destRhinoChain) {
@@ -181,6 +241,31 @@ export function useCrossChainTransfer(): UseCrossChainTransferReturn {
                     throw new Error(
                         `Cannot infer Rhino token symbol from ${destination.tokenAddress} on chain ${destination.chainId}`
                     )
+                }
+
+                // Path selection: Rhino SDA's `tokenOut` is whitelisted to USDC/USDT
+                // (DepositAddressTokenOutNotSupported for ETH/WETH/etc); anything
+                // else routes through the bridge quote/commit flow which supports
+                // the wider token set.
+                const useBridgePath = !SDA_SUPPORTED_TOKENS.has(tokenSymbol)
+
+                if (useBridgePath) {
+                    await runBridgePath({
+                        source,
+                        destination,
+                        sourceRhinoChain,
+                        destRhinoChain,
+                        tokenSymbol,
+                        setTransactions,
+                        setReceiveAmount,
+                        setFeeUsd,
+                        setEstimatedGasCostUsd,
+                        setIsFeeEstimationError,
+                        setQuoteExpiresAt,
+                        setCommitmentId,
+                    })
+                    setPath('bridge')
+                    return
                 }
 
                 // Run preview + provision in parallel — they don't depend on each other.
@@ -216,6 +301,7 @@ export function useCrossChainTransfer(): UseCrossChainTransferReturn {
                     setEstimatedGasCostUsd,
                     setIsFeeEstimationError,
                 })
+                setPath('sda')
             } catch (err) {
                 const message = err instanceof Error ? err.message : 'failed to calculate cross-chain transfer'
                 setError(message)
@@ -241,9 +327,80 @@ export function useCrossChainTransfer(): UseCrossChainTransferReturn {
         isCalculating,
         isFeeEstimationError,
         error,
+        path,
+        quoteExpiresAt,
+        commitmentId,
+        isQuoteExpired,
+        pollBridgeStatus,
         calculate,
         reset,
     }
+}
+
+interface BridgePathParams {
+    source: CrossChainSourceInfo
+    destination: CrossChainDestinationInfo
+    sourceRhinoChain: string
+    destRhinoChain: string
+    tokenSymbol: string
+    setTransactions: (tx: PreparedTransaction[] | null) => void
+    setReceiveAmount: (v: string | null) => void
+    setFeeUsd: (v: number | undefined) => void
+    setEstimatedGasCostUsd: (v: number | undefined) => void
+    setIsFeeEstimationError: (v: boolean) => void
+    setQuoteExpiresAt: (v: string | null) => void
+    setCommitmentId: (v: string | null) => void
+}
+
+/**
+ * Bridge path: quote → commit → calldata. Used for non-stablecoin tokenOut
+ * (ETH, WETH, etc.) where Rhino's SDA primitive rejects with
+ * `DepositAddressTokenOutNotSupported`.
+ */
+async function runBridgePath({
+    source,
+    destination,
+    sourceRhinoChain,
+    destRhinoChain,
+    tokenSymbol,
+    setTransactions,
+    setReceiveAmount,
+    setFeeUsd,
+    setEstimatedGasCostUsd,
+    setIsFeeEstimationError,
+    setQuoteExpiresAt,
+    setCommitmentId,
+}: BridgePathParams): Promise<void> {
+    void source
+    const quote: BridgeQuoteResponse = await getBridgeQuote({
+        amount: destination.tokenAmount,
+        token: tokenSymbol,
+        chainOut: destRhinoChain,
+        recipient: destination.recipientAddress,
+        depositor: source.address,
+        mode: 'receive', // UI always asks "merchant gets X" — user pays X + fee
+    })
+    void sourceRhinoChain // chainIn is fixed to ARBITRUM on backend
+
+    const commit: BridgeCommitResponse = await commitBridgeQuote(quote.quoteId)
+
+    if (!commit.contractAddress) {
+        throw new Error('Rhino did not return a bridge contract address — cannot construct tx')
+    }
+
+    setTransactions([
+        {
+            to: commit.calldata.to as Address,
+            data: commit.calldata.data as Hex,
+            value: commit.calldata.value ? BigInt(commit.calldata.value) : undefined,
+        },
+    ])
+    setReceiveAmount(quote.amountOut)
+    setFeeUsd(quote.feeUsd + quote.gasFeeUsd)
+    setEstimatedGasCostUsd(0) // gas paid by paymaster — same as SDA path
+    setIsFeeEstimationError(false)
+    setQuoteExpiresAt(quote.expiresAt)
+    setCommitmentId(commit.commitmentId)
 }
 
 interface SameChainParams {

--- a/src/features/payments/shared/hooks/useCrossChainTransfer.ts
+++ b/src/features/payments/shared/hooks/useCrossChainTransfer.ts
@@ -371,10 +371,13 @@ async function runBridgePath({
     setQuoteExpiresAt,
     setCommitmentId,
 }: BridgePathParams): Promise<void> {
-    void source
+    // Source is always USDC from the Peanut wallet — symbol-only is enough
+    // for Rhino (it resolves the address from its bridge config). For cross-
+    // token withdraw, tokenIn=USDC, tokenOut=destination token.
     const quote: BridgeQuoteResponse = await getBridgeQuote({
         amount: destination.tokenAmount,
-        token: tokenSymbol,
+        tokenIn: 'USDC',
+        tokenOut: tokenSymbol,
         chainOut: destRhinoChain,
         recipient: destination.recipientAddress,
         depositor: source.address,
@@ -382,7 +385,7 @@ async function runBridgePath({
     })
     void sourceRhinoChain // chainIn is fixed to ARBITRUM on backend
 
-    const commit: BridgeCommitResponse = await commitBridgeQuote(quote.quoteId)
+    const commit: BridgeCommitResponse = await commitBridgeQuote(quote.quoteId, quote.isSwap)
 
     if (!commit.contractAddress) {
         throw new Error('Rhino did not return a bridge contract address — cannot construct tx')

--- a/src/hooks/useTokenPrice.ts
+++ b/src/hooks/useTokenPrice.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { fetchTokenPrice } from '@/app/actions/tokens'
+import { fetchTokenPrice } from '@/services/tokens-price'
 import {
     PEANUT_WALLET_CHAIN,
     PEANUT_WALLET_TOKEN,

--- a/src/services/rhino-bridge.ts
+++ b/src/services/rhino-bridge.ts
@@ -17,7 +17,10 @@ import { getAuthHeaders } from '@/utils/auth-token'
 
 export interface BridgeQuoteParams {
     amount: string
-    token: string
+    /** Source token (what the user pays). Always USDC from the Peanut wallet. */
+    tokenIn: string
+    /** Destination token (what the recipient gets). Cross-token if != tokenIn. */
+    tokenOut: string
     chainOut: string
     recipient: string
     depositor: string
@@ -33,6 +36,9 @@ export interface BridgeQuoteResponse {
     gasFeeUsd: number
     estimatedDuration?: number
     expiresAt: string // ISO timestamp
+    /** Backend echoes this so the FE passes it back through commit — discriminates
+     *  the Rhino finalisation path (getSwapCalldata vs deposit-address). */
+    isSwap: boolean
 }
 
 export interface BridgeCommitResponse {
@@ -91,8 +97,8 @@ export function getBridgeQuote(params: BridgeQuoteParams): Promise<BridgeQuoteRe
     return postJson('/rhino/bridge/quote', params, 'Failed to get bridge quote')
 }
 
-export function commitBridgeQuote(quoteId: string): Promise<BridgeCommitResponse> {
-    return postJson('/rhino/bridge/commit', { quoteId }, 'Failed to commit bridge quote')
+export function commitBridgeQuote(quoteId: string, isSwap: boolean): Promise<BridgeCommitResponse> {
+    return postJson('/rhino/bridge/commit', { quoteId, isSwap }, 'Failed to commit bridge quote')
 }
 
 export function getBridgeStatus(bridgeId: string): Promise<BridgeStatusResponse> {

--- a/src/services/rhino-bridge.ts
+++ b/src/services/rhino-bridge.ts
@@ -49,6 +49,7 @@ export interface BridgeCommitResponse {
         value: string
     }
     contractAddress: string | null
+    kind: 'swap-calldata' | 'deposit-with-id'
 }
 
 export type BridgeStatus = 'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED' | 'EXPIRED' | string
@@ -97,8 +98,16 @@ export function getBridgeQuote(params: BridgeQuoteParams): Promise<BridgeQuoteRe
     return postJson('/rhino/bridge/quote', params, 'Failed to get bridge quote')
 }
 
-export function commitBridgeQuote(quoteId: string, isSwap: boolean): Promise<BridgeCommitResponse> {
-    return postJson('/rhino/bridge/commit', { quoteId, isSwap }, 'Failed to commit bridge quote')
+export function commitBridgeQuote(
+    quoteId: string,
+    isSwap: boolean,
+    isSameChainSwap: boolean
+): Promise<BridgeCommitResponse> {
+    return postJson(
+        '/rhino/bridge/commit',
+        { quoteId, isSwap, isSameChainSwap },
+        'Failed to commit bridge quote'
+    )
 }
 
 export function getBridgeStatus(bridgeId: string): Promise<BridgeStatusResponse> {

--- a/src/services/rhino-bridge.ts
+++ b/src/services/rhino-bridge.ts
@@ -103,11 +103,7 @@ export function commitBridgeQuote(
     isSwap: boolean,
     isSameChainSwap: boolean
 ): Promise<BridgeCommitResponse> {
-    return postJson(
-        '/rhino/bridge/commit',
-        { quoteId, isSwap, isSameChainSwap },
-        'Failed to commit bridge quote'
-    )
+    return postJson('/rhino/bridge/commit', { quoteId, isSwap, isSameChainSwap }, 'Failed to commit bridge quote')
 }
 
 export function getBridgeStatus(bridgeId: string): Promise<BridgeStatusResponse> {

--- a/src/services/rhino-bridge.ts
+++ b/src/services/rhino-bridge.ts
@@ -1,0 +1,113 @@
+'use client'
+
+/**
+ * Rhino Bridge service — non-stablecoin cross-chain outflow.
+ *
+ * SDA's `tokenOut` is whitelisted to USDC/USDT; cross-token withdraw
+ * (USDC → ETH, etc.) routes through Rhino's standard bridge contract.
+ * Direct calls to PEANUT_API_URL — no Next.js proxy in the path so this
+ * works identically on web and Capacitor.
+ *
+ * Pairs with peanut-api-ts /rhino/bridge/* routes.
+ */
+
+import { PEANUT_API_URL } from '@/constants/general.consts'
+import { fetchWithSentry } from '@/utils/sentry.utils'
+import { getAuthHeaders } from '@/utils/auth-token'
+
+export interface BridgeQuoteParams {
+    amount: string
+    token: string
+    chainOut: string
+    recipient: string
+    depositor: string
+    mode: 'pay' | 'receive'
+}
+
+export interface BridgeQuoteResponse {
+    quoteId: string
+    amountIn: string
+    amountOut: string
+    fee: string
+    feeUsd: number
+    gasFeeUsd: number
+    estimatedDuration?: number
+    expiresAt: string // ISO timestamp
+}
+
+export interface BridgeCommitResponse {
+    commitmentId: string
+    calldata: {
+        to: string
+        data: string
+        value: string
+    }
+    contractAddress: string | null
+}
+
+export type BridgeStatus = 'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED' | 'EXPIRED' | string
+
+export interface BridgeStatusResponse {
+    bridgeId: string
+    status: BridgeStatus
+    txHash?: string
+    updatedAt?: string
+    [key: string]: unknown
+}
+
+export interface BridgeChainConfig {
+    chain: string
+    tokens: string[]
+    enabled: boolean
+    contractAddress?: string
+}
+
+async function postJson<TReq, TRes>(path: string, body: TReq, errorLabel: string): Promise<TRes> {
+    const response = await fetchWithSentry(`${PEANUT_API_URL}${path}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+        body: JSON.stringify(body),
+    })
+    if (!response.ok) {
+        const text = await response.text().catch(() => '')
+        throw new Error(`${errorLabel}: ${response.status} ${text}`)
+    }
+    return (await response.json()) as TRes
+}
+
+async function getJson<TRes>(path: string, errorLabel: string): Promise<TRes> {
+    const response = await fetchWithSentry(`${PEANUT_API_URL}${path}`, {
+        method: 'GET',
+        headers: getAuthHeaders(),
+    })
+    if (!response.ok) {
+        const text = await response.text().catch(() => '')
+        throw new Error(`${errorLabel}: ${response.status} ${text}`)
+    }
+    return (await response.json()) as TRes
+}
+
+export function getBridgeQuote(params: BridgeQuoteParams): Promise<BridgeQuoteResponse> {
+    return postJson('/rhino/bridge/quote', params, 'Failed to get bridge quote')
+}
+
+export function commitBridgeQuote(quoteId: string): Promise<BridgeCommitResponse> {
+    return postJson('/rhino/bridge/commit', { quoteId }, 'Failed to commit bridge quote')
+}
+
+export function getBridgeStatus(bridgeId: string): Promise<BridgeStatusResponse> {
+    return getJson(`/rhino/bridge/status/${encodeURIComponent(bridgeId)}`, 'Failed to get bridge status')
+}
+
+export function getBridgeChains(): Promise<{ chains: BridgeChainConfig[] }> {
+    return getJson('/rhino/bridge/chains', 'Failed to get bridge chains')
+}
+
+/**
+ * Returns true when the quote is within the near-expiry window (default 15s).
+ * Hooks should re-quote before commit to avoid Rhino rejecting an expired ID.
+ */
+export function isQuoteNearExpiry(expiresAt: string, leadTimeMs = 15_000): boolean {
+    const expires = new Date(expiresAt).getTime()
+    return Number.isFinite(expires) && Date.now() + leadTimeMs >= expires
+}

--- a/src/services/rhino-sda.ts
+++ b/src/services/rhino-sda.ts
@@ -11,7 +11,12 @@ import { apiFetch } from '@/utils/api-fetch'
 import type { Address } from 'viem'
 
 export type RhinoTransferContext = 'withdraw' | 'pay-request' | 'claim-xchain'
-export type RhinoSupportedToken = 'USDC' | 'USDT'
+/**
+ * Token symbol passed to the Rhino backend. Plain string — Rhino validates
+ * against the (chainIn, chainOut) pair. The legacy `'USDC' | 'USDT'`
+ * restriction was an artificial FE limit that blocked cross-token withdraw.
+ */
+export type RhinoSupportedToken = string
 
 export interface SdaTransferRequest {
     context: RhinoTransferContext

--- a/src/services/rhino-sda.ts
+++ b/src/services/rhino-sda.ts
@@ -3,11 +3,16 @@
 /**
  * Client-side wrappers around the unified Rhino SDA-transfer backend.
  *
- * Three consumers: withdraw, pay-request-x-chain, claim-link-x-chain —
- * all route through these two calls.
+ * Direct calls to PEANUT_API_URL — no Next.js proxy in the path so this
+ * works identically on web (CORS-allowed origin) and native (no Next.js
+ * server exists). JWT forwarded for the backend's verifyAuth preHandler.
+ *
+ * Three consumers: withdraw, pay-request-x-chain, claim-link-x-chain.
  */
 
-import { apiFetch } from '@/utils/api-fetch'
+import { PEANUT_API_URL } from '@/constants/general.consts'
+import { fetchWithSentry } from '@/utils/sentry.utils'
+import { getAuthHeaders } from '@/utils/auth-token'
 import type { Address } from 'viem'
 
 export type RhinoTransferContext = 'withdraw' | 'pay-request' | 'claim-xchain'
@@ -57,8 +62,12 @@ export interface SdaPreviewResult {
 }
 
 async function postRhino<TReq, TRes>(path: string, body: TReq, errorLabel: string): Promise<TRes> {
-    const response = await apiFetch(path, `/api/peanut${path}`, {
+    const response = await fetchWithSentry(`${PEANUT_API_URL}${path}`, {
         method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            ...getAuthHeaders(),
+        },
         body: JSON.stringify(body),
     })
     if (!response.ok) {

--- a/src/services/tokens-price.ts
+++ b/src/services/tokens-price.ts
@@ -1,19 +1,20 @@
 'use client'
 
 /**
- * Token price + wallet portfolio — backend-proxied Mobula calls.
+ * Token price + wallet portfolio — direct backend calls.
  *
- * The Mobula API key can't be exposed to the client and Capacitor builds
- * can't use Next.js server actions, so these calls live on peanut-api-ts
- * (`GET /tokens/price`, `GET /tokens/wallet-portfolio`) and we hit them
- * via serverFetch (auto-routes web → /api/proxy/get/*, native → direct).
+ * Bypasses the Next.js /api/proxy machinery entirely so this works
+ * identically on web and Capacitor (which has no Next.js server).
+ * The endpoints are public on peanut-api-ts (no api-key, no JWT) — CORS +
+ * the per-IP rate limiter on /tokens/* are the gate.
  */
 
-import { serverFetch } from '@/utils/api-fetch'
+import { PEANUT_API_URL } from '@/constants/general.consts'
+import { fetchWithSentry } from '@/utils/sentry.utils'
 import { type ITokenPriceData, type IUserBalance } from '@/interfaces'
 
 async function getJson<T>(path: string, errorLabel: string): Promise<T | null> {
-    const response = await serverFetch(path, { method: 'GET' })
+    const response = await fetchWithSentry(`${PEANUT_API_URL}${path}`, { method: 'GET' })
     if (response.status === 404) return null
     if (!response.ok) {
         const text = await response.text().catch(() => '')

--- a/src/services/tokens-price.ts
+++ b/src/services/tokens-price.ts
@@ -1,0 +1,40 @@
+'use client'
+
+/**
+ * Token price + wallet portfolio — backend-proxied Mobula calls.
+ *
+ * The Mobula API key can't be exposed to the client and Capacitor builds
+ * can't use Next.js server actions, so these calls live on peanut-api-ts
+ * (`GET /tokens/price`, `GET /tokens/wallet-portfolio`) and we hit them
+ * via apiFetch (web → proxy, native → direct).
+ */
+
+import { apiFetch } from '@/utils/api-fetch'
+import { type ITokenPriceData, type IUserBalance } from '@/interfaces'
+
+async function getJson<T>(path: string, errorLabel: string): Promise<T | null> {
+    const response = await apiFetch(path, `/api/peanut${path}`, { method: 'GET' })
+    if (response.status === 404) return null
+    if (!response.ok) {
+        const text = await response.text().catch(() => '')
+        throw new Error(`${errorLabel}: ${response.status} ${text}`)
+    }
+    return (await response.json()) as T
+}
+
+export async function fetchTokenPrice(tokenAddress: string, chainId: string): Promise<ITokenPriceData | undefined> {
+    const qs = `address=${encodeURIComponent(tokenAddress)}&chainId=${encodeURIComponent(chainId)}`
+    const result = await getJson<ITokenPriceData>(`/tokens/price?${qs}`, 'Failed to fetch token price')
+    return result ?? undefined
+}
+
+export async function fetchWalletBalances(
+    address: string
+): Promise<{ balances: IUserBalance[]; totalBalance: number }> {
+    const qs = `address=${encodeURIComponent(address)}`
+    const result = await getJson<{ balances: IUserBalance[]; totalBalance: number }>(
+        `/tokens/wallet-portfolio?${qs}`,
+        'Failed to fetch wallet balances'
+    )
+    return result ?? { balances: [], totalBalance: 0 }
+}

--- a/src/services/tokens-price.ts
+++ b/src/services/tokens-price.ts
@@ -6,14 +6,14 @@
  * The Mobula API key can't be exposed to the client and Capacitor builds
  * can't use Next.js server actions, so these calls live on peanut-api-ts
  * (`GET /tokens/price`, `GET /tokens/wallet-portfolio`) and we hit them
- * via apiFetch (web → proxy, native → direct).
+ * via serverFetch (auto-routes web → /api/proxy/get/*, native → direct).
  */
 
-import { apiFetch } from '@/utils/api-fetch'
+import { serverFetch } from '@/utils/api-fetch'
 import { type ITokenPriceData, type IUserBalance } from '@/interfaces'
 
 async function getJson<T>(path: string, errorLabel: string): Promise<T | null> {
-    const response = await apiFetch(path, `/api/peanut${path}`, { method: 'GET' })
+    const response = await serverFetch(path, { method: 'GET' })
     if (response.status === 404) return null
     if (!response.ok) {
         const text = await response.text().catch(() => '')


### PR DESCRIPTION
## Summary

The Mobula calls in \`src/app/actions/tokens.ts\` ran **in the browser**, not on the server:
- No \`'use server'\` directive
- \`unstable_cache\` import is from \`@/utils/no-cache\` (a client-side shim, not \`next/cache\`)
- Imported by client hooks (\`useTokenPrice\`, \`Claim.tsx\`, \`estimateTransactionCostUsd\` → \`useCrossChainTransfer\`)

In the browser, \`process.env.MOBULA_API_URL\` and \`MOBULA_API_KEY\` are \`undefined\` (Next.js only exposes vars to client bundles when prefixed with \`NEXT_PUBLIC_\`). So:

\`\`\`ts
const MOBULA_API_URL = process.env.MOBULA_API_URL!  // undefined in browser
fetch(\`\${MOBULA_API_URL}/api/1/market/data?...\`)    // fetch(\"undefined/api/1/market/data?...\")
\`\`\`

The \`undefined/...\` URL is treated as relative to the current page → \`/withdraw/undefined/api/1/market/data\` got caught by the Next.js dev server, returning 200 from a default page handler. Mobula was never reached. Same bug for the wallet-portfolio call (\`fetchWalletBalances\`).

Symptom: selecting ETH on any chain logged \`error fetching token price for token 0xeee... on chain 1\`. Native / Capacitor builds also can't use Next.js server actions, so the only correct home for these calls is on \`peanut-api-ts\`.

## What changed

- New \`src/services/tokens-price.ts\` calls peanut-api-ts via \`apiFetch\` (web → proxy, native → direct):
  - \`fetchTokenPrice(address, chainId)\` → \`GET /tokens/price\`
  - \`fetchWalletBalances(address)\`     → \`GET /tokens/wallet-portfolio\`
- \`useTokenPrice\`, \`Claim.tsx\`, \`recover-funds/page.tsx\` swap to the new service.
- \`estimateTransactionCostUsd\` (kept in \`app/actions/tokens.ts\` per minimum-to-make-withdraw-work scope) imports \`fetchTokenPrice\` from the new service for its native-token-price lookup.
- Deletes broken Mobula bodies + \`IMobula*\` types + \`MOBULA_API_*\` consts from \`app/actions/tokens.ts\`. \`fetchTokenDetails\` (on-chain RPC, no Mobula) stays.

\`src/app/api/health/mobula/route.ts\` is a Next.js Route Handler running server-side, so it can keep direct Mobula access. Untouched.

## Pairs with

[peanut-api-ts #689](https://github.com/peanutprotocol/peanut-api-ts/pull/689) — adds the \`/tokens/price\` and \`/tokens/wallet-portfolio\` endpoints. **Merge that first.**

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`npm test\` — 960 pass, 1 unrelated locale-dependent failure (\`add-money-states.test.tsx:919\` expects \`10,000 USD\` but renders \`10.000 USD\` under es-ES — same flake reported on PR #1927; test file untouched here)
- [ ] Smoke after deploy: select ETH on Arbitrum → price loads (no \`/withdraw/undefined/...\` request)
- [ ] Smoke: cross-chain withdraw (USDC → another chain) — \`estimateTransactionCostUsd\` resolves
- [ ] Smoke: \`recover-funds\` page renders portfolio balances
- [ ] Native build: same paths via \`apiFetch\` (Capacitor → direct \`PEANUT_API_URL\`) — no regression

## Out of scope

- Other server-action-pattern files in \`src/app/actions/\` — broader Capacitor migration audit deferred.
- \`unstable_cache\` shim consumers besides this file — no plan to revisit.