### PR TITLE
fix(ci): add Vercel scope to preview deploy workflow

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -19,10 +19,10 @@ jobs:
             - name: Install Vercel CLI
               run: pnpm add --global vercel@latest
             - name: Link to Project
-              run: vercel link --yes --project=peanut-wallet --token=${{ secrets.VERCEL_TOKEN }}
+              run: vercel link --yes --project=peanut-wallet --scope=squirrellabs --token=${{ secrets.VERCEL_TOKEN }}
             - name: Pull Vercel Environment Information
-              run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+              run: vercel pull --yes --environment=preview --scope=squirrellabs --token=${{ secrets.VERCEL_TOKEN }}
             - name: Build Project Artifacts
               run: vercel build --target=preview --token=${{ secrets.VERCEL_TOKEN }}
             - name: Deploy Project Artifacts to Vercel
-              run: vercel deploy --prebuilt --archive=tgz --target=preview --token=${{ secrets.VERCEL_TOKEN }}
+              run: vercel deploy --prebuilt --archive=tgz --target=preview --scope=squirrellabs --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `--scope=squirrellabs` to `vercel link`, `vercel pull`, and `vercel deploy` commands in the preview deploy workflow

## Why

PR preview deploys have been failing with:

```
Error: Not authorized: Trying to access resource under scope "squirrelcores-projects".
You must re-authenticate to this scope or use a token with access to this scope.
```

The Vercel CLI was defaulting to the wrong team scope (`squirrelcores-projects`) when resolving the `peanut-wallet` project. The `VERCEL_TOKEN` secret only has access to the `squirrellabs` scope, so without an explicit `--scope` flag the CLI picks up the wrong org and fails authorization.

Production deploys via the Vercel dashboard are unaffected — this only impacts the CI-driven preview deploys on PRs.

## Test plan

- [ ] Open/re-run a PR and confirm the "Preview deploy" job passes