### PR TITLE
chore: sync main → dev (manual merge of #2049)

### DIFF
--- a/src/components/Home/KycCompletedModal/index.tsx
+++ b/src/components/Home/KycCompletedModal/index.tsx
@@ -4,12 +4,12 @@ import ActionModal from '@/components/Global/ActionModal'
 import type { IconName } from '@/components/Global/Icons/Icon'
 import InfoCard from '@/components/Global/InfoCard'
 import { useAuth } from '@/context/authContext'
-import { MantecaKycStatus } from '@/interfaces'
 import { countryData, MantecaSupportedExchanges, type CountryData } from '@/components/AddMoney/consts'
 import useUnifiedKycStatus from '@/hooks/useUnifiedKycStatus'
 import { useIdentityVerification } from '@/hooks/useIdentityVerification'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
+import { isKycStatusApproved } from '@/constants/kyc.consts'
 
 const KycCompletedModal = ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) => {
     const { user } = useAuth()
@@ -28,13 +28,13 @@ const KycCompletedModal = ({ isOpen, onClose }: { isOpen: boolean; onClose: () =
     const { getVerificationUnlockItems } = useIdentityVerification()
 
     const kycApprovalType = useMemo(() => {
+        if (isBridgeApproved && isMantecaApproved) return 'all'
+        if (isMantecaApproved) return 'manteca'
         if (isSumsubApproved) {
             if (sumsubVerificationRegionIntent === 'LATAM') return 'manteca'
             return 'bridge'
         }
-        if (isBridgeApproved && isMantecaApproved) return 'all'
         if (isBridgeApproved) return 'bridge'
-        if (isMantecaApproved) return 'manteca'
         return 'none'
     }, [isBridgeApproved, isMantecaApproved, isSumsubApproved, sumsubVerificationRegionIntent])
 
@@ -51,9 +51,9 @@ const KycCompletedModal = ({ isOpen, onClose }: { isOpen: boolean; onClose: () =
             // get the manteca approved country
             user?.user.kycVerifications?.forEach((v) => {
                 if (
-                    v.provider === 'MANTECA' &&
+                    (v.provider === 'MANTECA' || v.provider === 'SUMSUB') &&
                     supportedCountries.includes((v.mantecaGeo || '').toUpperCase()) &&
-                    v.status === MantecaKycStatus.ACTIVE
+                    isKycStatusApproved(v.status)
                 ) {
                     approvedCountry = v.mantecaGeo
                 }

--- a/src/hooks/__tests__/kyc-withdrawal-gate.test.tsx
+++ b/src/hooks/__tests__/kyc-withdrawal-gate.test.tsx
@@ -46,13 +46,14 @@ function setUser(authUser: Record<string, unknown>) {
 describe('kyc withdrawal gating', () => {
     afterEach(() => jest.resetAllMocks())
 
-    it('treats migrated SUMSUB ACTIVE rows as approved', () => {
+    it('treats migrated SUMSUB ACTIVE Manteca rows as approved', () => {
         setUser({
             user: {
                 bridgeKycStatus: null,
                 kycVerifications: [
                     {
                         provider: 'SUMSUB',
+                        mantecaGeo: 'AR',
                         status: 'ACTIVE',
                         updatedAt: '2026-03-26T23:02:30.330Z',
                     },
@@ -64,10 +65,11 @@ describe('kyc withdrawal gating', () => {
         const { result } = renderHook(() => useUnifiedKycStatus())
 
         expect(result.current.isSumsubApproved).toBe(true)
+        expect(result.current.isMantecaApproved).toBe(true)
         expect(result.current.isKycApproved).toBe(true)
     })
 
-    it('allows Argentina Manteca withdrawal when migrated KYC and rails are enabled', () => {
+    it('allows Argentina Manteca withdrawal when migrated KYC is country-scoped', () => {
         setUser({
             user: {
                 bridgeKycStatus: null,
@@ -80,11 +82,46 @@ describe('kyc withdrawal gating', () => {
                     },
                 ],
             },
-            rails: [enabledMantecaArRail],
+            rails: [],
         })
 
         const { result } = renderHook(() => useIdentityVerification())
 
         expect(result.current.isVerifiedForCountry('AR')).toBe(true)
+    })
+
+    it('allows Argentina Manteca withdrawal for a normal active Manteca row', () => {
+        setUser({
+            user: {
+                bridgeKycStatus: null,
+                kycVerifications: [
+                    {
+                        provider: 'MANTECA',
+                        mantecaGeo: 'AR',
+                        status: 'ACTIVE',
+                        updatedAt: '2025-10-30T01:12:06.099Z',
+                    },
+                ],
+            },
+            rails: [],
+        })
+
+        const { result } = renderHook(() => useIdentityVerification())
+
+        expect(result.current.isVerifiedForCountry('AR')).toBe(true)
+    })
+
+    it('does not allow Argentina Manteca withdrawal from an enabled rail alone', () => {
+        setUser({
+            user: {
+                bridgeKycStatus: null,
+                kycVerifications: [],
+            },
+            rails: [enabledMantecaArRail],
+        })
+
+        const { result } = renderHook(() => useIdentityVerification())
+
+        expect(result.current.isVerifiedForCountry('AR')).toBe(false)
     })
 })

--- a/src/hooks/__tests__/kyc-withdrawal-gate.test.tsx
+++ b/src/hooks/__tests__/kyc-withdrawal-gate.test.tsx
@@ -1,0 +1,90 @@
+import { renderHook } from '@testing-library/react'
+import { useIdentityVerification } from '../useIdentityVerification'
+import useUnifiedKycStatus from '../useUnifiedKycStatus'
+
+jest.mock('@/assets', () => ({
+    EUROPE_GLOBE_ICON: 'europe',
+    LATAM_GLOBE_ICON: 'latam',
+    NORTH_AMERICA_GLOBE_ICON: 'north-america',
+    REST_OF_WORLD_GLOBE_ICON: 'rest-of-world',
+}))
+
+jest.mock('@/components/AddMoney/consts', () => ({
+    BRIDGE_ALPHA3_TO_ALPHA2: { USA: 'US' },
+    MantecaSupportedExchanges: { AR: 'ARGENTINA', BR: 'BRAZIL' },
+    countryData: [
+        { id: 'AR', type: 'country', title: 'Argentina', path: 'argentina', iso2: 'AR' },
+        { id: 'US', type: 'country', title: 'United States', path: 'united-states', iso2: 'US' },
+    ],
+}))
+
+jest.mock('@/context/authContext', () => ({
+    useAuth: jest.fn(),
+}))
+
+import { useAuth } from '@/context/authContext'
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>
+
+const enabledMantecaArRail = {
+    id: 'rail-1',
+    railId: 'rail-def-1',
+    status: 'ENABLED',
+    rail: {
+        id: 'rail-def-1',
+        provider: { code: 'MANTECA', name: 'Manteca' },
+        method: { code: 'BANK_TRANSFER_AR', name: 'Bank Transfer AR', country: 'AR', currency: 'ARS' },
+    },
+}
+
+function setUser(authUser: Record<string, unknown>) {
+    mockUseAuth.mockReturnValue({
+        user: authUser,
+    } as unknown as ReturnType<typeof useAuth>)
+}
+
+describe('kyc withdrawal gating', () => {
+    afterEach(() => jest.resetAllMocks())
+
+    it('treats migrated SUMSUB ACTIVE rows as approved', () => {
+        setUser({
+            user: {
+                bridgeKycStatus: null,
+                kycVerifications: [
+                    {
+                        provider: 'SUMSUB',
+                        status: 'ACTIVE',
+                        updatedAt: '2026-03-26T23:02:30.330Z',
+                    },
+                ],
+            },
+            rails: [],
+        })
+
+        const { result } = renderHook(() => useUnifiedKycStatus())
+
+        expect(result.current.isSumsubApproved).toBe(true)
+        expect(result.current.isKycApproved).toBe(true)
+    })
+
+    it('allows Argentina Manteca withdrawal when migrated KYC and rails are enabled', () => {
+        setUser({
+            user: {
+                bridgeKycStatus: null,
+                kycVerifications: [
+                    {
+                        provider: 'SUMSUB',
+                        mantecaGeo: 'AR',
+                        status: 'ACTIVE',
+                        updatedAt: '2026-03-17T14:47:34.702Z',
+                    },
+                ],
+            },
+            rails: [enabledMantecaArRail],
+        })
+
+        const { result } = renderHook(() => useIdentityVerification())
+
+        expect(result.current.isVerifiedForCountry('AR')).toBe(true)
+    })
+})

--- a/src/hooks/useIdentityVerification.tsx
+++ b/src/hooks/useIdentityVerification.tsx
@@ -4,11 +4,11 @@ import useKycStatus from './useKycStatus'
 import useUnifiedKycStatus from './useUnifiedKycStatus'
 import { useMemo, useCallback } from 'react'
 import { useAuth } from '@/context/authContext'
-import { MantecaKycStatus } from '@/interfaces'
 import { BRIDGE_ALPHA3_TO_ALPHA2, MantecaSupportedExchanges, countryData } from '@/components/AddMoney/consts'
 import { getFlagUrl } from '@/constants/countryCurrencyMapping'
 import { type KYCRegionIntent } from '@/app/actions/types/sumsub.types'
 import React from 'react'
+import { isKycStatusApproved } from '@/constants/kyc.consts'
 
 /** Represents a geographic region with its display information */
 export type Region = {
@@ -134,17 +134,34 @@ export const useIdentityVerification = () => {
         (code: string) => {
             const upper = code.toUpperCase()
 
-            // Check if user has active Manteca verification for this specific country
             const mantecaActive =
                 user?.user.kycVerifications?.some(
                     (v) =>
                         v.provider === 'MANTECA' &&
                         (v.mantecaGeo || '').toUpperCase() === upper &&
-                        v.status === MantecaKycStatus.ACTIVE
+                        isKycStatusApproved(v.status)
+                ) ?? false
+
+            const migratedMantecaActive =
+                user?.user.kycVerifications?.some(
+                    (v) =>
+                        v.provider === 'SUMSUB' &&
+                        (v.mantecaGeo || '').toUpperCase() === upper &&
+                        isKycStatusApproved(v.status)
+                ) ?? false
+
+            const hasEnabledMantecaRail =
+                user?.rails?.some(
+                    (rail) =>
+                        rail.rail.provider.code === 'MANTECA' &&
+                        rail.rail.method.country.toUpperCase() === upper &&
+                        rail.status === 'ENABLED'
                 ) ?? false
 
             // Manteca countries need country-specific verification, others just need Bridge KYC
-            return isMantecaSupportedCountry(upper) ? mantecaActive : isUserBridgeKycApproved
+            return isMantecaSupportedCountry(upper)
+                ? mantecaActive || migratedMantecaActive || hasEnabledMantecaRail
+                : isUserBridgeKycApproved
         },
         [user, isUserBridgeKycApproved, isMantecaSupportedCountry]
     )

--- a/src/hooks/useIdentityVerification.tsx
+++ b/src/hooks/useIdentityVerification.tsx
@@ -137,31 +137,13 @@ export const useIdentityVerification = () => {
             const mantecaActive =
                 user?.user.kycVerifications?.some(
                     (v) =>
-                        v.provider === 'MANTECA' &&
+                        (v.provider === 'MANTECA' || v.provider === 'SUMSUB') &&
                         (v.mantecaGeo || '').toUpperCase() === upper &&
                         isKycStatusApproved(v.status)
-                ) ?? false
-
-            const migratedMantecaActive =
-                user?.user.kycVerifications?.some(
-                    (v) =>
-                        v.provider === 'SUMSUB' &&
-                        (v.mantecaGeo || '').toUpperCase() === upper &&
-                        isKycStatusApproved(v.status)
-                ) ?? false
-
-            const hasEnabledMantecaRail =
-                user?.rails?.some(
-                    (rail) =>
-                        rail.rail.provider.code === 'MANTECA' &&
-                        rail.rail.method.country.toUpperCase() === upper &&
-                        rail.status === 'ENABLED'
                 ) ?? false
 
             // Manteca countries need country-specific verification, others just need Bridge KYC
-            return isMantecaSupportedCountry(upper)
-                ? mantecaActive || migratedMantecaActive || hasEnabledMantecaRail
-                : isUserBridgeKycApproved
+            return isMantecaSupportedCountry(upper) ? mantecaActive : isUserBridgeKycApproved
         },
         [user, isUserBridgeKycApproved, isMantecaSupportedCountry]
     )

--- a/src/hooks/useUnifiedKycStatus.ts
+++ b/src/hooks/useUnifiedKycStatus.ts
@@ -1,7 +1,6 @@
 'use client'
 
 import { useAuth } from '@/context/authContext'
-import { MantecaKycStatus } from '@/interfaces'
 import { useMemo } from 'react'
 import { type SumsubKycStatus } from '@/app/actions/types/sumsub.types'
 import { isKycStatusApproved, isSumsubStatusInProgress } from '@/constants/kyc.consts'
@@ -18,7 +17,9 @@ export default function useUnifiedKycStatus() {
     const isMantecaApproved = useMemo(
         () =>
             user?.user.kycVerifications?.some(
-                (v) => v.provider === 'MANTECA' && v.status === MantecaKycStatus.ACTIVE
+                (v) =>
+                    (v.provider === 'MANTECA' || (v.provider === 'SUMSUB' && !!v.mantecaGeo)) &&
+                    isKycStatusApproved(v.status)
             ) ?? false,
         [user]
     )

--- a/src/hooks/useUnifiedKycStatus.ts
+++ b/src/hooks/useUnifiedKycStatus.ts
@@ -4,7 +4,7 @@ import { useAuth } from '@/context/authContext'
 import { MantecaKycStatus } from '@/interfaces'
 import { useMemo } from 'react'
 import { type SumsubKycStatus } from '@/app/actions/types/sumsub.types'
-import { isSumsubStatusInProgress } from '@/constants/kyc.consts'
+import { isKycStatusApproved, isSumsubStatusInProgress } from '@/constants/kyc.consts'
 
 /**
  * single source of truth for kyc status across all providers (bridge, manteca, sumsub).
@@ -32,7 +32,7 @@ export default function useUnifiedKycStatus() {
         [user]
     )
 
-    const isSumsubApproved = useMemo(() => sumsubVerification?.status === 'APPROVED', [sumsubVerification])
+    const isSumsubApproved = useMemo(() => isKycStatusApproved(sumsubVerification?.status), [sumsubVerification])
 
     const sumsubStatus = useMemo(() => (sumsubVerification?.status as SumsubKycStatus) ?? null, [sumsubVerification])
 


### PR DESCRIPTION
Manual-merge replacement for #2049 (which has unresolved conflicts).

## Conflicts

Two files, both touched by:
- dev (\`810167cff chore: fix PR lint errors\`, \`9d8a8e616 fix: consolidate Manteca supported countries\`) — cleanup to a new helper API
- main (\`cbf66b634 Fix migrated KYC withdrawal gating\`, \`25b6a13bf Tighten migrated Manteca KYC semantics\`) — bugfix to broaden the matching logic

### \`src/components/Home/KycCompletedModal/index.tsx\`

Both sides rewrote the verification-matching block in the \`isMantecaApproved\` useEffect.

| Aspect | dev | main | merged |
|---|---|---|---|
| Country gate | \`isMantecaSupportedCountryCode(v.mantecaGeo)\` | \`supportedCountries.includes(v.mantecaGeo.toUpperCase())\` | **dev's helper** (cleaner) |
| Status check | \`v.status === MantecaKycStatus.ACTIVE\` | \`isKycStatusApproved(v.status)\` | **main's helper** (bugfix — broader status set) |
| Provider filter | \`v.provider === 'MANTECA'\` | \`(v.provider === 'MANTECA' \\\\\\\\\|| v.provider === 'SUMSUB')\` | **main's filter** (bugfix — covers SUMSUB-provider rows) |

Net: kept dev's country helper, took main's broader provider + status logic. Dropped unused \`MantecaKycStatus\` and \`MantecaSupportedExchanges\` imports.

### \`src/hooks/useIdentityVerification.tsx\`

Same pattern — single-block import conflict; the body was auto-merged with dev's helper (\`isMantecaSupportedCountryCode\`) + main's broader logic (\`provider === MANTECA || SUMSUB\`, \`isKycStatusApproved\`). Cleaned up unused imports that the auto-merge left dangling.

## Verification

- typecheck clean
- 4/4 \`kyc-withdrawal-gate.test.tsx\` cases pass (covers the migrated-cohort behavior main introduced)

Closes #2049.