### PR TITLE
Fix Manteca restriction modal copy

### DIFF
--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -595,11 +595,13 @@ export default function MantecaWithdrawFlow() {
                 }}
                 isLoading={sumsubFlow.isLoading}
                 variant={
-                    mantecaRejection.state === 'fixable' || mantecaRejection.state === 'blocked'
-                        ? 'provider_rejection'
-                        : isUserSumsubKycApproved
-                          ? 'cross_region'
-                          : 'default'
+                    mantecaRejection.state === 'blocked'
+                        ? 'blocked'
+                        : mantecaRejection.state === 'fixable'
+                          ? 'provider_rejection'
+                          : isUserSumsubKycApproved
+                            ? 'cross_region'
+                            : 'default'
                 }
                 providerMessage={mantecaRejection.userMessage ?? undefined}
                 regionName={selectedCountry?.title}

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -246,11 +246,13 @@ const MantecaAddMoney: FC = () => {
                     }}
                     isLoading={sumsubFlow.isLoading}
                     variant={
-                        mantecaRejection.state === 'fixable' || mantecaRejection.state === 'blocked'
-                            ? 'provider_rejection'
-                            : isUserSumsubKycApproved
-                              ? 'cross_region'
-                              : 'default'
+                        mantecaRejection.state === 'blocked'
+                            ? 'blocked'
+                            : mantecaRejection.state === 'fixable'
+                              ? 'provider_rejection'
+                              : isUserSumsubKycApproved
+                                ? 'cross_region'
+                                : 'default'
                     }
                     providerMessage={mantecaRejection.userMessage ?? undefined}
                     regionName={selectedCountry?.title}

--- a/src/components/Claim/Link/MantecaFlowManager.tsx
+++ b/src/components/Claim/Link/MantecaFlowManager.tsx
@@ -142,11 +142,13 @@ const MantecaFlowManager: FC<MantecaFlowManagerProps> = ({ claimLinkData, amount
                 }}
                 isLoading={sumsubFlow.isLoading}
                 variant={
-                    mantecaRejection.state === 'fixable' || mantecaRejection.state === 'blocked'
-                        ? 'provider_rejection'
-                        : isUserSumsubKycApproved
-                          ? 'cross_region'
-                          : 'default'
+                    mantecaRejection.state === 'blocked'
+                        ? 'blocked'
+                        : mantecaRejection.state === 'fixable'
+                          ? 'provider_rejection'
+                          : isUserSumsubKycApproved
+                            ? 'cross_region'
+                            : 'default'
                 }
                 providerMessage={mantecaRejection.userMessage ?? undefined}
                 regionName={selectedCountry?.title}

--- a/src/constants/manteca.consts.ts
+++ b/src/constants/manteca.consts.ts
@@ -4,7 +4,7 @@ export const MANTECA_ARG_DEPOSIT_NAME = 'Sixalime Sas'
 export const MANTECA_ARG_DEPOSIT_CUIT = '30-71678845-3'
 export const MANTECA_US_NATIONALITY_RESTRICTION_CODE = 'MANTECA_US_NATIONALITY_RESTRICTED'
 export const MANTECA_US_NATIONALITY_RESTRICTION_MESSAGE =
-    'Manteca services are not available to US citizens at this time.'
+    'Payments from this country are not available for US citizens at this time.'
 
 // ui mirror of peanut-api-ts/src/manteca/consts.ts MANTECA_SUPPORTED_COUNTRIES.
 // first-party manteca bank/kyc rails are currently active only in argentina and brazil.


### PR DESCRIPTION
## Summary
- Replace provider-named Manteca restriction copy with country-payment wording.
- Route blocked Manteca restrictions through the existing blocked modal state in deposit, withdraw, and claim flows so users see Contact support instead of Upload document.

## Risks
- Existing persisted backend metadata may still contain the old message until refreshed; the frontend constant covers local fallback copy.
- Fixable provider rejections should still show the upload-document path.

## QA Guidelines
- In deposit and withdraw flows, open a Manteca US-nationality restricted account and confirm the modal says: Payments from this country are not available for US citizens at this time.
- Confirm the same modal uses the blocked state with Contact support, not the extra-documents/upload-document state.
- Confirm fixable Manteca rejections still show Upload document.