### PR TITLE
fix(card): redact PIN body before attaching to Sentry

### DIFF
--- a/src/utils/__tests__/sentry.utils.test.ts
+++ b/src/utils/__tests__/sentry.utils.test.ts
@@ -1,0 +1,28 @@
+import { sanitizeRequestBody } from '../sentry.utils'
+
+describe('sanitizeRequestBody', () => {
+    it('redacts the PIN-set endpoint body', () => {
+        const body = JSON.stringify({ pin: '1234' })
+        expect(sanitizeRequestBody('https://api.peanut.me/rain/cards/abc-123/pin', body)).toBe('[REDACTED]')
+    })
+
+    it('redacts regardless of cardId shape', () => {
+        const body = JSON.stringify({ pin: '0000' })
+        expect(sanitizeRequestBody('/rain/cards/00000000-0000-0000-0000-000000000000/pin', body)).toBe('[REDACTED]')
+    })
+
+    it('passes non-sensitive bodies through unchanged', () => {
+        const body = JSON.stringify({ amount: 1000 })
+        expect(sanitizeRequestBody('https://api.peanut.me/rain/cards/abc-123/withdraw/submit', body)).toBe(body)
+    })
+
+    it('returns null for null/undefined bodies', () => {
+        expect(sanitizeRequestBody('/rain/cards/abc-123/pin', null)).toBeNull()
+        expect(sanitizeRequestBody('/rain/cards/abc-123/pin', undefined)).toBeNull()
+    })
+
+    it('does not over-match — /pin must be a path segment, not a substring', () => {
+        const body = JSON.stringify({ thing: 'pin-pad' })
+        expect(sanitizeRequestBody('/rain/cards/abc-123/pinpad-config', body)).toBe(body)
+    })
+})

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -20,6 +20,24 @@ const SKIP_REPORTING: Array<{ pattern: string | RegExp; statuses: number[] }> = 
 ]
 
 /**
+ * URLs whose request body carries a card secret (PIN, etc). For these, the
+ * raw body is replaced with '[REDACTED]' before being attached to Sentry —
+ * any non-2xx, timeout, or network failure on /rain/cards/{id}/pin would
+ * otherwise ship the user's 4-digit PIN to Sentry as {"pin":"1234"}.
+ * (SKIP_REPORTING above filters the 429 rate-limit case; this catches the
+ * 400/401/403/409/500/502/504/timeout/network branches that still report.)
+ */
+const BODY_SENSITIVE_URLS: RegExp[] = [/\/rain\/cards\/[^/]+\/pin(?:[/?]|$)/]
+
+export const sanitizeRequestBody = (url: string, body: BodyInit | null | undefined): BodyInit | string | null => {
+    if (body == null) return null
+    for (const pattern of BODY_SENSITIVE_URLS) {
+        if (pattern.test(url)) return '[REDACTED]'
+    }
+    return body
+}
+
+/**
  * Map URL → feature tag so Sentry issues can be filtered by product surface
  * without wrapping every call site. Add new entries here as features grow.
  */
@@ -133,7 +151,7 @@ export const fetchWithSentry = async (
                             url,
                             method,
                             requestHeaders: sanitizeHeaders(options.headers || {}),
-                            requestBody: options.body || null,
+                            requestBody: sanitizeRequestBody(url, options.body),
                             status: response.status,
                             response: errorContent,
                         },
@@ -162,7 +180,7 @@ export const fetchWithSentry = async (
                         method: options.method || 'GET',
                         timeoutMs,
                         requestHeaders: sanitizeHeaders(options.headers || {}),
-                        requestBody: options.body || null,
+                        requestBody: sanitizeRequestBody(url, options.body),
                     },
                 })
             })
@@ -197,7 +215,7 @@ export const fetchWithSentry = async (
                     url,
                     method: options.method || 'GET',
                     requestHeaders: sanitizeHeaders(options.headers || {}),
-                    requestBody: options.body || null,
+                    requestBody: sanitizeRequestBody(url, options.body),
                     errorMessage,
                     errorName,
                     errorStack,


### PR DESCRIPTION
## Why

`fetchWithSentry` attaches the raw request body as `extra.requestBody` on every Sentry capture — non-2xx responses, timeouts, and network errors. `setCardPin` sends `{ pin: "1234" }` through this path, so any 4xx/5xx outside the existing `429` `SKIP_REPORTING` entry — `400/401/403/409/500/502/504`, timeouts, network failures — was shipping the user's 4-digit PIN to Sentry verbatim as `{"pin":"1234"}`.

PR #2088 closed the **PostHog session-replay** leak on the same surface; this closes the **Sentry** channel — one half of the leak was fixed, the other was still open.

## Fix

Two surgical additions in `src/utils/sentry.utils.ts`, mirroring the existing `sanitizeHeaders` pattern:

- `BODY_SENSITIVE_URLS` — regex list of routes whose request body must be redacted (`\/rain\/cards\/[^/]+\/pin(?:[/?]|$)/` currently, scoped tightly to the PIN endpoint, won't match `/pinpad-config` etc.).
- `sanitizeRequestBody(url, body)` — returns `'[REDACTED]'` when the URL matches, otherwise the body unchanged.

Applied at all three Sentry attach points: `captureMessage` (non-2xx), `captureException` (timeout), `captureException` (network). 

PAN/CVV are GETs (no body), and no other body-bearing route routed through `fetchWithSentry` carries a card secret — confirmed by grepping every `setCardPin`/`rainApi.*`/`cardApi.*` call site. PIN is the only one for now.

## Why this approach over alternatives

- **Not** a `beforeSend` global scrubber on `extra.requestBody` — same surgical-vs-global tradeoff PR #2088 chose. A URL-keyed allow-list keeps non-sensitive request bodies visible in Sentry for debugging.
- **Not** a generic body-key scrubber (redact any key named `pin`/`cvv`/`pan`) — over-aggressive; `pin` collides with unrelated keys (e.g. `pinned`, `dropPin`). URL-scoped is more precise.

## Files

- `src/utils/sentry.utils.ts` (+21/-3) — `BODY_SENSITIVE_URLS`, `sanitizeRequestBody`, three call-site swaps
- `src/utils/__tests__/sentry.utils.test.ts` (+28) — 5 unit tests: redacts PIN endpoint, redacts any cardId shape, passes other bodies through, handles null/undefined, doesn't over-match the substring

## Test plan

- [x] `jest src/utils/__tests__/sentry.utils.test.ts` — 5/5 pass locally
- [x] `tsc --noEmit` — no new errors introduced by this change
- [ ] After merge, trigger a deliberate PIN-endpoint 500 in staging (or temporarily raise a 400 via a malformed PIN), then confirm the Sentry event's `extra.requestBody` is `[REDACTED]` instead of `{"pin":"…"}`.

## Security note

Surfaced by a full card-feature security audit. F2 of the report; verifier confidence 9/10. Standalone PIN matters most for the physical-card roadmap + ATM withdrawals; combined with the `cardId` / `last4` / cardholder-name context already on the Sentry event, the disclosure threshold for "card secret" is crossed today on virtual cards too.