### PR TITLE
fix(card): action label + title-case names + drop Charged-in row

### DIFF
--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -354,6 +354,11 @@ function getActionText(type: TransactionType, status?: StatusPillType): string {
         case 'bank_request_fulfillment':
             actionText = 'Request paid via bank'
             break
+        case 'card_pay':
+            // 'Pay' for card spends — the underlying type literal `card_pay`
+            // is an internal discriminator (see TransactionType comment).
+            actionText = 'Pay'
+            break
     }
     return actionText
 }

--- a/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
+++ b/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
@@ -23,23 +23,16 @@ function parseCents(value: string | null | undefined): number | null {
     return Number.isFinite(n) ? n : null
 }
 
-/** Whether the transaction's local-currency block represents a real cross-
- *  currency charge that should be surfaced to the user. Normalizes the
- *  currency string and skips USD (the display currency). */
-function hasCrossCurrencyCharge(card: NonNullable<TransactionDetails['extraDataForDrawer']>['cardPayment']): boolean {
-    if (!card) return false
-    const currency = nonBlank(card.localCurrency)
-    if (!currency) return false
-    if (currency.toLowerCase() === 'usd') return false
-    return parseCents(card.localAmount) != null
-}
-
 /**
  * Whether CardPaymentRows would render any visible sub-row for this
  * transaction. The row-config in the receipt uses this to gate the
  * `cardPayment` slot — without it, we'd end up with a "visible" but
  * empty slot, which throws off `shouldHideBorder` and dangles the
  * preceding row's border into empty space.
+ *
+ * Note: cross-currency `Charged in` USED to live here, but the local
+ * fiat amount now flows through the receipt's heading (≈ ARS X) and
+ * exchange-rate row instead — same treatment as Manteca QR pays.
  */
 export function hasCardPaymentRowsContent(transaction: TransactionDetails): boolean {
     const card = transaction.extraDataForDrawer?.cardPayment
@@ -47,7 +40,6 @@ export function hasCardPaymentRowsContent(transaction: TransactionDetails): bool
 
     if (nonBlank(card.merchantCategory)) return true
     if (nonBlank(card.merchantCity) || nonBlank(card.merchantCountry)) return true
-    if (hasCrossCurrencyCharge(card)) return true
     if (card.settlementAdjusted && parseCents(card.authAmount) != null) return true
     if (transaction.status === 'failed' && card.declineReason) return true
     if (card.cancellationReason === 'auto_closed') return true
@@ -96,20 +88,6 @@ export function CardPaymentRows({
             key: 'location',
             label: 'Location',
             value: [cityClean, countryClean].filter(Boolean).join(', '),
-        })
-    }
-
-    // Cross-currency only — suppress when the local currency matches the USD
-    // display currency (everyone's seen "Charged in 150 usd" alongside $1.50
-    // and it's just noise). Normalized + NaN-guarded to avoid stray junk
-    // making it past the rendering predicate.
-    if (hasCrossCurrencyCharge(card)) {
-        const localCents = parseCents(card.localAmount)!
-        const currency = nonBlank(card.localCurrency)!.toUpperCase()
-        subRows.push({
-            key: 'chargedIn',
-            label: 'Charged in',
-            value: `${(localCents / 100).toFixed(2)} ${currency}`,
         })
     }
 

--- a/src/components/TransactionDetails/strategies/intent/card.ts
+++ b/src/components/TransactionDetails/strategies/intent/card.ts
@@ -1,13 +1,29 @@
 import { type HistoryEntry } from '@/hooks/useTransactionHistory'
 import { type TransactionStrategy, type TransactionStrategyOutput } from '../types'
 
