### PR TITLE
fix(history): refuse to build /claim URL when send-link IDs are missing

### DIFF
--- a/src/utils/__tests__/history.utils.test.ts
+++ b/src/utils/__tests__/history.utils.test.ts
@@ -16,8 +16,9 @@ import { completeHistoryEntry } from '../history.utils'
 import type { HistoryEntry } from '../history.utils'
 
 jest.mock('@/app/actions/currency', () => ({ getCurrencyPrice: jest.fn() }))
+const mockGetFromLocalStorage = jest.fn(() => null as string | null)
 jest.mock('@/utils/general.utils', () => ({
-    getFromLocalStorage: jest.fn(() => null),
+    getFromLocalStorage: (...args: unknown[]) => mockGetFromLocalStorage(...(args as [])),
     getTokenDetails: jest.fn(() => ({ symbol: 'USDC', decimals: 6 })),
 }))
 
@@ -78,5 +79,50 @@ describe('completeHistoryEntry amount-contract guards', () => {
             extraData: { ...baseEntry.extraData, kind: 'CRYPTO_DEPOSIT' },
         }
         await expect(completeHistoryEntry(entry)).resolves.toBeDefined()
+    })
+})
+
+describe('completeHistoryEntry SEND_LINK shareable URL', () => {
+    // BE staging shipped SEND_LINK rows missing extraData.contractVersion +
+    // extraData.depositIdx (decomplexify Phase 2 mapper drop). Without a
+    // guard, raw template interpolation produced /claim?v=undefined&i=undefined,
+    // which broke claim AND cancel — sender clicked Cancel, SDK threw
+    // "No Peanut vault for chainId=42161 version=undefined".
+    beforeEach(() => mockGetFromLocalStorage.mockReset())
+
+    it('builds the share URL when password + contractVersion + depositIdx are present', async () => {
+        mockGetFromLocalStorage.mockReturnValue('test-password')
+        const entry: HistoryEntry = {
+            ...baseEntry,
+            extraData: {
+                ...baseEntry.extraData,
+                kind: 'SEND_LINK',
+                contractVersion: 'v4.3',
+                depositIdx: 7,
+            },
+        }
+        const result = await completeHistoryEntry(entry)
+        // shareableUrl prepends window.location.origin (jsdom: http://localhost).
+        expect(result.extraData?.link).toBe(`${window.location.origin}/claim?c=42161&v=v4.3&i=7#p=test-password`)
+    })
+
+    it('skips the URL build when contractVersion is missing — no v=undefined leak', async () => {
+        mockGetFromLocalStorage.mockReturnValue('test-password')
+        const entry: HistoryEntry = {
+            ...baseEntry,
+            extraData: { ...baseEntry.extraData, kind: 'SEND_LINK', depositIdx: 7 },
+        }
+        const result = await completeHistoryEntry(entry)
+        expect(result.extraData?.link).toBe('')
+    })
+
+    it('skips the URL build when depositIdx is missing — no i=undefined leak', async () => {
+        mockGetFromLocalStorage.mockReturnValue('test-password')
+        const entry: HistoryEntry = {
+            ...baseEntry,
+            extraData: { ...baseEntry.extraData, kind: 'SEND_LINK', contractVersion: 'v4.3' },
+        }
+        const result = await completeHistoryEntry(entry)
+        expect(result.extraData?.link).toBe('')
     })
 })

--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -290,7 +290,12 @@ export async function completeHistoryEntry(entry: HistoryEntry): Promise<History
             const lookupKey = extraData.parentSendLinkPubKey ?? entry.uuid
             const password = getFromLocalStorage(`sendLink::password::${lookupKey}`)
             const { contractVersion, depositIdx } = extraData
-            if (password) {
+            // Skip URL build if BE didn't supply contractVersion + depositIdx —
+            // raw template interpolation produces literal "undefined" strings,
+            // which serialised as ?v=undefined&i=undefined and broke claim +
+            // cancel. The drawer falls back to "use device where created" copy
+            // when link is empty.
+            if (password && contractVersion != null && depositIdx != null) {
                 link = shareableUrl(`/claim?c=${entry.chainId}&v=${contractVersion}&i=${depositIdx}#p=${password}`)
             }
             const tokenDetails = getTokenDetails({


### PR DESCRIPTION
## Summary

- **Defensive guard** against the BE SEND_LINK extraData regression on `dev` (decomplexify `mapGenericIntent` dropped `contractVersion` + `depositIdx`).
- Without this guard, raw template interpolation produced literal `?v=undefined&i=undefined` query params. Sender clicked Cancel → SDK threw `No Peanut vault for chainId=42161 version=undefined`. Recipients hit the same broken URL on claim.
- The BE fix lives in https://github.com/peanutprotocol/peanut-api-ts/pull/769. This PR is the FE side of the same incident: even after the BE is fixed, this guard ensures a future regression can't silently leak `undefined` URLs.

## Behavior change

`completeHistoryEntry` SEND_LINK arm at `src/utils/history.utils.ts:294`:

| extraData | Before | After |
|---|---|---|
| `{contractVersion: 'v4.3', depositIdx: 7}` (well-formed) | `/claim?c=42161&v=v4.3&i=7#p=...` | `/claim?c=42161&v=v4.3&i=7#p=...` (unchanged) |
| `{depositIdx: 7}` (missing version) | `/claim?c=...&v=undefined&i=7#p=...` ❌ | `link=''` → drawer falls back to "use device where created" copy |
| `{contractVersion: 'v4.3'}` (missing idx) | `/claim?c=...&v=v4.3&i=undefined#p=...` ❌ | `link=''` → drawer falls back |

## Verify gap

The existing `src/utils/__tests__/history.utils.test.ts` mocked `getFromLocalStorage → null`, which skipped the `link` builder branch entirely — so even with deliberately-broken extraData the test passed. Extended the test to mock a password and assert link well-formedness directly.

## What's in this PR

1. **Guard** in `src/utils/history.utils.ts:293` — only build the URL when both `contractVersion` and `depositIdx` are non-nullish.
2. **3 new test cases** in `src/utils/__tests__/history.utils.test.ts` covering well-formed / missing-version / missing-idx. Verified the two new "missing" cases fail without the guard.

## Cross-repo

Pair with: https://github.com/peanutprotocol/peanut-api-ts/pull/769 (BE fix that restores the dropped fields).

## Test plan

- [x] `npx jest src/utils/__tests__/history.utils.test.ts` — 11/11 pass
- [x] Verified the 2 new "missing field" tests fail when the guard is reverted (stash + run)
- [ ] After merge + BE merge + staging deploy: create a fresh send-link on staging, copy URL, confirm `?v=X.X&i=N` (not `undefined`), confirm cancel succeeds