### PR TITLE
fix(ci): pin pnpm 10 + node 20 in Sync OpenAPI workflow

### DIFF
--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -19,10 +19,12 @@ jobs:
             - uses: actions/checkout@v4
 
             - uses: pnpm/action-setup@v4
+              with:
+                  version: 10
 
             - uses: actions/setup-node@v4
               with:
-                  node-version-file: .nvmrc
+                  node-version: '20'
                   cache: pnpm
 
             - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

The Sync OpenAPI workflow has been silently failing since at least 2026-05-15:

- `pnpm/action-setup@v4` had no version specified, and there's no `packageManager` field in package.json, so the action errored at **"No pnpm version is specified"**
- `actions/setup-node@v4` referenced `.nvmrc` but that file doesn't exist in this repo

Both fixed to match `tests.yml`: pnpm 10, node 20.

## Impact

The daily auto-PR for OpenAPI drift has not been running at all since the workflow landed in PR #2030 — meaning the **api.openapi.json snapshot has been silently drifting from deployed staging BE** for ~1 day (would compound if left). Fixing this restores the daily sync.

## Test plan

- [ ] Merge
- [ ] Manually trigger via `gh workflow run sync-openapi.yml --ref dev` once merged
- [ ] Confirm successful run + (if changes) an auto-PR opens