### PR TITLE
chore(console): drop Vercel Analytics, kill Base WAGMI 403s, exclude /relay/* from SW

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
         "@sumsub/cordova-idensic-mobile-sdk-plugin": "^1.42.0",
         "@tanstack/react-query": "5.8.4",
         "@typeform/embed-react": "^3.20.0",
-        "@vercel/analytics": "^1.4.1",
         "@zerodev/ecdsa-validator": "^5.4.9",
         "@zerodev/passkey-validator": "^5.6.0",
         "@zerodev/permissions": "5.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,9 +100,6 @@ importers:
       '@typeform/embed-react':
         specifier: ^3.20.0
         version: 3.20.0(react@19.2.4)
-      '@vercel/analytics':
-        specifier: ^1.4.1
-        version: 1.6.1(next@16.2.3(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@zerodev/ecdsa-validator':
         specifier: ^5.4.9
         version: 5.4.9(@zerodev/sdk@5.5.7(viem@2.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(viem@2.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
@@ -3129,32 +3126,6 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
-
-  '@vercel/analytics@1.6.1':
-    resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
-    peerDependencies:
-      '@remix-run/react': ^2
-      '@sveltejs/kit': ^1 || ^2
-      next: '>= 13'
-      react: ^18 || ^19 || ^19.0.0-rc
-      svelte: '>= 4'
-      vue: ^3
-      vue-router: ^4
-    peerDependenciesMeta:
-      '@remix-run/react':
-        optional: true
-      '@sveltejs/kit':
-        optional: true
-      next:
-        optional: true
-      react:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
-      vue-router:
-        optional: true
 
   '@wagmi/connectors@5.9.3':
     resolution: {integrity: sha512-HmSRFB3SFE1jAPs1E28I6/VOyA82i4KzC0OyG1JLEkOkyLlGsakPxtwXVdw/7kv9L4ppADWWktvwOjvhvpRmdQ==}
@@ -11645,11 +11616,6 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
-
-  '@vercel/analytics@1.6.1(next@16.2.3(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
-    optionalDependencies:
-      next: 16.2.3(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react: 19.2.4
 
   '@wagmi/connectors@5.9.3(@types/react@18.3.27)(@wagmi/core@2.19.0(@tanstack/query-core@5.8.3)(@types/react@18.3.27)(immer@11.1.3)(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(bufferutil@4.1.0)(immer@11.1.3)(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(utf-8-validate@5.0.10)(viem@2.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)':
     dependencies:

--- a/src/app/sw.ts
+++ b/src/app/sw.ts
@@ -1,6 +1,6 @@
 import { defaultCache } from '@serwist/next/worker'
 import type { PrecacheEntry, SerwistGlobalConfig } from 'serwist'
-import { Serwist } from 'serwist'
+import { NetworkOnly, Serwist } from 'serwist'
 
 // This declares the value of `injectionPoint` to TypeScript.
 // `injectionPoint` is the string that will be replaced by the
@@ -23,7 +23,19 @@ const serwist = new Serwist({
     // Auth API responses are now fetched cross-origin (api.peanut.me) so the SW
     // doesn't intercept them — same-origin /api/peanut/user/* proxy routes were
     // deleted with the proxy removal.
-    runtimeCaching: defaultCache,
+    //
+    // /relay/* is the PostHog reverse-proxy path (see next.config.js rewrites).
+    // Workbox's defaultCache strategies threw "no-response" on the recorder +
+    // dead-clicks scripts, polluting the console. PostHog assets carry their
+    // own versioning + cache headers; let the network handle them. NetworkOnly
+    // first so it wins ahead of any defaultCache JS-asset rule.
+    runtimeCaching: [
+        {
+            matcher: ({ url }) => url.pathname.startsWith('/relay/'),
+            handler: new NetworkOnly(),
+        },
+        ...defaultCache,
+    ],
     disableDevLogs: false,
 })
 

--- a/src/config/peanut.config.tsx
+++ b/src/config/peanut.config.tsx
@@ -1,6 +1,5 @@
 'use client'
 import { ContextProvider } from '@/config'
-import { Analytics } from '@vercel/analytics/react'
 import countries from 'i18n-iso-countries'
 import enLocale from 'i18n-iso-countries/langs/en.json'
 import { useEffect } from 'react'
@@ -66,10 +65,7 @@ export function PeanutProvider({ children }: { children: React.ReactNode }) {
 
     return (
         <ReduxProvider store={store}>
-            <ContextProvider cookies={null}>
-                {children}
-                <Analytics />
-            </ContextProvider>
+            <ContextProvider cookies={null}>{children}</ContextProvider>
         </ReduxProvider>
     )
 }

--- a/src/config/wagmi.config.tsx
+++ b/src/config/wagmi.config.tsx
@@ -2,7 +2,7 @@
 import { JustaNameContext } from '@/config/justaname.config'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { WagmiProvider, cookieToInitialState, createConfig, http, type Config } from 'wagmi'
-import { arbitrum, base, bsc, celo, gnosis, linea, mainnet, optimism, polygon, scroll, worldchain } from 'wagmi/chains'
+import { arbitrum, bsc, celo, gnosis, linea, mainnet, optimism, polygon, scroll, worldchain } from 'wagmi/chains'
 import { RETRY_STRATEGIES } from '@/utils/retry.utils'
 
 const queryClient = new QueryClient({
@@ -25,10 +25,14 @@ const queryClient = new QueryClient({
     },
 })
 
-export const networks = [arbitrum, mainnet, optimism, polygon, gnosis, base, scroll, bsc, linea, worldchain, celo]
+// Base intentionally absent: WAGMI's `http()` (no URL) defaults to mainnet.base.org,
+// which IP-rate-limits us with 403s and pollutes the console. We don't use Base for
+// external-wallet flows. If Base support is needed for an actual user flow, give it
+// an explicit RPC URL (Chainstack key) instead of `http()`.
+export const networks = [arbitrum, mainnet, optimism, polygon, gnosis, scroll, bsc, linea, worldchain, celo]
 
 export const wagmiConfig = createConfig({
-    chains: [arbitrum, mainnet, optimism, polygon, gnosis, base, scroll, bsc, linea, worldchain, celo],
+    chains: [arbitrum, mainnet, optimism, polygon, gnosis, scroll, bsc, linea, worldchain, celo],
     ssr: true,
     transports: {
         [arbitrum.id]: http(),
@@ -36,7 +40,6 @@ export const wagmiConfig = createConfig({
         [optimism.id]: http(),
         [polygon.id]: http(),
         [gnosis.id]: http(),
-        [base.id]: http(),
         [scroll.id]: http(),
         [bsc.id]: http(),
         [linea.id]: http(),


### PR DESCRIPTION
## Summary

Follow-up to #1998. Three small, independent fixes for staging-console noise that became visible after the PostHog `/ingest/`→`/relay/` rename.

### 1. Remove Vercel Analytics
Web Analytics isn't enabled on the Vercel project, so every page logged:
```
[Vercel Web Analytics] Failed to load script from /_vercel/insights/script.js
```
Removed the `<Analytics />` provider + dropped `@vercel/analytics` from deps. To re-enable later: turn Web Analytics on in Vercel project settings, then re-add.

### 2. Remove Base from WAGMI config
`wagmi.config.tsx` had `[base.id]: http()` with no URL → viem fell back to `mainnet.base.org` → IP-rate-limit returned `POST 403 (Forbidden)` repeatedly with full viem retry stack traces in console. Base isn't used for any external-wallet flow.

Removed `base` from `chains`, `transports`, and the shared `networks` array. **Kept** `PUBLIC_CLIENTS_BY_CHAIN[base]` in `clients.ts` — that's still needed for `/recover-funds` cross-chain recovery.

### 3. Exclude `/relay/*` from service worker
Verified the rewrite works (`curl https://staging.peanut.me/relay/static/posthog-recorder.js` → HTTP 200, 145KB). The problem was Workbox's `defaultCache` strategies throwing `no-response` on these scripts → console flood. PostHog assets carry their own versioning + cache headers; we don't want them in our SW cache. Prepended a `NetworkOnly` route for `/relay/*` so it bypasses any `defaultCache` JS-asset rule.

## Out of scope (flagged for a separate PR)

**ENS resolution broken on staging** — `GET https://api.staging.peanut.me/ens/vitalik.eth` returns 404 (verified from any client; not just `hugo0.eth`). The route exists in `peanut-api-ts/src/routes/ens/index.ts` and is registered unconditionally; production (`api.peanut.me/ens/...`) returns `401 "API key required"` on the same path so the route IS deployed there. Staging is missing it entirely → either staging is on an old deploy or a recent deploy failed to register the route. **This is a peanut-api-ts deployment/infra issue — needs investigation in that repo, not this one.**

## Test plan

- [x] `pnpm test` — 49/49 suites, 1054 passed
- [x] `pnpm prettier --check` on changed files — no diffs
- [ ] Manual: open staging after deploy → confirm absence of:
  - `[Vercel Web Analytics] Failed to load script` errors
  - `POST mainnet.base.org/ 403 (Forbidden)` errors
  - `sw.js Uncaught (in promise) no-response` errors for `/relay/static/*`

## Risk notes

- **#2**: If anyone has a flow that does `useChainId({ chainId: base.id })` or similar wagmi-with-Base-chainId, it'll now get an "unsupported chain" error. Verified by grep that no such usage exists in `src/`. The `networks` array (used by `TokenSelector`) still has Base in `TOKEN_SELECTOR_POPULAR_NETWORK_IDS` (separate hardcoded list) — that's a UI inconsistency worth cleaning up later but doesn't break anything (cross-chain sends route through Squid, not WAGMI).
- **#3**: NetworkOnly means `/relay/*` is never cached. PostHog event ingestion was never cached anyway (POST requests aren't cached by SWs); the recorder/dead-clicks scripts are GET, but they're external vendor JS we don't want stale copies of.