### PR TITLE
Fix Bridge KYC gates

### DIFF
--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -1118,7 +1118,7 @@ describe('GROUP 5: Bridge Bank Onramp', () => {
             isUserKycApproved: false,
             isUserMantecaKycApproved: false,
         })
-        mockGate.mockReturnValue({ type: 'needs_enrollment' })
+        mockGate.mockReturnValue({ type: 'needs_kyc' })
         resetQueryState({ step: 'inputAmount', amount: '100' })
 
         renderWithProviders(<OnrampBankPage />)

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -1113,12 +1113,12 @@ describe('GROUP 5: Bridge Bank Onramp', () => {
         expect(screen.getByText('Country not found')).toBeInTheDocument()
     })
 
-    test('user not KYC approved shows InitiateKycModal on Continue', async () => {
+    test('fresh user needs KYC before Bridge deposit confirmation', async () => {
         mockUseKycStatus.mockReturnValue({
             isUserKycApproved: false,
             isUserMantecaKycApproved: false,
         })
-        mockGate.mockReturnValue({ type: 'needs_enrollment' })
+        mockGate.mockReturnValue({ type: 'needs_kyc' })
         resetQueryState({ step: 'inputAmount', amount: '100' })
 
         renderWithProviders(<OnrampBankPage />)

--- a/src/components/Kyc/states/KycActionRequired.tsx
+++ b/src/components/Kyc/states/KycActionRequired.tsx
@@ -24,7 +24,7 @@ export const KycActionRequired = ({
                 icon={'retry' as IconName}
                 className="w-full"
                 shadowSize="4"
-                onClick={onResume}
+                onClick={() => onResume()}
                 disabled={isLoading}
             >
                 {isLoading ? 'Loading...' : 'Re-submit verification'}

--- a/src/components/Kyc/states/KycFailed.tsx
+++ b/src/components/Kyc/states/KycFailed.tsx
@@ -97,7 +97,7 @@ export const KycFailed = ({
                     variant="purple"
                     className="w-full"
                     shadowSize="4"
-                    onClick={onRetry}
+                    onClick={() => onRetry()}
                     disabled={isLoading}
                 >
                     {isLoading ? 'Loading...' : 'Retry verification'}

--- a/src/components/Kyc/states/KycNotStarted.tsx
+++ b/src/components/Kyc/states/KycNotStarted.tsx
@@ -15,7 +15,7 @@ export const KycNotStarted = ({ onResume, isLoading }: { onResume: () => void; i
                 payments."
             />
 
-            <Button className="w-full" shadowSize="4" onClick={onResume} disabled={isLoading}>
+            <Button className="w-full" shadowSize="4" onClick={() => onResume()} disabled={isLoading}>
                 {isLoading ? 'Loading...' : 'Continue verification'}
             </Button>
         </div>

--- a/src/components/Kyc/states/KycRequiresDocuments.tsx
+++ b/src/components/Kyc/states/KycRequiresDocuments.tsx
@@ -41,7 +41,13 @@ export const KycRequiresDocuments = ({
                 )}
             </div>
 
-            <Button icon="docs" className="w-full" shadowSize="4" onClick={onSubmitDocuments} disabled={isLoading}>
+            <Button
+                icon="docs"
+                className="w-full"
+                shadowSize="4"
+                onClick={() => onSubmitDocuments()}
+                disabled={isLoading}
+            >
                 {isLoading ? 'Loading...' : 'Submit documents'}
             </Button>
         </div>

--- a/src/components/Kyc/states/__tests__/KycNotStarted.test.tsx
+++ b/src/components/Kyc/states/__tests__/KycNotStarted.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { KycNotStarted } from '../KycNotStarted'
+
+jest.mock('use-haptic', () => ({
+    useHaptic: () => ({ triggerHaptic: jest.fn() }),
+}))
+
+jest.mock('@/hooks/useLongPress', () => ({
+    useLongPress: () => ({
+        isLongPressed: false,
+        pressProgress: 0,
+        handlers: {},
+    }),
+}))
+
+jest.mock('../../KYCStatusDrawerItem', () => ({
+    KYCStatusDrawerItem: () => <div data-testid="kyc-status-drawer-item" />,
+}))
+
+jest.mock('@/components/Global/InfoCard', () => ({
+    __esModule: true,
+    default: ({ description }: { description: string }) => <div>{description}</div>,
+}))
+
+describe('KycNotStarted', () => {
+    it('does not pass the click event to onResume', () => {
+        const onResume = jest.fn()
+        render(<KycNotStarted onResume={onResume} />)
+
+        fireEvent.click(screen.getByText('Continue verification'))
+
+        expect(onResume).toHaveBeenCalledTimes(1)
+        expect(onResume).toHaveBeenCalledWith()
+    })
+})

--- a/src/components/Kyc/states/__tests__/KycNotStarted.test.tsx
+++ b/src/components/Kyc/states/__tests__/KycNotStarted.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { type ReactNode } from 'react'
+import { KycActionRequired } from '../KycActionRequired'
+import { KycFailed } from '../KycFailed'
+import { KycNotStarted } from '../KycNotStarted'
+import { KycRequiresDocuments } from '../KycRequiresDocuments'
+
+jest.mock('use-haptic', () => ({
+    useHaptic: () => ({ triggerHaptic: jest.fn() }),
+}))
+
+jest.mock('@/hooks/useLongPress', () => ({
+    useLongPress: () => ({
+        isLongPressed: false,
+        pressProgress: 0,
+        handlers: {},
+    }),
+}))
+
+jest.mock('../../KYCStatusDrawerItem', () => ({
+    KYCStatusDrawerItem: () => <div data-testid="kyc-status-drawer-item" />,
+}))
+
+jest.mock('../../RejectLabelsList', () => ({
+    RejectLabelsList: () => <div data-testid="reject-labels-list" />,
+}))
+
+jest.mock('../../KycFailedContent', () => ({
+    KycFailedContent: () => <div data-testid="kyc-failed-content" />,
+}))
+
+jest.mock('../../CountryRegionRow', () => ({
+    CountryRegionRow: () => <div data-testid="country-region-row" />,
+}))
+
+jest.mock('@/components/Payment/PaymentInfoRow', () => ({
+    PaymentInfoRow: () => <div data-testid="payment-info-row" />,
+}))
+
+jest.mock('@/components/Global/Card', () => ({
+    __esModule: true,
+    default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('@/components/Global/InfoCard', () => ({
+    __esModule: true,
+    default: ({ description }: { description: string }) => <div>{description}</div>,
+}))
+
+jest.mock('@/context/ModalsContext', () => ({
+    useModalsContext: () => ({ setIsSupportModalOpen: jest.fn() }),
+}))
+
+describe('KycNotStarted', () => {
+    it('does not pass the click event to onResume', () => {
+        const onResume = jest.fn()
+        render(<KycNotStarted onResume={onResume} />)
+
+        fireEvent.click(screen.getByText('Continue verification'))
+
+        expect(onResume).toHaveBeenCalledTimes(1)
+        expect(onResume).toHaveBeenCalledWith()
+    })
+
+    it('does not pass the click event to action-required resume', () => {
+        const onResume = jest.fn()
+        render(<KycActionRequired onResume={onResume} />)
+
+        fireEvent.click(screen.getByText('Re-submit verification'))
+
+        expect(onResume).toHaveBeenCalledTimes(1)
+        expect(onResume).toHaveBeenCalledWith()
+    })
+
+    it('does not pass the click event to failed retry', () => {
+        const onRetry = jest.fn()
+        render(<KycFailed onRetry={onRetry} isSumsub={false} />)
+
+        fireEvent.click(screen.getByText('Retry verification'))
+
+        expect(onRetry).toHaveBeenCalledTimes(1)
+        expect(onRetry).toHaveBeenCalledWith()
+    })
+
+    it('does not pass the click event to document submission', () => {
+        const onSubmitDocuments = jest.fn()
+        render(<KycRequiresDocuments requirements={[]} onSubmitDocuments={onSubmitDocuments} />)
+
+        fireEvent.click(screen.getByText('Submit documents'))
+
+        expect(onSubmitDocuments).toHaveBeenCalledTimes(1)
+        expect(onSubmitDocuments).toHaveBeenCalledWith()
+    })
+})

--- a/src/hooks/__tests__/useBridgeTransferReadiness.test.ts
+++ b/src/hooks/__tests__/useBridgeTransferReadiness.test.ts
@@ -127,8 +127,20 @@ describe('useBridgeTransferReadiness', () => {
         expect(result.current.gate.type).toBe('ready')
     })
 
-    it('does not flag needs_enrollment when sumsub is not approved', () => {
+    it('needs_kyc when user has not started standard verification', () => {
         setup({ isSumsubApproved: false, bridgeRailStatus: null })
+        const { result } = renderHook(() => useBridgeTransferReadiness())
+        expect(result.current.gate.type).toBe('needs_kyc')
+    })
+
+    it('needs_kyc when standard verification is not approved and bridge rail is pending', () => {
+        setup({ isSumsubApproved: false, bridgeRailStatus: 'PENDING' })
+        const { result } = renderHook(() => useBridgeTransferReadiness())
+        expect(result.current.gate.type).toBe('needs_kyc')
+    })
+
+    it('ready when standard verification is not approved but bridge rail is enabled', () => {
+        setup({ isSumsubApproved: false, bridgeRailStatus: 'ENABLED' })
         const { result } = renderHook(() => useBridgeTransferReadiness())
         expect(result.current.gate.type).toBe('ready')
     })
@@ -151,6 +163,7 @@ describe('getKycModalVariant', () => {
         expect(getKycModalVariant('blocked_rejection')).toBe('blocked')
         expect(getKycModalVariant('fixable_rejection')).toBe('provider_rejection')
         expect(getKycModalVariant('needs_enrollment')).toBe('cross_region')
+        expect(getKycModalVariant('needs_kyc')).toBe('default')
         expect(getKycModalVariant('accept_tos')).toBe('default')
         expect(getKycModalVariant('ready')).toBe('default')
     })
@@ -168,6 +181,7 @@ describe('getGateProviderMessage', () => {
 
     it('returns undefined for non-rejection gates', () => {
         expect(getGateProviderMessage({ type: 'accept_tos' })).toBeUndefined()
+        expect(getGateProviderMessage({ type: 'needs_kyc' })).toBeUndefined()
         expect(getGateProviderMessage({ type: 'needs_enrollment' })).toBeUndefined()
         expect(getGateProviderMessage({ type: 'ready' })).toBeUndefined()
     })

--- a/src/hooks/__tests__/useBridgeTransferReadiness.test.ts
+++ b/src/hooks/__tests__/useBridgeTransferReadiness.test.ts
@@ -127,10 +127,10 @@ describe('useBridgeTransferReadiness', () => {
         expect(result.current.gate.type).toBe('ready')
     })
 
-    it('does not flag needs_enrollment when sumsub is not approved', () => {
+    it('needs_kyc when user has not started standard verification', () => {
         setup({ isSumsubApproved: false, bridgeRailStatus: null })
         const { result } = renderHook(() => useBridgeTransferReadiness())
-        expect(result.current.gate.type).toBe('ready')
+        expect(result.current.gate.type).toBe('needs_kyc')
     })
 
     it('accept_tos takes priority over fixable_rejection', () => {
@@ -151,6 +151,7 @@ describe('getKycModalVariant', () => {
         expect(getKycModalVariant('blocked_rejection')).toBe('blocked')
         expect(getKycModalVariant('fixable_rejection')).toBe('provider_rejection')
         expect(getKycModalVariant('needs_enrollment')).toBe('cross_region')
+        expect(getKycModalVariant('needs_kyc')).toBe('default')
         expect(getKycModalVariant('accept_tos')).toBe('default')
         expect(getKycModalVariant('ready')).toBe('default')
     })
@@ -168,6 +169,7 @@ describe('getGateProviderMessage', () => {
 
     it('returns undefined for non-rejection gates', () => {
         expect(getGateProviderMessage({ type: 'accept_tos' })).toBeUndefined()
+        expect(getGateProviderMessage({ type: 'needs_kyc' })).toBeUndefined()
         expect(getGateProviderMessage({ type: 'needs_enrollment' })).toBeUndefined()
         expect(getGateProviderMessage({ type: 'ready' })).toBeUndefined()
     })

--- a/src/hooks/useBridgeTransferReadiness.ts
+++ b/src/hooks/useBridgeTransferReadiness.ts
@@ -10,6 +10,7 @@ export type BridgeGateAction =
     | { type: 'accept_tos' }
     | { type: 'fixable_rejection'; userMessage: string | null }
     | { type: 'blocked_rejection'; userMessage: string | null }
+    | { type: 'needs_kyc' }
     | { type: 'needs_enrollment' }
     | { type: 'ready' }
 
@@ -20,8 +21,9 @@ export type BridgeGateAction =
  *   1. hard rejection (contact support — tos is moot)
  *   2. tos acceptance
  *   3. fixable rejection (user can submit additional details)
- *   4. needs enrollment (sumsub approved, no functional bridge rail yet)
- *   5. ready
+ *   4. needs standard kyc (fresh user)
+ *   5. needs enrollment (sumsub approved, no functional bridge rail yet)
+ *   6. ready
  *
  * Phase 6 of rail-gating: the bridge-state checks are derived from the
  * user's Bridge rails (via useBridgeTosStatus / useProviderRejectionStatus).
@@ -47,13 +49,18 @@ export function useBridgeTransferReadiness() {
             return { type: 'fixable_rejection', userMessage: bridgeRejection.userMessage }
         }
 
-        // 4. needs enrollment — sumsub approved but no Bridge rail in a
+        // 4. fresh user needs standard kyc before creating a transfer
+        if (!isUserSumsubKycApproved && !hasFunctionalRail(bridgeRails, 'BRIDGE')) {
+            return { type: 'needs_kyc' }
+        }
+
+        // 5. needs enrollment — sumsub approved but no Bridge rail in a
         // functional or in-progress state (the user has not started Bridge)
         if (isUserSumsubKycApproved && !hasFunctionalRail(bridgeRails, 'BRIDGE')) {
             return { type: 'needs_enrollment' }
         }
 
-        // 5. ready
+        // 6. ready
         return { type: 'ready' }
     }, [needsBridgeTos, bridgeRejection, isUserSumsubKycApproved, bridgeRails])
 

--- a/src/hooks/useBridgeTransferReadiness.ts
+++ b/src/hooks/useBridgeTransferReadiness.ts
@@ -4,12 +4,13 @@ import { useMemo } from 'react'
 import { useBridgeTosStatus } from './useBridgeTosStatus'
 import useProviderRejectionStatus from './useProviderRejectionStatus'
 import useKycStatus from './useKycStatus'
-import { hasFunctionalRail } from '@/utils/railGate.utils'
+import { hasEnabledRail, hasFunctionalRail } from '@/utils/railGate.utils'
 
 export type BridgeGateAction =
     | { type: 'accept_tos' }
     | { type: 'fixable_rejection'; userMessage: string | null }
     | { type: 'blocked_rejection'; userMessage: string | null }
+    | { type: 'needs_kyc' }
     | { type: 'needs_enrollment' }
     | { type: 'ready' }
 
@@ -20,8 +21,9 @@ export type BridgeGateAction =
  *   1. hard rejection (contact support — tos is moot)
  *   2. tos acceptance
  *   3. fixable rejection (user can submit additional details)
- *   4. needs enrollment (sumsub approved, no functional bridge rail yet)
- *   5. ready
+ *   4. needs standard kyc (fresh user)
+ *   5. needs enrollment (sumsub approved, no functional bridge rail yet)
+ *   6. ready
  *
  * Phase 6 of rail-gating: the bridge-state checks are derived from the
  * user's Bridge rails (via useBridgeTosStatus / useProviderRejectionStatus).
@@ -47,13 +49,19 @@ export function useBridgeTransferReadiness() {
             return { type: 'fixable_rejection', userMessage: bridgeRejection.userMessage }
         }
 
-        // 4. needs enrollment — sumsub approved but no Bridge rail in a
+        // 4. fresh user needs standard kyc before creating a transfer.
+        // an enabled bridge rail still passes for legacy/out-of-band approvals.
+        if (!isUserSumsubKycApproved && !hasEnabledRail(bridgeRails, 'BRIDGE')) {
+            return { type: 'needs_kyc' }
+        }
+
+        // 5. needs enrollment — sumsub approved but no Bridge rail in a
         // functional or in-progress state (the user has not started Bridge)
         if (isUserSumsubKycApproved && !hasFunctionalRail(bridgeRails, 'BRIDGE')) {
             return { type: 'needs_enrollment' }
         }
 
-        // 5. ready
+        // 6. ready
         return { type: 'ready' }
     }, [needsBridgeTos, bridgeRejection, isUserSumsubKycApproved, bridgeRails])
 


### PR DESCRIPTION
## Summary
- Fixes fresh Bridge-country deposit users (for example Germany) being treated as transfer-ready before standard KYC. Fresh users with no Sumsub approval and no functional Bridge rail now get a `needs_kyc` gate, so the deposit flow opens the standard KYC modal instead of the transfer confirmation slider.
- Keeps the existing JIT Bridge enrollment path separate: Sumsub-approved users without a functional Bridge rail still get `needs_enrollment` and the cross-region enrollment copy.
- Fixes abandoned-KYC drawer CTAs leaking React click events into KYC initiation. Resume, retry, and submit-doc handlers now call their callbacks with no event argument, preventing circular JSON errors from DOM event objects.
- Adds regression coverage for both paths: the Bridge readiness hook/add-money flow and the abandoned-KYC drawer CTA.

## Risks
- Bridge rail gating copy could be sensitive for users in intermediate states; verified users with pending or requires-information Bridge rails should still bypass fresh KYC and continue the existing flow.
- The drawer CTA wrapper change touches retry/action-required/additional-doc states, but only removes unintended click-event arguments.
- Build/typecheck on latest dev currently fail locally because `html-to-image`, `fuse.js`, and `p2-es` are missing; these are unrelated to this PR and outside the touched files.

## QA Guidelines
- Fresh new user selects Germany -> bank deposit -> enters amount -> Continue: verify the KYC modal appears, not the transfer confirmation slider.
- Sumsub-approved user with no Bridge rail selects a Bridge bank flow: verify the enrollment/cross-region modal still appears.
- Start KYC, abandon before submission, reopen the KYC status drawer, click Continue verification: verify the drawer closes and the SDK flow starts without the circular JSON error.
- Retry rejected/action-required KYC and submit additional documents from the drawer to confirm those CTAs still launch the expected flow.
- Automated checks run: `npm test -- KycNotStarted.test.tsx useBridgeTransferReadiness.test.ts add-money-states.test.tsx`.