### PR TITLE
fix(receipt): post-decomplexify entry-type gates (sendlink QR/Cancel, request CTAs, onramp deposit rows)

### DIFF
--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -5,7 +5,7 @@ import TransactionAvatarBadge from '@/components/TransactionDetails/TransactionA
 import { getBankAccountCountryCode } from '@/constants/countryCurrencyMapping'
 import { type TransactionDirection } from '@/components/TransactionDetails/TransactionDetailsHeaderCard'
 import { type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
-import { isCardPaymentEntry } from '@/components/TransactionDetails/transaction-predicates'
+import { isCardPaymentEntry, isPerkReward } from '@/components/TransactionDetails/transaction-predicates'
 import { useTransactionDetailsDrawer } from '@/hooks/useTransactionDetailsDrawer'
 import {
     formatNumberForDisplay,
@@ -21,7 +21,6 @@ import Image from 'next/image'
 import StatusPill, { type StatusPillType } from '../Global/StatusPill'
 import { VerifiedUserLabel } from '../UserHeader'
 import { isAddress } from 'viem'
-import { EHistoryEntryType } from '@/utils/history.utils'
 import { PerkIcon } from './PerkIcon'
 import { useHaptic } from 'use-haptic'
 import LazyLoadErrorBoundary from '@/components/Global/LazyLoadErrorBoundary'
@@ -96,7 +95,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
     }
 
     const isLinkTx = transaction.extraDataForDrawer?.isLinkTransaction ?? false
-    const isPerkReward = transaction.extraDataForDrawer?.originalType === EHistoryEntryType.PERK_REWARD
+    const isPerkRewardEntry = isPerkReward(transaction)
     // respect user's showFullName preference: use fullName only if showFullName is true, otherwise use username
     const userNameForAvatar =
         transaction.showFullName && transaction.fullName ? transaction.fullName : transaction.userName
@@ -184,7 +183,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
                                     height={30}
                                 />
                             </div>
-                        ) : isPerkReward ? (
+                        ) : isPerkRewardEntry ? (
                             <>
                                 <PerkIcon size="extra-small" />
                             </>
@@ -231,7 +230,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
                                 <span className="capitalize">
                                     {isTestTransaction
                                         ? 'Setup'
-                                        : isPerkReward
+                                        : isPerkRewardEntry
                                           ? 'Reward'
                                           : getActionText(type, status)}
                                 </span>

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -45,7 +45,12 @@ import { useModalsContext } from '@/context/ModalsContext'
 import { useRouter } from 'next/navigation'
 import { getBankAccountCountryCode } from '@/constants/countryCurrencyMapping'
 import { useToast } from '@/components/0_Bruddle/Toast'
-import { isPerkReward as isPerkRewardTransaction, usesCompletedTimestampLabel } from './transaction-predicates'
+import {
+    isPerkReward as isPerkRewardTransaction,
+    isRequestEntry,
+    isSendLinkEntry,
+    usesCompletedTimestampLabel,
+} from './transaction-predicates'
 import { useReceiptViewModel } from './useReceiptViewModel'
 import { CardPaymentRows } from './provider-rows/CardPaymentRows'
 import { MantecaDepositInfo } from './provider-rows/MantecaDepositInfo'
@@ -217,14 +222,16 @@ export const TransactionDetailsReceipt = ({
 
     const feeDisplay = transaction.fee !== undefined ? formatAmount(transaction.fee as number) : 'N/A'
 
-    // determine if the qr code and sharing section should be shown
-    // conditions: status is pending, there's a link, and it's a send_link/request sent by the user, or a request received by the user.
+    // QR + Share + Cancel block: pending, has a link, and either the sender of
+    // a send-link OR the recipient of a request. Routed through the entry-type
+    // predicates so post-decomplexify rows (TRANSACTION_INTENT + kind=LINK_CREATE
+    // / REQUEST_PAY) are recognised alongside the legacy originalType values.
     const shouldShowQrShare =
         transaction.status === 'pending' &&
-        transaction.extraDataForDrawer?.link &&
-        ((transaction.extraDataForDrawer.originalType === EHistoryEntryType.SEND_LINK &&
+        !!transaction.extraDataForDrawer?.link &&
+        ((isSendLinkEntry(transaction) &&
             transaction.extraDataForDrawer.originalUserRole === EHistoryUserRole.SENDER) ||
-            (transaction.extraDataForDrawer.originalType === EHistoryEntryType.REQUEST &&
+            (isRequestEntry(transaction) &&
                 transaction.extraDataForDrawer.originalUserRole === EHistoryUserRole.RECIPIENT))
 
     const getLabelText = (transaction: TransactionDetails) => {
@@ -638,8 +645,7 @@ export const TransactionDetailsReceipt = ({
                         Share Link
                     </ShareButton>
                     {/* show cancel button only if the current user sent the link/request */}
-                    {(transaction.extraDataForDrawer.originalType === EHistoryEntryType.SEND_LINK ||
-                        transaction.extraDataForDrawer.originalType === EHistoryEntryType.REQUEST) &&
+                    {(isSendLinkEntry(transaction) || isRequestEntry(transaction)) &&
                         transaction.extraDataForDrawer.originalUserRole === EHistoryUserRole.SENDER &&
                         setIsLoading &&
                         onClose && (

--- a/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
+++ b/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
@@ -14,19 +14,25 @@ import type { TransactionDetails } from '../transactionTransformer'
 jest.mock('@/assets', () => ({}))
 jest.mock('@/assets/payment-apps', () => ({ MERCADO_PAGO: '', PIX: '', SIMPLEFI: '' }))
 
-const tx = (originalType: string, kind?: string): TransactionDetails =>
+const tx = (originalType: string, kind?: string, extra?: Record<string, unknown>): TransactionDetails =>
     ({
-        extraDataForDrawer: { originalType, ...(kind ? { kind } : {}) },
+        extraDataForDrawer: { originalType, ...(kind ? { kind } : {}), ...(extra ?? {}) },
     }) as unknown as TransactionDetails
 
 // Source of truth: the BE's `toLegacyKindLabel` in
 // peanut-api-ts/src/ledger/card-spend.ts. If either side changes, update both
 // the predicate AND this table — that's the contract the predicate enforces.
+//
+// `requiresProvider` is set for predicates that need positive-identity beyond
+// kind alone. Only Manteca's onramp does today — Bridge + Manteca share the
+// FIAT_ONRAMP wire kind so the predicate uses the `provider` field
+// (peanut-api-ts#739 plumbs this through every projector) to disambiguate.
 const WIRE_SHAPES: Array<{
     predicate: (t: TransactionDetails) => boolean
     legacyTypes: string[]
     intentKind: string
     name: string
+    requiresProvider?: string
 }> = [
     { predicate: isSendLinkEntry, legacyTypes: ['SEND_LINK'], intentKind: 'LINK_CREATE', name: 'isSendLinkEntry' },
     { predicate: isRequestEntry, legacyTypes: ['REQUEST'], intentKind: 'REQUEST_PAY', name: 'isRequestEntry' },
@@ -41,29 +47,49 @@ const WIRE_SHAPES: Array<{
         legacyTypes: ['MANTECA_ONRAMP'],
         intentKind: 'FIAT_ONRAMP',
         name: 'isMantecaOnrampEntry',
+        requiresProvider: 'MANTECA',
     },
     { predicate: isDirectSendEntry, legacyTypes: ['DIRECT_SEND'], intentKind: 'P2P_SEND', name: 'isDirectSendEntry' },
 ]
 
 describe('entry-type predicates — legacy + TRANSACTION_INTENT dual shape', () => {
-    for (const { predicate, legacyTypes, intentKind, name } of WIRE_SHAPES) {
+    for (const { predicate, legacyTypes, intentKind, name, requiresProvider } of WIRE_SHAPES) {
+        const intentExtra = requiresProvider ? { provider: requiresProvider } : undefined
+
         for (const legacy of legacyTypes) {
             test(`${name} matches legacy ${legacy}`, () => {
                 expect(predicate(tx(legacy))).toBe(true)
             })
         }
 
-        test(`${name} matches TRANSACTION_INTENT + kind=${intentKind}`, () => {
-            expect(predicate(tx('TRANSACTION_INTENT', intentKind))).toBe(true)
+        test(`${name} matches TRANSACTION_INTENT + kind=${intentKind}${requiresProvider ? ` + provider=${requiresProvider}` : ''}`, () => {
+            expect(predicate(tx('TRANSACTION_INTENT', intentKind, intentExtra))).toBe(true)
         })
 
         test(`${name} does NOT match TRANSACTION_INTENT with a different kind`, () => {
-            expect(predicate(tx('TRANSACTION_INTENT', 'SOME_OTHER_KIND'))).toBe(false)
+            expect(predicate(tx('TRANSACTION_INTENT', 'SOME_OTHER_KIND', intentExtra))).toBe(false)
         })
 
         test(`${name} does NOT match an unrelated legacy type`, () => {
             expect(predicate(tx('UNRELATED_TYPE'))).toBe(false)
         })
+
+        if (requiresProvider) {
+            test(`${name} does NOT match TRANSACTION_INTENT + correct kind with a DIFFERENT provider`, () => {
+                // The smell this PR kills: predicates were inferring identity
+                // from field absence. Lock that this predicate now rejects a
+                // TI row that has the right kind but the wrong provider —
+                // forcing a positive-identity check rather than negative.
+                expect(predicate(tx('TRANSACTION_INTENT', intentKind, { provider: 'BRIDGE' }))).toBe(false)
+            })
+
+            test(`${name} does NOT match TRANSACTION_INTENT + correct kind without ANY provider`, () => {
+                // Defensive: before peanut-api-ts#739 ships everywhere, a TI
+                // row may arrive without provider. The predicate must NOT
+                // light up on absence — that would re-introduce the smell.
+                expect(predicate(tx('TRANSACTION_INTENT', intentKind))).toBe(false)
+            })
+        }
     }
 
     // Regression: until this PR, the dual-shape onramp checks in

--- a/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
+++ b/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
@@ -1,0 +1,86 @@
+// Locks the legacy / TRANSACTION_INTENT dual-shape predicates so adding a new
+// flow only needs to extend the predicate, not grep the whole receipt for
+// `originalType === EHistoryEntryType.X` chains. If you're tempted to inline
+// such a check elsewhere — write a predicate here instead and lock it below.
+import {
+    isDirectSendEntry,
+    isMantecaOnrampEntry,
+    isOnrampEntry,
+    isRequestEntry,
+    isSendLinkEntry,
+} from '../transaction-predicates'
+import type { TransactionDetails } from '../transactionTransformer'
+
+jest.mock('@/assets', () => ({}))
+jest.mock('@/assets/payment-apps', () => ({ MERCADO_PAGO: '', PIX: '', SIMPLEFI: '' }))
+
+const tx = (originalType: string, kind?: string): TransactionDetails =>
+    ({
+        extraDataForDrawer: { originalType, ...(kind ? { kind } : {}) },
+    }) as unknown as TransactionDetails
+
+// Source of truth: the BE's `toLegacyKindLabel` in
+// peanut-api-ts/src/ledger/card-spend.ts. If either side changes, update both
+// the predicate AND this table — that's the contract the predicate enforces.
+const WIRE_SHAPES: Array<{
+    predicate: (t: TransactionDetails) => boolean
+    legacyTypes: string[]
+    intentKind: string
+    name: string
+}> = [
+    { predicate: isSendLinkEntry, legacyTypes: ['SEND_LINK'], intentKind: 'LINK_CREATE', name: 'isSendLinkEntry' },
+    { predicate: isRequestEntry, legacyTypes: ['REQUEST'], intentKind: 'REQUEST_PAY', name: 'isRequestEntry' },
+    {
+        predicate: isOnrampEntry,
+        legacyTypes: ['BRIDGE_ONRAMP', 'MANTECA_ONRAMP'],
+        intentKind: 'FIAT_ONRAMP',
+        name: 'isOnrampEntry',
+    },
+    {
+        predicate: isMantecaOnrampEntry,
+        legacyTypes: ['MANTECA_ONRAMP'],
+        intentKind: 'FIAT_ONRAMP',
+        name: 'isMantecaOnrampEntry',
+    },
+    { predicate: isDirectSendEntry, legacyTypes: ['DIRECT_SEND'], intentKind: 'P2P_SEND', name: 'isDirectSendEntry' },
+]
+
+describe('entry-type predicates — legacy + TRANSACTION_INTENT dual shape', () => {
+    for (const { predicate, legacyTypes, intentKind, name } of WIRE_SHAPES) {
+        for (const legacy of legacyTypes) {
+            test(`${name} matches legacy ${legacy}`, () => {
+                expect(predicate(tx(legacy))).toBe(true)
+            })
+        }
+
+        test(`${name} matches TRANSACTION_INTENT + kind=${intentKind}`, () => {
+            expect(predicate(tx('TRANSACTION_INTENT', intentKind))).toBe(true)
+        })
+
+        test(`${name} does NOT match TRANSACTION_INTENT with a different kind`, () => {
+            expect(predicate(tx('TRANSACTION_INTENT', 'SOME_OTHER_KIND'))).toBe(false)
+        })
+
+        test(`${name} does NOT match an unrelated legacy type`, () => {
+            expect(predicate(tx('UNRELATED_TYPE'))).toBe(false)
+        })
+    }
+
+    // Regression: until this PR, the dual-shape onramp checks in
+    // useReceiptViewModel used `kind === 'ONRAMP'` literally — but the BE's
+    // toLegacyKindLabel renames TransactionIntentKind.ONRAMP → 'FIAT_ONRAMP',
+    // so every post-decomplexify onramp silently fell through the gate. Lock
+    // the correct kind string so a future copy-paste doesn't re-introduce it.
+    test('isOnrampEntry uses FIAT_ONRAMP, not raw ONRAMP', () => {
+        expect(isOnrampEntry(tx('TRANSACTION_INTENT', 'ONRAMP'))).toBe(false)
+        expect(isOnrampEntry(tx('TRANSACTION_INTENT', 'FIAT_ONRAMP'))).toBe(true)
+    })
+
+    // The cancel-by-sender SEND_LINK_CLAIM intent is also rendered as
+    // wire-kind LINK_CREATE (per toLegacyKindLabel collapsing SEND_LINK +
+    // SEND_LINK_CLAIM). isSendLinkEntry returns true for it — that's how
+    // the receipt-field exemption fires for "sender cancelled their own link".
+    test('isSendLinkEntry matches the SEND_LINK_CLAIM cancel-by-sender row (rendered as LINK_CREATE)', () => {
+        expect(isSendLinkEntry(tx('TRANSACTION_INTENT', 'LINK_CREATE'))).toBe(true)
+    })
+})

--- a/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
+++ b/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
@@ -36,12 +36,8 @@ const WIRE_SHAPES: Array<{
 }> = [
     { predicate: isSendLinkEntry, legacyTypes: ['SEND_LINK'], intentKind: 'LINK_CREATE', name: 'isSendLinkEntry' },
     { predicate: isRequestEntry, legacyTypes: ['REQUEST'], intentKind: 'REQUEST_PAY', name: 'isRequestEntry' },
-    {
-        predicate: isOnrampEntry,
-        legacyTypes: ['BRIDGE_ONRAMP', 'MANTECA_ONRAMP'],
-        intentKind: 'FIAT_ONRAMP',
-        name: 'isOnrampEntry',
-    },
+    // isOnrampEntry is legacy-only by design — see the predicate's docstring.
+    // Tested below outside the parameterised table.
     {
         predicate: isMantecaOnrampEntry,
         legacyTypes: ['MANTECA_ONRAMP'],
@@ -92,14 +88,23 @@ describe('entry-type predicates — legacy + TRANSACTION_INTENT dual shape', () 
         }
     }
 
-    // Regression: until this PR, the dual-shape onramp checks in
-    // useReceiptViewModel used `kind === 'ONRAMP'` literally — but the BE's
-    // toLegacyKindLabel renames TransactionIntentKind.ONRAMP → 'FIAT_ONRAMP',
-    // so every post-decomplexify onramp silently fell through the gate. Lock
-    // the correct kind string so a future copy-paste doesn't re-introduce it.
-    test('isOnrampEntry uses FIAT_ONRAMP, not raw ONRAMP', () => {
-        expect(isOnrampEntry(tx('TRANSACTION_INTENT', 'ONRAMP'))).toBe(false)
-        expect(isOnrampEntry(tx('TRANSACTION_INTENT', 'FIAT_ONRAMP'))).toBe(true)
+    test('isOnrampEntry matches legacy BRIDGE_ONRAMP', () => {
+        expect(isOnrampEntry(tx('BRIDGE_ONRAMP'))).toBe(true)
+    })
+
+    test('isOnrampEntry matches legacy MANTECA_ONRAMP', () => {
+        expect(isOnrampEntry(tx('MANTECA_ONRAMP'))).toBe(true)
+    })
+
+    // Legacy-only: BridgeHistoryFetcher / MantecaHistoryFetcher are
+    // unconditional gateways for onramp intents on the BE, so a TI-shape
+    // onramp can't reach the FE. The TI branch was removed to avoid
+    // dead-code; lock that here. (isMantecaOnrampEntry still has its own TI
+    // branch for the narrow mantecaUser-lookup-fails edge case.)
+    test('isOnrampEntry does NOT match TRANSACTION_INTENT + FIAT_ONRAMP (dead-code path removed)', () => {
+        expect(isOnrampEntry(tx('TRANSACTION_INTENT', 'FIAT_ONRAMP'))).toBe(false)
+        expect(isOnrampEntry(tx('TRANSACTION_INTENT', 'FIAT_ONRAMP', { provider: 'BRIDGE' }))).toBe(false)
+        expect(isOnrampEntry(tx('TRANSACTION_INTENT', 'FIAT_ONRAMP', { provider: 'MANTECA' }))).toBe(false)
     })
 
     // The cancel-by-sender SEND_LINK_CLAIM intent is also rendered as

--- a/src/components/TransactionDetails/__tests__/useReceiptViewModel.test.ts
+++ b/src/components/TransactionDetails/__tests__/useReceiptViewModel.test.ts
@@ -148,23 +148,12 @@ const PARITY_CASES: ParityCase[] = [
         legacyDrawer: { originalType: EHistoryEntryType.REQUEST, originalUserRole: EHistoryUserRole.SENDER },
         intentKind: 'REQUEST_PAY',
     },
-    {
-        name: 'pending bridge onramp with deposit instructions',
-        legacy: {
-            status: 'pending',
-            direction: 'bank_deposit',
-        },
-        legacyDrawer: {
-            originalType: EHistoryEntryType.BRIDGE_ONRAMP,
-            originalUserRole: EHistoryUserRole.RECIPIENT,
-            depositInstructions: { bank_name: 'Test Bank' },
-            // Both shapes carry provider as of peanut-api-ts#739 — BridgeHistoryFetcher
-            // emits it (was a lowercase 'bridge' literal before; standardised to
-            // intent.provider = 'BRIDGE').
-            provider: 'BRIDGE',
-        },
-        intentKind: 'FIAT_ONRAMP',
-    },
+    // No Bridge-onramp parity case: BridgeHistoryFetcher is the unconditional
+    // BE gateway for Bridge intents (peanut-api-ts/src/transaction-intent/
+    // history.ts:859), so a Bridge onramp never reaches the FE in TI shape.
+    // The legacy-only contract for `isOnrampEntry` is locked in
+    // `transaction-predicates.test.ts`. Adding a parity case here would
+    // assert equivalence between an in-flight row and an unreachable one.
     {
         name: 'pending manteca onramp (renders ARS/BRL deposit-info row)',
         legacy: { status: 'pending', direction: 'bank_deposit', currency: { code: 'ARS', symbol: '$' } },

--- a/src/components/TransactionDetails/__tests__/useReceiptViewModel.test.ts
+++ b/src/components/TransactionDetails/__tests__/useReceiptViewModel.test.ts
@@ -1,10 +1,20 @@
-// Locks the "cancelled-sendlink-sender keeps its data" visibility rule
-// so the staging regression (cancelled sendlink → empty receipt drawer)
-// can't come back.
+// Locks two behaviours of the receipt view model:
+//
+// 1. The "cancelled-sendlink-sender keeps its data" exemption (memo,
+//    attachment, token+network visible) — staging regression playtested
+//    2026-05-09, fixed in PR #1966.
+// 2. Wire-shape PARITY between legacy `originalType` rows and the
+//    post-decomplexify `TRANSACTION_INTENT + kind=<>` rows. Until this PR,
+//    half a dozen gates checked `originalType === EHistoryEntryType.X`
+//    one-sided, so the receipt drawer silently regressed for every new
+//    sendlink / request / onramp row on staging. The parity tests below feed
+//    equivalent legacy + intent shapes through the same view model and assert
+//    the rowVisibilityConfig is identical. Future one-sided gates fail here.
 import { renderHook } from '@testing-library/react'
 import { useReceiptViewModel } from '../useReceiptViewModel'
 import { EHistoryEntryType, EHistoryUserRole } from '@/hooks/useTransactionHistory'
 import type { TransactionDetails } from '../transactionTransformer'
+import type { IntentKind } from '../strategies/registry'
 
 jest.mock('@/assets', () => ({}))
 jest.mock('@/assets/payment-apps', () => ({ MERCADO_PAGO: '', PIX: '', SIMPLEFI: '' }))
@@ -35,64 +45,152 @@ const baseTx: TransactionDetails = {
     },
 } as unknown as TransactionDetails
 
-const senderSendLink = (status: string): TransactionDetails =>
+// Fixture builders that bypass the heavy TransactionDetails type so each
+// test case can express only the fields the assertion cares about. Cast at
+// the boundary rather than threading deep types through every literal.
+const withDrawer = (overrides: Record<string, unknown>, drawerOverrides: Record<string, unknown>): TransactionDetails =>
     ({
         ...baseTx,
-        status,
-        extraDataForDrawer: {
-            ...baseTx.extraDataForDrawer,
-            originalType: EHistoryEntryType.SEND_LINK,
-            originalUserRole: EHistoryUserRole.SENDER,
-        },
-    }) as TransactionDetails
+        ...overrides,
+        extraDataForDrawer: { ...(baseTx.extraDataForDrawer as Record<string, unknown>), ...drawerOverrides },
+    }) as unknown as TransactionDetails
+
+const renderConfig = (tx: TransactionDetails) =>
+    renderHook(() => useReceiptViewModel(tx, { isPublic: false })).result.current.rowVisibilityConfig
+
+const senderSendLink = (status: string): TransactionDetails =>
+    withDrawer({ status }, { originalType: EHistoryEntryType.SEND_LINK, originalUserRole: EHistoryUserRole.SENDER })
 
 const cancelledBankWithdraw = (): TransactionDetails =>
-    ({
-        ...baseTx,
-        status: 'cancelled',
-        direction: 'bank_withdraw',
-        extraDataForDrawer: {
-            originalType: EHistoryEntryType.BRIDGE_OFFRAMP,
-            originalUserRole: EHistoryUserRole.SENDER,
-        },
-    }) as TransactionDetails
+    withDrawer(
+        { status: 'cancelled', direction: 'bank_withdraw' },
+        { originalType: EHistoryEntryType.BRIDGE_OFFRAMP, originalUserRole: EHistoryUserRole.SENDER }
+    )
 
 describe('useReceiptViewModel — cancelled sendlink sender', () => {
     test('shows memo + attachment + token/network when sender cancels their own sendlink', () => {
-        const tx = senderSendLink('cancelled')
-        const { result } = renderHook(() => useReceiptViewModel(tx, { isPublic: false }))
-
-        expect(result.current.rowVisibilityConfig.comment).toBe(true)
-        expect(result.current.rowVisibilityConfig.attachment).toBe(true)
-        expect(result.current.rowVisibilityConfig.tokenAndNetwork).toBe(true)
-        expect(result.current.rowVisibilityConfig.cancelled).toBe(true)
+        const config = renderConfig(senderSendLink('cancelled'))
+        expect(config.comment).toBe(true)
+        expect(config.attachment).toBe(true)
+        expect(config.tokenAndNetwork).toBe(true)
+        expect(config.cancelled).toBe(true)
     })
 
     test('keeps the legacy suppress for a still-pending sender-side sendlink', () => {
         // Pre-cancel state: token+network row is intentionally suppressed
         // (sender already sees that at the top of the drawer); other fields
         // remain visible as before.
-        const tx = senderSendLink('pending')
-        const { result } = renderHook(() => useReceiptViewModel(tx, { isPublic: false }))
-
-        expect(result.current.rowVisibilityConfig.tokenAndNetwork).toBe(false)
-        expect(result.current.rowVisibilityConfig.comment).toBe(true)
-        expect(result.current.rowVisibilityConfig.attachment).toBe(true)
+        const config = renderConfig(senderSendLink('pending'))
+        expect(config.tokenAndNetwork).toBe(false)
+        expect(config.comment).toBe(true)
+        expect(config.attachment).toBe(true)
     })
 
     test('still hides memo + attachment for non-sendlink cancelled flows', () => {
-        // Bank withdraws etc. genuinely null out their fields on cancel —
-        // those gates must still apply.
-        const tx = cancelledBankWithdraw()
-        const { result } = renderHook(() => useReceiptViewModel(tx, { isPublic: false }))
-
-        expect(result.current.rowVisibilityConfig.comment).toBe(false)
-        expect(result.current.rowVisibilityConfig.attachment).toBe(false)
+        // Bank withdraws genuinely null out their fields on cancel — gates
+        // still apply.
+        const config = renderConfig(cancelledBankWithdraw())
+        expect(config.comment).toBe(false)
+        expect(config.attachment).toBe(false)
         // Pre-existing behaviour: tokenAndNetwork has no global `status !==
-        // 'cancelled'` gate — only a `!isPeanutWalletToken` suppress and the
+        // 'cancelled'` gate — only the !isPeanutWalletToken suppress and the
         // sendlink-sender pre-cancel hide. Cancelled non-sendlinks with a
-        // non-peanut-wallet token still surface this row. Lock that here so
-        // a future status-blanket gate doesn't sneak in unnoticed.
-        expect(result.current.rowVisibilityConfig.tokenAndNetwork).toBe(true)
+        // non-peanut-wallet token surface this row. Locked so a future
+        // status-blanket gate doesn't sneak in.
+        expect(config.tokenAndNetwork).toBe(true)
     })
+})
+
+// Decomplexify changed the wire shape for several entry types. The receipt
+// drawer must render the same fields whether the row is legacy or post-M3 —
+// otherwise the bug we shipped silently (QR/Share/Cancel block missing on
+// every new pending sendlink) comes back. Each row pair below is the same
+// real-world event in both shapes.
+type ParityCase = {
+    name: string
+    legacy: Record<string, unknown>
+    legacyDrawer: Record<string, unknown>
+    // Pinned to the strategy-registry IntentKind union: a kind not in the
+    // registry won't compile, so a future parity case can't reference a
+    // post-M3 wire kind the receipt doesn't actually know how to render.
+    intentKind: IntentKind
+    extraDrawer?: Record<string, unknown>
+}
+
+const PARITY_CASES: ParityCase[] = [
+    {
+        name: 'pending sendlink, sender side',
+        legacy: { status: 'pending' },
+        legacyDrawer: { originalType: EHistoryEntryType.SEND_LINK, originalUserRole: EHistoryUserRole.SENDER },
+        intentKind: 'LINK_CREATE',
+    },
+    {
+        name: 'cancelled sendlink, sender side (the original regression)',
+        legacy: { status: 'cancelled' },
+        legacyDrawer: { originalType: EHistoryEntryType.SEND_LINK, originalUserRole: EHistoryUserRole.SENDER },
+        intentKind: 'LINK_CREATE',
+    },
+    {
+        name: 'completed sendlink, sender side',
+        legacy: { status: 'completed', completedAt: '2026-05-02T00:00:00.000Z' as unknown as Date },
+        legacyDrawer: { originalType: EHistoryEntryType.SEND_LINK, originalUserRole: EHistoryUserRole.SENDER },
+        intentKind: 'LINK_CREATE',
+    },
+    {
+        name: 'pending request, recipient side (request pot OR individual)',
+        legacy: { status: 'pending', direction: 'request_sent' },
+        legacyDrawer: { originalType: EHistoryEntryType.REQUEST, originalUserRole: EHistoryUserRole.RECIPIENT },
+        intentKind: 'REQUEST_PAY',
+    },
+    {
+        name: 'pending request, payer side (about to pay)',
+        legacy: { status: 'pending' },
+        legacyDrawer: { originalType: EHistoryEntryType.REQUEST, originalUserRole: EHistoryUserRole.SENDER },
+        intentKind: 'REQUEST_PAY',
+    },
+    {
+        name: 'pending bridge onramp with deposit instructions',
+        legacy: {
+            status: 'pending',
+            direction: 'bank_deposit',
+        },
+        legacyDrawer: {
+            originalType: EHistoryEntryType.BRIDGE_ONRAMP,
+            originalUserRole: EHistoryUserRole.RECIPIENT,
+            depositInstructions: { bank_name: 'Test Bank' },
+        },
+        intentKind: 'FIAT_ONRAMP',
+    },
+    {
+        name: 'pending manteca onramp (renders ARS/BRL deposit-info row)',
+        legacy: { status: 'pending', direction: 'bank_deposit', currency: { code: 'ARS', symbol: '$' } },
+        legacyDrawer: { originalType: EHistoryEntryType.MANTECA_ONRAMP, originalUserRole: EHistoryUserRole.RECIPIENT },
+        intentKind: 'FIAT_ONRAMP',
+    },
+    {
+        name: 'completed direct send',
+        legacy: { status: 'completed', completedAt: '2026-05-02T00:00:00.000Z' as unknown as Date },
+        legacyDrawer: { originalType: EHistoryEntryType.DIRECT_SEND, originalUserRole: EHistoryUserRole.SENDER },
+        intentKind: 'P2P_SEND',
+    },
+]
+
+describe('useReceiptViewModel — wire-shape parity (legacy ↔ TRANSACTION_INTENT)', () => {
+    for (const { name, legacy, legacyDrawer, intentKind, extraDrawer = {} } of PARITY_CASES) {
+        test(name, () => {
+            const legacyRow = withDrawer(legacy, { ...legacyDrawer, ...extraDrawer })
+            const intentRow = withDrawer(legacy, {
+                ...legacyDrawer,
+                ...extraDrawer,
+                originalType: EHistoryEntryType.TRANSACTION_INTENT,
+                kind: intentKind,
+            })
+
+            const legacyConfig = renderConfig(legacyRow)
+            const intentConfig = renderConfig(intentRow)
+
+            // Whole-config equality — any divergence is a one-sided gate.
+            expect(intentConfig).toEqual(legacyConfig)
+        })
+    }
 })

--- a/src/components/TransactionDetails/__tests__/useReceiptViewModel.test.ts
+++ b/src/components/TransactionDetails/__tests__/useReceiptViewModel.test.ts
@@ -158,13 +158,24 @@ const PARITY_CASES: ParityCase[] = [
             originalType: EHistoryEntryType.BRIDGE_ONRAMP,
             originalUserRole: EHistoryUserRole.RECIPIENT,
             depositInstructions: { bank_name: 'Test Bank' },
+            // Both shapes carry provider as of peanut-api-ts#739 — BridgeHistoryFetcher
+            // emits it (was a lowercase 'bridge' literal before; standardised to
+            // intent.provider = 'BRIDGE').
+            provider: 'BRIDGE',
         },
         intentKind: 'FIAT_ONRAMP',
     },
     {
         name: 'pending manteca onramp (renders ARS/BRL deposit-info row)',
         legacy: { status: 'pending', direction: 'bank_deposit', currency: { code: 'ARS', symbol: '$' } },
-        legacyDrawer: { originalType: EHistoryEntryType.MANTECA_ONRAMP, originalUserRole: EHistoryUserRole.RECIPIENT },
+        legacyDrawer: {
+            originalType: EHistoryEntryType.MANTECA_ONRAMP,
+            originalUserRole: EHistoryUserRole.RECIPIENT,
+            // Positive-identity gate — Manteca and Bridge onramps share the
+            // FIAT_ONRAMP wire kind, so the Manteca-specific row gate uses
+            // provider rather than the absence of depositInstructions.
+            provider: 'MANTECA',
+        },
         intentKind: 'FIAT_ONRAMP',
     },
     {

--- a/src/components/TransactionDetails/provider-actions/CancelDepositActions.tsx
+++ b/src/components/TransactionDetails/provider-actions/CancelDepositActions.tsx
@@ -3,7 +3,8 @@
 import { Button } from '@/components/0_Bruddle/Button'
 import { Icon } from '@/components/Global/Icons/Icon'
 import { type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
-import { EHistoryEntryType, EHistoryUserRole } from '@/hooks/useTransactionHistory'
+import { isMantecaOnrampEntry, isRequestEntry } from '@/components/TransactionDetails/transaction-predicates'
+import { EHistoryUserRole } from '@/hooks/useTransactionHistory'
 import { TRANSACTIONS } from '@/constants/query.consts'
 import { cancelOnramp } from '@/app/actions/onramp'
 import { chargesApi } from '@/services/charges'
@@ -56,10 +57,11 @@ export function CancelDepositActions({
         }
     }
 
-    // 1. Bridge onramp pending — generic bank deposit cancel.
+    // 1. Bridge onramp pending — generic bank deposit cancel. Excludes REQUEST
+    // rows (those take the dedicated request-cancel branch below).
     const showBridgeOnrampCancel =
         transaction.direction === 'bank_deposit' &&
-        transaction.extraDataForDrawer?.originalType !== EHistoryEntryType.REQUEST &&
+        !isRequestEntry(transaction) &&
         transaction.status === 'pending' &&
         !!transaction.extraDataForDrawer?.depositInstructions
 
@@ -78,9 +80,7 @@ export function CancelDepositActions({
     }
 
     // 2. Manteca onramp pending.
-    const showMantecaCancel =
-        transaction.extraDataForDrawer?.originalType === EHistoryEntryType.MANTECA_ONRAMP &&
-        transaction.status === 'pending'
+    const showMantecaCancel = isMantecaOnrampEntry(transaction) && transaction.status === 'pending'
 
     if (showMantecaCancel) {
         return (

--- a/src/components/TransactionDetails/strategies/registry.ts
+++ b/src/components/TransactionDetails/strategies/registry.ts
@@ -60,7 +60,10 @@ type LegacyKey =
 // TRANSACTION_INTENT kinds rendered by an explicit strategy. Adding a new
 // BE TransactionIntentKind that should render distinctly requires updating
 // this union AND the STRATEGIES map below — TS guarantees both move together.
-type IntentKind =
+// Exported so dual-shape predicates in transaction-predicates.ts can pin
+// their kind argument to the same source-of-truth set (compile error if a
+// predicate matches a kind the strategy registry has never heard of).
+export type IntentKind =
     | 'P2P_SEND'
     | 'REQUEST_PAY'
     | 'QR_PAY'

--- a/src/components/TransactionDetails/transaction-predicates.ts
+++ b/src/components/TransactionDetails/transaction-predicates.ts
@@ -141,14 +141,13 @@ export function isOnrampEntry(transaction: TransactionDetails): boolean {
 }
 
 // Manteca-flavoured onramp specifically (renders the ARS/BRL deposit-info row).
-// Provider isn't on the drawer view-model. Legacy rows carried the provider
-// via originalType (MANTECA_ONRAMP vs BRIDGE_ONRAMP); post-M3, both collapse
-// to TRANSACTION_INTENT/kind=FIAT_ONRAMP. The behavioural discriminator the
-// drawer already uses is `extraDataForDrawer.depositInstructions` — Bridge
-// onramps ship it (and render their own depositInstructions row instead),
-// Manteca onramps don't. So Manteca === FIAT_ONRAMP without depositInstructions.
+// Legacy rows carried the provider via originalType (MANTECA_ONRAMP vs
+// BRIDGE_ONRAMP). Post-M3 rows arrive as TRANSACTION_INTENT/kind=FIAT_ONRAMP
+// for both providers; the discriminator is `extraDataForDrawer.provider`
+// (plumbed end-to-end as of peanut-api-ts#739 — every projector emits
+// `provider: intent.provider`). Positive identity, no field-absence smell.
 export function isMantecaOnrampEntry(transaction: TransactionDetails): boolean {
     if (transaction.extraDataForDrawer?.originalType === ('MANTECA_ONRAMP' as EHistoryEntryType)) return true
     if (!isTransactionIntentKind(transaction, 'FIAT_ONRAMP')) return false
-    return !transaction.extraDataForDrawer?.depositInstructions
+    return transaction.extraDataForDrawer?.provider === 'MANTECA'
 }

--- a/src/components/TransactionDetails/transaction-predicates.ts
+++ b/src/components/TransactionDetails/transaction-predicates.ts
@@ -129,23 +129,35 @@ export function isDirectSendEntry(transaction: TransactionDetails): boolean {
     )
 }
 
-// Bridge or Manteca on-ramp. Post-M3 the wire kind is 'FIAT_ONRAMP' (not the
-// raw BE enum 'ONRAMP' — the BE's toLegacyKindLabel renames it). Two
-// pre-existing dual-shape checks in this codebase used 'ONRAMP' literally,
-// which silently breaks every new onramp row; route them through here instead.
+// Bridge or Manteca on-ramp.
+//
+// Only matches the legacy originalType — the BE's BridgeHistoryFetcher /
+// MantecaHistoryFetcher are unconditional gateways for onramp intents
+// (peanut-api-ts/src/transaction-intent/history.ts:859-867), so an onramp
+// row physically can't reach the FE in TRANSACTION_INTENT shape. Adding a
+// TRANSACTION_INTENT/FIAT_ONRAMP branch here would be dead-code
+// future-proofing — drop it and update both predicates together if/when
+// the BE consolidates the dispatch. `isMantecaOnrampEntry` separately
+// keeps a TI branch because the mantecaUser-lookup-fails edge case can
+// route a Manteca intent through mapGenericIntent (still benign — the row
+// gates downstream all require fields Manteca's BE doesn't emit on TI).
 export function isOnrampEntry(transaction: TransactionDetails): boolean {
     const type = transaction.extraDataForDrawer?.originalType
-    if (type === ('BRIDGE_ONRAMP' as EHistoryEntryType)) return true
-    if (type === ('MANTECA_ONRAMP' as EHistoryEntryType)) return true
-    return isTransactionIntentKind(transaction, 'FIAT_ONRAMP')
+    return type === ('BRIDGE_ONRAMP' as EHistoryEntryType) || type === ('MANTECA_ONRAMP' as EHistoryEntryType)
 }
 
 // Manteca-flavoured onramp specifically (renders the ARS/BRL deposit-info row).
-// Legacy rows carried the provider via originalType (MANTECA_ONRAMP vs
-// BRIDGE_ONRAMP). Post-M3 rows arrive as TRANSACTION_INTENT/kind=FIAT_ONRAMP
-// for both providers; the discriminator is `extraDataForDrawer.provider`
-// (plumbed end-to-end as of peanut-api-ts#739 — every projector emits
-// `provider: intent.provider`). Positive identity, no field-absence smell.
+//
+// Two shapes:
+//   1. Legacy MANTECA_ONRAMP originalType — happy path; BE's
+//      MantecaHistoryFetcher emits this whenever mantecaUser is resolvable.
+//   2. TRANSACTION_INTENT/kind=FIAT_ONRAMP + provider=MANTECA — edge case
+//      when `mantecaUser` lookup returns null for a user with Manteca
+//      intents (orphan/inconsistent DB state). The dispatch falls through
+//      to mapGenericIntent → TI shape. Positive identity via provider, no
+//      field-absence smell.
+//
+// Bridge has no equivalent fallback — BridgeHistoryFetcher is unconditional.
 export function isMantecaOnrampEntry(transaction: TransactionDetails): boolean {
     if (transaction.extraDataForDrawer?.originalType === ('MANTECA_ONRAMP' as EHistoryEntryType)) return true
     if (!isTransactionIntentKind(transaction, 'FIAT_ONRAMP')) return false

--- a/src/components/TransactionDetails/transaction-predicates.ts
+++ b/src/components/TransactionDetails/transaction-predicates.ts
@@ -21,6 +21,10 @@ import { type TransactionDetails } from './transactionTransformer'
 // the Sets below use string literals because EHistoryEntryType is a string
 // enum, so the runtime values are interchangeable with their literal forms.
 import type { EHistoryEntryType } from '@/utils/history.utils'
+// Type-only — pins the kind argument of dual-shape predicates to the
+// strategy registry's source-of-truth IntentKind union. A drift between a
+// predicate kind and the registry is a compile error.
+import type { IntentKind } from './strategies/registry'
 
 const QR_PAYMENT_TYPES: ReadonlySet<EHistoryEntryType> = new Set<EHistoryEntryType>([
     'MANTECA_QR_PAYMENT' as EHistoryEntryType,
@@ -53,7 +57,7 @@ const COMPLETED_LABEL_TYPES: ReadonlySet<EHistoryEntryType> = new Set<EHistoryEn
 /** Post-M3, QR payments arrive as TRANSACTION_INTENT entries with
  *  `extraData.kind === 'QR_PAY'`. Pre-M3 (legacy rows still in the feed)
  *  used dedicated `originalType` values. Recognize both. */
-function isTransactionIntentKind(transaction: TransactionDetails, kind: string): boolean {
+function isTransactionIntentKind(transaction: TransactionDetails, kind: IntentKind): boolean {
     // String comparison — see top-of-file note on the type-only import. The
     // enum value 'TRANSACTION_INTENT' is identical to its string at runtime.
     return (
@@ -89,4 +93,62 @@ export function isCardPaymentEntry(transaction: TransactionDetails): boolean {
 
 export function isPerkReward(transaction: TransactionDetails): boolean {
     return transaction.extraDataForDrawer?.originalType === ('PERK_REWARD' as EHistoryEntryType)
+}
+
+// Post-M3, send-link rows from the BE arrive as TRANSACTION_INTENT entries with
+// extraData.kind === 'LINK_CREATE' (BE: toLegacyKindLabel maps both SEND_LINK and
+// SEND_LINK_CLAIM intents → 'LINK_CREATE'). Legacy rows (created pre-cutover and
+// still in some histories) keep originalType === SEND_LINK. Recognise both —
+// receipt CTAs (QR, Share, Cancel) and the receipt-field exemptions live or die
+// by this check.
+export function isSendLinkEntry(transaction: TransactionDetails): boolean {
+    return (
+        transaction.extraDataForDrawer?.originalType === ('SEND_LINK' as EHistoryEntryType) ||
+        isTransactionIntentKind(transaction, 'LINK_CREATE')
+    )
+}
+
+// Request links (individual requests) and request pots (multi-payer requests
+// with isRequestLink=true) both arrive as type=REQUEST (legacy rollup, the BE
+// pot rollup keeps the legacy type) or as TRANSACTION_INTENT/kind=REQUEST_PAY
+// for the post-M3 individual-contribution rows.
+export function isRequestEntry(transaction: TransactionDetails): boolean {
+    return (
+        transaction.extraDataForDrawer?.originalType === ('REQUEST' as EHistoryEntryType) ||
+        isTransactionIntentKind(transaction, 'REQUEST_PAY')
+    )
+}
+
+// Wallet-to-wallet direct send. Legacy originalType is DIRECT_SEND; post-M3
+// the row arrives as TRANSACTION_INTENT/kind=P2P_SEND (BE's toLegacyKindLabel
+// reuses the P2P_SEND label for the Lane-2b DIRECT_TRANSFER kind).
+export function isDirectSendEntry(transaction: TransactionDetails): boolean {
+    return (
+        transaction.extraDataForDrawer?.originalType === ('DIRECT_SEND' as EHistoryEntryType) ||
+        isTransactionIntentKind(transaction, 'P2P_SEND')
+    )
+}
+
+// Bridge or Manteca on-ramp. Post-M3 the wire kind is 'FIAT_ONRAMP' (not the
+// raw BE enum 'ONRAMP' — the BE's toLegacyKindLabel renames it). Two
+// pre-existing dual-shape checks in this codebase used 'ONRAMP' literally,
+// which silently breaks every new onramp row; route them through here instead.
+export function isOnrampEntry(transaction: TransactionDetails): boolean {
+    const type = transaction.extraDataForDrawer?.originalType
+    if (type === ('BRIDGE_ONRAMP' as EHistoryEntryType)) return true
+    if (type === ('MANTECA_ONRAMP' as EHistoryEntryType)) return true
+    return isTransactionIntentKind(transaction, 'FIAT_ONRAMP')
+}
+
+// Manteca-flavoured onramp specifically (renders the ARS/BRL deposit-info row).
+// Provider isn't on the drawer view-model. Legacy rows carried the provider
+// via originalType (MANTECA_ONRAMP vs BRIDGE_ONRAMP); post-M3, both collapse
+// to TRANSACTION_INTENT/kind=FIAT_ONRAMP. The behavioural discriminator the
+// drawer already uses is `extraDataForDrawer.depositInstructions` — Bridge
+// onramps ship it (and render their own depositInstructions row instead),
+// Manteca onramps don't. So Manteca === FIAT_ONRAMP without depositInstructions.
+export function isMantecaOnrampEntry(transaction: TransactionDetails): boolean {
+    if (transaction.extraDataForDrawer?.originalType === ('MANTECA_ONRAMP' as EHistoryEntryType)) return true
+    if (!isTransactionIntentKind(transaction, 'FIAT_ONRAMP')) return false
+    return !transaction.extraDataForDrawer?.depositInstructions
 }

--- a/src/components/TransactionDetails/transactionTransformer.ts
+++ b/src/components/TransactionDetails/transactionTransformer.ts
@@ -14,7 +14,26 @@ import { type StatusPillType } from '../Global/StatusPill'
 import type { Address } from 'viem'
 import { PEANUT_WALLET_CHAIN } from '@/constants/zerodev.consts'
 import { type HistoryEntryPerkReward, type ChargeEntry } from '@/services/services.types'
-import { dispatchStrategy } from './strategies/registry'
+import { dispatchStrategy, type IntentKind } from './strategies/registry'
+
+// Mirror of peanut-api-ts `enum TransactionProvider`. Receipts that branch
+// on provider (e.g. Manteca-specific deposit-info row) use this typed
+// value via `extraDataForDrawer.provider` for positive identity rather
+// than inferring from the absence of other fields.
+//
+// Stays a string union (not an enum) so it stays interchangeable with the
+// wire string at runtime and so adding a value here forces TS-side updates
+// at every gate that switches on it. Deprecated values are kept so old
+// rows that still carry them on the wire don't blow up the type system.
+export type Provider =
+    | 'PEANUT'
+    | 'BRIDGE'
+    | 'MANTECA'
+    | 'RHINO'
+    | 'RAIN'
+    | 'ONCHAIN'
+    | 'DEPRECATED_SIMPLEFI'
+    | 'DEPRECATED_SQUID'
 
 /**
  * @fileoverview maps raw transaction history data from the api/hook to the format needed by ui components.
@@ -247,8 +266,16 @@ export interface TransactionDetails {
         /** Post-M3 transaction-intent kind (P2P_SEND, QR_PAY, CARD_SPEND, …).
          *  Some predicates need this to disambiguate within TRANSACTION_INTENT
          *  entries — e.g. QR payments now arrive as TRANSACTION_INTENT + kind=QR_PAY
-         *  rather than a dedicated originalType. */
-        kind?: string
+         *  rather than a dedicated originalType. Pinned to the strategy
+         *  registry's IntentKind union — adding a new kind here is a TS-side
+         *  failure unless the registry knows about it too. */
+        kind?: IntentKind
+        /** TransactionProvider enum value from the BE (peanut-api-ts:
+         *  `enum TransactionProvider`). Every wire entry carries this as of
+         *  peanut-api-ts#739 — predicates branch on it for positive identity
+         *  (e.g. `provider === 'MANTECA'`) instead of inferring from the
+         *  presence/absence of other fields. */
+        provider?: Provider
         link?: string
         isLinkTransaction?: boolean
         transactionCardType?: TransactionCardType
@@ -484,7 +511,8 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
             addressExplorerUrl,
             originalType: entry.type as EHistoryEntryType,
             originalUserRole: entry.userRole as EHistoryUserRole,
-            kind: entry.extraData?.kind as string | undefined,
+            kind: entry.extraData?.kind as IntentKind | undefined,
+            provider: entry.extraData?.provider as Provider | undefined,
             link: entry.extraData?.link,
             isLinkTransaction: isLinkTx,
             transactionCardType,

--- a/src/components/TransactionDetails/transactionTransformer.ts
+++ b/src/components/TransactionDetails/transactionTransformer.ts
@@ -39,6 +39,15 @@ export type Provider =
  * @fileoverview maps raw transaction history data from the api/hook to the format needed by ui components.
  */
 
+// Wire-level read of `entry.extraData.kind` pinned to the strategy registry's
+// IntentKind union. Cast lives here so every comparison site below is
+// compile-checked — a typo in the kind string is a TS error, not a silent
+// false. Mirrors `isTransactionIntentKind` in transaction-predicates.ts
+// (which operates on TransactionDetails instead of the wire entry).
+function intentKindOf(entry: HistoryEntry): IntentKind | undefined {
+    return entry.extraData?.kind as IntentKind | undefined
+}
+
 /**
  * Should the receipt drawer's `bankAccountDetails` row render for this entry?
  *
@@ -59,10 +68,54 @@ function shouldPlumbBankAccountDetails(entry: HistoryEntry): boolean {
         return true
     }
     if (entry.type === EHistoryEntryType.TRANSACTION_INTENT) {
-        const kind = entry.extraData?.kind as string | undefined
+        const kind = intentKindOf(entry)
         if (kind === 'FIAT_OFFRAMP' || kind === 'CRYPTO_WITHDRAW') return true
     }
     return false
+}
+
+// Bank-deposit instructions blob — Bridge ships this verbatim from its
+// transfer API (BE: BridgeHistoryFetcher forwards `source_deposit_instructions`).
+// Multi-rail union of fields; `AddMoneyBankDetails` reads whichever subset
+// matches the rail. Exported so the transformer can cast at the wire
+// boundary and the drawer can keep its strict shape.
+export interface DrawerDepositInstructions {
+    amount: string
+    currency: string
+    bank_name: string
+    bank_address: string
+    payment_rail: string
+    deposit_message: string
+    // US format
+    bank_account_number?: string
+    bank_routing_number?: string
+    bank_beneficiary_name?: string
+    bank_beneficiary_address?: string
+    // European format
+    iban?: string
+    bic?: string
+    account_holder_name?: string
+    // UK faster_payments format
+    sort_code?: string
+    account_number?: string
+    // Mexican format (SPEI)
+    clabe?: string
+}
+
+// Manteca / Bridge offramp receipt block. Manteca populates
+// `depositDetails`; Bridge populates the broader fee/amount cluster.
+export interface DrawerReceipt {
+    depositDetails?: {
+        depositAddress: string
+        depositAlias: string
+    }
+    initial_amount?: string
+    developer_fee?: string
+    exchange_fee?: string
+    subtotal_amount?: string
+    gas_fee?: string
+    final_amount?: string
+    exchange_rate?: string
 }
 
 export type RewardData = {
@@ -144,7 +197,7 @@ function mapEntryStatusToUiStatus(entry: HistoryEntry, direction: TransactionDir
             const isUnclaimedSendLinkSender =
                 direction !== 'claim_external' &&
                 (entry.type === EHistoryEntryType.SEND_LINK ||
-                    (entry.type === EHistoryEntryType.TRANSACTION_INTENT && entry.extraData?.kind === 'LINK_CREATE'))
+                    (entry.type === EHistoryEntryType.TRANSACTION_INTENT && intentKindOf(entry) === 'LINK_CREATE'))
             return isUnclaimedSendLinkSender ? 'pending' : 'completed'
         }
         case 'SUCCESSFUL':
@@ -296,41 +349,8 @@ export interface TransactionDetails {
             campaignCapUsd?: number
             remainingCapUsd?: number
         }
-        depositInstructions?: {
-            amount: string
-            currency: string
-            bank_name: string
-            bank_address: string
-            payment_rail: string
-            deposit_message: string
-            // US format
-            bank_account_number?: string
-            bank_routing_number?: string
-            bank_beneficiary_name?: string
-            bank_beneficiary_address?: string
-            // European format
-            iban?: string
-            bic?: string
-            account_holder_name?: string
-            // UK faster_payments format
-            sort_code?: string
-            account_number?: string
-            // Mexican format (SPEI)
-            clabe?: string
-        }
-        receipt?: {
-            depositDetails?: {
-                depositAddress: string
-                depositAlias: string
-            }
-            initial_amount?: string
-            developer_fee?: string
-            exchange_fee?: string
-            subtotal_amount?: string
-            gas_fee?: string
-            final_amount?: string
-            exchange_rate?: string
-        }
+        depositInstructions?: DrawerDepositInstructions
+        receipt?: DrawerReceipt
         /** Card-payment specifics — populated for Rain CARD_SPEND / card-refund
          *  entries only. Drives the merchant hero, status timeline, decline
          *  reason, and "Adjusted from $X" settlement note in the drawer. */
@@ -497,7 +517,7 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
         // already sets memo=undefined for card entries, but defend in depth.
         memo: (() => {
             if (isTestDeposit) return 'Your peanut wallet is ready to use!'
-            const isCardEntry = entry.extraData?.kind === 'CARD_SPEND' || !!entry.extraData?.parentRainTxId
+            const isCardEntry = intentKindOf(entry) === 'CARD_SPEND' || !!entry.extraData?.parentRainTxId
             if (isCardEntry) return undefined
             return entry.memo?.trim()
         })(),
@@ -530,7 +550,7 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
             // decline-reason rows, and merchant-detail Card. The block falls
             // back to "Card payment" downstream when merchantName is null.
             cardPayment:
-                entry.extraData?.kind === 'CARD_SPEND' || entry.extraData?.parentRainTxId
+                intentKindOf(entry) === 'CARD_SPEND' || entry.extraData?.parentRainTxId
                     ? {
                           merchantName: entry.extraData?.merchantName as string | null,
                           merchantCategory: entry.extraData?.merchantCategory as string | null,
@@ -571,11 +591,14 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
                       remainingCapUsd?: number
                   }
                 | undefined,
+            // Wire-shape boundary: BE writes `Record<string, unknown>` here
+            // (BridgeHistoryFetcher forwards the raw API blob unchecked);
+            // drawer consumers expect the typed shape. Cast at the boundary.
             depositInstructions:
                 entry.type === EHistoryEntryType.BRIDGE_ONRAMP || entry.extraData?.fulfillmentType === 'bridge'
-                    ? entry.extraData?.depositInstructions
+                    ? (entry.extraData?.depositInstructions as DrawerDepositInstructions | undefined)
                     : undefined,
-            receipt: entry.extraData?.receipt,
+            receipt: entry.extraData?.receipt as DrawerReceipt | undefined,
         },
         sourceView: 'history',
         points: entry.points,

--- a/src/components/TransactionDetails/useReceiptViewModel.ts
+++ b/src/components/TransactionDetails/useReceiptViewModel.ts
@@ -10,7 +10,12 @@ import {
 import {
     hasShareableReceipt,
     isCardPaymentEntry,
+    isDirectSendEntry,
+    isMantecaOnrampEntry,
+    isOnrampEntry,
     isQRPayment as isQRPaymentTransaction,
+    isRequestEntry,
+    isSendLinkEntry,
 } from '@/components/TransactionDetails/transaction-predicates'
 import { hasCardPaymentRowsContent } from '@/components/TransactionDetails/provider-rows/CardPaymentRows'
 import { countryData } from '@/components/AddMoney/consts'
@@ -83,7 +88,7 @@ export function useReceiptViewModel(
         () =>
             !!transaction &&
             transaction.status === 'pending' &&
-            transaction.extraDataForDrawer?.originalType === EHistoryEntryType.REQUEST &&
+            isRequestEntry(transaction) &&
             transaction.extraDataForDrawer?.fulfillmentType === 'bridge',
         [transaction]
     )
@@ -92,7 +97,7 @@ export function useReceiptViewModel(
         () =>
             !!transaction &&
             transaction.status === 'pending' &&
-            transaction.extraDataForDrawer?.originalType === EHistoryEntryType.REQUEST &&
+            isRequestEntry(transaction) &&
             transaction.extraDataForDrawer?.originalUserRole === EHistoryUserRole.SENDER &&
             !transaction.extraDataForDrawer?.fulfillmentType,
         [transaction]
@@ -102,7 +107,7 @@ export function useReceiptViewModel(
         () =>
             !!transaction &&
             transaction.status === 'pending' &&
-            transaction.extraDataForDrawer?.originalType === EHistoryEntryType.REQUEST &&
+            isRequestEntry(transaction) &&
             transaction.extraDataForDrawer?.originalUserRole === EHistoryUserRole.RECIPIENT,
         [transaction]
     )
@@ -111,7 +116,7 @@ export function useReceiptViewModel(
         () =>
             !!transaction &&
             transaction.status === 'pending' &&
-            transaction.extraDataForDrawer?.originalType === EHistoryEntryType.SEND_LINK &&
+            isSendLinkEntry(transaction) &&
             transaction.extraDataForDrawer?.originalUserRole === EHistoryUserRole.SENDER,
         [transaction]
     )
@@ -140,7 +145,7 @@ export function useReceiptViewModel(
         () =>
             !!transaction &&
             transaction.status === 'cancelled' &&
-            transaction.extraDataForDrawer?.originalType === EHistoryEntryType.SEND_LINK &&
+            isSendLinkEntry(transaction) &&
             transaction.extraDataForDrawer?.originalUserRole === EHistoryUserRole.SENDER,
         [transaction]
     )
@@ -154,7 +159,7 @@ export function useReceiptViewModel(
         const willShowCompleted = !!(
             transaction.status === 'completed' &&
             transaction.completedAt &&
-            transaction.extraDataForDrawer?.originalType !== EHistoryEntryType.DIRECT_SEND
+            !isDirectSendEntry(transaction)
         )
 
         // "Show the user's own data even when the tx is in a cancelled state"
@@ -174,7 +179,7 @@ export function useReceiptViewModel(
                 // CANCELLED, surface it again — the row helps the sender
                 // confirm what they reclaimed.
                 !(
-                    transaction.extraDataForDrawer?.originalType === EHistoryEntryType.SEND_LINK &&
+                    isSendLinkEntry(transaction) &&
                     transaction.extraDataForDrawer?.originalUserRole === EHistoryUserRole.SENDER &&
                     transaction.status !== 'cancelled'
                 ) &&
@@ -186,7 +191,7 @@ export function useReceiptViewModel(
             completed: !!(
                 transaction.status === 'completed' &&
                 transaction.completedAt &&
-                transaction.extraDataForDrawer?.originalType !== EHistoryEntryType.DIRECT_SEND
+                !isDirectSendEntry(transaction)
             ),
             refunded: transaction.status === 'refunded',
             fee: transaction.fee !== undefined && transaction.status !== 'cancelled',
@@ -211,10 +216,7 @@ export function useReceiptViewModel(
                 transaction.status !== 'cancelled'
             ),
             depositInstructions: !!(
-                (transaction.extraDataForDrawer?.originalType === EHistoryEntryType.BRIDGE_ONRAMP ||
-                    // BRIDGE_ONRAMP also arrives as TRANSACTION_INTENT/kind=ONRAMP.
-                    (transaction.extraDataForDrawer?.originalType === EHistoryEntryType.TRANSACTION_INTENT &&
-                        transaction.extraDataForDrawer?.kind === 'ONRAMP') ||
+                (isOnrampEntry(transaction) ||
                     (isPendingBankRequest &&
                         transaction.extraDataForDrawer?.originalUserRole === EHistoryUserRole.SENDER)) &&
                 transaction.status === 'pending' &&
@@ -233,16 +235,11 @@ export function useReceiptViewModel(
                 transaction.status !== 'cancelled'
             ),
             attachment: !!(transaction.attachmentUrl && allowCancelledSenderFields),
-            mantecaDepositInfo:
-                !isPublic &&
-                (transaction.extraDataForDrawer?.originalType === EHistoryEntryType.MANTECA_ONRAMP ||
-                    // MANTECA_ONRAMP also arrives as TRANSACTION_INTENT/kind=ONRAMP. Provider
-                    // distinguishes Manteca from Bridge but isn't plumbed through to the FE;
-                    // Bridge onramps with deposit instructions take the branch above, leaving
-                    // this path for Manteca's ARS/BRL deposit info row.
-                    (transaction.extraDataForDrawer?.originalType === EHistoryEntryType.TRANSACTION_INTENT &&
-                        transaction.extraDataForDrawer?.kind === 'ONRAMP')) &&
-                transaction.status === 'pending',
+            // Provider isn't plumbed through to the FE, so this branch lights
+            // up for any FIAT_ONRAMP. Bridge onramps with a deposit_instructions
+            // payload take the `depositInstructions` branch above, leaving this
+            // path for Manteca's ARS/BRL deposit info row.
+            mantecaDepositInfo: !isPublic && isMantecaOnrampEntry(transaction) && transaction.status === 'pending',
             // Gate on whether CardPaymentRows would actually emit a sub-row;
             // otherwise an "all-data-absent" card spend leaves the slot
             // visible-but-empty and `shouldHideBorder` mis-attributes the

--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -98,6 +98,84 @@ export type HistoryEntryType = `${EHistoryEntryType}`
 export type HistoryUserRole = `${EHistoryUserRole}`
 export type HistoryStatus = `${EHistoryStatus}`
 
+/**
+ * Wire-shape extra-data carried on every HistoryEntry. Pre-this-type,
+ * the field was `Record<string, any>` — every consumer did an implicit
+ * cast and silent drift between BE writes and FE reads was invisible to
+ * the type system.
+ *
+ * Each field is optional because different BE projectors emit different
+ * subsets (Manteca emits `receipt`, Bridge emits `depositInstructions`,
+ * card spends emit the merchant/decline cluster, etc.). The interface
+ * documents the full superset; the deep object shapes are left loose
+ * (`Record<string, unknown>` / aliased typed shapes from
+ * `transactionTransformer.ts`) so the transformer keeps doing the
+ * boundary cast — but every scalar field now has a concrete type.
+ *
+ * If you add a field at a BE projector, mirror it here. If you stop
+ * reading one on the FE, remove it here.
+ */
+export interface HistoryEntryExtraData {
+    // Post-decomplexify wire-shape discriminators. Both pinned to
+    // string at this layer; downstream `extraDataForDrawer` narrows to
+    // `IntentKind` and `Provider` after the transformer runs.
+    kind?: string
+    provider?: string
+
+    // Common fields
+    link?: string
+    fulfillmentType?: 'bridge' | 'wallet'
+    bridgeTransferId?: string
+    usdAmount?: string
+    haveSentMoneyToUser?: boolean
+    /** Token-transfer block number — `string` from indexer, sometimes `number`
+     *  from on-chain webhooks. Treated as a presence signal, not parsed. */
+    blockNumber?: string | number
+
+    // Reaper-set on FAILED transitions for orphaned PENDING intents.
+    failReason?: string | null
+
+    // Card-spend cluster. Populated for Rain CARD_SPEND / card-refund
+    // intents only.
+    parentRainTxId?: string | null
+    rainTransactionId?: string | null
+    cardAuthAmount?: string | null
+    cardSettledAmount?: string | null
+    cardLocalAmount?: string | null
+    cardLocalCurrency?: string | null
+    settlementAdjusted?: boolean
+    cancellationReason?: string | null
+    declineReason?: string | null
+    declineCategory?: string | null
+    merchantName?: string | null
+    merchantCategory?: string | null
+    merchantCity?: string | null
+    merchantCountry?: string | null
+    merchantMcc?: string | null
+    merchantLogo?: string | null
+    merchantId?: string | null
+
+    // Perk reward + claim metadata. Shapes match
+    // TransactionDetails.extraDataForDrawer.perk* — kept loose here to
+    // avoid a cross-import; transformer narrows.
+    perkReward?: Record<string, unknown>
+    perk?: Record<string, unknown>
+
+    // Sendlink-create fields — written when the FE creates a sendlink so
+    // the claim URL can be rebuilt at history-render time from
+    // localStorage's password store.
+    contractVersion?: string
+    depositIdx?: string | number
+
+    // Bridge bank-deposit instructions. Renders the depositInstructions
+    // row on the receipt.
+    depositInstructions?: Record<string, unknown>
+
+    // Manteca / Bridge offramp receipt block. Manteca writes
+    // `receipt.depositDetails`; Bridge writes the broader receipt shape.
+    receipt?: Record<string, unknown>
+}
+
 export type HistoryEntry = {
     uuid: string
     type: HistoryEntryType
@@ -136,7 +214,7 @@ export type HistoryEntry = {
         userId?: string
         showFullName?: boolean
     }
-    extraData?: Record<string, any>
+    extraData?: HistoryEntryExtraData
     claimedAt?: string | Date
     createdAt?: string | Date
     completedAt?: string | Date


### PR DESCRIPTION
## What this fixes

A class of post-decomplexify regressions where the receipt drawer's inline `originalType === EHistoryEntryType.<X>` gates miss the post-M3 wire shape (`TRANSACTION_INTENT` + `extraData.kind`). Visible regressions on staging:

| Affected row / CTA | Before this PR (staging) | Production (legacy shape) |
|---|---|---|
| Pending sendlink — QR + Share Link + Cancel Link block | **Missing** (Hugo screenshotted this) | Renders |
| Cancelled sendlink — memo + attachment + token/network exemption from PR #1966 | **Missing** — exemption never fired for new rows | Renders |
| Pending request — Cancel + Pay CTAs | **Missing** | Renders |
| Pending Bridge onramp — `depositInstructions` row | **Missing** (kind='ONRAMP' literal; BE actually sends FIAT_ONRAMP) | Renders |
| Pending Manteca onramp — ARS/BRL deposit-info row | **Missing** (same FIAT_ONRAMP renaming bug) | Renders |
| `CancelDepositActions` — Bridge / Manteca cancel buttons | **Missing** for new rows | Renders |

## How

Extend `transaction-predicates.ts` with 5 dual-shape predicates: `isSendLinkEntry`, `isRequestEntry`, `isOnrampEntry`, `isMantecaOnrampEntry`, `isDirectSendEntry`. Each accepts a `TransactionDetails` and matches BOTH the legacy `originalType` and the post-M3 `TRANSACTION_INTENT + kind=<wire-label>` shapes. Then sweep every one-sided gate across `useReceiptViewModel.ts`, `TransactionDetailsReceipt.tsx`, and `provider-actions/CancelDepositActions.tsx`.

The Manteca-vs-Bridge discriminator in `isMantecaOnrampEntry` uses absence of `extraDataForDrawer.depositInstructions` — BE-confirmed disjoint: `peanut-api-ts/src/bridge/*` writes that field exclusively, `peanut-api-ts/src/manteca/*` writes `receipt.depositDetails` (different field, read directly by `MantecaDepositInfo.tsx`).

## Catch-net (so this whole class can't come back)

1. **Parity test suite** (`useReceiptViewModel.test.ts`): 8 representative rows expressed in both wire shapes (legacy + post-M3) feed through the same `useReceiptViewModel`; the test asserts identical `rowVisibilityConfig`. Any future one-sided gate fails here.
2. **`IntentKind` export** (`strategies/registry.ts`): the strategy dispatcher's source-of-truth union of post-M3 kinds is now exported. `transaction-predicates.ts` pins its `kind` argument to it, and so does the parity test's `ParityCase.intentKind` field. A predicate referencing a kind the registry can't dispatch (or a kind a future BE rename invalidates) is a **compile error**.
3. **`transaction-predicates.test.ts`** locks the dual-shape behaviour of every new predicate (legacy + intent + negative + cross-kind tests).

## Verification (BE-side authoritative wire-shape map)

Sourced from `peanut-api-ts/src/ledger/card-spend.ts:toLegacyKindLabel`:

| Legacy `originalType` | BE TransactionIntentKind | Wire `extraData.kind` |
|---|---|---|
| SEND_LINK | SEND_LINK, SEND_LINK_CLAIM | LINK_CREATE |
| REQUEST | P2P_REQUEST_FULFILL | REQUEST_PAY |
| BRIDGE_ONRAMP / MANTECA_ONRAMP | ONRAMP | FIAT_ONRAMP |
| BRIDGE_OFFRAMP / MANTECA_OFFRAMP | OFFRAMP | FIAT_OFFRAMP |
| DIRECT_SEND | DIRECT_TRANSFER | P2P_SEND |
| MANTECA_QR_PAYMENT / SIMPLEFI_QR_PAYMENT | QR_PAY | QR_PAY |

## Tests

- `pnpm typecheck` — clean
- `pnpm exec jest` — 43/43 suites, 981/981 pass, 4 skipped
- New: 13 predicate tests + 8 parity tests + reuses 3 prior `useReceiptViewModel` tests
- `pnpm exec prettier --check` — clean

## Risk

- **Pre-M3 rows (legacy `originalType`):** zero behaviour change — every predicate's first branch matches the legacy enum value.
- **Post-M3 rows:** strict improvement — all five affected paths above now render correctly. No previously-working flow gets hidden.
- **Manteca discriminator** (`!depositInstructions`): only differs from legacy if a Manteca onramp ever ships `depositInstructions`. BE code review confirms that field is exclusive to Bridge.