### PR TITLE
chore(seo): TODO comment for SPEI + Faster Payments DEPOSIT_RAILS

### DIFF
--- a/src/data/seo/exchanges.ts
+++ b/src/data/seo/exchanges.ts
@@ -25,7 +25,17 @@ interface DepositFrontmatter {
 }
 
 /** Crypto networks + fiat rails served at /deposit/via-{slug}. Hardcoded
- *  because rails have no entity data — they're purely a content-page concept. */
+ *  because rails have no entity data — they're purely a content-page concept.
+ *
+ *  TODO(reorg): two missing fiat keys need to be added during the next pass:
+ *      'faster-payments': 'Faster Payments',  // UK — GBP via Bridge, live
+ *      spei: 'SPEI Bank Transfer',            // Mexico — MXN via Bridge, live
+ *  MDX content already exists at mono/content/deposit/{spei,faster-payments}/
+ *  (pushed 2026-05-25). The pages 404 on the live site until the keys are
+ *  registered here — generateStaticParams iterates Object.keys(DEPOSIT_RAILS).
+ *  Both rails are wired end-to-end already: see src/utils/bridge.utils.ts
+ *  getCurrencyConfig('MX' | 'GB', ...) — onramp + offramp via Bridge.
+ *  Full context: mono/content/_system/ROADMAP.md (entry dated 2026-05-22). */
 export const DEPOSIT_RAILS: Record<string, string> = {
     ach: 'ACH Bank Transfer',
     sepa: 'SEPA Bank Transfer',


### PR DESCRIPTION
## Summary

- Inline TODO comment above `DEPOSIT_RAILS` in `src/data/seo/exchanges.ts` flagging that `spei` and `'faster-payments'` keys still need to be added.
- Hands the requirement to whoever does the next pass on this file (Konrad mentioned a reorg).

## Why

MDX hubs already exist at `mono/content/deposit/spei/` and `mono/content/deposit/faster-payments/` (pushed 2026-05-25 in mono commit [0745662](https://github.com/peanutprotocol/mono/commit/0745662)). The pages 404 on the live site until the two corresponding keys are added to `DEPOSIT_RAILS`, because `generateStaticParams` in `app/[locale]/(marketing)/deposit/[exchange]/page.tsx` iterates `Object.keys(DEPOSIT_RAILS)` to emit `via-{rail}` static params.

Both rails are wired end-to-end via Bridge already — see `src/utils/bridge.utils.ts` `getCurrencyConfig('MX' | 'GB', ...)`, which returns `paymentRail: 'spei'` for Mexico and `paymentRail: 'faster_payments'` for the UK, both for onramp + offramp.

## Test plan

- [ ] Visual check — comment block reads cleanly above the `DEPOSIT_RAILS` declaration
- [ ] No code paths exercised (comment-only change); `npm run typecheck` should be unaffected

## Follow-up

This PR doesn't add the keys — that's deferred to the planned reorg of this file. Full context in [mono/content/_system/ROADMAP.md](https://github.com/peanutprotocol/mono/blob/main/content/_system/ROADMAP.md) under the "Register `spei` + `faster-payments` in peanut-ui DEPOSIT_RAILS" row.