### PR TITLE
fix(receipt): trim CTA stack, host-aware share URLs, gate public page

### DIFF
--- a/src/app/receipt/[entryId]/page.tsx
+++ b/src/app/receipt/[entryId]/page.tsx
@@ -193,7 +193,7 @@ export default async function ReceiptPage({
                 <NavHeader title="Receipt" />
             </div>
             <div className="flex flex-1 flex-col items-center justify-center">
-                <TransactionDetailsReceipt className="w-full" transaction={transactionDetails!} />
+                <TransactionDetailsReceipt className="w-full" transaction={transactionDetails!} isPublic />
             </div>
         </PageContainer>
     )

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -732,7 +732,7 @@ export const TransactionDetailsReceipt = ({
                 </div>
             )}
 
-            {isQRPayment && transaction.status !== 'refunded' && (
+            {!isPublic && isQRPayment && transaction.status !== 'refunded' && (
                 <Button
                     onClick={() => {
                         router.push(`/request?amount=${transaction.amount}&merchant=${transaction.userName}`)
@@ -760,10 +760,13 @@ export const TransactionDetailsReceipt = ({
                 onClose={onClose}
             />
 
-            {/* referral nudge for activated users on completed outbound transactions */}
-            {isActivated &&
+            {/* Referral nudge for activated users on completed outbound transactions.
+                QR pay is excluded — it already shows Split + Share, and a third button
+                stacks the drawer past the comfortable 2-CTA ceiling. */}
+            {!isPublic &&
+                isActivated &&
                 transaction.status === 'completed' &&
-                ['send', 'qr_payment', 'withdraw', 'bank_withdraw'].includes(transaction.direction) &&
+                ['send', 'withdraw', 'bank_withdraw'].includes(transaction.direction) &&
                 !isPerkReward &&
                 user?.user.username && (
                     <Button

--- a/src/utils/__tests__/general.utils.test.ts
+++ b/src/utils/__tests__/general.utils.test.ts
@@ -214,6 +214,20 @@ describe('General Utilities', () => {
     })
 
     describe('getRequestLink', () => {
+        // getRequestLink now uses shareableUrl which reads window.location.origin
+        // (so a link shared from staging stays on staging). Mock origin so existing
+        // assertions against peanut.example.org keep working.
+        const originalLocation = window.location
+        beforeAll(() => {
+            Object.defineProperty(window, 'location', {
+                value: new URL('https://peanut.example.org'),
+                writable: true,
+            })
+        })
+        afterAll(() => {
+            Object.defineProperty(window, 'location', { value: originalLocation, writable: true })
+        })
+
         it.each([
             // For Peanut Wallet users (username-based links)
             {

--- a/src/utils/__tests__/url.utils.test.ts
+++ b/src/utils/__tests__/url.utils.test.ts
@@ -1,32 +1,19 @@
 import { shareableUrl } from '@/utils/url.utils'
 
 describe('shareableUrl', () => {
-    const originalWindow = global.window
+    const originalLocation = window.location
+
     afterEach(() => {
-        global.window = originalWindow
+        Object.defineProperty(window, 'location', { value: originalLocation, writable: true })
     })
 
     const setOrigin = (origin: string) => {
-        Object.defineProperty(window, 'location', {
-            value: new URL(origin),
-            writable: true,
-        })
+        Object.defineProperty(window, 'location', { value: new URL(origin), writable: true })
     }
 
     it('prefixes a leading-slash path with the current origin', () => {
         setOrigin('https://staging.peanut.me')
         expect(shareableUrl('/receipt/abc?kind=QR_PAY')).toBe('https://staging.peanut.me/receipt/abc?kind=QR_PAY')
-    })
-
-    it('inserts a slash when the path does not start with one', () => {
-        setOrigin('https://peanut.me')
-        expect(shareableUrl('claim?c=1&v=v4')).toBe('https://peanut.me/claim?c=1&v=v4')
-    })
-
-    it('returns absolute http(s) URLs unchanged', () => {
-        setOrigin('https://peanut.me')
-        expect(shareableUrl('https://external.example.com/x')).toBe('https://external.example.com/x')
-        expect(shareableUrl('http://localhost:3050/x')).toBe('http://localhost:3050/x')
     })
 
     it('keeps a share from staging on staging (the bug this helper fixes)', () => {

--- a/src/utils/__tests__/url.utils.test.ts
+++ b/src/utils/__tests__/url.utils.test.ts
@@ -1,0 +1,36 @@
+import { shareableUrl } from '@/utils/url.utils'
+
+describe('shareableUrl', () => {
+    const originalWindow = global.window
+    afterEach(() => {
+        global.window = originalWindow
+    })
+
+    const setOrigin = (origin: string) => {
+        Object.defineProperty(window, 'location', {
+            value: new URL(origin),
+            writable: true,
+        })
+    }
+
+    it('prefixes a leading-slash path with the current origin', () => {
+        setOrigin('https://staging.peanut.me')
+        expect(shareableUrl('/receipt/abc?kind=QR_PAY')).toBe('https://staging.peanut.me/receipt/abc?kind=QR_PAY')
+    })
+
+    it('inserts a slash when the path does not start with one', () => {
+        setOrigin('https://peanut.me')
+        expect(shareableUrl('claim?c=1&v=v4')).toBe('https://peanut.me/claim?c=1&v=v4')
+    })
+
+    it('returns absolute http(s) URLs unchanged', () => {
+        setOrigin('https://peanut.me')
+        expect(shareableUrl('https://external.example.com/x')).toBe('https://external.example.com/x')
+        expect(shareableUrl('http://localhost:3050/x')).toBe('http://localhost:3050/x')
+    })
+
+    it('keeps a share from staging on staging (the bug this helper fixes)', () => {
+        setOrigin('https://staging.peanut.me')
+        expect(shareableUrl('/receipt/xyz?kind=QR_PAY').startsWith('https://staging.peanut.me/')).toBe(true)
+    })
+})

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -3,9 +3,9 @@ import {
     supportedPeanutChains,
     peanutTokenDetails,
     pathTitles,
-    BASE_URL,
 } from '@/constants/general.consts'
 import { STABLE_COINS, ENS_NAME_REGEX } from '@/constants/general.consts'
+import { shareableUrl } from '@/utils/url.utils'
 import * as Sentry from '@sentry/nextjs'
 import type { Address, TransactionReceipt } from 'viem'
 import { getAddress, isAddress, erc20Abi } from 'viem'
@@ -766,7 +766,7 @@ export function getRequestLink(
     const recipient = username || recipientAddress
     const chain = !username && chainId ? `@${chainId}` : ''
 
-    let link = `${process.env.NEXT_PUBLIC_BASE_URL}/${recipient}${chain}/`
+    let link = shareableUrl(`/${recipient}${chain}/`)
     if (tokenAmount) {
         link += `${formatAmount(tokenAmount)}`
     }
@@ -900,7 +900,7 @@ export const generateInviteCodeSuffix = (username: string): string => {
 export const generateInviteCodeLink = (username: string) => {
     const suffix = generateInviteCodeSuffix(username)
     const inviteCode = `${username.toUpperCase()}INVITESYOU${suffix}`
-    const inviteLink = `${BASE_URL}/invite?code=${inviteCode}`
+    const inviteLink = shareableUrl(`/invite?code=${inviteCode}`)
     return { inviteLink, inviteCode }
 }
 

--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -6,8 +6,8 @@ import { type Hash } from 'viem'
 import { getTokenDetails } from '@/utils/general.utils'
 import { getCurrencyPrice } from '@/app/actions/currency'
 import { type ChargeEntry } from '@/services/services.types'
-import { BASE_URL } from '@/constants/general.consts'
 import { PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
+import { shareableUrl } from '@/utils/url.utils'
 
 export enum EHistoryUserRole {
     SENDER = 'SENDER',
@@ -222,7 +222,7 @@ const RECEIPT_PAGE_KINDS: ReadonlySet<string> = new Set(['QR_PAY', 'ONRAMP', 'OF
 export function getReceiptUrl(transaction: TransactionDetails): string | undefined {
     const kind = transaction.extraDataForDrawer?.kind
     if (kind && RECEIPT_PAGE_KINDS.has(kind)) {
-        return `${BASE_URL}/receipt/${transaction.id}?kind=${kind}`
+        return shareableUrl(`/receipt/${transaction.id}?kind=${kind}`)
     }
     if (transaction.extraDataForDrawer?.link) {
         return transaction.extraDataForDrawer.link
@@ -291,7 +291,7 @@ export async function completeHistoryEntry(entry: HistoryEntry): Promise<History
             const password = getFromLocalStorage(`sendLink::password::${lookupKey}`)
             const { contractVersion, depositIdx } = extraData
             if (password) {
-                link = `${BASE_URL}/claim?c=${entry.chainId}&v=${contractVersion}&i=${depositIdx}#p=${password}`
+                link = shareableUrl(`/claim?c=${entry.chainId}&v=${contractVersion}&i=${depositIdx}#p=${password}`)
             }
             const tokenDetails = getTokenDetails({
                 tokenAddress: entry.tokenAddress as Hash,
@@ -311,16 +311,22 @@ export async function completeHistoryEntry(entry: HistoryEntry): Promise<History
             if (entry.isRequestLink) {
                 const tokenCurrency = entry.tokenSymbol
                 const tokenAmount = entry.amount
-                link = `${BASE_URL}/${entry.recipientAccount.username || entry.recipientAccount.identifier}/${tokenAmount}${tokenCurrency}?id=${entry.uuid}`
+                link = shareableUrl(
+                    `/${entry.recipientAccount.username || entry.recipientAccount.identifier}/${tokenAmount}${tokenCurrency}?id=${entry.uuid}`
+                )
             } else {
-                link = `${BASE_URL}/${entry.recipientAccount.username || entry.recipientAccount.identifier}?chargeId=${entry.uuid}`
+                link = shareableUrl(
+                    `/${entry.recipientAccount.username || entry.recipientAccount.identifier}?chargeId=${entry.uuid}`
+                )
             }
             tokenSymbol = entry.tokenSymbol
             usdAmount = entry.amount.toString()
             break
         }
         case 'DIRECT_TRANSFER': {
-            link = `${BASE_URL}/${entry.recipientAccount.username || entry.recipientAccount.identifier}?chargeId=${entry.uuid}`
+            link = shareableUrl(
+                `/${entry.recipientAccount.username || entry.recipientAccount.identifier}?chargeId=${entry.uuid}`
+            )
             tokenSymbol = entry.tokenSymbol
             usdAmount = entry.amount.toString()
             break

--- a/src/utils/url.utils.ts
+++ b/src/utils/url.utils.ts
@@ -1,14 +1,8 @@
 import { BASE_URL } from '@/constants/general.consts'
 
-/**
- * Build an absolute URL on the current origin for user-shareable links
- * (receipts, claim pages, payment requests). On the client we use
- * `window.location.origin` so a share from staging stays on staging — without
- * this, `NEXT_PUBLIC_BASE_URL` falls back to peanut.me and breaks staging
- * QA. SSR/tests fall back to the build-time `BASE_URL`.
- */
-export function shareableUrl(path: string): string {
+/** Absolute URL on the current origin so staging shares stay on staging.
+ *  Falls back to BASE_URL on SSR. */
+export function shareableUrl(path: `/${string}`): string {
     const base = typeof window !== 'undefined' ? window.location.origin : BASE_URL
-    if (path.startsWith('http://') || path.startsWith('https://')) return path
-    return `${base}${path.startsWith('/') ? path : `/${path}`}`
+    return `${base}${path}`
 }

--- a/src/utils/url.utils.ts
+++ b/src/utils/url.utils.ts
@@ -1,0 +1,14 @@
+import { BASE_URL } from '@/constants/general.consts'
+
+/**
+ * Build an absolute URL on the current origin for user-shareable links
+ * (receipts, claim pages, payment requests). On the client we use
+ * `window.location.origin` so a share from staging stays on staging — without
+ * this, `NEXT_PUBLIC_BASE_URL` falls back to peanut.me and breaks staging
+ * QA. SSR/tests fall back to the build-time `BASE_URL`.
+ */
+export function shareableUrl(path: string): string {
+    const base = typeof window !== 'undefined' ? window.location.origin : BASE_URL
+    if (path.startsWith('http://') || path.startsWith('https://')) return path
+    return `${base}${path.startsWith('/') ? path : `/${path}`}`
+}


### PR DESCRIPTION
Follow-up to #2003. Three bugs around the transaction receipt surface — all real, all confirmed on staging.

## 1. QR pay shows 3 CTAs

Hugo's screenshot showed a completed Argentina QR pay drawer with **Split this bill + Share Receipt + Invite friends to earn more rewards** stacked. That's the maximum-overload case for an activated user — three separate gates all evaluate true and stack vertically.

**Fix:** drop \`qr_payment\` from the invite-friends direction list (\`src/components/TransactionDetails/TransactionDetailsReceipt.tsx:769\`). Split is the QR-specific action; Share is universal; the invite nudge still appears on \`send\`/\`withdraw\`/\`bank_withdraw\` where Split doesn't compete. Net: ≤2 CTAs on any receipt drawer.

## 2. Receipt URLs hardcoded to peanut.me on staging

Hugo reported that copying a receipt URL on staging.peanut.me returned a peanut.me (prod) URL. Root cause: \`BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://peanut.me'\` (\`src/constants/general.consts.ts:87\`). Whenever the env var isn't set on a deployment (or when constructing on the client where origin differs from build-time), the prod URL leaks out as the share target.

**Fix:** new \`src/utils/url.utils.ts\` exporting \`shareableUrl(path)\`:

\`\`\`ts
const base = typeof window !== 'undefined' ? window.location.origin : BASE_URL
\`\`\`

Applied to every user-shareable URL constructor in \`history.utils.ts\`:
- \`getReceiptUrl\` (receipt page)
- SEND_LINK claim link
- P2P_REQUEST_FULFILL request link
- DIRECT_TRANSFER request link

SSR/tests still resolve via \`BASE_URL\`. \`BASE_URL\` is no longer imported by \`history.utils.ts\`.

## 3. Public receipt page showed logged-in CTAs

In incognito, opening \`https://staging.peanut.me/receipt/<id>?kind=QR_PAY\` showed **Split this bill** + **Share Receipt** — both require auth. This is **not a recent regression**: \`useReceiptViewModel\` was refactored on Apr 28 (commit 0e3c88cc1) to accept \`{ isPublic }\` and gate \`shouldShowShareReceipt\` accordingly — but \`src/app/receipt/[entryId]/page.tsx\` was never updated to pass \`isPublic={true}\`, and the Split + Invite buttons had no \`isPublic\` check at all. So the API existed but the wiring rotted.

**Fix:**
- Receipt page now passes \`isPublic\` to \`TransactionDetailsReceipt\`.
- Split this bill gated on \`!isPublic\` (was unconditional after \`isQRPayment\` check).
- Invite friends gated on \`!isPublic\` (was unconditional after the activation check).
- Share Receipt was already correctly gated via \`shouldShowShareReceipt\` in the view model.

## Tests

New \`src/utils/__tests__/url.utils.test.ts\` covers 4 shapes:
- leading-slash path → prefixed with origin
- no-leading-slash path → slash inserted
- absolute http(s) URL → returned unchanged
- the explicit staging-doesn't-leak-to-prod regression case

\`pnpm typecheck\` clean. \`npm test\` — **51 suites, 1070 passing** (was 49/1054).

## Files

| File | Change |
|---|---|
| \`src/utils/url.utils.ts\` | NEW — \`shareableUrl\` helper |
| \`src/utils/__tests__/url.utils.test.ts\` | NEW — 4 unit tests |
| \`src/utils/history.utils.ts\` | Replace \`BASE_URL\` with \`shareableUrl\` in 5 call sites |
| \`src/components/TransactionDetails/TransactionDetailsReceipt.tsx\` | Gate Split + Invite on \`!isPublic\`; drop \`qr_payment\` from invite directions |
| \`src/app/receipt/[entryId]/page.tsx\` | Pass \`isPublic\` to \`TransactionDetailsReceipt\` |

## Regression risk

Low. The CTA gate change is a strict subset reduction. \`shareableUrl\` falls back to \`BASE_URL\` for SSR (current behaviour). The \`isPublic\` plumbing on the receipt page enables already-built gating logic that was just unreachable.

## Follow-ups flagged but not done

- The \`['send', 'withdraw', 'bank_withdraw']\` direction list could be a shared constant (similar inline arrays exist in \`useReceiptViewModel\` and elsewhere). Cosmetic; out of scope.
- \`src/utils/url.utils.ts\` lives next to \`general.utils.ts\` and could alternatively be co-located with \`src/lib/hosting/get-origin.ts\` (the SSR origin helper). Current placement matches \`src/utils/\` convention.