### PR TITLE
fix(card): decline mapping + rebalance push timing + declined row styling

### DIFF
--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -165,11 +165,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
     return (
         <>
             {/* the clickable card */}
-            <Card
-                position={position}
-                onClick={handleClick}
-                className={twMerge('cursor-pointer', isDeclinedCardSpend && 'opacity-60')}
-            >
+            <Card position={position} onClick={handleClick} className="cursor-pointer">
                 <div className="flex items-center justify-between">
                     <div className="flex items-center gap-3">
                         {/* txn avatar component handles icon/initials/colors */}
@@ -252,7 +248,12 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
                                         <span
                                             className={twMerge(
                                                 'font-semibold',
-                                                status === 'refunded' && 'text-gray-1 line-through'
+                                                status === 'refunded' && 'text-gray-1 line-through',
+                                                // Declined card spends: gray the amount so the row reads
+                                                // as "didn't go through" without the opacity-60 wash
+                                                // we used before (which dimmed merchant name + icons
+                                                // too and made the row hard to read at a glance).
+                                                isDeclinedCardSpend && 'text-gray-1'
                                             )}
                                         >
                                             {displayAmount}

--- a/src/utils/__tests__/cardDeclineReason.test.ts
+++ b/src/utils/__tests__/cardDeclineReason.test.ts
@@ -61,4 +61,33 @@ describe('friendlyDeclineReason', () => {
             expect(friendlyDeclineReason('card_locked', null)).toBe('Your card is locked')
         })
     })
+
+    describe('Rain prose strings normalize correctly', () => {
+        // Real example from 2026-05-11 staging webhook (Adidas decline).
+        // Rain emits human-readable prose, not just snake_case codes.
+        test('"account credit limit exceeded" → insufficient balance copy', () => {
+            expect(friendlyDeclineReason('account credit limit exceeded')).toBe('Insufficient balance')
+        })
+
+        test('"card spending limit exceeded" → spending-limit copy', () => {
+            expect(friendlyDeclineReason('card spending limit exceeded')).toBe('Spending limit reached')
+        })
+
+        test('mixed-case prose normalized too', () => {
+            expect(friendlyDeclineReason('Account Credit Limit Exceeded')).toBe('Insufficient balance')
+        })
+
+        test('snake_case + SCREAMING_CASE still hit the same friendly copy', () => {
+            // Pin the normalization: all three shapes for the same code
+            // must produce the same output.
+            expect(friendlyDeclineReason('insufficient_funds')).toBe('Insufficient balance')
+            expect(friendlyDeclineReason('INSUFFICIENT_FUNDS')).toBe('Insufficient balance')
+            expect(friendlyDeclineReason('Insufficient Funds')).toBe('Insufficient balance')
+        })
+
+        test('whitespace and punctuation tolerated', () => {
+            expect(friendlyDeclineReason('  insufficient   funds  ')).toBe('Insufficient balance')
+            expect(friendlyDeclineReason('insufficient-funds')).toBe('Insufficient balance')
+        })
+    })
 })

--- a/src/utils/cardDeclineReason.ts
+++ b/src/utils/cardDeclineReason.ts
@@ -8,10 +8,11 @@
  *     We prefer this when present because Rain reports `INSUFFICIENT_FUNDS`
  *     for both genuine shortfalls AND limit-too-low cases — the synthetic
  *     category distinguishes them so the user gets actionable copy.
- *   - `code` — Rain's raw decline string (snake_case alongside the older
- *     SCREAMING_CASE variants). Fallback when category is missing (older
- *     declines that pre-date the categorization), or for non-financial
- *     reasons (blocked merchant, locked card, etc.).
+ *   - `code` — Rain's raw decline string. Rain emits a mix of snake_case
+ *     codes (`insufficient_funds`), SCREAMING_CASE legacy variants
+ *     (`INSUFFICIENT_FUNDS`), AND human-readable prose
+ *     (`"account credit limit exceeded"`). We normalize the code before
+ *     lookup so all three shapes hit the same key.
  *
  * Unknown codes fall back to the generic copy mandated by the card-activity
  * spec.
@@ -30,19 +31,36 @@ const CATEGORY_COPY: Record<string, string> = {
     insufficient_balance: 'Insufficient balance',
 }
 
