### PR TITLE
feat(country-list): surface top corridors above alphabetical

### DIFF
--- a/src/components/AddMoney/consts/index.ts
+++ b/src/components/AddMoney/consts/index.ts
@@ -18,6 +18,11 @@ export const MantecaSupportedExchanges = {
     //BO: 'BOLIVIA',
 }
 
+// ISO-2 codes of our highest-volume corridors, surfaced at the top of the
+// add/withdraw country list (after the user's own country if geolocated).
+// Order here is the order shown to users.
+export const PREFERRED_COUNTRY_ISO2 = ['US', 'AR', 'BR', 'GB', 'DE', 'ES', 'PT'] as const
+
 export interface SpecificPaymentMethod {
     id: string
     icon: IconName | string | undefined

--- a/src/components/Common/CountryList.tsx
+++ b/src/components/Common/CountryList.tsx
@@ -4,6 +4,7 @@ import {
     countryData,
     MantecaSupportedExchanges,
     ALL_COUNTRIES_ALPHA3_TO_ALPHA2,
+    PREFERRED_COUNTRY_ISO2,
 } from '@/components/AddMoney/consts'
 import EmptyState from '@/components/Global/EmptyStates/EmptyState'
 import { SearchInput } from '@/components/SearchInput'
@@ -76,8 +77,15 @@ export const CountryList = ({
 
     const supportedCountries = countryData.filter((country) => country.type === 'country')
 
-    // sort countries based on user's geo location, fallback to alphabetical order
+    // sort countries: user's geo-located country first, then preferred countries
+    // (in declared order), then everyone else alphabetically.
     const sortedCountries = useMemo(() => {
+        const preferredRank = (country: CountryData) => {
+            const iso2 = country.iso2 ?? ALL_COUNTRIES_ALPHA3_TO_ALPHA2[country.id]
+            const i = iso2 ? PREFERRED_COUNTRY_ISO2.indexOf(iso2 as (typeof PREFERRED_COUNTRY_ISO2)[number]) : -1
+            return i === -1 ? Infinity : i
+        }
+
         return [...supportedCountries].sort((a, b) => {
             if (userGeoLocationCountryCode) {
                 const aIsUserCountry =
@@ -90,6 +98,11 @@ export const CountryList = ({
                 if (aIsUserCountry && !bIsUserCountry) return -1
                 if (!aIsUserCountry && bIsUserCountry) return 1
             }
+
+            const aRank = preferredRank(a)
+            const bRank = preferredRank(b)
+            if (aRank !== bRank) return aRank - bRank
+
             return a.title.localeCompare(b.title)
         })
     }, [userGeoLocationCountryCode])


### PR DESCRIPTION
## Summary

Most users picking a country in add-money / withdraw are heading for one of a handful of high-volume corridors. The list was strictly alphabetical after the IP-detected country, so they scrolled past ~190 entries to reach US, UK, Germany, Spain, Portugal, etc.

## What changed

- Added `PREFERRED_COUNTRY_ISO2` in `src/components/AddMoney/consts/index.ts` — the single source of truth for the order: `US, AR, BR, GB, DE, ES, PT`.
- Updated the existing sort in `src/components/Common/CountryList.tsx` to slot preferred countries **between** geolocation and alphabetical.

## Resulting order

1. **User's IP-geolocated country** (unchanged — `useGeoLocation()` still wins)
2. **`PREFERRED_COUNTRY_ISO2`** in declared order
3. **Everyone else alphabetical**

A user in France sees: FR → US → AR → BR → GB → DE → ES → PT → Albania → Algeria → … <br>
A user in Argentina sees: AR → US → BR → GB → DE → ES → PT → Albania → … (no duplicates; sort is stable, AR stays at slot 0 via geolocation)

## Abstraction note

Both flows already share `CountryList`, so changing one place covers both. Adding `PREFERRED_COUNTRY_ISO2` next to `MantecaSupportedExchanges` keeps all country-business-rule constants colocated. Future product asks ("add Mexico to the top") = one-line edit.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `npm test` — 47 suites / 1041 tests passing
- [ ] Manual: open `/add-money` and `/withdraw` on staging; confirm US/AR/BR/GB/DE/ES/PT appear at the top after the geolocated country, rest alphabetical
- [ ] Manual: switch VPN to a non-preferred country (e.g. France) and verify the geolocated country is still first