### PR TITLE
feat(ragdoll): drop from the ceiling on mount to telegraph drag

### DIFF
--- a/src/components/PeanutRagdoll/ragdoll.ts
+++ b/src/components/PeanutRagdoll/ragdoll.ts
@@ -28,6 +28,10 @@ const WORLD_H = 7.0
 const TOP_Y = GROUND_Y + WORLD_H
 const CENTER_Y = (GROUND_Y + TOP_Y) / 2
 
+// Drop-from-near-the-ceiling so the very first frame shows movement —
+// the fall is the affordance that tells users the peanut is draggable.
+const SPAWN_Y = TOP_Y - 1.0
+
 const SHELL_LOBE_R = 0.45
 const SHELL_OVERLAP = 0.55
 const ARM_W = 0.2
@@ -135,7 +139,6 @@ export function startRagdoll(canvas: HTMLCanvasElement): () => void {
 
     // ---- loop / sleep state ----
     let paused = false
-    let frozen = true
     let lastT = performance.now()
     let sleeping = false
     let rafId = 0
@@ -271,7 +274,7 @@ export function startRagdoll(canvas: HTMLCanvasElement): () => void {
     }
 
     function makeShellBody() {
-        const body: any = new (p2 as any).Body({ mass: 3, position: [0, 0.5] })
+        const body: any = new (p2 as any).Body({ mass: 3, position: [0, SPAWN_Y] })
         const top = new (p2 as any).Circle({ radius: SHELL_LOBE_R })
         const bot = new (p2 as any).Circle({ radius: SHELL_LOBE_R })
         body.addShape(top, [0, SHELL_OVERLAP / 2])
@@ -568,10 +571,6 @@ export function startRagdoll(canvas: HTMLCanvasElement): () => void {
         }
     }
 
-    function thaw() {
-        frozen = false
-    }
-
     function wake() {
         if (!sleeping && rafId !== 0) return
         sleeping = false
@@ -584,7 +583,7 @@ export function startRagdoll(canvas: HTMLCanvasElement): () => void {
         rafId = 0
         const dt = Math.min((t - lastT) / 1000, 1 / 30)
         lastT = t
-        if (!paused && !frozen) world.step(1 / 60, dt, 6)
+        if (!paused) world.step(1 / 60, dt, 6)
         updateFaceBobble(dt)
         updateRest(dt)
 
@@ -628,7 +627,6 @@ export function startRagdoll(canvas: HTMLCanvasElement): () => void {
         if (activePointerId !== null) return
         lastInteractionT = performance.now()
         if (sleeping) wake()
-        if (frozen) thaw()
         const w = pointerWorld(e)
         const hit = world.hitTest([w.x, w.y], world.bodies, 0.05).filter((b: any) => b.mass > 0)[0]
         if (!hit) return


### PR DESCRIPTION
Follow-up to #2095.

## Why
On /404 (and /rewards) the ragdoll spawned mid-cage at y=0.5 with `frozen = true` — the physics world was built but `world.step()` was gated until the first pointer-down. Net effect: a perfectly still peanut. Users had no signal that it was draggable.

## Change
- Spawn the shell at `TOP_Y - 1.0` (just under the ceiling).
- Remove the freeze gate (`frozen` flag, `thaw()`, the gated `world.step()`, the `if (frozen) thaw()` in `onPointerDown`) — all now-dead with physics live from frame 0.

First mounted frame → peanut falls → user notices the bouncing physics → "oh, I can grab it."

## Test plan
- [ ] Visit `/some-bogus-path` on a staging preview: peanut starts at the top of the pink area and falls/bounces down.
- [ ] Visit `/rewards` (same component path): same drop animation.
- [ ] After ~15s of no interaction the existing `IDLE_SLEEP_MS` sleep path still kicks in (peanut goes sleepy + the loop parks).
- [ ] Click-and-drag still works exactly as before — no regression from removing the `thaw()` call.