### PR TITLE
feat(404): rewrite as ragdoll page with support drawer link

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -14,15 +14,21 @@ const PeanutRagdoll = RAGDOLL_ENABLED ? dynamic(() => import('@/components/Peanu
 export default function NotFound() {
     const { openSupportWithMessage } = useModalsContext()
 
+    // Send only the pathname — query + hash can carry magic-link tokens,
+    // OAuth callback secrets, or signed-share params that we don't want
+    // landing in Crisp chat logs.
     const openSupport = () =>
         openSupportWithMessage(
-            `Hey! I hit a 404 — can you help?${typeof window !== 'undefined' ? `\n\nURL: ${window.location.href}` : ''}`
+            `Hey! I hit a 404 — can you help?${typeof window !== 'undefined' ? `\n\nPath: ${window.location.pathname}` : ''}`
         )
 
     return (
         <>
             <div className="flex min-h-[100dvh] flex-col md:h-[100dvh] md:flex-row">
-                <div className="relative h-[55dvh] w-full overflow-hidden bg-purple-1 md:h-full md:w-7/12">
+                <div
+                    aria-hidden="true"
+                    className="relative h-[55dvh] w-full overflow-hidden bg-purple-1 md:h-full md:w-7/12"
+                >
                     {PeanutRagdoll && <PeanutRagdoll />}
                 </div>
 
@@ -46,7 +52,7 @@ export default function NotFound() {
                             <a href="/" className="btn btn-purple shadow-4 block w-full text-center">
                                 Take me home
                             </a>
-                            <Button variant="stroke" onClick={openSupport}>
+                            <Button variant="stroke" className="w-full" onClick={openSupport}>
                                 Contact support
                             </Button>
                         </div>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -42,6 +42,7 @@ export default function NotFound() {
                             {/* Raw <a> instead of <Link>: forces a full page load when leaving the
                                 404, avoiding the historical React error #310 from hook-count
                                 mismatch between this route and the (mobile-ui) tree. */}
+                            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
                             <a href="/" className="btn btn-purple shadow-4 block w-full text-center">
                                 Take me home
                             </a>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,22 +1,58 @@
-import PageContainer from '@/components/0_Bruddle/PageContainer'
-import PEANUTMAN_CRY from '@/animations/GIF_ALPHA_BACKGORUND/512X512_ALPHA_GIF_konradurban_05.gif'
-import Image from 'next/image'
+'use client'
+
+import { Button } from '@/components/0_Bruddle/Button'
+import SupportDrawer from '@/components/Global/SupportDrawer'
+import { RAGDOLL_ENABLED } from '@/constants/ragdoll.consts'
+import { useModalsContext } from '@/context/ModalsContext'
+import dynamic from 'next/dynamic'
+
+// Same dynamic-import + kill-switch pattern as the rewards easter egg. When
+// RAGDOLL_ENABLED is false the chunk + p2-es never ship; the play area just
+// stays empty (pink). See ragdoll.consts.ts.
+const PeanutRagdoll = RAGDOLL_ENABLED ? dynamic(() => import('@/components/PeanutRagdoll'), { ssr: false }) : null
 
 export default function NotFound() {
+    const { openSupportWithMessage } = useModalsContext()
+
+    const openSupport = () =>
+        openSupportWithMessage(
+            `Hey! I hit a 404 — can you help?${typeof window !== 'undefined' ? `\n\nURL: ${window.location.href}` : ''}`
+        )
+
     return (
-        <PageContainer className="min-h-[100dvh] p-6">
-            <div className="my-auto flex h-full flex-col justify-center space-y-4">
-                <div className="shadow-4 flex w-full flex-col items-center space-y-2 border border-n-1 bg-white p-4">
-                    <h1 className="text-3xl font-extrabold">Not found</h1>
-                    <Image src={PEANUTMAN_CRY.src} className="" alt="Peanutman crying 😭" width={96} height={96} />
-                    <p>Woah there buddy, you&apos;re not supposed to be here.</p>
-                    {/* Use <a> instead of <Link> to force full page load — avoids React error #310
-                        caused by hook count mismatch between 404 (no mobile-ui layout) and home (with providers) */}
-                    <a href="/" className="btn btn-purple shadow-4">
-                        Take me home, I&apos;m scared
-                    </a>
+        <>
+            <div className="flex min-h-[100dvh] flex-col md:h-[100dvh] md:flex-row">
+                <div className="relative h-[55dvh] w-full overflow-hidden bg-purple-1 md:h-full md:w-7/12">
+                    {PeanutRagdoll && <PeanutRagdoll />}
+                </div>
+
+                <div className="flex flex-grow flex-col justify-center overflow-y-auto bg-white px-6 py-8 md:px-12">
+                    <div className="mx-auto w-full max-w-md space-y-8">
+                        <div className="space-y-3">
+                            <h1 className="text-3xl font-extrabold">Hmm, we can&apos;t find that page.</h1>
+                            <p className="text-base text-grey-1">
+                                If we&apos;ve sent you here, please{' '}
+                                <button type="button" onClick={openSupport} className="text-black underline">
+                                    let support know
+                                </button>{' '}
+                                so we can fix it.
+                            </p>
+                        </div>
+                        <div className="space-y-3">
+                            {/* Raw <a> instead of <Link>: forces a full page load when leaving the
+                                404, avoiding the historical React error #310 from hook-count
+                                mismatch between this route and the (mobile-ui) tree. */}
+                            <a href="/" className="btn btn-purple shadow-4 block w-full text-center">
+                                Take me home
+                            </a>
+                            <Button variant="stroke" onClick={openSupport}>
+                                Contact support
+                            </Button>
+                        </div>
+                    </div>
                 </div>
             </div>
-        </PageContainer>
+            <SupportDrawer />
+        </>
     )
 }


### PR DESCRIPTION
## Summary

- New copy stops blaming the user (the old 404 read \"Woah there buddy, you're not supposed to be here\" — bad UX when *we* sent them to a broken Peanut link).
- Adds a primary path to support: the existing `SupportDrawer` opens with a prefilled \"I hit a 404 on `<URL>`\" message via the standard `openSupportWithMessage` helper.
- Promotes the rewards-screen ragdoll easter egg to a front-and-center play surface on the 404.

## Layout

Layout C from design discussion — split panel, mirroring the signup flow shape:

- Mobile: ragdoll on top (55dvh), heading + copy + CTAs below
- Desktop: ragdoll left (`md:w-7/12`), card right

Reuses the parent-sized `<PeanutRagdoll />` introduced in #2061 (no fork, no props passed) and the same `dynamic(...) + RAGDOLL_ENABLED` kill-switch.

## DRY notes

- Support link: `openSupportWithMessage` from `ModalsContext` — same pattern as `ClaimError`, Manteca withdraw, IncreaseLimits.
- The inline \"let support know\" link in the body copy and the secondary \"Contact support\" CTA both call the same handler.
- `<SupportDrawer />` is rendered inline because 404 lives outside `(mobile-ui)/layout.tsx` where it normally mounts. Same approach as `[...recipient]/payment-layout-wrapper.tsx`.
- Card + Button + typography classes are all design-system primitives (Bruddle `Button` purple/stroke variants, `shadow-4`, `text-grey-1`).

## Stacking

Based on `feat/rewards-ragdoll-easter-egg` (#2061) because we need the parent-sized PeanutRagdoll variant from that PR. Will retarget base to `dev` once #2061 merges.

## Open design question

On desktop the ragdoll component renders a phone-shaped play area with white letterbox on the sides (per #2061's design choice). In the 7/12-wide left panel this leaves some white margin around the peanut. Two options:

1. **Keep as-is** — visually consistent with the rewards drawer easter egg
2. **Constrain the left panel** to roughly phone aspect so the letterbox disappears

Happy to go either way — flagging for design review.

## Test plan

- [ ] Hit `/dev/something-that-doesnt-exist` (or any 404 path) and confirm the new layout
- [ ] Click \"let support know\" in the body → support drawer opens with prefilled URL message
- [ ] Click \"Contact support\" CTA → same behavior
- [ ] Click \"Take me home\" → full page nav to `/`
- [ ] Confirm peanut ragdoll is draggable
- [ ] Mobile + desktop layouts
- [ ] Build with `NEXT_PUBLIC_RAGDOLL_ENABLED=false` → ragdoll chunk drops, page still renders (left panel just empty pink)