### PR TITLE
fix(xchain spend): pass principal+fee USDC on both crypto-withdraw and request-pay (TASK-19573)

### DIFF
--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -68,6 +68,7 @@ export default function WithdrawCryptoPage() {
     const {
         transactions,
         receiveAmount,
+        payAmount,
         feeUsd,
         isCalculating,
         isXChain,
@@ -324,7 +325,13 @@ export default function WithdrawCryptoPage() {
                 }
                 finalTxHash = (receipt?.transactionHash as Hex | undefined) ?? userOpHash ?? txHash
             } else {
-                const requiredUsdcAmount = parseUnits(usdAmount.toString(), PEANUT_WALLET_TOKEN_DECIMALS)
+                // payAmount is the USDC the kernel actually needs on-hand to execute
+                // the first tx — principal + Rhino fee on the SDA path (mode='receive'),
+                // principal on the bridge path. Passing the principal alone here
+                // under-funds the mixed-strategy collateral sweep and the subsequent
+                // transfer reverts with `ERC20: transfer amount exceeds balance`.
+                const sourceUsdcAmount = payAmount ?? usdAmount.toString()
+                const requiredUsdcAmount = parseUnits(sourceUsdcAmount, PEANUT_WALLET_TOKEN_DECIMALS)
                 const txResult = await sendTransactions(transactions, {
                     chainId: PEANUT_WALLET_CHAIN.id.toString(),
                     requiredUsdcAmount,
@@ -394,6 +401,8 @@ export default function WithdrawCryptoPage() {
         amountToWithdraw,
         address,
         transactions,
+        payAmount,
+        usdAmount,
         sendTransactions,
         sendMoney,
         isCrossChainWithdrawal,

--- a/src/features/payments/flows/semantic-request/useSemanticRequestFlow.ts
+++ b/src/features/payments/flows/semantic-request/useSemanticRequestFlow.ts
@@ -14,7 +14,7 @@
  */
 
 import { useCallback, useMemo, useEffect, useContext, useState } from 'react'
-import { type Address, type Hash } from 'viem'
+import { parseUnits, type Address, type Hash } from 'viem'
 import { useSemanticRequestFlowContext } from './SemanticRequestFlowContext'
 import { useChargeManager } from '@/features/payments/shared/hooks/useChargeManager'
 import { usePaymentRecorder } from '@/features/payments/shared/hooks/usePaymentRecorder'
@@ -22,7 +22,7 @@ import { useCrossChainTransfer } from '@/features/payments/shared/hooks/useCross
 import { useWallet } from '@/hooks/wallet/useWallet'
 import { useAuth } from '@/context/authContext'
 import { tokenSelectorContext } from '@/context'
-import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants/zerodev.consts'
+import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN, PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
 import { ErrorHandler } from '@/utils/friendly-error.utils'
 import { areEvmAddressesEqual } from '@/utils/general.utils'
 import { useQueryClient } from '@tanstack/react-query'
@@ -71,6 +71,7 @@ export function useSemanticRequestFlow() {
         transactions: routeTransactions,
         estimatedGasCostUsd: calculatedGasCost,
         receiveAmount: calculatedReceiveAmount,
+        payAmount: calculatedPayAmount,
         feeUsd: calculatedFeeUsd,
         calculate: calculateRoute,
         isCalculating: isCalculatingRoute,
@@ -500,13 +501,30 @@ export function useSemanticRequestFlow() {
                 // sibling site at line ~293 for the same fallback.
                 hash = (txResult.receipt?.transactionHash ?? txResult.userOpHash ?? txResult.txHash) as Hash
             } else if (needsRoute && routeTransactions && routeTransactions.length > 0) {
-                // cross-chain or token swap payment via Rhino SDA
+                // cross-chain or token swap payment via Rhino SDA. Pass
+                // `requiredUsdcAmount = payAmount` (principal + Rhino fee on SDA
+                // path) so a collateral-only payer auto-tops-up the kernel from
+                // their card before the route's transfer fires; without this,
+                // `useWallet.sendTransactions` falls through to the smart-only
+                // legacy path and the spend reverts with ERC20 insufficient
+                // balance. payAmount is null only when the route hasn't been
+                // calculated yet — gated by `needsRoute && routeTransactions`.
+                const requiredUsdcAmount = calculatedPayAmount
+                    ? parseUnits(calculatedPayAmount, PEANUT_WALLET_TOKEN_DECIMALS)
+                    : undefined
                 const txResult = await sendTransactions(
                     routeTransactions.map((tx) => ({
                         to: tx.to,
                         data: tx.data,
                         value: tx.value,
-                    }))
+                    })),
+                    requiredUsdcAmount !== undefined
+                        ? {
+                              chainId: PEANUT_WALLET_CHAIN.id.toString(),
+                              requiredUsdcAmount,
+                              kind: 'REQUEST_PAY',
+                          }
+                        : undefined
                 )
                 hash = (txResult.receipt?.transactionHash ?? txResult.userOpHash) as Hash
             } else {
@@ -556,6 +574,7 @@ export function useSemanticRequestFlow() {
         charge,
         needsRoute,
         routeTransactions,
+        calculatedPayAmount,
         selectedChainID,
         selectedTokenAddress,
         selectedTokenData,

--- a/src/features/payments/shared/hooks/useCrossChainTransfer.ts
+++ b/src/features/payments/shared/hooks/useCrossChainTransfer.ts
@@ -106,6 +106,14 @@ export interface UseCrossChainTransferReturn {
     transactions: PreparedTransaction[] | null
     sdaAddress: Address | null
     receiveAmount: string | null
+    /** USDC the kernel actually needs on-hand to execute `transactions[0]` — this
+     *  is principal + Rhino fee on the SDA path (where mode='receive' and Rhino
+     *  takes the fee at source) and equals principal on the bridge / same-chain
+     *  paths. Callers that route through `sendTransactions({ requiredUsdcAmount })`
+     *  MUST pass this, not the principal, or the kernel's collateral-sweep
+     *  shortfall is under-funded and the subsequent transfer reverts with
+     *  `ERC20: transfer amount exceeds balance`. */
+    payAmount: string | null
     feeUsd: number | undefined
     estimatedGasCostUsd: number | undefined
     minDepositLimitUsd: number | undefined
@@ -153,6 +161,7 @@ export function useCrossChainTransfer(): UseCrossChainTransferReturn {
     const [transactions, setTransactions] = useState<PreparedTransaction[] | null>(null)
     const [sdaAddress, setSdaAddress] = useState<Address | null>(null)
     const [receiveAmount, setReceiveAmount] = useState<string | null>(null)
+    const [payAmount, setPayAmount] = useState<string | null>(null)
     const [feeUsd, setFeeUsd] = useState<number | undefined>(undefined)
     const [estimatedGasCostUsd, setEstimatedGasCostUsd] = useState<number | undefined>(undefined)
     const [minDepositLimitUsd, setMinDepositLimitUsd] = useState<number | undefined>(undefined)
@@ -170,6 +179,7 @@ export function useCrossChainTransfer(): UseCrossChainTransferReturn {
         setTransactions(null)
         setSdaAddress(null)
         setReceiveAmount(null)
+        setPayAmount(null)
         setFeeUsd(undefined)
         setEstimatedGasCostUsd(undefined)
         setMinDepositLimitUsd(undefined)
@@ -222,6 +232,7 @@ export function useCrossChainTransfer(): UseCrossChainTransferReturn {
             setTransactions(null)
             setSdaAddress(null)
             setReceiveAmount(null)
+            setPayAmount(null)
             setFeeUsd(undefined)
             setEstimatedGasCostUsd(undefined)
             setPath(null)
@@ -243,6 +254,7 @@ export function useCrossChainTransfer(): UseCrossChainTransferReturn {
                         setEstimatedGasCostUsd,
                         setIsFeeEstimationError,
                         setReceiveAmount,
+                        setPayAmount,
                         skipGasEstimate,
                     })
                     setPath('same-chain')
@@ -280,6 +292,7 @@ export function useCrossChainTransfer(): UseCrossChainTransferReturn {
                         tokenSymbol,
                         setTransactions,
                         setReceiveAmount,
+                        setPayAmount,
                         setFeeUsd,
                         setEstimatedGasCostUsd,
                         setIsFeeEstimationError,
@@ -317,6 +330,7 @@ export function useCrossChainTransfer(): UseCrossChainTransferReturn {
                     setTransactions,
                     setSdaAddress,
                     setReceiveAmount,
+                    setPayAmount,
                     setFeeUsd,
                     setMinDepositLimitUsd,
                     setMaxDepositLimitUsd,
@@ -340,6 +354,7 @@ export function useCrossChainTransfer(): UseCrossChainTransferReturn {
         transactions,
         sdaAddress,
         receiveAmount,
+        payAmount,
         feeUsd,
         estimatedGasCostUsd,
         minDepositLimitUsd,
@@ -367,6 +382,7 @@ interface BridgePathParams {
     tokenSymbol: string
     setTransactions: (tx: PreparedTransaction[] | null) => void
     setReceiveAmount: (v: string | null) => void
+    setPayAmount: (v: string | null) => void
     setFeeUsd: (v: number | undefined) => void
     setEstimatedGasCostUsd: (v: number | undefined) => void
     setIsFeeEstimationError: (v: boolean) => void
@@ -387,6 +403,7 @@ async function runBridgePath({
     tokenSymbol,
     setTransactions,
     setReceiveAmount,
+    setPayAmount,
     setFeeUsd,
     setEstimatedGasCostUsd,
     setIsFeeEstimationError,
@@ -471,6 +488,10 @@ async function runBridgePath({
         bridgeCall,
     ])
     setReceiveAmount(quote.amountOut)
+    // Bridge path: mode='pay' → user pays exactly `amountIn` at source; the
+    // Rhino fee + gas come out of the destination amount. So the kernel needs
+    // `amountIn` USDC on-hand (same as the principal).
+    setPayAmount(quote.amountIn)
     setFeeUsd(quote.feeUsd + quote.gasFeeUsd)
     setEstimatedGasCostUsd(0) // gas paid by paymaster — same as SDA path
     setIsFeeEstimationError(false)
@@ -484,6 +505,7 @@ interface SameChainParams {
     setEstimatedGasCostUsd: (v: number | undefined) => void
     setIsFeeEstimationError: (v: boolean) => void
     setReceiveAmount: (v: string | null) => void
+    setPayAmount: (v: string | null) => void
     skipGasEstimate?: boolean
 }
 
@@ -493,6 +515,7 @@ async function buildSameChainTx({
     setEstimatedGasCostUsd,
     setIsFeeEstimationError,
     setReceiveAmount,
+    setPayAmount,
     skipGasEstimate,
 }: SameChainParams): Promise<void> {
     const tx = prepareRequestLinkFulfillmentTransaction({
@@ -513,6 +536,8 @@ async function buildSameChainTx({
         },
     ])
     setReceiveAmount(destination.tokenAmount)
+    // Same-chain, same-token: kernel pays exactly the principal.
+    setPayAmount(destination.tokenAmount)
     if (!skipGasEstimate && tx.unsignedTx.from && tx.unsignedTx.to && tx.unsignedTx.data) {
         try {
             const gasCost = await estimateTransactionCostUsd(
@@ -538,6 +563,7 @@ interface RhinoResultParams {
     setTransactions: (tx: PreparedTransaction[] | null) => void
     setSdaAddress: (v: Address | null) => void
     setReceiveAmount: (v: string | null) => void
+    setPayAmount: (v: string | null) => void
     setFeeUsd: (v: number | undefined) => void
     setMinDepositLimitUsd: (v: number | undefined) => void
     setMaxDepositLimitUsd: (v: number | undefined) => void
@@ -552,6 +578,7 @@ function applyRhinoResult({
     setTransactions,
     setSdaAddress,
     setReceiveAmount,
+    setPayAmount,
     setFeeUsd,
     setMinDepositLimitUsd,
     setMaxDepositLimitUsd,
@@ -576,6 +603,13 @@ function applyRhinoResult({
     ])
     setSdaAddress(sda.sdaAddress)
     setReceiveAmount(preview.receiveAmount)
+    // SDA path uses mode='receive' (preview at line ~310) — Rhino takes the fee
+    // at source. `payAmount` IS `principal + fee` and matches the on-chain
+    // transfer amount we just encoded above. Callers routing through
+    // sendTransactions({ requiredUsdcAmount }) MUST pass this — not the
+    // principal — or the kernel's collateral-sweep under-funds and the
+    // transfer reverts with `ERC20: transfer amount exceeds balance`.
+    setPayAmount(preview.payAmount)
     setFeeUsd(preview.feeUsd)
     setMinDepositLimitUsd(sda.minDepositLimitUsd)
     setMaxDepositLimitUsd(sda.maxDepositLimitUsd)


### PR DESCRIPTION
Same class of bug, two callsites.

## Confirmed failure on staging

\`\`\`
UserOperation reverted during simulation with reason: ERC20: transfer amount exceeds balance
\`\`\`

Cross-chain crypto withdraw, smart account = \$0, spending power on card \$35, withdraw \$5 to an ETH address.

## Root cause

The kernel UserOp's two inner calls:
1. \`coordinator.withdrawAsset(directTransfer=false, recipient=kernel, amount=0x4c4b40)\` → sweep **\$5.000000** from collateral
2. \`usdc.transfer(sda, amount=0x4c8006)\` → transfer **\$5.013510** out

Off by \$0.013510 — the Rhino bridge fee. \`previewSdaTransfer\` runs with \`mode='receive'\` (UI asks "merchant gets X", user pays X + fee), so the encoded transfer is for \`principal + fee\`. But the callsites passed only the **principal** as \`requiredUsdcAmount\` → \`useSpendBundle\` swept only principal → kernel under-funded → revert.

## Fix

1. **\`useCrossChainTransfer\`** — expose \`payAmount\`. Set in all three paths:
   - SDA (cross-chain stable→non-stable): \`preview.payAmount\` (principal + fee)
   - Bridge (non-SDA-supported tokens): \`quote.amountIn\` (= principal; fee comes out of destination)
   - Same-chain, same-token: \`destination.tokenAmount\` (no fee)
2. **\`crypto/page.tsx\`** — cross-chain branch uses \`payAmount\` for \`requiredUsdcAmount\`.
3. **\`semantic-request/useSemanticRequestFlow.ts\`** — cross-chain \`executePayment\` previously called \`sendTransactions(routeTransactions)\` without options at all, so a collateral-only payer paying a cross-chain request silently fell through \`useWallet.sendTransactions\`'s smart-only legacy branch. Now passes \`requiredUsdcAmount = payAmount\` + \`kind: 'REQUEST_PAY'\` to route through \`useSpendBundle\`.

Same-chain crypto withdraws / same-chain request pays unchanged — they route through \`sendMoney\` which already covers the collateral case.

## QA

Card-collateral-only payer, smart account \$0:
1. Cross-chain stable→ETH withdraw \$5 → ✅ kernel gets \$5.0135 from sweep, transfer \$5.0135 to SDA.
2. Cross-chain stable→stable withdraw (e.g. USDC Arb → USDT Polygon) → ✅ works (bridge path: \`amountIn = principal\`).
3. Cross-chain request pay (e.g. payer on Arb USDC, requester wants ETH on Base) → ✅ kernel auto-tops-up from collateral and bridges.
4. Same-chain crypto withdraw / request pay → unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)