### PR TITLE
fix(card): credit-card icon for Rain card-spend receipts

### DIFF
--- a/src/components/TransactionDetails/TransactionAvatarBadge.tsx
+++ b/src/components/TransactionDetails/TransactionAvatarBadge.tsx
@@ -85,6 +85,13 @@ const TransactionAvatarBadge: React.FC<TransactionAvatarBadgeProps> = ({
             // iconFillColor = context === 'card' ? AVATAR_TEXT_LIGHT : AVATAR_TEXT_DARK
             // textColor = context === 'card' ? AVATAR_TEXT_LIGHT : AVATAR_TEXT_DARK
             break
+        case 'card_pay':
+            // Rain card spend without a Rain-enriched merchant logo
+            // (TransactionDetailsHeaderCard prefers `avatarUrl` when set,
+            // so a real merchant brand mark wins over this fallback).
+            displayIconName = 'credit-card'
+            displayInitials = undefined
+            break
         case 'send':
         case 'request':
         case 'receive':

--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -50,6 +50,10 @@ export type TransactionType =
     | 'claim_external'
     | 'bank_claim'
     | 'pay'
+    // Rain card-spend / card-refund. Distinct from 'pay' (Manteca QR pay)
+    // so the avatar logic can render a credit-card icon instead of the
+    // Mercado Pago / PIX brand mark or the generic wallet fallback.
+    | 'card_pay'
 
 interface TransactionCardProps {
     type: TransactionType
@@ -102,7 +106,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
     let displayName = name
     if (isAddress(displayName)) {
         displayName = printableAddress(displayName)
-    } else if (type === 'pay' && displayName.length > 19) {
+    } else if ((type === 'pay' || type === 'card_pay') && displayName.length > 19) {
         displayName = shortenStringLong(displayName, 0, 16)
     }
 
@@ -315,6 +319,7 @@ function getActionIcon(
             iconSize = 8
             break
         case 'pay':
+        case 'card_pay':
             iconName = 'arrow-up-right'
             break
         case 'add':

--- a/src/components/TransactionDetails/__tests__/transactionTransformer.test.ts
+++ b/src/components/TransactionDetails/__tests__/transactionTransformer.test.ts
@@ -339,7 +339,7 @@ const cases: TestCase[] = [
         expect: { direction: 'bank_withdraw', transactionCardType: 'bank_withdraw', userName: 'Bank Account' },
     },
     {
-        name: 'TRANSACTION_INTENT × CARD_SPEND with merchant → qr_payment / pay',
+        name: 'TRANSACTION_INTENT × CARD_SPEND with merchant → qr_payment / card_pay',
         entry: baseEntry({
             type: EHistoryEntryType.TRANSACTION_INTENT,
             userRole: EHistoryUserRole.SENDER,
@@ -348,7 +348,7 @@ const cases: TestCase[] = [
         }),
         expect: {
             direction: 'qr_payment',
-            transactionCardType: 'pay',
+            transactionCardType: 'card_pay',
             userName: 'Acme Coffee',
             cardPaymentDefined: true,
         },
@@ -363,7 +363,7 @@ const cases: TestCase[] = [
         }),
         expect: {
             direction: 'qr_payment',
-            transactionCardType: 'pay',
+            transactionCardType: 'card_pay',
             userName: 'Card payment',
             cardPaymentDefined: true,
         },

--- a/src/components/TransactionDetails/strategies/intent/card.ts
+++ b/src/components/TransactionDetails/strategies/intent/card.ts
@@ -13,7 +13,10 @@ export const cardSpend: TransactionStrategy = (entry: HistoryEntry): Transaction
     const merchantName = (entry.extraData?.merchantName as string | null | undefined) ?? null
     return {
         direction: 'qr_payment',
-        transactionCardType: 'pay',
+        // Rain card-spend gets its own card type so the avatar can render
+        // a credit-card icon. 'pay' is reserved for Manteca QR pays which
+        // render the Mercado Pago / PIX brand mark instead.
+        transactionCardType: 'card_pay',
         nameForDetails: merchantName || 'Card payment',
         isPeerActuallyUser: false,
         isLinkTx: false,


### PR DESCRIPTION
## Summary

Rain card spends were rendering with the generic yellow wallet icon. Both card-spend and Manteca QR-pay strategies returned `transactionCardType: 'pay'`, so the avatar logic couldn't differentiate. QR pays get the Mercado Pago / PIX brand mark via `getAvatarUrl`; card spends fell to `TransactionAvatarBadge` with `'pay'`, which has no case for it, so they landed on the default `'wallet-outline'` branch.

Pairs with [peanut-api-ts #712](https://github.com/peanutprotocol/peanut-api-ts/pull/712), which fixed the QR-pay icon — that one routes through `currency.code === 'ARS' | 'BRL'`. Card spends need their own visual cue, hence this PR.

## Changes

- New `'card_pay'` value on the `TransactionType` union.
- `cardSpend` strategy returns `'card_pay'` (QR pay still returns `'pay'`).
- `TransactionAvatarBadge` maps `'card_pay'` → `'credit-card'` icon.
- `TransactionCard`'s lower-right arrow case + name-truncation rule treat `'card_pay'` identically to `'pay'`.
- Updated `transactionTransformer.test.ts` expectations.

When Rain enriches the merchant logo, `TransactionDetailsHeaderCard` already prefers the explicit `avatarUrl` over `TransactionAvatarBadge`, so a real brand mark wins over this fallback. Card spends without enriched logos now show the credit-card icon instead of a wallet.

## Test plan

- [x] Typecheck clean
- [x] `transactionTransformer.test.ts` updated and passing
- [x] Other Jest suites unaffected (one pre-existing failure in `add-money-states.test.tsx` unrelated)
- [ ] Staging: card spend without merchant logo shows credit-card icon
- [ ] Staging: card spend with Rain-enriched merchant logo still shows the merchant brand mark (avatarUrl wins)
- [ ] Staging: Manteca QR pay still shows Mercado Pago / PIX logo (unchanged)