### PR TITLE
chore(activation): remove FE escape hatch made redundant by BE #749

### DIFF
--- a/src/hooks/useActivationStatus.ts
+++ b/src/hooks/useActivationStatus.ts
@@ -91,12 +91,6 @@ export function useActivationStatus(): ActivationStatus {
                     activated: 'completed',
                 }
                 activationStep = milestoneToStep[beMilestone] ?? 'verify'
-                // BE hasFunded only checks bridge/manteca deposits, not P2P or crypto.
-                // if BE says "deposit" but user has balance (e.g. received via direct transfer),
-                // skip to outbound step.
-                if (activationStep === 'deposit' && hasBalance) {
-                    activationStep = 'outbound'
-                }
             } else {
                 if (!isUserKycApproved) {
                     activationStep = 'verify'


### PR DESCRIPTION
## Summary

[peanut-api-ts#749](https://github.com/peanutprotocol/peanut-api-ts/pull/749) broadened the activation milestone to derive from \`TransactionEntry\` — any POSTED PRINCIPAL entry on a user-owned account flips the milestone, regardless of intent kind. The FE's balance-based escape hatch (which compensated for the narrow BE check) is now dead code.

## What changed

\`src/hooks/useActivationStatus.ts\` — removed 6 lines:

\`\`\`diff
                 activationStep = milestoneToStep[beMilestone] ?? 'verify'
-                // BE hasFunded only checks bridge/manteca deposits, not P2P or crypto.
-                // if BE says "deposit" but user has balance (e.g. received via direct transfer),
-                // skip to outbound step.
-                if (activationStep === 'deposit' && hasBalance) {
-                    activationStep = 'outbound'
-                }
\`\`\`

The fallback branch for missing \`beMilestone\` still uses \`hasBalance\` — intentionally left in place to handle the (rare) case where the BE omits the milestone field entirely.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`npm test\` — 46 suites / 1029 tests passing
- [ ] Staging (after BE #749 deploys): user with \`activationMilestone='funded'\` from a DIRECT_TRANSFER receipt no longer sees the deposit CTA on home
- [ ] Staging: card-step gating still works (deposit → card → outbound transition)

## Risks

None — pure removal of dead code. Worst case the FE behaves identically.

## Related

- Investigation: [Activation Funnel Holistic Audit + Action Plan](https://www.notion.so/35d83811757980ca8f5cf102f274f46c)
- Upstream BE fix: peanutprotocol/peanut-api-ts#749