### PR TITLE
ci: fix auto-bump PR base + add pull_request trigger to Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,13 @@ name: Tests
 on:
     push:
         branches: ['**']
+    pull_request:
+        branches: [main, dev]
+
+# Cancel in-progress runs on the same PR / branch when a newer commit lands.
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
 
 jobs:
     test:

--- a/.github/workflows/update-content.yml
+++ b/.github/workflows/update-content.yml
@@ -66,5 +66,6 @@ jobs:
                     -f "sha=$COMMIT_SHA"
                   gh pr create \
                     --head "$BRANCH" \
+                    --base dev \
                     --title "Update content submodule" \
                     --body "Auto-generated: updates content submodule to latest peanut-content main."


### PR DESCRIPTION
## Summary

Two related fixes so the content auto-bump pipeline (peanut-content push → notify-ui dispatch → update-content workflow → PR) works end-to-end without admin override.

### 1. update-content.yml — target `dev`, not the default branch

`gh pr create` was opening auto-bump PRs against the repo default (`main`). Result: huge diff against main (everything dev had), `mergeStateStatus: DIRTY`. PR #1888 (April) and PR #1954 (today) both hit this. Adds `--base dev`.

### 2. tests.yml — trigger on `pull_request` too

The Tests workflow only fired on `push: branches: ['**']`. API-created branches (which `update-content.yml` uses for signed commits) don't fire push events, so `ci-success` — the required status check on dev — never ran. Auto-bump PR #1954 ended up `BLOCKED` and had to be admin-merged.

Adding `pull_request` trigger + a concurrency group so contributor PRs aren't double-billed (push + pull_request both fire — concurrency cancels the older run).

Note: `dev` already has both of these fixes (Tests has `pull_request` trigger; update-content's behavior issue is the only one that affects dev). This PR brings `main` in line.

## Test plan

- [ ] Vercel preview builds green
- [ ] After merge, next mirror cycle (mono content change → peanut-content push → notify-ui → update-content) opens a PR against `dev`, not `main`
- [ ] That PR's `ci-success` check fires (because pull_request trigger is now on Tests) and the PR can merge without admin override