### PR TITLE
feat(manteca-withdraw): switch to signSpend for collateral-only support

### DIFF
--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -31,7 +31,6 @@ import ValidatedInput from '@/components/Global/ValidatedInput'
 import AmountInput from '@/components/Global/AmountInput'
 import { formatUnits, parseUnits } from 'viem'
 import { PaymentInfoRow } from '@/components/Payment/PaymentInfoRow'
-import { useAuth } from '@/context/authContext'
 import { useModalsContext } from '@/context/ModalsContext'
 import Select from '@/components/Global/Select'
 import { SoundPlayer } from '@/components/Global/SoundPlayer'
@@ -90,11 +89,10 @@ export default function MantecaWithdrawFlow() {
     const [priceLock, setPriceLock] = useState<WithdrawPriceLock | null>(null)
     const [isLockingPrice, setIsLockingPrice] = useState(false)
     const router = useRouter()
-    const { sendMoney, spendableBalance: balance, balance: smartBalance } = useWallet()
+    const { spendableBalance: balance, balance: smartBalance } = useWallet()
     const { signSpend } = useSignSpendBundle()
     const { overview: rainCardOverview } = useRainCardOverview()
     const { isLoading, loadingState, setLoadingState } = useContext(loadingStateContext)
-    const { user } = useAuth()
     const { setIsSupportModalOpen, openSupportWithMessage } = useModalsContext()
     const queryClient = useQueryClient()
     const { isUserMantecaKycApproved, isUserSumsubKycApproved } = useKycStatus()
@@ -327,7 +325,10 @@ export default function MantecaWithdrawFlow() {
                 if (error instanceof InsufficientSpendableError) {
                     setErrorMessage('Not enough USDC in your wallet or card to cover this withdrawal.')
                 } else if (error instanceof SessionKeyGrantRequiredError) {
-                    setErrorMessage("One-time card authorization needed. You'll be asked to confirm once.")
+                    // Grant prompt was attempted inside signSpend and failed.
+                    // Telling the user "you'll be asked" is misleading — they
+                    // may retry and hit the same loop. Give an actionable hint.
+                    setErrorMessage('Card authorization failed. Please try again or contact support.')
                 } else if ((error as Error).toString().includes('not allowed')) {
                     setErrorMessage('Please confirm the transaction.')
                 } else {

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -1,7 +1,10 @@
 'use client'
 
 import { useWallet } from '@/hooks/wallet/useWallet'
-import { useSignUserOp } from '@/hooks/wallet/useSignUserOp'
+import { useSignSpendBundle } from '@/hooks/wallet/useSignSpendBundle'
+import { InsufficientSpendableError, SessionKeyGrantRequiredError } from '@/hooks/wallet/useSpendBundle'
+import { rainSpendingPowerToWei } from '@/utils/balance.utils'
+import { useRainCardOverview } from '@/hooks/useRainCardOverview'
 import { useState, useMemo, useContext, useEffect, useCallback, useId } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Button } from '@/components/0_Bruddle/Button'
@@ -50,7 +53,7 @@ import {
     MantecaAccountType,
     type MantecaBankCode,
 } from '@/constants/manteca.consts'
-import { PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
+import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
 import { TRANSACTIONS } from '@/constants/query.consts'
 import { useLimitsValidation } from '@/features/limits/hooks/useLimitsValidation'
 import { MIN_MANTECA_WITHDRAW_AMOUNT } from '@/constants/payment.consts'
@@ -87,8 +90,9 @@ export default function MantecaWithdrawFlow() {
     const [priceLock, setPriceLock] = useState<WithdrawPriceLock | null>(null)
     const [isLockingPrice, setIsLockingPrice] = useState(false)
     const router = useRouter()
-    const { sendMoney, spendableBalance: balance } = useWallet()
-    const { signTransferUserOp } = useSignUserOp()
+    const { sendMoney, spendableBalance: balance, balance: smartBalance } = useWallet()
+    const { signSpend } = useSignSpendBundle()
+    const { overview: rainCardOverview } = useRainCardOverview()
     const { isLoading, loadingState, setLoadingState } = useContext(loadingStateContext)
     const { user } = useAuth()
     const { setIsSupportModalOpen, openSupportWithMessage } = useModalsContext()
@@ -300,12 +304,31 @@ export default function MantecaWithdrawFlow() {
         try {
             setLoadingState('Preparing transaction')
 
-            // Step 1: Sign the UserOp (but don't broadcast yet)
-            let signedUserOpData
+            // Step 1: Sign the spend artifact (but don't broadcast yet).
+            // Route across smart-only / mixed / collateral-only — pure-collateral
+            // offramps (smart wallet empty, card collateral covers it) used to
+            // fail here because signTransferUserOp asks the paymaster to
+            // simulate a USDC transfer from a zero-balance smart account, which
+            // ZeroDev refuses to sponsor. signSpend picks the right routing,
+            // including a single-tap collateral-only path that lets Rain
+            // transfer straight from the collateral proxy to MANTECA's deposit
+            // address.
+            let signedArtifact
             try {
-                signedUserOpData = await signTransferUserOp(MANTECA_DEPOSIT_ADDRESS, usdAmount)
+                const requiredUsdcAmount = parseUnits(usdAmount, PEANUT_WALLET_TOKEN_DECIMALS)
+                signedArtifact = await signSpend({
+                    requiredUsdcAmount,
+                    recipient: MANTECA_DEPOSIT_ADDRESS,
+                    smartBalance: smartBalance ?? 0n,
+                    rainSpendingPower: rainSpendingPowerToWei(rainCardOverview?.balance?.spendingPower),
+                    kind: 'FIAT_OFFRAMP',
+                })
             } catch (error) {
-                if ((error as Error).toString().includes('not allowed')) {
+                if (error instanceof InsufficientSpendableError) {
+                    setErrorMessage('Not enough USDC in your wallet or card to cover this withdrawal.')
+                } else if (error instanceof SessionKeyGrantRequiredError) {
+                    setErrorMessage("One-time card authorization needed. You'll be asked to confirm once.")
+                } else if ((error as Error).toString().includes('not allowed')) {
                     setErrorMessage('Please confirm the transaction.')
                 } else {
                     captureException(error)
@@ -317,38 +340,42 @@ export default function MantecaWithdrawFlow() {
 
             setLoadingState('Withdrawing')
 
-            // Step 2: Build signed UserOp payload for backend
-            const signedUserOp = {
-                sender: signedUserOpData.signedUserOp.sender,
-                nonce: signedUserOpData.signedUserOp.nonce,
-                callData: signedUserOpData.signedUserOp.callData,
-                signature: signedUserOpData.signedUserOp.signature,
-                callGasLimit: signedUserOpData.signedUserOp.callGasLimit,
-                verificationGasLimit: signedUserOpData.signedUserOp.verificationGasLimit,
-                preVerificationGas: signedUserOpData.signedUserOp.preVerificationGas,
-                factory: signedUserOpData.signedUserOp.factory,
-                factoryData: signedUserOpData.signedUserOp.factoryData,
-                maxFeePerGas: signedUserOpData.signedUserOp.maxFeePerGas,
-                maxPriorityFeePerGas: signedUserOpData.signedUserOp.maxPriorityFeePerGas,
-                paymaster: signedUserOpData.signedUserOp.paymaster,
-                paymasterData: signedUserOpData.signedUserOp.paymasterData,
-                paymasterVerificationGasLimit: signedUserOpData.signedUserOp.paymasterVerificationGasLimit,
-                paymasterPostOpGasLimit: signedUserOpData.signedUserOp.paymasterPostOpGasLimit,
-            }
-
-            // Step 3: Call backend with signed tx (sign-then-broadcast pattern)
-            // Backend creates Manteca order FIRST, then broadcasts. No stuck funds!
-            const result = await mantecaApi.withdrawWithSignedTx({
-                priceLockCode: priceLock.priceLockCode,
-                amount: usdAmount,
-                destinationAddress: destinationAddress.toLowerCase(),
-                bankCode: selectedBank?.code,
-                accountType: accountType ?? undefined,
-                currency: currencyCode,
-                signedUserOp,
-                chainId: signedUserOpData.chainId,
-                entryPointAddress: signedUserOpData.entryPointAddress,
-            })
+            // Step 2: Send signed artifact to backend. Backend creates the
+            // Manteca order FIRST, then either broadcasts the signed UserOp
+            // (smart-only / mixed) or submits the Rain withdrawal via the
+            // user's session-key UserOp (collateral-only). No stuck funds.
+            const result = await mantecaApi.withdrawWithSignedTx(
+                signedArtifact.strategy === 'collateral-only'
+                    ? {
+                          kind: 'rainWithdrawal' as const,
+                          priceLockCode: priceLock.priceLockCode,
+                          amount: usdAmount,
+                          destinationAddress: destinationAddress.toLowerCase(),
+                          bankCode: selectedBank?.code,
+                          accountType: accountType ?? undefined,
+                          currency: currencyCode,
+                          signedRainWithdrawal: signedArtifact.rainWithdrawal,
+                          chainId: PEANUT_WALLET_CHAIN.id.toString(),
+                      }
+                    : {
+                          kind: 'userOp' as const,
+                          priceLockCode: priceLock.priceLockCode,
+                          amount: usdAmount,
+                          destinationAddress: destinationAddress.toLowerCase(),
+                          bankCode: selectedBank?.code,
+                          accountType: accountType ?? undefined,
+                          currency: currencyCode,
+                          signedUserOp: signedArtifact.signedUserOp.signedUserOp,
+                          chainId: signedArtifact.signedUserOp.chainId,
+                          entryPointAddress: signedArtifact.signedUserOp.entryPointAddress,
+                          // For mixed: tell backend about the Rain prepare intent
+                          // embedded in the UserOp's batched callData so it can
+                          // reconcile the collateral webhook to OFFRAMP in history.
+                          ...(signedArtifact.strategy === 'mixed'
+                              ? { rainPreparationId: signedArtifact.rainPreparationId }
+                              : {}),
+                      }
+            )
 
             if (result.error) {
                 posthog.capture(ANALYTICS_EVENTS.WITHDRAW_FAILED, {

--- a/src/services/manteca.ts
+++ b/src/services/manteca.ts
@@ -364,42 +364,84 @@ export const mantecaApi = {
     },
 
     /**
-     * Complete withdraw with signed UserOp (sign-then-broadcast pattern).
-     * This creates the Manteca order FIRST, then broadcasts the transaction.
-     * Prevents funds from being stuck if Manteca fails.
+     * Complete withdraw with a pre-signed transaction.
+     *
+     * Two shapes by `kind` — same discriminated-union shape as the QR-pay
+     * counterpart so a smart-wallet-empty card user can still offramp:
+     *  - 'userOp' (smart-only / mixed): backend broadcasts the signed
+     *    kernel UserOp via the bundler. For mixed, the UserOp's batched
+     *    callData embeds a Rain `withdrawAsset` call so collateral
+     *    materializes into the smart account atomically with the transfer
+     *    to MANTECA. `rainPreparationId` lets backend stamp the prepared
+     *    Rain intent with the on-chain hash so the collateral webhook
+     *    reconciles to OFFRAMP in history.
+     *  - 'rainWithdrawal' (collateral-only): backend submits the signed
+     *    Rain withdrawal via the user's session-key UserOp with
+     *    `directTransfer=true` straight to MANTECA's deposit address.
+     *    One passkey tap (admin EIP-712).
+     *
+     * In all cases, backend creates the Manteca order FIRST so funds
+     * don't leave the user's side if Manteca fails.
      */
-    withdrawWithSignedTx: async (params: {
-        priceLockCode: string
-        amount: string
-        destinationAddress: string
-        currency: string
-        bankCode?: string
-        accountType?: string
-        signedUserOp: Pick<
-            SignUserOperationReturnType,
-            | 'sender'
-            | 'nonce'
-            | 'callData'
-            | 'signature'
-            | 'callGasLimit'
-            | 'verificationGasLimit'
-            | 'preVerificationGas'
-            | 'maxFeePerGas'
-            | 'maxPriorityFeePerGas'
-            | 'paymaster'
-            | 'paymasterData'
-            | 'paymasterVerificationGasLimit'
-            | 'paymasterPostOpGasLimit'
-            | 'factory'
-            | 'factoryData'
-        >
-        chainId: string
-        entryPointAddress: string
-    }): Promise<MantecaWithdrawResponse> => {
+    withdrawWithSignedTx: async (
+        body:
+            | {
+                  kind: 'userOp'
+                  priceLockCode: string
+                  amount: string
+                  destinationAddress: string
+                  currency: string
+                  bankCode?: string
+                  accountType?: string
+                  signedUserOp: Pick<
+                      SignUserOperationReturnType,
+                      | 'sender'
+                      | 'nonce'
+                      | 'callData'
+                      | 'signature'
+                      | 'callGasLimit'
+                      | 'verificationGasLimit'
+                      | 'preVerificationGas'
+                      | 'maxFeePerGas'
+                      | 'maxPriorityFeePerGas'
+                      | 'paymaster'
+                      | 'paymasterData'
+                      | 'paymasterVerificationGasLimit'
+                      | 'paymasterPostOpGasLimit'
+                      | 'factory'
+                      | 'factoryData'
+                  >
+                  chainId: string
+                  entryPointAddress: string
+                  rainPreparationId?: string
+              }
+            | {
+                  kind: 'rainWithdrawal'
+                  priceLockCode: string
+                  amount: string
+                  destinationAddress: string
+                  currency: string
+                  bankCode?: string
+                  accountType?: string
+                  signedRainWithdrawal: {
+                      preparationId: string
+                      amount: string
+                      recipientAddress: Address
+                      directTransfer: boolean
+                      adminSalt: string
+                      adminNonce: string
+                      adminSignature: string
+                      executorSignature: string
+                      executorSalt: string
+                      expiresAt: number
+                  }
+                  chainId: string
+              }
+    ): Promise<MantecaWithdrawResponse> => {
         try {
             const response = await serverFetch('/manteca/withdraw/complete-with-signed-tx', {
                 method: 'POST',
-                body: jsonStringify(params),
+                body: jsonStringify(body),
             })
 
             const result = await response.json()

--- a/src/services/manteca.ts
+++ b/src/services/manteca.ts
@@ -412,7 +412,7 @@ export const mantecaApi = {
                       | 'factoryData'
                   >
                   chainId: string
-                  entryPointAddress: string
+                  entryPointAddress: Address
                   rainPreparationId?: string
               }
             | {
@@ -442,6 +442,7 @@ export const mantecaApi = {
             const response = await serverFetch('/manteca/withdraw/complete-with-signed-tx', {
                 method: 'POST',
                 body: jsonStringify(body),
+                timeoutMs: 120_000, // long-running signed-tx submission, mirrors completeQrPaymentWithSignedTx
             })
 
             const result = await response.json()


### PR DESCRIPTION
Drops \`signTransferUserOp\` (smart-only path) on the Manteca offramp page in favor of \`signSpend\` (the bundle hook). This is what makes the offramp work for users with \$0 smart wallet + funded card collateral — the \"cannot sign transaction\" error they were hitting.

## Why

\`signTransferUserOp\` only handles the smart-only path: it asks ZeroDev's paymaster to sponsor a USDC transfer from the smart account. With smart wallet empty + collateral funded, the paymaster refuses (zero balance to transfer from).

\`signSpend\` picks the right routing across smart-only / mixed / collateral-only and returns a discriminated artifact:
- \`smart-only\` → \`{ signedUserOp }\` (existing path)
- \`mixed\` → \`{ signedUserOp, rainPreparationId }\` (UserOp's batched callData embeds a Rain \`withdrawAsset\` so collateral materializes into the smart account atomically with the transfer to MANTECA)
- \`collateral-only\` → \`{ rainWithdrawal }\` (admin EIP-712 only — backend submits via session-key, one passkey tap)

## Body shape

Service \`mantecaApi.withdrawWithSignedTx\` now takes a discriminated body matching peanut-api-ts [#720](https://github.com/peanutprotocol/peanut-api-ts/pull/720)'s schema. Same shape as the QR-pay equivalent.

## Pairs with

peanut-api-ts [#720](https://github.com/peanutprotocol/peanut-api-ts/pull/720) — adds \`handleRainWithdrawalManteca\` + the discriminated body. Deploy together.

## Test plan

- [x] Typecheck clean
- [x] Existing test suites pass (the one that fails is a pre-existing \`lucide-react\` module-resolution thing in \`withdraw.utils.test.ts\`, unrelated)
- [ ] Staging — collateral-only user → one passkey tap, withdraw succeeds
- [ ] Smart-only / mixed users → existing UserOp path unchanged