### PR TITLE
fix(carousel): 7-day dismissal cooldown + suppress completed-action CTAs

### DIFF
--- a/src/hooks/useHomeCarouselCTAs.tsx
+++ b/src/hooks/useHomeCarouselCTAs.tsx
@@ -2,7 +2,7 @@
 
 import { type IconName } from '@/components/Global/Icons/Icon'
 import { useAuth } from '@/context/authContext'
-import { useEffect, useState, useCallback, useRef } from 'react'
+import { useEffect, useMemo, useState, useCallback, useRef } from 'react'
 import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils'
 import { useNotifications } from './useNotifications'
 import { useRouter } from 'next/navigation'
@@ -14,8 +14,19 @@ import { usePWAStatus } from './usePWAStatus'
 import { useGeoLocation } from './useGeoLocation'
 import { useCardPioneerInfo } from './useCardPioneerInfo'
 import { useActivationStatus } from './useActivationStatus'
+import { useTransactionHistory } from './useTransactionHistory'
 import { STAR_STRAIGHT_ICON } from '@/assets'
 import underMaintenanceConfig from '@/config/underMaintenance.config'
+
+// Days a dismissed CTA stays hidden before reappearing. Set above 1 so dismiss feels
+// "sticky" but below 14 so we still nudge users about valuable actions they haven't
+// adopted. Per-CTA cooldowns can come later via the user-signaling unification project.
+const DISMISS_COOLDOWN_DAYS = 7
+const DISMISS_COOLDOWN_MS = DISMISS_COOLDOWN_DAYS * 24 * 60 * 60 * 1000
+
+// CTAs gated by external state that can flip back (e.g. notification permission)
+// must not be persisted — they should re-evaluate every session.
+const TRANSIENT_CTA_IDS = new Set(['notification-prompt'])
 
 export type CarouselCTA = {
     id: string
@@ -35,16 +46,39 @@ export type CarouselCTA = {
     isPerkClaim?: boolean
 }
 
-const getDismissedCTAs = (userId: string | undefined): Set<string> => {
+/** Read dismissals from preferences, dropping any whose cooldown has expired.
+ *  Returns id → dismissedAt so callers can keep the timestamp around if needed.
+ *  Accepts the legacy `string[]` shape (no timestamps) — those entries are
+ *  treated as "dismissed now" so existing users get a fresh 7-day window from
+ *  the moment they pick up this code, rather than CTAs suddenly reappearing. */
+const getDismissedCTAs = (userId: string | undefined): Map<string, Date> => {
     const dismissed = getUserPreferences(userId)?.dismissedCarouselCTAs
-    return new Set(dismissed ?? [])
+    const now = new Date()
+    const cutoff = now.getTime() - DISMISS_COOLDOWN_MS
+
+    if (!dismissed) return new Map()
+
+    if (Array.isArray(dismissed)) {
+        // Legacy permanent-dismissal shape — coerce to "dismissed now".
+        return new Map(dismissed.map((id) => [id, now]))
+    }
+
+    const map = new Map<string, Date>()
+    for (const [id, iso] of Object.entries(dismissed)) {
+        const dismissedAt = new Date(iso)
+        if (!Number.isNaN(dismissedAt.getTime()) && dismissedAt.getTime() > cutoff) {
+            map.set(id, dismissedAt)
+        }
+    }
+    return map
 }
 
 export const useHomeCarouselCTAs = () => {
     const [carouselCTAs, setCarouselCTAs] = useState<CarouselCTA[]>([])
     const { user } = useAuth()
-    const dismissedRef = useRef<Set<string>>(new Set())
-    const { requestPermission, afterPermissionAttempt, isPermissionDenied, isPermissionGranted } = useNotifications()
+    const dismissedRef = useRef<Map<string, Date>>(new Map())
+    const { requestPermission, afterPermissionAttempt, isPermissionDenied, isPermissionGranted, isPushOptedIn } =
+        useNotifications()
     const router = useRouter()
     const { isUserKycApproved, isUserBridgeKycUnderReview, isUserMantecaKycApproved } = useKycStatus()
     const { deviceType } = useDeviceType()
@@ -60,16 +94,26 @@ export const useHomeCarouselCTAs = () => {
     } = useCardPioneerInfo()
     const { isActivated } = useActivationStatus()
 
-    // ctas gated by conditions that can change (e.g. permission state) should not be permanently dismissed
-    const TRANSIENT_CTA_IDS = new Set(['notification-prompt'])
+    // Completion signals — used to hide educational CTAs from users who've already
+    // done the action. Shares the React Query cache key with HomeHistory below, so
+    // this read is free when the home page is mounted.
+    const { data: latestHistory } = useTransactionHistory({ mode: 'latest', limit: 50 })
+    const hasMadeQrPayment = useMemo(
+        () => latestHistory?.entries.some((e) => e.extraData?.kind === 'QR_PAY') ?? false,
+        [latestHistory]
+    )
+    const hasSentInvites = (user?.invitesSent?.length ?? 0) > 0
 
     const dismissCTA = useCallback(
         (ctaId: string) => {
-            dismissedRef.current.add(ctaId)
+            dismissedRef.current.set(ctaId, new Date())
             if (!TRANSIENT_CTA_IDS.has(ctaId)) {
-                updateUserPreferences(user?.user?.userId, {
-                    dismissedCarouselCTAs: Array.from(dismissedRef.current).filter((id) => !TRANSIENT_CTA_IDS.has(id)),
-                })
+                const record: Record<string, string> = {}
+                for (const [id, dismissedAt] of dismissedRef.current) {
+                    if (TRANSIENT_CTA_IDS.has(id)) continue
+                    record[id] = dismissedAt.toISOString()
+                }
+                updateUserPreferences(user?.user?.userId, { dismissedCarouselCTAs: record })
             }
             setCarouselCTAs((prev) => prev.filter((c) => c.id !== ctaId))
         },
@@ -108,8 +152,8 @@ export const useHomeCarouselCTAs = () => {
             })
         }
 
-        // Generic invite CTA for non-LATAM activated users only
-        if (!isLatamUser && isActivated) {
+        // Generic invite CTA for non-LATAM activated users who haven't invited yet.
+        if (!isLatamUser && isActivated && !hasSentInvites) {
             _carouselCTAs.push({
                 id: 'invite-friends',
                 title: 'Invite friends. Earn rewards',
@@ -122,9 +166,12 @@ export const useHomeCarouselCTAs = () => {
                 },
             })
         }
-        // show notification cta only in pwa when notifications are not granted
-        // clicking it triggers native prompt (or shows reinstall modal if denied)
-        if (!isPermissionGranted && isPwa) {
+        // show notification cta only in pwa when the user is neither permission-granted
+        // (browser-native) nor opted-in (OneSignal subscription). Belt-and-suspenders
+        // because the two signals can diverge — e.g. browser permission revoked but
+        // OneSignal subscription still active. Clicking triggers the native prompt
+        // (or shows the reinstall modal if denied).
+        if (!isPermissionGranted && !isPushOptedIn && isPwa) {
             _carouselCTAs.push({
                 id: 'notification-prompt',
                 title: 'Stay in the loop!',
@@ -153,8 +200,9 @@ export const useHomeCarouselCTAs = () => {
             })
         }
 
-        // Show QR code payment prompt if user's Bridge or Manteca KYC is approved.
-        if (hasKycApproval) {
+        // Show QR code payment prompt if user's Bridge or Manteca KYC is approved
+        // AND they haven't already used QR pay (educational CTA — no point once adopted).
+        if (hasKycApproval && !hasMadeQrPayment) {
             _carouselCTAs.push({
                 id: 'qr-payment',
                 title: (
@@ -177,9 +225,9 @@ export const useHomeCarouselCTAs = () => {
         }
 
         // ------------------------------------------------------------------------------------------------
-        // LATAM rewards CTA - show to activated users in Argentina or Brazil only
-        // Encourage them to invite friends to earn more rewards (and complete KYC if needed)
-        if (isLatamUser && isActivated) {
+        // LATAM rewards CTA - show to activated users in Argentina or Brazil who haven't
+        // invited anyone yet. Encourages first-invite; we hide once they've sent at least one.
+        if (isLatamUser && isActivated && !hasSentInvites) {
             _carouselCTAs.push({
                 id: 'latam-cashback-invite',
                 title: (
@@ -227,6 +275,7 @@ export const useHomeCarouselCTAs = () => {
         user?.user?.userId,
         isPermissionGranted,
         isPermissionDenied,
+        isPushOptedIn,
         isUserKycApproved,
         isUserBridgeKycUnderReview,
         isUserMantecaKycApproved,
@@ -241,12 +290,14 @@ export const useHomeCarouselCTAs = () => {
         hasCardPioneerPurchased,
         isCardPioneerLoading,
         isActivated,
+        hasMadeQrPayment,
+        hasSentInvites,
     ])
 
     useEffect(() => {
         if (!user) {
             setCarouselCTAs([])
-            dismissedRef.current = new Set()
+            dismissedRef.current = new Map()
             return
         }
 

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -31,6 +31,12 @@ export function useNotifications() {
     const [sdkReady, setSdkReady] = useState(false)
     const [oneSignalInitialized, setOneSignalInitialized] = useState(false)
 
+    // OneSignal subscription-level opt-in (looser than browser permission — a user can
+    // have permission revoked at the browser but still appear opted-in in OneSignal,
+    // or vice versa). Tracked as state so consumers (like the carousel notification CTA)
+    // can hide themselves the moment EITHER signal confirms the user is signed up.
+    const [isPushOptedIn, setIsPushOptedIn] = useState(false)
+
     // update permission state from browser api
     const refreshPermissionState = useCallback(() => {
         if (typeof window === 'undefined' || typeof Notification === 'undefined') return
@@ -80,6 +86,7 @@ export function useNotifications() {
 
         const granted = await getPermissionGranted()
         const optedIn = await isPushSubscriptionOptedIn()
+        setIsPushOptedIn(optedIn)
 
         // if permission is granted, hide modal
         if (granted) {
@@ -353,6 +360,7 @@ export function useNotifications() {
         permissionState,
         isPermissionDenied: permissionState === 'denied',
         isPermissionGranted: permissionState === 'granted',
+        isPushOptedIn,
         isRequestingPermission,
         refreshPermissionState,
     }

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -473,7 +473,10 @@ export type UserPreferences = {
     hasSeenBalanceWarning?: { value: boolean; expiry: number }
     /** tracks surprise moment claim count for referral CTA copy (rewards v2). 0=first, 1=second, 2+=normal */
     rewards_surprise_claim_count?: number
-    dismissedCarouselCTAs?: string[]
+    /** Carousel CTAs the user has dismissed, with the ISO timestamp of each dismissal.
+     *  Read by useHomeCarouselCTAs to apply a per-CTA cooldown before re-showing.
+     *  Legacy shape was `string[]` (permanent dismissal); both are accepted on read. */
+    dismissedCarouselCTAs?: string[] | Record<string, string>
 }
 
 export const updateUserPreferences = (


### PR DESCRIPTION
## Summary

Two related polish fixes to the home carousel, addressing user feedback that CTAs feel either too sticky (dismissed forever) or wrong (shown for actions the user has already done).

## Changes

### 1. Dismissal cooldown — 7 days

After the missing-persistence bug was patched (March), dismissing a CTA via \`[x]\` hid it **forever**. That's the opposite extreme: a user who's not ready for the card today can never recover the prompt next week.

- New constant \`DISMISS_COOLDOWN_DAYS = 7\` in \`useHomeCarouselCTAs.tsx\`.
- Storage shape upgraded from \`string[]\` → \`Record<string, string>\` (id → ISO timestamp). \`UserPreferences\` type accepts both.
- Legacy \`string[]\` entries are coerced to "dismissed now" on first read, so existing users get a fresh 7-day window without CTAs surprise-reappearing on the next page load.

### 2. Suppress CTAs whose action is already done

Users complained that the carousel shows prompts for things they've already adopted. Three gates added:

| CTA | New gate | Data source |
|---|---|---|
| \`qr-payment\` | \`hasMadeQrPayment === false\` | Any \`useTransactionHistory({mode:'latest', limit:50})\` entry with \`extraData.kind === 'QR_PAY'\` |
| \`invite-friends\` / \`latam-cashback-invite\` | \`hasSentInvites === false\` | \`user.invitesSent.length > 0\` |
| \`notification-prompt\` | \`!isPushOptedIn\` (added to the existing \`!isPermissionGranted\` gate) | \`useNotifications\` now exposes \`isPushOptedIn\` (OneSignal subscription state) — see point below |

The history query uses the same React Query key the home page already runs, so there's no extra network cost.

### 3. \`useNotifications\` exposes \`isPushOptedIn\`

Browser-native \`Notification.permission\` and OneSignal subscription state can diverge — a user with permission revoked but still opted-in via OneSignal was seeing the "Stay in the loop" CTA despite being subscribed. Belt-and-suspenders: gate hides if **either** signal is positive.

## Files touched

- \`src/utils/general.utils.ts\` — UserPreferences type accepts old + new dismissal shapes
- \`src/hooks/useNotifications.ts\` — track + expose \`isPushOptedIn\` as state
- \`src/hooks/useHomeCarouselCTAs.tsx\` — cooldown + completion gates + transient-id constant lifted out of the component

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`npm test\` — 46 suites / 1029 tests passing
- [ ] Staging: dismiss the card-pioneer carousel CTA, reload — verify it stays hidden
- [ ] Staging: manually fast-forward localStorage timestamp by 8 days (\`localStorage.setItem(...)\`) — verify CTA reappears
- [ ] Staging: as a user with a completed QR payment, verify the qr-payment CTA does not render
- [ ] Staging: as a user with \`invitesSent.length > 0\`, verify invite-friends and latam-cashback-invite CTAs do not render
- [ ] Staging: as a user with OneSignal subscription but no browser permission, verify the notification-prompt CTA does not render

## Risks

- **Migration.** Existing users have \`dismissedCarouselCTAs: string[]\` in localStorage. On first read with this code, those entries are coerced to "dismissed now" — they remain dismissed for the next 7 days, then re-appear. This is the intended behavior change (we want previously-dismissed CTAs to come back, just not all at once).
- **QR payment check is bounded by limit:50.** A user with 50+ transactions whose only QR payment is older than that won't be detected. Acceptable for a CTA gate — those users are power users for whom the educational CTA is barely visible anyway. Robust fix would be a BE flag; deferred to user-signaling project.
- **History query timing.** \`hasMadeQrPayment\` is \`false\` until \`useTransactionHistory\` resolves. Worst case the CTA flashes briefly then hides — same race as the existing \`isActivated\` gate. Not a regression.

## Related

- Investigation context: [Activation Funnel Holistic Audit + Action Plan](https://www.notion.so/35d83811757980ca8f5cf102f274f46c)
- Related FE cleanup: peanutprotocol/peanut-ui#1989 (remove BE-fixed escape hatch)
- Upstream BE fix that started this audit: peanutprotocol/peanut-api-ts#749