### PR TITLE
fix(payments): show spendable balance + wait for collateral on input gate (TASK-19573)

### DIFF
--- a/src/features/payments/flows/contribute-pot/useContributePotFlow.ts
+++ b/src/features/payments/flows/contribute-pot/useContributePotFlow.ts
@@ -62,9 +62,9 @@ export function useContributePotFlow() {
         isConnected,
         address: walletAddress,
         sendMoney,
-        formattedBalance,
+        formattedSpendableBalance,
         hasSufficientSpendableBalance: hasSufficientBalance,
-        isFetchingBalance,
+        isFetchingSpendableBalance,
     } = useWallet()
 
     const isLoggedIn = !!user?.user?.userId
@@ -97,8 +97,10 @@ export function useContributePotFlow() {
         return hasSufficientBalance(amount)
     }, [amount, hasSufficientBalance])
 
-    // check if should show insufficient balance error
-    // only show after balance has loaded to avoid flash of error on initial render
+    // check if should show insufficient balance error.
+    // gate on !isFetchingSpendableBalance so we wait for both smart-account
+    // and Rain collateral to settle. See useSemanticRequestFlow for the
+    // same fix + reasoning (TASK-19573).
     const isInsufficientBalance = useMemo(() => {
         return (
             isLoggedIn &&
@@ -107,9 +109,9 @@ export function useContributePotFlow() {
             !isLoading &&
             !isCreatingCharge &&
             !isRecording &&
-            !isFetchingBalance
+            !isFetchingSpendableBalance
         )
-    }, [isLoggedIn, amount, hasEnoughBalance, isLoading, isCreatingCharge, isRecording, isFetchingBalance])
+    }, [isLoggedIn, amount, hasEnoughBalance, isLoading, isCreatingCharge, isRecording, isFetchingSpendableBalance])
 
     // calculate default slider value and suggested amount
     const sliderDefaults = useMemo(() => {
@@ -272,7 +274,7 @@ export function useContributePotFlow() {
         isLoggedIn,
         isConnected,
         walletAddress,
-        formattedBalance,
+        formattedBalance: formattedSpendableBalance,
 
         // actions
         setAmount: handleSetAmount,

--- a/src/features/payments/flows/direct-send/useDirectSendFlow.ts
+++ b/src/features/payments/flows/direct-send/useDirectSendFlow.ts
@@ -55,9 +55,9 @@ export function useDirectSendFlow() {
         isConnected,
         address: walletAddress,
         sendMoney,
-        formattedBalance,
+        formattedSpendableBalance,
         hasSufficientSpendableBalance: hasSufficientBalance,
-        isFetchingBalance,
+        isFetchingSpendableBalance,
     } = useWallet()
 
     const isLoggedIn = !!user?.user?.userId
@@ -91,18 +91,20 @@ export function useDirectSendFlow() {
     }, [amount, hasSufficientBalance])
 
     // check if should show insufficient balance error
-    // gate on !isFetchingBalance to avoid flash while balance is still loading
+    // gate on !isFetchingSpendableBalance so we wait for both smart-account
+    // and Rain collateral to settle. See useSemanticRequestFlow for the
+    // same fix + reasoning (TASK-19573).
     const isInsufficientBalance = useMemo(() => {
         return (
             isLoggedIn &&
             !!amount &&
             !hasEnoughBalance &&
-            !isFetchingBalance &&
+            !isFetchingSpendableBalance &&
             !isLoading &&
             !isCreatingCharge &&
             !isRecording
         )
-    }, [isLoggedIn, amount, hasEnoughBalance, isFetchingBalance, isLoading, isCreatingCharge, isRecording])
+    }, [isLoggedIn, amount, hasEnoughBalance, isFetchingSpendableBalance, isLoading, isCreatingCharge, isRecording])
 
     // execute the payment (called from input view)
     const executePayment = useCallback(async () => {
@@ -200,7 +202,7 @@ export function useDirectSendFlow() {
         isLoggedIn,
         isConnected,
         walletAddress,
-        formattedBalance,
+        formattedBalance: formattedSpendableBalance,
 
         // actions
         setAmount: handleSetAmount,

--- a/src/features/payments/flows/semantic-request/useSemanticRequestFlow.ts
+++ b/src/features/payments/flows/semantic-request/useSemanticRequestFlow.ts
@@ -83,9 +83,9 @@ export function useSemanticRequestFlow() {
         address: walletAddress,
         sendMoney,
         sendTransactions,
-        formattedBalance,
+        formattedSpendableBalance,
         hasSufficientSpendableBalance: hasSufficientBalance,
-        isFetchingBalance,
+        isFetchingSpendableBalance,
     } = useWallet()
 
     // use token selector context for ui integration
@@ -173,13 +173,18 @@ export function useSemanticRequestFlow() {
     }, [amount, hasSufficientBalance])
 
     // check if should show insufficient balance error
-    // gate on !isFetchingBalance to avoid flash while balance is still loading
+    // gate on !isFetchingSpendableBalance (NOT isFetchingBalance) so we wait
+    // for BOTH the smart-account AND the Rain collateral query to settle
+    // before deciding the user has insufficient funds. Otherwise a user with
+    // (smart < amount < smart+collateral) sees a flash of "insufficient" while
+    // collateral is still loading, which redirects them to /add-money even
+    // though useSpendBundle would route through collateral.
     const isInsufficientBalance = useMemo(() => {
         return (
             isLoggedIn &&
             !!amount &&
             !hasEnoughBalance &&
-            !isFetchingBalance &&
+            !isFetchingSpendableBalance &&
             !isLoading &&
             !isCreatingCharge &&
             !isFetchingCharge &&
@@ -190,7 +195,7 @@ export function useSemanticRequestFlow() {
         isLoggedIn,
         amount,
         hasEnoughBalance,
-        isFetchingBalance,
+        isFetchingSpendableBalance,
         isLoading,
         isCreatingCharge,
         isFetchingCharge,
@@ -602,7 +607,7 @@ export function useSemanticRequestFlow() {
         isConnected,
         isLoggedIn,
         walletAddress,
-        formattedBalance,
+        formattedBalance: formattedSpendableBalance,
         isXChain,
         isDiffToken,
         needsRoute,

--- a/src/hooks/wallet/useWallet.ts
+++ b/src/hooks/wallet/useWallet.ts
@@ -236,11 +236,25 @@ export const useWallet = () => {
     // the balance jumping when the rain number arrives.
     const isSpendableBalanceLoading = isBalanceLoading || isRainOverviewLoading
 
-    // formatted balance for display (e.g. "1,234.56")
+    // formatted balance for display (e.g. "1,234.56"). Smart-account only —
+    // use `formattedSpendableBalance` below for user-facing widgets that
+    // should reflect total spendable (smart + Rain collateral).
     const formattedBalance = useMemo(() => {
         if (balance === undefined) return '0.00'
         return formatCurrency(formatUnits(balance, PEANUT_WALLET_TOKEN_DECIMALS))
     }, [balance])
+
+    // Total spendable (smart + Rain collateral) formatted for display.
+    // Payment-input forms (request-pay, direct-send, contribute-pot) should
+    // show THIS rather than the smart-only number — otherwise a user with
+    // funds split across smart and collateral sees a smaller balance than
+    // they actually have and the "insufficient balance" gate trips even
+    // though useSpendBundle would route through collateral just fine
+    // (2026-05-08 jotest097 report TASK-19573).
+    const formattedSpendableBalance = useMemo(() => {
+        if (spendableBalance === undefined) return '0.00'
+        return formatCurrency(formatUnits(spendableBalance, PEANUT_WALLET_TOKEN_DECIMALS))
+    }, [spendableBalance])
 
     // Check if the user has enough spendable to cover a USD amount.
     // Spendable = smart account + Rain collateral `spendingPower`. Use this
@@ -261,6 +275,7 @@ export const useWallet = () => {
         balance,
         spendableBalance,
         formattedBalance,
+        formattedSpendableBalance,
         hasSufficientSpendableBalance,
         isConnected: isKernelClientReady,
         sendTransactions,


### PR DESCRIPTION
Closes [TASK-19573](https://www.notion.so/peanutprotocol/Cannot-pay-request-from-collateral-balance-also-wrong-excludes-collateral-35b83811757981e9bca5dad7c37a2bf3).

jotest097 reported that paying a request didn't use card collateral and the displayed balance excluded collateral. Two related FE bugs in the same surface — both fixed in this PR.

## Bug 1 — Insufficient-balance gate fires before Rain collateral loads

The home page's spendable balance correctly sums smart-account + Rain collateral, but the three payment-input flows (request-pay, direct-send, contribute-pot) gated their \`isInsufficientBalance\` flag on \`isFetchingBalance\` (smart-only) instead of \`isFetchingSpendableBalance\` (smart + Rain).

Result: the smart-account query settles first → flow concludes "insufficient" → CTA redirects to \`/add-money\` → Rain query settles a beat later but the user is already gone. \`useSpendBundle\` would have happily routed through collateral-only or mixed if it had been allowed to run.

Fix: gate on \`isFetchingSpendableBalance\` so both queries must settle before the insufficient-balance error fires.

## Bug 2 — Input form shows smart-only balance, hiding collateral

Same three flows passed \`formattedBalance\` (smart-only) to their input view's "$X.XX available" line. User sees "$5.00" instead of "$15.00" when they have $5 smart + $10 collateral.

Fix: \`useWallet\` exposes a new \`formattedSpendableBalance\` (mirror of \`formattedBalance\` but using \`spendableBalance\`). The three flow hooks now alias it through their existing \`formattedBalance\` return key, so the views render correctly with no view-side changes.

## Files

- \`src/hooks/wallet/useWallet.ts\` — new \`formattedSpendableBalance\` field.
- \`src/features/payments/flows/semantic-request/useSemanticRequestFlow.ts\` — switch to spendable for both gate + display.
- \`src/features/payments/flows/direct-send/useDirectSendFlow.ts\` — same.
- \`src/features/payments/flows/contribute-pot/useContributePotFlow.ts\` — same.

## Test plan

- [x] Typecheck clean. Tests pass (the 2 failing pre-existing on \`origin/dev\` are unrelated: \`countryCurrencyMapping\` + \`add-money-states\`).
- [ ] On staging: user with smart < amount < smart+collateral attempts to pay a request. Verify the CTA proceeds (no /add-money redirect).
- [ ] Verify the input view shows the spendable total ("\$15.00" with $5 smart + $10 collateral), not the smart-only number.
- [ ] Verify the same on direct-send and contribute-pot input views.
- [ ] Spend completes via collateral-only or mixed strategy as appropriate.
- [ ] User with sufficient smart-only funds: behavior unchanged (no regressions).

## Notes

- BE: no changes needed. \`useSpendBundle\` already routes through collateral; the bug was purely the FE blocking the user before the router got to choose.
- Each flow hook re-aliases \`formattedSpendableBalance\` as \`formattedBalance\` in its return so the downstream view code stays unchanged. Smaller diff than refactoring the views.