### PR TITLE
hotfix(carousel): hide bug-bounty CTA once SUPPORT_SURVIVOR badge earned

### DIFF
--- a/src/hooks/useHomeCarouselCTAs.tsx
+++ b/src/hooks/useHomeCarouselCTAs.tsx
@@ -109,6 +109,7 @@ export const useHomeCarouselCTAs = () => {
         [latestHistory]
     )
     const hasSentInvites = (user?.invitesSent?.length ?? 0) > 0
+    const hasSupportSurvivorBadge = user?.user?.badges?.some((b) => b.code === 'SUPPORT_SURVIVOR') ?? false
 
     const dismissCTA = useCallback(
         (ctaId: string) => {
@@ -261,11 +262,12 @@ export const useHomeCarouselCTAs = () => {
             })
         }
 
-        // Bug bounty — shown to activated users only. Server enforces the real
-        // eligibility (email verified, ≥1 payment OR KYC approved), lifetime
-        // caps, and the daily budget. This gate just keeps the CTA off cold
-        // accounts where the reward would be denied anyway.
-        if (isActivated) {
+        // Bug bounty — shown to activated users who haven't already claimed.
+        // Server enforces lifetime cap of 1 grant per user, so re-pinging the
+        // CTA after a successful claim would just bounce off `already_granted`.
+        // Hide once the SUPPORT_SURVIVOR badge is on the user — that's the
+        // server-side dedup marker, so it's the authoritative signal.
+        if (isActivated && !hasSupportSurvivorBadge) {
             _carouselCTAs.push({
                 id: 'bug-bounty',
                 title: (
@@ -329,6 +331,7 @@ export const useHomeCarouselCTAs = () => {
         isActivated,
         hasMadeQrPayment,
         hasSentInvites,
+        hasSupportSurvivorBadge,
         oneSignalInitialized,
         setIsIosPwaInstallModalOpen,
         toast,


### PR DESCRIPTION
## Summary

- Hide the home-carousel bug-bounty CTA for users who already have the `SUPPORT_SURVIVOR` badge.
- The server already enforces a lifetime cap of one grant per user. Without this gate the CTA stays visible after a successful claim and the next tap returns `already_granted` — confusing UX, noisy for support.

## Why a hotfix to main

The bug-bounty CTA shipped today as part of the prod release. The dedup gate was missed in that PR. This is the smallest safe fix — one boolean + one conditional + one dep array entry, matching the existing `hasSentInvites` pattern in the same hook.

## Test plan

- [x] Verified diff against current main
- [ ] CI: typecheck + tests + e2e green
- [ ] Manual on Vercel preview: log in as a user with the badge → CTA absent; log in as activated user without the badge → CTA visible