### PR TITLE
fix: check transfer readiness gate before 'under review' modal

### DIFF
--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -144,6 +144,12 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
             return { error: 'gate_blocked', silent: true }
         }
 
+        // bridge kyc still under review — don't initiate a new sumsub flow
+        if (isUserBridgeKycUnderReview) {
+            setShowKycStatusModal(true)
+            return { error: 'gate_blocked', silent: true }
+        }
+
         // scenario (1): happy path: if the user has already completed kyc, we can add the bank account directly
         // email and name are now collected by sumsub — no need to check them here
         if (isUserKycApproved) {

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -13,7 +13,7 @@ import { withdrawBankUrl, rewriteMethodPath } from '@/utils/native-routes'
 import { isCapacitor } from '@/utils/capacitor'
 import EmptyState from '../Global/EmptyStates/EmptyState'
 import { useAuth } from '@/context/authContext'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { DynamicBankAccountForm, type IBankAccountDetails } from './DynamicBankAccountForm'
 import { addBankAccount } from '@/app/actions/users'
 import { type AddBankAccountPayload } from '@/app/actions/types/users.types'
@@ -83,6 +83,9 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
     const { setIsSupportModalOpen } = useModalsContext()
     const [showKycStatusModal, setShowKycStatusModal] = useState(false)
 
+    // stores the callback to replay after tos acceptance in the list view
+    const pendingAfterTosRef = useRef<(() => void) | null>(null)
+
     // close kyc modal when sumsub sdk opens
     useEffect(() => {
         if (sumsubFlow.showWrapper) setIsKycModalOpen(false)
@@ -99,6 +102,27 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
 
     const currentCountry = countryData.find(
         (country) => country.type === 'country' && country.path === countrySlugFromUrl
+    )
+
+    /** returns true if the user is gated (caller should return early) */
+    const checkBridgeGate = useCallback(
+        (onAfterTos?: () => void): boolean => {
+            if (gate.type !== 'ready') {
+                if (gate.type === 'accept_tos') {
+                    pendingAfterTosRef.current = onAfterTos ?? null
+                    guardWithTos()
+                } else {
+                    setIsKycModalOpen(true)
+                }
+                return true
+            }
+            if (isUserBridgeKycUnderReview) {
+                setShowKycStatusModal(true)
+                return true
+            }
+            return false
+        },
+        [gate, isUserBridgeKycUnderReview, guardWithTos]
     )
 
     const handleFormSubmit = async (
@@ -181,19 +205,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
             const extraParams = isBankFromSend ? `method=${methodParam}` : undefined
             router.push(rewriteMethodPath(method.path, extraParams))
         } else if (method.id.includes('default-bank-withdraw') || method.id.includes('sepa-instant-withdraw')) {
-            // check transfer readiness gate first — tos takes priority over generic "under review"
-            if (gate.type !== 'ready') {
-                if (gate.type === 'accept_tos') {
-                    guardWithTos()
-                } else {
-                    setIsKycModalOpen(true)
-                }
-                return
-            }
-            if (isUserBridgeKycUnderReview) {
-                setShowKycStatusModal(true)
-                return
-            }
+            if (checkBridgeGate(() => handleWithdrawMethodClick(method))) return
 
             // Bridge methods: Set in context and navigate for amount input
             setSelectedMethod({
@@ -224,19 +236,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                 setIsSupportedTokensModalOpen(true)
                 return
             }
-            // check transfer readiness gate first — tos takes priority over generic "under review"
-            if (gate.type !== 'ready') {
-                if (gate.type === 'accept_tos') {
-                    guardWithTos()
-                } else {
-                    setIsKycModalOpen(true)
-                }
-                return
-            }
-            if (isUserBridgeKycUnderReview) {
-                setShowKycStatusModal(true)
-                return
-            }
+            if (checkBridgeGate(() => handleAddMethodClick(method))) return
 
             const target = rewriteMethodPath(method.path)
             // force full navigation in capacitor — router.push to same page with
@@ -286,6 +286,48 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
         )
     }
 
+    // shared modals — rendered once regardless of view (form vs list)
+    const sharedModals = (
+        <>
+            <InitiateKycModal
+                visible={isKycModalOpen}
+                onClose={() => setIsKycModalOpen(false)}
+                onVerify={async () => {
+                    if (gate.type === 'fixable_rejection') {
+                        await sumsubFlow.handleSelfHealResubmit('BRIDGE')
+                    } else {
+                        await sumsubFlow.handleInitiateKyc(
+                            'STANDARD',
+                            undefined,
+                            gate.type === 'needs_enrollment' || undefined
+                        )
+                    }
+                }}
+                onContactSupport={() => {
+                    setIsKycModalOpen(false)
+                    setIsSupportModalOpen(true)
+                }}
+                isLoading={sumsubFlow.isLoading}
+                error={sumsubFlow.error}
+                variant={getKycModalVariant(gate.type)}
+                providerMessage={getGateProviderMessage(gate)}
+                regionName={currentCountry?.title}
+            />
+            <BridgeTosStep
+                visible={showBridgeTos}
+                onComplete={() => {
+                    hideTos()
+                    const replay = pendingAfterTosRef.current
+                    pendingAfterTosRef.current = null
+                    if (replay) replay()
+                    else formRef.current?.handleSubmit()
+                }}
+                onSkip={hideTos}
+            />
+            <SumsubKycModals flow={sumsubFlow} />
+        </>
+    )
+
     if (view === 'form') {
         return (
             <div className="flex min-h-[inherit] flex-col justify-normal gap-8">
@@ -324,39 +366,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                     initialData={{}}
                     error={null}
                 />
-                <InitiateKycModal
-                    visible={isKycModalOpen}
-                    onClose={() => setIsKycModalOpen(false)}
-                    onVerify={async () => {
-                        if (gate.type === 'fixable_rejection') {
-                            await sumsubFlow.handleSelfHealResubmit('BRIDGE')
-                        } else {
-                            await sumsubFlow.handleInitiateKyc(
-                                'STANDARD',
-                                undefined,
-                                gate.type === 'needs_enrollment' || undefined
-                            )
-                        }
-                    }}
-                    onContactSupport={() => {
-                        setIsKycModalOpen(false)
-                        setIsSupportModalOpen(true)
-                    }}
-                    isLoading={sumsubFlow.isLoading}
-                    error={sumsubFlow.error}
-                    variant={getKycModalVariant(gate.type)}
-                    providerMessage={getGateProviderMessage(gate)}
-                    regionName={currentCountry?.title}
-                />
-                <BridgeTosStep
-                    visible={showBridgeTos}
-                    onComplete={() => {
-                        hideTos()
-                        formRef.current?.handleSubmit()
-                    }}
-                    onSkip={hideTos}
-                />
-                <SumsubKycModals flow={sumsubFlow} />
+                {sharedModals}
             </div>
         )
     }
@@ -471,39 +481,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                 isKycApprovedModalOpen={showKycStatusModal}
                 onClose={() => setShowKycStatusModal(false)}
             />
-            <InitiateKycModal
-                visible={isKycModalOpen}
-                onClose={() => setIsKycModalOpen(false)}
-                onVerify={async () => {
-                    if (gate.type === 'fixable_rejection') {
-                        await sumsubFlow.handleSelfHealResubmit('BRIDGE')
-                    } else {
-                        await sumsubFlow.handleInitiateKyc(
-                            'STANDARD',
-                            undefined,
-                            gate.type === 'needs_enrollment' || undefined
-                        )
-                    }
-                }}
-                onContactSupport={() => {
-                    setIsKycModalOpen(false)
-                    setIsSupportModalOpen(true)
-                }}
-                isLoading={sumsubFlow.isLoading}
-                error={sumsubFlow.error}
-                variant={getKycModalVariant(gate.type)}
-                providerMessage={getGateProviderMessage(gate)}
-                regionName={currentCountry?.title}
-            />
-            <BridgeTosStep
-                visible={showBridgeTos}
-                onComplete={() => {
-                    hideTos()
-                    // re-attempt the action after tos acceptance
-                }}
-                onSkip={hideTos}
-            />
-            <SumsubKycModals flow={sumsubFlow} />
+            {sharedModals}
         </div>
     )
 }

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -181,6 +181,15 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
             const extraParams = isBankFromSend ? `method=${methodParam}` : undefined
             router.push(rewriteMethodPath(method.path, extraParams))
         } else if (method.id.includes('default-bank-withdraw') || method.id.includes('sepa-instant-withdraw')) {
+            // check transfer readiness gate first — tos takes priority over generic "under review"
+            if (gate.type !== 'ready') {
+                if (gate.type === 'accept_tos') {
+                    guardWithTos()
+                } else {
+                    setIsKycModalOpen(true)
+                }
+                return
+            }
             if (isUserBridgeKycUnderReview) {
                 setShowKycStatusModal(true)
                 return
@@ -215,7 +224,15 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                 setIsSupportedTokensModalOpen(true)
                 return
             }
-            // show kyc status modal if user is kyc under review
+            // check transfer readiness gate first — tos takes priority over generic "under review"
+            if (gate.type !== 'ready') {
+                if (gate.type === 'accept_tos') {
+                    guardWithTos()
+                } else {
+                    setIsKycModalOpen(true)
+                }
+                return
+            }
             if (isUserBridgeKycUnderReview) {
                 setShowKycStatusModal(true)
                 return
@@ -453,6 +470,38 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
             <KycVerifiedOrReviewModal
                 isKycApprovedModalOpen={showKycStatusModal}
                 onClose={() => setShowKycStatusModal(false)}
+            />
+            <InitiateKycModal
+                visible={isKycModalOpen}
+                onClose={() => setIsKycModalOpen(false)}
+                onVerify={async () => {
+                    if (gate.type === 'fixable_rejection') {
+                        await sumsubFlow.handleSelfHealResubmit('BRIDGE')
+                    } else {
+                        await sumsubFlow.handleInitiateKyc(
+                            'STANDARD',
+                            undefined,
+                            gate.type === 'needs_enrollment' || undefined
+                        )
+                    }
+                }}
+                onContactSupport={() => {
+                    setIsKycModalOpen(false)
+                    setIsSupportModalOpen(true)
+                }}
+                isLoading={sumsubFlow.isLoading}
+                error={sumsubFlow.error}
+                variant={getKycModalVariant(gate.type)}
+                providerMessage={getGateProviderMessage(gate)}
+                regionName={currentCountry?.title}
+            />
+            <BridgeTosStep
+                visible={showBridgeTos}
+                onComplete={() => {
+                    hideTos()
+                    // re-attempt the action after tos acceptance
+                }}
+                onSkip={hideTos}
             />
             <SumsubKycModals flow={sumsubFlow} />
         </div>

--- a/src/features/limits/views/LimitsPageView.tsx
+++ b/src/features/limits/views/LimitsPageView.tsx
@@ -20,7 +20,7 @@ import { getProviderRoute } from '../utils'
 const LimitsPageView = () => {
     const onBack = useSafeBack('/profile', { replace: true })
     const { unlockedRegions, lockedRegions } = useIdentityVerification()
-    const { isUserKycApproved, isUserBridgeKycUnderReview } = useKycStatus()
+    const { isUserKycApproved, isUserBridgeKycUnderReview, isUserBridgeKycIncomplete } = useKycStatus()
     const { hasMantecaLimits } = useLimits()
 
     // check if user has any kyc at all
@@ -67,7 +67,7 @@ const LimitsPageView = () => {
 
             {/* locked regions - only render if there are actual locked regions */}
             {filteredLockedRegions.length > 0 && (
-                <LockedRegionsList regions={filteredLockedRegions} isBridgeKycPending={isUserBridgeKycUnderReview} />
+                <LockedRegionsList regions={filteredLockedRegions} isBridgeKycPending={isUserBridgeKycUnderReview || isUserBridgeKycIncomplete} />
             )}
 
             {/* rest of world - always shown with coming soon */}

--- a/src/features/limits/views/LimitsPageView.tsx
+++ b/src/features/limits/views/LimitsPageView.tsx
@@ -67,7 +67,10 @@ const LimitsPageView = () => {
 
             {/* locked regions - only render if there are actual locked regions */}
             {filteredLockedRegions.length > 0 && (
-                <LockedRegionsList regions={filteredLockedRegions} isBridgeKycPending={isUserBridgeKycUnderReview || isUserBridgeKycIncomplete} />
+                <LockedRegionsList
+                    regions={filteredLockedRegions}
+                    isBridgeKycPending={isUserBridgeKycUnderReview || isUserBridgeKycIncomplete}
+                />
             )}
 
             {/* rest of world - always shown with coming soon */}

--- a/src/hooks/__tests__/useBridgeTransferReadiness.test.ts
+++ b/src/hooks/__tests__/useBridgeTransferReadiness.test.ts
@@ -130,6 +130,12 @@ describe('useBridgeTransferReadiness', () => {
         const { result } = renderHook(() => useBridgeTransferReadiness())
         expect(result.current.gate.type).toBe('accept_tos')
     })
+
+    it('accept_tos when bridge incomplete and tos needed (main bug scenario)', () => {
+        setup({ needsBridgeTos: true, isBridgeIncomplete: true, isSumsubApproved: true })
+        const { result } = renderHook(() => useBridgeTransferReadiness())
+        expect(result.current.gate.type).toBe('accept_tos')
+    })
 })
 
 describe('getKycModalVariant', () => {

--- a/src/hooks/__tests__/useBridgeTransferReadiness.test.ts
+++ b/src/hooks/__tests__/useBridgeTransferReadiness.test.ts
@@ -41,6 +41,7 @@ function setup({
     isSumsubApproved = false,
     isBridgeApproved = false,
     isBridgeUnderReview = false,
+    isBridgeIncomplete = false,
 } = {}) {
     mockTosStatus.mockReturnValue({
         needsBridgeTos,
@@ -59,6 +60,7 @@ function setup({
         isUserSumsubKycApproved: isSumsubApproved,
         isUserBridgeKycApproved: isBridgeApproved,
         isUserBridgeKycUnderReview: isBridgeUnderReview,
+        isUserBridgeKycIncomplete: isBridgeIncomplete,
         isUserMantecaKycApproved: false,
         isUserKycApproved: isBridgeApproved,
     })
@@ -101,6 +103,12 @@ describe('useBridgeTransferReadiness', () => {
 
     it('ready when sumsub approved and bridge under review (enrollment not needed)', () => {
         setup({ isSumsubApproved: true, isBridgeUnderReview: true })
+        const { result } = renderHook(() => useBridgeTransferReadiness())
+        expect(result.current.gate.type).toBe('ready')
+    })
+
+    it('ready when sumsub approved and bridge incomplete (enrollment not needed)', () => {
+        setup({ isSumsubApproved: true, isBridgeIncomplete: true })
         const { result } = renderHook(() => useBridgeTransferReadiness())
         expect(result.current.gate.type).toBe('ready')
     })

--- a/src/hooks/useBridgeTransferReadiness.ts
+++ b/src/hooks/useBridgeTransferReadiness.ts
@@ -25,7 +25,8 @@ export type BridgeGateAction =
 export function useBridgeTransferReadiness() {
     const { needsBridgeTos } = useBridgeTosStatus()
     const { bridge: bridgeRejection } = useProviderRejectionStatus()
-    const { isUserSumsubKycApproved, isUserBridgeKycApproved, isUserBridgeKycUnderReview } = useKycStatus()
+    const { isUserSumsubKycApproved, isUserBridgeKycApproved, isUserBridgeKycUnderReview, isUserBridgeKycIncomplete } =
+        useKycStatus()
 
     const gate: BridgeGateAction = useMemo(() => {
         // 1. hard rejection — contact support (checked first because tos is moot for hard-rejected users)
@@ -41,14 +42,26 @@ export function useBridgeTransferReadiness() {
             return { type: 'fixable_rejection', userMessage: bridgeRejection.userMessage }
         }
 
-        // 4. needs enrollment (sumsub approved but bridge not started/approved)
-        if (isUserSumsubKycApproved && !isUserBridgeKycApproved && !isUserBridgeKycUnderReview) {
+        // 4. needs enrollment (sumsub approved but bridge not started/approved/in-progress)
+        if (
+            isUserSumsubKycApproved &&
+            !isUserBridgeKycApproved &&
+            !isUserBridgeKycUnderReview &&
+            !isUserBridgeKycIncomplete
+        ) {
             return { type: 'needs_enrollment' }
         }
 
         // 5. ready
         return { type: 'ready' }
-    }, [needsBridgeTos, bridgeRejection, isUserSumsubKycApproved, isUserBridgeKycApproved, isUserBridgeKycUnderReview])
+    }, [
+        needsBridgeTos,
+        bridgeRejection,
+        isUserSumsubKycApproved,
+        isUserBridgeKycApproved,
+        isUserBridgeKycUnderReview,
+        isUserBridgeKycIncomplete,
+    ])
 
     return { gate }
 }

--- a/src/hooks/useHomeCarouselCTAs.tsx
+++ b/src/hooks/useHomeCarouselCTAs.tsx
@@ -83,7 +83,8 @@ export const useHomeCarouselCTAs = () => {
     } = useNotifications()
     const toast = useToast()
     const router = useRouter()
-    const { isUserKycApproved, isUserBridgeKycUnderReview, isUserMantecaKycApproved } = useKycStatus()
+    const { isUserKycApproved, isUserBridgeKycUnderReview, isUserBridgeKycIncomplete, isUserMantecaKycApproved } =
+        useKycStatus()
     const { deviceType } = useDeviceType()
     const isPwa = usePWAStatus()
     const { setIsIosPwaInstallModalOpen, openSupportWithMessage } = useModalsContext()
@@ -287,7 +288,7 @@ export const useHomeCarouselCTAs = () => {
             })
         }
 
-        if (!hasKycApproval && !isUserBridgeKycUnderReview) {
+        if (!hasKycApproval && !isUserBridgeKycUnderReview && !isUserBridgeKycIncomplete) {
             _carouselCTAs.push({
                 id: 'kyc-prompt',
                 title: (
@@ -317,6 +318,7 @@ export const useHomeCarouselCTAs = () => {
         isPushOptedIn,
         isUserKycApproved,
         isUserBridgeKycUnderReview,
+        isUserBridgeKycIncomplete,
         isUserMantecaKycApproved,
         router,
         requestPermission,

--- a/src/hooks/useKycStatus.tsx
+++ b/src/hooks/useKycStatus.tsx
@@ -7,7 +7,7 @@ import useUnifiedKycStatus from './useUnifiedKycStatus'
  * existing consumers keep the same api shape.
  */
 export default function useKycStatus() {
-    const { isBridgeApproved, isMantecaApproved, isSumsubApproved, isKycApproved, isBridgeUnderReview } =
+    const { isBridgeApproved, isMantecaApproved, isSumsubApproved, isKycApproved, isBridgeUnderReview, isBridgeIncomplete } =
         useUnifiedKycStatus()
 
     return {
@@ -16,5 +16,6 @@ export default function useKycStatus() {
         isUserSumsubKycApproved: isSumsubApproved,
         isUserKycApproved: isKycApproved,
         isUserBridgeKycUnderReview: isBridgeUnderReview,
+        isUserBridgeKycIncomplete: isBridgeIncomplete,
     }
 }

--- a/src/hooks/useKycStatus.tsx
+++ b/src/hooks/useKycStatus.tsx
@@ -7,8 +7,14 @@ import useUnifiedKycStatus from './useUnifiedKycStatus'
  * existing consumers keep the same api shape.
  */
 export default function useKycStatus() {
-    const { isBridgeApproved, isMantecaApproved, isSumsubApproved, isKycApproved, isBridgeUnderReview, isBridgeIncomplete } =
-        useUnifiedKycStatus()
+    const {
+        isBridgeApproved,
+        isMantecaApproved,
+        isSumsubApproved,
+        isKycApproved,
+        isBridgeUnderReview,
+        isBridgeIncomplete,
+    } = useUnifiedKycStatus()
 
     return {
         isUserBridgeKycApproved: isBridgeApproved,

--- a/src/hooks/useUnifiedKycStatus.ts
+++ b/src/hooks/useUnifiedKycStatus.ts
@@ -55,18 +55,19 @@ export default function useUnifiedKycStatus() {
         [isBridgeApproved, isMantecaApproved, isSumsubApproved]
     )
 
-    const isBridgeUnderReview = useMemo(
-        () => user?.user.bridgeKycStatus === 'under_review' || user?.user.bridgeKycStatus === 'incomplete',
-        [user]
-    )
+    // bridge is actively reviewing submitted docs
+    const isBridgeUnderReview = useMemo(() => user?.user.bridgeKycStatus === 'under_review', [user])
+
+    // user still needs to complete requirements (tos, proof of address, etc.)
+    const isBridgeIncomplete = useMemo(() => user?.user.bridgeKycStatus === 'incomplete', [user])
 
     const isSumsubActionRequired = useMemo(() => sumsubStatus === 'ACTION_REQUIRED', [sumsubStatus])
 
     const isSumsubInProgress = useMemo(() => isSumsubStatusInProgress(sumsubStatus), [sumsubStatus])
 
     const isKycInProgress = useMemo(
-        () => isBridgeUnderReview || isSumsubInProgress,
-        [isBridgeUnderReview, isSumsubInProgress]
+        () => isBridgeUnderReview || isBridgeIncomplete || isSumsubInProgress,
+        [isBridgeUnderReview, isBridgeIncomplete, isSumsubInProgress]
     )
 
     return {
@@ -76,6 +77,7 @@ export default function useUnifiedKycStatus() {
         // bridge
         isBridgeApproved,
         isBridgeUnderReview,
+        isBridgeIncomplete,
         // manteca
         isMantecaApproved,
         // sumsub


### PR DESCRIPTION
## Summary
- **Bug:** Users with Bridge KYC `incomplete` status (needs TOS) saw "Your verification is under review" dead-end modal instead of the TOS acceptance flow
- **Root cause:** `AddWithdrawCountriesList` checked `isUserBridgeKycUnderReview` before the transfer readiness gate, and `isBridgeUnderReview` included both `under_review` AND `incomplete` statuses
- **Fix:** Gate check runs first (TOS → rejection → enrollment → ready), then falls back to "under review" modal only for genuinely reviewing users

## Changes
- `useUnifiedKycStatus` — split `isBridgeUnderReview` (only `under_review`) from new `isBridgeIncomplete` (only `incomplete`)
- `useKycStatus` — expose `isUserBridgeKycIncomplete`
- `AddWithdrawCountriesList` — check gate before status modal in both `handleAddMethodClick` and `handleWithdrawMethodClick`; added `BridgeTosStep` and `InitiateKycModal` to list view
- `useBridgeTransferReadiness` — skip `needs_enrollment` for `incomplete` users (already have Bridge rails)
- `useHomeCarouselCTAs` — exclude incomplete users from "start KYC" CTA
- `LimitsPageView` — use combined flag for locked regions badge

**Companion PR:** peanutprotocol/peanut-api-ts#843 (backend status mapping fix)

## Test plan
- [ ] `npm test` — all 53 suites pass (1074 tests)
- [ ] `npx tsc --noEmit` — clean
- [ ] User with `incomplete` status + TOS needed → sees TOS modal on country method click
- [ ] User with `under_review` status (genuinely reviewing) → sees "under review" modal
- [ ] User with `rejected` status → gate shows rejection modal