### PR TITLE
Rename "Founder House" badge to "Founder Haus"

### DIFF
--- a/src/components/Badges/BadgeStatusDrawer.tsx
+++ b/src/components/Badges/BadgeStatusDrawer.tsx
@@ -4,7 +4,7 @@ import { formatDate } from '@/utils/general.utils'
 import Card from '../Global/Card'
 import { PaymentInfoRow } from '../Payment/PaymentInfoRow'
 import ShareButton from '../Global/ShareButton'
-import { getBadgeIcon } from './badge.utils'
+import { getBadgeDisplayName, getBadgeIcon } from './badge.utils'
 import { BASE_URL } from '@/constants/general.consts'
 import { useAuth } from '@/context/authContext'
 
@@ -26,6 +26,7 @@ export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerP
     const username = authUser?.user.username
     const earnedAt = badge.earnedAt ? new Date(badge.earnedAt) : undefined
     const dateStr = earnedAt ? formatDate(earnedAt) : undefined
+    const displayName = getBadgeDisplayName(badge.code, badge.name)
 
     // generate profile link for sharing
     const profileLink = username ? `${BASE_URL}/${username}` : BASE_URL
@@ -50,7 +51,7 @@ export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerP
                                 <h2 className="flex items-center gap-2 text-xs font-medium text-grey-1">
                                     Badge unlocked!
                                 </h2>
-                                <h1 className={`text-lg font-extrabold md:text-4xl`}>{badge.name}</h1>
+                                <h1 className={`text-lg font-extrabold md:text-4xl`}>{displayName}</h1>
                             </div>
                         </div>
                     </Card>
@@ -65,7 +66,7 @@ export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerP
                             title=""
                             generateText={() =>
                                 Promise.resolve(
-                                    `I earned ${badge.name} badge on Peanut!\n\nJoin Peanut now and start earning points, unlocking achievements and moving money worldwide\n\n${profileLink}`
+                                    `I earned ${displayName} badge on Peanut!\n\nJoin Peanut now and start earning points, unlocking achievements and moving money worldwide\n\n${profileLink}`
                                 )
                             }
                         >

--- a/src/components/Badges/BadgeStatusItem.tsx
+++ b/src/components/Badges/BadgeStatusItem.tsx
@@ -4,7 +4,7 @@ import { type CardPosition } from '@/components/Global/Card/card.utils'
 import { BadgeStatusDrawer } from './BadgeStatusDrawer'
 import Image from 'next/image'
 import InvitesIcon from '../Home/InvitesIcon'
