### PR TITLE
polish(share-asset): drop VIRTUAL, ???? PAN, more sprinkles, fix peanut clip

### DIFF
--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -87,9 +87,7 @@ const CardPage: FC = () => {
     // Track whether the user has acknowledged the skip-badge celebration.
     // localStorage for M2; Phase 5 will read this from BE's
     // cardWaitlistSkipCelebrationSeenAt column.
-    const [skipCelebrationSeen, setSkipCelebrationSeen] = useState<boolean>(() =>
-        getSkipCelebrationSeen()
-    )
+    const [skipCelebrationSeen, setSkipCelebrationSeen] = useState<boolean>(() => getSkipCelebrationSeen())
 
     // Press-and-hold "see if you qualify" gate. Resets per mount: as long
     // as the user has not been issued a card, every fresh /card visit
@@ -483,13 +481,7 @@ const CardPage: FC = () => {
                 if (cardInfo!.waitlistJoinedAt) {
                     return <CardWaitlistJoinedScreen onPrev={onBack} />
                 }
-                return (
-                    <CardWaitlistScreen
-                        cardInfo={cardInfo!}
-                        onPrev={onBack}
-                        onJoined={refetchCardInfo}
-                    />
-                )
+                return <CardWaitlistScreen cardInfo={cardInfo!} onPrev={onBack} onJoined={refetchCardInfo} />
             }
             case 'waitlist-skip-celebration': {
                 // Pick the freshest skip badge for the celebration headline.
@@ -498,10 +490,11 @@ const CardPage: FC = () => {
                 // `user.user.badges` is the full collection from /get-user
                 // (with earnedAt) — fall back to cardInfo.skipBadges if it
                 // hasn't loaded yet so we still render something.
-                const allBadges = user?.user?.badges?.map((b) => ({
-                    code: b.code,
-                    earnedAt: b.earnedAt,
-                })) ?? cardInfo!.skipBadges.map((code) => ({ code }))
+                const allBadges =
+                    user?.user?.badges?.map((b) => ({
+                        code: b.code,
+                        earnedAt: b.earnedAt,
+                    })) ?? cardInfo!.skipBadges.map((code) => ({ code }))
                 return (
                     <BadgeSkipCelebration
                         badgeCode={skipCode}

--- a/src/app/(mobile-ui)/dev/debug/page.tsx
+++ b/src/app/(mobile-ui)/dev/debug/page.tsx
@@ -294,7 +294,7 @@ export default function DebugPage() {
                     key: 'grantFlowEarlyAccess',
                     label: 'Stamp /shhhhh early-access',
                     description:
-                        "Stamps users.card_flow_early_access_at so the outer gate opens without going through /shhhhh. Idempotent. Use to skip the LP when testing the inner flow directly.",
+                        'Stamps users.card_flow_early_access_at so the outer gate opens without going through /shhhhh. Idempotent. Use to skip the LP when testing the inner flow directly.',
                     run: async () => {
                         await call('grantFlowEarlyAccess', '/dev/cheats/grant-flow-early-access', { userId })
                         await refreshWhoami()
@@ -357,8 +357,7 @@ export default function DebugPage() {
                 {
                     key: 'revokeAllSkipBadges',
                     label: 'Revoke all waitlist-skip badges',
-                    description:
-                        'Clears every waitlist-skip badge so the user falls back to the waitlist queue path.',
+                    description: 'Clears every waitlist-skip badge so the user falls back to the waitlist queue path.',
                     run: async () => {
                         for (const { code } of WAITLIST_SKIP_BADGES) {
                             await call(`revoke_${code}`, '/dev/cheats/grant-badge', { userId, code, revoke: true })

--- a/src/app/(mobile-ui)/dev/share-builder/page.tsx
+++ b/src/app/(mobile-ui)/dev/share-builder/page.tsx
@@ -27,7 +27,14 @@ export default function ShareBuilderPage() {
     // ─── User inputs ─────────────────────────────────────────────────────
     const [username, setUsername] = useState('kkonrad')
     const [selectedBadges, setSelectedBadges] = useState<Set<string>>(
-        new Set(['OG_2025_10_12', 'DEVCONNECT_BA_2025', 'ARBIVERSE_DEVCONNECT_BA_2025', 'CARD_PIONEER', 'BETA_TESTER', 'SUPPORT_SURVIVOR'])
+        new Set([
+            'OG_2025_10_12',
+            'DEVCONNECT_BA_2025',
+            'ARBIVERSE_DEVCONNECT_BA_2025',
+            'CARD_PIONEER',
+            'BETA_TESTER',
+            'SUPPORT_SURVIVOR',
+        ])
     )
     const [tier, setTier] = useState<TierLevel>(3)
     const [points, setPoints] = useState(1247)
@@ -109,7 +116,7 @@ export default function ShareBuilderPage() {
                                 <button
                                     key={code}
                                     onClick={() => toggleBadge(code)}
-                                    className={`border-2 border-black rounded-full px-3 py-1 text-xs font-bold transition-colors ${
+                                    className={`rounded-full border-2 border-black px-3 py-1 text-xs font-bold transition-colors ${
                                         selectedBadges.has(code)
                                             ? 'bg-primary-1 text-n-1'
                                             : 'bg-white text-grey-1 hover:bg-grey-2'
@@ -120,13 +127,15 @@ export default function ShareBuilderPage() {
                                 </button>
                             ))}
                         </div>
-                        <div className="flex gap-2 mt-3 flex-wrap">
+                        <div className="mt-3 flex flex-wrap gap-2">
                             <PresetButton onClick={() => setSelectedBadges(new Set())}>0 badges</PresetButton>
                             <PresetButton onClick={() => setSelectedBadges(new Set(['OG_2025_10_12']))}>
                                 1 badge
                             </PresetButton>
                             <PresetButton
-                                onClick={() => setSelectedBadges(new Set(['OG_2025_10_12', 'DEVCONNECT_BA_2025', 'CARD_PIONEER']))}
+                                onClick={() =>
+                                    setSelectedBadges(new Set(['OG_2025_10_12', 'DEVCONNECT_BA_2025', 'CARD_PIONEER']))
+                                }
                             >
                                 3
                             </PresetButton>
@@ -143,7 +152,7 @@ export default function ShareBuilderPage() {
                                     <button
                                         key={t}
                                         onClick={() => setTier(t as TierLevel)}
-                                        className={`flex-1 border-2 border-black rounded-sm py-2 font-bold transition-colors ${
+                                        className={`flex-1 rounded-sm border-2 border-black py-2 font-bold transition-colors ${
                                             tier === t ? 'bg-primary-1' : 'bg-white hover:bg-grey-2'
                                         }`}
                                     >
@@ -244,12 +253,8 @@ export default function ShareBuilderPage() {
                     <Section title="Edge-case shortcuts">
                         <div className="grid grid-cols-2 gap-2 text-xs">
                             <PresetButton onClick={() => setUsername('me')}>2-char user</PresetButton>
-                            <PresetButton onClick={() => setUsername('twelvechars1')}>
-                                12 chars (max)
-                            </PresetButton>
-                            <PresetButton onClick={() => setUsername('thisistwentyplus_chars')}>
-                                20+ chars
-                            </PresetButton>
+                            <PresetButton onClick={() => setUsername('twelvechars1')}>12 chars (max)</PresetButton>
+                            <PresetButton onClick={() => setUsername('thisistwentyplus_chars')}>20+ chars</PresetButton>
                             <PresetButton
                                 onClick={() => {
                                     setMovedUsd(0)
@@ -287,27 +292,24 @@ export default function ShareBuilderPage() {
                             </PresetButton>
                         </div>
                         {username.length > 12 && (
-                            <p className="text-[10px] text-red mt-2 font-bold leading-snug">
-                                ⚠️ Username &gt; 12 chars · production caps at 12. The asset
-                                shrinks the @username pill defensively, but check the input gate
-                                in your caller.
+                            <p className="mt-2 text-[10px] font-bold leading-snug text-red">
+                                ⚠️ Username &gt; 12 chars · production caps at 12. The asset shrinks the @username pill
+                                defensively, but check the input gate in your caller.
                             </p>
                         )}
                     </Section>
                 </aside>
 
                 {/* ─── RIGHT: Preview ──────────────────────────────────── */}
-                <main className="flex-1 flex flex-col gap-4">
-                    <div className="border border-n-1 rounded-sm bg-grey-3 p-2 flex items-center justify-between text-xs">
+                <main className="flex flex-1 flex-col gap-4">
+                    <div className="flex items-center justify-between rounded-sm border border-n-1 bg-grey-3 p-2 text-xs">
                         <span className="font-mono">
                             {CANVAS_W} × {CANVAS_H} · scaled {(previewScale * 100).toFixed(0)}%
                         </span>
-                        <span className="font-mono text-grey-1">
-                            seed: {seedOverride ?? username ?? 'anon'}
-                        </span>
+                        <span className="font-mono text-grey-1">seed: {seedOverride ?? username ?? 'anon'}</span>
                     </div>
                     <div
-                        className="border-2 border-n-1 rounded-sm bg-background overflow-auto"
+                        className="overflow-auto rounded-sm border-2 border-n-1 bg-background"
                         style={{ minHeight: 200 }}
                     >
                         <div
@@ -343,9 +345,9 @@ export default function ShareBuilderPage() {
                         </div>
                     </div>
 
-                    <div className="border border-n-1 rounded-sm bg-white p-4 text-xs space-y-2">
+                    <div className="space-y-2 rounded-sm border border-n-1 bg-white p-4 text-xs">
                         <div className="font-bold uppercase tracking-wider text-grey-1">Resulting props</div>
-                        <pre className="font-mono text-[11px] overflow-auto whitespace-pre-wrap">
+                        <pre className="overflow-auto whitespace-pre-wrap font-mono text-[11px]">
                             {JSON.stringify(
                                 {
                                     username,
@@ -371,8 +373,8 @@ export default function ShareBuilderPage() {
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
     return (
-        <section className="border-2 border-n-1 rounded-sm bg-white shadow-4 p-4">
-            <h2 className="text-xs font-extrabold uppercase tracking-wider mb-3 text-grey-1">{title}</h2>
+        <section className="shadow-4 rounded-sm border-2 border-n-1 bg-white p-4">
+            <h2 className="mb-3 text-xs font-extrabold uppercase tracking-wider text-grey-1">{title}</h2>
             <div className="flex flex-col gap-3">{children}</div>
         </section>
     )
@@ -391,7 +393,7 @@ function PresetButton({ onClick, children }: { onClick: () => void; children: Re
     return (
         <button
             onClick={onClick}
-            className="border border-n-1 rounded-full bg-white hover:bg-grey-2 px-2 py-1 text-xs font-bold transition-colors"
+            className="rounded-full border border-n-1 bg-white px-2 py-1 text-xs font-bold transition-colors hover:bg-grey-2"
         >
             {children}
         </button>

--- a/src/assets/peanut/index.ts
+++ b/src/assets/peanut/index.ts
@@ -1,5 +1,6 @@
 export { default as PEANUTMAN_MOBILE } from './peanut-club.png'
 export { default as PEANUTMAN_PFP } from './peanut-pfp.svg'
 export { default as PEANUTMAN_RAISING_HANDS } from './peanut-raising-hands.svg'
+export { default as PEANUTMAN_HOLDING_BEER } from './peanut-holding-beer.svg'
 export { default as PEANUTMAN_LOGO } from './peanutman-logo.svg'
 export { default as PEANUTMAN_WAVING } from './peanutman-waving.svg'

--- a/src/components/Card/BadgeSkipCelebration.tsx
+++ b/src/components/Card/BadgeSkipCelebration.tsx
@@ -57,20 +57,13 @@ const NO_BADGE_HEADLINE = "You're in."
 
 type Phase = 'looking-up' | 'shaking' | 'revealed'
 
-const BadgeSkipCelebration: FC<Props> = ({
-    badgeCode,
-    username,
-    badges,
-    stats,
-    tier,
-    pointsBalance,
-    onContinue,
-}) => {
+const BadgeSkipCelebration: FC<Props> = ({ badgeCode, username, badges, stats, tier, pointsBalance, onContinue }) => {
     const [phase, setPhase] = useState<Phase>('looking-up')
     const { triggerHaptic } = useHaptic()
     const captureRef = useRef<HTMLDivElement | null>(null)
     const hasBadge = !!badgeCode
-    const headline = (badgeCode && SKIP_BADGE_HEADLINES[badgeCode]) || (hasBadge ? 'You skipped the line.' : NO_BADGE_HEADLINE)
+    const headline =
+        (badgeCode && SKIP_BADGE_HEADLINES[badgeCode]) || (hasBadge ? 'You skipped the line.' : NO_BADGE_HEADLINE)
     const subline = hasBadge
         ? 'You hold a badge that skips the closed-beta queue. Card’s yours.'
         : 'Welcome to the closed beta. Card’s yours.'
@@ -133,9 +126,7 @@ const BadgeSkipCelebration: FC<Props> = ({
             {/* Stage: pixelated card hangs out at first (carrying over from the
                 eligibility screen), then animates away while the share asset
                 slides up into view. */}
-            <div
-                className={`relative mx-auto w-full max-w-2xl ${getShakeClass(phase === 'shaking', 'strong')}`}
-            >
+            <div className={`relative mx-auto w-full max-w-2xl ${getShakeClass(phase === 'shaking', 'strong')}`}>
                 <AnimatePresence>
                     {!showAsset && (
                         <motion.div

--- a/src/components/Card/CardEligibilityCheckScreen.tsx
+++ b/src/components/Card/CardEligibilityCheckScreen.tsx
@@ -50,9 +50,7 @@ const CardEligibilityCheckScreen: FC<Props> = ({ onComplete, onPrev, username })
     }
 
     return (
-        <div
-            className={`flex min-h-[inherit] flex-col gap-6 ${getShakeClass(shake.on, shake.intensity)}`}
-        >
+        <div className={`flex min-h-[inherit] flex-col gap-6 ${getShakeClass(shake.on, shake.intensity)}`}>
             <NavHeader title="The door" onPrev={onPrev} />
 
             <div className="flex flex-col gap-2 text-center">

--- a/src/components/Card/CardUnlockHistoryItem.tsx
+++ b/src/components/Card/CardUnlockHistoryItem.tsx
@@ -44,13 +44,7 @@ const VIA_COPY: Record<CardUnlockHistoryEntry['via'], { title: string; subtitle:
     },
 }
 
-const CardUnlockHistoryItem: FC<Props> = ({
-    entry,
-    position = 'single',
-    className,
-    username,
-    skipBadges,
-}) => {
+const CardUnlockHistoryItem: FC<Props> = ({ entry, position = 'single', className, username, skipBadges }) => {
     const [isDrawerOpen, setIsDrawerOpen] = useState(false)
     const copy = VIA_COPY[entry.via]
 

--- a/src/components/Card/CardWaitlistScreen.tsx
+++ b/src/components/Card/CardWaitlistScreen.tsx
@@ -74,9 +74,7 @@ const CardWaitlistScreen: FC<Props> = ({ onPrev, onJoined }) => {
                 />
 
                 <div className="flex flex-col gap-3">
-                    <h1 className="text-2xl font-extrabold text-n-1">
-                        You don&apos;t have the required badge :(
-                    </h1>
+                    <h1 className="text-2xl font-extrabold text-n-1">You don&apos;t have the required badge :(</h1>
                     <p className="text-grey-1">
                         Instead, you can join the waitlist. We let in a few people every week.
                     </p>

--- a/src/components/Card/share-asset/PixelatedCardFace.tsx
+++ b/src/components/Card/share-asset/PixelatedCardFace.tsx
@@ -97,14 +97,21 @@ export const PixelatedCardFace: FC<PixelatedCardFaceProps> = ({
             )}
         </div>
 
-        {/* Bottom block: card number + Virtual pill */}
-        <div className="absolute" style={{ bottom: 24, left: 28, zIndex: 2 }}>
+        {/* Bottom: card number. The share asset deliberately obscures the
+            real PAN so it can't be screen-grabbed and posted — render
+            four groups of four `?` instead of the user's actual last4.
+            (The `last4` prop is still in the type for the in-app card
+            preview surface that uses the real number; share-asset
+            callers don't need to pass it.) Lowered toward the card
+            edge now that the Virtual pill is gone — gives the layout
+            room to breathe. */}
+        <div className="absolute" style={{ bottom: 32, left: 28, zIndex: 2 }}>
             {blurAll ? (
                 <PixelatedText
-                    text={`•••• ${last4}`}
-                    displayW={260}
-                    displayH={38}
-                    font="1000 38px Roboto, sans-serif"
+                    text="???? ???? ???? ????"
+                    displayW={420}
+                    displayH={42}
+                    font="1000 42px Roboto, sans-serif"
                     color="#000"
                 />
             ) : (
@@ -113,32 +120,12 @@ export const PixelatedCardFace: FC<PixelatedCardFaceProps> = ({
                         fontFamily: 'var(--font-roboto), sans-serif',
                         fontWeight: 1000,
                         letterSpacing: '0.06em',
-                        fontSize: 38,
+                        fontSize: 42,
                         lineHeight: 1,
                     }}
                 >
-                    •••• {last4}
+                    ???? ???? ???? ????
                 </div>
-            )}
-            {blurAll ? (
-                <div style={{ marginTop: 8 }}>
-                    <PixelatedText
-                        text="Virtual"
-                        displayW={80}
-                        displayH={22}
-                        font="600 15px Roboto, sans-serif"
-                        color="#000"
-                        bg="#FFF"
-                        borderColor="#000"
-                    />
-                </div>
-            ) : (
-                <span
-                    className="inline-block rounded-full border-[1.5px] border-black bg-white font-semibold"
-                    style={{ fontSize: 15, padding: '2px 14px', marginTop: 8 }}
-                >
-                    Virtual
-                </span>
             )}
         </div>
     </div>

--- a/src/components/Card/share-asset/PixelatedCardFace.tsx
+++ b/src/components/Card/share-asset/PixelatedCardFace.tsx
@@ -108,8 +108,8 @@ export const PixelatedCardFace: FC<PixelatedCardFaceProps> = ({
         <div className="absolute" style={{ bottom: 32, left: 28, zIndex: 2 }}>
             {blurAll ? (
                 <PixelatedText
-                    text="•••• ????"
-                    displayW={260}
+                    text="????"
+                    displayW={140}
                     displayH={42}
                     font="1000 42px Roboto, sans-serif"
                     color="#000"
@@ -124,7 +124,7 @@ export const PixelatedCardFace: FC<PixelatedCardFaceProps> = ({
                         lineHeight: 1,
                     }}
                 >
-                    •••• ????
+                    ????
                 </div>
             )}
         </div>

--- a/src/components/Card/share-asset/PixelatedCardFace.tsx
+++ b/src/components/Card/share-asset/PixelatedCardFace.tsx
@@ -42,6 +42,9 @@ const CELL_PX = 14
 const HAND_RASTER_PX = 36
 
 export interface PixelatedCardFaceProps {
+    /** Kept in the type for in-app surfaces that render the real card
+     *  number — the share-asset rendering deliberately ignores this and
+     *  always shows "????" so a screenshot can't leak the PAN. */
     last4?: string
     /** Extra classes for the outer card div (the pink rounded box). */
     className?: string
@@ -54,7 +57,6 @@ export interface PixelatedCardFaceProps {
 }
 
 export const PixelatedCardFace: FC<PixelatedCardFaceProps> = ({
-    last4 = 'XXXX',
     className,
     style,
     blurAll = false,

--- a/src/components/Card/share-asset/PixelatedCardFace.tsx
+++ b/src/components/Card/share-asset/PixelatedCardFace.tsx
@@ -56,11 +56,7 @@ export interface PixelatedCardFaceProps {
     blurAll?: boolean
 }
 
-export const PixelatedCardFace: FC<PixelatedCardFaceProps> = ({
-    className,
-    style,
-    blurAll = false,
-}) => (
+export const PixelatedCardFace: FC<PixelatedCardFaceProps> = ({ className, style, blurAll = false }) => (
     <div
         className={`relative overflow-hidden rounded-3xl border-[4px] border-black ${className ?? ''}`}
         style={{

--- a/src/components/Card/share-asset/PixelatedCardFace.tsx
+++ b/src/components/Card/share-asset/PixelatedCardFace.tsx
@@ -72,22 +72,14 @@ export const PixelatedCardFace: FC<PixelatedCardFaceProps> = ({
         <PixelatedHand />
 
         {/* Top row: peanut logo (left) + visa logo (right) */}
-        <div
-            className="absolute flex items-start justify-between"
-            style={{ top: 24, left: 28, right: 28, zIndex: 2 }}
-        >
+        <div className="absolute flex items-start justify-between" style={{ top: 24, left: 28, right: 28, zIndex: 2 }}>
             {blurAll ? (
                 <PixelatedImg src={ASSET_PEANUTMAN_LOGO} displayW={52} displayH={52} />
             ) : (
                 <img src={ASSET_PEANUTMAN_LOGO} alt="" aria-hidden style={{ height: 52, width: 'auto' }} />
             )}
             {blurAll ? (
-                <PixelatedImg
-                    src={ASSET_VISA_BRAND}
-                    displayW={80}
-                    displayH={32}
-                    invert
-                />
+                <PixelatedImg src={ASSET_VISA_BRAND} displayW={80} displayH={32} invert />
             ) : (
                 <img
                     src={ASSET_VISA_BRAND}
@@ -149,12 +141,7 @@ function cloneCanvas(source: HTMLCanvasElement): HTMLCanvasElement {
     return out
 }
 
-function rasterImg(
-    src: string,
-    rasterW: number,
-    rasterH: number,
-    onReady: (canvas: HTMLCanvasElement) => void,
-): void {
+function rasterImg(src: string, rasterW: number, rasterH: number, onReady: (canvas: HTMLCanvasElement) => void): void {
     const key = `${src}|${rasterW}x${rasterH}`
     const cached = rasterCache.get(key)
     if (cached) {
@@ -219,15 +206,7 @@ interface PixelatedTextProps {
     borderColor?: string
 }
 
-const PixelatedText: FC<PixelatedTextProps> = ({
-    text,
-    displayW,
-    displayH,
-    font,
-    color,
-    bg,
-    borderColor,
-}) => {
+const PixelatedText: FC<PixelatedTextProps> = ({ text, displayW, displayH, font, color, bg, borderColor }) => {
     // Use a slightly finer cell for text so glyphs remain just-readable as
     // blocky shapes; pure CELL_PX/14 produces unreadable mush at this size.
     const textCellPx = 6
@@ -258,8 +237,9 @@ const PixelatedText: FC<PixelatedTextProps> = ({
                 // Replace the px size inside the canvas-font shorthand with the
                 // raster-scaled px size. The original string drives styling
                 // (weight, family); we only adjust the numeric size.
-                ctx.font = font.replace(/(\d+(?:\.\d+)?)px/, (_, n) =>
-                    `${Math.max(1, Math.round(Number(n) * fontScale))}px`
+                ctx.font = font.replace(
+                    /(\d+(?:\.\d+)?)px/,
+                    (_, n) => `${Math.max(1, Math.round(Number(n) * fontScale))}px`
                 )
                 ctx.textBaseline = 'middle'
                 ctx.textAlign = 'left'
@@ -285,10 +265,8 @@ const PixelatedHand: FC = () => (
         ref={(node) => {
             if (!node || node.firstChild) return
             const handRatio = 560 / 471 // hand display w/h
-            const rasterW =
-                handRatio > 1 ? HAND_RASTER_PX : Math.max(1, Math.round(HAND_RASTER_PX * handRatio))
-            const rasterH =
-                handRatio > 1 ? Math.max(1, Math.round(HAND_RASTER_PX / handRatio)) : HAND_RASTER_PX
+            const rasterW = handRatio > 1 ? HAND_RASTER_PX : Math.max(1, Math.round(HAND_RASTER_PX * handRatio))
+            const rasterH = handRatio > 1 ? Math.max(1, Math.round(HAND_RASTER_PX / handRatio)) : HAND_RASTER_PX
             rasterImg(ASSET_CARD_HAND, rasterW, rasterH, (canvas) => {
                 canvas.style.width = '100%'
                 canvas.style.height = '100%'

--- a/src/components/Card/share-asset/PixelatedCardFace.tsx
+++ b/src/components/Card/share-asset/PixelatedCardFace.tsx
@@ -97,19 +97,19 @@ export const PixelatedCardFace: FC<PixelatedCardFaceProps> = ({
             )}
         </div>
 
-        {/* Bottom: card number. The share asset deliberately obscures the
-            real PAN so it can't be screen-grabbed and posted — render
-            four groups of four `?` instead of the user's actual last4.
-            (The `last4` prop is still in the type for the in-app card
-            preview surface that uses the real number; share-asset
-            callers don't need to pass it.) Lowered toward the card
-            edge now that the Virtual pill is gone — gives the layout
-            room to breathe. */}
+        {/* Bottom: card number — same `•••• ????` pattern in both modes.
+            The share asset deliberately obscures the real PAN so a
+            screenshot can't leak it; the eligibility-check tease uses
+            the same string for visual continuity. (The `last4` prop is
+            still in the type for in-app surfaces that show the real
+            card face — share-asset + tease callers just don't pass it.)
+            Lowered toward the card edge now that the Virtual pill is
+            gone — gives the layout room to breathe. */}
         <div className="absolute" style={{ bottom: 32, left: 28, zIndex: 2 }}>
             {blurAll ? (
                 <PixelatedText
-                    text="???? ???? ???? ????"
-                    displayW={420}
+                    text="•••• ????"
+                    displayW={260}
                     displayH={42}
                     font="1000 42px Roboto, sans-serif"
                     color="#000"
@@ -124,7 +124,7 @@ export const PixelatedCardFace: FC<PixelatedCardFaceProps> = ({
                         lineHeight: 1,
                     }}
                 >
-                    ???? ???? ???? ????
+                    •••• ????
                 </div>
             )}
         </div>

--- a/src/components/Card/share-asset/ShareAssetActions.tsx
+++ b/src/components/Card/share-asset/ShareAssetActions.tsx
@@ -36,12 +36,7 @@ interface Props {
     shareText: string
 }
 
-export const ShareAssetActions: FC<Props> = ({
-    captureRef,
-    source,
-    filename = 'peanut-card.png',
-    shareText,
-}) => {
+export const ShareAssetActions: FC<Props> = ({ captureRef, source, filename = 'peanut-card.png', shareText }) => {
     const [isSharing, setIsSharing] = useState(false)
     const [isSaving, setIsSaving] = useState(false)
 

--- a/src/components/Card/share-asset/ShareAssetD3.tsx
+++ b/src/components/Card/share-asset/ShareAssetD3.tsx
@@ -34,6 +34,7 @@ import {
 } from './shareAssetLayout'
 import type { ShareAssetD3Props, TierLevel } from './shareAsset.types'
 import { TIER_0_BADGE, TIER_1_BADGE, TIER_2_BADGE, TIER_3_BADGE } from '@/assets/badges'
+import { PEANUTMAN_HOLDING_BEER } from '@/assets/peanut'
 import { STAR_STRAIGHT_ICON } from '@/assets/icons'
 import { HandThumbsUp, HandThumbsUpV2, Eyes, Sparkle, Cloud, Star } from '@/assets/illustrations'
 import { PixelatedCardFace } from './PixelatedCardFace'
@@ -45,12 +46,13 @@ const ASSET_HAND_THUMBS_V2 = HandThumbsUpV2.src
 const ASSET_EYES = Eyes.src
 const ASSET_SPARKLE = Sparkle.src
 const ASSET_CLOUD = Cloud.src
-// Note: peanut character SVGs (peanut-raising-hands, peanutman-waving)
-// both crop the lower body at the source — the art style draws peanuts
-// without feet. Hugo flagged this twice (waving + raising-hands); we
-// dropped the character from the decoration pool rather than ship a
-// "missing feet" rendering. The PEANUTMAN_LOGO icon on the card itself
-// remains the only peanut-character surface on this asset.
+// The peanut character art style is intentionally legless — the body
+// tapers to a rounded point. Rather than dropping the character, we
+// place him BEHIND the card with his bottom inside the card's bbox so
+// only his head + arms peek out above the card edge. Of the available
+// poses, peanut-holding-beer is the most expressive (both arms visible,
+// holding a beer, peace sign) and reads cleanly at small sizes.
+const ASSET_PEANUT_CHAR = PEANUTMAN_HOLDING_BEER.src
 
 const TIER_SVG: Record<TierLevel, string> = {
     0: TIER_0_BADGE,
@@ -74,6 +76,7 @@ const DECO_ASSET: Record<DecorationPlacement['kind'], string> = {
     eyes: ASSET_EYES,
     sparkle: ASSET_SPARKLE,
     cloud: ASSET_CLOUD,
+    peanutChar: ASSET_PEANUT_CHAR,
 }
 
 const ANIM_CARD_DELAY = 100

--- a/src/components/Card/share-asset/ShareAssetD3.tsx
+++ b/src/components/Card/share-asset/ShareAssetD3.tsx
@@ -34,14 +34,18 @@ import {
 } from './shareAssetLayout'
 import type { ShareAssetD3Props, TierLevel } from './shareAsset.types'
 import { TIER_0_BADGE, TIER_1_BADGE, TIER_2_BADGE, TIER_3_BADGE } from '@/assets/badges'
-import { PEANUTMAN_WAVING } from '@/assets/peanut'
+import { PEANUTMAN_RAISING_HANDS } from '@/assets/peanut'
 import { STAR_STRAIGHT_ICON } from '@/assets/icons'
 import { HandThumbsUp, Eyes, Sparkle, Cloud } from '@/assets/illustrations'
 import { PixelatedCardFace } from './PixelatedCardFace'
 
 const ASSET_STAR = STAR_STRAIGHT_ICON.src
 const ASSET_HAND_THUMBS = HandThumbsUp.src
-const ASSET_PEANUTMAN_WAVING = PEANUTMAN_WAVING.src
+// peanut-raising-hands.svg renders the full-body peanut. The
+// peanutman-waving.svg viewBox crops the feet (Hugo flagged it twice;
+// re-anchoring via `bottom:` didn't help because the SVG itself is
+// cropped) — swap to raising-hands so the whole character shows.
+const ASSET_PEANUT_CHAR = PEANUTMAN_RAISING_HANDS.src
 const ASSET_EYES = Eyes.src
 const ASSET_SPARKLE = Sparkle.src
 const ASSET_CLOUD = Cloud.src
@@ -63,7 +67,7 @@ const TIER_LABEL: Record<TierLevel, string> = {
 const DECO_ASSET: Record<DecorationPlacement['kind'], string> = {
     star: ASSET_STAR,
     thumbsUp: ASSET_HAND_THUMBS,
-    peanutWaving: ASSET_PEANUTMAN_WAVING,
+    peanutChar: ASSET_PEANUT_CHAR,
     eyes: ASSET_EYES,
     sparkle: ASSET_SPARKLE,
     cloud: ASSET_CLOUD,

--- a/src/components/Card/share-asset/ShareAssetD3.tsx
+++ b/src/components/Card/share-asset/ShareAssetD3.tsx
@@ -34,21 +34,23 @@ import {
 } from './shareAssetLayout'
 import type { ShareAssetD3Props, TierLevel } from './shareAsset.types'
 import { TIER_0_BADGE, TIER_1_BADGE, TIER_2_BADGE, TIER_3_BADGE } from '@/assets/badges'
-import { PEANUTMAN_RAISING_HANDS } from '@/assets/peanut'
 import { STAR_STRAIGHT_ICON } from '@/assets/icons'
-import { HandThumbsUp, Eyes, Sparkle, Cloud } from '@/assets/illustrations'
+import { HandThumbsUp, HandThumbsUpV2, Eyes, Sparkle, Cloud, Star } from '@/assets/illustrations'
 import { PixelatedCardFace } from './PixelatedCardFace'
 
 const ASSET_STAR = STAR_STRAIGHT_ICON.src
+const ASSET_STAR_ALT = Star.src
 const ASSET_HAND_THUMBS = HandThumbsUp.src
-// peanut-raising-hands.svg renders the full-body peanut. The
-// peanutman-waving.svg viewBox crops the feet (Hugo flagged it twice;
-// re-anchoring via `bottom:` didn't help because the SVG itself is
-// cropped) — swap to raising-hands so the whole character shows.
-const ASSET_PEANUT_CHAR = PEANUTMAN_RAISING_HANDS.src
+const ASSET_HAND_THUMBS_V2 = HandThumbsUpV2.src
 const ASSET_EYES = Eyes.src
 const ASSET_SPARKLE = Sparkle.src
 const ASSET_CLOUD = Cloud.src
+// Note: peanut character SVGs (peanut-raising-hands, peanutman-waving)
+// both crop the lower body at the source — the art style draws peanuts
+// without feet. Hugo flagged this twice (waving + raising-hands); we
+// dropped the character from the decoration pool rather than ship a
+// "missing feet" rendering. The PEANUTMAN_LOGO icon on the card itself
+// remains the only peanut-character surface on this asset.
 
 const TIER_SVG: Record<TierLevel, string> = {
     0: TIER_0_BADGE,
@@ -66,8 +68,9 @@ const TIER_LABEL: Record<TierLevel, string> = {
 
 const DECO_ASSET: Record<DecorationPlacement['kind'], string> = {
     star: ASSET_STAR,
+    starAlt: ASSET_STAR_ALT,
     thumbsUp: ASSET_HAND_THUMBS,
-    peanutChar: ASSET_PEANUT_CHAR,
+    thumbsUpV2: ASSET_HAND_THUMBS_V2,
     eyes: ASSET_EYES,
     sparkle: ASSET_SPARKLE,
     cloud: ASSET_CLOUD,
@@ -443,39 +446,24 @@ const StampEl: FC<StampElProps> = ({ stamp, animate, delay }) => {
                 />
             )}
             <span className="stamp-issuer">PEANUT</span>
+            {/* Year denomination — dynamic, derived from badge.earnedAt at
+                layout time (see placeStamps in shareAssetLayout.ts). */}
             {stamp.badge.year && <span className="stamp-denom">{stamp.badge.year}</span>}
+            {/* Badge icon fills the stamp. Caption row was dropped (Hugo:
+                "remove the colored subtitle from the stamps, just the
+                badge svg, a bit larger") — icon now uses the full
+                stamp interior below the issuer/year row. */}
             <div
                 className="absolute inset-0 flex items-center justify-center"
-                style={{ paddingTop: '5%', paddingBottom: '15%' }}
+                style={{ paddingTop: '14%', paddingBottom: '6%' }}
             >
                 <img
                     src={stamp.badge.iconUrl}
                     alt=""
                     aria-hidden
-                    style={{ maxWidth: '88%', maxHeight: '70%', objectFit: 'contain' }}
+                    style={{ maxWidth: '94%', maxHeight: '94%', objectFit: 'contain' }}
                 />
             </div>
-            <figcaption
-                className="absolute"
-                style={{
-                    left: 8,
-                    right: 8,
-                    bottom: 10,
-                    textAlign: 'center',
-                    border: '2px solid #000',
-                    background: stamp.badge.captionBg,
-                    fontFamily: 'var(--font-roboto), sans-serif',
-                    fontWeight: 1000,
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.06em',
-                    fontSize: stamp.width >= 170 ? 22 : 18,
-                    padding: '4px 0',
-                    color: '#000',
-                    lineHeight: 1.05,
-                }}
-            >
-                {stamp.badge.caption}
-            </figcaption>
         </figure>
     )
 }

--- a/src/components/Card/share-asset/__tests__/shareAssetLayout.test.ts
+++ b/src/components/Card/share-asset/__tests__/shareAssetLayout.test.ts
@@ -126,18 +126,18 @@ describe('placeStamps', () => {
     })
 
     // Strict non-overlap invariant for the "unique-slot" range (1..6
-     // unique slots in the table). For every count 1..6 and across many
-     // seeds, no two placed stamps' rotation-aware bboxes may touch.
-     //
-     // We use the diagonal sqrt(w² + h²) as a worst-case radius from the
-     // stamp's center. Two stamps "overlap" if the distance between their
-     // centers is less than the sum of their radii. This is conservative
-     // (treats the rotated rect as a circumscribing circle) — if it
-     // passes, the actual rotated rects definitely don't overlap.
-     //
-     // For counts > 6 we deliberately stack (Hugo: "just stack them") so
-     // the invariant does not apply; the layout still stays within canvas
-     // (separate test below).
+    // unique slots in the table). For every count 1..6 and across many
+    // seeds, no two placed stamps' rotation-aware bboxes may touch.
+    //
+    // We use the diagonal sqrt(w² + h²) as a worst-case radius from the
+    // stamp's center. Two stamps "overlap" if the distance between their
+    // centers is less than the sum of their radii. This is conservative
+    // (treats the rotated rect as a circumscribing circle) — if it
+    // passes, the actual rotated rects definitely don't overlap.
+    //
+    // For counts > 6 we deliberately stack (Hugo: "just stack them") so
+    // the invariant does not apply; the layout still stays within canvas
+    // (separate test below).
     it('stamps never overlap for counts 1..6 (any seed)', () => {
         const seeds = ['kkonrad', 'hugo', 'asfsfsf', 'a', 'longusername', '0', 'seed-42', '🥜']
         for (let n = 1; n <= 6; n++) {

--- a/src/components/Card/share-asset/shareAssetLayout.ts
+++ b/src/components/Card/share-asset/shareAssetLayout.ts
@@ -168,7 +168,7 @@ export function placeStamps(badges: ShareAssetBadge[], rng: SeededRandom): Stamp
 // `kind` selects which SVG. PRNG picks which subset to actually render.
 
 interface DecorationCandidate {
-    kind: 'star' | 'starAlt' | 'thumbsUp' | 'thumbsUpV2' | 'eyes' | 'sparkle' | 'cloud'
+    kind: 'star' | 'starAlt' | 'thumbsUp' | 'thumbsUpV2' | 'eyes' | 'sparkle' | 'cloud' | 'peanutChar'
     top?: number
     bottom?: number
     left?: number
@@ -235,10 +235,21 @@ const DECORATION_POOL: readonly DecorationCandidate[] = [
     { kind: 'sparkle', bottom: 220, right: 280, size: 52, rotation: -8, safe: true },
     { kind: 'star', bottom: 60, right: 360, size: 34, rotation: -12, safe: true },
     { kind: 'cloud', bottom: 80, right: 60, size: 56, rotation: 8, safe: true },
+
+    // ── Peanut character — peeks up from BEHIND the card. The peanut
+    //    art style is legless (body tapers to a rounded point), so we
+    //    place him with his bottom inside the card's bbox (y≥254) and
+    //    only the head/arms visible above the card edge. Decorations
+    //    render at z-index 1; the card at z-index 3, with overflow:
+    //    hidden — so the body inside the card region is naturally
+    //    clipped without any extra masking. Two candidate positions
+    //    flanking the centre HERO stamp slot (top:140, left:504).
+    { kind: 'peanutChar', top: 120, left: 320, size: 180, rotation: -6, safe: true },
+    { kind: 'peanutChar', top: 130, left: 760, size: 170, rotation: 8, safe: true },
 ] as const
 
 export interface DecorationPlacement {
-    kind: 'star' | 'starAlt' | 'thumbsUp' | 'thumbsUpV2' | 'eyes' | 'sparkle' | 'cloud'
+    kind: 'star' | 'starAlt' | 'thumbsUp' | 'thumbsUpV2' | 'eyes' | 'sparkle' | 'cloud' | 'peanutChar'
     top?: number
     bottom?: number
     left?: number
@@ -247,21 +258,60 @@ export interface DecorationPlacement {
     rotation: number
 }
 
-/** Pick a handful of decorations from the pool. Pool is curated (stars,
- *  starAlt, thumbsUp, thumbsUpV2, eyes, sparkle, cloud) and stamp-safe.
- *  Pick 12-15 per render so the bigger pool actually fills the canvas;
- *  shuffle order = per-seed variety. */
+/** Axis-aligned bounding-box of a placed decoration in canvas coords.
+ *  Used by the non-overlap check below — treats every decoration as a
+ *  size × size square (conservative; tall assets won't be over-tight). */
+function decorationBbox(d: { top?: number; bottom?: number; left?: number; right?: number; size: number }): {
+    x0: number
+    y0: number
+    x1: number
+    y1: number
+} {
+    const left = d.left ?? CANVAS_W - (d.right ?? 0) - d.size
+    const top = d.top ?? CANVAS_H - (d.bottom ?? 0) - d.size
+    return { x0: left, y0: top, x1: left + d.size, y1: top + d.size }
+}
+
+/** AABB intersection with a small padding so decorations aren't just-not-touching. */
+function bboxesOverlap(
+    a: { x0: number; y0: number; x1: number; y1: number },
+    b: { x0: number; y0: number; x1: number; y1: number },
+    pad = 8
+): boolean {
+    return !(a.x1 + pad < b.x0 || a.x0 - pad > b.x1 || a.y1 + pad < b.y0 || a.y0 - pad > b.y1)
+}
+
+/** Greedy non-overlap placement. Walks the shuffled pool and accepts a
+ *  candidate only if its bbox doesn't intersect any already-placed
+ *  decoration. Target count 12-15; if the pool can't satisfy that
+ *  (collisions), returns whatever fit — never compromises the no-overlap
+ *  invariant. */
 export function placeDecorations(rng: SeededRandom): DecorationPlacement[] {
-    const picked = rng.shuffle([...DECORATION_POOL]).slice(0, rng.int(12, 15))
-    return picked.map((d) => ({
-        kind: d.kind,
-        top: d.top,
-        bottom: d.bottom,
-        left: d.left,
-        right: d.right,
-        size: d.size + rng.float(-4, 4),
-        rotation: d.rotation + rng.float(-6, 6),
-    }))
+    const target = rng.int(12, 15)
+    const shuffled = rng.shuffle([...DECORATION_POOL])
+    const accepted: DecorationPlacement[] = []
+    const acceptedBboxes: ReturnType<typeof decorationBbox>[] = []
+
+    for (const d of shuffled) {
+        if (accepted.length >= target) break
+        const sizeJitter = rng.float(-4, 4)
+        const rotJitter = rng.float(-6, 6)
+        const placement: DecorationPlacement = {
+            kind: d.kind,
+            top: d.top,
+            bottom: d.bottom,
+            left: d.left,
+            right: d.right,
+            size: d.size + sizeJitter,
+            rotation: d.rotation + rotJitter,
+        }
+        const bbox = decorationBbox(placement)
+        const collides = acceptedBboxes.some((other) => bboxesOverlap(bbox, other))
+        if (collides) continue
+        accepted.push(placement)
+        acceptedBboxes.push(bbox)
+    }
+    return accepted
 }
 
 // ─── Stats inline block ─────────────────────────────────────────────────

--- a/src/components/Card/share-asset/shareAssetLayout.ts
+++ b/src/components/Card/share-asset/shareAssetLayout.ts
@@ -168,7 +168,7 @@ export function placeStamps(badges: ShareAssetBadge[], rng: SeededRandom): Stamp
 // `kind` selects which SVG. PRNG picks which subset to actually render.
 
 interface DecorationCandidate {
-    kind: 'star' | 'thumbsUp' | 'peanutWaving' | 'eyes' | 'sparkle' | 'cloud'
+    kind: 'star' | 'thumbsUp' | 'peanutChar' | 'eyes' | 'sparkle' | 'cloud'
     top?: number
     bottom?: number
     left?: number
@@ -180,15 +180,11 @@ interface DecorationCandidate {
     safe: boolean
 }
 
-// Decoration pool. Peanut characters (peanutWaving / peanutHands) were
-// dropped from the default set — their large native size (140px) made
-// them collide with stamp slots at the right and bottom-left, which
-// then hid stamps underneath. Stars and thumbsUp are small enough to
-// tuck into gaps without competing with stamp positions.
-//
-// `peanutWaving` + `peanutHands` are still in the type union so we can
-// re-introduce them in low-stamp-count layouts later if design wants
-// the character vibe back.
+// Decoration pool. `peanutChar` is now backed by the raising-hands
+// asset (peanut-raising-hands.svg) — peanutman-waving.svg has a viewBox
+// that crops the feet, which Hugo flagged twice; raising-hands renders
+// the full body. Bottom-anchored via `bottom:` to keep feet clear of
+// the canvas edge regardless of natural aspect ratio.
 const DECORATION_POOL: readonly DecorationCandidate[] = [
     // Top strip — between EDITION block (left) and EARNED stamp (right)
     { kind: 'star', top: 36, left: 380, size: 72, rotation: 8, safe: true },
@@ -212,7 +208,7 @@ const DECORATION_POOL: readonly DecorationCandidate[] = [
     // taller than nominal (Hugo flagged this getting clipped at the
     // bottom). bottom:148 + size:96 leaves a comfortable gutter to the
     // pill region (y≥770).
-    { kind: 'peanutWaving', bottom: 220, left: 200, size: 96, rotation: -6, safe: true },
+    { kind: 'peanutChar', bottom: 220, left: 200, size: 96, rotation: -6, safe: true },
     // Bottom strip — between card-bottom (y=645) and username pill
     // (y≥770). Pill x range ~[400..800] worst case; keep decorations
     // in the gutters left of x=380 and right of x=820.
@@ -223,7 +219,7 @@ const DECORATION_POOL: readonly DecorationCandidate[] = [
 ] as const
 
 export interface DecorationPlacement {
-    kind: 'star' | 'thumbsUp' | 'peanutWaving' | 'eyes' | 'sparkle' | 'cloud'
+    kind: 'star' | 'thumbsUp' | 'peanutChar' | 'eyes' | 'sparkle' | 'cloud'
     top?: number
     bottom?: number
     left?: number

--- a/src/components/Card/share-asset/shareAssetLayout.ts
+++ b/src/components/Card/share-asset/shareAssetLayout.ts
@@ -196,20 +196,30 @@ const DECORATION_POOL: readonly DecorationCandidate[] = [
     { kind: 'thumbsUp', top: 56, left: 232, size: 92, rotation: -10, safe: true },
     { kind: 'eyes', top: 28, left: 580, size: 48, rotation: 6, safe: true },
     { kind: 'cloud', top: 16, left: 880, size: 64, rotation: -4, safe: true },
+    // Additional top sprinkles in the negative-space band above the card.
+    { kind: 'star', top: 100, left: 100, size: 36, rotation: -22, safe: true },
+    { kind: 'sparkle', top: 130, left: 980, size: 40, rotation: 18, safe: true },
     // Mid-right gap between slot 3 (y≤396) and slot 5 (y≥470)
     { kind: 'star', top: 410, right: 30, size: 44, rotation: 45, safe: true },
     { kind: 'sparkle', top: 420, right: 140, size: 42, rotation: -10, safe: true },
-    // Mid-left gap between slot 4 (y≤612) and slot 2 (y≥710). Small
-    // peanut character + a star. peanutWaving is the full-body asset
-    // — peanut-pfp.svg's viewBox crops the lower body so it can't be
-    // used as a small floater here (the SVG itself renders truncated).
-    { kind: 'peanutWaving', top: 640, left: 220, size: 64, rotation: -6, safe: true },
+    // Mid-left gap (between tier block bottom and stamps) + mid-right
+    // accents in the canvas margin outside the card's left/right edges.
+    { kind: 'cloud', top: 380, left: 26, size: 48, rotation: 10, safe: true },
+    { kind: 'eyes', top: 540, right: 220, size: 38, rotation: 22, safe: true },
     { kind: 'star', top: 650, left: 340, size: 40, rotation: 18, safe: true },
-    // Bottom-center between card-bottom (y=645) and username pill (y≥770).
-    // Pill x range ~[400..800] worst case; keep these in the gutters.
+    // Mid-left peanut character — anchored to BOTTOM so its feet stay
+    // clear of the canvas edge even if the SVG aspect ratio renders
+    // taller than nominal (Hugo flagged this getting clipped at the
+    // bottom). bottom:148 + size:96 leaves a comfortable gutter to the
+    // pill region (y≥770).
+    { kind: 'peanutWaving', bottom: 220, left: 200, size: 96, rotation: -6, safe: true },
+    // Bottom strip — between card-bottom (y=645) and username pill
+    // (y≥770). Pill x range ~[400..800] worst case; keep decorations
+    // in the gutters left of x=380 and right of x=820.
     { kind: 'sparkle', bottom: 220, right: 280, size: 52, rotation: -8, safe: true },
-    { kind: 'star', bottom: 110, left: 350, size: 40, rotation: 22, safe: true },
-    { kind: 'eyes', bottom: 150, right: 260, size: 48, rotation: -14, safe: true },
+    { kind: 'star', bottom: 110, left: 60, size: 40, rotation: 22, safe: true },
+    { kind: 'star', bottom: 60, right: 360, size: 34, rotation: -12, safe: true },
+    { kind: 'cloud', bottom: 80, right: 60, size: 56, rotation: 8, safe: true },
 ] as const
 
 export interface DecorationPlacement {
@@ -224,9 +234,10 @@ export interface DecorationPlacement {
 
 /** Pick a handful of decorations from the pool. Pool is curated (stars,
  *  thumbsUp, eyes, sparkle, cloud, mini peanut) and stamp-safe, so we
- *  just shuffle and take 6-8 to fill the canvas margins. */
+ *  just shuffle and take 8-11 to fill the canvas margins (bumped from
+ *  6-8 now that the pool grew). */
 export function placeDecorations(rng: SeededRandom): DecorationPlacement[] {
-    const picked = rng.shuffle([...DECORATION_POOL]).slice(0, rng.int(6, 8))
+    const picked = rng.shuffle([...DECORATION_POOL]).slice(0, rng.int(8, 11))
     return picked.map((d) => ({
         kind: d.kind,
         top: d.top,

--- a/src/components/Card/share-asset/shareAssetLayout.ts
+++ b/src/components/Card/share-asset/shareAssetLayout.ts
@@ -168,7 +168,7 @@ export function placeStamps(badges: ShareAssetBadge[], rng: SeededRandom): Stamp
 // `kind` selects which SVG. PRNG picks which subset to actually render.
 
 interface DecorationCandidate {
-    kind: 'star' | 'thumbsUp' | 'peanutChar' | 'eyes' | 'sparkle' | 'cloud'
+    kind: 'star' | 'starAlt' | 'thumbsUp' | 'thumbsUpV2' | 'eyes' | 'sparkle' | 'cloud'
     top?: number
     bottom?: number
     left?: number
@@ -180,46 +180,65 @@ interface DecorationCandidate {
     safe: boolean
 }
 
-// Decoration pool. `peanutChar` is now backed by the raising-hands
-// asset (peanut-raising-hands.svg) — peanutman-waving.svg has a viewBox
-// that crops the feet, which Hugo flagged twice; raising-hands renders
-// the full body. Bottom-anchored via `bottom:` to keep feet clear of
-// the canvas edge regardless of natural aspect ratio.
+// Decoration pool. No peanut characters — both peanut-raising-hands.svg
+// and peanutman-waving.svg crop the lower body at the SVG source (it's
+// the art style, not a bug we can fix). The pool sticks to stars,
+// sparkles, eyes, clouds, and thumbs-up so every decoration renders
+// fully formed.
+//
+// Layout-zone map on the 1200×900 canvas:
+//   - EARNED stamp:          x[920..1200], y[20..200]    (top-right)
+//   - EDITION + tier block:  x[20..360],   y[20..460]    (left band)
+//   - @username pill:        x[400..1144], y[770..900]   (bottom-right)
+//   - Card bbox:             x[264..884],  y[254..645]   (centre)
+//   - Stamp slots:           see STAMP_SLOTS above
+// All slots below sit OUTSIDE the chrome zones AND outside stamp slots.
 const DECORATION_POOL: readonly DecorationCandidate[] = [
-    // Top strip — between EDITION block (left) and EARNED stamp (right)
+    // ── Top strip (y=16..160) — above the card, between EDITION left and
+    //    EARNED right. Two natural columns left/right of the centre stamp.
+    { kind: 'cloud', top: 16, left: 880, size: 64, rotation: -4, safe: true },
     { kind: 'star', top: 36, left: 380, size: 72, rotation: 8, safe: true },
     { kind: 'sparkle', top: 52, left: 720, size: 56, rotation: -12, safe: true },
     { kind: 'thumbsUp', top: 56, left: 232, size: 92, rotation: -10, safe: true },
+    { kind: 'thumbsUpV2', top: 80, left: 700, size: 76, rotation: 12, safe: true },
     { kind: 'eyes', top: 28, left: 580, size: 48, rotation: 6, safe: true },
-    { kind: 'cloud', top: 16, left: 880, size: 64, rotation: -4, safe: true },
-    // Additional top sprinkles in the negative-space band above the card.
-    { kind: 'star', top: 100, left: 100, size: 36, rotation: -22, safe: true },
     { kind: 'sparkle', top: 130, left: 980, size: 40, rotation: 18, safe: true },
-    // Mid-right gap between slot 3 (y≤396) and slot 5 (y≥470)
+    { kind: 'starAlt', top: 110, left: 320, size: 52, rotation: -20, safe: true },
+
+    // ── Top-LEFT quadrant (Hugo flagged this as empty) — fits between
+    //    the EDITION header (y<120) and the tier block (y>158, x<360).
+    //    Tight space; small accents only.
+    { kind: 'star', top: 14, left: 56, size: 32, rotation: 22, safe: true },
+    { kind: 'sparkle', top: 8, left: 460, size: 36, rotation: -16, safe: true },
+    { kind: 'eyes', top: 130, left: 180, size: 36, rotation: 14, safe: true },
+
+    // ── Mid-right gap between stamp slot 3 (y≤396) and slot 5 (y≥470).
     { kind: 'star', top: 410, right: 30, size: 44, rotation: 45, safe: true },
     { kind: 'sparkle', top: 420, right: 140, size: 42, rotation: -10, safe: true },
-    // Mid-left gap (between tier block bottom and stamps) + mid-right
-    // accents in the canvas margin outside the card's left/right edges.
+
+    // ── Mid-left / mid-right margins outside the card.
     { kind: 'cloud', top: 380, left: 26, size: 48, rotation: 10, safe: true },
     { kind: 'eyes', top: 540, right: 220, size: 38, rotation: 22, safe: true },
-    { kind: 'star', top: 650, left: 340, size: 40, rotation: 18, safe: true },
-    // Mid-left peanut character — anchored to BOTTOM so its feet stay
-    // clear of the canvas edge even if the SVG aspect ratio renders
-    // taller than nominal (Hugo flagged this getting clipped at the
-    // bottom). bottom:148 + size:96 leaves a comfortable gutter to the
-    // pill region (y≥770).
-    { kind: 'peanutChar', bottom: 220, left: 200, size: 96, rotation: -6, safe: true },
-    // Bottom strip — between card-bottom (y=645) and username pill
-    // (y≥770). Pill x range ~[400..800] worst case; keep decorations
-    // in the gutters left of x=380 and right of x=820.
+    { kind: 'starAlt', top: 480, right: 200, size: 44, rotation: -8, safe: true },
+
+    // ── Bottom-CENTRE (Hugo flagged this as empty) — between card-bottom
+    //    (y=645) and the username pill top (y≥770). The pill ends at
+    //    x≈400 worst case, so anything in x[120..380] is safely in the
+    //    gutter to the LEFT of the pill.
+    { kind: 'star', top: 660, left: 200, size: 44, rotation: -14, safe: true },
+    { kind: 'sparkle', top: 700, left: 320, size: 48, rotation: 18, safe: true },
+    { kind: 'eyes', top: 670, left: 60, size: 40, rotation: -6, safe: true },
+    { kind: 'thumbsUpV2', top: 690, left: 130, size: 64, rotation: 8, safe: true },
+
+    // ── Lower-right (small sprinkles between EARNED-zone clear point and
+    //    the pill's top edge at y≈770).
     { kind: 'sparkle', bottom: 220, right: 280, size: 52, rotation: -8, safe: true },
-    { kind: 'star', bottom: 110, left: 60, size: 40, rotation: 22, safe: true },
     { kind: 'star', bottom: 60, right: 360, size: 34, rotation: -12, safe: true },
     { kind: 'cloud', bottom: 80, right: 60, size: 56, rotation: 8, safe: true },
 ] as const
 
 export interface DecorationPlacement {
-    kind: 'star' | 'thumbsUp' | 'peanutChar' | 'eyes' | 'sparkle' | 'cloud'
+    kind: 'star' | 'starAlt' | 'thumbsUp' | 'thumbsUpV2' | 'eyes' | 'sparkle' | 'cloud'
     top?: number
     bottom?: number
     left?: number
@@ -229,11 +248,11 @@ export interface DecorationPlacement {
 }
 
 /** Pick a handful of decorations from the pool. Pool is curated (stars,
- *  thumbsUp, eyes, sparkle, cloud, mini peanut) and stamp-safe, so we
- *  just shuffle and take 8-11 to fill the canvas margins (bumped from
- *  6-8 now that the pool grew). */
+ *  starAlt, thumbsUp, thumbsUpV2, eyes, sparkle, cloud) and stamp-safe.
+ *  Pick 12-15 per render so the bigger pool actually fills the canvas;
+ *  shuffle order = per-seed variety. */
 export function placeDecorations(rng: SeededRandom): DecorationPlacement[] {
-    const picked = rng.shuffle([...DECORATION_POOL]).slice(0, rng.int(8, 11))
+    const picked = rng.shuffle([...DECORATION_POOL]).slice(0, rng.int(12, 15))
     return picked.map((d) => ({
         kind: d.kind,
         top: d.top,

--- a/src/components/Home/HomeHistory.tsx
+++ b/src/components/Home/HomeHistory.tsx
@@ -147,9 +147,7 @@ const HomeHistory = ({
             // Process entries asynchronously to handle completeHistoryEntry
             const processEntries = async () => {
                 // Start with the fetched entries
-                const entries: Array<HistoryEntry | KycHistoryEntry | CardUnlockHistoryEntry> = [
-                    ...historyData.entries,
-                ]
+                const entries: Array<HistoryEntry | KycHistoryEntry | CardUnlockHistoryEntry> = [...historyData.entries]
 
                 // inject badge entries using user's badges (newest first) and earnedAt chronology
                 // filter out beta tester badge — it creates confusing first impressions for new users

--- a/src/types/api.generated.ts
+++ b/src/types/api.generated.ts
@@ -4824,6 +4824,77 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/card-waitlist/release": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Release users from the card waitlist */
+        post: {
+            parameters: {
+                query?: never;
+                header: {
+                    "x-admin-token": string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        userIds: string[];
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            released: string[];
+                            skipped: string[];
+                        };
+                    };
+                };
+                /** @description Default Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/points": {
         parameters: {
             query?: never;
@@ -5733,8 +5804,8 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get card pioneer info
-         * @description Get the authenticated user's card pioneer status and eligibility
+         * Get card info + waitlist state
+         * @description Returns the authenticated user's card flow access, eligibility, waitlist state, and skip-badge holdings.
          */
         get: {
             parameters: {
@@ -5754,17 +5825,14 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
-                            hasPurchased: boolean;
                             hasCardAccess: boolean;
-                            chargeStatus?: string;
-                            chargeUuid?: string;
-                            paymentUrl?: string;
                             isEligible: boolean;
                             eligibilityReason?: string;
-                            price: number;
-                            currentTier: number;
-                            slotsRemaining: number;
-                            recentPurchases: number;
+                            flowEarlyAccess: boolean;
+                            waitlistJoinedAt: string | null;
+                            waitlistPosition: number | null;
+                            waitlistReleasedAt: string | null;
+                            skipBadges: string[];
                         };
                     };
                 };
@@ -5790,7 +5858,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/card/purchase": {
+    "/card/waitlist/join": {
         parameters: {
             query?: never;
             header?: never;
@@ -5799,16 +5867,11 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /**
-         * Purchase card pioneer status
-         * @description Creates a charge for purchasing Card Pioneer status
-         */
+        /** Join the virtual-card waitlist */
         post: {
             parameters: {
                 query?: never;
-                header: {
-                    Authorization: string;
-                };
+                header?: never;
                 path?: never;
                 cookie?: never;
             };
@@ -5821,35 +5884,13 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
-                            chargeUuid: string;
-                            paymentUrl: string;
-                            price: number;
-                            recipientAddress: string;
-                            chainId: string;
-                            tokenAmount: string;
-                            tokenSymbol: string;
+                            joinedAt: string;
+                            position: number | null;
                         };
                     };
                 };
                 /** @description Default Response */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            chargeUuid: string;
-                            paymentUrl: string;
-                            price: number;
-                            recipientAddress: string;
-                            chainId: string;
-                            tokenAmount: string;
-                            tokenSymbol: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                400: {
+                403: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -5861,7 +5902,7 @@ export interface paths {
                     };
                 };
                 /** @description Default Response */
-                409: {
+                500: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -5869,7 +5910,108 @@ export interface paths {
                         "application/json": {
                             error: string;
                             message: string;
-                            chargeUuid?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/card/waitlist/state": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get the user’s current waitlist state */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            joinedAt: string | null;
+                            position: number | null;
+                            releasedAt: string | null;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/card/flow-early-access": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Grant the user early access to the /card flow (via /shhhhh) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            grantedAt: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                            message: string;
                         };
                     };
                 };
@@ -7045,41 +7187,6 @@ export interface paths {
                 };
                 header?: never;
                 path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/ws/charges/{username}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    username: string;
-                };
                 cookie?: never;
             };
             requestBody?: never;
@@ -8389,6 +8496,156 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/dev/cheats/grant-badge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        userId: string;
+                        code: "BETA_TESTER" | "DEVCONNECT_BA_2025" | "PRODUCT_HUNT" | "OG_2025_10_12" | "SEEDLING_DEVCONNECT_BA_2025" | "ARBIVERSE_DEVCONNECT_BA_2025" | "CARD_PIONEER" | "FOUNDER_HOUSE" | "SUPPORT_SURVIVOR";
+                        revoke?: boolean;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: true;
+                            userId: string;
+                            code: string;
+                            granted: boolean;
+                            earnedAt: string | null;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dev/cheats/reset-card": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        userId: string;
+                        /** @description If true, leave card_access_granted_at intact; only clear the card rows. */
+                        keepCardAccess?: boolean;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: true;
+                            deletedCards: number;
+                            cardAccessGrantedAt: string | null;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/dev/cheats/simulate-bridge-deposit": {
         parameters: {
             query?: never;
@@ -9517,6 +9774,467 @@ export interface paths {
                 };
             };
         };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dev/cheats/join-card-waitlist": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        userId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: true;
+                            joinedAt: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dev/cheats/release-from-waitlist": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        userId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: true;
+                            releasedAt: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dev/cheats/grant-flow-early-access": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        userId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: true;
+                            grantedAt: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dev/cheats/clear-skip-celebration": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        userId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: true;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dev/cheats/hit-activation-threshold": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        userId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: true;
+                            syntheticIntentId: string;
+                            note: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dev/cheats/reset-card-waitlist": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        userId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: true;
+                            deletedPerkUsages: number;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: false;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: false;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/ws/charges/{username}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    username: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;

--- a/src/types/api.openapi.json
+++ b/src/types/api.openapi.json
@@ -1,13837 +1,13089 @@
 {
-  "openapi": "3.0.3",
-  "info": {
-    "title": "peanut-api",
-    "version": "1.0.0"
-  },
-  "components": {
-    "schemas": {}
-  },
-  "paths": {
-    "/": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/test-error": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/apple-app-site-association": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/assetLinks.json": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/claim": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "chainId": {
-                    "pattern": "^[0-9]+$",
-                    "type": "string"
-                  },
-                  "version": {
-                    "default": "v4.3",
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "v4.3"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "v4.4"
-                        ]
-                      }
-                    ]
-                  },
-                  "claimParams": {
-                    "minItems": 3,
-                    "type": "array",
-                    "items": {}
-                  },
-                  "withMFA": {
-                    "default": false,
-                    "type": "boolean"
-                  },
-                  "depositDetails": {
-                    "type": "object",
-                    "properties": {
-                      "pubKey20": {
-                        "type": "string"
-                      },
-                      "amount": {
-                        "type": "string"
-                      },
-                      "tokenAddress": {
-                        "type": "string"
-                      },
-                      "contractType": {
-                        "type": "number"
-                      },
-                      "claimed": {
-                        "type": "boolean"
-                      },
-                      "requiresMFA": {
-                        "type": "boolean"
-                      },
-                      "timestamp": {
-                        "type": "number"
-                      },
-                      "tokenId": {
-                        "type": "string"
-                      },
-                      "senderAddress": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "pubKey20",
-                      "amount",
-                      "tokenAddress",
-                      "contractType",
-                      "claimed",
-                      "requiresMFA",
-                      "timestamp",
-                      "tokenId",
-                      "senderAddress"
-                    ]
-                  },
-                  "optimisticReturn": {
-                    "type": "boolean"
-                  },
-                  "campaignTag": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "chainId",
-                  "claimParams"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/healthz": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/ens/{ensName}": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "ensName",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/add-account": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "accountIdentifier": {
-                    "type": "string"
-                  },
-                  "accountType": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "iban"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "us"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "evm-address"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "peanut-wallet"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "bridgeBankAccount"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "manteca"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "simplefi-merchant"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "clabe"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "cbu"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "cvu"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "pix"
-                        ]
-                      }
-                    ]
-                  },
-                  "userId": {
-                    "type": "string"
-                  },
-                  "bridgeAccountIdentifier": {
-                    "type": "string"
-                  },
-                  "chainId": {
-                    "type": "string"
-                  },
-                  "telegramHandle": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "accountIdentifier",
-                  "accountType",
-                  "userId"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/users/username/{username}": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "username",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/get-user": {
-      "post": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/get-user-id": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "accountIdentifier": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "accountIdentifier"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/get-user-salt": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "email": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "email"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/update-user": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "userId": {
-                    "type": "string"
-                  },
-                  "username": {
-                    "type": "string"
-                  },
-                  "email": {
-                    "type": "string"
-                  },
-                  "fullName": {
-                    "type": "string"
-                  },
-                  "bridge_customer_id": {
-                    "type": "string"
-                  },
-                  "telegramUsername": {
-                    "type": "string"
-                  },
-                  "pushSubscriptionId": {
-                    "type": "string"
-                  },
-                  "showFullName": {
-                    "type": "boolean"
-                  },
-                  "hasSeenEarlyUserModal": {
-                    "type": "boolean"
-                  },
-                  "bridgeKycStatus": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "not_started"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "incomplete"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "under_review"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "approved"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "rejected"
-                        ]
-                      }
-                    ]
-                  },
-                  "showKycCompletedModal": {
-                    "type": "boolean"
-                  }
-                },
-                "required": [
-                  "userId"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/users/contacts": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "limit",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "offset",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "search",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/users/history": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "cursor",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "number"
-            },
-            "in": "query",
-            "name": "limit",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "targetUsername",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/users/track-transaction": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "payerAddress": {
-                    "type": "string"
-                  },
-                  "txHash": {
-                    "type": "string"
-                  },
-                  "sourceChainId": {
-                    "type": "string"
-                  },
-                  "sourceTokenAddress": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/history/{entryId}": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "kind",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "entryId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/api/users/{userId}/acknowledgments": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "userId",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/users/search": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/users/initiate-kyc": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/users/accounts": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "accountType": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "iban"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "us"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "clabe"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "gb"
-                        ]
-                      }
-                    ]
-                  },
-                  "accountNumber": {
-                    "type": "string"
-                  },
-                  "countryCode": {
-                    "type": "string"
-                  },
-                  "countryName": {
-                    "type": "string"
-                  },
-                  "accountOwnerType": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "individual"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "business"
-                        ]
-                      }
-                    ]
-                  },
-                  "accountOwnerName": {
-                    "type": "object",
-                    "properties": {
-                      "firstName": {
-                        "type": "string"
-                      },
-                      "lastName": {
-                        "type": "string"
-                      },
-                      "businessName": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "address": {
-                    "type": "object",
-                    "properties": {
-                      "street": {
-                        "type": "string"
-                      },
-                      "city": {
-                        "type": "string"
-                      },
-                      "country": {
-                        "type": "string"
-                      },
-                      "state": {
-                        "type": "string"
-                      },
-                      "postalCode": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "street",
-                      "city",
-                      "country",
-                      "postalCode"
-                    ]
-                  },
-                  "bic": {
-                    "type": "string"
-                  },
-                  "routingNumber": {
-                    "type": "string"
-                  },
-                  "sortCode": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "accountType",
-                  "accountNumber",
-                  "countryCode",
-                  "countryName",
-                  "accountOwnerType",
-                  "accountOwnerName",
-                  "address"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/users/{userId}": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "userId",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/users/interaction-status": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "userIds": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "required": [
-                  "userIds"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/users/limits": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/users/increase-limits": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/users/rails": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      },
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/users/bridge-tos-link": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/users/bridge-tos-confirm": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "additionalProperties": true
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/validate-bank-account-number": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "bankAccountNumber": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "bankAccountNumber"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/validate-bank-account": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/validate-bank-number": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/validate-bic": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "bic": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "bic"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/is-valid-bic": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "bic": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "bic"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/passkeys/register/options": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "username": {
-                    "type": "string"
-                  },
-                  "rpID": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "username"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/passkeys/register/verify": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "userId": {
-                    "type": "string"
-                  },
-                  "username": {
-                    "type": "string"
-                  },
-                  "cred": {},
-                  "rpID": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "userId",
-                  "username",
-                  "cred"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/passkeys/login/options": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "rpID": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/passkeys/login/verify": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "cred": {},
-                  "rpID": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "cred"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/requests": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "anyOf": [
-                  {
-                    "additionalProperties": false,
-                    "type": "object",
-                    "properties": {
-                      "chainId": {
-                        "type": "string"
-                      },
-                      "tokenAmount": {
-                        "type": "string"
-                      },
-                      "recipientAddress": {
-                        "type": "string"
-                      },
-                      "trackId": {
-                        "type": "string"
-                      },
-                      "reference": {
-                        "type": "string"
-                      },
-                      "tokenType": {
-                        "not": {}
-                      },
-                      "tokenAddress": {
-                        "not": {}
-                      },
-                      "tokenDecimals": {
-                        "not": {}
-                      },
-                      "tokenSymbol": {
-                        "not": {}
-                      }
-                    },
-                    "required": [
-                      "recipientAddress"
-                    ]
-                  },
-                  {
-                    "additionalProperties": false,
-                    "type": "object",
-                    "properties": {
-                      "chainId": {
-                        "type": "string"
-                      },
-                      "tokenAmount": {
-                        "type": "string"
-                      },
-                      "recipientAddress": {
-                        "type": "string"
-                      },
-                      "trackId": {
-                        "type": "string"
-                      },
-                      "reference": {
-                        "type": "string"
-                      },
-                      "tokenType": {
-                        "type": "string"
-                      },
-                      "tokenAddress": {
-                        "type": "string",
-                        "pattern": "^0x[a-fA-F0-9]{40}$"
-                      },
-                      "tokenDecimals": {
-                        "type": "string"
-                      },
-                      "tokenSymbol": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "chainId",
-                      "recipientAddress",
-                      "tokenType",
-                      "tokenAddress",
-                      "tokenDecimals",
-                      "tokenSymbol"
-                    ]
-                  }
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      },
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "recipient",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "tokenAmount",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "tokenAddress",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "chainId",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/requests/{uuid}": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "uuid",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      },
-      "patch": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "additionalProperties": false,
-                "type": "object",
-                "properties": {
-                  "chainId": {
-                    "type": "string"
-                  },
-                  "tokenAmount": {
-                    "type": "string"
-                  },
-                  "recipientAddress": {
-                    "type": "string"
-                  },
-                  "trackId": {
-                    "type": "string"
-                  },
-                  "reference": {
-                    "type": "string"
-                  },
-                  "tokenAddress": {
-                    "type": "string",
-                    "pattern": "^0x[a-fA-F0-9]{40}$"
-                  },
-                  "tokenDecimals": {
-                    "type": "string"
-                  },
-                  "tokenType": {
-                    "type": "string"
-                  },
-                  "tokenSymbol": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "uuid",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      },
-      "delete": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "uuid",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/charges": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "anyOf": [
-                  {
-                    "type": "object",
-                    "allOf": [
-                      {
-                        "type": "object",
-                        "properties": {
-                          "pricing_type": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "fixed_price"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "no_price"
-                                ]
-                              }
-                            ]
-                          },
-                          "local_price": {
-                            "type": "object",
-                            "properties": {
-                              "amount": {
-                                "type": "string"
-                              },
-                              "currency": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "amount"
-                            ]
-                          },
-                          "baseUrl": {
-                            "type": "string"
-                          },
-                          "reference": {
-                            "type": "string"
-                          },
-                          "transactionType": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "REQUEST"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "DIRECT_SEND"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "SEND_LINK"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "DEPOSIT"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "WITHDRAW"
-                                ]
-                              }
-                            ]
-                          },
-                          "attachment": {},
-                          "mimetype": {
-                            "type": "string"
-                          },
-                          "filename": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "pricing_type",
-                          "local_price"
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "checkout_id": {
-                            "type": "string"
-                          },
-                          "requestId": {
-                            "not": {}
-                          },
-                          "requestProps": {
-                            "type": "object",
-                            "properties": {
-                              "chainId": {
-                                "type": "string"
-                              },
-                              "tokenAddress": {
-                                "type": "string"
-                              },
-                              "tokenType": {
-                                "type": "string"
-                              },
-                              "tokenSymbol": {
-                                "type": "string"
-                              },
-                              "tokenDecimals": {
-                                "type": "integer"
-                              },
-                              "recipientAddress": {
-                                "type": "string"
-                              },
-                              "requesteeUsername": {
-                                "type": "string"
-                              },
-                              "tokenAmount": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        },
-                        "required": [
-                          "checkout_id"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "type": "object",
-                    "allOf": [
-                      {
-                        "type": "object",
-                        "properties": {
-                          "pricing_type": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "fixed_price"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "no_price"
-                                ]
-                              }
-                            ]
-                          },
-                          "local_price": {
-                            "type": "object",
-                            "properties": {
-                              "amount": {
-                                "type": "string"
-                              },
-                              "currency": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "amount"
-                            ]
-                          },
-                          "baseUrl": {
-                            "type": "string"
-                          },
-                          "reference": {
-                            "type": "string"
-                          },
-                          "transactionType": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "REQUEST"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "DIRECT_SEND"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "SEND_LINK"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "DEPOSIT"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "WITHDRAW"
-                                ]
-                              }
-                            ]
-                          },
-                          "attachment": {},
-                          "mimetype": {
-                            "type": "string"
-                          },
-                          "filename": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "pricing_type",
-                          "local_price"
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "checkout_id": {
-                            "not": {}
-                          },
-                          "requestId": {
-                            "type": "string"
-                          },
-                          "requestProps": {
-                            "type": "object",
-                            "properties": {
-                              "chainId": {
-                                "type": "string"
-                              },
-                              "tokenAddress": {
-                                "type": "string"
-                              },
-                              "tokenType": {
-                                "type": "string"
-                              },
-                              "tokenSymbol": {
-                                "type": "string"
-                              },
-                              "tokenDecimals": {
-                                "type": "integer"
-                              },
-                              "recipientAddress": {
-                                "type": "string"
-                              },
-                              "requesteeUsername": {
-                                "type": "string"
-                              },
-                              "tokenAmount": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        },
-                        "required": [
-                          "requestId"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "type": "object",
-                    "allOf": [
-                      {
-                        "type": "object",
-                        "properties": {
-                          "pricing_type": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "fixed_price"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "no_price"
-                                ]
-                              }
-                            ]
-                          },
-                          "local_price": {
-                            "type": "object",
-                            "properties": {
-                              "amount": {
-                                "type": "string"
-                              },
-                              "currency": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "amount"
-                            ]
-                          },
-                          "baseUrl": {
-                            "type": "string"
-                          },
-                          "reference": {
-                            "type": "string"
-                          },
-                          "transactionType": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "REQUEST"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "DIRECT_SEND"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "SEND_LINK"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "DEPOSIT"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "WITHDRAW"
-                                ]
-                              }
-                            ]
-                          },
-                          "attachment": {},
-                          "mimetype": {
-                            "type": "string"
-                          },
-                          "filename": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "pricing_type",
-                          "local_price"
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "checkout_id": {
-                            "not": {}
-                          },
-                          "requestId": {
-                            "not": {}
-                          },
-                          "requestProps": {
-                            "type": "object",
-                            "properties": {
-                              "chainId": {
-                                "type": "string"
-                              },
-                              "tokenAddress": {
-                                "type": "string"
-                              },
-                              "tokenType": {
-                                "type": "string"
-                              },
-                              "tokenSymbol": {
-                                "type": "string"
-                              },
-                              "tokenDecimals": {
-                                "type": "integer"
-                              },
-                              "recipientAddress": {
-                                "type": "string"
-                              },
-                              "requesteeUsername": {
-                                "type": "string"
-                              },
-                              "tokenAmount": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "chainId",
-                              "tokenAddress",
-                              "tokenType",
-                              "tokenSymbol",
-                              "tokenDecimals",
-                              "recipientAddress"
-                            ]
-                          }
-                        },
-                        "required": [
-                          "requestProps"
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      },
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "minimum": 1,
-              "maximum": 100,
-              "default": 25,
-              "type": "number"
-            },
-            "in": "query",
-            "name": "limit",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "starting_after",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "ending_before",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "status",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/charges/{uuid}/payments": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "hash": {
-                    "type": "string"
-                  },
-                  "chainId": {
-                    "type": "string"
-                  },
-                  "tokenAddress": {
-                    "type": "string"
-                  },
-                  "payerAddress": {
-                    "type": "string"
-                  },
-                  "sourceChainId": {
-                    "type": "string"
-                  },
-                  "sourceTokenAddress": {
-                    "type": "string"
-                  },
-                  "sourceTokenSymbol": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "hash",
-                  "chainId",
-                  "tokenAddress",
-                  "payerAddress"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "uuid",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/charges/{chargeId}": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "chargeId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      },
-      "delete": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "chargeId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/request-charges/{uuid}": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "uuid",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/direct-send": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "recipientAddress": {
-                    "pattern": "^0x[a-fA-F0-9]{40}$",
-                    "type": "string"
-                  },
-                  "chainId": {
-                    "type": "string"
-                  },
-                  "tokenAddress": {
-                    "pattern": "^0x[a-fA-F0-9]{40}$",
-                    "type": "string"
-                  },
-                  "tokenAmount": {
-                    "pattern": "^(0|[1-9]\\d*)(\\.\\d+)?$",
-                    "type": "string"
-                  },
-                  "tokenDecimals": {
-                    "minimum": 0,
-                    "maximum": 36,
-                    "type": "integer"
-                  },
-                  "tokenSymbol": {
-                    "type": "string"
-                  },
-                  "tokenType": {
-                    "type": "string"
-                  },
-                  "hash": {
-                    "pattern": "^0x[a-fA-F0-9]{64}$",
-                    "type": "string"
-                  },
-                  "payerAddress": {
-                    "pattern": "^0x[a-fA-F0-9]{40}$",
-                    "type": "string"
-                  },
-                  "memo": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "recipientAddress",
-                  "chainId",
-                  "tokenAddress",
-                  "tokenAmount",
-                  "tokenDecimals",
-                  "hash",
-                  "payerAddress"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/send-links": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      },
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "c",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "number"
-            },
-            "in": "query",
-            "name": "i",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "v",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/send-links/{pubKey}": {
-      "patch": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "pubKey",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      },
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "c",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "number"
-            },
-            "in": "query",
-            "name": "i",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "v",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "pubKey",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/send-links/claim/{txHash}/associate-user": {
-      "patch": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "txHash",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/bridge/webhooks": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/bridge/customers/{uuid}": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "uuid",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/bridge/customers/{uuid}/external-accounts": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "accountNumber": {
-                    "type": "string"
-                  },
-                  "bic": {
-                    "type": "string"
-                  },
-                  "country": {
-                    "type": "string"
-                  },
-                  "address": {
-                    "type": "object",
-                    "properties": {
-                      "street": {
-                        "type": "string"
-                      },
-                      "city": {
-                        "type": "string"
-                      },
-                      "country": {
-                        "type": "string"
-                      },
-                      "state": {
-                        "type": "string"
-                      },
-                      "postalCode": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "street",
-                      "city",
-                      "country",
-                      "postalCode"
-                    ]
-                  },
-                  "accountOwnerName": {
-                    "type": "object",
-                    "properties": {
-                      "firstName": {
-                        "type": "string"
-                      },
-                      "lastName": {
-                        "type": "string"
-                      },
-                      "businessName": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "accountOwnerType": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "business"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "individual"
-                        ]
-                      }
-                    ]
-                  },
-                  "routingNumber": {
-                    "type": "string"
-                  },
-                  "sortCode": {
-                    "type": "string"
-                  },
-                  "accountType": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "iban"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "us"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "clabe"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "gb"
-                        ]
-                      }
-                    ]
-                  },
-                  "reuseOnError": {
-                    "type": "boolean"
-                  }
-                },
-                "required": [
-                  "accountNumber",
-                  "country",
-                  "accountOwnerName",
-                  "accountOwnerType",
-                  "accountType"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "uuid",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      },
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "uuid",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/bridge/customers/{customerId}/external-accounts/{externalAccountId}": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "customerId",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "externalAccountId",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      },
-      "delete": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "customerId",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "externalAccountId",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/bridge/customers/{customerId}/external-accounts/{externalAccountId}/reactivate": {
-      "post": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "customerId",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "externalAccountId",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/bridge/kyc-links/{uuid}": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "uuid",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/bridge/kyc-links": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "business"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "individual"
-                        ]
-                      }
-                    ]
-                  },
-                  "fullName": {
-                    "type": "string"
-                  },
-                  "email": {
-                    "type": "string"
-                  },
-                  "redirectUri": {
-                    "type": "string"
-                  },
-                  "isEEA": {
-                    "type": "boolean"
-                  }
-                },
-                "required": [
-                  "type",
-                  "fullName",
-                  "email"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/bridge/customers/{uuid}/kyc-links": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "uuid",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/bridge/customers/{customerId}/liquidation-addresses": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "chain": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "arbitrum"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "base"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "avalance_c_chain"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "ethereum"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "optimism"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "polygon"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "solana"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "stellar"
-                        ]
-                      }
-                    ]
-                  },
-                  "currency": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "dai"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "usdc"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "eurc"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "usdt"
-                        ]
-                      }
-                    ]
-                  },
-                  "externalAccountId": {
-                    "type": "string"
-                  },
-                  "prefundedAccountId": {
-                    "type": "string"
-                  },
-                  "destinationWireMessage": {
-                    "type": "string"
-                  },
-                  "destinationSepaReference": {
-                    "type": "string"
-                  },
-                  "destinationSwiftReference": {
-                    "type": "string"
-                  },
-                  "destinationAchReference": {
-                    "type": "string"
-                  },
-                  "destinationPaymentRail": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "arbitrum"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "base"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "avalance_c_chain"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "ethereum"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "optimism"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "polygon"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "solana"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "stellar"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "ach"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "ach_push"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "ach_same_day"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "sepa"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "swift"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "wire"
-                        ]
-                      }
-                    ]
-                  },
-                  "destinationCurrency": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "eur"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "usd"
-                        ]
-                      }
-                    ]
-                  },
-                  "destinationAddress": {
-                    "type": "string"
-                  },
-                  "destinationBlockchainMemo": {
-                    "type": "string"
-                  },
-                  "customDeveloperFeePercent": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "chain",
-                  "currency",
-                  "externalAccountId"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "customerId",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/bridge/customers/{uuid}/liquidation-addresses": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "number"
-            },
-            "in": "query",
-            "name": "limit",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "startingAfter",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "endingBefore",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "uuid",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/bridge/customers/{customerId}/liquidation-addresses/{liquidationAddressId}/drains": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "customerId",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "liquidationAddressId",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/bridge/customers/{uuid}/transfers": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "number"
-            },
-            "in": "query",
-            "name": "limit",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "startingAfter",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "endingBefore",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "number"
-            },
-            "in": "query",
-            "name": "updatedBeforeMs",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "number"
-            },
-            "in": "query",
-            "name": "updatedAfterMs",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "uuid",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/bridge/transfers/{transferId}": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "transferId",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/bridge/offramp/create": {
-      "post": {
-        "summary": "Initiate an off-ramp transfer",
-        "tags": [
-          "offramp"
-        ],
-        "description": "This endpoint initiates a new off-ramp transfer. It uses the configured off-ramp provider (e.g., Bridge) to create a transfer and returns deposit instructions for the user.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "onBehalfOf": {
-                    "type": "string"
-                  },
-                  "provider": {
-                    "type": "string"
-                  },
-                  "amount": {
-                    "type": "string"
-                  },
-                  "sendLinkPubKey": {
-                    "type": "string"
-                  },
-                  "source": {
-                    "type": "object",
-                    "properties": {
-                      "currency": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "usdc"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "eurc"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "usdt"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "dai"
-                            ]
-                          }
-                        ]
-                      },
-                      "paymentRail": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "ethereum"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "polygon"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "base"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "optimism"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "solana"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "stellar"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "arbitrum"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "avalance_c_chain"
-                            ]
-                          }
-                        ]
-                      },
-                      "fromAddress": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "currency",
-                      "paymentRail"
-                    ]
-                  },
-                  "destination": {
-                    "type": "object",
-                    "properties": {
-                      "currency": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "usd"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "eur"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "mxn"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "gbp"
-                            ]
-                          }
-                        ]
-                      },
-                      "paymentRail": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "ach"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "ach_push"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "ach_same_day"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "wire"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "sepa"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "swift"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "spei"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "faster_payments"
-                            ]
-                          }
-                        ]
-                      },
-                      "externalAccountId": {
-                        "type": "string"
-                      },
-                      "wireMessage": {
-                        "type": "string"
-                      },
-                      "sepaReference": {
-                        "type": "string"
-                      },
-                      "achReference": {
-                        "type": "string"
-                      },
-                      "fasterPaymentsReference": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "currency",
-                      "paymentRail",
-                      "externalAccountId"
-                    ]
-                  },
-                  "features": {
-                    "type": "object",
-                    "properties": {
-                      "flexibleAmount": {
-                        "type": "boolean"
-                      },
-                      "staticTemplate": {
-                        "type": "boolean"
-                      },
-                      "allowAnyFromAddress": {
-                        "type": "boolean"
-                      }
-                    }
-                  },
-                  "developerFee": {
-                    "type": "string"
-                  },
-                  "developerFeePercent": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "onBehalfOf",
-                  "source",
-                  "destination"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "transferId": {
-                      "type": "string"
-                    },
-                    "depositInstructions": {
-                      "type": "object",
-                      "properties": {
-                        "toAddress": {
-                          "type": "string"
-                        },
-                        "blockchainMemo": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "toAddress"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "transferId",
-                    "depositInstructions"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/bridge/offramp/create-for-guest": {
-      "post": {
-        "summary": "Initiate an off-ramp transfer for a guest",
-        "tags": [
-          "offramp"
-        ],
-        "description": "This endpoint initiates a new off-ramp transfer for a guest user. It uses the configured off-ramp provider (e.g., Bridge) to create a transfer and returns deposit instructions for the user. This is intended for server-to-server use where the user is not authenticated.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "userId": {
-                    "type": "string"
-                  },
-                  "provider": {
-                    "type": "string"
-                  },
-                  "amount": {
-                    "type": "string"
-                  },
-                  "sendLinkPubKey": {
-                    "type": "string"
-                  },
-                  "source": {
-                    "type": "object",
-                    "properties": {
-                      "currency": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "usdc"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "eurc"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "usdt"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "dai"
-                            ]
-                          }
-                        ]
-                      },
-                      "paymentRail": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "ethereum"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "polygon"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "base"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "optimism"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "solana"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "stellar"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "arbitrum"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "avalance_c_chain"
-                            ]
-                          }
-                        ]
-                      },
-                      "fromAddress": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "currency",
-                      "paymentRail"
-                    ]
-                  },
-                  "destination": {
-                    "type": "object",
-                    "properties": {
-                      "currency": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "usd"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "eur"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "mxn"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "gbp"
-                            ]
-                          }
-                        ]
-                      },
-                      "paymentRail": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "ach"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "ach_push"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "ach_same_day"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "wire"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "sepa"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "swift"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "spei"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "faster_payments"
-                            ]
-                          }
-                        ]
-                      },
-                      "externalAccountId": {
-                        "type": "string"
-                      },
-                      "wireMessage": {
-                        "type": "string"
-                      },
-                      "sepaReference": {
-                        "type": "string"
-                      },
-                      "achReference": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "currency",
-                      "paymentRail",
-                      "externalAccountId"
-                    ]
-                  }
-                },
-                "required": [
-                  "userId",
-                  "source",
-                  "destination"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "transferId": {
-                      "type": "string"
-                    },
-                    "depositInstructions": {
-                      "type": "object",
-                      "properties": {
-                        "toAddress": {
-                          "type": "string"
-                        },
-                        "blockchainMemo": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "toAddress"
-                      ]
-                    },
-                    "quote": {
-                      "type": "object",
-                      "properties": {
-                        "initial_amount": {
-                          "type": "string"
-                        },
-                        "developer_fee": {
-                          "type": "string"
-                        },
-                        "exchange_fee": {
-                          "type": "string"
-                        },
-                        "subtotal_amount": {
-                          "type": "string"
-                        },
-                        "remaining_prefunded_amount": {
-                          "type": "string"
-                        },
-                        "gas_fee": {
-                          "type": "string"
-                        },
-                        "final_amount": {
-                          "type": "string"
-                        },
-                        "source_tx_hash": {
-                          "type": "string"
-                        },
-                        "destination_tx_hash": {
-                          "type": "string"
-                        },
-                        "exchange_rate": {
-                          "type": "string"
-                        },
-                        "url": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "initial_amount",
-                        "developer_fee",
-                        "exchange_fee",
-                        "subtotal_amount"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "transferId",
-                    "depositInstructions"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/bridge/transfers/{transferId}/confirm": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "txHash"
-                ],
-                "properties": {
-                  "txHash": {
-                    "type": "string",
-                    "minLength": 66,
-                    "maxLength": 66
-                  }
-                }
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "transferId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/bridge/onramp/create": {
-      "post": {
-        "summary": "Initiate an on-ramp transfer",
-        "tags": [
-          "onramp"
-        ],
-        "description": "This endpoint initiates a new on-ramp transfer (fiat to crypto). It creates a transfer from fiat to USDC on Arbitrum to the user's peanut wallet and returns bank deposit instructions.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "amount": {
-                    "type": "string"
-                  },
-                  "chargeId": {
-                    "type": "string"
-                  },
-                  "recipientAddress": {
-                    "type": "string"
-                  },
-                  "source": {
-                    "type": "object",
-                    "properties": {
-                      "currency": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "usd"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "eur"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "mxn"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "gbp"
-                            ]
-                          }
-                        ]
-                      },
-                      "paymentRail": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "ach"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "ach_push"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "ach_same_day"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "wire"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "sepa"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "swift"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "spei"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "faster_payments"
-                            ]
-                          }
-                        ]
-                      }
-                    },
-                    "required": [
-                      "currency",
-                      "paymentRail"
-                    ]
-                  }
-                },
-                "required": [
-                  "amount",
-                  "source"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "transferId": {
-                      "type": "string"
-                    },
-                    "depositInstructions": {
-                      "type": "object",
-                      "properties": {
-                        "amount": {
-                          "type": "string"
-                        },
-                        "currency": {
-                          "type": "string"
-                        },
-                        "depositMessage": {
-                          "type": "string"
-                        },
-                        "bankName": {
-                          "type": "string"
-                        },
-                        "bankAddress": {
-                          "type": "string"
-                        },
-                        "bankRoutingNumber": {
-                          "type": "string"
-                        },
-                        "bankAccountNumber": {
-                          "type": "string"
-                        },
-                        "bankBeneficiaryName": {
-                          "type": "string"
-                        },
-                        "bankBeneficiaryAddress": {
-                          "type": "string"
-                        },
-                        "iban": {
-                          "type": "string"
-                        },
-                        "bic": {
-                          "type": "string"
-                        },
-                        "accountHolderName": {
-                          "type": "string"
-                        },
-                        "clabe": {
-                          "type": "string"
-                        },
-                        "sortCode": {
-                          "type": "string"
-                        },
-                        "accountNumber": {
-                          "type": "string"
-                        },
-                        "reference": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "amount",
-                        "currency",
-                        "depositMessage"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "transferId",
-                    "depositInstructions"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/bridge/onramp/{transferId}/cancel": {
-      "delete": {
-        "summary": "Cancel an on-ramp transfer",
-        "tags": [
-          "onramp"
-        ],
-        "description": "This endpoint cancels an on-ramp transfer. The transfer must be in AWAITING_FUNDS/PENDING state. It updates the ledger and calls Bridge API to cancel the transfer.",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "transferId",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
-                    },
-                    "message": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "success",
-                    "message"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/bridge/onramp/create-for-guest": {
-      "post": {
-        "summary": "Initiate an on-ramp transfer for a guest",
-        "tags": [
-          "onramp"
-        ],
-        "description": "This endpoint initiates a new on-ramp transfer (fiat to crypto) for a guest. It creates a transfer from fiat to USDC on Arbitrum to the guest's peanut wallet and returns bank deposit instructions.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "amount": {
-                    "type": "string"
-                  },
-                  "source": {
-                    "type": "object",
-                    "properties": {
-                      "currency": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "usd"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "eur"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "mxn"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "gbp"
-                            ]
-                          }
-                        ]
-                      },
-                      "paymentRail": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "ach"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "ach_push"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "ach_same_day"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "wire"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "sepa"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "swift"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "spei"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "faster_payments"
-                            ]
-                          }
-                        ]
-                      }
-                    },
-                    "required": [
-                      "currency",
-                      "paymentRail"
-                    ]
-                  },
-                  "userId": {
-                    "type": "string"
-                  },
-                  "chargeId": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "amount",
-                  "source",
-                  "userId"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "transferId": {
-                      "type": "string"
-                    },
-                    "depositInstructions": {
-                      "type": "object",
-                      "properties": {
-                        "amount": {
-                          "type": "string"
-                        },
-                        "currency": {
-                          "type": "string"
-                        },
-                        "depositMessage": {
-                          "type": "string"
-                        },
-                        "bankName": {
-                          "type": "string"
-                        },
-                        "bankAddress": {
-                          "type": "string"
-                        },
-                        "bankRoutingNumber": {
-                          "type": "string"
-                        },
-                        "bankAccountNumber": {
-                          "type": "string"
-                        },
-                        "bankBeneficiaryName": {
-                          "type": "string"
-                        },
-                        "bankBeneficiaryAddress": {
-                          "type": "string"
-                        },
-                        "iban": {
-                          "type": "string"
-                        },
-                        "bic": {
-                          "type": "string"
-                        },
-                        "accountHolderName": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "amount",
-                        "currency",
-                        "depositMessage"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "transferId",
-                    "depositInstructions"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/bridge/onramp/quote": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "iban",
-                "us",
-                "clabe",
-                "gb"
-              ]
-            },
-            "in": "query",
-            "name": "accountType",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "sourceAmount",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/bridge/exchange-rate": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "iban",
-                "us",
-                "clabe",
-                "gb"
-              ]
-            },
-            "in": "query",
-            "name": "accountType",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/rain/cards/withdraw/session-approve": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "serializedApproval": {
-                    "minLength": 1,
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "serializedApproval"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    }
-                  },
-                  "required": [
-                    "ok"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/rain/cards/withdraw/prepare": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "amount": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  "recipientAddress": {
-                    "pattern": "^0x[0-9a-fA-F]{40}$",
-                    "type": "string"
-                  },
-                  "directTransfer": {
-                    "type": "boolean"
-                  },
-                  "kind": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "P2P_SEND"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "QR_PAY"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "LINK_CREATE"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "CRYPTO_WITHDRAW"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "FIAT_OFFRAMP"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "FIAT_ONRAMP"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "REQUEST_PAY"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "AUTO_REBALANCE"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "CARD_SPEND"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "DEPOSIT_EXTERNAL"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "OTHER"
-                        ]
-                      }
-                    ]
-                  },
-                  "totalAmountCents": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  "chargeId": {
-                    "minLength": 1,
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "amount",
-                  "recipientAddress",
-                  "directTransfer",
-                  "kind"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "preparationId": {
-                      "type": "string"
-                    },
-                    "coordinatorAddress": {
-                      "type": "string"
-                    },
-                    "collateralProxy": {
-                      "type": "string"
-                    },
-                    "adminAddress": {
-                      "type": "string"
-                    },
-                    "chainId": {
-                      "type": "string"
-                    },
-                    "tokenAddress": {
-                      "type": "string"
-                    },
-                    "amount": {
-                      "type": "string"
-                    },
-                    "recipientAddress": {
-                      "type": "string"
-                    },
-                    "directTransfer": {
-                      "type": "boolean"
-                    },
-                    "adminSalt": {
-                      "type": "string"
-                    },
-                    "adminNonce": {
-                      "type": "string"
-                    },
-                    "executorSignature": {
-                      "type": "string"
-                    },
-                    "executorSalt": {
-                      "type": "string"
-                    },
-                    "expiresAt": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "preparationId",
-                    "coordinatorAddress",
-                    "collateralProxy",
-                    "adminAddress",
-                    "chainId",
-                    "tokenAddress",
-                    "amount",
-                    "recipientAddress",
-                    "directTransfer",
-                    "adminSalt",
-                    "adminNonce",
-                    "executorSignature",
-                    "executorSalt",
-                    "expiresAt"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "425": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/rain/cards/withdraw/stamp": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "preparationId": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  "txHash": {
-                    "pattern": "^0x[0-9a-fA-F]{64}$",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "preparationId",
-                  "txHash"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    }
-                  },
-                  "required": [
-                    "ok"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/rain/cards/withdraw/submit": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "preparationId": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  "amount": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  "recipientAddress": {
-                    "pattern": "^0x[0-9a-fA-F]{40}$",
-                    "type": "string"
-                  },
-                  "directTransfer": {
-                    "type": "boolean"
-                  },
-                  "adminSalt": {
-                    "pattern": "^0x[0-9a-fA-F]{64}$",
-                    "type": "string"
-                  },
-                  "adminNonce": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  "adminSignature": {
-                    "pattern": "^0x[0-9a-fA-F]+$",
-                    "type": "string"
-                  },
-                  "executorSignature": {
-                    "type": "string"
-                  },
-                  "executorSalt": {
-                    "type": "string"
-                  },
-                  "expiresAt": {
-                    "type": "number"
-                  }
-                },
-                "required": [
-                  "preparationId",
-                  "amount",
-                  "recipientAddress",
-                  "directTransfer",
-                  "adminSalt",
-                  "adminNonce",
-                  "adminSignature",
-                  "executorSignature",
-                  "executorSalt",
-                  "expiresAt"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "txHash": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "txHash"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "410": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/manteca/qr-payment/init": {
-      "post": {
-        "summary": "Process QR payment",
-        "tags": [
-          "manteca"
-        ],
-        "description": "Process a QR payment through Manteca. Supports PIX, QR 3.0, and CODI payments.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "qrCode": {
-                    "description": "The QR code string to process for payment",
-                    "type": "string"
-                  },
-                  "amount": {
-                    "description": "Amount for static QR codes (optional for dynamic QR codes)",
-                    "type": "string"
-                  },
-                  "qrType": {
-                    "description": "Type of QR code (e.g. PIX, QR30, CODI). Used to select the correct fallback user for non-Manteca users.",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "qrCode"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/manteca/qr-payment/complete-with-signed-tx": {
-      "post": {
-        "summary": "Complete QR payment with signed transaction",
-        "tags": [
-          "manteca"
-        ],
-        "description": "Completes Manteca payment first, then either broadcasts the signed UserOp or submits the signed Rain withdrawal via the session key. This prevents funds from being stuck if Manteca fails.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "anyOf": [
-                  {
-                    "type": "object",
-                    "properties": {
-                      "kind": {
-                        "type": "string",
-                        "enum": [
-                          "userOp"
-                        ]
-                      },
-                      "paymentLockCode": {
-                        "description": "The payment lock code from init",
-                        "type": "string"
-                      },
-                      "qrType": {
-                        "description": "Type of QR code (e.g. PIX, QR30, CODI). Used to select the correct fallback user for non-Manteca users.",
-                        "type": "string"
-                      },
-                      "signedUserOp": {
-                        "type": "object",
-                        "properties": {
-                          "sender": {
-                            "type": "string"
-                          },
-                          "nonce": {},
-                          "callData": {
-                            "type": "string"
-                          },
-                          "signature": {
-                            "type": "string"
-                          },
-                          "factory": {
-                            "type": "string"
-                          },
-                          "factoryData": {
-                            "type": "string"
-                          },
-                          "callGasLimit": {},
-                          "verificationGasLimit": {},
-                          "preVerificationGas": {},
-                          "maxFeePerGas": {},
-                          "maxPriorityFeePerGas": {},
-                          "paymaster": {
-                            "type": "string"
-                          },
-                          "paymasterData": {
-                            "type": "string"
-                          },
-                          "paymasterVerificationGasLimit": {},
-                          "paymasterPostOpGasLimit": {}
-                        },
-                        "required": [
-                          "sender",
-                          "nonce",
-                          "callData",
-                          "signature",
-                          "callGasLimit",
-                          "verificationGasLimit",
-                          "preVerificationGas",
-                          "maxFeePerGas",
-                          "maxPriorityFeePerGas",
-                          "paymasterVerificationGasLimit",
-                          "paymasterPostOpGasLimit"
-                        ]
-                      },
-                      "chainId": {
-                        "type": "string"
-                      },
-                      "entryPointAddress": {
-                        "type": "string"
-                      },
-                      "rainPreparationId": {
-                        "minLength": 1,
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "kind",
-                      "paymentLockCode",
-                      "signedUserOp",
-                      "chainId",
-                      "entryPointAddress"
-                    ]
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "kind": {
-                        "type": "string",
-                        "enum": [
-                          "rainWithdrawal"
-                        ]
-                      },
-                      "paymentLockCode": {
-                        "description": "The payment lock code from init",
-                        "type": "string"
-                      },
-                      "qrType": {
-                        "type": "string"
-                      },
-                      "signedRainWithdrawal": {
-                        "type": "object",
-                        "properties": {
-                          "preparationId": {
-                            "minLength": 1,
-                            "type": "string"
-                          },
-                          "amount": {
-                            "minLength": 1,
-                            "type": "string"
-                          },
-                          "recipientAddress": {
-                            "pattern": "^0x[0-9a-fA-F]{40}$",
-                            "type": "string"
-                          },
-                          "directTransfer": {
-                            "type": "boolean"
-                          },
-                          "adminSalt": {
-                            "pattern": "^0x[0-9a-fA-F]{64}$",
-                            "type": "string"
-                          },
-                          "adminNonce": {
-                            "minLength": 1,
-                            "type": "string"
-                          },
-                          "adminSignature": {
-                            "pattern": "^0x[0-9a-fA-F]+$",
-                            "type": "string"
-                          },
-                          "executorSignature": {
-                            "type": "string"
-                          },
-                          "executorSalt": {
-                            "type": "string"
-                          },
-                          "expiresAt": {
-                            "type": "number"
-                          }
-                        },
-                        "required": [
-                          "preparationId",
-                          "amount",
-                          "recipientAddress",
-                          "directTransfer",
-                          "adminSalt",
-                          "adminNonce",
-                          "adminSignature",
-                          "executorSignature",
-                          "executorSalt",
-                          "expiresAt"
-                        ]
-                      },
-                      "chainId": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "kind",
-                      "paymentLockCode",
-                      "signedRainWithdrawal",
-                      "chainId"
-                    ]
-                  }
-                ]
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/manteca/deposit": {
-      "post": {
-        "summary": "Create deposit order (onramp)",
-        "tags": [
-          "manteca"
-        ],
-        "description": "Create a deposit order to convert fiat to crypto via Manteca. Returns deposit instructions.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "amount": {
-                    "type": "string"
-                  },
-                  "isUsdDenominated": {
-                    "type": "boolean"
-                  },
-                  "currency": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "ARS"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "BRL"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "CLP"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "COP"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "PUSD"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "CRC"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "GTQ"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "MXN"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "PHP"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "BOB"
-                        ]
-                      }
-                    ]
-                  },
-                  "chargeId": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "amount",
-                  "currency"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/manteca/deposit/{depositId}/cancel": {
-      "patch": {
-        "summary": "Cancel deposit order",
-        "tags": [
-          "manteca"
-        ],
-        "description": "Cancel a deposit order created via Manteca.",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "depositId",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/manteca/withdraw/init": {
-      "post": {
-        "summary": "Initialize withdraw with locked price",
-        "tags": [
-          "manteca"
-        ],
-        "description": "Creates a price lock for withdraw. Returns the locked exchange rate valid for ~120 seconds. Use this before showing the user the final amount.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "amount": {
-                    "description": "Amount to withdraw in USD (USDC)",
-                    "type": "string"
-                  },
-                  "currency": {
-                    "description": "Target fiat currency (e.g. ARS, BRL)",
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "ARS"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "BRL"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "CLP"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "COP"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "PUSD"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "CRC"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "GTQ"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "MXN"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "PHP"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "BOB"
-                        ]
-                      }
-                    ]
-                  }
-                },
-                "required": [
-                  "amount",
-                  "currency"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/manteca/withdraw": {
-      "post": {
-        "summary": "Create withdraw order (offramp)",
-        "tags": [
-          "manteca"
-        ],
-        "description": "Create a withdraw order to convert crypto to fiat via Manteca. Optionally use a pre-locked price from /withdraw/init.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "amount": {
-                    "description": "Amount to withdraw in crypto asset",
-                    "type": "string"
-                  },
-                  "txHash": {
-                    "description": "Transaction hash of the withdrawal",
-                    "type": "string"
-                  },
-                  "destinationAddress": {
-                    "description": "Destination address to withdraw to",
-                    "type": "string"
-                  },
-                  "bankCode": {
-                    "type": "string"
-                  },
-                  "accountType": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "SAVINGS"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "CHECKING"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "DEBIT"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "PHONE"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "VISTA"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "RUT"
-                        ]
-                      }
-                    ]
-                  },
-                  "currency": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "ARS"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "BRL"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "CLP"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "COP"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "PUSD"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "CRC"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "GTQ"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "MXN"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "PHP"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "BOB"
-                        ]
-                      }
-                    ]
-                  },
-                  "priceLockCode": {
-                    "description": "Price lock code from /withdraw/init. If not provided, a new price lock is created.",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "amount",
-                  "txHash",
-                  "destinationAddress"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/manteca/withdraw/complete-with-signed-tx": {
-      "post": {
-        "summary": "Complete withdraw with signed transaction (sign-then-broadcast)",
-        "tags": [
-          "manteca"
-        ],
-        "description": "Creates Manteca ramp-off order FIRST, then either broadcasts the signed UserOp or submits the signed Rain withdrawal via the session key. Prevents funds from being stuck if Manteca fails.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "anyOf": [
-                  {
-                    "type": "object",
-                    "properties": {
-                      "kind": {
-                        "type": "string",
-                        "enum": [
-                          "userOp"
-                        ]
-                      },
-                      "priceLockCode": {
-                        "description": "The price lock code from /withdraw/init",
-                        "type": "string"
-                      },
-                      "amount": {
-                        "description": "Amount to withdraw in USD (USDC)",
-                        "type": "string"
-                      },
-                      "destinationAddress": {
-                        "description": "Destination bank account address",
-                        "type": "string"
-                      },
-                      "bankCode": {
-                        "type": "string"
-                      },
-                      "accountType": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "SAVINGS"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "CHECKING"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "DEBIT"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "PHONE"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "VISTA"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "RUT"
-                            ]
-                          }
-                        ]
-                      },
-                      "currency": {
-                        "description": "Target fiat currency (must match price lock)",
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "ARS"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "BRL"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "CLP"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "COP"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "PUSD"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "CRC"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "GTQ"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "MXN"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "PHP"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "BOB"
-                            ]
-                          }
-                        ]
-                      },
-                      "signedUserOp": {
-                        "type": "object",
-                        "properties": {
-                          "sender": {
-                            "type": "string"
-                          },
-                          "nonce": {},
-                          "callData": {
-                            "type": "string"
-                          },
-                          "signature": {
-                            "type": "string"
-                          },
-                          "factory": {
-                            "type": "string"
-                          },
-                          "factoryData": {
-                            "type": "string"
-                          },
-                          "callGasLimit": {},
-                          "verificationGasLimit": {},
-                          "preVerificationGas": {},
-                          "maxFeePerGas": {},
-                          "maxPriorityFeePerGas": {},
-                          "paymaster": {
-                            "type": "string"
-                          },
-                          "paymasterData": {
-                            "type": "string"
-                          },
-                          "paymasterVerificationGasLimit": {},
-                          "paymasterPostOpGasLimit": {}
-                        },
-                        "required": [
-                          "sender",
-                          "nonce",
-                          "callData",
-                          "signature",
-                          "callGasLimit",
-                          "verificationGasLimit",
-                          "preVerificationGas",
-                          "maxFeePerGas",
-                          "maxPriorityFeePerGas",
-                          "paymasterVerificationGasLimit",
-                          "paymasterPostOpGasLimit"
-                        ]
-                      },
-                      "chainId": {
-                        "type": "string"
-                      },
-                      "entryPointAddress": {
-                        "type": "string"
-                      },
-                      "rainPreparationId": {
-                        "minLength": 1,
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "kind",
-                      "priceLockCode",
-                      "amount",
-                      "destinationAddress",
-                      "currency",
-                      "signedUserOp",
-                      "chainId",
-                      "entryPointAddress"
-                    ]
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "kind": {
-                        "type": "string",
-                        "enum": [
-                          "rainWithdrawal"
-                        ]
-                      },
-                      "priceLockCode": {
-                        "description": "The price lock code from /withdraw/init",
-                        "type": "string"
-                      },
-                      "amount": {
-                        "description": "Amount to withdraw in USD (USDC)",
-                        "type": "string"
-                      },
-                      "destinationAddress": {
-                        "description": "Destination bank account address",
-                        "type": "string"
-                      },
-                      "bankCode": {
-                        "type": "string"
-                      },
-                      "accountType": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "SAVINGS"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "CHECKING"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "DEBIT"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "PHONE"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "VISTA"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "RUT"
-                            ]
-                          }
-                        ]
-                      },
-                      "currency": {
-                        "description": "Target fiat currency (must match price lock)",
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "enum": [
-                              "ARS"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "BRL"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "CLP"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "COP"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "PUSD"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "CRC"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "GTQ"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "MXN"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "PHP"
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "enum": [
-                              "BOB"
-                            ]
-                          }
-                        ]
-                      },
-                      "signedRainWithdrawal": {
-                        "type": "object",
-                        "properties": {
-                          "preparationId": {
-                            "minLength": 1,
-                            "type": "string"
-                          },
-                          "amount": {
-                            "minLength": 1,
-                            "type": "string"
-                          },
-                          "recipientAddress": {
-                            "pattern": "^0x[0-9a-fA-F]{40}$",
-                            "type": "string"
-                          },
-                          "directTransfer": {
-                            "type": "boolean"
-                          },
-                          "adminSalt": {
-                            "pattern": "^0x[0-9a-fA-F]{64}$",
-                            "type": "string"
-                          },
-                          "adminNonce": {
-                            "minLength": 1,
-                            "type": "string"
-                          },
-                          "adminSignature": {
-                            "pattern": "^0x[0-9a-fA-F]+$",
-                            "type": "string"
-                          },
-                          "executorSignature": {
-                            "type": "string"
-                          },
-                          "executorSalt": {
-                            "type": "string"
-                          },
-                          "expiresAt": {
-                            "type": "number"
-                          }
-                        },
-                        "required": [
-                          "preparationId",
-                          "amount",
-                          "recipientAddress",
-                          "directTransfer",
-                          "adminSalt",
-                          "adminNonce",
-                          "adminSignature",
-                          "executorSignature",
-                          "executorSalt",
-                          "expiresAt"
-                        ]
-                      },
-                      "chainId": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "kind",
-                      "priceLockCode",
-                      "amount",
-                      "destinationAddress",
-                      "currency",
-                      "signedRainWithdrawal",
-                      "chainId"
-                    ]
-                  }
-                ]
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/manteca/webhook": {
-      "post": {
-        "summary": "Manteca webhook handler",
-        "tags": [
-          "manteca"
-        ],
-        "description": "Handle webhook notifications from Manteca about synthetic status updates",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "event": {
-                    "description": "Event type from Manteca",
-                    "type": "string"
-                  },
-                  "data": {
-                    "description": "Event payload from Manteca"
-                  }
-                },
-                "required": [
-                  "event",
-                  "data"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "md-webhook-signature",
-            "required": true,
-            "description": "HMAC signature for webhook verification"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/manteca/initiate-onboarding": {
-      "post": {
-        "summary": "Initiate Manteca onboarding",
-        "tags": [
-          "manteca"
-        ],
-        "description": "Creates an onboarding widget URL for the current user using userId as userExternalId and returns the URL",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "returnUrl": {
-                    "type": "string"
-                  },
-                  "failureUrl": {
-                    "type": "string"
-                  },
-                  "exchange": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "returnUrl"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/manteca/prices": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "enum": [
-                    "USDT"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "USDC"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "ETH"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "BTC"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "ARS"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "USD"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "BRL"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "CLP"
-                  ]
-                }
-              ]
-            },
-            "in": "query",
-            "name": "asset",
-            "required": true
-          },
-          {
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "enum": [
-                    "USDT"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "USDC"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "ETH"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "BTC"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "ARS"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "USD"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "BRL"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "CLP"
-                  ]
-                }
-              ]
-            },
-            "in": "query",
-            "name": "against",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/perks/claim": {
-      "post": {
-        "summary": "Claim a perk",
-        "tags": [
-          "perks"
-        ],
-        "description": "User-triggered action to claim USDC sponsorship for an eligible perk",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "usageId": {
-                    "description": "PerkUsage id to claim",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "usageId"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/perks/pending": {
-      "get": {
-        "summary": "Get pending perks",
-        "tags": [
-          "perks"
-        ],
-        "description": "Returns all PENDING_CLAIM perks for the authenticated user",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "perks": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "description": {
-                            "type": "string"
-                          },
-                          "reason": {
-                            "type": "string"
-                          },
-                          "amountUsd": {
-                            "type": "number"
-                          },
-                          "createdAt": {
-                            "type": "string"
-                          },
-                          "inviteeName": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "amountUsd",
-                          "createdAt"
-                        ]
-                      }
-                    }
-                  },
-                  "required": [
-                    "perks"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error",
-                    "message"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/invites/accept": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "inviteCode": {
-                    "type": "string"
-                  },
-                  "type": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "DIRECT"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "PAYMENT_LINK"
-                        ]
-                      }
-                    ]
-                  },
-                  "campaignTag": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "inviteCode",
-                  "type"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/invites": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/invites/validate": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "inviteCode": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "inviteCode"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/invites/waitlist-position": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/invites/graph": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/invites/graph/external": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/invites/user-graph": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/notifications/send": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "externalUserIds": {
-                    "minItems": 1,
-                    "maxItems": 10,
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "title": {
-                    "type": "string"
-                  },
-                  "message": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "data": {
-                    "type": "object",
-                    "additionalProperties": {}
-                  },
-                  "templateId": {
-                    "type": "string"
-                  },
-                  "idempotencyKey": {
-                    "type": "string"
-                  },
-                  "channel": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "push"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "email"
-                        ]
-                      }
-                    ]
-                  }
-                },
-                "required": [
-                  "externalUserIds"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/notifications": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/notifications/unread-count": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/notifications/mark-read": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/webhooks/onesignal": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/badge/award": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "campaignTag": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "campaignTag"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/admin/support/grant": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "username": {
-                    "minLength": 1,
-                    "maxLength": 64,
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "username"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "x-admin-token",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/points": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/points/history": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "minimum": 1,
-              "maximum": 100,
-              "type": "number"
-            },
-            "in": "query",
-            "name": "limit",
-            "required": false
-          },
-          {
-            "schema": {
-              "minimum": 0,
-              "type": "number"
-            },
-            "in": "query",
-            "name": "offset",
-            "required": false
-          },
-          {
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "enum": [
-                    "BRIDGE_FEE"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "MANTECA_FEE"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "RAIN_CARD_SPEND"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "CHARGE_FEE"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "P2P_SEND_LINK"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "P2P_REQUEST_PAYMENT"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "CRYPTO_WITHDRAW"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "SIGNUP"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "KYC_VERIFIED"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "TRANSITIVE_UPDATE"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "HANDSHAKE_BONUS"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "ADMIN_ADJUSTMENT"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "PERK_REDEMPTION"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "MIGRATION_FROM_OLD_SYSTEM"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "REFERRAL_REWARD_ACCRUAL"
-                  ]
-                }
-              ]
-            },
-            "in": "query",
-            "name": "type",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/points/leaderboard": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "minimum": 1,
-              "maximum": 500,
-              "type": "number"
-            },
-            "in": "query",
-            "name": "limit",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "boolean"
-            },
-            "in": "query",
-            "name": "includeMe",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/points/time-leaderboard": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "minimum": 1,
-              "maximum": 100,
-              "type": "number"
-            },
-            "in": "query",
-            "name": "limit",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "since",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/points/invites": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/points/cash-status": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/points/calculate": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "actionType": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "BRIDGE_TRANSFER"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "MANTECA_TRANSFER"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "MANTECA_QR_PAYMENT"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "P2P_SEND_LINK"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "P2P_REQUEST_PAYMENT"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "KYC_VERIFIED"
-                        ]
-                      }
-                    ]
-                  },
-                  "usdAmount": {
-                    "minimum": 0,
-                    "type": "number"
-                  },
-                  "otherUserId": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "actionType"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/points/admin/adjust": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "userId": {
-                    "type": "string"
-                  },
-                  "pointsChange": {
-                    "type": "number"
-                  },
-                  "reason": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "userId",
-                  "pointsChange",
-                  "reason"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "api-key",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/quests/leaderboards": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "minimum": 1,
-              "maximum": 10,
-              "default": 3,
-              "type": "number"
-            },
-            "in": "query",
-            "name": "limit",
-            "required": false
-          },
-          {
-            "schema": {
-              "default": false,
-              "type": "boolean"
-            },
-            "in": "query",
-            "name": "useTestTimePeriod",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/quests/{questId}/leaderboard": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "minimum": 1,
-              "maximum": 10,
-              "default": 10,
-              "type": "number"
-            },
-            "in": "query",
-            "name": "limit",
-            "required": false
-          },
-          {
-            "schema": {
-              "default": false,
-              "type": "boolean"
-            },
-            "in": "query",
-            "name": "useTestTimePeriod",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "questId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/qr/{code}": {
-      "get": {
-        "summary": "Get QR redirect or status",
-        "tags": [
-          "redirects"
-        ],
-        "description": "Returns redirect URL if claimed, or indicates QR is available to claim",
-        "parameters": [
-          {
-            "schema": {
-              "minLength": 16,
-              "maxLength": 16,
-              "type": "string"
-            },
-            "in": "path",
-            "name": "code",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/qr/{code}/claim": {
-      "post": {
-        "summary": "Claim a QR code",
-        "tags": [
-          "redirects"
-        ],
-        "description": "Claim an unclaimed QR code and tie it to your invite link",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "targetUrl": {
-                    "format": "uri",
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "schema": {
-              "minLength": 16,
-              "maxLength": 16,
-              "type": "string"
-            },
-            "in": "path",
-            "name": "code",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/rhino/deposit": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "destinationAddress": {
-                    "type": "string"
-                  },
-                  "type": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "EVM"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "SOL"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "TRON"
-                        ]
-                      }
-                    ]
-                  }
-                },
-                "required": [
-                  "destinationAddress",
-                  "type"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/rhino/request-fulfilment": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "EVM"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "SOL"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "TRON"
-                        ]
-                      }
-                    ]
-                  },
-                  "chargeId": {
-                    "type": "string"
-                  },
-                  "senderPeanutWalletAddress": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "type",
-                  "chargeId"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/rhino/rhinofi-event": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/rhino/status/{depositAddress}": {
-      "get": {
-        "tags": [
-          "rhino"
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "depositAddress",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/rhino/reset-status/{depositAddress}": {
-      "post": {
-        "tags": [
-          "rhino"
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "depositAddress",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/rhino/sda-transfer/preview": {
-      "post": {
-        "tags": [
-          "rhino"
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "chainIn": {
-                    "type": "string"
-                  },
-                  "chainOut": {
-                    "type": "string"
-                  },
-                  "token": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  "amount": {
-                    "type": "string"
-                  },
-                  "mode": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "pay"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "receive"
-                        ]
-                      }
-                    ]
-                  }
-                },
-                "required": [
-                  "chainIn",
-                  "chainOut",
-                  "token",
-                  "amount",
-                  "mode"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/rhino/sda-transfer": {
-      "post": {
-        "tags": [
-          "rhino"
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "context": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "withdraw"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "pay-request"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "claim-xchain"
-                        ]
-                      }
-                    ]
-                  },
-                  "contextId": {
-                    "type": "string"
-                  },
-                  "depositChain": {
-                    "type": "string"
-                  },
-                  "destinationChain": {
-                    "type": "string"
-                  },
-                  "destinationAddress": {
-                    "type": "string"
-                  },
-                  "tokenOut": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  "senderPeanutWalletAddress": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "context",
-                  "contextId",
-                  "depositChain",
-                  "destinationChain",
-                  "destinationAddress",
-                  "tokenOut"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/rhino/bridge/quote": {
-      "post": {
-        "tags": [
-          "rhino"
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "amount": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  "tokenIn": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  "tokenOut": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  "chainOut": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  "recipient": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  "depositor": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  "mode": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "pay"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "receive"
-                        ]
-                      }
-                    ]
-                  }
-                },
-                "required": [
-                  "amount",
-                  "tokenIn",
-                  "tokenOut",
-                  "chainOut",
-                  "recipient",
-                  "depositor",
-                  "mode"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/rhino/bridge/commit": {
-      "post": {
-        "tags": [
-          "rhino"
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "quoteId": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  "isSwap": {
-                    "type": "boolean"
-                  },
-                  "isSameChainSwap": {
-                    "type": "boolean"
-                  }
-                },
-                "required": [
-                  "quoteId",
-                  "isSwap",
-                  "isSameChainSwap"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/rhino/bridge/status/{bridgeId}": {
-      "get": {
-        "tags": [
-          "rhino"
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "in": "path",
-            "name": "bridgeId",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/rhino/bridge/chains": {
-      "get": {
-        "tags": [
-          "rhino"
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/card": {
-      "get": {
-        "summary": "Get card pioneer info",
-        "tags": [
-          "card"
-        ],
-        "description": "Get the authenticated user's card pioneer status and eligibility",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "hasPurchased": {
-                      "type": "boolean"
-                    },
-                    "hasCardAccess": {
-                      "type": "boolean"
-                    },
-                    "chargeStatus": {
-                      "type": "string"
-                    },
-                    "chargeUuid": {
-                      "type": "string"
-                    },
-                    "paymentUrl": {
-                      "type": "string"
-                    },
-                    "isEligible": {
-                      "type": "boolean"
-                    },
-                    "eligibilityReason": {
-                      "type": "string"
-                    },
-                    "price": {
-                      "type": "number"
-                    },
-                    "currentTier": {
-                      "type": "number"
-                    },
-                    "slotsRemaining": {
-                      "type": "number"
-                    },
-                    "recentPurchases": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "hasPurchased",
-                    "hasCardAccess",
-                    "isEligible",
-                    "price",
-                    "currentTier",
-                    "slotsRemaining",
-                    "recentPurchases"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error",
-                    "message"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/card/purchase": {
-      "post": {
-        "summary": "Purchase card pioneer status",
-        "tags": [
-          "card"
-        ],
-        "description": "Creates a charge for purchasing Card Pioneer status",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "Authorization",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "chargeUuid": {
-                      "type": "string"
-                    },
-                    "paymentUrl": {
-                      "type": "string"
-                    },
-                    "price": {
-                      "type": "number"
-                    },
-                    "recipientAddress": {
-                      "type": "string"
-                    },
-                    "chainId": {
-                      "type": "string"
-                    },
-                    "tokenAmount": {
-                      "type": "string"
-                    },
-                    "tokenSymbol": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "chargeUuid",
-                    "paymentUrl",
-                    "price",
-                    "recipientAddress",
-                    "chainId",
-                    "tokenAmount",
-                    "tokenSymbol"
-                  ]
-                }
-              }
-            }
-          },
-          "201": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "chargeUuid": {
-                      "type": "string"
-                    },
-                    "paymentUrl": {
-                      "type": "string"
-                    },
-                    "price": {
-                      "type": "number"
-                    },
-                    "recipientAddress": {
-                      "type": "string"
-                    },
-                    "chainId": {
-                      "type": "string"
-                    },
-                    "tokenAmount": {
-                      "type": "string"
-                    },
-                    "tokenSymbol": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "chargeUuid",
-                    "paymentUrl",
-                    "price",
-                    "recipientAddress",
-                    "chainId",
-                    "tokenAmount",
-                    "tokenSymbol"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error",
-                    "message"
-                  ]
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
-                    },
-                    "chargeUuid": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error",
-                    "message"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/sumsub/webhooks": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/users/identity": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/users/identity/resubmit": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/rain/cards": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "termsAccepted": {
-                    "type": "boolean"
-                  },
-                  "serializedApproval": {
-                    "minLength": 1,
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "anyOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "status": {
-                          "type": "string",
-                          "enum": [
-                            "pending"
-                          ]
-                        },
-                        "rainUserId": {
-                          "type": "string"
-                        },
-                        "message": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "status",
-                        "rainUserId",
-                        "message"
-                      ]
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "status": {
-                          "type": "string",
-                          "enum": [
-                            "incomplete"
-                          ]
-                        },
-                        "missing": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "questionnaireComplete": {
-                          "type": "boolean"
-                        },
-                        "sumsubAccessToken": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "status",
-                        "missing",
-                        "questionnaireComplete",
-                        "sumsubAccessToken"
-                      ]
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "status": {
-                          "type": "string",
-                          "enum": [
-                            "main-kyc-required"
-                          ]
-                        },
-                        "missingDocTypes": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "sumsubAccessToken": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "status",
-                        "missingDocTypes",
-                        "sumsubAccessToken"
-                      ]
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "status": {
-                          "type": "string",
-                          "enum": [
-                            "terms-required"
-                          ]
-                        },
-                        "isUsResident": {
-                          "type": "boolean"
-                        },
-                        "termsVersion": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "status",
-                        "isUsResident",
-                        "termsVersion"
-                      ]
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "status": {
-                          "type": "string"
-                        },
-                        "rainUserId": {
-                          "type": "string"
-                        },
-                        "message": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "status",
-                        "message"
-                      ]
-                    }
-                  ]
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "status": {
-                      "type": "object",
-                      "properties": {
-                        "hasApplication": {
-                          "type": "boolean"
-                        },
-                        "railStatus": {
-                          "type": "string"
-                        },
-                        "applicationStatus": {
-                          "type": "string"
-                        },
-                        "rainUserId": {
-                          "type": "string"
-                        },
-                        "contractAddress": {
-                          "type": "string"
-                        },
-                        "coordinatorAddress": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "hasApplication"
-                      ]
-                    },
-                    "balance": {
-                      "anyOf": [
-                        {
-                          "type": "null"
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "creditLimit": {
-                              "type": "number"
-                            },
-                            "pendingCharges": {
-                              "type": "number"
-                            },
-                            "postedCharges": {
-                              "type": "number"
-                            },
-                            "balanceDue": {
-                              "type": "number"
-                            },
-                            "spendingPower": {
-                              "type": "number"
-                            }
-                          },
-                          "required": [
-                            "creditLimit",
-                            "pendingCharges",
-                            "postedCharges",
-                            "balanceDue",
-                            "spendingPower"
-                          ]
-                        }
-                      ]
-                    },
-                    "cards": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string"
-                          },
-                          "rainCardId": {
-                            "type": "string"
-                          },
-                          "last4": {
-                            "type": "string"
-                          },
-                          "expiryMonth": {
-                            "type": "number"
-                          },
-                          "expiryYear": {
-                            "type": "number"
-                          },
-                          "status": {
-                            "type": "string"
-                          },
-                          "network": {
-                            "type": "string"
-                          },
-                          "issuedAt": {
-                            "type": "string"
-                          },
-                          "hasWithdrawApproval": {
-                            "type": "boolean"
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "rainCardId",
-                          "last4",
-                          "expiryMonth",
-                          "expiryYear",
-                          "status",
-                          "network",
-                          "issuedAt",
-                          "hasWithdrawApproval"
-                        ]
-                      }
-                    }
-                  },
-                  "required": [
-                    "status",
-                    "balance",
-                    "cards"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/rain/cards/status": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "hasApplication": {
-                      "type": "boolean"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "applicationStatus": {
-                      "type": "string"
-                    },
-                    "rainUserId": {
-                      "type": "string"
-                    },
-                    "contractAddress": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "hasApplication"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/rain/cards/{cardId}/activate": {
-      "post": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "cardId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/rain/cards/{cardId}/lock": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "verifiedWithdrawal": {
-                    "type": "object",
-                    "properties": {
-                      "preparationId": {
-                        "minLength": 1,
-                        "type": "string"
-                      },
-                      "amount": {
-                        "minLength": 1,
-                        "type": "string"
-                      },
-                      "recipientAddress": {
-                        "pattern": "^0x[0-9a-fA-F]{40}$",
-                        "type": "string"
-                      },
-                      "directTransfer": {
-                        "type": "boolean"
-                      },
-                      "adminSalt": {
-                        "pattern": "^0x[0-9a-fA-F]{64}$",
-                        "type": "string"
-                      },
-                      "adminNonce": {
-                        "minLength": 1,
-                        "type": "string"
-                      },
-                      "adminSignature": {
-                        "pattern": "^0x[0-9a-fA-F]+$",
-                        "type": "string"
-                      },
-                      "executorSignature": {
-                        "type": "string"
-                      },
-                      "executorSalt": {
-                        "type": "string"
-                      },
-                      "expiresAt": {
-                        "type": "number"
-                      }
-                    },
-                    "required": [
-                      "preparationId",
-                      "amount",
-                      "recipientAddress",
-                      "directTransfer",
-                      "adminSalt",
-                      "adminNonce",
-                      "adminSignature",
-                      "executorSignature",
-                      "executorSalt",
-                      "expiresAt"
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "cardId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/rain/cards/{cardId}/cancel": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "feedback": {
-                    "maxLength": 2000,
-                    "type": "string"
-                  },
-                  "verifiedWithdrawal": {
-                    "type": "object",
-                    "properties": {
-                      "preparationId": {
-                        "minLength": 1,
-                        "type": "string"
-                      },
-                      "amount": {
-                        "minLength": 1,
-                        "type": "string"
-                      },
-                      "recipientAddress": {
-                        "pattern": "^0x[0-9a-fA-F]{40}$",
-                        "type": "string"
-                      },
-                      "directTransfer": {
-                        "type": "boolean"
-                      },
-                      "adminSalt": {
-                        "pattern": "^0x[0-9a-fA-F]{64}$",
-                        "type": "string"
-                      },
-                      "adminNonce": {
-                        "minLength": 1,
-                        "type": "string"
-                      },
-                      "adminSignature": {
-                        "pattern": "^0x[0-9a-fA-F]+$",
-                        "type": "string"
-                      },
-                      "executorSignature": {
-                        "type": "string"
-                      },
-                      "executorSalt": {
-                        "type": "string"
-                      },
-                      "expiresAt": {
-                        "type": "number"
-                      }
-                    },
-                    "required": [
-                      "preparationId",
-                      "amount",
-                      "recipientAddress",
-                      "directTransfer",
-                      "adminSalt",
-                      "adminNonce",
-                      "adminSignature",
-                      "executorSignature",
-                      "executorSalt",
-                      "expiresAt"
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "cardId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/rain/cards/{cardId}/cancellation-feedback": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "feedback": {
-                    "minLength": 1,
-                    "maxLength": 2000,
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "feedback"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "cardId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    }
-                  },
-                  "required": [
-                    "ok"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/rain/cards/{cardId}": {
-      "patch": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "cardLimit": {
-                    "minimum": 0,
-                    "type": "number"
-                  },
-                  "limits": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "amount": {
-                          "minimum": 0,
-                          "type": "number"
-                        },
-                        "frequency": {
-                          "anyOf": [
-                            {
-                              "type": "string",
-                              "enum": [
-                                "perAuthorization"
-                              ]
-                            },
-                            {
-                              "type": "string",
-                              "enum": [
-                                "per24HourPeriod"
-                              ]
-                            },
-                            {
-                              "type": "string",
-                              "enum": [
-                                "per30DayPeriod"
-                              ]
-                            },
-                            {
-                              "type": "string",
-                              "enum": [
-                                "perAllTime"
-                              ]
-                            }
-                          ]
-                        }
-                      },
-                      "required": [
-                        "amount",
-                        "frequency"
-                      ]
-                    }
-                  },
-                  "autoBalanceEnabled": {
-                    "type": "boolean"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "cardId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    }
-                  },
-                  "required": [
-                    "ok"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/rain/cards/{cardId}/physical-waitlist": {
-      "post": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "cardId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "joinedAt": {
-                      "type": "string"
-                    },
-                    "position": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "joinedAt",
-                    "position"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "cardId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "joinedAt": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "position": {
-                      "anyOf": [
-                        {
-                          "type": "number"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "joinedAt",
-                    "position"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/rain/cards/{cardId}/limits": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "cardId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "limits": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "amount": {
-                            "type": "number"
-                          },
-                          "frequency": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "perAuthorization"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "per24HourPeriod"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "per30DayPeriod"
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "perAllTime"
-                                ]
-                              }
-                            ]
-                          }
-                        },
-                        "required": [
-                          "amount",
-                          "frequency"
-                        ]
-                      }
-                    }
-                  },
-                  "required": [
-                    "limits"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/rain/cards/balance": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "creditLimit": {
-                      "type": "number"
-                    },
-                    "pendingCharges": {
-                      "type": "number"
-                    },
-                    "postedCharges": {
-                      "type": "number"
-                    },
-                    "balanceDue": {
-                      "type": "number"
-                    },
-                    "spendingPower": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "creditLimit",
-                    "pendingCharges",
-                    "postedCharges",
-                    "balanceDue",
-                    "spendingPower"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/rain/cards/session-key-address": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "address": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "address"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/rain/cards/auto-balance/approve": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "serializedApproval": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  "cardLimit": {
-                    "minimum": 0,
-                    "type": "number"
-                  }
-                },
-                "required": [
-                  "serializedApproval"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    }
-                  },
-                  "required": [
-                    "ok"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/rain/cards/{cardId}/details": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "cardId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "pan": {
-                      "type": "string"
-                    },
-                    "cvv": {
-                      "type": "string"
-                    },
-                    "expiryMonth": {
-                      "type": "number"
-                    },
-                    "expiryYear": {
-                      "type": "number"
-                    },
-                    "last4": {
-                      "type": "string"
-                    },
-                    "network": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "pan",
-                    "cvv",
-                    "expiryMonth",
-                    "expiryYear",
-                    "last4",
-                    "network"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/rain/cards/{cardId}/pin": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "cardId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "pin": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "pin"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "pin": {
-                    "minLength": 4,
-                    "maxLength": 4,
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "pin"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "cardId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    }
-                  },
-                  "required": [
-                    "ok"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/rain/webhooks": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/tokens/price": {
-      "get": {
-        "tags": [
-          "tokens"
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "in": "query",
-            "name": "address",
-            "required": true
-          },
-          {
-            "schema": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "in": "query",
-            "name": "chainId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/tokens/wallet-portfolio": {
-      "get": {
-        "tags": [
-          "tokens"
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "in": "query",
-            "name": "address",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/ws/charges/{username}": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "username",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response"
-          }
-        }
-      }
-    },
-    "/dev/test-session": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "email": {
-                    "minLength": 5,
-                    "description": "Email. Finds or creates the user.",
-                    "type": "string"
-                  },
-                  "userId": {
-                    "type": "string"
-                  },
-                  "country": {
-                    "minLength": 2,
-                    "maxLength": 3,
-                    "type": "string"
-                  },
-                  "kyc": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "verified"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "pending"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "rejected"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "none"
-                        ]
-                      }
-                    ]
-                  },
-                  "provider": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "sumsub"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "bridge"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "manteca"
-                        ]
-                      }
-                    ]
-                  },
-                  "username": {
-                    "type": "string"
-                  },
-                  "harnessLabel": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "email"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "x-test-harness-secret",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "token": {
-                      "type": "string"
-                    },
-                    "user": {
-                      "type": "object",
-                      "properties": {
-                        "userId": {
-                          "type": "string"
-                        },
-                        "email": {
-                          "type": "string"
-                        },
-                        "username": {
-                          "type": "string"
-                        },
-                        "harnessLabel": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "userId",
-                        "email",
-                        "harnessLabel"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "token",
-                    "user"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/seed-scenario": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "scenario": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "send-link-pending"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "send-link-claimed"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "request-pot-open"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "kyc-matrix"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "user-with-bank-accounts"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "withdraw-ready"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "manteca-qr-payment"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "multi-user-send"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "points-and-perks"
-                        ]
-                      }
-                    ]
-                  },
-                  "harnessLabel": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "scenario"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "x-test-harness-secret",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "scenario": {
-                      "type": "string"
-                    },
-                    "data": {}
-                  },
-                  "required": [
-                    "scenario",
-                    "data"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/reproduce": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "scenario": {
-                    "description": "qa scenario name for logging",
-                    "type": "string"
-                  },
-                  "entry": {
-                    "type": "object",
-                    "properties": {
-                      "route": {
-                        "default": "/home",
-                        "type": "string"
-                      },
-                      "userId": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      }
-                    },
-                    "required": [
-                      "route"
-                    ]
-                  },
-                  "localStorage": {
-                    "type": "object",
-                    "additionalProperties": {}
-                  },
-                  "stepSnapshot": {
-                    "type": "object",
-                    "properties": {
-                      "userIds": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "tables": {
-                        "type": "object",
-                        "additionalProperties": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "patternProperties": {
-                              "^(.*)$": {}
-                            }
-                          }
-                        }
-                      },
-                      "capturedAt": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "userIds",
-                      "tables"
-                    ]
-                  },
-                  "stepActions": {
-                    "type": "array",
-                    "items": {}
-                  },
-                  "notes": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "scenario",
-                  "entry"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "header",
-            "name": "x-test-harness-secret",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "url": {
-                      "type": "string"
-                    },
-                    "sessionId": {
-                      "type": "string"
-                    },
-                    "userId": {
-                      "type": "string"
-                    },
-                    "token": {
-                      "type": "string"
-                    },
-                    "localStorage": {
-                      "type": "object",
-                      "additionalProperties": {}
-                    },
-                    "restored": {
-                      "type": "boolean"
-                    }
-                  },
-                  "required": [
-                    "url",
-                    "sessionId",
-                    "userId",
-                    "token",
-                    "localStorage"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/reproduce/{sessionId}": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "sessionId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "scenario": {
-                      "type": "string"
-                    },
-                    "entry": {
-                      "type": "object",
-                      "properties": {
-                        "route": {
-                          "type": "string"
-                        },
-                        "userId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        }
-                      },
-                      "required": [
-                        "route",
-                        "userId"
-                      ]
-                    },
-                    "localStorage": {
-                      "type": "object",
-                      "additionalProperties": {}
-                    },
-                    "stepActions": {
-                      "type": "array",
-                      "items": {}
-                    },
-                    "userId": {
-                      "type": "string"
-                    },
-                    "token": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "scenario",
-                    "entry",
-                    "localStorage",
-                    "userId",
-                    "token"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/poll": {
-      "post": {
-        "summary": "Run one polling cycle synchronously",
-        "tags": [
-          "dev"
-        ],
-        "description": "Triggers runPollingCycle() on demand — used by the QA harness to observe provider state transitions without waiting for the 5-minute interval.",
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    },
-                    "ms": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "ms"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/register-address": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "address": {
-                    "description": "0x-prefixed hex address (lowercased server-side)",
-                    "type": "string"
-                  },
-                  "userId": {
-                    "description": "Peanut user_id to associate with this address",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "address",
-                  "userId"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    },
-                    "registered": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "registered"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/reset-deposit-tracker": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    },
-                    "registeredAddresses": {
-                      "type": "number"
-                    },
-                    "skippedInvalid": {
-                      "type": "number"
-                    },
-                    "lastProcessedBlock": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "registeredAddresses",
-                    "skippedInvalid",
-                    "lastProcessedBlock"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/reset-harness-data/{label}": {
-      "post": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "label",
-            "required": true,
-            "description": "harnessLabel value to wipe"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    },
-                    "deleted": {
-                      "type": "number"
-                    },
-                    "label": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "deleted",
-                    "label"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/submit-to-providers": {
-      "post": {
-        "summary": "Run KYC provider submission synchronously for the given user/applicant",
-        "tags": [
-          "dev"
-        ],
-        "description": "Drives Peanut's submitToProviders(userId, applicantId) synchronously, the same function the Sumsub status-processor calls after GREEN. Used by QA harness to test routing (AR user → Manteca, US user → Bridge) end-to-end.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "userId": {
-                    "description": "Peanut user_id whose rails to submit",
-                    "type": "string"
-                  },
-                  "applicantId": {
-                    "description": "Sumsub applicant id with approved docs + extracted data",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "userId",
-                  "applicantId"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    },
-                    "ms": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "ms"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/trigger-sumsub-webhook": {
-      "post": {
-        "summary": "Synthesise a Sumsub webhook and run the status-processor",
-        "tags": [
-          "dev"
-        ],
-        "description": "Invokes processSumsubKycUpdate({ applicantId, externalUserId, reviewAnswer, reviewStatus, source: 'webhook' }) — same entry point as the real /sumsub/webhooks route, minus HMAC. Used by the QA harness to exercise the full Sumsub → routing chain without real webhook delivery.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "applicantId": {
-                    "description": "Sumsub applicant id",
-                    "type": "string"
-                  },
-                  "externalUserId": {
-                    "description": "Peanut user_id (applicant.externalUserId)",
-                    "type": "string"
-                  },
-                  "reviewAnswer": {
-                    "default": "GREEN",
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "GREEN"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "RED"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "ERROR"
-                        ]
-                      }
-                    ]
-                  },
-                  "reviewStatus": {
-                    "description": "Sumsub reviewStatus (default: \"completed\")",
-                    "type": "string"
-                  },
-                  "levelName": {
-                    "type": "string"
-                  },
-                  "webhookType": {
-                    "description": "e.g. \"applicantReviewed\"",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "applicantId",
-                  "externalUserId"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    },
-                    "ms": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "ms"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/ledger/history": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "userId",
-            "required": true,
-            "description": "Peanut user_id (varchar)"
-          },
-          {
-            "schema": {
-              "minimum": 1,
-              "maximum": 500,
-              "default": 50,
-              "type": "integer"
-            },
-            "in": "query",
-            "name": "limit",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    },
-                    "userId": {
-                      "type": "string"
-                    },
-                    "count": {
-                      "type": "number"
-                    },
-                    "intents": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string"
-                          },
-                          "kind": {
-                            "type": "string"
-                          },
-                          "provider": {
-                            "type": "string"
-                          },
-                          "status": {
-                            "type": "string"
-                          },
-                          "requestedAmount": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "requestedAsset": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "settledAmount": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "settledAsset": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "fxRate": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "createdAt": {
-                            "type": "string"
-                          },
-                          "completedAt": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "entryCount": {
-                            "type": "number"
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "kind",
-                          "provider",
-                          "status",
-                          "requestedAmount",
-                          "requestedAsset",
-                          "settledAmount",
-                          "settledAsset",
-                          "fxRate",
-                          "createdAt",
-                          "completedAt",
-                          "entryCount"
-                        ]
-                      }
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "userId",
-                    "count",
-                    "intents"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/invite-code": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "ensureUsername",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "inviteCode": {
-                      "type": "string"
-                    },
-                    "inviterUsername": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "inviteCode",
-                    "inviterUsername"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/whoami": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "userId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "userId": {
-                      "type": "string"
-                    },
-                    "username": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "email": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "hasMantecaUserId": {
-                      "type": "boolean"
-                    },
-                    "hasBridgeCustomerId": {
-                      "type": "boolean"
-                    },
-                    "bridgeKycStatus": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "walletAddresses": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "kycVerifications": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "provider": {
-                            "type": "string"
-                          },
-                          "status": {
-                            "type": "string"
-                          },
-                          "mantecaGeo": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          }
-                        },
-                        "required": [
-                          "provider",
-                          "status",
-                          "mantecaGeo"
-                        ]
-                      }
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "userId",
-                    "username",
-                    "email",
-                    "hasMantecaUserId",
-                    "hasBridgeCustomerId",
-                    "bridgeKycStatus",
-                    "walletAddresses",
-                    "kycVerifications"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/fund-sa": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "userId": {
-                    "type": "string"
-                  },
-                  "usdc": {
-                    "description": "6-decimal USDC, default 10000000 = $10",
-                    "type": "string"
-                  },
-                  "ethWei": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "userId"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "txHash": {
-                      "type": "string"
-                    },
-                    "saAddress": {
-                      "type": "string"
-                    },
-                    "usdcSent": {
-                      "type": "string"
-                    },
-                    "ethSent": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "txHash",
-                    "saAddress",
-                    "usdcSent",
-                    "ethSent"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/sweep-perk-to-kernel": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "amount": {
-                    "description": "6-decimal USDC base units; defaults to entire EOA balance",
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "txHash": {
-                      "type": "string"
-                    },
-                    "eoaAddress": {
-                      "type": "string"
-                    },
-                    "kernelAddress": {
-                      "type": "string"
-                    },
-                    "usdcSwept": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "txHash",
-                    "eoaAddress",
-                    "kernelAddress",
-                    "usdcSwept"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/peanut-make-deposit": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "amount": {
-                    "type": "string"
-                  },
-                  "recipientAddress": {
-                    "pattern": "^0x[0-9a-fA-F]{40}$",
-                    "description": "Address that the recipient will withdraw to",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "recipientAddress"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "vaultAddress": {
-                      "type": "string"
-                    },
-                    "depositIdx": {
-                      "type": "number"
-                    },
-                    "password": {
-                      "type": "string"
-                    },
-                    "pubKey20": {
-                      "type": "string"
-                    },
-                    "claimParams": {
-                      "type": "array",
-                      "items": {}
-                    },
-                    "makeDepositTxHash": {
-                      "type": "string"
-                    },
-                    "amount": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "vaultAddress",
-                    "depositIdx",
-                    "password",
-                    "pubKey20",
-                    "claimParams",
-                    "makeDepositTxHash",
-                    "amount"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/approve-kyc": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "userId": {
-                    "type": "string"
-                  },
-                  "provider": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "bridge"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "manteca"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "sumsub"
-                        ]
-                      }
-                    ]
-                  },
-                  "country": {
-                    "description": "ISO-2 (AR/BR/US/GB/DE/MX)",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "userId",
-                  "provider"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "updated": {
-                      "type": "string"
-                    },
-                    "details": {}
-                  },
-                  "required": [
-                    "ok",
-                    "updated",
-                    "details"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/fund-rain-collateral": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "userId": {
-                    "type": "string"
-                  },
-                  "amountMicros": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "userId"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "saAddress": {
-                      "type": "string"
-                    },
-                    "tokenAddress": {
-                      "type": "string"
-                    },
-                    "amountMicros": {
-                      "type": "string"
-                    },
-                    "txHash": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "saAddress",
-                    "tokenAddress",
-                    "amountMicros",
-                    "txHash"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/grant-card-access": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "userId": {
-                    "type": "string"
-                  },
-                  "revoke": {
-                    "type": "boolean"
-                  }
-                },
-                "required": [
-                  "userId"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "userId": {
-                      "type": "string"
-                    },
-                    "username": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "cardAccessGrantedAt": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "userId",
-                    "username",
-                    "cardAccessGrantedAt"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/simulate-bridge-deposit": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "userId": {
-                    "type": "string"
-                  },
-                  "amountUsd": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "userId",
-                  "amountUsd"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "virtualAccountId": {
-                      "type": "string"
-                    },
-                    "simulateResponse": {}
-                  },
-                  "required": [
-                    "ok",
-                    "virtualAccountId",
-                    "simulateResponse"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/reset-user": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "userId": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "userId"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "cleared": {
-                      "type": "object",
-                      "properties": {
-                        "kycVerifications": {
-                          "type": "number"
-                        },
-                        "ledgerIntents": {
-                          "type": "number"
-                        }
-                      },
-                      "required": [
-                        "kycVerifications",
-                        "ledgerIntents"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "cleared"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/complete-bridge-onramp": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "intentOrTransferId": {
-                    "description": "Either a TransactionIntent.id or a Bridge transfer id.",
-                    "type": "string"
-                  },
-                  "exchangeRate": {
-                    "type": "number"
-                  },
-                  "developerFee": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "intentOrTransferId"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "providerEventId": {
-                      "type": "string"
-                    },
-                    "intentId": {
-                      "type": "string"
-                    },
-                    "finalState": {
-                      "type": "string"
-                    },
-                    "statusChanged": {
-                      "type": "boolean"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "providerEventId",
-                    "finalState",
-                    "statusChanged"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/complete-bridge-offramp": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "intentOrTransferId": {
-                    "type": "string"
-                  },
-                  "exchangeRate": {
-                    "type": "number"
-                  },
-                  "developerFee": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "intentOrTransferId"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "providerEventId": {
-                      "type": "string"
-                    },
-                    "intentId": {
-                      "type": "string"
-                    },
-                    "finalState": {
-                      "type": "string"
-                    },
-                    "statusChanged": {
-                      "type": "boolean"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "providerEventId",
-                    "finalState",
-                    "statusChanged"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/fail-bridge-transfer": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "intentOrTransferId": {
-                    "type": "string"
-                  },
-                  "reason": {
-                    "type": "string"
-                  },
-                  "terminalState": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "error"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "returned"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "undeliverable"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "refunded"
-                        ]
-                      }
-                    ]
-                  }
-                },
-                "required": [
-                  "intentOrTransferId",
-                  "reason"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "providerEventId": {
-                      "type": "string"
-                    },
-                    "intentId": {
-                      "type": "string"
-                    },
-                    "finalState": {
-                      "type": "string"
-                    },
-                    "statusChanged": {
-                      "type": "boolean"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "providerEventId",
-                    "finalState",
-                    "statusChanged"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/complete-rhino-deposit": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "depositAddress": {
-                    "type": "string"
-                  },
-                  "chainIn": {
-                    "description": "Rhino's source-chain enum, e.g. BASE / ARBITRUM / BINANCE",
-                    "type": "string"
-                  },
-                  "token": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "USDC"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "USDT"
-                        ]
-                      }
-                    ]
-                  },
-                  "depositor": {
-                    "description": "Source-chain wallet that funded the SDA",
-                    "type": "string"
-                  },
-                  "recipient": {
-                    "description": "Destination peanut wallet address on Arbitrum",
-                    "type": "string"
-                  },
-                  "amountIn": {
-                    "description": "Human-unit source amount, e.g. \"1.00\"",
-                    "type": "string"
-                  },
-                  "amountOut": {
-                    "description": "Human-unit destination amount after FX + fees",
-                    "type": "string"
-                  },
-                  "amountOutUsd": {
-                    "type": "number"
-                  }
-                },
-                "required": [
-                  "depositAddress",
-                  "chainIn",
-                  "token",
-                  "depositor",
-                  "recipient",
-                  "amountIn",
-                  "amountOut",
-                  "amountOutUsd"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "providerEventId": {
-                      "type": "string"
-                    },
-                    "finalState": {
-                      "type": "string"
-                    },
-                    "statusChanged": {
-                      "type": "boolean"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "providerEventId",
-                    "finalState",
-                    "statusChanged"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/complete-rhino-req-fulfilment": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "depositAddress": {
-                    "type": "string"
-                  },
-                  "chainIn": {
-                    "description": "Rhino's source-chain enum, e.g. BASE / ARBITRUM / BINANCE",
-                    "type": "string"
-                  },
-                  "token": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "USDC"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "USDT"
-                        ]
-                      }
-                    ]
-                  },
-                  "depositor": {
-                    "description": "Source-chain wallet that funded the SDA",
-                    "type": "string"
-                  },
-                  "recipient": {
-                    "description": "Destination peanut wallet address on Arbitrum",
-                    "type": "string"
-                  },
-                  "amountIn": {
-                    "description": "Human-unit source amount, e.g. \"1.00\"",
-                    "type": "string"
-                  },
-                  "amountOut": {
-                    "description": "Human-unit destination amount after FX + fees",
-                    "type": "string"
-                  },
-                  "amountOutUsd": {
-                    "type": "number"
-                  }
-                },
-                "required": [
-                  "depositAddress",
-                  "chainIn",
-                  "token",
-                  "depositor",
-                  "recipient",
-                  "amountIn",
-                  "amountOut",
-                  "amountOutUsd"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "providerEventId": {
-                      "type": "string"
-                    },
-                    "intentId": {
-                      "type": "string"
-                    },
-                    "finalState": {
-                      "type": "string"
-                    },
-                    "statusChanged": {
-                      "type": "boolean"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "providerEventId",
-                    "finalState",
-                    "statusChanged"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/complete-rhino-withdraw": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "depositAddress": {
-                    "type": "string"
-                  },
-                  "chainIn": {
-                    "description": "Rhino's source-chain enum, e.g. BASE / ARBITRUM / BINANCE",
-                    "type": "string"
-                  },
-                  "token": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "USDC"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "USDT"
-                        ]
-                      }
-                    ]
-                  },
-                  "depositor": {
-                    "description": "Source-chain wallet that funded the SDA",
-                    "type": "string"
-                  },
-                  "recipient": {
-                    "description": "Destination peanut wallet address on Arbitrum",
-                    "type": "string"
-                  },
-                  "amountIn": {
-                    "description": "Human-unit source amount, e.g. \"1.00\"",
-                    "type": "string"
-                  },
-                  "amountOut": {
-                    "description": "Human-unit destination amount after FX + fees",
-                    "type": "string"
-                  },
-                  "amountOutUsd": {
-                    "type": "number"
-                  }
-                },
-                "required": [
-                  "depositAddress",
-                  "chainIn",
-                  "token",
-                  "depositor",
-                  "recipient",
-                  "amountIn",
-                  "amountOut",
-                  "amountOutUsd"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "providerEventId": {
-                      "type": "string"
-                    },
-                    "intentId": {
-                      "type": "string"
-                    },
-                    "finalState": {
-                      "type": "string"
-                    },
-                    "statusChanged": {
-                      "type": "boolean"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "providerEventId",
-                    "finalState",
-                    "statusChanged"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/complete-rhino-claim-xchain": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "depositAddress": {
-                    "type": "string"
-                  },
-                  "chainIn": {
-                    "description": "Rhino's source-chain enum, e.g. BASE / ARBITRUM / BINANCE",
-                    "type": "string"
-                  },
-                  "token": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "USDC"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "USDT"
-                        ]
-                      }
-                    ]
-                  },
-                  "depositor": {
-                    "description": "Source-chain wallet that funded the SDA",
-                    "type": "string"
-                  },
-                  "recipient": {
-                    "description": "Destination peanut wallet address on Arbitrum",
-                    "type": "string"
-                  },
-                  "amountIn": {
-                    "description": "Human-unit source amount, e.g. \"1.00\"",
-                    "type": "string"
-                  },
-                  "amountOut": {
-                    "description": "Human-unit destination amount after FX + fees",
-                    "type": "string"
-                  },
-                  "amountOutUsd": {
-                    "type": "number"
-                  }
-                },
-                "required": [
-                  "depositAddress",
-                  "chainIn",
-                  "token",
-                  "depositor",
-                  "recipient",
-                  "amountIn",
-                  "amountOut",
-                  "amountOutUsd"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "providerEventId": {
-                      "type": "string"
-                    },
-                    "finalState": {
-                      "type": "string"
-                    },
-                    "statusChanged": {
-                      "type": "boolean"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "providerEventId",
-                    "finalState",
-                    "statusChanged"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/fail-rhino-transfer": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "depositAddress": {
-                    "type": "string"
-                  },
-                  "chainIn": {
-                    "description": "Rhino's source-chain enum, e.g. BASE / ARBITRUM / BINANCE",
-                    "type": "string"
-                  },
-                  "token": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "enum": [
-                          "USDC"
-                        ]
-                      },
-                      {
-                        "type": "string",
-                        "enum": [
-                          "USDT"
-                        ]
-                      }
-                    ]
-                  },
-                  "depositor": {
-                    "description": "Source-chain wallet that funded the SDA",
-                    "type": "string"
-                  },
-                  "recipient": {
-                    "description": "Destination peanut wallet address on Arbitrum",
-                    "type": "string"
-                  },
-                  "amountIn": {
-                    "description": "Human-unit source amount, e.g. \"1.00\"",
-                    "type": "string"
-                  },
-                  "amountOut": {
-                    "description": "Human-unit destination amount after FX + fees",
-                    "type": "string"
-                  },
-                  "amountOutUsd": {
-                    "type": "number"
-                  },
-                  "reason": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "depositAddress",
-                  "chainIn",
-                  "token",
-                  "depositor",
-                  "recipient",
-                  "amountIn",
-                  "amountOut",
-                  "amountOutUsd"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "providerEventId": {
-                      "type": "string"
-                    },
-                    "intentId": {
-                      "type": "string"
-                    },
-                    "finalState": {
-                      "type": "string"
-                    },
-                    "statusChanged": {
-                      "type": "boolean"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "providerEventId",
-                    "finalState",
-                    "statusChanged"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/auto-complete-pending": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "userId": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "userId"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "completed": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "intentId": {
-                            "type": "string"
-                          },
-                          "kind": {
-                            "type": "string"
-                          },
-                          "provider": {
-                            "type": "string"
-                          },
-                          "finalState": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "intentId",
-                          "kind",
-                          "provider",
-                          "finalState"
-                        ]
-                      }
-                    },
-                    "skipped": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "intentId": {
-                            "type": "string"
-                          },
-                          "kind": {
-                            "type": "string"
-                          },
-                          "provider": {
-                            "type": "string"
-                          },
-                          "reason": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "intentId",
-                          "kind",
-                          "provider",
-                          "reason"
-                        ]
-                      }
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "completed",
-                    "skipped"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/full-setup": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "userId": {
-                    "type": "string"
-                  },
-                  "usdcMicros": {
-                    "description": "Defaults to 100 USDC.",
-                    "type": "string"
-                  },
-                  "bridgeDepositUsd": {
-                    "description": "Defaults to 25.",
-                    "type": "string"
-                  },
-                  "bridgeCountry": {
-                    "description": "ISO-2; defaults to US.",
-                    "type": "string"
-                  },
-                  "mantecaCountry": {
-                    "description": "Defaults to AR.",
-                    "type": "string"
-                  },
-                  "sumsubCountry": {
-                    "description": "Defaults to US.",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "userId"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "steps": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string"
-                          },
-                          "ok": {
-                            "type": "boolean"
-                          },
-                          "detail": {}
-                        },
-                        "required": [
-                          "name",
-                          "ok",
-                          "detail"
-                        ]
-                      }
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "steps"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "ok",
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/userid-by-username": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "username",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "userId": {
-                      "type": "string"
-                    },
-                    "username": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "userId",
-                    "username"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "suggestions": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "totalUsers": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "error",
-                    "suggestions",
-                    "totalUsers"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/list-users": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "prefix",
-            "required": false
-          },
-          {
-            "schema": {
-              "minimum": 1,
-              "maximum": 100,
-              "type": "number"
-            },
-            "in": "query",
-            "name": "limit",
-            "required": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "users": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "totalUsers": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "users",
-                    "totalUsers"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dev/cheats/mint-jwt": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "userId": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "userId"
-                ]
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "token": {
-                      "type": "string"
-                    },
-                    "userId": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "token",
-                    "userId"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "hint": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error",
-                    "hint"
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "hint": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error",
-                    "hint"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  "servers": [
-    {
-      "url": "http://localhost:5050"
-    }
-  ]
+	"openapi": "3.0.3",
+	"info": {
+		"title": "peanut-api",
+		"version": "1.0.0"
+	},
+	"components": {
+		"schemas": {}
+	},
+	"paths": {
+		"/": {
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/test-error": {
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/apple-app-site-association": {
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/assetLinks.json": {
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/claim": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"chainId": {
+										"pattern": "^[0-9]+$",
+										"type": "string"
+									},
+									"version": {
+										"default": "v4.3",
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["v4.3"]
+											},
+											{
+												"type": "string",
+												"enum": ["v4.4"]
+											}
+										]
+									},
+									"claimParams": {
+										"minItems": 3,
+										"type": "array",
+										"items": {}
+									},
+									"withMFA": {
+										"default": false,
+										"type": "boolean"
+									},
+									"depositDetails": {
+										"type": "object",
+										"properties": {
+											"pubKey20": {
+												"type": "string"
+											},
+											"amount": {
+												"type": "string"
+											},
+											"tokenAddress": {
+												"type": "string"
+											},
+											"contractType": {
+												"type": "number"
+											},
+											"claimed": {
+												"type": "boolean"
+											},
+											"requiresMFA": {
+												"type": "boolean"
+											},
+											"timestamp": {
+												"type": "number"
+											},
+											"tokenId": {
+												"type": "string"
+											},
+											"senderAddress": {
+												"type": "string"
+											}
+										},
+										"required": [
+											"pubKey20",
+											"amount",
+											"tokenAddress",
+											"contractType",
+											"claimed",
+											"requiresMFA",
+											"timestamp",
+											"tokenId",
+											"senderAddress"
+										]
+									},
+									"optimisticReturn": {
+										"type": "boolean"
+									},
+									"campaignTag": {
+										"type": "string"
+									}
+								},
+								"required": ["chainId", "claimParams"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/healthz": {
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/ens/{ensName}": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "ensName",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/add-account": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"accountIdentifier": {
+										"type": "string"
+									},
+									"accountType": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["iban"]
+											},
+											{
+												"type": "string",
+												"enum": ["us"]
+											},
+											{
+												"type": "string",
+												"enum": ["evm-address"]
+											},
+											{
+												"type": "string",
+												"enum": ["peanut-wallet"]
+											},
+											{
+												"type": "string",
+												"enum": ["bridgeBankAccount"]
+											},
+											{
+												"type": "string",
+												"enum": ["manteca"]
+											},
+											{
+												"type": "string",
+												"enum": ["simplefi-merchant"]
+											},
+											{
+												"type": "string",
+												"enum": ["clabe"]
+											},
+											{
+												"type": "string",
+												"enum": ["cbu"]
+											},
+											{
+												"type": "string",
+												"enum": ["cvu"]
+											},
+											{
+												"type": "string",
+												"enum": ["pix"]
+											}
+										]
+									},
+									"userId": {
+										"type": "string"
+									},
+									"bridgeAccountIdentifier": {
+										"type": "string"
+									},
+									"chainId": {
+										"type": "string"
+									},
+									"telegramHandle": {
+										"type": "string"
+									}
+								},
+								"required": ["accountIdentifier", "accountType", "userId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/users/username/{username}": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "username",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/get-user": {
+			"post": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/get-user-id": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"accountIdentifier": {
+										"type": "string"
+									}
+								},
+								"required": ["accountIdentifier"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/get-user-salt": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"email": {
+										"type": "string"
+									}
+								},
+								"required": ["email"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/update-user": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									},
+									"username": {
+										"type": "string"
+									},
+									"email": {
+										"type": "string"
+									},
+									"fullName": {
+										"type": "string"
+									},
+									"bridge_customer_id": {
+										"type": "string"
+									},
+									"telegramUsername": {
+										"type": "string"
+									},
+									"pushSubscriptionId": {
+										"type": "string"
+									},
+									"showFullName": {
+										"type": "boolean"
+									},
+									"hasSeenEarlyUserModal": {
+										"type": "boolean"
+									},
+									"bridgeKycStatus": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["not_started"]
+											},
+											{
+												"type": "string",
+												"enum": ["incomplete"]
+											},
+											{
+												"type": "string",
+												"enum": ["under_review"]
+											},
+											{
+												"type": "string",
+												"enum": ["approved"]
+											},
+											{
+												"type": "string",
+												"enum": ["rejected"]
+											}
+										]
+									},
+									"showKycCompletedModal": {
+										"type": "boolean"
+									}
+								},
+								"required": ["userId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/users/contacts": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "limit",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "offset",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "search",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/users/history": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "cursor",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "number"
+						},
+						"in": "query",
+						"name": "limit",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "targetUsername",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/users/track-transaction": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"payerAddress": {
+										"type": "string"
+									},
+									"txHash": {
+										"type": "string"
+									},
+									"sourceChainId": {
+										"type": "string"
+									},
+									"sourceTokenAddress": {
+										"type": "string"
+									}
+								}
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/history/{entryId}": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "kind",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "entryId",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/api/users/{userId}/acknowledgments": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "userId",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/users/search": {
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/users/initiate-kyc": {
+			"post": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/users/accounts": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"accountType": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["iban"]
+											},
+											{
+												"type": "string",
+												"enum": ["us"]
+											},
+											{
+												"type": "string",
+												"enum": ["clabe"]
+											},
+											{
+												"type": "string",
+												"enum": ["gb"]
+											}
+										]
+									},
+									"accountNumber": {
+										"type": "string"
+									},
+									"countryCode": {
+										"type": "string"
+									},
+									"countryName": {
+										"type": "string"
+									},
+									"accountOwnerType": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["individual"]
+											},
+											{
+												"type": "string",
+												"enum": ["business"]
+											}
+										]
+									},
+									"accountOwnerName": {
+										"type": "object",
+										"properties": {
+											"firstName": {
+												"type": "string"
+											},
+											"lastName": {
+												"type": "string"
+											},
+											"businessName": {
+												"type": "string"
+											}
+										}
+									},
+									"address": {
+										"type": "object",
+										"properties": {
+											"street": {
+												"type": "string"
+											},
+											"city": {
+												"type": "string"
+											},
+											"country": {
+												"type": "string"
+											},
+											"state": {
+												"type": "string"
+											},
+											"postalCode": {
+												"type": "string"
+											}
+										},
+										"required": ["street", "city", "country", "postalCode"]
+									},
+									"bic": {
+										"type": "string"
+									},
+									"routingNumber": {
+										"type": "string"
+									},
+									"sortCode": {
+										"type": "string"
+									}
+								},
+								"required": [
+									"accountType",
+									"accountNumber",
+									"countryCode",
+									"countryName",
+									"accountOwnerType",
+									"accountOwnerName",
+									"address"
+								]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/users/{userId}": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "userId",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/users/interaction-status": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userIds": {
+										"type": "array",
+										"items": {
+											"type": "string"
+										}
+									}
+								},
+								"required": ["userIds"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/users/limits": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/users/increase-limits": {
+			"post": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/users/rails": {
+			"post": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			},
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/users/bridge-tos-link": {
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/users/bridge-tos-confirm": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"additionalProperties": true
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/validate-bank-account-number": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"bankAccountNumber": {
+										"type": "string"
+									}
+								},
+								"required": ["bankAccountNumber"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/validate-bank-account": {
+			"post": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/validate-bank-number": {
+			"post": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/validate-bic": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"bic": {
+										"type": "string"
+									}
+								},
+								"required": ["bic"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/is-valid-bic": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"bic": {
+										"type": "string"
+									}
+								},
+								"required": ["bic"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/passkeys/register/options": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"username": {
+										"type": "string"
+									},
+									"rpID": {
+										"type": "string"
+									}
+								},
+								"required": ["username"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/passkeys/register/verify": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									},
+									"username": {
+										"type": "string"
+									},
+									"cred": {},
+									"rpID": {
+										"type": "string"
+									}
+								},
+								"required": ["userId", "username", "cred"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/passkeys/login/options": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"rpID": {
+										"type": "string"
+									}
+								}
+							}
+						}
+					}
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/passkeys/login/verify": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"cred": {},
+									"rpID": {
+										"type": "string"
+									}
+								},
+								"required": ["cred"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/requests": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"anyOf": [
+									{
+										"additionalProperties": false,
+										"type": "object",
+										"properties": {
+											"chainId": {
+												"type": "string"
+											},
+											"tokenAmount": {
+												"type": "string"
+											},
+											"recipientAddress": {
+												"type": "string"
+											},
+											"trackId": {
+												"type": "string"
+											},
+											"reference": {
+												"type": "string"
+											},
+											"tokenType": {
+												"not": {}
+											},
+											"tokenAddress": {
+												"not": {}
+											},
+											"tokenDecimals": {
+												"not": {}
+											},
+											"tokenSymbol": {
+												"not": {}
+											}
+										},
+										"required": ["recipientAddress"]
+									},
+									{
+										"additionalProperties": false,
+										"type": "object",
+										"properties": {
+											"chainId": {
+												"type": "string"
+											},
+											"tokenAmount": {
+												"type": "string"
+											},
+											"recipientAddress": {
+												"type": "string"
+											},
+											"trackId": {
+												"type": "string"
+											},
+											"reference": {
+												"type": "string"
+											},
+											"tokenType": {
+												"type": "string"
+											},
+											"tokenAddress": {
+												"type": "string",
+												"pattern": "^0x[a-fA-F0-9]{40}$"
+											},
+											"tokenDecimals": {
+												"type": "string"
+											},
+											"tokenSymbol": {
+												"type": "string"
+											}
+										},
+										"required": [
+											"chainId",
+											"recipientAddress",
+											"tokenType",
+											"tokenAddress",
+											"tokenDecimals",
+											"tokenSymbol"
+										]
+									}
+								]
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			},
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "recipient",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "tokenAmount",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "tokenAddress",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "chainId",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/requests/{uuid}": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "uuid",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			},
+			"patch": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"additionalProperties": false,
+								"type": "object",
+								"properties": {
+									"chainId": {
+										"type": "string"
+									},
+									"tokenAmount": {
+										"type": "string"
+									},
+									"recipientAddress": {
+										"type": "string"
+									},
+									"trackId": {
+										"type": "string"
+									},
+									"reference": {
+										"type": "string"
+									},
+									"tokenAddress": {
+										"type": "string",
+										"pattern": "^0x[a-fA-F0-9]{40}$"
+									},
+									"tokenDecimals": {
+										"type": "string"
+									},
+									"tokenType": {
+										"type": "string"
+									},
+									"tokenSymbol": {
+										"type": "string"
+									}
+								}
+							}
+						}
+					}
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "uuid",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			},
+			"delete": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "uuid",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/charges": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"multipart/form-data": {
+							"schema": {
+								"anyOf": [
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"type": "object",
+												"properties": {
+													"pricing_type": {
+														"anyOf": [
+															{
+																"type": "string",
+																"enum": ["fixed_price"]
+															},
+															{
+																"type": "string",
+																"enum": ["no_price"]
+															}
+														]
+													},
+													"local_price": {
+														"type": "object",
+														"properties": {
+															"amount": {
+																"type": "string"
+															},
+															"currency": {
+																"type": "string"
+															}
+														},
+														"required": ["amount"]
+													},
+													"baseUrl": {
+														"type": "string"
+													},
+													"reference": {
+														"type": "string"
+													},
+													"transactionType": {
+														"anyOf": [
+															{
+																"type": "string",
+																"enum": ["REQUEST"]
+															},
+															{
+																"type": "string",
+																"enum": ["DIRECT_SEND"]
+															},
+															{
+																"type": "string",
+																"enum": ["SEND_LINK"]
+															},
+															{
+																"type": "string",
+																"enum": ["DEPOSIT"]
+															},
+															{
+																"type": "string",
+																"enum": ["WITHDRAW"]
+															}
+														]
+													},
+													"attachment": {},
+													"mimetype": {
+														"type": "string"
+													},
+													"filename": {
+														"type": "string"
+													}
+												},
+												"required": ["pricing_type", "local_price"]
+											},
+											{
+												"type": "object",
+												"properties": {
+													"checkout_id": {
+														"type": "string"
+													},
+													"requestId": {
+														"not": {}
+													},
+													"requestProps": {
+														"type": "object",
+														"properties": {
+															"chainId": {
+																"type": "string"
+															},
+															"tokenAddress": {
+																"type": "string"
+															},
+															"tokenType": {
+																"type": "string"
+															},
+															"tokenSymbol": {
+																"type": "string"
+															},
+															"tokenDecimals": {
+																"type": "integer"
+															},
+															"recipientAddress": {
+																"type": "string"
+															},
+															"requesteeUsername": {
+																"type": "string"
+															},
+															"tokenAmount": {
+																"type": "string"
+															}
+														}
+													}
+												},
+												"required": ["checkout_id"]
+											}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"type": "object",
+												"properties": {
+													"pricing_type": {
+														"anyOf": [
+															{
+																"type": "string",
+																"enum": ["fixed_price"]
+															},
+															{
+																"type": "string",
+																"enum": ["no_price"]
+															}
+														]
+													},
+													"local_price": {
+														"type": "object",
+														"properties": {
+															"amount": {
+																"type": "string"
+															},
+															"currency": {
+																"type": "string"
+															}
+														},
+														"required": ["amount"]
+													},
+													"baseUrl": {
+														"type": "string"
+													},
+													"reference": {
+														"type": "string"
+													},
+													"transactionType": {
+														"anyOf": [
+															{
+																"type": "string",
+																"enum": ["REQUEST"]
+															},
+															{
+																"type": "string",
+																"enum": ["DIRECT_SEND"]
+															},
+															{
+																"type": "string",
+																"enum": ["SEND_LINK"]
+															},
+															{
+																"type": "string",
+																"enum": ["DEPOSIT"]
+															},
+															{
+																"type": "string",
+																"enum": ["WITHDRAW"]
+															}
+														]
+													},
+													"attachment": {},
+													"mimetype": {
+														"type": "string"
+													},
+													"filename": {
+														"type": "string"
+													}
+												},
+												"required": ["pricing_type", "local_price"]
+											},
+											{
+												"type": "object",
+												"properties": {
+													"checkout_id": {
+														"not": {}
+													},
+													"requestId": {
+														"type": "string"
+													},
+													"requestProps": {
+														"type": "object",
+														"properties": {
+															"chainId": {
+																"type": "string"
+															},
+															"tokenAddress": {
+																"type": "string"
+															},
+															"tokenType": {
+																"type": "string"
+															},
+															"tokenSymbol": {
+																"type": "string"
+															},
+															"tokenDecimals": {
+																"type": "integer"
+															},
+															"recipientAddress": {
+																"type": "string"
+															},
+															"requesteeUsername": {
+																"type": "string"
+															},
+															"tokenAmount": {
+																"type": "string"
+															}
+														}
+													}
+												},
+												"required": ["requestId"]
+											}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"type": "object",
+												"properties": {
+													"pricing_type": {
+														"anyOf": [
+															{
+																"type": "string",
+																"enum": ["fixed_price"]
+															},
+															{
+																"type": "string",
+																"enum": ["no_price"]
+															}
+														]
+													},
+													"local_price": {
+														"type": "object",
+														"properties": {
+															"amount": {
+																"type": "string"
+															},
+															"currency": {
+																"type": "string"
+															}
+														},
+														"required": ["amount"]
+													},
+													"baseUrl": {
+														"type": "string"
+													},
+													"reference": {
+														"type": "string"
+													},
+													"transactionType": {
+														"anyOf": [
+															{
+																"type": "string",
+																"enum": ["REQUEST"]
+															},
+															{
+																"type": "string",
+																"enum": ["DIRECT_SEND"]
+															},
+															{
+																"type": "string",
+																"enum": ["SEND_LINK"]
+															},
+															{
+																"type": "string",
+																"enum": ["DEPOSIT"]
+															},
+															{
+																"type": "string",
+																"enum": ["WITHDRAW"]
+															}
+														]
+													},
+													"attachment": {},
+													"mimetype": {
+														"type": "string"
+													},
+													"filename": {
+														"type": "string"
+													}
+												},
+												"required": ["pricing_type", "local_price"]
+											},
+											{
+												"type": "object",
+												"properties": {
+													"checkout_id": {
+														"not": {}
+													},
+													"requestId": {
+														"not": {}
+													},
+													"requestProps": {
+														"type": "object",
+														"properties": {
+															"chainId": {
+																"type": "string"
+															},
+															"tokenAddress": {
+																"type": "string"
+															},
+															"tokenType": {
+																"type": "string"
+															},
+															"tokenSymbol": {
+																"type": "string"
+															},
+															"tokenDecimals": {
+																"type": "integer"
+															},
+															"recipientAddress": {
+																"type": "string"
+															},
+															"requesteeUsername": {
+																"type": "string"
+															},
+															"tokenAmount": {
+																"type": "string"
+															}
+														},
+														"required": [
+															"chainId",
+															"tokenAddress",
+															"tokenType",
+															"tokenSymbol",
+															"tokenDecimals",
+															"recipientAddress"
+														]
+													}
+												},
+												"required": ["requestProps"]
+											}
+										]
+									}
+								]
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			},
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"minimum": 1,
+							"maximum": 100,
+							"default": 25,
+							"type": "number"
+						},
+						"in": "query",
+						"name": "limit",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "starting_after",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "ending_before",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "status",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/charges/{uuid}/payments": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"hash": {
+										"type": "string"
+									},
+									"chainId": {
+										"type": "string"
+									},
+									"tokenAddress": {
+										"type": "string"
+									},
+									"payerAddress": {
+										"type": "string"
+									},
+									"sourceChainId": {
+										"type": "string"
+									},
+									"sourceTokenAddress": {
+										"type": "string"
+									},
+									"sourceTokenSymbol": {
+										"type": "string"
+									}
+								},
+								"required": ["hash", "chainId", "tokenAddress", "payerAddress"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "uuid",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/charges/{chargeId}": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "chargeId",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			},
+			"delete": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "chargeId",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/request-charges/{uuid}": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "uuid",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/direct-send": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"recipientAddress": {
+										"pattern": "^0x[a-fA-F0-9]{40}$",
+										"type": "string"
+									},
+									"chainId": {
+										"type": "string"
+									},
+									"tokenAddress": {
+										"pattern": "^0x[a-fA-F0-9]{40}$",
+										"type": "string"
+									},
+									"tokenAmount": {
+										"pattern": "^(0|[1-9]\\d*)(\\.\\d+)?$",
+										"type": "string"
+									},
+									"tokenDecimals": {
+										"minimum": 0,
+										"maximum": 36,
+										"type": "integer"
+									},
+									"tokenSymbol": {
+										"type": "string"
+									},
+									"tokenType": {
+										"type": "string"
+									},
+									"hash": {
+										"pattern": "^0x[a-fA-F0-9]{64}$",
+										"type": "string"
+									},
+									"payerAddress": {
+										"pattern": "^0x[a-fA-F0-9]{40}$",
+										"type": "string"
+									},
+									"memo": {
+										"type": "string"
+									}
+								},
+								"required": [
+									"recipientAddress",
+									"chainId",
+									"tokenAddress",
+									"tokenAmount",
+									"tokenDecimals",
+									"hash",
+									"payerAddress"
+								]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/send-links": {
+			"post": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			},
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "c",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "number"
+						},
+						"in": "query",
+						"name": "i",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "v",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/send-links/{pubKey}": {
+			"patch": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "pubKey",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			},
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "c",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "number"
+						},
+						"in": "query",
+						"name": "i",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "v",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "pubKey",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/send-links/claim/{txHash}/associate-user": {
+			"patch": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "txHash",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/bridge/webhooks": {
+			"post": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/bridge/customers/{uuid}": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "uuid",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/bridge/customers/{uuid}/external-accounts": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"accountNumber": {
+										"type": "string"
+									},
+									"bic": {
+										"type": "string"
+									},
+									"country": {
+										"type": "string"
+									},
+									"address": {
+										"type": "object",
+										"properties": {
+											"street": {
+												"type": "string"
+											},
+											"city": {
+												"type": "string"
+											},
+											"country": {
+												"type": "string"
+											},
+											"state": {
+												"type": "string"
+											},
+											"postalCode": {
+												"type": "string"
+											}
+										},
+										"required": ["street", "city", "country", "postalCode"]
+									},
+									"accountOwnerName": {
+										"type": "object",
+										"properties": {
+											"firstName": {
+												"type": "string"
+											},
+											"lastName": {
+												"type": "string"
+											},
+											"businessName": {
+												"type": "string"
+											}
+										}
+									},
+									"accountOwnerType": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["business"]
+											},
+											{
+												"type": "string",
+												"enum": ["individual"]
+											}
+										]
+									},
+									"routingNumber": {
+										"type": "string"
+									},
+									"sortCode": {
+										"type": "string"
+									},
+									"accountType": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["iban"]
+											},
+											{
+												"type": "string",
+												"enum": ["us"]
+											},
+											{
+												"type": "string",
+												"enum": ["clabe"]
+											},
+											{
+												"type": "string",
+												"enum": ["gb"]
+											}
+										]
+									},
+									"reuseOnError": {
+										"type": "boolean"
+									}
+								},
+								"required": [
+									"accountNumber",
+									"country",
+									"accountOwnerName",
+									"accountOwnerType",
+									"accountType"
+								]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "uuid",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			},
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "uuid",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/bridge/customers/{customerId}/external-accounts/{externalAccountId}": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "customerId",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "externalAccountId",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			},
+			"delete": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "customerId",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "externalAccountId",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/bridge/customers/{customerId}/external-accounts/{externalAccountId}/reactivate": {
+			"post": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "customerId",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "externalAccountId",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/bridge/kyc-links/{uuid}": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "uuid",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/bridge/kyc-links": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"type": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["business"]
+											},
+											{
+												"type": "string",
+												"enum": ["individual"]
+											}
+										]
+									},
+									"fullName": {
+										"type": "string"
+									},
+									"email": {
+										"type": "string"
+									},
+									"redirectUri": {
+										"type": "string"
+									},
+									"isEEA": {
+										"type": "boolean"
+									}
+								},
+								"required": ["type", "fullName", "email"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/bridge/customers/{uuid}/kyc-links": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "uuid",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/bridge/customers/{customerId}/liquidation-addresses": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"chain": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["arbitrum"]
+											},
+											{
+												"type": "string",
+												"enum": ["base"]
+											},
+											{
+												"type": "string",
+												"enum": ["avalance_c_chain"]
+											},
+											{
+												"type": "string",
+												"enum": ["ethereum"]
+											},
+											{
+												"type": "string",
+												"enum": ["optimism"]
+											},
+											{
+												"type": "string",
+												"enum": ["polygon"]
+											},
+											{
+												"type": "string",
+												"enum": ["solana"]
+											},
+											{
+												"type": "string",
+												"enum": ["stellar"]
+											}
+										]
+									},
+									"currency": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["dai"]
+											},
+											{
+												"type": "string",
+												"enum": ["usdc"]
+											},
+											{
+												"type": "string",
+												"enum": ["eurc"]
+											},
+											{
+												"type": "string",
+												"enum": ["usdt"]
+											}
+										]
+									},
+									"externalAccountId": {
+										"type": "string"
+									},
+									"prefundedAccountId": {
+										"type": "string"
+									},
+									"destinationWireMessage": {
+										"type": "string"
+									},
+									"destinationSepaReference": {
+										"type": "string"
+									},
+									"destinationSwiftReference": {
+										"type": "string"
+									},
+									"destinationAchReference": {
+										"type": "string"
+									},
+									"destinationPaymentRail": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["arbitrum"]
+											},
+											{
+												"type": "string",
+												"enum": ["base"]
+											},
+											{
+												"type": "string",
+												"enum": ["avalance_c_chain"]
+											},
+											{
+												"type": "string",
+												"enum": ["ethereum"]
+											},
+											{
+												"type": "string",
+												"enum": ["optimism"]
+											},
+											{
+												"type": "string",
+												"enum": ["polygon"]
+											},
+											{
+												"type": "string",
+												"enum": ["solana"]
+											},
+											{
+												"type": "string",
+												"enum": ["stellar"]
+											},
+											{
+												"type": "string",
+												"enum": ["ach"]
+											},
+											{
+												"type": "string",
+												"enum": ["ach_push"]
+											},
+											{
+												"type": "string",
+												"enum": ["ach_same_day"]
+											},
+											{
+												"type": "string",
+												"enum": ["sepa"]
+											},
+											{
+												"type": "string",
+												"enum": ["swift"]
+											},
+											{
+												"type": "string",
+												"enum": ["wire"]
+											}
+										]
+									},
+									"destinationCurrency": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["eur"]
+											},
+											{
+												"type": "string",
+												"enum": ["usd"]
+											}
+										]
+									},
+									"destinationAddress": {
+										"type": "string"
+									},
+									"destinationBlockchainMemo": {
+										"type": "string"
+									},
+									"customDeveloperFeePercent": {
+										"type": "string"
+									}
+								},
+								"required": ["chain", "currency", "externalAccountId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "customerId",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/bridge/customers/{uuid}/liquidation-addresses": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "number"
+						},
+						"in": "query",
+						"name": "limit",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "startingAfter",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "endingBefore",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "uuid",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/bridge/customers/{customerId}/liquidation-addresses/{liquidationAddressId}/drains": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "customerId",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "liquidationAddressId",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/bridge/customers/{uuid}/transfers": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "number"
+						},
+						"in": "query",
+						"name": "limit",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "startingAfter",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "endingBefore",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "number"
+						},
+						"in": "query",
+						"name": "updatedBeforeMs",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "number"
+						},
+						"in": "query",
+						"name": "updatedAfterMs",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "uuid",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/bridge/transfers/{transferId}": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "transferId",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/bridge/offramp/create": {
+			"post": {
+				"summary": "Initiate an off-ramp transfer",
+				"tags": ["offramp"],
+				"description": "This endpoint initiates a new off-ramp transfer. It uses the configured off-ramp provider (e.g., Bridge) to create a transfer and returns deposit instructions for the user.",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"onBehalfOf": {
+										"type": "string"
+									},
+									"provider": {
+										"type": "string"
+									},
+									"amount": {
+										"type": "string"
+									},
+									"sendLinkPubKey": {
+										"type": "string"
+									},
+									"source": {
+										"type": "object",
+										"properties": {
+											"currency": {
+												"anyOf": [
+													{
+														"type": "string",
+														"enum": ["usdc"]
+													},
+													{
+														"type": "string",
+														"enum": ["eurc"]
+													},
+													{
+														"type": "string",
+														"enum": ["usdt"]
+													},
+													{
+														"type": "string",
+														"enum": ["dai"]
+													}
+												]
+											},
+											"paymentRail": {
+												"anyOf": [
+													{
+														"type": "string",
+														"enum": ["ethereum"]
+													},
+													{
+														"type": "string",
+														"enum": ["polygon"]
+													},
+													{
+														"type": "string",
+														"enum": ["base"]
+													},
+													{
+														"type": "string",
+														"enum": ["optimism"]
+													},
+													{
+														"type": "string",
+														"enum": ["solana"]
+													},
+													{
+														"type": "string",
+														"enum": ["stellar"]
+													},
+													{
+														"type": "string",
+														"enum": ["arbitrum"]
+													},
+													{
+														"type": "string",
+														"enum": ["avalance_c_chain"]
+													}
+												]
+											},
+											"fromAddress": {
+												"type": "string"
+											}
+										},
+										"required": ["currency", "paymentRail"]
+									},
+									"destination": {
+										"type": "object",
+										"properties": {
+											"currency": {
+												"anyOf": [
+													{
+														"type": "string",
+														"enum": ["usd"]
+													},
+													{
+														"type": "string",
+														"enum": ["eur"]
+													},
+													{
+														"type": "string",
+														"enum": ["mxn"]
+													},
+													{
+														"type": "string",
+														"enum": ["gbp"]
+													}
+												]
+											},
+											"paymentRail": {
+												"anyOf": [
+													{
+														"type": "string",
+														"enum": ["ach"]
+													},
+													{
+														"type": "string",
+														"enum": ["ach_push"]
+													},
+													{
+														"type": "string",
+														"enum": ["ach_same_day"]
+													},
+													{
+														"type": "string",
+														"enum": ["wire"]
+													},
+													{
+														"type": "string",
+														"enum": ["sepa"]
+													},
+													{
+														"type": "string",
+														"enum": ["swift"]
+													},
+													{
+														"type": "string",
+														"enum": ["spei"]
+													},
+													{
+														"type": "string",
+														"enum": ["faster_payments"]
+													}
+												]
+											},
+											"externalAccountId": {
+												"type": "string"
+											},
+											"wireMessage": {
+												"type": "string"
+											},
+											"sepaReference": {
+												"type": "string"
+											},
+											"achReference": {
+												"type": "string"
+											},
+											"fasterPaymentsReference": {
+												"type": "string"
+											}
+										},
+										"required": ["currency", "paymentRail", "externalAccountId"]
+									},
+									"features": {
+										"type": "object",
+										"properties": {
+											"flexibleAmount": {
+												"type": "boolean"
+											},
+											"staticTemplate": {
+												"type": "boolean"
+											},
+											"allowAnyFromAddress": {
+												"type": "boolean"
+											}
+										}
+									},
+									"developerFee": {
+										"type": "string"
+									},
+									"developerFeePercent": {
+										"type": "string"
+									}
+								},
+								"required": ["onBehalfOf", "source", "destination"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"transferId": {
+											"type": "string"
+										},
+										"depositInstructions": {
+											"type": "object",
+											"properties": {
+												"toAddress": {
+													"type": "string"
+												},
+												"blockchainMemo": {
+													"type": "string"
+												}
+											},
+											"required": ["toAddress"]
+										}
+									},
+									"required": ["transferId", "depositInstructions"]
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/bridge/offramp/create-for-guest": {
+			"post": {
+				"summary": "Initiate an off-ramp transfer for a guest",
+				"tags": ["offramp"],
+				"description": "This endpoint initiates a new off-ramp transfer for a guest user. It uses the configured off-ramp provider (e.g., Bridge) to create a transfer and returns deposit instructions for the user. This is intended for server-to-server use where the user is not authenticated.",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									},
+									"provider": {
+										"type": "string"
+									},
+									"amount": {
+										"type": "string"
+									},
+									"sendLinkPubKey": {
+										"type": "string"
+									},
+									"source": {
+										"type": "object",
+										"properties": {
+											"currency": {
+												"anyOf": [
+													{
+														"type": "string",
+														"enum": ["usdc"]
+													},
+													{
+														"type": "string",
+														"enum": ["eurc"]
+													},
+													{
+														"type": "string",
+														"enum": ["usdt"]
+													},
+													{
+														"type": "string",
+														"enum": ["dai"]
+													}
+												]
+											},
+											"paymentRail": {
+												"anyOf": [
+													{
+														"type": "string",
+														"enum": ["ethereum"]
+													},
+													{
+														"type": "string",
+														"enum": ["polygon"]
+													},
+													{
+														"type": "string",
+														"enum": ["base"]
+													},
+													{
+														"type": "string",
+														"enum": ["optimism"]
+													},
+													{
+														"type": "string",
+														"enum": ["solana"]
+													},
+													{
+														"type": "string",
+														"enum": ["stellar"]
+													},
+													{
+														"type": "string",
+														"enum": ["arbitrum"]
+													},
+													{
+														"type": "string",
+														"enum": ["avalance_c_chain"]
+													}
+												]
+											},
+											"fromAddress": {
+												"type": "string"
+											}
+										},
+										"required": ["currency", "paymentRail"]
+									},
+									"destination": {
+										"type": "object",
+										"properties": {
+											"currency": {
+												"anyOf": [
+													{
+														"type": "string",
+														"enum": ["usd"]
+													},
+													{
+														"type": "string",
+														"enum": ["eur"]
+													},
+													{
+														"type": "string",
+														"enum": ["mxn"]
+													},
+													{
+														"type": "string",
+														"enum": ["gbp"]
+													}
+												]
+											},
+											"paymentRail": {
+												"anyOf": [
+													{
+														"type": "string",
+														"enum": ["ach"]
+													},
+													{
+														"type": "string",
+														"enum": ["ach_push"]
+													},
+													{
+														"type": "string",
+														"enum": ["ach_same_day"]
+													},
+													{
+														"type": "string",
+														"enum": ["wire"]
+													},
+													{
+														"type": "string",
+														"enum": ["sepa"]
+													},
+													{
+														"type": "string",
+														"enum": ["swift"]
+													},
+													{
+														"type": "string",
+														"enum": ["spei"]
+													},
+													{
+														"type": "string",
+														"enum": ["faster_payments"]
+													}
+												]
+											},
+											"externalAccountId": {
+												"type": "string"
+											},
+											"wireMessage": {
+												"type": "string"
+											},
+											"sepaReference": {
+												"type": "string"
+											},
+											"achReference": {
+												"type": "string"
+											}
+										},
+										"required": ["currency", "paymentRail", "externalAccountId"]
+									}
+								},
+								"required": ["userId", "source", "destination"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"transferId": {
+											"type": "string"
+										},
+										"depositInstructions": {
+											"type": "object",
+											"properties": {
+												"toAddress": {
+													"type": "string"
+												},
+												"blockchainMemo": {
+													"type": "string"
+												}
+											},
+											"required": ["toAddress"]
+										},
+										"quote": {
+											"type": "object",
+											"properties": {
+												"initial_amount": {
+													"type": "string"
+												},
+												"developer_fee": {
+													"type": "string"
+												},
+												"exchange_fee": {
+													"type": "string"
+												},
+												"subtotal_amount": {
+													"type": "string"
+												},
+												"remaining_prefunded_amount": {
+													"type": "string"
+												},
+												"gas_fee": {
+													"type": "string"
+												},
+												"final_amount": {
+													"type": "string"
+												},
+												"source_tx_hash": {
+													"type": "string"
+												},
+												"destination_tx_hash": {
+													"type": "string"
+												},
+												"exchange_rate": {
+													"type": "string"
+												},
+												"url": {
+													"type": "string"
+												}
+											},
+											"required": [
+												"initial_amount",
+												"developer_fee",
+												"exchange_fee",
+												"subtotal_amount"
+											]
+										}
+									},
+									"required": ["transferId", "depositInstructions"]
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/bridge/transfers/{transferId}/confirm": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"required": ["txHash"],
+								"properties": {
+									"txHash": {
+										"type": "string",
+										"minLength": 66,
+										"maxLength": 66
+									}
+								}
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "transferId",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/bridge/onramp/create": {
+			"post": {
+				"summary": "Initiate an on-ramp transfer",
+				"tags": ["onramp"],
+				"description": "This endpoint initiates a new on-ramp transfer (fiat to crypto). It creates a transfer from fiat to USDC on Arbitrum to the user's peanut wallet and returns bank deposit instructions.",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"amount": {
+										"type": "string"
+									},
+									"chargeId": {
+										"type": "string"
+									},
+									"recipientAddress": {
+										"type": "string"
+									},
+									"source": {
+										"type": "object",
+										"properties": {
+											"currency": {
+												"anyOf": [
+													{
+														"type": "string",
+														"enum": ["usd"]
+													},
+													{
+														"type": "string",
+														"enum": ["eur"]
+													},
+													{
+														"type": "string",
+														"enum": ["mxn"]
+													},
+													{
+														"type": "string",
+														"enum": ["gbp"]
+													}
+												]
+											},
+											"paymentRail": {
+												"anyOf": [
+													{
+														"type": "string",
+														"enum": ["ach"]
+													},
+													{
+														"type": "string",
+														"enum": ["ach_push"]
+													},
+													{
+														"type": "string",
+														"enum": ["ach_same_day"]
+													},
+													{
+														"type": "string",
+														"enum": ["wire"]
+													},
+													{
+														"type": "string",
+														"enum": ["sepa"]
+													},
+													{
+														"type": "string",
+														"enum": ["swift"]
+													},
+													{
+														"type": "string",
+														"enum": ["spei"]
+													},
+													{
+														"type": "string",
+														"enum": ["faster_payments"]
+													}
+												]
+											}
+										},
+										"required": ["currency", "paymentRail"]
+									}
+								},
+								"required": ["amount", "source"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"transferId": {
+											"type": "string"
+										},
+										"depositInstructions": {
+											"type": "object",
+											"properties": {
+												"amount": {
+													"type": "string"
+												},
+												"currency": {
+													"type": "string"
+												},
+												"depositMessage": {
+													"type": "string"
+												},
+												"bankName": {
+													"type": "string"
+												},
+												"bankAddress": {
+													"type": "string"
+												},
+												"bankRoutingNumber": {
+													"type": "string"
+												},
+												"bankAccountNumber": {
+													"type": "string"
+												},
+												"bankBeneficiaryName": {
+													"type": "string"
+												},
+												"bankBeneficiaryAddress": {
+													"type": "string"
+												},
+												"iban": {
+													"type": "string"
+												},
+												"bic": {
+													"type": "string"
+												},
+												"accountHolderName": {
+													"type": "string"
+												},
+												"clabe": {
+													"type": "string"
+												},
+												"sortCode": {
+													"type": "string"
+												},
+												"accountNumber": {
+													"type": "string"
+												},
+												"reference": {
+													"type": "string"
+												}
+											},
+											"required": ["amount", "currency", "depositMessage"]
+										}
+									},
+									"required": ["transferId", "depositInstructions"]
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/bridge/onramp/{transferId}/cancel": {
+			"delete": {
+				"summary": "Cancel an on-ramp transfer",
+				"tags": ["onramp"],
+				"description": "This endpoint cancels an on-ramp transfer. The transfer must be in AWAITING_FUNDS/PENDING state. It updates the ledger and calls Bridge API to cancel the transfer.",
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "transferId",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean"
+										},
+										"message": {
+											"type": "string"
+										}
+									},
+									"required": ["success", "message"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"403": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/bridge/onramp/create-for-guest": {
+			"post": {
+				"summary": "Initiate an on-ramp transfer for a guest",
+				"tags": ["onramp"],
+				"description": "This endpoint initiates a new on-ramp transfer (fiat to crypto) for a guest. It creates a transfer from fiat to USDC on Arbitrum to the guest's peanut wallet and returns bank deposit instructions.",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"amount": {
+										"type": "string"
+									},
+									"source": {
+										"type": "object",
+										"properties": {
+											"currency": {
+												"anyOf": [
+													{
+														"type": "string",
+														"enum": ["usd"]
+													},
+													{
+														"type": "string",
+														"enum": ["eur"]
+													},
+													{
+														"type": "string",
+														"enum": ["mxn"]
+													},
+													{
+														"type": "string",
+														"enum": ["gbp"]
+													}
+												]
+											},
+											"paymentRail": {
+												"anyOf": [
+													{
+														"type": "string",
+														"enum": ["ach"]
+													},
+													{
+														"type": "string",
+														"enum": ["ach_push"]
+													},
+													{
+														"type": "string",
+														"enum": ["ach_same_day"]
+													},
+													{
+														"type": "string",
+														"enum": ["wire"]
+													},
+													{
+														"type": "string",
+														"enum": ["sepa"]
+													},
+													{
+														"type": "string",
+														"enum": ["swift"]
+													},
+													{
+														"type": "string",
+														"enum": ["spei"]
+													},
+													{
+														"type": "string",
+														"enum": ["faster_payments"]
+													}
+												]
+											}
+										},
+										"required": ["currency", "paymentRail"]
+									},
+									"userId": {
+										"type": "string"
+									},
+									"chargeId": {
+										"type": "string"
+									}
+								},
+								"required": ["amount", "source", "userId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"transferId": {
+											"type": "string"
+										},
+										"depositInstructions": {
+											"type": "object",
+											"properties": {
+												"amount": {
+													"type": "string"
+												},
+												"currency": {
+													"type": "string"
+												},
+												"depositMessage": {
+													"type": "string"
+												},
+												"bankName": {
+													"type": "string"
+												},
+												"bankAddress": {
+													"type": "string"
+												},
+												"bankRoutingNumber": {
+													"type": "string"
+												},
+												"bankAccountNumber": {
+													"type": "string"
+												},
+												"bankBeneficiaryName": {
+													"type": "string"
+												},
+												"bankBeneficiaryAddress": {
+													"type": "string"
+												},
+												"iban": {
+													"type": "string"
+												},
+												"bic": {
+													"type": "string"
+												},
+												"accountHolderName": {
+													"type": "string"
+												}
+											},
+											"required": ["amount", "currency", "depositMessage"]
+										}
+									},
+									"required": ["transferId", "depositInstructions"]
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/bridge/onramp/quote": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string",
+							"enum": ["iban", "us", "clabe", "gb"]
+						},
+						"in": "query",
+						"name": "accountType",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "sourceAmount",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/bridge/exchange-rate": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string",
+							"enum": ["iban", "us", "clabe", "gb"]
+						},
+						"in": "query",
+						"name": "accountType",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/rain/cards/withdraw/session-approve": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"serializedApproval": {
+										"minLength": 1,
+										"type": "string"
+									}
+								},
+								"required": ["serializedApproval"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean"
+										}
+									},
+									"required": ["ok"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rain/cards/withdraw/prepare": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"amount": {
+										"minLength": 1,
+										"type": "string"
+									},
+									"recipientAddress": {
+										"pattern": "^0x[0-9a-fA-F]{40}$",
+										"type": "string"
+									},
+									"directTransfer": {
+										"type": "boolean"
+									},
+									"kind": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["P2P_SEND"]
+											},
+											{
+												"type": "string",
+												"enum": ["QR_PAY"]
+											},
+											{
+												"type": "string",
+												"enum": ["LINK_CREATE"]
+											},
+											{
+												"type": "string",
+												"enum": ["CRYPTO_WITHDRAW"]
+											},
+											{
+												"type": "string",
+												"enum": ["FIAT_OFFRAMP"]
+											},
+											{
+												"type": "string",
+												"enum": ["FIAT_ONRAMP"]
+											},
+											{
+												"type": "string",
+												"enum": ["REQUEST_PAY"]
+											},
+											{
+												"type": "string",
+												"enum": ["AUTO_REBALANCE"]
+											},
+											{
+												"type": "string",
+												"enum": ["CARD_SPEND"]
+											},
+											{
+												"type": "string",
+												"enum": ["DEPOSIT_EXTERNAL"]
+											},
+											{
+												"type": "string",
+												"enum": ["OTHER"]
+											}
+										]
+									},
+									"totalAmountCents": {
+										"minLength": 1,
+										"type": "string"
+									},
+									"chargeId": {
+										"minLength": 1,
+										"type": "string"
+									}
+								},
+								"required": ["amount", "recipientAddress", "directTransfer", "kind"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"preparationId": {
+											"type": "string"
+										},
+										"coordinatorAddress": {
+											"type": "string"
+										},
+										"collateralProxy": {
+											"type": "string"
+										},
+										"adminAddress": {
+											"type": "string"
+										},
+										"chainId": {
+											"type": "string"
+										},
+										"tokenAddress": {
+											"type": "string"
+										},
+										"amount": {
+											"type": "string"
+										},
+										"recipientAddress": {
+											"type": "string"
+										},
+										"directTransfer": {
+											"type": "boolean"
+										},
+										"adminSalt": {
+											"type": "string"
+										},
+										"adminNonce": {
+											"type": "string"
+										},
+										"executorSignature": {
+											"type": "string"
+										},
+										"executorSalt": {
+											"type": "string"
+										},
+										"expiresAt": {
+											"type": "number"
+										}
+									},
+									"required": [
+										"preparationId",
+										"coordinatorAddress",
+										"collateralProxy",
+										"adminAddress",
+										"chainId",
+										"tokenAddress",
+										"amount",
+										"recipientAddress",
+										"directTransfer",
+										"adminSalt",
+										"adminNonce",
+										"executorSignature",
+										"executorSalt",
+										"expiresAt"
+									]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"425": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"502": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rain/cards/withdraw/stamp": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"preparationId": {
+										"minLength": 1,
+										"type": "string"
+									},
+									"txHash": {
+										"pattern": "^0x[0-9a-fA-F]{64}$",
+										"type": "string"
+									}
+								},
+								"required": ["preparationId", "txHash"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean"
+										}
+									},
+									"required": ["ok"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"409": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rain/cards/withdraw/submit": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"preparationId": {
+										"minLength": 1,
+										"type": "string"
+									},
+									"amount": {
+										"minLength": 1,
+										"type": "string"
+									},
+									"recipientAddress": {
+										"pattern": "^0x[0-9a-fA-F]{40}$",
+										"type": "string"
+									},
+									"directTransfer": {
+										"type": "boolean"
+									},
+									"adminSalt": {
+										"pattern": "^0x[0-9a-fA-F]{64}$",
+										"type": "string"
+									},
+									"adminNonce": {
+										"minLength": 1,
+										"type": "string"
+									},
+									"adminSignature": {
+										"pattern": "^0x[0-9a-fA-F]+$",
+										"type": "string"
+									},
+									"executorSignature": {
+										"type": "string"
+									},
+									"executorSalt": {
+										"type": "string"
+									},
+									"expiresAt": {
+										"type": "number"
+									}
+								},
+								"required": [
+									"preparationId",
+									"amount",
+									"recipientAddress",
+									"directTransfer",
+									"adminSalt",
+									"adminNonce",
+									"adminSignature",
+									"executorSignature",
+									"executorSalt",
+									"expiresAt"
+								]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"txHash": {
+											"type": "string"
+										}
+									},
+									"required": ["txHash"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"409": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"410": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"502": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/manteca/qr-payment/init": {
+			"post": {
+				"summary": "Process QR payment",
+				"tags": ["manteca"],
+				"description": "Process a QR payment through Manteca. Supports PIX, QR 3.0, and CODI payments.",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"qrCode": {
+										"description": "The QR code string to process for payment",
+										"type": "string"
+									},
+									"amount": {
+										"description": "Amount for static QR codes (optional for dynamic QR codes)",
+										"type": "string"
+									},
+									"qrType": {
+										"description": "Type of QR code (e.g. PIX, QR30, CODI). Used to select the correct fallback user for non-Manteca users.",
+										"type": "string"
+									}
+								},
+								"required": ["qrCode"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/manteca/qr-payment/complete-with-signed-tx": {
+			"post": {
+				"summary": "Complete QR payment with signed transaction",
+				"tags": ["manteca"],
+				"description": "Completes Manteca payment first, then either broadcasts the signed UserOp or submits the signed Rain withdrawal via the session key. This prevents funds from being stuck if Manteca fails.",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"anyOf": [
+									{
+										"type": "object",
+										"properties": {
+											"kind": {
+												"type": "string",
+												"enum": ["userOp"]
+											},
+											"paymentLockCode": {
+												"description": "The payment lock code from init",
+												"type": "string"
+											},
+											"qrType": {
+												"description": "Type of QR code (e.g. PIX, QR30, CODI). Used to select the correct fallback user for non-Manteca users.",
+												"type": "string"
+											},
+											"signedUserOp": {
+												"type": "object",
+												"properties": {
+													"sender": {
+														"type": "string"
+													},
+													"nonce": {},
+													"callData": {
+														"type": "string"
+													},
+													"signature": {
+														"type": "string"
+													},
+													"factory": {
+														"type": "string"
+													},
+													"factoryData": {
+														"type": "string"
+													},
+													"callGasLimit": {},
+													"verificationGasLimit": {},
+													"preVerificationGas": {},
+													"maxFeePerGas": {},
+													"maxPriorityFeePerGas": {},
+													"paymaster": {
+														"type": "string"
+													},
+													"paymasterData": {
+														"type": "string"
+													},
+													"paymasterVerificationGasLimit": {},
+													"paymasterPostOpGasLimit": {}
+												},
+												"required": [
+													"sender",
+													"nonce",
+													"callData",
+													"signature",
+													"callGasLimit",
+													"verificationGasLimit",
+													"preVerificationGas",
+													"maxFeePerGas",
+													"maxPriorityFeePerGas",
+													"paymasterVerificationGasLimit",
+													"paymasterPostOpGasLimit"
+												]
+											},
+											"chainId": {
+												"type": "string"
+											},
+											"entryPointAddress": {
+												"type": "string"
+											},
+											"rainPreparationId": {
+												"minLength": 1,
+												"type": "string"
+											}
+										},
+										"required": [
+											"kind",
+											"paymentLockCode",
+											"signedUserOp",
+											"chainId",
+											"entryPointAddress"
+										]
+									},
+									{
+										"type": "object",
+										"properties": {
+											"kind": {
+												"type": "string",
+												"enum": ["rainWithdrawal"]
+											},
+											"paymentLockCode": {
+												"description": "The payment lock code from init",
+												"type": "string"
+											},
+											"qrType": {
+												"type": "string"
+											},
+											"signedRainWithdrawal": {
+												"type": "object",
+												"properties": {
+													"preparationId": {
+														"minLength": 1,
+														"type": "string"
+													},
+													"amount": {
+														"minLength": 1,
+														"type": "string"
+													},
+													"recipientAddress": {
+														"pattern": "^0x[0-9a-fA-F]{40}$",
+														"type": "string"
+													},
+													"directTransfer": {
+														"type": "boolean"
+													},
+													"adminSalt": {
+														"pattern": "^0x[0-9a-fA-F]{64}$",
+														"type": "string"
+													},
+													"adminNonce": {
+														"minLength": 1,
+														"type": "string"
+													},
+													"adminSignature": {
+														"pattern": "^0x[0-9a-fA-F]+$",
+														"type": "string"
+													},
+													"executorSignature": {
+														"type": "string"
+													},
+													"executorSalt": {
+														"type": "string"
+													},
+													"expiresAt": {
+														"type": "number"
+													}
+												},
+												"required": [
+													"preparationId",
+													"amount",
+													"recipientAddress",
+													"directTransfer",
+													"adminSalt",
+													"adminNonce",
+													"adminSignature",
+													"executorSignature",
+													"executorSalt",
+													"expiresAt"
+												]
+											},
+											"chainId": {
+												"type": "string"
+											}
+										},
+										"required": ["kind", "paymentLockCode", "signedRainWithdrawal", "chainId"]
+									}
+								]
+							}
+						}
+					}
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/manteca/deposit": {
+			"post": {
+				"summary": "Create deposit order (onramp)",
+				"tags": ["manteca"],
+				"description": "Create a deposit order to convert fiat to crypto via Manteca. Returns deposit instructions.",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"amount": {
+										"type": "string"
+									},
+									"isUsdDenominated": {
+										"type": "boolean"
+									},
+									"currency": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["ARS"]
+											},
+											{
+												"type": "string",
+												"enum": ["BRL"]
+											},
+											{
+												"type": "string",
+												"enum": ["CLP"]
+											},
+											{
+												"type": "string",
+												"enum": ["COP"]
+											},
+											{
+												"type": "string",
+												"enum": ["PUSD"]
+											},
+											{
+												"type": "string",
+												"enum": ["CRC"]
+											},
+											{
+												"type": "string",
+												"enum": ["GTQ"]
+											},
+											{
+												"type": "string",
+												"enum": ["MXN"]
+											},
+											{
+												"type": "string",
+												"enum": ["PHP"]
+											},
+											{
+												"type": "string",
+												"enum": ["BOB"]
+											}
+										]
+									},
+									"chargeId": {
+										"type": "string"
+									}
+								},
+								"required": ["amount", "currency"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/manteca/deposit/{depositId}/cancel": {
+			"patch": {
+				"summary": "Cancel deposit order",
+				"tags": ["manteca"],
+				"description": "Cancel a deposit order created via Manteca.",
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "depositId",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/manteca/withdraw/init": {
+			"post": {
+				"summary": "Initialize withdraw with locked price",
+				"tags": ["manteca"],
+				"description": "Creates a price lock for withdraw. Returns the locked exchange rate valid for ~120 seconds. Use this before showing the user the final amount.",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"amount": {
+										"description": "Amount to withdraw in USD (USDC)",
+										"type": "string"
+									},
+									"currency": {
+										"description": "Target fiat currency (e.g. ARS, BRL)",
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["ARS"]
+											},
+											{
+												"type": "string",
+												"enum": ["BRL"]
+											},
+											{
+												"type": "string",
+												"enum": ["CLP"]
+											},
+											{
+												"type": "string",
+												"enum": ["COP"]
+											},
+											{
+												"type": "string",
+												"enum": ["PUSD"]
+											},
+											{
+												"type": "string",
+												"enum": ["CRC"]
+											},
+											{
+												"type": "string",
+												"enum": ["GTQ"]
+											},
+											{
+												"type": "string",
+												"enum": ["MXN"]
+											},
+											{
+												"type": "string",
+												"enum": ["PHP"]
+											},
+											{
+												"type": "string",
+												"enum": ["BOB"]
+											}
+										]
+									}
+								},
+								"required": ["amount", "currency"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/manteca/withdraw": {
+			"post": {
+				"summary": "Create withdraw order (offramp)",
+				"tags": ["manteca"],
+				"description": "Create a withdraw order to convert crypto to fiat via Manteca. Optionally use a pre-locked price from /withdraw/init.",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"amount": {
+										"description": "Amount to withdraw in crypto asset",
+										"type": "string"
+									},
+									"txHash": {
+										"description": "Transaction hash of the withdrawal",
+										"type": "string"
+									},
+									"destinationAddress": {
+										"description": "Destination address to withdraw to",
+										"type": "string"
+									},
+									"bankCode": {
+										"type": "string"
+									},
+									"accountType": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["SAVINGS"]
+											},
+											{
+												"type": "string",
+												"enum": ["CHECKING"]
+											},
+											{
+												"type": "string",
+												"enum": ["DEBIT"]
+											},
+											{
+												"type": "string",
+												"enum": ["PHONE"]
+											},
+											{
+												"type": "string",
+												"enum": ["VISTA"]
+											},
+											{
+												"type": "string",
+												"enum": ["RUT"]
+											}
+										]
+									},
+									"currency": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["ARS"]
+											},
+											{
+												"type": "string",
+												"enum": ["BRL"]
+											},
+											{
+												"type": "string",
+												"enum": ["CLP"]
+											},
+											{
+												"type": "string",
+												"enum": ["COP"]
+											},
+											{
+												"type": "string",
+												"enum": ["PUSD"]
+											},
+											{
+												"type": "string",
+												"enum": ["CRC"]
+											},
+											{
+												"type": "string",
+												"enum": ["GTQ"]
+											},
+											{
+												"type": "string",
+												"enum": ["MXN"]
+											},
+											{
+												"type": "string",
+												"enum": ["PHP"]
+											},
+											{
+												"type": "string",
+												"enum": ["BOB"]
+											}
+										]
+									},
+									"priceLockCode": {
+										"description": "Price lock code from /withdraw/init. If not provided, a new price lock is created.",
+										"type": "string"
+									}
+								},
+								"required": ["amount", "txHash", "destinationAddress"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/manteca/withdraw/complete-with-signed-tx": {
+			"post": {
+				"summary": "Complete withdraw with signed transaction (sign-then-broadcast)",
+				"tags": ["manteca"],
+				"description": "Creates Manteca ramp-off order FIRST, then either broadcasts the signed UserOp or submits the signed Rain withdrawal via the session key. Prevents funds from being stuck if Manteca fails.",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"anyOf": [
+									{
+										"type": "object",
+										"properties": {
+											"kind": {
+												"type": "string",
+												"enum": ["userOp"]
+											},
+											"priceLockCode": {
+												"description": "The price lock code from /withdraw/init",
+												"type": "string"
+											},
+											"amount": {
+												"description": "Amount to withdraw in USD (USDC)",
+												"type": "string"
+											},
+											"destinationAddress": {
+												"description": "Destination bank account address",
+												"type": "string"
+											},
+											"bankCode": {
+												"type": "string"
+											},
+											"accountType": {
+												"anyOf": [
+													{
+														"type": "string",
+														"enum": ["SAVINGS"]
+													},
+													{
+														"type": "string",
+														"enum": ["CHECKING"]
+													},
+													{
+														"type": "string",
+														"enum": ["DEBIT"]
+													},
+													{
+														"type": "string",
+														"enum": ["PHONE"]
+													},
+													{
+														"type": "string",
+														"enum": ["VISTA"]
+													},
+													{
+														"type": "string",
+														"enum": ["RUT"]
+													}
+												]
+											},
+											"currency": {
+												"description": "Target fiat currency (must match price lock)",
+												"anyOf": [
+													{
+														"type": "string",
+														"enum": ["ARS"]
+													},
+													{
+														"type": "string",
+														"enum": ["BRL"]
+													},
+													{
+														"type": "string",
+														"enum": ["CLP"]
+													},
+													{
+														"type": "string",
+														"enum": ["COP"]
+													},
+													{
+														"type": "string",
+														"enum": ["PUSD"]
+													},
+													{
+														"type": "string",
+														"enum": ["CRC"]
+													},
+													{
+														"type": "string",
+														"enum": ["GTQ"]
+													},
+													{
+														"type": "string",
+														"enum": ["MXN"]
+													},
+													{
+														"type": "string",
+														"enum": ["PHP"]
+													},
+													{
+														"type": "string",
+														"enum": ["BOB"]
+													}
+												]
+											},
+											"signedUserOp": {
+												"type": "object",
+												"properties": {
+													"sender": {
+														"type": "string"
+													},
+													"nonce": {},
+													"callData": {
+														"type": "string"
+													},
+													"signature": {
+														"type": "string"
+													},
+													"factory": {
+														"type": "string"
+													},
+													"factoryData": {
+														"type": "string"
+													},
+													"callGasLimit": {},
+													"verificationGasLimit": {},
+													"preVerificationGas": {},
+													"maxFeePerGas": {},
+													"maxPriorityFeePerGas": {},
+													"paymaster": {
+														"type": "string"
+													},
+													"paymasterData": {
+														"type": "string"
+													},
+													"paymasterVerificationGasLimit": {},
+													"paymasterPostOpGasLimit": {}
+												},
+												"required": [
+													"sender",
+													"nonce",
+													"callData",
+													"signature",
+													"callGasLimit",
+													"verificationGasLimit",
+													"preVerificationGas",
+													"maxFeePerGas",
+													"maxPriorityFeePerGas",
+													"paymasterVerificationGasLimit",
+													"paymasterPostOpGasLimit"
+												]
+											},
+											"chainId": {
+												"type": "string"
+											},
+											"entryPointAddress": {
+												"type": "string"
+											},
+											"rainPreparationId": {
+												"minLength": 1,
+												"type": "string"
+											}
+										},
+										"required": [
+											"kind",
+											"priceLockCode",
+											"amount",
+											"destinationAddress",
+											"currency",
+											"signedUserOp",
+											"chainId",
+											"entryPointAddress"
+										]
+									},
+									{
+										"type": "object",
+										"properties": {
+											"kind": {
+												"type": "string",
+												"enum": ["rainWithdrawal"]
+											},
+											"priceLockCode": {
+												"description": "The price lock code from /withdraw/init",
+												"type": "string"
+											},
+											"amount": {
+												"description": "Amount to withdraw in USD (USDC)",
+												"type": "string"
+											},
+											"destinationAddress": {
+												"description": "Destination bank account address",
+												"type": "string"
+											},
+											"bankCode": {
+												"type": "string"
+											},
+											"accountType": {
+												"anyOf": [
+													{
+														"type": "string",
+														"enum": ["SAVINGS"]
+													},
+													{
+														"type": "string",
+														"enum": ["CHECKING"]
+													},
+													{
+														"type": "string",
+														"enum": ["DEBIT"]
+													},
+													{
+														"type": "string",
+														"enum": ["PHONE"]
+													},
+													{
+														"type": "string",
+														"enum": ["VISTA"]
+													},
+													{
+														"type": "string",
+														"enum": ["RUT"]
+													}
+												]
+											},
+											"currency": {
+												"description": "Target fiat currency (must match price lock)",
+												"anyOf": [
+													{
+														"type": "string",
+														"enum": ["ARS"]
+													},
+													{
+														"type": "string",
+														"enum": ["BRL"]
+													},
+													{
+														"type": "string",
+														"enum": ["CLP"]
+													},
+													{
+														"type": "string",
+														"enum": ["COP"]
+													},
+													{
+														"type": "string",
+														"enum": ["PUSD"]
+													},
+													{
+														"type": "string",
+														"enum": ["CRC"]
+													},
+													{
+														"type": "string",
+														"enum": ["GTQ"]
+													},
+													{
+														"type": "string",
+														"enum": ["MXN"]
+													},
+													{
+														"type": "string",
+														"enum": ["PHP"]
+													},
+													{
+														"type": "string",
+														"enum": ["BOB"]
+													}
+												]
+											},
+											"signedRainWithdrawal": {
+												"type": "object",
+												"properties": {
+													"preparationId": {
+														"minLength": 1,
+														"type": "string"
+													},
+													"amount": {
+														"minLength": 1,
+														"type": "string"
+													},
+													"recipientAddress": {
+														"pattern": "^0x[0-9a-fA-F]{40}$",
+														"type": "string"
+													},
+													"directTransfer": {
+														"type": "boolean"
+													},
+													"adminSalt": {
+														"pattern": "^0x[0-9a-fA-F]{64}$",
+														"type": "string"
+													},
+													"adminNonce": {
+														"minLength": 1,
+														"type": "string"
+													},
+													"adminSignature": {
+														"pattern": "^0x[0-9a-fA-F]+$",
+														"type": "string"
+													},
+													"executorSignature": {
+														"type": "string"
+													},
+													"executorSalt": {
+														"type": "string"
+													},
+													"expiresAt": {
+														"type": "number"
+													}
+												},
+												"required": [
+													"preparationId",
+													"amount",
+													"recipientAddress",
+													"directTransfer",
+													"adminSalt",
+													"adminNonce",
+													"adminSignature",
+													"executorSignature",
+													"executorSalt",
+													"expiresAt"
+												]
+											},
+											"chainId": {
+												"type": "string"
+											}
+										},
+										"required": [
+											"kind",
+											"priceLockCode",
+											"amount",
+											"destinationAddress",
+											"currency",
+											"signedRainWithdrawal",
+											"chainId"
+										]
+									}
+								]
+							}
+						}
+					}
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/manteca/webhook": {
+			"post": {
+				"summary": "Manteca webhook handler",
+				"tags": ["manteca"],
+				"description": "Handle webhook notifications from Manteca about synthetic status updates",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"event": {
+										"description": "Event type from Manteca",
+										"type": "string"
+									},
+									"data": {
+										"description": "Event payload from Manteca"
+									}
+								},
+								"required": ["event", "data"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "md-webhook-signature",
+						"required": true,
+						"description": "HMAC signature for webhook verification"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/manteca/initiate-onboarding": {
+			"post": {
+				"summary": "Initiate Manteca onboarding",
+				"tags": ["manteca"],
+				"description": "Creates an onboarding widget URL for the current user using userId as userExternalId and returns the URL",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"returnUrl": {
+										"type": "string"
+									},
+									"failureUrl": {
+										"type": "string"
+									},
+									"exchange": {
+										"type": "string"
+									}
+								},
+								"required": ["returnUrl"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/manteca/prices": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"anyOf": [
+								{
+									"type": "string",
+									"enum": ["USDT"]
+								},
+								{
+									"type": "string",
+									"enum": ["USDC"]
+								},
+								{
+									"type": "string",
+									"enum": ["ETH"]
+								},
+								{
+									"type": "string",
+									"enum": ["BTC"]
+								},
+								{
+									"type": "string",
+									"enum": ["ARS"]
+								},
+								{
+									"type": "string",
+									"enum": ["USD"]
+								},
+								{
+									"type": "string",
+									"enum": ["BRL"]
+								},
+								{
+									"type": "string",
+									"enum": ["CLP"]
+								}
+							]
+						},
+						"in": "query",
+						"name": "asset",
+						"required": true
+					},
+					{
+						"schema": {
+							"anyOf": [
+								{
+									"type": "string",
+									"enum": ["USDT"]
+								},
+								{
+									"type": "string",
+									"enum": ["USDC"]
+								},
+								{
+									"type": "string",
+									"enum": ["ETH"]
+								},
+								{
+									"type": "string",
+									"enum": ["BTC"]
+								},
+								{
+									"type": "string",
+									"enum": ["ARS"]
+								},
+								{
+									"type": "string",
+									"enum": ["USD"]
+								},
+								{
+									"type": "string",
+									"enum": ["BRL"]
+								},
+								{
+									"type": "string",
+									"enum": ["CLP"]
+								}
+							]
+						},
+						"in": "query",
+						"name": "against",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/perks/claim": {
+			"post": {
+				"summary": "Claim a perk",
+				"tags": ["perks"],
+				"description": "User-triggered action to claim USDC sponsorship for an eligible perk",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"usageId": {
+										"description": "PerkUsage id to claim",
+										"type": "string"
+									}
+								},
+								"required": ["usageId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/perks/pending": {
+			"get": {
+				"summary": "Get pending perks",
+				"tags": ["perks"],
+				"description": "Returns all PENDING_CLAIM perks for the authenticated user",
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"perks": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"id": {
+														"type": "string"
+													},
+													"name": {
+														"type": "string"
+													},
+													"description": {
+														"type": "string"
+													},
+													"reason": {
+														"type": "string"
+													},
+													"amountUsd": {
+														"type": "number"
+													},
+													"createdAt": {
+														"type": "string"
+													},
+													"inviteeName": {
+														"type": "string"
+													}
+												},
+												"required": ["id", "amountUsd", "createdAt"]
+											}
+										}
+									},
+									"required": ["perks"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										},
+										"message": {
+											"type": "string"
+										}
+									},
+									"required": ["error", "message"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/invites/accept": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"inviteCode": {
+										"type": "string"
+									},
+									"type": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["DIRECT"]
+											},
+											{
+												"type": "string",
+												"enum": ["PAYMENT_LINK"]
+											}
+										]
+									},
+									"campaignTag": {
+										"type": "string"
+									}
+								},
+								"required": ["inviteCode", "type"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/invites": {
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/invites/validate": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"inviteCode": {
+										"type": "string"
+									}
+								},
+								"required": ["inviteCode"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/invites/waitlist-position": {
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/invites/graph": {
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/invites/graph/external": {
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/invites/user-graph": {
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/notifications/send": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"externalUserIds": {
+										"minItems": 1,
+										"maxItems": 10,
+										"type": "array",
+										"items": {
+											"type": "string"
+										}
+									},
+									"title": {
+										"type": "string"
+									},
+									"message": {
+										"type": "string"
+									},
+									"url": {
+										"type": "string"
+									},
+									"data": {
+										"type": "object",
+										"additionalProperties": {}
+									},
+									"templateId": {
+										"type": "string"
+									},
+									"idempotencyKey": {
+										"type": "string"
+									},
+									"channel": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["push"]
+											},
+											{
+												"type": "string",
+												"enum": ["email"]
+											}
+										]
+									}
+								},
+								"required": ["externalUserIds"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/notifications": {
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/notifications/unread-count": {
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/notifications/mark-read": {
+			"post": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/webhooks/onesignal": {
+			"post": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/badge/award": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"campaignTag": {
+										"type": "string"
+									}
+								},
+								"required": ["campaignTag"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/admin/support/grant": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"username": {
+										"minLength": 1,
+										"maxLength": 64,
+										"type": "string"
+									}
+								},
+								"required": ["username"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "x-admin-token",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/admin/card-waitlist/release": {
+			"post": {
+				"summary": "Release users from the card waitlist",
+				"tags": ["admin"],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userIds": {
+										"minItems": 1,
+										"maxItems": 100,
+										"type": "array",
+										"items": {
+											"type": "string"
+										}
+									}
+								},
+								"required": ["userIds"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "x-admin-token",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"released": {
+											"type": "array",
+											"items": {
+												"type": "string"
+											}
+										},
+										"skipped": {
+											"type": "array",
+											"items": {
+												"type": "string"
+											}
+										}
+									},
+									"required": ["released", "skipped"]
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										},
+										"message": {
+											"type": "string"
+										}
+									},
+									"required": ["error", "message"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										},
+										"message": {
+											"type": "string"
+										}
+									},
+									"required": ["error", "message"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/points": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/points/history": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"minimum": 1,
+							"maximum": 100,
+							"type": "number"
+						},
+						"in": "query",
+						"name": "limit",
+						"required": false
+					},
+					{
+						"schema": {
+							"minimum": 0,
+							"type": "number"
+						},
+						"in": "query",
+						"name": "offset",
+						"required": false
+					},
+					{
+						"schema": {
+							"anyOf": [
+								{
+									"type": "string",
+									"enum": ["BRIDGE_FEE"]
+								},
+								{
+									"type": "string",
+									"enum": ["MANTECA_FEE"]
+								},
+								{
+									"type": "string",
+									"enum": ["RAIN_CARD_SPEND"]
+								},
+								{
+									"type": "string",
+									"enum": ["CHARGE_FEE"]
+								},
+								{
+									"type": "string",
+									"enum": ["P2P_SEND_LINK"]
+								},
+								{
+									"type": "string",
+									"enum": ["P2P_REQUEST_PAYMENT"]
+								},
+								{
+									"type": "string",
+									"enum": ["CRYPTO_WITHDRAW"]
+								},
+								{
+									"type": "string",
+									"enum": ["SIGNUP"]
+								},
+								{
+									"type": "string",
+									"enum": ["KYC_VERIFIED"]
+								},
+								{
+									"type": "string",
+									"enum": ["TRANSITIVE_UPDATE"]
+								},
+								{
+									"type": "string",
+									"enum": ["HANDSHAKE_BONUS"]
+								},
+								{
+									"type": "string",
+									"enum": ["ADMIN_ADJUSTMENT"]
+								},
+								{
+									"type": "string",
+									"enum": ["PERK_REDEMPTION"]
+								},
+								{
+									"type": "string",
+									"enum": ["MIGRATION_FROM_OLD_SYSTEM"]
+								},
+								{
+									"type": "string",
+									"enum": ["REFERRAL_REWARD_ACCRUAL"]
+								}
+							]
+						},
+						"in": "query",
+						"name": "type",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/points/leaderboard": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"minimum": 1,
+							"maximum": 500,
+							"type": "number"
+						},
+						"in": "query",
+						"name": "limit",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "boolean"
+						},
+						"in": "query",
+						"name": "includeMe",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/points/time-leaderboard": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"minimum": 1,
+							"maximum": 100,
+							"type": "number"
+						},
+						"in": "query",
+						"name": "limit",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "since",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/points/invites": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/points/cash-status": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/points/calculate": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"actionType": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["BRIDGE_TRANSFER"]
+											},
+											{
+												"type": "string",
+												"enum": ["MANTECA_TRANSFER"]
+											},
+											{
+												"type": "string",
+												"enum": ["MANTECA_QR_PAYMENT"]
+											},
+											{
+												"type": "string",
+												"enum": ["P2P_SEND_LINK"]
+											},
+											{
+												"type": "string",
+												"enum": ["P2P_REQUEST_PAYMENT"]
+											},
+											{
+												"type": "string",
+												"enum": ["KYC_VERIFIED"]
+											}
+										]
+									},
+									"usdAmount": {
+										"minimum": 0,
+										"type": "number"
+									},
+									"otherUserId": {
+										"type": "string"
+									}
+								},
+								"required": ["actionType"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/points/admin/adjust": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									},
+									"pointsChange": {
+										"type": "number"
+									},
+									"reason": {
+										"type": "string"
+									}
+								},
+								"required": ["userId", "pointsChange", "reason"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "api-key",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/quests/leaderboards": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"minimum": 1,
+							"maximum": 10,
+							"default": 3,
+							"type": "number"
+						},
+						"in": "query",
+						"name": "limit",
+						"required": false
+					},
+					{
+						"schema": {
+							"default": false,
+							"type": "boolean"
+						},
+						"in": "query",
+						"name": "useTestTimePeriod",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/quests/{questId}/leaderboard": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"minimum": 1,
+							"maximum": 10,
+							"default": 10,
+							"type": "number"
+						},
+						"in": "query",
+						"name": "limit",
+						"required": false
+					},
+					{
+						"schema": {
+							"default": false,
+							"type": "boolean"
+						},
+						"in": "query",
+						"name": "useTestTimePeriod",
+						"required": false
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "questId",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/qr/{code}": {
+			"get": {
+				"summary": "Get QR redirect or status",
+				"tags": ["redirects"],
+				"description": "Returns redirect URL if claimed, or indicates QR is available to claim",
+				"parameters": [
+					{
+						"schema": {
+							"minLength": 16,
+							"maxLength": 16,
+							"type": "string"
+						},
+						"in": "path",
+						"name": "code",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/qr/{code}/claim": {
+			"post": {
+				"summary": "Claim a QR code",
+				"tags": ["redirects"],
+				"description": "Claim an unclaimed QR code and tie it to your invite link",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"targetUrl": {
+										"format": "uri",
+										"type": "string"
+									}
+								}
+							}
+						}
+					}
+				},
+				"parameters": [
+					{
+						"schema": {
+							"minLength": 16,
+							"maxLength": 16,
+							"type": "string"
+						},
+						"in": "path",
+						"name": "code",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/rhino/deposit": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"destinationAddress": {
+										"type": "string"
+									},
+									"type": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["EVM"]
+											},
+											{
+												"type": "string",
+												"enum": ["SOL"]
+											},
+											{
+												"type": "string",
+												"enum": ["TRON"]
+											}
+										]
+									}
+								},
+								"required": ["destinationAddress", "type"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/rhino/request-fulfilment": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"type": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["EVM"]
+											},
+											{
+												"type": "string",
+												"enum": ["SOL"]
+											},
+											{
+												"type": "string",
+												"enum": ["TRON"]
+											}
+										]
+									},
+									"chargeId": {
+										"type": "string"
+									},
+									"senderPeanutWalletAddress": {
+										"type": "string"
+									}
+								},
+								"required": ["type", "chargeId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/rhino/rhinofi-event": {
+			"post": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/rhino/status/{depositAddress}": {
+			"get": {
+				"tags": ["rhino"],
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "depositAddress",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/rhino/reset-status/{depositAddress}": {
+			"post": {
+				"tags": ["rhino"],
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "depositAddress",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/rhino/sda-transfer/preview": {
+			"post": {
+				"tags": ["rhino"],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"chainIn": {
+										"type": "string"
+									},
+									"chainOut": {
+										"type": "string"
+									},
+									"token": {
+										"minLength": 1,
+										"type": "string"
+									},
+									"amount": {
+										"type": "string"
+									},
+									"mode": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["pay"]
+											},
+											{
+												"type": "string",
+												"enum": ["receive"]
+											}
+										]
+									}
+								},
+								"required": ["chainIn", "chainOut", "token", "amount", "mode"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/rhino/sda-transfer": {
+			"post": {
+				"tags": ["rhino"],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"context": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["withdraw"]
+											},
+											{
+												"type": "string",
+												"enum": ["pay-request"]
+											},
+											{
+												"type": "string",
+												"enum": ["claim-xchain"]
+											}
+										]
+									},
+									"contextId": {
+										"type": "string"
+									},
+									"depositChain": {
+										"type": "string"
+									},
+									"destinationChain": {
+										"type": "string"
+									},
+									"destinationAddress": {
+										"type": "string"
+									},
+									"tokenOut": {
+										"minLength": 1,
+										"type": "string"
+									},
+									"senderPeanutWalletAddress": {
+										"type": "string"
+									}
+								},
+								"required": [
+									"context",
+									"contextId",
+									"depositChain",
+									"destinationChain",
+									"destinationAddress",
+									"tokenOut"
+								]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/rhino/bridge/quote": {
+			"post": {
+				"tags": ["rhino"],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"amount": {
+										"minLength": 1,
+										"type": "string"
+									},
+									"tokenIn": {
+										"minLength": 1,
+										"type": "string"
+									},
+									"tokenOut": {
+										"minLength": 1,
+										"type": "string"
+									},
+									"chainOut": {
+										"minLength": 1,
+										"type": "string"
+									},
+									"recipient": {
+										"minLength": 1,
+										"type": "string"
+									},
+									"depositor": {
+										"minLength": 1,
+										"type": "string"
+									},
+									"mode": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["pay"]
+											},
+											{
+												"type": "string",
+												"enum": ["receive"]
+											}
+										]
+									}
+								},
+								"required": [
+									"amount",
+									"tokenIn",
+									"tokenOut",
+									"chainOut",
+									"recipient",
+									"depositor",
+									"mode"
+								]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/rhino/bridge/commit": {
+			"post": {
+				"tags": ["rhino"],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"quoteId": {
+										"minLength": 1,
+										"type": "string"
+									},
+									"isSwap": {
+										"type": "boolean"
+									},
+									"isSameChainSwap": {
+										"type": "boolean"
+									}
+								},
+								"required": ["quoteId", "isSwap", "isSameChainSwap"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/rhino/bridge/status/{bridgeId}": {
+			"get": {
+				"tags": ["rhino"],
+				"parameters": [
+					{
+						"schema": {
+							"minLength": 1,
+							"type": "string"
+						},
+						"in": "path",
+						"name": "bridgeId",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/rhino/bridge/chains": {
+			"get": {
+				"tags": ["rhino"],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/card": {
+			"get": {
+				"summary": "Get card info + waitlist state",
+				"tags": ["card"],
+				"description": "Returns the authenticated user's card flow access, eligibility, waitlist state, and skip-badge holdings.",
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "Authorization",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"hasCardAccess": {
+											"type": "boolean"
+										},
+										"isEligible": {
+											"type": "boolean"
+										},
+										"eligibilityReason": {
+											"type": "string"
+										},
+										"flowEarlyAccess": {
+											"type": "boolean"
+										},
+										"waitlistJoinedAt": {
+											"anyOf": [
+												{
+													"type": "string"
+												},
+												{
+													"type": "null"
+												}
+											]
+										},
+										"waitlistPosition": {
+											"anyOf": [
+												{
+													"type": "number"
+												},
+												{
+													"type": "null"
+												}
+											]
+										},
+										"waitlistReleasedAt": {
+											"anyOf": [
+												{
+													"type": "string"
+												},
+												{
+													"type": "null"
+												}
+											]
+										},
+										"skipBadges": {
+											"type": "array",
+											"items": {
+												"type": "string"
+											}
+										}
+									},
+									"required": [
+										"hasCardAccess",
+										"isEligible",
+										"flowEarlyAccess",
+										"waitlistJoinedAt",
+										"waitlistPosition",
+										"waitlistReleasedAt",
+										"skipBadges"
+									]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										},
+										"message": {
+											"type": "string"
+										}
+									},
+									"required": ["error", "message"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/card/waitlist/join": {
+			"post": {
+				"summary": "Join the virtual-card waitlist",
+				"tags": ["card"],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"joinedAt": {
+											"type": "string"
+										},
+										"position": {
+											"anyOf": [
+												{
+													"type": "number"
+												},
+												{
+													"type": "null"
+												}
+											]
+										}
+									},
+									"required": ["joinedAt", "position"]
+								}
+							}
+						}
+					},
+					"403": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										},
+										"message": {
+											"type": "string"
+										}
+									},
+									"required": ["error", "message"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										},
+										"message": {
+											"type": "string"
+										}
+									},
+									"required": ["error", "message"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/card/waitlist/state": {
+			"get": {
+				"summary": "Get the user\u2019s current waitlist state",
+				"tags": ["card"],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"joinedAt": {
+											"anyOf": [
+												{
+													"type": "string"
+												},
+												{
+													"type": "null"
+												}
+											]
+										},
+										"position": {
+											"anyOf": [
+												{
+													"type": "number"
+												},
+												{
+													"type": "null"
+												}
+											]
+										},
+										"releasedAt": {
+											"anyOf": [
+												{
+													"type": "string"
+												},
+												{
+													"type": "null"
+												}
+											]
+										}
+									},
+									"required": ["joinedAt", "position", "releasedAt"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										},
+										"message": {
+											"type": "string"
+										}
+									},
+									"required": ["error", "message"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/card/flow-early-access": {
+			"post": {
+				"summary": "Grant the user early access to the /card flow (via /shhhhh)",
+				"tags": ["card"],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"grantedAt": {
+											"type": "string"
+										}
+									},
+									"required": ["grantedAt"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										},
+										"message": {
+											"type": "string"
+										}
+									},
+									"required": ["error", "message"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/sumsub/webhooks": {
+			"post": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/users/identity": {
+			"post": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/users/identity/resubmit": {
+			"post": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/rain/cards": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"termsAccepted": {
+										"type": "boolean"
+									},
+									"serializedApproval": {
+										"minLength": 1,
+										"type": "string"
+									}
+								}
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"anyOf": [
+										{
+											"type": "object",
+											"properties": {
+												"status": {
+													"type": "string",
+													"enum": ["pending"]
+												},
+												"rainUserId": {
+													"type": "string"
+												},
+												"message": {
+													"type": "string"
+												}
+											},
+											"required": ["status", "rainUserId", "message"]
+										},
+										{
+											"type": "object",
+											"properties": {
+												"status": {
+													"type": "string",
+													"enum": ["incomplete"]
+												},
+												"missing": {
+													"type": "array",
+													"items": {
+														"type": "string"
+													}
+												},
+												"questionnaireComplete": {
+													"type": "boolean"
+												},
+												"sumsubAccessToken": {
+													"type": "string"
+												}
+											},
+											"required": [
+												"status",
+												"missing",
+												"questionnaireComplete",
+												"sumsubAccessToken"
+											]
+										},
+										{
+											"type": "object",
+											"properties": {
+												"status": {
+													"type": "string",
+													"enum": ["main-kyc-required"]
+												},
+												"missingDocTypes": {
+													"type": "array",
+													"items": {
+														"type": "string"
+													}
+												},
+												"sumsubAccessToken": {
+													"type": "string"
+												}
+											},
+											"required": ["status", "missingDocTypes", "sumsubAccessToken"]
+										},
+										{
+											"type": "object",
+											"properties": {
+												"status": {
+													"type": "string",
+													"enum": ["terms-required"]
+												},
+												"isUsResident": {
+													"type": "boolean"
+												},
+												"termsVersion": {
+													"type": "string"
+												}
+											},
+											"required": ["status", "isUsResident", "termsVersion"]
+										},
+										{
+											"type": "object",
+											"properties": {
+												"status": {
+													"type": "string"
+												},
+												"rainUserId": {
+													"type": "string"
+												},
+												"message": {
+													"type": "string"
+												}
+											},
+											"required": ["status", "message"]
+										}
+									]
+								}
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"status": {
+											"type": "object",
+											"properties": {
+												"hasApplication": {
+													"type": "boolean"
+												},
+												"railStatus": {
+													"type": "string"
+												},
+												"applicationStatus": {
+													"type": "string"
+												},
+												"rainUserId": {
+													"type": "string"
+												},
+												"contractAddress": {
+													"type": "string"
+												},
+												"coordinatorAddress": {
+													"type": "string"
+												}
+											},
+											"required": ["hasApplication"]
+										},
+										"balance": {
+											"anyOf": [
+												{
+													"type": "null"
+												},
+												{
+													"type": "object",
+													"properties": {
+														"creditLimit": {
+															"type": "number"
+														},
+														"pendingCharges": {
+															"type": "number"
+														},
+														"postedCharges": {
+															"type": "number"
+														},
+														"balanceDue": {
+															"type": "number"
+														},
+														"spendingPower": {
+															"type": "number"
+														}
+													},
+													"required": [
+														"creditLimit",
+														"pendingCharges",
+														"postedCharges",
+														"balanceDue",
+														"spendingPower"
+													]
+												}
+											]
+										},
+										"cards": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"id": {
+														"type": "string"
+													},
+													"rainCardId": {
+														"type": "string"
+													},
+													"last4": {
+														"type": "string"
+													},
+													"expiryMonth": {
+														"type": "number"
+													},
+													"expiryYear": {
+														"type": "number"
+													},
+													"status": {
+														"type": "string"
+													},
+													"network": {
+														"type": "string"
+													},
+													"issuedAt": {
+														"type": "string"
+													},
+													"hasWithdrawApproval": {
+														"type": "boolean"
+													}
+												},
+												"required": [
+													"id",
+													"rainCardId",
+													"last4",
+													"expiryMonth",
+													"expiryYear",
+													"status",
+													"network",
+													"issuedAt",
+													"hasWithdrawApproval"
+												]
+											}
+										}
+									},
+									"required": ["status", "balance", "cards"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rain/cards/status": {
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"hasApplication": {
+											"type": "boolean"
+										},
+										"status": {
+											"type": "string"
+										},
+										"applicationStatus": {
+											"type": "string"
+										},
+										"rainUserId": {
+											"type": "string"
+										},
+										"contractAddress": {
+											"type": "string"
+										}
+									},
+									"required": ["hasApplication"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rain/cards/{cardId}/activate": {
+			"post": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "cardId",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/rain/cards/{cardId}/lock": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"verifiedWithdrawal": {
+										"type": "object",
+										"properties": {
+											"preparationId": {
+												"minLength": 1,
+												"type": "string"
+											},
+											"amount": {
+												"minLength": 1,
+												"type": "string"
+											},
+											"recipientAddress": {
+												"pattern": "^0x[0-9a-fA-F]{40}$",
+												"type": "string"
+											},
+											"directTransfer": {
+												"type": "boolean"
+											},
+											"adminSalt": {
+												"pattern": "^0x[0-9a-fA-F]{64}$",
+												"type": "string"
+											},
+											"adminNonce": {
+												"minLength": 1,
+												"type": "string"
+											},
+											"adminSignature": {
+												"pattern": "^0x[0-9a-fA-F]+$",
+												"type": "string"
+											},
+											"executorSignature": {
+												"type": "string"
+											},
+											"executorSalt": {
+												"type": "string"
+											},
+											"expiresAt": {
+												"type": "number"
+											}
+										},
+										"required": [
+											"preparationId",
+											"amount",
+											"recipientAddress",
+											"directTransfer",
+											"adminSalt",
+											"adminNonce",
+											"adminSignature",
+											"executorSignature",
+											"executorSalt",
+											"expiresAt"
+										]
+									}
+								}
+							}
+						}
+					}
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "cardId",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/rain/cards/{cardId}/cancel": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"feedback": {
+										"maxLength": 2000,
+										"type": "string"
+									},
+									"verifiedWithdrawal": {
+										"type": "object",
+										"properties": {
+											"preparationId": {
+												"minLength": 1,
+												"type": "string"
+											},
+											"amount": {
+												"minLength": 1,
+												"type": "string"
+											},
+											"recipientAddress": {
+												"pattern": "^0x[0-9a-fA-F]{40}$",
+												"type": "string"
+											},
+											"directTransfer": {
+												"type": "boolean"
+											},
+											"adminSalt": {
+												"pattern": "^0x[0-9a-fA-F]{64}$",
+												"type": "string"
+											},
+											"adminNonce": {
+												"minLength": 1,
+												"type": "string"
+											},
+											"adminSignature": {
+												"pattern": "^0x[0-9a-fA-F]+$",
+												"type": "string"
+											},
+											"executorSignature": {
+												"type": "string"
+											},
+											"executorSalt": {
+												"type": "string"
+											},
+											"expiresAt": {
+												"type": "number"
+											}
+										},
+										"required": [
+											"preparationId",
+											"amount",
+											"recipientAddress",
+											"directTransfer",
+											"adminSalt",
+											"adminNonce",
+											"adminSignature",
+											"executorSignature",
+											"executorSalt",
+											"expiresAt"
+										]
+									}
+								}
+							}
+						}
+					}
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "cardId",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/rain/cards/{cardId}/cancellation-feedback": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"feedback": {
+										"minLength": 1,
+										"maxLength": 2000,
+										"type": "string"
+									}
+								},
+								"required": ["feedback"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "cardId",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean"
+										}
+									},
+									"required": ["ok"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rain/cards/{cardId}": {
+			"patch": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"cardLimit": {
+										"minimum": 0,
+										"type": "number"
+									},
+									"limits": {
+										"type": "array",
+										"items": {
+											"type": "object",
+											"properties": {
+												"amount": {
+													"minimum": 0,
+													"type": "number"
+												},
+												"frequency": {
+													"anyOf": [
+														{
+															"type": "string",
+															"enum": ["perAuthorization"]
+														},
+														{
+															"type": "string",
+															"enum": ["per24HourPeriod"]
+														},
+														{
+															"type": "string",
+															"enum": ["per30DayPeriod"]
+														},
+														{
+															"type": "string",
+															"enum": ["perAllTime"]
+														}
+													]
+												}
+											},
+											"required": ["amount", "frequency"]
+										}
+									},
+									"autoBalanceEnabled": {
+										"type": "boolean"
+									}
+								}
+							}
+						}
+					}
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "cardId",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean"
+										}
+									},
+									"required": ["ok"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"502": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rain/cards/{cardId}/physical-waitlist": {
+			"post": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "cardId",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"joinedAt": {
+											"type": "string"
+										},
+										"position": {
+											"type": "number"
+										}
+									},
+									"required": ["joinedAt", "position"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "cardId",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"joinedAt": {
+											"anyOf": [
+												{
+													"type": "string"
+												},
+												{
+													"type": "null"
+												}
+											]
+										},
+										"position": {
+											"anyOf": [
+												{
+													"type": "number"
+												},
+												{
+													"type": "null"
+												}
+											]
+										}
+									},
+									"required": ["joinedAt", "position"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rain/cards/{cardId}/limits": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "cardId",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"limits": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"amount": {
+														"type": "number"
+													},
+													"frequency": {
+														"anyOf": [
+															{
+																"type": "string",
+																"enum": ["perAuthorization"]
+															},
+															{
+																"type": "string",
+																"enum": ["per24HourPeriod"]
+															},
+															{
+																"type": "string",
+																"enum": ["per30DayPeriod"]
+															},
+															{
+																"type": "string",
+																"enum": ["perAllTime"]
+															}
+														]
+													}
+												},
+												"required": ["amount", "frequency"]
+											}
+										}
+									},
+									"required": ["limits"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"502": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rain/cards/balance": {
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"creditLimit": {
+											"type": "number"
+										},
+										"pendingCharges": {
+											"type": "number"
+										},
+										"postedCharges": {
+											"type": "number"
+										},
+										"balanceDue": {
+											"type": "number"
+										},
+										"spendingPower": {
+											"type": "number"
+										}
+									},
+									"required": [
+										"creditLimit",
+										"pendingCharges",
+										"postedCharges",
+										"balanceDue",
+										"spendingPower"
+									]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rain/cards/session-key-address": {
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"address": {
+											"type": "string"
+										}
+									},
+									"required": ["address"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rain/cards/auto-balance/approve": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"serializedApproval": {
+										"minLength": 1,
+										"type": "string"
+									},
+									"cardLimit": {
+										"minimum": 0,
+										"type": "number"
+									}
+								},
+								"required": ["serializedApproval"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean"
+										}
+									},
+									"required": ["ok"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rain/cards/{cardId}/details": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "cardId",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"pan": {
+											"type": "string"
+										},
+										"cvv": {
+											"type": "string"
+										},
+										"expiryMonth": {
+											"type": "number"
+										},
+										"expiryYear": {
+											"type": "number"
+										},
+										"last4": {
+											"type": "string"
+										},
+										"network": {
+											"type": "string"
+										}
+									},
+									"required": ["pan", "cvv", "expiryMonth", "expiryYear", "last4", "network"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"429": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rain/cards/{cardId}/pin": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "cardId",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"pin": {
+											"anyOf": [
+												{
+													"type": "string"
+												},
+												{
+													"type": "null"
+												}
+											]
+										}
+									},
+									"required": ["pin"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"429": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			},
+			"put": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"pin": {
+										"minLength": 4,
+										"maxLength": 4,
+										"type": "string"
+									}
+								},
+								"required": ["pin"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "cardId",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean"
+										}
+									},
+									"required": ["ok"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"429": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/rain/webhooks": {
+			"post": {
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/tokens/price": {
+			"get": {
+				"tags": ["tokens"],
+				"parameters": [
+					{
+						"schema": {
+							"minLength": 1,
+							"type": "string"
+						},
+						"in": "query",
+						"name": "address",
+						"required": true
+					},
+					{
+						"schema": {
+							"minLength": 1,
+							"type": "string"
+						},
+						"in": "query",
+						"name": "chainId",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/tokens/wallet-portfolio": {
+			"get": {
+				"tags": ["tokens"],
+				"parameters": [
+					{
+						"schema": {
+							"minLength": 1,
+							"type": "string"
+						},
+						"in": "query",
+						"name": "address",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		},
+		"/dev/test-session": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"email": {
+										"minLength": 5,
+										"description": "Email. Finds or creates the user.",
+										"type": "string"
+									},
+									"userId": {
+										"type": "string"
+									},
+									"country": {
+										"minLength": 2,
+										"maxLength": 3,
+										"type": "string"
+									},
+									"kyc": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["verified"]
+											},
+											{
+												"type": "string",
+												"enum": ["pending"]
+											},
+											{
+												"type": "string",
+												"enum": ["rejected"]
+											},
+											{
+												"type": "string",
+												"enum": ["none"]
+											}
+										]
+									},
+									"provider": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["sumsub"]
+											},
+											{
+												"type": "string",
+												"enum": ["bridge"]
+											},
+											{
+												"type": "string",
+												"enum": ["manteca"]
+											}
+										]
+									},
+									"username": {
+										"type": "string"
+									},
+									"harnessLabel": {
+										"type": "string"
+									}
+								},
+								"required": ["email"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "x-test-harness-secret",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"token": {
+											"type": "string"
+										},
+										"user": {
+											"type": "object",
+											"properties": {
+												"userId": {
+													"type": "string"
+												},
+												"email": {
+													"type": "string"
+												},
+												"username": {
+													"type": "string"
+												},
+												"harnessLabel": {
+													"type": "string"
+												}
+											},
+											"required": ["userId", "email", "harnessLabel"]
+										}
+									},
+									"required": ["token", "user"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/seed-scenario": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"scenario": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["send-link-pending"]
+											},
+											{
+												"type": "string",
+												"enum": ["send-link-claimed"]
+											},
+											{
+												"type": "string",
+												"enum": ["request-pot-open"]
+											},
+											{
+												"type": "string",
+												"enum": ["kyc-matrix"]
+											},
+											{
+												"type": "string",
+												"enum": ["user-with-bank-accounts"]
+											},
+											{
+												"type": "string",
+												"enum": ["withdraw-ready"]
+											},
+											{
+												"type": "string",
+												"enum": ["manteca-qr-payment"]
+											},
+											{
+												"type": "string",
+												"enum": ["multi-user-send"]
+											},
+											{
+												"type": "string",
+												"enum": ["points-and-perks"]
+											}
+										]
+									},
+									"harnessLabel": {
+										"type": "string"
+									}
+								},
+								"required": ["scenario"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "x-test-harness-secret",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"scenario": {
+											"type": "string"
+										},
+										"data": {}
+									},
+									"required": ["scenario", "data"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/reproduce": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"scenario": {
+										"description": "qa scenario name for logging",
+										"type": "string"
+									},
+									"entry": {
+										"type": "object",
+										"properties": {
+											"route": {
+												"default": "/home",
+												"type": "string"
+											},
+											"userId": {
+												"anyOf": [
+													{
+														"type": "string"
+													},
+													{
+														"type": "null"
+													}
+												]
+											}
+										},
+										"required": ["route"]
+									},
+									"localStorage": {
+										"type": "object",
+										"additionalProperties": {}
+									},
+									"stepSnapshot": {
+										"type": "object",
+										"properties": {
+											"userIds": {
+												"type": "array",
+												"items": {
+													"type": "string"
+												}
+											},
+											"tables": {
+												"type": "object",
+												"additionalProperties": {
+													"type": "array",
+													"items": {
+														"type": "object",
+														"patternProperties": {
+															"^(.*)$": {}
+														}
+													}
+												}
+											},
+											"capturedAt": {
+												"type": "string"
+											}
+										},
+										"required": ["userIds", "tables"]
+									},
+									"stepActions": {
+										"type": "array",
+										"items": {}
+									},
+									"notes": {
+										"type": "string"
+									}
+								},
+								"required": ["scenario", "entry"]
+							}
+						}
+					},
+					"required": true
+				},
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "x-test-harness-secret",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"url": {
+											"type": "string"
+										},
+										"sessionId": {
+											"type": "string"
+										},
+										"userId": {
+											"type": "string"
+										},
+										"token": {
+											"type": "string"
+										},
+										"localStorage": {
+											"type": "object",
+											"additionalProperties": {}
+										},
+										"restored": {
+											"type": "boolean"
+										}
+									},
+									"required": ["url", "sessionId", "userId", "token", "localStorage"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/reproduce/{sessionId}": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "sessionId",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"scenario": {
+											"type": "string"
+										},
+										"entry": {
+											"type": "object",
+											"properties": {
+												"route": {
+													"type": "string"
+												},
+												"userId": {
+													"anyOf": [
+														{
+															"type": "string"
+														},
+														{
+															"type": "null"
+														}
+													]
+												}
+											},
+											"required": ["route", "userId"]
+										},
+										"localStorage": {
+											"type": "object",
+											"additionalProperties": {}
+										},
+										"stepActions": {
+											"type": "array",
+											"items": {}
+										},
+										"userId": {
+											"type": "string"
+										},
+										"token": {
+											"type": "string"
+										}
+									},
+									"required": ["scenario", "entry", "localStorage", "userId", "token"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/poll": {
+			"post": {
+				"summary": "Run one polling cycle synchronously",
+				"tags": ["dev"],
+				"description": "Triggers runPollingCycle() on demand \u2014 used by the QA harness to observe provider state transitions without waiting for the 5-minute interval.",
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean"
+										},
+										"ms": {
+											"type": "number"
+										}
+									},
+									"required": ["ok", "ms"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean"
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/register-address": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"address": {
+										"description": "0x-prefixed hex address (lowercased server-side)",
+										"type": "string"
+									},
+									"userId": {
+										"description": "Peanut user_id to associate with this address",
+										"type": "string"
+									}
+								},
+								"required": ["address", "userId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean"
+										},
+										"registered": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "registered"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean"
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/reset-deposit-tracker": {
+			"post": {
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean"
+										},
+										"registeredAddresses": {
+											"type": "number"
+										},
+										"skippedInvalid": {
+											"type": "number"
+										},
+										"lastProcessedBlock": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "registeredAddresses", "skippedInvalid", "lastProcessedBlock"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean"
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/reset-harness-data/{label}": {
+			"post": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "label",
+						"required": true,
+						"description": "harnessLabel value to wipe"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean"
+										},
+										"deleted": {
+											"type": "number"
+										},
+										"label": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "deleted", "label"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean"
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/submit-to-providers": {
+			"post": {
+				"summary": "Run KYC provider submission synchronously for the given user/applicant",
+				"tags": ["dev"],
+				"description": "Drives Peanut's submitToProviders(userId, applicantId) synchronously, the same function the Sumsub status-processor calls after GREEN. Used by QA harness to test routing (AR user \u2192 Manteca, US user \u2192 Bridge) end-to-end.",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"description": "Peanut user_id whose rails to submit",
+										"type": "string"
+									},
+									"applicantId": {
+										"description": "Sumsub applicant id with approved docs + extracted data",
+										"type": "string"
+									}
+								},
+								"required": ["userId", "applicantId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean"
+										},
+										"ms": {
+											"type": "number"
+										}
+									},
+									"required": ["ok", "ms"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean"
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/trigger-sumsub-webhook": {
+			"post": {
+				"summary": "Synthesise a Sumsub webhook and run the status-processor",
+				"tags": ["dev"],
+				"description": "Invokes processSumsubKycUpdate({ applicantId, externalUserId, reviewAnswer, reviewStatus, source: 'webhook' }) \u2014 same entry point as the real /sumsub/webhooks route, minus HMAC. Used by the QA harness to exercise the full Sumsub \u2192 routing chain without real webhook delivery.",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"applicantId": {
+										"description": "Sumsub applicant id",
+										"type": "string"
+									},
+									"externalUserId": {
+										"description": "Peanut user_id (applicant.externalUserId)",
+										"type": "string"
+									},
+									"reviewAnswer": {
+										"default": "GREEN",
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["GREEN"]
+											},
+											{
+												"type": "string",
+												"enum": ["RED"]
+											},
+											{
+												"type": "string",
+												"enum": ["ERROR"]
+											}
+										]
+									},
+									"reviewStatus": {
+										"description": "Sumsub reviewStatus (default: \"completed\")",
+										"type": "string"
+									},
+									"levelName": {
+										"type": "string"
+									},
+									"webhookType": {
+										"description": "e.g. \"applicantReviewed\"",
+										"type": "string"
+									}
+								},
+								"required": ["applicantId", "externalUserId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean"
+										},
+										"ms": {
+											"type": "number"
+										}
+									},
+									"required": ["ok", "ms"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean"
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/ledger/history": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "userId",
+						"required": true,
+						"description": "Peanut user_id (varchar)"
+					},
+					{
+						"schema": {
+							"minimum": 1,
+							"maximum": 500,
+							"default": 50,
+							"type": "integer"
+						},
+						"in": "query",
+						"name": "limit",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean"
+										},
+										"userId": {
+											"type": "string"
+										},
+										"count": {
+											"type": "number"
+										},
+										"intents": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"id": {
+														"type": "string"
+													},
+													"kind": {
+														"type": "string"
+													},
+													"provider": {
+														"type": "string"
+													},
+													"status": {
+														"type": "string"
+													},
+													"requestedAmount": {
+														"anyOf": [
+															{
+																"type": "string"
+															},
+															{
+																"type": "null"
+															}
+														]
+													},
+													"requestedAsset": {
+														"anyOf": [
+															{
+																"type": "string"
+															},
+															{
+																"type": "null"
+															}
+														]
+													},
+													"settledAmount": {
+														"anyOf": [
+															{
+																"type": "string"
+															},
+															{
+																"type": "null"
+															}
+														]
+													},
+													"settledAsset": {
+														"anyOf": [
+															{
+																"type": "string"
+															},
+															{
+																"type": "null"
+															}
+														]
+													},
+													"fxRate": {
+														"anyOf": [
+															{
+																"type": "string"
+															},
+															{
+																"type": "null"
+															}
+														]
+													},
+													"createdAt": {
+														"type": "string"
+													},
+													"completedAt": {
+														"anyOf": [
+															{
+																"type": "string"
+															},
+															{
+																"type": "null"
+															}
+														]
+													},
+													"entryCount": {
+														"type": "number"
+													}
+												},
+												"required": [
+													"id",
+													"kind",
+													"provider",
+													"status",
+													"requestedAmount",
+													"requestedAsset",
+													"settledAmount",
+													"settledAsset",
+													"fxRate",
+													"createdAt",
+													"completedAt",
+													"entryCount"
+												]
+											}
+										}
+									},
+									"required": ["ok", "userId", "count", "intents"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean"
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/invite-code": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "ensureUsername",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"inviteCode": {
+											"type": "string"
+										},
+										"inviterUsername": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "inviteCode", "inviterUsername"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/whoami": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "userId",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"userId": {
+											"type": "string"
+										},
+										"username": {
+											"anyOf": [
+												{
+													"type": "string"
+												},
+												{
+													"type": "null"
+												}
+											]
+										},
+										"email": {
+											"anyOf": [
+												{
+													"type": "string"
+												},
+												{
+													"type": "null"
+												}
+											]
+										},
+										"hasMantecaUserId": {
+											"type": "boolean"
+										},
+										"hasBridgeCustomerId": {
+											"type": "boolean"
+										},
+										"bridgeKycStatus": {
+											"anyOf": [
+												{
+													"type": "string"
+												},
+												{
+													"type": "null"
+												}
+											]
+										},
+										"walletAddresses": {
+											"type": "array",
+											"items": {
+												"type": "string"
+											}
+										},
+										"kycVerifications": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"provider": {
+														"type": "string"
+													},
+													"status": {
+														"type": "string"
+													},
+													"mantecaGeo": {
+														"anyOf": [
+															{
+																"type": "string"
+															},
+															{
+																"type": "null"
+															}
+														]
+													}
+												},
+												"required": ["provider", "status", "mantecaGeo"]
+											}
+										}
+									},
+									"required": [
+										"ok",
+										"userId",
+										"username",
+										"email",
+										"hasMantecaUserId",
+										"hasBridgeCustomerId",
+										"bridgeKycStatus",
+										"walletAddresses",
+										"kycVerifications"
+									]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/fund-sa": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									},
+									"usdc": {
+										"description": "6-decimal USDC, default 10000000 = $10",
+										"type": "string"
+									},
+									"ethWei": {
+										"type": "string"
+									}
+								},
+								"required": ["userId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"txHash": {
+											"type": "string"
+										},
+										"saAddress": {
+											"type": "string"
+										},
+										"usdcSent": {
+											"type": "string"
+										},
+										"ethSent": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "txHash", "saAddress", "usdcSent", "ethSent"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/sweep-perk-to-kernel": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"amount": {
+										"description": "6-decimal USDC base units; defaults to entire EOA balance",
+										"type": "string"
+									}
+								}
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"txHash": {
+											"type": "string"
+										},
+										"eoaAddress": {
+											"type": "string"
+										},
+										"kernelAddress": {
+											"type": "string"
+										},
+										"usdcSwept": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "txHash", "eoaAddress", "kernelAddress", "usdcSwept"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/peanut-make-deposit": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"amount": {
+										"type": "string"
+									},
+									"recipientAddress": {
+										"pattern": "^0x[0-9a-fA-F]{40}$",
+										"description": "Address that the recipient will withdraw to",
+										"type": "string"
+									}
+								},
+								"required": ["recipientAddress"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"vaultAddress": {
+											"type": "string"
+										},
+										"depositIdx": {
+											"type": "number"
+										},
+										"password": {
+											"type": "string"
+										},
+										"pubKey20": {
+											"type": "string"
+										},
+										"claimParams": {
+											"type": "array",
+											"items": {}
+										},
+										"makeDepositTxHash": {
+											"type": "string"
+										},
+										"amount": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"ok",
+										"vaultAddress",
+										"depositIdx",
+										"password",
+										"pubKey20",
+										"claimParams",
+										"makeDepositTxHash",
+										"amount"
+									]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/approve-kyc": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									},
+									"provider": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["bridge"]
+											},
+											{
+												"type": "string",
+												"enum": ["manteca"]
+											},
+											{
+												"type": "string",
+												"enum": ["sumsub"]
+											}
+										]
+									},
+									"country": {
+										"description": "ISO-2 (AR/BR/US/GB/DE/MX)",
+										"type": "string"
+									}
+								},
+								"required": ["userId", "provider"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"updated": {
+											"type": "string"
+										},
+										"details": {}
+									},
+									"required": ["ok", "updated", "details"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/fund-rain-collateral": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									},
+									"amountMicros": {
+										"type": "string"
+									}
+								},
+								"required": ["userId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"saAddress": {
+											"type": "string"
+										},
+										"tokenAddress": {
+											"type": "string"
+										},
+										"amountMicros": {
+											"type": "string"
+										},
+										"txHash": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "saAddress", "tokenAddress", "amountMicros", "txHash"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/grant-card-access": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									},
+									"revoke": {
+										"type": "boolean"
+									}
+								},
+								"required": ["userId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"userId": {
+											"type": "string"
+										},
+										"username": {
+											"anyOf": [
+												{
+													"type": "string"
+												},
+												{
+													"type": "null"
+												}
+											]
+										},
+										"cardAccessGrantedAt": {
+											"anyOf": [
+												{
+													"type": "string"
+												},
+												{
+													"type": "null"
+												}
+											]
+										}
+									},
+									"required": ["ok", "userId", "username", "cardAccessGrantedAt"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/grant-badge": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									},
+									"code": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["BETA_TESTER"]
+											},
+											{
+												"type": "string",
+												"enum": ["DEVCONNECT_BA_2025"]
+											},
+											{
+												"type": "string",
+												"enum": ["PRODUCT_HUNT"]
+											},
+											{
+												"type": "string",
+												"enum": ["OG_2025_10_12"]
+											},
+											{
+												"type": "string",
+												"enum": ["SEEDLING_DEVCONNECT_BA_2025"]
+											},
+											{
+												"type": "string",
+												"enum": ["ARBIVERSE_DEVCONNECT_BA_2025"]
+											},
+											{
+												"type": "string",
+												"enum": ["CARD_PIONEER"]
+											},
+											{
+												"type": "string",
+												"enum": ["FOUNDER_HOUSE"]
+											},
+											{
+												"type": "string",
+												"enum": ["SUPPORT_SURVIVOR"]
+											}
+										]
+									},
+									"revoke": {
+										"type": "boolean"
+									}
+								},
+								"required": ["userId", "code"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"userId": {
+											"type": "string"
+										},
+										"code": {
+											"type": "string"
+										},
+										"granted": {
+											"type": "boolean"
+										},
+										"earnedAt": {
+											"anyOf": [
+												{
+													"type": "string"
+												},
+												{
+													"type": "null"
+												}
+											]
+										}
+									},
+									"required": ["ok", "userId", "code", "granted", "earnedAt"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/reset-card": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									},
+									"keepCardAccess": {
+										"description": "If true, leave card_access_granted_at intact; only clear the card rows.",
+										"type": "boolean"
+									}
+								},
+								"required": ["userId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"deletedCards": {
+											"type": "number"
+										},
+										"cardAccessGrantedAt": {
+											"anyOf": [
+												{
+													"type": "string"
+												},
+												{
+													"type": "null"
+												}
+											]
+										}
+									},
+									"required": ["ok", "deletedCards", "cardAccessGrantedAt"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/simulate-bridge-deposit": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									},
+									"amountUsd": {
+										"type": "string"
+									}
+								},
+								"required": ["userId", "amountUsd"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"virtualAccountId": {
+											"type": "string"
+										},
+										"simulateResponse": {}
+									},
+									"required": ["ok", "virtualAccountId", "simulateResponse"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/reset-user": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									}
+								},
+								"required": ["userId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"cleared": {
+											"type": "object",
+											"properties": {
+												"kycVerifications": {
+													"type": "number"
+												},
+												"ledgerIntents": {
+													"type": "number"
+												}
+											},
+											"required": ["kycVerifications", "ledgerIntents"]
+										}
+									},
+									"required": ["ok", "cleared"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/complete-bridge-onramp": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"intentOrTransferId": {
+										"description": "Either a TransactionIntent.id or a Bridge transfer id.",
+										"type": "string"
+									},
+									"exchangeRate": {
+										"type": "number"
+									},
+									"developerFee": {
+										"type": "string"
+									}
+								},
+								"required": ["intentOrTransferId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"providerEventId": {
+											"type": "string"
+										},
+										"intentId": {
+											"type": "string"
+										},
+										"finalState": {
+											"type": "string"
+										},
+										"statusChanged": {
+											"type": "boolean"
+										}
+									},
+									"required": ["ok", "providerEventId", "finalState", "statusChanged"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/complete-bridge-offramp": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"intentOrTransferId": {
+										"type": "string"
+									},
+									"exchangeRate": {
+										"type": "number"
+									},
+									"developerFee": {
+										"type": "string"
+									}
+								},
+								"required": ["intentOrTransferId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"providerEventId": {
+											"type": "string"
+										},
+										"intentId": {
+											"type": "string"
+										},
+										"finalState": {
+											"type": "string"
+										},
+										"statusChanged": {
+											"type": "boolean"
+										}
+									},
+									"required": ["ok", "providerEventId", "finalState", "statusChanged"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/fail-bridge-transfer": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"intentOrTransferId": {
+										"type": "string"
+									},
+									"reason": {
+										"type": "string"
+									},
+									"terminalState": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["error"]
+											},
+											{
+												"type": "string",
+												"enum": ["returned"]
+											},
+											{
+												"type": "string",
+												"enum": ["undeliverable"]
+											},
+											{
+												"type": "string",
+												"enum": ["refunded"]
+											}
+										]
+									}
+								},
+								"required": ["intentOrTransferId", "reason"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"providerEventId": {
+											"type": "string"
+										},
+										"intentId": {
+											"type": "string"
+										},
+										"finalState": {
+											"type": "string"
+										},
+										"statusChanged": {
+											"type": "boolean"
+										}
+									},
+									"required": ["ok", "providerEventId", "finalState", "statusChanged"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/complete-rhino-deposit": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"depositAddress": {
+										"type": "string"
+									},
+									"chainIn": {
+										"description": "Rhino's source-chain enum, e.g. BASE / ARBITRUM / BINANCE",
+										"type": "string"
+									},
+									"token": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["USDC"]
+											},
+											{
+												"type": "string",
+												"enum": ["USDT"]
+											}
+										]
+									},
+									"depositor": {
+										"description": "Source-chain wallet that funded the SDA",
+										"type": "string"
+									},
+									"recipient": {
+										"description": "Destination peanut wallet address on Arbitrum",
+										"type": "string"
+									},
+									"amountIn": {
+										"description": "Human-unit source amount, e.g. \"1.00\"",
+										"type": "string"
+									},
+									"amountOut": {
+										"description": "Human-unit destination amount after FX + fees",
+										"type": "string"
+									},
+									"amountOutUsd": {
+										"type": "number"
+									}
+								},
+								"required": [
+									"depositAddress",
+									"chainIn",
+									"token",
+									"depositor",
+									"recipient",
+									"amountIn",
+									"amountOut",
+									"amountOutUsd"
+								]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"providerEventId": {
+											"type": "string"
+										},
+										"finalState": {
+											"type": "string"
+										},
+										"statusChanged": {
+											"type": "boolean"
+										}
+									},
+									"required": ["ok", "providerEventId", "finalState", "statusChanged"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/complete-rhino-req-fulfilment": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"depositAddress": {
+										"type": "string"
+									},
+									"chainIn": {
+										"description": "Rhino's source-chain enum, e.g. BASE / ARBITRUM / BINANCE",
+										"type": "string"
+									},
+									"token": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["USDC"]
+											},
+											{
+												"type": "string",
+												"enum": ["USDT"]
+											}
+										]
+									},
+									"depositor": {
+										"description": "Source-chain wallet that funded the SDA",
+										"type": "string"
+									},
+									"recipient": {
+										"description": "Destination peanut wallet address on Arbitrum",
+										"type": "string"
+									},
+									"amountIn": {
+										"description": "Human-unit source amount, e.g. \"1.00\"",
+										"type": "string"
+									},
+									"amountOut": {
+										"description": "Human-unit destination amount after FX + fees",
+										"type": "string"
+									},
+									"amountOutUsd": {
+										"type": "number"
+									}
+								},
+								"required": [
+									"depositAddress",
+									"chainIn",
+									"token",
+									"depositor",
+									"recipient",
+									"amountIn",
+									"amountOut",
+									"amountOutUsd"
+								]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"providerEventId": {
+											"type": "string"
+										},
+										"intentId": {
+											"type": "string"
+										},
+										"finalState": {
+											"type": "string"
+										},
+										"statusChanged": {
+											"type": "boolean"
+										}
+									},
+									"required": ["ok", "providerEventId", "finalState", "statusChanged"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/complete-rhino-withdraw": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"depositAddress": {
+										"type": "string"
+									},
+									"chainIn": {
+										"description": "Rhino's source-chain enum, e.g. BASE / ARBITRUM / BINANCE",
+										"type": "string"
+									},
+									"token": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["USDC"]
+											},
+											{
+												"type": "string",
+												"enum": ["USDT"]
+											}
+										]
+									},
+									"depositor": {
+										"description": "Source-chain wallet that funded the SDA",
+										"type": "string"
+									},
+									"recipient": {
+										"description": "Destination peanut wallet address on Arbitrum",
+										"type": "string"
+									},
+									"amountIn": {
+										"description": "Human-unit source amount, e.g. \"1.00\"",
+										"type": "string"
+									},
+									"amountOut": {
+										"description": "Human-unit destination amount after FX + fees",
+										"type": "string"
+									},
+									"amountOutUsd": {
+										"type": "number"
+									}
+								},
+								"required": [
+									"depositAddress",
+									"chainIn",
+									"token",
+									"depositor",
+									"recipient",
+									"amountIn",
+									"amountOut",
+									"amountOutUsd"
+								]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"providerEventId": {
+											"type": "string"
+										},
+										"intentId": {
+											"type": "string"
+										},
+										"finalState": {
+											"type": "string"
+										},
+										"statusChanged": {
+											"type": "boolean"
+										}
+									},
+									"required": ["ok", "providerEventId", "finalState", "statusChanged"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/complete-rhino-claim-xchain": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"depositAddress": {
+										"type": "string"
+									},
+									"chainIn": {
+										"description": "Rhino's source-chain enum, e.g. BASE / ARBITRUM / BINANCE",
+										"type": "string"
+									},
+									"token": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["USDC"]
+											},
+											{
+												"type": "string",
+												"enum": ["USDT"]
+											}
+										]
+									},
+									"depositor": {
+										"description": "Source-chain wallet that funded the SDA",
+										"type": "string"
+									},
+									"recipient": {
+										"description": "Destination peanut wallet address on Arbitrum",
+										"type": "string"
+									},
+									"amountIn": {
+										"description": "Human-unit source amount, e.g. \"1.00\"",
+										"type": "string"
+									},
+									"amountOut": {
+										"description": "Human-unit destination amount after FX + fees",
+										"type": "string"
+									},
+									"amountOutUsd": {
+										"type": "number"
+									}
+								},
+								"required": [
+									"depositAddress",
+									"chainIn",
+									"token",
+									"depositor",
+									"recipient",
+									"amountIn",
+									"amountOut",
+									"amountOutUsd"
+								]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"providerEventId": {
+											"type": "string"
+										},
+										"finalState": {
+											"type": "string"
+										},
+										"statusChanged": {
+											"type": "boolean"
+										}
+									},
+									"required": ["ok", "providerEventId", "finalState", "statusChanged"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/fail-rhino-transfer": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"depositAddress": {
+										"type": "string"
+									},
+									"chainIn": {
+										"description": "Rhino's source-chain enum, e.g. BASE / ARBITRUM / BINANCE",
+										"type": "string"
+									},
+									"token": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": ["USDC"]
+											},
+											{
+												"type": "string",
+												"enum": ["USDT"]
+											}
+										]
+									},
+									"depositor": {
+										"description": "Source-chain wallet that funded the SDA",
+										"type": "string"
+									},
+									"recipient": {
+										"description": "Destination peanut wallet address on Arbitrum",
+										"type": "string"
+									},
+									"amountIn": {
+										"description": "Human-unit source amount, e.g. \"1.00\"",
+										"type": "string"
+									},
+									"amountOut": {
+										"description": "Human-unit destination amount after FX + fees",
+										"type": "string"
+									},
+									"amountOutUsd": {
+										"type": "number"
+									},
+									"reason": {
+										"type": "string"
+									}
+								},
+								"required": [
+									"depositAddress",
+									"chainIn",
+									"token",
+									"depositor",
+									"recipient",
+									"amountIn",
+									"amountOut",
+									"amountOutUsd"
+								]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"providerEventId": {
+											"type": "string"
+										},
+										"intentId": {
+											"type": "string"
+										},
+										"finalState": {
+											"type": "string"
+										},
+										"statusChanged": {
+											"type": "boolean"
+										}
+									},
+									"required": ["ok", "providerEventId", "finalState", "statusChanged"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/auto-complete-pending": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									}
+								},
+								"required": ["userId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"completed": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"intentId": {
+														"type": "string"
+													},
+													"kind": {
+														"type": "string"
+													},
+													"provider": {
+														"type": "string"
+													},
+													"finalState": {
+														"type": "string"
+													}
+												},
+												"required": ["intentId", "kind", "provider", "finalState"]
+											}
+										},
+										"skipped": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"intentId": {
+														"type": "string"
+													},
+													"kind": {
+														"type": "string"
+													},
+													"provider": {
+														"type": "string"
+													},
+													"reason": {
+														"type": "string"
+													}
+												},
+												"required": ["intentId", "kind", "provider", "reason"]
+											}
+										}
+									},
+									"required": ["ok", "completed", "skipped"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/full-setup": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									},
+									"usdcMicros": {
+										"description": "Defaults to 100 USDC.",
+										"type": "string"
+									},
+									"bridgeDepositUsd": {
+										"description": "Defaults to 25.",
+										"type": "string"
+									},
+									"bridgeCountry": {
+										"description": "ISO-2; defaults to US.",
+										"type": "string"
+									},
+									"mantecaCountry": {
+										"description": "Defaults to AR.",
+										"type": "string"
+									},
+									"sumsubCountry": {
+										"description": "Defaults to US.",
+										"type": "string"
+									}
+								},
+								"required": ["userId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"steps": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string"
+													},
+													"ok": {
+														"type": "boolean"
+													},
+													"detail": {}
+												},
+												"required": ["name", "ok", "detail"]
+											}
+										}
+									},
+									"required": ["ok", "steps"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/userid-by-username": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "username",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"userId": {
+											"type": "string"
+										},
+										"username": {
+											"type": "string"
+										}
+									},
+									"required": ["userId", "username"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										},
+										"suggestions": {
+											"type": "array",
+											"items": {
+												"type": "string"
+											}
+										},
+										"totalUsers": {
+											"type": "number"
+										}
+									},
+									"required": ["error", "suggestions", "totalUsers"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/list-users": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "query",
+						"name": "prefix",
+						"required": false
+					},
+					{
+						"schema": {
+							"minimum": 1,
+							"maximum": 100,
+							"type": "number"
+						},
+						"in": "query",
+						"name": "limit",
+						"required": false
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"users": {
+											"type": "array",
+											"items": {
+												"type": "string"
+											}
+										},
+										"totalUsers": {
+											"type": "number"
+										}
+									},
+									"required": ["users", "totalUsers"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/mint-jwt": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									}
+								},
+								"required": ["userId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"token": {
+											"type": "string"
+										},
+										"userId": {
+											"type": "string"
+										}
+									},
+									"required": ["token", "userId"]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										},
+										"hint": {
+											"type": "string"
+										}
+									},
+									"required": ["error", "hint"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										},
+										"hint": {
+											"type": "string"
+										}
+									},
+									"required": ["error", "hint"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/join-card-waitlist": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									}
+								},
+								"required": ["userId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"joinedAt": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "joinedAt"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/release-from-waitlist": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									}
+								},
+								"required": ["userId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"releasedAt": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "releasedAt"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/grant-flow-early-access": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									}
+								},
+								"required": ["userId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"grantedAt": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "grantedAt"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/clear-skip-celebration": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									}
+								},
+								"required": ["userId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										}
+									},
+									"required": ["ok"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/hit-activation-threshold": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									}
+								},
+								"required": ["userId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"syntheticIntentId": {
+											"type": "string"
+										},
+										"note": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "syntheticIntentId", "note"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/dev/cheats/reset-card-waitlist": {
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"userId": {
+										"type": "string"
+									}
+								},
+								"required": ["userId"]
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"deletedPerkUsages": {
+											"type": "number"
+										}
+									},
+									"required": ["ok", "deletedPerkUsages"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"ok": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["ok", "error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/ws/charges/{username}": {
+			"get": {
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "path",
+						"name": "username",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response"
+					}
+				}
+			}
+		}
+	},
+	"servers": [
+		{
+			"url": "http://localhost:5050"
+		}
+	]
 }


### PR DESCRIPTION
## Summary
Follow-up to #2094 — visual polish on the share asset.

**Card face:**
- Drop the \"Virtual\" pill from the share-asset card. Lowers noise + frees the bottom strip.
- Card number locked to \`???? ???? ???? ????\` regardless of \`last4\` prop. Asset deliberately obscures the real PAN so a screenshot + post can't leak it.
- Number bumped to 42px + dropped lower now the pill is gone.

**Decoration pool:**
- Added 7 more sprinkle candidates in unused margin zones (top corners, mid-left cloud, mid-right eyes, bottom edges).
- Per-render pick count 6-8 → 8-11.

**Peanut character bottom clipping:**
- \`peanutWaving\` sat at \`top:640\` with tall-aspect renders pushing its feet outside the canvas. Re-anchored via \`bottom:220\` so feet sit on a fixed offset from the canvas floor.
- Size 64 → 96 so the character reads cleanly at thumbnail scale.

## Test plan
- [ ] /dev/share-builder — confirm 5+ decoration sprinkles, peanut character feet visible
- [ ] Card face shows \`???? ???? ???? ????\` and no Virtual pill
- [ ] CardUnlockDrawer in history feed renders the new asset
- [ ] BadgeSkipCelebration reveal still works end-to-end

24/24 shareAsset tests + typecheck clean.