### PR TITLE
fix(flags): alias european_union.svg to /flags/eu.svg

### DIFF
--- a/scripts/copy-flags.mjs
+++ b/scripts/copy-flags.mjs
@@ -12,6 +12,16 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const src = resolve(root, 'node_modules/circle-flags/flags')
 const dest = resolve(root, 'public/flags')
 
+// circle-flags ships some flags under verbose filenames that don't match the
+// ISO-2 / short codes the rest of the app uses. Mirror them under the short
+// name we actually request. `countryCurrencyMapping.ts` maps EUR → 'eu'; the
+// package only has 'european_union.svg', so without this alias every EUR-
+// currency fallback (e.g. SEPA onramps without IBAN signal, the KYC icon
+// strip) 404s in production.
+const ALIASES = {
+    european_union: 'eu',
+}
+
 if (!existsSync(src)) {
     console.error(`[copy-flags] source missing: ${src}. Run \`pnpm install\` first.`)
     process.exit(1)
@@ -19,4 +29,15 @@ if (!existsSync(src)) {
 
 mkdirSync(dest, { recursive: true })
 cpSync(src, dest, { recursive: true })
+
+for (const [from, to] of Object.entries(ALIASES)) {
+    const fromPath = resolve(src, `${from}.svg`)
+    const toPath = resolve(dest, `${to}.svg`)
+    if (!existsSync(fromPath)) {
+        console.error(`[copy-flags] alias source missing: ${from}.svg`)
+        process.exit(1)
+    }
+    cpSync(fromPath, toPath)
+}
+
 console.log(`[copy-flags] copied SVGs from circle-flags → public/flags/`)


### PR DESCRIPTION
## Summary

Visible symptom: **broken Bank Account avatar** on EUR bank-deposit ("Add from Bank Account") rows in the activity feed and receipt drawer (Hugo's screenshot from the dev → main release prep).

Root cause: `countryCurrencyMapping.ts` maps the EUR currency code to flagCode `eu`, so every EUR-currency flag fallback requests `/flags/eu.svg`. The `circle-flags` npm package (pinned 2.8.3) ships the same artwork under **`european_union.svg`**, not `eu.svg`. `scripts/copy-flags.mjs` does a flat recursive copy with no renaming — so `/flags/eu.svg` 404s on every fresh install (Vercel, CI, any dev who didn't manually copy the file locally before the `67ff7348a` migration on 2026-04-24).

I verified locally: stray `public/flags/eu.svg` on my machine is byte-identical to `node_modules/circle-flags/flags/european_union.svg` — someone (probably me) renamed it manually at the migration and never updated the install script. `public/flags/` is gitignored, so the manual rename never propagated.

## Blast radius (everything fixed by this PR)

- Bank Account avatar for any EUR bank tx that falls back to the currency-only flag (SEPA onramps without IBAN signal — see "Out of scope" below)
- `getFlagUrl('eu')` hardcoded in `src/components/Kyc/CountryFlagAndName.tsx:23` (KYC icon strip — `[us, eu, gb, mx]`)
- Any future direct caller of `getFlagUrl('eu')`

I cross-checked every other `flagCode` in `countryCurrencyMapping.ts` against the circle-flags package — **only `eu` is missing**. The fix is narrow.

## What changed

`scripts/copy-flags.mjs`:

- After the recursive copy, mirror `european_union.svg → eu.svg` via a small alias map. Asset-only, zero JS/TS code change, zero runtime behavior change.
- Fails loud (`process.exit(1)`) if the alias source file disappears in a future circle-flags upgrade, so we won't silently regress.

## Out of scope (separate fix in flight)

The screenshot also exposes a deeper plumbing bug: `shouldPlumbBankAccountDetails` in `transactionTransformer.ts:36` doesn't handle onramp types (`BRIDGE_ONRAMP`, `MANTECA_ONRAMP`, `TRANSACTION_INTENT × FIAT_ONRAMP`), so the avatar can't use the sender's IBAN prefix and falls through to currency-only. Even with this PR, a Spanish user doing an EUR onramp will see the EU circle flag instead of the Spanish flag — and the IBAN row will still be missing from the receipt drawer.

That fix is being worked in parallel on `fix/post-decomplexify-entry-type-gates` (introduces `isOnrampEntry` predicate and friends in `transaction-predicates.ts`). This PR is deliberately scoped to the asset so it can ship to the release branch without entangling with the behavior-change PR.

## Test plan

- [x] Ran patched `node scripts/copy-flags.mjs` in a fresh worktree; verified `public/flags/eu.svg` is created and byte-identical to `european_union.svg`.
- [x] Confirmed every other mapping `flagCode` already resolves under circle-flags (`ar bg br ch cz dk gb hu is mx no pl ro se us` — all present).
- [ ] On preview: load any EUR bank-rail history row; Bank Account avatar renders the EU circle flag instead of the broken-image alt text.
- [ ] On preview: KYC flow icon strip renders all four flags (`us, eu, gb, mx`).