+/**
+ * Keys are normalized: lowercase + non-alphanumerics → underscore. So
+ * `INSUFFICIENT_FUNDS`, `insufficient_funds`, and `"insufficient funds"` all
+ * collide on `insufficient_funds`. Add new entries in normalized form only.
+ */
 const FRIENDLY: Record<string, string> = {
-    INSUFFICIENT_FUNDS: 'Insufficient balance',
     insufficient_funds: 'Insufficient balance',
+    // Rain prose seen in production webhooks (2026-05-11 Adidas decline):
+    // "account credit limit exceeded" means the user has spent down their
+    // available collateral — funding issue, not per-tx-limit. The matching
+    // BE category is `insufficient_balance`; keep this string in sync.
+    account_credit_limit_exceeded: 'Insufficient balance',
+    credit_limit_exceeded: 'Insufficient balance',
+    // Per-tx cardLimit breached (user's configured per-authorization cap)
     card_spending_limit_exceeded: 'Spending limit reached',
-    CARD_SPENDING_LIMIT_EXCEEDED: 'Spending limit reached',
+    spending_limit_exceeded: 'Spending limit reached',
     blocked_merchant: "This merchant isn't supported",
     blocked_mcc: "This merchant isn't supported",
-    BLOCKED_MERCHANT: "This merchant isn't supported",
-    BLOCKED_MCC: "This merchant isn't supported",
     card_locked: 'Your card is locked',
-    CARD_LOCKED: 'Your card is locked',
     invalid_pin: 'Incorrect PIN',
-    INVALID_PIN: 'Incorrect PIN',
+}
+
+/** Collapse Rain's three flavours (snake_case, SCREAMING_CASE, prose) into a
+ *  single lookup key. lower-case + replace runs of non-alphanumerics with one
+ *  underscore + trim edge underscores. */
+function normalizeDeclineCode(code: string): string {
+    return code
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '_')
+        .replace(/^_+|_+$/g, '')
 }
 
 export function friendlyDeclineReason(code: string | null | undefined, category?: DeclineCategory | null): string {
@@ -50,5 +68,5 @@ export function friendlyDeclineReason(code: string | null | undefined, category?
     // INSUFFICIENT_FUNDS/limit-too-low collision Rain leaves on the wire.
     if (category && CATEGORY_COPY[category]) return CATEGORY_COPY[category]
     if (!code) return 'Transaction declined'
-    return FRIENDLY[code] ?? FRIENDLY[code.toLowerCase()] ?? FRIENDLY[code.toUpperCase()] ?? 'Transaction declined'
+    return FRIENDLY[normalizeDeclineCode(code)] ?? 'Transaction declined'
 }


### PR DESCRIPTION
Pairs with **peanut-api-ts#<companion>**. Two BE fixes mirrored by two FE fixes.

## #2 — Decline mapping bug (cross-repo)

Production webhook from 2026-05-11 (Adidas decline at \$176.85):
\`\`\`
declinedReason: \"account credit limit exceeded\"
\`\`\`
That string contains the word "limit", so the BE \`categorizeCardDecline\` mis-categorized it as \`limit_too_low\` (sending users to /card/limit). And the FE \`friendlyDeclineReason\` lookup table only had snake_case keys, so the prose fell through to "Transaction declined". Two bugs combining to make the most common decline cause render as the least useful message.

**This PR (FE)**: normalize the code at lookup time (lowercase + non-alphanumeric → underscore + trim) and add the prose variants. Snake_case + SCREAMING_CASE + "Insufficient Funds" all collide on the same key. 8 new tests pin the normalization.

**Companion (BE)**: distinguish \`"credit"\` (insufficient_balance) from \`"spending limit"\` (limit_too_low) instead of the catch-all \`.includes('limit')\`.

## #4 — Declined-card row styling

Was: \`opacity-60\` on whole card → merchant name + icons all washed out.
Now: \`text-gray-1\` on just the amount text → row reads "didn't go through" without losing legibility. Mirrors refunded row's amount-gray pattern (minus the line-through, since declined ≠ undone).

## Test plan

- [x] 16 FE tests (8 new) — \`pnpm test --testPathPattern=cardDeclineReason\` passes.
- [ ] Trigger a real card decline on staging — confirm receipt drawer shows "Insufficient balance" (not "Transaction declined") for \`"account credit limit exceeded"\`.
- [ ] Same flow, verify activity feed row has gray amount + readable merchant name.

## Companion PR

Backend with the categorization fix + rebalance-notification timing fix (rebalance push moved from on-chain submit → Rain collateral webhook, since the on-chain landing fires ~3-5s before Rain actually credits the spending power).