### PR TITLE
fix(useTransactionHistory): stop calling hooks conditionally

### DIFF
--- a/src/hooks/__tests__/useTransactionHistory.test.tsx
+++ b/src/hooks/__tests__/useTransactionHistory.test.tsx
@@ -29,13 +29,17 @@ describe('useTransactionHistory', () => {
     // between renders changed the hook order and crashed the component.
     it('switching mode between renders does not crash (hook order stable)', () => {
         const wrapper = makeWrapper()
+        // The overload signatures require literal `mode`; narrow per branch so the
+        // hook is called with a concrete mode each time. Pre-fix, this rerender
+        // chain crashed React with "Rendered different hooks than during the previous render".
         const { rerender } = renderHook(
-            ({ mode }: { mode: 'latest' | 'infinite' }) => useTransactionHistory({ mode, enabled: false }),
-            { wrapper, initialProps: { mode: 'latest' } }
+            ({ mode }: { mode: 'latest' | 'infinite' }) =>
+                mode === 'latest'
+                    ? useTransactionHistory({ mode: 'latest', enabled: false })
+                    : useTransactionHistory({ mode: 'infinite', enabled: false }),
+            { wrapper, initialProps: { mode: 'latest' as 'latest' | 'infinite' } }
         )
 
-        // The crash this test guards against would surface here as
-        // "Rendered fewer/more hooks than expected".
         expect(() => rerender({ mode: 'infinite' })).not.toThrow()
         expect(() => rerender({ mode: 'latest' })).not.toThrow()
     })

--- a/src/hooks/__tests__/useTransactionHistory.test.tsx
+++ b/src/hooks/__tests__/useTransactionHistory.test.tsx
@@ -1,0 +1,57 @@
+import { renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useTransactionHistory } from '@/hooks/useTransactionHistory'
+import type { ReactNode } from 'react'
+
+// Mock the network — these tests assert hook-order behaviour, not fetching.
+jest.mock('@/utils/api-fetch', () => ({
+    serverFetch: jest.fn(() =>
+        Promise.resolve({
+            ok: true,
+            statusText: 'OK',
+            json: () => Promise.resolve({ entries: [], hasMore: false }),
+        })
+    ),
+}))
+
+function makeWrapper() {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+    Wrapper.displayName = 'TestQueryClientWrapper'
+    return Wrapper
+}
+
+describe('useTransactionHistory', () => {
+    // Regression test for the Rules-of-Hooks violation: the hook previously
+    // called useQuery OR useInfiniteQuery based on `mode`, so switching modes
+    // between renders changed the hook order and crashed the component.
+    it('switching mode between renders does not crash (hook order stable)', () => {
+        const wrapper = makeWrapper()
+        const { rerender } = renderHook(
+            ({ mode }: { mode: 'latest' | 'infinite' }) => useTransactionHistory({ mode, enabled: false }),
+            { wrapper, initialProps: { mode: 'latest' } }
+        )
+
+        // The crash this test guards against would surface here as
+        // "Rendered fewer/more hooks than expected".
+        expect(() => rerender({ mode: 'infinite' })).not.toThrow()
+        expect(() => rerender({ mode: 'latest' })).not.toThrow()
+    })
+
+    it('returns the latest-mode query shape for mode="latest"', () => {
+        const wrapper = makeWrapper()
+        const { result } = renderHook(() => useTransactionHistory({ mode: 'latest', enabled: false }), { wrapper })
+        // useQuery result — has data/isLoading but no fetchNextPage.
+        expect(result.current).toHaveProperty('data')
+        expect(result.current).not.toHaveProperty('fetchNextPage')
+    })
+
+    it('returns the infinite-mode query shape for mode="infinite"', () => {
+        const wrapper = makeWrapper()
+        const { result } = renderHook(() => useTransactionHistory({ mode: 'infinite', enabled: false }), { wrapper })
+        // useInfiniteQuery result — exposes fetchNextPage.
+        expect(result.current).toHaveProperty('fetchNextPage')
+    })
+})

--- a/src/hooks/useTransactionHistory.ts
+++ b/src/hooks/useTransactionHistory.ts
@@ -76,34 +76,33 @@ export function useTransactionHistory({
         }
     }
 
-    // Latest transactions mode (for home page)
-    // Two-tier caching: TQ in-memory (30s) → SW disk cache (1 week) → Network
-    // Balance: Fresh enough for home page + reduces redundant SW cache hits
-    if (mode === 'latest') {
-        return useQuery({
-            queryKey: [TRANSACTIONS, 'latest', { limit, targetUsername: filterMutualTxs ? username : undefined }],
-            queryFn: () => fetchHistory({ limit }),
-            enabled,
-            // 30s cache: Fresh enough for home page widget
-            // On cold start, will fetch → SW responds <50ms from cache
-            staleTime: 30 * 1000, // 30 seconds (balance: freshness vs performance)
-            gcTime: 5 * 60 * 1000, // Keep in memory for 5min
-            // Refetch on mount - TQ automatically skips if data is fresh (< staleTime)
-            refetchOnMount: true,
-            // Refetch on focus - TQ automatically skips if data is fresh (< staleTime)
-            refetchOnWindowFocus: true,
-        })
-    }
+    // Both hooks run unconditionally on every render (Rules of Hooks). The disabled one
+    // sits idle thanks to its `enabled` flag — no network, no work — so this has no
+    // runtime cost over the conditional version, while removing the hook-order corruption
+    // that bites if a caller ever flips `mode` mid-life.
 
-    // Infinite query mode (for main history page)
-    // Uses longer staleTime since user is actively browsing (less critical for instant updates)
-    return useInfiniteQuery({
+    // Latest transactions (home page).
+    // Two-tier caching: TQ in-memory (30s) → SW disk cache (1 week) → Network.
+    const latestQuery = useQuery({
+        queryKey: [TRANSACTIONS, 'latest', { limit, targetUsername: filterMutualTxs ? username : undefined }],
+        queryFn: () => fetchHistory({ limit }),
+        enabled: mode === 'latest' && enabled,
+        staleTime: 30 * 1000,
+        gcTime: 5 * 60 * 1000,
+        refetchOnMount: true,
+        refetchOnWindowFocus: true,
+    })
+
+    // Infinite scrolling (main history page).
+    const infiniteQuery = useInfiniteQuery({
         queryKey: [TRANSACTIONS, 'infinite', { limit }],
         queryFn: ({ pageParam }) => fetchHistory({ cursor: pageParam, limit }),
         initialPageParam: undefined as string | undefined,
         getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.cursor : undefined),
-        enabled,
-        staleTime: 30 * 1000, // 30 seconds (infinite scroll doesn't need instant updates)
-        gcTime: 5 * 60 * 1000, // Keep in memory for 5min
+        enabled: mode === 'infinite' && enabled,
+        staleTime: 30 * 1000,
+        gcTime: 5 * 60 * 1000,
     })
+
+    return mode === 'latest' ? latestQuery : infiniteQuery
 }


### PR DESCRIPTION
## Summary

Fixes a Rules-of-Hooks violation in `useTransactionHistory`. Surfaced by ESLint when it was wired up in #1976 — one of two `react-hooks/rules-of-hooks` errors flagged across the codebase.

## The bug

```ts
export function useTransactionHistory({ mode, ... }) {
    // ...
    if (mode === 'latest') {
        return useQuery({ ... })             // ← line 83 before fix
    }
    return useInfiniteQuery({ ... })         // ← line 100 before fix
}
```

The hook called `useQuery` OR `useInfiniteQuery` based on the runtime `mode` argument. Rules of Hooks requires every hook to run in the **same order on every render** — React tracks hooks by call-site position, not by name. If `mode` ever flips between renders the slot at position N changes from `useQuery` to `useInfiniteQuery`, which corrupts React's internal state.

**Latent today.** Callers fix `mode` at construction and never change it:

- Home page: `mode: 'latest'` (forever)
- History page: `mode: 'infinite'` (forever)

Per-instance the hook order is stable, so no crash in production *yet*. But the moment anyone writes:

```tsx
useTransactionHistory({ mode: showAll ? 'infinite' : 'latest' })
```

…with `showAll` toggled by a UI control, the component will crash with "Rendered fewer/more hooks than expected" — or, scarier, silently wire the wrong query's state to whatever downstream uses the result. Pure latent footgun.

## The fix

Call both hooks unconditionally, gate fetching via each one's `enabled` flag, return whichever matches the current mode:

```ts
const latestQuery = useQuery({
    ...,
    enabled: mode === 'latest' && enabled,
})

const infiniteQuery = useInfiniteQuery({
    ...,
    enabled: mode === 'infinite' && enabled,
})

return mode === 'latest' ? latestQuery : infiniteQuery
```

Both hooks always run in the same order. The inactive one is idle (no fetch, no work, no network cost). The existing function-overload signatures (lines 30-42) keep the caller's return type narrow.

## Test plan

New unit test `src/hooks/__tests__/useTransactionHistory.test.tsx`:

- **Regression test:** rerenders the hook with alternating `mode` values and asserts no throw. Would have failed on the pre-fix code with React's "Rendered different hooks" error.
- Asserts the latest-mode return shape (`data`, no `fetchNextPage`).
- Asserts the infinite-mode return shape (has `fetchNextPage`).

- [x] `pnpm typecheck` — clean (asset TS2307s pre-exist, unrelated)
- [x] `pnpm test` — 46 suites / 1007 tests pass (3 new)
- [x] `pnpm lint` on the file — clean (rules-of-hooks gone)
- [x] `pnpm prettier --check` — clean

## Risk

Low. Behaviour-preserving refactor:
- Same query keys
- Same `enabled` semantics (just `&& mode === '<x>'` added)
- Same `staleTime` / `gcTime` / `refetchOnMount` / `refetchOnWindowFocus`
- Same return values

The disabled query is genuinely zero-cost — React Query short-circuits before any fetch when `enabled: false`.

## Follow-up

This was 1 of 2 `react-hooks/rules-of-hooks` errors flagged in ESLint output. Wait — actually both come from this same file (lines 83 + 100 = the two branches of the same `if/else`). Fixing the structure here addresses both. After this lands, that rule should be at 0 errors.