### PR TITLE
feat(payment-graph): ?user=<username> deep-link

### DIFF
--- a/src/app/(mobile-ui)/dev/payment-graph/page.tsx
+++ b/src/app/(mobile-ui)/dev/payment-graph/page.tsx
@@ -74,6 +74,12 @@ export default function PaymentGraphPage() {
         )
     }
 
+    // Deep-link focus: ?user=<username> seeds the camera/highlight on a specific
+    // node. Used by Discord live-log links and any other "show me this user's
+    // network" entry point. The InvitesGraph component resolves username → node.id
+    // once after data loads (case-insensitive), then behaves normally on clicks.
+    const initialFocusUsername = searchParams.get('user') ?? undefined
+
     return (
         <div className="fixed inset-0 z-50 flex flex-col bg-gray-50">
             <InvitesGraph
@@ -82,6 +88,7 @@ export default function PaymentGraphPage() {
                 mode="payment"
                 topNodes={5000}
                 performanceMode={performanceMode}
+                initialFocusUsername={initialFocusUsername}
                 onClose={handleClose}
                 width={typeof window !== 'undefined' ? window.innerWidth : 1200}
                 height={typeof window !== 'undefined' ? window.innerHeight - 120 : 800}

--- a/src/components/Global/InvitesGraph/index.tsx
+++ b/src/components/Global/InvitesGraph/index.tsx
@@ -595,13 +595,18 @@ export default function InvitesGraph(props: InvitesGraphProps) {
     useEffect(() => {
         if (initialFocusAppliedRef.current) return
         if (!initialFocusUsername || !filteredGraphData) return
+        // Only attempt resolution once nodes are populated. An empty filtered
+        // set (loading races, visibility filter momentarily excluding all)
+        // should NOT trip the ref-lock — wait for real data.
+        if (filteredGraphData.nodes.length === 0) return
         const needle = initialFocusUsername.toLowerCase()
         const match = filteredGraphData.nodes.find((n) => n.username?.toLowerCase() === needle)
         if (match) {
             setSelectedUserId(match.id)
         }
-        // Set the ref regardless of match so we don't spin trying every render
-        // when the username isn't present (filtered out, top-N cap, etc.).
+        // Lock regardless of match — username not in data (filtered out,
+        // top-N cap, deleted user) is a definitive "no result" once nodes
+        // are populated. Avoids spinning.
         initialFocusAppliedRef.current = true
     }, [initialFocusUsername, filteredGraphData])
 

--- a/src/components/Global/InvitesGraph/index.tsx
+++ b/src/components/Global/InvitesGraph/index.tsx
@@ -119,6 +119,11 @@ interface BaseProps {
     forceConfig?: ForceConfig
     /** Visibility configuration for toggling element rendering */
     visibilityConfig?: VisibilityConfig
+    /** Seed the selected/focused node by username on first load. Used for
+     *  deep-links like /dev/payment-graph?user=alice from Discord live-log.
+     *  Resolution happens once after the graph data arrives; subsequent
+     *  user clicks override it normally. Case-insensitive match. */
+    initialFocusUsername?: string
     /** Render prop for additional overlays */
     renderOverlays?: (props: {
         showUsernames: boolean
@@ -194,6 +199,7 @@ export default function InvitesGraph(props: InvitesGraphProps) {
         forceConfig: initialForceConfig = DEFAULT_FORCE_CONFIG,
         visibilityConfig: initialVisibilityConfig = DEFAULT_VISIBILITY_CONFIG,
         renderOverlays,
+        initialFocusUsername,
     } = props
 
     const isMinimal = props.minimal === true
@@ -580,6 +586,24 @@ export default function InvitesGraph(props: InvitesGraphProps) {
             }
         }
     }, [selectedUserId, filteredGraphData])
+
+    // Deep-link focus: resolve `initialFocusUsername` to a node.id once after the
+    // graph data first loads. Used by Discord live-log links like
+    // /dev/payment-graph?user=alice. Ref-guarded so re-renders don't pull the
+    // camera back if the user has since clicked away.
+    const initialFocusAppliedRef = useRef(false)
+    useEffect(() => {
+        if (initialFocusAppliedRef.current) return
+        if (!initialFocusUsername || !filteredGraphData) return
+        const needle = initialFocusUsername.toLowerCase()
+        const match = filteredGraphData.nodes.find((n) => n.username?.toLowerCase() === needle)
+        if (match) {
+            setSelectedUserId(match.id)
+        }
+        // Set the ref regardless of match so we don't spin trying every render
+        // when the username isn't present (filtered out, top-N cap, etc.).
+        initialFocusAppliedRef.current = true
+    }, [initialFocusUsername, filteredGraphData])
 
     // Build map of nodeId → inviter username for tooltips
     const inviterMap = useMemo(() => {


### PR DESCRIPTION
## Summary

Adds \`?user=<username>\` deep-linking to \`/dev/payment-graph\` so external tools (Discord live-log, ops scripts) can link directly into the graph focused on a specific user.

URL shape:
\`\`\`
https://peanut.me/dev/payment-graph?password=...&user=alice
\`\`\`

## Companion PR

[peanutprotocol/peanut-api-ts#828](https://github.com/peanutprotocol/peanut-api-ts/pull/828) already emits these URLs in the Discord live-log feed via the new \`🕸️ [↗]\` cluster on every user-keyed event (signups, KYC, invites, badges, intents). URL is forward-compatible — this PR makes the consumer side honor the param.

## Implementation

Two surgical changes:

**\`src/components/Global/InvitesGraph/index.tsx\`** — new optional \`initialFocusUsername\` prop. Ref-guarded one-shot effect resolves username → \`node.id\` once after the graph data loads (case-insensitive), then behaves normally on user clicks. Match failure (filtered out, top-N cap) is silent — no spin.

**\`src/app/(mobile-ui)/dev/payment-graph/page.tsx\`** — reads \`?user=\` from URL via existing \`searchParams\` and passes it through to InvitesGraph.

## Test plan

- [x] \`pnpm typecheck\` — no new errors in changed files (pre-existing missing-asset module errors unrelated)
- [x] \`pnpm prettier --check\` clean
- [ ] Post-deploy: visit \`/dev/payment-graph?password=...&user=<a-known-username>\` — graph should highlight + camera-position on that user on load
- [ ] Verify clicking another node after load works normally (i.e. the deep-link doesn't lock focus)
- [ ] Verify unknown username silently no-ops (no error, no infinite re-attempt)

## Scope

Additive only. No backend / DB / network changes. The graph data fetch is unchanged.