### PR TITLE
fix(navigation): stop router.back() loops in add-money + card flows

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/hooks/useBridgeTransferReadiness'
 import { useModalsContext } from '@/context/ModalsContext'
 import { useCreateOnramp } from '@/hooks/useCreateOnramp'
-import { useRouter, useParams, useSearchParams } from 'next/navigation'
+import { useParams, useSearchParams } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import countryCurrencyMappings, { isNonEuroSepaCountry, isUKCountry } from '@/constants/countryCurrencyMapping'
 import { formatUnits } from 'viem'
@@ -40,12 +40,12 @@ import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { addMoneyCountryUrl } from '@/utils/native-routes'
+import { useSafeBack } from '@/hooks/useSafeBack'
 
 // Step type for URL state
 type BridgeBankStep = 'inputAmount' | 'showDetails'
 
 export default function OnrampBankPage() {
-    const router = useRouter()
     const params = useParams()
     const _searchParams = useSearchParams()
 
@@ -88,6 +88,10 @@ export default function OnrampBankPage() {
         if (!selectedCountryPath) return null
         return countryData.find((country) => country.type === 'country' && country.path === selectedCountryPath)
     }, [selectedCountryPath])
+
+    // Used by the inputAmount step + the country-not-found state to leave this page.
+    // Falls back to the country method-selection if user deep-linked in, otherwise pops history.
+    const safeBackToCountry = useSafeBack(selectedCountryPath ? addMoneyCountryUrl(selectedCountryPath) : '/add-money')
 
     const nonEuroCurrency = countryCurrencyMappings.find(
         (currency) =>
@@ -277,13 +281,7 @@ export default function OnrampBankPage() {
         setIsRiskAccepted(false)
     }
 
-    const handleBack = () => {
-        if (selectedCountry) {
-            router.push(addMoneyCountryUrl(selectedCountry.path))
-        } else {
-            router.push('/add-money')
-        }
-    }
+    const handleBack = safeBackToCountry
 
     // Redirect to inputAmount if showDetails is accessed without required data (deep link / back navigation)
     useEffect(() => {
@@ -300,7 +298,7 @@ export default function OnrampBankPage() {
     if (!selectedCountry) {
         return (
             <div className="space-y-8 self-start">
-                <NavHeader title="Not Found" onPrev={() => router.push('/add-money')} />
+                <NavHeader title="Not Found" onPrev={safeBackToCountry} />
                 <EmptyState title="Country not found" description="Please try a different country." icon="search" />
             </div>
         )

--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -89,9 +89,7 @@ export default function OnrampBankPage() {
         return countryData.find((country) => country.type === 'country' && country.path === selectedCountryPath)
     }, [selectedCountryPath])
 
-    // Used by the inputAmount step + the country-not-found state to leave this page.
-    // Falls back to the country method-selection if user deep-linked in, otherwise pops history.
-    const safeBackToCountry = useSafeBack(selectedCountryPath ? addMoneyCountryUrl(selectedCountryPath) : '/add-money')
+    const onBack = useSafeBack(selectedCountryPath ? addMoneyCountryUrl(selectedCountryPath) : '/add-money')
 
     const nonEuroCurrency = countryCurrencyMappings.find(
         (currency) =>
@@ -281,8 +279,6 @@ export default function OnrampBankPage() {
         setIsRiskAccepted(false)
     }
 
-    const handleBack = safeBackToCountry
-
     // Redirect to inputAmount if showDetails is accessed without required data (deep link / back navigation)
     useEffect(() => {
         if (urlState.step === 'showDetails' && !onrampData?.transferId) {
@@ -298,7 +294,7 @@ export default function OnrampBankPage() {
     if (!selectedCountry) {
         return (
             <div className="space-y-8 self-start">
-                <NavHeader title="Not Found" onPrev={safeBackToCountry} />
+                <NavHeader title="Not Found" onPrev={onBack} />
                 <EmptyState title="Country not found" description="Please try a different country." icon="search" />
             </div>
         )
@@ -322,7 +318,7 @@ export default function OnrampBankPage() {
 
         return (
             <div className="flex flex-col justify-start space-y-8">
-                <NavHeader title="Add Money" onPrev={handleBack} />
+                <NavHeader title="Add Money" onPrev={onBack} />
                 <div className="my-auto flex flex-grow flex-col justify-center gap-4 md:my-0">
                     <div className="text-sm font-bold">How much do you want to add?</div>
                     <AmountInput

--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -300,7 +300,7 @@ export default function OnrampBankPage() {
     if (!selectedCountry) {
         return (
             <div className="space-y-8 self-start">
-                <NavHeader title="Not Found" onPrev={() => router.back()} />
+                <NavHeader title="Not Found" onPrev={() => router.push('/add-money')} />
                 <EmptyState title="Country not found" description="Please try a different country." icon="search" />
             </div>
         )
@@ -316,7 +316,7 @@ export default function OnrampBankPage() {
         if (!onrampData?.transferId) {
             return <PeanutLoading />
         }
-        return <AddMoneyBankDetails />
+        return <AddMoneyBankDetails onBack={() => setUrlState({ step: 'inputAmount' })} />
     }
 
     if (urlState.step === 'inputAmount') {

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -1336,6 +1336,7 @@ describe('GROUP 8: InputAmountStep Component', () => {
                 setCurrencyAmount={jest.fn()}
                 limitsValidation={{ isBlocking: false, isWarning: false, currency: 'USD' }}
                 limitsCurrency="USD"
+                onBack={jest.fn()}
             />
         )
 
@@ -1355,6 +1356,7 @@ describe('GROUP 8: InputAmountStep Component', () => {
                 setCurrencyAmount={jest.fn()}
                 limitsValidation={{ isBlocking: false, isWarning: false, currency: 'USD' }}
                 limitsCurrency="USD"
+                onBack={jest.fn()}
             />
         )
 
@@ -1372,6 +1374,7 @@ describe('GROUP 8: InputAmountStep Component', () => {
                 setCurrencyAmount={jest.fn()}
                 limitsValidation={{ isBlocking: false, isWarning: false, currency: 'USD' }}
                 limitsCurrency="USD"
+                onBack={jest.fn()}
             />
         )
 
@@ -1395,6 +1398,7 @@ describe('GROUP 8: InputAmountStep Component', () => {
                 setCurrencyAmount={jest.fn()}
                 limitsValidation={{ isBlocking: true, isWarning: false, currency: 'USD' }}
                 limitsCurrency="USD"
+                onBack={jest.fn()}
             />
         )
 
@@ -1413,6 +1417,7 @@ describe('GROUP 8: InputAmountStep Component', () => {
                 setCurrencyAmount={jest.fn()}
                 limitsValidation={{ isBlocking: false, isWarning: false, currency: 'USD' }}
                 limitsCurrency="USD"
+                onBack={jest.fn()}
             />
         )
 
@@ -1437,6 +1442,7 @@ describe('GROUP 8: InputAmountStep Component', () => {
                 setCurrencyAmount={jest.fn()}
                 limitsValidation={{ isBlocking: true, isWarning: false, currency: 'USD' }}
                 limitsCurrency="USD"
+                onBack={jest.fn()}
             />
         )
 
@@ -1454,6 +1460,7 @@ describe('GROUP 8: InputAmountStep Component', () => {
                 setCurrencyAmount={jest.fn()}
                 limitsValidation={{ isBlocking: false, isWarning: false, currency: 'USD' }}
                 limitsCurrency="USD"
+                onBack={jest.fn()}
             />
         )
 
@@ -1473,6 +1480,7 @@ describe('GROUP 8: InputAmountStep Component', () => {
                 currencyData={{ isLoading: true, symbol: null, price: null }}
                 limitsValidation={{ isBlocking: false, isWarning: false, currency: 'USD' }}
                 limitsCurrency="USD"
+                onBack={jest.fn()}
             />
         )
 
@@ -1491,6 +1499,7 @@ describe('GROUP 8: InputAmountStep Component', () => {
                 setCurrencyAmount={jest.fn()}
                 limitsValidation={{ isBlocking: false, isWarning: false, currency: 'USD' }}
                 limitsCurrency="USD"
+                onBack={jest.fn()}
             />
         )
 

--- a/src/app/(mobile-ui)/add-money/crypto/page.tsx
+++ b/src/app/(mobile-ui)/add-money/crypto/page.tsx
@@ -12,9 +12,9 @@ import { PEANUT_WALLET_CHAIN } from '@/constants/zerodev.consts'
 import { getExplorerUrl } from '@/utils/general.utils'
 import { EHistoryEntryType, EHistoryUserRole } from '@/hooks/useTransactionHistory'
 import { useQuery } from '@tanstack/react-query'
-import { useRouter } from 'next/navigation'
 import { useCallback, useMemo, useState } from 'react'
 import { useQueryState, parseAsStringEnum } from 'nuqs'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
@@ -23,7 +23,7 @@ const DEPOSIT_EXPLORER_BASE_URL = getExplorerUrl(PEANUT_WALLET_CHAIN.id.toString
 
 const AddMoneyCryptoPage = () => {
     const { user } = useAuth()
-    const router = useRouter()
+    const onBack = useSafeBack('/add-money')
     const { address: peanutWalletAddress } = useWallet()
     const [network] = useQueryState(
         'network',
@@ -123,9 +123,7 @@ const AddMoneyCryptoPage = () => {
             depositAddressData={depositAddressData}
             isLoading={isLoading}
             onSuccess={handleSuccess}
-            // Explicit push to /add-money — router.back() loops when /add-money/crypto was
-            // a deep-link entry (no prior history) or when the user re-enters via bottom-nav.
-            onBack={() => router.push('/add-money')}
+            onBack={onBack}
         />
     )
 }

--- a/src/app/(mobile-ui)/add-money/crypto/page.tsx
+++ b/src/app/(mobile-ui)/add-money/crypto/page.tsx
@@ -106,6 +106,9 @@ const AddMoneyCryptoPage = () => {
                 usdAmount={depositResult.amount?.toString()}
                 amount={depositResult.tokenAmount}
                 transactionDetails={depositTransactionDetails}
+                // Replace /add-money/crypto with /home on Done — otherwise browser/device back
+                // from /home pops into the now-reset deposit view, creating a loop.
+                replaceOnDone
                 onComplete={() => {
                     setShowSuccessView(false)
                     setDepositResult(null)
@@ -120,7 +123,9 @@ const AddMoneyCryptoPage = () => {
             depositAddressData={depositAddressData}
             isLoading={isLoading}
             onSuccess={handleSuccess}
-            onBack={() => router.back()}
+            // Explicit push to /add-money — router.back() loops when /add-money/crypto was
+            // a deep-link entry (no prior history) or when the user re-enters via bottom-nav.
+            onBack={() => router.push('/add-money')}
         />
     )
 }

--- a/src/app/(mobile-ui)/add-money/crypto/page.tsx
+++ b/src/app/(mobile-ui)/add-money/crypto/page.tsx
@@ -106,8 +106,6 @@ const AddMoneyCryptoPage = () => {
                 usdAmount={depositResult.amount?.toString()}
                 amount={depositResult.tokenAmount}
                 transactionDetails={depositTransactionDetails}
-                // Replace /add-money/crypto with /home on Done — otherwise browser/device back
-                // from /home pops into the now-reset deposit view, creating a loop.
                 replaceOnDone
                 onComplete={() => {
                     setShowSuccessView(false)

--- a/src/app/(mobile-ui)/add-money/us/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/us/bank/page.tsx
@@ -1,5 +1,9 @@
+'use client'
+
 import AddMoneyBankDetails from '@/components/AddMoney/components/AddMoneyBankDetails'
+import { useRouter } from 'next/navigation'
 
 export default function USBankPage() {
-    return <AddMoneyBankDetails flow="add-money" />
+    const router = useRouter()
+    return <AddMoneyBankDetails flow="add-money" onBack={() => router.push('/add-money')} />
 }

--- a/src/app/(mobile-ui)/add-money/us/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/us/bank/page.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import AddMoneyBankDetails from '@/components/AddMoney/components/AddMoneyBankDetails'
-import { useRouter } from 'next/navigation'
+import { useSafeBack } from '@/hooks/useSafeBack'
 
 export default function USBankPage() {
-    const router = useRouter()
-    return <AddMoneyBankDetails flow="add-money" onBack={() => router.push('/add-money')} />
+    const onBack = useSafeBack('/add-money')
+    return <AddMoneyBankDetails flow="add-money" onBack={onBack} />
 }

--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -315,6 +315,12 @@ const CardPage: FC = () => {
                 />
             )
         }
+        // /card is a backend-state-driven screen, not a multi-step user flow: state
+        // (add-card/pending/manual-review/rejected/active) is derived from `overview`+`cardInfo`,
+        // not pushed to history. router.back() therefore loops or no-ops when /card was a
+        // deep-link entry or when state changed in-place. Always push the natural parent (/home),
+        // matching the sub-pages (card/pin, card/limit, card/add-to-wallet) that already do this.
+        const onPrevHome = () => router.push('/home')
         switch (state) {
             case 'pioneer':
                 return <CardPioneerFlow cardInfo={cardInfo!} refetchCardInfo={refetchCardInfo} />
@@ -322,14 +328,14 @@ const CardPage: FC = () => {
                 return (
                     <AddCardEntryScreen
                         onApply={() => handleApply(false)}
-                        onPrev={() => router.back()}
+                        onPrev={onPrevHome}
                         applyError={applyError}
                     />
                 )
             case 'pending':
-                return <ApplicationStatusScreen variant="pending" onPrev={() => router.back()} />
+                return <ApplicationStatusScreen variant="pending" onPrev={onPrevHome} />
             case 'manual-review':
-                return <ApplicationStatusScreen variant="manual-review" onPrev={() => router.back()} />
+                return <ApplicationStatusScreen variant="manual-review" onPrev={onPrevHome} />
             case 'rejected':
                 // No retry CTA: Rain denials are terminal on our side. The
                 // only path forward is support reviewing the case manually
@@ -340,12 +346,12 @@ const CardPage: FC = () => {
                     <ApplicationStatusScreen
                         variant="rejected"
                         onContactSupport={() => setIsSupportModalOpen(true)}
-                        onPrev={() => router.back()}
+                        onPrev={onPrevHome}
                     />
                 )
             case 'active': {
                 const card = findActiveCard(overview)!
-                return <YourCardScreen overview={overview!} card={card} onPrev={() => router.back()} />
+                return <YourCardScreen overview={overview!} card={card} onPrev={onPrevHome} />
             }
             default:
                 return null

--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -25,6 +25,7 @@ import { SumsubKycWrapper } from '@/components/Kyc/SumsubKycWrapper'
 import { rainApi, type ApplyForCardResponse } from '@/services/rain'
 import { useGrantSessionKey } from '@/hooks/wallet/useGrantSessionKey'
 import { useModalsContext } from '@/context/ModalsContext'
+import { useSafeBack } from '@/hooks/useSafeBack'
 
 const CardPage: FC = () => {
     const router = useRouter()
@@ -47,6 +48,7 @@ const CardPage: FC = () => {
     const { overview, isLoading: overviewLoading, error: overviewError } = useRainCardOverview()
     const { serializeGrant } = useGrantSessionKey()
     const { setIsSupportModalOpen } = useModalsContext()
+    const onPrevSafe = useSafeBack('/home')
 
     // Sumsub card-application token — populated when POST /rain/cards reports
     // the user still needs to complete the rain-card-application level.
@@ -315,12 +317,10 @@ const CardPage: FC = () => {
                 />
             )
         }
-        // /card is a backend-state-driven screen, not a multi-step user flow: state
-        // (add-card/pending/manual-review/rejected/active) is derived from `overview`+`cardInfo`,
-        // not pushed to history. router.back() therefore loops or no-ops when /card was a
-        // deep-link entry or when state changed in-place. Always push the natural parent (/home),
-        // matching the sub-pages (card/pin, card/limit, card/add-to-wallet) that already do this.
-        const onPrevHome = () => router.push('/home')
+        // /card is a backend-state-driven screen: state (add-card/pending/.../active) is
+        // derived from `overview`+`cardInfo`, not pushed to history. useSafeBack pops
+        // in-app history when there's something to pop and falls back to /home for
+        // deep-link entries.
         switch (state) {
             case 'pioneer':
                 return <CardPioneerFlow cardInfo={cardInfo!} refetchCardInfo={refetchCardInfo} />
@@ -328,14 +328,14 @@ const CardPage: FC = () => {
                 return (
                     <AddCardEntryScreen
                         onApply={() => handleApply(false)}
-                        onPrev={onPrevHome}
+                        onPrev={onPrevSafe}
                         applyError={applyError}
                     />
                 )
             case 'pending':
-                return <ApplicationStatusScreen variant="pending" onPrev={onPrevHome} />
+                return <ApplicationStatusScreen variant="pending" onPrev={onPrevSafe} />
             case 'manual-review':
-                return <ApplicationStatusScreen variant="manual-review" onPrev={onPrevHome} />
+                return <ApplicationStatusScreen variant="manual-review" onPrev={onPrevSafe} />
             case 'rejected':
                 // No retry CTA: Rain denials are terminal on our side. The
                 // only path forward is support reviewing the case manually
@@ -346,12 +346,12 @@ const CardPage: FC = () => {
                     <ApplicationStatusScreen
                         variant="rejected"
                         onContactSupport={() => setIsSupportModalOpen(true)}
-                        onPrev={onPrevHome}
+                        onPrev={onPrevSafe}
                     />
                 )
             case 'active': {
                 const card = findActiveCard(overview)!
-                return <YourCardScreen overview={overview!} card={card} onPrev={onPrevHome} />
+                return <YourCardScreen overview={overview!} card={card} onPrev={onPrevSafe} />
             }
             default:
                 return null

--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -48,7 +48,7 @@ const CardPage: FC = () => {
     const { overview, isLoading: overviewLoading, error: overviewError } = useRainCardOverview()
     const { serializeGrant } = useGrantSessionKey()
     const { setIsSupportModalOpen } = useModalsContext()
-    const onPrevSafe = useSafeBack('/home')
+    const onBack = useSafeBack('/home')
 
     // Sumsub card-application token — populated when POST /rain/cards reports
     // the user still needs to complete the rain-card-application level.
@@ -317,25 +317,15 @@ const CardPage: FC = () => {
                 />
             )
         }
-        // /card is a backend-state-driven screen: state (add-card/pending/.../active) is
-        // derived from `overview`+`cardInfo`, not pushed to history. useSafeBack pops
-        // in-app history when there's something to pop and falls back to /home for
-        // deep-link entries.
         switch (state) {
             case 'pioneer':
                 return <CardPioneerFlow cardInfo={cardInfo!} refetchCardInfo={refetchCardInfo} />
             case 'add-card':
-                return (
-                    <AddCardEntryScreen
-                        onApply={() => handleApply(false)}
-                        onPrev={onPrevSafe}
-                        applyError={applyError}
-                    />
-                )
+                return <AddCardEntryScreen onApply={() => handleApply(false)} onPrev={onBack} applyError={applyError} />
             case 'pending':
-                return <ApplicationStatusScreen variant="pending" onPrev={onPrevSafe} />
+                return <ApplicationStatusScreen variant="pending" onPrev={onBack} />
             case 'manual-review':
-                return <ApplicationStatusScreen variant="manual-review" onPrev={onPrevSafe} />
+                return <ApplicationStatusScreen variant="manual-review" onPrev={onBack} />
             case 'rejected':
                 // No retry CTA: Rain denials are terminal on our side. The
                 // only path forward is support reviewing the case manually
@@ -346,12 +336,12 @@ const CardPage: FC = () => {
                     <ApplicationStatusScreen
                         variant="rejected"
                         onContactSupport={() => setIsSupportModalOpen(true)}
-                        onPrev={onPrevSafe}
+                        onPrev={onBack}
                     />
                 )
             case 'active': {
                 const card = findActiveCard(overview)!
-                return <YourCardScreen overview={overview!} card={card} onPrev={onPrevSafe} />
+                return <YourCardScreen overview={overview!} card={card} onPrev={onBack} />
             }
             default:
                 return null

--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -25,16 +25,13 @@ import { usePullToRefresh } from '@/hooks/usePullToRefresh'
 import { useNetworkStatus } from '@/hooks/useNetworkStatus'
 import { useAccountSetupRedirect } from '@/hooks/useAccountSetupRedirect'
 import { useNativePlugins } from '@/hooks/useNativePlugins'
-import { installNavTracker } from '@/hooks/useSafeBack'
+// Side-effect import: useSafeBack patches history.pushState at module load. Importing here
+// guarantees the patch is installed before any child page's mount-time router.push.
+import '@/hooks/useSafeBack'
 import { isCapacitor } from '@/utils/capacitor'
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
     useNativePlugins()
-    // Patch history.pushState once per page load so useSafeBack can tell deep-link entries
-    // (no in-app history) from in-app navigations. Idempotent and side-effect-only.
-    useEffect(() => {
-        installNavTracker()
-    }, [])
     const pathName = usePathname()
 
     // Allow access to public paths without authentication

--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -25,10 +25,16 @@ import { usePullToRefresh } from '@/hooks/usePullToRefresh'
 import { useNetworkStatus } from '@/hooks/useNetworkStatus'
 import { useAccountSetupRedirect } from '@/hooks/useAccountSetupRedirect'
 import { useNativePlugins } from '@/hooks/useNativePlugins'
+import { installNavTracker } from '@/hooks/useSafeBack'
 import { isCapacitor } from '@/utils/capacitor'
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
     useNativePlugins()
+    // Patch history.pushState once per page load so useSafeBack can tell deep-link entries
+    // (no in-app history) from in-app navigations. Idempotent and side-effect-only.
+    useEffect(() => {
+        installNavTracker()
+    }, [])
     const pathName = usePathname()
 
     // Allow access to public paths without authentication

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -2,6 +2,7 @@
 
 import { useSearchParams, useRouter } from 'next/navigation'
 import { useState, useCallback, useMemo, useEffect, useContext, useRef } from 'react'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { PeanutDoesntStoreAnyPersonalInformation } from '@/components/Kyc/PeanutDoesntStoreAnyPersonalInformation'
 import Card from '@/components/Global/Card'
 import { Button } from '@/components/0_Bruddle/Button'
@@ -72,10 +73,10 @@ type PaymentProcessor = 'MANTECA'
 export default function QRPayPage() {
     const searchParams = useSearchParams()
     const router = useRouter()
-    // QR pay is a deep-link entry: users scan a QR straight into /qr-pay so history is often
-    // empty, which makes router.back() a no-op. Every "leave this screen" action (modal dismiss,
-    // error-screen Go Back, "Not now" CTA) should drop the user at /home instead.
-    const exitToHome = useCallback(() => router.push('/home'), [router])
+    // QR pay is a deep-link entry (PWA QR scan, push notification): history is often empty,
+    // so router.back() no-ops. useSafeBack pops if there's in-app history, otherwise lands
+    // the user on /home — guarantees every "leave this screen" action moves them somewhere.
+    const exitToHome = useSafeBack('/home')
     const qrCode = decodeURIComponent(searchParams.get('qrCode') || '')
     const timestamp = searchParams.get('t')
     const qrType = searchParams.get('type')

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -73,10 +73,7 @@ type PaymentProcessor = 'MANTECA'
 export default function QRPayPage() {
     const searchParams = useSearchParams()
     const router = useRouter()
-    // QR pay is a deep-link entry (PWA QR scan, push notification): history is often empty,
-    // so router.back() no-ops. useSafeBack pops if there's in-app history, otherwise lands
-    // the user on /home — guarantees every "leave this screen" action moves them somewhere.
-    const exitToHome = useSafeBack('/home')
+    const onBack = useSafeBack('/home')
     const qrCode = decodeURIComponent(searchParams.get('qrCode') || '')
     const timestamp = searchParams.get('t')
     const qrType = searchParams.get('type')
@@ -844,7 +841,7 @@ export default function QRPayPage() {
                 <NavHeader title="Pay" />
                 <ActionModal
                     visible
-                    onClose={exitToHome}
+                    onClose={onBack}
                     title={isFixable ? 'We need an updated document' : 'QR payments are not available'}
                     description={
                         isFixable
@@ -884,7 +881,7 @@ export default function QRPayPage() {
                 <NavHeader title="Pay" />
                 <ActionModal
                     visible={kycGateState === QrKycState.REQUIRES_IDENTITY_VERIFICATION}
-                    onClose={exitToHome}
+                    onClose={onBack}
                     title="Verify your identity to continue"
                     description="You'll need to verify your identity before paying with a QR code. Don't worry it usually just takes a few minutes."
                     icon={
@@ -906,7 +903,7 @@ export default function QRPayPage() {
                 />
                 <ActionModal
                     visible={kycGateState === QrKycState.IDENTITY_VERIFICATION_IN_PROGRESS}
-                    onClose={exitToHome}
+                    onClose={onBack}
                     title="Complete your verification"
                     description="Your identity is being verified. If you did not finish the process, please continue to complete it."
                     icon="shield"
@@ -921,7 +918,7 @@ export default function QRPayPage() {
                         },
                         {
                             text: 'Not now',
-                            onClick: exitToHome,
+                            onClick: onBack,
                             variant: 'transparent',
                             className: 'underline text-sm font-medium w-full h-fit mt-3',
                         },
@@ -946,7 +943,7 @@ export default function QRPayPage() {
                         We're working to restore service as soon as possible.
                     </p>
                 </Card>
-                <Button onClick={exitToHome} variant="purple" shadowSize="4">
+                <Button onClick={onBack} variant="purple" shadowSize="4">
                     Go Back
                 </Button>
                 <button
@@ -972,7 +969,7 @@ export default function QRPayPage() {
                         {errorInitiatingPayment || 'An error occurred while getting the QR details.'}
                     </p>
 
-                    <Button onClick={exitToHome} variant="purple">
+                    <Button onClick={onBack} variant="purple">
                         Go Back
                     </Button>
                 </Card>

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -72,6 +72,10 @@ type PaymentProcessor = 'MANTECA'
 export default function QRPayPage() {
     const searchParams = useSearchParams()
     const router = useRouter()
+    // QR pay is a deep-link entry: users scan a QR straight into /qr-pay so history is often
+    // empty, which makes router.back() a no-op. Every "leave this screen" action (modal dismiss,
+    // error-screen Go Back, "Not now" CTA) should drop the user at /home instead.
+    const exitToHome = useCallback(() => router.push('/home'), [router])
     const qrCode = decodeURIComponent(searchParams.get('qrCode') || '')
     const timestamp = searchParams.get('t')
     const qrType = searchParams.get('type')
@@ -839,7 +843,7 @@ export default function QRPayPage() {
                 <NavHeader title="Pay" />
                 <ActionModal
                     visible
-                    onClose={() => router.back()}
+                    onClose={exitToHome}
                     title={isFixable ? 'We need an updated document' : 'QR payments are not available'}
                     description={
                         isFixable
@@ -879,7 +883,7 @@ export default function QRPayPage() {
                 <NavHeader title="Pay" />
                 <ActionModal
                     visible={kycGateState === QrKycState.REQUIRES_IDENTITY_VERIFICATION}
-                    onClose={() => router.back()}
+                    onClose={exitToHome}
                     title="Verify your identity to continue"
                     description="You'll need to verify your identity before paying with a QR code. Don't worry it usually just takes a few minutes."
                     icon={
@@ -901,7 +905,7 @@ export default function QRPayPage() {
                 />
                 <ActionModal
                     visible={kycGateState === QrKycState.IDENTITY_VERIFICATION_IN_PROGRESS}
-                    onClose={() => router.back()}
+                    onClose={exitToHome}
                     title="Complete your verification"
                     description="Your identity is being verified. If you did not finish the process, please continue to complete it."
                     icon="shield"
@@ -916,9 +920,7 @@ export default function QRPayPage() {
                         },
                         {
                             text: 'Not now',
-                            onClick: () => {
-                                router.back()
-                            },
+                            onClick: exitToHome,
                             variant: 'transparent',
                             className: 'underline text-sm font-medium w-full h-fit mt-3',
                         },
@@ -943,7 +945,7 @@ export default function QRPayPage() {
                         We're working to restore service as soon as possible.
                     </p>
                 </Card>
-                <Button onClick={() => router.back()} variant="purple" shadowSize="4">
+                <Button onClick={exitToHome} variant="purple" shadowSize="4">
                     Go Back
                 </Button>
                 <button
@@ -969,7 +971,7 @@ export default function QRPayPage() {
                         {errorInitiatingPayment || 'An error occurred while getting the QR details.'}
                     </p>
 
-                    <Button onClick={() => router.back()} variant="purple">
+                    <Button onClick={exitToHome} variant="purple">
                         Go Back
                     </Button>
                 </Card>

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -73,7 +73,9 @@ type PaymentProcessor = 'MANTECA'
 export default function QRPayPage() {
     const searchParams = useSearchParams()
     const router = useRouter()
-    const onBack = useSafeBack('/home')
+    // QR-pay screens are terminal — leaving /qr-pay in history would let browser back from
+    // /home pop the user back into a stale error / KYC screen. Replace instead of push.
+    const onBack = useSafeBack('/home', { replace: true })
     const qrCode = decodeURIComponent(searchParams.get('qrCode') || '')
     const timestamp = searchParams.get('t')
     const qrType = searchParams.get('type')

--- a/src/app/(mobile-ui)/rewards/invites/page.tsx
+++ b/src/app/(mobile-ui)/rewards/invites/page.tsx
@@ -11,6 +11,7 @@ import { useAuth } from '@/context/authContext'
 import { invitesApi } from '@/services/invites'
 import { useQuery } from '@tanstack/react-query'
 import { useRouter } from 'next/navigation'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { STAR_STRAIGHT_ICON } from '@/assets'
 import Image from 'next/image'
 import EmptyState from '@/components/Global/EmptyStates/EmptyState'
@@ -25,6 +26,7 @@ import { profileUrl } from '@/utils/native-routes'
 
 const InvitesPage = () => {
     const router = useRouter()
+    const onBack = useSafeBack('/rewards')
     const { user } = useAuth()
     const listRef = useRef(null)
     const listInView = useInView(listRef, { once: true, margin: '-50px' })
@@ -66,7 +68,7 @@ const InvitesPage = () => {
 
     return (
         <PageContainer className="flex flex-col">
-            <NavHeader title="Rewards" onPrev={() => router.back()} />
+            <NavHeader title="Rewards" onPrev={onBack} />
 
             <section className="mx-auto mb-auto mt-10 w-full space-y-4">
                 <Card className="flex flex-col items-center justify-center gap-2 p-4">

--- a/src/app/(mobile-ui)/rewards/page.tsx
+++ b/src/app/(mobile-ui)/rewards/page.tsx
@@ -14,6 +14,7 @@ import { invitesApi } from '@/services/invites'
 import { getInitialsFromName } from '@/utils/general.utils'
 import { useQuery } from '@tanstack/react-query'
 import { useRouter } from 'next/navigation'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { STAR_STRAIGHT_ICON, TIER_0_BADGE, TIER_1_BADGE, TIER_2_BADGE, TIER_3_BADGE } from '@/assets'
 import Image from 'next/image'
 import { pointsApi } from '@/services/points'
@@ -33,6 +34,7 @@ import InviteePointsBadge from '@/components/Points/InviteePointsBadge'
 
 const PointsPage = () => {
     const router = useRouter()
+    const onBack = useSafeBack('/home')
     const { user, fetchUser } = useAuth()
     const [isInviteModalOpen, setIsInviteModalOpen] = useState(false)
     const inviteesRef = useRef(null)
@@ -112,7 +114,7 @@ const PointsPage = () => {
 
     return (
         <PageContainer className="flex flex-col">
-            <NavHeader title="Rewards" onPrev={() => router.back()} />
+            <NavHeader title="Rewards" onPrev={onBack} />
 
             <section className="mx-auto mb-auto mt-10 w-full space-y-4">
                 {/* rewards hero — pending claimable as primary, lifetime as secondary */}

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -48,6 +48,7 @@ import { parseUnits } from 'viem'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { withdrawCountryUrl } from '@/utils/native-routes'
+import { useSafeBack } from '@/hooks/useSafeBack'
 
 type View = 'INITIAL' | 'SUCCESS'
 
@@ -97,6 +98,9 @@ export default function WithdrawBankPage() {
     // check if we came from send flow - using method param to detect (only bank goes through this page)
     const methodParam = searchParams.get('method')
     const fromSendFlow = methodParam === 'bank'
+    // Non-success back: prefer popping in-app history (we have nuqs steps); on deep-link entry,
+    // fall back to the originating flow.
+    const onBackToFlow = useSafeBack(fromSendFlow ? '/send' : '/withdraw')
 
     const nonEuroCurrency = countryCurrencyMappings.find(
         (currency) =>
@@ -349,10 +353,7 @@ export default function WithdrawBankPage() {
                         setAmountToWithdraw('')
                         setSelectedMethod(null)
                     } else {
-                        // Explicit push instead of router.back() — this page is reached via
-                        // /withdraw (default) or /send (when methodParam === 'bank'). Honour the
-                        // entry context so the user lands back in the flow they started in.
-                        router.push(fromSendFlow ? '/send' : '/withdraw')
+                        onBackToFlow()
                     }
                 }}
             />

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -349,9 +349,10 @@ export default function WithdrawBankPage() {
                         setAmountToWithdraw('')
                         setSelectedMethod(null)
                     } else {
-                        // Explicit push instead of router.back() — this page is reached only
-                        // via /withdraw setting amountToWithdraw, so the natural parent is /withdraw.
-                        router.push('/withdraw')
+                        // Explicit push instead of router.back() — this page is reached via
+                        // /withdraw (default) or /send (when methodParam === 'bank'). Honour the
+                        // entry context so the user lands back in the flow they started in.
+                        router.push(fromSendFlow ? '/send' : '/withdraw')
                     }
                 }}
             />

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -349,7 +349,9 @@ export default function WithdrawBankPage() {
                         setAmountToWithdraw('')
                         setSelectedMethod(null)
                     } else {
-                        router.back()
+                        // Explicit push instead of router.back() — this page is reached only
+                        // via /withdraw setting amountToWithdraw, so the natural parent is /withdraw.
+                        router.push('/withdraw')
                     }
                 }}
             />

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -98,9 +98,7 @@ export default function WithdrawBankPage() {
     // check if we came from send flow - using method param to detect (only bank goes through this page)
     const methodParam = searchParams.get('method')
     const fromSendFlow = methodParam === 'bank'
-    // Non-success back: prefer popping in-app history (we have nuqs steps); on deep-link entry,
-    // fall back to the originating flow.
-    const onBackToFlow = useSafeBack(fromSendFlow ? '/send' : '/withdraw')
+    const onBack = useSafeBack(fromSendFlow ? '/send' : '/withdraw')
 
     const nonEuroCurrency = countryCurrencyMappings.find(
         (currency) =>
@@ -353,7 +351,7 @@ export default function WithdrawBankPage() {
                         setAmountToWithdraw('')
                         setSelectedMethod(null)
                     } else {
-                        onBackToFlow()
+                        onBack()
                     }
                 }}
             />

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -20,6 +20,7 @@ import { NATIVE_TOKEN_ADDRESS } from '@/utils/token.utils'
 import * as peanutInterfaces from '@/interfaces/peanut-sdk-types'
 import { useRouter } from 'next/navigation'
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { captureMessage } from '@sentry/nextjs'
 import type { Address, Hex, TransactionReceipt } from 'viem'
 import { parseUnits } from 'viem'
@@ -37,6 +38,7 @@ import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 export default function WithdrawCryptoPage() {
     const router = useRouter()
+    const onBackToWithdraw = useSafeBack('/withdraw')
     const { isConnected: isPeanutWallet, address, sendTransactions, sendMoney } = useWallet()
     const { resetTokenContextProvider } = useContext(tokenSelectorContext)
     const {
@@ -440,7 +442,7 @@ export default function WithdrawCryptoPage() {
                 <InitialWithdrawView
                     amount={usdAmount}
                     onReview={handleSetupReview}
-                    onBack={() => router.push('/withdraw')}
+                    onBack={onBackToWithdraw}
                     isProcessing={isPreparingReview}
                 />
             )}

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -440,7 +440,7 @@ export default function WithdrawCryptoPage() {
                 <InitialWithdrawView
                     amount={usdAmount}
                     onReview={handleSetupReview}
-                    onBack={() => router.back()}
+                    onBack={() => router.push('/withdraw')}
                     isProcessing={isPreparingReview}
                 />
             )}

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -38,7 +38,7 @@ import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 export default function WithdrawCryptoPage() {
     const router = useRouter()
-    const onBackToWithdraw = useSafeBack('/withdraw')
+    const onBack = useSafeBack('/withdraw')
     const { isConnected: isPeanutWallet, address, sendTransactions, sendMoney } = useWallet()
     const { resetTokenContextProvider } = useContext(tokenSelectorContext)
     const {
@@ -442,7 +442,7 @@ export default function WithdrawCryptoPage() {
                 <InitialWithdrawView
                     amount={usdAmount}
                     onReview={handleSetupReview}
-                    onBack={onBackToWithdraw}
+                    onBack={onBack}
                     isProcessing={isPreparingReview}
                 />
             )}

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -119,8 +119,7 @@ export default function MantecaWithdrawFlow() {
         return countryData.find((country) => country.type === 'country' && country.path === countryPath)
     }, [countryPath])
 
-    // Back from the amountInput step exits this flow to the country page.
-    const onBackToCountry = useSafeBack(withdrawCountryUrl(selectedCountry?.path || ''))
+    const onBack = useSafeBack(withdrawCountryUrl(selectedCountry?.path || ''))
 
     const countryConfig = useMemo(() => {
         if (!selectedCountry) return undefined
@@ -618,7 +617,7 @@ export default function MantecaWithdrawFlow() {
                     } else if (step === 'bankDetails') {
                         setStep('amountInput')
                     } else {
-                        onBackToCountry()
+                        onBack()
                     }
                 }}
             />

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -7,6 +7,7 @@ import { rainSpendingPowerToWei } from '@/utils/balance.utils'
 import { useRainCardOverview } from '@/hooks/useRainCardOverview'
 import { useState, useMemo, useContext, useEffect, useCallback, useId } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Card } from '@/components/0_Bruddle/Card'
 import NavHeader from '@/components/Global/NavHeader'
@@ -117,6 +118,9 @@ export default function MantecaWithdrawFlow() {
     const selectedCountry = useMemo(() => {
         return countryData.find((country) => country.type === 'country' && country.path === countryPath)
     }, [countryPath])
+
+    // Back from the amountInput step exits this flow to the country page.
+    const onBackToCountry = useSafeBack(withdrawCountryUrl(selectedCountry?.path || ''))
 
     const countryConfig = useMemo(() => {
         if (!selectedCountry) return undefined
@@ -614,10 +618,7 @@ export default function MantecaWithdrawFlow() {
                     } else if (step === 'bankDetails') {
                         setStep('amountInput')
                     } else {
-                        router.back()
-                        setTimeout(() => {
-                            router.replace(withdrawCountryUrl(selectedCountry?.path || ''))
-                        }, 100)
+                        onBackToCountry()
                     }
                 }}
             />

--- a/src/components/AddMoney/components/AddMoneyBankDetails.tsx
+++ b/src/components/AddMoney/components/AddMoneyBankDetails.tsx
@@ -40,15 +40,15 @@ import { useQueryState, parseAsString } from 'nuqs'
  * See PR description of fix/bridge-fee-display-quote for full writeup.
  */
 
-// Discriminated union: add-money flow requires onBack (parent owns step navigation, typically
-// setUrlState({ step: 'inputAmount' })). request-fulfillment flow steps back internally via
-// RequestFulfillmentFlowContext, so onBack is forbidden there.
+// add-money flow requires onBack (parent owns step navigation, typically
+// setUrlState({ step: 'inputAmount' })). request-fulfillment steps back internally via
+// RequestFulfillmentFlowContext.
 type AddMoneyBankDetailsProps =
     | { flow?: 'add-money'; onBack: () => void }
     | { flow: 'request-fulfillment'; onBack?: never }
 
 export default function AddMoneyBankDetails(props: AddMoneyBankDetailsProps) {
-    const { flow = 'add-money', onBack } = props
+    const { flow = 'add-money' } = props
     const isAddMoneyFlow = flow === 'add-money'
 
     // URL state - read amount from URL query params
@@ -244,12 +244,10 @@ Please use these details to complete your bank transfer.`
     }
 
     const handleBack = () => {
-        if (isAddMoneyFlow) {
-            // onBack is required by the type for add-money flow — parent (e.g.
-            // [country]/bank/page.tsx) steps back via URL state.
-            onBack!()
-        } else {
+        if (props.flow === 'request-fulfillment') {
             setRequestFulfilmentBankFlowStep(RequestFulfillmentBankFlowStep.BankCountryList)
+        } else {
+            props.onBack()
         }
     }
 

--- a/src/components/AddMoney/components/AddMoneyBankDetails.tsx
+++ b/src/components/AddMoney/components/AddMoneyBankDetails.tsx
@@ -42,9 +42,13 @@ import { useQueryState, parseAsString } from 'nuqs'
 
 interface IAddMoneyBankDetails {
     flow?: 'add-money' | 'request-fulfillment'
+    // add-money flow only — parent owns step navigation via URL state, so it must pass the back
+    // handler (e.g. setUrlState({ step: 'inputAmount' })). Ignored for request-fulfillment flow,
+    // which uses RequestFulfillmentFlowContext to step back internally.
+    onBack?: () => void
 }
 
-export default function AddMoneyBankDetails({ flow = 'add-money' }: IAddMoneyBankDetails) {
+export default function AddMoneyBankDetails({ flow = 'add-money', onBack }: IAddMoneyBankDetails) {
     const isAddMoneyFlow = flow === 'add-money'
 
     // URL state - read amount from URL query params
@@ -241,7 +245,10 @@ Please use these details to complete your bank transfer.`
 
     const handleBack = () => {
         if (isAddMoneyFlow) {
-            router.back()
+            // onBack is required for add-money flow — parent (e.g. [country]/bank/page.tsx)
+            // steps back via URL state. Falling back to router.back() here would loop
+            // when the page was deep-linked or refreshed.
+            onBack?.()
         } else {
             setRequestFulfilmentBankFlowStep(RequestFulfillmentBankFlowStep.BankCountryList)
         }

--- a/src/components/AddMoney/components/AddMoneyBankDetails.tsx
+++ b/src/components/AddMoney/components/AddMoneyBankDetails.tsx
@@ -40,15 +40,15 @@ import { useQueryState, parseAsString } from 'nuqs'
  * See PR description of fix/bridge-fee-display-quote for full writeup.
  */
 
-interface IAddMoneyBankDetails {
-    flow?: 'add-money' | 'request-fulfillment'
-    // add-money flow only — parent owns step navigation via URL state, so it must pass the back
-    // handler (e.g. setUrlState({ step: 'inputAmount' })). Ignored for request-fulfillment flow,
-    // which uses RequestFulfillmentFlowContext to step back internally.
-    onBack?: () => void
-}
+// Discriminated union: add-money flow requires onBack (parent owns step navigation, typically
+// setUrlState({ step: 'inputAmount' })). request-fulfillment flow steps back internally via
+// RequestFulfillmentFlowContext, so onBack is forbidden there.
+type AddMoneyBankDetailsProps =
+    | { flow?: 'add-money'; onBack: () => void }
+    | { flow: 'request-fulfillment'; onBack?: never }
 
-export default function AddMoneyBankDetails({ flow = 'add-money', onBack }: IAddMoneyBankDetails) {
+export default function AddMoneyBankDetails(props: AddMoneyBankDetailsProps) {
+    const { flow = 'add-money', onBack } = props
     const isAddMoneyFlow = flow === 'add-money'
 
     // URL state - read amount from URL query params
@@ -245,10 +245,9 @@ Please use these details to complete your bank transfer.`
 
     const handleBack = () => {
         if (isAddMoneyFlow) {
-            // onBack is required for add-money flow — parent (e.g. [country]/bank/page.tsx)
-            // steps back via URL state. Falling back to router.back() here would loop
-            // when the page was deep-linked or refreshed.
-            onBack?.()
+            // onBack is required by the type for add-money flow — parent (e.g.
+            // [country]/bank/page.tsx) steps back via URL state.
+            onBack!()
         } else {
             setRequestFulfilmentBankFlowStep(RequestFulfillmentBankFlowStep.BankCountryList)
         }

--- a/src/components/AddMoney/components/InputAmountStep.tsx
+++ b/src/components/AddMoney/components/InputAmountStep.tsx
@@ -29,8 +29,6 @@ interface InputAmountStepProps {
     limitsValidation?: LimitsValidationWithUser
     // required - must be provided by caller based on the payment flow's currency (ARS, BRL, USD)
     limitsCurrency: LimitCurrency
-    // Parent decides where back goes — never default to router.back(): on this step it pops out of
-    // the flow entirely, but on a refresh / deep-link the stack is empty and back becomes a no-op.
     onBack: () => void
 }
 

--- a/src/components/AddMoney/components/InputAmountStep.tsx
+++ b/src/components/AddMoney/components/InputAmountStep.tsx
@@ -4,7 +4,6 @@ import { Button } from '@/components/0_Bruddle/Button'
 import { Icon } from '@/components/Global/Icons/Icon'
 import NavHeader from '@/components/Global/NavHeader'
 import AmountInput from '@/components/Global/AmountInput'
-import { useRouter } from 'next/navigation'
 import ErrorAlert from '@/components/Global/ErrorAlert'
 import { useCurrency } from '@/hooks/useCurrency'
 import PeanutLoading from '@/components/Global/PeanutLoading'
@@ -30,6 +29,9 @@ interface InputAmountStepProps {
     limitsValidation?: LimitsValidationWithUser
     // required - must be provided by caller based on the payment flow's currency (ARS, BRL, USD)
     limitsCurrency: LimitCurrency
+    // Parent decides where back goes — never default to router.back(): on this step it pops out of
+    // the flow entirely, but on a refresh / deep-link the stack is empty and back becomes a no-op.
+    onBack: () => void
 }
 
 const InputAmountStep = ({
@@ -45,9 +47,8 @@ const InputAmountStep = ({
     setDisplayedAmount,
     limitsValidation,
     limitsCurrency,
+    onBack,
 }: InputAmountStepProps) => {
-    const router = useRouter()
-
     if (currencyData?.isLoading) {
         return <PeanutLoading />
     }
@@ -62,7 +63,7 @@ const InputAmountStep = ({
 
     return (
         <div className="flex min-h-[inherit] flex-col justify-start space-y-8">
-            <NavHeader title="Add Money" onPrev={() => router.back()} />
+            <NavHeader title="Add Money" onPrev={onBack} />
             <div className="my-auto flex flex-grow flex-col justify-center gap-4 md:my-0">
                 <div className="text-sm font-bold">How much do you want to add?</div>
 

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -68,8 +68,7 @@ const MantecaAddMoney: FC = () => {
     const selectedCountry = useMemo(() => {
         return countryData.find((country) => country.type === 'country' && country.path === selectedCountryPath)
     }, [selectedCountryPath])
-    // Back from the inputAmount step exits this flow back to the country page.
-    const onBackToCountry = useSafeBack(addMoneyCountryUrl(selectedCountryPath))
+    const onBack = useSafeBack(addMoneyCountryUrl(selectedCountryPath))
     const { isUserMantecaKycApproved, isUserSumsubKycApproved } = useKycStatus()
     const { manteca: mantecaRejection } = useProviderRejectionStatus()
     const currencyData = useCurrency(selectedCountry?.currency ?? 'ARS')
@@ -270,7 +269,7 @@ const MantecaAddMoney: FC = () => {
                     setDisplayedAmount={handleDisplayedAmountChange}
                     limitsValidation={limitsValidation}
                     limitsCurrency={limitsValidation.currency}
-                    onBack={onBackToCountry}
+                    onBack={onBack}
                 />
             </>
         )

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -2,7 +2,8 @@
 import { type FC, useEffect, useMemo, useState, useCallback } from 'react'
 import MantecaDepositShareDetails from '@/components/AddMoney/components/MantecaDepositShareDetails'
 import InputAmountStep from '@/components/AddMoney/components/InputAmountStep'
-import { useParams, useSearchParams } from 'next/navigation'
+import { useParams, useRouter, useSearchParams } from 'next/navigation'
+import { addMoneyCountryUrl } from '@/utils/native-routes'
 import { type CountryData, countryData } from '@/components/AddMoney/consts'
 import { type MantecaDepositResponseData } from '@/types/manteca.types'
 import { useCurrency } from '@/hooks/useCurrency'
@@ -31,6 +32,7 @@ type CurrencyDenomination = 'USD' | 'ARS' | 'BRL' | 'MXN' | 'EUR'
 
 const MantecaAddMoney: FC = () => {
     const params = useParams()
+    const router = useRouter()
     const searchParams = useSearchParams()
     const queryClient = useQueryClient()
 
@@ -266,6 +268,7 @@ const MantecaAddMoney: FC = () => {
                     setDisplayedAmount={handleDisplayedAmountChange}
                     limitsValidation={limitsValidation}
                     limitsCurrency={limitsValidation.currency}
+                    onBack={() => router.push(addMoneyCountryUrl(selectedCountryPath))}
                 />
             </>
         )
@@ -276,7 +279,13 @@ const MantecaAddMoney: FC = () => {
         if (!depositDetails) {
             return null
         }
-        return <MantecaDepositShareDetails depositDetails={depositDetails} currencyAmount={localCurrencyAmount} />
+        return (
+            <MantecaDepositShareDetails
+                depositDetails={depositDetails}
+                currencyAmount={localCurrencyAmount}
+                onBack={() => setUrlState({ step: 'inputAmount' })}
+            />
+        )
     }
 
     return null

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -2,8 +2,9 @@
 import { type FC, useEffect, useMemo, useState, useCallback } from 'react'
 import MantecaDepositShareDetails from '@/components/AddMoney/components/MantecaDepositShareDetails'
 import InputAmountStep from '@/components/AddMoney/components/InputAmountStep'
-import { useParams, useRouter, useSearchParams } from 'next/navigation'
+import { useParams, useSearchParams } from 'next/navigation'
 import { addMoneyCountryUrl } from '@/utils/native-routes'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { type CountryData, countryData } from '@/components/AddMoney/consts'
 import { type MantecaDepositResponseData } from '@/types/manteca.types'
 import { useCurrency } from '@/hooks/useCurrency'
@@ -32,7 +33,6 @@ type CurrencyDenomination = 'USD' | 'ARS' | 'BRL' | 'MXN' | 'EUR'
 
 const MantecaAddMoney: FC = () => {
     const params = useParams()
-    const router = useRouter()
     const searchParams = useSearchParams()
     const queryClient = useQueryClient()
 
@@ -68,6 +68,8 @@ const MantecaAddMoney: FC = () => {
     const selectedCountry = useMemo(() => {
         return countryData.find((country) => country.type === 'country' && country.path === selectedCountryPath)
     }, [selectedCountryPath])
+    // Back from the inputAmount step exits this flow back to the country page.
+    const onBackToCountry = useSafeBack(addMoneyCountryUrl(selectedCountryPath))
     const { isUserMantecaKycApproved, isUserSumsubKycApproved } = useKycStatus()
     const { manteca: mantecaRejection } = useProviderRejectionStatus()
     const currencyData = useCurrency(selectedCountry?.currency ?? 'ARS')
@@ -268,7 +270,7 @@ const MantecaAddMoney: FC = () => {
                     setDisplayedAmount={handleDisplayedAmountChange}
                     limitsValidation={limitsValidation}
                     limitsCurrency={limitsValidation.currency}
-                    onBack={() => router.push(addMoneyCountryUrl(selectedCountryPath))}
+                    onBack={onBackToCountry}
                 />
             </>
         )

--- a/src/components/AddMoney/components/MantecaDepositShareDetails.tsx
+++ b/src/components/AddMoney/components/MantecaDepositShareDetails.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import NavHeader from '@/components/Global/NavHeader'
-import { useParams, useRouter } from 'next/navigation'
+import { useParams } from 'next/navigation'
 import { useMemo } from 'react'
 import { countryData } from '@/components/AddMoney/consts'
 import { getFlagUrl } from '@/constants/countryCurrencyMapping'
@@ -22,11 +22,13 @@ import { shortenStringLong, formatCurrency } from '@/utils/general.utils'
 const MantecaDepositShareDetails = ({
     depositDetails,
     currencyAmount,
+    onBack,
 }: {
     depositDetails: MantecaDepositResponseData
     currencyAmount?: string | undefined
+    // Parent owns step navigation — usually a setUrlState({ step: 'inputAmount' }).
+    onBack: () => void
 }) => {
-    const router = useRouter()
     const params = useParams()
     const currentCountryName = params.country as string
 
@@ -84,7 +86,7 @@ const MantecaDepositShareDetails = ({
 
     return (
         <div className="flex h-full w-full flex-col justify-start gap-8 self-start">
-            <NavHeader title={'Add Money'} onPrev={router.back} />
+            <NavHeader title={'Add Money'} onPrev={onBack} />
             <div className="my-auto flex h-full w-full flex-col justify-center space-y-4">
                 {/* Amount Display Card */}
                 <Card className="p-4">

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -47,8 +47,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
     const router = useRouter()
     const params = useParams()
     const searchParams = useSearchParams()
-    // Parent for "leave this list" depends on the flow direction.
-    const onBackToFlowRoot = useSafeBack(flow === 'add' ? '/add-money' : '/withdraw')
+    const onBack = useSafeBack(flow === 'add' ? '/add-money' : '/withdraw')
 
     // check if coming from send flow and what type
     const methodParam = searchParams.get('method')
@@ -264,7 +263,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
     if (!currentCountry) {
         return (
             <div className="space-y-8 self-start">
-                <NavHeader title="Not Found" onPrev={onBackToFlowRoot} />
+                <NavHeader title="Not Found" onPrev={onBack} />
                 <EmptyState title="Country not found" description="Please try a different country." icon="search" />
             </div>
         )
@@ -430,7 +429,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                         router.push(`/withdraw?method=${methodParam}`)
                     } else {
                         setSelectedMethod(null)
-                        onBackToFlowRoot()
+                        onBack()
                     }
                 }}
             />

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -8,6 +8,7 @@ import AvatarWithBadge from '@/components/Profile/AvatarWithBadge'
 import { getColorForUsername } from '@/utils/color.utils'
 import Image, { type StaticImageData } from 'next/image'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { withdrawBankUrl, rewriteMethodPath } from '@/utils/native-routes'
 import { isCapacitor } from '@/utils/capacitor'
 import EmptyState from '../Global/EmptyStates/EmptyState'
@@ -46,6 +47,8 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
     const router = useRouter()
     const params = useParams()
     const searchParams = useSearchParams()
+    // Parent for "leave this list" depends on the flow direction.
+    const onBackToFlowRoot = useSafeBack(flow === 'add' ? '/add-money' : '/withdraw')
 
     // check if coming from send flow and what type
     const methodParam = searchParams.get('method')
@@ -261,7 +264,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
     if (!currentCountry) {
         return (
             <div className="space-y-8 self-start">
-                <NavHeader title="Not Found" onPrev={() => router.back()} />
+                <NavHeader title="Not Found" onPrev={onBackToFlowRoot} />
                 <EmptyState title="Country not found" description="Please try a different country." icon="search" />
             </div>
         )
@@ -427,7 +430,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                         router.push(`/withdraw?method=${methodParam}`)
                     } else {
                         setSelectedMethod(null)
-                        router.back()
+                        onBackToFlowRoot()
                     }
                 }}
             />

--- a/src/features/payments/flows/contribute-pot/views/ContributePotInputView.tsx
+++ b/src/features/payments/flows/contribute-pot/views/ContributePotInputView.tsx
@@ -18,13 +18,13 @@ import UserCard from '@/components/User/UserCard'
 import ErrorAlert from '@/components/Global/ErrorAlert'
 import SupportCTA from '@/components/Global/SupportCTA'
 import { useContributePotFlow } from '../useContributePotFlow'
-import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { useAuth } from '@/context/authContext'
 import { RequestPotActionList } from '../components/RequestPotActionList'
+import { useSafeBack } from '@/hooks/useSafeBack'
 
 export function ContributePotInputView() {
-    const router = useRouter()
+    const handleGoBack = useSafeBack('/')
     const { isFetchingUser } = useAuth()
     const {
         amount,
@@ -50,15 +50,6 @@ export function ContributePotInputView() {
     const handlePayWithPeanut = () => {
         if (canProceed && hasSufficientBalance && !isLoading) {
             executeContribution()
-        }
-    }
-
-    // handle back navigation
-    const handleGoBack = () => {
-        if (window.history.length > 1) {
-            router.back()
-        } else {
-            router.push('/')
         }
     }
 

--- a/src/features/payments/flows/contribute-pot/views/ContributePotInputView.tsx
+++ b/src/features/payments/flows/contribute-pot/views/ContributePotInputView.tsx
@@ -24,7 +24,7 @@ import { RequestPotActionList } from '../components/RequestPotActionList'
 import { useSafeBack } from '@/hooks/useSafeBack'
 
 export function ContributePotInputView() {
-    const handleGoBack = useSafeBack('/')
+    const onBack = useSafeBack('/')
     const { isFetchingUser } = useAuth()
     const {
         amount,
@@ -75,7 +75,7 @@ export function ContributePotInputView() {
 
     return (
         <div className="flex min-h-[inherit] flex-col justify-between gap-8">
-            <NavHeader onPrev={handleGoBack} title="Pay" />
+            <NavHeader onPrev={onBack} title="Pay" />
 
             <div className="my-auto flex h-full flex-col justify-center space-y-4">
                 {/* recipient card with pot info */}

--- a/src/features/payments/flows/direct-send/views/SendInputView.tsx
+++ b/src/features/payments/flows/direct-send/views/SendInputView.tsx
@@ -25,7 +25,7 @@ import SendWithPeanutCta from '@/features/payments/shared/components/SendWithPea
 import { PaymentMethodActionList } from '@/features/payments/shared/components/PaymentMethodActionList'
 
 export function SendInputView() {
-    const handleGoBack = useSafeBack('/')
+    const onBack = useSafeBack('/')
     const { isFetchingUser } = useAuth()
     const {
         amount,
@@ -56,7 +56,7 @@ export function SendInputView() {
 
     return (
         <div className="flex min-h-[inherit] flex-col justify-between gap-8">
-            <NavHeader onPrev={handleGoBack} title="Pay" />
+            <NavHeader onPrev={onBack} title="Pay" />
 
             <div className="my-auto flex h-full flex-col justify-center space-y-4">
                 {/* recipient card */}

--- a/src/features/payments/flows/direct-send/views/SendInputView.tsx
+++ b/src/features/payments/flows/direct-send/views/SendInputView.tsx
@@ -19,13 +19,13 @@ import FileUploadInput from '@/components/Global/FileUploadInput'
 import ErrorAlert from '@/components/Global/ErrorAlert'
 import SupportCTA from '@/components/Global/SupportCTA'
 import { useDirectSendFlow } from '../useDirectSendFlow'
-import { useRouter } from 'next/navigation'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { useAuth } from '@/context/authContext'
 import SendWithPeanutCta from '@/features/payments/shared/components/SendWithPeanutCta'
 import { PaymentMethodActionList } from '@/features/payments/shared/components/PaymentMethodActionList'
 
 export function SendInputView() {
-    const router = useRouter()
+    const handleGoBack = useSafeBack('/')
     const { isFetchingUser } = useAuth()
     const {
         amount,
@@ -47,15 +47,6 @@ export function SendInputView() {
     const handleSubmit = () => {
         if (canProceed && hasSufficientBalance && !isLoading) {
             executePayment()
-        }
-    }
-
-    // handle back navigation
-    const handleGoBack = () => {
-        if (window.history.length > 1) {
-            router.back()
-        } else {
-            router.push('/')
         }
     }
 

--- a/src/features/payments/flows/semantic-request/views/SemanticRequestInputView.tsx
+++ b/src/features/payments/flows/semantic-request/views/SemanticRequestInputView.tsx
@@ -29,7 +29,7 @@ import { tokenSelectorContext } from '@/context'
 import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants/zerodev.consts'
 
 export function SemanticRequestInputView() {
-    const handleGoBack = useSafeBack('/')
+    const onBack = useSafeBack('/')
     const {
         amount,
         recipient,
@@ -148,7 +148,7 @@ export function SemanticRequestInputView() {
 
     return (
         <div className="flex min-h-[inherit] flex-col justify-between gap-8">
-            <NavHeader onPrev={handleGoBack} title="Pay" />
+            <NavHeader onPrev={onBack} title="Pay" />
 
             <div className="my-auto flex h-full flex-col justify-center space-y-4">
                 {/* recipient card */}

--- a/src/features/payments/flows/semantic-request/views/SemanticRequestInputView.tsx
+++ b/src/features/payments/flows/semantic-request/views/SemanticRequestInputView.tsx
@@ -21,7 +21,7 @@ import ErrorAlert from '@/components/Global/ErrorAlert'
 import SupportCTA from '@/components/Global/SupportCTA'
 import TokenSelector from '@/components/Global/TokenSelector/TokenSelector'
 import { useSemanticRequestFlow } from '../useSemanticRequestFlow'
-import { useRouter } from 'next/navigation'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import SendWithPeanutCta from '@/features/payments/shared/components/SendWithPeanutCta'
 import { PaymentMethodActionList } from '@/features/payments/shared/components/PaymentMethodActionList'
 import { printableAddress, areEvmAddressesEqual } from '@/utils/general.utils'
@@ -29,7 +29,7 @@ import { tokenSelectorContext } from '@/context'
 import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants/zerodev.consts'
 
 export function SemanticRequestInputView() {
-    const router = useRouter()
+    const handleGoBack = useSafeBack('/')
     const {
         amount,
         recipient,
@@ -102,15 +102,6 @@ export function SemanticRequestInputView() {
             if (res && res.success) {
                 setCurrentView('EXTERNAL_WALLET')
             }
-        }
-    }
-
-    // handle back navigation
-    const handleGoBack = () => {
-        if (window.history.length > 1) {
-            router.back()
-        } else {
-            router.push('/')
         }
     }
 

--- a/src/features/payments/shared/components/PaymentSuccessView.tsx
+++ b/src/features/payments/shared/components/PaymentSuccessView.tsx
@@ -61,6 +61,10 @@ type DirectSuccessViewProps = {
     isExternalWalletFlow?: boolean
     isWithdrawFlow?: boolean
     redirectTo?: string
+    // When true, the "Done"/cancel navigation replaces the current history entry instead of
+    // pushing. Use for terminal flows (e.g. deposit success) so browser/device back doesn't
+    // pop the user back into the now-completed flow.
+    replaceOnDone?: boolean
     onComplete?: () => void
     points?: number
     // props to receive data directly instead of from redux
@@ -83,6 +87,7 @@ const PaymentSuccessView = ({
     isExternalWalletFlow,
     isWithdrawFlow,
     redirectTo = '/home',
+    replaceOnDone = false,
     onComplete,
     points,
     chargeDetails,
@@ -217,10 +222,11 @@ const PaymentSuccessView = ({
     const handleDone = () => {
         // Navigate first, then call onComplete - otherwise onComplete may reset state
         // causing this component to unmount before router.push executes
-        if (!!authUser?.user.userId) {
-            router.push(redirectTo)
+        const target = !!authUser?.user.userId ? redirectTo : '/setup'
+        if (replaceOnDone) {
+            router.replace(target)
         } else {
-            router.push('/setup')
+            router.push(target)
         }
         onComplete?.()
     }

--- a/src/hooks/__tests__/useSafeBack.test.ts
+++ b/src/hooks/__tests__/useSafeBack.test.ts
@@ -1,36 +1,22 @@
 import { renderHook, act } from '@testing-library/react'
-import { useSafeBack, installNavTracker, __testing } from '@/hooks/useSafeBack'
+import { useSafeBack, __testing } from '@/hooks/useSafeBack'
 
 const mockBack = jest.fn()
 const mockPush = jest.fn()
-// Stable router object across calls — matches real Next.js semantics. Without this, every
-// useRouter() call would return a fresh reference and useCallback would invalidate every render.
-const mockRouter = {
-    back: mockBack,
-    push: mockPush,
-    replace: jest.fn(),
-    prefetch: jest.fn(),
-}
+const mockRouter = { back: mockBack, push: mockPush, replace: jest.fn(), prefetch: jest.fn() }
 
 jest.mock('next/navigation', () => ({
     useRouter: () => mockRouter,
 }))
 
-// installNavTracker patches window.history.pushState once per page load. Reset the patch
-// (and the captured original) between every test so each case starts from a clean global.
-let originalPushState: typeof window.history.pushState
 beforeEach(() => {
     mockBack.mockReset()
     mockPush.mockReset()
-    if (!originalPushState) originalPushState = window.history.pushState.bind(window.history)
-    window.history.pushState = originalPushState
     __testing.reset()
 })
 
 describe('useSafeBack', () => {
-    it('falls back to push(fallbackUrl) when no in-app navigation has occurred (cold deep-link)', () => {
-        installNavTracker()
-
+    it('pushes fallback on cold deep-link (no in-app history)', () => {
         const { result } = renderHook(() => useSafeBack('/home'))
         act(() => result.current())
 
@@ -38,9 +24,7 @@ describe('useSafeBack', () => {
         expect(mockBack).not.toHaveBeenCalled()
     })
 
-    it('calls router.back() once an in-app pushState has happened', () => {
-        installNavTracker()
-        // Simulate an in-app navigation — Next.js + nuqs both go through pushState.
+    it('calls router.back() after an in-app pushState', () => {
         act(() => {
             window.history.pushState({}, '', '/some-route')
         })
@@ -52,55 +36,32 @@ describe('useSafeBack', () => {
         expect(mockPush).not.toHaveBeenCalled()
     })
 
-    it('decrements on popstate so an over-pop falls back to fallbackUrl', () => {
-        installNavTracker()
+    it('falls back again after popstate drains the counter', () => {
         act(() => {
             window.history.pushState({}, '', '/screen-a')
-        })
-        expect(__testing.getCount()).toBe(1)
-
-        // User pressed browser back: popstate fires, counter drops to 0.
-        act(() => {
             window.dispatchEvent(new PopStateEvent('popstate'))
         })
-        expect(__testing.getCount()).toBe(0)
 
         const { result } = renderHook(() => useSafeBack('/home'))
         act(() => result.current())
 
-        // No in-app entries left to pop → fallback.
         expect(mockPush).toHaveBeenCalledWith('/home')
         expect(mockBack).not.toHaveBeenCalled()
     })
 
-    it('clamps count at 0 — extra popstates do not go negative', () => {
-        installNavTracker()
+    it('clamps the counter at 0 — extra popstates do not go negative', () => {
         act(() => {
             window.dispatchEvent(new PopStateEvent('popstate'))
             window.dispatchEvent(new PopStateEvent('popstate'))
-            window.dispatchEvent(new PopStateEvent('popstate'))
         })
-        expect(__testing.getCount()).toBe(0)
+
+        const { result } = renderHook(() => useSafeBack('/home'))
+        act(() => result.current())
+
+        expect(mockPush).toHaveBeenCalledWith('/home')
     })
 
-    it('install is idempotent — calling it twice does not double-patch pushState', () => {
-        installNavTracker()
-        const afterFirst = window.history.pushState
-        installNavTracker()
-        const afterSecond = window.history.pushState
-
-        expect(afterFirst).toBe(afterSecond)
-
-        // And the counter increments by one (not two) on a single pushState call.
-        act(() => {
-            window.history.pushState({}, '', '/x')
-        })
-        expect(__testing.getCount()).toBe(1)
-    })
-
-    it('counter survives nuqs-style query-only pushes', () => {
-        installNavTracker()
-        // nuqs with { history: 'push' } pushes a same-pathname URL with new query.
+    it('counts nuqs-style same-path query pushes', () => {
         act(() => {
             window.history.pushState({}, '', '/screen?step=1')
             window.history.pushState({}, '', '/screen?step=2')
@@ -110,29 +71,5 @@ describe('useSafeBack', () => {
         act(() => result.current())
 
         expect(mockBack).toHaveBeenCalledTimes(1)
-        expect(mockPush).not.toHaveBeenCalled()
-    })
-
-    it('returned callback is stable when router and fallback do not change', () => {
-        installNavTracker()
-        const { result, rerender } = renderHook(({ url }: { url: string }) => useSafeBack(url), {
-            initialProps: { url: '/home' },
-        })
-        const first = result.current
-        rerender({ url: '/home' })
-        expect(result.current).toBe(first)
-    })
-
-    it('returned callback changes when fallbackUrl changes', () => {
-        installNavTracker()
-        const { result, rerender } = renderHook(({ url }: { url: string }) => useSafeBack(url), {
-            initialProps: { url: '/home' },
-        })
-        const first = result.current
-        rerender({ url: '/withdraw' })
-        expect(result.current).not.toBe(first)
-
-        act(() => result.current())
-        expect(mockPush).toHaveBeenCalledWith('/withdraw')
     })
 })

--- a/src/hooks/__tests__/useSafeBack.test.ts
+++ b/src/hooks/__tests__/useSafeBack.test.ts
@@ -3,7 +3,8 @@ import { useSafeBack, __testing } from '@/hooks/useSafeBack'
 
 const mockBack = jest.fn()
 const mockPush = jest.fn()
-const mockRouter = { back: mockBack, push: mockPush, replace: jest.fn(), prefetch: jest.fn() }
+const mockReplace = jest.fn()
+const mockRouter = { back: mockBack, push: mockPush, replace: mockReplace, prefetch: jest.fn() }
 
 jest.mock('next/navigation', () => ({
     useRouter: () => mockRouter,
@@ -12,6 +13,7 @@ jest.mock('next/navigation', () => ({
 beforeEach(() => {
     mockBack.mockReset()
     mockPush.mockReset()
+    mockReplace.mockReset()
     __testing.reset()
 })
 
@@ -71,5 +73,28 @@ describe('useSafeBack', () => {
         act(() => result.current())
 
         expect(mockBack).toHaveBeenCalledTimes(1)
+    })
+
+    it('with { replace: true }, uses router.replace for the no-history fallback', () => {
+        const { result } = renderHook(() => useSafeBack('/home', { replace: true }))
+        act(() => result.current())
+
+        expect(mockReplace).toHaveBeenCalledWith('/home')
+        expect(mockPush).not.toHaveBeenCalled()
+        expect(mockBack).not.toHaveBeenCalled()
+    })
+
+    it('with { replace: true }, still calls router.back() when in-app history exists', () => {
+        act(() => {
+            window.history.pushState({}, '', '/some-route')
+        })
+
+        const { result } = renderHook(() => useSafeBack('/home', { replace: true }))
+        act(() => result.current())
+
+        // replace only affects the fallback branch — back() is unchanged.
+        expect(mockBack).toHaveBeenCalledTimes(1)
+        expect(mockReplace).not.toHaveBeenCalled()
+        expect(mockPush).not.toHaveBeenCalled()
     })
 })

--- a/src/hooks/__tests__/useSafeBack.test.ts
+++ b/src/hooks/__tests__/useSafeBack.test.ts
@@ -1,0 +1,138 @@
+import { renderHook, act } from '@testing-library/react'
+import { useSafeBack, installNavTracker, __testing } from '@/hooks/useSafeBack'
+
+const mockBack = jest.fn()
+const mockPush = jest.fn()
+// Stable router object across calls — matches real Next.js semantics. Without this, every
+// useRouter() call would return a fresh reference and useCallback would invalidate every render.
+const mockRouter = {
+    back: mockBack,
+    push: mockPush,
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+}
+
+jest.mock('next/navigation', () => ({
+    useRouter: () => mockRouter,
+}))
+
+// installNavTracker patches window.history.pushState once per page load. Reset the patch
+// (and the captured original) between every test so each case starts from a clean global.
+let originalPushState: typeof window.history.pushState
+beforeEach(() => {
+    mockBack.mockReset()
+    mockPush.mockReset()
+    if (!originalPushState) originalPushState = window.history.pushState.bind(window.history)
+    window.history.pushState = originalPushState
+    __testing.reset()
+})
+
+describe('useSafeBack', () => {
+    it('falls back to push(fallbackUrl) when no in-app navigation has occurred (cold deep-link)', () => {
+        installNavTracker()
+
+        const { result } = renderHook(() => useSafeBack('/home'))
+        act(() => result.current())
+
+        expect(mockPush).toHaveBeenCalledWith('/home')
+        expect(mockBack).not.toHaveBeenCalled()
+    })
+
+    it('calls router.back() once an in-app pushState has happened', () => {
+        installNavTracker()
+        // Simulate an in-app navigation — Next.js + nuqs both go through pushState.
+        act(() => {
+            window.history.pushState({}, '', '/some-route')
+        })
+
+        const { result } = renderHook(() => useSafeBack('/home'))
+        act(() => result.current())
+
+        expect(mockBack).toHaveBeenCalledTimes(1)
+        expect(mockPush).not.toHaveBeenCalled()
+    })
+
+    it('decrements on popstate so an over-pop falls back to fallbackUrl', () => {
+        installNavTracker()
+        act(() => {
+            window.history.pushState({}, '', '/screen-a')
+        })
+        expect(__testing.getCount()).toBe(1)
+
+        // User pressed browser back: popstate fires, counter drops to 0.
+        act(() => {
+            window.dispatchEvent(new PopStateEvent('popstate'))
+        })
+        expect(__testing.getCount()).toBe(0)
+
+        const { result } = renderHook(() => useSafeBack('/home'))
+        act(() => result.current())
+
+        // No in-app entries left to pop → fallback.
+        expect(mockPush).toHaveBeenCalledWith('/home')
+        expect(mockBack).not.toHaveBeenCalled()
+    })
+
+    it('clamps count at 0 — extra popstates do not go negative', () => {
+        installNavTracker()
+        act(() => {
+            window.dispatchEvent(new PopStateEvent('popstate'))
+            window.dispatchEvent(new PopStateEvent('popstate'))
+            window.dispatchEvent(new PopStateEvent('popstate'))
+        })
+        expect(__testing.getCount()).toBe(0)
+    })
+
+    it('install is idempotent — calling it twice does not double-patch pushState', () => {
+        installNavTracker()
+        const afterFirst = window.history.pushState
+        installNavTracker()
+        const afterSecond = window.history.pushState
+
+        expect(afterFirst).toBe(afterSecond)
+
+        // And the counter increments by one (not two) on a single pushState call.
+        act(() => {
+            window.history.pushState({}, '', '/x')
+        })
+        expect(__testing.getCount()).toBe(1)
+    })
+
+    it('counter survives nuqs-style query-only pushes', () => {
+        installNavTracker()
+        // nuqs with { history: 'push' } pushes a same-pathname URL with new query.
+        act(() => {
+            window.history.pushState({}, '', '/screen?step=1')
+            window.history.pushState({}, '', '/screen?step=2')
+        })
+
+        const { result } = renderHook(() => useSafeBack('/home'))
+        act(() => result.current())
+
+        expect(mockBack).toHaveBeenCalledTimes(1)
+        expect(mockPush).not.toHaveBeenCalled()
+    })
+
+    it('returned callback is stable when router and fallback do not change', () => {
+        installNavTracker()
+        const { result, rerender } = renderHook(({ url }: { url: string }) => useSafeBack(url), {
+            initialProps: { url: '/home' },
+        })
+        const first = result.current
+        rerender({ url: '/home' })
+        expect(result.current).toBe(first)
+    })
+
+    it('returned callback changes when fallbackUrl changes', () => {
+        installNavTracker()
+        const { result, rerender } = renderHook(({ url }: { url: string }) => useSafeBack(url), {
+            initialProps: { url: '/home' },
+        })
+        const first = result.current
+        rerender({ url: '/withdraw' })
+        expect(result.current).not.toBe(first)
+
+        act(() => result.current())
+        expect(mockPush).toHaveBeenCalledWith('/withdraw')
+    })
+})

--- a/src/hooks/useSafeBack.ts
+++ b/src/hooks/useSafeBack.ts
@@ -1,0 +1,69 @@
+'use client'
+
+import { useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+
+/**
+ * Back-button primitive for deep-linkable screens.
+ *
+ * Plain `router.back()` is a no-op when the current screen is the first entry in the tab's
+ * history (cold deep-link, QR scan, push notification, PWA install). The user clicks back
+ * and nothing happens — the bug Konrad reported on the Pix decode error screen, and the
+ * back-loop bugs in add-money/card.
+ *
+ * useSafeBack tracks whether the user has navigated within our app this session by patching
+ * `history.pushState` once at install time. If there's an in-app history entry to pop, it
+ * pops. Otherwise it pushes the caller-supplied fallback URL (typically a parent route or
+ * /home), guaranteeing the back button always moves the user somewhere.
+ *
+ * The patch survives Next.js routing, nuqs query-state pushes, and any direct
+ * `window.history.pushState` call — anything that grows the history stack is tracked.
+ */
+
+// Module-local — single source of truth across the app for "how many in-app pushes are
+// still poppable?". popstate (browser/device back) decrements; pushState increments.
+let inAppPushCount = 0
+let installed = false
+
+export function installNavTracker(): void {
+    if (installed || typeof window === 'undefined') return
+    installed = true
+
+    const origPushState = window.history.pushState.bind(window.history)
+    window.history.pushState = function patchedPushState(...args) {
+        inAppPushCount++
+        return origPushState(...(args as Parameters<typeof origPushState>))
+    }
+
+    window.addEventListener('popstate', () => {
+        // Floor at 0 — a user can pop past our app's entries (e.g. back out into the
+        // previous site that loaded our PWA). Don't go negative; treat as "exited."
+        inAppPushCount = Math.max(0, inAppPushCount - 1)
+    })
+}
+
+export function useSafeBack(fallbackUrl: string): () => void {
+    const router = useRouter()
+    return useCallback(() => {
+        if (inAppPushCount > 0) {
+            router.back()
+        } else {
+            router.push(fallbackUrl)
+        }
+    }, [router, fallbackUrl])
+}
+
+// Test-only escape hatches. Module state is global so tests must reset it between cases.
+// Not exported from any barrel — tests reach in directly.
+export const __testing = {
+    reset(): void {
+        inAppPushCount = 0
+        installed = false
+    },
+    getCount(): number {
+        return inAppPushCount
+    },
+    isInstalled(): boolean {
+        return installed
+    },
+}

--- a/src/hooks/useSafeBack.ts
+++ b/src/hooks/useSafeBack.ts
@@ -2,8 +2,15 @@ import { useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 
 /**
- * Returns a back handler. Calls `router.back()` when in-app history exists; otherwise pushes
- * `fallbackUrl`. The module-level patch below installs on import — side-effect imported from
+ * Returns a back handler. Calls `router.back()` when in-app history exists; otherwise
+ * navigates to `fallbackUrl`.
+ *
+ * Pass `{ replace: true }` for terminal flows (error screens, success screens) where
+ * leaving the current URL in history would let browser back pop the user into a now-stale
+ * state. The fallback uses `router.replace` instead of `router.push`. The in-app `back()`
+ * branch is unchanged either way — `replace` only affects the no-history fallback.
+ *
+ * The module-level patch below installs on import — side-effect imported from
  * `(mobile-ui)/layout.tsx` so the patch beats any child's mount-time router.push.
  */
 
@@ -22,15 +29,23 @@ if (typeof window !== 'undefined' && !installed) {
     })
 }
 
-export function useSafeBack(fallbackUrl: string): () => void {
+type Options = {
+    /** Use router.replace instead of router.push for the no-history fallback. */
+    replace?: boolean
+}
+
+export function useSafeBack(fallbackUrl: string, options: Options = {}): () => void {
     const router = useRouter()
+    const { replace = false } = options
     return useCallback(() => {
         if (inAppPushCount > 0) {
             router.back()
+        } else if (replace) {
+            router.replace(fallbackUrl)
         } else {
             router.push(fallbackUrl)
         }
-    }, [router, fallbackUrl])
+    }, [router, fallbackUrl, replace])
 }
 
 // Tests only — module state is global so cases must reset between runs.

--- a/src/hooks/useSafeBack.ts
+++ b/src/hooks/useSafeBack.ts
@@ -1,43 +1,23 @@
-'use client'
-
 import { useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 
 /**
- * Back-button primitive for deep-linkable screens.
- *
- * Plain `router.back()` is a no-op when the current screen is the first entry in the tab's
- * history (cold deep-link, QR scan, push notification, PWA install). The user clicks back
- * and nothing happens — the bug Konrad reported on the Pix decode error screen, and the
- * back-loop bugs in add-money/card.
- *
- * useSafeBack tracks whether the user has navigated within our app this session by patching
- * `history.pushState` once at install time. If there's an in-app history entry to pop, it
- * pops. Otherwise it pushes the caller-supplied fallback URL (typically a parent route or
- * /home), guaranteeing the back button always moves the user somewhere.
- *
- * The patch survives Next.js routing, nuqs query-state pushes, and any direct
- * `window.history.pushState` call — anything that grows the history stack is tracked.
+ * Returns a back handler. Calls `router.back()` when in-app history exists; otherwise pushes
+ * `fallbackUrl`. The module-level patch below installs on import — side-effect imported from
+ * `(mobile-ui)/layout.tsx` so the patch beats any child's mount-time router.push.
  */
 
-// Module-local — single source of truth across the app for "how many in-app pushes are
-// still poppable?". popstate (browser/device back) decrements; pushState increments.
 let inAppPushCount = 0
 let installed = false
 
-export function installNavTracker(): void {
-    if (installed || typeof window === 'undefined') return
+if (typeof window !== 'undefined' && !installed) {
     installed = true
-
-    const origPushState = window.history.pushState.bind(window.history)
-    window.history.pushState = function patchedPushState(...args) {
+    const orig = window.history.pushState.bind(window.history)
+    window.history.pushState = function patched(...args: Parameters<typeof orig>) {
         inAppPushCount++
-        return origPushState(...(args as Parameters<typeof origPushState>))
+        return orig(...args)
     }
-
     window.addEventListener('popstate', () => {
-        // Floor at 0 — a user can pop past our app's entries (e.g. back out into the
-        // previous site that loaded our PWA). Don't go negative; treat as "exited."
         inAppPushCount = Math.max(0, inAppPushCount - 1)
     })
 }
@@ -53,17 +33,9 @@ export function useSafeBack(fallbackUrl: string): () => void {
     }, [router, fallbackUrl])
 }
 
-// Test-only escape hatches. Module state is global so tests must reset it between cases.
-// Not exported from any barrel — tests reach in directly.
+// Tests only — module state is global so cases must reset between runs.
 export const __testing = {
     reset(): void {
         inAppPushCount = 0
-        installed = false
-    },
-    getCount(): number {
-        return inAppPushCount
-    },
-    isInstalled(): boolean {
-        return installed
     },
 }


### PR DESCRIPTION
## Summary

Holistic fix for a class of back-button bugs reported by Hugo (add-money / card back loops) and Konrad (Pix QR decode error screen "Go Back" no-op). All instances of the same disease:

> `router.back()` is a no-op (or pops out of the app entirely) when the screen was reached via deep link, QR scan, push notification, or PWA cold start — there's no in-app history to pop.

Introduces a single primitive — **`useSafeBack(fallbackUrl, options?)`** — that pops in-app history when there's something to pop, otherwise pushes (or replaces, for terminal flows) the caller-supplied parent URL. Migrates 16 callsites to it. Replaces three ad-hoc `window.history.length > 1 ? router.back() : router.push('/')` implementations. Removes a `setTimeout(router.replace, 100)` hack from `withdraw/manteca` that signalled the same disease.

## The primitive — `src/hooks/useSafeBack.ts`

- Patches `window.history.pushState` once at **module load** (not `useEffect`, so it beats any child's mount-time `router.push`).
- A module-level counter increments on every `pushState` (catches Next.js routing, nuqs query-state pushes, manual `pushState` — anything that grows the stack).
- Decrements on `popstate`, clamped at 0.
- `useSafeBack(fallbackUrl)` returns a memoised callback: `router.back()` if counter > 0, else `router.push(fallbackUrl)`.
- `useSafeBack(url, { replace: true })` for terminal flows — uses `router.replace` for the no-history fallback so browser back from the destination can't pop into a stale screen. The in-app `back()` branch is unchanged either way.
- Side-effect imported from `(mobile-ui)/layout.tsx` to guarantee load order.

~50 lines of code, 7 focused unit tests.

## Files migrated to `useSafeBack`

| File | Fallback | Mode | Was |
|---|---|---|---|
| `card/page.tsx` (5 sites) | `/home` | push | `router.back()` |
| `add-money/crypto/page.tsx` | `/add-money` | push | `router.back()` |
| `add-money/[country]/bank/page.tsx` | country page | push | `router.back()` |
| `add-money/us/bank/page.tsx` | `/add-money` | push | (broken — no back) |
| `MantecaAddMoney.tsx` | country page | push | `router.push` |
| `withdraw/crypto/page.tsx` | `/withdraw` | push | `router.back()` |
| `withdraw/[country]/bank/page.tsx` | `/send` or `/withdraw` | push | `router.back()` |
| `withdraw/manteca/page.tsx` | country page | push | `router.back()` + `setTimeout(router.replace)` hack |
| `qr-pay/page.tsx` (6 sites) | `/home` | **replace** | `router.back()` |
| `rewards/page.tsx` | `/home` | push | `router.back()` |
| `rewards/invites/page.tsx` | `/rewards` | push | `router.back()` |
| `AddWithdrawCountriesList.tsx` (2 sites) | `/add-money` or `/withdraw` (from `flow` prop) | push | `router.back()` |
| `SendInputView.tsx` | `/` | push | manual `history.length > 1` pattern |
| `ContributePotInputView.tsx` | `/` | push | manual `history.length > 1` pattern |
| `SemanticRequestInputView.tsx` | `/` | push | manual `history.length > 1` pattern |

## Shared sub-components now take `onBack` from parent

`InputAmountStep`, `AddMoneyBankDetails`, `MantecaDepositShareDetails` used to hard-code `router.back()` — fragile because they don't know their flow context. Now they require an `onBack` prop and the parent decides (either a `useSafeBack` callback for screen exits or a `setUrlState({ step: 'previous' })` for in-flow step-back).

`AddMoneyBankDetails` uses a discriminated union to enforce `onBack` is provided for `add-money` flow but forbidden for `request-fulfillment` (which steps back via `RequestFulfillmentFlowContext`).

## Bonus: `PaymentSuccessView` gains `replaceOnDone`

When `true`, the success-view "Done" navigation uses `router.replace` instead of `router.push`. Used by `add-money/crypto` so browser-back from `/home` doesn't pop into the now-reset deposit screen. Defaults to `false`. Equivalent semantics to `useSafeBack(url, { replace: true })` but applied at the "Done" CTA rather than the back arrow.

## Known behaviour change

`SendInputView`, `ContributePotInputView`, `SemanticRequestInputView` previously used `window.history.length > 1` which could be true on a cold deep-link from another site (browser-added entries). Old behaviour: back-exit to the referring site (e.g. Twitter). New behaviour: push `/`. **This is a UX shift on the external-referrer path** — arguably better (keeps users in the app) but a real change. Flagged here in case anyone disagrees.

## Deferred to follow-up PR

The hook is in place; the rest of the sweep can land mechanically. These are intentionally NOT migrated in this PR to keep scope on reported bugs:

- `DirectSendPageWrapper`, `SemanticRequestPageWrapper`, `ContributePotPageWrapper` — flow-context decisions worth reviewing with the flow owners.
- `Profile/views/ProfileEdit.view.tsx` — single site, easy follow-up.
- `Profile/components/PublicProfile.tsx` — has an `isInternalReferrer` referrer check on top of `history.length > 1`; the referrer check is extra logic worth preserving.
- `Card/CardInfoScreen.tsx`, `Card/CardPioneerFlow.tsx` (only the final-step exit), `Badges/index.tsx`, `features/limits/views/{Bridge,Manteca}LimitsView.tsx`, `SemanticRequestReceiptView`, `Request/direct-request/views/Initial.direct.request.view.tsx`.
- `useNativePlugins.ts` (Capacitor hardware back) — different semantics (`canGoBack` from Capacitor + `App.minimizeApp()` fallback); not the same bug class.

Also a candidate: ESLint rule banning bare `router.back()` outside `useSafeBack`. Cheap regression net.

## CodeRabbit

| Comment | Status |
|---|---|
| `withdraw/[country]/bank` ignores `fromSendFlow` (Major) | ✅ Fixed (commit `4a61a430`) |
| `AddMoneyBankDetails` should use discriminated union (Critical) | ✅ Fixed (commit `4a61a430`, tightened in `fce4ad84`) |
| `qr-pay` `exitToHome` should use `router.replace` not `push` (Major) | ✅ Fixed (commit `a84aff91`) — added `{ replace: true }` option to `useSafeBack` and opted `/qr-pay` in |
| `useSafeBack` `__testing.reset()` should teardown patched globals (Minor) | 🚫 Stale — filed against the consolidated commit; the simplify pass made install strictly idempotent (`installed` flag short-circuits any re-stacking), so the teardown CodeRabbit asks for is structurally impossible. Will reply on thread. |

## Test plan

- [x] `pnpm typecheck` — clean (asset `TS2307` errors pre-exist on dev, unrelated)
- [x] `pnpm test` — 41 suites / 943 tests pass, including 7 tests for `useSafeBack`
- [x] `pnpm prettier --check` — clean
- [x] All CI checks green (lint, typecheck, unit, e2e, analyze, Deploy-Preview)

Manual QA against the reported bugs (verify on the Vercel preview):

- [ ] **Konrad's bug:** Open `/qr-pay?qrCode=<invalid>` in a fresh tab → "We could not decode this Pix QR code" → Go Back → lands on `/home`. Then press browser back from `/home` → does NOT pop back into the QR error screen (replace mode). Repeat with the KYC modal "Not now" CTA.
- [ ] **Hugo's bug 1 (add-money success loop):** `/home` → Add money → Crypto → complete deposit → "Back to home" → `/home`; press device/browser back → does NOT pop into deposit view.
- [ ] **Hugo's bug 2 (add-money back loop):** `/home` → Add money → Bank → Mexico → enter amount → continue → details → back returns to input amount; back returns to country page; back returns to method selection; back returns to `/home`.
- [ ] **Hugo's bug 3 (card back loop):** `/card` in any state (add-card / pending / manual-review / rejected / active) → back returns to `/home`, no loop.
- [ ] Withdraw crypto → back returns to `/withdraw`.
- [ ] Withdraw → country → bank → success "X" → `/home`; non-success back → `/withdraw` (or `/send` when entered via send flow).
- [ ] Rewards back → `/home`. Rewards/invites back → `/rewards`.

## Commit history

1. `fix(navigation): stop router.back() loops in add-money + card flows` — initial targeted fix
2. `fix(navigation): address CodeRabbit findings` — fromSendFlow + discriminated union
3. `fix(qr-pay): replace all router.back() with explicit /home exit` — Konrad's report
4. `refactor(navigation): consolidate back-button bug class behind useSafeBack` — holistic primitive + 16-site migration
5. `refactor(navigation): simplify useSafeBack per /simplify review` — move install to module load (correctness), trim hook 69→41 lines, tests 138→75, standardize naming to `onBack` everywhere
6. `feat(useSafeBack): add { replace: true } option for terminal flows` — addresses CodeRabbit's qr-pay replace concern
