### PR TITLE
fix(ui): swap cancel X-in-circle for lucide Ban icon

### DIFF
--- a/src/components/Global/Icons/Icon.tsx
+++ b/src/components/Global/Icons/Icon.tsx
@@ -11,6 +11,7 @@ import {
     ArrowUp,
     ArrowUpRight,
     Award,
+    Ban,
     Banknote,
     Bell,
     Camera,
@@ -96,6 +97,7 @@ export type IconName =
     | 'minus-circle'
     | 'meter'
     | 'cancel'
+    | 'ban'
     | 'download'
     | 'double-check'
     | 'eye'
@@ -260,6 +262,7 @@ const iconComponents: Record<IconName, ComponentType<SVGProps<SVGSVGElement>>> =
     'user-plus': (props) => <LucideWrapper Icon={UserPlus} {...props} />,
     copy: (props) => <LucideWrapper Icon={Copy} {...props} />,
     cancel: (props) => <LucideWrapper Icon={X} {...props} />,
+    ban: (props) => <LucideWrapper Icon={Ban} {...props} />,
     'qr-code': (props) => <LucideWrapper Icon={QrCode} boostKey="qr-code" {...props} />,
     'scan-qr-code': (props) => <LucideWrapper Icon={ScanQrCode} boostKey="scan-qr-code" {...props} />,
     history: (props) => <LucideWrapper Icon={History} {...props} />,

--- a/src/components/Send/link/views/Success.link.send.view.tsx
+++ b/src/components/Send/link/views/Success.link.send.view.tsx
@@ -85,11 +85,7 @@ const LinkSendSuccessView = () => {
                         >
                             {!isLoading && (
                                 <div className="flex items-center">
-                                    <Icon
-                                        name="cancel"
-                                        size={14}
-                                        className="mr-0.5 rounded-full border border-black p-0.5"
-                                    />
+                                    <Icon name="ban" size={18} />
                                 </div>
                             )}
                             <span>{cancelLinkText}</span>

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -656,15 +656,7 @@ export const TransactionDetailsReceipt = ({
                                 className="flex w-full items-center gap-1"
                                 shadowSize="4"
                             >
-                                <div className="flex items-center">
-                                    {!isLoading && (
-                                        <Icon
-                                            name="cancel"
-                                            size={14}
-                                            className="mr-0.5 rounded-full border border-black p-0.5"
-                                        />
-                                    )}
-                                </div>
+                                <div className="flex items-center">{!isLoading && <Icon name="ban" size={18} />}</div>
                                 <span>{cancelLinkText}</span>
                             </Button>
                         )}
@@ -681,9 +673,8 @@ export const TransactionDetailsReceipt = ({
             {isPendingRequester && setIsLoading && onClose && (
                 <div className="pr-1">
                     <Button
-                        icon="cancel"
-                        iconContainerClassName="border border-black w-4 h-4 mr-1 rounded-full"
-                        iconClassName="p-1"
+                        icon="ban"
+                        iconSize={18}
                         loading={isLoading}
                         disabled={isLoading}
                         onClick={closeRequestLink}
@@ -709,9 +700,8 @@ export const TransactionDetailsReceipt = ({
                         Pay
                     </Button>
                     <Button
-                        icon="cancel"
-                        iconContainerClassName="border border-black w-4 h-4 mr-1 rounded-full"
-                        iconClassName="p-1"
+                        icon="ban"
+                        iconSize={18}
                         disabled={isLoading}
                         onClick={() => {
                             setIsLoading(true)

--- a/src/components/TransactionDetails/provider-actions/CancelDepositActions.tsx
+++ b/src/components/TransactionDetails/provider-actions/CancelDepositActions.tsx
@@ -148,7 +148,7 @@ function CancelButton({
             shadowSize="4"
         >
             <div className="flex items-center">
-                <Icon name="cancel" size={14} className="mr-0.5 rounded-full border border-black p-0.5" />
+                <Icon name="ban" size={18} />
             </div>
             <span>{label}</span>
         </Button>


### PR DESCRIPTION
## Summary

Followup to #2002. The cancel-link/cancel-deposit buttons used \`<Icon name=\"cancel\" />\` (a plain X) wrapped in CSS to draw a circle around it (\`border border-black rounded-full p-0.5\`). With the icon at size=14 alongside Share Link's icon at size=18, the visible numbers diverged and looked suspect during QA even though the outer sizes were close.

Swapping all 5 call sites to \`<Icon name=\"ban\" size={18} />\` — \`Ban\` is the lucide icon that ships X-in-circle as a single path, no CSS scaffolding needed. Now both Share and Cancel buttons render their icon at exactly 18px and the two read consistently in the DOM.

### Changed call sites

- \`TransactionDetailsReceipt.tsx\` — Cancel link (sender flow)
- \`TransactionDetailsReceipt.tsx\` — Cancel request (requester)
- \`TransactionDetailsReceipt.tsx\` — Cancel request (requestee)
- \`Send/link/views/Success.link.send.view.tsx\` — Cancel link
- \`provider-actions/CancelDepositActions.tsx\` — Cancel deposit

### What was removed

- \`iconContainerClassName=\"border border-black w-4 h-4 mr-1 rounded-full\"\` + \`iconClassName=\"p-1\"\` (Button.icon callers)
- \`className=\"mr-0.5 rounded-full border border-black p-0.5\"\` wrappers (\`<Icon>\` callers)
- Surrounding \`<div className=\"flex items-center\">\` wrappers no longer needed

\`name=\"cancel\"\` stays for genuine close-X usages (modals, toasts).

### Test plan

- [ ] Cancel link (any pending send link): icon is the lucide X-in-circle (Ban), same size as the Share Link share icon next to it
- [ ] Cancel request flows: same
- [ ] Cancel deposit: same
- [ ] Plain X (\`name=\"cancel\"\`) usages elsewhere (modal closes etc) still render as before