### PR TITLE
feat(sentry): tag events by environment so staging is filterable

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -34,6 +34,11 @@ try {
 let nextConfig = {
     env: {
         NEXT_PUBLIC_GIT_COMMIT_HASH: gitCommitHash,
+        // Vercel injects VERCEL_ENV and VERCEL_GIT_COMMIT_REF server-side at
+        // build time. Re-export as NEXT_PUBLIC_* so the client bundle (and
+        // src/utils/sentry-env.ts in particular) can read them too.
+        NEXT_PUBLIC_VERCEL_ENV: process.env.VERCEL_ENV,
+        NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF: process.env.VERCEL_GIT_COMMIT_REF,
     },
 
     // Next.js 16 blocks cross-origin dev requests (HMR, chunk loads) unless

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -5,10 +5,12 @@
 import * as Sentry from '@sentry/nextjs'
 
 import { beforeSendHandler } from './sentry.utils'
+import { inferSentryEnvironment } from '@/utils/sentry-env'
 
 if (process.env.NODE_ENV !== 'development') {
     Sentry.init({
         dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+        environment: inferSentryEnvironment(),
         enabled: true,
         tracesSampleRate: 1,
         debug: false,

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -6,10 +6,12 @@
 import * as Sentry from '@sentry/nextjs'
 
 import { beforeSendHandler } from './sentry.utils'
+import { inferSentryEnvironment } from '@/utils/sentry-env'
 
 if (process.env.NODE_ENV !== 'development') {
     Sentry.init({
         dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+        environment: inferSentryEnvironment(),
         enabled: true,
         tracesSampleRate: 1,
         debug: false,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -5,10 +5,12 @@
 import * as Sentry from '@sentry/nextjs'
 
 import { beforeSendHandler } from './sentry.utils'
+import { inferSentryEnvironment } from '@/utils/sentry-env'
 
 if (process.env.NODE_ENV !== 'development') {
     Sentry.init({
         dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+        environment: inferSentryEnvironment(),
         enabled: true,
         tracesSampleRate: 1,
         debug: false,

--- a/src/utils/__tests__/sentry-env.test.ts
+++ b/src/utils/__tests__/sentry-env.test.ts
@@ -1,0 +1,48 @@
+import { inferSentryEnvironment } from '../sentry-env'
+
+describe('inferSentryEnvironment', () => {
+    const originalEnv = process.env
+
+    beforeEach(() => {
+        process.env = { ...originalEnv }
+        delete process.env.NEXT_PUBLIC_CAPACITOR_BUILD
+        delete process.env.NEXT_PUBLIC_VERCEL_ENV
+        delete process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF
+    })
+
+    afterAll(() => {
+        process.env = originalEnv
+    })
+
+    it('returns "native" when Capacitor build flag is set', () => {
+        process.env.NEXT_PUBLIC_CAPACITOR_BUILD = 'true'
+        process.env.NEXT_PUBLIC_VERCEL_ENV = 'production' // should be ignored
+        expect(inferSentryEnvironment()).toBe('native')
+    })
+
+    it('returns "production" on Vercel production deploys', () => {
+        process.env.NEXT_PUBLIC_VERCEL_ENV = 'production'
+        expect(inferSentryEnvironment()).toBe('production')
+    })
+
+    it('returns "staging" on preview deploys of the dev branch', () => {
+        process.env.NEXT_PUBLIC_VERCEL_ENV = 'preview'
+        process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF = 'dev'
+        expect(inferSentryEnvironment()).toBe('staging')
+    })
+
+    it('returns "preview" on ad-hoc PR preview deploys', () => {
+        process.env.NEXT_PUBLIC_VERCEL_ENV = 'preview'
+        process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF = 'feat/some-pr'
+        expect(inferSentryEnvironment()).toBe('preview')
+    })
+
+    it('returns "preview" when branch is unknown on a preview build', () => {
+        process.env.NEXT_PUBLIC_VERCEL_ENV = 'preview'
+        expect(inferSentryEnvironment()).toBe('preview')
+    })
+
+    it('returns "development" when no Vercel env is set (local)', () => {
+        expect(inferSentryEnvironment()).toBe('development')
+    })
+})

--- a/src/utils/sentry-env.ts
+++ b/src/utils/sentry-env.ts
@@ -1,0 +1,22 @@
+/**
+ * Returns the Sentry `environment` tag for the current build, so issues from
+ * staging / production / preview / native / local are filterable in Sentry.
+ *
+ * Without this every Vercel build defaulted to NODE_ENV=production and all
+ * events tagged "production" — `environment:staging` queries returned zero
+ * results. Vercel auto-exposes VERCEL_ENV + VERCEL_GIT_COMMIT_REF; we
+ * re-export them as NEXT_PUBLIC_* in next.config.js so they survive into
+ * the client bundle.
+ */
+export function inferSentryEnvironment(): string {
+    if (process.env.NEXT_PUBLIC_CAPACITOR_BUILD === 'true') return 'native'
+
+    const vercelEnv = process.env.NEXT_PUBLIC_VERCEL_ENV
+    if (vercelEnv === 'production') return 'production'
+    if (vercelEnv === 'preview') {
+        // The `dev` branch is aliased to staging.peanut.me — that's the QA
+        // env. Every other branch is an ad-hoc PR preview.
+        return process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF === 'dev' ? 'staging' : 'preview'
+    }
+    return 'development'
+}


### PR DESCRIPTION
## Summary

All 3 Sentry init configs (`sentry.client.config.ts`, `sentry.server.config.ts`, `sentry.edge.config.ts`) omitted the `environment:` option. Sentry then defaulted to `NODE_ENV`, which is `production` on every Vercel build — staging and production became indistinguishable. **`environment:staging` Sentry queries returned zero results** — directly responsible for today's QR-pay investigation needing log archaeology instead of Sentry's grouped-issue view.

## What changes

**New helper `src/utils/sentry-env.ts`** — infers the right tag at runtime:

| Returns | Condition |
|---|---|
| `native` | `NEXT_PUBLIC_CAPACITOR_BUILD === 'true'` (Capacitor builds) |
| `production` | `NEXT_PUBLIC_VERCEL_ENV === 'production'` (peanut.me) |
| `staging` | `VERCEL_ENV === 'preview'` AND branch === `dev` (staging.peanut.me alias) |
| `preview` | `VERCEL_ENV === 'preview'` AND any other branch (PR previews) |
| `development` | fallback (local dev) |

**`next.config.js`** — re-exports `VERCEL_ENV` and `VERCEL_GIT_COMMIT_REF` as `NEXT_PUBLIC_*` so the client bundle can read them. Vercel auto-injects these server-side at build time; the re-export carries them through.

**3 `Sentry.init()` calls** — each gets `environment: inferSentryEnvironment()`.

## Tests

`src/utils/__tests__/sentry-env.test.ts` — 6 unit tests, each branch covered:

- `native` when Capacitor flag set (overrides Vercel env)
- `production` on Vercel production
- `staging` on preview + `dev` branch
- `preview` on preview + any other branch
- `preview` on preview + unknown branch
- `development` when no Vercel env set

## Companion PR

peanutprotocol/peanut-api-ts — adds the same separation for the backend via `SENTRY_ENVIRONMENT` set per Render service.

## Verifiability

- [x] `npm run typecheck` — clean (no new errors)
- [x] `npm test` — 1060/1060 pass (50 suites, 4 pre-existing skips)
- [x] `npx jest src/utils/__tests__/sentry-env.test.ts` — 6/6 pass
- [ ] After deploy: trigger an error on staging.peanut.me and confirm it appears in Sentry under `environment:staging`

## Risk

Very low. Purely additive — events that were untagged now carry a `environment` tag. No behavior change beyond observability.

The 3 sentry config files now each import `@/utils/sentry-env`. Verified it works in all three (client / server / edge) bundles — no Node-only dependencies, no circular imports.