### PR TITLE
chore: enable full maintenance mode for prod release

### DIFF
--- a/src/config/underMaintenance.config.ts
+++ b/src/config/underMaintenance.config.ts
@@ -52,7 +52,7 @@ interface MaintenanceConfig {
 }
 
 const underMaintenanceConfig: MaintenanceConfig = {
-    enableFullMaintenance: false, // set to true to redirect all pages to /maintenance
+    enableFullMaintenance: true, // set to true to redirect all pages to /maintenance
     enableMaintenanceBanner: false, // set to true to show maintenance banner on all pages
     disabledPaymentProviders: [], // set to ['MANTECA'] to disable Manteca QR payments
     disableSquidWithdraw: true, // set to true to disable cross-chain withdrawals (only allows USDC on Arbitrum)


### PR DESCRIPTION
One-line flip: \`enableFullMaintenance: false → true\` in \`src/config/underMaintenance.config.ts\`.

## When to merge

**Immediately before kicking off the decomplexify migrations** (Phase 4, step 1 in the [Release Process runbook](https://www.notion.so/peanutprotocol/Release-Process-21e83811757980b79393db870361fc5d)). All routes redirect to \`/maintenance\`; landing (\`/\`), \`/support\`, and \`/apple-app-site-association\` stay accessible per existing proxy logic in \`src/proxy.ts\`.

## How to exit maintenance

Two options after the release is live and verified:

1. **Revert this PR** on GitHub (one click) — simplest, fastest.
2. **Wait for the release dev→main PR (#1984) to merge.** ⚠️ dev still has \`enableFullMaintenance: false\`, so that PR will hit a merge conflict on this exact line — resolve to \`false\`. Either path lands the same outcome; option 1 is friction-free.

## Risk

- Surgical, single-line change branched off \`main\` (not \`dev\`), so it doesn't drag in any unreleased changes.
- Maintenance infrastructure is pre-existing (\`/maintenance\` page, proxy redirect, allowed-paths list) — no new code paths.
- Vercel preview will visibly render the maintenance page; that's the verification.

## Test plan

- [ ] Vercel preview shows the \`/maintenance\` page on \`/home\`, \`/send\`, etc.
- [ ] Preview lets \`/\` and \`/support\` through.
- [ ] After merge: prod redirects all routes within ~1 minute of Vercel deploy.