### PR TITLE
fix(carousel): handle Brave SDK-fail, kill QR-payment flicker, surface dead clicks

### DIFF
--- a/src/components/0_Bruddle/Toast.tsx
+++ b/src/components/0_Bruddle/Toast.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { AnimatePresence, motion } from 'framer-motion'
-import React, { createContext, useCallback, useContext, useState } from 'react'
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 type ToastType = 'success' | 'error' | 'info' | 'warning'
@@ -74,13 +74,18 @@ export const ToastProvider = ({ children }: { children: React.ReactNode }) => {
         }, toast.duration)
     }, [])
 
-    const contextValue: ToastContextType = {
-        toast: createToast,
-        success: (message, options) => createToast({ ...options, type: 'success', message }),
-        error: (message, options) => createToast({ ...options, type: 'error', message }),
-        info: (message, options) => createToast({ ...options, type: 'info', message }),
-        warning: (message, options) => createToast({ ...options, type: 'warning', message }),
-    }
+    // Memoized so consumers that include this in effect/callback dep arrays
+    // don't re-fire on every render. createToast is already useCallback-stable.
+    const contextValue: ToastContextType = useMemo(
+        () => ({
+            toast: createToast,
+            success: (message, options) => createToast({ ...options, type: 'success', message }),
+            error: (message, options) => createToast({ ...options, type: 'error', message }),
+            info: (message, options) => createToast({ ...options, type: 'info', message }),
+            warning: (message, options) => createToast({ ...options, type: 'warning', message }),
+        }),
+        [createToast]
+    )
 
     const getPositionClasses = (position: ToastPosition = 'top-right') => {
         const positions: Record<ToastPosition, string> = {

--- a/src/hooks/useHomeCarouselCTAs.tsx
+++ b/src/hooks/useHomeCarouselCTAs.tsx
@@ -105,10 +105,9 @@ export const useHomeCarouselCTAs = () => {
     // done the action. Shares the React Query cache key with HomeHistory below, so
     // this read is free when the home page is mounted.
     const { data: latestHistory } = useTransactionHistory({ mode: 'latest', limit: 50 })
-    // `undefined` while history is loading — distinct from `false` (loaded, no
-    // QR pay) so we can gate the QR-payment CTA on "we actually know." Without
-    // this, the CTA flashes in on first paint then disappears once history
-    // resolves with a prior QR_PAY entry.
+    // `boolean | undefined` (no `?? false`) so the QR-payment CTA gate can
+    // distinguish "loaded, none found" from "still loading" — see the strict
+    // `=== false` check below.
     const hasMadeQrPayment: boolean | undefined = useMemo(
         () => latestHistory?.entries.some((e) => e.extraData?.kind === 'QR_PAY'),
         [latestHistory]
@@ -177,11 +176,8 @@ export const useHomeCarouselCTAs = () => {
                 },
             })
         }
-        // Show notification CTA only when the OneSignal SDK has actually loaded
-        // (Brave + Shields blocks the SDK script and the service worker, so the
-        // SDK never initializes — clicking would silently no-op since
-        // requestPermission early-returns on `!oneSignalInitialized`). Plus the
-        // usual permission/subscription gates.
+        // Brave Shields blocks the OneSignal SDK; requestPermission no-ops
+        // until init succeeds, so don't render a click-to-no-op CTA.
         if (oneSignalInitialized && !isPermissionGranted && !isPushOptedIn && isPwa) {
             _carouselCTAs.push({
                 id: 'notification-prompt',
@@ -199,17 +195,11 @@ export const useHomeCarouselCTAs = () => {
                     }
                     const result = await requestPermission()
                     await afterPermissionAttempt()
-                    // Result still 'default' means the browser either suppressed
-                    // the prompt (corporate policy, Shields, fingerprinting) or
-                    // the user dismissed it. Either way, calling again won't help
-                    // this session — dismiss the CTA and tell the user what
-                    // happened so they don't tap a dead button forever.
+                    // 'default' = browser suppressed prompt (policy/Shields) or
+                    // user dismissed it — calling again won't help this session.
                     if (result === 'default') {
-                        toast.info(
-                            'Your browser blocked the notification prompt. Enable notifications for Peanut in your browser settings, then reload.'
-                        )
-                        dismissedRef.current.set('notification-prompt', new Date())
-                        setCarouselCTAs((prev) => prev.filter((c) => c.id !== 'notification-prompt'))
+                        toast.warning('Notifications blocked by your browser. Enable them in site settings and reload.')
+                        dismissCTA('notification-prompt')
                     }
                 },
             })
@@ -229,11 +219,8 @@ export const useHomeCarouselCTAs = () => {
             })
         }
 
