### PR TITLE
feat(card): receipt-drawer copy for hold-release + pending auth

### DIFF
--- a/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
+++ b/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
@@ -46,6 +46,15 @@ export function hasCardPaymentRowsContent(transaction: TransactionDetails): bool
     // through nonBlank.
     if (transaction.status === 'failed' && (nonBlank(card.declineReason) || card.declineCategory)) return true
     if (card.cancellationReason === 'auto_closed') return true
+    // Hold-release explanation: Rain auths now sit at AWAITING_SETTLEMENT
+    // (PENDING badge on the FE) until they settle or release. Both the
+    // pending and cancelled states need a row in the receipt — pending so
+    // the user understands the money isn't fully spent yet, cancelled so
+    // they know why the hold released without a charge.
+    if (transaction.status === 'pending' && !card.isRefund) return true
+    if (card.cancellationReason === 'auth_reversed' || card.cancellationReason === 'auth_expired_uncaptured') {
+        return true
+    }
     return false
 }
 
@@ -130,6 +139,39 @@ export function CardPaymentRows({
             key: 'autoCloseNote',
             label: 'Note',
             value: "Automatically cancelled — the merchant didn't complete it",
+        })
+    }
+
+    // BE-driven cancellationReason taxonomy from peanut-api-ts auth-lifecycle
+    // PR. `auth_reversed` = merchant explicitly dropped the hold;
+    // `auth_expired_uncaptured` = Rain emitted completed-with-zero (the
+    // 14-day window closed without a capture). Both translate to "funds
+    // returned"; different copy so the user knows what to do next (nothing
+    // for reversed; contact the merchant if expired-uncaptured was unwanted).
+    if (card.cancellationReason === 'auth_reversed') {
+        subRows.push({
+            key: 'authReversedNote',
+            label: 'Note',
+            value: 'Hold released — the merchant cancelled the authorization. Funds are back on your card.',
+        })
+    }
+    if (card.cancellationReason === 'auth_expired_uncaptured') {
+        subRows.push({
+            key: 'authExpiredNote',
+            label: 'Note',
+            value: "Hold released — the merchant didn't capture the payment in time. Funds are back on your card.",
+        })
+    }
+
+    // Pending card spends now sit at AWAITING_SETTLEMENT (PENDING badge)
+    // for up to ~14 days while Rain waits for the merchant to capture or
+    // release. Without this row, users see "Pending" and worry the money
+    // is stuck — exact wording per @jjramirezn on the auth-lifecycle PR.
+    if (transaction.status === 'pending' && !card.isRefund) {
+        subRows.push({
+            key: 'pendingNote',
+            label: 'Status',
+            value: 'Authorized, awaiting settlement or reversal',
         })
     }
 

--- a/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
+++ b/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
@@ -34,6 +34,13 @@ function parseCents(value: string | null | undefined): number | null {
  * fiat amount now flows through the receipt's heading (≈ ARS X) and
  * exchange-rate row instead — same treatment as Manteca QR pays.
  */
+/**
+ * KEEP IN SYNC with `CardPaymentRows` below — every condition that pushes
+ * a sub-row in the renderer needs a matching predicate here. The parent
+ * receipt uses this to decide whether to show the slot at all, so a
+ * missed condition here means a row exists but its border gets clipped.
+ * (No automated check today; verify by inspection when adding rows.)
+ */
 export function hasCardPaymentRowsContent(transaction: TransactionDetails): boolean {
     const card = transaction.extraDataForDrawer?.cardPayment
     if (!card) return false
@@ -148,14 +155,16 @@ export function CardPaymentRows({
     // 14-day window closed without a capture). Both translate to "funds
     // returned"; different copy so the user knows what to do next (nothing
     // for reversed; contact the merchant if expired-uncaptured was unwanted).
+    // `else if` (rather than two independent `if`s) makes the mutual
+    // exclusion explicit — guards against a future refactor that might
+    // start storing both at once.
     if (card.cancellationReason === 'auth_reversed') {
         subRows.push({
             key: 'authReversedNote',
             label: 'Note',
             value: 'Hold released — the merchant cancelled the authorization. Funds are back on your card.',
         })
-    }
-    if (card.cancellationReason === 'auth_expired_uncaptured') {
+    } else if (card.cancellationReason === 'auth_expired_uncaptured') {
         subRows.push({
             key: 'authExpiredNote',
             label: 'Note',
@@ -167,7 +176,15 @@ export function CardPaymentRows({
     // for up to ~14 days while Rain waits for the merchant to capture or
     // release. Without this row, users see "Pending" and worry the money
     // is stuck — exact wording per @jjramirezn on the auth-lifecycle PR.
-    if (transaction.status === 'pending' && !card.isRefund) {
+    // Guarded against any cancellation-note already in place: a
+    // transient pending+cancellationReason payload would otherwise render
+    // both "Authorized, awaiting..." AND "Hold released..." simultaneously,
+    // which is contradictory copy.
+    const hasCancellationNote =
+        card.cancellationReason === 'auto_closed' ||
+        card.cancellationReason === 'auth_reversed' ||
+        card.cancellationReason === 'auth_expired_uncaptured'
+    if (transaction.status === 'pending' && !card.isRefund && !hasCancellationNote) {
         subRows.push({
             key: 'pendingNote',
             label: 'Status',


### PR DESCRIPTION
Pairs with **peanut-api-ts#<auth-lifecycle PR>**. Surfaces the new states the BE now emits.

## Three new receipt-drawer rows

1. **Pending card spend (AWAITING_SETTLEMENT)** — \`status: pending\`, not a refund:
   > **Status:** Authorized, awaiting settlement or reversal

2. **Cancelled, \`cancellationReason: 'auth_reversed'\`** (merchant dropped the hold):
   > **Note:** Hold released — the merchant cancelled the authorization. Funds are back on your card.

3. **Cancelled, \`cancellationReason: 'auth_expired_uncaptured'\`** (Rain \`completed\` with amount 0):
   > **Note:** Hold released — the merchant didn't capture the payment in time. Funds are back on your card.

## Why

Today: an Adidas-style auth that never captures shows up in the feed as a \"completed\" $0 charge. The user loses \$176 of spending power for ~14 days with no in-app explanation. After the BE PR lands, that same flow shows up as **Pending** with the status-detail row above, then transitions to **Cancelled** with the hold-released note when Rain emits \`completed\` with amount 0 (or earlier if reversed).

## Files

- \`src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx\` — add three sub-row blocks + extend the visibility gate so the slot renders for pending and the two new cancellation reasons.

No transformer change — \`cancellationReason: string | null\` was already plumbed through \`extraDataForDrawer.cardPayment\` and the new BE values flow through as strings.

## Test plan

- [ ] Trigger a real card auth on staging — confirm \`/history/:entryId\` receipt drawer shows "Authorized, awaiting settlement or reversal" while pending.
- [ ] Let it expire (or fake \`completed\` with amount=0 via webhook replay) — confirm receipt flips to "Hold released — the merchant didn't capture..." and intent status reads "Cancelled".
- [ ] Trigger a reversal mid-flight — confirm "Hold released — the merchant cancelled..." copy.
- [ ] Confirm successful settlement still renders the standard completed receipt (no new rows).
- [ ] Confirm declined card spends still show the existing decline-reason row.

## Cross-repo

Deploy BE first so the new \`cancellationReason\` values land in metadata. The FE is forward-compatible — pre-BE intents still render via the existing rules.