-export const qrPay: TransactionStrategy = (entry: HistoryEntry): TransactionStrategyOutput => ({
-    direction: 'qr_payment',
-    transactionCardType: 'pay',
-    nameForDetails: entry.recipientAccount?.identifier || 'Merchant',
-    isPeerActuallyUser: false,
-    isLinkTx: false,
-})
+/** Rain often returns merchant names ALL-CAPS when its enrichment pipeline
+ *  doesn't recognize the brand ("BOYACA", "ANTHROPIC"). When that happens,
+ *  display them in Title Case for readability — but only when the name is
+ *  long enough that title-casing won't garble a real acronym (KFC, IBM,
+ *  BBC stay as-is). Mixed-case names are returned unchanged so enriched
+ *  brand names like "iPhone Store" or "Acme Coffee" aren't mangled. */
+const ACRONYM_LENGTH_THRESHOLD = 4
+function normalizeMerchantName(raw: string): string {
+    if (raw !== raw.toUpperCase()) return raw
+    if (raw.length <= ACRONYM_LENGTH_THRESHOLD) return raw
+    return raw.toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+export const qrPay: TransactionStrategy = (entry: HistoryEntry): TransactionStrategyOutput => {
+    const raw = entry.recipientAccount?.identifier
+    return {
+        direction: 'qr_payment',
+        transactionCardType: 'pay',
+        nameForDetails: raw ? normalizeMerchantName(raw) : 'Merchant',
+        isPeerActuallyUser: false,
+        isLinkTx: false,
+    }
+}
 
 export const cardSpend: TransactionStrategy = (entry: HistoryEntry): TransactionStrategyOutput => {
     const merchantName = (entry.extraData?.merchantName as string | null | undefined) ?? null
@@ -17,7 +33,7 @@ export const cardSpend: TransactionStrategy = (entry: HistoryEntry): Transaction
         // a credit-card icon. 'pay' is reserved for Manteca QR pays which
         // render the Mercado Pago / PIX brand mark instead.
         transactionCardType: 'card_pay',
-        nameForDetails: merchantName || 'Card payment',
+        nameForDetails: merchantName ? normalizeMerchantName(merchantName) : 'Card payment',
         isPeerActuallyUser: false,
         isLinkTx: false,
     }
@@ -25,10 +41,11 @@ export const cardSpend: TransactionStrategy = (entry: HistoryEntry): Transaction
 
 export const cardRefund: TransactionStrategy = (entry: HistoryEntry): TransactionStrategyOutput => {
     const merchantName = (entry.extraData?.merchantName as string | null | undefined) ?? null
+    const cleaned = merchantName ? normalizeMerchantName(merchantName) : null
     return {
         direction: 'receive',
         transactionCardType: 'receive',
-        nameForDetails: merchantName ? `Refund from ${merchantName}` : 'Card refund',
+        nameForDetails: cleaned ? `Refund from ${cleaned}` : 'Card refund',
         isPeerActuallyUser: false,
         isLinkTx: false,
     }


### PR DESCRIPTION
Follow-up to #1944 (already merged). Three small UX polish items I queued after that PR:

## Changes

1. **`Card_pay` → `Pay`** in the activity-row action label. `getActionText` was falling through to the type literal because `'card_pay'` wasn't in its switch. Adds a case.

2. **Title-case ALL-CAPS merchant names**. Rain returns names ALL-CAPS when its enrichment pipeline doesn't recognize the brand (`BOYACA`, `ANTHROPIC`). Title-case at display time for readability — but only when the input is fully uppercase AND length > 4, so real acronyms like `KFC` / `IBM` / `BBC` stay intact, and mixed-case enriched names like `iPhone Store` aren't mangled. Applied in the `qrPay`, `cardSpend`, and `cardRefund` strategies.

3. **Drop `Charged in` sub-row from `CardPaymentRows`**. Pairs with peanut-api-ts [#713](https://github.com/peanutprotocol/peanut-api-ts/pull/713) which surfaces card-spend local fiat as the receipt `currency` block + populates `extraData.receipt.exchange_rate`. The local fiat amount now flows through the receipt heading's `≈ ARS X` subtext, the activity-row's same subtext, and the dedicated `Exchange rate` row — same UX as Manteca QR pays. No need for a third place to render it.

## Test plan

- [x] Typecheck clean
- [x] `transactionTransformer.test.ts` 33/33 pass
- [ ] Staging: activity-row action label reads `Pay`, not `Card_pay`
- [ ] BOYACA / ANTHROPIC render Title-Case; KFC stays uppercase
- [ ] Card-spend receipt: no `Charged in` row, ARS info in heading + exchange-rate row instead

## Note

Deploy alongside peanut-api-ts [#713](https://github.com/peanutprotocol/peanut-api-ts/pull/713) — without it, the heading subtext + exchange-rate row won't appear, and the dropped `Charged in` row leaves no surface for the local fiat info.