### PR TITLE
fix(claim-link): fall back to latest contract version when link URL has bad 'v' (TASK-19573)

### DIFF
--- a/src/utils/peanut-link.utils.ts
+++ b/src/utils/peanut-link.utils.ts
@@ -4,6 +4,7 @@
 import { keccak256, toBytes } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import type { Hex } from 'viem'
+import { getLatestContractVersion } from './peanut-claim.utils'
 
 /** Mirror of SDK `generateKeysFromString(s)` — keccak256(utf8(s)) is the
  *  private key; address derives from it. Used by the send-link flow to
@@ -22,12 +23,21 @@ export interface PeanutLinkParams {
     trackId: string
 }
 
-/** Mirror of SDK `getParamsFromLink(link)`. */
+/** Mirror of SDK `getParamsFromLink(link)`.
+ *
+ *  `contractVersion` falls back to the chain's latest deployed version when
+ *  the URL is missing `v=`, has `v=` empty, or somehow encodes the literal
+ *  string `undefined`/`null` (a historical FE bug stored some links with
+ *  `v=undefined` — see staging cancel-link failures). Avoids `getContractAddress`
+ *  throwing `No Peanut vault for chainId=X version=undefined` on cancel/claim.
+ */
 export function getParamsFromLink(link: string): PeanutLinkParams {
     const url = new URL(link)
     const params = url.searchParams
     const chainId = params.get('c') ?? ''
-    const contractVersion = params.get('v') ?? ''
+    const rawVersion = params.get('v')
+    const looksMissing = !rawVersion || rawVersion === 'undefined' || rawVersion === 'null'
+    const contractVersion = looksMissing && chainId ? getLatestContractVersion({ chainId }) : (rawVersion ?? '')
     const trackId = params.get('t') ?? ''
     const indices = params.get('i') ?? '0'
     // Multi-link form `(1,2),(3,4)` — first integer.


### PR DESCRIPTION
## Bug

Cancel-link failing on staging with:

\`\`\`
Error: No Peanut vault for chainId=42161 version=undefined
    at getContractAddress (peanut-claim.utils.ts:28)
    at createClaimPayload (useClaimLink.tsx:64)
    ...
\`\`\`

## Why

Some send links have \`v=undefined\` literal in the URL (historical FE bug — a callsite stringified an undefined \`contractVersion\` into the link). \`getParamsFromLink\` returned the string \`'undefined'\` for \`contractVersion\`; \`getContractAddress(42161, 'undefined')\` doesn't match the inlined \`VAULT_ADDRESSES\` table and throws.

## Fix

\`getParamsFromLink\` now treats missing / empty / literal \`'undefined'\` / \`'null'\` as a missing version, and falls back to \`getLatestContractVersion({ chainId })\` for the link's chain (v4.4 on Arbitrum mainnet, v4.3 on Sepolia — the only ones our VAULT_ADDRESSES table knows). Read-side resilience for malformed links already in the wild; new links keep being built with the explicit version via \`getLinkFromParams\` as before.

## QA

- Cancel an existing send link → succeeds (the cancel-flow goes through \`createClaimPayload\` → \`signWithdrawalMessage\` → \`getContractAddress\`, which previously crashed).
- Claim a regular link → unchanged behavior.
- Test impact: \`getParamsFromLink\` callers (the \`/utils\` suite) — 425 tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)