### PR TITLE
chore: disable maintenance mode post-release

### DIFF
--- a/src/config/underMaintenance.config.ts
+++ b/src/config/underMaintenance.config.ts
@@ -52,7 +52,7 @@ interface MaintenanceConfig {
 }
 
 const underMaintenanceConfig: MaintenanceConfig = {
-    enableFullMaintenance: true, // set to true to redirect all pages to /maintenance
+    enableFullMaintenance: false, // set to true to redirect all pages to /maintenance
     enableMaintenanceBanner: false, // set to true to show maintenance banner on all pages
     disabledPaymentProviders: [], // set to ['MANTECA'] to disable Manteca QR payments
     disableXchainWithdraw: false, // set to true to disable cross-chain withdrawals (only allows USDC on Arbitrum)


### PR DESCRIPTION
**URGENT — post-cutover maint-off**

The decomplexify cutover (PR #1984 + peanut-api-ts#747) is live. Flipping `enableFullMaintenance` back to `false`.

Why this is separate: PR #1985 (maint=true) was merged into `main` only, never back-merged to `dev`. So PR #1984's dev→main merge kept main's `true` (3-way merge: dev didn't change the line, main did → result keeps main's value).

One-line change. Merge ASAP.