### PR TITLE
Show Manteca US nationality restriction

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
+++ b/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
@@ -83,6 +83,8 @@ jest.mock('@/hooks/useQrKycGate', () => ({
         PROCEED_TO_PAY: 'proceed_to_pay',
         REQUIRES_IDENTITY_VERIFICATION: 'requires_identity_verification',
         IDENTITY_VERIFICATION_IN_PROGRESS: 'identity_verification_in_progress',
+        PROVIDER_REJECTION_FIXABLE: 'provider_rejection_fixable',
+        PROVIDER_REJECTION_BLOCKED: 'provider_rejection_blocked',
     },
     useQrKycGate: (...args: any[]) => mockUseQrKycGate(...args),
 }))
@@ -474,6 +476,7 @@ function applyDefaults() {
     mockUseQrKycGate.mockReturnValue({
         kycGateState: 'proceed_to_pay',
         shouldBlockPay: false,
+        userMessage: null,
     })
 
     mockUseAuth.mockReturnValue({
@@ -596,6 +599,7 @@ describe('GROUP 1: Loading & KYC Gate', () => {
         mockUseQrKycGate.mockReturnValue({
             kycGateState: 'loading',
             shouldBlockPay: true,
+            userMessage: null,
         })
 
         renderQrPay({ qrCode: 'mercadopago://pay?id=123', type: 'MERCADO_PAGO', t: '1' })
@@ -606,6 +610,7 @@ describe('GROUP 1: Loading & KYC Gate', () => {
         mockUseQrKycGate.mockReturnValue({
             kycGateState: 'requires_identity_verification',
             shouldBlockPay: true,
+            userMessage: null,
         })
 
         renderQrPay({ qrCode: 'mercadopago://pay?id=123', type: 'MERCADO_PAGO', t: '1' })
@@ -620,6 +625,7 @@ describe('GROUP 1: Loading & KYC Gate', () => {
         mockUseQrKycGate.mockReturnValue({
             kycGateState: 'identity_verification_in_progress',
             shouldBlockPay: true,
+            userMessage: null,
         })
 
         renderQrPay({ qrCode: 'mercadopago://pay?id=123', type: 'MERCADO_PAGO', t: '1' })

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -125,7 +125,7 @@ export default function QRPayPage() {
         return paymentProcessor ? maintenanceConfig.disabledPaymentProviders.includes(paymentProcessor) : false
     }, [paymentProcessor])
 
-    const { shouldBlockPay, kycGateState } = useQrKycGate(paymentProcessor)
+    const { shouldBlockPay, kycGateState, userMessage: qrKycUserMessage } = useQrKycGate(paymentProcessor)
     const { isUserSumsubKycApproved } = useKycStatus()
     const sumsubFlow = useMultiPhaseKycFlow({})
     const queryClient = useQueryClient()
@@ -863,7 +863,8 @@ export default function QRPayPage() {
                     description={
                         isFixable
                             ? 'We need an updated document to enable QR payments. Please upload a clearer photo of your ID.'
-                            : 'QR payments are not available for your account. Contact support for help.'
+                            : (qrKycUserMessage ??
+                              'QR payments are not available for your account. Contact support for help.')
                     }
                     icon={
                         methodIcon ? (

--- a/src/constants/kyc.consts.ts
+++ b/src/constants/kyc.consts.ts
@@ -9,6 +9,8 @@ export type KycVerificationStatus = MantecaKycStatus | SumsubKycStatus | string
 
 export type KycStatusCategory = 'completed' | 'processing' | 'failed' | 'action_required'
 
+export const MAX_SELF_HEAL_ATTEMPTS = 3
+
 // sets of status values by category — single source of truth
 // REVERIFYING = user is approved but re-verifying for a new region (cross-region KYC).
 // treated as approved for access checks — user retains existing provider access.

--- a/src/constants/manteca.consts.ts
+++ b/src/constants/manteca.consts.ts
@@ -2,6 +2,9 @@ export const MANTECA_DEPOSIT_ADDRESS = '0x959e088a09f61aB01cb83b0eBCc74b2CF6d620
 
 export const MANTECA_ARG_DEPOSIT_NAME = 'Sixalime Sas'
 export const MANTECA_ARG_DEPOSIT_CUIT = '30-71678845-3'
+export const MANTECA_US_NATIONALITY_RESTRICTION_CODE = 'MANTECA_US_NATIONALITY_RESTRICTED'
+export const MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE =
+    'Manteca services are not available to US citizens at this time.'
 
 // ui mirror of peanut-api-ts/src/manteca/consts.ts MANTECA_SUPPORTED_COUNTRIES.
 // first-party manteca bank/kyc rails are currently active only in argentina and brazil.

--- a/src/hooks/__tests__/useProviderRejectionStatus.test.ts
+++ b/src/hooks/__tests__/useProviderRejectionStatus.test.ts
@@ -1,0 +1,53 @@
+import { renderHook } from '@testing-library/react'
+import { useAuth } from '@/context/authContext'
+import {
+    MANTECA_US_NATIONALITY_RESTRICTION_CODE,
+    MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE,
+} from '@/constants/manteca.consts'
+import useProviderRejectionStatus from '../useProviderRejectionStatus'
+
+jest.mock('@/context/authContext', () => ({
+    useAuth: jest.fn(),
+}))
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>
+
+describe('useProviderRejectionStatus', () => {
+    afterEach(() => jest.resetAllMocks())
+
+    it('returns the Manteca restriction message for US-nationality provider rejection metadata', () => {
+        mockUseAuth.mockReturnValue({
+            user: {
+                user: {
+                    kycVerifications: [
+                        {
+                            provider: 'MANTECA',
+                            status: 'REJECTED',
+                            rejectType: 'PROVIDER_FINAL',
+                            updatedAt: '2026-05-22T00:00:00.000Z',
+                            metadata: { restrictionCode: MANTECA_US_NATIONALITY_RESTRICTION_CODE },
+                        },
+                    ],
+                },
+                rails: [
+                    {
+                        status: 'REJECTED',
+                        metadata: {
+                            restrictionCode: MANTECA_US_NATIONALITY_RESTRICTION_CODE,
+                            selfHealable: false,
+                        },
+                        rail: {
+                            provider: { code: 'MANTECA' },
+                            method: { code: 'BANK_TRANSFER_AR', country: 'AR' },
+                        },
+                    },
+                ],
+            },
+        } as unknown as ReturnType<typeof useAuth>)
+
+        const { result } = renderHook(() => useProviderRejectionStatus())
+
+        expect(result.current.manteca.state).toBe('blocked')
+        expect(result.current.manteca.userMessage).toBe(MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE)
+    })
+})

--- a/src/hooks/__tests__/useProviderRejectionStatus.test.ts
+++ b/src/hooks/__tests__/useProviderRejectionStatus.test.ts
@@ -50,4 +50,83 @@ describe('useProviderRejectionStatus', () => {
         expect(result.current.manteca.state).toBe('blocked')
         expect(result.current.manteca.userMessage).toBe(MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE)
     })
+
+    it('detects restriction metadata on any rejected Manteca rail', () => {
+        mockUseAuth.mockReturnValue({
+            user: {
+                user: {
+                    kycVerifications: [
+                        {
+                            provider: 'MANTECA',
+                            status: 'REJECTED',
+                            rejectType: 'PROVIDER_FINAL',
+                            updatedAt: '2026-05-22T00:00:00.000Z',
+                            metadata: {},
+                        },
+                    ],
+                },
+                rails: [
+                    {
+                        status: 'REJECTED',
+                        metadata: { selfHealable: false },
+                        rail: {
+                            provider: { code: 'MANTECA' },
+                            method: { code: 'BANK_TRANSFER_AR', country: 'AR' },
+                        },
+                    },
+                    {
+                        status: 'REJECTED',
+                        metadata: {
+                            restrictionCode: MANTECA_US_NATIONALITY_RESTRICTION_CODE,
+                            selfHealable: false,
+                        },
+                        rail: {
+                            provider: { code: 'MANTECA' },
+                            method: { code: 'PIX_BR', country: 'BR' },
+                        },
+                    },
+                ],
+            },
+        } as unknown as ReturnType<typeof useAuth>)
+
+        const { result } = renderHook(() => useProviderRejectionStatus())
+
+        expect(result.current.manteca.state).toBe('blocked')
+        expect(result.current.manteca.userMessage).toBe(MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE)
+    })
+
+    it('shows the generic support message for non-restricted permanent rejection', () => {
+        mockUseAuth.mockReturnValue({
+            user: {
+                user: {
+                    kycVerifications: [
+                        {
+                            provider: 'MANTECA',
+                            status: 'REJECTED',
+                            rejectType: 'PROVIDER_FINAL',
+                            updatedAt: '2026-05-22T00:00:00.000Z',
+                            metadata: {},
+                        },
+                    ],
+                },
+                rails: [
+                    {
+                        status: 'REJECTED',
+                        metadata: { selfHealable: false },
+                        rail: {
+                            provider: { code: 'MANTECA' },
+                            method: { code: 'BANK_TRANSFER_AR', country: 'AR' },
+                        },
+                    },
+                ],
+            },
+        } as unknown as ReturnType<typeof useAuth>)
+
+        const { result } = renderHook(() => useProviderRejectionStatus())
+
+        expect(result.current.manteca.state).toBe('blocked')
+        expect(result.current.manteca.userMessage).toBe(
+            "We couldn't verify your identity. Please contact support for assistance."
+        )
+    })
 })

--- a/src/hooks/__tests__/useQrKycGate.test.ts
+++ b/src/hooks/__tests__/useQrKycGate.test.ts
@@ -1,0 +1,58 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { useAuth } from '@/context/authContext'
+import {
+    MANTECA_US_NATIONALITY_RESTRICTION_CODE,
+    MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE,
+} from '@/constants/manteca.consts'
+import { QrKycState, useQrKycGate } from '../useQrKycGate'
+
+jest.mock('@/context/authContext', () => ({
+    useAuth: jest.fn(),
+}))
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>
+
+describe('useQrKycGate', () => {
+    afterEach(() => jest.resetAllMocks())
+
+    it('blocks restricted Manteca users and returns the restriction message', async () => {
+        mockUseAuth.mockReturnValue({
+            isFetchingUser: false,
+            fetchUser: jest.fn(),
+            user: {
+                user: {
+                    bridgeKycStatus: null,
+                    kycVerifications: [
+                        { provider: 'SUMSUB', status: 'APPROVED' },
+                        {
+                            provider: 'MANTECA',
+                            status: 'REJECTED',
+                            rejectType: 'PROVIDER_FINAL',
+                            updatedAt: '2026-05-22T00:00:00.000Z',
+                            metadata: { restrictionCode: MANTECA_US_NATIONALITY_RESTRICTION_CODE },
+                        },
+                    ],
+                },
+                rails: [
+                    {
+                        status: 'REJECTED',
+                        metadata: {
+                            restrictionCode: MANTECA_US_NATIONALITY_RESTRICTION_CODE,
+                            selfHealable: false,
+                        },
+                        rail: {
+                            provider: { code: 'MANTECA' },
+                            method: { code: 'MERCADOPAGO_QR_AR', country: 'AR' },
+                        },
+                    },
+                ],
+            },
+        } as unknown as ReturnType<typeof useAuth>)
+
+        const { result } = renderHook(() => useQrKycGate('MANTECA'))
+
+        await waitFor(() => expect(result.current.kycGateState).toBe(QrKycState.PROVIDER_REJECTION_BLOCKED))
+        expect(result.current.shouldBlockPay).toBe(true)
+        expect(result.current.userMessage).toBe(MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE)
+    })
+})

--- a/src/hooks/__tests__/useQrKycGate.test.ts
+++ b/src/hooks/__tests__/useQrKycGate.test.ts
@@ -55,4 +55,90 @@ describe('useQrKycGate', () => {
         expect(result.current.shouldBlockPay).toBe(true)
         expect(result.current.userMessage).toBe(MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE)
     })
+
+    it('blocks restricted Manteca users when restriction metadata is only on a rail', async () => {
+        mockUseAuth.mockReturnValue({
+            isFetchingUser: false,
+            fetchUser: jest.fn(),
+            user: {
+                user: {
+                    bridgeKycStatus: null,
+                    kycVerifications: [
+                        { provider: 'SUMSUB', status: 'APPROVED' },
+                        {
+                            provider: 'MANTECA',
+                            status: 'REJECTED',
+                            rejectType: 'PROVIDER_FINAL',
+                            updatedAt: '2026-05-22T00:00:00.000Z',
+                            metadata: {},
+                        },
+                    ],
+                },
+                rails: [
+                    {
+                        status: 'REJECTED',
+                        metadata: { selfHealable: false },
+                        rail: {
+                            provider: { code: 'MANTECA' },
+                            method: { code: 'MERCADOPAGO_QR_AR', country: 'AR' },
+                        },
+                    },
+                    {
+                        status: 'REJECTED',
+                        metadata: {
+                            restrictionCode: MANTECA_US_NATIONALITY_RESTRICTION_CODE,
+                            selfHealable: false,
+                        },
+                        rail: {
+                            provider: { code: 'MANTECA' },
+                            method: { code: 'PIX_BR', country: 'BR' },
+                        },
+                    },
+                ],
+            },
+        } as unknown as ReturnType<typeof useAuth>)
+
+        const { result } = renderHook(() => useQrKycGate('MANTECA'))
+
+        await waitFor(() => expect(result.current.kycGateState).toBe(QrKycState.PROVIDER_REJECTION_BLOCKED))
+        expect(result.current.userMessage).toBe(MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE)
+    })
+
+    it('marks self-healable Manteca rejections as fixable', async () => {
+        mockUseAuth.mockReturnValue({
+            isFetchingUser: false,
+            fetchUser: jest.fn(),
+            user: {
+                user: {
+                    bridgeKycStatus: null,
+                    kycVerifications: [
+                        { provider: 'SUMSUB', status: 'APPROVED' },
+                        {
+                            provider: 'MANTECA',
+                            status: 'REJECTED',
+                            rejectType: 'PROVIDER_FIXABLE',
+                            updatedAt: '2026-05-22T00:00:00.000Z',
+                            metadata: { selfHealAttempt: 1 },
+                        },
+                    ],
+                },
+                rails: [
+                    {
+                        status: 'REJECTED',
+                        metadata: { selfHealable: true },
+                        rail: {
+                            provider: { code: 'MANTECA' },
+                            method: { code: 'MERCADOPAGO_QR_AR', country: 'AR' },
+                        },
+                    },
+                ],
+            },
+        } as unknown as ReturnType<typeof useAuth>)
+
+        const { result } = renderHook(() => useQrKycGate('MANTECA'))
+
+        await waitFor(() => expect(result.current.kycGateState).toBe(QrKycState.PROVIDER_REJECTION_FIXABLE))
+        expect(result.current.shouldBlockPay).toBe(true)
+        expect(result.current.userMessage).toBeNull()
+    })
 })

--- a/src/hooks/useProviderRejectionStatus.ts
+++ b/src/hooks/useProviderRejectionStatus.ts
@@ -3,10 +3,9 @@
 import { useAuth } from '@/context/authContext'
 import { useMemo } from 'react'
 import type { IUserRail, IUserKycVerification } from '@/interfaces/interfaces'
-import {
-    MANTECA_US_NATIONALITY_RESTRICTION_CODE,
-    MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE,
-} from '@/constants/manteca.consts'
+import { MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE } from '@/constants/manteca.consts'
+import { MAX_SELF_HEAL_ATTEMPTS } from '@/constants/kyc.consts'
+import { hasMantecaUsNationalityRestrictionMetadata } from '@/utils/manteca-restriction.utils'
 
 export type ProviderRejectionState = 'happy' | 'processing' | 'fixable' | 'blocked'
 
@@ -19,8 +18,6 @@ export interface ProviderRejectionInfo {
     selfHealAttempt: number
     maxAttempts: number
 }
-
-const MAX_SELF_HEAL_ATTEMPTS = 3
 
 /**
  * derives per-provider fixable/blocked/processing state from rails + kycVerifications.
@@ -78,13 +75,12 @@ export default function useProviderRejectionStatus() {
             // has rejected rails
             if (rejectedRails.length > 0) {
                 const firstRejectedMetadata = (rejectedRails[0].metadata ?? {}) as Record<string, unknown>
+                const rejectedRailsMetadata = rejectedRails.map((rail) => rail.metadata)
                 const isSelfHealable = firstRejectedMetadata.selfHealable === true
                 const rejectType = kycVerification?.rejectType
-                const restrictionCode =
-                    (metadata.restrictionCode as string | undefined) ??
-                    (firstRejectedMetadata.restrictionCode as string | undefined)
                 const isMantecaUsNationalityRestricted =
-                    providerCode === 'MANTECA' && restrictionCode === MANTECA_US_NATIONALITY_RESTRICTION_CODE
+                    providerCode === 'MANTECA' &&
+                    hasMantecaUsNationalityRestrictionMetadata([metadata, ...rejectedRailsMetadata])
 
                 // check if fixable: selfHealable flag on rail + rejectType + attempt limit
                 const isFixable =

--- a/src/hooks/useProviderRejectionStatus.ts
+++ b/src/hooks/useProviderRejectionStatus.ts
@@ -3,6 +3,10 @@
 import { useAuth } from '@/context/authContext'
 import { useMemo } from 'react'
 import type { IUserRail, IUserKycVerification } from '@/interfaces/interfaces'
+import {
+    MANTECA_US_NATIONALITY_RESTRICTION_CODE,
+    MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE,
+} from '@/constants/manteca.consts'
 
 export type ProviderRejectionState = 'happy' | 'processing' | 'fixable' | 'blocked'
 
@@ -76,9 +80,15 @@ export default function useProviderRejectionStatus() {
                 const firstRejectedMetadata = (rejectedRails[0].metadata ?? {}) as Record<string, unknown>
                 const isSelfHealable = firstRejectedMetadata.selfHealable === true
                 const rejectType = kycVerification?.rejectType
+                const restrictionCode =
+                    (metadata.restrictionCode as string | undefined) ??
+                    (firstRejectedMetadata.restrictionCode as string | undefined)
+                const isMantecaUsNationalityRestricted =
+                    providerCode === 'MANTECA' && restrictionCode === MANTECA_US_NATIONALITY_RESTRICTION_CODE
 
                 // check if fixable: selfHealable flag on rail + rejectType + attempt limit
                 const isFixable =
+                    !isMantecaUsNationalityRestricted &&
                     isSelfHealable &&
                     rejectType !== 'PROVIDER_FINAL' &&
                     rejectType !== 'FINAL' &&
@@ -91,7 +101,9 @@ export default function useProviderRejectionStatus() {
 
                 if (!isFixable) {
                     // permanently rejected — generic message regardless of underlying reason
-                    userMessage = "We couldn't verify your identity. Please contact support for assistance."
+                    userMessage = isMantecaUsNationalityRestricted
+                        ? MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE
+                        : "We couldn't verify your identity. Please contact support for assistance."
                 } else if (Array.isArray(reasons) && reasons.length > 0) {
                     // bridge format: { reason: string, developer_reason: string }
                     // manteca format: { task: string, reason: string }

--- a/src/hooks/useQrKycGate.ts
+++ b/src/hooks/useQrKycGate.ts
@@ -4,6 +4,10 @@ import { useCallback, useState, useEffect, useRef } from 'react'
 import { useAuth } from '@/context/authContext'
 import { MantecaKycStatus } from '@/interfaces'
 import { isKycStatusApproved, isSumsubStatusInProgress } from '@/constants/kyc.consts'
+import {
+    MANTECA_US_NATIONALITY_RESTRICTION_CODE,
+    MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE,
+} from '@/constants/manteca.consts'
 
 const MAX_SELF_HEAL_ATTEMPTS = 3
 
@@ -19,6 +23,7 @@ export enum QrKycState {
 export interface QrKycGateResult {
     kycGateState: QrKycState
     shouldBlockPay: boolean
+    userMessage: string | null
 }
 
 /**
@@ -30,13 +35,19 @@ export interface QrKycGateResult {
 export function useQrKycGate(paymentProcessor?: 'MANTECA' | null): QrKycGateResult {
     const { user, isFetchingUser, fetchUser } = useAuth()
     const [kycGateState, setKycGateState] = useState<QrKycState>(QrKycState.LOADING)
+    const [userMessage, setUserMessage] = useState<string | null>(null)
     const hasRequestedUserFetchRef = useRef(false)
+
+    const setGateState = useCallback((state: QrKycState, message: string | null = null) => {
+        setKycGateState(state)
+        setUserMessage(message)
+    }, [])
 
     const determineKycGateState = useCallback(async () => {
         const currentUser = user?.user
         // while auth is fetching, keep loading to avoid flashing the verify modal
         if (isFetchingUser) {
-            setKycGateState(QrKycState.LOADING)
+            setGateState(QrKycState.LOADING)
             return
         }
 
@@ -44,7 +55,7 @@ export function useQrKycGate(paymentProcessor?: 'MANTECA' | null): QrKycGateResu
             // on public routes (like qr pay), auth may not auto-fetch; trigger it explicitly once and wait
             if (!hasRequestedUserFetchRef.current) {
                 hasRequestedUserFetchRef.current = true
-                setKycGateState(QrKycState.LOADING)
+                setGateState(QrKycState.LOADING)
                 try {
                     await fetchUser()
                 } catch {
@@ -53,7 +64,7 @@ export function useQrKycGate(paymentProcessor?: 'MANTECA' | null): QrKycGateResu
                 return
             }
             // if we already tried fetching and still have no user, require verification
-            setKycGateState(QrKycState.REQUIRES_IDENTITY_VERIFICATION)
+            setGateState(QrKycState.REQUIRES_IDENTITY_VERIFICATION)
             return
         }
 
@@ -72,16 +83,21 @@ export function useQrKycGate(paymentProcessor?: 'MANTECA' | null): QrKycGateResu
                     ?.filter((v) => v.provider === 'MANTECA')
                     .sort((a, b) => new Date(b.updatedAt ?? 0).getTime() - new Date(a.updatedAt ?? 0).getTime())[0]
                 const kycMeta = (mantecaKyc?.metadata ?? {}) as Record<string, unknown>
+                const restrictionCode =
+                    (kycMeta.restrictionCode as string | undefined) ?? (railMeta.restrictionCode as string | undefined)
+                const isMantecaUsNationalityRestricted = restrictionCode === MANTECA_US_NATIONALITY_RESTRICTION_CODE
                 const isFixable =
+                    !isMantecaUsNationalityRestricted &&
                     railMeta.selfHealable === true &&
                     mantecaKyc?.rejectType !== 'PROVIDER_FINAL' &&
                     ((kycMeta.selfHealAttempt as number) || 0) < MAX_SELF_HEAL_ATTEMPTS
-                setKycGateState(
-                    isFixable ? QrKycState.PROVIDER_REJECTION_FIXABLE : QrKycState.PROVIDER_REJECTION_BLOCKED
+                setGateState(
+                    isFixable ? QrKycState.PROVIDER_REJECTION_FIXABLE : QrKycState.PROVIDER_REJECTION_BLOCKED,
+                    isMantecaUsNationalityRestricted ? MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE : null
                 )
                 return
             }
-            setKycGateState(QrKycState.PROCEED_TO_PAY)
+            setGateState(QrKycState.PROCEED_TO_PAY)
             return
         }
 
@@ -93,24 +109,24 @@ export function useQrKycGate(paymentProcessor?: 'MANTECA' | null): QrKycGateResu
             mantecaKycs.some((v) => v.provider === 'MANTECA' && v.status === MantecaKycStatus.ACTIVE)
 
         if (hasAnyActiveMantecaKyc) {
-            setKycGateState(QrKycState.PROCEED_TO_PAY)
+            setGateState(QrKycState.PROCEED_TO_PAY)
             return
         }
 
         if (currentUser.bridgeKycStatus === 'approved') {
-            setKycGateState(QrKycState.PROCEED_TO_PAY)
+            setGateState(QrKycState.PROCEED_TO_PAY)
             return
         }
 
         // check if bridge kyc is in progress (user started but hasn't completed)
         // bridge kyc status is 'incomplete' or 'under_review' when user has initiated the kyc process
         if (currentUser.bridgeKycStatus === 'under_review' || currentUser.bridgeKycStatus === 'incomplete') {
-            setKycGateState(QrKycState.IDENTITY_VERIFICATION_IN_PROGRESS)
+            setGateState(QrKycState.IDENTITY_VERIFICATION_IN_PROGRESS)
             return
         }
 
         if (hasAnyMantecaKyc) {
-            setKycGateState(QrKycState.IDENTITY_VERIFICATION_IN_PROGRESS)
+            setGateState(QrKycState.IDENTITY_VERIFICATION_IN_PROGRESS)
             return
         }
 
@@ -119,12 +135,12 @@ export function useQrKycGate(paymentProcessor?: 'MANTECA' | null): QrKycGateResu
             (v) => v.provider === 'SUMSUB' && isSumsubStatusInProgress(v.status)
         )
         if (hasSumsubInProgress) {
-            setKycGateState(QrKycState.IDENTITY_VERIFICATION_IN_PROGRESS)
+            setGateState(QrKycState.IDENTITY_VERIFICATION_IN_PROGRESS)
             return
         }
 
-        setKycGateState(QrKycState.REQUIRES_IDENTITY_VERIFICATION)
-    }, [user?.user, user?.rails, isFetchingUser, paymentProcessor, fetchUser])
+        setGateState(QrKycState.REQUIRES_IDENTITY_VERIFICATION)
+    }, [user?.user, user?.rails, isFetchingUser, paymentProcessor, fetchUser, setGateState])
 
     useEffect(() => {
         determineKycGateState()
@@ -132,6 +148,7 @@ export function useQrKycGate(paymentProcessor?: 'MANTECA' | null): QrKycGateResu
 
     const result: QrKycGateResult = {
         kycGateState,
+        userMessage,
         shouldBlockPay:
             kycGateState === QrKycState.REQUIRES_IDENTITY_VERIFICATION ||
             kycGateState === QrKycState.IDENTITY_VERIFICATION_IN_PROGRESS ||

--- a/src/hooks/useQrKycGate.ts
+++ b/src/hooks/useQrKycGate.ts
@@ -3,13 +3,9 @@
 import { useCallback, useState, useEffect, useRef } from 'react'
 import { useAuth } from '@/context/authContext'
 import { MantecaKycStatus } from '@/interfaces'
-import { isKycStatusApproved, isSumsubStatusInProgress } from '@/constants/kyc.consts'
-import {
-    MANTECA_US_NATIONALITY_RESTRICTION_CODE,
-    MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE,
-} from '@/constants/manteca.consts'
-
-const MAX_SELF_HEAL_ATTEMPTS = 3
+import { isKycStatusApproved, isSumsubStatusInProgress, MAX_SELF_HEAL_ATTEMPTS } from '@/constants/kyc.consts'
+import { MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE } from '@/constants/manteca.consts'
+import { hasMantecaUsNationalityRestrictionMetadata } from '@/utils/manteca-restriction.utils'
 
 export enum QrKycState {
     LOADING = 'loading',
@@ -79,13 +75,15 @@ export function useQrKycGate(paymentProcessor?: 'MANTECA' | null): QrKycGateResu
             )
             if (rejectedMantecaRails.length > 0) {
                 const railMeta = (rejectedMantecaRails[0].metadata ?? {}) as Record<string, unknown>
+                const rejectedRailMetadata = rejectedMantecaRails.map((rail) => rail.metadata)
                 const mantecaKyc = currentUser.kycVerifications
                     ?.filter((v) => v.provider === 'MANTECA')
                     .sort((a, b) => new Date(b.updatedAt ?? 0).getTime() - new Date(a.updatedAt ?? 0).getTime())[0]
                 const kycMeta = (mantecaKyc?.metadata ?? {}) as Record<string, unknown>
-                const restrictionCode =
-                    (kycMeta.restrictionCode as string | undefined) ?? (railMeta.restrictionCode as string | undefined)
-                const isMantecaUsNationalityRestricted = restrictionCode === MANTECA_US_NATIONALITY_RESTRICTION_CODE
+                const isMantecaUsNationalityRestricted = hasMantecaUsNationalityRestrictionMetadata([
+                    kycMeta,
+                    ...rejectedRailMetadata,
+                ])
                 const isFixable =
                     !isMantecaUsNationalityRestricted &&
                     railMeta.selfHealable === true &&

--- a/src/utils/manteca-restriction.utils.ts
+++ b/src/utils/manteca-restriction.utils.ts
@@ -1,0 +1,13 @@
+import { MANTECA_US_NATIONALITY_RESTRICTION_CODE } from '@/constants/manteca.consts'
+
+function getMetadataRecord(metadata: unknown): Record<string, unknown> {
+    return metadata && typeof metadata === 'object' && !Array.isArray(metadata)
+        ? (metadata as Record<string, unknown>)
+        : {}
+}
+
+export function hasMantecaUsNationalityRestrictionMetadata(metadataList: unknown[]): boolean {
+    return metadataList.some(
+        (metadata) => getMetadataRecord(metadata).restrictionCode === MANTECA_US_NATIONALITY_RESTRICTION_CODE
+    )
+}


### PR DESCRIPTION
## Summary
- Add shared frontend constants for the Manteca US-nationality restriction code and message.
- Teach provider rejection handling to show the restriction copy instead of the generic contact-support message.
- Extend the QR KYC gate with an optional userMessage and display it in QR Pay blocked state.
- Add targeted hook tests for provider rejection and QR KYC gate behavior.

## Risks
- The UI relies on backend metadata using restrictionCode=MANTECA_US_NATIONALITY_RESTRICTED.
- Existing generic blocked states are intentionally unchanged unless that restriction metadata is present.

## QA Guidelines
- Verify blocked Manteca users see: Manteca services are not available to US citizens at this time.
- Verify normal permanent provider rejection still shows the existing generic copy.
- Verify fixable Manteca rejection still offers document upload.
- Automated checks run: targeted Jest hook tests passed; npm run typecheck passed; git diff --check passed.