### PR TITLE
fix(history): shorten UUID identifiers in feed + drawer

### DIFF
--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -10,7 +10,7 @@ import { useTransactionDetailsDrawer } from '@/hooks/useTransactionDetailsDrawer
 import {
     formatNumberForDisplay,
     formatCurrency,
-    printableAddress,
+    printableUserHandle,
     isStableCoin,
     shortenStringLong,
 } from '@/utils/general.utils'
@@ -20,7 +20,6 @@ import { twMerge } from 'tailwind-merge'
 import Image from 'next/image'
 import StatusPill, { type StatusPillType } from '../Global/StatusPill'
 import { VerifiedUserLabel } from '../UserHeader'
-import { isAddress } from 'viem'
 import { PerkIcon } from './PerkIcon'
 import { useHaptic } from 'use-haptic'
 import LazyLoadErrorBoundary from '@/components/Global/LazyLoadErrorBoundary'
@@ -103,8 +102,12 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
     // check if this is a test transaction (setup confirmation)
     const isTestTransaction = name === 'Enjoy Peanut!'
     let displayName = name
-    if (isAddress(displayName)) {
-        displayName = printableAddress(displayName)
+    // Shortens crypto addresses AND raw UUIDs (usernameless Peanut users whose
+    // `identifier` arrives as a userId) so the feed row never renders a 36-char
+    // string.
+    const shortened = printableUserHandle(displayName)
+    if (shortened !== displayName) {
+        displayName = shortened
     } else if ((type === 'pay' || type === 'card_pay') && displayName.length > 19) {
         displayName = shortenStringLong(displayName, 0, 16)
     }

--- a/src/components/TransactionDetails/TransactionDetailsHeaderCard.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsHeaderCard.tsx
@@ -3,10 +3,9 @@
 import StatusBadge, { type StatusType } from '@/components/Global/Badges/StatusBadge'
 import TransactionAvatarBadge from '@/components/TransactionDetails/TransactionAvatarBadge'
 import { type TransactionType } from '@/components/TransactionDetails/TransactionCard'
-import { printableAddress } from '@/utils/general.utils'
+import { printableUserHandle } from '@/utils/general.utils'
 import Image from 'next/image'
 import React from 'react'
-import { isAddress as isWalletAddress } from 'viem'
 import Card from '../Global/Card'
 import { Icon, type IconName } from '../Global/Icons/Icon'
 import { VerifiedUserLabel } from '../UserHeader'
@@ -73,8 +72,10 @@ const getTitle = (
         }
         titleText = titleByDirection[direction] ?? userName ?? 'Link Transaction'
     } else {
-        const isAddress = isWalletAddress(userName)
-        const displayName = isAddress ? printableAddress(userName) : userName
+        // Shorten crypto addresses AND raw UUIDs (usernameless Peanut users
+        // whose `identifier` arrives as a userId) so the header never renders
+        // a 36-char string.
+        const displayName = printableUserHandle(userName)
 
         // check if this is a test transaction (setup confirmation)
         // note: bad check, but its a quick fix for now - kush (18 nov 2025), to be handled in the backend post devconnect.

--- a/src/utils/__tests__/general.utils.test.ts
+++ b/src/utils/__tests__/general.utils.test.ts
@@ -1,4 +1,11 @@
-import { formatAmount, formatExtendedNumber, getRequestLink, formatTokenAmount } from '../general.utils'
+import {
+    formatAmount,
+    formatExtendedNumber,
+    getRequestLink,
+    formatTokenAmount,
+    isUuid,
+    printableUserHandle,
+} from '../general.utils'
 import { AccountType } from '@/interfaces'
 
 describe('General Utilities', () => {
@@ -404,6 +411,47 @@ describe('General Utilities', () => {
             },
         ])('should return the correct link', ({ requestData, expectedLink }) => {
             expect(getRequestLink(requestData)).toBe(expectedLink)
+        })
+    })
+
+    describe('isUuid', () => {
+        it('matches lowercase, uppercase, and mixed-case UUIDs', () => {
+            expect(isUuid('7077676f-2bba-4ef2-b2ab-2d37aed69c69')).toBe(true)
+            expect(isUuid('7077676F-2BBA-4EF2-B2AB-2D37AED69C69')).toBe(true)
+            expect(isUuid('c4fc57cb-deae-4ea2-bdb3-aeaa996255ad')).toBe(true)
+        })
+
+        it('rejects non-UUID strings', () => {
+            expect(isUuid('alice')).toBe(false)
+            expect(isUuid('')).toBe(false)
+            expect(isUuid('0x1234567890123456789012345678901234567890')).toBe(false)
+            // Missing one hex char in the last group.
+            expect(isUuid('7077676f-2bba-4ef2-b2ab-2d37aed69c6')).toBe(false)
+            // Wrong delimiter.
+            expect(isUuid('7077676f2bba4ef2b2ab2d37aed69c69')).toBe(false)
+        })
+    })
+
+    describe('printableUserHandle', () => {
+        it('shortens UUID identifiers so the activity feed never renders the full string', () => {
+            const out = printableUserHandle('7077676f-2bba-4ef2-b2ab-2d37aed69c69')
+            expect(out).not.toBe('7077676f-2bba-4ef2-b2ab-2d37aed69c69')
+            expect(out).toContain('...')
+            expect(out.length).toBeLessThan('7077676f-2bba-4ef2-b2ab-2d37aed69c69'.length)
+        })
+
+        it('shortens EVM addresses', () => {
+            const out = printableUserHandle('0x1234567890123456789012345678901234567890')
+            expect(out).toContain('...')
+        })
+
+        it('leaves real usernames untouched', () => {
+            expect(printableUserHandle('alice')).toBe('alice')
+            expect(printableUserHandle('hugo.peanut')).toBe('hugo.peanut')
+        })
+
+        it('returns empty string unchanged', () => {
+            expect(printableUserHandle('')).toBe('')
         })
     })
 })

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -44,6 +44,14 @@ export const shortenStringLong = (s?: string, chars?: number, firstChars?: numbe
 // These are for display purposes, not cryptographic validation
 const SOLANA_ADDRESS_REGEX = /^[1-9a-zA-Z]{32,44}$/
 const TRON_ADDRESS_REGEX = /^[Tt][0-9a-zA-Z]{33}$/
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/**
+ * Checks if a string is a UUID (v1–v5 shape). Used to detect raw user IDs that
+ * leak into the history feed when a peer account has no username (BE falls back
+ * to userId for `recipientAccount.identifier`).
+ */
+export const isUuid = (s: string): boolean => UUID_REGEX.test(s)
 
 /**
  * Checks if a string looks like a Solana address (32-44 alphanumeric characters, no 0)
@@ -71,6 +79,19 @@ export const isCryptoAddress = (address: string): boolean => {
 export const printableAddress = (address: string, firstCharsLen?: number, lastCharsLen?: number): string => {
     if (!isCryptoAddress(address)) return address
     return shortenStringLong(address, undefined, firstCharsLen, lastCharsLen)
+}
+
+/**
+ * Renders a peer handle for the activity feed: shortens crypto addresses and
+ * UUID-shaped identifiers (e.g. usernameless Peanut users whose `identifier`
+ * arrives as a raw userId), and leaves real usernames untouched.
+ */
+export const printableUserHandle = (handle: string, firstCharsLen?: number, lastCharsLen?: number): string => {
+    if (!handle) return handle
+    if (isCryptoAddress(handle) || isUuid(handle)) {
+        return shortenStringLong(handle, undefined, firstCharsLen, lastCharsLen)
+    }
+    return handle
 }
 
 /**


### PR DESCRIPTION
## Summary

When a peer Peanut user has no username, the BE falls back `recipientAccount.identifier` to the raw userId (UUID). This leaked into the UI as a 36-char string in two places: the activity feed row (`7077676f-2bba-4ef2-b2ab-2d37aed69c69`) and the transaction drawer header (`Sent to 7077676f-2bba-4ef2-b2ab-2d37aed69c69`).

This treats UUID-shaped identifiers the same way we already treat crypto addresses: render them shortened. Routing (avatar click → `profileUrl(userName)`) still uses the full identifier so the link continues to resolve.

- New `isUuid` + `printableUserHandle` helpers in `general.utils.ts`. `printableUserHandle` shortens crypto addresses **and** UUIDs, leaves real usernames untouched.
- `TransactionDetailsHeaderCard.tsx` and `TransactionCard.tsx` switched from `printableAddress`/`isAddress` to `printableUserHandle`.

### Surface area / regression notes

- Side effect: Solana/Tron addresses landing as the userName in these two spots are now shortened too (previously only EVM was — `isAddress(viem)` is EVM-only). That's strictly an improvement, but flagging in case any screenshots/tests baked in the full-length variant.
- Avatar initials and the `VerifiedUserLabel`'s `username` prop still receive the full identifier — only the display-text gets shortened. Avatar color hashing stays stable.
- Click handler still routes to `/<uuid>` profile, which resolves.
- UUID regex is strict 8-4-4-4-12 hex; can't false-positive on real usernames.
- Not fixed here (out of scope): the root cause is the BE falling back to userId for usernameless users — same leak may surface elsewhere (push copy, emails, search). Worth a follow-up; this PR is the targeted UI guard.

## Test plan

- [x] Unit tests for `isUuid` (lower/upper/mixed case, rejects non-UUIDs) and `printableUserHandle` (UUID, address, plain username, empty string)
- [x] `npm test` — 52/52 in `general.utils.test.ts`
- [x] `pnpm prettier --check` on touched files
- [x] Typecheck on touched files (only pre-existing asset-module errors remain)
- [ ] Manual: hit a history entry whose peer has no username — feed row + drawer header should show `7077676f...d69c69` instead of the full UUID; clicking the avatar should still navigate to the user's profile.