### PR TITLE
fix(carousel): make the home-screen + notifications CTAs actually work

### DIFF
--- a/src/components/Global/IosPwaInstallModal/index.tsx
+++ b/src/components/Global/IosPwaInstallModal/index.tsx
@@ -24,12 +24,21 @@ const IosPwaInstallModal = () => {
         }
     }
 
-    // Firefox iOS uses WebKit but its UI doesn't expose "Add to Home Screen" the
-    // way Safari/Chrome iOS do, and the steps differ enough that the Safari video
-    // misleads more than it helps. Redirect users to Safari instead.
+    // Firefox iOS doesn't expose "Add to Home Screen" — redirect to Safari.
     const isFirefox = browserType === BrowserType.FIREFOX
-
     const videoSource = getVideoSource()
+
+    const videoContent =
+        !isFirefox && !isLoading ? (
+            <video className="max-h-[60vh] w-full object-contain" autoPlay loop muted playsInline key={videoSource}>
+                {/* .mov assets are H.264 in a QuickTime container — Chrome/Edge/Firefox
+                    play them under video/mp4 but reject video/quicktime. mp4 first;
+                    quicktime stays as a fallback for older Safari. */}
+                <source src={videoSource} type="video/mp4" />
+                <source src={videoSource} type="video/quicktime" />
+                Your browser does not support the video tag.
+            </video>
+        ) : undefined
 
     return (
         <ActionModal
@@ -50,28 +59,7 @@ const IosPwaInstallModal = () => {
                     variant: 'purple',
                 },
             ]}
-            content={
-                !isFirefox && !isLoading ? (
-                    <div className="flex w-full flex-col">
-                        <video
-                            className="max-h-[60vh] w-full object-contain"
-                            autoPlay
-                            loop
-                            muted
-                            playsInline
-                            key={videoSource}
-                        >
-                            {/* The .mov assets are H.264 inside a QuickTime container — every
-                                modern browser plays them under the video/mp4 MIME, but most
-                                refuse video/quicktime. Keep mp4 first; quicktime is a fallback
-                                for older Safari that insists on the exact MIME. */}
-                            <source src={videoSource} type="video/mp4" />
-                            <source src={videoSource} type="video/quicktime" />
-                            Your browser does not support the video tag.
-                        </video>
-                    </div>
-                ) : undefined
-            }
+            content={videoContent}
         />
     )
 }

--- a/src/components/Global/IosPwaInstallModal/index.tsx
+++ b/src/components/Global/IosPwaInstallModal/index.tsx
@@ -24,6 +24,11 @@ const IosPwaInstallModal = () => {
         }
     }
 
