### PR TITLE
feat(card/withdraw): security-verification overlay between mixed-flow…

### DIFF
--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import '../../styles/globals.css'
 import QRScannerOverlay from '@/components/Global/QRScannerOverlay'
+import SecurityVerificationOverlay from '@/components/Global/SecurityVerificationOverlay'
 import SupportDrawer from '@/components/Global/SupportDrawer'
 import JoinWaitlistPage from '@/components/Invites/JoinWaitlistPage'
 import { useRouter } from 'next/navigation'
@@ -225,6 +226,8 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
             <SupportDrawer />
 
             <QRScannerOverlay />
+
+            <SecurityVerificationOverlay />
         </div>
     )
 }

--- a/src/components/Global/SecurityVerificationOverlay/index.tsx
+++ b/src/components/Global/SecurityVerificationOverlay/index.tsx
@@ -1,0 +1,32 @@
+'use client'
+import PeanutLoading from '@/components/Global/PeanutLoading'
+import { useModalsContext } from '@/context/ModalsContext'
+
+/**
+ * Full-screen security-verification overlay. Mounted globally; visibility
+ * is driven by `isSecurityVerificationOpen` in ModalsContext.
+ *
+ * Use case: the mixed card-withdraw flow signs an admin EIP-712 (tap #1)
+ * then sends a UserOp (tap #2). Between the two passkey prompts there's a
+ * short — but visible — gap while the kernel prepares the follow-up op.
+ * This overlay gives the user something to look at and confirms the app
+ * is actively working, even when the gap is fast.
+ *
+ * Reusable: any flow that wants the same "Verifying security…" beat can
+ * toggle the state via `setIsSecurityVerificationOpen`.
+ */
+const MESSAGE = 'Verifying security…'
+
+export default function SecurityVerificationOverlay() {
+    const { isSecurityVerificationOpen } = useModalsContext()
+    if (!isSecurityVerificationOpen) return null
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-background"
+            role="status"
+            aria-live="polite"
+        >
+            <PeanutLoading message={MESSAGE} />
+        </div>
+    )
+}

--- a/src/context/ModalsContext.tsx
+++ b/src/context/ModalsContext.tsx
@@ -99,3 +99,14 @@ export function useModalsContext() {
     }
     return context
 }
+
+/**
+ * Non-throwing variant — returns the context or `undefined` when the
+ * provider isn't mounted (isolated test trees, Storybook, etc.). Use
+ * when the consumer can sensibly no-op without modal access (e.g.
+ * UI-polish overlays); prefer `useModalsContext` everywhere a missing
+ * provider should be a hard error.
+ */
+export function useModalsContextOptional(): ModalsContextType | undefined {
+    return useContext(ModalsContext)
+}

--- a/src/context/ModalsContext.tsx
+++ b/src/context/ModalsContext.tsx
@@ -21,6 +21,12 @@ interface ModalsContextType {
     // QR Scanner
     isQRScannerOpen: boolean
     setIsQRScannerOpen: (isOpen: boolean) => void
+
+    // Security Verification Overlay — shown between the two passkey taps
+    // of the mixed card-withdraw flow so the user has something to look at
+    // while the kernel prepares the follow-up UserOp.
+    isSecurityVerificationOpen: boolean
+    setIsSecurityVerificationOpen: (isOpen: boolean) => void
 }
 
 const ModalsContext = createContext<ModalsContextType | undefined>(undefined)
