### PR TITLE
fix(history): route SEND_LINK_CLAIM through sendLink strategy

### DIFF
--- a/src/components/TransactionDetails/__tests__/fixtures/render-baseline.json
+++ b/src/components/TransactionDetails/__tests__/fixtures/render-baseline.json
@@ -2697,7 +2697,7 @@
         "kind": "PERK_REWARD",
         "txHash": "<TX_HASH>",
         "perkReward": {
-          "reason": "✨ Peanut Mystery Rewards",
+          "reason": "\u2728 Peanut Mystery Rewards",
           "discountPercentage": 100,
           "originatingTxId": null,
           "originatingTxType": "MANUAL",
@@ -3167,9 +3167,9 @@
                 "price_details": {
                   "rate": 4597916.4,
                   "currency": "ARS",
-                  "base_amount": 0.000026751248,
+                  "base_amount": 2.6751248e-05,
                   "paid_amount": 0,
-                  "final_amount": 0.000026751248,
+                  "final_amount": 2.6751248e-05,
                   "discount_rate": 0,
                   "currency_amount": 123,
                   "currency_final_amount": 123
@@ -3190,9 +3190,9 @@
                 "price_details": {
                   "rate": 4597916.4,
                   "currency": "ARS",
-                  "base_amount": 0.000026751248,
+                  "base_amount": 2.6751248e-05,
                   "paid_amount": 0,
-                  "final_amount": 0.000026751248,
+                  "final_amount": 2.6751248e-05,
                   "discount_rate": 0,
                   "currency_amount": 123,
                   "currency_final_amount": 123
@@ -3236,9 +3236,9 @@
                 "price_details": {
                   "rate": 138734817.45,
                   "currency": "ARS",
-                  "base_amount": 8.9e-7,
+                  "base_amount": 8.9e-07,
                   "paid_amount": 0,
-                  "final_amount": 8.9e-7,
+                  "final_amount": 8.9e-07,
                   "discount_rate": 0,
                   "currency_amount": 123,
                   "currency_final_amount": 123
@@ -3540,9 +3540,9 @@
       "createdAt": "<TIMESTAMP>"
     },
     "expected": {
-      "direction": "send",
-      "userName": "<UUID>",
-      "transactionCardType": "send",
+      "direction": "receive",
+      "userName": "<EVM_ADDRESS>",
+      "transactionCardType": "receive",
       "provider": "PEANUT",
       "cardPaymentDefined": false,
       "bankAccountDetailsDefined": false

--- a/src/components/TransactionDetails/strategies/registry.ts
+++ b/src/components/TransactionDetails/strategies/registry.ts
@@ -24,6 +24,7 @@ import { intentFallback } from './fallback'
 export type IntentKind =
     | 'DIRECT_TRANSFER'
     | 'SEND_LINK'
+    | 'SEND_LINK_CLAIM'
     | 'P2P_REQUEST_FULFILL'
     | 'QR_PAY'
     | 'CRYPTO_DEPOSIT'
@@ -39,6 +40,7 @@ const STRATEGIES: Record<IntentKind, TransactionStrategy> = {
     DIRECT_TRANSFER: p2pSendOrRequestFulfill,
     P2P_REQUEST_FULFILL: p2pSendOrRequestFulfill,
     SEND_LINK: sendLink,
+    SEND_LINK_CLAIM: sendLink,
     QR_PAY: qrPay,
     CRYPTO_DEPOSIT: cryptoDeposit,
     CRYPTO_WITHDRAW: cryptoWithdraw,


### PR DESCRIPTION
## Summary

Fixes [PEANUT-UI-QCX](https://peanut-c34d84c05.sentry.io/issues/PEANUT-UI-QCX) — \`transactionTransformer: unhandled TRANSACTION_INTENT kind \"SEND_LINK_CLAIM\"\` (3 events / 2 users since the decomplexify cutover).

## What was broken

Post-decomplexify the BE splits a single send-link into two intent rows:
- \`SEND_LINK\` — sender's create-and-deposit (debits sender)
- \`SEND_LINK_CLAIM\` — recipient's claim (credits recipient)

The FE strategy registry (\`src/components/TransactionDetails/strategies/registry.ts\`) only knew about \`SEND_LINK\`. When a \`SEND_LINK_CLAIM\` entry arrived, it fell through to \`intentFallback\`, which:
1. Logged the warn to Sentry via \`pipelineAlert(\"unknown_transformer_kind\", ...)\`
2. Returned a generic \`direction: 'send', transactionCardType: 'send', nameForDetails: 'Transaction'\` shape — wrong for a recipient-side row

## Fix

One-line mapping: \`SEND_LINK_CLAIM: sendLink\`. The existing \`sendLink\` strategy already handles all four \`userRole\` paths (SENDER / RECIPIENT / BOTH / public-claim) — its RECIPIENT branch (lines 9–31) returns \`direction: 'receive'\` with the sender's identifier as the display name, which is exactly what \`SEND_LINK_CLAIM\` needs.

\`Record<IntentKind, TransactionStrategy>\` enforces completeness at the type level — the union and the map are kept in sync by TS.

## Fixture update

\`send_link_claim-peanut-completed-recipient\` in \`render-baseline.json\` was capturing the broken fallback output (\`direction: 'send'\`, \`userName: '<UUID>'\`). Updated to match the correct receive-side rendering (\`direction: 'receive'\`, \`userName: '<EVM_ADDRESS>'\` — the sender's address since they're not a Peanut user).

## Test plan

- [x] \`pnpm typecheck\` — passes (the existing typecheck errors about \`@/animations/*\` and \`@/assets/*\` are pre-existing, unrelated to this change)
- [x] \`pnpm test --testPathPattern='TransactionDetails'\` — 93/94 → 49/49 passing
- [ ] Merge → confirm no new \`PEANUT-UI-QCX\` events appear in Sentry
- [ ] Spot-check a recipient's history showing a claimed send-link — direction arrow should point inward, sender's address shown

## Out of scope

There are other Prisma \`TransactionIntentKind\` values the FE still doesn't register (\`P2P_SEND\`, \`INTERNAL_TRANSFER\`, \`REWARD_PAYOUT\`, \`REFUND\`, \`CHARGEBACK\`). Those don't appear in prod traffic yet but would warrant a separate audit. Filed as a follow-up note rather than expanded scope here.