### PR TITLE
Show Bridge EEA uplift remediation CTA

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -14,6 +14,8 @@ import {
     useBridgeTransferReadiness,
     getKycModalVariant,
     getGateProviderMessage,
+    getGateProviderTitle,
+    getGateActionLabel,
 } from '@/hooks/useBridgeTransferReadiness'
 import { useModalsContext } from '@/context/ModalsContext'
 import { useCreateOnramp } from '@/hooks/useCreateOnramp'
@@ -419,7 +421,9 @@ export default function OnrampBankPage() {
                     isLoading={sumsubFlow.isLoading}
                     error={sumsubFlow.error}
                     variant={getKycModalVariant(gate.type)}
+                    providerTitle={getGateProviderTitle(gate)}
                     providerMessage={getGateProviderMessage(gate)}
+                    providerActionLabel={getGateActionLabel(gate)}
                     regionName={selectedCountry?.title}
                 />
 

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -122,7 +122,9 @@ const mockGate = jest.fn().mockReturnValue({ type: 'ready' })
 jest.mock('@/hooks/useBridgeTransferReadiness', () => ({
     useBridgeTransferReadiness: () => ({ gate: mockGate() }),
     getKycModalVariant: () => 'default',
+    getGateProviderTitle: () => undefined,
     getGateProviderMessage: () => undefined,
+    getGateActionLabel: () => undefined,
 }))
 
 jest.mock('@/context/ModalsContext', () => ({

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -37,6 +37,8 @@ import {
     useBridgeTransferReadiness,
     getKycModalVariant,
     getGateProviderMessage,
+    getGateProviderTitle,
+    getGateActionLabel,
 } from '@/hooks/useBridgeTransferReadiness'
 import { useModalsContext } from '@/context/ModalsContext'
 import ExchangeRate from '@/components/ExchangeRate'
@@ -493,7 +495,9 @@ export default function WithdrawBankPage() {
                 isLoading={sumsubFlow.isLoading}
                 error={sumsubFlow.error}
                 variant={getKycModalVariant(gate.type)}
+                providerTitle={getGateProviderTitle(gate)}
                 providerMessage={getGateProviderMessage(gate)}
+                providerActionLabel={getGateActionLabel(gate)}
                 regionName={getCountryFromPath(country)?.title}
             />
             <SumsubKycModals flow={sumsubFlow} />

--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -59,6 +59,14 @@ export interface SelfHealResubmissionResponse {
     userMessage: string
     attempt: number
     maxAttempts: number
+    questionnaireCluster?:
+        | 'source_of_funds'
+        | 'tax_id'
+        | 'address'
+        | 'birth_details'
+        | 'eea_uplift'
+        | 'eea_tin_reupload'
+    questionnaireVariant?: 'eea_uplift_with_tin'
 }
 
 // initiate self-heal document resubmission for a provider-rejected user

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -34,6 +34,8 @@ import {
     useBridgeTransferReadiness,
     getKycModalVariant,
     getGateProviderMessage,
+    getGateProviderTitle,
+    getGateActionLabel,
 } from '@/hooks/useBridgeTransferReadiness'
 import { useBridgeTosGuard } from '@/hooks/useBridgeTosGuard'
 import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
@@ -316,7 +318,9 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                 isLoading={sumsubFlow.isLoading}
                 error={sumsubFlow.error}
                 variant={getKycModalVariant(gate.type)}
+                providerTitle={getGateProviderTitle(gate)}
                 providerMessage={getGateProviderMessage(gate)}
+                providerActionLabel={getGateActionLabel(gate)}
                 regionName={currentCountry?.title}
             />
             <BridgeTosStep

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -37,6 +37,8 @@ import {
     useBridgeTransferReadiness,
     getKycModalVariant,
     getGateProviderMessage,
+    getGateProviderTitle,
+    getGateActionLabel,
 } from '@/hooks/useBridgeTransferReadiness'
 import { useBridgeTosGuard } from '@/hooks/useBridgeTosGuard'
 import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
@@ -538,7 +540,9 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                             isLoading={sumsubFlow.isLoading}
                             error={sumsubFlow.error}
                             variant={getKycModalVariant(gate.type)}
+                            providerTitle={getGateProviderTitle(gate)}
                             providerMessage={getGateProviderMessage(gate)}
+                            providerActionLabel={getGateActionLabel(gate)}
                         />
                     </>
                 )

--- a/src/components/Kyc/InitiateKycModal.tsx
+++ b/src/components/Kyc/InitiateKycModal.tsx
@@ -12,14 +12,16 @@ interface InitiateKycModalProps {
     error?: string | null
     /** when set, shows provider-specific messaging instead of generic "verify your identity" */
     variant?: 'default' | 'provider_rejection' | 'blocked' | 'cross_region' | 'processing'
+    providerTitle?: string
     providerMessage?: string
+    providerActionLabel?: string
     /** country name shown in cross_region variant (e.g. "Brazil", "Argentina") */
     regionName?: string
 }
 
 // confirmation modal shown before starting KYC or provider resubmission.
 // for fresh KYC: "Verify your identity"
-// for provider rejections: "We need extra documents"
+// for provider rejections: provider-specific copy when available
 // for blocked: provider payment setup issue — contact support
 // for cross-region: "Your identity is verified, submit a local ID"
 export const InitiateKycModal = ({
@@ -30,7 +32,9 @@ export const InitiateKycModal = ({
     isLoading,
     error,
     variant = 'default',
+    providerTitle,
     providerMessage,
+    providerActionLabel,
     regionName,
 }: InitiateKycModalProps) => {
     const isProviderRejection = variant === 'provider_rejection'
@@ -42,7 +46,7 @@ export const InitiateKycModal = ({
         if (error) return 'Something went wrong'
         if (isProcessing) return 'Document review in progress'
         if (isBlocked) return 'Payment setup issue'
-        if (isProviderRejection) return 'We need extra documents'
+        if (isProviderRejection) return providerTitle || 'We need more details'
         if (isCrossRegion) return 'Submit local ID'
         return 'Verify your identity'
     }
@@ -81,7 +85,7 @@ export const InitiateKycModal = ({
         }
         if (isProviderRejection) {
             return {
-                text: isLoading ? 'Loading...' : 'Upload document',
+                text: isLoading ? 'Loading...' : providerActionLabel || 'Provide details',
                 onClick: onVerify,
                 icon: 'upload' as IconName,
             }

--- a/src/components/Kyc/KycVerificationInProgressModal.tsx
+++ b/src/components/Kyc/KycVerificationInProgressModal.tsx
@@ -68,6 +68,22 @@ export const KycVerificationInProgressModal = ({
         )
     }
 
+    if (phase === 'checking') {
+        return (
+            <ActionModal
+                visible={isOpen}
+                onClose={onClose}
+                isLoadingIcon
+                iconContainerClassName="bg-yellow-1 text-black"
+                title="Checking your details..."
+                description="Please keep this open while we check whether anything else is needed."
+                ctas={[]}
+                preventClose
+                hideModalCloseButton
+            />
+        )
+    }
+
     if (phase === 'preparing') {
         // Progressive copy based on elapsed time in preparing phase
         const getPreparingCopy = () => {

--- a/src/hooks/__tests__/useBridgeTransferReadiness.test.ts
+++ b/src/hooks/__tests__/useBridgeTransferReadiness.test.ts
@@ -1,5 +1,11 @@
 import { renderHook } from '@testing-library/react'
-import { useBridgeTransferReadiness, getKycModalVariant, getGateProviderMessage } from '../useBridgeTransferReadiness'
+import {
+    useBridgeTransferReadiness,
+    getKycModalVariant,
+    getGateProviderMessage,
+    getGateProviderTitle,
+    getGateActionLabel,
+} from '../useBridgeTransferReadiness'
 import type { BridgeGateAction } from '../useBridgeTransferReadiness'
 
 // mock the three dependency hooks
@@ -44,6 +50,8 @@ function setup({
     needsBridgeTos = false,
     bridgeState = 'happy' as ProviderRejectionState,
     bridgeUserMessage = null as string | null,
+    bridgeModalTitle = null as string | null,
+    bridgeActionLabel = null as string | null,
     bridgeRejectedRailCount = 0,
     isSumsubApproved = false,
     isBridgeApproved = false,
@@ -60,6 +68,8 @@ function setup({
             ...defaultRejection,
             state: bridgeState,
             userMessage: bridgeUserMessage,
+            modalTitle: bridgeModalTitle,
+            actionLabel: bridgeActionLabel,
             rejectedRails: Array.from(
                 { length: bridgeRejectedRailCount },
                 (_, index) => ({ id: `rail-${index}` }) as any
@@ -104,10 +114,17 @@ describe('useBridgeTransferReadiness', () => {
     })
 
     it('fixable_rejection when selfHealable and no tos needed', () => {
-        setup({ bridgeState: 'fixable', bridgeUserMessage: 'upload clearer photo' })
+        setup({
+            bridgeState: 'fixable',
+            bridgeUserMessage: 'upload clearer photo',
+            bridgeModalTitle: 'We need an updated document',
+            bridgeActionLabel: 'Upload ID',
+        })
         const { result } = renderHook(() => useBridgeTransferReadiness())
         expect(result.current.gate.type).toBe('fixable_rejection')
         expect((result.current.gate as any).userMessage).toBe('upload clearer photo')
+        expect((result.current.gate as any).modalTitle).toBe('We need an updated document')
+        expect((result.current.gate as any).actionLabel).toBe('Upload ID')
     })
 
     it('needs_enrollment when sumsub approved but bridge not started', () => {
@@ -179,7 +196,14 @@ describe('getKycModalVariant', () => {
 describe('getGateProviderMessage', () => {
     it('returns userMessage for rejection gates', () => {
         expect(getGateProviderMessage({ type: 'blocked_rejection', userMessage: 'blocked msg' })).toBe('blocked msg')
-        expect(getGateProviderMessage({ type: 'fixable_rejection', userMessage: 'fix msg' })).toBe('fix msg')
+        expect(
+            getGateProviderMessage({
+                type: 'fixable_rejection',
+                userMessage: 'fix msg',
+                modalTitle: null,
+                actionLabel: null,
+            })
+        ).toBe('fix msg')
         expect(getGateProviderMessage({ type: 'provider_processing', userMessage: 'processing msg' })).toBe(
             'processing msg'
         )
@@ -193,5 +217,24 @@ describe('getGateProviderMessage', () => {
         expect(getGateProviderMessage({ type: 'accept_tos' })).toBeUndefined()
         expect(getGateProviderMessage({ type: 'needs_enrollment' })).toBeUndefined()
         expect(getGateProviderMessage({ type: 'ready' })).toBeUndefined()
+    })
+})
+
+describe('getGateProviderTitle and getGateActionLabel', () => {
+    it('returns fixable rejection modal copy', () => {
+        const gate: BridgeGateAction = {
+            type: 'fixable_rejection',
+            userMessage: 'details needed',
+            modalTitle: 'We need more details',
+            actionLabel: 'Provide required details',
+        }
+
+        expect(getGateProviderTitle(gate)).toBe('We need more details')
+        expect(getGateActionLabel(gate)).toBe('Provide required details')
+    })
+
+    it('returns undefined for non-fixable gates', () => {
+        expect(getGateProviderTitle({ type: 'accept_tos' })).toBeUndefined()
+        expect(getGateActionLabel({ type: 'ready' })).toBeUndefined()
     })
 })

--- a/src/hooks/__tests__/useMultiPhaseKycFlow.test.ts
+++ b/src/hooks/__tests__/useMultiPhaseKycFlow.test.ts
@@ -1,0 +1,52 @@
+import { getBridgeNextQuestionnaireClusterFromUser } from '../useMultiPhaseKycFlow'
+import type { IUserProfile } from '@/interfaces'
+
+describe('getBridgeNextQuestionnaireClusterFromUser', () => {
+    it('detects EEA TIN reupload from Bridge remediation metadata', () => {
+        const user = {
+            user: {
+                kycVerifications: [
+                    {
+                        provider: 'BRIDGE',
+                        updatedAt: '2026-05-22T00:00:00.000Z',
+                        metadata: {
+                            bridgeRemediation: {
+                                status: 'AWAITING_INPUT',
+                                nextAction: {
+                                    questionnaireCluster: 'eea_tin_reupload',
+                                },
+                            },
+                        },
+                    },
+                ],
+            },
+            rails: [],
+        } as unknown as IUserProfile
+
+        expect(getBridgeNextQuestionnaireClusterFromUser(user)).toBe('eea_tin_reupload')
+    })
+
+    it('does not auto-continue when Bridge is not waiting for input', () => {
+        const user = {
+            user: {
+                kycVerifications: [
+                    {
+                        provider: 'BRIDGE',
+                        updatedAt: '2026-05-22T00:00:00.000Z',
+                        metadata: {
+                            bridgeRemediation: {
+                                status: 'AWAITING_PROVIDER',
+                                nextAction: {
+                                    questionnaireCluster: 'eea_tin_reupload',
+                                },
+                            },
+                        },
+                    },
+                ],
+            },
+            rails: [],
+        } as unknown as IUserProfile
+
+        expect(getBridgeNextQuestionnaireClusterFromUser(user)).toBeNull()
+    })
+})

--- a/src/hooks/__tests__/useProviderRejectionStatus.test.ts
+++ b/src/hooks/__tests__/useProviderRejectionStatus.test.ts
@@ -70,7 +70,7 @@ describe('deriveProviderRejectionInfo', () => {
         expect(info.requiredAction).toBe('BRIDGE_CUSTOMER_FIELDS')
         expect(info.actionLabel).toBe('Provide required details')
         expect(info.actionHandler).toBe('sumsub')
-        expect(info.userMessage).toBe('We need required EEA details to keep payments enabled.')
+        expect(info.userMessage).toBe('We need additional details to keep payments enabled.')
     })
 
     it('marks Bridge RFI customer-field remediation as fixable even when Bridge rejected the customer', () => {

--- a/src/hooks/__tests__/useProviderRejectionStatus.test.ts
+++ b/src/hooks/__tests__/useProviderRejectionStatus.test.ts
@@ -24,6 +24,55 @@ const bridgeVerification = (metadata: IUserKycVerification['metadata']): IUserKy
 })
 
 describe('deriveProviderRejectionInfo', () => {
+    it('shows EEA uplift for an approved Bridge user as a Sumsub details action', () => {
+        const info = deriveProviderRejectionInfo(
+            'BRIDGE',
+            [
+                bridgeRail(
+                    {
+                        bridgeRemediation: {
+                            status: 'AWAITING_INPUT',
+                            nextAction: {
+                                payloadType: 'BRIDGE_CUSTOMER_FIELDS',
+                                requirementKey: 'sof_individual_primary_purpose',
+                                questionnaireCluster: 'eea_uplift',
+                                effectiveDate: '2026-06-29',
+                                maxAttempts: 3,
+                            },
+                        },
+                    },
+                    'REQUIRES_EXTRA_INFORMATION'
+                ),
+            ],
+            [
+                {
+                    ...bridgeVerification({
+                        bridgeRemediation: {
+                            status: 'AWAITING_INPUT',
+                            nextAction: {
+                                payloadType: 'BRIDGE_CUSTOMER_FIELDS',
+                                requirementKey: 'sof_individual_primary_purpose',
+                                questionnaireCluster: 'eea_uplift',
+                                effectiveDate: '2026-06-29',
+                                maxAttempts: 3,
+                            },
+                        },
+                    }),
+                    status: 'approved',
+                    providerRawStatus: 'active',
+                    rejectType: null,
+                    rejectLabels: null,
+                },
+            ]
+        )
+
+        expect(info.state).toBe('fixable')
+        expect(info.requiredAction).toBe('BRIDGE_CUSTOMER_FIELDS')
+        expect(info.actionLabel).toBe('Provide required details')
+        expect(info.actionHandler).toBe('sumsub')
+        expect(info.userMessage).toBe('We need required EEA details to keep payments enabled.')
+    })
+
     it('marks Bridge RFI customer-field remediation as fixable even when Bridge rejected the customer', () => {
         const info = deriveProviderRejectionInfo(
             'BRIDGE',

--- a/src/hooks/__tests__/useProviderRejectionStatus.test.ts
+++ b/src/hooks/__tests__/useProviderRejectionStatus.test.ts
@@ -73,6 +73,43 @@ describe('deriveProviderRejectionInfo', () => {
         expect(info.userMessage).toBe('We need additional details to keep payments enabled.')
     })
 
+    it('shows EEA TIN reupload copy for database-check follow-up', () => {
+        const info = deriveProviderRejectionInfo(
+            'BRIDGE',
+            [
+                bridgeRail(
+                    {
+                        bridgeRemediation: {
+                            status: 'AWAITING_INPUT',
+                            nextAction: {
+                                payloadType: 'BRIDGE_CUSTOMER_FIELDS',
+                                requirementKey: 'database_check_failed',
+                                questionnaireCluster: 'eea_tin_reupload',
+                                effectiveDate: '2026-06-29',
+                                maxAttempts: 3,
+                            },
+                        },
+                    },
+                    'REQUIRES_EXTRA_INFORMATION'
+                ),
+            ],
+            [bridgeVerification({ selfHealAttempt: 1 })]
+        )
+
+        expect(info.state).toBe('fixable')
+        expect(info.requiredAction).toBe('BRIDGE_CUSTOMER_FIELDS')
+        expect(info.actionTitle).toBe('TIN re-upload needed')
+        expect(info.modalTitle).toBe('Re-upload your TIN')
+        expect(info.modalDescription).toBe(
+            'Please re-upload your tax ID so Bridge can verify it against your personal details.'
+        )
+        expect(info.actionLabel).toBe('Re-upload TIN')
+        expect(info.actionHandler).toBe('sumsub')
+        expect(info.userMessage).toBe(
+            'Bridge could not match your tax ID to your personal details. Please re-upload your tax ID document.'
+        )
+    })
+
     it('marks Bridge RFI customer-field remediation as fixable even when Bridge rejected the customer', () => {
         const info = deriveProviderRejectionInfo(
             'BRIDGE',

--- a/src/hooks/__tests__/useProviderRejectionStatus.test.ts
+++ b/src/hooks/__tests__/useProviderRejectionStatus.test.ts
@@ -101,12 +101,12 @@ describe('deriveProviderRejectionInfo', () => {
         expect(info.actionTitle).toBe('TIN re-upload needed')
         expect(info.modalTitle).toBe('Re-upload your TIN')
         expect(info.modalDescription).toBe(
-            'Please re-upload your tax ID so Bridge can verify it against your personal details.'
+            'Please re-upload your tax ID so our verification provider can check it against your personal details.'
         )
         expect(info.actionLabel).toBe('Re-upload TIN')
         expect(info.actionHandler).toBe('sumsub')
         expect(info.userMessage).toBe(
-            'Bridge could not match your tax ID to your personal details. Please re-upload your tax ID document.'
+            'Our verification provider could not match your tax ID to your personal details. Please re-upload your tax ID document.'
         )
     })
 

--- a/src/hooks/useBridgeTransferReadiness.ts
+++ b/src/hooks/useBridgeTransferReadiness.ts
@@ -7,7 +7,12 @@ import useKycStatus from './useKycStatus'
 
 export type BridgeGateAction =
     | { type: 'accept_tos' }
-    | { type: 'fixable_rejection'; userMessage: string | null }
+    | {
+          type: 'fixable_rejection'
+          userMessage: string | null
+          modalTitle: string | null
+          actionLabel: string | null
+      }
     | { type: 'blocked_rejection'; userMessage: string | null }
     | { type: 'provider_processing'; userMessage: string | null }
     | { type: 'needs_enrollment' }
@@ -41,7 +46,12 @@ export function useBridgeTransferReadiness() {
 
         // 3. fixable rejection — user can submit additional details
         if (bridgeRejection.state === 'fixable') {
-            return { type: 'fixable_rejection', userMessage: bridgeRejection.userMessage }
+            return {
+                type: 'fixable_rejection',
+                userMessage: bridgeRejection.userMessage,
+                modalTitle: bridgeRejection.modalTitle,
+                actionLabel: bridgeRejection.actionLabel,
+            }
         }
 
         // 4. provider processing — no user action needed
@@ -87,5 +97,15 @@ export function getGateProviderMessage(gate: BridgeGateAction): string | undefin
     if (gate.type === 'fixable_rejection' || gate.type === 'blocked_rejection' || gate.type === 'provider_processing') {
         return gate.userMessage ?? undefined
     }
+    return undefined
+}
+
+export function getGateProviderTitle(gate: BridgeGateAction): string | undefined {
+    if (gate.type === 'fixable_rejection') return gate.modalTitle ?? undefined
+    return undefined
+}
+
+export function getGateActionLabel(gate: BridgeGateAction): string | undefined {
+    if (gate.type === 'fixable_rejection') return gate.actionLabel ?? undefined
     return undefined
 }

--- a/src/hooks/useBridgeTransferReadiness.ts
+++ b/src/hooks/useBridgeTransferReadiness.ts
@@ -69,7 +69,7 @@ export function useBridgeTransferReadiness() {
             return { type: 'needs_enrollment' }
         }
 
-        // 5. ready
+        // 6. ready
         return { type: 'ready' }
     }, [
         needsBridgeTos,

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -93,6 +93,7 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
     const preparingTimerRef = useRef<NodeJS.Timeout | null>(null)
     const preparingElapsedIntervalRef = useRef<NodeJS.Timeout | null>(null)
     const isRealtimeFlowRef = useRef(false)
+    const isMountedRef = useRef(true)
 
     // bridge ToS state
     const [tosLink, setTosLink] = useState<string | null>(null)
@@ -105,6 +106,12 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
 
     // rail tracking
     const { allSettled, needsBridgeTos, startTracking, stopTracking } = useRailStatusTracking()
+
+    useEffect(() => {
+        return () => {
+            isMountedRef.current = false
+        }
+    }, [])
 
     const clearPreparingTimer = useCallback(() => {
         if (preparingTimerRef.current) {
@@ -210,13 +217,25 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
         setModalPhase('checking')
         setForceShowModal(true)
 
+        // the second SDK completion happens after React records the TIN cluster from the first auto-continue.
         const canAutoContinueTin = lastSelfHealQuestionnaireCluster !== 'eea_tin_reupload'
         for (
             let elapsed = 0;
-            elapsed <= BRIDGE_ACTION_AUTO_CONTINUE_TIMEOUT_MS;
+            elapsed < BRIDGE_ACTION_AUTO_CONTINUE_TIMEOUT_MS;
             elapsed += BRIDGE_ACTION_AUTO_CONTINUE_INTERVAL_MS
         ) {
-            const updatedUser = await fetchUser()
+            if (!isMountedRef.current) return
+
+            let updatedUser
+            try {
+                updatedUser = await fetchUser()
+            } catch (error) {
+                console.error('[useMultiPhaseKycFlow] failed to refresh user during action continuation', error)
+                if (elapsed + BRIDGE_ACTION_AUTO_CONTINUE_INTERVAL_MS < BRIDGE_ACTION_AUTO_CONTINUE_TIMEOUT_MS) {
+                    await wait(BRIDGE_ACTION_AUTO_CONTINUE_INTERVAL_MS)
+                }
+                continue
+            }
             const nextCluster = getBridgeNextQuestionnaireClusterFromUser(updatedUser)
 
             if (nextCluster === 'eea_tin_reupload' && canAutoContinueTin) {
@@ -225,15 +244,20 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
                     setForceShowModal(false)
                     return
                 }
+                console.warn('[useMultiPhaseKycFlow] failed to start EEA TIN reupload continuation')
                 break
             }
 
-            if (nextCluster === 'eea_tin_reupload') break
-            if (elapsed < BRIDGE_ACTION_AUTO_CONTINUE_TIMEOUT_MS) {
+            if (nextCluster === 'eea_tin_reupload') {
+                await wait(BRIDGE_ACTION_AUTO_CONTINUE_INTERVAL_MS)
+                break
+            }
+            if (elapsed + BRIDGE_ACTION_AUTO_CONTINUE_INTERVAL_MS < BRIDGE_ACTION_AUTO_CONTINUE_TIMEOUT_MS) {
                 await wait(BRIDGE_ACTION_AUTO_CONTINUE_INTERVAL_MS)
             }
         }
 
+        if (!isMountedRef.current) return
         setModalPhase('preparing')
         setForceShowModal(true)
         startTracking()

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -219,42 +219,49 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
 
         // the second SDK completion happens after React records the TIN cluster from the first auto-continue.
         const canAutoContinueTin = lastSelfHealQuestionnaireCluster !== 'eea_tin_reupload'
-        for (
-            let elapsed = 0;
-            elapsed < BRIDGE_ACTION_AUTO_CONTINUE_TIMEOUT_MS;
-            elapsed += BRIDGE_ACTION_AUTO_CONTINUE_INTERVAL_MS
-        ) {
-            if (!isMountedRef.current) return
+        try {
+            for (
+                let elapsed = 0;
+                elapsed < BRIDGE_ACTION_AUTO_CONTINUE_TIMEOUT_MS;
+                elapsed += BRIDGE_ACTION_AUTO_CONTINUE_INTERVAL_MS
+            ) {
+                if (!isMountedRef.current) return
 
-            let updatedUser
-            try {
-                updatedUser = await fetchUser()
-            } catch (error) {
-                console.error('[useMultiPhaseKycFlow] failed to refresh user during action continuation', error)
+                let updatedUser
+                try {
+                    updatedUser = await fetchUser()
+                } catch (error) {
+                    console.error('[useMultiPhaseKycFlow] failed to refresh user during action continuation', error)
+                    if (elapsed + BRIDGE_ACTION_AUTO_CONTINUE_INTERVAL_MS < BRIDGE_ACTION_AUTO_CONTINUE_TIMEOUT_MS) {
+                        await wait(BRIDGE_ACTION_AUTO_CONTINUE_INTERVAL_MS)
+                    }
+                    continue
+                }
+                if (!isMountedRef.current) return
+
+                const nextCluster = getBridgeNextQuestionnaireClusterFromUser(updatedUser)
+
+                if (nextCluster === 'eea_tin_reupload' && canAutoContinueTin) {
+                    const started = await handleSelfHealResubmit('BRIDGE')
+                    if (!isMountedRef.current) return
+                    if (started) {
+                        setForceShowModal(false)
+                        return
+                    }
+                    console.warn('[useMultiPhaseKycFlow] failed to start EEA TIN reupload continuation')
+                    break
+                }
+
+                if (nextCluster === 'eea_tin_reupload') {
+                    await wait(BRIDGE_ACTION_AUTO_CONTINUE_INTERVAL_MS)
+                    break
+                }
                 if (elapsed + BRIDGE_ACTION_AUTO_CONTINUE_INTERVAL_MS < BRIDGE_ACTION_AUTO_CONTINUE_TIMEOUT_MS) {
                     await wait(BRIDGE_ACTION_AUTO_CONTINUE_INTERVAL_MS)
                 }
-                continue
             }
-            const nextCluster = getBridgeNextQuestionnaireClusterFromUser(updatedUser)
-
-            if (nextCluster === 'eea_tin_reupload' && canAutoContinueTin) {
-                const started = await handleSelfHealResubmit('BRIDGE')
-                if (started) {
-                    setForceShowModal(false)
-                    return
-                }
-                console.warn('[useMultiPhaseKycFlow] failed to start EEA TIN reupload continuation')
-                break
-            }
-
-            if (nextCluster === 'eea_tin_reupload') {
-                await wait(BRIDGE_ACTION_AUTO_CONTINUE_INTERVAL_MS)
-                break
-            }
-            if (elapsed + BRIDGE_ACTION_AUTO_CONTINUE_INTERVAL_MS < BRIDGE_ACTION_AUTO_CONTINUE_TIMEOUT_MS) {
-                await wait(BRIDGE_ACTION_AUTO_CONTINUE_INTERVAL_MS)
-            }
+        } catch (error) {
+            console.error('[useMultiPhaseKycFlow] action continuation failed', error)
         }
 
         if (!isMountedRef.current) return

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -3,12 +3,48 @@ import { useAuth } from '@/context/authContext'
 import { useSumsubKycFlow } from '@/hooks/useSumsubKycFlow'
 import { useRailStatusTracking } from '@/hooks/useRailStatusTracking'
 import { getBridgeTosLink, confirmBridgeTos } from '@/app/actions/users'
-import { type KycModalPhase } from '@/interfaces'
+import { type IUserProfile, type KycModalPhase } from '@/interfaces'
 import { type KYCRegionIntent } from '@/app/actions/types/sumsub.types'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 const PREPARING_TIMEOUT_MS = 30000
+const BRIDGE_ACTION_AUTO_CONTINUE_TIMEOUT_MS = 20000
+const BRIDGE_ACTION_AUTO_CONTINUE_INTERVAL_MS = 2000
+
+function wait(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === 'object'
+}
+
+function getBridgeRemediationFromUser(userProfile?: IUserProfile | null): Record<string, unknown> | null {
+    const bridgeVerification = userProfile?.user?.kycVerifications
+        ?.filter((verification) => verification.provider === 'BRIDGE')
+        .sort((a, b) => new Date(b.updatedAt ?? 0).getTime() - new Date(a.updatedAt ?? 0).getTime())[0]
+    const verificationRemediation = bridgeVerification?.metadata?.bridgeRemediation
+    if (isRecord(verificationRemediation)) return verificationRemediation
+
+    const railRemediation = userProfile?.rails
+        ?.filter((rail) => rail.rail.provider.code === 'BRIDGE')
+        .map((rail) => rail.metadata?.bridgeRemediation)
+        .find(isRecord)
+
+    return railRemediation ?? null
+}
+
+export function getBridgeNextQuestionnaireClusterFromUser(userProfile?: IUserProfile | null): string | null {
+    const bridgeRemediation = getBridgeRemediationFromUser(userProfile)
+    if (bridgeRemediation?.status !== 'AWAITING_INPUT') return null
+
+    const nextAction = bridgeRemediation.nextAction
+    if (!isRecord(nextAction)) return null
+
+    const questionnaireCluster = nextAction.questionnaireCluster
+    return typeof questionnaireCluster === 'string' ? questionnaireCluster : null
+}
 
 /**
  * confirms bridge ToS acceptance (with one retry) then polls fetchUser
@@ -150,6 +186,7 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
         isVerificationProgressModalOpen,
         closeVerificationProgressModal,
         isActionFlow,
+        lastSelfHealQuestionnaireCluster,
     } = useSumsubKycFlow({ onKycSuccess: handleSumsubApproved, onManualClose, regionIntent })
 
     // keep ref in sync
@@ -169,6 +206,39 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
         }
     }, [liveKycStatus, fetchUser, regionIntent])
 
+    const handleActionFlowComplete = useCallback(async () => {
+        setModalPhase('checking')
+        setForceShowModal(true)
+
+        const canAutoContinueTin = lastSelfHealQuestionnaireCluster !== 'eea_tin_reupload'
+        for (
+            let elapsed = 0;
+            elapsed <= BRIDGE_ACTION_AUTO_CONTINUE_TIMEOUT_MS;
+            elapsed += BRIDGE_ACTION_AUTO_CONTINUE_INTERVAL_MS
+        ) {
+            const updatedUser = await fetchUser()
+            const nextCluster = getBridgeNextQuestionnaireClusterFromUser(updatedUser)
+
+            if (nextCluster === 'eea_tin_reupload' && canAutoContinueTin) {
+                const started = await handleSelfHealResubmit('BRIDGE')
+                if (started) {
+                    setForceShowModal(false)
+                    return
+                }
+                break
+            }
+
+            if (nextCluster === 'eea_tin_reupload') break
+            if (elapsed < BRIDGE_ACTION_AUTO_CONTINUE_TIMEOUT_MS) {
+                await wait(BRIDGE_ACTION_AUTO_CONTINUE_INTERVAL_MS)
+            }
+        }
+
+        setModalPhase('preparing')
+        setForceShowModal(true)
+        startTracking()
+    }, [fetchUser, handleSelfHealResubmit, lastSelfHealQuestionnaireCluster, startTracking])
+
     // wrap handleSdkComplete to track real-time flow
     const handleSdkComplete = useCallback(() => {
         posthog.capture(ANALYTICS_EVENTS.KYC_SUBMITTED, { region_intent: regionIntent })
@@ -177,9 +247,9 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
         // for action flows (manteca, self-heal), the base status is already APPROVED
         // and won't transition — directly start the preparing/tracking phase
         if (isActionFlow) {
-            handleSumsubApproved()
+            void handleActionFlowComplete()
         }
-    }, [originalHandleSdkComplete, handleSumsubApproved, isActionFlow, regionIntent])
+    }, [originalHandleSdkComplete, handleActionFlowComplete, isActionFlow, regionIntent])
 
     // wrap handleInitiateKyc to reset state for new attempts
     const handleInitiateKyc = useCallback(

--- a/src/hooks/useProviderRejectionStatus.ts
+++ b/src/hooks/useProviderRejectionStatus.ts
@@ -118,7 +118,7 @@ function getActionModalTitle(action?: ProviderRemediationAction) {
 
 function getActionModalDescription(action?: ProviderRemediationAction) {
     if (isEeaTinReuploadAction(action)) {
-        return 'Please re-upload your tax ID so Bridge can verify it against your personal details.'
+        return 'Please re-upload your tax ID so our verification provider can check it against your personal details.'
     }
 
     const payloadType = action?.payloadType
@@ -163,7 +163,7 @@ function getBridgeActionMessage(action?: ProviderRemediationAction) {
         return 'We need additional details to keep payments enabled.'
     }
     if (isEeaTinReuploadAction(action)) {
-        return 'Bridge could not match your tax ID to your personal details. Please re-upload your tax ID document.'
+        return 'Our verification provider could not match your tax ID to your personal details. Please re-upload your tax ID document.'
     }
 
     switch (action?.payloadType) {

--- a/src/hooks/useProviderRejectionStatus.ts
+++ b/src/hooks/useProviderRejectionStatus.ts
@@ -16,6 +16,8 @@ type ProviderRemediationStatus = 'APPROVED' | 'AWAITING_INPUT' | 'AWAITING_PROVI
 interface ProviderRemediationAction {
     payloadType: ProviderRemediationPayloadType
     requirementKey?: string
+    questionnaireCluster?: 'source_of_funds' | 'tax_id' | 'address' | 'birth_details' | 'eea_uplift'
+    effectiveDate?: string
     maxAttempts?: number
 }
 
@@ -116,8 +118,10 @@ function getActionHandler(payloadType?: ProviderRemediationPayloadType): Provide
     return payloadType === 'BRIDGE_TOS' ? 'tos' : 'sumsub'
 }
 
-function getActionLabel(payloadType?: ProviderRemediationPayloadType) {
-    switch (payloadType) {
+function getActionLabel(action?: ProviderRemediationAction) {
+    if (action?.questionnaireCluster === 'eea_uplift') return 'Provide required details'
+
+    switch (action?.payloadType) {
         case 'BRIDGE_TOS':
             return 'Accept terms'
         case 'BRIDGE_IDENTIFYING_INFORMATION':
@@ -132,6 +136,10 @@ function getActionLabel(payloadType?: ProviderRemediationPayloadType) {
 }
 
 function getBridgeActionMessage(action?: ProviderRemediationAction) {
+    if (action?.questionnaireCluster === 'eea_uplift') {
+        return 'We need required EEA details to keep payments enabled.'
+    }
+
     switch (action?.payloadType) {
         case 'BRIDGE_TOS':
             return 'Please accept the terms to enable payments.'
@@ -279,7 +287,7 @@ export function deriveProviderRejectionInfo(
             actionTitle: getActionTitle(payloadType),
             modalTitle: getActionModalTitle(payloadType),
             modalDescription: getActionModalDescription(payloadType),
-            actionLabel: getActionLabel(payloadType),
+            actionLabel: getActionLabel(bridgeAction),
             actionHandler: getActionHandler(payloadType),
         }
     }

--- a/src/hooks/useProviderRejectionStatus.ts
+++ b/src/hooks/useProviderRejectionStatus.ts
@@ -16,7 +16,14 @@ type ProviderRemediationStatus = 'APPROVED' | 'AWAITING_INPUT' | 'AWAITING_PROVI
 interface ProviderRemediationAction {
     payloadType: ProviderRemediationPayloadType
     requirementKey?: string
-    questionnaireCluster?: 'source_of_funds' | 'tax_id' | 'address' | 'birth_details' | 'eea_uplift'
+    questionnaireCluster?:
+        | 'source_of_funds'
+        | 'tax_id'
+        | 'address'
+        | 'birth_details'
+        | 'eea_uplift'
+        | 'eea_tin_reupload'
+    questionnaireVariant?: 'eea_uplift_with_tin'
     effectiveDate?: string
     maxAttempts?: number
 }
@@ -71,7 +78,14 @@ function emptyProviderInfo(
     }
 }
 
-function getActionTitle(payloadType?: ProviderRemediationPayloadType) {
+function isEeaTinReuploadAction(action?: ProviderRemediationAction) {
+    return action?.questionnaireCluster === 'eea_tin_reupload'
+}
+
+function getActionTitle(action?: ProviderRemediationAction) {
+    if (isEeaTinReuploadAction(action)) return 'TIN re-upload needed'
+
+    const payloadType = action?.payloadType
     switch (payloadType) {
         case 'BRIDGE_TOS':
             return 'Terms acceptance needed'
@@ -85,7 +99,10 @@ function getActionTitle(payloadType?: ProviderRemediationPayloadType) {
     }
 }
 
-function getActionModalTitle(payloadType?: ProviderRemediationPayloadType) {
+function getActionModalTitle(action?: ProviderRemediationAction) {
+    if (isEeaTinReuploadAction(action)) return 'Re-upload your TIN'
+
+    const payloadType = action?.payloadType
     switch (payloadType) {
         case 'BRIDGE_TOS':
             return 'Terms acceptance needed'
@@ -99,7 +116,12 @@ function getActionModalTitle(payloadType?: ProviderRemediationPayloadType) {
     }
 }
 
-function getActionModalDescription(payloadType?: ProviderRemediationPayloadType) {
+function getActionModalDescription(action?: ProviderRemediationAction) {
+    if (isEeaTinReuploadAction(action)) {
+        return 'Please re-upload your tax ID so Bridge can verify it against your personal details.'
+    }
+
+    const payloadType = action?.payloadType
     switch (payloadType) {
         case 'BRIDGE_TOS':
             return 'Please accept the terms to enable payments.'
@@ -120,6 +142,7 @@ function getActionHandler(payloadType?: ProviderRemediationPayloadType): Provide
 
 function getActionLabel(action?: ProviderRemediationAction) {
     if (action?.questionnaireCluster === 'eea_uplift') return 'Provide required details'
+    if (isEeaTinReuploadAction(action)) return 'Re-upload TIN'
 
     switch (action?.payloadType) {
         case 'BRIDGE_TOS':
@@ -138,6 +161,9 @@ function getActionLabel(action?: ProviderRemediationAction) {
 function getBridgeActionMessage(action?: ProviderRemediationAction) {
     if (action?.questionnaireCluster === 'eea_uplift') {
         return 'We need additional details to keep payments enabled.'
+    }
+    if (isEeaTinReuploadAction(action)) {
+        return 'Bridge could not match your tax ID to your personal details. Please re-upload your tax ID document.'
     }
 
     switch (action?.payloadType) {
@@ -284,9 +310,9 @@ export function deriveProviderRejectionInfo(
             selfHealAttempt,
             maxAttempts,
             requiredAction: payloadType ?? null,
-            actionTitle: getActionTitle(payloadType),
-            modalTitle: getActionModalTitle(payloadType),
-            modalDescription: getActionModalDescription(payloadType),
+            actionTitle: getActionTitle(bridgeAction),
+            modalTitle: getActionModalTitle(bridgeAction),
+            modalDescription: getActionModalDescription(bridgeAction),
             actionLabel: getActionLabel(bridgeAction),
             actionHandler: getActionHandler(payloadType),
         }

--- a/src/hooks/useProviderRejectionStatus.ts
+++ b/src/hooks/useProviderRejectionStatus.ts
@@ -137,7 +137,7 @@ function getActionLabel(action?: ProviderRemediationAction) {
 
 function getBridgeActionMessage(action?: ProviderRemediationAction) {
     if (action?.questionnaireCluster === 'eea_uplift') {
-        return 'We need required EEA details to keep payments enabled.'
+        return 'We need additional details to keep payments enabled.'
     }
 
     switch (action?.payloadType) {

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -272,6 +272,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         if (selfHealProviderRef.current) {
             selfHealProviderRef.current = null
             setIsActionFlow(false)
+            // this intentionally reads the captured pre-update value. action flows are polled by useMultiPhaseKycFlow.
             if (!isActionFlow) void fetchUser()
             return
         }
@@ -333,6 +334,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         setError(null)
         userInitiatedRef.current = true
         selfHealProviderRef.current = provider
+        setLastSelfHealQuestionnaireCluster(null)
 
         try {
             const response = await initiateSelfHealResubmission(provider)

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -43,6 +43,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     const userInitiatedRef = useRef(false)
     // tracks self-heal provider for token refresh — null when in regular KYC flow
     const selfHealProviderRef = useRef<'BRIDGE' | 'MANTECA' | null>(null)
+    const [lastSelfHealQuestionnaireCluster, setLastSelfHealQuestionnaireCluster] = useState<string | null>(null)
 
     useEffect(() => {
         regionIntentRef.current = regionIntent
@@ -144,6 +145,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
             userInitiatedRef.current = true
             initiatingRef.current = true
             selfHealProviderRef.current = null
+            setLastSelfHealQuestionnaireCluster(null)
             setIsLoading(true)
             setError(null)
 
@@ -293,6 +295,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 throw new Error(response.error || 'Failed to refresh self-heal token')
             }
             setAccessToken(response.data.token)
+            setLastSelfHealQuestionnaireCluster(response.data.questionnaireCluster ?? null)
             return response.data.token
         }
 
@@ -342,6 +345,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
 
             if (response.data?.token) {
                 setAccessToken(response.data.token)
+                setLastSelfHealQuestionnaireCluster(response.data.questionnaireCluster ?? null)
                 setIsActionFlow(true)
                 setShowWrapper(true)
                 return true
@@ -377,5 +381,6 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         closeVerificationModalAndGoHome,
         resetError,
         isActionFlow,
+        lastSelfHealQuestionnaireCluster,
     }
 }

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -272,12 +272,12 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         if (selfHealProviderRef.current) {
             selfHealProviderRef.current = null
             setIsActionFlow(false)
-            void fetchUser()
+            if (!isActionFlow) void fetchUser()
             return
         }
         setIsActionFlow(false)
         setIsVerificationProgressModalOpen(true)
-    }, [fetchUser])
+    }, [fetchUser, isActionFlow])
 
     // called when user manually closes the sdk modal
     const handleClose = useCallback(() => {

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -3,7 +3,7 @@ import { type SumsubKycStatus } from '@/app/actions/types/sumsub.types'
 export type RecipientType = 'address' | 'ens' | 'iban' | 'us' | 'username'
 
 // phases for the multi-phase kyc verification modal
-export type KycModalPhase = 'verifying' | 'preparing' | 'bridge_tos' | 'complete'
+export type KycModalPhase = 'verifying' | 'checking' | 'preparing' | 'bridge_tos' | 'complete'
 
 // per-provider rail status for tracking after kyc approval
 export type ProviderDisplayStatus = 'setting_up' | 'requires_tos' | 'requires_documents' | 'enabled' | 'failed'


### PR DESCRIPTION
## Summary
- show EEA uplift as a fixable Bridge remediation requirement
- use the existing Sumsub remediation path for the applicant action
- add coverage for approved Bridge users with EEA uplift metadata

## Risks
- UI depends on API metadata carrying questionnaireCluster = eea_uplift
- post-submit state relies on the existing provider remediation waiting state

## QA Guidelines
- verify affected approved Bridge users see “Provide required details”
- verify the CTA opens the existing Sumsub remediation flow
- verify users move to the waiting/provider-review state after completing the action