### PR TITLE
fix(icons): pass explicit size to Lucide icons rendered as Button children

### DIFF
--- a/src/app/(mobile-ui)/home/page.tsx
+++ b/src/app/(mobile-ui)/home/page.tsx
@@ -385,31 +385,18 @@ function ActionButtonWithHref({ label, action, href, variant = 'primary-soft', s
 
 function ActionButton({ label, action, variant = 'primary-soft', size = 'small' }: Omit<ActionButtonProps, 'href'>) {
     const renderIcon = (): React.ReactNode => {
-        return (
-            <div
-                className={twMerge(
-                    'flex items-center justify-center',
-                    size === 'small'
-                        ? 'size-[22px] md:size-[23px]' // Add/Withdraw size
-                        : 'size-[22px] md:size-[23px]' // Send/Request size
-                )}
-            >
-                {(() => {
-                    switch (action) {
-                        case 'send':
-                            return <Icon name="arrow-up-right" className="h-full w-full" fill="currentColor" />
-                        case 'withdraw':
-                            return <Icon name="arrow-up" className="h-full w-full" fill="currentColor" />
-                        case 'add':
-                            return <Icon name="arrow-down" className="h-full w-full" fill="currentColor" />
-                        case 'request':
-                            return <Icon name="arrow-down-left" className="h-full w-full" fill="currentColor" />
-                        default:
-                            return null
-                    }
-                })()}
-            </div>
-        )
+        switch (action) {
+            case 'send':
+                return <Icon name="arrow-up-right" size={18} fill="currentColor" />
+            case 'withdraw':
+                return <Icon name="arrow-up" size={18} fill="currentColor" />
+            case 'add':
+                return <Icon name="arrow-down" size={18} fill="currentColor" />
+            case 'request':
+                return <Icon name="arrow-down-left" size={18} fill="currentColor" />
+            default:
+                return null
+        }
     }
 
     return (

--- a/src/app/(mobile-ui)/home/page.tsx
+++ b/src/app/(mobile-ui)/home/page.tsx
@@ -356,11 +356,7 @@ function WalletBalance({
 
             {!isFetchingBalance && (
                 <button onClick={onToggleBalanceVisibility}>
-                    <Icon
-                        name={isBalanceHidden ? 'eye-slash' : 'eye'}
-                        className={'h-8 w-8 md:h-10 md:w-10'}
-                        fill={'black'}
-                    />
+                    <Icon name={isBalanceHidden ? 'eye-slash' : 'eye'} size={24} fill={'black'} />
                 </button> // no balance <> no icon
             )}
         </div>

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -935,7 +935,7 @@ export default function QRPayPage() {
             <div className="my-auto flex h-full w-full flex-col justify-center space-y-4">
                 <Card className="flex w-full flex-col items-center gap-2 p-4">
                     <div className="flex h-12 w-12 items-center justify-center rounded-full bg-secondary-1 p-3">
-                        <Icon name="alert" className="h-full" />
+                        <Icon name="alert" size={24} />
                     </div>
                     <span className="text-lg font-bold">Service Temporarily Unavailable</span>
                     <p className="text-center font-normal text-grey-1">
@@ -962,7 +962,7 @@ export default function QRPayPage() {
             <div className="my-auto flex h-full flex-col justify-center space-y-4">
                 <Card className="relative z-10 flex w-full flex-col items-center gap-4 p-4">
                     <div className="flex h-12 w-12 items-center justify-center rounded-full bg-secondary-1 p-3">
-                        <Icon name="alert" className="h-full" />
+                        <Icon name="alert" size={24} />
                     </div>
                     <p className="font-medium">
                         {' '}
@@ -989,7 +989,7 @@ export default function QRPayPage() {
             <div className="my-auto flex h-full w-full flex-col justify-center space-y-4">
                 <Card className="flex w-full flex-col items-center gap-2 p-4">
                     <div className="flex h-12 w-12 items-center justify-center rounded-full bg-secondary-1 p-3">
-                        <Icon name="qr-code" className="h-full" />
+                        <Icon name="qr-code" size={24} />
                     </div>
                     <span className="text-lg font-bold">We couldn't get the amount</span>
                     <p className="max-w-52 text-center font-normal text-grey-1">
@@ -1393,7 +1393,7 @@ const QrPayPageLoading = ({ message }: { message: string }) => {
 
                 <Card className="relative z-10 flex w-full flex-col items-center gap-4 p-4">
                     <div className="flex h-12 w-12 items-center justify-center rounded-full bg-secondary-1 p-3">
-                        <Icon name="clock" className="h-full" />
+                        <Icon name="clock" size={24} />
                     </div>
                     <p className="font-medium">{message}</p>
                 </Card>

--- a/src/components/ActionListCard/index.tsx
+++ b/src/components/ActionListCard/index.tsx
@@ -69,7 +69,7 @@ export const ActionListCard = ({
                         className="h-6 w-6 rounded-full p-0 shadow-[0.12rem_0.12rem_0_#000000]"
                     >
                         <div className="flex size-7 items-center justify-center">
-                            <Icon name="chevron-up" className="h-9 rotate-90" />
+                            <Icon name="chevron-up" size={24} className="rotate-90" />
                         </div>
                     </Button>
                 )}

--- a/src/components/AddMoney/views/CryptoDeposit.view.tsx
+++ b/src/components/AddMoney/views/CryptoDeposit.view.tsx
@@ -180,7 +180,7 @@ const CryptoDepositView = ({ network, depositAddressData, isLoading, onSuccess, 
                                             className="ml-auto h-6 w-6 flex-shrink-0 rounded-full p-0 shadow-[0.12rem_0.12rem_0_#000000]"
                                         >
                                             <div className="flex size-7 items-center justify-center">
-                                                <Icon name="chevron-up" className="h-9 rotate-90" />
+                                                <Icon name="chevron-up" size={24} className="rotate-90" />
                                             </div>
                                         </Button>
                                     )}

--- a/src/components/Badges/BadgesRow.tsx
+++ b/src/components/Badges/BadgesRow.tsx
@@ -135,7 +135,7 @@ const BadgesRow = ({ badges, className, isSelfProfile = true }: BadgesRowProps) 
                             onClick={scrollRight}
                             aria-label="Show next badges"
                         >
-                            <Icon name="chevron-up" className="h-9 rotate-90" />
+                            <Icon name="chevron-up" size={24} className="rotate-90" />
                         </Button>
                     </div>
                 )}
@@ -149,7 +149,7 @@ const BadgesRow = ({ badges, className, isSelfProfile = true }: BadgesRowProps) 
                             onClick={scrollLeft}
                             aria-label="Show previous badges"
                         >
-                            <Icon name="chevron-up" className="h-9 -rotate-90" />
+                            <Icon name="chevron-up" size={24} className="-rotate-90" />
                         </Button>
                     </div>
                 )}

--- a/src/components/Card/CardPurchaseScreen.tsx
+++ b/src/components/Card/CardPurchaseScreen.tsx
@@ -116,7 +116,7 @@ const CardPurchaseScreen = ({
                     <>
                         <Card className="flex flex-col items-center gap-4 p-6">
                             <div className="flex size-16 items-center justify-center rounded-full bg-purple-1">
-                                <Icon name="wallet" size={32} />
+                                <Icon name="wallet" size={24} />
                             </div>
                             <div className="text-center">
                                 <h2 className="text-xl font-bold">Confirm Purchase</h2>
@@ -151,7 +151,7 @@ const CardPurchaseScreen = ({
                     <>
                         <Card className="flex flex-col items-center gap-4 p-6">
                             <div className="flex size-16 items-center justify-center rounded-full bg-yellow-1">
-                                <Icon name="clock" size={32} />
+                                <Icon name="clock" size={24} />
                             </div>
                             <div className="text-center">
                                 <h2 className="text-xl font-bold">Complete Payment</h2>
@@ -181,7 +181,7 @@ const CardPurchaseScreen = ({
                 {purchaseState === 'error' && (
                     <Card className="flex flex-col items-center gap-4 p-6">
                         <div className="flex size-16 items-center justify-center rounded-full bg-error-1">
-                            <Icon name="cancel" size={32} />
+                            <Icon name="cancel" size={24} />
                         </div>
                         <div className="text-center">
                             <h2 className="text-xl font-bold">Something Went Wrong</h2>

--- a/src/components/Global/BalanceWarningModal/index.tsx
+++ b/src/components/Global/BalanceWarningModal/index.tsx
@@ -95,7 +95,7 @@ export default function BalanceWarningModal({ visible, onCloseAction }: BalanceW
         >
             <div className="flex w-full flex-col items-center justify-center gap-6 p-6 text-center">
                 <div className="flex size-16 items-center justify-center rounded-full bg-yellow-400">
-                    <Icon name="alert" className="size-8" />
+                    <Icon name="alert" size={24} />
                 </div>
 
                 <div className="space-y-4">

--- a/src/components/Global/FlowHeader/index.tsx
+++ b/src/components/Global/FlowHeader/index.tsx
@@ -14,7 +14,7 @@ const FlowHeader = ({ onPrev, disableBackBtn, rightElement }: FlowHeaderProps) =
             <div className="w-fit">
                 {onPrev && (
                     <Button variant="stroke" className="h-7 w-7 p-0" onClick={onPrev} disabled={disableBackBtn}>
-                        <Icon name="chevron-up" size={32} className="h-8 w-8 -rotate-90" />
+                        <Icon name="chevron-up" size={24} className="-rotate-90" />
                     </Button>
                 )}
             </div>

--- a/src/components/Global/Icons/Icon.tsx
+++ b/src/components/Global/Icons/Icon.tsx
@@ -300,6 +300,28 @@ const iconComponents: Record<IconName, ComponentType<SVGProps<SVGSVGElement>>> =
     trash: (props) => <LucideWrapper Icon={Trash2} {...props} />,
 }
 
+// MUI → Lucide sizing legacy.
+//
+// Pre-migration, every <Icon> was a MUI SvgIcon. MUI emotion-injects
+//   .MuiSvgIcon-root { width: 1em; height: 1em }
+//   .MuiSvgIcon-fontSizeMedium { font-size: 1.5rem }
+// at runtime, after Tailwind's static stylesheet. Same specificity, later
+// in the cascade → MUI's rules silently clamped every icon to 24×24
+// regardless of `h-X w-X` / `size-X` / `size={N>24}` written at the call
+// site. Lucide ships no such clamp, so call sites that wrote h-8 / h-12 /
+// size={32} suddenly render at their stated size — visibly bigger than prod.
+//
+// Convention going forward (locked in by the 2026-05-12 audit):
+//   - The default `size = 24` here matches the old MUI clamp ceiling.
+//   - Call sites that need a different size pass `size={N}` explicitly.
+//   - Don't reintroduce Tailwind `h-X w-X` to size icons — pass `size` so
+//     the rendered width/height attrs and the visual size agree, and the
+//     sizing is local to the call site rather than dependent on a global
+//     CSS rule.
+//   - Open question for a later pass: are there icons we *want* larger
+//     than MUI's old 24px ceiling? Right now we standardise on 24 for
+//     parity with prod; the design call to upsize specific icons (eye,
+//     back chevrons, etc) can come later. See PR #1972 for the audit.
 export const Icon: FC<IconProps> = ({ name, size = 24, width, height, className, ...props }) => {
     const IconComponent = iconComponents[name]
 

--- a/src/components/Global/InvitesGraph/index.tsx
+++ b/src/components/Global/InvitesGraph/index.tsx
@@ -2015,7 +2015,7 @@ export default function InvitesGraph(props: InvitesGraphProps) {
         return (
             <div className="flex flex-1 items-center justify-center">
                 <div className="flex items-center gap-3">
-                    <Icon name="pending" size={32} className="animate-spin text-purple-600" />
+                    <Icon name="pending" size={24} className="animate-spin text-purple-600" />
                     <span className="text-lg font-medium text-gray-700">Loading network...</span>
                 </div>
             </div>

--- a/src/components/Global/NavHeader/index.tsx
+++ b/src/components/Global/NavHeader/index.tsx
@@ -35,8 +35,8 @@ const NavHeader = ({
                     <Button variant="stroke" className="h-7 w-7 p-0">
                         <Icon
                             name={icon}
-                            size={32}
-                            className={twMerge('h-8 w-8', icon === 'chevron-up' && ' -rotate-90')}
+                            size={24}
+                            className={twMerge(icon === 'chevron-up' && '-rotate-90') || undefined}
                         />
                     </Button>
                 </Link>
@@ -44,8 +44,8 @@ const NavHeader = ({
                 <Button variant="stroke" className="h-7 w-7 p-0" onClick={onPrev} disabled={disableBackBtn}>
                     <Icon
                         name={icon}
-                        size={32}
-                        className={twMerge('h-8 w-8', icon === 'chevron-up' && ' -rotate-90')}
+                        size={24}
+                        className={twMerge(icon === 'chevron-up' && '-rotate-90') || undefined}
                     />
                 </Button>
             )}

--- a/src/components/Global/QRScanner/index.tsx
+++ b/src/components/Global/QRScanner/index.tsx
@@ -74,7 +74,7 @@ function ScannerControls({ onClose, onToggleCamera }: { onClose: () => void; onT
                 className="border-1 mx-auto flex h-8 w-8 items-center justify-center border-white p-0"
                 onClick={onClose}
             >
-                <Icon name="cancel" fill="white" />
+                <Icon name="cancel" size={18} fill="white" />
             </Button>
             <span className="text-3xl font-extrabold">Scan to pay</span>
             <Button

--- a/src/components/Global/ShareButton/index.tsx
+++ b/src/components/Global/ShareButton/index.tsx
@@ -120,9 +120,9 @@ const ShareButton = ({
             shadowSize="4"
         >
             <span className="flex items-center gap-2">
-                {showIcon && iconPosition === 'left' && <Icon name="share" />}
+                {showIcon && iconPosition === 'left' && <Icon name="share" size={18} />}
                 {children}
-                {showIcon && iconPosition === 'right' && <Icon name="share" />}
+                {showIcon && iconPosition === 'right' && <Icon name="share" size={18} />}
             </span>
         </Button>
     )

--- a/src/components/Global/SuccessViewComponents/SuccessViewDetailsCard.tsx
+++ b/src/components/Global/SuccessViewComponents/SuccessViewDetailsCard.tsx
@@ -24,7 +24,7 @@ export const SuccessViewDetailsCard: React.FC<SuccessViewDetailsCardProps> = ({
                     <div
                         className={`flex h-14 w-14 min-w-14 items-center justify-center rounded-full bg-secondary-7 font-bold`}
                     >
-                        <Icon name="link" size={32} className="text-white" />
+                        <Icon name="link" size={24} className="text-white" />
                     </div>
                     <div className="space-y-1">
                         <h1 className="text-lg font-bold">{title}</h1>

--- a/src/components/Global/TokenSelector/Components/TokenListItem.tsx
+++ b/src/components/Global/TokenSelector/Components/TokenListItem.tsx
@@ -132,7 +132,7 @@ const TokenListItem: React.FC<TokenListItemProps> = ({
                         </div>
                     ) : (
                         (isEnabled || isPopularToken) && (
-                            <Icon name="chevron-up" size={32} className="h-8 w-8 flex-shrink-0 rotate-90 text-black" />
+                            <Icon name="chevron-up" size={24} className="flex-shrink-0 rotate-90 text-black" />
                         )
                     )}
                 </div>

--- a/src/components/Global/TokenSelector/TokenSelector.tsx
+++ b/src/components/Global/TokenSelector/TokenSelector.tsx
@@ -374,7 +374,7 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
                                 )}
                         </div>
                     </div>
-                    <Icon name="chevron-up" size={32} className="h-8 w-8 flex-shrink-0 rotate-90 text-black" />
+                    <Icon name="chevron-up" size={24} className="flex-shrink-0 rotate-90 text-black" />
                 </div>
             </Button>
 

--- a/src/components/Home/PerkClaimModal.tsx
+++ b/src/components/Home/PerkClaimModal.tsx
@@ -394,7 +394,7 @@ function GiftBoxContent({ perk, onHoldComplete, claimPhase }: GiftBoxContentProp
                             <div
                                 className={`rounded-full bg-primary-1 p-3 shadow-lg transition-transform ${holdProgress > 30 ? 'animate-bounce' : ''}`}
                             >
-                                <Icon name="gift" size={28} className="text-white" />
+                                <Icon name="gift" size={24} className="text-white" />
                             </div>
                         </div>
                     </div>

--- a/src/components/Kyc/SumsubKycWrapper.tsx
+++ b/src/components/Kyc/SumsubKycWrapper.tsx
@@ -341,7 +341,7 @@ export const SumsubKycWrapper = ({
                     />
                 ) : sdkLoadError ? (
                     <div className="flex h-full flex-col items-center justify-center gap-4 p-8">
-                        <Icon name="alert" className="text-red-500 h-12 w-12" />
+                        <Icon name="alert" size={24} className="text-red-500" />
                         <p className="text-center text-lg font-medium">
                             Failed to load verification. Please check your connection and try again.
                         </p>

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -699,7 +699,7 @@ export const TransactionDetailsReceipt = ({
                         shadowSize="4"
                         className="flex w-full items-center gap-1"
                     >
-                        <Icon name="currency" />
+                        <Icon name="currency" size={18} />
                         Pay
                     </Button>
                     <Button


### PR DESCRIPTION
## Why
PR #1971 fixed icon sizing via the \`Button.icon=\` prop path, but call sites that render \`<Icon>\` as **children** of \`<Button>\` bypass that path entirely. Under MUI they were clamped to 18px by the global \`.btn svg { @apply icon-18 !important }\` rule; Lucide icons escape that rule via \`custom-size\` and fall back to \`Icon\`'s 24px default. Visible regression on the home page (Add/Withdraw/Send/Request) and a few other spots.

## Holistic audit

226 \`<Icon>\` render sites across \`src/\`. Categorized by sizing pattern:

| Pattern | Count | Regression risk |
|---|---|---|
| Explicit \`size={N}\` | ~170 | None |
| Explicit \`h-X w-X\` / \`size-X\` className | ~43 | None |
| **\`<Icon>\` in \`<Button>\` as child, no size** | **4** | **Regressed (18→24)** |
| \`<Icon>\` outside any button, no size | 1 | None (default was always 24) |

Plus the home page action buttons, which used \`size-[22px]\` wrapper + \`h-full w-full\` Icon className — under MUI the \`.btn svg\` \`!important\` clamped them to 18px regardless; under Lucide they render at the wrapper's full 22-23px.

**Verified from live DOM measurement** (peanut.me/home vs localhost:3050/home):

| Button | Prod (MUI) | Dev tip (Lucide) |
|---|---|---|
| Add | 18×18 | 23×23 |
| Withdraw | 18×18 | 23×23 |
| Send | 18×18 | 23×23 |
| Request | 18×18 | 23×23 |

## Fixes

Pass explicit \`size={18}\` to every icon that was relying on the global rule:

- \`src/app/(mobile-ui)/home/page.tsx\` — drop the wrapper div + \`h-full w-full\` pattern entirely. Also collapses the \`size === 'small' ? 'size-[22px]' : 'size-[22px]'\` ternary that was a pre-existing copy-paste bug (both branches identical despite the comments saying they should differ).
- \`src/components/TransactionDetails/TransactionDetailsReceipt.tsx:702\` — \`<Icon name=\"currency\" size={18} />\`
- \`src/components/Global/ShareButton/index.tsx:123,125\` — \`<Icon name=\"share\" size={18} />\`
- \`src/components/Global/QRScanner/index.tsx:77\` — \`<Icon name=\"cancel\" size={18} fill=\"white\" />\`

Net: +16 / -29 lines.

## Why \`size={18}\` and not something proportional

Matches prod exactly. The home page wrapper code had comments suggesting the small/large branches should differ but the values were identical — fixing that intent is a separate design call. This PR restores parity first.

## Test plan
- [x] \`pnpm test\` — 950/950 pass
- [ ] QA: visual check on \`/home\` (Add/Withdraw/Send/Request) — icons should match peanut.me prod
- [ ] QA: transaction details \"Pay\" button, ShareButton everywhere, QR scanner close button

## Follow-ups (out of scope)
- Consider an ESLint rule banning \`<Icon>\` without explicit \`size\` inside \`<Button>\` to prevent future regressions of this class.
- Investigate the optical-weight differences (Lucide stroke vs MUI fill) — separate visual-design concern.