### PR TITLE
fix(card): mask PIN + PAN + CVV + expiry in PostHog session recordings

### DIFF
--- a/src/components/Card/CardFace.tsx
+++ b/src/components/Card/CardFace.tsx
@@ -125,7 +125,12 @@ const CardFace: FC<Props> = ({
                     ) : showingDetails ? (
                         <>
                             <div className="flex items-center gap-2">
-                                <span className="text-xl font-extrabold tracking-wider">{formatPan(revealed.pan)}</span>
+                                {/* ph-no-capture: PAN out of session recordings. Wraps only
+                                 * the digits, not the copy button — we still want to see in
+                                 * replays whether the user tapped copy. */}
+                                <span className="ph-no-capture text-xl font-extrabold tracking-wider">
+                                    {formatPan(revealed.pan)}
+                                </span>
                                 {onCopy && (
                                     <button
                                         type="button"
@@ -141,7 +146,8 @@ const CardFace: FC<Props> = ({
                                 <div className="text-s flex gap-6">
                                     <div>
                                         <div className="opacity-70">Expiry</div>
-                                        <div className="font-bold">
+                                        {/* ph-no-capture: expiry digits out of recordings. */}
+                                        <div className="ph-no-capture font-bold">
                                             {String(revealed.expiryMonth).padStart(2, '0')}/
                                             {String(revealed.expiryYear).slice(-2)}
                                         </div>
@@ -149,7 +155,8 @@ const CardFace: FC<Props> = ({
                                     <div className="flex items-end gap-1">
                                         <div>
                                             <div className="opacity-70">CVV</div>
-                                            <div className="font-bold">{revealed.cvv}</div>
+                                            {/* ph-no-capture: CVV out of recordings. */}
+                                            <div className="ph-no-capture font-bold">{revealed.cvv}</div>
                                         </div>
                                         {onCopy && (
                                             <button

--- a/src/components/Card/CardPinScreen.tsx
+++ b/src/components/Card/CardPinScreen.tsx
@@ -134,7 +134,11 @@ const CardPinScreen: FC<Props> = ({ cardId, onPrev }) => {
                      * (52px), so the wrapper locks to that — `****`, the
                      * skeleton, and the real digits all sit centered in the
                      * same 52px row and the eye button never jumps. */}
-                    <div className="flex h-[52px] items-center">
+                    {/* ph-no-capture: PostHog skips this subtree in session
+                     * replays so the revealed PIN digits never land in
+                     * recordings. The skeleton + masked '****' state are
+                     * also covered, which is fine — they're not sensitive. */}
+                    <div className="ph-no-capture flex h-[52px] items-center">
                         {loading ? (
                             <div className="h-[52px] w-32 animate-pulse rounded bg-grey-2" />
                         ) : (

--- a/src/components/Card/PinInput.tsx
+++ b/src/components/Card/PinInput.tsx
@@ -28,7 +28,10 @@ const PinInput: FC<Props> = ({ value, onChange, length = 4, autoFocus = true, di
         <button
             type="button"
             onClick={() => inputRef.current?.focus()}
-            className={twMerge('flex items-center justify-center gap-4', className)}
+            // ph-no-capture: PostHog skips this subtree in session replays
+            // so neither the entered digits nor the filled-dot count (which
+            // would leak partial PINs) ever land in recordings.
+            className={twMerge('ph-no-capture flex items-center justify-center gap-4', className)}
             disabled={disabled}
         >
             {Array.from({ length }).map((_, i) => {


### PR DESCRIPTION
## Why

PostHog session replays were leaking sensitive card data:

- The revealed PIN on /card/pin (the 4-digit `<span>{pin}</span>` reveal)
- The filled-dot count on the PIN input during setup (leaks partial PINs)
- PAN, CVV, expiry digits on YourCardScreen when the user taps the eye to reveal card details

## Fix

PostHog's [`ph-no-capture` class](https://posthog.com/docs/session-replay/privacy) skips the element + descendants from session replays. Added to four sensitive subtrees, wrapping the smallest containing element so that non-sensitive surrounding UI (eye toggle, copy buttons, labels) stays visible in replays — important for debugging UX flow without leaking secrets.

| Location | What's masked |
|---|---|
| `PinInput` root button | Entered digits + filled-dot count |
| `CardPinScreen` reveal block | The 4-digit reveal span |
| `CardFace` PAN span | PAN digits only — copy button stays visible |
| `CardFace` expiry div | Month/year digits |
| `CardFace` CVV div | 3-digit code |

Preview / marketing `CardFace` branch is intentionally **not** masked — it uses hard-coded fake data (`6969042088800420` / `NUTTY YOU`).

## Why this approach over alternatives

- **Not** a global `session_recording.maskAllInputs` setting — that would mask every input across the app (KYC name, address, phone, etc.) which would hurt UX-debug visibility everywhere.
- **Not** `ph-mask-text` — that replaces text with `*` characters but keeps the original character count, which would still leak PIN length and partial state. `ph-no-capture` removes the subtree entirely.

## Files

- `src/components/Card/PinInput.tsx` (+3/-0)
- `src/components/Card/CardPinScreen.tsx` (+5/-1)
- `src/components/Card/CardFace.tsx` (+11/-3)

## Test plan

- [ ] Open a PostHog session-replay of the /card flow before merge, screenshot for the before. After merge, repeat — PIN/PAN/CVV/expiry should appear as empty boxes in the replay.
- [ ] User-facing rendering unchanged in browser (the class has no visual effect)
- [ ] CI typecheck + tests pass

## Notes for parallel work

`src/components/Card/**` is in `card-rebuild` agent's claimed scope per WORKING.md (active on `feat/card-activation`). These are 1-line additive className changes to existing files — surgical, conflict risk is low, but flagging for awareness.