### PR TITLE
fix(payments): surface Rain cooldown error verbatim on every collateral spend path (TASK-19573)

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -18,6 +18,7 @@ import AmountInput from '@/components/Global/AmountInput'
 import { useWallet } from '@/hooks/wallet/useWallet'
 import { useSignSpendBundle } from '@/hooks/wallet/useSignSpendBundle'
 import { InsufficientSpendableError, SessionKeyGrantRequiredError } from '@/hooks/wallet/useSpendBundle'
+import { rainCollateralErrorMessage } from '@/utils/friendly-error.utils'
 import { useRainCardOverview } from '@/hooks/useRainCardOverview'
 import { rainSpendingPowerToWei } from '@/utils/balance.utils'
 import { isTxReverted, saveRedirectUrl, formatNumberForDisplay } from '@/utils/general.utils'
@@ -496,10 +497,13 @@ export default function QRPayPage() {
                 kind: 'QR_PAY',
             })
         } catch (error) {
+            const rainMsg = rainCollateralErrorMessage(error)
             if (error instanceof InsufficientSpendableError) {
                 setErrorMessage('Not enough USDC in your wallet or card to cover this payment.')
             } else if (error instanceof SessionKeyGrantRequiredError) {
                 setErrorMessage("One-time card authorization needed. You'll be asked to confirm once.")
+            } else if (rainMsg) {
+                setErrorMessage(rainMsg)
             } else if ((error as Error).toString().includes('not allowed')) {
                 setErrorMessage('Please confirm the transaction.')
             } else {

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -3,6 +3,7 @@
 import { useWallet } from '@/hooks/wallet/useWallet'
 import { useSignSpendBundle } from '@/hooks/wallet/useSignSpendBundle'
 import { InsufficientSpendableError, SessionKeyGrantRequiredError } from '@/hooks/wallet/useSpendBundle'
+import { rainCollateralErrorMessage } from '@/utils/friendly-error.utils'
 import { rainSpendingPowerToWei } from '@/utils/balance.utils'
 import { useRainCardOverview } from '@/hooks/useRainCardOverview'
 import { useState, useMemo, useContext, useEffect, useCallback, useId } from 'react'
@@ -327,6 +328,7 @@ export default function MantecaWithdrawFlow() {
                     kind: 'FIAT_OFFRAMP',
                 })
             } catch (error) {
+                const rainMsg = rainCollateralErrorMessage(error)
                 if (error instanceof InsufficientSpendableError) {
                     setErrorMessage('Not enough USDC in your wallet or card to cover this withdrawal.')
                 } else if (error instanceof SessionKeyGrantRequiredError) {
@@ -334,6 +336,8 @@ export default function MantecaWithdrawFlow() {
                     // Telling the user "you'll be asked" is misleading — they
                     // may retry and hit the same loop. Give an actionable hint.
                     setErrorMessage('Card authorization failed. Please try again or contact support.')
+                } else if (rainMsg) {
+                    setErrorMessage(rainMsg)
                 } else if ((error as Error).toString().includes('not allowed')) {
                     setErrorMessage('Please confirm the transaction.')
                 } else {

--- a/src/utils/friendly-error.utils.tsx
+++ b/src/utils/friendly-error.utils.tsx
@@ -1,3 +1,18 @@
+/** Safely extract a string-form of an unknown error + its `.message` if any.
+ *  Lets the matchers below use `string` methods without unsafe property access
+ *  while still accepting whatever shape callers throw (Error, string, object). */
+function extractErrorParts(error: unknown): { text: string; message: string | undefined } {
+    if (typeof error === 'string') return { text: error, message: error }
+    if (error && typeof error === 'object') {
+        const obj = error as { toString?: () => unknown; message?: unknown }
+        const rawText = typeof obj.toString === 'function' ? obj.toString() : ''
+        const text = typeof rawText === 'string' ? rawText : ''
+        const message = typeof obj.message === 'string' ? obj.message : undefined
+        return { text, message }
+    }
+    return { text: '', message: undefined }
+}
+
 /**
  * Returns the verbatim error message when it's an actionable Rain card-
  * collateral error from the backend (`/rain/cards/withdraw/prepare`):
@@ -9,22 +24,22 @@
  * Use this in any callsite that does its own catch on a Rain-touching spend
  * (signSpend / spend / sendMoney / sendTransactions(requiredUsdcAmount)).
  */
-export const rainCollateralErrorMessage = (error: any): string | null => {
-    const text = error?.toString?.() ?? ''
+export const rainCollateralErrorMessage = (error: unknown): string | null => {
+    const { text, message } = extractErrorParts(error)
     if (
         text.includes('A previous withdrawal is still active for this card') ||
         text.includes('A previous withdrawal signature is still active') ||
         text.includes('Insufficient collateral balance for this withdrawal')
     ) {
-        return error?.message ?? text
+        return message ?? text
     }
     return null
 }
 
 /** UI-friendly error message extractor. Matches substrings on common
  *  wallet / viem / Peanut API error messages and returns user-facing copy. */
-export const ErrorHandler = (error: any): string => {
-    const text = error?.toString?.() ?? ''
+export const ErrorHandler = (error: unknown): string => {
+    const { text, message } = extractErrorParts(error)
     // Rain card-collateral errors — surface the backend's already user-
     // friendly copy verbatim (includes the "Try again in about M min." hint
     // on the cooldown case). Covers every spend path that touches Rain.
@@ -66,7 +81,7 @@ export const ErrorHandler = (error: any): string => {
     if (text.includes('Error making the gasless deposit through the peanut api.'))
         return 'Error making the gasless deposit through the peanut api.'
     if (text.includes('Error sending the transaction.')) return 'Error sending the transaction.'
-    if (text.includes('Error getting the link with transactionHash')) return error.message
+    if (text.includes('Error getting the link with transactionHash')) return message ?? text
     if (text.includes('transfer amount exceeds balance'))
         return 'You do not have enough balance to complete the transaction.'
     if (text.includes('does not match the target chain for the transaction'))
@@ -77,6 +92,6 @@ export const ErrorHandler = (error: any): string => {
         return 'Could not claim link, please refresh page. If problem persist confirm link with sender'
     if (text.includes('Send link already claimed')) return 'Send link already claimed'
     if (text.toLowerCase().includes('liquidity'))
-        return error.message || 'Low liquidity. Please try a smaller amount or different route.'
+        return message || 'Low liquidity. Please try a smaller amount or different route.'
     return 'There was an issue with your request. Please contact support.'
 }

--- a/src/utils/friendly-error.utils.tsx
+++ b/src/utils/friendly-error.utils.tsx
@@ -1,7 +1,35 @@
+/**
+ * Returns the verbatim error message when it's an actionable Rain card-
+ * collateral error from the backend (`/rain/cards/withdraw/prepare`):
+ * - 425/409: "A previous withdrawal is still active for this card. Try
+ *   again in about M min." (+ legacy TooEarlyError variant)
+ * - 422: "Insufficient collateral balance for this withdrawal"
+ *
+ * Returns null for anything else so callers fall through to their own copy.
+ * Use this in any callsite that does its own catch on a Rain-touching spend
+ * (signSpend / spend / sendMoney / sendTransactions(requiredUsdcAmount)).
+ */
+export const rainCollateralErrorMessage = (error: any): string | null => {
+    const text = error?.toString?.() ?? ''
+    if (
+        text.includes('A previous withdrawal is still active for this card') ||
+        text.includes('A previous withdrawal signature is still active') ||
+        text.includes('Insufficient collateral balance for this withdrawal')
+    ) {
+        return error?.message ?? text
+    }
+    return null
+}
+
 /** UI-friendly error message extractor. Matches substrings on common
  *  wallet / viem / Peanut API error messages and returns user-facing copy. */
 export const ErrorHandler = (error: any): string => {
     const text = error?.toString?.() ?? ''
+    // Rain card-collateral errors — surface the backend's already user-
+    // friendly copy verbatim (includes the "Try again in about M min." hint
+    // on the cooldown case). Covers every spend path that touches Rain.
+    const rainMsg = rainCollateralErrorMessage(error)
+    if (rainMsg) return rainMsg
     if (text.includes('insufficient funds')) return "You don't have enough funds."
     if (text.includes('user rejected transaction')) return 'Please confirm the transaction in your wallet.'
     if (text.includes('not deployed on chain')) return 'Bulk is not able on this chain, please try another chain.'


### PR DESCRIPTION
Pairs with peanut-api-ts#767 (BE maps Rain's 409 ConflictError to a 425 with a parsed \`Try again in about M min.\` suffix).

## What

Rain's signatures API allows one active withdrawal sig per Rain user; switching flows mid-cooldown (e.g. pay a request, then open a different withdraw) returns 425 with copy that's already user-actionable. That message was being masked by generic copy on a couple of paths.

## Where this can happen

Every spend path that touches Rain card collateral. Routes through one of:

- \`useSpendBundle.spend()\` → \`useSendMoney\` → flow hooks (direct-send / semantic-request / contribute-pot)
- \`useWallet.sendTransactions({ requiredUsdcAmount })\` → cross-chain crypto withdraw, link create, bank withdraw
- \`useSignSpendBundle\` direct callsites → QR pay, Manteca offramp, Lock/Cancel card modals

All except QR pay and Manteca already routed through \`ErrorHandler\` (semantic-request / direct-send / contribute-pot / crypto-withdraw / link-create) or surfaced \`e.message\` verbatim (Lock/Cancel card modals). The two outliers had a generic \`Could not sign the transaction\` fallback that masked the Rain message.

## Fix

1. **\`friendly-error.utils\`** — extract \`rainCollateralErrorMessage(error)\` that returns the BE message verbatim for the 425 cooldown + 422 insufficient-collateral cases, null otherwise. \`ErrorHandler\` uses it as the first branch. Single sink for every path that goes through ErrorHandler.
2. **\`qr-pay/page.tsx\`** + **\`withdraw/manteca/page.tsx\`** — these have their own catch on \`signSpend\` with a generic fallback. Add a \`rainCollateralErrorMessage\` branch before the fallback so they surface the BE copy too.

## QA

- Trigger the cooldown: pay a request from collateral, immediately open a different withdraw (different amount/recipient) before the 6.5min sig window expires. Each entry point below should show \`A previous withdrawal is still active for this card. Try again in about M min.\` (or \`Insufficient collateral balance for this withdrawal\` if applicable):
  - Request pay
  - Direct send
  - Pot contribute
  - Crypto withdraw (cross-chain)
  - Bank withdraw
  - Link create
  - QR pay
  - Manteca offramp
  - Lock / Cancel card

🤖 Generated with [Claude Code](https://claude.com/claude-code)