### PR TITLE
chore(sentry): force staging rebuild + document Vercel env-scope footgun

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,6 +1,12 @@
 // This file configures the initialization of Sentry on the client.
 // The config you add here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
+//
+// NOTE: `NEXT_PUBLIC_SENTRY_DSN` must be scoped to All Environments on Vercel
+// (or every env that builds an alias serving traffic — e.g. staging.peanut.me).
+// Vercel does NOT auto-rebuild when env-var scope changes, so changing the
+// scope without re-triggering a build leaves the DSN undefined in the cached
+// bundle and Sentry silently disabled. Burned by this 2026-05-14.
 
 import * as Sentry from '@sentry/nextjs'
 import posthog from 'posthog-js'


### PR DESCRIPTION
## Why
\`NEXT_PUBLIC_SENTRY_DSN\` was missing from Vercel's "Preview" scope for the dev branch, so \`staging.peanut.me\` was building with \`dsn=undefined\` → Sentry SDK loaded but silently disabled. Scope fixed to "All Environments" earlier today, but Vercel doesn't re-bake env vars without a fresh build.

## Change
Comment-only edit on \`sentry.client.config.ts\`:
- Documents the env-var-scope footgun inline so the next person knows the cache-clear requirement.
- Diff is 6 lines of comments — no behavior change.

## Side effect (the point of the PR)
Pushing a new commit to \`dev\` invalidates Vercel's build cache for the staging deployment, forcing a fresh build that inlines the new env-var scope. Once merged, \`staging.peanut.me\` will have the DSN baked in and FE Sentry will start receiving \`environment:staging\` events.

## Test plan
- [ ] After merge: scrape staging bundle for \`d2f7d5e16a3c2cecdd301c7f94e440d0\` — should appear in main-app chunk
- [ ] Trigger a JS error on \`staging.peanut.me\` (e.g. \`throw new Error('probe')\` in console)
- [ ] Confirm Sentry event with \`environment:staging\` arrives within ~30s