### PR TITLE
feat(manteca): pay QR from Rain card collateral when smart wallet is low

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
+++ b/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
@@ -97,9 +97,32 @@ jest.mock('@/hooks/wallet/useWallet', () => ({
     useWallet: () => mockUseWallet(),
 }))
 
-const mockSignTransferUserOp = jest.fn()
-jest.mock('@/hooks/wallet/useSignUserOp', () => ({
-    useSignUserOp: () => ({ signTransferUserOp: mockSignTransferUserOp }),
+const mockSignSpend = jest.fn()
+jest.mock('@/hooks/wallet/useSignSpendBundle', () => ({
+    useSignSpendBundle: () => ({ signSpend: mockSignSpend }),
+}))
+
+jest.mock('@/hooks/wallet/useSpendBundle', () => ({
+    InsufficientSpendableError: class extends Error {
+        constructor() {
+            super('Insufficient spendable balance')
+            this.name = 'InsufficientSpendableError'
+        }
+    },
+    SessionKeyGrantRequiredError: class extends Error {
+        constructor() {
+            super('Session-key grant required')
+            this.name = 'SessionKeyGrantRequiredError'
+        }
+    },
+}))
+
+jest.mock('@/hooks/useRainCardOverview', () => ({
+    useRainCardOverview: () => ({ overview: { balance: { spendingPower: 0 } } }),
+}))
+
+jest.mock('@/utils/balance.utils', () => ({
+    rainSpendingPowerToWei: jest.fn(() => 0n),
 }))
 
 const mockUseTransactionDetailsDrawer = jest.fn()
@@ -500,26 +523,29 @@ function applyDefaults() {
         },
     })
 
-    mockSignTransferUserOp.mockResolvedValue({
+    mockSignSpend.mockResolvedValue({
+        strategy: 'smart-only',
         signedUserOp: {
-            sender: '0x1',
-            nonce: '0x0',
-            callData: '0x',
-            signature: '0x',
-            callGasLimit: '0x0',
-            verificationGasLimit: '0x0',
-            preVerificationGas: '0x0',
-            factory: null,
-            factoryData: null,
-            maxFeePerGas: '0x0',
-            maxPriorityFeePerGas: '0x0',
-            paymaster: null,
-            paymasterData: null,
-            paymasterVerificationGasLimit: '0x0',
-            paymasterPostOpGasLimit: '0x0',
+            signedUserOp: {
+                sender: '0x1',
+                nonce: '0x0',
+                callData: '0x',
+                signature: '0x',
+                callGasLimit: '0x0',
+                verificationGasLimit: '0x0',
+                preVerificationGas: '0x0',
+                factory: null,
+                factoryData: null,
+                maxFeePerGas: '0x0',
+                maxPriorityFeePerGas: '0x0',
+                paymaster: null,
+                paymasterData: null,
+                paymasterVerificationGasLimit: '0x0',
+                paymasterPostOpGasLimit: '0x0',
+            },
+            chainId: '42161',
+            entryPointAddress: '0xentry',
         },
-        chainId: 137,
-        entryPointAddress: '0xentry',
     })
 }
 
@@ -778,7 +804,7 @@ describe('GROUP 3: Processing States', () => {
         })
 
         // After clicking pay, loading state should trigger PeanutLoading
-        // (signTransferUserOp resolves, then completeQrPayment hangs)
+        // (signSpend resolves, then completeQrPayment hangs)
         await waitFor(() => {
             // Component is in loading state - either shows PeanutLoading or loading button text
             const loadingEl = screen.queryByTestId('peanut-loading')
@@ -806,8 +832,8 @@ describe('GROUP 3: Processing States', () => {
             creationTime: '2026-04-16T00:00:00Z',
         })
 
-        // signTransferUserOp rejects with "not allowed" — wallet confirmation denied
-        mockSignTransferUserOp.mockRejectedValue(new Error('User action is not allowed'))
+        // signSpend rejects with "not allowed" — wallet confirmation denied
+        mockSignSpend.mockRejectedValue(new Error('User action is not allowed'))
 
         renderQrPay({ qrCode: 'mercadopago://pay?id=123', type: 'MERCADO_PAGO', t: '1' })
 

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -15,12 +15,15 @@ import Image from 'next/image'
 import PeanutLoading from '@/components/Global/PeanutLoading'
 import AmountInput from '@/components/Global/AmountInput'
 import { useWallet } from '@/hooks/wallet/useWallet'
-import { useSignUserOp } from '@/hooks/wallet/useSignUserOp'
+import { useSignSpendBundle } from '@/hooks/wallet/useSignSpendBundle'
+import { InsufficientSpendableError, SessionKeyGrantRequiredError } from '@/hooks/wallet/useSpendBundle'
+import { useRainCardOverview } from '@/hooks/useRainCardOverview'
+import { rainSpendingPowerToWei } from '@/utils/balance.utils'
 import { isTxReverted, saveRedirectUrl, formatNumberForDisplay } from '@/utils/general.utils'
 import { getShakeClass, type ShakeIntensity } from '@/utils/perk.utils'
 import { calculateSavingsInCents, isArgentinaMantecaQrPayment, getSavingsMessage } from '@/utils/qr-payment.utils'
 import ErrorAlert from '@/components/Global/ErrorAlert'
-import { PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
+import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
 import { PERK_HOLD_DURATION_MS } from '@/constants/general.consts'
 import { MANTECA_DEPOSIT_ADDRESS } from '@/constants/manteca.consts'
 import { MIN_MANTECA_QR_PAYMENT_AMOUNT, MIN_PIX_AMOUNT_BRL } from '@/constants/payment.consts'
@@ -71,7 +74,8 @@ export default function QRPayPage() {
     const timestamp = searchParams.get('t')
     const qrType = searchParams.get('type')
     const { spendableBalance: balance, sendMoney } = useWallet()
-    const { signTransferUserOp } = useSignUserOp()
+    const { signSpend } = useSignSpendBundle()
+    const { overview: rainCardOverview } = useRainCardOverview()
     const [isSuccess, setIsSuccess] = useState(false)
     const [errorMessage, setErrorMessage] = useState<string | null>(null)
     const [balanceErrorMessage, setBalanceErrorMessage] = useState<string | null>(null)
@@ -445,50 +449,64 @@ export default function QRPayPage() {
         }
 
         setLoadingState('Preparing transaction')
-        let signedUserOpData
+        // Route across smart-only / mixed / collateral-only — pure-collateral
+        // payments (smart wallet empty, card collateral covers it) used to fail
+        // here because ZeroDev's paymaster simulated a USDC transfer from a
+        // zero-balance smart account and refused to sponsor. The signSpend
+        // hook now picks the right routing, including a single-tap
+        // collateral-only path that lets Rain transfer straight from the
+        // collateral proxy to MANTECA's deposit address.
+        let signedArtifact
         try {
-            signedUserOpData = await signTransferUserOp(MANTECA_DEPOSIT_ADDRESS, finalPaymentLock.paymentAgainstAmount)
+            const requiredUsdcAmount = parseUnits(finalPaymentLock.paymentAgainstAmount, PEANUT_WALLET_TOKEN_DECIMALS)
+            signedArtifact = await signSpend({
+                requiredUsdcAmount,
+                recipient: MANTECA_DEPOSIT_ADDRESS,
+                smartBalance: balance ?? 0n,
+                rainSpendingPower: rainSpendingPowerToWei(rainCardOverview?.balance?.spendingPower),
+                kind: 'QR_PAY',
+            })
         } catch (error) {
-            if ((error as Error).toString().includes('not allowed')) {
+            if (error instanceof InsufficientSpendableError) {
+                setErrorMessage('Not enough USDC in your wallet or card to cover this payment.')
+            } else if (error instanceof SessionKeyGrantRequiredError) {
+                setErrorMessage('Card permission needed to pay from card balance — please try again.')
+            } else if ((error as Error).toString().includes('not allowed')) {
                 setErrorMessage('Please confirm the transaction.')
             } else {
                 captureException(error)
                 setErrorMessage('Could not sign the transaction.')
-                setIsSuccess(false)
             }
+            setIsSuccess(false)
             setLoadingState('Idle')
             return
         }
 
-        // Send signed UserOp to backend for coordinated execution
-        // Backend will: 1) Complete Manteca payment, 2) Broadcast UserOp only if Manteca succeeds
-        // schedule "paying" state after 3 seconds to give user feedback that payment is processing
+        // Send signed artifact to backend for coordinated execution.
+        // Backend creates the Manteca order FIRST, then either broadcasts the
+        // signed UserOp (smart-only / mixed) or submits the Rain withdrawal via
+        // the user's session-key UserOp (collateral-only).
+        // Schedule "paying" state after 3s so the user sees something is happening.
         payingStateTimerRef.current = setTimeout(() => setLoadingState('Paying'), 3000)
         try {
-            const signedUserOp = {
-                sender: signedUserOpData.signedUserOp.sender,
-                nonce: signedUserOpData.signedUserOp.nonce,
-                callData: signedUserOpData.signedUserOp.callData,
-                signature: signedUserOpData.signedUserOp.signature,
-                callGasLimit: signedUserOpData.signedUserOp.callGasLimit,
-                verificationGasLimit: signedUserOpData.signedUserOp.verificationGasLimit,
-                preVerificationGas: signedUserOpData.signedUserOp.preVerificationGas,
-                factory: signedUserOpData.signedUserOp.factory,
-                factoryData: signedUserOpData.signedUserOp.factoryData,
-                maxFeePerGas: signedUserOpData.signedUserOp.maxFeePerGas,
-                maxPriorityFeePerGas: signedUserOpData.signedUserOp.maxPriorityFeePerGas,
-                paymaster: signedUserOpData.signedUserOp.paymaster,
-                paymasterData: signedUserOpData.signedUserOp.paymasterData,
-                paymasterVerificationGasLimit: signedUserOpData.signedUserOp.paymasterVerificationGasLimit,
-                paymasterPostOpGasLimit: signedUserOpData.signedUserOp.paymasterPostOpGasLimit,
-            }
-            const qrPayment = await mantecaApi.completeQrPaymentWithSignedTx({
-                paymentLockCode: finalPaymentLock.code,
-                signedUserOp,
-                chainId: signedUserOpData.chainId,
-                entryPointAddress: signedUserOpData.entryPointAddress,
-                qrType: qrType ?? undefined,
-            })
+            const requestBody =
+                signedArtifact.strategy === 'collateral-only'
+                    ? ({
+                          kind: 'rainWithdrawal' as const,
+                          paymentLockCode: finalPaymentLock.code,
+                          qrType: qrType ?? undefined,
+                          signedRainWithdrawal: signedArtifact.rainWithdrawal,
+                          chainId: PEANUT_WALLET_CHAIN.id.toString(),
+                      } as const)
+                    : ({
+                          kind: 'userOp' as const,
+                          paymentLockCode: finalPaymentLock.code,
+                          qrType: qrType ?? undefined,
+                          signedUserOp: signedArtifact.signedUserOp.signedUserOp,
+                          chainId: signedArtifact.signedUserOp.chainId,
+                          entryPointAddress: signedArtifact.signedUserOp.entryPointAddress,
+                      } as const)
+            const qrPayment = await mantecaApi.completeQrPaymentWithSignedTx(requestBody)
             // clear the timer since we got a response
             if (payingStateTimerRef.current) {
                 clearTimeout(payingStateTimerRef.current)
@@ -535,7 +553,16 @@ export default function QRPayPage() {
         } finally {
             setLoadingState('Idle')
         }
-    }, [paymentLock?.code, signTransferUserOp, qrCode, currencyAmount, setLoadingState, qrType])
+    }, [
+        paymentLock?.code,
+        signSpend,
+        balance,
+        rainCardOverview?.balance?.spendingPower,
+        qrCode,
+        currencyAmount,
+        setLoadingState,
+        qrType,
+    ])
 
     const payQR = useCallback(async () => {
         if (paymentProcessor === 'MANTECA') {

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -470,7 +470,7 @@ export default function QRPayPage() {
             if (error instanceof InsufficientSpendableError) {
                 setErrorMessage('Not enough USDC in your wallet or card to cover this payment.')
             } else if (error instanceof SessionKeyGrantRequiredError) {
-                setErrorMessage('Card permission needed to pay from card balance — please try again.')
+                setErrorMessage("One-time card authorization needed. You'll be asked to confirm once.")
             } else if ((error as Error).toString().includes('not allowed')) {
                 setErrorMessage('Please confirm the transaction.')
             } else {
@@ -505,6 +505,12 @@ export default function QRPayPage() {
                           signedUserOp: signedArtifact.signedUserOp.signedUserOp,
                           chainId: signedArtifact.signedUserOp.chainId,
                           entryPointAddress: signedArtifact.signedUserOp.entryPointAddress,
+                          // For mixed: tell backend about the Rain prepare intent
+                          // embedded in the UserOp's batched callData so it can
+                          // reconcile the collateral webhook to QR_PAY in history.
+                          ...(signedArtifact.strategy === 'mixed'
+                              ? { rainPreparationId: signedArtifact.rainPreparationId }
+                              : {}),
                       } as const)
             const qrPayment = await mantecaApi.completeQrPaymentWithSignedTx(requestBody)
             // clear the timer since we got a response
@@ -524,6 +530,11 @@ export default function QRPayPage() {
             // this ensures a consistent reward experience regardless of amount.
 
             setIsSuccess(true)
+            posthog.capture(ANALYTICS_EVENTS.CARD_WITHDRAW_SUCCEEDED, {
+                strategy: signedArtifact.strategy,
+                kind: 'QR_PAY',
+                flow: 'sign-only',
+            })
         } catch (error) {
             // clear the timer on error to prevent race condition
             if (payingStateTimerRef.current) {
@@ -553,16 +564,7 @@ export default function QRPayPage() {
         } finally {
             setLoadingState('Idle')
         }
-    }, [
-        paymentLock?.code,
-        signSpend,
-        balance,
-        rainCardOverview?.balance?.spendingPower,
-        qrCode,
-        currencyAmount,
-        setLoadingState,
-        qrType,
-    ])
+    }, [paymentLock, signSpend, balance, rainCardOverview, qrCode, currencyAmount, setLoadingState, qrType])
 
     const payQR = useCallback(async () => {
         if (paymentProcessor === 'MANTECA') {

--- a/src/hooks/wallet/useSignSpendBundle.ts
+++ b/src/hooks/wallet/useSignSpendBundle.ts
@@ -1,0 +1,306 @@
+'use client'
+
+import { useCallback } from 'react'
+import type { Address, Hex } from 'viem'
+import { encodeFunctionData, erc20Abi } from 'viem'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { useKernelClient } from '@/context/kernelClient.context'
+import { useAuth } from '@/context/authContext'
+import { AccountType } from '@/interfaces'
+import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN, PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
+import {
+    RAIN_WITHDRAW_EIP712_DOMAIN_NAME,
+    RAIN_WITHDRAW_EIP712_DOMAIN_VERSION,
+    rainCoordinatorAbi,
+    rainWithdrawEip712Types,
+} from '@/constants/rain.consts'
+import { rainApi, type TransactionIntentKind } from '@/services/rain'
+import { useRainCardOverview } from '@/hooks/useRainCardOverview'
+import { useGrantSessionKey, type GrantSessionKeyError } from './useGrantSessionKey'
+import { useSignUserOp, type SignedUserOpData } from './useSignUserOp'
+import {
+    computeSpendStrategy,
+    InsufficientSpendableError,
+    SessionKeyGrantRequiredError,
+    type SpendStrategy,
+} from './useSpendBundle'
+
+/**
+ * Wire payload for a Rain withdrawal that the backend will broadcast (via
+ * session-key UserOp) AFTER its precondition succeeds (e.g. Manteca order
+ * created). Mirrors `/rain/cards/withdraw/submit`'s body.
+ */
+export interface SignedRainWithdrawal {
+    preparationId: string
+    amount: string
+    recipientAddress: Address
+    directTransfer: boolean
+    adminSalt: Hex
+    adminNonce: string
+    adminSignature: Hex
+    executorSignature: string
+    executorSalt: string
+    expiresAt: number
+}
+
+export type SignedSpendArtifact =
+    | {
+          strategy: 'smart-only'
+          /** Single-transfer USDC UserOp from the smart account. Backend broadcasts. */
+          signedUserOp: SignedUserOpData
+      }
+    | {
+          strategy: 'mixed'
+          /** Batch UserOp `[withdrawAsset, transfer]` from the smart account. Backend broadcasts. */
+          signedUserOp: SignedUserOpData
+          /** TransactionIntent id created by `/rain/cards/withdraw/prepare`.
+           *  Backend echoes / stamps this so the Rain webhook reconciles correctly. */
+          rainPreparationId: string
+      }
+    | {
+          strategy: 'collateral-only'
+          /** Backend submits this directly via the user's session-key UserOp on the
+           *  Rain coordinator (`directTransfer=true` straight to the recipient). */
+          rainWithdrawal: SignedRainWithdrawal
+      }
+
+export interface SignSpendBundleInput {
+    /** Total USDC (token smallest units) the spend must deliver. */
+    requiredUsdcAmount: bigint
+    /** Final recipient — required (Manteca-style flows always have a fixed destination). */
+    recipient: Address
+    /** Smart-account USDC balance right now, in token smallest units. */
+    smartBalance: bigint
+    /** Rain collateral `spendingPower` right now, in token smallest units. */
+    rainSpendingPower: bigint
+    /** User-semantic category of this spend (QR_PAY, FIAT_OFFRAMP, …).
+     *  Persisted on the `TransactionIntent` the backend creates in /prepare. */
+    kind: TransactionIntentKind
+    /** Fires once routing is picked, before any signing. */
+    onStrategyDecided?: (strategy: Exclude<SpendStrategy, 'insufficient'>) => void
+    /** Fires right before the one-time session-key grant prompt appears. */
+    onGrantRequired?: () => void
+}
+
+/**
+ * Sign-only sibling of `useSpendBundle`. Picks a strategy
+ * (collateral-only / smart-only / mixed) and returns the signed artifacts
+ * WITHOUT broadcasting. Designed for Manteca's sign-then-broadcast pattern,
+ * where the backend gates the broadcast on creating the Manteca order first.
+ *
+ * Strategies map to backend behaviour:
+ * - smart-only: backend broadcasts the signed UserOp via the bundler.
+ * - mixed: backend broadcasts the signed UserOp (which atomically pulls
+ *   collateral and forwards the full amount to the recipient).
+ * - collateral-only: backend submits the signed Rain withdrawal directly via
+ *   the user's session-key UserOp, with `directTransfer=true` so Rain's
+ *   coordinator transfers from the collateral proxy straight to the recipient
+ *   (1 passkey tap total — admin EIP-712 only).
+ *
+ * Conversion note: Rain's coordinator takes amounts in cents (2dp), our
+ * internal representation is USDC wei (6dp). We round up so a sub-cent
+ * shortfall still withdraws at least one cent.
+ */
+function usdcWeiToRainCents(amountWei: bigint): bigint {
+    if (amountWei <= 0n) return 0n
+    const divisor = 10n ** BigInt(PEANUT_WALLET_TOKEN_DECIMALS - 2)
+    return (amountWei + divisor - 1n) / divisor
+}
+
+export const useSignSpendBundle = () => {
+    const { getClientForChain } = useKernelClient()
+    const { signCallsUserOp } = useSignUserOp()
+    const { user } = useAuth()
+    const { overview } = useRainCardOverview()
+    const { grant } = useGrantSessionKey()
+
+    const signSpend = useCallback(
+        async (input: SignSpendBundleInput): Promise<SignedSpendArtifact> => {
+            const {
+                requiredUsdcAmount,
+                recipient,
+                smartBalance,
+                rainSpendingPower,
+                kind,
+                onStrategyDecided,
+                onGrantRequired,
+            } = input
+
+            // Manteca-style flows always have a single recipient and no
+            // subsequent kernel calls — collateral-only is always eligible.
+            const strategy = computeSpendStrategy({
+                smart: smartBalance,
+                rain: rainSpendingPower,
+                amount: requiredUsdcAmount,
+                collateralOnlyAllowed: true,
+            })
+            if (strategy === 'insufficient') {
+                posthog.capture(ANALYTICS_EVENTS.CARD_WITHDRAW_FAILED, {
+                    strategy: 'insufficient',
+                    error_kind: 'insufficient',
+                    flow: 'sign-only',
+                })
+                throw new InsufficientSpendableError()
+            }
+
+            onStrategyDecided?.(strategy)
+            posthog.capture(ANALYTICS_EVENTS.CARD_WITHDRAW_ATTEMPTED, { strategy, kind, flow: 'sign-only' })
+
+            const chainIdNum = PEANUT_WALLET_CHAIN.id
+            const chainIdStr = chainIdNum.toString()
+
+            // Pre-flight: any strategy that touches Rain collateral requires
+            // the one-time session-key grant. If missing, run the inline grant
+            // flow now.
+            const touchesCollateral = strategy === 'collateral-only' || strategy === 'mixed'
+            const card = overview?.cards?.[0]
+            if (touchesCollateral && card && !card.hasWithdrawApproval) {
+                onGrantRequired?.()
+                const grantResult = await grant()
+                if (!grantResult.ok) {
+                    throw new SessionKeyGrantRequiredError(grantResult.error as GrantSessionKeyError)
+                }
+            }
+
+            // ─── smart-only ─────────────────────────────────────────────────
+            if (strategy === 'smart-only') {
+                const transferData = encodeFunctionData({
+                    abi: erc20Abi,
+                    functionName: 'transfer',
+                    args: [recipient, requiredUsdcAmount],
+                })
+                const signedUserOp = await signCallsUserOp(
+                    [{ to: PEANUT_WALLET_TOKEN as Hex, value: 0n, data: transferData }],
+                    chainIdStr
+                )
+                return { strategy, signedUserOp }
+            }
+
+            // ─── collateral-only ────────────────────────────────────────────
+            // Only sign the admin EIP-712 — backend submits the withdrawal via
+            // the user's session-key UserOp (1 tap total).
+            if (strategy === 'collateral-only') {
+                const prep = await rainApi.prepareWithdrawal({
+                    amount: usdcWeiToRainCents(requiredUsdcAmount).toString(),
+                    recipientAddress: recipient,
+                    directTransfer: true,
+                    kind,
+                })
+
+                const kernelClient = getClientForChain(chainIdStr)
+                const adminSignature = (await kernelClient.account!.signTypedData({
+                    domain: {
+                        name: RAIN_WITHDRAW_EIP712_DOMAIN_NAME,
+                        version: RAIN_WITHDRAW_EIP712_DOMAIN_VERSION,
+                        chainId: chainIdNum,
+                        verifyingContract: prep.collateralProxy as Address,
+                        salt: prep.adminSalt as Hex,
+                    },
+                    types: rainWithdrawEip712Types,
+                    primaryType: 'Withdraw',
+                    message: {
+                        user: prep.adminAddress as Address,
+                        asset: prep.tokenAddress as Address,
+                        amount: BigInt(prep.amount),
+                        recipient: prep.recipientAddress as Address,
+                        nonce: BigInt(prep.adminNonce),
+                    },
+                })) as Hex
+
+                return {
+                    strategy,
+                    rainWithdrawal: {
+                        preparationId: prep.preparationId,
+                        amount: prep.amount,
+                        recipientAddress: prep.recipientAddress as Address,
+                        directTransfer: prep.directTransfer,
+                        adminSalt: prep.adminSalt as Hex,
+                        adminNonce: prep.adminNonce,
+                        adminSignature,
+                        executorSignature: prep.executorSignature,
+                        executorSalt: prep.executorSalt,
+                        expiresAt: prep.expiresAt,
+                    },
+                }
+            }
+
+            // ─── mixed ──────────────────────────────────────────────────────
+            // Pull the shortfall from collateral into the smart account, then
+            // forward the full amount to the recipient — one atomic UserOp,
+            // signed without broadcasting. Two passkey taps (admin sig + UserOp).
+            const adminAddress = user?.accounts.find((a) => a.type === AccountType.PEANUT_WALLET)?.identifier as
+                | Address
+                | undefined
+            if (!adminAddress) throw new Error('useSignSpendBundle: missing peanut-wallet address for mixed spend')
+
+            const shortfall = requiredUsdcAmount - smartBalance
+            const prep = await rainApi.prepareWithdrawal({
+                amount: usdcWeiToRainCents(shortfall).toString(),
+                // directTransfer=false sends tokens to the admin (kernel). Same
+                // semantics as broadcasting useSpendBundle.spend's mixed path.
+                recipientAddress: adminAddress,
+                directTransfer: false,
+                kind,
+                totalAmountCents: usdcWeiToRainCents(requiredUsdcAmount).toString(),
+            })
+
+            const kernelClient = getClientForChain(chainIdStr)
+            const adminSignature = (await kernelClient.account!.signTypedData({
+                domain: {
+                    name: RAIN_WITHDRAW_EIP712_DOMAIN_NAME,
+                    version: RAIN_WITHDRAW_EIP712_DOMAIN_VERSION,
+                    chainId: chainIdNum,
+                    verifyingContract: prep.collateralProxy as Address,
+                    salt: prep.adminSalt as Hex,
+                },
+                types: rainWithdrawEip712Types,
+                primaryType: 'Withdraw',
+                message: {
+                    user: prep.adminAddress as Address,
+                    asset: prep.tokenAddress as Address,
+                    amount: BigInt(prep.amount),
+                    recipient: prep.recipientAddress as Address,
+                    nonce: BigInt(prep.adminNonce),
+                },
+            })) as Hex
+
+            const withdrawCall = {
+                to: prep.coordinatorAddress as Hex,
+                value: 0n,
+                data: encodeFunctionData({
+                    abi: rainCoordinatorAbi,
+                    functionName: 'withdrawAsset',
+                    args: [
+                        prep.collateralProxy as Address,
+                        prep.tokenAddress as Address,
+                        BigInt(prep.amount),
+                        prep.recipientAddress as Address,
+                        BigInt(prep.expiresAt),
+                        prep.executorSalt as Hex,
+                        prep.executorSignature as Hex,
+                        [prep.adminSalt as Hex],
+                        [adminSignature],
+                        prep.directTransfer,
+                    ],
+                }),
+            }
+
+            const transferCall = {
+                to: PEANUT_WALLET_TOKEN as Hex,
+                value: 0n,
+                data: encodeFunctionData({
+                    abi: erc20Abi,
+                    functionName: 'transfer',
+                    args: [recipient, requiredUsdcAmount],
+                }),
+            }
+
+            const signedUserOp = await signCallsUserOp([withdrawCall, transferCall], chainIdStr)
+            return { strategy, signedUserOp, rainPreparationId: prep.preparationId }
+        },
+        [getClientForChain, signCallsUserOp, user, overview, grant]
+    )
+
+    return { signSpend }
+}

--- a/src/hooks/wallet/useSignSpendBundle.ts
+++ b/src/hooks/wallet/useSignSpendBundle.ts
@@ -6,9 +6,7 @@ import { encodeFunctionData, erc20Abi } from 'viem'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { useKernelClient } from '@/context/kernelClient.context'
-import { useAuth } from '@/context/authContext'
-import { AccountType } from '@/interfaces'
-import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN, PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
+import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants/zerodev.consts'
 import {
     RAIN_WITHDRAW_EIP712_DOMAIN_NAME,
     RAIN_WITHDRAW_EIP712_DOMAIN_VERSION,
@@ -25,6 +23,7 @@ import {
     SessionKeyGrantRequiredError,
     type SpendStrategy,
 } from './useSpendBundle'
+import { usdcWeiToRainCents } from '@/utils/balance.utils'
 
 /**
  * Wire payload for a Rain withdrawal that the backend will broadcast (via
@@ -97,21 +96,11 @@ export interface SignSpendBundleInput {
  *   the user's session-key UserOp, with `directTransfer=true` so Rain's
  *   coordinator transfers from the collateral proxy straight to the recipient
  *   (1 passkey tap total — admin EIP-712 only).
- *
- * Conversion note: Rain's coordinator takes amounts in cents (2dp), our
- * internal representation is USDC wei (6dp). We round up so a sub-cent
- * shortfall still withdraws at least one cent.
  */
-function usdcWeiToRainCents(amountWei: bigint): bigint {
-    if (amountWei <= 0n) return 0n
-    const divisor = 10n ** BigInt(PEANUT_WALLET_TOKEN_DECIMALS - 2)
-    return (amountWei + divisor - 1n) / divisor
-}
 
 export const useSignSpendBundle = () => {
     const { getClientForChain } = useKernelClient()
     const { signCallsUserOp } = useSignUserOp()
-    const { user } = useAuth()
     const { overview } = useRainCardOverview()
     const { grant } = useGrantSessionKey()
 
@@ -152,15 +141,32 @@ export const useSignSpendBundle = () => {
 
             // Pre-flight: any strategy that touches Rain collateral requires
             // the one-time session-key grant. If missing, run the inline grant
-            // flow now.
+            // flow now. Reject when the overview hasn't loaded yet — we can't
+            // tell whether the grant was already given, and signing
+            // optimistically would crash on the backend submission.
             const touchesCollateral = strategy === 'collateral-only' || strategy === 'mixed'
-            const card = overview?.cards?.[0]
-            if (touchesCollateral && card && !card.hasWithdrawApproval) {
-                onGrantRequired?.()
-                const grantResult = await grant()
-                if (!grantResult.ok) {
-                    throw new SessionKeyGrantRequiredError(grantResult.error as GrantSessionKeyError)
+            if (touchesCollateral) {
+                if (!overview) {
+                    throw new SessionKeyGrantRequiredError({ kind: 'unexpected' } as GrantSessionKeyError)
                 }
+                const card = overview.cards?.[0]
+                if (card && !card.hasWithdrawApproval) {
+                    onGrantRequired?.()
+                    const grantResult = await grant()
+                    if (!grantResult.ok) {
+                        throw new SessionKeyGrantRequiredError(grantResult.error as GrantSessionKeyError)
+                    }
+                }
+            }
+
+            // Resolve the kernel account once for all strategies. The non-null
+            // assertion on `client.account` was crash-prone if auth was still
+            // hydrating; do the guard once and reuse `account.address` as the
+            // canonical admin address (rather than re-deriving from useAuth).
+            const kernelClient = getClientForChain(chainIdStr)
+            const kernelAccount = kernelClient.account
+            if (!kernelAccount) {
+                throw new Error('useSignSpendBundle: kernel account not initialized')
             }
 
             // ─── smart-only ─────────────────────────────────────────────────
@@ -188,8 +194,7 @@ export const useSignSpendBundle = () => {
                     kind,
                 })
 
-                const kernelClient = getClientForChain(chainIdStr)
-                const adminSignature = (await kernelClient.account!.signTypedData({
+                const adminSignature = (await kernelAccount.signTypedData({
                     domain: {
                         name: RAIN_WITHDRAW_EIP712_DOMAIN_NAME,
                         version: RAIN_WITHDRAW_EIP712_DOMAIN_VERSION,
@@ -229,10 +234,9 @@ export const useSignSpendBundle = () => {
             // Pull the shortfall from collateral into the smart account, then
             // forward the full amount to the recipient — one atomic UserOp,
             // signed without broadcasting. Two passkey taps (admin sig + UserOp).
-            const adminAddress = user?.accounts.find((a) => a.type === AccountType.PEANUT_WALLET)?.identifier as
-                | Address
-                | undefined
-            if (!adminAddress) throw new Error('useSignSpendBundle: missing peanut-wallet address for mixed spend')
+            // Use the kernel account's own address as the admin recipient (the
+            // address we sign FROM) instead of re-deriving from useAuth.
+            const adminAddress = kernelAccount.address as Address
 
             const shortfall = requiredUsdcAmount - smartBalance
             const prep = await rainApi.prepareWithdrawal({
@@ -245,8 +249,7 @@ export const useSignSpendBundle = () => {
                 totalAmountCents: usdcWeiToRainCents(requiredUsdcAmount).toString(),
             })
 
-            const kernelClient = getClientForChain(chainIdStr)
-            const adminSignature = (await kernelClient.account!.signTypedData({
+            const adminSignature = (await kernelAccount.signTypedData({
                 domain: {
                     name: RAIN_WITHDRAW_EIP712_DOMAIN_NAME,
                     version: RAIN_WITHDRAW_EIP712_DOMAIN_VERSION,
@@ -299,7 +302,7 @@ export const useSignSpendBundle = () => {
             const signedUserOp = await signCallsUserOp([withdrawCall, transferCall], chainIdStr)
             return { strategy, signedUserOp, rainPreparationId: prep.preparationId }
         },
-        [getClientForChain, signCallsUserOp, user, overview, grant]
+        [getClientForChain, signCallsUserOp, overview, grant]
     )
 
     return { signSpend }

--- a/src/hooks/wallet/useSignUserOp.ts
+++ b/src/hooks/wallet/useSignUserOp.ts
@@ -29,6 +29,33 @@ export const useSignUserOp = () => {
     const { getClientForChain } = useKernelClient()
 
     /**
+     * Signs a UserOperation containing arbitrary kernel calls without
+     * broadcasting it. Used by sign-then-broadcast flows (Manteca) where the
+     * backend gates the broadcast on an external precondition.
+     */
+    const signCallsUserOp = useCallback(
+        async (
+            calls: { to: Hex; value: bigint; data: Hex }[],
+            chainId: string = PEANUT_WALLET_CHAIN.id.toString()
+        ): Promise<SignedUserOpData> => {
+            const client = getClientForChain(chainId)
+            if (!client.account) {
+                throw new Error('Smart account not initialized')
+            }
+            const signedUserOp = await signUserOperation(client, {
+                account: client.account,
+                callData: await client.account.encodeCalls(calls),
+            })
+            return {
+                signedUserOp,
+                chainId,
+                entryPointAddress: USER_OP_ENTRY_POINT.address,
+            }
+        },
+        [getClientForChain]
+    )
+
+    /**
      * Signs a USDC transfer UserOperation without broadcasting it.
      *
      * @param toAddress - Recipient address
@@ -45,45 +72,23 @@ export const useSignUserOp = () => {
             chainId: string = PEANUT_WALLET_CHAIN.id.toString()
         ): Promise<SignedUserOpData> => {
             try {
-                const client = getClientForChain(chainId)
-
-                // Ensure account is initialized
-                if (!client.account) {
-                    throw new Error('Smart account not initialized')
-                }
-
-                // Parse amount to USDC decimals (6 decimals)
                 const amount = parseUnits(amountInUsd.replace(/,/g, ''), PEANUT_WALLET_TOKEN_DECIMALS)
-
-                // Encode USDC transfer function call
                 const txData = encodeFunctionData({
                     abi: erc20Abi,
                     functionName: 'transfer',
                     args: [toAddress, amount],
                 }) as Hex
 
-                // Build USDC transfer call (not native token transfer)
-                const calls = [
-                    {
-                        to: PEANUT_WALLET_TOKEN as Hex, // USDC contract address
-                        value: 0n, // No native token sent
-                        data: txData, // Encoded transfer call
-                    },
-                ]
-
-                // Sign the UserOperation (does NOT broadcast)
-                // This fills in all required fields (gas, nonce, paymaster, signature)
-                const signedUserOp = await signUserOperation(client, {
-                    account: client.account,
-                    callData: await client.account!.encodeCalls(calls),
-                })
-
-                // Return everything the backend needs to submit the UserOp
-                return {
-                    signedUserOp,
-                    chainId,
-                    entryPointAddress: USER_OP_ENTRY_POINT.address,
-                }
+                return await signCallsUserOp(
+                    [
+                        {
+                            to: PEANUT_WALLET_TOKEN as Hex,
+                            value: 0n,
+                            data: txData,
+                        },
+                    ],
+                    chainId
+                )
             } catch (error) {
                 console.error('[useSignUserOp] Error signing UserOperation:', error)
                 captureException(error, {
@@ -97,8 +102,8 @@ export const useSignUserOp = () => {
                 throw error
             }
         },
-        [getClientForChain]
+        [signCallsUserOp]
     )
 
-    return { signTransferUserOp }
+    return { signTransferUserOp, signCallsUserOp }
 }

--- a/src/hooks/wallet/useSignUserOp.ts
+++ b/src/hooks/wallet/useSignUserOp.ts
@@ -38,18 +38,27 @@ export const useSignUserOp = () => {
             calls: { to: Hex; value: bigint; data: Hex }[],
             chainId: string = PEANUT_WALLET_CHAIN.id.toString()
         ): Promise<SignedUserOpData> => {
-            const client = getClientForChain(chainId)
-            if (!client.account) {
-                throw new Error('Smart account not initialized')
-            }
-            const signedUserOp = await signUserOperation(client, {
-                account: client.account,
-                callData: await client.account.encodeCalls(calls),
-            })
-            return {
-                signedUserOp,
-                chainId,
-                entryPointAddress: USER_OP_ENTRY_POINT.address,
+            try {
+                const client = getClientForChain(chainId)
+                if (!client.account) {
+                    throw new Error('Smart account not initialized')
+                }
+                const signedUserOp = await signUserOperation(client, {
+                    account: client.account,
+                    callData: await client.account.encodeCalls(calls),
+                })
+                return {
+                    signedUserOp,
+                    chainId,
+                    entryPointAddress: USER_OP_ENTRY_POINT.address,
+                }
+            } catch (error) {
+                console.error('[useSignUserOp] Error signing calls UserOperation:', error)
+                captureException(error, {
+                    tags: { feature: 'sign-user-op' },
+                    extra: { callCount: calls.length, chainId },
+                })
+                throw error
             }
         },
         [getClientForChain]

--- a/src/hooks/wallet/useSpendBundle.ts
+++ b/src/hooks/wallet/useSpendBundle.ts
@@ -19,6 +19,7 @@ import { rainApi, type TransactionIntentKind } from '@/services/rain'
 import { useZeroDev } from '@/hooks/useZeroDev'
 import { useRainCardOverview } from '@/hooks/useRainCardOverview'
 import { useGrantSessionKey, type GrantSessionKeyError } from './useGrantSessionKey'
+import { usdcWeiToRainCents } from '@/utils/balance.utils'
 
 export type SpendStrategy = 'collateral-only' | 'smart-only' | 'mixed' | 'insufficient'
 
@@ -87,19 +88,9 @@ export class SessionKeyGrantRequiredError extends Error {
     }
 }
 
-/**
- * Rain's `/signatures/withdrawals` API, the EIP-712 `Withdraw` message it
- * signs, and the on-chain `coordinator.withdrawAsset` all take `amount` in
- * **cents** (2 decimals) — Rain's sample V2 code calls the field
- * `amountInCents`. Our internal representation is USDC wei (token decimals,
- * typically 6). Convert at the Rain boundary, rounding up so a sub-cent
- * shortfall still withdraws at least one cent.
- */
-function usdcWeiToRainCents(amountWei: bigint): bigint {
-    if (amountWei <= 0n) return 0n
-    const divisor = 10n ** BigInt(PEANUT_WALLET_TOKEN_DECIMALS - 2)
-    return (amountWei + divisor - 1n) / divisor
-}
+// `usdcWeiToRainCents` lives in @/utils/balance.utils alongside its sibling
+// `rainSpendingPowerToWei` — both convert at the Rain wire boundary (cents,
+// 2dp) ↔ USDC wei (PEANUT_WALLET_TOKEN_DECIMALS).
 
 /**
  * Pure routing helper — decides which bucket(s) a spend will pull from.

--- a/src/services/manteca.ts
+++ b/src/services/manteca.ts
@@ -125,57 +125,70 @@ export const mantecaApi = {
         return response.json()
     },
     /**
-     * Complete QR payment with a pre-signed UserOperation.
-     * This allows the backend to complete the Manteca payment BEFORE broadcasting the transaction,
-     * preventing funds from being stuck in Manteca if their payment fails.
+     * Complete QR payment with a pre-signed transaction.
      *
-     * Flow:
-     * 1. Frontend signs UserOp (funds still in user's wallet)
-     * 2. Backend receives signed UserOp
-     * 3. Backend completes Manteca payment first
-     * 4. If Manteca succeeds, backend broadcasts UserOp
-     * 5. If Manteca fails, UserOp is never broadcasted (funds safe)
+     * Two shapes by `kind`:
+     * - 'userOp' (smart-only / mixed): backend broadcasts the signed kernel
+     *   UserOp via the bundler. For mixed, the UserOp's batched callData
+     *   embeds a Rain `withdrawAsset` call so collateral materializes into
+     *   the smart account atomically with the transfer to MANTECA.
+     * - 'rainWithdrawal' (collateral-only): backend submits the signed Rain
+     *   withdrawal via the user's session-key UserOp with `directTransfer=true`
+     *   straight to MANTECA's deposit address. One passkey tap (admin EIP-712).
+     *
+     * In all cases, backend creates the Manteca order FIRST so funds don't
+     * leave the user's side if Manteca fails.
      */
-    completeQrPaymentWithSignedTx: async ({
-        paymentLockCode,
-        signedUserOp,
-        chainId,
-        entryPointAddress,
-        qrType,
-    }: {
-        paymentLockCode: string
-        qrType?: string
-        signedUserOp: Pick<
-            SignUserOperationReturnType,
-            | 'sender'
-            | 'nonce'
-            | 'callData'
-            | 'signature'
-            | 'callGasLimit'
-            | 'verificationGasLimit'
-            | 'preVerificationGas'
-            | 'maxFeePerGas'
-            | 'maxPriorityFeePerGas'
-            | 'paymaster'
-            | 'paymasterData'
-            | 'paymasterVerificationGasLimit'
-            | 'paymasterPostOpGasLimit'
-            | 'factory'
-            | 'factoryData'
-        >
-        chainId: string
-        entryPointAddress: Address
-    }): Promise<QrPayment> => {
+    completeQrPaymentWithSignedTx: async (
+        body:
+            | {
+                  kind: 'userOp'
+                  paymentLockCode: string
+                  qrType?: string
+                  signedUserOp: Pick<
+                      SignUserOperationReturnType,
+                      | 'sender'
+                      | 'nonce'
+                      | 'callData'
+                      | 'signature'
+                      | 'callGasLimit'
+                      | 'verificationGasLimit'
+                      | 'preVerificationGas'
+                      | 'maxFeePerGas'
+                      | 'maxPriorityFeePerGas'
+                      | 'paymaster'
+                      | 'paymasterData'
+                      | 'paymasterVerificationGasLimit'
+                      | 'paymasterPostOpGasLimit'
+                      | 'factory'
+                      | 'factoryData'
+                  >
+                  chainId: string
+                  entryPointAddress: Address
+              }
+            | {
+                  kind: 'rainWithdrawal'
+                  paymentLockCode: string
+                  qrType?: string
+                  signedRainWithdrawal: {
+                      preparationId: string
+                      amount: string
+                      recipientAddress: Address
+                      directTransfer: boolean
+                      adminSalt: string
+                      adminNonce: string
+                      adminSignature: string
+                      executorSignature: string
+                      executorSalt: string
+                      expiresAt: number
+                  }
+                  chainId: string
+              }
+    ): Promise<QrPayment> => {
         const response = await serverFetch('/manteca/qr-payment/complete-with-signed-tx', {
             method: 'POST',
-            body: jsonStringify({
-                paymentLockCode,
-                signedUserOp,
-                chainId,
-                entryPointAddress,
-                qrType,
-            }),
-            timeoutMs: 120_000, // long-running signed userop submission
+            body: jsonStringify(body),
+            timeoutMs: 120_000, // long-running signed-tx submission
         })
 
         if (!response.ok) {

--- a/src/services/manteca.ts
+++ b/src/services/manteca.ts
@@ -165,6 +165,11 @@ export const mantecaApi = {
                   >
                   chainId: string
                   entryPointAddress: Address
+                  /** Set when the UserOp embeds a Rain `withdrawAsset` call (mixed
+                   *  strategy). Lets backend stamp the prepared intent with the
+                   *  on-chain tx hash so the collateral webhook reconciles to the
+                   *  right kind in history (vs. an unmatched generic charge). */
+                  rainPreparationId?: string
               }
             | {
                   kind: 'rainWithdrawal'

--- a/src/utils/balance.utils.ts
+++ b/src/utils/balance.utils.ts
@@ -26,3 +26,14 @@ export const rainSpendingPowerToWei = (spendingPowerCents: number | null | undef
     const widenFactor = BigInt(10 ** (PEANUT_WALLET_TOKEN_DECIMALS - 2))
     return BigInt(Math.floor(spendingPowerCents)) * widenFactor
 }
+
+/**
+ * Convert a USDC wei amount (PEANUT_WALLET_TOKEN_DECIMALS, typically 6dp) to
+ * Rain's native cents (2dp). Rounds up so a sub-cent shortfall still
+ * withdraws at least one cent — Rain rejects 0-amount withdrawals.
+ */
+export const usdcWeiToRainCents = (amountWei: bigint): bigint => {
+    if (amountWei <= 0n) return 0n
+    const divisor = 10n ** BigInt(PEANUT_WALLET_TOKEN_DECIMALS - 2)
+    return (amountWei + divisor - 1n) / divisor
+}


### PR DESCRIPTION
## Summary

Closes the Manteca QR pay bug where users with funds parked in card collateral couldn't pay because ZeroDev's paymaster refused to sponsor a USDC transfer from a near-zero smart-account balance.

**Repro flow:** top up → auto-rebalance moves to card collateral → smart wallet drains → Manteca QR pay → paymaster sponsor rejection → "Could not sign the transaction." (paymaster error visible in browser console).

## Approach

Route the Manteca QR pay spend through \`useSpendBundle\`'s strategy decision (smart-only / mixed / collateral-only) using a new sign-only sibling hook that returns signed artifacts WITHOUT broadcasting. Backend keeps gating the broadcast on creating the Manteca order first (preserves the existing atomicity guarantee — funds never leave the user if Manteca fails).

## Frontend changes

- **\`useSignSpendBundle\`** (new) — sign-only sibling of \`useSpendBundle.spend\`. Returns a discriminated artifact per strategy:
  - **smart-only**: signed kernel UserOp (single \`USDC.transfer\`)
  - **mixed**: signed kernel UserOp (batched \`[withdrawAsset, transfer]\`) + \`rainPreparationId\` — paymaster sees the materialized balance during simulation
  - **collateral-only**: signed admin EIP-712 only (no UserOp) — backend submits via session-key UserOp with \`directTransfer=true\` straight to MANTECA
- **\`useSignUserOp\`** — added generic \`signCallsUserOp(calls, chainId)\`. \`signTransferUserOp\` is a thin wrapper.
- **\`mantecaApi.completeQrPaymentWithSignedTx\`** — body is now a discriminated union (\`kind: 'userOp'\` or \`kind: 'rainWithdrawal'\`).
- **\`qr-pay/page.tsx\` \`handleMantecaPayment\`** — swapped the smart-only-only \`signTransferUserOp\` call for \`signSpend\` + dispatches to the right request shape. Surfaces \`InsufficientSpendableError\` and \`SessionKeyGrantRequiredError\` with friendly copy.

## UX outcomes by strategy

| Strategy | Tap count |
|---|---|
| smart-only | 1 (UserOp) |
| mixed | 2 (admin EIP-712 + UserOp) |
| collateral-only | 1 (admin EIP-712 only) |

## Companion PR

Backend route changes: peanutprotocol/peanut-api-ts (\`feat/manteca-collateral\`).

## Out of scope

Manteca withdraw flow has the same architectural issue (\`signTransferUserOp\` smart-only path); follow-up PR will apply the same pattern there.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`npm test\` — qr-pay test suite passes (22 tests)
- [ ] Staging: pay a Mercado Pago QR with smart-account balance ≥ amount → 1 tap (existing path)
- [ ] Staging: pay a Mercado Pago QR with split balance (smart + collateral both partially) → 2 taps, mixed UserOp succeeds
- [ ] **Staging: pay a Mercado Pago QR with smart=0, collateral covers** → 1 tap (admin EIP-712), payment goes through (the original bug repro)
- [ ] Staging: payment with insufficient total → "Not enough USDC in your wallet or card" message (no paymaster error)