### PR TITLE
chore: trim TransactionDetails comments + fix HarnessBootstrap SSR

### DIFF
--- a/src/app/ClientProviders.tsx
+++ b/src/app/ClientProviders.tsx
@@ -21,9 +21,15 @@ import { PeanutDebug } from '@/context/PeanutDebug'
 
 // Harness bootstrap ships only in harness builds. In prod bundles the dynamic
 // import is in dead code behind `if (false)` and webpack drops the chunk.
+// Note: was `ssr: false`. Discovered 2026-04-30 via the harness fake-spinner
+// audit: `dynamic({ssr: false})` triggers `BAILOUT_TO_CLIENT_SIDE_RENDERING`
+// in Next.js 16 + Turbopack, and the SSR'd HTML in that case has only ~2
+// script tags vs ~95 with ssr:true. ssr:true gives Playwright a fully-streamed
+// page that hydrates more reliably. HarnessBootstrap is `'use client'` and
+// tolerates SSR (it gates internally on window/sessionStorage).
 const HarnessBootstrap = HARNESS_ENABLED
     ? dynamic(() => import('@/context/HarnessBootstrap').then((m) => m.HarnessBootstrap), {
-          ssr: false,
+          ssr: true,
       })
     : null
 

--- a/src/components/TransactionDetails/strategies/fallback.ts
+++ b/src/components/TransactionDetails/strategies/fallback.ts
@@ -6,9 +6,9 @@ import { pipelineAlert } from '@/utils/pipelineAlerts'
 export const intentFallback: TransactionStrategy = (entry: HistoryEntry): TransactionStrategyOutput => {
     const kind = (entry.extraData?.kind as string | undefined) ?? 'OTHER'
 
-    // Card refunds arrive with kind ∈ {OTHER, REFUND} + parentRainTxId set
-    // (provider === RAIN). Scope strictly to these two kinds — guarding only
-    // on parentRainTxId would misroute any future intent carrying the linkage.
+    // Card refunds arrive with kind ∈ {OTHER, REFUND} + parentRainTxId set.
+    // Scope strictly to these two kinds — guarding only on parentRainTxId
+    // would misroute any future intent that carries the linkage.
     if ((kind === 'OTHER' || kind === 'REFUND') && entry.extraData?.parentRainTxId) {
         return cardRefund(entry)
     }

--- a/src/components/TransactionDetails/strategies/intent/fiat-offramp.ts
+++ b/src/components/TransactionDetails/strategies/intent/fiat-offramp.ts
@@ -3,9 +3,8 @@ import { type TransactionStrategy, type TransactionStrategyOutput } from '../typ
 
 export const fiatOfframp: TransactionStrategy = (entry: HistoryEntry): TransactionStrategyOutput => {
     if (entry.userRole === EHistoryUserRole.RECIPIENT) {
-        // Multi-user fulfillment edge case — viewer received a bank
-        // withdraw initiated by another user. USDC arrives in viewer's
-        // wallet from offramp funder.
+        // Multi-user fulfilment: viewer received USDC from an offramp
+        // initiated by another user.
         return {
             direction: 'receive',
             transactionCardType: 'receive',

--- a/src/components/TransactionDetails/strategies/intent/p2p-send.ts
+++ b/src/components/TransactionDetails/strategies/intent/p2p-send.ts
@@ -1,5 +1,4 @@
-// REQUEST_PAY is the post-decomplexify rename of P2P_REQUEST_FULFILL;
-// shares this strategy with P2P_SEND.
+// REQUEST_PAY shares this strategy with P2P_SEND.
 
 import { EHistoryUserRole, type HistoryEntry } from '@/hooks/useTransactionHistory'
 import { type TransactionStrategy, type TransactionStrategyOutput } from '../types'

--- a/src/components/TransactionDetails/strategies/legacy/bank-send-link-claim.ts
+++ b/src/components/TransactionDetails/strategies/legacy/bank-send-link-claim.ts
@@ -12,7 +12,7 @@ const BANK_CLAIM: TransactionStrategyOutput = {
 export const bankSendLinkClaim: TransactionStrategy = (entry: HistoryEntry): TransactionStrategyOutput => {
     const senderSide = entry.userRole === EHistoryUserRole.SENDER || entry.userRole === EHistoryUserRole.BOTH
     if (senderSide && entry.recipientAccount.isUser) {
-        // Claimed by a peanut user (kyc'd or not). Render as direct send.
+        // Claimed by a Peanut user (KYC'd or not) — render as direct send.
         return {
             direction: 'send',
             transactionCardType: 'send',

--- a/src/components/TransactionDetails/strategies/legacy/direct-send.ts
+++ b/src/components/TransactionDetails/strategies/legacy/direct-send.ts
@@ -20,10 +20,8 @@ export const directSend: TransactionStrategy = (entry: HistoryEntry): Transactio
         fullName: entry.senderAccount?.fullName ?? '',
         showFullName: entry.senderAccount?.showFullName,
         isPeerActuallyUser: true,
-        // Original behaviour: if the sender side has no senderAccount, the
-        // entry was created by an external (non-Peanut) actor, render as a
-        // public-link receive. The legacy switch toggled `isLinkTx` based on
-        // `!entry.senderAccount` regardless of `isPeerActuallyUser`.
+        // No senderAccount → entry was created by an external (non-Peanut)
+        // actor; render as a public-link receive.
         isLinkTx: !entry.senderAccount,
     }
 }

--- a/src/components/TransactionDetails/strategies/legacy/external-account.ts
+++ b/src/components/TransactionDetails/strategies/legacy/external-account.ts
@@ -1,5 +1,5 @@
-// Strategies for entries that withdraw to / deposit from external (non-user)
-// destinations: bank accounts, raw wallet addresses, merchant accounts.
+// Strategies for entries against external (non-user) destinations: bank
+// accounts, raw wallet addresses, merchant accounts.
 
 import { type HistoryEntry } from '@/hooks/useTransactionHistory'
 import { type TransactionStrategy, type TransactionStrategyOutput } from '../types'

--- a/src/components/TransactionDetails/strategies/legacy/request.ts
+++ b/src/components/TransactionDetails/strategies/legacy/request.ts
@@ -10,9 +10,6 @@ export const request: TransactionStrategy = (entry: HistoryEntry): TransactionSt
             fullName: entry.recipientAccount?.fullName ?? '',
             showFullName: entry.recipientAccount?.showFullName,
             isPeerActuallyUser: !!entry.recipientAccount?.isUser || !!entry.senderAccount?.isUser,
-            // Mirrors the legacy fall-through: REQUEST × bridge × SENDER
-            // doesn't explicitly set isLinkTx, so it lands on the
-            // post-switch `isLinkTx = !isPeerActuallyUser` line.
             isLinkTx: !(!!entry.recipientAccount?.isUser || !!entry.senderAccount?.isUser),
         }
     }

--- a/src/components/TransactionDetails/strategies/legacy/send-link.ts
+++ b/src/components/TransactionDetails/strategies/legacy/send-link.ts
@@ -41,8 +41,7 @@ export const sendLink: TransactionStrategy = (entry: HistoryEntry): TransactionS
     }
     if (entry.userRole === EHistoryUserRole.BOTH) {
         // Sender claimed their own link → cancelled. uiStatus override
-        // matches the pre-strategy switch (set uiStatus='cancelled' before
-        // the global status mapper runs).
+        // bypasses the global status mapper.
         return {
             direction: 'send',
             transactionCardType: 'send',
@@ -52,7 +51,7 @@ export const sendLink: TransactionStrategy = (entry: HistoryEntry): TransactionS
             uiStatus: 'cancelled',
         }
     }
-    // userRole = SENDER_PUBLIC / unknown — public-link claim path
+    // SENDER_PUBLIC / unknown — public-link claim path
     return {
         direction: 'claim_external',
         transactionCardType: 'claim_external',

--- a/src/components/TransactionDetails/strategies/registry.ts
+++ b/src/components/TransactionDetails/strategies/registry.ts
@@ -1,14 +1,9 @@
-// Composite-key registry for the transformer's per-kind strategies.
-//
-// Key shape:
-//   - Legacy EHistoryEntryType cases: just the type ("DIRECT_SEND")
-//   - TRANSACTION_INTENT cases: "TRANSACTION_INTENT:<kind>" so each
-//     intent kind owns its own strategy without nested-switch dispatch.
-//
-// `dispatchStrategy(entry)` returns the matching strategy, or — for
-// TRANSACTION_INTENT entries with an unknown kind — the intent fallback,
-// which routes card refunds to cardRefund and logs the rest via
-// pipelineAlert. Legacy types with no strategy fall to legacyFallback.
+// Composite-key registry for per-kind strategies.
+//   - Legacy EHistoryEntryType cases keyed by the type ("DIRECT_SEND")
+//   - TRANSACTION_INTENT cases keyed by "TRANSACTION_INTENT:<kind>"
+// Unknown intent kinds fall through to `intentFallback` (which routes card
+// refunds and logs the rest via pipelineAlert); unknown legacy types fall
+// through to `legacyFallback`.
 
 import { type HistoryEntry } from '@/hooks/useTransactionHistory'
 import { type TransactionStrategy } from './types'
@@ -33,14 +28,13 @@ import { fiatOfframp } from './intent/fiat-offramp'
 import { qrPay, cardSpend } from './intent/card'
 import { intentFallback, legacyFallback } from './fallback'
 
-// String literal values match the EHistoryEntryType enum (history.utils.ts)
-// and the BE TransactionIntentKind enum. Inlined here so tests that mock
-// `@/hooks/useTransactionHistory` (and thus break the enum re-export) can
-// still load this module — the registry is wired at module-init time.
+// Inlined string literal — matches the EHistoryEntryType / BE
+// TransactionIntentKind values. Kept as a literal so tests that mock
+// `@/hooks/useTransactionHistory` (breaking the enum re-export) can still
+// load this module at init time.
 const TRANSACTION_INTENT = 'TRANSACTION_INTENT'
 
-// Legacy EHistoryEntryType values handled by a strategy. Adding a new legacy
-// type here without a corresponding entry in STRATEGIES is a compile error.
+// Adding a legacy type here without a corresponding STRATEGIES entry is a compile error.
 type LegacyKey =
     | 'DIRECT_SEND'
     | 'SEND_LINK'
@@ -57,9 +51,8 @@ type LegacyKey =
     | 'SIMPLEFI_QR_PAYMENT'
     | 'PERK_REWARD'
 
-// TRANSACTION_INTENT kinds rendered by an explicit strategy. Adding a new
-// BE TransactionIntentKind that should render distinctly requires updating
-// this union AND the STRATEGIES map below — TS guarantees both move together.
+// Adding a TransactionIntentKind here requires a matching STRATEGIES entry —
+// TS guarantees both move together.
 type IntentKind =
     | 'P2P_SEND'
     | 'REQUEST_PAY'

--- a/src/components/TransactionDetails/strategies/types.ts
+++ b/src/components/TransactionDetails/strategies/types.ts
@@ -1,11 +1,8 @@
-// Per-kind strategy contract for transactionTransformer's pre-globals
-// switch. Each strategy decides direction + card type + counterparty
-// name + a few flags from the row's shape; the post-strategy code in
-// mapTransactionDataForDrawer handles status mapping, reaper override,
-// derived fields (explorer URL, token logos, initials).
-//
-// Strategies are pure functions of HistoryEntry — no DOM, no fetches,
-// no mutable state. Tests import them directly.
+// Per-kind strategy contract. Each strategy decides direction + card type +
+// counterparty name + a few flags from the row's shape;
+// `mapTransactionDataForDrawer` handles status mapping, reaper override, and
+// derived fields (explorer URL, token logos, initials). Strategies are pure
+// functions of HistoryEntry — no IO, no mutable state.
 
 import { type TransactionType as TransactionCardType } from '@/components/TransactionDetails/TransactionCard'
 import { type TransactionDirection } from '@/components/TransactionDetails/TransactionDetailsHeaderCard'

--- a/src/components/TransactionDetails/transaction-predicates.ts
+++ b/src/components/TransactionDetails/transaction-predicates.ts
@@ -1,25 +1,17 @@
 /**
- * Receipt-side type predicates.
+ * Receipt-side type predicates. Centralised so adding a provider is a one-line
+ * change rather than a grep-and-edit across the receipt.
  *
- * Pre-M3 the receipt branched on `originalType === EHistoryEntryType.X` in
- * many places, often as multi-element OR chains (e.g. "is this any kind of
- * QR payment?", "is this any kind of bank flow?"). This module centralises
- * those checks so adding a provider is one line in one place rather than a
- * grep-and-edit across the receipt.
- *
- * Predicates take `TransactionDetails` (the drawer view model) — not raw
- * `HistoryEntry` — because some require fields that only exist after the
- * transformer runs (e.g. `extraDataForDrawer.cardPayment`).
+ * Predicates take `TransactionDetails` (the drawer view model) rather than
+ * raw `HistoryEntry` because some need fields the transformer derives
+ * (e.g. `extraDataForDrawer.cardPayment`).
  */
 
 import { type TransactionDetails } from './transactionTransformer'
-// Type-only import — the runtime enum lives in utils/history.utils, which
-// ends up in a circular load with this file under the jest module graph
-// (utils/history.utils → transactionTransformer → TransactionCard →
-// transaction-predicates → back to utils/history.utils, mid-evaluation).
-// Importing only the type lets the transpiler erase this line entirely;
-// the Sets below use string literals because EHistoryEntryType is a string
-// enum, so the runtime values are interchangeable with their literal forms.
+// Type-only import to avoid a jest circular-load cycle through
+// utils/history.utils → transactionTransformer → TransactionCard. The Sets
+// below use string literals because EHistoryEntryType is a string enum, so
+// runtime values match their literal forms.
 import type { EHistoryEntryType } from '@/utils/history.utils'
 
 const QR_PAYMENT_TYPES: ReadonlySet<EHistoryEntryType> = new Set<EHistoryEntryType>([
@@ -27,9 +19,8 @@ const QR_PAYMENT_TYPES: ReadonlySet<EHistoryEntryType> = new Set<EHistoryEntryTy
     'SIMPLEFI_QR_PAYMENT' as EHistoryEntryType,
 ])
 
-// Types whose receipt is shareable (split-bill prompt + share-receipt button).
-// Same as QR-payments today plus Manteca on/off-ramps; kept as its own set so
-// "shareable" can diverge from "QR" later without a sweep.
+// Receipts that show the split-bill prompt + share-receipt button. Kept as
+// its own set so "shareable" can diverge from "QR" without a sweep.
 const SHAREABLE_RECEIPT_TYPES: ReadonlySet<EHistoryEntryType> = new Set<EHistoryEntryType>([
     'MANTECA_QR_PAYMENT' as EHistoryEntryType,
     'SIMPLEFI_QR_PAYMENT' as EHistoryEntryType,
@@ -38,7 +29,7 @@ const SHAREABLE_RECEIPT_TYPES: ReadonlySet<EHistoryEntryType> = new Set<EHistory
 ])
 
 // Types where the timestamp label reads "Completed" (one-shot bank/onchain
-// flows) instead of "Sent"/"Received" (peer-shaped flows).
+// flows) instead of "Sent"/"Received" (peer-shaped).
 const COMPLETED_LABEL_TYPES: ReadonlySet<EHistoryEntryType> = new Set<EHistoryEntryType>([
     'WITHDRAW' as EHistoryEntryType,
     'DEPOSIT' as EHistoryEntryType,
@@ -50,12 +41,10 @@ const COMPLETED_LABEL_TYPES: ReadonlySet<EHistoryEntryType> = new Set<EHistoryEn
     'MANTECA_ONRAMP' as EHistoryEntryType,
 ])
 
-/** Post-M3, QR payments arrive as TRANSACTION_INTENT entries with
- *  `extraData.kind === 'QR_PAY'`. Pre-M3 (legacy rows still in the feed)
- *  used dedicated `originalType` values. Recognize both. */
+/** QR payments arrive as TRANSACTION_INTENT entries with
+ *  `extraData.kind === 'QR_PAY'`; legacy rows in the feed use dedicated
+ *  `originalType` values. Recognize both. */
 function isTransactionIntentKind(transaction: TransactionDetails, kind: string): boolean {
-    // String comparison — see top-of-file note on the type-only import. The
-    // enum value 'TRANSACTION_INTENT' is identical to its string at runtime.
     return (
         transaction.extraDataForDrawer?.originalType === ('TRANSACTION_INTENT' as EHistoryEntryType) &&
         transaction.extraDataForDrawer?.kind === kind
@@ -71,7 +60,6 @@ export function isQRPayment(transaction: TransactionDetails): boolean {
 export function hasShareableReceipt(transaction: TransactionDetails): boolean {
     const type = transaction.extraDataForDrawer?.originalType
     if (type && SHAREABLE_RECEIPT_TYPES.has(type)) return true
-    // QR payments via the unified intent path should also be shareable.
     return isTransactionIntentKind(transaction, 'QR_PAY')
 }
 

--- a/src/components/TransactionDetails/transactionTransformer.ts
+++ b/src/components/TransactionDetails/transactionTransformer.ts
@@ -21,17 +21,11 @@ import { dispatchStrategy } from './strategies/registry'
  */
 
 /**
- * Should the receipt drawer's `bankAccountDetails` row render for this entry?
- *
- * Original gate (pre-decomplexify) only fired for legacy `BRIDGE_OFFRAMP` and
- * `BANK_SEND_LINK_CLAIM × RECIPIENT`. Post-decomplexify, the same flows arrive
- * as `TRANSACTION_INTENT` with `kind ∈ {FIAT_OFFRAMP, CRYPTO_WITHDRAW}`, so the
- * gate must include those too — otherwise the IBAN row disappears and the
- * country-by-IBAN flag fallback in `getBankAccountCountryCode` kicks in,
- * showing an EU flag for an ES IBAN (Hugo's screenshot d on 2026-04-29).
- *
- * Also includes legacy `MANTECA_OFFRAMP` — independent legacy bug, was never
- * plumbed before. Catches Argentina/Brazil rail withdrawals.
+ * Whether the receipt drawer's `bankAccountDetails` row should render. Covers
+ * legacy `BRIDGE_OFFRAMP`, `MANTECA_OFFRAMP`, `BANK_SEND_LINK_CLAIM × RECIPIENT`,
+ * plus the unified `TRANSACTION_INTENT` form (`kind ∈ {FIAT_OFFRAMP, CRYPTO_WITHDRAW}`).
+ * Without these, `getBankAccountCountryCode` falls through to its IBAN-prefix
+ * heuristic and renders the wrong country flag.
  */
 function shouldPlumbBankAccountDetails(entry: HistoryEntry): boolean {
     if (entry.type === EHistoryEntryType.BRIDGE_OFFRAMP) return true
@@ -56,13 +50,9 @@ export type RewardData = {
 export const REWARD_TOKENS: { [key: string]: RewardData } = {}
 
 /**
- * User-facing copy for reaper-failed rows. Keyed by the failReason string
- * the BE reaper writes (`${kindStr.toLowerCase()}_timeout`).
- *
- * Why per-kind: a generic "Transaction failed" is ambiguous ("did funds
- * move?"). These strings make clear the action never happened — no funds
- * moved, no chain TX exists. Don't show a Cancel button; the row is already
- * terminal.
+ * User-facing copy for reaper-failed rows. Keyed by the BE reaper's failReason
+ * string (`${kindStr.toLowerCase()}_timeout`). Per-kind copy makes clear no
+ * funds moved — a generic "Transaction failed" leaves the user wondering.
  */
 const REAPER_FAIL_COPY: Record<string, string> = {
     p2p_send_timeout: "Send didn't complete",
@@ -78,9 +68,8 @@ const REAPER_FAIL_COPY: Record<string, string> = {
 
 /**
  * Map raw `entry.status` to the drawer's StatusPillType. Two regimes:
- * Bridge/bank rails (AWAITING_FUNDS / FUNDS_RECEIVED / PAYMENT_*) and
- * the rest (NEW/PENDING/COMPLETED/...). SEND_LINK with COMPLETED status
- * stays "pending" until claimed (sender-side).
+ * Bridge/bank rails (AWAITING_FUNDS / FUNDS_RECEIVED / PAYMENT_*) and the
+ * rest. Sender-side SEND_LINK COMPLETED stays "pending" until claimed.
  */
 function mapEntryStatusToUiStatus(entry: HistoryEntry, direction: TransactionDirection): StatusPillType {
     const status = entry.status?.toUpperCase()
@@ -117,11 +106,10 @@ function mapEntryStatusToUiStatus(entry: HistoryEntry, direction: TransactionDir
         case 'PENDING':
             return 'pending'
         case 'COMPLETED': {
-            // Send links stay 'pending' for the sender side until the link is
-            // claimed — the BE's intent.status hits COMPLETED on escrow, but
-            // from the sender's UI perspective the link isn't "done" until
-            // claimed. Covers both legacy `EHistoryEntryType.SEND_LINK` rows
-            // and post-decomplexify `TRANSACTION_INTENT × kind=LINK_CREATE`.
+            // Sender side: send-links stay 'pending' until claimed. The BE
+            // intent hits COMPLETED on escrow, but from the sender's
+            // perspective the link isn't done until someone claims it.
+            // Covers both legacy SEND_LINK and TRANSACTION_INTENT × LINK_CREATE.
             const isUnclaimedSendLinkSender =
                 direction !== 'claim_external' &&
                 (entry.type === EHistoryEntryType.SEND_LINK ||
@@ -154,8 +142,8 @@ function mapEntryStatusToUiStatus(entry: HistoryEntry, direction: TransactionDir
 }
 
 /**
- * Derived display fields — explorer URLs, token/chain icons, reward
- * lookup. Computed from `entry` alone; doesn't read the strategy output.
+ * Derived display fields — explorer URLs, token/chain icons, reward lookup.
+ * Computed from `entry` alone; independent of the strategy output.
  */
 function computeDerivedFields(entry: HistoryEntry): {
     explorerUrlWithTx: string | undefined
@@ -170,8 +158,8 @@ function computeDerivedFields(entry: HistoryEntry): {
         | undefined
     rewardData: RewardData | undefined
 } {
-    // For deposits, force the explorer URL to Peanut's wallet chain
-    // (Arbitrum) — the underlying chainId field is the deposit-source chain.
+    // For deposits, the explorer URL must point to Peanut's wallet chain
+    // (Arbitrum) — entry.chainId here is the deposit-source chain.
     const explorerUrlChainID =
         entry.type === EHistoryEntryType.DEPOSIT ? PEANUT_WALLET_CHAIN.id.toString() : entry.chainId
     const baseUrl = getExplorerUrl(explorerUrlChainID)
@@ -244,10 +232,9 @@ export interface TransactionDetails {
         addressExplorerUrl?: string
         originalType: EHistoryEntryType
         originalUserRole: EHistoryUserRole
-        /** Post-M3 transaction-intent kind (P2P_SEND, QR_PAY, CARD_SPEND, …).
-         *  Some predicates need this to disambiguate within TRANSACTION_INTENT
-         *  entries — e.g. QR payments now arrive as TRANSACTION_INTENT + kind=QR_PAY
-         *  rather than a dedicated originalType. */
+        /** Transaction-intent kind (P2P_SEND, QR_PAY, CARD_SPEND, …).
+         *  Predicates use this to disambiguate within TRANSACTION_INTENT entries —
+         *  e.g. QR payments arrive as TRANSACTION_INTENT + kind=QR_PAY. */
         kind?: string
         link?: string
         isLinkTransaction?: boolean
@@ -304,18 +291,17 @@ export interface TransactionDetails {
             final_amount?: string
             exchange_rate?: string
         }
-        /** Card-payment specifics — populated for Rain CARD_SPEND / card-refund
-         *  entries only. Drives the merchant hero, status timeline, decline
-         *  reason, and "Adjusted from $X" settlement note in the drawer. */
+        /** Card-payment specifics — populated only for Rain CARD_SPEND /
+         *  card-refund entries. Drives the merchant hero, status timeline,
+         *  decline reason, and "Adjusted from $X" settlement note. */
         cardPayment?: {
             merchantName: string | null
             merchantCategory: string | null
             merchantCity: string | null
             merchantCountry: string | null
             merchantMcc: string | null
-            /** Rain-enriched brand logo URL when their enrichment identified the
-             *  merchant. Drawer keeps the generic card icon for v1; this is
-             *  plumbed so a future swap doesn't need a backend change. */
+            /** Rain-enriched brand logo URL. Drawer uses the generic card icon
+             *  for v1; plumbed so a future swap is FE-only. */
             merchantLogo: string | null
             merchantId: string | null
             localAmount: string | null
@@ -375,10 +361,9 @@ interface MappedTransactionData {
  * @returns an object containing structured transactiondetails and the transactioncardtype.
  */
 export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransactionData {
-    // initialize variables
-    // Pick the per-kind strategy. Post-strategy code below applies status
-    // mapping, the reaper-failed override, and derived fields (explorer
-    // URL, token logos, initials).
+    // Per-kind strategy decides direction/card-type/peer fields. The code
+    // below layers on status mapping, reaper-failed override, and derived
+    // fields (explorer URL, token logos, initials).
     const out = dispatchStrategy(entry)(entry)
     const direction: TransactionDirection = out.direction
     const transactionCardType: TransactionCardType = out.transactionCardType
@@ -396,13 +381,12 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
         isPeerActuallyUser = false
     }
 
-    // Reaper-failed rows (orphaned PENDING intents the BE timed out — see
-    // peanut-api-ts/src/ledger/reaper.ts) get user-friendly copy. Without
-    // this branch the row renders with whatever userName the kind-switch
-    // landed on, which for a P2P_SEND that never confirmed is misleading
-    // ("Sent to alice" implies funds moved). The reaper sets
-    // metadata.failReason to '${kind}_timeout' before transitioning FAILED;
-    // the BE history fetcher surfaces it as `entry.extraData.failReason`.
+    // Reaper-failed rows (orphaned PENDING intents timed out by the BE
+    // reaper — see peanut-api-ts/src/ledger/reaper.ts) get user-friendly
+    // copy. Without this branch a P2P_SEND that never confirmed renders as
+    // "Sent to alice" — implying funds moved when they didn't. The reaper
+    // sets `metadata.failReason='${kind}_timeout'` before FAILED, surfaced
+    // here as `entry.extraData.failReason`.
     const reaperFailReason = entry.extraData?.failReason as string | undefined
     if (entry.status === 'FAILED' && reaperFailReason && reaperFailReason.endsWith('_timeout')) {
         nameForDetails = REAPER_FAIL_COPY[reaperFailReason] ?? 'Transaction did not complete'
@@ -413,7 +397,6 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
     // map raw entry.status via the shared helper.
     if (!strategyOverrodeUiStatus) uiStatus = mapEntryStatusToUiStatus(entry, direction)
 
-    // parse the amount from the usdamount string in extradata
     const amount = entry.extraData?.usdAmount
         ? parseFloat(String(entry.extraData.usdAmount).replace(/[^\d.-]/g, ''))
         : 0
@@ -450,18 +433,14 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
         isVerified: entry.isVerified && isPeerActuallyUser,
         // only show verification badge if the other person is a peanut user
         date: new Date(entry.timestamp),
-        // Peanut product convention: fees are baked into the displayed exchange
-        // rate, never surfaced as a separate line item. Keep the backend field
-        // populated for ops/debug, but never thread it to the UI. `fee` stays
-        // `undefined` so `rowVisibilityConfig.fee` is always false and the
-        // drawer's fee row never renders. If this rule changes, update
-        // docs/product-conventions.md first.
+        // Peanut convention: fees are baked into the displayed exchange rate,
+        // never surfaced as a separate line item. Keep undefined so the
+        // drawer's fee row never renders.
         fee: undefined,
-        // memo carries free-form user notes from non-card flows (link memos,
-        // request comments). Card spends + Rain refunds suppress this — the
-        // merchant name and any decline reason render inside CardPaymentRows
-        // in the drawer, so a duplicate "Comment" row is just noise. Backend
-        // already sets memo=undefined for card entries, but defend in depth.
+        // Memo carries free-form notes from non-card flows. Suppress for card
+        // spends + Rain refunds — merchant name + decline reason already render
+        // in CardPaymentRows; a duplicate "Comment" row is noise. Defence-in-
+        // depth: backend also sets memo=undefined for card entries.
         memo: (() => {
             if (isTestDeposit) return 'Your peanut wallet is ready to use!'
             const isCardEntry = entry.extraData?.kind === 'CARD_SPEND' || !!entry.extraData?.parentRainTxId
@@ -485,16 +464,11 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
             rewardData,
             fulfillmentType: entry.extraData?.fulfillmentType,
             bridgeTransferId: entry.extraData?.bridgeTransferId,
-            // Card-payment specifics — populated only for Rain CARD_SPEND /
-            // card-refund entries. Drawer reads these to render the merchant
-            // hero, status timeline, decline reason, and "Adjusted from $X"
-            // settlement note. Backend source: src/transaction-intent/history.ts.
-            // Build the cardPayment block for any card-shaped intent (CARD_SPEND
-            // kind) and for Rain refunds (parentRainTxId set). Earlier we
-            // guarded on merchantName presence, but that dropped the block for
-            // unknown-merchant spends — losing the de-emphasis-on-failed,
-            // decline-reason rows, and merchant-detail Card. The block falls
-            // back to "Card payment" downstream when merchantName is null.
+            // Build the cardPayment block for any card-shaped intent
+            // (kind=CARD_SPEND) and for Rain refunds (parentRainTxId set).
+            // Don't gate on merchantName — unknown-merchant spends still need
+            // the decline-reason rows and merchant-detail Card; downstream
+            // falls back to "Card payment" when merchantName is null.
             cardPayment:
                 entry.extraData?.kind === 'CARD_SPEND' || entry.extraData?.parentRainTxId
                     ? {
@@ -538,10 +512,9 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
         },
         sourceView: 'history',
         points: entry.points,
-        // shouldPlumbBankAccountDetails gates on type/kind/role; also require
-        // identifier + type to be present so getBankAccountLabel doesn't crash
-        // on rows whose recipientAccount payload is incomplete (seen on
-        // mid-flight FIAT_OFFRAMP intents before the BE stamps the account).
+        // Also require identifier + type so getBankAccountLabel doesn't crash
+        // on rows with incomplete recipientAccount payload (mid-flight
+        // FIAT_OFFRAMP intents before the BE stamps the account).
         bankAccountDetails:
             shouldPlumbBankAccountDetails(entry) && entry.recipientAccount?.identifier && entry.recipientAccount?.type
                 ? {

--- a/src/hooks/wallet/useWallet.ts
+++ b/src/hooks/wallet/useWallet.ts
@@ -55,10 +55,9 @@ export const useWallet = () => {
     const isAddressReady = !!address && !!userAddress && userAddress.toLowerCase() === address.toLowerCase()
 
     // Dev-only diagnostic: if the gate refuses to fetch balance even though
-    // the user has loaded, log WHY exactly once. This was the silent-$0 bug
-    // shape we hit during the 2026-04-27 card playtest — without this log
-    // the only symptom is "balance shows 0 even though chain has funds",
-    // and you have to read four hooks deep to find which condition failed.
+    // the user has loaded, log WHY exactly once. Without this the only
+    // symptom is "balance shows 0 though chain has funds", and the failing
+    // condition is buried four hooks deep.
     const loggedReasonRef = useRef<string | null>(null)
     useEffect(() => {
         if (process.env.NODE_ENV === 'production') return

--- a/src/utils/account-mask.utils.ts
+++ b/src/utils/account-mask.utils.ts
@@ -34,11 +34,10 @@ interface MaskRule {
  * Per-rail rules. Account types come from the BE's `Account.type` field
  * (peanut-api-ts/prisma/schema.prisma `AccountType` enum).
  */
-// Keyed on the uppercased account type. BE sends Prisma `AccountType` enum
-// values (`BANK_IBAN`, `BANK_ACH`, `BANK_CLABE`, ...) — list both the bare
-// name and the BANK_ prefix so display logic works regardless of which
-// shape comes through. Without the BANK_* entries the lookup falls to
-// the 'plain' fallback below, which renders the raw lowercase IBAN.
+// Keyed on uppercased account type. BE sends Prisma `AccountType` values
+// (`BANK_IBAN`, `BANK_ACH`, …); both the bare name and the `BANK_*` form
+// are listed so the lookup matches either shape — without the `BANK_*`
+// entries it would fall through to 'plain' and render a raw lowercase IBAN.
 const MASK_RULES: Record<string, MaskRule> = {
     IBAN: { mode: 'last-4' },
     BANK_IBAN: { mode: 'last-4' },
@@ -81,11 +80,8 @@ export function maskAccountIdentifier(
             return `**** **** **** ${last4}`
         }
         case 'last-4-account-only': {
-            // For US ACH the saved identifier shape is variable — sometimes the
-            // routing number is included, sometimes only the account number.
-            // The conservative move: show the last 4 digits of whatever we
-            // have. If a future BE shape exposes routingNumber separately, a
-            // richer rendering ("Bank · **** 6789") slots in here.
+            // US ACH identifier shape is variable — routing number may or may
+            // not be included. Conservative: show last 4 of whatever we have.
             const cleaned = identifier.replace(/\s+/g, '')
             if (cleaned.length <= 4) return cleaned
             return `**** ${cleaned.slice(-4)}`
@@ -95,12 +91,10 @@ export function maskAccountIdentifier(
             return identifier.slice(0, 29) + '…'
         }
         case 'plain':
-            // BE sometimes ships IBAN-shaped identifiers without a precise
-            // type (`MANTECA_ALIAS` aliasing an IBAN, guest-claim flows, or
-            // legacy rows with type=null). Detect IBAN shape (2 letters
-            // followed by digits) and uppercase + 4-char-group via
-            // formatIban so the receipt drawer doesn't render
-            // `es2700750984...` lowercase. Non-IBAN plain values pass through.
+            // BE sometimes ships IBAN-shaped identifiers without a precise type
+            // (MANTECA_ALIAS aliasing an IBAN, guest-claim flows, type=null
+            // rows). Detect IBAN shape (2 letters + digits) and run formatIban
+            // so the receipt doesn't render a raw lowercase IBAN.
             if (/^[a-zA-Z]{2}\d/.test(identifier)) {
                 return formatIban(identifier)
             }

--- a/src/utils/friendly-error.utils.tsx
+++ b/src/utils/friendly-error.utils.tsx
@@ -1,7 +1,5 @@
-/** UI-friendly error message extractor. Pre-decomplexify this matched
- *  on the Peanut SDK's `SDKStatus` enum codes; with the SDK gone, the
- *  function falls back to substring matching on common wallet / viem /
- *  Peanut API error messages. */
+/** UI-friendly error message extractor. Substring-matches common
+ *  wallet / viem / Peanut API error messages. */
 export const ErrorHandler = (error: any): string => {
     const text = error?.toString?.() ?? ''
     if (text.includes('insufficient funds')) return "You don't have enough funds."

--- a/src/utils/peanut-claim.utils.ts
+++ b/src/utils/peanut-claim.utils.ts
@@ -1,10 +1,6 @@
-/** Inlined `signWithdrawalMessage` + vault address lookup, replacing the
- *  same-named exports from `@squirrel-labs/peanut-sdk`.
- *
- *  Only the v4.x EIP-712 path (Arb mainnet 42161 + Arb Sepolia 421614)
- *  is supported — older versions and non-Arb chains were dropped in
- *  decomplexify "multi-chain → Arb-only".
- */
+/** Inlined `signWithdrawalMessage` + vault address lookup. Replaces the
+ *  same-named exports from `@squirrel-labs/peanut-sdk`. Supports only the
+ *  v4.x EIP-712 path on Arb mainnet (42161) and Arb Sepolia (421614). */
 
 import { keccak256, encodePacked, toBytes, type Abi } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'

--- a/src/utils/pipelineAlerts.ts
+++ b/src/utils/pipelineAlerts.ts
@@ -1,12 +1,8 @@
 /**
- * Single entry point for cross-cutting Sentry signals from the
- * FE-side rendering pipeline (transformer, receipt drawer, etc).
- * Mirrors peanut-api-ts/src/utils/pipelineAlerts.ts — same category
- * union and tag schema so dashboards filter consistently across BE/FE.
- *
- * Sentry import is lazy: importing `@sentry/nextjs` at module scope adds
- * weight to non-browser bundles (test runner, SSR). The dynamic import
- * keeps the helper a no-op when Sentry isn't initialised.
+ * Single entry point for cross-cutting Sentry signals from the FE rendering
+ * pipeline. Mirrors peanut-api-ts/src/utils/pipelineAlerts.ts — same category
+ * union and tag schema so dashboards filter consistently across BE/FE. Sentry
+ * import is lazy to keep the helper a no-op in test runner / SSR bundles.
  */
 
 export type PipelineAlertCategory =


### PR DESCRIPTION
## Summary
- Most of the diff is post-merger comment hygiene across the TransactionDetails strategies and a few utils — verbose docstrings narrating the M3 cutover are noise now that the cutover has shipped.
- One functional change: `HarnessBootstrap` was `dynamic(..., { ssr: false })`, which pushed Next 16 + Turbopack into a render bailout that produced ~2 script tags of SSR output. Switching to `ssr: true` restores the expected ~95-tag SSR document and unblocks Playwright hydration on the harness build.

## Test plan
- [x] `pnpm typecheck` — clean.
- [x] `pnpm prettier --check` — clean.
- [x] `npm test` — 39 suites, 923 tests passing.
- [ ] Smoke: harness `bin/qa ui --scenario e2e-fresh-user-empty-states` (or any fresh-load scenario) to confirm hydration works end-to-end on the prod build.