-import { getBadgeIcon } from './badge.utils'
+import { getBadgeDisplayName, getBadgeIcon } from './badge.utils'
 import { type BadgeHistoryEntry } from './badge.types'
 
 export const BadgeStatusItem = ({
@@ -15,6 +15,7 @@ export const BadgeStatusItem = ({
     entry: BadgeHistoryEntry
 }) => {
     const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+    const displayName = getBadgeDisplayName(entry.code, entry.name)
 
     const badge = useMemo(
         () => ({
@@ -38,7 +39,7 @@ export const BadgeStatusItem = ({
                 <div className={'relative flex h-8 w-8 items-center justify-center rounded-full'}>
                     <Image
                         src={getBadgeIcon(entry.code)}
-                        alt={`${entry.name} icon`}
+                        alt={`${displayName} icon`}
                         className="size-10 object-contain"
                         width={32}
                         height={32}
@@ -48,7 +49,7 @@ export const BadgeStatusItem = ({
                 {/* text content */}
                 <div className="flex-1">
                     <div className="flex flex-row items-center gap-2">
-                        <div className="min-w-0 flex-1 truncate font-roboto text-[16px] font-medium">{entry.name}</div>
+                        <div className="min-w-0 flex-1 truncate font-roboto text-[16px] font-medium">{displayName}</div>
                     </div>
                     <div className="flex items-center gap-1 text-sm font-medium text-gray-1">
                         <span className="capitalize">Badge unlocked!</span>

--- a/src/components/Badges/BadgesRow.tsx
+++ b/src/components/Badges/BadgesRow.tsx
@@ -7,7 +7,7 @@ import { Tooltip } from '../Tooltip'
 import { twMerge } from 'tailwind-merge'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Icon } from '../Global/Icons/Icon'
-import { getBadgeIcon, getPublicBadgeDescription } from './badge.utils'
+import { getBadgeDisplayName, getBadgeIcon, getPublicBadgeDescription } from './badge.utils'
 
 type UIBadge = {
     code: string
@@ -102,20 +102,21 @@ const BadgesRow = ({ badges, className, isSelfProfile = true }: BadgesRowProps) 
                         const displayDescription = isSelfProfile
                             ? badge.description
                             : getPublicBadgeDescription(badge.code) || badge.description
+                        const displayName = getBadgeDisplayName(badge.code, badge.name)
 
                         return (
                             <Tooltip
                                 key={badge.code}
                                 content={
                                     <div className="flex flex-col items-center justify-center gap-1">
-                                        <div className="relative text-sm font-bold">{badge.name}</div>
+                                        <div className="relative text-sm font-bold">{displayName}</div>
                                         <p className="text-center font-normal">{displayDescription}</p>
                                     </div>
                                 }
                             >
                                 <Image
                                     src={getBadgeIcon(badge.code)}
-                                    alt={badge.name}
+                                    alt={displayName}
                                     className="min-h-10 min-w-10 object-contain"
                                     height={48}
                                     width={48}

--- a/src/components/Badges/badge.utils.ts
+++ b/src/components/Badges/badge.utils.ts
@@ -18,6 +18,12 @@ const CODE_TO_PATH: Record<string, string> = {
     SUPPORT_SURVIVOR: '/badges/support_survivor.svg',
 }
 
+// front-end display name overrides for badges. backend codes/names stay the same;
+// this is purely for what the user sees.
+const DISPLAY_NAME_OVERRIDES: Record<string, string> = {
+    FOUNDER_HOUSE: 'Founder Haus',
+}
+
 // public-facing descriptions for badges (third-person perspective)
 const PUBLIC_DESCRIPTIONS: Record<string, string> = {
     BETA_TESTER: `They broke things so others don't have to. Welcome to the chaos club.`,
@@ -32,7 +38,7 @@ const PUBLIC_DESCRIPTIONS: Record<string, string> = {
     SEEDLING_DEVCONNECT_BA_2025: 'Peanut Ambassador. They spread the word and brought others into the ecosystem.',
     ARBIVERSE_DEVCONNECT_BA_2025: 'Peanut 🤝 Arbiverse. They joined us at the amazing Arbiverse booth.',
     CARD_PIONEER: 'A true Card Pioneer. Among the first to pay everywhere with Peanut.',
-    FOUNDER_HOUSE: 'Checked in at the Founder House. Builds IRL, not just on-chain.',
+    FOUNDER_HOUSE: 'Checked in at the Founder Haus. Builds IRL, not just on-chain.',
     SUPPORT_SURVIVOR: 'Survived a real bug and helped us fix it. The brave kind of user.',
 }
 
@@ -46,4 +52,11 @@ export function getBadgeIcon(code?: string) {
 export function getPublicBadgeDescription(code?: string): string | null {
     if (!code) return null
     return PUBLIC_DESCRIPTIONS[code] || null
+}
+
+// returns the display name for a badge, applying any front-end override on top
+// of whatever the backend provided. backend storage is untouched.
+export function getBadgeDisplayName(code: string | undefined, fallback: string): string {
+    if (code && DISPLAY_NAME_OVERRIDES[code]) return DISPLAY_NAME_OVERRIDES[code]
+    return fallback
 }

--- a/src/components/Badges/index.tsx
+++ b/src/components/Badges/index.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image'
 import type { StaticImageData } from 'next/image'
 import NavHeader from '../Global/NavHeader'
 import { useSafeBack } from '@/hooks/useSafeBack'
-import { getBadgeIcon } from './badge.utils'
+import { getBadgeDisplayName, getBadgeIcon } from './badge.utils'
 import { getCardPosition } from '../Global/Card/card.utils'
 import EmptyState from '../Global/EmptyStates/EmptyState'
 import { Icon } from '../Global/Icons/Icon'
@@ -33,7 +33,7 @@ export const Badges = () => {
         // get badges from user object and map to card fields
         const raw = authUser?.user?.badges || []
         return raw.map((b) => ({
-            title: b.name,
+            title: getBadgeDisplayName(b.code, b.name),
             description: b.description || '',
             logo: getBadgeIcon(b.code),
         }))


### PR DESCRIPTION
## Summary
- Display label for the `FOUNDER_HOUSE` badge now reads **Founder Haus** in the UI.
- Backend code, the `FOUNDER_HOUSE` constant, asset path (`founder_house.png`) and invite-code slug (`founderhaus`) are unchanged — pure display rename.
- Added a small `getBadgeDisplayName(code, fallback)` helper in `badge.utils.ts` so the override applies wherever the backend badge name is rendered (BadgesRow tooltip + alt, BadgeStatusDrawer h1 + share text, BadgeStatusItem title + alt, Badges page list/modal title).
- Public description was also tweaked from "Founder House" → "Founder Haus" for consistency.

## Test plan
- [ ] Profile with the Founder House badge shows "Founder Haus" in the tooltip on `BadgesRow`.
- [ ] `BadgeStatusDrawer` (newly earned badge drawer) shows "Founder Haus" as the title and in the share message.
- [ ] Activity feed `BadgeStatusItem` shows "Founder Haus".
- [ ] `/badges` page card title and the "tap to view" modal show "Founder Haus".
- [ ] Other badges unaffected.