### PR TITLE
fix(recipient): always prefer username, centralize the resolver

### DIFF
--- a/src/components/Claim/Link/Initial.view.tsx
+++ b/src/components/Claim/Link/Initial.view.tsx
@@ -15,7 +15,8 @@ import { loadingStateContext, tokenSelectorContext } from '@/context'
 import { useAuth } from '@/context/authContext'
 import { useWallet } from '@/hooks/wallet/useWallet'
 import { sendLinksApi } from '@/services/sendLinks'
-import { areEvmAddressesEqual, formatTokenAmount, printableAddress } from '@/utils/general.utils'
+import { areEvmAddressesEqual, formatTokenAmount } from '@/utils/general.utils'
+import { useRecipientDisplay } from '@/hooks/useRecipientDisplay'
 import { ErrorHandler } from '@/utils/friendly-error.utils'
 import { fetchWithSentry } from '@/utils/sentry.utils'
 import { apiFetch } from '@/utils/api-fetch'
@@ -57,6 +58,11 @@ export const InitialClaimLinkView = (props: IClaimScreenProps) => {
     // get campaign tag from claim link url
     const params = useSearchParams()
     const campaignTag = params.get('campaignTag')
+
+    const senderDisplay = useRecipientDisplay({
+        user: props.claimLinkData.sender,
+        address: props.claimLinkData.senderAddress,
+    })
 
     const {
         onNext,
@@ -919,7 +925,7 @@ export const InitialClaimLinkView = (props: IClaimScreenProps) => {
                     avatarSize="small"
                     transactionType="CLAIM_LINK"
                     recipientType="USERNAME"
-                    recipientName={claimLinkData.sender?.username ?? printableAddress(claimLinkData.senderAddress)}
+                    recipientName={senderDisplay.displayName}
                     amount={
                         isReward
                             ? formatTokenAmount(Number(formatUnits(claimLinkData.amount, claimLinkData.tokenDecimals)))!

--- a/src/components/Claim/Link/Onchain/Confirm.view.tsx
+++ b/src/components/Claim/Link/Onchain/Confirm.view.tsx
@@ -9,7 +9,8 @@ import { PaymentInfoRow } from '@/components/Payment/PaymentInfoRow'
 import { loadingStateContext, tokenSelectorContext } from '@/context'
 import { useTokenChainIcons } from '@/hooks/useTokenChainIcons'
 import { useWallet } from '@/hooks/wallet/useWallet'
-import { formatTokenAmount, printableAddress, isStableCoin } from '@/utils/general.utils'
+import { formatTokenAmount, isStableCoin } from '@/utils/general.utils'
+import { useRecipientDisplay } from '@/hooks/useRecipientDisplay'
 import { ErrorHandler } from '@/utils/friendly-error.utils'
 import * as Sentry from '@sentry/nextjs'
 import { useContext, useState, useMemo } from 'react'
@@ -38,6 +39,10 @@ export const ConfirmClaimLinkView = ({
     const { address } = useWallet()
     const { user } = useAuth()
     const { claimLinkXchain, claimLink } = useClaimLink()
+    const senderDisplay = useRecipientDisplay({
+        user: claimLinkData.sender,
+        address: claimLinkData.senderAddress,
+    })
     const { selectedChainID, selectedTokenAddress, isXChain } = useContext(tokenSelectorContext)
     const { setLoadingState, isLoading } = useContext(loadingStateContext)
     const [errorState, setErrorState] = useState<{
@@ -168,7 +173,7 @@ export const ConfirmClaimLinkView = ({
                 <PeanutActionDetailsCard
                     transactionType="CLAIM_LINK"
                     recipientType="USERNAME"
-                    recipientName={claimLinkData.sender?.username ?? printableAddress(claimLinkData.senderAddress)}
+                    recipientName={senderDisplay.displayName}
                     amount={
                         isReward
                             ? formatTokenAmount(Number(formatUnits(claimLinkData.amount, claimLinkData.tokenDecimals)))!

--- a/src/components/Claim/Link/Onchain/Success.view.tsx
+++ b/src/components/Claim/Link/Onchain/Success.view.tsx
@@ -8,7 +8,8 @@ import { useAuth } from '@/context/authContext'
 import { useClaimBankFlow } from '@/context/ClaimBankFlowContext'
 import { useUserStore } from '@/redux/hooks'
 import { ESendLinkStatus, sendLinksApi } from '@/services/sendLinks'
-import { formatTokenAmount, getTokenDetails, printableAddress, shortenStringLong } from '@/utils/general.utils'
+import { formatTokenAmount, getTokenDetails, shortenStringLong } from '@/utils/general.utils'
+import { useRecipientDisplay } from '@/hooks/useRecipientDisplay'
 import { useQueryClient } from '@tanstack/react-query'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useMemo } from 'react'
@@ -35,6 +36,10 @@ export const SuccessClaimLinkView = ({
     const { triggerHaptic } = useHaptic()
     const params = useSearchParams()
     const campaignTag = params.get('campaignTag')
+    const senderDisplay = useRecipientDisplay({
+        user: claimLinkData.sender,
+        address: claimLinkData.senderAddress,
+    })
 
     // @dev: Claimers don't earn points (only senders do), so we don't call calculatePoints
     // Points will show in activity history once the sender's transaction is processed
@@ -134,18 +139,14 @@ export const SuccessClaimLinkView = ({
             | 'CLAIM_LINK_BANK_ACCOUNT'
             | 'CLAIM_LINK',
         recipientType: isBankClaim ? ('BANK_ACCOUNT' as const) : ('USERNAME' as const),
-        recipientName: isBankClaim
-            ? maskedAccountNumber
-            : (claimLinkData.sender?.username ?? printableAddress(claimLinkData.senderAddress)),
+        recipientName: isBankClaim ? maskedAccountNumber : senderDisplay.displayName,
         amount: isBankClaim
             ? (formatTokenAmount(
                   Number(formatUnits(claimLinkData.amount, claimLinkData.tokenDecimals)) * (tokenPrice ?? 0)
               ) ?? '')
             : formatUnits(claimLinkData.amount, tokenDetails?.decimals ?? 6),
         tokenSymbol: isBankClaim ? (offrampDetails?.quote.destination_currency ?? '') : claimLinkData.tokenSymbol,
-        message: isBankClaim
-            ? maskedAccountNumber
-            : `from ${claimLinkData.sender?.username || printableAddress(claimLinkData.senderAddress)}`,
+        message: isBankClaim ? maskedAccountNumber : `from ${senderDisplay.displayName}`,
         title: isBankClaim ? 'You will receive' : 'You claimed',
     }
 

--- a/src/components/Common/CountryListRouter.tsx
+++ b/src/components/Common/CountryListRouter.tsx
@@ -3,7 +3,8 @@ import NavHeader from '@/components/Global/NavHeader'
 import PeanutActionDetailsCard from '@/components/Global/PeanutActionDetailsCard'
 import { ClaimBankFlowStep, useClaimBankFlow } from '@/context/ClaimBankFlowContext'
 import { formatUnits } from 'viem'
-import { formatTokenAmount, printableAddress } from '@/utils/general.utils'
+import { formatTokenAmount } from '@/utils/general.utils'
+import { useRecipientDisplay } from '@/hooks/useRecipientDisplay'
 import { CountryList } from '@/components/Common/CountryList'
 import { type ClaimLinkData } from '@/services/sendLinks'
 import { type CountryData, MantecaSupportedExchanges } from '@/components/AddMoney/consts'
@@ -38,9 +39,10 @@ export const CountryListRouter = ({ claimLinkData, inputTitle }: ICountryListRou
         }
     }
 
-    const recipientName = useMemo(() => {
-        return claimLinkData?.sender?.username ?? printableAddress(claimLinkData?.senderAddress ?? '')
-    }, [claimLinkData])
+    const { displayName: recipientName } = useRecipientDisplay({
+        user: claimLinkData?.sender,
+        address: claimLinkData?.senderAddress ?? '',
+    })
 
     const amount = useMemo(() => {
         return formatTokenAmount(Number(formatUnits(claimLinkData?.amount ?? 0n, claimLinkData?.tokenDecimals ?? 0)))

--- a/src/components/Global/AddressLink/index.tsx
+++ b/src/components/Global/AddressLink/index.tsx
@@ -1,4 +1,5 @@
 import { printableAddress, isCryptoAddress } from '@/utils/general.utils'
+import { normalizeEnsName } from '@/utils/ens.utils'
 import { usePrimaryName } from '@justaname.id/react'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
@@ -26,12 +27,8 @@ const AddressLink = ({ address, className = '', isLink = true }: AddressLinkProp
     })
 
     useEffect(() => {
-        // Update display: prefer ENS name for EVM addresses, otherwise shorten any crypto address
-        if (isAddress(address) && ensName) {
-            // for peanut ens names, strip the domain from the displayed string so its just a username (no ens subdomain)
-            const peanutEnsDomain = process.env.NEXT_PUBLIC_JUSTANAME_ENS_DOMAIN || ''
-            const normalizedEnsName = ensName.replace(peanutEnsDomain, '').replace(/\.$/, '')
-
+        const normalizedEnsName = isAddress(address) ? normalizeEnsName(ensName) : null
+        if (normalizedEnsName) {
             setDisplayAddress(normalizedEnsName)
             setUrlAddress(normalizedEnsName)
         } else {

--- a/src/features/payments/shared/components/PaymentSuccessView.tsx
+++ b/src/features/payments/shared/components/PaymentSuccessView.tsx
@@ -29,7 +29,8 @@ import { EHistoryUserRole } from '@/hooks/useTransactionHistory'
 import { type RecipientType } from '@/lib/url-parser/types/payment'
 import { useUserStore } from '@/redux/hooks'
 import type { TRequestChargeResponse, PaymentCreationResponse, ChargeEntry } from '@/services/services.types'
-import { formatAmount, getInitialsFromName, printableAddress } from '@/utils/general.utils'
+import { formatAmount, getInitialsFromName } from '@/utils/general.utils'
+import { resolveRecipientDisplay } from '@/utils/recipient-display'
 import { useQueryClient } from '@tanstack/react-query'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
@@ -116,7 +117,10 @@ const PaymentSuccessView = ({
         if (parsedPaymentData?.recipient?.identifier) {
             return parsedPaymentData.recipient.identifier
         }
-        return printableAddress(chargeDetails?.requestLink?.recipientAddress || '')
+        return resolveRecipientDisplay({
+            user: chargeDetails?.requestLink?.recipientAccount?.user,
+            address: chargeDetails?.requestLink?.recipientAddress || '',
+        }).displayName
     }, [user, parsedPaymentData, chargeDetails])
 
     const amountValue = useMemo(() => {

--- a/src/hooks/useRecipientDisplay.ts
+++ b/src/hooks/useRecipientDisplay.ts
@@ -1,0 +1,38 @@
+'use client'
+
+import { usePrimaryName } from '@justaname.id/react'
+import { useMemo } from 'react'
+import { isAddress } from 'viem'
+
+import { resolveRecipientDisplay, type RecipientDisplay, type ResolveRecipientInput } from '@/utils/recipient-display'
+import { normalizeEnsName } from '@/utils/ens.utils'
+
+/**
+ * Returns a recipient display result without blocking on the ENS lookup:
+ * the synchronous resolution (username or printable address) is returned
+ * immediately, and the result upgrades to ENS only if a primary name
+ * resolves AND no Peanut username was already available. Username always
+ * dominates — if we know who the recipient is on Peanut, ENS never wins.
+ *
+ * ENS resolution is skipped when a username is already known, or when the
+ * address isn't a valid EVM address (Solana/Tron/bank-id inputs).
+ */
+export function useRecipientDisplay(input: Omit<ResolveRecipientInput, 'ensName'>): RecipientDisplay {
+    const skipEnsLookup = !!input.user?.username || !isAddress(input.address)
+
+    const { primaryName } = usePrimaryName({
+        address: skipEnsLookup ? undefined : (input.address as `0x${string}`),
+        chainId: 1,
+        priority: 'onChain',
+    })
+
+    return useMemo(
+        () =>
+            resolveRecipientDisplay({
+                user: input.user,
+                address: input.address,
+                ensName: normalizeEnsName(primaryName),
+            }),
+        [input.user, input.address, primaryName]
+    )
+}

--- a/src/utils/__tests__/general.utils.test.ts
+++ b/src/utils/__tests__/general.utils.test.ts
@@ -337,6 +337,56 @@ describe('General Utilities', () => {
                 },
                 expectedLink: 'https://peanut.example.org/satoshi/?chargeId=charge_123456789',
             },
+            // The bug we're fixing: BE returns an EVM_ADDRESS-typed account
+            // for a recipient that DOES have a Peanut user attached. Username
+            // wins regardless of `type`.
+            {
+                requestData: {
+                    recipientAccount: {
+                        type: AccountType.EVM_ADDRESS,
+                        user: {
+                            username: 'hugo0',
+                        },
+                    },
+                    recipientAddress: '0xb009da0b0824ba04bfd7eb2757e064a8e184d338',
+                    chainId: '42161',
+                    tokenAmount: '0.38',
+                    tokenSymbol: 'USDC',
+                    uuid: '04acc664-c572-4d12-bb15-6d286ac80e81',
+                },
+                expectedLink: 'https://peanut.example.org/hugo0/0.38USDC?id=04acc664-c572-4d12-bb15-6d286ac80e81',
+            },
+            // Defensive: unprojected Prisma enum value flowing through. Same
+            // outcome — username wins.
+            {
+                requestData: {
+                    recipientAccount: {
+                        type: 'WALLET_SMART',
+                        user: {
+                            username: 'satoshi',
+                        },
+                    },
+                    recipientAddress: '0x1234567890123456789012345678901234567890',
+                    chainId: '1',
+                    uuid: 'c4fc57cb-deae-4ea2-bdb3-aeaa996255ad',
+                },
+                expectedLink: 'https://peanut.example.org/satoshi/?id=c4fc57cb-deae-4ea2-bdb3-aeaa996255ad',
+            },
+            // PEANUT_WALLET type with no `user` field — previously threw
+            // TypeError via `user!.username`. Now falls back to the address
+            // gracefully.
+            {
+                requestData: {
+                    recipientAccount: {
+                        type: AccountType.PEANUT_WALLET,
+                    },
+                    recipientAddress: '0x1234567890123456789012345678901234567890',
+                    chainId: '42161',
+                    uuid: 'c4fc57cb-deae-4ea2-bdb3-aeaa996255ad',
+                },
+                expectedLink:
+                    'https://peanut.example.org/0x1234567890123456789012345678901234567890@42161/?id=c4fc57cb-deae-4ea2-bdb3-aeaa996255ad',
+            },
             // Token symbol but no amount
             {
                 requestData: {

--- a/src/utils/__tests__/recipient-display.test.ts
+++ b/src/utils/__tests__/recipient-display.test.ts
@@ -1,0 +1,76 @@
+import { resolveRecipientDisplay } from '../recipient-display'
+
+describe('resolveRecipientDisplay', () => {
+    describe('username preference (wins over everything)', () => {
+        it('returns username when user.username is set', () => {
+            const result = resolveRecipientDisplay({
+                user: { username: 'hugo0' },
+                address: '0xb009da0b0824ba04bfd7eb2757e064a8e184d338',
+            })
+            expect(result).toEqual({ displayName: 'hugo0', kind: 'username' })
+        })
+
+        it('prefers username over ENS name', () => {
+            const result = resolveRecipientDisplay({
+                user: { username: 'hugo0' },
+                address: '0xb009da0b0824ba04bfd7eb2757e064a8e184d338',
+                ensName: 'vitalik.eth',
+            })
+            expect(result).toEqual({ displayName: 'hugo0', kind: 'username' })
+        })
+    })
+
+    describe('ENS fallback (when no username)', () => {
+        it('returns ENS name when no username but ensName is set', () => {
+            const result = resolveRecipientDisplay({
+                user: null,
+                address: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+                ensName: 'vitalik.eth',
+            })
+            expect(result).toEqual({ displayName: 'vitalik.eth', kind: 'ens' })
+        })
+
+        it('returns ENS name when user is undefined', () => {
+            const result = resolveRecipientDisplay({
+                address: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+                ensName: 'vitalik.eth',
+            })
+            expect(result).toEqual({ displayName: 'vitalik.eth', kind: 'ens' })
+        })
+    })
+
+    describe('address fallback', () => {
+        it('returns printable address when nothing else is available', () => {
+            const result = resolveRecipientDisplay({
+                address: '0xb009da0b0824ba04bfd7eb2757e064a8e184d338',
+            })
+            expect(result.kind).toBe('address')
+            // printableAddress shortens; just check it's a shortened form, not
+            // brittle on the exact char-count which lives in general.utils
+            expect(result.displayName).toContain('0xb009')
+            expect(result.displayName).toContain('d338')
+        })
+
+        it('falls back to address when user has no username (null/empty)', () => {
+            const result = resolveRecipientDisplay({
+                user: { username: null },
+                address: '0xb009da0b0824ba04bfd7eb2757e064a8e184d338',
+            })
+            expect(result.kind).toBe('address')
+        })
+    })
+
+    describe('the bug we fixed', () => {
+        // BE returned EVM-typed recipientAccount for a Peanut user. Old code
+        // checked `type === PEANUT_WALLET` and never matched → fell to address
+        // branch. Reproduce by giving the resolver the user object directly
+        // (which is what the new BE shape contains regardless of `type`).
+        it('uses username when a user is linked, even on a non-PEANUT_WALLET account', () => {
+            const result = resolveRecipientDisplay({
+                user: { username: 'hugo0' },
+                address: '0xb009da0b0824ba04bfd7eb2757e064a8e184d338',
+            })
+            expect(result.displayName).toBe('hugo0')
+        })
+    })
+})

--- a/src/utils/ens.utils.ts
+++ b/src/utils/ens.utils.ts
@@ -2,6 +2,21 @@ import { JustaName } from '@justaname.id/sdk'
 import { rpcUrls } from '@/constants/general.consts'
 import { mainnet } from 'viem/chains'
 
+const PEANUT_ENS_DOMAIN = process.env.NEXT_PUBLIC_JUSTANAME_ENS_DOMAIN || ''
+
+/**
+ * Strip the Peanut JustaName subdomain suffix and trailing dot from an
+ * ENS primary name so it renders as a plain handle (e.g. `hugo0.peanut.me.`
+ * → `hugo0`). Non-Peanut ENS names pass through with the trailing dot
+ * removed.
+ */
+export function normalizeEnsName(ensName: string | null | undefined): string | null {
+    if (!ensName) return null
+    const stripped =
+        PEANUT_ENS_DOMAIN && ensName.endsWith(PEANUT_ENS_DOMAIN) ? ensName.slice(0, -PEANUT_ENS_DOMAIN.length) : ensName
+    return stripped.replace(/\.$/, '')
+}
+
 /**
  * Resolves an Ethereum address to its username using JustaName ENS resolution
  * @param address - The Ethereum address to resolve

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -6,7 +6,6 @@ import {
     BASE_URL,
 } from '@/constants/general.consts'
 import { STABLE_COINS, ENS_NAME_REGEX } from '@/constants/general.consts'
-import { AccountType } from '@/interfaces/interfaces'
 import * as Sentry from '@sentry/nextjs'
 import type { Address, TransactionReceipt } from 'viem'
 import { getAddress, isAddress, erc20Abi } from 'viem'
@@ -723,10 +722,10 @@ export const formatExtendedNumber = (amount: string | number, minDigitsForFomatt
 export function getRequestLink(
     requestData: {
         recipientAccount: {
-            type: string
+            type?: string
             user?: {
-                username: string
-            }
+                username?: string | null
+            } | null
         }
         recipientAddress: string
         chainId?: string
@@ -735,12 +734,17 @@ export function getRequestLink(
     } & ({ uuid: string; chargeId?: never } | { uuid?: never; chargeId: string })
 ): string {
     const { recipientAccount, recipientAddress, chainId, tokenAmount, tokenSymbol, uuid, chargeId } = requestData
-    const isPeanutWallet = recipientAccount.type === AccountType.PEANUT_WALLET
-    const recipient = isPeanutWallet ? recipientAccount.user!.username : recipientAddress
-    let chain: string = ''
-    if (!isPeanutWallet && chainId) {
-        chain = `@${chainId}`
-    }
+
+    // Prefer the Peanut username whenever a user is linked to the
+    // recipient account, regardless of `account.type`. The old check
+    // coupled username preference to a specific account-type discriminator
+    // and broke whenever the BE returned an `EVM_ADDRESS`/`WALLET_SMART`
+    // shape for a recipient who happened to be a Peanut user — every
+    // shared link rendered the address slug instead of the handle.
+    const username = recipientAccount.user?.username
+    const recipient = username || recipientAddress
+    const chain = !username && chainId ? `@${chainId}` : ''
+
     let link = `${process.env.NEXT_PUBLIC_BASE_URL}/${recipient}${chain}/`
     if (tokenAmount) {
         link += `${formatAmount(tokenAmount)}`
@@ -919,12 +923,12 @@ export const getValidRedirectUrl = (redirectUrl: string, fallbackRoute: string) 
 export const getContributorsFromCharge = (charges: ChargeEntry[]) => {
     return charges.map((charge) => {
         const successfulPayment = charge.payments.at(-1)
-        let username = successfulPayment?.payerAccount?.user?.username
-        if (successfulPayment?.payerAccount?.type === 'evm-address') {
-            username = successfulPayment.payerAccount.identifier
-        }
-
-        const isPeanutUser = successfulPayment?.payerAccount?.type === AccountType.PEANUT_WALLET
+        // Prefer the Peanut handle whenever the payer has a linked user,
+        // regardless of account.type. Falls back to the raw on-chain
+        // identifier for anonymous on-chain contributors.
+        const payerAccount = successfulPayment?.payerAccount
+        const username = payerAccount?.user?.username || payerAccount?.identifier
+        const isPeanutUser = !!payerAccount?.user?.username
 
         return {
             uuid: charge.uuid,
@@ -932,7 +936,7 @@ export const getContributorsFromCharge = (charges: ChargeEntry[]) => {
             amount: charge.tokenAmount,
             username,
             fulfillmentPayment: charge.fulfillmentPayment,
-            isUserVerified: isUserKycVerified(successfulPayment?.payerAccount?.user),
+            isUserVerified: isUserKycVerified(payerAccount?.user),
             isPeanutUser,
         }
     })

--- a/src/utils/recipient-display.ts
+++ b/src/utils/recipient-display.ts
@@ -1,0 +1,35 @@
+/**
+ * "Given recipient data, produce a display name + URL slug" — replaces the
+ * ad-hoc `account.user?.username ?? printableAddress(addr)` shapes scattered
+ * across the codebase. Preference order:
+ *
+ *   1. Peanut username (when a user is linked to the recipient account)
+ *   2. ENS name (when one is known — provided by the caller, not resolved here)
+ *   3. Shortened 0x address
+ *
+ * Pure / synchronous. ENS lookup is async and lives in `useRecipientDisplay`.
+ */
+import { printableAddress } from './general.utils'
+
+export type RecipientKind = 'username' | 'ens' | 'address'
+
+export type RecipientDisplay = {
+    displayName: string
+    kind: RecipientKind
+}
+
+export type ResolveRecipientInput = {
+    user?: { username?: string | null } | null
+    address: string
+    ensName?: string | null
+}
+
+export function resolveRecipientDisplay(input: ResolveRecipientInput): RecipientDisplay {
+    if (input.user?.username) {
+        return { displayName: input.user.username, kind: 'username' }
+    }
+    if (input.ensName) {
+        return { displayName: input.ensName, kind: 'ens' }
+    }
+    return { displayName: printableAddress(input.address), kind: 'address' }
+}


### PR DESCRIPTION
## The bug

[Staging screenshot](https://staging.peanut.me/0xb009da0b0824ba04bfd7eb2757e064a8e184d338@42161/0.38USDC?id=04acc664-c572-4d12-bb15-6d286ac80e81) — request link for username \`hugo0\` rendered as \`peanut.me/0xb009...d338@42161/0.38USDC\` instead of \`peanut.me/hugo0/0.38USDC\`. Discord link preview showed \`0xb009...d338 is requesting $0.38\`.

## Root cause

\`getRequestLink\` gated username preference on \`recipientAccount.type === AccountType.PEANUT_WALLET\` (string \`'peanut-wallet'\`). After the decomplexify cutover, the BE started returning the raw Prisma enum (\`WALLET_SMART\`, \`EVM_ADDRESS\`, …) from \`/requests\` and \`/request-charges\` — only \`/get-user\` and \`/users/username/:username\` applied the legacy projection. The predicate became deterministically false for every Peanut user, and the address slug fallback always won. A \`!\` non-null assertion on \`user!.username\` was hiding the no-username branch from the type system too.

This is the symptom of a deeper smell: a type-discriminator (\`account.type\`) was being used as a stand-in for a user-presence check. The two are different invariants. Whenever BE-side account resolution flips which row backs the recipient (counterparty row vs. wallet-owned row), the UI breaks silently.

The BE side of the drift is fixed in peanutprotocol/peanut-api-ts#753 (apply the legacy-vocabulary projection at every response boundary). This PR fixes the FE so it doesn't depend on the projection at all — the predicate now checks for the user object directly.

## What this PR does

1. **New \`src/utils/recipient-display.ts\`** — pure sync \`resolveRecipientDisplay({ user?, address, ensName? })\` returning \`{ displayName, kind }\`. Codifies the team rule: **Peanut user → ENS → 0x address**, in one place.
2. **New \`src/hooks/useRecipientDisplay.ts\`** — wraps the resolver with non-blocking ENS via \`usePrimaryName\`. Shows the sync result immediately (username or printable address) and upgrades to ENS only when no username was already available, so the username preference is preserved. The ENS lookup is skipped entirely when a username is known or the address isn't EVM-shaped.
3. **New \`normalizeEnsName\` in \`src/utils/ens.utils.ts\`** — single helper replacing three near-duplicate normalizations (\`AddressLink\`, \`resolveAddressToUsername\`, and the new hook).
4. **\`getRequestLink\` rewritten** — predicate is now \`user?.username || address\`. \`!\` non-null assertion dropped. \`AccountType\` import removed (no longer used in the file). Test type widened so type and user are both optional/nullable.
5. **\`getContributorsFromCharge\` rewritten** — same predicate. \`isPeanutUser\` is now \`!!user?.username\` (presence-based, not type-based).
6. **\`PaymentSuccessView\` migrated** — address fallback now goes through the resolver, so a Peanut user attached to the charge \`requestLink.recipientAccount\` is preferred over the raw address.
7. **4 ad-hoc \`sender?.username ?? printableAddress(addr)\` sites migrated** — \`Claim/Link/Initial.view.tsx\`, \`Claim/Link/Onchain/Confirm.view.tsx\`, \`Claim/Link/Onchain/Success.view.tsx\`, \`Common/CountryListRouter.tsx\`. All use \`useRecipientDisplay\` now, which adds ENS-on-demand UX they didn't have before.
8. **\`AddressLink\` migrated** to share \`normalizeEnsName\`.
9. **Tests** — 4 new \`getRequestLink\` cases pin the bug shape (EVM_ADDRESS-with-user → username wins; \`WALLET_SMART\` raw enum → username wins; PEANUT_WALLET-without-user → graceful address fallback, no TypeError). 8 new tests for \`resolveRecipientDisplay\` covering all branches and the username-dominates-ENS rule.

## Behaviour change risk

The old code emitted \`@chainId\` on the URL whenever \`type !== 'peanut-wallet'\`. The new code emits \`@chainId\` whenever there's no username. **Same outcome for the cases that matter**: with a username we drop the chain suffix (it's a Peanut handle, chain is implicit), without a username we keep it. Every pre-existing test case continues to pass. New test cases prove the bug shape now resolves correctly.

\`getContributorsFromCharge\` had a stale branch \`if (type === 'evm-address') username = identifier\` that stomped a legitimate Peanut username. The new code prefers the username and falls back to the identifier — semantically what the original code was trying to express.

## Test plan

- [x] \`npm test\` — 1046 tests pass (4 new in \`recipient-display\`, 4 new in \`general.utils\`)
- [x] \`npm run typecheck\` — clean for changed files (pre-existing GIF-asset errors on dev unrelated)
- [x] \`pnpm prettier --check\` on all touched files
- [ ] Manual staging smoke: create a request as a Peanut user, verify share URL uses username slug
- [ ] Manual staging smoke: claim a sendlink, verify sender name renders as handle + (lazy) ENS upgrade

## Companion BE PR

peanutprotocol/peanut-api-ts#753 — applies the type projection at the request/charge response boundaries that were leaking raw enum. The two PRs are independently shippable: the FE PR is the principled fix (doesn't depend on BE projection); the BE PR is defense-in-depth.

## Follow-up tickets (post-release)

1. Unify FE \`AccountType\` enum with BE Prisma enum. The legacy lowercase strings exist only to bridge the cutover; once we regenerate FE types from BE OpenAPI, the projection helper can be deleted.
2. \`useRecipientDisplay\` could replace more sites — \`AddressLink\` doesn't take an account/user shape today, so passing a \`username\` prop would close the loop for transaction history rendering. Out of scope for this release.