### PR TITLE
fix(ui): profile copy-username icon 24 → 20 to match verified check

### DIFF
--- a/src/components/Global/CopyToClipboard/index.tsx
+++ b/src/components/Global/CopyToClipboard/index.tsx
@@ -11,7 +11,7 @@ interface Props {
     textToCopy: string
     fill?: string
     className?: string
-    iconSize?: '2' | '3' | '4' | '6' | '8'
+    iconSize?: '2' | '3' | '4' | '5' | '6' | '8'
     type?: 'button' | 'icon'
     buttonSize?: ButtonSize
     onCopy?: () => void
@@ -36,11 +36,12 @@ const CopyToClipboard = forwardRef<CopyToClipboardRef, Props>(
             copy()
         }
 
-        // convert tailwind size to pixels (2=8px, 3=12px, 4=16px, 6=24px, 8=32px)
+        // convert tailwind size to pixels (2=8px, 3=12px, 4=16px, 5=20px, 6=24px, 8=32px)
         const sizeMap: Record<string, number> = {
             '2': 8,
             '3': 12,
             '4': 16,
+            '5': 20,
             '6': 24,
             '8': 32,
         }

--- a/src/components/Profile/components/ProfileHeader.tsx
+++ b/src/components/Profile/components/ProfileHeader.tsx
@@ -51,7 +51,7 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
                         haveSentMoneyToUser={haveSentMoneyToUser}
                         isAuthenticatedUserVerified={isAuthenticatedUserVerified && isSelfProfile} // can be true only for self profile
                     />
-                    <CopyToClipboard textToCopy={username} fill="black" iconSize="6" />
+                    <CopyToClipboard textToCopy={username} fill="black" iconSize="5" />
                 </div>
                 {/* Username with share drawer */}
                 {showShareButton && (


### PR DESCRIPTION
Followup. Bumped from iconSize='4' (16) to '6' (24) for tappability, but the sibling verified-check icon next to it is 20px — so 24 was now overshooting and looked too big on desktop. Adds a '5' (20px) step to CopyToClipboard's scale and uses it. Tappable AND visually matched with the sibling.

### Test plan
- [ ] Own profile page: copy-username icon visually same size as the green verified check next to it (both 20px)
- [ ] Other CopyToClipboard usages unaffected