### PR TITLE
fix(qr-drawer): restore drag-down by adding a peek snap point

### DIFF
--- a/src/components/Global/QRBottomDrawer/index.tsx
+++ b/src/components/Global/QRBottomDrawer/index.tsx
@@ -16,8 +16,11 @@ interface QRBottomDrawerProps {
 const QRBottomDrawer = ({ url, collapsedTitle, expandedTitle, text, buttonText, className }: QRBottomDrawerProps) => {
     const contentRef = useRef<HTMLDivElement>(null)
 
-    const snapPoints = [0.75, 1] // 75%, 100% of screen height
-    const [activeSnapPoint, setActiveSnapPoint] = useState<number | string | null>(snapPoints[0]) // Start with the smallest snap point
+    // Three snap points so drag-down at the medium state transitions to a peek
+    // (just the title) instead of being hard-blocked. dismissible={false} keeps
+    // the drawer from ever closing on drag.
+    const snapPoints = [0.15, 0.75, 1] // 15% peek, 75% medium, 100% full
+    const [activeSnapPoint, setActiveSnapPoint] = useState<number | string | null>(snapPoints[1]) // Start in the medium state
 
     const handleSnapPointChange = (snapPoint: number | string | null) => {
         setActiveSnapPoint(snapPoint)
@@ -36,7 +39,7 @@ const QRBottomDrawer = ({ url, collapsedTitle, expandedTitle, text, buttonText, 
                 <DrawerContent className={`min-h-[200px] p-5 ${className || ''}`}>
                     <DrawerTitle className="mb-8 space-y-2">
                         <h2 className="text-lg font-bold">
-                            {activeSnapPoint === snapPoints[0] ? collapsedTitle : expandedTitle}
+                            {activeSnapPoint === snapPoints[snapPoints.length - 1] ? expandedTitle : collapsedTitle}
                         </h2>
                     </DrawerTitle>
                     <div ref={contentRef}>


### PR DESCRIPTION
## Summary

Follow-up to #2005. That PR fixed the visual duplication when pulling the **My QR** drawer down, but it did it by setting \`dismissible={false}\` — which inside vaul **hard-blocks any drag motion** below the first snap point ([vaul source: \`index.mjs:1040-1041\`](https://github.com/emilkowalski/vaul/blob/main/src/index.tsx)). On staging this felt rigid: the drawer could only toggle between 0.75 and 1.0 and pulling down did nothing.

## Fix

Add a third snap point at \`0.15\` (peek state, shows just the title + drag handle) below the existing 0.75. vaul only short-circuits drag at the *first* snap, so:

- Drag down at 0.75 → smoothly transitions to 0.15 peek (visible motion, the \"transition to the other state\" feel)
- Drag down at 0.15 → stays put (no duplication, because \`dismissible={false}\` still prevents close)
- Drag up reverses normally

The drawer continues to start in the medium (0.75) state, so initial rendering is unchanged. Title selection now keys off the topmost snap (\`expandedTitle\` only at snap 1) so the existing \"My QR\" → \"Show QR to Get Paid\" transition still fires only between medium and full — unchanged from before.

## Why not full elastic rubber-band

vaul 1.1.2 doesn't expose an elastic-only mode: \`dismissible={false}\` blocks the drag, \`dismissible={true}\` triggers \`closeDrawer()\` at the first snap which collides with this drawer's forced-open state and re-creates the duplication bug. A new bottom snap is the cleanest way to give pull-down a visible result without reintroducing the close conflict.

## Test plan

- [ ] Open QR scanner.
- [ ] Drawer opens at the medium state showing \"My QR\".
- [ ] Pull drawer down — transitions to a peek (just title visible), no duplicated content.
- [ ] Pull drawer up from peek — returns to medium.
- [ ] Pull drawer up from medium — expands to full, title changes to \"Show QR to Get Paid\".
- [ ] Confirm Share button and QR code still render at full.