### PR TITLE
feat(auth): consume sliding-refresh JWT from /get-user

### DIFF
--- a/src/hooks/query/__tests__/user.test.tsx
+++ b/src/hooks/query/__tests__/user.test.tsx
@@ -78,6 +78,21 @@ describe('useUserQuery — JWT sliding refresh', () => {
         expect(result.current.data).not.toHaveProperty('token')
     })
 
+    it.each([
+        ['empty string', ''],
+        ['null', null],
+    ])('strips falsy token (%s) without calling setAuthToken', async (_label, falsyToken) => {
+        mockApiFetch.mockResolvedValueOnce(
+            mockResponse(200, { user: { userId: 'u1', username: 'alice' }, token: falsyToken })
+        )
+
+        const { result } = renderHook(() => useUserQuery(), { wrapper: makeWrapper() })
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+        expect(result.current.data).not.toHaveProperty('token')
+        expect(mockSetAuthToken).not.toHaveBeenCalled()
+    })
+
     it('clears the token on 401 (dead JWT) without touching setAuthToken', async () => {
         mockApiFetch.mockResolvedValueOnce(mockResponse(401, null))
 

--- a/src/hooks/query/__tests__/user.test.tsx
+++ b/src/hooks/query/__tests__/user.test.tsx
@@ -1,0 +1,99 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+
+import { useUserQuery } from '../user'
+import { apiFetch } from '@/utils/api-fetch'
+import { setAuthToken, clearAuthToken } from '@/utils/auth-token'
+
+jest.mock('@/utils/api-fetch', () => ({ apiFetch: jest.fn() }))
+jest.mock('@/utils/auth-token', () => ({
+    setAuthToken: jest.fn(),
+    clearAuthToken: jest.fn(),
+}))
+jest.mock('@/hooks/usePWAStatus', () => ({ usePWAStatus: () => false }))
+jest.mock('@/hooks/useGetDeviceType', () => ({ useDeviceType: () => ({ deviceType: 'desktop' }) }))
+jest.mock('@/redux/hooks', () => ({
+    useAppDispatch: () => jest.fn(),
+    useUserStore: () => ({ user: null }),
+}))
+jest.mock('posthog-js', () => ({ default: { capture: jest.fn() }, capture: jest.fn() }))
+
+const mockApiFetch = apiFetch as jest.MockedFunction<typeof apiFetch>
+const mockSetAuthToken = setAuthToken as jest.MockedFunction<typeof setAuthToken>
+const mockClearAuthToken = clearAuthToken as jest.MockedFunction<typeof clearAuthToken>
+
+function makeWrapper() {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+    Wrapper.displayName = 'TestQueryClientWrapper'
+    return Wrapper
+}
+
+function mockResponse(status: number, body: unknown): Response {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: () => Promise.resolve(body),
+    } as unknown as Response
+}
+
+describe('useUserQuery — JWT sliding refresh', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('calls setAuthToken when the response includes a refreshed token', async () => {
+        const refreshed = 'new.jwt.token'
+        mockApiFetch.mockResolvedValueOnce(
+            mockResponse(200, { user: { userId: 'u1', username: 'alice' }, token: refreshed })
+        )
+
+        const { result } = renderHook(() => useUserQuery(), { wrapper: makeWrapper() })
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+        expect(mockSetAuthToken).toHaveBeenCalledWith(refreshed)
+        expect(mockSetAuthToken).toHaveBeenCalledTimes(1)
+    })
+
+    it('does NOT call setAuthToken when the response has no token field', async () => {
+        mockApiFetch.mockResolvedValueOnce(mockResponse(200, { user: { userId: 'u1', username: 'alice' } }))
+
+        const { result } = renderHook(() => useUserQuery(), { wrapper: makeWrapper() })
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+        expect(mockSetAuthToken).not.toHaveBeenCalled()
+    })
+
+    it('strips the token from the data exposed to consumers', async () => {
+        mockApiFetch.mockResolvedValueOnce(
+            mockResponse(200, { user: { userId: 'u1', username: 'alice' }, token: 'leak.me.not' })
+        )
+
+        const { result } = renderHook(() => useUserQuery(), { wrapper: makeWrapper() })
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+        expect(result.current.data).not.toHaveProperty('token')
+    })
+
+    it('clears the token on 401 (dead JWT) without touching setAuthToken', async () => {
+        mockApiFetch.mockResolvedValueOnce(mockResponse(401, null))
+
+        const { result } = renderHook(() => useUserQuery(), { wrapper: makeWrapper() })
+        await waitFor(() => expect(result.current.isFetched).toBe(true))
+
+        expect(mockClearAuthToken).toHaveBeenCalledTimes(1)
+        expect(mockSetAuthToken).not.toHaveBeenCalled()
+    })
+
+    it('clears the token on 404 (user no longer exists)', async () => {
+        mockApiFetch.mockResolvedValueOnce(mockResponse(404, null))
+
+        const { result } = renderHook(() => useUserQuery(), { wrapper: makeWrapper() })
+        await waitFor(() => expect(result.current.isFetched).toBe(true))
+
+        expect(mockClearAuthToken).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/hooks/query/user.ts
+++ b/src/hooks/query/user.ts
@@ -8,7 +8,7 @@ import { usePWAStatus } from '../usePWAStatus'
 import { useDeviceType } from '../useGetDeviceType'
 import { USER } from '@/constants/query.consts'
 import { apiFetch } from '@/utils/api-fetch'
-import { clearAuthToken } from '@/utils/auth-token'
+import { clearAuthToken, setAuthToken } from '@/utils/auth-token'
 
 // custom error class for backend errors (5xx) that should trigger retry
 export class BackendError extends Error {
@@ -29,14 +29,23 @@ export const useUserQuery = (dependsOn: boolean = true) => {
     const fetchUser = async (): Promise<IUserProfile | null> => {
         const userResponse = await apiFetch('/get-user', { method: 'POST', body: '{}' })
         if (userResponse.ok) {
-            const userData: IUserProfile | null = await userResponse.json()
-            if (userData) {
+            const payload: (IUserProfile & { token?: string }) | null = await userResponse.json()
+
+            // Sliding refresh: backend re-mints when the JWT crosses half its
+            // lifetime and ships the new one alongside the user payload. Swap
+            // it in client-side so active users never hit the 30d hard logout.
+            if (payload?.token) {
+                setAuthToken(payload.token)
+                delete payload.token
+            }
+
+            if (payload) {
                 // Was: hitUserMetric(userData.user.userId, 'login', ...) → POST /users/:id/metrics/login.
                 // DB `user_metrics` table deprecated 2026-04-24; analytics is PostHog's job.
                 posthog.capture(ANALYTICS_EVENTS.LOGIN, { isPwa, deviceType })
-                dispatch(userActions.setUser(userData))
+                dispatch(userActions.setUser(payload))
             }
-            return userData
+            return payload
         }
 
         // 5xx = backend error, throw so tanstack retries

--- a/src/hooks/query/user.ts
+++ b/src/hooks/query/user.ts
@@ -34,8 +34,10 @@ export const useUserQuery = (dependsOn: boolean = true) => {
             // Sliding refresh: backend re-mints when the JWT crosses half its
             // lifetime and ships the new one alongside the user payload. Swap
             // it in client-side so active users never hit the 30d hard logout.
-            if (payload?.token) {
-                setAuthToken(payload.token)
+            // Strip `token` unconditionally so auth state never leaks into the
+            // user store, even if the backend ever sends a falsy value.
+            if (payload && 'token' in payload) {
+                if (payload.token) setAuthToken(payload.token)
                 delete payload.token
             }
 


### PR DESCRIPTION
## Summary

Client half of the JWT sliding-refresh — kills the 30-day hard logout for active users.

When `/get-user` includes a refreshed `token` in its response (companion peanutprotocol/peanut-api-ts#751), swap it in via `setAuthToken` so the cookie/localStorage holds the new token going forward. Strip `token` from the payload before it reaches the user store so consumers never see auth state mixed into domain data.

## What changes

**`src/hooks/query/user.ts`** — `fetchUser`:
```ts
const payload: (IUserProfile & { token?: string }) | null = await userResponse.json()
if (payload?.token) {
    setAuthToken(payload.token)
    delete payload.token
}
// ... existing 401/404 cleanup, redux dispatch, etc.
```

That's it for behavior. 14 lines added, 5 deleted.

## Tests

`src/hooks/query/__tests__/user.test.tsx` — 5 tests, all passing:

- calls `setAuthToken` when the response includes a refreshed token
- does NOT call `setAuthToken` when the response has no `token` field
- strips `token` from the data exposed to consumers
- clears the token on 401 (dead JWT) without touching `setAuthToken`
- clears the token on 404 (user no longer exists)

## Forward compatibility

If this lands before the backend PR, nothing breaks — the API just doesn't include `token`, the `if (payload?.token)` branch is skipped, behavior is identical to today.

If the backend lands first, behavior is also unchanged until the UI updates — backend just sends an extra JSON field that the old UI ignores.

So merge order doesn't matter.

## Verifiability

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1034 passed, 4 skipped, 0 failed (47 suites)
- [x] Hook test mocks `apiFetch` + `setAuthToken`/`clearAuthToken`; asserts call counts + arguments + that `token` is stripped from `result.current.data`

## Risk

- **Low.** Strictly additive — the change only fires when the API ships the new field. Existing flow unchanged.
- `setAuthToken` is the same call site `auth-token.ts` already uses on login. No new storage code paths.