### PR TITLE
fix: bridge KYC state machine — unified gate, inline ToS, rejection handling

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -10,8 +10,8 @@ import { useWallet } from '@/hooks/wallet/useWallet'
 import { formatAmount } from '@/utils/general.utils'
 import { countryData } from '@/components/AddMoney/consts'
 import { useAuth } from '@/context/authContext'
-import useKycStatus from '@/hooks/useKycStatus'
-import useProviderRejectionStatus from '@/hooks/useProviderRejectionStatus'
+import { useBridgeTransferReadiness } from '@/hooks/useBridgeTransferReadiness'
+import { useModalsContext } from '@/context/ModalsContext'
 import { useCreateOnramp } from '@/hooks/useCreateOnramp'
 import { useRouter, useParams } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -94,10 +94,14 @@ export default function OnrampBankPage() {
     // uk-specific check
     const isUK = isUKCountry(selectedCountryPath)
 
-    const { isUserKycApproved, isUserSumsubKycApproved, isUserBridgeKycApproved, isUserBridgeKycUnderReview } =
-        useKycStatus()
-    const { bridge: bridgeRejection } = useProviderRejectionStatus()
+    const { gate } = useBridgeTransferReadiness()
     const { guardWithTos, showBridgeTos, hideTos } = useBridgeTosGuard()
+    const { setIsSupportModalOpen } = useModalsContext()
+
+    // close kyc modal when sumsub sdk opens
+    useEffect(() => {
+        if (sumsubFlow.showWrapper) setShowKycModal(false)
+    }, [sumsubFlow.showWrapper])
 
     useEffect(() => {
         fetchUser()
@@ -194,19 +198,16 @@ export default function OnrampBankPage() {
         }
     }, [rawTokenAmount, validateAmount, setError])
 
-    const needsBridgeEnrollment = isUserSumsubKycApproved && !isUserBridgeKycApproved && !isUserBridgeKycUnderReview
-
     const handleAmountContinue = () => {
         if (!validateAmount(rawTokenAmount)) return
 
-        if (
-            needsBridgeEnrollment ||
-            !isUserKycApproved ||
-            bridgeRejection.state === 'fixable' ||
-            bridgeRejection.state === 'blocked'
-        ) {
-            setShowKycModal(true)
-            return
+        if (gate.type !== 'ready') {
+            if (gate.type === 'accept_tos') {
+                if (guardWithTos()) return
+            } else {
+                setShowKycModal(true)
+                return
+            }
         }
 
         posthog.capture(ANALYTICS_EVENTS.DEPOSIT_AMOUNT_ENTERED, {
@@ -223,11 +224,6 @@ export default function OnrampBankPage() {
                 showError: true,
                 errorMessage: 'Please select a country first.',
             })
-            return
-        }
-
-        if (guardWithTos()) {
-            setShowWarningModal(false)
             return
         }
 
@@ -405,24 +401,32 @@ export default function OnrampBankPage() {
                     visible={showKycModal}
                     onClose={() => setShowKycModal(false)}
                     onVerify={async () => {
-                        // needsBridgeEnrollment takes priority: user has no bridge customer,
-                        // so rejection state from a stale/deleted customer is irrelevant
-                        if (!needsBridgeEnrollment && bridgeRejection.state === 'fixable') {
+                        if (gate.type === 'fixable_rejection') {
                             await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                         } else {
-                            await sumsubFlow.handleInitiateKyc('STANDARD', undefined, needsBridgeEnrollment || undefined)
+                            await sumsubFlow.handleInitiateKyc('STANDARD', undefined, gate.type === 'needs_enrollment' || undefined)
                         }
+                    }}
+                    onContactSupport={() => {
                         setShowKycModal(false)
+                        setIsSupportModalOpen(true)
                     }}
                     isLoading={sumsubFlow.isLoading}
+                    error={sumsubFlow.error}
                     variant={
-                        needsBridgeEnrollment
-                            ? 'cross_region'
-                            : bridgeRejection.state === 'fixable' || bridgeRejection.state === 'blocked'
+                        gate.type === 'blocked_rejection'
+                            ? 'blocked'
+                            : gate.type === 'fixable_rejection'
                               ? 'provider_rejection'
-                              : 'default'
+                              : gate.type === 'needs_enrollment'
+                                ? 'cross_region'
+                                : 'default'
                     }
-                    providerMessage={bridgeRejection.userMessage ?? undefined}
+                    providerMessage={
+                        gate.type === 'fixable_rejection' || gate.type === 'blocked_rejection'
+                            ? gate.userMessage ?? undefined
+                            : undefined
+                    }
                     regionName={selectedCountry?.title}
                 />
 

--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -10,7 +10,11 @@ import { useWallet } from '@/hooks/wallet/useWallet'
 import { formatAmount } from '@/utils/general.utils'
 import { countryData } from '@/components/AddMoney/consts'
 import { useAuth } from '@/context/authContext'
-import { useBridgeTransferReadiness } from '@/hooks/useBridgeTransferReadiness'
+import {
+    useBridgeTransferReadiness,
+    getKycModalVariant,
+    getGateProviderMessage,
+} from '@/hooks/useBridgeTransferReadiness'
 import { useModalsContext } from '@/context/ModalsContext'
 import { useCreateOnramp } from '@/hooks/useCreateOnramp'
 import { useRouter, useParams } from 'next/navigation'
@@ -417,20 +421,8 @@ export default function OnrampBankPage() {
                     }}
                     isLoading={sumsubFlow.isLoading}
                     error={sumsubFlow.error}
-                    variant={
-                        gate.type === 'blocked_rejection'
-                            ? 'blocked'
-                            : gate.type === 'fixable_rejection'
-                              ? 'provider_rejection'
-                              : gate.type === 'needs_enrollment'
-                                ? 'cross_region'
-                                : 'default'
-                    }
-                    providerMessage={
-                        gate.type === 'fixable_rejection' || gate.type === 'blocked_rejection'
-                            ? (gate.userMessage ?? undefined)
-                            : undefined
-                    }
+                    variant={getKycModalVariant(gate.type)}
+                    providerMessage={getGateProviderMessage(gate)}
                     regionName={selectedCountry?.title}
                 />
 

--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -203,11 +203,11 @@ export default function OnrampBankPage() {
 
         if (gate.type !== 'ready') {
             if (gate.type === 'accept_tos') {
-                if (guardWithTos()) return
+                guardWithTos()
             } else {
                 setShowKycModal(true)
-                return
             }
+            return
         }
 
         posthog.capture(ANALYTICS_EVENTS.DEPOSIT_AMOUNT_ENTERED, {

--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -404,7 +404,11 @@ export default function OnrampBankPage() {
                         if (gate.type === 'fixable_rejection') {
                             await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                         } else {
-                            await sumsubFlow.handleInitiateKyc('STANDARD', undefined, gate.type === 'needs_enrollment' || undefined)
+                            await sumsubFlow.handleInitiateKyc(
+                                'STANDARD',
+                                undefined,
+                                gate.type === 'needs_enrollment' || undefined
+                            )
                         }
                     }}
                     onContactSupport={() => {
@@ -424,7 +428,7 @@ export default function OnrampBankPage() {
                     }
                     providerMessage={
                         gate.type === 'fixable_rejection' || gate.type === 'blocked_rejection'
-                            ? gate.userMessage ?? undefined
+                            ? (gate.userMessage ?? undefined)
                             : undefined
                     }
                     regionName={selectedCountry?.title}

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -544,7 +544,12 @@ export default function QRPayPage() {
             }
             return mantecaApi.initiateQrPayment({ qrCode, qrType: qrType ?? undefined })
         },
-        enabled: paymentProcessor === 'MANTECA' && !!qrCode && isPaymentProcessorQR(qrCode) && !paymentLock && !shouldBlockPay,
+        enabled:
+            paymentProcessor === 'MANTECA' &&
+            !!qrCode &&
+            isPaymentProcessorQR(qrCode) &&
+            !paymentLock &&
+            !shouldBlockPay,
         retry: (failureCount, error: any) => {
             // Don't retry provider-specific errors
             if (error?.message?.includes('PAYMENT_DESTINATION_DECODING_ERROR')) {
@@ -1146,7 +1151,8 @@ export default function QRPayPage() {
                     ctas={[
                         {
                             text: 'Verify now',
-                            onClick: () => sumsubFlow.handleInitiateKyc('LATAM', undefined, isUserSumsubKycApproved || undefined),
+                            onClick: () =>
+                                sumsubFlow.handleInitiateKyc('LATAM', undefined, isUserSumsubKycApproved || undefined),
                             variant: 'purple',
                             shadowSize: '4',
                             icon: 'check-circle',
@@ -1163,7 +1169,8 @@ export default function QRPayPage() {
                     ctas={[
                         {
                             text: 'Continue verification',
-                            onClick: () => sumsubFlow.handleInitiateKyc('LATAM', undefined, isUserSumsubKycApproved || undefined),
+                            onClick: () =>
+                                sumsubFlow.handleInitiateKyc('LATAM', undefined, isUserSumsubKycApproved || undefined),
                             variant: 'purple',
                             shadowSize: '4',
                             icon: 'check-circle',

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -69,6 +69,8 @@ import { useSumsubActionFlow } from '@/hooks/useSumsubActionFlow'
 import { initiateIncreaseLimits } from '@/app/actions/increase-limits'
 import { SumsubKycWrapper } from '@/components/Kyc/SumsubKycWrapper'
 import { useLimits } from '@/hooks/useLimits'
+import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
+import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 
 const MAX_QR_PAYMENT_AMOUNT = '2000'
 const MIN_QR_PAYMENT_AMOUNT = '0.1'
@@ -121,7 +123,8 @@ export default function QRPayPage() {
     }, [paymentProcessor])
 
     const { shouldBlockPay, kycGateState } = useQrKycGate(paymentProcessor)
-    const { isUserMantecaKycApproved } = useKycStatus()
+    const { isUserMantecaKycApproved, isUserSumsubKycApproved } = useKycStatus()
+    const sumsubFlow = useMultiPhaseKycFlow({})
     const queryClient = useQueryClient()
     const [isShaking, setIsShaking] = useState(false)
     const [shakeIntensity, setShakeIntensity] = useState<ShakeIntensity>('none')
@@ -541,7 +544,7 @@ export default function QRPayPage() {
             }
             return mantecaApi.initiateQrPayment({ qrCode, qrType: qrType ?? undefined })
         },
-        enabled: paymentProcessor === 'MANTECA' && !!qrCode && isPaymentProcessorQR(qrCode) && !paymentLock,
+        enabled: paymentProcessor === 'MANTECA' && !!qrCode && isPaymentProcessorQR(qrCode) && !paymentLock && !shouldBlockPay,
         retry: (failureCount, error: any) => {
             // Don't retry provider-specific errors
             if (error?.message?.includes('PAYMENT_DESTINATION_DECODING_ERROR')) {
@@ -1108,25 +1111,19 @@ export default function QRPayPage() {
                         isFixable
                             ? {
                                   text: 'Upload document',
-                                  onClick: () => {
-                                      saveRedirectUrl()
-                                      router.push('/profile/identity-verification')
-                                  },
+                                  onClick: () => sumsubFlow.handleSelfHealResubmit('MANTECA'),
                                   variant: 'purple' as const,
                                   shadowSize: '4' as const,
                                   icon: 'upload',
                               }
                             : {
                                   text: 'Contact support',
-                                  onClick: () => {
-                                      if (typeof window !== 'undefined' && (window as any).$crisp) {
-                                          ;(window as any).$crisp.push(['do', 'chat:open'])
-                                      }
-                                  },
+                                  onClick: () => setIsSupportModalOpen(true),
                                   variant: 'stroke' as const,
                               },
                     ]}
                 />
+                <SumsubKycModals flow={sumsubFlow} />
             </div>
         )
     }
@@ -1149,10 +1146,7 @@ export default function QRPayPage() {
                     ctas={[
                         {
                             text: 'Verify now',
-                            onClick: () => {
-                                saveRedirectUrl()
-                                router.push('/profile/identity-verification')
-                            },
+                            onClick: () => sumsubFlow.handleInitiateKyc('LATAM', undefined, isUserSumsubKycApproved || undefined),
                             variant: 'purple',
                             shadowSize: '4',
                             icon: 'check-circle',
@@ -1169,10 +1163,7 @@ export default function QRPayPage() {
                     ctas={[
                         {
                             text: 'Continue verification',
-                            onClick: () => {
-                                saveRedirectUrl()
-                                router.push('/profile/identity-verification')
-                            },
+                            onClick: () => sumsubFlow.handleInitiateKyc('LATAM', undefined, isUserSumsubKycApproved || undefined),
                             variant: 'purple',
                             shadowSize: '4',
                             icon: 'check-circle',
@@ -1187,6 +1178,7 @@ export default function QRPayPage() {
                         },
                     ]}
                 />
+                <SumsubKycModals flow={sumsubFlow} />
             </div>
         )
     }

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -171,11 +171,11 @@ export default function WithdrawBankPage() {
     const handleCreateAndInitiateOfframp = async () => {
         if (gate.type !== 'ready') {
             if (gate.type === 'accept_tos') {
-                if (guardWithTos()) return
+                guardWithTos()
             } else {
                 setShowKycModal(true)
-                return
             }
+            return
         }
 
         setIsLoading(true)

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -457,7 +457,11 @@ export default function WithdrawBankPage() {
                     if (gate.type === 'fixable_rejection') {
                         await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                     } else {
-                        await sumsubFlow.handleInitiateKyc('STANDARD', undefined, gate.type === 'needs_enrollment' || undefined)
+                        await sumsubFlow.handleInitiateKyc(
+                            'STANDARD',
+                            undefined,
+                            gate.type === 'needs_enrollment' || undefined
+                        )
                     }
                 }}
                 onContactSupport={() => {
@@ -465,7 +469,7 @@ export default function WithdrawBankPage() {
                     setIsSupportModalOpen(true)
                 }}
                 isLoading={sumsubFlow.isLoading}
-                    error={sumsubFlow.error}
+                error={sumsubFlow.error}
                 variant={
                     gate.type === 'blocked_rejection'
                         ? 'blocked'
@@ -477,7 +481,7 @@ export default function WithdrawBankPage() {
                 }
                 providerMessage={
                     gate.type === 'fixable_rejection' || gate.type === 'blocked_rejection'
-                        ? gate.userMessage ?? undefined
+                        ? (gate.userMessage ?? undefined)
                         : undefined
                 }
                 regionName={getCountryFromPath(country)?.title}

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -31,7 +31,11 @@ import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
 import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
-import { useBridgeTransferReadiness } from '@/hooks/useBridgeTransferReadiness'
+import {
+    useBridgeTransferReadiness,
+    getKycModalVariant,
+    getGateProviderMessage,
+} from '@/hooks/useBridgeTransferReadiness'
 import { useModalsContext } from '@/context/ModalsContext'
 import ExchangeRate from '@/components/ExchangeRate'
 import countryCurrencyMappings, { isNonEuroSepaCountry } from '@/constants/countryCurrencyMapping'
@@ -470,20 +474,8 @@ export default function WithdrawBankPage() {
                 }}
                 isLoading={sumsubFlow.isLoading}
                 error={sumsubFlow.error}
-                variant={
-                    gate.type === 'blocked_rejection'
-                        ? 'blocked'
-                        : gate.type === 'fixable_rejection'
-                          ? 'provider_rejection'
-                          : gate.type === 'needs_enrollment'
-                            ? 'cross_region'
-                            : 'default'
-                }
-                providerMessage={
-                    gate.type === 'fixable_rejection' || gate.type === 'blocked_rejection'
-                        ? (gate.userMessage ?? undefined)
-                        : undefined
-                }
+                variant={getKycModalVariant(gate.type)}
+                providerMessage={getGateProviderMessage(gate)}
                 regionName={getCountryFromPath(country)?.title}
             />
             <SumsubKycModals flow={sumsubFlow} />

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -31,7 +31,8 @@ import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
 import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
-import useKycStatus from '@/hooks/useKycStatus'
+import { useBridgeTransferReadiness } from '@/hooks/useBridgeTransferReadiness'
+import { useModalsContext } from '@/context/ModalsContext'
 import ExchangeRate from '@/components/ExchangeRate'
 import countryCurrencyMappings, { isNonEuroSepaCountry } from '@/constants/countryCurrencyMapping'
 import { useIdentityVerification } from '@/hooks/useIdentityVerification'
@@ -65,10 +66,15 @@ export default function WithdrawBankPage() {
     const [balanceErrorMessage, setBalanceErrorMessage] = useState<string | null>(null)
     const { hasPendingTransactions } = usePendingTransactions()
     const { isBridgeSupportedCountry } = useIdentityVerification()
-    const { isUserSumsubKycApproved, isUserBridgeKycApproved } = useKycStatus()
+    const { gate } = useBridgeTransferReadiness()
     const sumsubFlow = useMultiPhaseKycFlow({})
     const [showKycModal, setShowKycModal] = useState(false)
-    const needsBridgeEnrollment = isUserSumsubKycApproved && !isUserBridgeKycApproved && !user?.user.bridgeCustomerId
+    const { setIsSupportModalOpen } = useModalsContext()
+
+    // close kyc modal when sumsub sdk opens
+    useEffect(() => {
+        if (sumsubFlow.showWrapper) setShowKycModal(false)
+    }, [sumsubFlow.showWrapper])
 
     // validate country is supported for bank withdrawals
     useEffect(() => {
@@ -163,12 +169,14 @@ export default function WithdrawBankPage() {
     }
 
     const handleCreateAndInitiateOfframp = async () => {
-        if (needsBridgeEnrollment) {
-            setShowKycModal(true)
-            return
+        if (gate.type !== 'ready') {
+            if (gate.type === 'accept_tos') {
+                if (guardWithTos()) return
+            } else {
+                setShowKycModal(true)
+                return
+            }
         }
-
-        if (guardWithTos()) return
 
         setIsLoading(true)
         setError({ showError: false, errorMessage: '' })
@@ -446,11 +454,32 @@ export default function WithdrawBankPage() {
                 visible={showKycModal}
                 onClose={() => setShowKycModal(false)}
                 onVerify={async () => {
-                    await sumsubFlow.handleInitiateKyc('STANDARD', undefined, true)
+                    if (gate.type === 'fixable_rejection') {
+                        await sumsubFlow.handleSelfHealResubmit('BRIDGE')
+                    } else {
+                        await sumsubFlow.handleInitiateKyc('STANDARD', undefined, gate.type === 'needs_enrollment' || undefined)
+                    }
+                }}
+                onContactSupport={() => {
                     setShowKycModal(false)
+                    setIsSupportModalOpen(true)
                 }}
                 isLoading={sumsubFlow.isLoading}
-                variant="cross_region"
+                    error={sumsubFlow.error}
+                variant={
+                    gate.type === 'blocked_rejection'
+                        ? 'blocked'
+                        : gate.type === 'fixable_rejection'
+                          ? 'provider_rejection'
+                          : gate.type === 'needs_enrollment'
+                            ? 'cross_region'
+                            : 'default'
+                }
+                providerMessage={
+                    gate.type === 'fixable_rejection' || gate.type === 'blocked_rejection'
+                        ? gate.userMessage ?? undefined
+                        : undefined
+                }
                 regionName={getCountryFromPath(country)?.title}
             />
             <SumsubKycModals flow={sumsubFlow} />

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -408,28 +408,10 @@ export default function MantecaWithdrawFlow() {
         resetState()
     }, [])
 
+    // todo: temp disabled for local testing — restore before merging
     useEffect(() => {
-        // Skip balance check if transaction is being processed
-        // Use hasPendingTransactions to prevent race condition with optimistic updates
-        // isLoading covers the gap between sendMoney completing and API withdraw completing
-        if (hasPendingTransactions || isLoading) {
-            return
-        }
-
-        if (!usdAmount || usdAmount === '0.00' || isNaN(Number(usdAmount)) || balance === undefined) {
-            setBalanceErrorMessage(null)
-            return
-        }
-        const paymentAmount = parseUnits(usdAmount, PEANUT_WALLET_TOKEN_DECIMALS)
-        // only check min amount and balance here - max amount is handled by limits validation
-        if (paymentAmount < parseUnits(MIN_MANTECA_WITHDRAW_AMOUNT.toString(), PEANUT_WALLET_TOKEN_DECIMALS)) {
-            setBalanceErrorMessage(`Withdraw amount must be at least $${MIN_MANTECA_WITHDRAW_AMOUNT}`)
-        } else if (paymentAmount > balance) {
-            setBalanceErrorMessage('Not enough balance to complete withdrawal.')
-        } else {
-            setBalanceErrorMessage(null)
-        }
-    }, [usdAmount, balance, hasPendingTransactions, isLoading])
+        setBalanceErrorMessage(null)
+    }, [usdAmount, balance])
 
     // Fetch points early to avoid latency penalty - fetch as soon as we have usdAmount
     // Use flowId as uniqueId to prevent cache collisions between different withdrawal flows

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -408,10 +408,28 @@ export default function MantecaWithdrawFlow() {
         resetState()
     }, [])
 
-    // todo: temp disabled for local testing — restore before merging
     useEffect(() => {
-        setBalanceErrorMessage(null)
-    }, [usdAmount, balance])
+        // Skip balance check if transaction is being processed
+        // Use hasPendingTransactions to prevent race condition with optimistic updates
+        // isLoading covers the gap between sendMoney completing and API withdraw completing
+        if (hasPendingTransactions || isLoading) {
+            return
+        }
+
+        if (!usdAmount || usdAmount === '0.00' || isNaN(Number(usdAmount)) || balance === undefined) {
+            setBalanceErrorMessage(null)
+            return
+        }
+        const paymentAmount = parseUnits(usdAmount, PEANUT_WALLET_TOKEN_DECIMALS)
+        // only check min amount and balance here - max amount is handled by limits validation
+        if (paymentAmount < parseUnits(MIN_MANTECA_WITHDRAW_AMOUNT.toString(), PEANUT_WALLET_TOKEN_DECIMALS)) {
+            setBalanceErrorMessage(`Withdraw amount must be at least $${MIN_MANTECA_WITHDRAW_AMOUNT}`)
+        } else if (paymentAmount > balance) {
+            setBalanceErrorMessage('Not enough balance to complete withdrawal.')
+        } else {
+            setBalanceErrorMessage(null)
+        }
+    }, [usdAmount, balance, hasPendingTransactions, isLoading])
 
     // Fetch points early to avoid latency penalty - fetch as soon as we have usdAmount
     // Use flowId as uniqueId to prevent cache collisions between different withdrawal flows
@@ -744,9 +762,7 @@ export default function MantecaWithdrawFlow() {
                                   : 'Review'}
                         </Button>
 
-                        {(errorMessage || sumsubFlow.error) && (
-                            <ErrorAlert description={(errorMessage || sumsubFlow.error)!} />
-                        )}
+                        {(errorMessage || sumsubFlow.error) && <ErrorAlert description={(errorMessage || sumsubFlow.error)!} />}
                     </div>
                 </div>
             )}
@@ -803,9 +819,7 @@ export default function MantecaWithdrawFlow() {
                     >
                         {isLoading ? loadingState : 'Withdraw'}
                     </Button>
-                    {(errorMessage || sumsubFlow.error) && (
-                        <ErrorAlert description={(errorMessage || sumsubFlow.error)!} />
-                    )}
+                    {(errorMessage || sumsubFlow.error) && <ErrorAlert description={(errorMessage || sumsubFlow.error)!} />}
                 </div>
             )}
         </div>

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -762,7 +762,9 @@ export default function MantecaWithdrawFlow() {
                                   : 'Review'}
                         </Button>
 
-                        {(errorMessage || sumsubFlow.error) && <ErrorAlert description={(errorMessage || sumsubFlow.error)!} />}
+                        {(errorMessage || sumsubFlow.error) && (
+                            <ErrorAlert description={(errorMessage || sumsubFlow.error)!} />
+                        )}
                     </div>
                 </div>
             )}
@@ -819,7 +821,9 @@ export default function MantecaWithdrawFlow() {
                     >
                         {isLoading ? loadingState : 'Withdraw'}
                     </Button>
-                    {(errorMessage || sumsubFlow.error) && <ErrorAlert description={(errorMessage || sumsubFlow.error)!} />}
+                    {(errorMessage || sumsubFlow.error) && (
+                        <ErrorAlert description={(errorMessage || sumsubFlow.error)!} />
+                    )}
                 </div>
             )}
         </div>

--- a/src/app/(mobile-ui)/withdraw/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/page.tsx
@@ -165,44 +165,13 @@ export default function WithdrawPage() {
         }
     }, [])
 
+    // todo: temp disabled for local testing — restore before merging
     const validateAmount = useCallback(
-        (amountStr: string): boolean => {
-            if (!amountStr) {
-                setError({ showError: false, errorMessage: '' })
-                return true
-            }
-
-            const amount = Number(amountStr)
-            if (!Number.isFinite(amount) || amount <= 0) {
-                setError({ showError: true, errorMessage: 'Please enter a valid number.' })
-                return false
-            }
-
-            // convert the entered token amount to USD
-            const price = selectedTokenData?.price ?? 0 // 0 for safety; will fail below
-            const usdEquivalent = price ? amount * price : amount // if no price assume token pegged 1 USD
-
-            if (usdEquivalent >= minUsdAmount && amount <= maxDecimalAmount) {
-                setError({ showError: false, errorMessage: '' })
-                return true
-            }
-
-            // determine message
-            let message = ''
-            if (usdEquivalent < minUsdAmount) {
-                const minDisplay = minUsdAmount % 1 === 0 ? `$${minUsdAmount}` : `$${minUsdAmount.toFixed(2)}`
-                message = isFromSendFlow
-                    ? `Minimum send amount is ${minDisplay}.`
-                    : `Minimum withdrawal is ${minDisplay}.`
-            } else if (amount > maxDecimalAmount) {
-                message = 'Amount exceeds your wallet balance.'
-            } else {
-                message = 'Please enter a valid amount.'
-            }
-            setError({ showError: true, errorMessage: message })
-            return false
+        (_amountStr: string): boolean => {
+            setError({ showError: false, errorMessage: '' })
+            return true
         },
-        [maxDecimalAmount, setError, selectedTokenData?.price, isFromSendFlow, minUsdAmount]
+        [setError]
     )
 
     const handleTokenAmountChange = useCallback(
@@ -296,17 +265,12 @@ export default function WithdrawPage() {
     }
 
     // check if continue button should be disabled
+    // todo: temp disabled for local testing — restore before merging
     const isContinueDisabled = useMemo(() => {
         if (!rawTokenAmount) return true
-
         const numericAmount = parseFloat(rawTokenAmount)
-        if (!Number.isFinite(numericAmount) || numericAmount <= 0) return true
-
-        const usdEq = (selectedTokenData?.price ?? 1) * numericAmount
-        if (usdEq < minUsdAmount) return true // below country-specific minimum
-
-        return numericAmount > maxDecimalAmount || error.showError
-    }, [rawTokenAmount, maxDecimalAmount, error.showError, selectedTokenData?.price, minUsdAmount])
+        return !Number.isFinite(numericAmount) || numericAmount <= 0
+    }, [rawTokenAmount])
 
     if (step === 'inputAmount') {
         // only show limits card for bank/manteca withdrawals, not crypto

--- a/src/app/(mobile-ui)/withdraw/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/page.tsx
@@ -165,13 +165,44 @@ export default function WithdrawPage() {
         }
     }, [])
 
-    // todo: temp disabled for local testing — restore before merging
     const validateAmount = useCallback(
-        (_amountStr: string): boolean => {
-            setError({ showError: false, errorMessage: '' })
-            return true
+        (amountStr: string): boolean => {
+            if (!amountStr) {
+                setError({ showError: false, errorMessage: '' })
+                return true
+            }
+
+            const amount = Number(amountStr)
+            if (!Number.isFinite(amount) || amount <= 0) {
+                setError({ showError: true, errorMessage: 'Please enter a valid number.' })
+                return false
+            }
+
+            // convert the entered token amount to USD
+            const price = selectedTokenData?.price ?? 0 // 0 for safety; will fail below
+            const usdEquivalent = price ? amount * price : amount // if no price assume token pegged 1 USD
+
+            if (usdEquivalent >= minUsdAmount && amount <= maxDecimalAmount) {
+                setError({ showError: false, errorMessage: '' })
+                return true
+            }
+
+            // determine message
+            let message = ''
+            if (usdEquivalent < minUsdAmount) {
+                const minDisplay = minUsdAmount % 1 === 0 ? `$${minUsdAmount}` : `$${minUsdAmount.toFixed(2)}`
+                message = isFromSendFlow
+                    ? `Minimum send amount is ${minDisplay}.`
+                    : `Minimum withdrawal is ${minDisplay}.`
+            } else if (amount > maxDecimalAmount) {
+                message = 'Amount exceeds your wallet balance.'
+            } else {
+                message = 'Please enter a valid amount.'
+            }
+            setError({ showError: true, errorMessage: message })
+            return false
         },
-        [setError]
+        [maxDecimalAmount, setError, selectedTokenData?.price, isFromSendFlow, minUsdAmount]
     )
 
     const handleTokenAmountChange = useCallback(
@@ -265,12 +296,17 @@ export default function WithdrawPage() {
     }
 
     // check if continue button should be disabled
-    // todo: temp disabled for local testing — restore before merging
     const isContinueDisabled = useMemo(() => {
         if (!rawTokenAmount) return true
+
         const numericAmount = parseFloat(rawTokenAmount)
-        return !Number.isFinite(numericAmount) || numericAmount <= 0
-    }, [rawTokenAmount])
+        if (!Number.isFinite(numericAmount) || numericAmount <= 0) return true
+
+        const usdEq = (selectedTokenData?.price ?? 1) * numericAmount
+        if (usdEq < minUsdAmount) return true // below country-specific minimum
+
+        return numericAmount > maxDecimalAmount || error.showError
+    }, [rawTokenAmount, maxDecimalAmount, error.showError, selectedTokenData?.price, minUsdAmount])
 
     if (step === 'inputAmount') {
         // only show limits card for bank/manteca withdrawals, not crypto

--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -40,10 +40,7 @@ export const initiateSumsubKyc = async (params?: {
 
         if (!response.ok) {
             return {
-                error:
-                    responseJson.userMessage ||
-                    responseJson.error ||
-                    'Failed to initiate identity verification',
+                error: responseJson.userMessage || responseJson.error || 'Failed to initiate identity verification',
             }
         }
 

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -296,7 +296,11 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                         if (gate.type === 'fixable_rejection') {
                             await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                         } else {
-                            await sumsubFlow.handleInitiateKyc('STANDARD', undefined, gate.type === 'needs_enrollment' || undefined)
+                            await sumsubFlow.handleInitiateKyc(
+                                'STANDARD',
+                                undefined,
+                                gate.type === 'needs_enrollment' || undefined
+                            )
                         }
                     }}
                     onContactSupport={() => {
@@ -316,7 +320,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                     }
                     providerMessage={
                         gate.type === 'fixable_rejection' || gate.type === 'blocked_rejection'
-                            ? gate.userMessage ?? undefined
+                            ? (gate.userMessage ?? undefined)
                             : undefined
                     }
                     regionName={currentCountry?.title}

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -100,11 +100,11 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
         // return a non-visible error to prevent the form from treating this as success
         if (gate.type !== 'ready') {
             if (gate.type === 'accept_tos') {
-                if (guardWithTos()) return { error: '__silent__' }
+                guardWithTos()
             } else {
                 setIsKycModalOpen(true)
-                return { error: '__silent__' }
             }
+            return { error: '__silent__' }
         }
 
         // scenario (1): happy path: if the user has already completed kyc, we can add the bank account directly

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -10,7 +10,7 @@ import Image, { type StaticImageData } from 'next/image'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import EmptyState from '../Global/EmptyStates/EmptyState'
 import { useAuth } from '@/context/authContext'
-import { useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { DynamicBankAccountForm, type IBankAccountDetails } from './DynamicBankAccountForm'
 import { addBankAccount } from '@/app/actions/users'
 import { type AddBankAccountPayload } from '@/app/actions/types/users.types'
@@ -21,13 +21,16 @@ import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { useAppDispatch } from '@/redux/hooks'
 import { bankFormActions } from '@/redux/slices/bank-form-slice'
 import useKycStatus from '@/hooks/useKycStatus'
-import useProviderRejectionStatus from '@/hooks/useProviderRejectionStatus'
 import KycVerifiedOrReviewModal from '../Global/KycVerifiedOrReviewModal'
 import { ActionListCard } from '@/components/ActionListCard'
 import TokenAndNetworkConfirmationModal from '../Global/TokenAndNetworkConfirmationModal'
 import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
+import { useBridgeTransferReadiness } from '@/hooks/useBridgeTransferReadiness'
+import { useBridgeTosGuard } from '@/hooks/useBridgeTosGuard'
+import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
+import { useModalsContext } from '@/context/ModalsContext'
 
 interface AddWithdrawCountriesListProps {
     flow: 'add' | 'withdraw'
@@ -66,10 +69,16 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
     const formRef = useRef<{ handleSubmit: () => void }>(null)
     const [isSupportedTokensModalOpen, setIsSupportedTokensModalOpen] = useState(false)
 
-    const { isUserKycApproved, isUserBridgeKycUnderReview, isUserSumsubKycApproved, isUserBridgeKycApproved } =
-        useKycStatus()
-    const { bridge: bridgeRejection } = useProviderRejectionStatus()
+    const { isUserKycApproved, isUserBridgeKycUnderReview } = useKycStatus()
+    const { gate } = useBridgeTransferReadiness()
+    const { guardWithTos, showBridgeTos, hideTos } = useBridgeTosGuard()
+    const { setIsSupportModalOpen } = useModalsContext()
     const [showKycStatusModal, setShowKycStatusModal] = useState(false)
+
+    // close kyc modal when sumsub sdk opens
+    useEffect(() => {
+        if (sumsubFlow.showWrapper) setIsKycModalOpen(false)
+    }, [sumsubFlow.showWrapper])
 
     const countryPathParts = Array.isArray(params.country) ? params.country : [params.country]
     const isBankPage = countryPathParts[countryPathParts.length - 1] === 'bank'
@@ -87,20 +96,15 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
         // (the multi-phase flow may have completed but websocket/state not yet propagated)
         await fetchUser()
 
-        // block users with bridge provider rejection
-        if (bridgeRejection.state === 'fixable') {
-            await sumsubFlow.handleSelfHealResubmit('BRIDGE')
-            return {}
-        }
-        if (bridgeRejection.state === 'blocked') {
-            return { error: 'Bank transfers are not available for your account. Please contact support.' }
-        }
-
-        // JIT bridge enrollment: user is sumsub-approved but no bridge customer yet
-        // show the KYC modal — enrollment happens when user clicks "Start Verification"
-        if (isUserSumsubKycApproved && !isUserBridgeKycApproved && !user?.user.bridgeCustomerId) {
-            setIsKycModalOpen(true)
-            return {}
+        // unified bridge gate: tos → fixable rejection → blocked → enrollment
+        // return a non-visible error to prevent the form from treating this as success
+        if (gate.type !== 'ready') {
+            if (gate.type === 'accept_tos') {
+                if (guardWithTos()) return { error: '__silent__' }
+            } else {
+                setIsKycModalOpen(true)
+                return { error: '__silent__' }
+            }
         }
 
         // scenario (1): happy path: if the user has already completed kyc, we can add the bank account directly
@@ -289,12 +293,41 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                     visible={isKycModalOpen}
                     onClose={() => setIsKycModalOpen(false)}
                     onVerify={async () => {
-                        await sumsubFlow.handleInitiateKyc('STANDARD', undefined, true)
+                        if (gate.type === 'fixable_rejection') {
+                            await sumsubFlow.handleSelfHealResubmit('BRIDGE')
+                        } else {
+                            await sumsubFlow.handleInitiateKyc('STANDARD', undefined, gate.type === 'needs_enrollment' || undefined)
+                        }
+                    }}
+                    onContactSupport={() => {
                         setIsKycModalOpen(false)
+                        setIsSupportModalOpen(true)
                     }}
                     isLoading={sumsubFlow.isLoading}
-                    variant="cross_region"
+                    error={sumsubFlow.error}
+                    variant={
+                        gate.type === 'blocked_rejection'
+                            ? 'blocked'
+                            : gate.type === 'fixable_rejection'
+                              ? 'provider_rejection'
+                              : gate.type === 'needs_enrollment'
+                                ? 'cross_region'
+                                : 'default'
+                    }
+                    providerMessage={
+                        gate.type === 'fixable_rejection' || gate.type === 'blocked_rejection'
+                            ? gate.userMessage ?? undefined
+                            : undefined
+                    }
                     regionName={currentCountry?.title}
+                />
+                <BridgeTosStep
+                    visible={showBridgeTos}
+                    onComplete={() => {
+                        hideTos()
+                        formRef.current?.handleSubmit()
+                    }}
+                    onSkip={hideTos}
                 />
                 <SumsubKycModals flow={sumsubFlow} />
             </div>

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -27,7 +27,11 @@ import TokenAndNetworkConfirmationModal from '../Global/TokenAndNetworkConfirmat
 import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
-import { useBridgeTransferReadiness } from '@/hooks/useBridgeTransferReadiness'
+import {
+    useBridgeTransferReadiness,
+    getKycModalVariant,
+    getGateProviderMessage,
+} from '@/hooks/useBridgeTransferReadiness'
 import { useBridgeTosGuard } from '@/hooks/useBridgeTosGuard'
 import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
 import { useModalsContext } from '@/context/ModalsContext'
@@ -91,7 +95,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
     const handleFormSubmit = async (
         payload: AddBankAccountPayload,
         rawData: IBankAccountDetails
-    ): Promise<{ error?: string }> => {
+    ): Promise<{ error?: string; silent?: boolean }> => {
         // re-fetch user to ensure we have the latest KYC status
         // (the multi-phase flow may have completed but websocket/state not yet propagated)
         await fetchUser()
@@ -104,7 +108,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
             } else {
                 setIsKycModalOpen(true)
             }
-            return { error: '__silent__' }
+            return { error: 'gate_blocked', silent: true }
         }
 
         // scenario (1): happy path: if the user has already completed kyc, we can add the bank account directly
@@ -309,20 +313,8 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                     }}
                     isLoading={sumsubFlow.isLoading}
                     error={sumsubFlow.error}
-                    variant={
-                        gate.type === 'blocked_rejection'
-                            ? 'blocked'
-                            : gate.type === 'fixable_rejection'
-                              ? 'provider_rejection'
-                              : gate.type === 'needs_enrollment'
-                                ? 'cross_region'
-                                : 'default'
-                    }
-                    providerMessage={
-                        gate.type === 'fixable_rejection' || gate.type === 'blocked_rejection'
-                            ? (gate.userMessage ?? undefined)
-                            : undefined
-                    }
+                    variant={getKycModalVariant(gate.type)}
+                    providerMessage={getGateProviderMessage(gate)}
                     regionName={currentCountry?.title}
                 />
                 <BridgeTosStep

--- a/src/components/AddWithdraw/DynamicBankAccountForm.tsx
+++ b/src/components/AddWithdraw/DynamicBankAccountForm.tsx
@@ -249,7 +249,8 @@ export const DynamicBankAccountForm = forwardRef<{ handleSubmit: () => void }, D
                     name: data.name,
                 })
                 if (result.error) {
-                    setSubmissionError(result.error)
+                    // '__silent__' is a sentinel from the gate check — don't show it to the user
+                    if (result.error !== '__silent__') setSubmissionError(result.error)
                     setIsSubmitting(false)
                 } else {
                     // Save form data to Redux after successful submission

--- a/src/components/AddWithdraw/DynamicBankAccountForm.tsx
+++ b/src/components/AddWithdraw/DynamicBankAccountForm.tsx
@@ -54,7 +54,10 @@ export type IBankAccountDetails = {
 interface DynamicBankAccountFormProps {
     country: string
     countryName?: string
-    onSuccess: (payload: AddBankAccountPayload, rawData: IBankAccountDetails) => Promise<{ error?: string }>
+    onSuccess: (
+        payload: AddBankAccountPayload,
+        rawData: IBankAccountDetails
+    ) => Promise<{ error?: string; silent?: boolean }>
     initialData?: Partial<IBankAccountDetails>
     flow?: 'claim' | 'withdraw'
     actionDetailsProps?: Partial<PeanutActionDetailsCardProps>
@@ -249,8 +252,7 @@ export const DynamicBankAccountForm = forwardRef<{ handleSubmit: () => void }, D
                     name: data.name,
                 })
                 if (result.error) {
-                    // '__silent__' is a sentinel from the gate check — don't show it to the user
-                    if (result.error !== '__silent__') setSubmissionError(result.error)
+                    if (!result.silent) setSubmissionError(result.error)
                     setIsSubmitting(false)
                 } else {
                     // Save form data to Redux after successful submission

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -32,7 +32,11 @@ import { sendLinksApi } from '@/services/sendLinks'
 import { useSearchParams } from 'next/navigation'
 import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
-import { useBridgeTransferReadiness } from '@/hooks/useBridgeTransferReadiness'
+import {
+    useBridgeTransferReadiness,
+    getKycModalVariant,
+    getGateProviderMessage,
+} from '@/hooks/useBridgeTransferReadiness'
 import { useBridgeTosGuard } from '@/hooks/useBridgeTosGuard'
 import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
 import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
@@ -523,7 +527,8 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                                         gate.type === 'needs_enrollment' || undefined
                                     )
                                 }
-                                setShowKycModal(false)
+                                // only close if sdk opened — if it errored, keep modal open to show error
+                                if (sumsubFlow.showWrapper) setShowKycModal(false)
                             }}
                             onContactSupport={() => {
                                 setShowKycModal(false)
@@ -531,20 +536,8 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                             }}
                             isLoading={sumsubFlow.isLoading}
                             error={sumsubFlow.error}
-                            variant={
-                                gate.type === 'blocked_rejection'
-                                    ? 'blocked'
-                                    : gate.type === 'fixable_rejection'
-                                      ? 'provider_rejection'
-                                      : gate.type === 'needs_enrollment'
-                                        ? 'cross_region'
-                                        : 'default'
-                            }
-                            providerMessage={
-                                gate.type === 'fixable_rejection' || gate.type === 'blocked_rejection'
-                                    ? (gate.userMessage ?? undefined)
-                                    : undefined
-                            }
+                            variant={getKycModalVariant(gate.type)}
+                            providerMessage={getGateProviderMessage(gate)}
                         />
                     </>
                 )

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -159,11 +159,11 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
             const isGuestFlow = bankClaimType === BankClaimType.GuestBankClaim
             if (!isGuestFlow && gate.type !== 'ready') {
                 if (gate.type === 'accept_tos') {
-                    if (guardWithTos()) return
+                    guardWithTos()
                 } else {
                     setShowKycModal(true)
-                    return
                 }
+                return
             }
 
             setLoadingState('Executing transaction')

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -515,7 +515,11 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                                 if (gate.type === 'fixable_rejection') {
                                     await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                                 } else {
-                                    await sumsubFlow.handleInitiateKyc('STANDARD', undefined, gate.type === 'needs_enrollment' || undefined)
+                                    await sumsubFlow.handleInitiateKyc(
+                                        'STANDARD',
+                                        undefined,
+                                        gate.type === 'needs_enrollment' || undefined
+                                    )
                                 }
                                 setShowKycModal(false)
                             }}
@@ -536,7 +540,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                             }
                             providerMessage={
                                 gate.type === 'fixable_rejection' || gate.type === 'blocked_rejection'
-                                    ? gate.userMessage ?? undefined
+                                    ? (gate.userMessage ?? undefined)
                                     : undefined
                             }
                         />

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -32,6 +32,11 @@ import { sendLinksApi } from '@/services/sendLinks'
 import { useSearchParams } from 'next/navigation'
 import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
+import { useBridgeTransferReadiness } from '@/hooks/useBridgeTransferReadiness'
+import { useBridgeTosGuard } from '@/hooks/useBridgeTosGuard'
+import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
+import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
+import { useModalsContext } from '@/context/ModalsContext'
 
 type BankAccountWithId = IBankAccountDetails &
     (
@@ -74,6 +79,10 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
     const { isLoading, setLoadingState } = useContext(loadingStateContext)
     const { claimLink } = useClaimLink()
     const dispatch = useAppDispatch()
+    const { gate } = useBridgeTransferReadiness()
+    const { guardWithTos, showBridgeTos, hideTos } = useBridgeTosGuard()
+    const [showKycModal, setShowKycModal] = useState(false)
+    const { setIsSupportModalOpen } = useModalsContext()
 
     // inline sumsub kyc flow for users who need verification
     // regionIntent is NOT passed here to avoid creating a backend record on mount.
@@ -144,11 +153,20 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
      */
     const handleCreateOfframpAndClaim = async (account: BankAccountWithId) => {
         try {
-            setLoadingState('Executing transaction')
             setError(null)
 
-            // determine user for offramp based on the bank claim type
+            // for logged-in users, check bridge readiness before proceeding
             const isGuestFlow = bankClaimType === BankClaimType.GuestBankClaim
+            if (!isGuestFlow && gate.type !== 'ready') {
+                if (gate.type === 'accept_tos') {
+                    if (guardWithTos()) return
+                } else {
+                    setShowKycModal(true)
+                    return
+                }
+            }
+
+            setLoadingState('Executing transaction')
             const userForOfframp = isGuestFlow
                 ? await getUserById(claimLinkData.sender?.userId ?? claimLinkData.senderAddress)
                 : user?.user
@@ -465,22 +483,64 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
         case ClaimBankFlowStep.BankConfirmClaim:
             if (localBankDetails) {
                 return (
-                    <ConfirmBankClaimView
-                        claimLinkData={claimLinkData}
-                        onConfirm={() => handleCreateOfframpAndClaim(localBankDetails)}
-                        onBack={() => {
-                            setClaimBankFlowStep(
-                                savedAccounts.length > 0
-                                    ? ClaimBankFlowStep.SavedAccountsList
-                                    : ClaimBankFlowStep.BankDetailsForm
-                            )
-                            setError(null)
-                        }}
-                        isProcessing={isLoading}
-                        error={error}
-                        bankDetails={localBankDetails}
-                        fullName={receiverFullName}
-                    />
+                    <>
+                        <ConfirmBankClaimView
+                            claimLinkData={claimLinkData}
+                            onConfirm={() => handleCreateOfframpAndClaim(localBankDetails)}
+                            onBack={() => {
+                                setClaimBankFlowStep(
+                                    savedAccounts.length > 0
+                                        ? ClaimBankFlowStep.SavedAccountsList
+                                        : ClaimBankFlowStep.BankDetailsForm
+                                )
+                                setError(null)
+                            }}
+                            isProcessing={isLoading}
+                            error={error}
+                            bankDetails={localBankDetails}
+                            fullName={receiverFullName}
+                        />
+                        <BridgeTosStep
+                            visible={showBridgeTos}
+                            onComplete={() => {
+                                hideTos()
+                                handleCreateOfframpAndClaim(localBankDetails)
+                            }}
+                            onSkip={hideTos}
+                        />
+                        <InitiateKycModal
+                            visible={showKycModal}
+                            onClose={() => setShowKycModal(false)}
+                            onVerify={async () => {
+                                if (gate.type === 'fixable_rejection') {
+                                    await sumsubFlow.handleSelfHealResubmit('BRIDGE')
+                                } else {
+                                    await sumsubFlow.handleInitiateKyc('STANDARD', undefined, gate.type === 'needs_enrollment' || undefined)
+                                }
+                                setShowKycModal(false)
+                            }}
+                            onContactSupport={() => {
+                                setShowKycModal(false)
+                                setIsSupportModalOpen(true)
+                            }}
+                            isLoading={sumsubFlow.isLoading}
+                            error={sumsubFlow.error}
+                            variant={
+                                gate.type === 'blocked_rejection'
+                                    ? 'blocked'
+                                    : gate.type === 'fixable_rejection'
+                                      ? 'provider_rejection'
+                                      : gate.type === 'needs_enrollment'
+                                        ? 'cross_region'
+                                        : 'default'
+                            }
+                            providerMessage={
+                                gate.type === 'fixable_rejection' || gate.type === 'blocked_rejection'
+                                    ? gate.userMessage ?? undefined
+                                    : undefined
+                            }
+                        />
+                    </>
                 )
             }
             return null

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -305,6 +305,8 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                     setBankDetails(bankDetails)
                     setReceiverFullName(`${bankDetails.firstName} ${bankDetails.lastName}`)
                     setClaimBankFlowStep(ClaimBankFlowStep.BankConfirmClaim)
+                } else {
+                    return { error: 'Failed to process bank account. Please try again.' }
                 }
             } finally {
                 setIsProcessingKycSuccess(false)

--- a/src/components/Home/ActivationCTAs.tsx
+++ b/src/components/Home/ActivationCTAs.tsx
@@ -55,7 +55,7 @@ const STEPS: Record<Exclude<ActivationStep, 'completed'>, StepConfig> = {
  */
 export default function ActivationCTAs({ activationStep }: ActivationCTAsProps) {
     const router = useRouter()
-    const { setIsQRScannerOpen } = useModalsContext()
+    const { setIsQRScannerOpen, setIsSupportModalOpen } = useModalsContext()
     const { hasFixableRejection, hasBlockedRejection, primaryRejection } = useProviderRejectionStatus()
 
     const lastTrackedStep = useRef<ActivationStep | null>(null)
@@ -117,9 +117,7 @@ export default function ActivationCTAs({ activationStep }: ActivationCTAsProps) 
                     className="mt-2 w-full"
                     onClick={() => {
                         if (hasProviderRejection && hasBlockedRejection && !hasFixableRejection) {
-                            if (typeof window !== 'undefined' && (window as any).$crisp) {
-                                ;(window as any).$crisp.push(['do', 'chat:open'])
-                            }
+                            setIsSupportModalOpen(true)
                         } else if (activationStep === 'outbound' && !hasProviderRejection) {
                             setIsQRScannerOpen(true)
                         } else {

--- a/src/components/Kyc/BridgeTosStep.tsx
+++ b/src/components/Kyc/BridgeTosStep.tsx
@@ -85,8 +85,7 @@ export const BridgeTosStep = ({ visible, onComplete, onSkip }: BridgeTosStepProp
                 icon={error ? ('alert' as IconName) : ('badge' as IconName)}
                 title={error ? 'Could not load terms' : 'Accept Terms of Service'}
                 description={
-                    error ||
-                    'To enable bank transfers, you need to accept our payment partner\'s Terms of Service.'
+                    error || "To enable bank transfers, you need to accept our payment partner's Terms of Service."
                 }
                 ctas={[
                     {

--- a/src/components/Kyc/BridgeTosStep.tsx
+++ b/src/components/Kyc/BridgeTosStep.tsx
@@ -21,19 +21,18 @@ export const BridgeTosStep = ({ visible, onComplete, onSkip }: BridgeTosStepProp
     const [showIframe, setShowIframe] = useState(false)
     const [tosLink, setTosLink] = useState<string | null>(null)
     const [isLoading, setIsLoading] = useState(false)
+    const [isConfirming, setIsConfirming] = useState(false)
     const [error, setError] = useState<string | null>(null)
 
-    // auto-fetch ToS link when step becomes visible so the iframe opens directly
-    // (skips the intermediate "Accept Terms" confirmation modal)
+    // reset state when step is hidden
     useEffect(() => {
-        if (visible) {
-            handleAcceptTerms()
-        } else {
+        if (!visible) {
             setShowIframe(false)
+            setIsConfirming(false)
             setTosLink(null)
             setError(null)
         }
-    }, [visible]) // eslint-disable-line react-hooks/exhaustive-deps
+    }, [visible])
 
     const handleAcceptTerms = useCallback(async () => {
         setIsLoading(true)
@@ -60,12 +59,15 @@ export const BridgeTosStep = ({ visible, onComplete, onSkip }: BridgeTosStepProp
 
     const handleIframeClose = useCallback(
         async (source?: 'manual' | 'completed' | 'tos_accepted') => {
-            setShowIframe(false)
-
             if (source === 'tos_accepted') {
+                // keep iframe mounted while confirming to prevent the ActionModal from flashing
+                setIsConfirming(true)
+                setShowIframe(false)
                 await confirmBridgeTosAndAwaitRails(fetchUser)
+                setIsConfirming(false)
                 onComplete()
             } else {
+                setShowIframe(false)
                 onSkip()
             }
         },
@@ -76,32 +78,33 @@ export const BridgeTosStep = ({ visible, onComplete, onSkip }: BridgeTosStepProp
 
     return (
         <>
-            {/* only show modal on error — normal flow goes straight to iframe */}
-            {error && !showIframe && (
-                <ActionModal
-                    visible={true}
-                    onClose={onSkip}
-                    icon={'alert' as IconName}
-                    title="Could not load terms"
-                    description={error}
-                    ctas={[
-                        {
-                            text: 'Try again',
-                            onClick: handleAcceptTerms,
-                            disabled: isLoading,
-                            variant: 'purple',
-                            className: 'w-full',
-                            shadowSize: '4',
-                        },
-                        {
-                            text: 'Skip for now',
-                            onClick: onSkip,
-                            variant: 'transparent' as const,
-                            className: 'underline text-sm font-medium w-full h-fit mt-3',
-                        },
-                    ]}
-                />
-            )}
+            {/* confirmation modal — hidden when iframe is open or ToS is being confirmed */}
+            <ActionModal
+                visible={visible && !showIframe && !isConfirming}
+                onClose={onSkip}
+                icon={error ? ('alert' as IconName) : ('badge' as IconName)}
+                title={error ? 'Could not load terms' : 'Accept Terms of Service'}
+                description={
+                    error ||
+                    'To enable bank transfers, you need to accept our payment partner\'s Terms of Service.'
+                }
+                ctas={[
+                    {
+                        text: isLoading ? 'Loading...' : error ? 'Try again' : 'Accept Terms',
+                        onClick: handleAcceptTerms,
+                        disabled: isLoading,
+                        variant: 'purple',
+                        className: 'w-full',
+                        shadowSize: '4',
+                    },
+                    {
+                        text: 'Not now',
+                        onClick: onSkip,
+                        variant: 'transparent' as const,
+                        className: 'underline text-sm font-medium w-full h-fit mt-3',
+                    },
+                ]}
+            />
 
             {tosLink && <IframeWrapper src={tosLink} visible={showIframe} onClose={handleIframeClose} skipStartView />}
         </>

--- a/src/components/Kyc/BridgeTosStep.tsx
+++ b/src/components/Kyc/BridgeTosStep.tsx
@@ -60,12 +60,16 @@ export const BridgeTosStep = ({ visible, onComplete, onSkip }: BridgeTosStepProp
     const handleIframeClose = useCallback(
         async (source?: 'manual' | 'completed' | 'tos_accepted') => {
             if (source === 'tos_accepted') {
-                // keep iframe mounted while confirming to prevent the ActionModal from flashing
                 setIsConfirming(true)
                 setShowIframe(false)
-                await confirmBridgeTosAndAwaitRails(fetchUser)
-                setIsConfirming(false)
-                onComplete()
+                try {
+                    await confirmBridgeTosAndAwaitRails(fetchUser)
+                    onComplete()
+                } catch {
+                    setError('Something went wrong confirming your terms. Please try again.')
+                } finally {
+                    setIsConfirming(false)
+                }
             } else {
                 setShowIframe(false)
                 onSkip()

--- a/src/components/Kyc/InitiateKycModal.tsx
+++ b/src/components/Kyc/InitiateKycModal.tsx
@@ -6,9 +6,12 @@ interface InitiateKycModalProps {
     visible: boolean
     onClose: () => void
     onVerify: () => void
+    onContactSupport?: () => void
     isLoading?: boolean
+    /** error message from a failed verify/resubmit attempt */
+    error?: string | null
     /** when set, shows provider-specific messaging instead of generic "verify your identity" */
-    variant?: 'default' | 'provider_rejection' | 'cross_region'
+    variant?: 'default' | 'provider_rejection' | 'blocked' | 'cross_region'
     providerMessage?: string
     /** country name shown in cross_region variant (e.g. "Brazil", "Argentina") */
     regionName?: string
@@ -17,20 +20,34 @@ interface InitiateKycModalProps {
 // confirmation modal shown before starting KYC or provider resubmission.
 // for fresh KYC: "Verify your identity"
 // for provider rejections: "We need extra documents"
+// for blocked: "Verification issue — contact support"
 // for cross-region: "Your identity is verified, we need a local ID"
 export const InitiateKycModal = ({
     visible,
     onClose,
     onVerify,
+    onContactSupport,
     isLoading,
+    error,
     variant = 'default',
     providerMessage,
     regionName,
 }: InitiateKycModalProps) => {
     const isProviderRejection = variant === 'provider_rejection'
+    const isBlocked = variant === 'blocked'
     const isCrossRegion = variant === 'cross_region'
 
+    const getTitle = () => {
+        if (error) return 'Something went wrong'
+        if (isBlocked) return 'Verification issue'
+        if (isProviderRejection) return 'We need extra documents'
+        return 'Verify your identity'
+    }
+
     const getDescription = () => {
+        if (error) return `${error} Please contact support for assistance.`
+        if (isBlocked)
+            return providerMessage || "We couldn't verify your identity. Please contact support for assistance."
         if (isProviderRejection) return providerMessage || 'Please upload a clearer photo of your ID to continue.'
         if (isCrossRegion) {
             const region = regionName ? ` from ${regionName}` : ''
@@ -39,29 +56,53 @@ export const InitiateKycModal = ({
         return 'To continue, you need to complete identity verification. This usually takes just a few minutes.'
     }
 
+    const getCta = () => {
+        if (error || isBlocked) {
+            return {
+                text: 'Contact support',
+                onClick: onContactSupport ?? onClose,
+            }
+        }
+        if (isProviderRejection) {
+            return {
+                text: isLoading ? 'Loading...' : 'Upload document',
+                onClick: onVerify,
+                icon: 'upload' as IconName,
+            }
+        }
+        return {
+            text: isLoading ? 'Loading...' : 'Start Verification',
+            onClick: onVerify,
+            icon: 'check-circle' as IconName,
+        }
+    }
+
+    const cta = getCta()
+
     return (
         <ActionModal
             visible={visible}
             onClose={onClose}
-            title={isProviderRejection ? 'We need extra documents' : 'Verify your identity'}
+            title={getTitle()}
             description={getDescription()}
             preventClose
-            icon={'badge' as IconName}
+            icon={(error || isBlocked ? 'alert' : 'badge') as IconName}
+            iconContainerClassName={isBlocked ? 'bg-yellow-1' : ''}
             modalPanelClassName="max-w-full m-2"
             ctaClassName="grid grid-cols-1 gap-3"
             ctas={[
                 {
-                    text: isLoading ? 'Loading...' : isProviderRejection ? 'Upload document' : 'Start Verification',
-                    onClick: onVerify,
+                    text: cta.text,
+                    onClick: cta.onClick,
                     variant: 'purple',
-                    disabled: isLoading,
+                    disabled: isLoading && !isBlocked,
                     shadowSize: '4',
-                    icon: isProviderRejection ? 'upload' : 'check-circle',
+                    ...(cta.icon ? { icon: cta.icon } : {}),
                     className: 'h-11',
                 },
             ]}
             footer={
-                isProviderRejection ? undefined : (
+                isProviderRejection || isBlocked ? undefined : (
                     <PeanutDoesntStoreAnyPersonalInformation className="w-full justify-center" />
                 )
             }

--- a/src/components/Kyc/states/KycProviderRejection.tsx
+++ b/src/components/Kyc/states/KycProviderRejection.tsx
@@ -4,6 +4,7 @@ import { KYCStatusDrawerItem } from '../KYCStatusDrawerItem'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Icon } from '@/components/Global/Icons/Icon'
 import type { ProviderRejectionInfo } from '@/hooks/useProviderRejectionStatus'
+import { useModalsContext } from '@/context/ModalsContext'
 
 /**
  * shown when a user is sumsub-approved but a provider (bridge/manteca) rejected their documents.
@@ -18,6 +19,7 @@ export const KycProviderRejection = ({
     rejection: ProviderRejectionInfo
     onStartResubmission?: () => void
 }) => {
+    const { setIsSupportModalOpen } = useModalsContext()
     const providerLabel = rejection.provider === 'BRIDGE' ? 'Bank transfers' : 'QR payments'
     const isFixable = rejection.state === 'fixable'
 
@@ -59,15 +61,7 @@ export const KycProviderRejection = ({
                     Upload document
                 </Button>
             ) : (
-                <Button
-                    variant="stroke"
-                    className="w-full"
-                    onClick={() => {
-                        if (typeof window !== 'undefined' && (window as any).$crisp) {
-                            ;(window as any).$crisp.push(['do', 'chat:open'])
-                        }
-                    }}
-                >
+                <Button variant="stroke" className="w-full" onClick={() => setIsSupportModalOpen(true)}>
                     Contact support
                 </Button>
             )}

--- a/src/components/Profile/views/RegionsVerification.view.tsx
+++ b/src/components/Profile/views/RegionsVerification.view.tsx
@@ -11,6 +11,7 @@ import { KycProcessingModal } from '@/components/Kyc/modals/KycProcessingModal'
 import { KycActionRequiredModal } from '@/components/Kyc/modals/KycActionRequiredModal'
 import { KycFailedModal } from '@/components/Kyc/modals/KycFailedModal'
 import ActionModal from '@/components/Global/ActionModal'
+import { useModalsContext } from '@/context/ModalsContext'
 import { useIdentityVerification, getRegionIntent, type Region } from '@/hooks/useIdentityVerification'
 import useUnifiedKycStatus from '@/hooks/useUnifiedKycStatus'
 import useProviderRejectionStatus from '@/hooks/useProviderRejectionStatus'
@@ -56,6 +57,7 @@ const RegionsVerification = () => {
     const { sumsubStatus, sumsubRejectLabels, sumsubRejectType, sumsubVerificationRegionIntent, isSumsubApproved } =
         useUnifiedKycStatus()
     const { bridge: bridgeRejection, manteca: mantecaRejection, hasAnyRejection } = useProviderRejectionStatus()
+    const { setIsSupportModalOpen } = useModalsContext()
     const [selectedRegion, setSelectedRegion] = useState<Region | null>(null)
     // keeps the region display stable during modal close animation
     const displayRegionRef = useRef<Region | null>(null)
@@ -218,10 +220,8 @@ const RegionsVerification = () => {
                         : {
                               text: 'Contact support',
                               onClick: () => {
-                                  if (typeof window !== 'undefined' && (window as any).$crisp) {
-                                      ;(window as any).$crisp.push(['do', 'chat:open'])
-                                  }
                                   handleModalClose()
+                                  setIsSupportModalOpen(true)
                               },
                               variant: 'purple' as const,
                               shadowSize: '4' as const,

--- a/src/hooks/__tests__/useBridgeTransferReadiness.test.ts
+++ b/src/hooks/__tests__/useBridgeTransferReadiness.test.ts
@@ -1,0 +1,151 @@
+import { renderHook } from '@testing-library/react'
+import { useBridgeTransferReadiness, getKycModalVariant, getGateProviderMessage } from '../useBridgeTransferReadiness'
+import type { BridgeGateAction } from '../useBridgeTransferReadiness'
+
+// mock the three dependency hooks
+jest.mock('../useBridgeTosStatus', () => ({
+    useBridgeTosStatus: jest.fn(),
+}))
+jest.mock('../useProviderRejectionStatus', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}))
+jest.mock('../useKycStatus', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}))
+
+import { useBridgeTosStatus } from '../useBridgeTosStatus'
+import useProviderRejectionStatus from '../useProviderRejectionStatus'
+import useKycStatus from '../useKycStatus'
+
+const mockTosStatus = useBridgeTosStatus as jest.MockedFunction<typeof useBridgeTosStatus>
+const mockRejectionStatus = useProviderRejectionStatus as jest.MockedFunction<typeof useProviderRejectionStatus>
+const mockKycStatus = useKycStatus as jest.MockedFunction<typeof useKycStatus>
+
+const defaultRejection = {
+    provider: 'BRIDGE' as const,
+    state: 'happy' as const,
+    userMessage: null,
+    rejectedRails: [],
+    kycVerification: null,
+    selfHealAttempt: 0,
+    maxAttempts: 3,
+}
+
+function setup({
+    needsBridgeTos = false,
+    bridgeState = 'happy' as const,
+    bridgeUserMessage = null as string | null,
+    isSumsubApproved = false,
+    isBridgeApproved = false,
+    isBridgeUnderReview = false,
+} = {}) {
+    mockTosStatus.mockReturnValue({
+        needsBridgeTos,
+        isBridgeFullyEnabled: false,
+        bridgeRails: [],
+    })
+    mockRejectionStatus.mockReturnValue({
+        bridge: { ...defaultRejection, state: bridgeState, userMessage: bridgeUserMessage },
+        manteca: { ...defaultRejection, provider: 'MANTECA' },
+        hasFixableRejection: bridgeState === 'fixable',
+        hasBlockedRejection: bridgeState === 'blocked',
+        hasAnyRejection: bridgeState === 'fixable' || bridgeState === 'blocked',
+        primaryRejection: null,
+    })
+    mockKycStatus.mockReturnValue({
+        isUserSumsubKycApproved: isSumsubApproved,
+        isUserBridgeKycApproved: isBridgeApproved,
+        isUserBridgeKycUnderReview: isBridgeUnderReview,
+        isUserMantecaKycApproved: false,
+        isUserKycApproved: isBridgeApproved,
+    })
+}
+
+describe('useBridgeTransferReadiness', () => {
+    afterEach(() => jest.resetAllMocks())
+
+    it('returns ready when no issues', () => {
+        setup({ isSumsubApproved: true, isBridgeApproved: true })
+        const { result } = renderHook(() => useBridgeTransferReadiness())
+        expect(result.current.gate.type).toBe('ready')
+    })
+
+    it('blocked_rejection takes priority over accept_tos', () => {
+        setup({ needsBridgeTos: true, bridgeState: 'blocked', bridgeUserMessage: 'permanently rejected' })
+        const { result } = renderHook(() => useBridgeTransferReadiness())
+        expect(result.current.gate.type).toBe('blocked_rejection')
+        expect((result.current.gate as any).userMessage).toBe('permanently rejected')
+    })
+
+    it('accept_tos fires when tos needed and no hard rejection', () => {
+        setup({ needsBridgeTos: true })
+        const { result } = renderHook(() => useBridgeTransferReadiness())
+        expect(result.current.gate.type).toBe('accept_tos')
+    })
+
+    it('fixable_rejection when selfHealable and no tos needed', () => {
+        setup({ bridgeState: 'fixable', bridgeUserMessage: 'upload clearer photo' })
+        const { result } = renderHook(() => useBridgeTransferReadiness())
+        expect(result.current.gate.type).toBe('fixable_rejection')
+        expect((result.current.gate as any).userMessage).toBe('upload clearer photo')
+    })
+
+    it('needs_enrollment when sumsub approved but bridge not started', () => {
+        setup({ isSumsubApproved: true })
+        const { result } = renderHook(() => useBridgeTransferReadiness())
+        expect(result.current.gate.type).toBe('needs_enrollment')
+    })
+
+    it('ready when sumsub approved and bridge under review (enrollment not needed)', () => {
+        setup({ isSumsubApproved: true, isBridgeUnderReview: true })
+        const { result } = renderHook(() => useBridgeTransferReadiness())
+        expect(result.current.gate.type).toBe('ready')
+    })
+
+    it('ready when sumsub approved and bridge approved', () => {
+        setup({ isSumsubApproved: true, isBridgeApproved: true })
+        const { result } = renderHook(() => useBridgeTransferReadiness())
+        expect(result.current.gate.type).toBe('ready')
+    })
+
+    it('accept_tos takes priority over fixable_rejection', () => {
+        setup({ needsBridgeTos: true, bridgeState: 'fixable' })
+        const { result } = renderHook(() => useBridgeTransferReadiness())
+        expect(result.current.gate.type).toBe('accept_tos')
+    })
+
+    it('accept_tos takes priority over needs_enrollment', () => {
+        setup({ needsBridgeTos: true, isSumsubApproved: true })
+        const { result } = renderHook(() => useBridgeTransferReadiness())
+        expect(result.current.gate.type).toBe('accept_tos')
+    })
+})
+
+describe('getKycModalVariant', () => {
+    it('maps gate types to modal variants', () => {
+        expect(getKycModalVariant('blocked_rejection')).toBe('blocked')
+        expect(getKycModalVariant('fixable_rejection')).toBe('provider_rejection')
+        expect(getKycModalVariant('needs_enrollment')).toBe('cross_region')
+        expect(getKycModalVariant('accept_tos')).toBe('default')
+        expect(getKycModalVariant('ready')).toBe('default')
+    })
+})
+
+describe('getGateProviderMessage', () => {
+    it('returns userMessage for rejection gates', () => {
+        expect(getGateProviderMessage({ type: 'blocked_rejection', userMessage: 'blocked msg' })).toBe('blocked msg')
+        expect(getGateProviderMessage({ type: 'fixable_rejection', userMessage: 'fix msg' })).toBe('fix msg')
+    })
+
+    it('returns undefined for null userMessage', () => {
+        expect(getGateProviderMessage({ type: 'blocked_rejection', userMessage: null })).toBeUndefined()
+    })
+
+    it('returns undefined for non-rejection gates', () => {
+        expect(getGateProviderMessage({ type: 'accept_tos' })).toBeUndefined()
+        expect(getGateProviderMessage({ type: 'needs_enrollment' })).toBeUndefined()
+        expect(getGateProviderMessage({ type: 'ready' })).toBeUndefined()
+    })
+})

--- a/src/hooks/useBridgeTosStatus.ts
+++ b/src/hooks/useBridgeTosStatus.ts
@@ -15,8 +15,10 @@ export const useBridgeTosStatus = () => {
         // bridge can require tos_acceptance as part of additionalRequirements
         // even when rails are in other states (REJECTED, REQUIRES_EXTRA_INFORMATION)
         const hasTosInRequirements = bridgeRails.some((r) => {
-            const reqs = r.metadata?.additionalRequirements as string[] | undefined
-            return reqs?.some((req) => req === 'tos_acceptance' || req === 'tos_v2_acceptance')
+            const reqs = Array.isArray(r.metadata?.additionalRequirements)
+                ? (r.metadata.additionalRequirements as string[])
+                : []
+            return reqs.some((req) => req === 'tos_acceptance' || req === 'tos_v2_acceptance')
         })
 
         const needsBridgeTos = hasRequiresInformation || hasTosInRequirements

--- a/src/hooks/useBridgeTosStatus.ts
+++ b/src/hooks/useBridgeTosStatus.ts
@@ -9,7 +9,17 @@ export const useBridgeTosStatus = () => {
     return useMemo(() => {
         const rails: IUserRail[] = user?.rails ?? []
         const bridgeRails = rails.filter((r) => r.rail.provider.code === 'BRIDGE')
-        const needsBridgeTos = bridgeRails.some((r) => r.status === 'REQUIRES_INFORMATION')
+
+        const hasRequiresInformation = bridgeRails.some((r) => r.status === 'REQUIRES_INFORMATION')
+
+        // bridge can require tos_acceptance as part of additionalRequirements
+        // even when rails are in other states (REJECTED, REQUIRES_EXTRA_INFORMATION)
+        const hasTosInRequirements = bridgeRails.some((r) => {
+            const reqs = r.metadata?.additionalRequirements as string[] | undefined
+            return reqs?.some((req) => req === 'tos_acceptance' || req === 'tos_v2_acceptance')
+        })
+
+        const needsBridgeTos = hasRequiresInformation || hasTosInRequirements
         const isBridgeFullyEnabled = bridgeRails.length > 0 && bridgeRails.every((r) => r.status === 'ENABLED')
 
         return { needsBridgeTos, isBridgeFullyEnabled, bridgeRails }

--- a/src/hooks/useBridgeTransferReadiness.ts
+++ b/src/hooks/useBridgeTransferReadiness.ts
@@ -52,3 +52,19 @@ export function useBridgeTransferReadiness() {
 
     return { gate }
 }
+
+/** maps gate type to InitiateKycModal variant */
+export function getKycModalVariant(gateType: BridgeGateAction['type']) {
+    if (gateType === 'blocked_rejection') return 'blocked' as const
+    if (gateType === 'fixable_rejection') return 'provider_rejection' as const
+    if (gateType === 'needs_enrollment') return 'cross_region' as const
+    return 'default' as const
+}
+
+/** extracts provider message from gate for InitiateKycModal */
+export function getGateProviderMessage(gate: BridgeGateAction): string | undefined {
+    if (gate.type === 'fixable_rejection' || gate.type === 'blocked_rejection') {
+        return gate.userMessage ?? undefined
+    }
+    return undefined
+}

--- a/src/hooks/useBridgeTransferReadiness.ts
+++ b/src/hooks/useBridgeTransferReadiness.ts
@@ -1,0 +1,54 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useBridgeTosStatus } from './useBridgeTosStatus'
+import useProviderRejectionStatus from './useProviderRejectionStatus'
+import useKycStatus from './useKycStatus'
+
+export type BridgeGateAction =
+    | { type: 'accept_tos' }
+    | { type: 'fixable_rejection'; userMessage: string | null }
+    | { type: 'blocked_rejection'; userMessage: string | null }
+    | { type: 'needs_enrollment' }
+    | { type: 'ready' }
+
+/**
+ * unified pre-transfer gate for bridge bank flows.
+ * determines what needs to happen before a transfer can proceed,
+ * in the correct priority order:
+ *   1. hard rejection (contact support — tos is moot)
+ *   2. tos acceptance
+ *   3. fixable rejection (user can submit additional details)
+ *   4. needs enrollment (sumsub approved, bridge not started)
+ *   5. ready
+ */
+export function useBridgeTransferReadiness() {
+    const { needsBridgeTos } = useBridgeTosStatus()
+    const { bridge: bridgeRejection } = useProviderRejectionStatus()
+    const { isUserSumsubKycApproved, isUserBridgeKycApproved, isUserBridgeKycUnderReview } = useKycStatus()
+
+    const gate: BridgeGateAction = useMemo(() => {
+        // 1. hard rejection — contact support (checked first because tos is moot for hard-rejected users)
+        if (bridgeRejection.state === 'blocked') {
+            return { type: 'blocked_rejection', userMessage: bridgeRejection.userMessage }
+        }
+
+        // 2. tos acceptance — only if user can actually proceed after accepting
+        if (needsBridgeTos) return { type: 'accept_tos' }
+
+        // 3. fixable rejection — user can submit additional details
+        if (bridgeRejection.state === 'fixable') {
+            return { type: 'fixable_rejection', userMessage: bridgeRejection.userMessage }
+        }
+
+        // 4. needs enrollment (sumsub approved but bridge not started/approved)
+        if (isUserSumsubKycApproved && !isUserBridgeKycApproved && !isUserBridgeKycUnderReview) {
+            return { type: 'needs_enrollment' }
+        }
+
+        // 5. ready
+        return { type: 'ready' }
+    }, [needsBridgeTos, bridgeRejection, isUserSumsubKycApproved, isUserBridgeKycApproved, isUserBridgeKycUnderReview])
+
+    return { gate }
+}

--- a/src/hooks/useProviderRejectionStatus.ts
+++ b/src/hooks/useProviderRejectionStatus.ts
@@ -85,14 +85,17 @@ export default function useProviderRejectionStatus() {
                 let userMessage: string | null = null
                 const reasons = firstRejectedMetadata.rejectionReasons
                 const endorsementIssues = firstRejectedMetadata.endorsementIssues
-                if (Array.isArray(reasons) && reasons.length > 0) {
+
+                if (!isFixable) {
+                    // permanently rejected — generic message regardless of underlying reason
+                    userMessage = "We couldn't verify your identity. Please contact support for assistance."
+                } else if (Array.isArray(reasons) && reasons.length > 0) {
                     // bridge format: { reason: string, developer_reason: string }
                     // manteca format: { task: string, reason: string }
                     const first = reasons[0]
                     userMessage = first?.reason || first?.developer_reason || null
                 } else if (Array.isArray(endorsementIssues) && endorsementIssues.length > 0) {
-                    // bridge endorsement issues: plain strings like 'government_id_verification_failed'
-                    userMessage = `ID verification failed. Please upload a clearer photo.`
+                    userMessage = 'ID verification failed. Please upload a clearer photo.'
                 }
 
                 return {

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -92,7 +92,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         const fetchCurrentStatus = async () => {
             try {
                 const response = await initiateSumsubKyc({ regionIntent })
-                if (response.data?.status && !initiatingRef.current) {
+                if (response.data?.status && !initiatingRef.current && !showWrapperRef.current) {
                     setLiveKycStatus(response.data.status)
                 }
             } catch {

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -88,6 +88,12 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         if (!regionIntent) return
         // skip if handleInitiateKyc is already in progress — it handles status sync itself
         if (initiatingRef.current) return
+        // skip if user already initiated a flow in this session — the SDK or
+        // handleInitiateKyc manages status from here. without this guard,
+        // the async fetch can resolve after initiatingRef is reset but before
+        // showWrapperRef is updated by the batched render, causing a false
+        // APPROVED transition that closes the SDK.
+        if (userInitiatedRef.current) return
 
         const fetchCurrentStatus = async () => {
             try {

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -137,7 +137,8 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
 
             // for cross-region: pre-set prevStatusRef to APPROVED so the fetchCurrentStatus
             // effect (which also fires when regionIntent changes) doesn't trigger onKycSuccess
-            // when it sees the existing APPROVED status.
+            // when it sees the existing APPROVED status. save previous value to restore on failure.
+            const savedPrevStatus = prevStatusRef.current
             if (crossRegion) {
                 prevStatusRef.current = 'APPROVED'
             }
@@ -150,6 +151,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 })
 
                 if (response.error) {
+                    if (crossRegion) prevStatusRef.current = savedPrevStatus
                     setError(response.error)
                     return
                 }
@@ -196,6 +198,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                     setError('Could not initiate verification. Please try again.')
                 }
             } catch (e: unknown) {
+                if (crossRegion) prevStatusRef.current = savedPrevStatus
                 const message = e instanceof Error ? e.message : 'An unexpected error occurred'
                 setError(message)
             } finally {


### PR DESCRIPTION
## Summary

- **Unified pre-transfer gate** (`useBridgeTransferReadiness`): single hook enforcing correct priority across all Bridge bank flows — hard rejection → ToS acceptance → fixable rejection → enrollment → ready
- **Expanded ToS detection** (`useBridgeTosStatus`): now checks `tos_acceptance`/`tos_v2_acceptance` in rail `additionalRequirements` metadata, not just `REQUIRES_INFORMATION` status
- **Inline KYC in QR pay**: replaced redirect to `/profile/identity-verification` with inline Sumsub SDK (`handleInitiateKyc('LATAM')`)
- **Rejection handling**: withdraw/deposit/claim flows now show correct modals — "Contact support" for hard rejections, "Upload document" for fixable rejections (self-heal via applicant action)
- **BridgeTosStep UX**: shows confirmation modal before iframe, prevents modal flash during ToS confirmation
- **Fixed support CTAs**: replaced broken `$crisp.push` with `setIsSupportModalOpen` in KycProviderRejection, ActivationCTAs, RegionsVerification
- **Fixed SDK auto-close**: race condition in `useSumsubKycFlow` where `fetchCurrentStatus` closed the SDK wrapper on first attempt
- **Error display**: `InitiateKycModal` now shows error state with "Contact support" when self-heal/KYC initiation fails

## Files changed (15)

| File | Change |
|------|--------|
| `hooks/useBridgeTransferReadiness.ts` | **NEW** — unified gate hook |
| `hooks/useBridgeTosStatus.ts` | Check `additionalRequirements` for ToS |
| `hooks/useSumsubKycFlow.ts` | Fix race condition (guard `fetchCurrentStatus` with `showWrapperRef`) |
| `hooks/useProviderRejectionStatus.ts` | Generic message for permanent rejections |
| `components/Kyc/InitiateKycModal.tsx` | Added `blocked` variant, `error` prop |
| `components/Kyc/BridgeTosStep.tsx` | Confirmation modal + `isConfirming` state |
| `components/Kyc/states/KycProviderRejection.tsx` | `$crisp` → `setIsSupportModalOpen` |
| `components/Home/ActivationCTAs.tsx` | `$crisp` → `setIsSupportModalOpen` |
| `components/Profile/views/RegionsVerification.view.tsx` | `$crisp` → `setIsSupportModalOpen` |
| `app/(mobile-ui)/withdraw/[country]/bank/page.tsx` | Unified gate, rejection handling |
| `app/(mobile-ui)/add-money/[country]/bank/page.tsx` | Unified gate, rejection handling |
| `app/(mobile-ui)/qr-pay/page.tsx` | Inline KYC (no redirect), gate blocks query |
| `components/AddWithdraw/AddWithdrawCountriesList.tsx` | Unified gate, `__silent__` sentinel |
| `components/AddWithdraw/DynamicBankAccountForm.tsx` | Skip `__silent__` error display |
| `components/Claim/Link/views/BankFlowManager.view.tsx` | ToS guard + rejection for claims |

## Backend dependency

Requires [peanutprotocol/peanut-api-ts#fix/bridge-tos-transfer-guard](https://github.com/peanutprotocol/peanut-api-ts/pull/) for:
- Transfer creation ToS guard (`fetchCustomerById` check)
- `confirm-bridge-tos` full status processor (correct rail state after ToS)
- `get-bridge-tos-link` fallback for non-REQUIRES_INFORMATION rails
- `initiate-kyc` regionIntent overwrite for non-approved users

## Testing done

Tested locally with FE pointed to local BE + staging DB:

1. **Hard-rejected user** (duplicate_customer_detected, PROVIDER_FINAL): sees "Verification issue" + "Contact support" modal → opens support drawer ✅
2. **Fixable-rejected user** (government_id_verification_failed, PROVIDER_FIXABLE): sees "We need extra documents" + "Upload document" → Sumsub SDK opens inline → self-heal webhook fires → rails transition to REQUIRES_INFORMATION ✅
3. **Self-heal error state**: set unrecognized reject label → classifier defaults to CONTACT_SUPPORT → modal shows "Something went wrong" + "Contact support" ✅
4. **ToS acceptance (withdraw)**: user with REQUIRES_INFORMATION rails → "Accept Terms of Service" modal → iframe opens → accept → confirmation without modal flash ✅
5. **QR pay (unverified user)**: scan QR → inline KYC modal (not redirect) → "Verify now" → Sumsub SDK opens inline ✅
6. **QR pay (verified user)**: scan QR → proceeds to payment directly ✅
7. **Identity verification page**: SDK no longer auto-closes on first click (race condition fix) ✅
8. **Contact support CTAs**: all "Contact support" buttons across KYC modals now open the support drawer ✅

## Test plan

- [ ] Verify withdraw flow for hard-rejected Bridge user → sees "Contact support" not "Start verification"
- [ ] Verify withdraw flow for fixable-rejected Bridge user → self-heal opens Sumsub SDK inline
- [ ] Verify deposit flow shows ToS modal before proceeding when ToS not accepted
- [ ] Verify QR pay shows inline KYC modal (not redirect) for unverified users
- [ ] Verify identity verification page SDK stays open on first click
- [ ] Verify claim link flow handles ToS + rejection states
- [ ] Regression: happy path withdraw/deposit/claim for fully approved users still works