### PR TITLE
fix(404): ragdoll legs render rotated + take-me-home padding

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -49,7 +49,7 @@ export default function NotFound() {
                                 404, avoiding the historical React error #310 from hook-count
                                 mismatch between this route and the (mobile-ui) tree. */}
                             {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-                            <a href="/" className="btn btn-purple shadow-4 block w-full text-center">
+                            <a href="/" className="btn btn-purple shadow-4 flex w-full text-center">
                                 Take me home
                             </a>
                             <Button variant="stroke" className="w-full" onClick={openSupport}>

--- a/src/components/PeanutRagdoll/ragdoll.ts
+++ b/src/components/PeanutRagdoll/ragdoll.ts
@@ -407,7 +407,6 @@ export function startRagdoll(canvas: HTMLCanvasElement): () => void {
         })
         leftLeg.__sw = LEG_SPRITE_W
         leftLeg.__sh = LEG_SPRITE_H
-        leftLeg.__spriteAngle = -Math.PI / 2
         const rightLeg: any = makeLimbSegment({
             position: [HIP_X, hipY - LEG_L / 2],
             width: LEG_W,
@@ -417,7 +416,7 @@ export function startRagdoll(canvas: HTMLCanvasElement): () => void {
         })
         rightLeg.__sw = LEG_SPRITE_W
         rightLeg.__sh = LEG_SPRITE_H
-        rightLeg.__spriteAngle = Math.PI / 2
+        rightLeg.__flipX = true
 
         const FOOT_DX = FOOT_R * 0.5
         const leftFoot: any = makeEndCap({


### PR DESCRIPTION
Follow-up to #2087 review.

## Summary
- **Ragdoll legs were drawn horizontal.** `leg.svg` has vertical natural orientation (viewBox 67×144, hip at -Y, ankle at +Y) and the physics body is a vertical box. The `±π/2 __spriteAngle` on each leg was rotating the already-aligned sprite 90° off-axis, so the legs rendered as horizontal stripes from each hip. Dropping the rotation and mirroring the right leg via `__flipX` puts them back where they belong. This also fixes the same bug on the /rewards easter-egg (same component).
- **"Take me home" CTA had no vertical padding.** The raw `<a className="btn btn-purple shadow-4 block w-full text-center">` used `block`, which overrode `.btn`'s `inline-flex items-center justify-center`. Text floated to the top of the `h-13` box. Swapped `block → flex` to restore the centering.

Caught by @jjramirezn in https://github.com/peanutprotocol/peanut-ui/pull/2087#discussion_r3297712481.

## Test plan
- [ ] Hit `/some-bogus-path` on staging → peanut renders sitting with legs *vertical* (no horizontal pancakes from the hips).
- [ ] "Take me home" label is vertically centered inside the pink button.
- [ ] Drag the peanut around — joints still hold, no `__flipX`-induced mirroring weirdness on the right leg.
- [ ] Confirm `/rewards` ragdoll easter egg also reads correctly (same component).