### PR TITLE
fix: skip ENABLED rails in bridge ToS requirements check

### DIFF
--- a/src/hooks/useBridgeTosStatus.ts
+++ b/src/hooks/useBridgeTosStatus.ts
@@ -13,8 +13,10 @@ export const useBridgeTosStatus = () => {
         const hasRequiresInformation = bridgeRails.some((r) => r.status === 'REQUIRES_INFORMATION')
 
         // bridge can require tos_acceptance as part of additionalRequirements
-        // even when rails are in other states (REJECTED, REQUIRES_EXTRA_INFORMATION)
+        // but only on non-ENABLED rails — ENABLED means tos was already accepted,
+        // stale metadata should not re-trigger the tos modal
         const hasTosInRequirements = bridgeRails.some((r) => {
+            if (r.status === 'ENABLED') return false
             const reqs = Array.isArray(r.metadata?.additionalRequirements)
                 ? (r.metadata.additionalRequirements as string[])
                 : []


### PR DESCRIPTION
Dev sync of #2025.

## Summary
- ENABLED Bridge rails with stale `additionalRequirements` metadata were incorrectly triggering the ToS modal
- Fix: skip ENABLED rails in the `hasTosInRequirements` check in `useBridgeTosStatus`