### PR TITLE
fix(LP): add bottom padding to hero so subtext doesn't crowd the marquee

### DIFF
--- a/src/components/LandingPage/hero.tsx
+++ b/src/components/LandingPage/hero.tsx
@@ -141,7 +141,7 @@ export function Hero({ primaryCta, secondaryCta, buttonVisible, buttonScale = 1 
     return (
         <section
             id="hero"
-            className="relative flex min-h-[85vh] w-full flex-col items-center justify-between bg-primary-1 px-4 py-4 xl:h-fit xl:justify-center"
+            className="relative flex min-h-[85vh] w-full flex-col items-center justify-between bg-primary-1 px-4 pb-12 pt-4 md:pb-16 xl:h-fit xl:justify-center xl:pb-4"
         >
             <CloudsCss />
             <div className="relative mt-10 w-full md:mt-0">
@@ -170,7 +170,7 @@ export function Hero({ primaryCta, secondaryCta, buttonVisible, buttonScale = 1 
             </div>
             <PeanutMascot />
 
-            <div className="relative z-20 mb-4 flex w-full flex-col items-center justify-center md:mb-0">
+            <div className="relative z-20 flex w-full flex-col items-center justify-center">
                 <h2 className="font-roboto-flex-extrabold mt-18 text-center text-[2.375rem] font-extraBlack text-black md:text-heading">
                     TAP. SCAN. ANYWHERE.
                 </h2>


### PR DESCRIPTION
## Summary

The hero section uses `justify-between` on a `min-h-[85vh]` flex column with only `py-4` padding. Below `xl`, this pins the bottom content (CTA + "Join +10,000 cool people" subtext) flush to the section's bottom edge, leaving only ~16px before the yellow Marquee — visibly cramped, with italic descenders ("p", "j") closing the gap further.

## What changed

- `hero.tsx` section: `py-4` → `pt-4 pb-12 md:pb-16` (with `xl:pb-4` since `xl` switches to `justify-center` and stacks naturally)
- Removed the redundant `mb-4 md:mb-0` from the inner content div — it was a second knob doing the same job as `py-4`

DRY rationale: spacing-between-hero-and-the-next-section is the hero's concern, so it lives at the section's seam in one place. Any future sibling section gets the same breathing room — not just the Marquee.

## Test plan

- [ ] At sm/md/lg viewports: subtext sits clearly above the yellow marquee with comfortable spacing
- [ ] At xl+: layout unchanged (still natural `justify-center` stacking)
- [ ] Mobile sticky CTA still anchors correctly

## Notes for reviewer

Not visually verified locally (CSS-only, no dev server boot for a 4-line change). Worth an eyeball pass in preview at md/lg breakpoints.

Bonus observation (not in this PR): `hero.tsx` has two `<motion.img src={Star.src}>` star elements at lines 188-203 that are byte-identical to the two at lines 154-169 — same `absolute` classes, same animations. Looks like a copy-paste leftover; worth a separate cleanup.