### PR TITLE
hotfix: disable cross-chain withdraws and sends pending issue investigation

### DIFF
--- a/src/config/underMaintenance.config.ts
+++ b/src/config/underMaintenance.config.ts
@@ -55,8 +55,8 @@ const underMaintenanceConfig: MaintenanceConfig = {
     enableFullMaintenance: false, // set to true to redirect all pages to /maintenance
     enableMaintenanceBanner: false, // set to true to show maintenance banner on all pages
     disabledPaymentProviders: [], // set to ['MANTECA'] to disable Manteca QR payments
-    disableXchainWithdraw: false, // set to true to disable cross-chain withdrawals (only allows USDC on Arbitrum)
-    disableXchainSend: false, // set to true to disable cross-chain sends (claim, request payments - only allows USDC on Arbitrum)
+    disableXchainWithdraw: true, // set to true to disable cross-chain withdrawals (only allows USDC on Arbitrum)
+    disableXchainSend: true, // set to true to disable cross-chain sends (claim, request payments - only allows USDC on Arbitrum)
     disableCardPioneers: true, // set to false to enable the Card Pioneers waitlist feature
 }
 


### PR DESCRIPTION
## What

Flips two kill-switches in `src/config/underMaintenance.config.ts`:

- `disableXchainWithdraw: false → true`
- `disableXchainSend: false → true`

## Why

Cross-chain flows (Rhino SDA) are being temporarily disabled while an issue is under investigation.

## Effect

- **Withdraw** token selector restricted to USDC on Arbitrum; same-chain withdrawals keep working.
- **Send** (claim links, request payments) token selector restricted to USDC on Arbitrum; same-chain operations keep working.
- Users see an info message explaining cross-chain is temporarily unavailable.

## Scope / caveats

- Frontend-only kill switch. The backend `/rhino/bridge/*` routes stay live — direct API callers are not blocked. Sufficient for a UI outage; a hard block would need backend gating too.
- Revert both flags once the investigation closes.

## QA

- Withdraw flow: token selector shows only USDC/Arbitrum + the unavailable message.
- Claim / request-payment flows: same restriction.
- Same-chain USDC-on-Arbitrum withdraw still completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)