### PR TITLE
Allow Sumsub-approved QR pay fallback

### DIFF
--- a/src/hooks/__tests__/useQrKycGate.test.ts
+++ b/src/hooks/__tests__/useQrKycGate.test.ts
@@ -1,9 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react'
 import { useAuth } from '@/context/authContext'
-import {
-    MANTECA_US_NATIONALITY_RESTRICTION_CODE,
-    MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE,
-} from '@/constants/manteca.consts'
+import { MANTECA_US_NATIONALITY_RESTRICTION_CODE } from '@/constants/manteca.consts'
 import { QrKycState, useQrKycGate } from '../useQrKycGate'
 
 jest.mock('@/context/authContext', () => ({
@@ -15,7 +12,7 @@ const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>
 describe('useQrKycGate', () => {
     afterEach(() => jest.resetAllMocks())
 
-    it('blocks restricted Manteca users and returns the restriction message', async () => {
+    it('allows Sumsub-approved users to pay QR through fallback despite Manteca US restriction', async () => {
         mockUseAuth.mockReturnValue({
             isFetchingUser: false,
             fetchUser: jest.fn(),
@@ -51,12 +48,12 @@ describe('useQrKycGate', () => {
 
         const { result } = renderHook(() => useQrKycGate('MANTECA'))
 
-        await waitFor(() => expect(result.current.kycGateState).toBe(QrKycState.PROVIDER_REJECTION_BLOCKED))
-        expect(result.current.shouldBlockPay).toBe(true)
-        expect(result.current.userMessage).toBe(MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE)
+        await waitFor(() => expect(result.current.kycGateState).toBe(QrKycState.PROCEED_TO_PAY))
+        expect(result.current.shouldBlockPay).toBe(false)
+        expect(result.current.userMessage).toBeNull()
     })
 
-    it('blocks restricted Manteca users when restriction metadata is only on a rail', async () => {
+    it('allows Sumsub-approved users when restriction metadata is only on a rail', async () => {
         mockUseAuth.mockReturnValue({
             isFetchingUser: false,
             fetchUser: jest.fn(),
@@ -100,8 +97,9 @@ describe('useQrKycGate', () => {
 
         const { result } = renderHook(() => useQrKycGate('MANTECA'))
 
-        await waitFor(() => expect(result.current.kycGateState).toBe(QrKycState.PROVIDER_REJECTION_BLOCKED))
-        expect(result.current.userMessage).toBe(MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE)
+        await waitFor(() => expect(result.current.kycGateState).toBe(QrKycState.PROCEED_TO_PAY))
+        expect(result.current.shouldBlockPay).toBe(false)
+        expect(result.current.userMessage).toBeNull()
     })
 
     it('marks self-healable Manteca rejections as fixable', async () => {

--- a/src/hooks/useQrKycGate.ts
+++ b/src/hooks/useQrKycGate.ts
@@ -4,7 +4,6 @@ import { useCallback, useState, useEffect, useRef } from 'react'
 import { useAuth } from '@/context/authContext'
 import { MantecaKycStatus } from '@/interfaces'
 import { isKycStatusApproved, isSumsubStatusInProgress, MAX_SELF_HEAL_ATTEMPTS } from '@/constants/kyc.consts'
-import { MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE } from '@/constants/manteca.consts'
 import { hasMantecaUsNationalityRestrictionMetadata } from '@/utils/manteca-restriction.utils'
 
 export enum QrKycState {
@@ -84,14 +83,17 @@ export function useQrKycGate(paymentProcessor?: 'MANTECA' | null): QrKycGateResu
                     kycMeta,
                     ...rejectedRailMetadata,
                 ])
+                if (isMantecaUsNationalityRestricted) {
+                    setGateState(QrKycState.PROCEED_TO_PAY)
+                    return
+                }
                 const isFixable =
-                    !isMantecaUsNationalityRestricted &&
                     railMeta.selfHealable === true &&
                     mantecaKyc?.rejectType !== 'PROVIDER_FINAL' &&
                     ((kycMeta.selfHealAttempt as number) || 0) < MAX_SELF_HEAL_ATTEMPTS
                 setGateState(
                     isFixable ? QrKycState.PROVIDER_REJECTION_FIXABLE : QrKycState.PROVIDER_REJECTION_BLOCKED,
-                    isMantecaUsNationalityRestricted ? MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE : null
+                    null
                 )
                 return
             }


### PR DESCRIPTION
## Summary
- Updates QR Pay gating so Sumsub-approved users can proceed even when their personal Manteca rails carry the US-nationality restriction.
- Keeps generic/fixable Manteca rejection handling unchanged for QR Pay.
- Updates `useQrKycGate` tests for the fallback behavior.

## Risks
- The Manteca restriction message will no longer appear on QR Pay for Sumsub-approved users; it remains available in provider/KYC status surfaces.
- Backend PR must land with this PR so the frontend and API agree that QR fallback is allowed.

## QA Guidelines
- With a Sumsub-approved user plus rejected Manteca US-nationality metadata, open QR Pay and confirm payment is not blocked by the KYC gate.
- Confirm fixable Manteca rejection still shows the document update state.
- Confirm activation/KYC status still reports Manteca service restriction.

Verification run locally:
- `npx jest src/hooks/__tests__/useQrKycGate.test.ts --runInBand` passed.
- `npm run typecheck` is blocked in the fresh worktree by existing missing local asset files, unrelated to this hook change.