### PR TITLE
chore(badges): drop FE displayName override for FOUNDER_HOUSE

### DIFF
--- a/src/components/Badges/badge.utils.ts
+++ b/src/components/Badges/badge.utils.ts
@@ -61,7 +61,6 @@ const BADGES: Record<string, BadgeMeta> = {
     FOUNDER_HOUSE: {
         path: '/badges/founder_house.svg',
         description: 'Built IRL at Founder Haus. On-chain energy, off-chain handshakes.',
-        displayName: 'Founder Haus',
     },
     BUG_WHISPERER: {
         path: '/badges/bug_whisperer.svg',


### PR DESCRIPTION
## Summary

One-line cleanup: drops `displayName: 'Founder Haus'` from the `FOUNDER_HOUSE` entry in `src/components/Badges/badge.utils.ts`. Once the BE rename ships (peanut-api-ts#870 → boot-sync upserts `acknowledgment_definitions.name='Founder Haus'`), the API returns the correct name directly and `getBadgeDisplayName` falls through to the backend value — the FE override becomes dead weight.

## Replaces #2081

Konrad's revert (#2081) was opened on 2026-05-22, before #2086 (2026-05-24) collapsed the badge maps into a single `BADGES` record and added the `SUPPORT_SURVIVOR → Bug Whisperer` alias (which also uses `displayName`). The mechanical revert no longer applies cleanly, and removing the `getBadgeDisplayName` helper entirely would break the SUPPORT_SURVIVOR alias.

The actual cleanup needed against current dev is a single line. Hence this replacement.

## ⚠️ Merge order

**Do not merge until peanut-api-ts#870 is in prod.** Merging earlier reverts the user-visible label back to 'Founder House'.

Sequence:
1. peanut-api-ts#870 → dev → release → **prod** (boot-sync renames `FOUNDER_HOUSE.name = 'Founder Haus'`)
2. Verify in prod: `SELECT name FROM app.acknowledgment_definitions WHERE code='FOUNDER_HOUSE'` returns `'Founder Haus'`
3. Then merge this PR

## Test plan

- [ ] CI green
- [ ] After step 2 above, merge + verify FE still shows "Founder Haus" everywhere (BadgesRow tooltip, BadgeStatusDrawer, BadgeStatusItem, `/badges` page, profile)