### PR TITLE
feat(kyc): differentiate identity-verified from per-rail status

### DIFF
--- a/src/components/Kyc/KycStatusItem.tsx
+++ b/src/components/Kyc/KycStatusItem.tsx
@@ -93,9 +93,15 @@ export const KycStatusItem = ({
     const isInitiatedButNotStarted = !!verification && isKycStatusNotStarted(kycStatus)
 
     const subtitle = useMemo(() => {
-        // provider rejection takes priority when sumsub is approved
+        // priority: identity-level signals first, then per-rail signals.
+        // identity-level: rejection (action vs. blocked), action-required, pending, verified.
+        // per-rail: bridge bank rails needing extra docs (e.g. proof of address) is rail-scoped,
+        // NOT identity-scoped — surface a rail-specific label so verified users don't read
+        // "Action needed" as "your identity is still pending" (the conflation we fixed BE-side
+        // on 2026-05-17 by stopping `under_review` flips from per-rail endorsement state).
         if (isApproved && hasFixableRejection) return 'Action needed'
         if (isApproved && hasBlockedRejection) return 'Verification issue'
+        if (isApproved && hasBridgeDocsNeeded) return 'Verified · bank docs needed'
         if (hasBridgeDocsNeeded) return 'Action needed'
         if (isInitiatedButNotStarted) return 'Not completed'
         if (isActionRequired) return 'Action needed'

--- a/src/hooks/__tests__/useUnifiedKycStatus.test.ts
+++ b/src/hooks/__tests__/useUnifiedKycStatus.test.ts
@@ -1,0 +1,129 @@
+import { renderHook } from '@testing-library/react'
+import useUnifiedKycStatus from '../useUnifiedKycStatus'
+
+// mock authContext — the hook reads `user.user.bridgeKycStatus` + `user.user.kycVerifications`
+jest.mock('@/context/authContext', () => ({
+    useAuth: jest.fn(),
+}))
+
+import { useAuth } from '@/context/authContext'
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>
+
+function withUser(partial: {
+    bridgeKycStatus?: string | null
+    kycVerifications?: Array<{
+        provider: string
+        status: string
+        updatedAt?: string
+        metadata?: Record<string, unknown>
+        rejectLabels?: unknown
+        rejectType?: string | null
+    }>
+}) {
+    mockUseAuth.mockReturnValue({
+        user: {
+            user: {
+                bridgeKycStatus: partial.bridgeKycStatus,
+                kycVerifications: partial.kycVerifications ?? [],
+            },
+        },
+    } as unknown as ReturnType<typeof useAuth>)
+}
+
+describe('useUnifiedKycStatus', () => {
+    afterEach(() => jest.clearAllMocks())
+
+    test('bridgeKycStatus="approved" → isBridgeApproved true, isBridgeUnderReview false', () => {
+        // regression: post-2026-05-17 BE fix, a user whose `base` endorsement is approved
+        // is reported as `bridge_kyc_status='approved'` even when rail-specific endorsements
+        // are still incomplete. This hook MUST trust that signal.
+        withUser({ bridgeKycStatus: 'approved' })
+        const { result } = renderHook(() => useUnifiedKycStatus())
+        expect(result.current.isBridgeApproved).toBe(true)
+        expect(result.current.isBridgeUnderReview).toBe(false)
+        expect(result.current.isKycApproved).toBe(true)
+        expect(result.current.isKycInProgress).toBe(false)
+    })
+
+    test('bridgeKycStatus="under_review" → isBridgeUnderReview true', () => {
+        withUser({ bridgeKycStatus: 'under_review' })
+        const { result } = renderHook(() => useUnifiedKycStatus())
+        expect(result.current.isBridgeApproved).toBe(false)
+        expect(result.current.isBridgeUnderReview).toBe(true)
+        expect(result.current.isKycInProgress).toBe(true)
+    })
+
+    test('bridgeKycStatus="incomplete" → isBridgeUnderReview true (also pending)', () => {
+        withUser({ bridgeKycStatus: 'incomplete' })
+        const { result } = renderHook(() => useUnifiedKycStatus())
+        expect(result.current.isBridgeUnderReview).toBe(true)
+    })
+
+    test('bridgeKycStatus="rejected" → not approved, not under review', () => {
+        withUser({ bridgeKycStatus: 'rejected' })
+        const { result } = renderHook(() => useUnifiedKycStatus())
+        expect(result.current.isBridgeApproved).toBe(false)
+        expect(result.current.isBridgeUnderReview).toBe(false)
+    })
+
+    test('SUMSUB kycVerification APPROVED → isSumsubApproved true', () => {
+        withUser({
+            kycVerifications: [{ provider: 'SUMSUB', status: 'APPROVED', updatedAt: '2026-05-15T10:00:00Z' }],
+        })
+        const { result } = renderHook(() => useUnifiedKycStatus())
+        expect(result.current.isSumsubApproved).toBe(true)
+        expect(result.current.isKycApproved).toBe(true)
+    })
+
+    test('multiple SUMSUB verifications → uses most recently updated', () => {
+        withUser({
+            kycVerifications: [
+                { provider: 'SUMSUB', status: 'REJECTED', updatedAt: '2026-05-10T10:00:00Z' },
+                { provider: 'SUMSUB', status: 'APPROVED', updatedAt: '2026-05-15T10:00:00Z' },
+            ],
+        })
+        const { result } = renderHook(() => useUnifiedKycStatus())
+        expect(result.current.isSumsubApproved).toBe(true)
+        expect(result.current.sumsubStatus).toBe('APPROVED')
+    })
+
+    test('MANTECA verification ACTIVE → isMantecaApproved true', () => {
+        withUser({
+            kycVerifications: [{ provider: 'MANTECA', status: 'ACTIVE' }],
+        })
+        const { result } = renderHook(() => useUnifiedKycStatus())
+        expect(result.current.isMantecaApproved).toBe(true)
+        expect(result.current.isKycApproved).toBe(true)
+    })
+
+    test('isKycApproved: any provider approved is enough', () => {
+        withUser({
+            bridgeKycStatus: 'rejected',
+            kycVerifications: [{ provider: 'SUMSUB', status: 'APPROVED', updatedAt: '2026-05-15T10:00:00Z' }],
+        })
+        const { result } = renderHook(() => useUnifiedKycStatus())
+        expect(result.current.isBridgeApproved).toBe(false)
+        expect(result.current.isSumsubApproved).toBe(true)
+        expect(result.current.isKycApproved).toBe(true)
+    })
+
+    test('sumsub ACTION_REQUIRED → isSumsubActionRequired true + isSumsubInProgress true', () => {
+        withUser({
+            kycVerifications: [{ provider: 'SUMSUB', status: 'ACTION_REQUIRED', updatedAt: '2026-05-15T10:00:00Z' }],
+        })
+        const { result } = renderHook(() => useUnifiedKycStatus())
+        expect(result.current.isSumsubActionRequired).toBe(true)
+        expect(result.current.isKycInProgress).toBe(true)
+    })
+
+    test('no user / undefined → all signals false', () => {
+        mockUseAuth.mockReturnValue({ user: null } as unknown as ReturnType<typeof useAuth>)
+        const { result } = renderHook(() => useUnifiedKycStatus())
+        expect(result.current.isBridgeApproved).toBe(false)
+        expect(result.current.isBridgeUnderReview).toBe(false)
+        expect(result.current.isSumsubApproved).toBe(false)
+        expect(result.current.isMantecaApproved).toBe(false)
+        expect(result.current.isKycApproved).toBe(false)
+    })
+})


### PR DESCRIPTION
## Summary

Pairs with peanut-api-ts [PR #834](https://github.com/peanutprotocol/peanut-api-ts/pull/834) which fixes the BE conflation between identity verification (\`base\` endorsement) and per-rail availability (sepa/spei/faster_payments). With the BE fix, verified users with an outstanding rail document requirement no longer get \`bridge_kyc_status='under_review'\` — they correctly show as \`'approved'\`.

This PR aligns the FE so the identity-status card reflects both signals without misleading the user.

## Changes

- \`src/components/Kyc/KycStatusItem.tsx\` — subtitle precedence updated. When the user is identity-verified AND a Bridge bank rail is in \`REQUIRES_EXTRA_INFORMATION\`, we now show **"Verified · bank docs needed"** instead of the ambiguous **"Action needed"** that previously read as identity-pending. The detail drawer (\`KycRequiresDocuments\`) was already correct — the bug was at the surface card.
- \`src/hooks/__tests__/useUnifiedKycStatus.test.ts\` (new) — 10 regression tests locking in the post-BE-fix behavior. Specifically the case \`bridgeKycStatus='approved'\` → \`isBridgeApproved=true\` AND \`isBridgeUnderReview=false\`. Prevents a future BE/FE refactor from reintroducing the conflation on this side.

## Behavior matrix

| BE state | Old FE subtitle | New FE subtitle |
|---|---|---|
| base approved, no rail issues | Verified | Verified |
| base approved, rail needs docs | Action needed | **Verified · bank docs needed** |
| base approved, sumsub action required | Action needed | Action needed |
| base approved, fixable rejection | Action needed | Action needed |
| base approved, blocked rejection | Verification issue | Verification issue |
| under_review | Processing | Processing |
| rejected | Failed | Failed |

Only one row changes: the verified-with-rail-docs case. Everything else is preserved.

## Risk

Minimal. Pure copy change in one component + new test file. No hook changes, no API contract changes, no new state. The visual difference is one new subtitle string variant that only renders when the user already had both signals true (which today renders the same fallback "Action needed").

## Test plan

- [x] \`npm test src/hooks/__tests__/useUnifiedKycStatus.test.ts\` — 10/10 pass
- [x] All existing hooks tests still pass (39/39)
- [ ] Manual smoke: user with \`bridgeKycStatus='approved'\` + a rail with status \`REQUIRES_EXTRA_INFORMATION\` should see "Verified · bank docs needed" on the identity-status card; clicking opens drawer with the rail-specific docs prompt as before.

## Cross-repo notes

This PR is decoupled from the BE PR — it's safe to land either order:
- If BE merges first: existing users who hit the conflated under_review state get correctly re-classified to approved on the next webhook/poll. The new FE subtitle copy then appears for them.
- If FE merges first: no user-visible change until BE PR ships (the new subtitle only renders when both signals are true, which the BE doesn't currently produce together).

## Follow-ups (deferred to KYC capability state machine §13)

- Consolidate \`useUnifiedKycStatus\`, \`useIdentityVerification\`, \`useQrKycGate\`, \`useMultiPhaseKycFlow\` into one capability hook reading a new \`/me/capabilities?intent=X&country=Y\` BE endpoint.
- Replace the per-rail status derivation in \`KycStatusItem\` / \`KycStatusDrawer\` with a typed capability shape from that endpoint.