### PR TITLE
feat(card): push notifications for issued, spend settled, declined, rebalance

### DIFF
--- a/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
+++ b/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
@@ -41,7 +41,7 @@ export function hasCardPaymentRowsContent(transaction: TransactionDetails): bool
     if (nonBlank(card.merchantCategory)) return true
     if (nonBlank(card.merchantCity) || nonBlank(card.merchantCountry)) return true
     if (card.settlementAdjusted && parseCents(card.authAmount) != null) return true
-    if (transaction.status === 'failed' && card.declineReason) return true
+    if (transaction.status === 'failed' && (card.declineReason || card.declineCategory)) return true
     if (card.cancellationReason === 'auto_closed') return true
     return false
 }
@@ -104,12 +104,14 @@ export function CardPaymentRows({
         }
     }
 
-    // Spec §4.4 — show why a card spend declined.
-    if (transaction.status === 'failed' && card.declineReason) {
+    // Spec §4.4 — show why a card spend declined. Prefer the BE-computed
+    // synthetic category (disambiguates INSUFFICIENT_FUNDS vs limit-too-low);
+    // fall back to the raw Rain code for non-financial declines.
+    if (transaction.status === 'failed' && (card.declineReason || card.declineCategory)) {
         subRows.push({
             key: 'declineReason',
             label: 'Decline reason',
-            value: friendlyDeclineReason(card.declineReason),
+            value: friendlyDeclineReason(card.declineReason, card.declineCategory),
         })
     }
 

--- a/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
+++ b/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
@@ -41,7 +41,10 @@ export function hasCardPaymentRowsContent(transaction: TransactionDetails): bool
     if (nonBlank(card.merchantCategory)) return true
     if (nonBlank(card.merchantCity) || nonBlank(card.merchantCountry)) return true
     if (card.settlementAdjusted && parseCents(card.authAmount) != null) return true
-    if (transaction.status === 'failed' && (card.declineReason || card.declineCategory)) return true
+    // declineCategory is BE-controlled (one of 3 enum literals) — no
+    // whitespace risk. declineReason is Rain's free-form prose — gate it
+    // through nonBlank.
+    if (transaction.status === 'failed' && (nonBlank(card.declineReason) || card.declineCategory)) return true
     if (card.cancellationReason === 'auto_closed') return true
     return false
 }
