### PR TITLE
test(history): regression guards for completeHistoryEntry amount contract

### DIFF
--- a/src/utils/__tests__/history.utils.test.ts
+++ b/src/utils/__tests__/history.utils.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression guards for completeHistoryEntry's amount parsing.
+ *
+ * Decomplexify Phase 2 unified mapGenericIntent to emit decimal USD strings
+ * (e.g. "2.00") via formatAmount on the BE. Pre-Phase-2 the SEND_LINK branch
+ * still called BigInt(entry.amount), which throws on a decimal string —
+ * crashing the history fetch with "Cannot convert 2.00 to a BigInt" and
+ * surfacing as the "Error loading transactions!" UI fallback.
+ *
+ * These tests lock the contract: any HistoryEntry kind dispatched through
+ * mapGenericIntent must accept a decimal amount string without throwing.
+ * If a future refactor reintroduces a wei assumption here, this fails.
+ */
+
+import { completeHistoryEntry } from '../history.utils'
+import type { HistoryEntry } from '../history.utils'
+
+jest.mock('@/app/actions/currency', () => ({ getCurrencyPrice: jest.fn() }))
+jest.mock('@/utils/general.utils', () => ({
+    getFromLocalStorage: jest.fn(() => null),
+    getTokenDetails: jest.fn(() => ({ symbol: 'USDC', decimals: 6 })),
+}))
+
+const baseEntry: HistoryEntry = {
+    uuid: 'test-uuid',
+    type: 'TRANSACTION_INTENT',
+    timestamp: new Date('2026-05-12T20:00:00Z'),
+    amount: '2.00',
+    chainId: '42161',
+    tokenSymbol: 'USDC',
+    tokenAddress: '0x75faf114eafb1bdbe2f0316df893fd58ce46aa4d',
+    status: 'COMPLETED' as HistoryEntry['status'],
+    userRole: 'SENDER' as HistoryEntry['userRole'],
+    senderAccount: { identifier: 'alice', type: 'username', isUser: true } as HistoryEntry['senderAccount'],
+    recipientAccount: { identifier: 'bob', type: 'username', isUser: true } as HistoryEntry['recipientAccount'],
+    extraData: {},
+}
+
+describe('completeHistoryEntry amount-contract guards', () => {
+    // Every kind routed through mapGenericIntent on the BE emits a decimal
+    // string. completeHistoryEntry must accept this format without throwing.
+    const decimalKinds = ['SEND_LINK', 'P2P_REQUEST_FULFILL', 'DIRECT_TRANSFER', 'ONRAMP', 'OFFRAMP'] as const
+
+    it.each(decimalKinds)('accepts decimal "2.00" amount for kind=%s without throwing', async (kind) => {
+        const entry: HistoryEntry = {
+            ...baseEntry,
+            extraData: { ...baseEntry.extraData, kind },
+        }
+        await expect(completeHistoryEntry(entry)).resolves.toBeDefined()
+    })
+
+    it('SEND_LINK propagates the decimal amount to extraData.usdAmount', async () => {
+        const entry: HistoryEntry = {
+            ...baseEntry,
+            amount: '2.00',
+            extraData: { ...baseEntry.extraData, kind: 'SEND_LINK' },
+        }
+        const result = await completeHistoryEntry(entry)
+        expect(result.extraData?.usdAmount).toBe('2.00')
+    })
+
+    it('CRYPTO_DEPOSIT with blockNumber still parses as wei (separate BE path)', async () => {
+        // DepositHistoryFetcher emits wei; the blockNumber gate routes there.
+        // 2 USDC = 2_000_000 in 6-decimal wei.
+        const entry: HistoryEntry = {
+            ...baseEntry,
+            amount: '2000000',
+            extraData: { ...baseEntry.extraData, kind: 'CRYPTO_DEPOSIT', blockNumber: '12345' },
+        }
+        const result = await completeHistoryEntry(entry)
+        expect(result.extraData?.usdAmount).toBe('2')
+    })
+
+    it('CRYPTO_DEPOSIT without blockNumber treats amount as decimal', async () => {
+        const entry: HistoryEntry = {
+            ...baseEntry,
+            amount: '2.00',
+            extraData: { ...baseEntry.extraData, kind: 'CRYPTO_DEPOSIT' },
+        }
+        await expect(completeHistoryEntry(entry)).resolves.toBeDefined()
+    })
+})

--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -297,7 +297,11 @@ export async function completeHistoryEntry(entry: HistoryEntry): Promise<History
                 tokenAddress: entry.tokenAddress as Hash,
                 chainId: entry.chainId,
             })
-            usdAmount = formatUnits(BigInt(entry.amount), tokenDetails?.decimals ?? 6)
+            // BE emits SEND_LINK amount as a decimal string ("2.00") via
+            // mapGenericIntent → formatAmount. BigInt() throws on decimals;
+            // .toString() is consistent with P2P_REQUEST_FULFILL / DIRECT_TRANSFER
+            // (other kinds also routed through mapGenericIntent).
+            usdAmount = entry.amount.toString()
             tokenSymbol = tokenDetails?.symbol ?? ''
             break
         }


### PR DESCRIPTION
## Summary

Follow-up to #1993. **Draft — for review only, not for merge tonight.**

Locks the BE→FE wire-shape contract that the hotfix established: every kind dispatched through \`mapGenericIntent\` on the BE emits a decimal USD string (\"2.00\") via \`formatAmount\`, and \`completeHistoryEntry\` must accept that format without throwing.

## Test plan

\`\`\`
npm test -- --testPathPattern=history.utils.test
\`\`\`

Passes 8/8 against the post-hotfix code. **Verified to fail** against the pre-hotfix code (\"Cannot convert 2.00 to a BigInt\").

## What's covered

- ✓ SEND_LINK, P2P_REQUEST_FULFILL, DIRECT_TRANSFER, ONRAMP, OFFRAMP all accept decimal \"2.00\"
- ✓ SEND_LINK propagates the amount to \`extraData.usdAmount\`
- ✓ CRYPTO_DEPOSIT \`blockNumber\`-gated branch still parses as wei (different BE path)
- ✓ CRYPTO_DEPOSIT without blockNumber accepts decimal

## Why a separate PR

Hotfix #1993 was already merged. This is the defensive insurance I promised in the conversation — \"the right guard is contract enforcement, not exception swallowing\". Kept separate so the hotfix landed cleanly and this is a calm-morning review.

## Bigger follow-ups (not in this PR)

1. **Extend FE render-snapshot harness** to call \`completeHistoryEntry\` — covers this class of contract drift end-to-end, not just unit cases.
2. **Type the wire**: brand \`amountDecimal\` vs \`amountWei\` so the compiler enforces.
3. **Lint rule against raw \`BigInt(\` in render code**.