### PR TITLE
fix(icons): restore MUI-era 18/16px sizing for Lucide icons in buttons

### DIFF
--- a/src/components/0_Bruddle/Button.tsx
+++ b/src/components/0_Bruddle/Button.tsx
@@ -66,6 +66,12 @@ const buttonSizes: Record<ButtonSize, string> = {
     large: 'btn-large',
 }
 
+const buttonIconSizes: Record<ButtonSize, number> = {
+    small: 16,
+    medium: 16,
+    large: 18,
+}
+
 const buttonShadows: Record<ShadowType, Record<ShadowSize, string>> = {
     primary: {
         '3': 'btn-shadow-primary-3',
@@ -142,11 +148,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             className
         )
 
-        // Match the pre-Lucide visual: the global '.btn svg' rule used to force
-        // 18px in default/large buttons and 16px in small/medium (see tailwind.config.js).
-        // Lucide icons opt out of that rule via 'custom-size', so we recreate the
-        // size table here. Explicit iconSize wins.
-        const resolvedIconSize = iconSize ?? (size === 'small' || size === 'medium' ? 16 : 18)
+        const resolvedIconSize = iconSize ?? (size && buttonIconSizes[size]) ?? 18
 
         const renderIcon = () => {
             if (!icon || loading) return null

--- a/src/components/0_Bruddle/Button.tsx
+++ b/src/components/0_Bruddle/Button.tsx
@@ -142,16 +142,18 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             className
         )
 
+        // Match the pre-Lucide visual: the global '.btn svg' rule used to force
+        // 18px in default/large buttons and 16px in small/medium (see tailwind.config.js).
+        // Lucide icons opt out of that rule via 'custom-size', so we recreate the
+        // size table here. Explicit iconSize wins.
+        const resolvedIconSize = iconSize ?? (size === 'small' || size === 'medium' ? 16 : 18)
+
         const renderIcon = () => {
             if (!icon || loading) return null
             return (
                 <div className={twMerge('flex size-6 items-center justify-center', iconContainerClassName)}>
                     {typeof icon === 'string' ? (
-                        <Icon
-                            size={iconSize}
-                            name={icon as IconName}
-                            className={twMerge(!iconSize && 'min-h-4 min-w-4', iconClassName)}
-                        />
+                        <Icon size={resolvedIconSize} name={icon as IconName} className={iconClassName} />
                     ) : (
                         icon
                     )}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -452,7 +452,12 @@ module.exports = {
                     '@apply w-18 h-12 px-2 text-lg': {},
                 },
                 '.btn-small svg, .btn-medium svg': {
-                    '@apply icon-16': {},
+                    // Legacy MUI-era icons keep the auto 16px sizing; modern Lucide icons
+                    // carry 'custom-size' (set by the Icon wrapper) and manage their own
+                    // width/height via the size prop. Symmetric with the `.btn svg` rule above.
+                    '&:not(.custom-size)': {
+                        '@apply icon-16': {},
+                    },
                 },
                 '.btn-square.btn-small': {
                     '@apply w-8': {},


### PR DESCRIPTION
## Summary
Restores Lucide icon sizing inside buttons to the pre-Lucide MUI baseline (18px in default/large buttons, 16px in small/medium).

## The bug
The Lucide migration (PR #1880-ish, commit 8158a69c2) added \`custom-size\` to every Lucide icon to escape \`.btn svg { @apply icon-18 first:mr-1.5 last:ml-1.5 }\` — that auto-margin was eating SVG width inside flex wrappers (home-page arrows rendering 10×22). Necessary fix, but the side effect: Lucide icons now also escape the **size** half of that rule (and the \`.btn-small svg, .btn-medium svg { @apply icon-16 }\` rule) and render at the \`Icon\` default of 24px.

Visible regression vs prod:
- Default \`.btn\` (h-13): MUI 18px → Lucide 24px (+33%)
- \`.btn-small\` / \`.btn-medium\` (h-8/h-9): MUI 16px → Lucide 24px (+50%)

## The fix
Push the size from \`Button.tsx\` instead of relying on the global CSS rule:
- \`resolvedIconSize = iconSize ?? (size === 'small' || size === 'medium' ? 16 : 18)\`
- Drop the \`min-h-4 min-w-4\` floor (size is now always explicit; floor was a leftover)
- Add \`:not(.custom-size)\` to the \`.btn-small svg, .btn-medium svg\` rule (symmetric with the \`.btn svg\` rule above it — keeps legacy MUI behavior, gives explicit Lucide \`size={N}\` precedence)

\`custom-size\` stays — the auto-margin bug it fixes is unrelated to size.

## Test plan
- [x] \`pnpm test\` — 947/947 pass
- [x] Local dev: \`/dev/components#buttons\` — Share/Copy default buttons measure 18×18 (was 24×24 on dev tip)
- [ ] QA: spot-check icon-bearing buttons across the app (home action grid, send-money CTAs, NavHeader back button, small/medium dialog buttons)
- [ ] No regression on the home-page arrow bug (\`<Icon name="arrow-up-right">\` inside size-22 flex wrapper) — \`custom-size\` is preserved

## Risk
Low. Only affects buttons whose \`icon\` prop is passed and \`iconSize\` is **not** explicitly set. Explicit \`iconSize\` callers keep their current sizes.