### PR TITLE
fix(receipt): keep sender data visible on cancelled sendlinks

### DIFF
--- a/src/components/TransactionDetails/__tests__/useReceiptViewModel.test.ts
+++ b/src/components/TransactionDetails/__tests__/useReceiptViewModel.test.ts
@@ -1,0 +1,92 @@
+// Locks the "cancelled-sendlink-sender keeps its data" visibility rule
+// so the staging regression (cancelled sendlink → empty receipt drawer)
+// can't come back.
+import { renderHook } from '@testing-library/react'
+import { useReceiptViewModel } from '../useReceiptViewModel'
+import { EHistoryEntryType, EHistoryUserRole } from '@/hooks/useTransactionHistory'
+import type { TransactionDetails } from '../transactionTransformer'
+
+jest.mock('@/assets', () => ({}))
+jest.mock('@/assets/payment-apps', () => ({ MERCADO_PAGO: '', PIX: '', SIMPLEFI: '' }))
+
+const baseTx: TransactionDetails = {
+    id: 'tx-1',
+    amount: '5',
+    currency: { code: 'USD', symbol: '$' },
+    direction: 'send',
+    status: 'pending',
+    createdAt: '2026-05-01T00:00:00.000Z',
+    txHash: '0xtxhash',
+    memo: 'pizza money',
+    attachmentUrl: 'https://example.com/receipt.png',
+    fee: 0,
+    points: 0,
+    sourceView: 'history',
+    tokenSymbol: 'USDC',
+    tokenDisplayDetails: {
+        tokenSymbol: 'USDC',
+        chainName: 'Polygon',
+        tokenIcon: '',
+        chainIcon: '',
+    },
+    extraDataForDrawer: {
+        originalType: EHistoryEntryType.SEND_LINK,
+        originalUserRole: EHistoryUserRole.SENDER,
+    },
+} as unknown as TransactionDetails
+
+const senderSendLink = (status: string): TransactionDetails =>
+    ({
+        ...baseTx,
+        status,
+        extraDataForDrawer: {
+            ...baseTx.extraDataForDrawer,
+            originalType: EHistoryEntryType.SEND_LINK,
+            originalUserRole: EHistoryUserRole.SENDER,
+        },
+    }) as TransactionDetails
+
+const cancelledBankWithdraw = (): TransactionDetails =>
+    ({
+        ...baseTx,
+        status: 'cancelled',
+        direction: 'bank_withdraw',
+        extraDataForDrawer: {
+            originalType: EHistoryEntryType.BRIDGE_OFFRAMP,
+            originalUserRole: EHistoryUserRole.SENDER,
+        },
+    }) as TransactionDetails
+
+describe('useReceiptViewModel — cancelled sendlink sender', () => {
+    test('shows memo + attachment + token/network when sender cancels their own sendlink', () => {
+        const tx = senderSendLink('cancelled')
+        const { result } = renderHook(() => useReceiptViewModel(tx, { isPublic: false }))
+
+        expect(result.current.rowVisibilityConfig.comment).toBe(true)
+        expect(result.current.rowVisibilityConfig.attachment).toBe(true)
+        expect(result.current.rowVisibilityConfig.tokenAndNetwork).toBe(true)
+        expect(result.current.rowVisibilityConfig.cancelled).toBe(true)
+    })
+
+    test('keeps the legacy suppress for a still-pending sender-side sendlink', () => {
+        // Pre-cancel state: token+network row is intentionally suppressed
+        // (sender already sees that at the top of the drawer); other fields
+        // remain visible as before.
+        const tx = senderSendLink('pending')
+        const { result } = renderHook(() => useReceiptViewModel(tx, { isPublic: false }))
+
+        expect(result.current.rowVisibilityConfig.tokenAndNetwork).toBe(false)
+        expect(result.current.rowVisibilityConfig.comment).toBe(true)
+        expect(result.current.rowVisibilityConfig.attachment).toBe(true)
+    })
+
+    test('still hides memo + attachment for non-sendlink cancelled flows', () => {
+        // Bank withdraws etc. genuinely null out their fields on cancel —
+        // those gates must still apply.
+        const tx = cancelledBankWithdraw()
+        const { result } = renderHook(() => useReceiptViewModel(tx, { isPublic: false }))
+
+        expect(result.current.rowVisibilityConfig.comment).toBe(false)
+        expect(result.current.rowVisibilityConfig.attachment).toBe(false)
+    })
+})

