### PR TITLE
fix: missing flag SVGs (Bonaire +5) and strip invite share copy

### DIFF
--- a/scripts/copy-flags.mjs
+++ b/scripts/copy-flags.mjs
@@ -18,9 +18,23 @@ const dest = resolve(root, 'public/flags')
 // package only has 'european_union.svg', so without this alias every EUR-
 // currency fallback (e.g. SEPA onramps without IBAN signal, the KYC icon
 // strip) 404s in production.
-const ALIASES = {
-    european_union: 'eu',
-}
+//
+// Several ISO-2 codes are also absent from circle-flags because they cover
+// composite territories (BQ → Bonaire/Saba/Sint Eustatius, SH → Saint Helena/
+// Ascension/Tristan) or uninhabited dependencies (BV, HM, SJ, UM). Without
+// these aliases, `/flags/bq.svg` etc. 404 and the country list shows the
+// generic UN fallback. Point each one at the closest meaningful flag the
+// package ships — Bonaire for BQ, Saint Helena island for SH, and the parent
+// country for the four dependencies.
+const ALIASES = [
+    ['european_union', 'eu'],
+    ['bq-bo', 'bq'],
+    ['sh-hl', 'sh'],
+    ['no', 'bv'],
+    ['no', 'sj'],
+    ['au', 'hm'],
+    ['us', 'um'],
+]
 
 if (!existsSync(src)) {
     console.error(`[copy-flags] source missing: ${src}. Run \`pnpm install\` first.`)
@@ -30,7 +44,7 @@ if (!existsSync(src)) {
 mkdirSync(dest, { recursive: true })
 cpSync(src, dest, { recursive: true })
 
-for (const [from, to] of Object.entries(ALIASES)) {
+for (const [from, to] of ALIASES) {
     const fromPath = resolve(src, `${from}.svg`)
     const toPath = resolve(dest, `${to}.svg`)
     if (!existsSync(fromPath)) {

--- a/src/components/Global/EarlyUserModal/index.tsx
+++ b/src/components/Global/EarlyUserModal/index.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useState } from 'react'
 import ActionModal from '../ActionModal'
 import ShareButton from '../ShareButton'
-import { generateInviteCodeLink, generateInvitesShareText } from '@/utils/general.utils'
+import { generateInviteCodeLink } from '@/utils/general.utils'
 import { useAuth } from '@/context/authContext'
 import { updateUserById } from '@/app/actions/users'
 import posthog from 'posthog-js'
@@ -47,10 +47,7 @@ const EarlyUserModal = () => {
                         </span>
                     </p>
 
-                    <ShareButton
-                        generateText={() => Promise.resolve(generateInvitesShareText(inviteLink))}
-                        title="Share your invite link"
-                    >
+                    <ShareButton url={inviteLink} title="Share your invite link">
                         Share Invite link
                     </ShareButton>
                     <a

--- a/src/components/Global/InviteFriendsModal/index.tsx
+++ b/src/components/Global/InviteFriendsModal/index.tsx
@@ -4,7 +4,7 @@ import ActionModal from '@/components/Global/ActionModal'
 import Card from '@/components/Global/Card'
 import CopyToClipboard from '@/components/Global/CopyToClipboard'
 import ShareButton from '@/components/Global/ShareButton'
-import { generateInviteCodeLink, generateInvitesShareText } from '@/utils/general.utils'
+import { generateInviteCodeLink } from '@/utils/general.utils'
 import { ANALYTICS_EVENTS, MODAL_TYPES, REFERRAL_SOURCES } from '@/constants/analytics.consts'
 import posthog from 'posthog-js'
 import { useEffect, useRef } from 'react'
@@ -74,7 +74,7 @@ export default function InviteFriendsModal({ visible, onClose, username, source 
                         </Card>
                     </div>
                     <ShareButton
-                        generateText={() => Promise.resolve(generateInvitesShareText(inviteLink))}
+                        url={inviteLink}
                         title="Share your invite link"
                         onSuccess={() => {
                             posthog.capture(ANALYTICS_EVENTS.INVITE_LINK_SHARED, { source })

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -62,7 +62,7 @@ import ContributorCard from '../Global/Contributors/ContributorCard'
 import { requestsApi } from '@/services/requests'
 import { PasskeyDocsLink } from '../Setup/Views/SignTestTransaction'
 import { useActivationStatus } from '@/hooks/useActivationStatus'
-import { generateInviteCodeLink, generateInvitesShareText } from '@/utils/general.utils'
+import { generateInviteCodeLink } from '@/utils/general.utils'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
@@ -774,13 +774,12 @@ export const TransactionDetailsReceipt = ({
                         shadowSize="4"
                         onClick={async () => {
                             const { inviteLink } = generateInviteCodeLink(user.user.username!)
-                            const text = generateInvitesShareText(inviteLink)
                             posthog.capture(ANALYTICS_EVENTS.INVITE_LINK_SHARED, { source: 'transaction_receipt' })
                             try {
                                 if (navigator.share) {
-                                    await navigator.share({ text })
+                                    await navigator.share({ url: inviteLink })
                                 } else {
-                                    await navigator.clipboard.writeText(text)
+                                    await navigator.clipboard.writeText(inviteLink)
                                     // Desktop fallback: navigator.share is mobile-only.
                                     // Without a toast the click is silent and users assume
                                     // the button is broken.

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -877,10 +877,6 @@ export function slugify(text: string): string {
         .replace(/^-+|-+$/g, '') // Remove leading and trailing hyphens
 }
 
-export const generateInvitesShareText = (inviteLink: string) => {
-    return `I'm using Peanut, an invite-only app for easy payments. With it you can pay friends, use merchants, and move money in and out of your bank, even cross-border. Here's my invite: ${inviteLink}`
-}
-
 /**
  * Generate a deterministic 3-digit suffix from username — pure hash.
  *


### PR DESCRIPTION
## Summary

Three small fixes bundled into one PR.

### 1. Bonaire flag (and 5 other 404s)

`circle-flags` doesn't ship a plain `bq.svg` — only the per-island variants `bq-bo.svg` (Bonaire), `bq-sa.svg` (Saba), `bq-se.svg` (Sint Eustatius). Same story for Saint Helena (`sh-hl`, `sh-ac`, `sh-ta` but no `sh.svg`). Four uninhabited dependencies (`bv`, `hm`, `sj`, `um`) ship nothing at all. The country lists in `AddMoney/consts/index.ts` reference all of these, so `/flags/<code>.svg` 404s and the UI falls back to the generic UN flag.

Extended the alias map in `scripts/copy-flags.mjs`:

| ISO-2 | mirrored from | rationale |
| --- | --- | --- |
| `bq` | `bq-bo.svg` | Bonaire flag (largest BES island, the one the user actually sees) |
| `sh` | `sh-hl.svg` | Saint Helena island flag |
| `bv` | `no.svg` | Bouvet — Norwegian dependency, uninhabited |
| `sj` | `no.svg` | Svalbard/Jan Mayen — Norwegian |
| `hm` | `au.svg` | Heard/McDonald — Australian, uninhabited |
| `um` | `us.svg` | US Minor Outlying Islands |

Verified locally — all 7 alias files generate post-`pnpm copy-flags`.

### 2. Circle-flags color accuracy (no code change)

Briefly investigated. circle-flags intentionally snaps every flag to a small standardized palette ("Try to match the flag's original colors with the nearest color from the palette" per the contributor guide) for visual consistency at small circular sizes. Fixable only by switching libraries (e.g. `flag-icons` + CSS mask) or self-patching individual SVGs. **Recommendation: keep as-is** — the drift is small, the library is the de-facto standard for circular flags, and Peanut isn't a vexillology app. Revisit if/when a specific flag looks wildly wrong.

### 3. Strip invite share copy

The old "I'm using Peanut, an invite-only app for easy payments…" blurb is gone. Share now copies just the invite link. `generateInvitesShareText` deleted from `general.utils.ts`; three call sites updated:

- `EarlyUserModal` → `<ShareButton url={inviteLink} />`
- `InviteFriendsModal` → `<ShareButton url={inviteLink} />`
- `TransactionDetailsReceipt` receipt CTA → `navigator.share({ url: inviteLink })`

`ShareButton.url` already handles toast + clipboard fallback.

## Test plan

- [ ] `pnpm test` — passes (52/52 in touched suites)
- [ ] Visit `/dev/components` or country picker → Bonaire row shows the correct flag, not the UN fallback
- [ ] Open Invite Friends modal → tap Share → clipboard contains only the invite URL (no marketing text)
- [ ] Same on a completed transaction receipt's "Invite friends to earn more rewards" CTA