### PR TITLE
fix(withdraw): record cross-chain payments even when collateral-routed

### DIFF
--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -339,16 +339,25 @@ export default function WithdrawCryptoPage() {
 
             if (!finalTxHash) throw new Error('Withdrawal returned no transaction identifier')
 
-            // Skip recordPayment when funds moved via Rain collateral — the
-            // charge indexer watches for smart-account-outgoing transfers, but
-            // a coordinator-driven withdraw moves USDC from the collateral proxy
-            // and would leave the Charge unmatched ("failed" in history). The
-            // Rain webhook + TransactionIntent reconciliation is the source of
-            // truth for those flows.
+            // Skip recordPayment when funds moved via Rain collateral on a
+            // SAME-chain withdrawal — the charge indexer watches for
+            // smart-account-outgoing transfers, but a coordinator-driven
+            // withdraw moves USDC from the collateral proxy and would leave
+            // the Charge unmatched ("failed" in history). The Rain webhook +
+            // TransactionIntent reconciliation is the source of truth there.
+            //
+            // Cross-chain withdraws ALWAYS need recordPayment to fire — the
+            // BE validator's cross-chain branch transitions the charge intent
+            // to COMPLETED directly (trusts the source-chain submission since
+            // Rhino owns delivery downstream). Without this call the intent
+            // gets stuck at PENDING because nothing else triggers the
+            // transition for the bridge-path (depositWithId, mode='pay')
+            // flow we use for non-stable destinations.
             const routedThroughCollateral = strategy === 'collateral-only' || strategy === 'mixed'
+            const skipRecordPayment = routedThroughCollateral && !isCrossChainWithdrawal
 
             let payment: Awaited<ReturnType<typeof recordPayment>> | null = null
-            if (!routedThroughCollateral) {
+            if (!skipRecordPayment) {
                 payment = await recordPayment({
                     chargeId: chargeDetails.uuid,
                     chainId: PEANUT_WALLET_CHAIN.id.toString(),


### PR DESCRIPTION
Cross-chain CRYPTO_WITHDRAW intents got stuck at \"Pending\" forever:

1. Same-chain Rain-collateral withdraws skip \`recordPayment\` by design — the BE charge indexer can't match coordinator-driven moves out of the collateral proxy, so it relies on the Rain webhook + TransactionIntent reconciliation path instead.
2. The skip was applied indiscriminately to BOTH same-chain and cross-chain Rain-collateral spends. But cross-chain has no Rain reconciliation — those funds go to Rhino's bridge contract, not a merchant — so the intent never reached \`COMPLETED\`.

## Fix

Tighten the skip: only **same-chain + collateral-routed** is exempt. Cross-chain spends always call \`recordPayment\`.

## Pairs with

[peanut-api-ts PR #717](https://github.com/peanutprotocol/peanut-api-ts/pull/717) — extends the BE validator's cross-chain branch to transition cross-chain \`CRYPTO_WITHDRAW\` charges to \`COMPLETED\` directly (trusts the source-chain submission since Rhino owns delivery downstream).

## Test plan

- [x] Typecheck clean
- [ ] Staging cross-chain ETH withdraw via Rain collateral → drawer transitions to \"Completed\" shortly after source-chain UserOp lands (was \"Pending\" indefinitely)
- [ ] Same-chain Rain-collateral withdraw still skips \`recordPayment\` (existing reconciliation path)
- [ ] Cross-chain via smart-only strategy unchanged (already called \`recordPayment\`)