### PR TITLE
[TASK-19471] fix(card): unstick users post-Sumsub by polling instead of single re-apply

### DIFF
--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '@/context/authContext'
 import { RAIN_CARD_OVERVIEW_QUERY_KEY, useRainCardOverview } from '@/hooks/useRainCardOverview'
 import underMaintenanceConfig from '@/config/underMaintenance.config'
 import { computeCardState, findActiveCard, type CardTopLevelState } from '@/components/Card/cardState.utils'
+import { pollUntilApplyAdvances } from '@/components/Card/cardApply.utils'
 import CardPioneerFlow from '@/components/Card/CardPioneerFlow'
 import AddCardEntryScreen from '@/components/Card/AddCardEntryScreen'
 import ApplicationStatusScreen from '@/components/Card/ApplicationStatusScreen'
@@ -183,10 +184,38 @@ const CardPage: FC = () => {
         sumsubCompletedRef.current = true
         posthog.capture(ANALYTICS_EVENTS.CARD_SUMSUB_COMPLETED)
         setSumsubToken(null)
-        // Re-submit now that the user finished the applicant action. Backend
-        // will return terms-required next (since termsAccepted is still false).
-        await handleApply(false)
-    }, [handleApply])
+        setApplyError(null)
+        setIsIssuing(true)
+
+        try {
+            const res = await pollUntilApplyAdvances({
+                fetchApply: () => rainApi.applyForCard({ termsAccepted: false }),
+                intervalMs: 1000,
+                timeoutMs: 15000,
+            })
+            if (res.status === 'timeout') {
+                setApplyError('Verification is taking longer than expected. Please try again.')
+                return
+            }
+            posthog.capture(ANALYTICS_EVENTS.CARD_APPLY_SUCCEEDED, { outcome: res.status })
+            if (res.status === 'main-kyc-required' && 'sumsubAccessToken' in res) {
+                setSumsubToken(res.sumsubAccessToken)
+                posthog.capture(ANALYTICS_EVENTS.CARD_SUMSUB_OPENED)
+            } else if (res.status === 'terms-required' && 'isUsResident' in res) {
+                setPendingTerms({ isUsResident: res.isUsResident })
+            } else {
+                setPendingTerms(null)
+                invalidateOverview()
+            }
+        } catch (e) {
+            const message = e instanceof Error ? e.message : 'Failed to apply for card'
+            console.error('[card apply] post-sumsub poll error:', e)
+            setApplyError(message)
+            posthog.capture(ANALYTICS_EVENTS.CARD_APPLY_FAILED, { error_message: message })
+        } finally {
+            setIsIssuing(false)
+        }
+    }, [invalidateOverview])
 
     const handleSumsubClose = useCallback(() => {
         if (!sumsubCompletedRef.current) {

--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -22,7 +22,7 @@ import Loading from '@/components/Global/Loading'
 import { Button } from '@/components/0_Bruddle/Button'
 import PageContainer from '@/components/0_Bruddle/PageContainer'
 import { SumsubKycWrapper } from '@/components/Kyc/SumsubKycWrapper'
-import { rainApi } from '@/services/rain'
+import { rainApi, type ApplyForCardResponse } from '@/services/rain'
 import { useGrantSessionKey } from '@/hooks/wallet/useGrantSessionKey'
 import { useModalsContext } from '@/context/ModalsContext'
 
@@ -88,6 +88,33 @@ const CardPage: FC = () => {
         void queryClient.invalidateQueries({ queryKey: [RAIN_CARD_OVERVIEW_QUERY_KEY] })
     }, [queryClient])
 
+    // Routes a non-incomplete apply response to the right next screen. Shared
+    // by the user-initiated apply path and the post-Sumsub poll, since both
+    // need the same main-kyc-required / terms-required / default fan-out.
+    // The `incomplete` branch is caller-specific (open Sumsub vs keep polling)
+    // and stays inline.
+    const advanceFromApplyResponse = useCallback(
+        (res: ApplyForCardResponse) => {
+            // Main applicant is missing a doc Rain requires (e.g. SELFIE
+            // after liveness was added to the level). Open WebSDK at the
+            // MAIN level — Sumsub asks only for the missing step. Same
+            // wrapper handles both action and main-level tokens.
+            if (res.status === 'main-kyc-required' && 'sumsubAccessToken' in res) {
+                setSumsubToken(res.sumsubAccessToken)
+                posthog.capture(ANALYTICS_EVENTS.CARD_SUMSUB_OPENED)
+                return
+            }
+            if (res.status === 'terms-required' && 'isUsResident' in res) {
+                setPendingTerms({ isUsResident: res.isUsResident })
+                return
+            }
+            // pending / already-applied → state machine routes based on overview.
+            setPendingTerms(null)
+            invalidateOverview()
+        },
+        [invalidateOverview]
+    )
+
     const handleApply = useCallback(
         async (termsAccepted = false, serializedApproval?: string) => {
             setApplyError(null)
@@ -103,22 +130,7 @@ const CardPage: FC = () => {
                     posthog.capture(ANALYTICS_EVENTS.CARD_SUMSUB_OPENED)
                     return
                 }
-                // Main applicant is missing a doc Rain requires (e.g. SELFIE
-                // after liveness was added to the level). Open WebSDK at the
-                // MAIN level — Sumsub asks only for the missing step. Same
-                // wrapper handles both action and main-level tokens.
-                if (res.status === 'main-kyc-required' && 'sumsubAccessToken' in res) {
-                    setSumsubToken(res.sumsubAccessToken)
-                    posthog.capture(ANALYTICS_EVENTS.CARD_SUMSUB_OPENED)
-                    return
-                }
-                if (res.status === 'terms-required' && 'isUsResident' in res) {
-                    setPendingTerms({ isUsResident: res.isUsResident })
-                    return
-                }
-                // pending / already-applied → state machine routes based on overview.
-                setPendingTerms(null)
-                invalidateOverview()
+                advanceFromApplyResponse(res)
             } catch (e) {
                 const message = e instanceof Error ? e.message : 'Failed to apply for card'
                 console.error('[card apply] error:', e)
@@ -126,7 +138,7 @@ const CardPage: FC = () => {
                 posthog.capture(ANALYTICS_EVENTS.CARD_APPLY_FAILED, { error_message: message })
             }
         },
-        [invalidateOverview]
+        [advanceFromApplyResponse]
     )
 
     const handleAcceptTerms = useCallback(async () => {
@@ -193,20 +205,12 @@ const CardPage: FC = () => {
                 intervalMs: 1000,
                 timeoutMs: 15000,
             })
-            if (res.status === 'timeout') {
+            if (!res) {
                 setApplyError('Verification is taking longer than expected. Please try again.')
                 return
             }
             posthog.capture(ANALYTICS_EVENTS.CARD_APPLY_SUCCEEDED, { outcome: res.status })
-            if (res.status === 'main-kyc-required' && 'sumsubAccessToken' in res) {
-                setSumsubToken(res.sumsubAccessToken)
-                posthog.capture(ANALYTICS_EVENTS.CARD_SUMSUB_OPENED)
-            } else if (res.status === 'terms-required' && 'isUsResident' in res) {
-                setPendingTerms({ isUsResident: res.isUsResident })
-            } else {
-                setPendingTerms(null)
-                invalidateOverview()
-            }
+            advanceFromApplyResponse(res)
         } catch (e) {
             const message = e instanceof Error ? e.message : 'Failed to apply for card'
             console.error('[card apply] post-sumsub poll error:', e)
@@ -215,7 +219,7 @@ const CardPage: FC = () => {
         } finally {
             setIsIssuing(false)
         }
-    }, [invalidateOverview])
+    }, [advanceFromApplyResponse])
 
     const handleSumsubClose = useCallback(() => {
         if (!sumsubCompletedRef.current) {

--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -192,6 +192,12 @@ const CardPage: FC = () => {
     // CARD_SUMSUB_CLOSED and inflate the abandonment number.
     const sumsubCompletedRef = useRef(false)
 
+    // Aborts the post-Sumsub poll on unmount so we don't burn 15 sequential
+    // fetches (and setState on an unmounted component) when an impatient user
+    // navigates away from the pending screen mid-poll.
+    const pollAbortRef = useRef<AbortController | null>(null)
+    useEffect(() => () => pollAbortRef.current?.abort(), [])
+
     const handleSumsubComplete = useCallback(async () => {
         sumsubCompletedRef.current = true
         posthog.capture(ANALYTICS_EVENTS.CARD_SUMSUB_COMPLETED)
@@ -199,12 +205,18 @@ const CardPage: FC = () => {
         setApplyError(null)
         setIsIssuing(true)
 
+        pollAbortRef.current?.abort()
+        const controller = new AbortController()
+        pollAbortRef.current = controller
+
         try {
             const res = await pollUntilApplyAdvances({
                 fetchApply: () => rainApi.applyForCard({ termsAccepted: false }),
                 intervalMs: 1000,
                 timeoutMs: 15000,
+                signal: controller.signal,
             })
+            if (controller.signal.aborted) return
             if (!res) {
                 setApplyError('Verification is taking longer than expected. Please try again.')
                 return
@@ -212,12 +224,13 @@ const CardPage: FC = () => {
             posthog.capture(ANALYTICS_EVENTS.CARD_APPLY_SUCCEEDED, { outcome: res.status })
             advanceFromApplyResponse(res)
         } catch (e) {
+            if (controller.signal.aborted) return
             const message = e instanceof Error ? e.message : 'Failed to apply for card'
             console.error('[card apply] post-sumsub poll error:', e)
             setApplyError(message)
             posthog.capture(ANALYTICS_EVENTS.CARD_APPLY_FAILED, { error_message: message })
         } finally {
-            setIsIssuing(false)
+            if (!controller.signal.aborted) setIsIssuing(false)
         }
     }, [advanceFromApplyResponse])
 

--- a/src/components/Card/__tests__/cardApply.utils.test.ts
+++ b/src/components/Card/__tests__/cardApply.utils.test.ts
@@ -69,4 +69,43 @@ describe('pollUntilApplyAdvances', () => {
 
         expect(fetchApply).toHaveBeenCalledTimes(1)
     })
+
+    it('returns null and stops polling once the signal is aborted', async () => {
+        const controller = new AbortController()
+        const fetchApply = jest.fn().mockImplementation(async () => {
+            // abort during the second fetch so we exercise the post-fetch guard
+            if (fetchApply.mock.calls.length === 2) controller.abort()
+            return { status: 'incomplete', sumsubAccessToken: 't' }
+        })
+
+        const result = await pollUntilApplyAdvances({
+            fetchApply,
+            intervalMs: 0,
+            timeoutMs: 10_000,
+            signal: controller.signal,
+            sleep: noSleep,
+        })
+
+        expect(result).toBeNull()
+        // 1: first poll (incomplete) → sleep → check signal (aborted) → return
+        // 2: second poll fired before the post-sleep check sees the abort — no third
+        expect(fetchApply).toHaveBeenCalledTimes(2)
+    })
+
+    it('returns null immediately when signal is already aborted', async () => {
+        const controller = new AbortController()
+        controller.abort()
+        const fetchApply = jest.fn()
+
+        const result = await pollUntilApplyAdvances({
+            fetchApply,
+            intervalMs: 0,
+            timeoutMs: 10_000,
+            signal: controller.signal,
+            sleep: noSleep,
+        })
+
+        expect(result).toBeNull()
+        expect(fetchApply).not.toHaveBeenCalled()
+    })
 })

--- a/src/components/Card/__tests__/cardApply.utils.test.ts
+++ b/src/components/Card/__tests__/cardApply.utils.test.ts
@@ -35,7 +35,7 @@ describe('pollUntilApplyAdvances', () => {
         expect(fetchApply).toHaveBeenCalledTimes(1)
     })
 
-    it('returns timeout once the deadline is exceeded', async () => {
+    it('returns null once the deadline is exceeded', async () => {
         const fetchApply = jest.fn().mockResolvedValue({ status: 'incomplete', sumsubAccessToken: 't' })
         let clock = 0
         const tick = (ms: number) => {
@@ -50,8 +50,8 @@ describe('pollUntilApplyAdvances', () => {
             now: () => clock,
         })
 
-        expect(result).toEqual({ status: 'timeout' })
-        // 3 polls at clock 0, 1000, 2000 — the 4th would be past the deadline
+        expect(result).toBeNull()
+        // 3 polls at clock 0, 1000, 2000 — the deadline check fires after sleep #3
         expect(fetchApply).toHaveBeenCalledTimes(3)
     })
 

--- a/src/components/Card/__tests__/cardApply.utils.test.ts
+++ b/src/components/Card/__tests__/cardApply.utils.test.ts
@@ -1,0 +1,72 @@
+import { pollUntilApplyAdvances } from '@/components/Card/cardApply.utils'
+
+const noSleep = async () => {}
+
+describe('pollUntilApplyAdvances', () => {
+    it('returns the first non-incomplete response', async () => {
+        const fetchApply = jest
+            .fn()
+            .mockResolvedValueOnce({ status: 'incomplete', sumsubAccessToken: 't1' })
+            .mockResolvedValueOnce({ status: 'incomplete', sumsubAccessToken: 't2' })
+            .mockResolvedValueOnce({ status: 'terms-required', isUsResident: false })
+
+        const result = await pollUntilApplyAdvances({
+            fetchApply,
+            intervalMs: 0,
+            timeoutMs: 10_000,
+            sleep: noSleep,
+        })
+
+        expect(result).toEqual({ status: 'terms-required', isUsResident: false })
+        expect(fetchApply).toHaveBeenCalledTimes(3)
+    })
+
+    it('returns immediately when the first response advances', async () => {
+        const fetchApply = jest.fn().mockResolvedValueOnce({ status: 'pending' })
+
+        const result = await pollUntilApplyAdvances({
+            fetchApply,
+            intervalMs: 1000,
+            timeoutMs: 10_000,
+            sleep: noSleep,
+        })
+
+        expect(result).toEqual({ status: 'pending' })
+        expect(fetchApply).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns timeout once the deadline is exceeded', async () => {
+        const fetchApply = jest.fn().mockResolvedValue({ status: 'incomplete', sumsubAccessToken: 't' })
+        let clock = 0
+        const tick = (ms: number) => {
+            clock += ms
+        }
+
+        const result = await pollUntilApplyAdvances({
+            fetchApply,
+            intervalMs: 1000,
+            timeoutMs: 3000,
+            sleep: async (ms) => tick(ms),
+            now: () => clock,
+        })
+
+        expect(result).toEqual({ status: 'timeout' })
+        // 3 polls at clock 0, 1000, 2000 — the 4th would be past the deadline
+        expect(fetchApply).toHaveBeenCalledTimes(3)
+    })
+
+    it('propagates errors from fetchApply', async () => {
+        const fetchApply = jest.fn().mockRejectedValue(new Error('network down'))
+
+        await expect(
+            pollUntilApplyAdvances({
+                fetchApply,
+                intervalMs: 0,
+                timeoutMs: 10_000,
+                sleep: noSleep,
+            })
+        ).rejects.toThrow('network down')
+
+        expect(fetchApply).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/components/Card/cardApply.utils.ts
+++ b/src/components/Card/cardApply.utils.ts
@@ -1,0 +1,31 @@
+/**
+ * Sumsub's auto-review usually settles in well under a second, but sometimes
+ * lags. Poll the apply endpoint until backend stops returning `incomplete`,
+ * then surface the response. Returns `{ status: 'timeout' }` if the deadline
+ * passes without advancement so the caller can show a retry message.
+ *
+ * Without this, the immediate post-Sumsub re-apply races against Sumsub and
+ * dumps the user back on the "Start Secure Verification" interstitial when
+ * the WebSDK re-opens against an already-approved applicant.
+ */
+export async function pollUntilApplyAdvances<R extends { status: string }>({
+    fetchApply,
+    intervalMs,
+    timeoutMs,
+    sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
+    now = () => Date.now(),
+}: {
+    fetchApply: () => Promise<R>
+    intervalMs: number
+    timeoutMs: number
+    sleep?: (ms: number) => Promise<void>
+    now?: () => number
+}): Promise<R | { status: 'timeout' }> {
+    const start = now()
+    while (true) {
+        const res = await fetchApply()
+        if (res.status !== 'incomplete') return res
+        await sleep(intervalMs)
+        if (now() - start >= timeoutMs) return { status: 'timeout' as const }
+    }
+}

--- a/src/components/Card/cardApply.utils.ts
+++ b/src/components/Card/cardApply.utils.ts
@@ -1,31 +1,37 @@
 /**
  * Sumsub's auto-review usually settles in well under a second, but sometimes
  * lags. Poll the apply endpoint until backend stops returning `incomplete`,
- * then surface the response. Returns `null` if the deadline passes without
- * advancement so the caller can show a retry message.
+ * then surface the response. Returns `null` on timeout or when `signal` is
+ * aborted so the caller can show a retry message (or stop entirely).
  *
  * Without this, the immediate post-Sumsub re-apply races against Sumsub and
  * dumps the user back on the "Start Secure Verification" interstitial when
- * the WebSDK re-opens against an already-approved applicant.
+ * the WebSDK re-opens against an already-approved applicant. The signal lets
+ * the caller stop the loop on unmount so we don't burn 15 sequential fetches
+ * after the user navigates away from the pending screen.
  */
 export async function pollUntilApplyAdvances<R extends { status: string }>({
     fetchApply,
     intervalMs,
     timeoutMs,
+    signal,
     sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
     now = () => Date.now(),
 }: {
     fetchApply: () => Promise<R>
     intervalMs: number
     timeoutMs: number
+    signal?: AbortSignal
     sleep?: (ms: number) => Promise<void>
     now?: () => number
 }): Promise<R | null> {
     const start = now()
     while (true) {
+        if (signal?.aborted) return null
         const res = await fetchApply()
         if (res.status !== 'incomplete') return res
         await sleep(intervalMs)
+        if (signal?.aborted) return null
         if (now() - start >= timeoutMs) return null
     }
 }

--- a/src/components/Card/cardApply.utils.ts
+++ b/src/components/Card/cardApply.utils.ts
@@ -1,8 +1,8 @@
 /**
  * Sumsub's auto-review usually settles in well under a second, but sometimes
  * lags. Poll the apply endpoint until backend stops returning `incomplete`,
- * then surface the response. Returns `{ status: 'timeout' }` if the deadline
- * passes without advancement so the caller can show a retry message.
+ * then surface the response. Returns `null` if the deadline passes without
+ * advancement so the caller can show a retry message.
  *
  * Without this, the immediate post-Sumsub re-apply races against Sumsub and
  * dumps the user back on the "Start Secure Verification" interstitial when
@@ -20,12 +20,12 @@ export async function pollUntilApplyAdvances<R extends { status: string }>({
     timeoutMs: number
     sleep?: (ms: number) => Promise<void>
     now?: () => number
-}): Promise<R | { status: 'timeout' }> {
+}): Promise<R | null> {
     const start = now()
     while (true) {
         const res = await fetchApply()
         if (res.status !== 'incomplete') return res
         await sleep(intervalMs)
-        if (now() - start >= timeoutMs) return { status: 'timeout' as const }
+        if (now() - start >= timeoutMs) return null
     }
 }

--- a/src/components/Kyc/SumsubKycWrapper.tsx
+++ b/src/components/Kyc/SumsubKycWrapper.tsx
@@ -7,6 +7,7 @@ import { Icon, type IconName } from '@/components/Global/Icons/Icon'
 import { Button, type ButtonVariant } from '@/components/0_Bruddle/Button'
 import { useModalsContext } from '@/context/ModalsContext'
 import StartVerificationView from '../Global/IframeWrapper/StartVerificationView'
+import { evaluateSumsubStatusEvent, type SumsubStatusEventPayload } from './sumsubStatusEvent.utils'
 
 // todo: move to consts
 const SUMSUB_SDK_URL = 'https://static.sumsub.com/idensic/static/sns-websdk-builder.js'
@@ -131,55 +132,22 @@ export const SumsubKycWrapper = ({
                 if (isMultiLevelRef.current) return
                 stableOnComplete()
             }
-            const handleStatusChanged = (payload: {
-                reviewStatus?: string
-                reviewResult?: { reviewAnswer?: string }
-            }) => {
-                console.log('[sumsub] onApplicantStatusChanged fired', payload)
-                // ignore status events that fire within 3s of sdk init — these reflect
-                // pre-existing state (e.g. user already approved), not a new submission
-                if (Date.now() - sdkInitTime < 3000) {
-                    console.log('[sumsub] ignoring early onApplicantStatusChanged (pre-existing state)')
-                    return
-                }
-                // for multi-level workflows (LATAM), Level 1 fires completed+GREEN
-                // before Level 2 is shown. don't close the SDK.
-                if (isMultiLevelRef.current) return
-                // auto-close when sumsub shows success screen
-                if (payload?.reviewStatus === 'completed' && payload?.reviewResult?.reviewAnswer === 'GREEN') {
-                    hasSubmittedRef.current = true
-                    stableOnComplete()
-                }
+            // RED stays open so the user can resubmit; the resubmission path
+            // emits onApplicantActionSubmitted, which handleActionSubmitted
+            // closes. See evaluateSumsubStatusEvent for the early-guard rules.
+            const handleStatusEvent = (eventName: string) => (payload: SumsubStatusEventPayload) => {
+                console.log(`[sumsub] ${eventName} fired`, payload)
+                const evaluation = evaluateSumsubStatusEvent({
+                    payload,
+                    sdkInitTime,
+                    now: Date.now(),
+                    isMultiLevel: !!isMultiLevelRef.current,
+                })
+                if (evaluation.markSubmitted) hasSubmittedRef.current = true
+                if (evaluation.autoClose) stableOnComplete()
             }
-
-            // For applicant actions (rain-card-application, additional-docs):
-            // the SDK fires onApplicantActionStatusChanged with the action's
-            // CURRENT state on launch — including for actions that are already
-            // `completed + RED + RETRY` from a prior attempt. If we close on
-            // any `completed`, the modal disappears before the WebSDK can
-            // render its "data mismatch / retry" UI for RETRY-able actions,
-            // and the user is permanently stuck.
-            //
-            // Mirror handleStatusChanged: ignore events within 3s of SDK init
-            // (those reflect pre-existing state, not a new submission), and
-            // only close on success (completed + GREEN). RED stays open so
-            // the user can resubmit; the resubmission path emits
-            // onApplicantActionSubmitted, which `handleActionSubmitted` closes.
-            const handleActionCompleted = (payload: {
-                reviewStatus?: string
-                reviewResult?: { reviewAnswer?: string }
-            }) => {
-                console.log('[sumsub] onApplicantActionStatusChanged fired', payload)
-                if (Date.now() - sdkInitTime < 3000) {
-                    console.log('[sumsub] ignoring early onApplicantActionStatusChanged (pre-existing state)')
-                    return
-                }
-                if (isMultiLevelRef.current) return
-                if (payload?.reviewStatus === 'completed' && payload?.reviewResult?.reviewAnswer === 'GREEN') {
-                    hasSubmittedRef.current = true
-                    stableOnComplete()
-                }
-            }
+            const handleStatusChanged = handleStatusEvent('onApplicantStatusChanged')
+            const handleActionCompleted = handleStatusEvent('onApplicantActionStatusChanged')
 
             const sdk = window.snsWebSdk
                 .init(accessToken, stableOnRefreshToken)

--- a/src/components/Kyc/__tests__/sumsubStatusEvent.utils.test.ts
+++ b/src/components/Kyc/__tests__/sumsubStatusEvent.utils.test.ts
@@ -1,0 +1,111 @@
+import { evaluateSumsubStatusEvent } from '@/components/Kyc/sumsubStatusEvent.utils'
+
+const greenPayload = { reviewStatus: 'completed', reviewResult: { reviewAnswer: 'GREEN' } }
+const redPayload = { reviewStatus: 'completed', reviewResult: { reviewAnswer: 'RED' } }
+const pendingPayload = { reviewStatus: 'pending' }
+const emptyPayload = {}
+
+describe('evaluateSumsubStatusEvent', () => {
+    describe('within the 3s early-event guard', () => {
+        it('GREEN marks submitted but does not auto-close', () => {
+            expect(
+                evaluateSumsubStatusEvent({
+                    payload: greenPayload,
+                    sdkInitTime: 1000,
+                    now: 2999,
+                    isMultiLevel: false,
+                })
+            ).toEqual({ markSubmitted: true, autoClose: false })
+        })
+
+        it('RED is a no-op (stale retry state — let user resubmit)', () => {
+            expect(
+                evaluateSumsubStatusEvent({
+                    payload: redPayload,
+                    sdkInitTime: 1000,
+                    now: 2999,
+                    isMultiLevel: false,
+                })
+            ).toEqual({ markSubmitted: false, autoClose: false })
+        })
+
+        it('non-completed status is a no-op', () => {
+            expect(
+                evaluateSumsubStatusEvent({
+                    payload: pendingPayload,
+                    sdkInitTime: 1000,
+                    now: 2999,
+                    isMultiLevel: false,
+                })
+            ).toEqual({ markSubmitted: false, autoClose: false })
+        })
+
+        it('multi-level + GREEN still marks submitted (close-warning fix takes priority)', () => {
+            expect(
+                evaluateSumsubStatusEvent({
+                    payload: greenPayload,
+                    sdkInitTime: 1000,
+                    now: 2999,
+                    isMultiLevel: true,
+                })
+            ).toEqual({ markSubmitted: true, autoClose: false })
+        })
+    })
+
+    describe('outside the early-event guard', () => {
+        it('GREEN marks submitted AND auto-closes', () => {
+            expect(
+                evaluateSumsubStatusEvent({
+                    payload: greenPayload,
+                    sdkInitTime: 1000,
+                    now: 5000,
+                    isMultiLevel: false,
+                })
+            ).toEqual({ markSubmitted: true, autoClose: true })
+        })
+
+        it('multi-level suppresses both flags even on GREEN', () => {
+            expect(
+                evaluateSumsubStatusEvent({
+                    payload: greenPayload,
+                    sdkInitTime: 1000,
+                    now: 5000,
+                    isMultiLevel: true,
+                })
+            ).toEqual({ markSubmitted: false, autoClose: false })
+        })
+
+        it('RED is a no-op', () => {
+            expect(
+                evaluateSumsubStatusEvent({
+                    payload: redPayload,
+                    sdkInitTime: 1000,
+                    now: 5000,
+                    isMultiLevel: false,
+                })
+            ).toEqual({ markSubmitted: false, autoClose: false })
+        })
+
+        it('empty payload is a no-op', () => {
+            expect(
+                evaluateSumsubStatusEvent({
+                    payload: emptyPayload,
+                    sdkInitTime: 1000,
+                    now: 5000,
+                    isMultiLevel: false,
+                })
+            ).toEqual({ markSubmitted: false, autoClose: false })
+        })
+    })
+
+    it('boundary at exactly 3000ms is treated as outside guard', () => {
+        expect(
+            evaluateSumsubStatusEvent({
+                payload: greenPayload,
+                sdkInitTime: 1000,
+                now: 4000,
+                isMultiLevel: false,
+            })
+        ).toEqual({ markSubmitted: true, autoClose: true })
+    })
+})

--- a/src/components/Kyc/sumsubStatusEvent.utils.ts
+++ b/src/components/Kyc/sumsubStatusEvent.utils.ts
@@ -1,0 +1,52 @@
+export interface SumsubStatusEventPayload {
+    reviewStatus?: string
+    reviewResult?: { reviewAnswer?: string }
+}
+
+export interface SumsubStatusEventEvaluation {
+    /** Mark the user as having submitted — suppresses the close-warning modal. */
+    markSubmitted: boolean
+    /** Auto-close the SDK. */
+    autoClose: boolean
+}
+
+/**
+ * The SDK fires the action's CURRENT state on launch — including stale
+ * `completed + RED + RETRY` from a prior attempt. Auto-closing on those would
+ * dump the user out before they could resubmit, so within this window we
+ * never auto-close.
+ */
+const EARLY_EVENT_GUARD_MS = 3000
+
+/**
+ * Decide what to do when Sumsub fires a status / action-status event. Within
+ * the early-event guard, GREEN still flips `markSubmitted` so the close
+ * button doesn't show "Stop verification?" against an already-approved
+ * applicant — it just doesn't auto-close (caller renders the SDK's success
+ * screen instead).
+ */
+export function evaluateSumsubStatusEvent({
+    payload,
+    sdkInitTime,
+    now,
+    isMultiLevel,
+}: {
+    payload: SumsubStatusEventPayload
+    sdkInitTime: number
+    now: number
+    isMultiLevel: boolean
+}): SumsubStatusEventEvaluation {
+    const isCompletedGreen = payload?.reviewStatus === 'completed' && payload?.reviewResult?.reviewAnswer === 'GREEN'
+
+    if (now - sdkInitTime < EARLY_EVENT_GUARD_MS) {
+        return { markSubmitted: isCompletedGreen, autoClose: false }
+    }
+    if (isMultiLevel) {
+        // Level 1 fires completed+GREEN before Level 2 is shown — don't close.
+        return { markSubmitted: false, autoClose: false }
+    }
+    if (isCompletedGreen) {
+        return { markSubmitted: true, autoClose: true }
+    }
+    return { markSubmitted: false, autoClose: false }
+}


### PR DESCRIPTION
## Summary

Fixes a flow-blocker reported in the card QA thread on 2026-05-03: after completing Sumsub verification, users get bounced back to the "Start Secure Verification" interstitial and, on re-entry, see a misleading "Stop verification?" warning when they try to close the modal.

**Root cause** is a race between Sumsub's auto-review and our re-apply call. `handleSumsubComplete` was firing `applyForCard` immediately on Sumsub's submitted event — but Sumsub hadn't yet marked the action `completed + GREEN`, so backend returned `incomplete` again and the WebSDK re-mounted from scratch.

## Changes

- **`card/page.tsx`** — `handleSumsubComplete` now polls `applyForCard` every 1s for up to 15s while showing the pending screen, then advances on the first non-`incomplete` response. On timeout, surfaces "Verification is taking longer than expected. Please try again." through `applyError`.
- **`SumsubKycWrapper.tsx`** — both status-event handlers now flip `hasSubmittedRef` on early `completed + GREEN` events. Defensive: if the wrapper ever does re-mount against an approved applicant, the X close button no longer pops "Stop verification?". The 3s guard's original purpose (not auto-closing on stale RED+RETRY) stays intact.

Logic extracted to two pure helpers (`cardApply.utils.ts`, `sumsubStatusEvent.utils.ts`) with **13 new unit tests** covering happy path, timeout, error propagation, and the early-guard / GREEN / RED / multi-level matrix.

## Notion

Closes the "Stuck state when KYC verification ends before webhook arrives" task.

## Test plan

- [ ] `pnpm typecheck` clean (verified locally)
- [ ] `npm test` — all Card + Kyc suites pass; pre-existing failure in `add-money-states.test.tsx` is unrelated (exists on `dev` too)
- [ ] On staging, complete a card application end-to-end:
  - Pending screen shows briefly (or for a second or two if Sumsub lags) after Sumsub success
  - User advances to `CardTermsScreen` automatically — no flash of "Secure Verification" interstitial
  - If Sumsub takes >15s, user sees "try again" message and can re-tap "Get your card"
- [ ] Edge case: re-enter Sumsub against an already-approved applicant — close button skips "Stop verification?" warning