-        // Show QR code payment prompt if user's Bridge or Manteca KYC is approved
-        // AND we've confirmed (history loaded) they haven't used QR pay yet.
-        // `hasMadeQrPayment === false` distinguishes "loaded, none found" from
-        // `undefined` (still loading) — gating on the strict false avoids the
-        // flash-then-disappear when history resolves with a prior QR_PAY entry.
+        // Strict `=== false` gates on "history loaded, no QR pay" — `undefined`
+        // (still loading) keeps the CTA hidden so it doesn't flash in then out.
         if (hasKycApproval && hasMadeQrPayment === false) {
             _carouselCTAs.push({
                 id: 'qr-payment',
@@ -327,6 +314,7 @@ export const useHomeCarouselCTAs = () => {
         oneSignalInitialized,
         setIsIosPwaInstallModalOpen,
         toast,
+        dismissCTA,
     ])
 
     useEffect(() => {

--- a/src/hooks/useHomeCarouselCTAs.tsx
+++ b/src/hooks/useHomeCarouselCTAs.tsx
@@ -17,6 +17,7 @@ import { useActivationStatus } from './useActivationStatus'
 import { useTransactionHistory } from './useTransactionHistory'
 import { STAR_STRAIGHT_ICON } from '@/assets'
 import underMaintenanceConfig from '@/config/underMaintenance.config'
+import { useToast } from '@/components/0_Bruddle/Toast'
 
 // Days a dismissed CTA stays hidden before reappearing. Set above 1 so dismiss feels
 // "sticky" but below 14 so we still nudge users about valuable actions they haven't
@@ -76,8 +77,15 @@ export const useHomeCarouselCTAs = () => {
     const [carouselCTAs, setCarouselCTAs] = useState<CarouselCTA[]>([])
     const { user } = useAuth()
     const dismissedRef = useRef<Map<string, Date>>(new Map())
-    const { requestPermission, afterPermissionAttempt, isPermissionDenied, isPermissionGranted, isPushOptedIn } =
-        useNotifications()
+    const {
+        requestPermission,
+        afterPermissionAttempt,
+        isPermissionDenied,
+        isPermissionGranted,
+        isPushOptedIn,
+        oneSignalInitialized,
+    } = useNotifications()
+    const toast = useToast()
     const router = useRouter()
     const { isUserKycApproved, isUserBridgeKycUnderReview, isUserMantecaKycApproved } = useKycStatus()
     const { deviceType } = useDeviceType()
@@ -97,8 +105,12 @@ export const useHomeCarouselCTAs = () => {
     // done the action. Shares the React Query cache key with HomeHistory below, so
     // this read is free when the home page is mounted.
     const { data: latestHistory } = useTransactionHistory({ mode: 'latest', limit: 50 })
-    const hasMadeQrPayment = useMemo(
-        () => latestHistory?.entries.some((e) => e.extraData?.kind === 'QR_PAY') ?? false,
+    // `undefined` while history is loading — distinct from `false` (loaded, no
+    // QR pay) so we can gate the QR-payment CTA on "we actually know." Without
+    // this, the CTA flashes in on first paint then disappears once history
+    // resolves with a prior QR_PAY entry.
+    const hasMadeQrPayment: boolean | undefined = useMemo(
+        () => latestHistory?.entries.some((e) => e.extraData?.kind === 'QR_PAY'),
         [latestHistory]
     )
     const hasSentInvites = (user?.invitesSent?.length ?? 0) > 0
@@ -165,11 +177,12 @@ export const useHomeCarouselCTAs = () => {
                 },
             })
         }
-        // show notification cta only in pwa when the user is neither permission-granted
-        // (browser-native) nor opted-in (OneSignal subscription). Belt-and-suspenders
-        // because the two signals can diverge — e.g. browser permission revoked but
-        // OneSignal subscription still active.
-        if (!isPermissionGranted && !isPushOptedIn && isPwa) {
+        // Show notification CTA only when the OneSignal SDK has actually loaded
+        // (Brave + Shields blocks the SDK script and the service worker, so the
+        // SDK never initializes — clicking would silently no-op since
+        // requestPermission early-returns on `!oneSignalInitialized`). Plus the
+        // usual permission/subscription gates.
+        if (oneSignalInitialized && !isPermissionGranted && !isPushOptedIn && isPwa) {
             _carouselCTAs.push({
                 id: 'notification-prompt',
                 title: 'Stay in the loop!',
@@ -184,8 +197,20 @@ export const useHomeCarouselCTAs = () => {
                         setIsIosPwaInstallModalOpen(true)
                         return
                     }
-                    await requestPermission()
+                    const result = await requestPermission()
                     await afterPermissionAttempt()
+                    // Result still 'default' means the browser either suppressed
+                    // the prompt (corporate policy, Shields, fingerprinting) or
+                    // the user dismissed it. Either way, calling again won't help
+                    // this session — dismiss the CTA and tell the user what
+                    // happened so they don't tap a dead button forever.
+                    if (result === 'default') {
+                        toast.info(
+                            'Your browser blocked the notification prompt. Enable notifications for Peanut in your browser settings, then reload.'
+                        )
+                        dismissedRef.current.set('notification-prompt', new Date())
+                        setCarouselCTAs((prev) => prev.filter((c) => c.id !== 'notification-prompt'))
+                    }
                 },
             })
         }
@@ -205,8 +230,11 @@ export const useHomeCarouselCTAs = () => {
         }
 
         // Show QR code payment prompt if user's Bridge or Manteca KYC is approved
-        // AND they haven't already used QR pay (educational CTA — no point once adopted).
-        if (hasKycApproval && !hasMadeQrPayment) {
+        // AND we've confirmed (history loaded) they haven't used QR pay yet.
+        // `hasMadeQrPayment === false` distinguishes "loaded, none found" from
+        // `undefined` (still loading) — gating on the strict false avoids the
+        // flash-then-disappear when history resolves with a prior QR_PAY entry.
+        if (hasKycApproval && hasMadeQrPayment === false) {
             _carouselCTAs.push({
                 id: 'qr-payment',
                 title: (
@@ -296,6 +324,9 @@ export const useHomeCarouselCTAs = () => {
         isActivated,
         hasMadeQrPayment,
         hasSentInvites,
+        oneSignalInitialized,
+        setIsIosPwaInstallModalOpen,
+        toast,
     ])
 
     useEffect(() => {

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import OneSignal from 'react-onesignal'
+import { captureException } from '@sentry/nextjs'
 import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils'
 import { useUserStore } from '@/redux/hooks'
 import posthog from 'posthog-js'
@@ -256,7 +257,13 @@ export function useNotifications() {
                 setOneSignalInitialized(true)
                 setSdkReady(true)
             } catch (e) {
+                // OneSignal init failures were previously swallowed with console.warn,
+                // so we had zero visibility on Brave/Android where Shields blocks the
+                // SDK script + service worker registration. Without this, the
+                // notification CTA renders but every click no-ops (requestPermission
+                // returns early when oneSignalInitialized stays false).
                 console.warn('OneSignal init failed', e)
+                captureException(e, { tags: { source: 'onesignal_init' } })
             }
         }
 
@@ -278,6 +285,7 @@ export function useNotifications() {
             }
         } catch (error) {
             console.warn('Error requesting permission:', error)
+            captureException(error, { tags: { source: 'onesignal_request_permission' } })
         } finally {
             setIsRequestingPermission(false)
         }
@@ -369,5 +377,6 @@ export function useNotifications() {
         isPushOptedIn,
         isRequestingPermission,
         refreshPermissionState,
+        oneSignalInitialized,
     }
 }

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -257,11 +257,7 @@ export function useNotifications() {
                 setOneSignalInitialized(true)
                 setSdkReady(true)
             } catch (e) {
-                // OneSignal init failures were previously swallowed with console.warn,
-                // so we had zero visibility on Brave/Android where Shields blocks the
-                // SDK script + service worker registration. Without this, the
-                // notification CTA renders but every click no-ops (requestPermission
-                // returns early when oneSignalInitialized stays false).
+                // Surface Brave/Shields SDK-block failures; previously silent.
                 console.warn('OneSignal init failed', e)
                 captureException(e, { tags: { source: 'onesignal_init' } })
             }


### PR DESCRIPTION
Follow-up to #2003. Three real bugs Hugo hit on Brave Beta phone after testing on staging.

## Diagnosis (and why we missed it before)

Hugo's clicks on the \"Stay in the loop\" CTA produced **zero \`notification_permission_requested\` events in PostHog over multiple sessions** on Brave Beta Android. That event is the FIRST thing \`requestPermission()\` fires, so the click never reached the OneSignal call.

The only path that skips the posthog event is the early return:

\`\`\`ts
if (typeof window === 'undefined' || !oneSignalInitialized) return 'default'
\`\`\`

So \`oneSignalInitialized\` was \`false\` when Hugo clicked. Brave Shields almost certainly blocks the OneSignal SDK script + service-worker registration. The bootstrap catch in \`useNotifications.ts\` swallowed the failure with \`console.warn\` — no Sentry, no posthog — so we had zero signal.

## What this PR fixes

### 1. \"Stay in the loop\" silent dead-click (Brave Shields)

- **Capture init + request-permission errors to Sentry.** Adds tagged \`captureException\` to both catches. Next failure on any browser surfaces.
- **Gate the notification CTA on \`oneSignalInitialized\`.** Expose the flag from \`useNotifications\` and require it before rendering the CTA. If the SDK never loads (Brave), the user simply doesn't see a button whose click is guaranteed to no-op. Better than a dead button.
- **Surface \`requestPermission() === 'default'\` to the user.** If the SDK is loaded but the browser suppressed the prompt (corporate policy, fingerprinting, user dismissed), show a toast pointing them at browser settings and dismiss the CTA for this session.

### 2. CTA persists across app sessions

After a silent no-op tap, Hugo closed the app and reopened — same CTA. Currently the CTA only dismisses via the X button or when permission state flips, neither of which happens during a silent fail.

**Fix:** if \`requestPermission()\` returns \`'default'\` (no progress), mark the CTA dismissed for this session. Combined with the SDK-init gate above, the CTA also won't reappear on next mount if the SDK still can't load.

### 3. QR-payment CTA flicker

The CTA appears for one paint, then disappears. Root cause:

\`\`\`ts
// Before — '?? false' defaults to 'never made QR pay' while history loads
const hasMadeQrPayment = latestHistory?.entries.some((e) => e.extraData?.kind === 'QR_PAY') ?? false

// CTA gate: hasKycApproval && !hasMadeQrPayment
// → true initially (hasMadeQrPayment is the default false)
// → flips to false once history resolves with a prior QR_PAY entry
\`\`\`

Same flicker pattern as the iOS PWA install CTA fixed in #2003 via \`usePWAStatus\` sync init.

**Fix:** let \`hasMadeQrPayment\` be \`boolean | undefined\`. Gate on \`hasMadeQrPayment === false\` so the CTA only appears once we've confirmed the user has no QR_PAY entry. \`undefined\` (still loading) hides it.

## Justification — why this slipped past #2003

#2003 handled the three post-init permission states (granted/denied/default-after-prompt). It didn't contemplate **SDK-never-initialized** as a fourth state. The only way that state would have been on the radar is a Sentry signal — and we didn't have Sentry capture on the init path. Adding it now (plus the gate that hides the CTA entirely in that state) closes the loop both for users (no dead button) and for us (we'll see future failures).

The QR-payment flicker is structurally identical to the iOS PWA-install flicker — initial state defaults to \"render the CTA\" while loading, resolves to \"hide it\" after data lands. The install gate got fixed via \`usePWAStatus\` synchronous init; the QR gate just needed the same \"are we sure?\" check.

## Files

- \`src/hooks/useNotifications.ts\` — Sentry captures + expose \`oneSignalInitialized\`
- \`src/hooks/useHomeCarouselCTAs.tsx\` — SDK-init gate, silent-failure toast, session dismiss, QR flicker gate

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`npm test\` — 51 suites / 1068 passing (unchanged)
- [ ] Staging on Brave Beta Android: tap \"Stay in the loop\" → SDK fails to init → CTA disappears on next mount (was: persistent dead button)
- [ ] Staging on Brave with Shields off: tap → prompt appears → grant → CTA disappears (was: same, still works)
- [ ] Staging on iOS Safari PWA: notification CTA still works end-to-end
- [ ] Staging anywhere: tap \"Stay in the loop\" → dismiss browser prompt → toast appears + CTA disappears for session (was: CTA persisted)
- [ ] Staging with a prior QR pay: no QR-payment CTA flash on home page load (was: brief flash then hide)

## Regression risk

- The SDK-init gate means users where OneSignal load is briefly delayed (slow network, large bundle) might not see the notification CTA at all on cold start. Acceptable — they can refresh or revisit. Beats a dead button.
- The Sentry capture will produce new error volume for Brave/Shields users. That's the point — we need the signal. Tag is \`source:onesignal_init\` / \`source:onesignal_request_permission\` for easy filtering/triage.