### PR TITLE
feat(observability): wire posthog.sentryIntegration for Sentry ↔ PostHog cross-link

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -3,6 +3,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs'
+import posthog from 'posthog-js'
 
 import { beforeSendHandler } from './sentry.utils'
 import { inferSentryEnvironment } from '@/utils/sentry-env'
@@ -20,6 +21,15 @@ if (process.env.NODE_ENV !== 'development') {
         integrations: [
             Sentry.captureConsoleIntegration({
                 levels: ['error', 'warn'],
+            }),
+            // Cross-link Sentry ↔ PostHog: every Sentry error becomes a `$exception`
+            // event in PostHog with a Sentry deeplink, and the Sentry event gets a
+            // PostHog tag pointing back at the user's profile + session replay.
+            // posthog.init() runs in instrumentation-client.ts; the integration uses
+            // the singleton lazily, so init order doesn't matter.
+            posthog.sentryIntegration({
+                organization: 'peanut-c34d84c05',
+                projectId: 4505827431415808,
             }),
         ],
 


### PR DESCRIPTION
## Summary
- Add `posthog.sentryIntegration({ organization, projectId })` to the FE Sentry client init.
- Cross-links FE Sentry errors with PostHog user profiles + session replays in both directions.

## What this gives us
- Open a Sentry issue → click the PostHog tag → land on the affected user's profile + session replay of the exact moment the error fired.
- Open a PostHog user → see their `\$exception` events with deeplinks back to the Sentry issue.

## Implementation note
`posthog.init()` runs in `instrumentation-client.ts`. The Sentry integration captures a reference to the posthog singleton lazily, so Next.js's load order between `instrumentation-client.ts` and `sentry.client.config.ts` doesn't matter — when an exception is captured, the integration checks if posthog is initialized and dispatches accordingly.

Scope: FE-only (this PR). Server/edge configs would need `posthog-node`, which isn't a peanut-ui dep. BE-side integration belongs in a separate api-ts PR.

## Test plan
- [ ] Local dev: gating still skips both Sentry + PostHog init (NODE_ENV=development gate matches the existing posthog.init gate)
- [ ] After merge → preview deploy: trigger a JS error and confirm:
  - Sentry event has a `PostHog` tag with a working deeplink to the user
  - PostHog person shows a `\$exception` event with a Sentry URL property
- [ ] Verify session replay link from Sentry → PostHog plays back the error context

## Risks
- Low. Pure additive — adds one integration to the Sentry init array.
- If PostHog isn't initialized (e.g. ad-blockers), the integration no-ops; Sentry continues normally.

## Pre-reqs (env vars per environment)
See Hugo's audit summary. Required for this to actually fire data:
- \`NEXT_PUBLIC_SENTRY_DSN\` — must be set on Vercel for the env that hosts \`staging.peanut.me\` (currently missing on staging, confirmed by zero ingest requests)
- \`NEXT_PUBLIC_POSTHOG_KEY\` — already set (FE PostHog working on both prod and staging)