@@ -38,6 +44,9 @@ export function ModalsProvider({ children }: { children: ReactNode }) {
 
     // QR Scanner
     const [isQRScannerOpen, setIsQRScannerOpen] = useState(false)
+
+    // Security Verification Overlay
+    const [isSecurityVerificationOpen, setIsSecurityVerificationOpen] = useState(false)
 
     const openSupportWithMessage = useCallback((message: string) => {
         setSupportPrefilledMessage(message)
@@ -64,6 +73,10 @@ export function ModalsProvider({ children }: { children: ReactNode }) {
             // QR Scanner
             isQRScannerOpen,
             setIsQRScannerOpen,
+
+            // Security Verification Overlay
+            isSecurityVerificationOpen,
+            setIsSecurityVerificationOpen,
         }),
         [
             isIosPwaInstallModalOpen,
@@ -72,6 +85,7 @@ export function ModalsProvider({ children }: { children: ReactNode }) {
             supportPrefilledMessage,
             openSupportWithMessage,
             isQRScannerOpen,
+            isSecurityVerificationOpen,
         ]
     )
 

--- a/src/hooks/wallet/useSpendBundle.ts
+++ b/src/hooks/wallet/useSpendBundle.ts
@@ -20,7 +20,7 @@ import { useZeroDev } from '@/hooks/useZeroDev'
 import { useRainCardOverview } from '@/hooks/useRainCardOverview'
 import { useGrantSessionKey, type GrantSessionKeyError } from './useGrantSessionKey'
 import { usdcWeiToRainCents } from '@/utils/balance.utils'
-import { useModalsContext } from '@/context/ModalsContext'
+import { useModalsContextOptional } from '@/context/ModalsContext'
 
 export type SpendStrategy = 'collateral-only' | 'smart-only' | 'mixed' | 'insufficient'
 
@@ -137,7 +137,12 @@ export const useSpendBundle = () => {
     const { user } = useAuth()
     const { overview } = useRainCardOverview()
     const { grant } = useGrantSessionKey()
-    const { setIsSecurityVerificationOpen } = useModalsContext()
+    // Optional — overlay is UI polish, not correctness. If ModalsProvider
+    // isn't mounted (isolated component tests, future Storybook stories,
+    // etc.), the toggle silently no-ops instead of throwing and blocking
+    // the actual spend. Production trees mount the provider via
+    // contextProvider, so the overlay still renders end-to-end.
+    const modals = useModalsContextOptional()
 
     const spend = useCallback(
         async (input: SpendBundleInput): Promise<SpendBundleResult> => {
@@ -315,7 +320,7 @@ export const useSpendBundle = () => {
                 // look at and the UI feels intentional rather than frozen.
                 // try/finally guarantees the overlay closes on success AND on
                 // bundler / kernel failure.
-                setIsSecurityVerificationOpen(true)
+                modals?.setIsSecurityVerificationOpen?.(true)
                 try {
                     // Backend `/prepare` normalizes the executor salt (bytes32) and signature
                     // to 0x-hex regardless of what Rain returned — trust the wire shape here.
@@ -373,7 +378,7 @@ export const useSpendBundle = () => {
                     posthog.capture(ANALYTICS_EVENTS.CARD_WITHDRAW_SUCCEEDED, { strategy, kind })
                     return { strategy, userOpHash, receipt, intentId: prep.preparationId }
                 } finally {
-                    setIsSecurityVerificationOpen(false)
+                    modals?.setIsSecurityVerificationOpen?.(false)
                 }
             } catch (e) {
                 const errorKind =
@@ -389,7 +394,7 @@ export const useSpendBundle = () => {
                 throw e
             }
         },
-        [getClientForChain, handleSendUserOpEncoded, user, overview, grant, setIsSecurityVerificationOpen]
+        [getClientForChain, handleSendUserOpEncoded, user, overview, grant, modals]
     )
 
     return { spend }

--- a/src/hooks/wallet/useSpendBundle.ts
+++ b/src/hooks/wallet/useSpendBundle.ts
@@ -20,6 +20,7 @@ import { useZeroDev } from '@/hooks/useZeroDev'
 import { useRainCardOverview } from '@/hooks/useRainCardOverview'
 import { useGrantSessionKey, type GrantSessionKeyError } from './useGrantSessionKey'
 import { usdcWeiToRainCents } from '@/utils/balance.utils'
+import { useModalsContext } from '@/context/ModalsContext'
 
 export type SpendStrategy = 'collateral-only' | 'smart-only' | 'mixed' | 'insufficient'
 
@@ -136,6 +137,7 @@ export const useSpendBundle = () => {
     const { user } = useAuth()
     const { overview } = useRainCardOverview()
     const { grant } = useGrantSessionKey()
+    const { setIsSecurityVerificationOpen } = useModalsContext()
 
     const spend = useCallback(
         async (input: SpendBundleInput): Promise<SpendBundleResult> => {
@@ -306,59 +308,73 @@ export const useSpendBundle = () => {
                     },
                 })) as Hex
 
-                // Backend `/prepare` normalizes the executor salt (bytes32) and signature
-                // to 0x-hex regardless of what Rain returned — trust the wire shape here.
-                const withdrawCall: UserOpEncodedParams = {
-                    to: prep.coordinatorAddress as Hex,
-                    value: 0n,
-                    data: encodeFunctionData({
-                        abi: rainCoordinatorAbi,
-                        functionName: 'withdrawAsset',
-                        args: [
-                            prep.collateralProxy as Address,
-                            prep.tokenAddress as Address,
-                            BigInt(prep.amount),
-                            prep.recipientAddress as Address,
-                            BigInt(prep.expiresAt),
-                            prep.executorSalt as Hex,
-                            prep.executorSignature as Hex,
-                            [prep.adminSalt as Hex],
-                            [adminSignature],
-                            prep.directTransfer,
-                        ],
-                    }),
+                // Mixed = two passkey taps. The admin EIP-712 sig (tap #1) just
+                // resolved; the kernel now prepares the follow-up UserOp which
+                // will trigger tap #2. The gap is short but visible — show the
+                // security-verification overlay so the user has something to
+                // look at and the UI feels intentional rather than frozen.
+                // try/finally guarantees the overlay closes on success AND on
+                // bundler / kernel failure.
+                setIsSecurityVerificationOpen(true)
+                try {
+                    // Backend `/prepare` normalizes the executor salt (bytes32) and signature
+                    // to 0x-hex regardless of what Rain returned — trust the wire shape here.
+                    const withdrawCall: UserOpEncodedParams = {
+                        to: prep.coordinatorAddress as Hex,
+                        value: 0n,
+                        data: encodeFunctionData({
+                            abi: rainCoordinatorAbi,
+                            functionName: 'withdrawAsset',
+                            args: [
+                                prep.collateralProxy as Address,
+                                prep.tokenAddress as Address,
+                                BigInt(prep.amount),
+                                prep.recipientAddress as Address,
+                                BigInt(prep.expiresAt),
+                                prep.executorSalt as Hex,
+                                prep.executorSignature as Hex,
+                                [prep.adminSalt as Hex],
+                                [adminSignature],
+                                prep.directTransfer,
+                            ],
+                        }),
+                    }
+
+                    const transferCall: UserOpEncodedParams | null = recipient
+                        ? {
+                              to: PEANUT_WALLET_TOKEN as Hex,
+                              value: 0n,
+                              data: encodeFunctionData({
+                                  abi: erc20Abi,
+                                  functionName: 'transfer',
+                                  args: [recipient, requiredUsdcAmount],
+                              }),
+                          }
+                        : null
+
+                    const calls: UserOpEncodedParams[] = [
+                        withdrawCall,
+                        ...(transferCall ? [transferCall] : []),
+                        ...subsequentCalls,
+                    ]
+                    const { userOpHash, receipt } = await handleSendUserOpEncoded(calls, chainIdStr)
+
+                    // Stamp the intent so the Rain collateral webhook reconciles to the
+                    // right category (P2P_SEND, CRYPTO_WITHDRAW, etc). Non-blocking —
+                    // a stamp failure leaves the intent PENDING, which only affects
+                    // history labeling, not the spend itself.
+                    const mixedTxHash = (receipt?.transactionHash as Hex | undefined) ?? (userOpHash as Hex | undefined)
+                    if (mixedTxHash) {
+                        rainApi
+                            .stampWithdrawal({ preparationId: prep.preparationId, txHash: mixedTxHash })
+                            .catch(() => {})
+                    }
+
+                    posthog.capture(ANALYTICS_EVENTS.CARD_WITHDRAW_SUCCEEDED, { strategy, kind })
+                    return { strategy, userOpHash, receipt, intentId: prep.preparationId }
+                } finally {
+                    setIsSecurityVerificationOpen(false)
                 }
-
-                const transferCall: UserOpEncodedParams | null = recipient
-                    ? {
-                          to: PEANUT_WALLET_TOKEN as Hex,
-                          value: 0n,
-                          data: encodeFunctionData({
-                              abi: erc20Abi,
-                              functionName: 'transfer',
-                              args: [recipient, requiredUsdcAmount],
-                          }),
-                      }
-                    : null
-
-                const calls: UserOpEncodedParams[] = [
-                    withdrawCall,
-                    ...(transferCall ? [transferCall] : []),
-                    ...subsequentCalls,
-                ]
-                const { userOpHash, receipt } = await handleSendUserOpEncoded(calls, chainIdStr)
-
-                // Stamp the intent so the Rain collateral webhook reconciles to the
-                // right category (P2P_SEND, CRYPTO_WITHDRAW, etc). Non-blocking —
-                // a stamp failure leaves the intent PENDING, which only affects
-                // history labeling, not the spend itself.
-                const mixedTxHash = (receipt?.transactionHash as Hex | undefined) ?? (userOpHash as Hex | undefined)
-                if (mixedTxHash) {
-                    rainApi.stampWithdrawal({ preparationId: prep.preparationId, txHash: mixedTxHash }).catch(() => {})
-                }
-
-                posthog.capture(ANALYTICS_EVENTS.CARD_WITHDRAW_SUCCEEDED, { strategy, kind })
-                return { strategy, userOpHash, receipt, intentId: prep.preparationId }
             } catch (e) {
                 const errorKind =
                     e instanceof SessionKeyGrantRequiredError
@@ -373,7 +389,7 @@ export const useSpendBundle = () => {
                 throw e
             }
         },
-        [getClientForChain, handleSendUserOpEncoded, user, overview, grant]
+        [getClientForChain, handleSendUserOpEncoded, user, overview, grant, setIsSecurityVerificationOpen]
     )
 
     return { spend }


### PR DESCRIPTION
… taps

The mixed card-withdraw path runs two passkey prompts back-to-back: an admin EIP-712 signature, then the kernel UserOp that fires the coordinator.withdrawAsset + USDC transfer atomically. Between them the kernel prepares the follow-up op — short on modern devices, but visible enough that the UI looks frozen even when it isn't.

Add a global fullscreen PeanutLoading overlay ("Verifying security…") mounted from the mobile layout, driven by isSecurityVerificationOpen on ModalsContext. useSpendBundle toggles it inside the mixed branch only — opens after the admin sig resolves, closes via try/finally so a bundler failure can't leave the overlay stuck.

Reusable: any future flow that wants the same "between taps" beat can flip the same state via setIsSecurityVerificationOpen, no new component needed.