### PR TITLE
hotfix(card): bind session-key approval to real wallet address

### DIFF
--- a/src/hooks/wallet/useGrantSessionKey.ts
+++ b/src/hooks/wallet/useGrantSessionKey.ts
@@ -153,7 +153,14 @@ export const useGrantSessionKey = (): GrantSessionKeyResult => {
         // produce a passkey prompt.
         posthog.capture(ANALYTICS_EVENTS.CARD_SESSION_KEY_PROMPTED)
         // Triggers the passkey prompt — this is the one-time install.
+        // `address` is forced to the user's actual wallet so the approval
+        // binds to the deployed kernel. Pre-2025-09-18 users sit at a
+        // legacy V0_0_2-derived address (migrated in place to V0_0_3); the
+        // natural counterfactual of `createKernelAccount({sudo: newValidator})`
+        // is a different, never-funded address. Forcing the address here makes
+        // the grant work for both legacy and post-migration users.
         const sessionKernelAccount = await createKernelAccount(peanutPublicClient, {
+            address: kernelClient.account!.address,
             entryPoint: getEntryPoint('0.7'),
             kernelVersion: KERNEL_V3_1,
             plugins: {


### PR DESCRIPTION
## Summary

Pre-2025-09-18 users were systematically broken by the auto-balance grant flow: their session-key approval was bound to a never-funded counterfactual address instead of their real wallet, causing every rebalance to revert with \`ERC20: transfer amount exceeds balance\`.

## Root cause

\`createKernelClientForChain\` builds legacy wallets via \`createKernelMigrationAccount({ address, ... })\`, which **forces** the historical V0_0_2-derived address (where the user's USDC actually lives) — even though the validator inside is V0_0_3_PATCHED after migration.

\`useGrantSessionKey.runSerialize\` then constructed the session-key kernel via plain \`createKernelAccount({ plugins: { sudo: newValidator } })\` with **no address override**. The resulting counterfactual was the natural hash of (V0_0_3 validator alone) — a brand-new address that has never held USDC. The BE deserialized that approval and submitted UserOps trying to deploy + transfer from the empty address. Simulation reverted forever.

Confirmed in prod via:
- User \`9768e33f-b6d4-4b6e-89d0-7b4e2cf7fdf9\` (legacy account)
- Real wallet: \`0xB9D77f0A3e954109dDae3C302Ac56C87baD60440\` — holds 20.597801 USDC
- Approval-bound address: \`0x4a5aFdeC72c74f8e38E05970526963E1aa907EeC\` — empty
- Rebalance log: \`UserOperation reverted during simulation with reason: ERC20: transfer amount exceeds balance\`

## Fix

Force \`address: kernelClient.account!.address\` in the session-key \`createKernelAccount\` call. This binds the approval to the real wallet for both cohorts:
- **Legacy users** — locks to the migration-forced historical address (where the funds are).
- **Post-migration users** — \`account.address\` equals the natural V0_0_3 counterfactual anyway, so no behavior change.

## Post-merge cleanup

Existing stored approvals on pre-migration users are bound to wrong (empty) addresses and need to be wiped so the activation prompt re-triggers:

\`\`\`sql
UPDATE app.rain_cards
SET serialized_approval = NULL,
    updated_at = NOW()
WHERE serialized_approval IS NOT NULL
  AND user_id IN (
      SELECT user_id FROM public.users WHERE created_at < '2025-09-18'
  );
\`\`\`

Run after the FE deploy lands. Users next session will see the \`EnableAutoBalanceBanner\` again, tap to grant a fresh (correct) approval, and auto-balance starts working.

## Test plan

- [ ] Legacy alpha tester (\`9768e33f…\`): wipe \`serialized_approval\`, re-grant from FE, confirm next rebalance sweep mines on Arbitrum and clears the dust into collateral
- [ ] Post-migration tester: re-grant, confirm the approval-bound address still matches their wallet (regression check)
- [ ] \`tsc --noEmit\` passes
- [ ] Prettier clean