### PR TITLE
feat(card): swipe between wallet-add steps

### DIFF
--- a/src/components/Card/AddToWalletCarousel.tsx
+++ b/src/components/Card/AddToWalletCarousel.tsx
@@ -1,11 +1,15 @@
 'use client'
-import { type FC, useState } from 'react'
+import { type FC, type PointerEvent as ReactPointerEvent, useRef, useState } from 'react'
 import Image, { type StaticImageData } from 'next/image'
 import { twMerge } from 'tailwind-merge'
 import NavHeader from '@/components/Global/NavHeader'
 import { Button } from '@/components/0_Bruddle/Button'
 import { APPLE_WALLET_STEPS, GOOGLE_WALLET_STEPS } from '@/assets/cards'
 import { useWalletPlatform, type WalletPlatform } from '@/hooks/useWalletPlatform'
+
+// Pixel threshold for treating a pointer drag as a swipe. Smaller values
+// feel jumpy on desktop trackpads; larger values miss short mobile flicks.
+const SWIPE_THRESHOLD_PX = 50
 
 interface Step {
     title: string
@@ -38,6 +42,7 @@ const AddToWalletCarousel: FC<Props> = ({ onDone, onPrev }) => {
     const steps: Step[] = STEPS_BY_PLATFORM[platform === 'android' ? 'android' : 'ios']
     const [index, setIndex] = useState(0)
     const isLast = index === steps.length - 1
+    const isFirst = index === 0
     const step = steps[index]
 
     const onNext = () => {
@@ -45,27 +50,62 @@ const AddToWalletCarousel: FC<Props> = ({ onDone, onPrev }) => {
         else setIndex((i) => i + 1)
     }
 
+    // Swipe gestures on the step body. Pointer events cover mouse + touch +
+    // pen in one handler. We only act on the final delta in `onPointerUp`
+    // (vs reacting on every move), so vertical scroll inside the container
+    // is unaffected — the threshold check filters incidental drags.
+    const pointerStartXRef = useRef<number | null>(null)
+    const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+        pointerStartXRef.current = e.clientX
+    }
+    const onPointerUp = (e: ReactPointerEvent<HTMLDivElement>) => {
+        const startX = pointerStartXRef.current
+        pointerStartXRef.current = null
+        if (startX == null) return
+        const deltaX = e.clientX - startX
+        if (Math.abs(deltaX) < SWIPE_THRESHOLD_PX) return
+        if (deltaX < 0) {
+            // Swipe left → next step. Don't auto-fire onDone on the last step
+            // via swipe — keeps a deliberate confirmation tap on the CTA so
+            // the user doesn't accidentally exit the carousel.
+            if (!isLast) setIndex((i) => i + 1)
+        } else if (!isFirst) {
+            setIndex((i) => i - 1)
+        }
+    }
+
     return (
         <div className="flex min-h-[inherit] flex-col gap-6">
             <NavHeader title={platformLabel} onPrev={onPrev} />
 
             <div className="my-auto flex flex-col items-center gap-6 text-center">
-                <div className="w-full max-w-xs overflow-hidden rounded-sm border border-n-1">
-                    <Image src={step.image} alt="" aria-hidden className="h-auto w-full" priority />
-                </div>
+                {/* touch-pan-y lets vertical scrolling still work while
+                    horizontal pan is captured for swipe. */}
+                <div
+                    className="flex w-full touch-pan-y flex-col items-center gap-6"
+                    onPointerDown={onPointerDown}
+                    onPointerUp={onPointerUp}
+                    onPointerCancel={() => {
+                        pointerStartXRef.current = null
+                    }}
+                >
+                    <div className="w-full max-w-xs overflow-hidden rounded-sm border border-n-1">
+                        <Image src={step.image} alt="" aria-hidden className="h-auto w-full" priority />
+                    </div>
 
-                <div className="text-xl font-extrabold">{step.title}</div>
+                    <div className="text-xl font-extrabold">{step.title}</div>
 
-                <div className="flex items-center gap-2" aria-label={`Step ${index + 1} of ${steps.length}`}>
-                    {steps.map((_, i) => (
-                        <span
-                            key={i}
-                            className={twMerge(
-                                'h-2 w-2 rounded-full transition-colors',
-                                i === index ? 'bg-primary-1' : 'bg-grey-4'
-                            )}
-                        />
-                    ))}
+                    <div className="flex items-center gap-2" aria-label={`Step ${index + 1} of ${steps.length}`}>
+                        {steps.map((_, i) => (
+                            <span
+                                key={i}
+                                className={twMerge(
+                                    'h-2 w-2 rounded-full transition-colors',
+                                    i === index ? 'bg-primary-1' : 'bg-grey-4'
+                                )}
+                            />
+                        ))}
+                    </div>
                 </div>
 
                 <Button variant="purple" shadowSize="4" className="w-full" onClick={onNext}>


### PR DESCRIPTION
## What

Add horizontal pointer-swipe gestures to the **Add to Wallet** carousel so users can swipe through the 4 wallet-setup screenshots instead of tapping Next every time.

## Behavior

- **Swipe left** → next step (clamped at the last step)
- **Swipe right** → previous step (clamped at the first step)
- **50px threshold** before a drag counts as a swipe — incidental movement won't change steps
- **Last-step swipe does NOT auto-fire `onDone`** — keeps a deliberate confirmation tap on the CTA so users can't accidentally exit the carousel
- **Next button still works** — swipe is additive, not a replacement
- Touch + mouse + pen all covered (single `onPointer*` handler)

## How

Pointer events captured on the step body (image + title + step dots). Records `clientX` at `pointerDown`, computes delta at `pointerUp`, updates `index` if past threshold. `touch-pan-y` on the container keeps vertical scrolling unaffected.

No new dependency — `framer-motion` is in package.json but unnecessary for a 50-line gesture handler. Avoiding the import keeps the bundle slim.

## Files

- `src/components/Card/AddToWalletCarousel.tsx` (+55/-15) — new pointer handlers, `isFirst` boundary check, wrapper div around the swipeable region

## Test plan

- [x] `pnpm typecheck` clean (own file)
- [ ] Manual on mobile — swipe left/right cycles through the 4 steps
- [ ] Manual on desktop — click-and-drag with mouse advances steps
- [ ] Manual — swipe past the last step does nothing (stays on step 4 with "Done" button)
- [ ] Manual — Next button still advances normally
- [ ] Regression — vertical scroll on the page still works during touch interaction

## Risk

Low. Pure additive UX. The carousel state machine (`index` clamped 0..steps.length-1) is unchanged; swipe just calls the same `setIndex` mutator as the Next button.