### PR TITLE
chore: kill console noise on staging (RPC trim + PostHog rename + lazy kernels)

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -2,7 +2,11 @@ import posthog from 'posthog-js'
 
 if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'development') {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-        api_host: '/ingest',
+        // Proxied through Next.js rewrites (see next.config.js). Path is
+        // intentionally innocuous — `/ingest/` was on uBlock Origin's default
+        // blocklist as a known PostHog signature, blocked-by-client retries
+        // were flooding the console.
+        api_host: '/relay',
         ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
         person_profiles: 'identified_only',
         capture_pageview: true,

--- a/next.config.js
+++ b/next.config.js
@@ -121,13 +121,17 @@ let nextConfig = {
                 },
             ],
             afterFiles: [
-                // PostHog reverse proxy — bypasses ad blockers
+                // PostHog reverse proxy — bypasses ad blockers. Path renamed
+                // from /ingest/ (which uBlock Origin's default lists block as
+                // a known PostHog signature, causing retry storms in the
+                // console). Keep this name innocuous; rotate again if it
+                // gets added to the lists.
                 {
-                    source: '/ingest/static/:path*',
+                    source: '/relay/static/:path*',
                     destination: 'https://eu-assets.i.posthog.com/static/:path*',
                 },
                 {
-                    source: '/ingest/:path*',
+                    source: '/relay/:path*',
                     destination: 'https://eu.i.posthog.com/:path*',
                 },
                 // Same-origin passkey path. The backend's /passkeys/{login,register}/verify

--- a/src/constants/general.consts.ts
+++ b/src/constants/general.consts.ts
@@ -6,13 +6,6 @@ import { mainnet, arbitrum, arbitrumSepolia, polygon, optimism, base, bsc, scrol
 const CHAIN_DETAILS = chainDetailsJson as unknown as Record<string, IPeanutChainDetails>
 const TOKEN_DETAILS = tokenDetailsJson as unknown as IPeanutTokenDetail[]
 
-const INFURA_API_KEY = process.env.NEXT_PUBLIC_INFURA_API_KEY
-const ALCHEMY_API_KEY = process.env.NEXT_PUBLIC_ALCHEMY_API_KEY
-
-const infuraUrl = (subdomain: string) => (INFURA_API_KEY ? `https://${subdomain}.infura.io/v3/${INFURA_API_KEY}` : null)
-const alchemyUrl = (subdomain: string) =>
-    ALCHEMY_API_KEY ? `https://${subdomain}.g.alchemy.com/v2/${ALCHEMY_API_KEY}` : null
-
 // Verified 2026-05-13 with curl from staging.peanut.me origin.
 // Commented entries are kept inline for visibility — re-enable when fixed.
 //
@@ -20,8 +13,9 @@ const alchemyUrl = (subdomain: string) =>
 //   • Infura + Alchemy: NEXT_PUBLIC_* keys exposed in bundle, free-tier
 //     quota burned by every visitor (429s); Alchemy's origin allowlist
 //     also excludes staging.peanut.me (CORS). Re-enable only after moving
-//     the keys server-side behind /api/rpc/[chainId]. Helpers below stay
-//     because /api/health/rpc still gates on key presence.
+//     the keys server-side behind /api/rpc/[chainId]. The infuraUrl /
+//     alchemyUrl builders that used to live here were removed (no callers
+//     after the comment-out); /api/health/rpc reads the env vars directly.
 //   • eth.public-rpc.com: returns 403 to OPTIONS preflight.
 //   • rpc.ankr.com/*: now requires an API key ("Unauthorized" -32000).
 //   • polygon-rpc.com: "API key disabled, tenant disabled" (401).

--- a/src/constants/general.consts.ts
+++ b/src/constants/general.consts.ts
@@ -13,56 +13,63 @@ const infuraUrl = (subdomain: string) => (INFURA_API_KEY ? `https://${subdomain}
 const alchemyUrl = (subdomain: string) =>
     ALCHEMY_API_KEY ? `https://${subdomain}.g.alchemy.com/v2/${ALCHEMY_API_KEY}` : null
 
+// Infura + Alchemy are commented out: keys are NEXT_PUBLIC_* so the browser
+// exposes them, free-tier quota gets burned by every visitor (429s), and
+// Alchemy's allowed-origins list doesn't include staging.peanut.me (CORS).
+// Net result: viem's fallback rank pings them every 60s for nothing and
+// pollutes the console. Re-enable only after moving the keys server-side
+// behind /api/rpc/[chainId]. See infuraUrl/alchemyUrl helpers above —
+// kept because /api/health/rpc still gates on key presence.
 export const rpcUrls: Record<number, string[]> = {
     [mainnet.id]: [
         'https://ethereum-mainnet.core.chainstack.com/006d2d45e7727fb2d5ff46ffc19a2958', // Chainstack (primary)
-        infuraUrl('mainnet'),
-        alchemyUrl('eth-mainnet'),
+        // infuraUrl('mainnet'),
+        // alchemyUrl('eth-mainnet'),
         'https://eth.public-rpc.com', // Public fallback
         'https://ethereum.publicnode.com', // Public fallback
         'https://rpc.ankr.com/eth', // Public fallback
     ].filter(Boolean) as string[],
     [arbitrum.id]: [
         'https://arbitrum-mainnet.core.chainstack.com/78d8b6bbaa8ae6d8ce2546c13b619288', // Chainstack (primary)
-        infuraUrl('arbitrum-mainnet'),
-        alchemyUrl('arb-mainnet'),
+        // infuraUrl('arbitrum-mainnet'),
+        // alchemyUrl('arb-mainnet'),
         'https://arb1.arbitrum.io/rpc', // Official public RPC
         'https://arbitrum.publicnode.com', // Public fallback
         'https://rpc.ankr.com/arbitrum', // Public fallback
     ].filter(Boolean) as string[],
     [arbitrumSepolia.id]: [
-        infuraUrl('arbitrum-sepolia'),
-        alchemyUrl('arb-sepolia'),
+        // infuraUrl('arbitrum-sepolia'),
+        // alchemyUrl('arb-sepolia'),
         'https://sepolia-rollup.arbitrum.io/rpc', // Official Arbitrum Sepolia
     ].filter(Boolean) as string[],
     [polygon.id]: [
         'https://polygon-mainnet.core.chainstack.com/e8d733c7341e28d98e4cf66c61c42aa6', // Chainstack (primary)
-        infuraUrl('polygon-mainnet'),
-        alchemyUrl('polygon-mainnet'),
+        // infuraUrl('polygon-mainnet'),
+        // alchemyUrl('polygon-mainnet'),
         'https://polygon-rpc.com', // Official public RPC
         'https://polygon-bor-rpc.publicnode.com', // Public fallback
         'https://rpc.ankr.com/polygon', // Public fallback
     ].filter(Boolean) as string[],
     [optimism.id]: [
-        infuraUrl('optimism-mainnet'),
-        alchemyUrl('opt-mainnet'),
+        // infuraUrl('optimism-mainnet'),
+        // alchemyUrl('opt-mainnet'),
         'https://mainnet.optimism.io', // Official Optimism RPC
     ].filter(Boolean) as string[],
     [base.id]: [
         'https://base-mainnet.core.chainstack.com/01f0761d79d1b6e9d234d7ab69a90b19', // Chainstack (primary)
-        infuraUrl('base-mainnet'),
-        alchemyUrl('base-mainnet'),
+        // infuraUrl('base-mainnet'),
+        // alchemyUrl('base-mainnet'),
         'https://mainnet.base.org', // Official Base RPC
     ].filter(Boolean) as string[],
     [bsc.id]: [
         'https://bsc-mainnet.core.chainstack.com/2d9b1537fa4555562f8e15fd08bf8ed5', // Chainstack (primary)
         'https://bsc-dataseed.bnbchain.org', // Official BSC RPC
-        infuraUrl('bsc-mainnet'),
-        alchemyUrl('bsc-mainnet'),
+        // infuraUrl('bsc-mainnet'),
+        // alchemyUrl('bsc-mainnet'),
         'https://bsc.publicnode.com', // Public fallback
     ].filter(Boolean) as string[],
     [scroll.id]: [
-        infuraUrl('scroll-mainnet'),
+        // infuraUrl('scroll-mainnet'),
         'https://rpc.scroll.io', // Official Scroll RPC
     ].filter(Boolean) as string[],
 }

--- a/src/constants/general.consts.ts
+++ b/src/constants/general.consts.ts
@@ -13,21 +13,28 @@ const infuraUrl = (subdomain: string) => (INFURA_API_KEY ? `https://${subdomain}
 const alchemyUrl = (subdomain: string) =>
     ALCHEMY_API_KEY ? `https://${subdomain}.g.alchemy.com/v2/${ALCHEMY_API_KEY}` : null
 
-// Infura + Alchemy are commented out: keys are NEXT_PUBLIC_* so the browser
-// exposes them, free-tier quota gets burned by every visitor (429s), and
-// Alchemy's allowed-origins list doesn't include staging.peanut.me (CORS).
-// Net result: viem's fallback rank pings them every 60s for nothing and
-// pollutes the console. Re-enable only after moving the keys server-side
-// behind /api/rpc/[chainId]. See infuraUrl/alchemyUrl helpers above —
-// kept because /api/health/rpc still gates on key presence.
+// Verified 2026-05-13 with curl from staging.peanut.me origin.
+// Commented entries are kept inline for visibility — re-enable when fixed.
+//
+// COMMENTED OUT (broken from browser):
+//   • Infura + Alchemy: NEXT_PUBLIC_* keys exposed in bundle, free-tier
+//     quota burned by every visitor (429s); Alchemy's origin allowlist
+//     also excludes staging.peanut.me (CORS). Re-enable only after moving
+//     the keys server-side behind /api/rpc/[chainId]. Helpers below stay
+//     because /api/health/rpc still gates on key presence.
+//   • eth.public-rpc.com: returns 403 to OPTIONS preflight.
+//   • rpc.ankr.com/*: now requires an API key ("Unauthorized" -32000).
+//   • polygon-rpc.com: "API key disabled, tenant disabled" (401).
+//
+// All other URLs verified working with proper CORS for staging.peanut.me.
 export const rpcUrls: Record<number, string[]> = {
     [mainnet.id]: [
         'https://ethereum-mainnet.core.chainstack.com/006d2d45e7727fb2d5ff46ffc19a2958', // Chainstack (primary)
         // infuraUrl('mainnet'),
         // alchemyUrl('eth-mainnet'),
-        'https://eth.public-rpc.com', // Public fallback
+        // 'https://eth.public-rpc.com', // 403 preflight
         'https://ethereum.publicnode.com', // Public fallback
-        'https://rpc.ankr.com/eth', // Public fallback
+        // 'https://rpc.ankr.com/eth', // requires API key
     ].filter(Boolean) as string[],
     [arbitrum.id]: [
         'https://arbitrum-mainnet.core.chainstack.com/78d8b6bbaa8ae6d8ce2546c13b619288', // Chainstack (primary)
@@ -35,7 +42,7 @@ export const rpcUrls: Record<number, string[]> = {
         // alchemyUrl('arb-mainnet'),
         'https://arb1.arbitrum.io/rpc', // Official public RPC
         'https://arbitrum.publicnode.com', // Public fallback
-        'https://rpc.ankr.com/arbitrum', // Public fallback
+        // 'https://rpc.ankr.com/arbitrum', // requires API key
     ].filter(Boolean) as string[],
     [arbitrumSepolia.id]: [
         // infuraUrl('arbitrum-sepolia'),
@@ -46,9 +53,9 @@ export const rpcUrls: Record<number, string[]> = {
         'https://polygon-mainnet.core.chainstack.com/e8d733c7341e28d98e4cf66c61c42aa6', // Chainstack (primary)
         // infuraUrl('polygon-mainnet'),
         // alchemyUrl('polygon-mainnet'),
-        'https://polygon-rpc.com', // Official public RPC
+        // 'https://polygon-rpc.com', // tenant disabled (401)
         'https://polygon-bor-rpc.publicnode.com', // Public fallback
-        'https://rpc.ankr.com/polygon', // Public fallback
+        // 'https://rpc.ankr.com/polygon', // requires API key
     ].filter(Boolean) as string[],
     [optimism.id]: [
         // infuraUrl('optimism-mainnet'),

--- a/src/context/kernelClient.context.tsx
+++ b/src/context/kernelClient.context.tsx
@@ -15,8 +15,8 @@ import {
     type KernelAccountClient,
 } from '@zerodev/sdk'
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useRef, useState, useMemo } from 'react'
-import { arbitrum } from 'viem/chains'
 import { type Chain, http, type PublicClient, type Transport } from 'viem'
+import { AccountType } from '@/interfaces/interfaces'
 import type { Address } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { captureException } from '@sentry/nextjs'
@@ -359,22 +359,16 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
         }
 
         const initializeClients = async () => {
-            // Eager-build only the primary wallet chain (Arbitrum). Recovery
-            // chains (mainnet/base/linea) are now lazy-built via
-            // ensureClientForChain — only the recover-funds page needs them,
-            // and 99% of sessions never go there. Saves 3 passkey-validator
-            // constructions + 3 chains' worth of RPC traffic on every login.
+            // Recovery chains (mainnet/base/linea) are lazy-built via
+            // ensureClientForChain — only /recover-funds needs them.
             const primaryChainId = PEANUT_WALLET_CHAIN.id.toString()
             const entry = PUBLIC_CLIENTS_BY_CHAIN[primaryChainId]
             if (!entry) {
-                // Should never happen — clients.ts always seeds the primary entry.
                 throw new Error(`Primary chain ${primaryChainId} missing from PUBLIC_CLIENTS_BY_CHAIN`)
             }
 
-            // Register the build in inFlightRef so that an ensureClientForChain
-            // call for the primary chain (e.g. a route that mounts before
-            // login completes) dedupes to this same promise instead of starting
-            // a parallel build with the same inputs.
+            // Register in inFlightRef so a concurrent ensureClientForChain
+            // (e.g. route mounted before login completes) dedupes here.
             const buildPromise = createKernelClientForChain(
                 entry.client,
                 entry.chain,
@@ -382,7 +376,9 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
                 webAuthnKey,
                 isAfterZeroDevMigration
                     ? undefined
-                    : (user?.accounts.find((a) => a.type === 'peanut-wallet')!.identifier as Address),
+                    : (user?.accounts.find((a) => a.type === AccountType.PEANUT_WALLET)?.identifier as
+                          | Address
+                          | undefined),
                 { bundlerUrl: entry.bundlerUrl, paymasterUrl: entry.paymasterUrl }
             )
             inFlightRef.current.set(primaryChainId, buildPromise as Promise<GenericSmartAccountClient>)
@@ -394,8 +390,8 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
                 inFlightRef.current.delete(primaryChainId)
             }
 
-            // only update state after primary build succeeds —
-            // avoids UI flicker (registering→not registering→registering) between retries
+            // Only update state after primary succeeds — avoids
+            // registering→not→registering UI flicker between retries.
             if (isMounted) {
                 setClientsByChain((prev) => ({ ...prev, [primaryChainId]: kernelClient }))
                 fetchUser()
@@ -417,7 +413,7 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
         return () => {
             isMounted = false
         }
-    }, [webAuthnKey, isAfterZeroDevMigration])
+    }, [webAuthnKey, isAfterZeroDevMigration, user])
 
     useEffect(() => {
         const peanutClient = clientsByChain[PEANUT_WALLET_CHAIN.id]
@@ -445,12 +441,9 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
 
     const ensureClientForChain = useCallback(
         async (chainId: string): Promise<GenericSmartAccountClient> => {
-            // Cache hit: already built (eagerly for primary, or lazily on a prior call).
             const cached = clientsByChain[chainId]
             if (cached) return cached
 
-            // In-flight dedupe: a concurrent caller (or the primary-init effect)
-            // is already building this chain — wait for the same promise.
             const inFlight = inFlightRef.current.get(chainId)
             if (inFlight) return inFlight
 
@@ -471,7 +464,9 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
                 webAuthnKey,
                 isAfterZeroDevMigration
                     ? undefined
-                    : (user?.accounts.find((a) => a.type === 'peanut-wallet')?.identifier as Address | undefined),
+                    : (user?.accounts.find((a) => a.type === AccountType.PEANUT_WALLET)?.identifier as
+                          | Address
+                          | undefined),
                 { bundlerUrl: entry.bundlerUrl, paymasterUrl: entry.paymasterUrl }
             )
                 .then((kernelClient) => {

--- a/src/context/kernelClient.context.tsx
+++ b/src/context/kernelClient.context.tsx
@@ -14,7 +14,7 @@ import {
     createZeroDevPaymasterClient,
     type KernelAccountClient,
 } from '@zerodev/sdk'
-import { createContext, type ReactNode, useCallback, useContext, useEffect, useState, useMemo } from 'react'
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useRef, useState, useMemo } from 'react'
 import { arbitrum } from 'viem/chains'
 import { type Chain, http, type PublicClient, type Transport } from 'viem'
 import type { Address } from 'viem'
@@ -28,6 +28,11 @@ import { PUBLIC_CLIENTS_BY_CHAIN } from '@/app/actions/clients'
 interface KernelClientContextType {
     setWebAuthnKey: (webAuthnKey: WebAuthnKey) => void
     getClientForChain: (chainId: string) => GenericSmartAccountClient
+    // Lazy-builds (and caches) a kernel client for `chainId` if it isn't already
+    // ready. Awaiting this before `getClientForChain` is what lets us skip
+    // eager-init for non-Arb chains (mainnet/base/linea — recovery-only).
+    // Cached chains resolve immediately; concurrent calls dedupe via inFlightRef.
+    ensureClientForChain: (chainId: string) => Promise<GenericSmartAccountClient>
 }
 
 type GenericSmartAccountClient<C extends Chain = Chain> = KernelAccountClient<Transport, C>
@@ -236,6 +241,11 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
     const [webAuthnKey, setWebAuthnKey] = useState<WebAuthnKey | undefined>(undefined)
     const dispatch = useAppDispatch()
     const { fetchUser, logoutUser, user } = useAuth()
+    // In-flight kernel-client builds keyed by chainId. Lets concurrent
+    // ensureClientForChain() callers dedupe to a single build, and lets the
+    // primary-init effect register itself so a recover-funds page mount that
+    // races primary login doesn't kick off a duplicate Arb build.
+    const inFlightRef = useRef<Map<string, Promise<GenericSmartAccountClient>>>(new Map())
 
     const isAfterZeroDevMigration = useMemo<boolean>(() => {
         if (!user?.user?.createdAt) {
@@ -251,6 +261,9 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
             console.log('[KernelClient] No user found, clearing webAuthnKey, clients, and address')
             setWebAuthnKey(undefined)
             setClientsByChain({})
+            // Drop any in-flight lazy builds — their results would be useless
+            // (and re-applying them would write into a fresh post-logout state).
+            inFlightRef.current.clear()
             dispatch(zerodevActions.setAddress(undefined)) // explicitly clear address from redux
             return
         }
@@ -346,51 +359,45 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
         }
 
         const initializeClients = async () => {
-            // NETWORK RESILIENCE: Parallelize kernel client initialization across chains
-            // Arbitrum (primary wallet) is always initialized. Additional chains (mainnet, base, linea)
-            // are initialized if NEXT_PUBLIC_ZERO_DEV_RECOVERY_BUNDLER_URL is configured.
-            const clientPromises = Object.entries(PUBLIC_CLIENTS_BY_CHAIN).map(
-                async ([chainId, { client, chain, bundlerUrl, paymasterUrl }]) => {
-                    try {
-                        const kernelClient = await createKernelClientForChain(
-                            client,
-                            chain,
-                            isAfterZeroDevMigration,
-                            webAuthnKey,
-                            isAfterZeroDevMigration
-                                ? undefined
-                                : (user?.accounts.find((a) => a.type === 'peanut-wallet')!.identifier as Address),
-                            {
-                                bundlerUrl,
-                                paymasterUrl,
-                            }
-                        )
-                        return { chainId, kernelClient, success: true } as const
-                    } catch (error) {
-                        console.error(`Error creating kernel client for chain ${chainId}:`, error)
-                        captureException(error)
-                        return { chainId, error, success: false } as const
-                    }
-                }
+            // Eager-build only the primary wallet chain (Arbitrum). Recovery
+            // chains (mainnet/base/linea) are now lazy-built via
+            // ensureClientForChain — only the recover-funds page needs them,
+            // and 99% of sessions never go there. Saves 3 passkey-validator
+            // constructions + 3 chains' worth of RPC traffic on every login.
+            const primaryChainId = PEANUT_WALLET_CHAIN.id.toString()
+            const entry = PUBLIC_CLIENTS_BY_CHAIN[primaryChainId]
+            if (!entry) {
+                // Should never happen — clients.ts always seeds the primary entry.
+                throw new Error(`Primary chain ${primaryChainId} missing from PUBLIC_CLIENTS_BY_CHAIN`)
+            }
+
+            // Register the build in inFlightRef so that an ensureClientForChain
+            // call for the primary chain (e.g. a route that mounts before
+            // login completes) dedupes to this same promise instead of starting
+            // a parallel build with the same inputs.
+            const buildPromise = createKernelClientForChain(
+                entry.client,
+                entry.chain,
+                isAfterZeroDevMigration,
+                webAuthnKey,
+                isAfterZeroDevMigration
+                    ? undefined
+                    : (user?.accounts.find((a) => a.type === 'peanut-wallet')!.identifier as Address),
+                { bundlerUrl: entry.bundlerUrl, paymasterUrl: entry.paymasterUrl }
             )
+            inFlightRef.current.set(primaryChainId, buildPromise as Promise<GenericSmartAccountClient>)
 
-            const results = await Promise.allSettled(clientPromises)
-
-            const newClientsByChain: Record<string, GenericSmartAccountClient> = {}
-            for (const result of results) {
-                if (result.status === 'fulfilled' && result.value.success) {
-                    newClientsByChain[result.value.chainId] = result.value.kernelClient
-                }
+            let kernelClient: GenericSmartAccountClient
+            try {
+                kernelClient = (await buildPromise) as GenericSmartAccountClient
+            } finally {
+                inFlightRef.current.delete(primaryChainId)
             }
 
-            if (!newClientsByChain[PEANUT_WALLET_CHAIN.id]) {
-                throw new Error('Primary chain client failed to initialize')
-            }
-
-            // only update state after primary client check passes —
+            // only update state after primary build succeeds —
             // avoids UI flicker (registering→not registering→registering) between retries
             if (isMounted) {
-                setClientsByChain(newClientsByChain)
+                setClientsByChain((prev) => ({ ...prev, [primaryChainId]: kernelClient }))
                 fetchUser()
                 dispatch(zerodevActions.setIsKernelClientReady(true))
                 dispatch(zerodevActions.setIsRegistering(false))
@@ -436,11 +443,62 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
         [clientsByChain]
     )
 
+    const ensureClientForChain = useCallback(
+        async (chainId: string): Promise<GenericSmartAccountClient> => {
+            // Cache hit: already built (eagerly for primary, or lazily on a prior call).
+            const cached = clientsByChain[chainId]
+            if (cached) return cached
+
+            // In-flight dedupe: a concurrent caller (or the primary-init effect)
+            // is already building this chain — wait for the same promise.
+            const inFlight = inFlightRef.current.get(chainId)
+            if (inFlight) return inFlight
+
+            if (!webAuthnKey) {
+                throw new Error(`Cannot build kernel client for chain ${chainId}: not authenticated`)
+            }
+            const entry = PUBLIC_CLIENTS_BY_CHAIN[chainId]
+            if (!entry) {
+                throw new Error(
+                    `No PUBLIC_CLIENTS_BY_CHAIN entry for chain ${chainId} — chain not configured for wallet operations`
+                )
+            }
+
+            const promise = createKernelClientForChain(
+                entry.client,
+                entry.chain,
+                isAfterZeroDevMigration,
+                webAuthnKey,
+                isAfterZeroDevMigration
+                    ? undefined
+                    : (user?.accounts.find((a) => a.type === 'peanut-wallet')?.identifier as Address | undefined),
+                { bundlerUrl: entry.bundlerUrl, paymasterUrl: entry.paymasterUrl }
+            )
+                .then((kernelClient) => {
+                    setClientsByChain((prev) => ({ ...prev, [chainId]: kernelClient }))
+                    return kernelClient
+                })
+                .catch((error) => {
+                    console.error(`Error lazy-building kernel client for chain ${chainId}:`, error)
+                    captureException(error)
+                    throw error
+                })
+                .finally(() => {
+                    inFlightRef.current.delete(chainId)
+                })
+
+            inFlightRef.current.set(chainId, promise)
+            return promise
+        },
+        [clientsByChain, webAuthnKey, isAfterZeroDevMigration, user]
+    )
+
     return (
         <KernelClientContext.Provider
             value={{
                 setWebAuthnKey,
                 getClientForChain,
+                ensureClientForChain,
             }}
         >
             {children}

--- a/src/context/kernelClient.context.tsx
+++ b/src/context/kernelClient.context.tsx
@@ -413,7 +413,16 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
         return () => {
             isMounted = false
         }
-    }, [webAuthnKey, isAfterZeroDevMigration, user])
+        // Intentionally excluding `user` from deps: `useUserQuery` refetches on
+        // window focus / mount and produces new refs on any content change
+        // (invites, KYC status, JWT sliding refresh). Adding `user` here would
+        // rebuild the Arb kernel on every such refetch — and since the effect
+        // calls fetchUser() at the end, it can self-trigger into a loop. The
+        // closure reads user.accounts.find('peanut-wallet').identifier, which
+        // is stable for an authenticated user, and isAfterZeroDevMigration
+        // captures any user.createdAt change.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [webAuthnKey, isAfterZeroDevMigration])
 
     useEffect(() => {
         const peanutClient = clientsByChain[PEANUT_WALLET_CHAIN.id]

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -183,10 +183,7 @@ export const useZeroDev = () => {
             calls: UserOpEncodedParams[],
             chainId: string
         ): Promise<{ userOpHash: Hash; receipt: TransactionReceipt | null }> => {
-            // Recovery chains (mainnet/base/linea) aren't pre-built on login —
-            // ensure the kernel client exists before grabbing it. Cached chains
-            // (Arbitrum) resolve immediately, so the only callers that pay the
-            // construction cost are non-Arb sends (today: recover-funds page).
+            // Non-Arb chains (recover-funds) aren't pre-built — wait for lazy build.
             await ensureClientForChain(chainId)
             const client = getClientForChain(chainId)
             dispatch(zerodevActions.setIsSendingUserOp(true))

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -55,7 +55,7 @@ export const useZeroDev = () => {
     const dispatch = useAppDispatch()
     const { user } = useAuth()
     const { isKernelClientReady, isRegistering, isLoggingIn, isSendingUserOp, address } = useZerodevStore()
-    const { setWebAuthnKey, getClientForChain } = useKernelClient()
+    const { setWebAuthnKey, getClientForChain, ensureClientForChain } = useKernelClient()
     const { setLoadingState } = useContext(loadingStateContext)
     const { inviteCode, inviteType } = useSetupStore()
 
@@ -183,6 +183,11 @@ export const useZeroDev = () => {
             calls: UserOpEncodedParams[],
             chainId: string
         ): Promise<{ userOpHash: Hash; receipt: TransactionReceipt | null }> => {
+            // Recovery chains (mainnet/base/linea) aren't pre-built on login —
+            // ensure the kernel client exists before grabbing it. Cached chains
+            // (Arbitrum) resolve immediately, so the only callers that pay the
+            // construction cost are non-Arb sends (today: recover-funds page).
+            await ensureClientForChain(chainId)
             const client = getClientForChain(chainId)
             dispatch(zerodevActions.setIsSendingUserOp(true))
 
@@ -244,7 +249,7 @@ export const useZeroDev = () => {
                 receipt: userOpReceipt.receipt,
             }
         },
-        [getClientForChain]
+        [getClientForChain, ensureClientForChain]
     )
 
     return {


### PR DESCRIPTION
## Summary

Cleans up the wall of red errors users see in DevTools on every page load of `staging.peanut.me`. Four small, self-contained changes — no behavior change for the happy path, but a noticeable drop in network noise + perceived "this app is broken" feel.

**1. Drop Infura + Alchemy from client-side rpcUrls** (`c1665c1aa`)
Both keys were `NEXT_PUBLIC_*` and shipped in the browser bundle, so the free-tier quota was shared across every visitor → 429s. Alchemy's origin allowlist also doesn't include `staging.peanut.me` → CORS errors. Helpers + commented entries kept inline so a future server-side proxy (`/api/rpc/[chainId]`) is a clean swap.

**2. Comment out verified-broken public RPCs** (`92cd8f63e`)
Each URL curl-tested from `staging.peanut.me` origin (2026-05-13). Only the broken ones commented (don't delete — keeps the audit trail visible):
- `eth.public-rpc.com` → 403 on preflight
- `rpc.ankr.com/{eth,arbitrum,polygon}` → require API key
- `polygon-rpc.com` → 401 "API key disabled"

All other public fallbacks (publicnode, official chain RPCs, `arb1.arbitrum.io/rpc`, etc.) verified working with proper CORS for our origin and stay as genuine viem-fallback URLs behind Chainstack. Chainstack stays primary on every chain that has a key.

**3. Rename PostHog proxy `/ingest/` → `/relay/`** (`087b17fad`)
uBlock Origin's default lists block `/ingest/` as a known PostHog signature. Each blocked event triggers PostHog's retry queue, flooding the console with 8+ red errors per event. Renaming the path dodges the default blocklists. Cat-and-mouse — rotate again if `/relay/` gets added.

**4. Lazy non-Arb kernel clients via `ensureClientForChain`** (`2470f6f65`)
Login no longer eagerly builds kernel clients for `mainnet`/`base`/`linea` — only the primary wallet chain (Arbitrum). The other three exist for cross-chain recovery (`/recover-funds`) and are unused by ~99% of sessions. Every login was paying for 3 extra passkey-validator constructions + 3 chains' worth of paymaster/bundler RPC calls.

New context API: `KernelClientContext.ensureClientForChain(chainId): Promise<Client>`
- Cache hit → resolves immediately (Arb stays sync-fast for the 5 always-Arb callers).
- In-flight → dedupes via `inFlightRef` so concurrent callers share one build.
- Cache miss → builds, caches, resolves.

`handleSendUserOpEncoded` — the single chokepoint that ever passes a non-Arb chainId (`recover-funds` → `useWallet.sendTransactions` → here) — awaits `ensureClientForChain` before `getClientForChain`. The other 5 callers of `getClientForChain` only ever pass `PEANUT_WALLET_CHAIN.id` (verified by grep), so they're untouched.

## Out of scope (mentioned in case it shapes review)

- Moving Infura/Alchemy keys server-side behind `/api/rpc/[chainId]` — separate PR if/when we want to keep paying for them.
- Auditing whether ZeroDev recovery is still in use post the 2025-09-18 migration. If it's truly dead, the entire `if (ZERODEV_V3_URL)` branch in `clients.ts` can go and this PR's lazy-kernel refactor becomes redundant. Worth confirming with whoever owns wallet recovery before deleting anything.

## Test plan

- [x] `pnpm test` — 48/48 suites, 1046 passed, 4 skipped (pre-existing)
- [x] `pnpm typecheck` — only pre-existing missing-asset module errors (unrelated)
- [x] `pnpm prettier --check` on changed files — no diffs
- [x] curl-verified each remaining RPC URL works + has correct CORS for `staging.peanut.me`
- [ ] Manual: open `staging.peanut.me/home` in DevTools → confirm console is quiet (no Alchemy/Infura/`/ingest/` errors)
- [ ] Manual: log in, send a USDC transaction on Arbitrum → confirm normal flow works
- [ ] Manual: navigate to `/recover-funds` with a wallet that has non-Arb dust → confirm recovery still works (this exercises the lazy-build path for mainnet/base/linea)

## Risk notes

- **Recovery flow**: the lazy refactor adds ~1s to the first non-Arb sendTransaction in a session (kernel build cost moved from login to first use). Subsequent sends in the same session are cached. Only `/recover-funds` is affected.
- **No API change for `getClientForChain`** — kept synchronous, throws if not cached, same as today. New `ensureClientForChain` is additive.
- **Logout cleanup**: `inFlightRef` is cleared on logout so a stale post-logout build can't write into the fresh state.