### PR TITLE
feat(invites): map 'survivor' invite code → SUPPORT_SURVIVOR badge

### DIFF
--- a/src/components/Invites/InvitesPage.tsx
+++ b/src/components/Invites/InvitesPage.tsx
@@ -26,6 +26,7 @@ const INVITE_CODE_TO_CAMPAIGN_MAP: Record<string, string> = {
     arbiverseinvitesyou: 'ARBIVERSE_DEVCONNECT_BA_2025',
     squirrelinvitesyou: 'ARBIVERSE_DEVCONNECT_BA_2025', // temporary: maps to arbiverse until 12pm noon tomorrow
     founderhaus: 'FOUNDER_HOUSE',
+    survivor: 'SUPPORT_SURVIVOR',
 }
 
 function InvitePageContent() {


### PR DESCRIPTION
## Summary
- Adds `survivor: 'SUPPORT_SURVIVOR'` to `INVITE_CODE_TO_CAMPAIGN_MAP` in `src/components/Invites/InvitesPage.tsx`.
- Pairs with peanut-api-ts PR #798, which whitelists `SUPPORT_SURVIVOR` on `/badge/award`.
- Lets support agents share a single URL that awards the bug-bounty badge on signup, mirroring the existing `founderhaus` → `FOUNDER_HOUSE` flow.

## Scope
- **Badge only.** The \$5 USDC still requires `POST /admin/support/grant` with the admin token. This PR does not wire money to the link.
- Replayability caveat: vanilla URL = anyone who clicks + signs up gets the badge. Same as `founderhaus`.

## Example link
After both PRs land:
- `https://peanut.me/invite?code=survivor` — recipient signs up, gets badge.
- Or `https://peanut.me/invite?code=<any>&campaign=SUPPORT_SURVIVOR` — campaign param override path.

## Test plan
- [ ] Visit `/invite?code=survivor` as a new user → complete signup → SUPPORT_SURVIVOR badge appears on `/home`.
- [ ] Visit `/invite?code=survivor` as an existing user with the badge → no error (idempotent on BE).