### PR TITLE
feat(404): rewrite as ragdoll page with support drawer link (re-target to dev)

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -14,15 +14,21 @@ const PeanutRagdoll = RAGDOLL_ENABLED ? dynamic(() => import('@/components/Peanu
 export default function NotFound() {
     const { openSupportWithMessage } = useModalsContext()
 
+    // Send only the pathname — query + hash can carry magic-link tokens,
+    // OAuth callback secrets, or signed-share params that we don't want
+    // landing in Crisp chat logs.
     const openSupport = () =>
         openSupportWithMessage(
-            `Hey! I hit a 404 — can you help?${typeof window !== 'undefined' ? `\n\nURL: ${window.location.href}` : ''}`
+            `Hey! I hit a 404 — can you help?${typeof window !== 'undefined' ? `\n\nPath: ${window.location.pathname}` : ''}`
         )
 
     return (
         <>
             <div className="flex min-h-[100dvh] flex-col md:h-[100dvh] md:flex-row">
-                <div className="relative h-[55dvh] w-full overflow-hidden bg-purple-1 md:h-full md:w-7/12">
+                <div
+                    aria-hidden="true"
+                    className="relative h-[55dvh] w-full overflow-hidden bg-purple-1 md:h-full md:w-7/12"
+                >
                     {PeanutRagdoll && <PeanutRagdoll />}
                 </div>
 
@@ -46,7 +52,7 @@ export default function NotFound() {
                             <a href="/" className="btn btn-purple shadow-4 block w-full text-center">
                                 Take me home
                             </a>
-                            <Button variant="stroke" onClick={openSupport}>
+                            <Button variant="stroke" className="w-full" onClick={openSupport}>
                                 Contact support
                             </Button>
                         </div>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -42,6 +42,7 @@ export default function NotFound() {
                             {/* Raw <a> instead of <Link>: forces a full page load when leaving the
                                 404, avoiding the historical React error #310 from hook-count
                                 mismatch between this route and the (mobile-ui) tree. */}
+                            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
                             <a href="/" className="btn btn-purple shadow-4 block w-full text-center">
                                 Take me home
                             </a>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,22 +1,58 @@
-import PageContainer from '@/components/0_Bruddle/PageContainer'
-import PEANUTMAN_CRY from '@/animations/GIF_ALPHA_BACKGORUND/512X512_ALPHA_GIF_konradurban_05.gif'
-import Image from 'next/image'
+'use client'
+
+import { Button } from '@/components/0_Bruddle/Button'
+import SupportDrawer from '@/components/Global/SupportDrawer'
+import { RAGDOLL_ENABLED } from '@/constants/ragdoll.consts'
+import { useModalsContext } from '@/context/ModalsContext'
+import dynamic from 'next/dynamic'
+
+// Same dynamic-import + kill-switch pattern as the rewards easter egg. When
+// RAGDOLL_ENABLED is false the chunk + p2-es never ship; the play area just
+// stays empty (pink). See ragdoll.consts.ts.
+const PeanutRagdoll = RAGDOLL_ENABLED ? dynamic(() => import('@/components/PeanutRagdoll'), { ssr: false }) : null
 
 export default function NotFound() {
+    const { openSupportWithMessage } = useModalsContext()
+
+    const openSupport = () =>
+        openSupportWithMessage(
+            `Hey! I hit a 404 — can you help?${typeof window !== 'undefined' ? `\n\nURL: ${window.location.href}` : ''}`
+        )
+
     return (
-        <PageContainer className="min-h-[100dvh] p-6">
-            <div className="my-auto flex h-full flex-col justify-center space-y-4">
-                <div className="shadow-4 flex w-full flex-col items-center space-y-2 border border-n-1 bg-white p-4">
-                    <h1 className="text-3xl font-extrabold">Not found</h1>
-                    <Image src={PEANUTMAN_CRY.src} className="" alt="Peanutman crying 😭" width={96} height={96} />
-                    <p>Woah there buddy, you&apos;re not supposed to be here.</p>
-                    {/* Use <a> instead of <Link> to force full page load — avoids React error #310
-                        caused by hook count mismatch between 404 (no mobile-ui layout) and home (with providers) */}
-                    <a href="/" className="btn btn-purple shadow-4">
-                        Take me home, I&apos;m scared
-                    </a>
+        <>
+            <div className="flex min-h-[100dvh] flex-col md:h-[100dvh] md:flex-row">
+                <div className="relative h-[55dvh] w-full overflow-hidden bg-purple-1 md:h-full md:w-7/12">
+                    {PeanutRagdoll && <PeanutRagdoll />}
+                </div>
+
+                <div className="flex flex-grow flex-col justify-center overflow-y-auto bg-white px-6 py-8 md:px-12">
+                    <div className="mx-auto w-full max-w-md space-y-8">
+                        <div className="space-y-3">
+                            <h1 className="text-3xl font-extrabold">Hmm, we can&apos;t find that page.</h1>
+                            <p className="text-base text-grey-1">
+                                If we&apos;ve sent you here, please{' '}
+                                <button type="button" onClick={openSupport} className="text-black underline">
+                                    let support know
+                                </button>{' '}
+                                so we can fix it.
+                            </p>
+                        </div>
+                        <div className="space-y-3">
+                            {/* Raw <a> instead of <Link>: forces a full page load when leaving the
+                                404, avoiding the historical React error #310 from hook-count
+                                mismatch between this route and the (mobile-ui) tree. */}
+                            <a href="/" className="btn btn-purple shadow-4 block w-full text-center">
+                                Take me home
+                            </a>
+                            <Button variant="stroke" onClick={openSupport}>
+                                Contact support
+                            </Button>
+                        </div>
+                    </div>
                 </div>
             </div>
-        </PageContainer>
+            <SupportDrawer />
+        </>
     )
 }


### PR DESCRIPTION
## Summary
- Re-opens #2083, which was accidentally merged into `feat/rewards-ragdoll-easter-egg` ~12s after that branch had already been merged into `dev`, so the 404 changes never reached dev/staging.
- Same 3 commits, clean against current `dev` (touches only `src/app/not-found.tsx`).

## Test plan
- [ ] Hit a non-existent route on a preview deploy (e.g. `/en/afshahsf`) and confirm the ragdoll 404 with support drawer link renders instead of the old "Not found / Peanutman crying" page.
- [ ] "Take me home" still navigates to `/`.