@@ -107,11 +110,16 @@ export function CardPaymentRows({
     // Spec §4.4 — show why a card spend declined. Prefer the BE-computed
     // synthetic category (disambiguates INSUFFICIENT_FUNDS vs limit-too-low);
     // fall back to the raw Rain code for non-financial declines.
-    if (transaction.status === 'failed' && (card.declineReason || card.declineCategory)) {
+    // Pass declineReason through nonBlank so Rain's whitespace-padded
+    // placeholders ("  ", " - ") don't sneak into copy and produce a
+    // "Transaction declined" row for an intent with no real decline data.
+    // declineCategory is BE-controlled (enum literal) — no whitespace risk.
+    const declineReasonClean = nonBlank(card.declineReason)
+    if (transaction.status === 'failed' && (declineReasonClean || card.declineCategory)) {
         subRows.push({
             key: 'declineReason',
             label: 'Decline reason',
-            value: friendlyDeclineReason(card.declineReason, card.declineCategory),
+            value: friendlyDeclineReason(declineReasonClean, card.declineCategory),
         })
     }
 

--- a/src/components/TransactionDetails/transactionTransformer.ts
+++ b/src/components/TransactionDetails/transactionTransformer.ts
@@ -321,6 +321,12 @@ export interface TransactionDetails {
             localAmount: string | null
             localCurrency: string | null
             declineReason: string | null
+            /** Synthetic category set by the BE (`'limit_too_low' |
+             *  'insufficient_balance' | 'other'`). Preferred over the raw
+             *  `declineReason` for friendly-copy mapping because Rain returns
+             *  `INSUFFICIENT_FUNDS` for both real shortfalls and limit-too-low
+             *  cases. */
+            declineCategory: string | null
             authAmount: string | null
             settledAmount: string | null
             settlementAdjusted: boolean
@@ -508,6 +514,7 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
                           localAmount: entry.extraData?.cardLocalAmount as string | null,
                           localCurrency: entry.extraData?.cardLocalCurrency as string | null,
                           declineReason: entry.extraData?.declineReason as string | null,
+                          declineCategory: entry.extraData?.declineCategory as string | null,
                           authAmount: entry.extraData?.cardAuthAmount as string | null,
                           settledAmount: entry.extraData?.cardSettledAmount as string | null,
                           settlementAdjusted: Boolean(entry.extraData?.settlementAdjusted),

--- a/src/components/TransactionDetails/transactionTransformer.ts
+++ b/src/components/TransactionDetails/transactionTransformer.ts
@@ -321,12 +321,12 @@ export interface TransactionDetails {
             localAmount: string | null
             localCurrency: string | null
             declineReason: string | null
-            /** Synthetic category set by the BE (`'limit_too_low' |
-             *  'insufficient_balance' | 'other'`). Preferred over the raw
+            /** Synthetic category set by the BE. Preferred over the raw
              *  `declineReason` for friendly-copy mapping because Rain returns
              *  `INSUFFICIENT_FUNDS` for both real shortfalls and limit-too-low
-             *  cases. */
-            declineCategory: string | null
+             *  cases. Union kept narrow so unknown strings from the wire are
+             *  caught by the consumer rather than mis-mapped. */
+            declineCategory: 'limit_too_low' | 'insufficient_balance' | 'other' | null
             authAmount: string | null
             settledAmount: string | null
             settlementAdjusted: boolean
@@ -513,8 +513,14 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
                           merchantId: entry.extraData?.merchantId as string | null,
                           localAmount: entry.extraData?.cardLocalAmount as string | null,
                           localCurrency: entry.extraData?.cardLocalCurrency as string | null,
-                          declineReason: entry.extraData?.declineReason as string | null,
-                          declineCategory: entry.extraData?.declineCategory as string | null,
+                          declineReason: (entry.extraData?.declineReason as string | null | undefined) ?? null,
+                          declineCategory:
+                              (entry.extraData?.declineCategory as
+                                  | 'limit_too_low'
+                                  | 'insufficient_balance'
+                                  | 'other'
+                                  | null
+                                  | undefined) ?? null,
                           authAmount: entry.extraData?.cardAuthAmount as string | null,
                           settledAmount: entry.extraData?.cardSettledAmount as string | null,
                           settlementAdjusted: Boolean(entry.extraData?.settlementAdjusted),

--- a/src/utils/__tests__/cardDeclineReason.test.ts
+++ b/src/utils/__tests__/cardDeclineReason.test.ts
@@ -1,0 +1,64 @@
+import { friendlyDeclineReason } from '../cardDeclineReason'
+
+describe('friendlyDeclineReason', () => {
+    describe('category takes precedence over raw code', () => {
+        test('limit_too_low overrides INSUFFICIENT_FUNDS', () => {
+            // The Rain bug case: raw reason says broke, but the synthetic
+            // category says the limit blocked the spend. We want the
+            // actionable "raise your limit" copy.
+            expect(friendlyDeclineReason('INSUFFICIENT_FUNDS', 'limit_too_low')).toBe(
+                'Card limit reached — increase your limit'
+            )
+        })
+
+        test('insufficient_balance category matches direct copy', () => {
+            expect(friendlyDeclineReason('INSUFFICIENT_FUNDS', 'insufficient_balance')).toBe('Insufficient balance')
+        })
+
+        test('"other" category falls through to raw-code mapping', () => {
+            // 'other' intentionally has no CATEGORY_COPY entry so non-financial
+            // declines still render their specific friendly text.
+            expect(friendlyDeclineReason('blocked_merchant', 'other')).toBe("This merchant isn't supported")
+        })
+
+        test('"other" + no code → generic fallback', () => {
+            expect(friendlyDeclineReason(null, 'other')).toBe('Transaction declined')
+        })
+    })
+
+    describe('raw-code mapping (no category)', () => {
+        test('SCREAMING_CASE Rain code', () => {
+            expect(friendlyDeclineReason('INSUFFICIENT_FUNDS')).toBe('Insufficient balance')
+        })
+
+        test('snake_case Rain code', () => {
+            expect(friendlyDeclineReason('card_spending_limit_exceeded')).toBe('Spending limit reached')
+        })
+
+        test('case-insensitive fallback when exact case not in map', () => {
+            // The map has BLOCKED_MERCHANT + blocked_merchant; "Blocked_Merchant"
+            // would only hit via toLowerCase().
+            expect(friendlyDeclineReason('Blocked_Merchant')).toBe("This merchant isn't supported")
+        })
+
+        test('unknown code → generic fallback', () => {
+            expect(friendlyDeclineReason('SOME_UNMAPPED_REASON')).toBe('Transaction declined')
+        })
+
+        test('null/undefined code → generic fallback', () => {
+            expect(friendlyDeclineReason(null)).toBe('Transaction declined')
+            expect(friendlyDeclineReason(undefined)).toBe('Transaction declined')
+        })
+    })
+
+    describe('legacy intents (category omitted)', () => {
+        test('honors raw code when category is undefined', () => {
+            // Older declines that pre-date the categorization land here.
+            expect(friendlyDeclineReason('INSUFFICIENT_FUNDS')).toBe('Insufficient balance')
+        })
+
+        test('honors raw code when category is null', () => {
+            expect(friendlyDeclineReason('card_locked', null)).toBe('Your card is locked')
+        })
+    })
+})

--- a/src/utils/cardDeclineReason.ts
+++ b/src/utils/cardDeclineReason.ts
@@ -1,12 +1,26 @@
 /**
- * Translate raw Rain decline codes to friendly messages for the activity feed.
- * Backend persists the code as-is on intent metadata; the human-readable mapping
- * lives here so it can be tweaked / i18n'd without a migration.
+ * Translate decline reasons / categories to friendly messages for the
+ * activity feed and the receipt drawer.
  *
- * Codes from Rain's gateway responses (snake_case Rain shapes alongside the
- * older SCREAMING_CASE ones). Unknown codes fall back to the generic copy
- * mandated by the card-activity spec.
+ * Two inputs land here:
+ *   - `category` — BE-computed synthetic category (see `notifications/card.ts`
+ *     in peanut-api-ts): `'limit_too_low' | 'insufficient_balance' | 'other'`.
+ *     We prefer this when present because Rain reports `INSUFFICIENT_FUNDS`
+ *     for both genuine shortfalls AND limit-too-low cases — the synthetic
+ *     category distinguishes them so the user gets actionable copy.
+ *   - `code` — Rain's raw decline string (snake_case alongside the older
+ *     SCREAMING_CASE variants). Fallback when category is missing (older
+ *     declines that pre-date the categorization), or for non-financial
+ *     reasons (blocked merchant, locked card, etc.).
+ *
+ * Unknown codes fall back to the generic copy mandated by the card-activity
+ * spec.
  */
+
+const CATEGORY_COPY: Record<string, string> = {
+    limit_too_low: 'Card limit reached — increase your limit',
+    insufficient_balance: 'Insufficient balance',
+}
 
 const FRIENDLY: Record<string, string> = {
     INSUFFICIENT_FUNDS: 'Insufficient balance',
@@ -23,7 +37,10 @@ const FRIENDLY: Record<string, string> = {
     INVALID_PIN: 'Incorrect PIN',
 }
 
-export function friendlyDeclineReason(code: string | null | undefined): string {
+export function friendlyDeclineReason(code: string | null | undefined, category?: string | null): string {
+    // Prefer the BE-computed category — it disambiguates the
+    // INSUFFICIENT_FUNDS/limit-too-low collision Rain leaves on the wire.
+    if (category && CATEGORY_COPY[category]) return CATEGORY_COPY[category]
     if (!code) return 'Transaction declined'
     return FRIENDLY[code] ?? FRIENDLY[code.toLowerCase()] ?? FRIENDLY[code.toUpperCase()] ?? 'Transaction declined'
 }

--- a/src/utils/cardDeclineReason.ts
+++ b/src/utils/cardDeclineReason.ts
@@ -17,6 +17,14 @@
  * spec.
  */
 
+export type DeclineCategory = 'limit_too_low' | 'insufficient_balance' | 'other'
+
+/**
+ * Category-specific copy. NOTE: `'other'` is intentionally absent — it falls
+ * through to the raw-code lookup so non-financial declines (blocked_merchant,
+ * card_locked, invalid_pin) still render their specific friendly copy.
+ * Adding `'other'` here would mask the raw-code mapping for those cases.
+ */
 const CATEGORY_COPY: Record<string, string> = {
     limit_too_low: 'Card limit reached — increase your limit',
     insufficient_balance: 'Insufficient balance',
@@ -37,7 +45,7 @@ const FRIENDLY: Record<string, string> = {
     INVALID_PIN: 'Incorrect PIN',
 }
 
-export function friendlyDeclineReason(code: string | null | undefined, category?: string | null): string {
+export function friendlyDeclineReason(code: string | null | undefined, category?: DeclineCategory | null): string {
     // Prefer the BE-computed category — it disambiguates the
     // INSUFFICIENT_FUNDS/limit-too-low collision Rain leaves on the wire.
     if (category && CATEGORY_COPY[category]) return CATEGORY_COPY[category]


### PR DESCRIPTION
Pairs with **peanut-api-ts#<push-notifications PR>**. BE drives all four push triggers + the synthetic decline category; this FE PR teaches the receipt drawer to read the new category so the in-app copy matches the push body.

## Why

The card lifecycle has zero push notifications today (other than KYC + 3DS). Users get card-issued events, spend confirmations, declines, and auto-rebalance completions surfaced after the fact — or not at all. This PR (paired with the BE PR) closes that gap and adds nuanced copy for the most-confusing decline case.

## Decline category — the meaty bit

Rain returns \`INSUFFICIENT_FUNDS\` for **both** genuine shortfalls AND limit-too-low cases. A real user hit this: had funds in their smart wallet, but the per-tx \`cardLimit\` was below the spend, the auto-rebalancer didn't have headroom to top up, and Rain reported it as \"insufficient funds\". The misleading copy sent the user to top up funds they already had.

BE now computes a synthetic \`declineCategory\` (\`'limit_too_low' | 'insufficient_balance' | 'other'\`) by comparing the declined amount against the card's \`cardLimit\` AND keying off Rain's raw reason. The category gates both the push body and the receipt drawer copy.

## Files

- \`src/utils/cardDeclineReason.ts\` — \`friendlyDeclineReason(code, category?)\`: prefer category when present, fall back to the raw-code map.
- \`src/components/TransactionDetails/transactionTransformer.ts\` — surface \`declineCategory\` on the typed \`extraDataForDrawer.cardPayment\`.
- \`src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx\` — read either field for visibility + copy.

## Test plan

- [ ] Mock a card-spend intent with \`metadata.declineCategory: 'limit_too_low'\` — receipt drawer shows \"Card limit reached — increase your limit\" regardless of raw \`declineReason\`.
- [ ] Same with \`'insufficient_balance'\` → \"Insufficient balance\".
- [ ] Legacy intent with only \`declineReason: 'INSUFFICIENT_FUNDS'\` (no category) → falls back to \"Insufficient balance\" via the raw-code map.
- [ ] Blocked merchant (\`declineReason: 'blocked_merchant'\`, no category) → \"This merchant isn't supported\" via raw fallback.
- [ ] On staging, trigger a real card decline with a low \`cardLimit\`, confirm the push notification body matches the receipt drawer copy.

## Cross-repo deploy order

BE first (sets the synthetic category + sends the push). Then FE (reads the category). Both are backwards-compatible: legacy intents without the category still render via the raw-code fallback.