### PR TITLE
fix: prevent translation extension crashes across all browsers

### DIFF
--- a/src/components/Global/TranslationSafeWrapper.tsx
+++ b/src/components/Global/TranslationSafeWrapper.tsx
@@ -1,18 +1,8 @@
 'use client'
 import { useTranslationMutationHandler } from '@/hooks/useTranslationMutationHandler'
-import { useRef } from 'react'
 
-// wraps the app to handle google translate dom mutations globally
-// prevents "Failed to execute 'insertBefore' on 'Node'" errors
-// while still allowing translations to work properly
+// patches dom methods globally to prevent translation extension crashes
 export const TranslationSafeWrapper = ({ children }: { children: React.ReactNode }) => {
-    const wrapperRef = useRef<HTMLDivElement>(null)
-    // attach mutation observer to handle translation service dom changes
-    useTranslationMutationHandler(wrapperRef)
-
-    return (
-        <div ref={wrapperRef} className="contents">
-            {children}
-        </div>
-    )
+    useTranslationMutationHandler()
+    return <>{children}</>
 }

--- a/src/hooks/useTranslationMutationHandler.ts
+++ b/src/hooks/useTranslationMutationHandler.ts
@@ -1,67 +1,30 @@
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 
-// handles translation service dom mutations to prevent errors while allowing translations
-export const useTranslationMutationHandler = (targetRef: React.RefObject<HTMLElement>) => {
-    // keep reference to observer instance for cleanup
-    const observerRef = useRef<MutationObserver | null>(null)
+let patched = false
 
+// patches removeChild and insertBefore to prevent crashes when browser
+// translation extensions (google translate, brave translate, etc) move
+// dom nodes out of their react-managed parents. without this, react's
+// reconciliation throws "not a child of this node" during unmount/update.
+export const useTranslationMutationHandler = () => {
     useEffect(() => {
-        const setupObserver = () => {
-            if (!targetRef.current) return
+        if (patched) return
+        patched = true
 
-            if (observerRef.current) {
-                observerRef.current.disconnect()
+        const originalRemoveChild = Node.prototype.removeChild
+        Node.prototype.removeChild = function <T extends Node>(child: T): T {
+            if (child.parentNode !== this) {
+                return child
             }
-
-            observerRef.current = new MutationObserver((mutations) => {
-                mutations.forEach((mutation) => {
-                    if (mutation.type === 'childList') {
-                        mutation.addedNodes.forEach((node) => {
-                            if (node.nodeType === 1) {
-                                try {
-                                    const element = node as Element
-                                    // handle translated content nodes that google translate adds
-                                    if (element.hasAttribute('data-translated')) {
-                                        const parent = element.parentElement
-                                        if (parent) {
-                                            // remove any duplicate translations to prevent conflicts
-                                            const existingTranslations = parent.querySelectorAll('[data-translated]')
-                                            existingTranslations.forEach((el) => {
-                                                if (el !== element && el.textContent === element.textContent) {
-                                                    el.remove()
-                                                }
-                                            })
-
-                                            // append new translation if not already present
-                                            if (!parent.contains(element)) {
-                                                requestAnimationFrame(() => {
-                                                    try {
-                                                        parent.appendChild(element)
-                                                    } catch (e) {
-                                                        console.error(e)
-                                                    }
-                                                })
-                                            }
-                                        }
-                                    }
-                                } catch (e) {
-                                    console.error(e)
-                                }
-                            }
-                        })
-                    }
-                })
-            })
-
-            // observe changes to dom structure and attributes
-            observerRef.current.observe(targetRef.current, {
-                childList: true,
-                subtree: true,
-                attributes: true,
-            })
+            return originalRemoveChild.call(this, child) as T
         }
 
-        setupObserver()
-        return () => observerRef.current?.disconnect()
-    }, [targetRef])
+        const originalInsertBefore = Node.prototype.insertBefore
+        Node.prototype.insertBefore = function <T extends Node>(newNode: T, refNode: Node | null): T {
+            if (refNode && refNode.parentNode !== this) {
+                return newNode
+            }
+            return originalInsertBefore.call(this, newNode, refNode) as T
+        }
+    }, [])
 }

--- a/src/hooks/useTranslationMutationHandler.ts
+++ b/src/hooks/useTranslationMutationHandler.ts
@@ -1,19 +1,27 @@
 import { useEffect } from 'react'
 
-let patched = false
+const PATCH_KEY = '__peanut_translation_patched__'
 
 // patches removeChild and insertBefore to prevent crashes when browser
 // translation extensions (google translate, brave translate, etc) move
 // dom nodes out of their react-managed parents. without this, react's
 // reconciliation throws "not a child of this node" during unmount/update.
+//
+// intentionally no useEffect cleanup — patches are permanent for the page
+// lifetime. removing them on unmount would re-expose the crash.
 export const useTranslationMutationHandler = () => {
     useEffect(() => {
-        if (patched) return
-        patched = true
+        // window global survives HMR — module-scoped flag resets on hot reload,
+        // which would nest patched wrappers around each other
+        if ((window as any)[PATCH_KEY]) return
+        ;(window as any)[PATCH_KEY] = true
 
         const originalRemoveChild = Node.prototype.removeChild
         Node.prototype.removeChild = function <T extends Node>(child: T): T {
             if (child.parentNode !== this) {
+                if (process.env.NODE_ENV !== 'production') {
+                    console.warn('[translation-patch] removeChild: node is not a child, skipping', child)
+                }
                 return child
             }
             return originalRemoveChild.call(this, child) as T
@@ -22,6 +30,9 @@ export const useTranslationMutationHandler = () => {
         const originalInsertBefore = Node.prototype.insertBefore
         Node.prototype.insertBefore = function <T extends Node>(newNode: T, refNode: Node | null): T {
             if (refNode && refNode.parentNode !== this) {
+                if (process.env.NODE_ENV !== 'production') {
+                    console.warn('[translation-patch] insertBefore: ref node is not a child, skipping', refNode)
+                }
                 return newNode
             }
             return originalInsertBefore.call(this, newNode, refNode) as T


### PR DESCRIPTION
## Summary
- fixes TASK-19604
- Rewrites `useTranslationMutationHandler` to patch `Node.prototype.removeChild` and `insertBefore` instead of using a MutationObserver
- The old hook only handled Google Translate's `data-translated` attribute — Brave Translate, Safari, and others use different DOM manipulation patterns that were never caught
- Removes the unnecessary wrapper `<div>` from `TranslationSafeWrapper` (no longer needs a ref)

### Bug

When the site is translated (any browser), clicking "Continue with Mercado Pago" on the claim invite modal crashes with:
```
NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
```

Translation extensions move/wrap DOM text nodes. When React reconciles (e.g. modal close/state change), it tries to `removeChild` on nodes that were moved — crash.

### Fix

Standard React ecosystem fix ([facebook/react#11538](https://github.com/facebook/react/issues/11538)): patch `removeChild` and `insertBefore` to gracefully return the node when `child.parentNode !== this`, instead of throwing.

## Test plan

- [x] No type errors in changed files
- [x] Translate site to Spanish (Brave/Chrome/Safari) → claim link → click Mercado Pago → "Don't lose your invite" modal → click "Continue with Mercado Pago" → should NOT crash
- [x] Same flow without translation enabled → should still work normally