### PR TITLE
fix(spend-flows): use txHash fallback for collateral-only sendMoney

### DIFF
--- a/src/features/payments/flows/contribute-pot/useContributePotFlow.ts
+++ b/src/features/payments/flows/contribute-pot/useContributePotFlow.ts
@@ -193,7 +193,11 @@ export function useContributePotFlow() {
 
                 // step 2: send money via peanut wallet
                 const txResult = await sendMoney(recipient.address, amount, { kind: 'REQUEST_PAY' })
-                const hash = (txResult.receipt?.transactionHash ?? txResult.userOpHash) as Hash
+                // For the collateral-only strategy useSpendBundle returns only
+                // `txHash` (Rain coordinator submits the on-chain tx; no UserOp
+                // hash + no receipt land here). Fall back to it so users with
+                // card collateral can pay without smart-account balance.
+                const hash = (txResult.receipt?.transactionHash ?? txResult.userOpHash ?? txResult.txHash) as Hash
 
                 setTxHash(hash)
 

--- a/src/features/payments/flows/direct-send/useDirectSendFlow.ts
+++ b/src/features/payments/flows/direct-send/useDirectSendFlow.ts
@@ -134,7 +134,11 @@ export function useDirectSendFlow() {
 
             // step 2: send money via peanut wallet
             const txResult = await sendMoney(recipient.address, amount, { kind: 'P2P_SEND' })
-            const hash = (txResult.receipt?.transactionHash ?? txResult.userOpHash) as Hash
+            // For the collateral-only strategy useSpendBundle returns only
+            // `txHash` (Rain coordinator submits the on-chain tx; no UserOp
+            // hash + no receipt land here). Fall back to it so users with
+            // card collateral can pay without smart-account balance.
+            const hash = (txResult.receipt?.transactionHash ?? txResult.userOpHash ?? txResult.txHash) as Hash
 
             setTxHash(hash)
 

--- a/src/features/payments/flows/semantic-request/useSemanticRequestFlow.ts
+++ b/src/features/payments/flows/semantic-request/useSemanticRequestFlow.ts
@@ -290,7 +290,11 @@ export function useSemanticRequestFlow() {
                 if (isSameChainSameToken) {
                     // direct payment - same as old flow when isPeanutWallet && same token/chain
                     const txResult = await sendMoney(recipient.resolvedAddress, amount, { kind: 'REQUEST_PAY' })
-                    const hash = (txResult.receipt?.transactionHash ?? txResult.userOpHash) as Hash
+                    // For the collateral-only strategy useSpendBundle returns only
+                    // `txHash` (Rain coordinator submits the on-chain tx). Fall
+                    // back to it so card-collateral users don't get an
+                    // undefined hash here.
+                    const hash = (txResult.receipt?.transactionHash ?? txResult.userOpHash ?? txResult.txHash) as Hash
                     setTxHash(hash)
 
                     // record payment
@@ -475,7 +479,9 @@ export function useSemanticRequestFlow() {
                 const txResult = await sendMoney(charge.requestLink.recipientAddress as Address, charge.tokenAmount, {
                     kind: 'REQUEST_PAY',
                 })
-                hash = (txResult.receipt?.transactionHash ?? txResult.userOpHash) as Hash
+                // collateral-only routes return `txHash` only — see
+                // sibling site at line ~293 for the same fallback.
+                hash = (txResult.receipt?.transactionHash ?? txResult.userOpHash ?? txResult.txHash) as Hash
             } else if (needsRoute && routeTransactions && routeTransactions.length > 0) {
                 // cross-chain or token swap payment via Rhino SDA
                 const txResult = await sendTransactions(


### PR DESCRIPTION
## Summary

Re-audit (corrected — SimpleFi is gone from active flows; QR pay is already wired to \`signSpend\`):

\`sendMoney\` already routes through \`useSpendBundle\` (smart-only / mixed / collateral-only — see \`useSendMoney.ts:67\`). What's broken: four call sites hardcoded \`receipt?.transactionHash ?? userOpHash\` for the on-chain hash, but both are \`undefined\` on the collateral-only path (Rain coordinator submits the on-chain tx; no UserOp, no receipt). Result: users with **only** Rain collateral hit \`hash = undefined\` → \`setTxHash(undefined)\`, \`recordPayment\` records garbage, receipt page can't find the tx.

## Fix

Add \`txResult.txHash\` as the third fallback for the four plain-\`sendMoney\` callers:

- \`useDirectSendFlow\` (P2P send)
- \`useContributePotFlow\` (pot contribute)
- \`useSemanticRequestFlow\` (request payment, two sites)

Bank withdraw at \`/withdraw/[country]/bank/page.tsx:230\` already does this.

Manteca withdraw is a separate Track-B mirror (uses \`signTransferUserOp\` + custom signed-tx endpoint, needs the QR-pay collateral pattern from #697–#703). Filed as follow-up.

## Test plan

- [x] Typecheck (no new errors; pre-existing \`@capgo\` import errors unrelated)
- [x] Existing \`useSendMoney\` test suite passes (6 tests)
- [ ] Staging — collateral-only user (smart wallet \$0, card-collateral funded) can:
  - P2P send to a peanut user
  - Contribute to a pot
  - Pay a semantic request (same-chain same-token)
  - All three should land with a valid \`txHash\` on the receipt
- [ ] Smart-only / mixed paths unchanged

## Net effect

Every plain-\`sendMoney\` spend flow now works end-to-end for users with only Rain collateral and no smart-account balance — one tap (admin EIP-712 sig), no UserOp.