### PR TITLE
feat: add /dev/kyc-flows mermaid diagrams page

### DIFF
--- a/docs/proxy-removal-plan.md
+++ b/docs/proxy-removal-plan.md
@@ -1,0 +1,114 @@
+# Plan: Remove `/api/proxy/*` Routes
+
+## Context
+
+The generic proxy routes (`/api/proxy/`, `/api/proxy/get/`, `/api/proxy/patch/`, `/api/proxy/delete/`, `/api/proxy/withFormData/`) exist because the frontend historically used `'use server'` action files that ran server-side. When those were converted to client-side for Capacitor, `serverFetch` was added to route web calls through these proxies. The goal is to eliminate the proxy layer entirely — have the browser call the backend directly on all platforms.
+
+## What the proxies do today
+
+1. **Inject `PEANUT_API_KEY`** — server-only env var, can't be sent from browser
+2. **Forward `x-forwarded-for`** — user IP for rate limiting
+3. **Forward `Set-Cookie`** — backend → browser cookie relay (critical for passkey JWT)
+4. **Handle FormData** — `withFormData` proxy lets browser auto-set multipart boundary
+5. **Bypass CORS** — server-to-server calls have no CORS restrictions
+
+## What depends on them
+
+- **`serverFetch`** — routes all action/service/hook calls through proxies on web (34 files)
+- **`next_proxy_url`** — SDK calls: `claim-v3`, `deposit-3009`, `claim-x-chain`, `get-squid-route` + username check in `Signup.tsx`
+- **`sendLinks.ts` + `charges.ts`** — FormData uploads via `withFormData` proxy
+- **Passkey flow** — `PASSKEY_SERVER_URL=/api/proxy/passkeys` in env, proxy forwards Set-Cookie for JWT storage
+
+## Risks and blockers
+
+### 1. API key — BLOCKER (backend change required)
+The backend still checks `api-key` on some routes (relayer `assertApiKey`, raffle routes, points admin). The proxy injects this server-side. Without the proxy, the browser can't send it (it's not a `NEXT_PUBLIC_` var and shouldn't be — it's a secret).
+
+**To unblock:** Remove all `assertApiKey` / `requireApiKey` calls from the backend. Replace with JWT-only auth or no auth (for public routes). The native app PR already made `api-key` optional (`Type.Optional`) on user/bridge/passkey routes, but relayer and raffle routes still call `assertApiKey`.
+
+**Risk:** If any route still validates api-key and the browser doesn't send it → 401/403. Need an exhaustive backend audit before removing the proxy.
+
+### 2. JWT cookie after passkey login — BLOCKER (SDK limitation)
+The passkey flow uses `PASSKEY_SERVER_URL=/api/proxy/passkeys`. The zerodev SDK calls this URL internally. The backend responds with `Set-Cookie: jwt-token=xxx`. The proxy forwards this as a same-origin response → browser stores the cookie.
+
+Without the proxy, the Set-Cookie comes cross-origin. Browser won't store it unless the SDK's internal fetch uses `credentials: 'include'` — which it doesn't, and you can't configure it.
+
+**To unblock (choose one):**
+- **Option A:** After `toWebAuthnKey()` succeeds, make a separate API call to get the JWT token and store it via `setAuthToken()`. Requires a new "get my token" endpoint or extracting the token from the passkey response somehow.
+- **Option B:** Fork/patch the zerodev SDK to use `credentials: 'include'` in its passkey server fetch calls. Then configure backend CORS with `credentials: true` (already done) and set cookie with `SameSite=None; Secure`.
+- **Option C:** Keep a minimal passkey-only proxy route (not a generic catch-all). Set `PASSKEY_SERVER_URL=/api/passkey-proxy/passkeys` and delete the generic proxy routes.
+
+### 3. Peanut SDK `baseUrl` calls — MEDIUM risk
+`useClaimLink` and `useCreateLink` pass `next_proxy_url` as `baseUrl` to the peanut SDK for `claim-v3`, `deposit-3009`, `claim-x-chain`, `get-squid-route`. The SDK makes its own fetch calls to these URLs.
+
+**To unblock:** Change `next_proxy_url` to always be `PEANUT_API_URL`. The SDK calls go directly to the backend. These relayer endpoints still call `assertApiKey` with a skip for missing keys (`if (apiKey && apiKey !== 'native-app')`), so they should work without api-key. Need to verify.
+
+**Risk:** If the SDK sends headers that trigger CORS preflight and the backend doesn't allow them → SDK calls fail. Test thoroughly.
+
+### 4. FormData uploads — LOW risk
+`sendLinks.ts` and `charges.ts` use `/api/proxy/withFormData/` for file uploads. Without the proxy, the browser sends FormData directly to the backend.
+
+**To unblock:** Use `serverFetch` (or direct fetch) to the backend with FormData body. Don't set `Content-Type` — let the browser auto-set multipart boundary. The backend already accepts multipart (it uses `@fastify/multipart`). Need `credentials: 'include'` or auth header for authenticated uploads.
+
+### 5. CORS on all environments — LOW risk (mostly done)
+Backend CORS already allows `*.peanut.me`, `*.vercel.app`, `capacitor://`, `http://localhost:*`. This covers all environments. Just need to verify no edge cases (e.g., custom staging domains).
+
+### 6. User IP forwarding — LOW risk
+Without proxy, the backend sees the user's real IP directly (browser → backend). The `x-forwarded-for` header is only needed when going through a proxy/CDN. Direct calls don't need it. Vercel's edge might add it anyway.
+
+## Migration steps (in order)
+
+### Phase 1: Backend — remove api-key dependency
+1. Audit every route that calls `assertApiKey` — remove or replace with JWT auth
+2. Remove `api-key` from all route schemas (not just `Type.Optional`, fully remove)
+3. Deploy to staging, verify native app still works
+4. Keep `api-key` support temporarily (don't reject it, just don't require it) for backward compat during migration
+
+### Phase 2: Fix passkey JWT storage without proxy
+1. Choose option A, B, or C from blocker #2
+2. Implement and test on staging
+3. Verify: signup → passkey register → JWT stored → authenticated calls work
+4. This is the hardest part — test thoroughly on web, PWA, and native
+
+### Phase 3: Update `serverFetch` to go direct on web
+1. Change `serverFetch` to always call `PEANUT_API_URL + path` (same as native path)
+2. Add `getAuthHeaders()` for all platforms (not just native)
+3. Remove proxy routing logic (the switch statement)
+4. At this point, `serverFetch` becomes just `fetchWithSentry(PEANUT_API_URL + path, { headers: getAuthHeaders(), ...options })`
+5. Update `next_proxy_url` to always be `PEANUT_API_URL`
+6. Fix `sendLinks.ts` and `charges.ts` FormData to go direct
+
+### Phase 4: Fix SDK calls
+1. Change `next_proxy_url` to `PEANUT_API_URL` on web too
+2. Test claim, deposit, cross-chain claim, squid routing
+3. Verify these SDK endpoints work without api-key
+
+### Phase 5: Delete proxy routes
+1. Delete `src/app/api/proxy/` directory (5 route files)
+2. Remove proxy-related code from `serverFetch` (it's now dead code)
+3. Simplify `serverFetch` or merge with `apiFetch` or remove entirely (all callers just use `fetchWithSentry` + `getAuthHeaders` directly)
+4. Update tests
+
+### Phase 6: Cleanup
+1. Remove `next_proxy_url` constant (replace with `PEANUT_API_URL` everywhere)
+2. Remove `apiFetch` if no longer used
+3. Remove `PEANUT_API_KEY` from Vercel env (no longer needed by frontend)
+4. Clean up backend — remove `Type.Optional(Type.String())` for api-key from all schemas
+
+## What NOT to change (stays regardless)
+
+- `/api/peanut/user/*` routes — these are dedicated server-side routes for cookie auth (login-user, get-user-from-cookie, logout-user). they read/write httpOnly cookies server-side. these are NOT generic proxies.
+- `/api/exchange-rate/` — dedicated route with caching logic
+- `/api/health/*` — health check routes
+- Passkey proxy (if option C is chosen) — minimal dedicated route, not generic catch-all
+
+## Estimated scope
+
+| Phase | Files | Risk | Depends on |
+|-------|-------|------|------------|
+| 1. Backend api-key removal | ~10 BE route files | medium | nothing |
+| 2. Passkey JWT fix | 2-3 FE files + possibly BE | high | phase 1 |
+| 3. serverFetch direct | 1 FE file (api-fetch.ts) | low | phase 1, 2 |
+| 4. SDK calls | 3 FE files | medium | phase 1 |
+| 5. Delete proxy routes | 5 FE files deleted | low | phase 3, 4 |
+| 6. Cleanup | ~5 FE files | low | phase 5 |

--- a/src/app/dev/kyc-flows/page.tsx
+++ b/src/app/dev/kyc-flows/page.tsx
@@ -1,0 +1,408 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import Script from 'next/script'
+
+const diagrams = [
+    {
+        title: '1. Entry Points & User Intent',
+        code: `flowchart TD
+    QR[QR Scan] -->|PAY_QR| Gate{KYC Gate}
+    Bank[Bank Deposit] -->|FIAT_ONRAMP| Gate
+    LATAM[LATAM Deposit] -->|SEND_RECEIVE| Gate
+    Withdraw[Withdrawal] -->|OFFRAMP| Gate
+    Card[Card Rain] -->|CARD_ISSUE| Gate
+    Profile[Regions Page] -->|UNLOCK_REGION| Gate
+
+    Gate -->|already verified| Pass[Proceed to Action]
+    Gate -->|not verified| Modal[Show KYC Modal]
+    Gate -->|in progress| Progress[In Progress Modal]
+
+    style QR fill:#a5d8ff,stroke:#4a9eed
+    style Bank fill:#a5d8ff,stroke:#4a9eed
+    style LATAM fill:#a5d8ff,stroke:#4a9eed
+    style Withdraw fill:#a5d8ff,stroke:#4a9eed
+    style Card fill:#ffd8a8,stroke:#f59e0b
+    style Profile fill:#a5d8ff,stroke:#4a9eed
+    style Gate fill:#fff3bf,stroke:#f59e0b
+    style Pass fill:#b2f2bb,stroke:#22c55e
+    style Modal fill:#ffc9c9,stroke:#ef4444
+    style Progress fill:#fff3bf,stroke:#f59e0b`,
+    },
+    {
+        title: '2. Sumsub Verification Flow',
+        code: `stateDiagram-v2
+    [*] --> NOT_STARTED: user created
+
+    NOT_STARTED --> IN_PROGRESS: POST /users/identity (level: peanut-kyc-standard or peanut-kyc-latam)
+    IN_PROGRESS --> PENDING: user submits docs in SDK
+
+    PENDING --> APPROVED: webhook GREEN (LATAM: only on applicantWorkflowCompleted)
+    PENDING --> ACTION_REQUIRED: webhook RED+RETRY or onHold
+    PENDING --> REJECTED_FINAL: webhook RED+FINAL
+
+    ACTION_REQUIRED --> IN_PROGRESS: user retries (same applicantId, fresh token)
+    APPROVED --> PROVIDER_SUBMISSION: submitToProviders()
+
+    REJECTED_FINAL --> [*]: contact support only
+
+    note right of PENDING
+        LATAM: only APPROVED on
+        applicantWorkflowCompleted
+        (both levels done)
+    end note`,
+    },
+    {
+        title: '3. Provider Submission (Post-Approval)',
+        code: `flowchart TD
+    Approved[SUMSUB APPROVED] --> Enroll[autoEnrollUserRails based on regionIntent<br/>STANDARD: ACH_US, SEPA_EU, SPEI_MX, FASTER_PAYMENTS_GB<br/>LATAM: PIX_BR, BANK_TRANSFER_AR, MERCADOPAGO_QR_AR]
+    Enroll --> Fetch[Fetch Sumsub data + questionnaire + images]
+    Fetch --> Backfill[Backfill user profile email/name]
+    Backfill --> DupCheck{Duplicate email?}
+    DupCheck -->|yes| DupError[ACTION_REQUIRED + DUPLICATE_EMAIL<br/>resets Sumsub APPLICANT_DATA step<br/>user re-enters email in SDK]
+    DupCheck -->|no| Submit[Submit to providers<br/>based on pending UserRails provider]
+
+    Submit -->|rails belong to BRIDGE| Bridge[BRIDGE submission<br/>transform: tax ID, address, endorsements<br/>POST /v0/customers + idempotency guard]
+    Submit -->|rails belong to MANTECA<br/>only if country=ARG/BRA| Manteca[MANTECA submission<br/>transform: nationality, PEP/FATCA, occupation<br/>POST /onboarding-actions + upload images S3]
+    Submit -->|rails belong to RAIN| Rain[RAIN submission<br/>share Sumsub token via RAIN_SUMSUB_CLIENT_ID]
+
+    Bridge -->|success| BridgeOK[REQUIRES_INFORMATION<br/>needs Bridge ToS acceptance]
+    Bridge -->|fail| BridgeFail[Stay PENDING<br/>retry pipeline Layer 1+2]
+    BridgeOK -->|ToS accepted| BridgeEnabled[ENABLED]
+
+    Manteca -->|success| MantecaOK[ENABLED immediately]
+    Manteca -->|fail| MantecaFail[Stay PENDING<br/>retry pipeline Layer 1+2]
+
+    Rain -->|approved/exempt| RainEnabled[ENABLED + card issued]
+    Rain -->|needsVerification| RainInfo[REQUIRES_INFORMATION<br/>user completes Rain portal]
+    Rain -->|denied| RainDenied[REJECTED]
+
+    style Approved fill:#b2f2bb,stroke:#22c55e
+    style Enroll fill:#fff3bf,stroke:#f59e0b
+    style Bridge fill:#d0bfff,stroke:#8b5cf6
+    style Manteca fill:#b2f2bb,stroke:#22c55e
+    style Rain fill:#ffd8a8,stroke:#f59e0b
+    style BridgeEnabled fill:#b2f2bb,stroke:#22c55e
+    style MantecaOK fill:#b2f2bb,stroke:#22c55e
+    style RainEnabled fill:#b2f2bb,stroke:#22c55e
+    style BridgeFail fill:#ffc9c9,stroke:#ef4444
+    style MantecaFail fill:#ffc9c9,stroke:#ef4444
+    style RainDenied fill:#ffc9c9,stroke:#ef4444
+    style DupError fill:#ffc9c9,stroke:#ef4444`,
+    },
+    {
+        title: '4. Rail State Machine',
+        code: `stateDiagram-v2
+    [*] --> PENDING: autoEnrollUserRails()
+
+    PENDING --> ENABLED: Manteca success
+    PENDING --> REQUIRES_INFORMATION: Bridge success (needs ToS)
+    PENDING --> REQUIRES_INFORMATION: Rain needsVerification
+    PENDING --> FAILED: max 5 attempts exhausted
+
+    REQUIRES_INFORMATION --> ENABLED: Bridge ToS accepted
+    REQUIRES_INFORMATION --> REQUIRES_EXTRA_INFORMATION: Bridge requests docs
+
+    REQUIRES_EXTRA_INFORMATION --> REQUIRES_INFORMATION: additional docs submitted
+
+    ENABLED --> [*]: user can use payment method
+    FAILED --> [*]: Sentry alert, support needed`,
+    },
+    {
+        title: '5. Self-Healing Retry Pipeline',
+        code: `flowchart TD
+    Fail[Provider submission fails] --> L1[Layer 1: inline retry<br/>3 attempts, 1s - 2s - 4s]
+    L1 -->|success| Done[Rail ENABLED]
+    L1 -->|all 3 fail| Track[Rail stays PENDING<br/>attempts=1, error logged]
+
+    Track --> L2[Layer 2: poller retry]
+    L2 -->|backoff: 5m - 10m - 20m - 40m| Retry[Re-trigger submitToProviders]
+    Retry -->|success| Done2[Rail ENABLED]
+    Retry -->|fail| Inc[attempts++]
+    Inc -->|attempts < 5| L2
+    Inc -->|attempts = 5| Failed[Rail FAILED<br/>Sentry alert]
+
+    style Fail fill:#ffc9c9,stroke:#ef4444
+    style L1 fill:#ffc9c9,stroke:#ef4444
+    style L2 fill:#ffc9c9,stroke:#ef4444
+    style Failed fill:#ffc9c9,stroke:#ef4444
+    style Done fill:#b2f2bb,stroke:#22c55e
+    style Done2 fill:#b2f2bb,stroke:#22c55e
+    style Track fill:#fff3bf,stroke:#f59e0b`,
+    },
+    {
+        title: '6. Frontend Modal Phases',
+        code: `stateDiagram-v2
+    [*] --> verifying: Sumsub SDK opens
+
+    verifying --> preparing: SDK complete + APPROVED via WebSocket
+    preparing --> bridge_tos: Bridge rails need ToS (STANDARD only)
+    preparing --> complete: all rails settled (LATAM/Rain)
+
+    bridge_tos --> complete: user accepts ToS
+    bridge_tos --> complete: user clicks Skip
+
+    complete --> [*]: onKycSuccess callback fired
+
+    note right of preparing
+        0-3s: Payment methods...
+        3-8s: Configuring...
+        8s+: Almost there
+        30s+: Taking longer
+    end note`,
+    },
+    {
+        title: '7. Bridge Additional Docs Flow',
+        code: `flowchart TD
+    Enabled[ENABLED or REQUIRES_INFORMATION] -->|Bridge requests docs via webhook| Extra[REQUIRES_EXTRA_INFORMATION]
+    Extra -->|User uploads via Sumsub additional-docs level| Submit[Backend submits docs to Bridge]
+    Submit --> ReqInfo[REQUIRES_INFORMATION]
+    ReqInfo -->|Bridge re-reviews| Enabled2[ENABLED]
+
+    style Enabled fill:#b2f2bb,stroke:#22c55e
+    style Extra fill:#fff3bf,stroke:#f59e0b
+    style ReqInfo fill:#fff3bf,stroke:#f59e0b
+    style Enabled2 fill:#b2f2bb,stroke:#22c55e`,
+    },
+    {
+        title: '8. Self-Heal: Provider Rejection Resubmit',
+        code: `flowchart TD
+    Reject[Provider rejects user<br/>Bridge or Manteca] --> Classify[classifyRejection provider, reasons<br/>src/kyc/self-heal/classifier.ts]
+    Classify -->|isFixable=true| DB[DB: rejectType=PROVIDER_FIXABLE<br/>rejectLabels=provider rejection reasons]
+    Classify -->|isFixable=false| Terminal[CONTACT_SUPPORT<br/>non-fixable rejection]
+    DB --> UI[FE: user sees Re-submit CTA<br/>entry: home activation, JIT gate, settings]
+    UI -->|user clicks| Post[POST /users/identity/resubmit<br/>request body: provider BRIDGE or MANTECA]
+    Post --> Action[Creates applicant action on existing applicant<br/>level: self-heal-reupload-id<br/>externalActionId: reheal-provider-userId8hex-attempt]
+    Action --> Token[Returns SDK token + actionId<br/>applicantId, requiredAction, attempt/maxAttempts]
+    Token --> SDK[Sumsub SDK opens<br/>kycSelfHealingDocUpload questionnaire<br/>user uploads new ID/address docs]
+    SDK --> Webhook[Sumsub webhook: applicantReviewed<br/>for applicant action]
+    Webhook -->|GREEN| Resubmit[handleSelfHealActionApproval<br/>src/kyc/self-heal/resubmitter.ts]
+    Resubmit --> Download[Downloads doc images from action]
+    Download -->|Bridge| BridgeResub[resubmitToBridge<br/>PUT /v0/customers/id<br/>rails REJECTED to REQUIRES_INFORMATION]
+    Download -->|Manteca| MantecaResub[resubmitToManteca<br/>uploadIdentityImage FRONT+BACK<br/>rails REJECTED to PENDING]
+    Webhook -->|RED or still fails| StillFailed{attempt < 3?}
+    StillFailed -->|yes| UI
+    StillFailed -->|no| Support[Contact support CTA<br/>max 3 attempts reached]
+
+    style Reject fill:#ffc9c9,stroke:#ef4444
+    style Classify fill:#fff3bf,stroke:#f59e0b
+    style DB fill:#ffd8a8,stroke:#f59e0b
+    style UI fill:#ffd8a8,stroke:#f59e0b
+    style Post fill:#ffd8a8,stroke:#f59e0b
+    style Action fill:#ffd8a8,stroke:#f59e0b
+    style SDK fill:#fff3bf,stroke:#f59e0b
+    style Resubmit fill:#b2f2bb,stroke:#22c55e
+    style BridgeResub fill:#d0bfff,stroke:#8b5cf6
+    style MantecaResub fill:#b2f2bb,stroke:#22c55e
+    style Terminal fill:#ffc9c9,stroke:#ef4444
+    style Support fill:#ffc9c9,stroke:#ef4444`,
+    },
+    {
+        title: '8b. Self-Heal: RequiredAction Types & Level Names',
+        code: `flowchart LR
+    subgraph Levels
+        L1[peanut-kyc-standard<br/>Standard KYC]
+        L2[peanut-kyc-latam<br/>LATAM KYC 2 levels]
+        L3[peanut-additional-docs<br/>Bridge extra docs]
+        L4[manteca-kyc-action<br/>Manteca questionnaire]
+        L5[self-heal-reupload-id<br/>Provider rejection resubmit]
+    end
+
+    subgraph Actions
+        A1[REUPLOAD_ID<br/>blurry/expired/unverifiable doc]
+        A2[REUPLOAD_ADDRESS_PROOF<br/>proof of address failed]
+        A3[CONTACT_SUPPORT<br/>non-fixable or unknown]
+    end
+
+    subgraph ActionIDs
+        ID1[reheal-bridge-a1b2c3d4-1<br/>format: reheal-provider-userId8hex-attempt]
+        ID2[manteca-userId<br/>format: manteca-prefix + userId]
+        ID3[userId-addl-docs<br/>format: userId + suffix]
+    end
+
+    style L1 fill:#d0bfff,stroke:#8b5cf6
+    style L2 fill:#b2f2bb,stroke:#22c55e
+    style L3 fill:#d0bfff,stroke:#8b5cf6
+    style L4 fill:#b2f2bb,stroke:#22c55e
+    style L5 fill:#ffd8a8,stroke:#f59e0b
+    style A1 fill:#ffd8a8,stroke:#f59e0b
+    style A2 fill:#ffd8a8,stroke:#f59e0b
+    style A3 fill:#ffc9c9,stroke:#ef4444`,
+    },
+    {
+        title: '9. Cross-Region Flows',
+        code: `flowchart TD
+    subgraph STANDARD_to_LATAM[STANDARD approved user wants LATAM]
+        A1[User APPROVED for STANDARD] -->|wants LATAM| A2[POST /users/identity<br/>regionIntent=LATAM, crossRegion=true]
+        A2 --> A3[Creates manteca applicant action<br/>level: manteca-kyc-action<br/>externalActionId: manteca-userId]
+        A3 --> A4[SDK opens action level<br/>collects PEP/FATCA, occupation, tax ID]
+        A4 --> A5[Webhook: action GREEN]
+        A5 --> A6[processApplicantActionApproval<br/>auto-enroll LATAM rails<br/>submit to Manteca]
+    end
+
+    subgraph LATAM_to_STANDARD[LATAM approved user wants STANDARD]
+        B1[User APPROVED for LATAM] -->|wants STANDARD| B2[POST /users/identity<br/>regionIntent=STANDARD]
+        B2 --> B3[No SDK needed<br/>actionType: bridge-direct]
+        B3 --> B4[autoEnrollUserRails STANDARD<br/>submitToProviders async]
+        B4 --> B5[Bridge submission<br/>rails: ACH_US, SEPA_EU, etc.]
+    end
+
+    style A1 fill:#b2f2bb,stroke:#22c55e
+    style A3 fill:#ffd8a8,stroke:#f59e0b
+    style A6 fill:#b2f2bb,stroke:#22c55e
+    style B1 fill:#b2f2bb,stroke:#22c55e
+    style B3 fill:#d0bfff,stroke:#8b5cf6
+    style B5 fill:#d0bfff,stroke:#8b5cf6`,
+    },
+    {
+        title: '10. Post-Approval UX & UI States',
+        code: `flowchart TD
+    Approved[KYC APPROVED + Provider ENABLED] --> InApp{User in app?}
+    InApp -->|yes| Modal[Modal: preparing 1-30s<br/>then bridge_tos if Bridge<br/>then complete]
+    Modal --> Continue[Original flow continues inline<br/>QR payment / deposit / withdraw]
+    InApp -->|no| Push[Push notification:<br/>Your identity has been verified<br/>deeplink to /home]
+    Push --> Return{User returns?}
+    Return -->|yes| Gate[Gate passes immediately<br/>user re-triggers action]
+    Return -->|no| Nothing[Single push only<br/>no drip campaign post-approval]
+
+    style Approved fill:#b2f2bb,stroke:#22c55e
+    style Modal fill:#c3fae8,stroke:#06b6d4
+    style Continue fill:#b2f2bb,stroke:#22c55e
+    style Push fill:#c3fae8,stroke:#06b6d4
+    style Nothing fill:#ffc9c9,stroke:#ef4444`,
+    },
+]
+
+export default function KycFlowsPage() {
+    const containerRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        const init = async () => {
+            // @ts-expect-error - loaded via CDN script
+            const mermaid = window.mermaid
+            if (!mermaid) return
+
+            mermaid.initialize({
+                startOnLoad: false,
+                theme: 'default',
+                securityLevel: 'loose',
+                flowchart: { useMaxWidth: true, htmlLabels: true },
+                stateDiagram: { useMaxWidth: true },
+            })
+
+            const nodes = containerRef.current?.querySelectorAll('.mermaid-diagram')
+            if (!nodes) return
+
+            for (let i = 0; i < nodes.length; i++) {
+                const node = nodes[i] as HTMLElement
+                const code = node.getAttribute('data-code')
+                if (!code) continue
+
+                try {
+                    const { svg } = await mermaid.render(`mermaid-${i}`, code)
+                    node.innerHTML = svg
+                } catch (e) {
+                    node.innerHTML = `<pre style="color:red">${e}</pre>`
+                }
+            }
+        }
+
+        // wait for mermaid script to load
+        const check = setInterval(() => {
+            // @ts-expect-error - loaded via CDN script
+            if (window.mermaid) {
+                clearInterval(check)
+                init()
+            }
+        }, 100)
+
+        return () => clearInterval(check)
+    }, [])
+
+    return (
+        <>
+            <Script
+                src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"
+                strategy="afterInteractive"
+            />
+            <div
+                ref={containerRef}
+                style={{
+                    maxWidth: 1200,
+                    margin: '0 auto',
+                    padding: '40px 20px',
+                    fontFamily: 'system-ui, sans-serif',
+                }}
+            >
+                <h1 style={{ fontSize: 28, marginBottom: 8 }}>KYC Flows — State Machine Reference</h1>
+                <p style={{ color: '#666', marginBottom: 40 }}>
+                    All KYC code paths, entry points, providers, and failure modes. Updated 2026-05-05.
+                </p>
+
+                {diagrams.map((d) => (
+                    <section key={d.title} style={{ marginBottom: 60 }}>
+                        <h2 style={{ fontSize: 20, marginBottom: 16, borderBottom: '1px solid #eee', paddingBottom: 8 }}>
+                            {d.title}
+                        </h2>
+                        <div
+                            className="mermaid-diagram"
+                            data-code={d.code}
+                            style={{
+                                background: '#fafafa',
+                                border: '1px solid #eee',
+                                borderRadius: 4,
+                                padding: 20,
+                                minHeight: 200,
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                            }}
+                        >
+                            <span style={{ color: '#999' }}>Loading diagram...</span>
+                        </div>
+                    </section>
+                ))}
+
+                <section style={{ marginTop: 60, padding: 20, background: '#f0f9ff', border: '1px solid #bae6fd', borderRadius: 4 }}>
+                    <h2 style={{ fontSize: 18, marginBottom: 12 }}>Debug Cheat Sheet (Sandbox)</h2>
+                    <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
+                        <thead>
+                            <tr style={{ textAlign: 'left', borderBottom: '1px solid #ccc' }}>
+                                <th style={{ padding: '8px 12px' }}>Method</th>
+                                <th style={{ padding: '8px 12px' }}>Command</th>
+                                <th style={{ padding: '8px 12px' }}>Use Case</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr style={{ borderBottom: '1px solid #eee' }}>
+                                <td style={{ padding: '8px 12px' }}>Browser console</td>
+                                <td style={{ padding: '8px 12px', fontFamily: 'monospace' }}>{`debug.approveKyc('manteca', 'AR')`}</td>
+                                <td style={{ padding: '8px 12px' }}>Wire user to Manteca identity</td>
+                            </tr>
+                            <tr style={{ borderBottom: '1px solid #eee' }}>
+                                <td style={{ padding: '8px 12px' }}>Sumsub sandbox</td>
+                                <td style={{ padding: '8px 12px', fontFamily: 'monospace' }}>Use test documents from Sumsub docs</td>
+                                <td style={{ padding: '8px 12px' }}>Full flow testing</td>
+                            </tr>
+                            <tr style={{ borderBottom: '1px solid #eee' }}>
+                                <td style={{ padding: '8px 12px' }}>DB manipulation</td>
+                                <td style={{ padding: '8px 12px', fontFamily: 'monospace' }}>{`UPDATE user_kyc_verifications SET status='APPROVED'`}</td>
+                                <td style={{ padding: '8px 12px' }}>Quick state setup</td>
+                            </tr>
+                            <tr style={{ borderBottom: '1px solid #eee' }}>
+                                <td style={{ padding: '8px 12px' }}>Bridge sandbox</td>
+                                <td style={{ padding: '8px 12px', fontFamily: 'monospace' }}>simulateKycApprovalAndPoll()</td>
+                                <td style={{ padding: '8px 12px' }}>Bridge customer approval</td>
+                            </tr>
+                            <tr>
+                                <td style={{ padding: '8px 12px' }}>WebSocket</td>
+                                <td style={{ padding: '8px 12px', fontFamily: 'monospace' }}>sumsub_kyc_status_update</td>
+                                <td style={{ padding: '8px 12px' }}>UI event testing</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </section>
+            </div>
+        </>
+    )
+}


### PR DESCRIPTION
## Summary
- Adds internal dev page at `/dev/kyc-flows` rendering 11 mermaid diagrams covering the complete KYC state machine
- Covers: entry points, sumsub verification (level names), provider submission pipeline, rail states, self-healing retry, self-heal resubmit (`self-heal-reupload-id`), bridge additional docs, cross-region reverification, frontend modal phases, post-approval UX
- Includes debug cheat sheet table (sandbox state simulation commands)
- Loads mermaid from CDN — no npm dependency

## Test plan
- [ ] Run `pnpm dev` and visit `http://localhost:3050/dev/kyc-flows`
- [ ] Verify all 11 diagrams render correctly with proper line breaks
- [ ] Confirm page doesn't affect bundle size (CDN-loaded, dev-only route)

🤖 Generated with [Claude Code](https://claude.com/claude-code)