### PR TITLE
fix(qr-drawer): prevent dismiss-on-drag-down duplication

### DIFF
--- a/src/components/Global/QRBottomDrawer/index.tsx
+++ b/src/components/Global/QRBottomDrawer/index.tsx
@@ -31,6 +31,7 @@ const QRBottomDrawer = ({ url, collapsedTitle, expandedTitle, text, buttonText, 
                 activeSnapPoint={activeSnapPoint}
                 setActiveSnapPoint={handleSnapPointChange}
                 modal={false}
+                dismissible={false}
             >
                 <DrawerContent className={`min-h-[200px] p-5 ${className || ''}`}>
                     <DrawerTitle className="mb-8 space-y-2">


### PR DESCRIPTION
## Summary

When pulling the persistent **My QR** bottom drawer down on the QR-scanner screen, the drag handle, title (\"My QR\") and QR code render twice mid-gesture.

**Root cause:** `QRBottomDrawer` uses vaul with `open={true}` hardcoded and no `onOpenChange`, but doesn't set `dismissible={false}`. vaul defaults `dismissible: true`, so dragging down past the first snap point (0.75) triggers an internal `closeDrawer()`. Because `open` is forced `true`, the drawer immediately re-mounts — painting a second copy of the content while the closing copy is still translating down.

**Fix:** add `dismissible={false}`. vaul has an explicit early-return that disallows drag-to-close at the first snap point when `dismissible` is false, which matches this component's intent (the drawer is a peek/expand element, never dismissable).

One-line change.

## Test plan
- [ ] Open QR scanner, drag the **My QR** drawer down — drawer stays at snap point 0.75, no duplicated content.
- [ ] Drag up — drawer still expands to 100% snap point.
- [ ] Confirm QR code still renders and Share button still works.