### PR TITLE
fix(ui): vertically center bottom-nav Home + Support

### DIFF
--- a/src/components/Global/WalletNavigation/index.tsx
+++ b/src/components/Global/WalletNavigation/index.tsx
@@ -80,7 +80,7 @@ const MobileNav: React.FC<MobileNavProps> = ({ pathName }) => {
                 href="/home"
                 translate="no"
                 className={classNames(
-                    'notranslate mb-4 flex flex-col items-center justify-center object-contain hover:cursor-pointer',
+                    'notranslate flex flex-col items-center justify-center object-contain hover:cursor-pointer',
                     { 'text-primary-1': pathName === '/home' }
                 )}
             >
@@ -102,7 +102,7 @@ const MobileNav: React.FC<MobileNavProps> = ({ pathName }) => {
                 }}
                 translate="no"
                 className={classNames(
-                    'notranslate mb-4 flex flex-col items-center justify-center object-contain  hover:cursor-pointer',
+                    'notranslate flex flex-col items-center justify-center object-contain hover:cursor-pointer',
                     { 'text-primary-1': pathName === '/support' }
                 )}
             >


### PR DESCRIPTION
## Summary

The Home and Support cells in the mobile bottom-nav had a stray \`mb-4\` (16px bottom margin) that shoved their icon+label block up and left visible empty space below. Removed it. With \`flex flex-col justify-center\` inside an \`h-20\` (80px) cell, the content now sits in the actual middle of the cell.

The center QR button is untouched — its \`-translate-y-1/3\` "pill above the bar" treatment is intentional.

### Verified locally

DOM measurements after the fix:
- **Home**: icon 20px from top of cell, label 20px from bottom — balanced
- **Support**: icon 18px from top, label 18px from bottom — balanced
- Center QR button still sits in its raised pill position

### Test plan

- [ ] \`/home\` (or any logged-in page on mobile viewport) — bottom nav Home + Support icons and labels look vertically centered, no obvious empty space below them
- [ ] Center QR CTA still pops up above the nav bar (unchanged)