+    // Firefox iOS uses WebKit but its UI doesn't expose "Add to Home Screen" the
+    // way Safari/Chrome iOS do, and the steps differ enough that the Safari video
+    // misleads more than it helps. Redirect users to Safari instead.
+    const isFirefox = browserType === BrowserType.FIREFOX
+
     const videoSource = getVideoSource()
 
     return (
@@ -31,11 +36,23 @@ const IosPwaInstallModal = () => {
             visible={isIosPwaInstallModalOpen}
             onClose={onClose}
             title="Add Peanut to your Home Screen"
-            description="Follow a quick guide to add the app to your home screen, no download needed."
+            description={
+                isFirefox
+                    ? 'Firefox on iOS does not support installing apps to the home screen. Please open this page in Safari to continue.'
+                    : 'Follow a quick guide to add the app to your home screen, no download needed.'
+            }
             icon="mobile-install"
+            ctas={[
+                {
+                    text: 'Got it!',
+                    onClick: onClose,
+                    shadowSize: '4',
+                    variant: 'purple',
+                },
+            ]}
             content={
-                <div className="flex w-full flex-col">
-                    {!isLoading && (
+                !isFirefox && !isLoading ? (
+                    <div className="flex w-full flex-col">
                         <video
                             className="max-h-[60vh] w-full object-contain"
                             autoPlay
@@ -44,11 +61,16 @@ const IosPwaInstallModal = () => {
                             playsInline
                             key={videoSource}
                         >
+                            {/* The .mov assets are H.264 inside a QuickTime container — every
+                                modern browser plays them under the video/mp4 MIME, but most
+                                refuse video/quicktime. Keep mp4 first; quicktime is a fallback
+                                for older Safari that insists on the exact MIME. */}
+                            <source src={videoSource} type="video/mp4" />
                             <source src={videoSource} type="video/quicktime" />
                             Your browser does not support the video tag.
                         </video>
-                    )}
-                </div>
+                    </div>
+                ) : undefined
             }
         />
     )

--- a/src/components/Home/HomeCarouselCTA/CarouselCTA.tsx
+++ b/src/components/Home/HomeCarouselCTA/CarouselCTA.tsx
@@ -3,9 +3,8 @@
 import { Icon, type IconName } from '@/components/Global/Icons/Icon'
 import type { StaticImageData } from 'next/image'
 import Image from 'next/image'
-import React, { useState } from 'react'
+import React from 'react'
 import { twMerge } from 'tailwind-merge'
-import ActionModal from '@/components/Global/ActionModal'
 import { CAROUSEL_CLOSE_BUTTON_POSITION, CAROUSEL_CLOSE_ICON_SIZE } from '@/constants/carousel.consts'
 import { useHaptic } from 'use-haptic'
 import { Card } from '@/components/0_Bruddle/Card'
@@ -19,8 +18,6 @@ interface CarouselCTAProps {
     onClose: () => void
     onClick?: () => void | Promise<void>
     iconContainerClassName?: string
-    // Notification-specific props
-    isPermissionDenied?: boolean
     secondaryIcon?: StaticImageData | string
     iconSize?: number
     // Perk claim indicator - shows pink dot instead of X close button
@@ -35,13 +32,11 @@ const CarouselCTA = ({
     onClick,
     logo,
     iconContainerClassName,
-    isPermissionDenied,
     secondaryIcon,
     iconSize = 22,
     logoSize = 36,
     isPerkClaim,
 }: CarouselCTAProps) => {
-    const [showPermissionDeniedModal, setShowPermissionDeniedModal] = useState(false)
     const { triggerHaptic } = useHaptic()
 
     const handleClose = (e: React.MouseEvent) => {
@@ -52,9 +47,7 @@ const CarouselCTA = ({
     const handleClick = async () => {
         try {
             triggerHaptic()
-            if (isPermissionDenied) {
-                setShowPermissionDeniedModal(true)
-            } else if (onClick) {
+            if (onClick) {
                 await onClick()
             }
         } catch (error) {
@@ -71,112 +64,72 @@ const CarouselCTA = ({
         if (icon === 'shield') {
             return 'Close verification prompt'
         }
-        if (icon === 'bell' || isPermissionDenied) {
+        if (icon === 'bell') {
             return 'Close notification prompt'
         }
         return 'Close prompt'
     }
 
     return (
-        <>
-            <Card
-                onClick={handleClick}
-                className="embla__slide relative flex flex-row items-center justify-around px-2 py-2 md:py-3"
-            >
-                {/* Close button or pink dot indicator for perk claims */}
-                {isPerkClaim ? (
-                    <div className={twMerge(CAROUSEL_CLOSE_BUTTON_POSITION, 'z-10')} aria-label="Claimable perk">
-                        <div className="h-2.5 w-2.5 rounded-full bg-primary-1" />
-                    </div>
-                ) : (
-                    <button
-                        type="button"
-                        aria-label={getAriaLabel()}
-                        onClick={handleClose}
-                        className={twMerge(
-                            CAROUSEL_CLOSE_BUTTON_POSITION,
-                            'z-10 cursor-pointer p-0 text-black outline-none'
-                        )}
-                    >
-                        <Icon name="cancel" size={CAROUSEL_CLOSE_ICON_SIZE} />
-                    </button>
-                )}
-
-                {/* Icon container */}
-                <div
+        <Card
+            onClick={handleClick}
+            className="embla__slide relative flex flex-row items-center justify-around px-2 py-2 md:py-3"
+        >
+            {/* Close button or pink dot indicator for perk claims */}
+            {isPerkClaim ? (
+                <div className={twMerge(CAROUSEL_CLOSE_BUTTON_POSITION, 'z-10')} aria-label="Claimable perk">
+                    <div className="h-2.5 w-2.5 rounded-full bg-primary-1" />
+                </div>
+            ) : (
+                <button
+                    type="button"
+                    aria-label={getAriaLabel()}
+                    onClick={handleClose}
                     className={twMerge(
-                        'relative flex size-8 items-center justify-center rounded-full',
-                        logo ? 'bg-transparent' : 'bg-primary-1',
-                        iconContainerClassName
+                        CAROUSEL_CLOSE_BUTTON_POSITION,
+                        'z-10 cursor-pointer p-0 text-black outline-none'
                     )}
                 >
-                    {/* Show icon only if logo isn't provided. Logo takes precedence over icon. */}
-                    {!logo && <Icon name={icon} size={iconSize} />}
-                    {logo && (
-                        <Image
-                            src={logo}
-                            alt={typeof title === 'string' ? title : 'logo'}
-                            width={logoSize}
-                            height={logoSize}
-                        />
-                    )}
-                    {secondaryIcon && (
-                        <Image
-                            src={secondaryIcon}
-                            alt="secondary icon"
-                            height={64}
-                            width={64}
-                            quality={100}
-                            className="absolute -right-1 bottom-0 z-50 size-4 rounded-full object-cover"
-                        />
-                    )}
-                </div>
-
-                {/* Content */}
-                <div className="flex w-[80%] flex-col">
-                    <p className="font-medium">{title}</p>
-                    <p className="text-xs text-gray-1">{description}</p>
-                </div>
-            </Card>
-
-            {/* Permission denied modal for notification CTA */}
-            {isPermissionDenied && showPermissionDeniedModal && (
-                <ActionModal
-                    visible={showPermissionDeniedModal}
-                    title="Turn notifications back on"
-                    description={
-                        <p>
-                            <span>To keep getting updates, you'll need to reinstall the app on your home screen. </span>
-                            <br />
-                            <span>Don't worry, your account and data are safe. It only takes a minute.</span>
-                        </p>
-                    }
-                    icon="bell"
-                    onClose={() => {
-                        setShowPermissionDeniedModal(false)
-                    }}
-                    ctaClassName="md:flex-col gap-4"
-                    ctas={[
-                        {
-                            text: 'Got it!',
-                            onClick: () => {
-                                setShowPermissionDeniedModal(false)
-                            },
-                            shadowSize: '4',
-                            variant: 'purple',
-                        },
-                        {
-                            text: 'Reinstall later',
-                            onClick: () => {
-                                setShowPermissionDeniedModal(false)
-                            },
-                            variant: 'transparent',
-                            className: 'underline h-6',
-                        },
-                    ]}
-                />
+                    <Icon name="cancel" size={CAROUSEL_CLOSE_ICON_SIZE} />
+                </button>
             )}
-        </>
+
+            {/* Icon container */}
+            <div
+                className={twMerge(
+                    'relative flex size-8 items-center justify-center rounded-full',
+                    logo ? 'bg-transparent' : 'bg-primary-1',
+                    iconContainerClassName
+                )}
+            >
+                {/* Show icon only if logo isn't provided. Logo takes precedence over icon. */}
+                {!logo && <Icon name={icon} size={iconSize} />}
+                {logo && (
+                    <Image
+                        src={logo}
+                        alt={typeof title === 'string' ? title : 'logo'}
+                        width={logoSize}
+                        height={logoSize}
+                    />
+                )}
+                {secondaryIcon && (
+                    <Image
+                        src={secondaryIcon}
+                        alt="secondary icon"
+                        height={64}
+                        width={64}
+                        quality={100}
+                        className="absolute -right-1 bottom-0 z-50 size-4 rounded-full object-cover"
+                    />
+                )}
+            </div>
+
+            {/* Content */}
+            <div className="flex w-[80%] flex-col">
+                <p className="font-medium">{title}</p>
+                <p className="text-xs text-gray-1">{description}</p>
+            </div>
+        </Card>
     )
 }
 

--- a/src/components/Home/HomeCarouselCTA/index.tsx
+++ b/src/components/Home/HomeCarouselCTA/index.tsx
@@ -109,7 +109,6 @@ const HomeCarouselCTA = () => {
                         onClick={cta.onClick}
                         logo={cta.logo}
                         iconContainerClassName={cta.iconContainerClassName}
-                        isPermissionDenied={cta.isPermissionDenied}
                         secondaryIcon={cta.secondaryIcon}
                         iconSize={16}
                         logoSize={cta.logoSize}

--- a/src/hooks/useHomeCarouselCTAs.tsx
+++ b/src/hooks/useHomeCarouselCTAs.tsx
@@ -38,7 +38,6 @@ export type CarouselCTA = {
     // optional handlers for notification prompt
     onClick?: () => void | Promise<void>
     onClose?: () => void
-    isPermissionDenied?: boolean
     iconContainerClassName?: string
     secondaryIcon?: StaticImageData | string
     iconSize?: number
@@ -169,8 +168,7 @@ export const useHomeCarouselCTAs = () => {
         // show notification cta only in pwa when the user is neither permission-granted
         // (browser-native) nor opted-in (OneSignal subscription). Belt-and-suspenders
         // because the two signals can diverge — e.g. browser permission revoked but
-        // OneSignal subscription still active. Clicking triggers the native prompt
-        // (or shows the reinstall modal if denied).
+        // OneSignal subscription still active.
         if (!isPermissionGranted && !isPushOptedIn && isPwa) {
             _carouselCTAs.push({
                 id: 'notification-prompt',
@@ -178,11 +176,17 @@ export const useHomeCarouselCTAs = () => {
                 description: 'Turn on notifications and get alerts for all your wallet activity.',
                 icon: 'bell',
                 onClick: async () => {
-                    // trigger native notification permission prompt
+                    // If the user has already denied browser permission, the OS won't
+                    // re-prompt — they have to reinstall the PWA. Open the install
+                    // modal directly instead of routing through a dead-end "Got it"
+                    // dialog that gave them no path forward.
+                    if (isPermissionDenied) {
+                        setIsIosPwaInstallModalOpen(true)
+                        return
+                    }
                     await requestPermission()
                     await afterPermissionAttempt()
                 },
-                isPermissionDenied, // if true, CarouselCTA shows reinstall modal instead
             })
         }
 

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -236,8 +236,14 @@ export function useNotifications() {
                                 }
                             }
 
+                            // mirror OneSignal subscription state into local state so consumers
+                            // that gate on `isPushOptedIn` (e.g. the home carousel CTA) react
+                            // without waiting for the next permissionChange event.
+                            const optedIn = Boolean(event.current?.optedIn)
+                            setIsPushOptedIn(optedIn)
+
                             // hide modal when user opts in
-                            if (event.current?.optedIn) {
+                            if (optedIn) {
                                 posthog.capture(ANALYTICS_EVENTS.NOTIFICATION_SUBSCRIBED)
                                 setShowPermissionModal(false)
                             }

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -239,7 +239,7 @@ export function useNotifications() {
                             // mirror OneSignal subscription state into local state so consumers
                             // that gate on `isPushOptedIn` (e.g. the home carousel CTA) react
                             // without waiting for the next permissionChange event.
-                            const optedIn = Boolean(event.current?.optedIn)
+                            const optedIn = !!event.current?.optedIn
                             setIsPushOptedIn(optedIn)
 
                             // hide modal when user opts in

--- a/src/hooks/usePWAStatus.ts
+++ b/src/hooks/usePWAStatus.ts
@@ -16,8 +16,14 @@ const detectIsPWA = (): boolean => {
     )
 }
 
+// Cache the initial detection at module scope — several hooks consume usePWAStatus
+// on a single page load (home, setup, brave-install, user query). Without this,
+// each mount re-runs matchMedia + navigator + referrer reads.
+let cachedInitial: boolean | null = null
+const getInitial = () => (cachedInitial ??= detectIsPWA())
+
 export const usePWAStatus = () => {
-    const [isPWA, setIsPWA] = useState<boolean>(detectIsPWA)
+    const [isPWA, setIsPWA] = useState(getInitial)
 
     useEffect(() => {
         if (typeof window === 'undefined') return

--- a/src/hooks/usePWAStatus.ts
+++ b/src/hooks/usePWAStatus.ts
@@ -1,10 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useSyncExternalStore } from 'react'
 import { isCapacitor } from '@/utils/capacitor'
 
-// Initialize synchronously on the client so iOS PWA users don't briefly see the
-// "Add to home screen" CTA before the effect resolves. SSR still gets `false`
-// (no window); the hydration mismatch is the same one we'd have on any
-// client-only signal and React reconciles after first paint.
 const detectIsPWA = (): boolean => {
     if (typeof window === 'undefined') return false
     if (isCapacitor()) return true
@@ -16,25 +12,22 @@ const detectIsPWA = (): boolean => {
     )
 }
 
-// Cache the initial detection at module scope — several hooks consume usePWAStatus
-// on a single page load (home, setup, brave-install, user query). Without this,
-// each mount re-runs matchMedia + navigator + referrer reads.
-let cachedInitial: boolean | null = null
-const getInitial = () => (cachedInitial ??= detectIsPWA())
+// Cache the detection so multiple consumers share one read per page. The cache
+// is invalidated inside subscribe() so a new consumer mounting after a
+// mid-session install sees the current value.
+let cached: boolean | null = null
+const getSnapshot = (): boolean => (cached ??= detectIsPWA())
+const getServerSnapshot = (): boolean => false
 
-export const usePWAStatus = () => {
-    const [isPWA, setIsPWA] = useState(getInitial)
-
-    useEffect(() => {
-        if (typeof window === 'undefined') return
-
-        // Listen for changes in display mode (e.g. user installs PWA mid-session)
-        const mediaQuery = window.matchMedia('(display-mode: standalone)')
-        const handleChange = (e: MediaQueryListEvent) => setIsPWA(e.matches)
-
-        mediaQuery.addEventListener('change', handleChange)
-        return () => mediaQuery.removeEventListener('change', handleChange)
-    }, [])
-
-    return isPWA
+const subscribe = (notify: () => void): (() => void) => {
+    if (typeof window === 'undefined') return () => {}
+    const mq = window.matchMedia('(display-mode: standalone)')
+    const handler = () => {
+        cached = detectIsPWA()
+        notify()
+    }
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
 }
+
+export const usePWAStatus = (): boolean => useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)

--- a/src/hooks/usePWAStatus.ts
+++ b/src/hooks/usePWAStatus.ts
@@ -1,26 +1,28 @@
 import { useEffect, useState } from 'react'
 import { isCapacitor } from '@/utils/capacitor'
 
+// Initialize synchronously on the client so iOS PWA users don't briefly see the
+// "Add to home screen" CTA before the effect resolves. SSR still gets `false`
+// (no window); the hydration mismatch is the same one we'd have on any
+// client-only signal and React reconciles after first paint.
+const detectIsPWA = (): boolean => {
+    if (typeof window === 'undefined') return false
+    if (isCapacitor()) return true
+    return (
+        window.matchMedia('(display-mode: standalone)').matches ||
+        (window.navigator as any).standalone ||
+        document.referrer.includes('android-app://') ||
+        window.location.href.includes('?mode=pwa')
+    )
+}
+
 export const usePWAStatus = () => {
-    const [isPWA, setIsPWA] = useState(false)
+    const [isPWA, setIsPWA] = useState<boolean>(detectIsPWA)
 
     useEffect(() => {
-        // capacitor native app is treated as "installed" (same as PWA)
-        if (isCapacitor()) {
-            setIsPWA(true)
-            return
-        }
+        if (typeof window === 'undefined') return
 
-        // Check if the app is running in standalone mode (PWA)
-        const isStandalone =
-            window.matchMedia('(display-mode: standalone)').matches ||
-            (window.navigator as any).standalone ||
-            document.referrer.includes('android-app://') ||
-            window.location.href.includes('?mode=pwa')
-
-        setIsPWA(isStandalone)
-
-        // Listen for changes in display mode
+        // Listen for changes in display mode (e.g. user installs PWA mid-session)
         const mediaQuery = window.matchMedia('(display-mode: standalone)')
         const handleChange = (e: MediaQueryListEvent) => setIsPWA(e.matches)
 


### PR DESCRIPTION
## Summary

Five bugs in the home carousel's install + notification CTAs. Each was a real user-visible dead end. Surfaced by playtesting after #1990 landed.

## Bugs fixed

1. **iOS PWA install video was blank in non-Safari browsers.** The `.mov` assets are served with `type=\"video/quicktime\"`, which Chrome/Edge/Firefox refuse to play even though the underlying H.264 stream is mp4-compatible. Hugo hit this in Chrome devtools mobile emulation — the modal showed title + description but a white box where the video should be. Added an `video/mp4` source ahead of the quicktime fallback.

2. **iOS PWA install modal had no \"done\" affordance.** Just an autoplay/loop video; the only way to close it was the implicit modal X. Added a single \"Got it!\" CTA.

3. **Firefox iOS got the Safari install video.** Firefox iOS does not support installing PWAs to the home screen — the Safari video misleads. Replaced the video with a redirect message asking the user to open the page in Safari.

4. **Dead-end \"Turn notifications back on\" modal.** When browser permission was denied, clicking the notification CTA opened a modal with two buttons (\"Got it!\" / \"Reinstall later\") that both just closed it. No path forward despite the description telling users they \"need to reinstall the app on your home screen.\" Deleted the modal entirely and wired the denied click to open the iOS install modal — which is what the message was already pointing at.

5. **\`isPushOptedIn\` stayed stale after OneSignal subscription change.** The \`PushSubscription.change\` listener updated modal visibility but not the state, so consumers (the home carousel) only refreshed via the slower \`permissionChange\` path. Mirror the event payload into state directly.

## Polish

- **\`usePWAStatus\` flicker.** Hook initialised \`isPWA\` to \`false\` and only updated in a \`useEffect\`. iOS PWA users briefly saw the \"Add to home screen\" CTA between mount and first effect. Now initialised synchronously on the client; SSR still returns \`false\` (no window).

## Files

- \`src/components/Global/IosPwaInstallModal/index.tsx\` — mp4 mime source + Firefox iOS message + Got it CTA
- \`src/components/Home/HomeCarouselCTA/CarouselCTA.tsx\` — strip dead-end denied modal + the \`isPermissionDenied\` prop + ActionModal import
- \`src/components/Home/HomeCarouselCTA/index.tsx\` — stop passing the deleted prop
- \`src/hooks/useHomeCarouselCTAs.tsx\` — denied click opens install modal directly; drop \`isPermissionDenied\` from the CTA type
- \`src/hooks/useNotifications.ts\` — \`setIsPushOptedIn(Boolean(event.current?.optedIn))\` in subscription change listener
- \`src/hooks/usePWAStatus.ts\` — synchronous init via \`useState\` initializer

## Skipped — product calls, not bugs

- **Show notification CTA in non-PWA browsers.** Currently gated on \`isPwa\`. Android Chrome + desktop fully support web push but get no prompt. Whether we want to opt those users in is a product decision.
- **Android install CTA.** \`deviceType === IOS && !isPwa\` skips Android entirely. Android Chrome supports \`beforeinstallprompt\` and full PWA installation. New flow, separate PR.

## Regression risk

Low across the board.

- Video mime — strict superset (mp4 first, quicktime kept as fallback). Anything that played before still plays.
- Got it CTA — additive.
- Firefox iOS branch — only changes behaviour for Firefox iOS, which was already broken.
- Dead-end modal removal — the deleted modal was functionally a no-op. Routing to the install modal is a strict improvement (gives the user an action).
- \`isPushOptedIn\` — one-line state mirror, no behaviour change for already-correct paths.
- \`usePWAStatus\` synchronous init — same final value, just available one render earlier. SSR returns \`false\` exactly as before.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`npm test\` — 49 suites / 1054 tests passing
- [ ] Staging: real iPhone Safari (non-PWA) — verify install CTA opens modal with playable video + Got it button
- [ ] Staging: Chrome devtools mobile emulation — verify install modal shows the video (was blank before)
- [ ] Staging: install PWA → grant notifications → verify carousel notification CTA disappears immediately (was waiting for next nav)
- [ ] Staging: install PWA → deny notifications → click notification CTA again → verify iOS install modal opens (was dead-end modal)
- [ ] Staging: iOS PWA user lands on /home → verify no flash of \"Add to home screen\" CTA

## Related

- Follow-up to #1990 (carousel cooldown + completion gates)