### PR TITLE
refactor(shhhhh): use shared FAQsPanel instead of inline accordion

### DIFF
--- a/src/app/shhhhh/ShhhhhLandingPage.tsx
+++ b/src/app/shhhhh/ShhhhhLandingPage.tsx
@@ -8,6 +8,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import posthog from 'posthog-js'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Marquee } from '@/components/LandingPage'
+import { FAQsPanel } from '@/components/Global/FAQs'
 import { useAuth } from '@/context/authContext'
 import { PixelatedCardFace } from '@/components/Card/share-asset/PixelatedCardFace'
 import { Sparkle, Star } from '@/assets/illustrations'
@@ -31,34 +32,42 @@ const badges: Array<{ code: string; name: string; src: string }> = [
 
 const faqQuestions = [
     {
+        id: 'what',
         question: "WHAT'S THE PEANUT CARD?",
         answer: 'A non-custodial card. Top up with stablecoins, then use the card for everyday spending wherever Visa is accepted.',
     },
     {
+        id: 'where',
         question: 'WHERE DOES IT WORK?',
         answer: 'Accepted wherever Visa is accepted — about 150 million merchants. Online, in-store, ATMs.',
     },
     {
+        id: 'safe',
         question: 'IS MY MONEY SAFE?',
         answer: "It's yours. Non-custodial — your stablecoins stay in your wallet until the moment you use the card. We don't hold custody. We don't lend it out.",
     },
     {
+        id: 'ten',
         question: "WHAT'S THE $10?",
         answer: 'A welcome reward. Complete verification + first $100 in card spend → $10 unlocked to your balance. Same deal whether you signed up yourself or got referred. If you referred someone, you also are eligible for $10 when they activate. Subject to eligibility and program terms.',
     },
     {
+        id: 'waitlist',
         question: 'HOW LONG IS THE WAITLIST?',
         answer: "We're letting in about 20 people a week during closed beta. Order matters. Badges skip the line entirely.",
     },
     {
+        id: 'regions',
         question: 'WHERE CAN I GET THE CARD?',
         answer: "We're rolling out to select regions first and adding more as our partners' coverage expands. Eligibility is shown during signup.",
     },
     {
+        id: 'fees',
         question: 'ANY FEES?',
         answer: 'No monthly fees. No annual fees. Standard fees and limits apply per the cardholder terms.',
     },
     {
+        id: 'shhhhh',
         question: 'WHY "SHHHHH"?',
         answer: "We'd rather under-promise and over-deliver to a small group than blast the whole internet on day one. Word travels.",
     },
@@ -420,33 +429,8 @@ export default function ShhhhhLandingPage() {
 
             <Marquee {...marqueeProps} />
 
-            {/* §6 — FAQ (cream — inline accordion, no white panel) */}
-            <section
-                className="relative overflow-hidden px-4 py-24 text-n-1 md:py-32"
-                style={{ backgroundColor: '#F9F4F0' }}
-            >
-                <div className="mx-auto max-w-3xl">
-                    <h2 className="font-roboto-flex-extrabold text-heading font-extraBlack uppercase md:text-headingMedium">
-                        FAQ.
-                    </h2>
-                    <div className="mt-10 border-y-2 border-n-1">
-                        {faqQuestions.map((q, idx) => (
-                            <details
-                                key={q.question}
-                                className={`group py-5 ${idx > 0 ? 'border-t-2 border-n-1' : ''}`}
-                            >
-                                <summary className="font-roboto-flex-extrabold flex cursor-pointer list-none items-center justify-between gap-4 text-lg font-extraBlack uppercase md:text-xl [&::-webkit-details-marker]:hidden">
-                                    <span>{q.question}</span>
-                                    <span className="shrink-0 text-3xl leading-none transition-transform duration-200 group-open:rotate-45">
-                                        +
-                                    </span>
-                                </summary>
-                                <p className="mt-4 text-lg font-semibold leading-6 text-n-1 md:text-xl">{q.answer}</p>
-                            </details>
-                        ))}
-                    </div>
-                </div>
-            </section>
+            {/* §6 — FAQ */}
+            <FAQsPanel heading="FAQ." questions={faqQuestions} />
 
             <Marquee {...marqueeProps} />
 


### PR DESCRIPTION
## Summary

The inline `<details>` FAQ accordion in `ShhhhhLandingPage.tsx` renders the same markup as the shared `FAQsPanel` component (after #2074's restyle). Replace the inline copy with the shared component.

- Drops the `§6 — FAQ` `<section>` block in `ShhhhhLandingPage.tsx` (cream background, max-w-3xl wrapper, mapped `<details>` rows)
- Replaces it with `<FAQsPanel heading="FAQ." questions={faqQuestions} />`
- Adds an `id` slug (`what`, `where`, `safe`, `ten`, `waitlist`, `regions`, `fees`, `shhhhh`) to each FAQ entry to satisfy `FAQsPanel`'s question schema

Net: **+11 / −27** in one file. No visual change.

## Why now

This was originally [`8dc85ff1f` on PR #2073](https://github.com/peanutprotocol/peanut-ui/pull/2073/commits/8dc85ff1ff4030dd72908b5a87632b5f0ba01d91), reverted [the same day](https://github.com/peanutprotocol/peanut-ui/pull/2073/commits/a2bae988fd2c7edd12b8a5a2ad35d4d10e3eec52) because #2074 (the `FAQsPanel` restyle to match the shhhhh look) hadn't merged yet. Without it the shared component would have rendered in the old pink-pill design and regressed `/shhhhh`'s FAQ section.

#2074 has since shipped to `dev` and been merged into `feat/card-activation`, so the dependency is satisfied — re-applying the dedup is now safe.

## Test plan

- [ ] `/shhhhh` FAQ section renders identically to `feat/card-activation` HEAD (cream `#F9F4F0` background, hairline `border-y-2 border-n-1` dividers, `+`→`×` toggle on open, uppercase questions, large semibold answers)
- [ ] Each row toggles open/closed independently
- [ ] Mobile: questions and answers wrap correctly at ≤768px

## Notes for reviewer

`FAQsPanel` wraps the answer body in a `<div>` containing a `<p className="whitespace-pre-line">` (vs the previous bare `<p>`), and runs answers through `linkifyText`. None of the eight `/shhhhh` FAQ answers contain markdown links or pre-line newlines, so the rendered output is identical.

Targeting `feat/card-activation` per Hugo's note when closing #2073 ("cherry-pick if any LandingPage refactors from this PR are still wanted") — this is the only piece from #2073 that's effectively missing on that branch.