### PR TITLE
feat(payments): pass chargeId to Rain withdraw prepare for request payments (TASK-19573)

### DIFF
--- a/src/features/payments/flows/contribute-pot/useContributePotFlow.ts
+++ b/src/features/payments/flows/contribute-pot/useContributePotFlow.ts
@@ -194,7 +194,14 @@ export function useContributePotFlow() {
                 }
 
                 // step 2: send money via peanut wallet
-                const txResult = await sendMoney(recipient.address, amount, { kind: 'REQUEST_PAY' })
+                const txResult = await sendMoney(recipient.address, amount, {
+                    kind: 'REQUEST_PAY',
+                    // Lets the backend settle the charge directly when the spend
+                    // routes through Rain card collateral (the on-chain validator
+                    // can't verify a collateral-contract tx). recordPayment below is
+                    // then routed through the same trusted-completion path.
+                    chargeId: chargeResult.uuid,
+                })
                 // For the collateral-only strategy useSpendBundle returns only
                 // `txHash` (Rain coordinator submits the on-chain tx; no UserOp
                 // hash + no receipt land here). Fall back to it so users with

--- a/src/features/payments/flows/direct-send/useDirectSendFlow.ts
+++ b/src/features/payments/flows/direct-send/useDirectSendFlow.ts
@@ -135,7 +135,14 @@ export function useDirectSendFlow() {
             setCharge(chargeResult)
 
             // step 2: send money via peanut wallet
-            const txResult = await sendMoney(recipient.address, amount, { kind: 'P2P_SEND' })
+            const txResult = await sendMoney(recipient.address, amount, {
+                kind: 'P2P_SEND',
+                // Lets the backend settle the charge directly when the spend routes
+                // through Rain card collateral (the on-chain validator can't verify
+                // a collateral-contract tx). recordPayment below is then routed
+                // through the same trusted-completion path.
+                chargeId: chargeResult.uuid,
+            })
             // For the collateral-only strategy useSpendBundle returns only
             // `txHash` (Rain coordinator submits the on-chain tx; no UserOp
             // hash + no receipt land here). Fall back to it so users with

--- a/src/features/payments/flows/semantic-request/useSemanticRequestFlow.ts
+++ b/src/features/payments/flows/semantic-request/useSemanticRequestFlow.ts
@@ -490,6 +490,11 @@ export function useSemanticRequestFlow() {
                 // direct payment for same-chain same-token (e.g. direct requests)
                 const txResult = await sendMoney(charge.requestLink.recipientAddress as Address, charge.tokenAmount, {
                     kind: 'REQUEST_PAY',
+                    // See sibling site (~line 297): lets the backend settle the
+                    // charge directly when the spend routes through Rain card
+                    // collateral; recordPayment below is routed through the same
+                    // trusted-completion path.
+                    chargeId: charge.uuid,
                 })
                 // collateral-only routes return `txHash` only — see
                 // sibling site at line ~293 for the same fallback.

--- a/src/features/payments/flows/semantic-request/useSemanticRequestFlow.ts
+++ b/src/features/payments/flows/semantic-request/useSemanticRequestFlow.ts
@@ -294,7 +294,14 @@ export function useSemanticRequestFlow() {
                 // if cross-chain or different token → go to confirm view
                 if (isSameChainSameToken) {
                     // direct payment - same as old flow when isPeanutWallet && same token/chain
-                    const txResult = await sendMoney(recipient.resolvedAddress, amount, { kind: 'REQUEST_PAY' })
+                    const txResult = await sendMoney(recipient.resolvedAddress, amount, {
+                        kind: 'REQUEST_PAY',
+                        // Lets the backend settle the charge directly when the spend
+                        // routes through Rain card collateral (the on-chain validator
+                        // can't verify a collateral-contract tx). recordPayment below
+                        // is then routed through the same trusted-completion path.
+                        chargeId: chargeResult.uuid,
+                    })
                     // For the collateral-only strategy useSpendBundle returns only
                     // `txHash` (Rain coordinator submits the on-chain tx). Fall
                     // back to it so card-collateral users don't get an

--- a/src/hooks/wallet/useSendMoney.ts
+++ b/src/hooks/wallet/useSendMoney.ts
@@ -23,6 +23,11 @@ type SendMoneyParams = {
      *  other semantics (QR pay, crypto withdraw, request pay, …) should pass
      *  the appropriate kind explicitly. */
     kind?: RainCollateralKind
+    /** When this send pays a Peanut request/charge, the charge uuid. If the spend
+     *  routes entirely through Rain collateral the backend completes the charge
+     *  itself — the result's `strategy === 'collateral-only'` is the caller's
+     *  signal to skip `recordPayment`. Ignored for other strategies. */
+    chargeId?: string
     /** Optional UI hook — fires once routing is picked, before any signing prompt. */
     onStrategyDecided?: (strategy: Exclude<SpendStrategy, 'insufficient'>) => void
     /** Optional UI hook — fires when we're about to prompt for the one-time
@@ -60,6 +65,7 @@ export const useSendMoney = ({ address }: UseSendMoneyOptions) => {
             toAddress,
             amountInUsd,
             kind = 'P2P_SEND',
+            chargeId,
             onStrategyDecided,
             onGrantRequired,
         }: SendMoneyParams) => {
@@ -70,6 +76,7 @@ export const useSendMoney = ({ address }: UseSendMoneyOptions) => {
                 smartBalance: smartBalance ?? 0n,
                 rainSpendingPower: rainSpendingPowerToWei(overview?.balance?.spendingPower),
                 kind,
+                chargeId,
                 onStrategyDecided,
                 onGrantRequired,
             })

--- a/src/hooks/wallet/useSpendBundle.ts
+++ b/src/hooks/wallet/useSpendBundle.ts
@@ -41,6 +41,12 @@ export interface SpendBundleInput {
      *  the Rain collateral webhook can be reconciled and categorized correctly
      *  in history (instead of showing up as a generic "card payment"). */
     kind: RainCollateralKind
+    /** When this spend pays a Peanut request/charge AND it routes entirely through
+     *  Rain collateral (`collateral-only`), the charge uuid. The backend uses the
+     *  charge intent itself as the prep and marks it COMPLETED on confirm — so the
+     *  caller MUST skip its own `recordPayment` when `strategy === 'collateral-only'`.
+     *  Ignored for `smart-only` and `mixed` (those keep the recordPayment path). */
+    chargeId?: string
     /** Extra calls to include in the kernel UserOp (for approve+deposit-style flows).
      *  If present, collateral-only routing is NOT eligible — calls must run from the kernel. */
     subsequentCalls?: UserOpEncodedParams[]
@@ -140,6 +146,7 @@ export const useSpendBundle = () => {
                 smartBalance,
                 rainSpendingPower,
                 kind,
+                chargeId,
                 onStrategyDecided,
                 onGrantRequired,
             } = input
@@ -190,6 +197,9 @@ export const useSpendBundle = () => {
                         recipientAddress: recipient!,
                         directTransfer: true,
                         kind,
+                        // When set, the backend completes the charge directly on
+                        // confirm — caller must skip recordPayment for this strategy.
+                        chargeId,
                     })
 
                     const kernelClient = getClientForChain(chainIdStr)

--- a/src/hooks/wallet/useWallet.ts
+++ b/src/hooks/wallet/useWallet.ts
@@ -103,11 +103,12 @@ export const useWallet = () => {
     const { spend: spendBundle } = useSpendBundle()
 
     const sendMoney = useCallback(
-        async (toAddress: Address, amountInUsd: string, options?: { kind?: RainCollateralKind }) => {
+        async (toAddress: Address, amountInUsd: string, options?: { kind?: RainCollateralKind; chargeId?: string }) => {
             const result = await sendMoneyMutation.mutateAsync({
                 toAddress,
                 amountInUsd,
                 kind: options?.kind,
+                chargeId: options?.chargeId,
             })
             // `strategy` lets same-chain callers distinguish "funds left the smart
             // account" (smart-only) from "funds left Rain collateral" (collateral-

--- a/src/services/rain.ts
+++ b/src/services/rain.ts
@@ -84,6 +84,10 @@ export interface PrepareRainWithdrawalInput {
     /** Total user-initiated spend in cents. For mixed strategy this differs from
      *  `amount` (which is only the collateral shortfall). History shows this. */
     totalAmountCents?: string
+    /** When this withdrawal pays a Peanut request/charge, the charge uuid.
+     *  The backend then uses the charge intent itself as the prep and marks it
+     *  COMPLETED on confirm — so the FE must NOT also call `recordPayment`. */
+    chargeId?: string
 }
 
 export interface PrepareRainWithdrawalResponse {


### PR DESCRIPTION
Follow-up to #1995 (merged). Pairs with peanut-api-ts#755 — **deploy together**.

## What

When a request / direct-send / pot charge is paid and the spend routes entirely through Rain card collateral, the on-chain `RequestPaymentValidator` can't verify the tx (funds leave Rain's collateral contract, not the smart wallet). The backend (api#755) now settles the charge itself when `/rain/cards/withdraw/prepare` is called with a `chargeId`. This PR threads the charge uuid down:

`useWallet.sendMoney` → `useSendMoney` → `useSpendBundle` → `rainApi.prepareWithdrawal` (only the `collateral-only` branch passes it).

`recordPayment` still runs from the flow hooks — the backend routes it through the same trusted-completion path (idempotent). Smart-only / mixed strategies are unchanged (`chargeId` ignored).

## Files

- `services/rain.ts` — `PrepareRainWithdrawalInput.chargeId?`
- `hooks/wallet/useSpendBundle.ts` — `SpendBundleInput.chargeId?`, passed in the `collateral-only` branch
- `hooks/wallet/useSendMoney.ts` — `SendMoneyParams.chargeId?`, threaded
- `hooks/wallet/useWallet.ts` — `sendMoney` opts gain `chargeId?`
- `features/payments/flows/{semantic-request,direct-send,contribute-pot}` — pass `charge.uuid`

## QA

See api#755. FE-side: smoke the request-pay / direct-send / pot-contribute flows for both a smart-balance user (unchanged) and a card-collateral-only user (one COMPLETED row, no duplicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)