### PR TITLE
feat(card): nudge AR/BR card spends toward the cheaper local rail

### DIFF
--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -53,6 +53,7 @@ import {
 } from './transaction-predicates'
 import { useReceiptViewModel } from './useReceiptViewModel'
 import { CardPaymentRows } from './provider-rows/CardPaymentRows'
+import { LocalRailNudge } from './provider-rows/LocalRailNudge'
 import { MantecaDepositInfo } from './provider-rows/MantecaDepositInfo'
 import { BridgeDepositInstructions } from './provider-rows/BridgeDepositInstructions'
 import { CancelDepositActions } from './provider-actions/CancelDepositActions'
@@ -634,6 +635,12 @@ export const TransactionDetailsReceipt = ({
                     )}
                 </div>
             </Card>
+
+            {/* Local-rail nudge — card spends in a country with a cheaper
+                first-party rail (AR → QR, BR → Pix). Self-gates: renders
+                nothing for other countries / non-card-spend transactions.
+                Hidden on public receipts (same rule as the referral nudge). */}
+            {!isPublic && <LocalRailNudge transaction={transaction} />}
 
             {/* share and cancel buttons section (only if qr is shown) */}
             {shouldShowQrShare && transaction.extraDataForDrawer?.link && (

--- a/src/components/TransactionDetails/__tests__/LocalRailNudge.test.tsx
+++ b/src/components/TransactionDetails/__tests__/LocalRailNudge.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * LocalRailNudge — country → local-rail nudge on card-spend receipts.
+ *
+ * The nudge fires only for a Rain card spend whose merchant sits in a
+ * country with a cheaper first-party rail (AR → QR, BR → Pix). Every other
+ * country, and every non-card-spend transaction, must render nothing.
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { LocalRailNudge } from '../provider-rows/LocalRailNudge'
+import { type TransactionDetails } from '../transactionTransformer'
+
+/** Minimal TransactionDetails shaped for the nudge's two inputs only. */
+function tx(transactionCardType: string, merchantCountry: string | null): TransactionDetails {
+    return {
+        extraDataForDrawer: {
+            transactionCardType,
+            cardPayment: { merchantCountry },
+        },
+    } as unknown as TransactionDetails
+}
+
+describe('LocalRailNudge', () => {
+    it('nudges Argentina card spends toward QR', () => {
+        render(<LocalRailNudge transaction={tx('card_pay', 'AR')} />)
+        expect(screen.getByText(/In Argentina, paying with QR costs around 9% less/)).toBeInTheDocument()
+    })
+
+    it('nudges Brazil card spends toward Pix', () => {
+        render(<LocalRailNudge transaction={tx('card_pay', 'BR')} />)
+        expect(screen.getByText(/In Brazil, paying with Pix costs around 9% less/)).toBeInTheDocument()
+    })
+
+    it('recovers the country code from a city-joined value', () => {
+        render(<LocalRailNudge transaction={tx('card_pay', 'São Paulo, BR')} />)
+        expect(screen.getByText(/In Brazil, paying with Pix/)).toBeInTheDocument()
+    })
+
+    it('renders nothing for a country with no local rail', () => {
+        const { container } = render(<LocalRailNudge transaction={tx('card_pay', 'US')} />)
+        expect(container).toBeEmptyDOMElement()
+    })
+
+    it('renders nothing for a non-card-spend transaction', () => {
+        const { container } = render(<LocalRailNudge transaction={tx('send', 'AR')} />)
+        expect(container).toBeEmptyDOMElement()
+    })
+
+    it('renders nothing when the merchant country is absent', () => {
+        const { container } = render(<LocalRailNudge transaction={tx('card_pay', null)} />)
+        expect(container).toBeEmptyDOMElement()
+    })
+})

--- a/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
+++ b/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
@@ -6,6 +6,7 @@ import { PaymentInfoRow } from '@/components/Payment/PaymentInfoRow'
 import { type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
 import { friendlyDeclineReason } from '@/utils/cardDeclineReason'
 import { getFlagUrl } from '@/constants/countryCurrencyMapping'
+import { extractMerchantIso2 } from '@/components/TransactionDetails/transaction-details.utils'
 
 /** Strings from Rain's sandbox arrive whitespace-padded ("  ", " - ") and
  *  legacy intents in the DB pre-date the backend cleanField pass — treat any
@@ -24,20 +25,6 @@ function parseCents(value: string | null | undefined): number | null {
     if (value == null) return null
     const n = Number(value)
     return Number.isFinite(n) ? n : null
-}
-
-/** Extract a 2-letter ISO code from a merchant-country value. Rain populates
- *  the field as ISO-2 in nominal data, but legacy intents and edge merchants
- *  sometimes ship it joined with the city ("San Francisco, US") or in
- *  whitespace-padded form. Return the lowercased 2-letter tail when one is
- *  recoverable, null otherwise. Drives both the visibility gate and the
- *  flag URL — a single source so the row never renders without a flag. */
-function extractIso2(value: string | null | undefined): string | null {
-    if (!value) return null
-    const trimmed = value.trim()
-    if (trimmed.length === 0) return null
-    const tail = trimmed.split(/[\s,]+/).pop() ?? ''
-    return /^[a-z]{2}$/i.test(tail) ? tail.toLowerCase() : null
 }
 
 /**
@@ -62,7 +49,7 @@ export function hasCardPaymentRowsContent(transaction: TransactionDetails): bool
     const card = transaction.extraDataForDrawer?.cardPayment
     if (!card) return false
 
-    if (extractIso2(card.merchantCountry)) return true
+    if (extractMerchantIso2(card.merchantCountry)) return true
     if (card.settlementAdjusted && parseCents(card.authAmount) != null) return true
     // declineCategory is BE-controlled (one of 3 enum literals) — no
     // whitespace risk. declineReason is Rain's free-form prose — gate it
@@ -119,7 +106,7 @@ export function CardPaymentRows({
     // Country flag replaces the prior "City, COUNTRY" text — it's denser
     // and recognisable at a glance; the merchant name on the receipt head
     // carries the city information for users who want it.
-    const iso2 = extractIso2(card.merchantCountry)
+    const iso2 = extractMerchantIso2(card.merchantCountry)
     if (iso2) {
         subRows.push({
             key: 'location',

--- a/src/components/TransactionDetails/provider-rows/LocalRailNudge.tsx
+++ b/src/components/TransactionDetails/provider-rows/LocalRailNudge.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import Card from '@/components/Global/Card'
+import { Icon } from '@/components/Global/Icons/Icon'
+import { type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
+import { extractMerchantIso2 } from '@/components/TransactionDetails/transaction-details.utils'
+
+/**
+ * Countries where Peanut has a first-party local payment rail that's cheaper
+ * than spending on the Rain card. A card spend whose merchant sits in one of
+ * these countries gets nudged toward the local rail. Add a country here to
+ * light up the nudge for it — mirrors MANTECA_GEO_RAIL_MAP in peanut-api-ts.
+ *
+ * `rail` is the printable, user-facing rail name (reads as "pay with {rail}").
+ */
+const LOCAL_RAIL_BY_COUNTRY: Record<string, { countryName: string; rail: string }> = {
+    AR: { countryName: 'Argentina', rail: 'QR' },
+    BR: { countryName: 'Brazil', rail: 'Pix' },
+}
+
+/**
+ * Informational nudge on a card-spend receipt: when the merchant is in a
+ * country where Peanut has a cheaper local rail (Argentina → QR, Brazil →
+ * Pix), let the user know they could pay a better way next time.
+ *
+ * Card spends route through Rain and cost ~9% more than the local rail (see
+ * `calculateSavingsInCents` in qr-payment.utils — 9.13% vs card). Renders
+ * nothing for any other country or for non-card-spend transactions.
+ */
+export function LocalRailNudge({ transaction }: { transaction: TransactionDetails }) {
+    // Card spends only. Refunds map to a 'receive' card type, so gating on
+    // 'card_pay' naturally excludes them — a refund is not a payment choice.
+    if (transaction.extraDataForDrawer?.transactionCardType !== 'card_pay') return null
+
+    const iso2 = extractMerchantIso2(transaction.extraDataForDrawer.cardPayment?.merchantCountry)
+    const local = iso2 ? LOCAL_RAIL_BY_COUNTRY[iso2.toUpperCase()] : undefined
+    if (!local) return null
+
+    return (
+        <Card position="single" className="px-4 py-4">
+            <div className="flex items-center gap-3">
+                <Icon name="info" size={20} className="shrink-0 text-grey-1" />
+                <div className="flex flex-col gap-1">
+                    <span className="font-semibold text-gray-900">Pay like a local next time</span>
+                    <span className="text-sm text-gray-600">
+                        In {local.countryName}, paying with {local.rail} costs around 9% less than using your card.
+                    </span>
+                </div>
+            </div>
+        </Card>
+    )
+}

--- a/src/components/TransactionDetails/transaction-details.utils.ts
+++ b/src/components/TransactionDetails/transaction-details.utils.ts
@@ -58,3 +58,19 @@ export const getBankAccountLabel = (type: string) => {
     if (t.endsWith('clabe')) return 'CLABE'
     return 'Account Number'
 }
+
+/**
+ * Recover a 2-letter ISO country code from a Rain merchant-country value.
+ * Rain populates the field as ISO-2 in nominal data, but legacy intents and
+ * edge merchants sometimes ship it joined with the city ("San Francisco, US")
+ * or in whitespace-padded form. Returns the lowercased 2-letter tail when one
+ * is recoverable, null otherwise. Shared by CardPaymentRows (location flag)
+ * and LocalRailNudge (country → local-rail nudge).
+ */
+export function extractMerchantIso2(value: string | null | undefined): string | null {
+    if (!value) return null
+    const trimmed = value.trim()
+    if (trimmed.length === 0) return null
+    const tail = trimmed.split(/[\s,]+/).pop() ?? ''
+    return /^[a-z]{2}$/i.test(tail) ? tail.toLowerCase() : null
+}


### PR DESCRIPTION
## Why

A Rain card spend in **Argentina or Brazil** costs the user **~9% more** than paying through Peanut's first-party local rail (QR / Pix) — the card's FX path is simply worse. Users who reach for the card don't know the cheaper option exists, so they keep overpaying.

[Discord thread](https://discord.com/channels/972435984954302464/1503868198724833380)

## What

An **informational nudge** on the card-spend receipt drawer. When the merchant country has a cheaper local rail, the receipt tells the user they could pay a better way next time:

> **Pay like a local next time**
> In Argentina, paying with QR costs around 9% less than using your card.

- **No CTA** — purely educational. Lowest-friction way to surface the option where the user is already looking (reviewing the card transaction).
- Renders **nothing** for any other country or non-card-spend transaction.
- Hidden on **public receipts** (same rule as the referral nudge).

## Country → rail map

Coverage is a single map — *"configurable later" = add a row*:

```ts
const LOCAL_RAIL_BY_COUNTRY = {
    AR: { countryName: 'Argentina', rail: 'QR' },
    BR: { countryName: 'Brazil',    rail: 'Pix' },
}
```

It mirrors `MANTECA_GEO_RAIL_MAP` in peanut-api-ts. The ~9% figure is the same delta `calculateSavingsInCents` already uses (9.13% vs card).

## Scope

**Frontend-only.** `merchantCountry` is already on the card-spend intent (`extraDataForDrawer.cardPayment`) — no backend change. The ISO-2 recovery parser that `CardPaymentRows` used for the location-flag row is now shared as `extractMerchantIso2`, so both surfaces read the merchant-country field identically (handles legacy `"City, BR"`-joined values).

## Files

- `provider-rows/LocalRailNudge.tsx` — new component + country map
- `transaction-details.utils.ts` — `extractMerchantIso2` (lifted from CardPaymentRows, now shared)
- `provider-rows/CardPaymentRows.tsx` — use the shared parser
- `TransactionDetailsReceipt.tsx` — render the nudge, gated `!isPublic`
- `__tests__/LocalRailNudge.test.tsx` — new

## Test plan

- [x] `npm run typecheck` clean
- [x] Prettier clean
- [x] `LocalRailNudge.test.tsx` — 6/6 (AR, BR, city-joined country, no-rail country, non-card-spend, absent country)
- [x] Full `TransactionDetails` suite — 100/100 (extractMerchantIso2 move verified)
- [ ] Manual — open a card-spend receipt for an AR/BR merchant → nudge shows; a US merchant → no nudge; a card refund → no nudge