--- a/src/components/TransactionDetails/__tests__/useReceiptViewModel.test.ts
+++ b/src/components/TransactionDetails/__tests__/useReceiptViewModel.test.ts
@@ -88,5 +88,11 @@ describe('useReceiptViewModel — cancelled sendlink sender', () => {
 
         expect(result.current.rowVisibilityConfig.comment).toBe(false)
         expect(result.current.rowVisibilityConfig.attachment).toBe(false)
+        // Pre-existing behaviour: tokenAndNetwork has no global `status !==
+        // 'cancelled'` gate — only a `!isPeanutWalletToken` suppress and the
+        // sendlink-sender pre-cancel hide. Cancelled non-sendlinks with a
+        // non-peanut-wallet token still surface this row. Lock that here so
+        // a future status-blanket gate doesn't sneak in unnoticed.
+        expect(result.current.rowVisibilityConfig.tokenAndNetwork).toBe(true)
     })
 })

--- a/src/components/TransactionDetails/useReceiptViewModel.ts
+++ b/src/components/TransactionDetails/useReceiptViewModel.ts
@@ -157,6 +157,11 @@ export function useReceiptViewModel(
             transaction.extraDataForDrawer?.originalType !== EHistoryEntryType.DIRECT_SEND
         )
 
+        // "Show the user's own data even when the tx is in a cancelled state"
+        // gate. True for everything that isn't cancelled, plus the
+        // sendlink-sender-cancelled exemption — drives memo + attachment.
+        const allowCancelledSenderFields = transaction.status !== 'cancelled' || isSendLinkSenderCancelled
+
         return {
             createdAt: !!transaction.createdAt && !willShowCompleted,
             to: transaction.direction === 'claim_external',
@@ -221,16 +226,13 @@ export function useReceiptViewModel(
             // Sender-side sendlink rows keep their memo + attachment after
             // cancel — the data belongs to the sender, not the (never-arrived)
             // recipient. Bank/onramp cancellations hide these as before.
-            comment: !!(transaction.memo?.trim() && (transaction.status !== 'cancelled' || isSendLinkSenderCancelled)),
+            comment: !!(transaction.memo?.trim() && allowCancelledSenderFields),
             networkFee: !!(
                 transaction.networkFeeDetails &&
                 transaction.sourceView === 'status' &&
                 transaction.status !== 'cancelled'
             ),
-            attachment: !!(
-                transaction.attachmentUrl &&
-                (transaction.status !== 'cancelled' || isSendLinkSenderCancelled)
-            ),
+            attachment: !!(transaction.attachmentUrl && allowCancelledSenderFields),
             mantecaDepositInfo:
                 !isPublic &&
                 (transaction.extraDataForDrawer?.originalType === EHistoryEntryType.MANTECA_ONRAMP ||

--- a/src/components/TransactionDetails/useReceiptViewModel.ts
+++ b/src/components/TransactionDetails/useReceiptViewModel.ts
@@ -130,6 +130,21 @@ export function useReceiptViewModel(
         return countryData.find((c) => c.currency === transaction.currency?.code)
     }, [transaction?.currency?.code])
 
+    // A sendlink-sender row whose status is now CANCELLED is the result of
+    // the sender clicking Cancel on their own link. The reclaim tx + memo +
+    // attachment + token/network are all real data the user wants to see;
+    // the legacy `status !== 'cancelled'` gates were aimed at bank/onramp
+    // flows where cancellation reverses every line item. Keep that behaviour
+    // there and exempt sendlink-sender-cancelled rows.
+    const isSendLinkSenderCancelled = useMemo(
+        () =>
+            !!transaction &&
+            transaction.status === 'cancelled' &&
+            transaction.extraDataForDrawer?.originalType === EHistoryEntryType.SEND_LINK &&
+            transaction.extraDataForDrawer?.originalUserRole === EHistoryUserRole.SENDER,
+        [transaction]
+    )
+
     const rowVisibilityConfig = useMemo<Record<TransactionDetailsRowKey, boolean>>(() => {
         if (!transaction) return ALL_ROWS_HIDDEN
 
@@ -149,9 +164,14 @@ export function useReceiptViewModel(
                 transaction.tokenDisplayDetails &&
                 transaction.sourceView === 'history' &&
                 !isPeanutWalletToken &&
+                // Suppress for pending/completed sendlinks (the sender already
+                // sees the token + network at the top of the drawer). Once
+                // CANCELLED, surface it again — the row helps the sender
+                // confirm what they reclaimed.
                 !(
                     transaction.extraDataForDrawer?.originalType === EHistoryEntryType.SEND_LINK &&
-                    transaction.extraDataForDrawer?.originalUserRole === EHistoryUserRole.SENDER
+                    transaction.extraDataForDrawer?.originalUserRole === EHistoryUserRole.SENDER &&
+                    transaction.status !== 'cancelled'
                 ) &&
                 transaction.status !== 'refunded'
             ),
@@ -198,13 +218,19 @@ export function useReceiptViewModel(
             ),
             peanutFee: false,
             points: !!(transaction.points && transaction.points > 0 && transaction.status !== 'cancelled'),
-            comment: !!(transaction.memo?.trim() && transaction.status !== 'cancelled'),
+            // Sender-side sendlink rows keep their memo + attachment after
+            // cancel — the data belongs to the sender, not the (never-arrived)
+            // recipient. Bank/onramp cancellations hide these as before.
+            comment: !!(transaction.memo?.trim() && (transaction.status !== 'cancelled' || isSendLinkSenderCancelled)),
             networkFee: !!(
                 transaction.networkFeeDetails &&
                 transaction.sourceView === 'status' &&
                 transaction.status !== 'cancelled'
             ),
-            attachment: !!(transaction.attachmentUrl && transaction.status !== 'cancelled'),
+            attachment: !!(
+                transaction.attachmentUrl &&
+                (transaction.status !== 'cancelled' || isSendLinkSenderCancelled)
+            ),
             mantecaDepositInfo:
                 !isPublic &&
                 (transaction.extraDataForDrawer?.originalType === EHistoryEntryType.MANTECA_ONRAMP ||
@@ -222,7 +248,7 @@ export function useReceiptViewModel(
             cardPayment: isCardPaymentEntry(transaction) && hasCardPaymentRowsContent(transaction),
             closed: !!(transaction.status === 'closed' && transaction.cancelledDate),
         }
-    }, [transaction, isPublic, isPendingBankRequest, isPeanutWalletToken])
+    }, [transaction, isPublic, isPendingBankRequest, isPeanutWalletToken, isSendLinkSenderCancelled])
 
     const visibleRows = useMemo(
         () => transactionDetailsRowKeys.filter((key) => rowVisibilityConfig[key]),


### PR DESCRIPTION
## Summary

When a sender cancels their own sendlink, the receipt drawer was hiding `tokenAndNetwork`, `comment`, and `attachment` rows because the legacy visibility gates blanket-hid those fields on \`status === 'cancelled'\`. That makes sense for bank deposits / on-ramps / off-ramps where cancellation reverses every line item, but for a sendlink-cancel-by-sender the memo, attachment, and token+network the sender chose are all real data they want to confirm on the receipt.

Reported in [Cancelled sendlink generates 3 separate history items](https://www.notion.so/peanutprotocol/Cancelled-sendlink-generates-3-separate-history-items-35b83811757981ae8102ec415e87236b) (Jota's handoff note: "please check also the receipt fields and ctas missing").

> Pairs with peanut-api-ts#732 which fixes the duplicate-history-row half of the same bug. This PR fixes the empty-receipt-drawer half.

## What changed

`src/components/TransactionDetails/useReceiptViewModel.ts`:
- Introduces an \`isSendLinkSenderCancelled\` memoised flag.
- Exempts that case from the \`status !== 'cancelled'\` gates on \`comment\` + \`attachment\`.
- Surfaces \`tokenAndNetwork\` again after cancel (still suppressed pre-cancel — the sender already sees the token+network at the top of the drawer).

Bank/onramp/offramp cancellations keep their existing field-hiding behaviour.

## CTAs

I audited the receipt CTAs and there's nothing to change here:
- **Cancel link / Share link / QR**: gated on \`status === 'pending'\` (correct — can't cancel/share a link that's already cancelled).
- **Share Receipt**: gated on \`shouldShowShareReceipt\` which depends on \`txHash + direction\`, not status — already shows once the cancel tx has a hash.
- **View on Explorer**: the \`txId\` row already renders whenever \`txHash\` exists, including for cancelled sendlinks.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm exec jest\` — 41/41 suites, 939/939 tests pass (incl. 3 new ones)
- [x] \`pnpm exec prettier --check\` (on changed files) — clean
- [ ] Post-merge: cancel a sendlink on staging, open the receipt drawer, verify token/network + comment + attachment are visible

## Blast radius

Single-file change to a memoised pure derivation. New tests lock both the new behaviour and the legacy "other cancelled flows stay hidden" path, so the regression can't sneak back in.