### PR TITLE
fix(profile): verified checkmark only on Sumsub approval

### DIFF
--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -25,7 +25,10 @@ export const Profile = () => {
     const [isInviteFriendsModalOpen, setIsInviteFriendsModalOpen] = useState(false)
     const router = useRouter()
     const onBack = useSafeBack('/home')
-    const { isUserKycApproved } = useKycStatus()
+    // Profile "verified" reflects identity verification only. Bridge/Manteca
+    // approval just means a payment rail is enabled, not that the human has
+    // been ID-verified — only Sumsub clears that bar.
+    const { isUserSumsubKycApproved } = useKycStatus()
     const { hasCardAccess } = useCardPioneerInfo()
 
     const logout = async () => {
@@ -41,7 +44,7 @@ export const Profile = () => {
         <div className="h-full w-full bg-background">
             <NavHeader hideLabel showLogoutBtn onPrev={onBack} />
             <div className="space-y-8">
-                <ProfileHeader name={displayName} username={username} isVerified={isUserKycApproved} />
+                <ProfileHeader name={displayName} username={username} isVerified={isUserSumsubKycApproved} />
                 <div className="space-y-4">
                     <ProfileMenuItem
                         icon="smile"
@@ -76,7 +79,7 @@ export const Profile = () => {
                             label="Regions & Verification"
                             href="/profile/identity-verification"
                             position="middle"
-                            highlight={!isUserKycApproved}
+                            highlight={!isUserSumsubKycApproved}
                         />
 
                         <ProfileMenuItem icon="meter" label="Payment limits" href="/limits" position="middle" />


### PR DESCRIPTION
## Summary
- Profile's verified state was using \`isUserKycApproved\` = Bridge OR Manteca OR Sumsub. That's the wrong bar — Bridge/Manteca approval means a payment rail is enabled, not that the human has been ID-verified. Only Sumsub clears that.
- Both indicators in \`Profile/index.tsx\` (the \`<ProfileHeader isVerified>\` checkmark and the "Regions & Verification" menu highlight) now read \`isUserSumsubKycApproved\` so they agree.

## Why this matters
Real users on \`hugostagqa\` etc. were seeing the verified checkmark with no Sumsub on file because we had a payment rail enabled for them. The label was lying about identity verification.

## Test plan
- [ ] Sumsub-approved user → checkmark shows, "Regions & Verification" not highlighted
- [ ] Bridge-only or Manteca-only approved user (no Sumsub) → no checkmark, "Regions & Verification" highlighted
- [ ] Brand-new user (nothing approved) → no checkmark, "Regions & Verification" highlighted
- [ ] \`pnpm typecheck\` (clean — verified locally)
- [ ] \`npm test\` (no new failures — the one pre-existing failure in \`add-money-states.test.tsx\` is unrelated)