### PR TITLE
Revert frontend Founder Haus override

### DIFF
--- a/src/components/Badges/BadgeStatusDrawer.tsx
+++ b/src/components/Badges/BadgeStatusDrawer.tsx
@@ -4,7 +4,7 @@ import { formatDate } from '@/utils/general.utils'
 import Card from '../Global/Card'
 import { PaymentInfoRow } from '../Payment/PaymentInfoRow'
 import ShareButton from '../Global/ShareButton'
-import { getBadgeDisplayName, getBadgeIcon } from './badge.utils'
+import { getBadgeIcon } from './badge.utils'
 import { BASE_URL } from '@/constants/general.consts'
 import { useAuth } from '@/context/authContext'
 
@@ -26,7 +26,6 @@ export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerP
     const username = authUser?.user.username
     const earnedAt = badge.earnedAt ? new Date(badge.earnedAt) : undefined
     const dateStr = earnedAt ? formatDate(earnedAt) : undefined
-    const displayName = getBadgeDisplayName(badge.code, badge.name)
 
     // generate profile link for sharing
     const profileLink = username ? `${BASE_URL}/${username}` : BASE_URL
@@ -51,7 +50,7 @@ export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerP
                                 <h2 className="flex items-center gap-2 text-xs font-medium text-grey-1">
                                     Badge unlocked!
                                 </h2>
-                                <h1 className={`text-lg font-extrabold md:text-4xl`}>{displayName}</h1>
+                                <h1 className={`text-lg font-extrabold md:text-4xl`}>{badge.name}</h1>
                             </div>
                         </div>
                     </Card>
@@ -66,7 +65,7 @@ export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerP
                             title=""
                             generateText={() =>
                                 Promise.resolve(
-                                    `I earned ${displayName} badge on Peanut!\n\nJoin Peanut now and start earning points, unlocking achievements and moving money worldwide\n\n${profileLink}`
+                                    `I earned ${badge.name} badge on Peanut!\n\nJoin Peanut now and start earning points, unlocking achievements and moving money worldwide\n\n${profileLink}`
                                 )
                             }
                         >

--- a/src/components/Badges/BadgeStatusItem.tsx
+++ b/src/components/Badges/BadgeStatusItem.tsx
@@ -4,7 +4,7 @@ import { type CardPosition } from '@/components/Global/Card/card.utils'
 import { BadgeStatusDrawer } from './BadgeStatusDrawer'
 import Image from 'next/image'
 import InvitesIcon from '../Home/InvitesIcon'
