### PR TITLE
fix(crosschain-withdraw): use source USDC amount in 'pay'-mode quote

### DIFF
--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -135,6 +135,9 @@ export default function WithdrawCryptoPage() {
                     address: address as Address,
                     tokenAddress: PEANUT_WALLET_TOKEN as Address,
                     chainId: PEANUT_WALLET_CHAIN.id.toString(),
+                    // amountToWithdraw is USD-denominated; source token is USDC (1:1).
+                    // Required for the bridge path's 'pay' mode (cross-chain ETH/etc).
+                    tokenAmount: amountToWithdraw,
                 },
                 destination: {
                     recipientAddress: chargeDetails.requestLink.recipientAddress as Address,
@@ -150,7 +153,7 @@ export default function WithdrawCryptoPage() {
                 skipGasEstimate: true, // peanut wallet handles gas
             })
         }
-    }, [currentView, chargeDetails, withdrawData, calculateRoute, address])
+    }, [currentView, chargeDetails, withdrawData, calculateRoute, address, amountToWithdraw])
 
     const handleSetupReview = useCallback(
         async (data: Omit<WithdrawData, 'amount'>) => {

--- a/src/features/payments/shared/hooks/useCrossChainTransfer.ts
+++ b/src/features/payments/shared/hooks/useCrossChainTransfer.ts
@@ -72,6 +72,11 @@ export interface CrossChainSourceInfo {
     address: Address
     tokenAddress: Address
     chainId: string
+    /** USDC amount (decimal string) the user is spending. Required for the
+     *  bridge path's 'pay' mode (cross-chain non-stable destinations like ETH);
+     *  Rhino sizes the swap by this. Optional for SDA / 'receive' paths where
+     *  Rhino sizes the swap by destination.tokenAmount. */
+    tokenAmount?: string
 }
 
 export interface CrossChainDestinationInfo {
@@ -401,8 +406,22 @@ async function runBridgePath({
     //     source USDC the user spends; Rhino computes the destination output.
     const isSameChainSwap = sourceRhinoChain === destRhinoChain
     const mode: 'pay' | 'receive' = isSameChainSwap ? 'receive' : 'pay'
+    // 'pay' mode → amount is the source USDC the user spends (Rhino computes
+    // destination output). 'receive' mode → amount is the destination token
+    // the recipient gets (Rhino computes source input). Mixing them up makes
+    // Rhino swap a tiny fraction of the intended size — e.g. passing 0.000417
+    // (the destination ETH estimate) under 'pay' tells Rhino to spend
+    // 0.000417 USDC, not 1 USDC.
+    const quoteAmount = mode === 'pay' ? source.tokenAmount : destination.tokenAmount
+    if (!quoteAmount) {
+        throw new Error(
+            `Cross-chain ${mode === 'pay' ? 'pay' : 'receive'}-mode quote requires ${
+                mode === 'pay' ? 'source.tokenAmount' : 'destination.tokenAmount'
+            }`
+        )
+    }
     const quote: BridgeQuoteResponse = await getBridgeQuote({
-        amount: destination.tokenAmount,
+        amount: quoteAmount,
         tokenIn: 'USDC',
         tokenOut: tokenSymbol,
         chainOut: destRhinoChain,


### PR DESCRIPTION
## Summary

For cross-chain non-stable destinations (ETH/WETH/etc), `runBridgePath` calls Rhino with `mode='pay'` — that mode's contract is "**amount is the source USDC the user spends**". The code was passing `destination.tokenAmount` (the estimated ETH output) instead. For a \$1 → ETH withdraw, Rhino read `0.000417` as **USDC** and dutifully swapped just that fraction of a cent.

### Repro
[arbiscan.io/tx/0x259af83…7](https://arbiscan.io/tx/0x259af83403997fb7e4a5270b2504140092a1f1343da3f5befadf65af6ebb3617):
- 1 USDC in → 0.999578 stayed in smart account
- 0.000422 USDC → KyberSwap → 1.78e-7 ETH (~\$0.0007 worth)

The comment block at lines 396–401 in `useCrossChainTransfer.ts` already documented the right contract; the code just didn't follow it.

## Changes

1. Add optional `tokenAmount` to `CrossChainSourceInfo`. Required when `mode='pay'` resolves; throws a clear error if missing.
2. Withdraw page passes `amountToWithdraw` (USD = USDC 1:1) as the source amount.
3. `runBridgePath` picks `source.tokenAmount` for `'pay'` and `destination.tokenAmount` for `'receive'`.

The same-chain swap path and the SDA path are unaffected.

## Test plan

- [x] Typecheck (no new errors)
- [ ] Re-run the same \$1 → ETH cross-chain withdraw on staging — should now actually swap 1 USDC and yield ~\$1 worth of ETH on the destination chain
- [ ] Same-chain swap path (USDC → ETH on Arb) still works (mode='receive', unchanged)
- [ ] SDA path (cross-chain stablecoin) still works (unchanged)

## Follow-up

Cross-chain non-stable **semantic-requests** are now runtime-gated (the hook throws a clear error instead of silently misbehaving). To make this a UX gate (block selection in the request flow) or to actually support it, we'd need either:
- A pre-quote round-trip to compute source USDC needed for the desired destination amount, or
- Disable cross-chain non-stable destinations entirely in the request creation UI

Filing separately.