### PR TITLE
feat(card): return collateral on lock/cancel via 1-tap signed withdraw

### DIFF
--- a/src/components/Card/CancelCardModal.tsx
+++ b/src/components/Card/CancelCardModal.tsx
@@ -8,7 +8,11 @@ import { Button } from '@/components/0_Bruddle/Button'
 import { Icon } from '@/components/Global/Icons/Icon'
 import SlideToAction from '@/components/Card/SlideToAction'
 import { rainApi } from '@/services/rain'
-import { RAIN_CARD_OVERVIEW_QUERY_KEY } from '@/hooks/useRainCardOverview'
+import { RAIN_CARD_OVERVIEW_QUERY_KEY, useRainCardOverview } from '@/hooks/useRainCardOverview'
+import { useSignSpendBundle } from '@/hooks/wallet/useSignSpendBundle'
+import { InsufficientSpendableError, SessionKeyGrantRequiredError } from '@/hooks/wallet/useSpendBundle'
+import { useWallet } from '@/hooks/wallet/useWallet'
+import { rainSpendingPowerToWei } from '@/utils/balance.utils'
 
 type Phase = 'confirm' | 'canceling' | 'feedback' | 'submitting-feedback' | 'thanks'
 
@@ -24,6 +28,9 @@ const CancelCardModal: FC<Props> = ({ cardId, isOpen, onClose }) => {
     const [error, setError] = useState<string | null>(null)
     const [canceled, setCanceled] = useState(false)
     const queryClient = useQueryClient()
+    const { overview } = useRainCardOverview()
+    const { address: smartWalletAddress } = useWallet()
+    const { signSpend } = useSignSpendBundle()
 
     useEffect(() => {
         if (!isOpen) {
@@ -50,12 +57,39 @@ const CancelCardModal: FC<Props> = ({ cardId, isOpen, onClose }) => {
         setPhase('canceling')
         setError(null)
         try {
-            await rainApi.cancelCard(cardId)
+            // Cancel can be terminal on Rain's side (collateral contract may
+            // become unreachable), so we MUST drain it BEFORE the cancel.
+            // Backend enforces order — this just delivers the signed body.
+            const spendingPowerWei = rainSpendingPowerToWei(overview?.balance?.spendingPower)
+            let verifiedWithdrawal: import('@/hooks/wallet/useSignSpendBundle').SignedRainWithdrawal | undefined
+            if (spendingPowerWei > 0n) {
+                if (!smartWalletAddress) {
+                    throw new Error('Wallet not ready — please retry in a moment')
+                }
+                // Force collateral-only routing — same pattern as LockCardModal.
+                const artifact = await signSpend({
+                    requiredUsdcAmount: spendingPowerWei,
+                    recipient: smartWalletAddress as `0x${string}`,
+                    smartBalance: 0n,
+                    rainSpendingPower: spendingPowerWei,
+                    kind: 'CRYPTO_WITHDRAW',
+                })
+                if (artifact.strategy !== 'collateral-only') {
+                    throw new Error('Unexpected withdrawal strategy — please contact support')
+                }
+                verifiedWithdrawal = artifact.rainWithdrawal
+            }
+            await rainApi.cancelCard(cardId, { verifiedWithdrawal })
             posthog.capture(ANALYTICS_EVENTS.CARD_CANCEL_CONFIRMED)
             setCanceled(true)
             setPhase('feedback')
         } catch (e) {
-            const message = e instanceof Error ? e.message : 'Failed to cancel card'
+            let message = e instanceof Error ? e.message : 'Failed to cancel card'
+            if (e instanceof InsufficientSpendableError) {
+                message = 'Could not return your card balance. Please try again or contact support.'
+            } else if (e instanceof SessionKeyGrantRequiredError) {
+                message = 'Card authorization failed. Please try again or contact support.'
+            }
             setError(message)
             posthog.capture(ANALYTICS_EVENTS.CARD_CANCEL_FAILED, { error_message: message })
             setPhase('confirm')

--- a/src/components/Card/LockCardModal.tsx
+++ b/src/components/Card/LockCardModal.tsx
@@ -8,7 +8,11 @@ import { Button } from '@/components/0_Bruddle/Button'
 import { Icon } from '@/components/Global/Icons/Icon'
 import SlideToAction from '@/components/Card/SlideToAction'
 import { rainApi } from '@/services/rain'
-import { RAIN_CARD_OVERVIEW_QUERY_KEY } from '@/hooks/useRainCardOverview'
+import { RAIN_CARD_OVERVIEW_QUERY_KEY, useRainCardOverview } from '@/hooks/useRainCardOverview'
+import { useSignSpendBundle } from '@/hooks/wallet/useSignSpendBundle'
+import { InsufficientSpendableError, SessionKeyGrantRequiredError } from '@/hooks/wallet/useSpendBundle'
+import { useWallet } from '@/hooks/wallet/useWallet'
+import { rainSpendingPowerToWei } from '@/utils/balance.utils'
 
 type Mode = 'lock' | 'unlock'
 type Phase = 'prompt' | 'loading' | 'success' | 'error'
@@ -40,6 +44,9 @@ const LockCardModal: FC<Props> = ({ cardId, mode, isOpen, onClose }) => {
     const [phase, setPhase] = useState<Phase>('prompt')
     const [error, setError] = useState<string | null>(null)
     const queryClient = useQueryClient()
+    const { overview } = useRainCardOverview()
+    const { address: smartWalletAddress } = useWallet()
+    const { signSpend } = useSignSpendBundle()
 
     useEffect(() => {
         if (!isOpen) {
@@ -55,13 +62,49 @@ const LockCardModal: FC<Props> = ({ cardId, mode, isOpen, onClose }) => {
         setPhase('loading')
         setError(null)
         try {
-            if (mode === 'lock') await rainApi.lockCard(cardId)
-            else await rainApi.activateCard(cardId)
+            if (mode === 'lock') {
+                // If the user has spending power, return collateral to their
+                // smart wallet BEFORE locking so funds stay liquid. The
+                // backend gates the lock on a successful withdrawal — order
+                // is handled there. We only need to deliver the signed body.
+                const spendingPowerWei = rainSpendingPowerToWei(overview?.balance?.spendingPower)
+                let verifiedWithdrawal: import('@/hooks/wallet/useSignSpendBundle').SignedRainWithdrawal | undefined
+                if (spendingPowerWei > 0n) {
+                    if (!smartWalletAddress) {
+                        throw new Error('Wallet not ready — please retry in a moment')
+                    }
+                    // Force collateral-only routing: smart=0n eliminates the
+                    // smart-only and mixed branches, so the strategy resolver
+                    // picks 'collateral-only' and signs a Rain withdrawal
+                    // straight to the user's smart wallet (1 passkey tap).
+                    const artifact = await signSpend({
+                        requiredUsdcAmount: spendingPowerWei,
+                        recipient: smartWalletAddress as `0x${string}`,
+                        smartBalance: 0n,
+                        rainSpendingPower: spendingPowerWei,
+                        kind: 'CRYPTO_WITHDRAW',
+                    })
+                    if (artifact.strategy !== 'collateral-only') {
+                        throw new Error('Unexpected withdrawal strategy — please contact support')
+                    }
+                    verifiedWithdrawal = artifact.rainWithdrawal
+                }
+                await rainApi.lockCard(cardId, verifiedWithdrawal)
+            } else {
+                await rainApi.activateCard(cardId)
+            }
             await queryClient.invalidateQueries({ queryKey: [RAIN_CARD_OVERVIEW_QUERY_KEY] })
             posthog.capture(mode === 'lock' ? ANALYTICS_EVENTS.CARD_LOCKED : ANALYTICS_EVENTS.CARD_UNLOCKED)
             setPhase('success')
         } catch (e) {
-            const message = e instanceof Error ? e.message : `Failed to ${mode} card`
+            // Friendlier copy for the two known sign-time errors. Any other
+            // throw (passkey cancelled, network, backend) keeps its message.
+            let message = e instanceof Error ? e.message : `Failed to ${mode} card`
+            if (e instanceof InsufficientSpendableError) {
+                message = 'Could not return your card balance. Please try again or contact support.'
+            } else if (e instanceof SessionKeyGrantRequiredError) {
+                message = 'Card authorization failed. Please try again or contact support.'
+            }
             setError(message)
             posthog.capture(ANALYTICS_EVENTS.CARD_LOCK_FAILED, { mode, error_message: message })
             setPhase('error')

--- a/src/services/rain.ts
+++ b/src/services/rain.ts
@@ -10,6 +10,7 @@
 import Cookies from 'js-cookie'
 import { PEANUT_API_KEY, PEANUT_API_URL } from '@/constants/general.consts'
 import { fetchWithSentry } from '@/utils/sentry.utils'
+import type { SignedRainWithdrawal } from '@/hooks/wallet/useSignSpendBundle'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -199,6 +200,8 @@ interface RequestOpts {
     rateLimitSensitive?: boolean
     /** Mirror PCI no-cache intent on the client fetch for secrets endpoints. */
     noStore?: boolean
+    /** Override fetchWithSentry's default 10s timeout (e.g. UserOp submissions). */
+    timeoutMs?: number
 }
 
 async function rainRequest<T>(opts: RequestOpts): Promise<T> {
@@ -212,12 +215,16 @@ async function rainRequest<T>(opts: RequestOpts): Promise<T> {
     if (opts.body !== undefined) headers['Content-Type'] = 'application/json'
     if (opts.noStore) headers['Cache-Control'] = 'no-store'
 
-    const response = await fetchWithSentry(`${PEANUT_API_URL}${opts.path}`, {
-        method: opts.method,
-        headers,
-        body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
-        cache: 'no-store',
-    })
+    const response = await fetchWithSentry(
+        `${PEANUT_API_URL}${opts.path}`,
+        {
+            method: opts.method,
+            headers,
+            body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+            cache: 'no-store',
+        },
+        opts.timeoutMs
+    )
 
     if (response.status === 429 && opts.rateLimitSensitive) {
         const err = await response.json().catch(() => ({}))
@@ -341,24 +348,46 @@ export const rainApi = {
         return status
     },
 
-    /** Lock an active card. Returns the new Rain status. */
-    lockCard: async (cardId: string): Promise<string> => {
+    /**
+     * Lock an active card. When the user has positive spending power, the
+     * caller MUST pass `verifiedWithdrawal` — the backend returns 400
+     * otherwise. Funds are returned to the user's smart wallet before the
+     * lock so they stay liquid. Returns the new Rain status.
+     */
+    lockCard: async (cardId: string, verifiedWithdrawal?: SignedRainWithdrawal): Promise<string> => {
         const { status } = await rainRequest<{ status: string }>({
             method: 'POST',
             path: `/rain/cards/${cardId}/lock`,
+            body: verifiedWithdrawal ? { verifiedWithdrawal } : {},
+            // Withdrawal path includes a UserOp wait — extend past the 10s default.
+            timeoutMs: verifiedWithdrawal ? 120_000 : undefined,
         })
         return status
     },
 
-    /** Cancel a card. Optional feedback persisted on RainCard.cancellationReason. */
-    cancelCard: async (cardId: string, feedback?: string): Promise<string> => {
+    /**
+     * Cancel a card. When the user has positive spending power, the caller
+     * MUST pass `verifiedWithdrawal` — the backend returns 400 otherwise.
+     * Funds are returned to the user's smart wallet before the cancel,
+     * since cancel can be terminal on Rain's side.
+     * Optional feedback persisted on RainCard.cancellationReason.
+     */
+    cancelCard: async (
+        cardId: string,
+        opts?: { feedback?: string; verifiedWithdrawal?: SignedRainWithdrawal }
+    ): Promise<string> => {
+        const body: Record<string, unknown> = {}
+        if (opts?.feedback) body.feedback = opts.feedback
+        if (opts?.verifiedWithdrawal) body.verifiedWithdrawal = opts.verifiedWithdrawal
         const { status } = await rainRequest<{ status: string }>({
             method: 'POST',
             path: `/rain/cards/${cardId}/cancel`,
             // Always send an object — Fastify's schema validator rejects a
             // missing body against `Type.Optional(Type.Object(...))` when the
             // request has no Content-Type, producing "body must be object".
-            body: feedback ? { feedback } : {},
+            body,
+            // Withdrawal path includes a UserOp wait — extend past the 10s default.
+            timeoutMs: opts?.verifiedWithdrawal ? 120_000 : undefined,
         })
         return status
     },


### PR DESCRIPTION
Pairs with **peanut-api-ts#727**. Both must deploy together (BE first, FE second).

## Why

When a user locks or cancels their card, USDC sitting in the Rain collateral contract should return to their smart wallet so funds stay liquid (and so a Rain-side cancel can't strand them). On unlock, the existing rebalance service refills collateral.

## UX

One passkey tap acts as **both** the action confirmation AND the authorisation for the collateral return. Modal copy stays "Slide to Lock" / "Slide to Cancel" — the withdrawal is implementation detail, not a user concept.

| State | Behaviour |
|---|---|
| spendingPower = 0 | Skip signing; call lock/cancel with no body. Same as today. |
| spendingPower > 0 | One passkey tap → sign Rain withdrawal → call lock/cancel with body → backend withdraws then flips status. |
| Passkey cancelled / sign failure | Card stays in current state. Friendly error copy. |

## Files

- \`src/services/rain.ts\`
  - \`lockCard(cardId, verifiedWithdrawal?)\` — accepts optional signed Rain withdrawal.
  - \`cancelCard(cardId, opts?)\` — opts is now \`{ feedback?, verifiedWithdrawal? }\`.
  - \`rainRequest\` accepts \`timeoutMs\` so lock/cancel can use 120s when a withdrawal body is present (the default 10s is shorter than a UserOp wait).
- \`src/components/Card/LockCardModal.tsx\` — pre-lock prepare → sign → submit-with-body via \`useSignSpendBundle\`. Forces collateral-only by passing \`smartBalance: 0n\`.
- \`src/components/Card/CancelCardModal.tsx\` — same pattern in \`runCancel\`.

## Test plan

- [ ] User with spendingPower 0: lock/cancel still work, no passkey prompt.
- [ ] User with positive spending power: lock prompts for one passkey tap → on success, smart wallet USDC balance increases by spendingPower, card flips to LOCKED.
- [ ] Same for cancel: tap → withdrawal lands → card flips to CANCELED → feedback phase appears.
- [ ] Cancel passkey → check on-chain that the smart wallet received the USDC BEFORE the Rain card status change (order matters).
- [ ] Cancel the passkey prompt mid-flow → card stays ACTIVE, error copy surfaces.
- [ ] Unlock a previously-locked card → collateral refills via the existing rebalance service (no new tap).
- [ ] Verify that \`useWallet().address\` is populated when the modal opens — if not, error message handles the race ("Wallet not ready").

## Cross-repo deploy notes

- BE first: peanut-api-ts#727 needs to land before this FE deploys. Without the BE changes, the new request body shape returns 400 from the backend's old TypeBox schema.
- After BE deploy: verify that lock/cancel still works for spendingPower=0 users (they hit the no-body path).
- After FE deploy: smoke-test a real card lock + cancel on staging with a positive spendingPower.

## Notes

- Pre-existing add-money-states test failure is unrelated (fails on origin/dev too).