### PR TITLE
fix(card): live PIN validation + drop redundant waitlist modal

### DIFF
--- a/src/components/Card/CardPinSetupFlow.tsx
+++ b/src/components/Card/CardPinSetupFlow.tsx
@@ -94,6 +94,12 @@ const CardPinSetupFlow: FC<Props> = ({ cardId, onDone }) => {
         )
     }
 
+    // Validate live once the user has typed all 4 digits so they see the
+    // failure reason BEFORE clicking Continue (and the button stays disabled
+    // for invalid PINs). Past behavior: 1111 only failed on the next step
+    // after the user re-entered + submitted, surprising them.
+    const choosePinValidation = first.length === 4 ? validatePin(first) : null
+
     return (
         <div className="flex flex-col items-center gap-6 text-center">
             <div className="flex flex-col gap-2">
@@ -106,13 +112,16 @@ const CardPinSetupFlow: FC<Props> = ({ cardId, onDone }) => {
                 <li>No repeating digits (1111)</li>
                 <li>You can change your PIN later</li>
             </ul>
+            {choosePinValidation && !choosePinValidation.valid && (
+                <p className="text-sm text-red">{choosePinValidation.reason}</p>
+            )}
             {error && <p className="text-sm text-red">{error}</p>}
             <Button
                 variant="purple"
                 shadowSize="4"
                 className="w-full"
                 onClick={onContinueFromChoose}
-                disabled={first.length < 4}
+                disabled={!choosePinValidation || !choosePinValidation.valid}
             >
                 Continue
             </Button>

--- a/src/components/Card/PhysicalCardScreen.tsx
+++ b/src/components/Card/PhysicalCardScreen.tsx
@@ -6,7 +6,6 @@ import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import NavHeader from '@/components/Global/NavHeader'
 import { Button } from '@/components/0_Bruddle/Button'
 import Loading from '@/components/Global/Loading'
-import Modal from '@/components/Global/Modal'
 import CardFace from '@/components/Card/CardFace'
 import { rainApi } from '@/services/rain'
 
@@ -21,7 +20,6 @@ interface Props {
 const PhysicalCardScreen: FC<Props> = ({ cardId, last4, onPrev }) => {
     const queryClient = useQueryClient()
     const [joining, setJoining] = useState(false)
-    const [showJoinedModal, setShowJoinedModal] = useState(false)
     const [error, setError] = useState<string | null>(null)
 
     const { data, isLoading } = useQuery({
@@ -49,7 +47,11 @@ const PhysicalCardScreen: FC<Props> = ({ cardId, last4, onPrev }) => {
             const result = await rainApi.joinPhysicalWaitlist(cardId)
             await queryClient.invalidateQueries({ queryKey: [PHYSICAL_WAITLIST_QUERY_KEY, cardId] })
             posthog.capture(ANALYTICS_EVENTS.CARD_PHYSICAL_WAITLIST_JOINED, { position: result.position })
-            setShowJoinedModal(true)
+            // Inline "You are on the list!" status (driven by data?.joinedAt
+            // after the invalidate above) is the only confirmation now. The
+            // separate "You are in!" modal that used to fire here rendered as
+            // a stacked second confirmation over the inline status and ended
+            // up positioned over the page chrome — see 2026-05-19 screenshot.
         } catch (e) {
             setError(e instanceof Error ? e.message : 'Failed to join waitlist')
         } finally {
@@ -94,29 +96,6 @@ const PhysicalCardScreen: FC<Props> = ({ cardId, last4, onPrev }) => {
                     </Button>
                 </div>
             )}
-
-            <Modal
-                visible={showJoinedModal}
-                onClose={() => setShowJoinedModal(false)}
-                className="items-center justify-center"
-            >
-                <div className="mx-auto w-full max-w-sm rounded-sm border border-n-1 bg-white p-6">
-                    <div className="flex flex-col items-center gap-4 text-center">
-                        <div className="text-xl font-extrabold">You are in!</div>
-                        <p className="text-sm text-grey-1">
-                            We will let you know as soon as cards are ready to be shipped.
-                        </p>
-                        <Button
-                            variant="purple"
-                            shadowSize="4"
-                            className="w-full"
-                            onClick={() => setShowJoinedModal(false)}
-                        >
-                            Close
-                        </Button>
-                    </div>
-                </div>
-            </Modal>
         </div>
     )
 }

--- a/src/components/Card/PhysicalCardScreen.tsx
+++ b/src/components/Card/PhysicalCardScreen.tsx
@@ -3,11 +3,13 @@ import { type FC, useEffect, useRef, useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import Image from 'next/image'
 import NavHeader from '@/components/Global/NavHeader'
 import { Button } from '@/components/0_Bruddle/Button'
 import Loading from '@/components/Global/Loading'
 import CardFace from '@/components/Card/CardFace'
 import { rainApi } from '@/services/rain'
+import { PEANUTMAN_RAISING_HANDS } from '@/assets/peanut'
 
 export const PHYSICAL_WAITLIST_QUERY_KEY = 'rain-physical-waitlist'
 
@@ -71,6 +73,7 @@ const PhysicalCardScreen: FC<Props> = ({ cardId, last4, onPrev }) => {
                 </div>
             ) : data?.joinedAt ? (
                 <div className="flex flex-col items-center gap-3 text-center">
+                    <Image src={PEANUTMAN_RAISING_HANDS} alt="" aria-hidden className="h-32 w-auto" />
                     <h1 className="text-xl font-extrabold">You are on the list!</h1>
                     <p className="text-sm text-grey-1">
                         You are #{data.position} on the list. We&apos;ll let you know when cards are ready to be


### PR DESCRIPTION
## Bug 1 — PIN validation only ran on Continue click

User typed `1111`, advanced to the Confirm step, re-entered, hit Save, and only THEN saw the failure. \`CardPinSetupFlow.onContinueFromChoose\` did call \`validatePin\` and block the step transition, but the user perception was that they "got through" because nothing told them the PIN was invalid until they clicked.

**Fix:** validate live once 4 digits are entered. Show the failure reason inline AND keep the Continue button disabled for invalid PINs — user can't even click through.

```ts
const choosePinValidation = first.length === 4 ? validatePin(first) : null
// ...
<Button ... disabled={!choosePinValidation || !choosePinValidation.valid} />
```

`onContinueFromChoose` still runs `validatePin` as defense in depth.

## Bug 2 — physical card waitlist shows two stacked confirmations

After joining the waitlist, BOTH appear:
- Inline status: "You are on the list! You are #N on the list. We'll let you know when cards are ready to be shipped." (driven by `data?.joinedAt` after query invalidation)
- "You are in!" modal: "We will let you know as soon as cards are ready to be shipped." (driven by local `showJoinedModal` state)

Two confirmations saying the same thing — and the modal renders over the page chrome (see screenshot below).

**Fix:** drop the modal. The inline status is the single source of truth.

| Before | After |
|--------|-------|
| Modal stacked over inline status (and over the page chrome) | Inline "You are on the list!" only |

## Files

- `src/components/Card/CardPinSetupFlow.tsx` (+11/-1) — live `choosePinValidation` + disabled button gate
- `src/components/Card/PhysicalCardScreen.tsx` (+4/-26) — drop `Modal` import, `showJoinedModal` state, and the modal block

## Test plan

- [x] Existing `pin.utils` tests (5/5) still pass — `validatePin` itself unchanged
- [x] Prettier clean on both files
- [ ] Manual — type `1111`, confirm Continue stays disabled + "No repeating digits" appears inline
- [ ] Manual — type `1234`, confirm Continue stays disabled + "No sequential digits" appears inline
- [ ] Manual — type a valid PIN, confirm Continue enables and the flow proceeds normally
- [ ] Manual — join physical card waitlist, confirm ONLY the inline "You are on the list!" appears (no modal)

## Risk

Low. PIN fix tightens UX without changing what's valid (same `validatePin` rules). Modal removal is purely subtractive — no state machine changes, no API calls touched.