### PR TITLE
feat(history): pass data-testid through Global Card to TransactionCard

### DIFF
--- a/src/components/Global/Card/index.tsx
+++ b/src/components/Global/Card/index.tsx
@@ -9,9 +9,18 @@ interface CardProps {
     onClick?: () => void
     border?: boolean
     ref?: React.Ref<HTMLDivElement>
+    'data-testid'?: string
 }
 
-const Card: React.FC<CardProps> = ({ children, position = 'single', className = '', onClick, border = true, ref }) => {
+const Card: React.FC<CardProps> = ({
+    children,
+    position = 'single',
+    className = '',
+    onClick,
+    border = true,
+    ref,
+    'data-testid': dataTestId,
+}) => {
     const getBorderRadius = () => {
         switch (position) {
             case 'single':
@@ -49,6 +58,7 @@ const Card: React.FC<CardProps> = ({ children, position = 'single', className = 
             ref={ref}
             className={twMerge('w-full bg-white px-4 py-2', getBorderRadius(), getBorder(), className)}
             onClick={onClick}
+            data-testid={dataTestId}
         >
             {children}
         </div>

--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -165,7 +165,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
     return (
         <>
             {/* the clickable card */}
-            <Card position={position} onClick={handleClick} className="cursor-pointer">
+            <Card position={position} onClick={handleClick} className="cursor-pointer" data-testid="transaction-card">
                 <div className="flex items-center justify-between">
                     <div className="flex items-center gap-3">
                         {/* txn avatar component handles icon/initials/colors */}


### PR DESCRIPTION
## Summary

Lets the Nutcracker harness reliably locate a transaction row via a stable selector (\`[data-testid=\"transaction-card\"]\`) instead of class-name fallbacks that drift or match unintended elements.

## Why

The Global Card component strictly destructures its props (no spread), so \`data-testid\` wasn't forwarded to the underlying div. Harness scenarios that click the first history row (\`e2e-receipt-drawer-*\`) listed \`[data-testid=\"transaction-row\"]\`, \`.transaction-row\`, \`button[aria-label*=\"transaction\"]\`, \`a[href*=\"/history?\"]\` as candidate selectors — **none of which match the actual DOM**.

The click silently no-op'd, the drawer never opened, and the scenario's body-text assertion ran against the still-history-page content. Last night's sweep silently passed these as fake-greens (proven last night when I strengthened the bridge-offramp assertion: now correctly fails before this PR, passes after this PR + paired BE PR #762).

## Changes

- \`src/components/Global/Card/index.tsx\`: added \`'data-testid'?: string\` prop, forwarded to the underlying div.
- \`src/components/TransactionDetails/TransactionCard.tsx\`: set \`data-testid=\"transaction-card\"\` on the outer Card.

## Paired with

- **peanut-api-ts/#762** — \`fix(testing): seed Bridge intents with raw.amount\` — fixes the amount-formatting half of the same fake-pass.

## Verification

\`bin/qa ui --scenario e2e-receipt-drawer-bridge-offramp --label final-verify-1\` against latest dev + this PR + #762 → **4/4 green**, drawer opens, row classified correctly (\"Bank Account\" / \"Withdraw\" / US flag), amount renders as \"\$12.5\" (not \"\$1,250\").

## Risk

Lowest possible — pure additive type+prop on an internal component. No behavior change for any current user. Bundle impact: 0 bytes runtime, ~30 bytes minified DOM attribute per Card render.