### PR TITLE
fix(qr-drawer): use buffer snap to absorb hard drags without duplication

### DIFF
--- a/src/components/Global/QRBottomDrawer/index.tsx
+++ b/src/components/Global/QRBottomDrawer/index.tsx
@@ -16,11 +16,13 @@ interface QRBottomDrawerProps {
 const QRBottomDrawer = ({ url, collapsedTitle, expandedTitle, text, buttonText, className }: QRBottomDrawerProps) => {
     const contentRef = useRef<HTMLDivElement>(null)
 
-    // Three snap points so drag-down at the medium state transitions to a peek
-    // (just the title) instead of being hard-blocked. dismissible={false} keeps
-    // the drawer from ever closing on drag.
-    const snapPoints = [0.15, 0.75, 1] // 15% peek, 75% medium, 100% full
-    const [activeSnapPoint, setActiveSnapPoint] = useState<number | string | null>(snapPoints[1]) // Start in the medium state
+    // Three snap points with a smaller "buffer" below the medium state. Hard
+    // drag-downs land at 0.5 instead of vaul's closeDrawer() path, which is the
+    // only thing that produced the duplication artifact (vaul/index.mjs:656
+    // only fires closeDrawer at the FIRST snap point; keeping the medium snap
+    // at index 1 means a normal drag never trips it).
+    const snapPoints = [0.5, 0.75, 1]
+    const [activeSnapPoint, setActiveSnapPoint] = useState<number | string | null>(snapPoints[1])
 
     const handleSnapPointChange = (snapPoint: number | string | null) => {
         setActiveSnapPoint(snapPoint)
@@ -34,7 +36,6 @@ const QRBottomDrawer = ({ url, collapsedTitle, expandedTitle, text, buttonText, 
                 activeSnapPoint={activeSnapPoint}
                 setActiveSnapPoint={handleSnapPointChange}
                 modal={false}
-                dismissible={false}
             >
                 <DrawerContent className={`min-h-[200px] p-5 ${className || ''}`}>
                     <DrawerTitle className="mb-8 space-y-2">


### PR DESCRIPTION
## Summary

Follow-up to #2005 and #2008. Staging feedback: \`dismissible={false}\` (kept after #2008) hard-blocks the drag motion at the lowest snap point — drawer feels rigid. We want to restore the production-style elastic feel (drag down a little → snaps back to middle, drag up → expand) while keeping the duplication artifact away.

## Root cause, recap

vaul only ever calls \`closeDrawer()\` in one place when snap points are configured ([\`index.mjs:656\`](https://github.com/emilkowalski/vaul/blob/main/src/index.tsx)):

\`\`\`js
if (isFirst && dragDirection < 0 && dismissible) {
    closeDrawer();
}
\`\`\`

That call is what collides with our forced \`open={true}\` and produces the duplicated content during a fast drag-down. It only fires when the user is at the **first** snap point.

## Fix

Add a phantom \`0.5\` buffer **below** the medium snap and drop \`dismissible={false}\`:

- \`snapPoints = [0.5, 0.75, 1]\`, drawer starts at index 1 (\`0.75\`)
- A normal drag-down from the medium state moves to \`0.5\` (index 0) via vaul's directional-snap path — never trips line 656 because \`isFirst\` is false during that interaction.
- A small drag-down still rubber-bands back to \`0.75\` (closest-snap path), matching production.
- Drag-up still expands to full at index 2, identical to production.
- \`expandedTitle\` is shown only at the topmost snap, so the \"My QR\" → \"Show QR to Get Paid\" toggle still happens exactly between medium and full.

Three lines changed: snap array, initial index, removal of \`dismissible={false}\`.

## Known edge case

If the user is already at \`0.5\` and performs another fast drag-down, \`isFirst\` is true and \`closeDrawer()\` can fire — re-introducing the duplication. This requires two consecutive hard drag-downs, which won't happen by accident. If staging shows it in practice, we can deepen the buffer (\`[0.3, 0.5, 0.75, 1]\`) or lower it to near-zero.

## Test plan
- [ ] Open QR scanner — drawer opens at the medium state with \"My QR\" title.
- [ ] Pull up → drawer expands to full, title becomes \"Show QR to Get Paid\".
- [ ] Pull down slightly → drawer snaps back to medium (no duplication).
- [ ] Pull down hard → drawer transitions to the smaller \`0.5\` state (no duplication).
- [ ] Pull back up from \`0.5\` → returns to medium.