### PR TITLE
fix(activity-card): only treat currency.amount as USD when code is USD

### DIFF
--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -112,7 +112,16 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
 
     const sign = getTransactionSign(transaction)
     let usdAmount = amount
-    if (!isStableCoin(transaction.tokenSymbol ?? 'USDC')) {
+    // `currency.amount` is treated as the USD-equivalent ONLY when it's
+    // actually denominated in USD — that's the cross-token-withdraw case
+    // (amount=ETH destination, currency={USD-equiv, USD}). For local-fiat
+    // currency blocks (ARS / BRL on Manteca QR pays + Rain card spends with
+    // a non-USD merchant) `amount` is already the USD-denominated value and
+    // `currency` just carries the local fiat for the "≈ X" subtext below.
+    // Without the USD guard the activity row would render the ARS amount
+    // formatted as `$X` (e.g. `$40,200` for a $30.24 BOYACA card spend).
+    const currencyCodeForUsdCheck = transaction.currency?.code?.toUpperCase()
+    if (!isStableCoin(transaction.tokenSymbol ?? 'USDC') && currencyCodeForUsdCheck === 'USD') {
         usdAmount = Number(transaction.currency?.amount ?? amount)
     }
 


### PR DESCRIPTION
Follow-up to #1944 / #1945. The activity-card row's main `\$X` figure was wrong for card spends with a non-USD merchant — e.g. a \$30.24 BOYACA spend rendered as `-\$40,200.00`.

## Bug

`TransactionCard.tsx`:

```ts
let usdAmount = amount
if (!isStableCoin(transaction.tokenSymbol ?? 'USDC')) {
    usdAmount = Number(transaction.currency?.amount ?? amount)
}
```

That switch was meant for cross-token withdraws — `amount = ETH destination, currency = {USD-equiv, 'USD'}`. For those, `currency.amount` IS the USD value to display.

But for Manteca QR pays + Rain card spends (post peanut-api-ts [#712](https://github.com/peanutprotocol/peanut-api-ts/pull/712)/[#713](https://github.com/peanutprotocol/peanut-api-ts/pull/713)) `currency` carries the LOCAL fiat (`{40200.00, 'ARS'}`) for the `≈ X` subtext below, and `amount` is already the USD-denominated main value. Since `tokenSymbol = 'USD'` for card spends (not in `STABLE_COINS`), the condition was wrongly substituting the ARS amount as the main USD figure.

## Fix

Add a USD guard: only swap to `currency.amount` when `currency.code === 'USD'`. Local-fiat blocks fall through to `amount` unchanged. The `≈ X` subtext logic below is unaffected.

## Test plan

- [x] Typecheck clean
- [ ] Staging: BOYACA card spend renders `-\$30.24` main with `≈ ARS 40,200.00` subtext (was `-\$40,200.00`)
- [ ] Manteca QR pay renders `-\$X.XX` USDC main with `≈ ARS Y` subtext
- [ ] Cross-token withdraw (USDC → ETH on Base) still renders the USD-equivalent as main (unchanged path)

## Pairs with

peanut-api-ts [#714](https://github.com/peanutprotocol/peanut-api-ts/pull/714) — adds the auth-time exchange-rate fallback so the receipt's `Exchange rate` row appears immediately on pending card spends instead of waiting for settlement.