### PR TITLE
feat(activity): lazy ENS reverse-lookup for unknown counterparties

### DIFF
--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -105,20 +105,13 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
     // check if this is a test transaction (setup confirmation)
     const isTestTransaction = name === 'Enjoy Peanut!'
 
-    // Lazy ENS reverse-lookup for unknown counterparties: when `name` is an
-    // EVM address (the BE couldn't attach a Peanut username), ask JustaName
-    // for the primary name. Hook fires conditionally via `address: undefined`
-    // when we already have a username — no wasted requests. JustaName's
-    // SWR-cached client dedupes repeat lookups across rows.
-    const ensLookupAddress = isAddress(name) ? (name as `0x${string}`) : undefined
+    // ENS reverse-lookup for raw addresses; hook is a no-op when name is a username.
     const { primaryName } = usePrimaryName({
-        address: ensLookupAddress,
+        address: isAddress(name) ? (name as `0x${string}`) : undefined,
         chainId: 1,
         priority: 'onChain',
     })
-    const ensName = normalizeEnsName(primaryName)
-
-    let displayName = ensName ?? name
+    let displayName = normalizeEnsName(primaryName) ?? name
     // Shortens crypto addresses AND raw UUIDs (usernameless Peanut users whose
     // `identifier` arrives as a userId) so the feed row never renders a 36-char
     // string.

--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -18,6 +18,9 @@ import { getAvatarUrl, getTransactionSign } from '@/utils/history.utils'
 import React, { lazy, Suspense } from 'react'
 import { twMerge } from 'tailwind-merge'
 import Image from 'next/image'
+import { isAddress } from 'viem'
+import { usePrimaryName } from '@justaname.id/react'
+import { normalizeEnsName } from '@/utils/ens.utils'
 import StatusPill, { type StatusPillType } from '../Global/StatusPill'
 import { VerifiedUserLabel } from '../UserHeader'
 import { PerkIcon } from './PerkIcon'
@@ -101,7 +104,21 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
     const avatarUrl = getAvatarUrl(transaction)
     // check if this is a test transaction (setup confirmation)
     const isTestTransaction = name === 'Enjoy Peanut!'
-    let displayName = name
+
+    // Lazy ENS reverse-lookup for unknown counterparties: when `name` is an
+    // EVM address (the BE couldn't attach a Peanut username), ask JustaName
+    // for the primary name. Hook fires conditionally via `address: undefined`
+    // when we already have a username — no wasted requests. JustaName's
+    // SWR-cached client dedupes repeat lookups across rows.
+    const ensLookupAddress = isAddress(name) ? (name as `0x${string}`) : undefined
+    const { primaryName } = usePrimaryName({
+        address: ensLookupAddress,
+        chainId: 1,
+        priority: 'onChain',
+    })
+    const ensName = normalizeEnsName(primaryName)
+
+    let displayName = ensName ?? name
     // Shortens crypto addresses AND raw UUIDs (usernameless Peanut users whose
     // `identifier` arrives as a userId) so the feed row never renders a 36-char
     // string.


### PR DESCRIPTION
## What

Adds a lazy JustaName ENS reverse-lookup at the row level in `TransactionCard`. When the BE history fetcher couldn't attach a Peanut username (i.e. \`name\` arrives as a raw 0x address), the row asks for the address's ENS primary name. If found, the row upgrades from \`0x70dc…fb571c\` → \`peanuthelp.peanut.me\` (or \`vitalik.eth\`, etc.).

## Why

Today, any external counterparty without a Peanut username renders as a truncated 0x string in the activity feed. Specifically, every \$5 bug-bounty grant from the perk wallet shows up as \`0x70dc…fb571c +\$5\` instead of the friendlier \`peanuthelp +\$5\`.

This is the FE companion to peanut-api-ts#797 (which seeds the \`peanuthelp\` user + ENS subname). Together they fix the perk-wallet-as-counterparty case AND opportunistically improve every other 0x row that happens to have an ENS primary name registered.

## Performance

- **Hook fires conditionally**: \`address: undefined\` skips the lookup entirely when \`name\` is already a username (most rows).
- **JustaName SWR-cached**: same address across rows = single network call ever.
- **Non-blocking**: synchronous render unchanged — addresses paint immediately, upgrade in place when ENS resolves.
- **Bounded surface**: HomeHistory shows ~5 rows; full History page recurs counterparties so cache amortizes.

## Test plan

- [ ] Local: peanut-ui dev shows ENS upgrade on a known address (use vitalik.eth or peanuthelp once #797 lands)
- [ ] Local: rows with usernames render unchanged (no extra network call in devtools)
- [ ] No regressions in TransactionCard render snapshot tests
- [ ] After #797 + this merge: send \$5 grant to a test user, confirm activity row shows \`peanuthelp.peanut.me\` once the SWR resolves (~200ms)