### PR TITLE
fix: skip ENABLED rails in bridge ToS requirements check

### DIFF
--- a/src/hooks/useBridgeTosStatus.ts
+++ b/src/hooks/useBridgeTosStatus.ts
@@ -13,8 +13,10 @@ export const useBridgeTosStatus = () => {
         const hasRequiresInformation = bridgeRails.some((r) => r.status === 'REQUIRES_INFORMATION')
 
         // bridge can require tos_acceptance as part of additionalRequirements
-        // even when rails are in other states (REJECTED, REQUIRES_EXTRA_INFORMATION)
+        // but only on non-ENABLED rails — ENABLED means tos was already accepted,
+        // stale metadata should not re-trigger the tos modal
         const hasTosInRequirements = bridgeRails.some((r) => {
+            if (r.status === 'ENABLED') return false
             const reqs = Array.isArray(r.metadata?.additionalRequirements)
                 ? (r.metadata.additionalRequirements as string[])
                 : []


### PR DESCRIPTION
## Summary
- ENABLED Bridge rails with stale `additionalRequirements` metadata (containing `tos_acceptance` / `tos_v2_acceptance`) were incorrectly triggering the ToS modal, causing users to see "Could not load terms" / "Bridge ToS already accepted"
- Fix: skip ENABLED rails in the `hasTosInRequirements` check in `useBridgeTosStatus` — ENABLED means ToS was already accepted
- **7 users affected** (all with approved KYC + ENABLED rails + successful past payments)

## Root cause
`additionalRequirements` in `user_rails.metadata` was never cleared when rails transitioned to ENABLED. The frontend checked this metadata on all rails regardless of status. Companion backend PR: peanutprotocol/peanut-api-ts#XXX

## Test plan
- [x] `useBridgeTransferReadiness` tests pass (13/13)
- [x] Full test suite passes (178/178)
- [ ] Verify affected user no longer sees ToS modal after data cleanup