### PR TITLE
feat(card): manual-grant users bypass maintenance gate

### DIFF
--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -63,13 +63,16 @@ const CardPage: FC = () => {
     // Maintenance gate: redirect non-access users away during a Pioneer
     // outage, but let users with hasCardAccess (manual grant or completed
     // purchase) keep reaching their card. Wait for cardInfo so we don't
-    // bounce them before we know their access state.
+    // bounce them before we know their access state — and bail on fetch
+    // error so the retry UI below stays reachable instead of redirecting
+    // a granted user mid-blip.
     useEffect(() => {
         if (!underMaintenanceConfig.disableCardPioneers) return
         if (pioneerLoading) return
+        if (pioneerError) return
         if (cardInfo?.hasCardAccess) return
         router.replace('/home')
-    }, [router, pioneerLoading, cardInfo?.hasCardAccess])
+    }, [router, pioneerLoading, pioneerError, cardInfo?.hasCardAccess])
 
     const state = computeCardState({
         overview,
@@ -265,7 +268,9 @@ const CardPage: FC = () => {
         return ''
     }, [invalidateOverview])
 
-    if (underMaintenanceConfig.disableCardPioneers && !cardInfo?.hasCardAccess) return null
+    if (underMaintenanceConfig.disableCardPioneers && !pioneerLoading && !pioneerError && !cardInfo?.hasCardAccess) {
+        return null
+    }
 
     if (state === 'loading') {
         return (

--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -60,9 +60,16 @@ const CardPage: FC = () => {
     // Card mid-apply before the state machine sees the new state.
     const [isIssuing, setIsIssuing] = useState(false)
 
+    // Maintenance gate: redirect non-access users away during a Pioneer
+    // outage, but let users with hasCardAccess (manual grant or completed
+    // purchase) keep reaching their card. Wait for cardInfo so we don't
+    // bounce them before we know their access state.
     useEffect(() => {
-        if (underMaintenanceConfig.disableCardPioneers) router.replace('/home')
-    }, [router])
+        if (!underMaintenanceConfig.disableCardPioneers) return
+        if (pioneerLoading) return
+        if (cardInfo?.hasCardAccess) return
+        router.replace('/home')
+    }, [router, pioneerLoading, cardInfo?.hasCardAccess])
 
     const state = computeCardState({
         overview,
@@ -258,7 +265,7 @@ const CardPage: FC = () => {
         return ''
     }, [invalidateOverview])
 
-    if (underMaintenanceConfig.disableCardPioneers) return null
+    if (underMaintenanceConfig.disableCardPioneers && !cardInfo?.hasCardAccess) return null
 
     if (state === 'loading') {
         return (

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -9,6 +9,7 @@ import ProfileMenuItem from './components/ProfileMenuItem'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import useKycStatus from '@/hooks/useKycStatus'
+import { useCardPioneerInfo } from '@/hooks/useCardPioneerInfo'
 import underMaintenanceConfig from '@/config/underMaintenance.config'
 import Card from '../Global/Card'
 import ShowNameToggle from './components/ShowNameToggle'
@@ -23,6 +24,7 @@ export const Profile = () => {
     const [isInviteFriendsModalOpen, setIsInviteFriendsModalOpen] = useState(false)
     const router = useRouter()
     const { isUserKycApproved } = useKycStatus()
+    const { hasCardAccess } = useCardPioneerInfo()
 
     const logout = async () => {
         await logoutUser()
@@ -47,7 +49,7 @@ export const Profile = () => {
                     />
                     {/* Menu Items - First Group */}
                     <div>
-                        {!underMaintenanceConfig.disableCardPioneers && (
+                        {(!underMaintenanceConfig.disableCardPioneers || hasCardAccess) && (
                             <ProfileMenuItem icon="credit-card" label="Your Card" href="/card" position="first" />
                         )}
                         <ProfileMenuItem icon="achievements" label="Your Badges" href="/badges" position="middle" />

--- a/src/config/underMaintenance.config.ts
+++ b/src/config/underMaintenance.config.ts
@@ -57,7 +57,7 @@ const underMaintenanceConfig: MaintenanceConfig = {
     disabledPaymentProviders: [], // set to ['MANTECA'] to disable Manteca QR payments
     disableXchainWithdraw: false, // set to true to disable cross-chain withdrawals (only allows USDC on Arbitrum)
     disableXchainSend: false, // set to true to disable cross-chain sends (claim, request payments - only allows USDC on Arbitrum)
-    disableCardPioneers: false, // set to false to enable the Card Pioneers waitlist feature
+    disableCardPioneers: true, // set to false to enable the Card Pioneers waitlist feature
 }
 
 // shared user-facing copy for cross-chain disabled paths — keep wording aligned with TokenSelector banner

--- a/src/hooks/useCardPioneerInfo.ts
+++ b/src/hooks/useCardPioneerInfo.ts
@@ -3,11 +3,15 @@
 import { useQuery } from '@tanstack/react-query'
 import { cardApi, type CardInfoResponse } from '@/services/card'
 import { useAuth } from '@/context/authContext'
-import underMaintenanceConfig from '@/config/underMaintenance.config'
 
 /**
  * Hook to fetch Card Pioneer info for the authenticated user.
  * Returns eligibility status, purchase status, and pricing.
+ *
+ * Fetches unconditionally for authenticated users — the maintenance flag
+ * (`underMaintenanceConfig.disableCardPioneers`) gates UI rendering, not
+ * data fetching, so manual-grant users (`hasCardAccess: true`) can still
+ * reach their card during a Pioneer-feature outage.
  */
 export const useCardPioneerInfo = () => {
     const { user } = useAuth()
@@ -15,7 +19,7 @@ export const useCardPioneerInfo = () => {
     const query = useQuery<CardInfoResponse>({
         queryKey: ['card-info', user?.user?.userId],
         queryFn: () => cardApi.getInfo(),
-        enabled: !!user?.user?.userId && !underMaintenanceConfig.disableCardPioneers,
+        enabled: !!user?.user?.userId,
         staleTime: 60_000, // 1 minute
         retry: 1,
     })
@@ -28,6 +32,7 @@ export const useCardPioneerInfo = () => {
         // Convenience booleans - return undefined while loading to prevent flash
         isEligible: query.isLoading ? undefined : (query.data?.isEligible ?? false),
         hasPurchased: query.isLoading ? undefined : (query.data?.hasPurchased ?? false),
+        hasCardAccess: query.isLoading ? undefined : (query.data?.hasCardAccess ?? false),
         price: query.data?.price ?? 10,
     }
 }


### PR DESCRIPTION
## Summary

- Manual-grant users (\`cardAccessGrantedAt\` set on the BE → \`hasCardAccess: true\`) keep reaching their card even when the FE maintenance kill-switch \`disableCardPioneers\` is on. Lets us run a closed-test cohort without exposing the public Pioneer waitlist.
- Flips \`disableCardPioneers\` to \`true\` so the gate takes effect on deploy.

## Behaviour matrix

| Maintenance flag | hasCardAccess | Profile "Your Card" | \`/card\` route |
|---|---|---|---|
| OFF | any | shown | accessible (unchanged) |
| ON | false | hidden | redirects to \`/home\` |
| ON | true | shown | accessible (AddCard or YourCard) |

## Files

- \`src/hooks/useCardPioneerInfo.ts\` — fetch unconditionally for authed users (was gated on the maintenance flag); expose \`hasCardAccess\` convenience boolean.
- \`src/app/(mobile-ui)/card/page.tsx\` — redirect + null-render bypass for \`hasCardAccess\` users; redirect now waits for cardInfo so we don't bounce them before reading state.
- \`src/components/Profile/index.tsx\` — gate "Your Card" menu on \`!disableCardPioneers || hasCardAccess\`.
- \`src/config/underMaintenance.config.ts\` — \`disableCardPioneers: false → true\`.

## Test plan

- [ ] On staging, user **without** \`cardAccessGrantedAt\`: \`/card\` redirects to \`/home\`; "Your Card" hidden in profile.
- [ ] Grant access via \`POST /dev/grant-card-access\` (or \`scripts/grant-card-access.ts\`).
- [ ] User **with** \`cardAccessGrantedAt\`: \`/card\` opens AddCardEntryScreen; "Your Card" visible in profile.
- [ ] Granted user can complete Rain card application end-to-end.

## Notes

- BE-side \`CARD_PIONEERS_ENABLED\` constant is independent of this change and remains \`false\` on \`dev\`/\`main\`. The BE \`/card\` info endpoint already returns \`hasCardAccess: !!cardAccessGrantedAt\` regardless of the BE flag, so no BE change needed.
- Pioneer **modal** on \`/home\` and **carousel CTA** still gated only on the maintenance flag — they're marketing surfaces, not access surfaces, and don't block manual users from getting a card. Out of scope here.