### PR TITLE
fix(navigation): close back-button gaps left by #1965

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,15 @@ const tsPlugin = require('@typescript-eslint/eslint-plugin')
 const reactPlugin = require('eslint-plugin-react')
 const reactHooksPlugin = require('eslint-plugin-react-hooks')
 const nextPlugin = require('@next/eslint-plugin-next')
+const importPlugin = require('eslint-plugin-import-x')
 const globals = require('globals')
+
+// Barrel paths banned by CLAUDE.md ("no barrel imports — never `import * as X from
+// '@/constants'` or create `index.ts` barrels. Import from specific files"). The bare
+// alias resolves to `<dir>/index.{ts,tsx}` which forces the bundler to load every
+// re-export, hurting build perf. Existing violations remain (~135 across the codebase)
+// — the guard is preventative; cleanup belongs in a separate sweep.
+const BANNED_BARREL_PATHS = ['@/constants', '@/components', '@/assets', '@/context', '@/interfaces', '@/config']
 
 module.exports = [
     {
@@ -40,8 +48,15 @@ module.exports = [
             react: reactPlugin,
             'react-hooks': reactHooksPlugin,
             '@next/next': nextPlugin,
+            'import-x': importPlugin,
         },
-        settings: { react: { version: 'detect' } },
+        settings: {
+            react: { version: 'detect' },
+            'import-x/resolver': {
+                typescript: { project: './tsconfig.json' },
+                node: true,
+            },
+        },
         rules: {
             ...tsPlugin.configs.recommended.rules,
             ...reactPlugin.configs.recommended.rules,
@@ -56,6 +71,25 @@ module.exports = [
             'react/prop-types': 'off',
             // Allow unescaped quotes — too noisy and prettier handles spacing
             'react/no-unescaped-entities': 'off',
+
+            // Ban barrel imports — see BANNED_BARREL_PATHS above.
+            'no-restricted-imports': [
+                'error',
+                {
+                    paths: BANNED_BARREL_PATHS.map((path) => ({
+                        name: path,
+                        message: `Import from a specific file instead of the '${path}' barrel — barrels force the bundler to load every re-export and hurt build perf. See CLAUDE.md.`,
+                    })),
+                },
+            ],
+
+            // Ban self-imports — CLAUDE.md import rules. Confirmed firing on synthetic test.
+            'import-x/no-self-import': 'error',
+            // import-x/no-cycle is intentionally NOT enabled. The plugin's no-cycle silently
+            // fails on synthetic A↔B cycles under ESLint 9 flat config in this setup —
+            // verified against both eslint-plugin-import 2.32 and eslint-plugin-import-x 4.16.
+            // Self-imports are still caught above. Revisit when the plugin matures or someone
+            // figures out the resolver gotcha.
 
             // Project-specific: catch the back-button bug class.
             // See src/hooks/useSafeBack.ts, PR #1965 (router.back), PR #1997 (sibling patterns).
@@ -73,7 +107,7 @@ module.exports = [
                     selector:
                         "JSXAttribute[name.name=/^(onPrev|onBack)$/] > JSXExpressionContainer > ArrowFunctionExpression[body.type='CallExpression'][body.callee.object.name='router'][body.callee.property.name=/^(push|replace)$/]",
                     message:
-                        "Bare router.push/replace as onPrev/onBack creates a parent↔child cycle once the parent uses useSafeBack (the push grows in-app history, useSafeBack pops back to this screen, repeat). Use useSafeBack(parentUrl) — pass { replace: true } to preserve replace semantics. See PR #1997.",
+                        'Bare router.push/replace as onPrev/onBack creates a parent↔child cycle once the parent uses useSafeBack (the push grows in-app history, useSafeBack pops back to this screen, repeat). Use useSafeBack(parentUrl) — pass { replace: true } to preserve replace semantics. See PR #1997.',
                 },
                 {
                     selector:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -57,14 +57,29 @@ module.exports = [
             // Allow unescaped quotes — too noisy and prettier handles spacing
             'react/no-unescaped-entities': 'off',
 
-            // Project-specific: ban bare router.back() outside useSafeBack.
-            // See src/hooks/useSafeBack.ts and PR #1965.
+            // Project-specific: catch the back-button bug class.
+            // See src/hooks/useSafeBack.ts, PR #1965 (router.back), PR #1997 (sibling patterns).
             'no-restricted-syntax': [
                 'error',
                 {
                     selector: "CallExpression[callee.object.name='router'][callee.property.name='back']",
                     message:
                         "Don't call router.back() directly — it no-ops on deep-link entries (cold tab, QR scan, push notification). Use useSafeBack(fallbackUrl) from '@/hooks/useSafeBack' instead. See PR #1965.",
+                },
+                {
+                    // Only matches the simple () => router.push|replace(x) arrow-body shape —
+                    // multi-statement handlers (state resets, conditional branches) keep their
+                    // freedom since they often combine navigation with intentional side effects.
+                    selector:
+                        "JSXAttribute[name.name=/^(onPrev|onBack)$/] > JSXExpressionContainer > ArrowFunctionExpression[body.type='CallExpression'][body.callee.object.name='router'][body.callee.property.name=/^(push|replace)$/]",
+                    message:
+                        "Bare router.push/replace as onPrev/onBack creates a parent↔child cycle once the parent uses useSafeBack (the push grows in-app history, useSafeBack pops back to this screen, repeat). Use useSafeBack(parentUrl) — pass { replace: true } to preserve replace semantics. See PR #1997.",
+                },
+                {
+                    selector:
+                        "MemberExpression[object.object.name='window'][object.property.name='history'][property.name='length']",
+                    message:
+                        "window.history.length is the pre-useSafeBack idiom (history.length > 1 ? back : push). It misfires on cold-load from external referrers — useSafeBack's pushState counter is more accurate. See PR #1965.",
                 },
             ],
         },
@@ -77,6 +92,13 @@ module.exports = [
     {
         // Capacitor hardware back: different bug class (canGoBack + minimizeApp).
         files: ['src/hooks/useNativePlugins.ts'],
+        rules: { 'no-restricted-syntax': 'off' },
+    },
+    {
+        // PublicProfile is the one place we intentionally keep an isInternalReferrer +
+        // window.history.length check. The referrer signal is orthogonal to useSafeBack's
+        // counter; migrating loses information for external-referrer cold-loads.
+        files: ['src/components/Profile/components/PublicProfile.tsx'],
         rules: { 'no-restricted-syntax': 'off' },
     },
 ]

--- a/package.json
+++ b/package.json
@@ -136,6 +136,8 @@
         "@typescript-eslint/eslint-plugin": "^8.59.1",
         "@typescript-eslint/parser": "^8.59.1",
         "eslint": "^9.39.4",
+        "eslint-import-resolver-typescript": "^4.4.4",
+        "eslint-plugin-import-x": "^4.16.2",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
         "globals": "^15.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,12 @@ importers:
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@1.21.7)
+      eslint-import-resolver-typescript:
+        specifier: ^4.4.4
+        version: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import-x:
+        specifier: ^4.16.2
+        version: 4.16.2(@typescript-eslint/utils@8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-react:
         specifier: ^7.37.5
         version: 7.37.5(eslint@9.39.4(jiti@1.21.7))
@@ -1408,6 +1414,9 @@ packages:
     resolution: {integrity: sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g==}
     engines: {node: '>=16.0.0'}
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
@@ -1923,6 +1932,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@package-json/types@0.0.12':
+    resolution: {integrity: sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==}
+
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
     deprecated: 'The package is now available as "qr": npm install qr'
@@ -2434,6 +2446,9 @@ packages:
       rollup:
         optional: true
 
+  '@rtsao/scc@1.1.0':
+    resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
   '@safe-global/safe-apps-provider@0.18.6':
     resolution: {integrity: sha512-4LhMmjPWlIO8TTDC2AwLk44XKXaK6hfBTWyljDm0HQ6TWlOEijVWNrt2s3OCVMSxlXAcEzYfqyu1daHZooTC2Q==}
 
@@ -2864,6 +2879,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/json5@0.0.29':
+    resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
   '@types/lodash@4.17.23':
     resolution: {integrity: sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA==}
 
@@ -3008,6 +3026,109 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
+    resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
+    cpu: [arm]
+    os: [android]
+
+  '@unrs/resolver-binding-android-arm64@1.11.1':
+    resolution: {integrity: sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==}
+    cpu: [arm64]
+    os: [android]
+
+  '@unrs/resolver-binding-darwin-arm64@1.11.1':
+    resolution: {integrity: sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-darwin-x64@1.11.1':
+    resolution: {integrity: sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-freebsd-x64@1.11.1':
+    resolution: {integrity: sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
+    resolution: {integrity: sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
+    resolution: {integrity: sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
+    resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
+    resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
+    resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
+    resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
+    resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
+    resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
+    resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
+    resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
+    resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
+    resolution: {integrity: sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
+    resolution: {integrity: sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
+    resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
+    cpu: [x64]
+    os: [win32]
 
   '@vercel/analytics@1.6.1':
     resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
@@ -3381,6 +3502,10 @@ packages:
 
   array.prototype.findlast@1.2.5:
     resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.findlastindex@1.2.6:
+    resolution: {integrity: sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==}
     engines: {node: '>= 0.4'}
 
   array.prototype.flat@1.3.3:
@@ -3794,6 +3919,10 @@ packages:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
 
+  comment-parser@1.4.6:
+    resolution: {integrity: sha512-ObxuY6vnbWTN6Od72xfwN9DbzC7Y2vv8u1Soi9ahRKL37gb6y1qk6/dgjs+3JWuXJHWvsg3BXIwzd/rkmAwavg==}
+    engines: {node: '>= 12.0.0'}
+
   common-tags@1.8.2:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
     engines: {node: '>=4.0.0'}
@@ -3973,6 +4102,14 @@ packages:
 
   debounce@1.2.1:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
+
+  debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -4260,6 +4397,75 @@ packages:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
     engines: {node: '>=6.0'}
     hasBin: true
+
+  eslint-import-context@0.1.9:
+    resolution: {integrity: sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      unrs-resolver: ^1.0.0
+    peerDependenciesMeta:
+      unrs-resolver:
+        optional: true
+
+  eslint-import-resolver-node@0.3.10:
+    resolution: {integrity: sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==}
+
+  eslint-import-resolver-typescript@4.4.4:
+    resolution: {integrity: sha512-1iM2zeBvrYmUNTj2vSC/90JTHDth+dfOfiNKkxApWRsTJYNrc8rOdxxIf5vazX+BiAXTeOT0UvWpGI/7qIWQOw==}
+    engines: {node: ^16.17.0 || >=18.6.0}
+    peerDependencies:
+      eslint: '*'
+      eslint-plugin-import: '*'
+      eslint-plugin-import-x: '*'
+    peerDependenciesMeta:
+      eslint-plugin-import:
+        optional: true
+      eslint-plugin-import-x:
+        optional: true
+
+  eslint-module-utils@2.12.1:
+    resolution: {integrity: sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+
+  eslint-plugin-import-x@4.16.2:
+    resolution: {integrity: sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/utils': ^8.56.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      eslint-import-resolver-node: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/utils':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+
+  eslint-plugin-import@2.32.0:
+    resolution: {integrity: sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
 
   eslint-plugin-react-hooks@5.2.0:
     resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
@@ -4930,6 +5136,9 @@ packages:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
 
+  is-bun-module@2.0.0:
+    resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
+
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -5326,6 +5535,10 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json5@1.0.2:
+    resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
+    hasBin: true
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -5773,6 +5986,11 @@ packages:
   nanospinner@1.2.2:
     resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
 
+  napi-postinstall@0.3.4:
+    resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    hasBin: true
+
   native-run@2.0.3:
     resolution: {integrity: sha512-U1PllBuzW5d1gfan+88L+Hky2eZx+9gv3Pf6rNBxKbORxi7boHzqiA6QFGSnqMem4j0A9tZ08NMIs5+0m/VS1Q==}
     engines: {node: '>=16.0.0'}
@@ -5912,6 +6130,10 @@ packages:
 
   object.fromentries@2.0.8:
     resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
+    engines: {node: '>= 0.4'}
+
+  object.groupby@1.0.3:
+    resolution: {integrity: sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==}
     engines: {node: '>= 0.4'}
 
   object.values@1.2.1:
@@ -6892,6 +7114,10 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  stable-hash-x@0.2.0:
+    resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
+    engines: {node: '>=12.0.0'}
+
   stack-generator@1.1.0:
     resolution: {integrity: sha512-sZDVjwC56vZoo+a5t0LH/1sMQLWYLi/r+Z2ztyCAOhOX3QBP34GWxK0FWf2eU1TIU2CJKCKBAtDZycUh/ZKMlw==}
 
@@ -6980,6 +7206,10 @@ packages:
   strip-bom-string@1.0.0:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
+
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
 
   strip-bom@4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
@@ -7213,6 +7443,9 @@ packages:
   ts-pattern@5.9.0:
     resolution: {integrity: sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==}
 
+  tsconfig-paths@3.15.0:
+    resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
+
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
@@ -7323,6 +7556,9 @@ packages:
 
   unplugin@1.0.1:
     resolution: {integrity: sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==}
+
+  unrs-resolver@1.11.1:
+    resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
   unstorage@1.17.4:
     resolution: {integrity: sha512-fHK0yNg38tBiJKp/Vgsq4j0JEsCmgqH58HAn707S7zGkArbZsVr/CwINoi+nh3h98BRCwKvx1K3Xg9u3VV83sw==}
@@ -9314,6 +9550,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    dependencies:
+      '@emnapi/core': 1.8.1
+      '@emnapi/runtime': 1.8.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
       '@emnapi/core': 1.8.1
@@ -9828,6 +10071,8 @@ snapshots:
 
   '@oxc-resolver/binding-win32-x64-msvc@11.16.4':
     optional: true
+
+  '@package-json/types@0.0.12': {}
 
   '@paulmillr/qr@0.2.1': {}
 
@@ -10594,6 +10839,9 @@ snapshots:
     optionalDependencies:
       rollup: 3.29.5
 
+  '@rtsao/scc@1.1.0':
+    optional: true
+
   '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
@@ -11166,6 +11414,9 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/json5@0.0.29':
+    optional: true
+
   '@types/lodash@4.17.23': {}
 
   '@types/mdast@4.0.4':
@@ -11335,6 +11586,65 @@ snapshots:
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-android-arm64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-arm64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-x64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-freebsd-x64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.12
+    optional: true
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
+    optional: true
 
   '@vercel/analytics@1.6.1(next@16.2.3(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
     optionalDependencies:
@@ -12174,7 +12484,7 @@ snapshots:
 
   array-includes@3.1.9:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-abstract: 1.24.2
@@ -12192,16 +12502,27 @@ snapshots:
       es-object-atoms: 1.1.1
       es-shim-unscopables: 1.1.0
 
+  array.prototype.findlastindex@1.2.6:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-shim-unscopables: 1.1.0
+    optional: true
+
   array.prototype.flat@1.3.3:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-abstract: 1.24.2
       es-shim-unscopables: 1.1.0
 
   array.prototype.flatmap@1.3.3:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-abstract: 1.24.2
       es-shim-unscopables: 1.1.0
@@ -12599,6 +12920,8 @@ snapshots:
 
   commander@7.2.0: {}
 
+  comment-parser@1.4.6: {}
+
   common-tags@1.8.2: {}
 
   commondir@1.0.1: {}
@@ -12791,6 +13114,11 @@ snapshots:
   dayjs@1.11.13: {}
 
   debounce@1.2.1: {}
+
+  debug@3.2.7:
+    dependencies:
+      ms: 2.1.3
+    optional: true
 
   debug@4.4.3(supports-color@10.2.2):
     dependencies:
@@ -13153,6 +13481,99 @@ snapshots:
       esutils: 2.0.3
     optionalDependencies:
       source-map: 0.6.1
+
+  eslint-import-context@0.1.9(unrs-resolver@1.11.1):
+    dependencies:
+      get-tsconfig: 4.13.0
+      stable-hash-x: 0.2.0
+    optionalDependencies:
+      unrs-resolver: 1.11.1
+
+  eslint-import-resolver-node@0.3.10:
+    dependencies:
+      debug: 3.2.7
+      is-core-module: 2.16.1
+      resolve: 2.0.0-next.6
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
+      get-tsconfig: 4.13.0
+      is-bun-module: 2.0.0
+      stable-hash-x: 0.2.0
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      '@package-json/types': 0.0.12
+      '@typescript-eslint/types': 8.59.1
+      comment-parser: 1.4.6
+      debug: 4.4.3(supports-color@10.2.2)
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
+      is-glob: 4.0.3
+      minimatch: 10.2.5
+      semver: 7.7.3
+      stable-hash-x: 0.2.0
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      '@typescript-eslint/utils': 8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      eslint-import-resolver-node: 0.3.10
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@1.21.7))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+    optional: true
 
   eslint-plugin-react-hooks@5.2.0(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
@@ -13712,7 +14133,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -14029,6 +14450,10 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-bun-module@2.0.0:
+    dependencies:
+      semver: 7.7.3
 
   is-callable@1.2.7: {}
 
@@ -14623,6 +15048,11 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json5@1.0.2:
+    dependencies:
+      minimist: 1.2.8
+    optional: true
 
   json5@2.2.3: {}
 
@@ -15307,6 +15737,8 @@ snapshots:
     dependencies:
       picocolors: 1.1.1
 
+  napi-postinstall@0.3.4: {}
+
   native-run@2.0.3:
     dependencies:
       '@ionic/utils-fs': 3.1.7
@@ -15444,10 +15876,17 @@ snapshots:
 
   object.fromentries@2.0.8:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-abstract: 1.24.2
       es-object-atoms: 1.1.1
+
+  object.groupby@1.0.3:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+    optional: true
 
   object.values@1.2.1:
     dependencies:
@@ -16572,6 +17011,8 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  stable-hash-x@0.2.0: {}
+
   stack-generator@1.1.0:
     dependencies:
       stackframe: 1.3.4
@@ -16667,7 +17108,7 @@ snapshots:
 
   string.prototype.trimend@1.0.9:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
@@ -16700,6 +17141,9 @@ snapshots:
       ansi-regex: 6.2.2
 
   strip-bom-string@1.0.0: {}
+
+  strip-bom@3.0.0:
+    optional: true
 
   strip-bom@4.0.0: {}
 
@@ -16846,7 +17290,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
-      minimatch: 3.1.2
+      minimatch: 3.1.5
 
   text-decoder@1.2.3:
     dependencies:
@@ -16943,6 +17387,14 @@ snapshots:
       jest-util: 29.7.0
 
   ts-pattern@5.9.0: {}
+
+  tsconfig-paths@3.15.0:
+    dependencies:
+      '@types/json5': 0.0.29
+      json5: 1.0.2
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+    optional: true
 
   tslib@1.14.1: {}
 
@@ -17079,6 +17531,30 @@ snapshots:
       chokidar: 3.6.0
       webpack-sources: 3.3.3
       webpack-virtual-modules: 0.5.0
+
+  unrs-resolver@1.11.1:
+    dependencies:
+      napi-postinstall: 0.3.4
+    optionalDependencies:
+      '@unrs/resolver-binding-android-arm-eabi': 1.11.1
+      '@unrs/resolver-binding-android-arm64': 1.11.1
+      '@unrs/resolver-binding-darwin-arm64': 1.11.1
+      '@unrs/resolver-binding-darwin-x64': 1.11.1
+      '@unrs/resolver-binding-freebsd-x64': 1.11.1
+      '@unrs/resolver-binding-linux-arm-gnueabihf': 1.11.1
+      '@unrs/resolver-binding-linux-arm-musleabihf': 1.11.1
+      '@unrs/resolver-binding-linux-arm64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-arm64-musl': 1.11.1
+      '@unrs/resolver-binding-linux-ppc64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-riscv64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-riscv64-musl': 1.11.1
+      '@unrs/resolver-binding-linux-s390x-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-x64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-x64-musl': 1.11.1
+      '@unrs/resolver-binding-wasm32-wasi': 1.11.1
+      '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
+      '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
+      '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
   unstorage@1.17.4(idb-keyval@6.2.2):
     dependencies:

--- a/src/app/(mobile-ui)/card/add-to-wallet/page.tsx
+++ b/src/app/(mobile-ui)/card/add-to-wallet/page.tsx
@@ -1,21 +1,21 @@
 'use client'
 import { type FC, useEffect } from 'react'
-import { useRouter } from 'next/navigation'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import PageContainer from '@/components/0_Bruddle/PageContainer'
 import AddToWalletCarousel from '@/components/Card/AddToWalletCarousel'
 import { useWalletPlatform } from '@/hooks/useWalletPlatform'
+import { useSafeBack } from '@/hooks/useSafeBack'
 
 const AddToWalletPage: FC = () => {
-    const router = useRouter()
     const platform = useWalletPlatform()
+    const onBack = useSafeBack('/card')
     useEffect(() => {
         posthog.capture(ANALYTICS_EVENTS.CARD_ADD_TO_WALLET_VIEWED, { platform: platform ?? 'unknown' })
     }, [platform])
     return (
         <PageContainer>
-            <AddToWalletCarousel onDone={() => router.push('/card')} onPrev={() => router.push('/card')} />
+            <AddToWalletCarousel onDone={onBack} onPrev={onBack} />
         </PageContainer>
     )
 }

--- a/src/app/(mobile-ui)/card/add-to-wallet/page.tsx
+++ b/src/app/(mobile-ui)/card/add-to-wallet/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { type FC, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import PageContainer from '@/components/0_Bruddle/PageContainer'
@@ -8,6 +9,7 @@ import { useWalletPlatform } from '@/hooks/useWalletPlatform'
 import { useSafeBack } from '@/hooks/useSafeBack'
 
 const AddToWalletPage: FC = () => {
+    const router = useRouter()
     const platform = useWalletPlatform()
     const onBack = useSafeBack('/card')
     useEffect(() => {
@@ -15,7 +17,7 @@ const AddToWalletPage: FC = () => {
     }, [platform])
     return (
         <PageContainer>
-            <AddToWalletCarousel onDone={onBack} onPrev={onBack} />
+            <AddToWalletCarousel onDone={() => router.push('/card')} onPrev={onBack} />
         </PageContainer>
     )
 }

--- a/src/app/(mobile-ui)/card/limit/page.tsx
+++ b/src/app/(mobile-ui)/card/limit/page.tsx
@@ -1,17 +1,17 @@
 'use client'
 import { type FC } from 'react'
-import { useRouter } from 'next/navigation'
 import PageContainer from '@/components/0_Bruddle/PageContainer'
 import Loading from '@/components/Global/Loading'
 import { Button } from '@/components/0_Bruddle/Button'
 import { useRainCardOverview } from '@/hooks/useRainCardOverview'
 import { findActiveCard } from '@/components/Card/cardState.utils'
 import CardLimitsScreen from '@/components/Card/CardLimitsScreen'
+import { useSafeBack } from '@/hooks/useSafeBack'
 
 const CardLimitPage: FC = () => {
-    const router = useRouter()
     const { overview, isLoading } = useRainCardOverview()
     const card = findActiveCard(overview)
+    const onBack = useSafeBack('/card')
 
     if (isLoading) {
         return (
@@ -28,7 +28,7 @@ const CardLimitPage: FC = () => {
             <PageContainer>
                 <div className="flex min-h-[inherit] w-full flex-col items-center justify-center gap-4 p-4 text-center">
                     <p className="text-n-1">No active card to manage limits for.</p>
-                    <Button variant="purple" shadowSize="4" onClick={() => router.push('/card')}>
+                    <Button variant="purple" shadowSize="4" onClick={onBack}>
                         Back to Card
                     </Button>
                 </div>
@@ -38,7 +38,7 @@ const CardLimitPage: FC = () => {
 
     return (
         <PageContainer>
-            <CardLimitsScreen cardId={card.id} onPrev={() => router.push('/card')} />
+            <CardLimitsScreen cardId={card.id} onPrev={onBack} />
         </PageContainer>
     )
 }

--- a/src/app/(mobile-ui)/card/physical/page.tsx
+++ b/src/app/(mobile-ui)/card/physical/page.tsx
@@ -1,17 +1,17 @@
 'use client'
 import { type FC } from 'react'
-import { useRouter } from 'next/navigation'
 import PageContainer from '@/components/0_Bruddle/PageContainer'
 import Loading from '@/components/Global/Loading'
 import { Button } from '@/components/0_Bruddle/Button'
 import { useRainCardOverview } from '@/hooks/useRainCardOverview'
 import { findActiveCard } from '@/components/Card/cardState.utils'
 import PhysicalCardScreen from '@/components/Card/PhysicalCardScreen'
+import { useSafeBack } from '@/hooks/useSafeBack'
 
 const PhysicalCardPage: FC = () => {
-    const router = useRouter()
     const { overview, isLoading } = useRainCardOverview()
     const card = findActiveCard(overview)
+    const onBack = useSafeBack('/card')
 
     if (isLoading) {
         return (
@@ -28,7 +28,7 @@ const PhysicalCardPage: FC = () => {
             <PageContainer>
                 <div className="flex min-h-[inherit] w-full flex-col items-center justify-center gap-4 p-4 text-center">
                     <p className="text-n-1">No active card.</p>
-                    <Button variant="purple" shadowSize="4" onClick={() => router.push('/card')}>
+                    <Button variant="purple" shadowSize="4" onClick={onBack}>
                         Back to Card
                     </Button>
                 </div>
@@ -38,7 +38,7 @@ const PhysicalCardPage: FC = () => {
 
     return (
         <PageContainer>
-            <PhysicalCardScreen cardId={card.id} last4={card.last4} onPrev={() => router.push('/card')} />
+            <PhysicalCardScreen cardId={card.id} last4={card.last4} onPrev={onBack} />
         </PageContainer>
     )
 }

--- a/src/app/(mobile-ui)/card/pin/page.tsx
+++ b/src/app/(mobile-ui)/card/pin/page.tsx
@@ -1,17 +1,17 @@
 'use client'
 import { type FC } from 'react'
-import { useRouter } from 'next/navigation'
 import PageContainer from '@/components/0_Bruddle/PageContainer'
 import Loading from '@/components/Global/Loading'
 import { Button } from '@/components/0_Bruddle/Button'
 import { useRainCardOverview } from '@/hooks/useRainCardOverview'
 import { findActiveCard } from '@/components/Card/cardState.utils'
 import CardPinScreen from '@/components/Card/CardPinScreen'
+import { useSafeBack } from '@/hooks/useSafeBack'
 
 const CardPinPage: FC = () => {
-    const router = useRouter()
     const { overview, isLoading } = useRainCardOverview()
     const card = findActiveCard(overview)
+    const onBack = useSafeBack('/card')
 
     if (isLoading) {
         return (
@@ -28,7 +28,7 @@ const CardPinPage: FC = () => {
             <PageContainer>
                 <div className="flex min-h-[inherit] w-full flex-col items-center justify-center gap-4 p-4 text-center">
                     <p className="text-n-1">No active card.</p>
-                    <Button variant="purple" shadowSize="4" onClick={() => router.push('/card')}>
+                    <Button variant="purple" shadowSize="4" onClick={onBack}>
                         Back to Card
                     </Button>
                 </div>
@@ -38,7 +38,7 @@ const CardPinPage: FC = () => {
 
     return (
         <PageContainer>
-            <CardPinScreen cardId={card.id} onPrev={() => router.push('/card')} />
+            <CardPinScreen cardId={card.id} onPrev={onBack} />
         </PageContainer>
     )
 }

--- a/src/app/(mobile-ui)/profile/backup/page.tsx
+++ b/src/app/(mobile-ui)/profile/backup/page.tsx
@@ -8,13 +8,13 @@ import InfoCard from '@/components/Global/InfoCard'
 import NavHeader from '@/components/Global/NavHeader'
 import NavigationArrow from '@/components/Global/NavigationArrow'
 import { useDeviceType } from '@/hooks/useGetDeviceType'
-import { useRouter } from 'next/navigation'
 import { useState } from 'react'
+import { useSafeBack } from '@/hooks/useSafeBack'
 
 type FaqModal = 'lose-phone' | 'change-phone' | 'export-keys' | null
 
 export default function BackupPage() {
-    const router = useRouter()
+    const onBack = useSafeBack('/profile', { replace: true })
     const { deviceType } = useDeviceType()
     const [activeModal, setActiveModal] = useState<FaqModal>(null)
 
@@ -38,7 +38,7 @@ export default function BackupPage() {
     return (
         <PageContainer>
             <div className="mb-6 space-y-4">
-                <NavHeader title="Backup" onPrev={() => router.replace('/profile')} />
+                <NavHeader title="Backup" onPrev={onBack} />
 
                 <EmptyState
                     title="Non-custodial wallet"

--- a/src/app/(mobile-ui)/profile/exchange-rate/page.tsx
+++ b/src/app/(mobile-ui)/profile/exchange-rate/page.tsx
@@ -7,9 +7,11 @@ import { useWallet } from '@/hooks/wallet/useWallet'
 import { printableUsdc } from '@/utils/balance.utils'
 import { getExchangeRateWidgetRedirectRoute } from '@/utils/exchangeRateWidget.utils'
 import { useRouter } from 'next/navigation'
+import { useSafeBack } from '@/hooks/useSafeBack'
 
 export default function ExchangeRatePage() {
     const router = useRouter()
+    const onBack = useSafeBack('/profile', { replace: true })
     const { balance } = useWallet()
 
     const handleCtaAction = (sourceCurrency: string, destinationCurrency: string) => {
@@ -21,7 +23,7 @@ export default function ExchangeRatePage() {
 
     return (
         <PageContainer className="flex flex-col">
-            <NavHeader title="Exchange rate & fees" onPrev={() => router.replace('/profile')} />
+            <NavHeader title="Exchange rate & fees" onPrev={onBack} />
             <div className="m-auto">
                 <ExchangeRateWidget ctaIcon="arrow-down" ctaLabel="Try it!" ctaAction={handleCtaAction} />
             </div>

--- a/src/components/Badges/index.tsx
+++ b/src/components/Badges/index.tsx
@@ -3,7 +3,7 @@
 import Image from 'next/image'
 import type { StaticImageData } from 'next/image'
 import NavHeader from '../Global/NavHeader'
-import { useRouter } from 'next/navigation'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { getBadgeIcon } from './badge.utils'
 import { getCardPosition } from '../Global/Card/card.utils'
 import EmptyState from '../Global/EmptyStates/EmptyState'
@@ -17,7 +17,7 @@ import { useAuth } from '@/context/authContext'
 type BadgeView = { title: string; description: string; logo: string | StaticImageData }
 
 export const Badges = () => {
-    const router = useRouter()
+    const onBack = useSafeBack('/profile')
     const { user: authUser } = useUserStore()
     const { fetchUser } = useAuth()
     const [isBadgeModalOpen, setIsBadgeModalOpen] = useState(false)
@@ -42,12 +42,7 @@ export const Badges = () => {
     if (!badges.length) {
         return (
             <div className="flex min-h-[inherit] flex-col items-center justify-center gap-8">
-                <NavHeader
-                    title="Your Badges"
-                    onPrev={() => {
-                        router.back()
-                    }}
-                />
+                <NavHeader title="Your Badges" onPrev={onBack} />
                 <div className="my-auto">
                     <EmptyState
                         icon="achievements"
@@ -61,12 +56,7 @@ export const Badges = () => {
 
     return (
         <div className="h-full w-full space-y-10">
-            <NavHeader
-                title="Your Badges"
-                onPrev={() => {
-                    router.back()
-                }}
-            />
+            <NavHeader title="Your Badges" onPrev={onBack} />
             <div className="space-y-4">
                 <div>
                     {badges.map((badge, idx) => (

--- a/src/components/Card/CardInfoScreen.tsx
+++ b/src/components/Card/CardInfoScreen.tsx
@@ -3,7 +3,7 @@
 import { Button } from '@/components/0_Bruddle/Button'
 import NavHeader from '@/components/Global/NavHeader'
 import PioneerCard3D from '@/components/LandingPage/PioneerCard3D'
-import { useRouter } from 'next/navigation'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { useEffect, useState, useRef } from 'react'
 
 interface CardInfoScreenProps {
@@ -91,7 +91,7 @@ const RollingNumber = ({ value, duration = 400 }: { value: number; duration?: nu
 }
 
 const CardInfoScreen = ({ onContinue, hasPurchased, slotsRemaining, recentPurchases }: CardInfoScreenProps) => {
-    const router = useRouter()
+    const onBack = useSafeBack('/home')
     const [displayValue, setDisplayValue] = useState<number | null>(null)
     const timeoutRef = useRef<NodeJS.Timeout | null>(null)
     const hasAnimated = useRef(false)
@@ -133,7 +133,7 @@ const CardInfoScreen = ({ onContinue, hasPurchased, slotsRemaining, recentPurcha
 
     return (
         <div className="flex min-h-[inherit] flex-col gap-8">
-            <NavHeader title="Join Peanut Pioneers" onPrev={() => router.back()} />
+            <NavHeader title="Join Peanut Pioneers" onPrev={onBack} />
 
             <div className="my-auto flex flex-col gap-6">
                 {/* Description and FAQ link */}

--- a/src/components/Card/CardPioneerFlow.tsx
+++ b/src/components/Card/CardPioneerFlow.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation'
 import { useQueryStates, parseAsStringEnum } from 'nuqs'
 import { cardApi, type CardInfoResponse } from '@/services/card'
 import { useAuth } from '@/context/authContext'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import CardInfoScreen from '@/components/Card/CardInfoScreen'
 import CardGeoScreen from '@/components/Card/CardGeoScreen'
 import CardDetailsScreen from '@/components/Card/CardDetailsScreen'
@@ -20,6 +21,7 @@ interface Props {
 
 const CardPioneerFlow: FC<Props> = ({ cardInfo, refetchCardInfo }) => {
     const router = useRouter()
+    const exitFlow = useSafeBack('/home')
     const { fetchUser } = useAuth()
 
     const [urlState, setUrlState] = useQueryStates(
@@ -56,7 +58,7 @@ const CardPioneerFlow: FC<Props> = ({ cardInfo, refetchCardInfo }) => {
     const goToPreviousStep = () => {
         const currentIndex = STEP_ORDER.indexOf(currentStep)
         if (currentIndex > 0) goToStep(STEP_ORDER[currentIndex - 1])
-        else router.back()
+        else exitFlow()
     }
 
     const handleInitiatePurchase = async () => {

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -9,6 +9,7 @@ import ProfileMenuItem from './components/ProfileMenuItem'
 import { useRouter } from 'next/navigation'
 import { useState, useMemo } from 'react'
 import useKycStatus from '@/hooks/useKycStatus'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { useCardPioneerInfo } from '@/hooks/useCardPioneerInfo'
 import underMaintenanceConfig from '@/config/underMaintenance.config'
 import Card from '../Global/Card'
@@ -23,6 +24,7 @@ export const Profile = () => {
     const [isKycApprovedModalOpen, setIsKycApprovedModalOpen] = useState(false)
     const [isInviteFriendsModalOpen, setIsInviteFriendsModalOpen] = useState(false)
     const router = useRouter()
+    const onBack = useSafeBack('/home')
     const { isUserKycApproved } = useKycStatus()
     const { hasCardAccess } = useCardPioneerInfo()
 
@@ -37,7 +39,7 @@ export const Profile = () => {
 
     return (
         <div className="h-full w-full bg-background">
-            <NavHeader hideLabel showLogoutBtn onPrev={() => router.push('/home')} />
+            <NavHeader hideLabel showLogoutBtn onPrev={onBack} />
             <div className="space-y-8">
                 <ProfileHeader name={displayName} username={username} isVerified={isUserKycApproved} />
                 <div className="space-y-4">

--- a/src/components/Profile/views/ProfileEdit.view.tsx
+++ b/src/components/Profile/views/ProfileEdit.view.tsx
@@ -10,9 +10,11 @@ import { useCallback, useEffect, useState } from 'react'
 import ProfileEditField from '../components/ProfileEditField'
 import ProfileHeader from '../components/ProfileHeader'
 import useKycStatus from '@/hooks/useKycStatus'
+import { useSafeBack } from '@/hooks/useSafeBack'
 
 export const ProfileEditView = () => {
     const router = useRouter()
+    const onBack = useSafeBack('/profile')
     const { user, fetchUser } = useAuth()
     const { isUserKycApproved } = useKycStatus()
 
@@ -113,7 +115,7 @@ export const ProfileEditView = () => {
 
     return (
         <div className="space-y-8">
-            <NavHeader title="Edit Profile" onPrev={() => router.back()} />
+            <NavHeader title="Edit Profile" onPrev={onBack} />
 
             <ProfileHeader name={fullName} username={username} isVerified={isUserKycApproved} />
 

--- a/src/components/Profile/views/RegionsVerification.view.tsx
+++ b/src/components/Profile/views/RegionsVerification.view.tsx
@@ -18,7 +18,7 @@ import useProviderRejectionStatus from '@/hooks/useProviderRejectionStatus'
 import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { useAuth } from '@/context/authContext'
 import Image from 'next/image'
-import { useRouter } from 'next/navigation'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { useState, useCallback, useRef, useMemo } from 'react'
 import { type KYCRegionIntent } from '@/app/actions/types/sumsub.types'
 
@@ -51,7 +51,7 @@ function getModalVariant(
 }
 
 const RegionsVerification = () => {
-    const router = useRouter()
+    const onBack = useSafeBack('/profile', { replace: true })
     const { user } = useAuth()
     const { unlockedRegions, lockedRegions } = useIdentityVerification()
     const { sumsubStatus, sumsubRejectLabels, sumsubRejectType, sumsubVerificationRegionIntent, isSumsubApproved } =
@@ -130,11 +130,7 @@ const RegionsVerification = () => {
 
     return (
         <div className="flex min-h-[inherit] flex-col space-y-8">
-            <NavHeader
-                title="Regions & Verification"
-                onPrev={() => router.replace('/profile')}
-                titleClassName="text-xl md:text-2xl"
-            />
+            <NavHeader title="Regions & Verification" onPrev={onBack} titleClassName="text-xl md:text-2xl" />
             <div className="my-auto">
                 <h1 className="font-bold">Unlocked regions</h1>
                 <p className="mt-2 text-sm">

--- a/src/components/Request/direct-request/views/Initial.direct.request.view.tsx
+++ b/src/components/Request/direct-request/views/Initial.direct.request.view.tsx
@@ -17,10 +17,10 @@ import { usersApi } from '@/services/users'
 import { formatAmount } from '@/utils/general.utils'
 import { printableUsdc } from '@/utils/balance.utils'
 import { captureException } from '@sentry/nextjs'
-import { useRouter } from 'next/navigation'
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { useUserInteractions } from '@/hooks/useUserInteractions'
 import { useUserByUsername } from '@/hooks/useUserByUsername'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { isUserKycVerified } from '@/constants/kyc.consts'
 
 interface DirectRequestInitialViewProps {
@@ -28,7 +28,7 @@ interface DirectRequestInitialViewProps {
 }
 
 const DirectRequestInitialView = ({ username }: DirectRequestInitialViewProps) => {
-    const router = useRouter()
+    const onBack = useSafeBack('/home')
     const { user: authUser } = useUserStore()
     const { balance, address } = useWallet()
     const [attachmentOptions, setAttachmentOptions] = useState<IAttachmentOptions>({
@@ -172,7 +172,7 @@ const DirectRequestInitialView = ({ username }: DirectRequestInitialViewProps) =
     if (validationError) {
         return (
             <div className="flex flex-col items-center justify-center gap-8">
-                {!!authUser?.user.userId ? <NavHeader onPrev={() => router.back()} title="Request" /> : null}
+                {!!authUser?.user.userId ? <NavHeader onPrev={onBack} title="Request" /> : null}
                 <div className="my-auto flex h-full w-full flex-col items-center justify-center space-y-4 md:w-6/12">
                     <ValidationErrorView {...validationError} />
                 </div>
@@ -206,7 +206,7 @@ const DirectRequestInitialView = ({ username }: DirectRequestInitialViewProps) =
     return (
         <div className="flex min-h-[inherit] flex-col justify-between gap-8">
             {!!authUser?.user.userId ? (
-                <NavHeader onPrev={() => router.back()} title="Request" />
+                <NavHeader onPrev={onBack} title="Request" />
             ) : (
                 <div className="text-center text-xl font-extrabold md:hidden">Request</div>
             )}

--- a/src/components/Request/link/views/Create.request.link.view.tsx
+++ b/src/components/Request/link/views/Create.request.link.view.tsx
@@ -26,13 +26,14 @@ import { printableUsdc } from '@/utils/balance.utils'
 import * as Sentry from '@sentry/nextjs'
 import * as peanutInterfaces from '@/interfaces/peanut-sdk-types'
 import { useQueryClient } from '@tanstack/react-query'
-import { useRouter, useSearchParams } from 'next/navigation'
+import { useSearchParams } from 'next/navigation'
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { Icon as IconComponent } from '@/components/Global/Icons/Icon'
+import { useSafeBack } from '@/hooks/useSafeBack'
 
 export const CreateRequestLinkView = () => {
     const toast = useToast()
-    const router = useRouter()
+    const onBack = useSafeBack('/home')
     const { address, isConnected, balance } = useWallet()
     const { user } = useAuth()
     const { selectedChainID, setSelectedChainID, selectedTokenAddress, setSelectedTokenAddress, selectedTokenData } =
@@ -359,7 +360,7 @@ export const CreateRequestLinkView = () => {
 
     return (
         <div className="flex min-h-[inherit] w-full flex-col justify-start space-y-8">
-            <NavHeader onPrev={() => router.push('/home')} title="Request" />
+            <NavHeader onPrev={onBack} title="Request" />
             <div className="my-auto flex flex-grow flex-col justify-center gap-4 md:my-0">
                 <PeanutActionCard type="request" />
 

--- a/src/features/limits/views/BridgeLimitsView.tsx
+++ b/src/features/limits/views/BridgeLimitsView.tsx
@@ -4,7 +4,7 @@ import NavHeader from '@/components/Global/NavHeader'
 import Card from '@/components/Global/Card'
 import { Icon } from '@/components/Global/Icons/Icon'
 import { useLimits } from '@/hooks/useLimits'
-import { useRouter } from 'next/navigation'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { MAX_QR_PAYMENT_AMOUNT_FOREIGN } from '@/constants/payment.consts'
 import Image from 'next/image'
 import * as Accordion from '@radix-ui/react-accordion'
@@ -23,7 +23,7 @@ import EmptyState from '@/components/Global/EmptyStates/EmptyState'
  * url state: ?region=us|mexico|europe|argentina|brazil (persists source region)
  */
 const BridgeLimitsView = () => {
-    const router = useRouter()
+    const onBack = useSafeBack('/limits')
     const { bridgeLimits, isLoading, error, hasMantecaLimits } = useLimits()
 
     // url state for source region (where user came from)
@@ -46,7 +46,7 @@ const BridgeLimitsView = () => {
 
     return (
         <div className="flex min-h-[inherit] flex-col space-y-6">
-            <NavHeader title="Limits" onPrev={() => router.back()} titleClassName="text-xl md:text-2xl" />
+            <NavHeader title="Limits" onPrev={onBack} titleClassName="text-xl md:text-2xl" />
 
             {isLoading && <PeanutLoading coverFullScreen />}
 

--- a/src/features/limits/views/LimitsPageView.tsx
+++ b/src/features/limits/views/LimitsPageView.tsx
@@ -10,6 +10,7 @@ import { useLimits } from '@/hooks/useLimits'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { useMemo } from 'react'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import CryptoLimitsSection from '../components/CryptoLimitsSection'
 import FiatLimitsLockedCard from '../components/FiatLimitsLockedCard'
 import { REST_OF_WORLD_GLOBE_ICON } from '@/assets'
@@ -17,7 +18,7 @@ import InfoCard from '@/components/Global/InfoCard'
 import { getProviderRoute } from '../utils'
 
 const LimitsPageView = () => {
-    const router = useRouter()
+    const onBack = useSafeBack('/profile', { replace: true })
     const { unlockedRegions, lockedRegions } = useIdentityVerification()
     const { isUserKycApproved, isUserBridgeKycUnderReview } = useKycStatus()
     const { hasMantecaLimits } = useLimits()
@@ -48,11 +49,7 @@ const LimitsPageView = () => {
 
     return (
         <div className="flex min-h-[inherit] flex-col space-y-6">
-            <NavHeader
-                title="Payment limits"
-                onPrev={() => router.replace('/profile')}
-                titleClassName="text-xl md:text-2xl"
-            />
+            <NavHeader title="Payment limits" onPrev={onBack} titleClassName="text-xl md:text-2xl" />
 
             {/* page description */}
             <InfoCard

--- a/src/features/limits/views/MantecaLimitsView.tsx
+++ b/src/features/limits/views/MantecaLimitsView.tsx
@@ -4,7 +4,7 @@ import NavHeader from '@/components/Global/NavHeader'
 import Card from '@/components/Global/Card'
 import { Icon } from '@/components/Global/Icons/Icon'
 import { useLimits } from '@/hooks/useLimits'
-import { useRouter } from 'next/navigation'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { useState } from 'react'
 import PeriodToggle from '../components/PeriodToggle'
 import LimitsProgressBar from '../components/LimitsProgressBar'
@@ -27,13 +27,13 @@ import EmptyState from '@/components/Global/EmptyStates/EmptyState'
  * shows monthly/yearly limits per currency with remaining amounts
  */
 const MantecaLimitsView = () => {
-    const router = useRouter()
+    const onBack = useSafeBack('/limits')
     const { mantecaLimits, isLoading, error } = useLimits()
     const [period, setPeriod] = useState<LimitsPeriod>('monthly')
 
     return (
         <div className="flex min-h-[inherit] flex-col space-y-6">
-            <NavHeader title="Limits" onPrev={() => router.back()} titleClassName="text-xl md:text-2xl" />
+            <NavHeader title="Limits" onPrev={onBack} titleClassName="text-xl md:text-2xl" />
 
             {isLoading && <PeanutLoading coverFullScreen />}
 

--- a/src/features/payments/flows/contribute-pot/ContributePotPageWrapper.tsx
+++ b/src/features/payments/flows/contribute-pot/ContributePotPageWrapper.tsx
@@ -14,7 +14,7 @@ import { requestsApi } from '@/services/requests'
 import PeanutLoading from '@/components/Global/PeanutLoading'
 import ErrorAlert from '@/components/Global/ErrorAlert'
 import NavHeader from '@/components/Global/NavHeader'
-import { useRouter } from 'next/navigation'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { useEffect, useState } from 'react'
 import { type TRequestResponse } from '@/services/services.types'
 
@@ -23,7 +23,7 @@ interface ContributePotPageWrapperProps {
 }
 
 export function ContributePotPageWrapper({ requestId }: ContributePotPageWrapperProps) {
-    const router = useRouter()
+    const onBack = useSafeBack('/home')
     const [request, setRequest] = useState<TRequestResponse | null>(null)
     const [isLoading, setIsLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
@@ -57,7 +57,7 @@ export function ContributePotPageWrapper({ requestId }: ContributePotPageWrapper
     if (isLoading) {
         return (
             <div className="flex min-h-[inherit] w-full flex-col gap-4">
-                <NavHeader title="Pay" onPrev={() => router.back()} />
+                <NavHeader title="Pay" onPrev={onBack} />
                 <div className="flex flex-grow flex-col items-center justify-center gap-4 py-8">
                     <PeanutLoading />
                 </div>
@@ -69,7 +69,7 @@ export function ContributePotPageWrapper({ requestId }: ContributePotPageWrapper
     if (error || !request) {
         return (
             <div className="flex w-full flex-col gap-4">
-                <NavHeader title="Pay" onPrev={() => router.back()} />
+                <NavHeader title="Pay" onPrev={onBack} />
                 <ErrorAlert description={error || 'request not found'} />
             </div>
         )

--- a/src/features/payments/flows/direct-send/DirectSendPageWrapper.tsx
+++ b/src/features/payments/flows/direct-send/DirectSendPageWrapper.tsx
@@ -16,7 +16,7 @@ import { AccountType } from '@/interfaces'
 import PeanutLoading from '@/components/Global/PeanutLoading'
 import ErrorAlert from '@/components/Global/ErrorAlert'
 import NavHeader from '@/components/Global/NavHeader'
-import { useRouter } from 'next/navigation'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { useMemo } from 'react'
 import { type Address } from 'viem'
 import type { DirectSendRecipient } from './DirectSendFlowContext'
@@ -27,7 +27,7 @@ interface DirectSendPageWrapperProps {
 }
 
 export function DirectSendPageWrapper({ username }: DirectSendPageWrapperProps) {
-    const router = useRouter()
+    const onBack = useSafeBack('/home')
     const { user, isLoading, error } = useUserByUsername(username)
 
     // resolve user to recipient
@@ -50,7 +50,7 @@ export function DirectSendPageWrapper({ username }: DirectSendPageWrapperProps) 
     if (isLoading) {
         return (
             <div className="flex min-h-[inherit] w-full flex-col gap-4">
-                <NavHeader title="Send" onPrev={() => router.back()} />
+                <NavHeader title="Send" onPrev={onBack} />
                 <div className="flex flex-grow flex-col items-center justify-center gap-4 py-8">
                     <PeanutLoading />
                 </div>
@@ -62,7 +62,7 @@ export function DirectSendPageWrapper({ username }: DirectSendPageWrapperProps) 
     if (error || !recipient) {
         return (
             <div className="flex w-full flex-col gap-4">
-                <NavHeader title="Send" onPrev={() => router.back()} />
+                <NavHeader title="Send" onPrev={onBack} />
                 <ErrorAlert description={error || `user @${username} not found or has no peanut wallet`} />
             </div>
         )

--- a/src/features/payments/flows/semantic-request/SemanticRequestPageWrapper.tsx
+++ b/src/features/payments/flows/semantic-request/SemanticRequestPageWrapper.tsx
@@ -17,7 +17,8 @@ import { parsePaymentURL, type ParseUrlError } from '@/lib/url-parser/parser'
 import PeanutLoading from '@/components/Global/PeanutLoading'
 import ErrorAlert from '@/components/Global/ErrorAlert'
 import NavHeader from '@/components/Global/NavHeader'
-import { useRouter, useSearchParams } from 'next/navigation'
+import { useSearchParams } from 'next/navigation'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { useEffect, useState } from 'react'
 import { type ParsedURL } from '@/lib/url-parser/types/payment'
 import { formatAmount } from '@/utils/general.utils'
@@ -27,7 +28,7 @@ interface SemanticRequestPageWrapperProps {
 }
 
 export function SemanticRequestPageWrapper({ recipient }: SemanticRequestPageWrapperProps) {
-    const router = useRouter()
+    const onBack = useSafeBack('/home')
     const searchParams = useSearchParams()
     const chargeIdFromUrl = searchParams.get('chargeId')
 
@@ -85,7 +86,7 @@ export function SemanticRequestPageWrapper({ recipient }: SemanticRequestPageWra
     if (isLoading) {
         return (
             <div className="flex min-h-[inherit] w-full flex-col gap-4">
-                <NavHeader title="Pay" onPrev={() => router.back()} />
+                <NavHeader title="Pay" onPrev={onBack} />
                 <div className="flex flex-grow flex-col items-center justify-center gap-4 py-8">
                     <PeanutLoading />
                 </div>
@@ -97,7 +98,7 @@ export function SemanticRequestPageWrapper({ recipient }: SemanticRequestPageWra
     if (error || !parsedUrl) {
         return (
             <div className="flex w-full flex-col gap-4">
-                <NavHeader title="Pay" onPrev={() => router.back()} />
+                <NavHeader title="Pay" onPrev={onBack} />
                 <ErrorAlert description={error?.message || 'invalid payment url'} />
             </div>
         )

--- a/src/features/payments/flows/semantic-request/views/SemanticRequestReceiptView.tsx
+++ b/src/features/payments/flows/semantic-request/views/SemanticRequestReceiptView.tsx
@@ -18,10 +18,10 @@ import { BASE_URL } from '@/constants/general.consts'
 import { useTokenChainIcons } from '@/hooks/useTokenChainIcons'
 import PeanutLoading from '@/components/Global/PeanutLoading'
 import NavHeader from '@/components/Global/NavHeader'
-import { useRouter } from 'next/navigation'
+import { useSafeBack } from '@/hooks/useSafeBack'
 
 export function SemanticRequestReceiptView() {
-    const router = useRouter()
+    const onBack = useSafeBack('/home')
     const { charge, recipient, parsedUrl, isFetchingCharge } = useSemanticRequestFlow()
 
     const { tokenIconUrl, chainIconUrl, resolvedChainName, resolvedTokenSymbol } = useTokenChainIcons({
@@ -97,7 +97,7 @@ export function SemanticRequestReceiptView() {
     if (isFetchingCharge || !charge) {
         return (
             <div className="flex min-h-[inherit] flex-col gap-4">
-                <NavHeader title="Receipt" onPrev={() => router.back()} />
+                <NavHeader title="Receipt" onPrev={onBack} />
                 <div className="flex flex-grow flex-col items-center justify-center gap-4 py-8">
                     <PeanutLoading />
                 </div>
@@ -109,7 +109,7 @@ export function SemanticRequestReceiptView() {
     if (!transactionForReceipt) {
         return (
             <div className="flex min-h-[inherit] flex-col gap-4">
-                <NavHeader title="Receipt" onPrev={() => router.back()} />
+                <NavHeader title="Receipt" onPrev={onBack} />
                 <div className="flex flex-grow flex-col items-center justify-center gap-4 py-8">
                     <p className="text-sm text-grey-1">Unable to load receipt details</p>
                 </div>
@@ -119,7 +119,7 @@ export function SemanticRequestReceiptView() {
 
     return (
         <div className="flex min-h-[inherit] flex-col gap-4">
-            <NavHeader title="Receipt" onPrev={() => router.back()} />
+            <NavHeader title="Receipt" onPrev={onBack} />
             <div className="flex w-full flex-grow flex-col justify-center gap-4">
                 <TransactionDetailsReceipt
                     transaction={transactionForReceipt}


### PR DESCRIPTION
## Summary

Follow-up to #1965. The /card/limit back-loop Hugo reported on staging is a **sibling** of the bug #1965 fixed, not a regression from it.

`/card/limit`'s back arrow wires `onPrev={() => router.push('/card')}` — a forward push dressed as a back action. Once #1965 made `/card`'s back arrow actually pop in-app history (via `useSafeBack`), the parent↔child interaction became a tight cycle:

1. `/card` → `/card/limit` (history grows)
2. `/card/limit` back → `router.push('/card')` (history grows again, URL = `/card`)
3. `/card` back → `useSafeBack` sees counter > 0 → `router.back()` → pops to `/card/limit`
4. Repeat.

Pre-#1965, the cycle existed but was masked because `/card`'s bare `router.back()` would just exit the SPA on cold-load. The grep-driven migration in #1965 found every `router.back()` callsite but didn't catch `onPrev={() => router.push(parentUrl)}` — same intent, different API.

## Files migrated

**Primary fix — the reported cycle (4 sibling `/card/*` pages):**

| File | Was | Now |
|---|---|---|
| `card/limit/page.tsx` | `router.push('/card')` | `useSafeBack('/card')` |
| `card/pin/page.tsx` | `router.push('/card')` | `useSafeBack('/card')` |
| `card/physical/page.tsx` | `router.push('/card')` | `useSafeBack('/card')` |
| `card/add-to-wallet/page.tsx` | `router.push('/card')` (both `onPrev` + `onDone`) | `useSafeBack('/card')` |

**Easy wins from #1965's "Deferred to follow-up" list:**

| File | Fallback |
|---|---|
| `Profile/views/ProfileEdit.view.tsx` | `/profile` |
| `Badges/index.tsx` | `/profile` |
| `Card/CardInfoScreen.tsx` (NavHeader) | `/home` |
| `Card/CardPioneerFlow.tsx` (info-step exit only) | `/home` |
| `features/limits/views/BridgeLimitsView.tsx` | `/limits` |
| `features/limits/views/MantecaLimitsView.tsx` | `/limits` |

## Still deferred (intentionally)

Matching #1965's original intent — these need flow-owner review, not a mechanical sweep:

- `features/payments/flows/{direct-send,semantic-request,contribute-pot}/PageWrapper.tsx` — flow-context decisions; the right fallback depends on entry point.
- `features/payments/flows/semantic-request/views/SemanticRequestReceiptView.tsx` — same flow-context concern.
- `components/Request/direct-request/views/Initial.direct.request.view.tsx` — request entry view.
- `components/Profile/components/PublicProfile.tsx` — has an `isInternalReferrer` check on top of `history.length > 1`. `useSafeBack` would drop the referrer check; the original PR flagged this as worth preserving.
- `hooks/useNativePlugins.ts` — Capacitor hardware back, different semantics (`canGoBack` + `App.minimizeApp()`).

## Regression test

The cycle is reproducible manually but writing it as a Jest test would require mocking the entire `/card` page tree (`useRainCardOverview`, `findActiveCard`, `useAuth`, etc.) for what's effectively a 4-line wiring change already covered by `useSafeBack.test.ts`. A Playwright e2e against a sandbox Rain-card user would be the right level — leaving as a follow-up since it needs the live fixture.

## Test plan

- [x] `pnpm typecheck` — no new errors (asset `TS2307` errors pre-exist on dev, unrelated)
- [x] `pnpm test` — 48 suites / 1046 tests pass
- [x] `pnpm prettier --write` — all 10 files clean

Manual QA on Vercel preview (the reported bug + siblings):

- [ ] `/card` → "Spending limit" → back → lands on `/card`. Press back again on `/card` → lands on `/home`. **No cycle.**
- [ ] `/card` → "Card PIN" → back → `/card` → back → `/home`. No cycle.
- [ ] `/card` → "Physical card" → back → `/card` → back → `/home`. No cycle.
- [ ] `/card` → "Add to Apple/Google Wallet" → back / Done → `/card` → back → `/home`. No cycle.
- [ ] Cold deep-link to `/card/limit` (paste URL into fresh tab) → back → `/card` (push fallback, since no in-app history). Back from `/card` → `/home` (push fallback). No cycle.
- [ ] `/profile` → "Edit" → back → `/profile`.
- [ ] `/profile` → "Badges" → back → `/profile`.
- [ ] `/limits` → "Bridge" or "Manteca" provider → back → `/limits`.