### PR TITLE
fix(history): drop wei→decimal parse for SEND_LINK amounts

### DIFF
--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -297,7 +297,11 @@ export async function completeHistoryEntry(entry: HistoryEntry): Promise<History
                 tokenAddress: entry.tokenAddress as Hash,
                 chainId: entry.chainId,
             })
-            usdAmount = formatUnits(BigInt(entry.amount), tokenDetails?.decimals ?? 6)
+            // BE emits SEND_LINK amount as a decimal string ("2.00") via
+            // mapGenericIntent → formatAmount. BigInt() throws on decimals;
+            // .toString() is consistent with P2P_REQUEST_FULFILL / DIRECT_TRANSFER
+            // (other kinds also routed through mapGenericIntent).
+            usdAmount = entry.amount.toString()
             tokenSymbol = tokenDetails?.symbol ?? ''
             break
         }


### PR DESCRIPTION
## Summary

Hotfix for the post-merge regression Hugo screenshotted last night: history view shows **\"Error loading transactions!\"** for any user whose history contains a `SEND_LINK` row.

## Root cause

Decomplexify Phase 2 unified the BE history mapper such that `mapGenericIntent` (SEND_LINK, P2P_SEND, REWARD_PAYOUT, CRYPTO_WITHDRAW, etc.) emits **decimal** USD strings via `formatAmount()` (\"2.00\"). The FE `completeHistoryEntry` switch in `src/utils/history.utils.ts:300` still called `BigInt(entry.amount)` for `SEND_LINK` — which throws on \"2.00\":

\`\`\`
SyntaxError: Cannot convert 2.00 to a BigInt
\`\`\`

That exception bubbles up to TanStack Query, the history hook lands in error state, the UI shows the friendly fallback.

## Why this slipped past Phase 2 review

The Phase 2 render-snapshot covers `dispatchStrategy` + `transactionTransformer` but does **not** call `completeHistoryEntry`. Adding that to the snapshot is the right follow-up so this class of contract drift can't recur silently.

## The fix

Drop `formatUnits(BigInt(entry.amount), tokenDetails?.decimals ?? 6)` in the SEND_LINK branch; use `entry.amount.toString()` to match the post-Phase-2 wire contract already followed by `P2P_REQUEST_FULFILL`, `DIRECT_TRANSFER`, `ONRAMP`, `OFFRAMP`.

`CRYPTO_DEPOSIT` is **untouched** — it goes through `DepositHistoryFetcher` (separate BE path), which still emits wei. Its existing `extraData.blockNumber`-gated `BigInt` branch stays correct.

## Risk

Lowest possible — one branch of one switch, behavior changes from \"throws\" to \"renders the BE-supplied decimal string.\" The change cannot make any currently-rendering history row look different.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `npm test -- --testPathPattern=history` — 8/8 pass
- [ ] Staging deploy + reload `/history` on an account with SEND_LINK rows → no error toast
- [ ] Hugo's morning eyeball

## Follow-ups (NOT in this PR)

1. **Extend FE render-snapshot harness** to call `completeHistoryEntry` on every fixture row — would catch this class of drift at CI time.
2. **Type the wire**: `entry.amount: string` is ambiguous (decimal vs wei). Branded types or split fields (`amountDecimal` / `amountWei`) make the compiler enforce the contract.
3. **Lint rule against `BigInt(` in render code** — force callers through typed parse helpers.

Each is a separate PR.