### PR TITLE
test(types): FE half of FE↔BE api-key contract

### DIFF
--- a/src/types/__tests__/api-key-contract.test.ts
+++ b/src/types/__tests__/api-key-contract.test.ts
@@ -1,0 +1,44 @@
+import openapi from '../api.openapi.json'
+
+// FE↔BE contract: peanut-ui auths via JWT Bearer only; `apiFetch` does not
+// send an `Api-Key` header. Any route in the committed OpenAPI snapshot that
+// requires `api-key` is therefore uncallable from the UI and will return
+// 4xx for every user. This regression has shipped twice (PR #766 for
+// /charges, PR peanut-api-ts#773 for bank/*); this test is the FE half of
+// the guard. The BE half lives in peanut-api-ts at
+// test/unit/api-key-leak.test.ts.
+//
+// The snapshot is refreshed by `pnpm gen:api:live` (curls the running API).
+// If the BE drifts and an api-key requirement comes back, refreshing the
+// snapshot trips this test.
+//
+// Allowlist: paths under /points/admin/* are intentional — chip-side scripts
+// hit them with a 'points'-permission key, never the UI.
+
+const ALLOWED_REQUIRED_PATHS = [/^\/points\/admin(\/|$)/]
+
+type HeaderParam = { in?: string; name?: string; required?: boolean }
+type Operation = { parameters?: HeaderParam[] }
+type Paths = Record<string, Record<string, Operation>>
+
+const paths = (openapi as unknown as { paths: Paths }).paths
+
+describe('FE↔BE contract: UI-callable routes must not require api-key', () => {
+    it('no route in the committed OpenAPI snapshot requires api-key (outside allowlist)', () => {
+        const offenders: string[] = []
+        for (const [path, methods] of Object.entries(paths)) {
+            if (ALLOWED_REQUIRED_PATHS.some((re) => re.test(path))) continue
+            for (const [method, op] of Object.entries(methods)) {
+                if (!op || typeof op !== 'object') continue
+                const params = op.parameters ?? []
+                for (const p of params) {
+                    if (p.in === 'header' && p.name?.toLowerCase() === 'api-key' && p.required === true) {
+                        offenders.push(`${method.toUpperCase()} ${path}`)
+                        break
+                    }
+                }
+            }
+        }
+        expect(offenders).toEqual([])
+    })
+})


### PR DESCRIPTION
## Why

Companion to [peanut-api-ts#773](https://github.com/peanutprotocol/peanut-api-ts/pull/773). The BE half is locked in there — no route under \`src/routes/**\` can require \`api-key\` (schema-level \`Type.String\` or handler-level \`assertApiKey\`) outside a tiny allowlist. This PR adds the symmetric FE half so the contract is bidirectional.

UI auth is JWT Bearer only — \`apiFetch\` (\`src/utils/api-fetch.ts\`) does not attach an \`Api-Key\` header. Any BE route that requires \`api-key\` is therefore uncallable from the UI and returns 4xx for every user. This shape has shipped twice now:

1. **#766** (\`/charges\` + \`/card/purchase\`) — fixed.
2. **peanut-api-ts#773** (\`/is-valid-bic\`, \`/validate-bank-account-number\`) — in flight.

## What

\`src/types/__tests__/api-key-contract.test.ts\` walks every operation in the committed OpenAPI snapshot (\`src/types/api.openapi.json\`, refreshed by \`pnpm gen:api:live\`) and fails the build if any operation declares an \`api-key\` header parameter with \`required: true\`, except for paths under \`/points/admin/*\` (internal admin endpoint, intentional).

Deterministic — pure JSON walk, no app boot, no network. Runs alongside the existing Jest suite.

## Why this catches future drift

The contract test reads the **committed** snapshot, and \`pnpm gen:api:live\` refreshes it by curling a running peanut-api-ts. So the workflow is:

1. BE adds an \`api-key\` requirement back (deliberately or by mistake).
2. FE dev runs \`pnpm gen:api:live\` (or the type-gen step runs in CI when the BE OpenAPI changes).
3. \`api.openapi.json\` updates.
4. This test fails the PR.

Even if step 2 doesn't happen immediately, the BE-side guard in #773 already fails the BE PR — so the regression is caught at the BE side first. This is the second layer.

## Out of scope

- Cleaning up the 36 routes that still declare \`'api-key': Type.Optional(Type.String())\` in their headers schema on the BE side. Functionally harmless (Fastify accepts the missing header) but it's leftover cruft from the \`eb616b8c\` migration.
- The \`iban-to-bic\` stale-dataset issue that triggered the original report (missing bank code 0075 for Banco Popular). Tracked separately — likely action is to drop the BIC field entirely (Bridge accepts SEPA IBAN-only).

## QA

- \`npx jest src/types/__tests__/api-key-contract.test.ts\` passes.
- Sanity check: temporarily removing \`/points/admin\` from \`ALLOWED_REQUIRED_PATHS\` makes the test fail, naming \`POST /points/admin/adjust\` as the offender — confirming the assertion is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)