-import { getBadgeDisplayName, getBadgeIcon } from './badge.utils'
+import { getBadgeIcon } from './badge.utils'
 import { type BadgeHistoryEntry } from './badge.types'
 
 export const BadgeStatusItem = ({
@@ -15,7 +15,6 @@ export const BadgeStatusItem = ({
     entry: BadgeHistoryEntry
 }) => {
     const [isDrawerOpen, setIsDrawerOpen] = useState(false)
-    const displayName = getBadgeDisplayName(entry.code, entry.name)
 
     const badge = useMemo(
         () => ({
@@ -39,7 +38,7 @@ export const BadgeStatusItem = ({
                 <div className={'relative flex h-8 w-8 items-center justify-center rounded-full'}>
                     <Image
                         src={getBadgeIcon(entry.code)}
-                        alt={`${displayName} icon`}
+                        alt={`${entry.name} icon`}
                         className="size-10 object-contain"
                         width={32}
                         height={32}
@@ -49,7 +48,7 @@ export const BadgeStatusItem = ({
                 {/* text content */}
                 <div className="flex-1">
                     <div className="flex flex-row items-center gap-2">
-                        <div className="min-w-0 flex-1 truncate font-roboto text-[16px] font-medium">{displayName}</div>
+                        <div className="min-w-0 flex-1 truncate font-roboto text-[16px] font-medium">{entry.name}</div>
                     </div>
                     <div className="flex items-center gap-1 text-sm font-medium text-gray-1">
                         <span className="capitalize">Badge unlocked!</span>

--- a/src/components/Badges/BadgesRow.tsx
+++ b/src/components/Badges/BadgesRow.tsx
@@ -7,7 +7,7 @@ import { Tooltip } from '../Tooltip'
 import { twMerge } from 'tailwind-merge'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Icon } from '../Global/Icons/Icon'
-import { getBadgeDisplayName, getBadgeIcon, getPublicBadgeDescription } from './badge.utils'
+import { getBadgeIcon, getPublicBadgeDescription } from './badge.utils'
 
 type UIBadge = {
     code: string
@@ -102,21 +102,20 @@ const BadgesRow = ({ badges, className, isSelfProfile = true }: BadgesRowProps) 
                         const displayDescription = isSelfProfile
                             ? badge.description
                             : getPublicBadgeDescription(badge.code) || badge.description
-                        const displayName = getBadgeDisplayName(badge.code, badge.name)
 
                         return (
                             <Tooltip
                                 key={badge.code}
                                 content={
                                     <div className="flex flex-col items-center justify-center gap-1">
-                                        <div className="relative text-sm font-bold">{displayName}</div>
+                                        <div className="relative text-sm font-bold">{badge.name}</div>
                                         <p className="text-center font-normal">{displayDescription}</p>
                                     </div>
                                 }
                             >
                                 <Image
                                     src={getBadgeIcon(badge.code)}
-                                    alt={displayName}
+                                    alt={badge.name}
                                     className="min-h-10 min-w-10 object-contain"
                                     height={48}
                                     width={48}

--- a/src/components/Badges/badge.utils.ts
+++ b/src/components/Badges/badge.utils.ts
@@ -18,12 +18,6 @@ const CODE_TO_PATH: Record<string, string> = {
     SUPPORT_SURVIVOR: '/badges/support_survivor.svg',
 }
 
-// front-end display name overrides for badges. backend codes/names stay the same;
-// this is purely for what the user sees.
-const DISPLAY_NAME_OVERRIDES: Record<string, string> = {
-    FOUNDER_HOUSE: 'Founder Haus',
-}
-
 // public-facing descriptions for badges (third-person perspective)
 const PUBLIC_DESCRIPTIONS: Record<string, string> = {
     BETA_TESTER: `They broke things so others don't have to. Welcome to the chaos club.`,
@@ -38,7 +32,7 @@ const PUBLIC_DESCRIPTIONS: Record<string, string> = {
     SEEDLING_DEVCONNECT_BA_2025: 'Peanut Ambassador. They spread the word and brought others into the ecosystem.',
     ARBIVERSE_DEVCONNECT_BA_2025: 'Peanut 🤝 Arbiverse. They joined us at the amazing Arbiverse booth.',
     CARD_PIONEER: 'A true Card Pioneer. Among the first to pay everywhere with Peanut.',
-    FOUNDER_HOUSE: 'Checked in at the Founder Haus. Builds IRL, not just on-chain.',
+    FOUNDER_HOUSE: 'Checked in at the Founder House. Builds IRL, not just on-chain.',
     SUPPORT_SURVIVOR: 'Survived a real bug and helped us fix it. The brave kind of user.',
 }
 
@@ -52,11 +46,4 @@ export function getBadgeIcon(code?: string) {
 export function getPublicBadgeDescription(code?: string): string | null {
     if (!code) return null
     return PUBLIC_DESCRIPTIONS[code] || null
-}
-
-// returns the display name for a badge, applying any front-end override on top
-// of whatever the backend provided. backend storage is untouched.
-export function getBadgeDisplayName(code: string | undefined, fallback: string): string {
-    if (code && DISPLAY_NAME_OVERRIDES[code]) return DISPLAY_NAME_OVERRIDES[code]
-    return fallback
 }

--- a/src/components/Badges/index.tsx
+++ b/src/components/Badges/index.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image'
 import type { StaticImageData } from 'next/image'
 import NavHeader from '../Global/NavHeader'
 import { useSafeBack } from '@/hooks/useSafeBack'
-import { getBadgeDisplayName, getBadgeIcon } from './badge.utils'
+import { getBadgeIcon } from './badge.utils'
 import { getCardPosition } from '../Global/Card/card.utils'
 import EmptyState from '../Global/EmptyStates/EmptyState'
 import { Icon } from '../Global/Icons/Icon'
@@ -33,7 +33,7 @@ export const Badges = () => {
         // get badges from user object and map to card fields
         const raw = authUser?.user?.badges || []
         return raw.map((b) => ({
-            title: getBadgeDisplayName(b.code, b.name),
+            title: b.name,
             description: b.description || '',
             logo: getBadgeIcon(b.code),
         }))


### PR DESCRIPTION
## Summary
Reverts #2077. Removes the frontend-only `getBadgeDisplayName` override that maps `FOUNDER_HOUSE` → "Founder Haus" in [src/components/Badges/](src/components/Badges/).

The clean fix is on the backend — updating the `name` column on the `FOUNDER_HOUSE` row in `app.acknowledgment_definitions`:

```sql
UPDATE app.acknowledgment_definitions
SET name = 'Founder Haus'
WHERE code = 'FOUNDER_HOUSE';
```

Once that ships, the API will return "Founder Haus" directly and the frontend shim becomes dead weight. This PR removes it.

## ⚠️ Do not merge until the backend rename is deployed
Merging this before the BE update lands will make the badge display "Founder House" again. Ping Kush — there's a Slack thread about it.

Kept as **draft** so it doesn't auto-merge.

## Test plan
- [ ] Backend `acknowledgment_definitions` row for `FOUNDER_HOUSE` has `name = 'Founder Haus'` in prod.
- [ ] After merging, profile page, BadgesRow tooltip, BadgeStatusDrawer, BadgeStatusItem, and `/badges` page all still show "Founder Haus" (now sourced from BE, not FE override).