### PR TITLE
docs(rain): clarify cents-in / wei-out asymmetry in withdraw types

### DIFF
--- a/src/hooks/wallet/useSpendBundle.ts
+++ b/src/hooks/wallet/useSpendBundle.ts
@@ -89,8 +89,11 @@ export class SessionKeyGrantRequiredError extends Error {
 }
 
 // `usdcWeiToRainCents` lives in @/utils/balance.utils alongside its sibling
-// `rainSpendingPowerToWei` — both convert at the Rain wire boundary (cents,
-// 2dp) ↔ USDC wei (PEANUT_WALLET_TOKEN_DECIMALS).
+// `rainSpendingPowerToWei`. Rain's wire convention is asymmetric: cents (2dp)
+// on INPUT to /prepare, USDC wei (PEANUT_WALLET_TOKEN_DECIMALS) on OUTPUT in
+// the signed parameters (what the EIP-712 message + coordinator sign over).
+// `usdcWeiToRainCents` is for the input side only — never call it on amounts
+// returned from Rain.
 
 /**
  * Pure routing helper — decides which bucket(s) a spend will pull from.

--- a/src/services/rain.ts
+++ b/src/services/rain.ts
@@ -70,7 +70,9 @@ export type TransactionIntentKind =
     | 'OTHER'
 
 export interface PrepareRainWithdrawalInput {
-    amount: string // native units as decimal string (USDC cents: e.g. "500000" for $5.00 at 6dp)
+    /** Rain cents (2dp), as a decimal string. e.g. `"500"` for $5.00.
+     *  Convert from USDC wei via `usdcWeiToRainCents` at the boundary. */
+    amount: string
     recipientAddress: string
     directTransfer: boolean
     /** User-semantic kind — drives history categorization for the collateral webhook. */
@@ -88,6 +90,10 @@ export interface PrepareRainWithdrawalResponse {
     adminAddress: string
     chainId: string
     tokenAddress: string
+    /** USDC wei (PEANUT_WALLET_TOKEN_DECIMALS, typically 6dp) — NOT cents.
+     *  Rain accepts cents on input but echoes the on-chain wire value here:
+     *  it's what the EIP-712 message and `coordinator.withdrawAsset` sign
+     *  over, and what /submit broadcasts unchanged. Don't re-convert. */
     amount: string
     recipientAddress: string
     directTransfer: boolean

--- a/src/utils/balance.utils.ts
+++ b/src/utils/balance.utils.ts
@@ -29,8 +29,14 @@ export const rainSpendingPowerToWei = (spendingPowerCents: number | null | undef
 
 /**
  * Convert a USDC wei amount (PEANUT_WALLET_TOKEN_DECIMALS, typically 6dp) to
- * Rain's native cents (2dp). Rounds up so a sub-cent shortfall still
- * withdraws at least one cent — Rain rejects 0-amount withdrawals.
+ * cents (2dp), the unit Rain's `/signatures/withdrawals` API takes on its
+ * INPUT side. Rounds up so a sub-cent shortfall still withdraws at least one
+ * cent — Rain rejects 0-amount withdrawals.
+ *
+ * Asymmetry warning: Rain accepts cents on input but RETURNS the signed
+ * amount in USDC wei (it's what the EIP-712 message + on-chain coordinator
+ * sign over). The prepare → /submit roundtrip is cents-in / wei-out. Don't
+ * use this function on values returned from Rain.
  */
 export const usdcWeiToRainCents = (amountWei: bigint): bigint => {
     if (amountWei <= 0n) return 0n


### PR DESCRIPTION
Doc-only follow-up to #1937. Companion to peanut-api-ts PR (linked once opened) which carries both the bug fix and matching backend doc updates.

## Why

Rain's withdrawal API has an asymmetric unit convention that bit me on staging:
- **Input** to /prepare: amount in cents (2dp)
- **Output** signed parameters: amount in **USDC wei** (6dp)

The codebase only documented the cents side. The next reader (or me, again) shouldn't have to re-derive that.

## What changed

- \`PrepareRainWithdrawalInput.amount\`: cents (with \`usdcWeiToRainCents\` pointer)
- \`PrepareRainWithdrawalResponse.amount\`: USDC wei, NOT cents — "Don't re-convert"
- \`usdcWeiToRainCents\` JSDoc: asymmetry warning, "Don't use this function on values returned from Rain"
- \`useSpendBundle\` helper-pointer comment: spells out the asymmetry

## Test plan

- [x] \`pnpm typecheck\` clean
- No behaviour changes