### PR TITLE
fix(ui): icon sizing QA follow-ups (Koshagra)

### DIFF
--- a/src/app/(mobile-ui)/home/page.tsx
+++ b/src/app/(mobile-ui)/home/page.tsx
@@ -380,16 +380,17 @@ function ActionButtonWithHref({ label, action, href, variant = 'primary-soft', s
 }
 
 function ActionButton({ label, action, variant = 'primary-soft', size = 'small' }: Omit<ActionButtonProps, 'href'>) {
+    const iconSize = size === 'large' ? 18 : 16
     const renderIcon = (): React.ReactNode => {
         switch (action) {
             case 'send':
-                return <Icon name="arrow-up-right" size={18} fill="currentColor" />
+                return <Icon name="arrow-up-right" size={iconSize} fill="currentColor" />
             case 'withdraw':
-                return <Icon name="arrow-up" size={18} fill="currentColor" />
+                return <Icon name="arrow-up" size={iconSize} fill="currentColor" />
             case 'add':
-                return <Icon name="arrow-down" size={18} fill="currentColor" />
+                return <Icon name="arrow-down" size={iconSize} fill="currentColor" />
             case 'request':
-                return <Icon name="arrow-down-left" size={18} fill="currentColor" />
+                return <Icon name="arrow-down-left" size={iconSize} fill="currentColor" />
             default:
                 return null
         }

--- a/src/components/Global/ExchangeRateWidget/index.tsx
+++ b/src/components/Global/ExchangeRateWidget/index.tsx
@@ -209,7 +209,7 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
                                     height={160}
                                     className="size-4 rounded-full object-cover"
                                 />
-                                {sourceCurrency} <Icon name="chevron-down" className="text-gray-1" size={10} />
+                                {sourceCurrency} <Icon name="chevron-down" className="text-gray-1" size={14} />
                             </button>
                         }
                     />
@@ -268,7 +268,7 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
                                     height={160}
                                     className="size-4 rounded-full object-cover"
                                 />
-                                {destinationCurrency} <Icon name="chevron-down" className="text-gray-1" size={10} />
+                                {destinationCurrency} <Icon name="chevron-down" className="text-gray-1" size={14} />
                             </button>
                         }
                     />
@@ -313,7 +313,7 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
 
             {typeof destinationAmount === 'number' && destinationAmount > 0 && (
                 <div className="flex items-center">
-                    <Icon name="info" className="text-gray-1" size={10} />
+                    <Icon name="info" className="text-gray-1" size={14} />
                     <p className="text-xs text-gray-1">{deliveryTimeText}</p>
                 </div>
             )}

--- a/src/components/Profile/components/ProfileHeader.tsx
+++ b/src/components/Profile/components/ProfileHeader.tsx
@@ -51,7 +51,7 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
                         haveSentMoneyToUser={haveSentMoneyToUser}
                         isAuthenticatedUserVerified={isAuthenticatedUserVerified && isSelfProfile} // can be true only for self profile
                     />
-                    <CopyToClipboard textToCopy={username} fill="black" iconSize="4" />
+                    <CopyToClipboard textToCopy={username} fill="black" iconSize="6" />
                 </div>
                 {/* Username with share drawer */}
                 {showShareButton && (

--- a/src/components/Profile/components/PublicProfile.tsx
+++ b/src/components/Profile/components/PublicProfile.tsx
@@ -117,9 +117,7 @@ const PublicProfile: React.FC<PublicProfileProps> = ({ username, isLoggedIn = fa
                             shadowSize="4"
                             className="flex w-1/2 items-center justify-center gap-2 rounded-full py-3"
                         >
-                            <div className="flex size-5 items-center justify-center">
-                                <Icon name="arrow-up-right" size={8} fill="black" />
-                            </div>
+                            <Icon name="arrow-up-right" size={18} fill="black" />
                             <span className="font-bold">Send</span>
                         </Button>
 
@@ -135,9 +133,7 @@ const PublicProfile: React.FC<PublicProfileProps> = ({ username, isLoggedIn = fa
                             shadowSize="4"
                             className="flex w-1/2 items-center justify-center gap-2 rounded-full py-3"
                         >
-                            <div className="flex size-5 items-center justify-center">
-                                <Icon name="arrow-down-left" size={8} fill="black" />
-                            </div>
+                            <Icon name="arrow-down-left" size={18} fill="black" />
                             <span className="font-bold">Request</span>
                         </Button>
                     </div>

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -495,7 +495,7 @@ export const TransactionDetailsReceipt = ({
                                         className="flex items-center gap-2 hover:underline"
                                     >
                                         <span>{shortenStringLong(transaction.txHash)}</span>
-                                        <Icon name="external-link" size={12} />
+                                        <Icon name="external-link" size={14} />
                                     </Link>
                                 ) : (
                                     <div className="flex items-center gap-2">
@@ -626,7 +626,7 @@ export const TransactionDetailsReceipt = ({
                                     className="flex items-center underline"
                                 >
                                     Download
-                                    <Icon name="download" className="h-3" />
+                                    <Icon name="download" size={14} />
                                 </Link>
                             }
                             hideBottomBorder


### PR DESCRIPTION
## Summary

Item-by-item fixes for the icon-sizing notes Koshagra flagged in QA, plus two extras from Hugo's session.

### Items addressed

| # | Source | Issue | Fix |
|---|---|---|---|
| 1 | Hugo | Home: Add/Withdraw arrows same size as Send/Request even though their buttons are smaller | \`ActionButton\` now picks iconSize from the button size prop — 16 for \`small\` (Add/Withdraw), 18 for \`large\` (Send/Request) |
| 2 | Hugo | Public-profile Send/Request arrows tiny | \`PublicProfile.tsx\`: was \`<Icon size={8}>\` inside a 20px wrapper div. Dropped wrapper, bumped icon to 18 (matches home Send/Request) |
| 3 | Koshagra | Exchange-rate widget chevrons too small | \`ExchangeRateWidget\`: 2 chevron-down (currency pickers) + 1 info-glyph (delivery time): 10 → 14 |
| 4 | Koshagra | Copy-username icon too small, had to focus-tap | \`ProfileHeader\`: \`<CopyToClipboard iconSize="4">\` → \`"6"\` (16 → 24px) |
| 5 | Hugo / Koshagra | External-link icon on tx hashes | \`TransactionDetailsReceipt\`: 12 → 14 |
| 6 | Hugo / Koshagra | Activity drawer audit | Found one stretched icon: \`<Icon name="download" className="h-3">\` was 12px tall × 24px wide because only height was set and Icon defaults width to 24. Switched to \`size={14}\` for proper proportions. Other drawer icons (14, 16, 18, 20) looked fine, left alone. |

Notes:
- Koshagra's "icons on activity drawers smaller than earlier" — most are fine. The only fix needed there was the download glyph (above).
- "Chevron too big in back and country select" is struck out in Koshagra's notes (already addressed in earlier PRs).

### Test plan

- [ ] \`/home\` — Add/Withdraw arrows look ~2px smaller than Send/Request arrows
- [ ] Visit any other user's profile (\`/{username}\`) — Send + Request arrows are clearly visible, similar weight to home arrows
- [ ] Exchange-rate widget (Profile → Exchange rate, or any flow that shows it): chevron-down next to flag is bigger, info-glyph next to delivery time is bigger
- [ ] Profile header — copy-username icon is bigger (24px), easier to tap
- [ ] Transaction detail with an on-chain tx — external-link icon next to hash slightly bigger
- [ ] Transaction detail with an attachment — "Download" link's icon is properly square, not stretched