### PR TITLE
feat(qr-pay): live card-vs-local-rail savings for ARS + BRL

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
+++ b/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
@@ -153,6 +153,10 @@ jest.mock('@/app/actions/currency', () => ({
     getCurrencyPrice: jest.fn(() => Promise.resolve({ sell: 1200, buy: 1250 })),
 }))
 
+jest.mock('@/hooks/useCardMarkupRate', () => ({
+    useCardMarkupRate: jest.fn(() => ({ data: null })),
+}))
+
 jest.mock('@/app/actions/increase-limits', () => ({
     initiateIncreaseLimits: jest.fn(),
 }))
@@ -271,6 +275,7 @@ jest.mock('@/utils/perk.utils', () => ({
 
 jest.mock('@/utils/qr-payment.utils', () => ({
     calculateSavingsInCents: jest.fn(() => 0),
+    hasCardMarkupComparison: jest.fn(() => false),
     isArgentinaMantecaQrPayment: jest.fn(() => false),
     getSavingsMessage: jest.fn(() => ''),
 }))
@@ -1073,12 +1078,12 @@ describe('GROUP 4: Success States', () => {
 
     test('Argentina QR3 success shows savings message', async () => {
         const {
-            isArgentinaMantecaQrPayment,
+            hasCardMarkupComparison,
             calculateSavingsInCents,
             getSavingsMessage,
         } = require('@/utils/qr-payment.utils')
 
-        isArgentinaMantecaQrPayment.mockReturnValue(true)
+        hasCardMarkupComparison.mockReturnValue(true)
         calculateSavingsInCents.mockReturnValue(150)
         getSavingsMessage.mockReturnValue('You saved $1.50 vs card!')
 

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -1399,8 +1399,8 @@ export default function QRPayPage() {
                                     value={`~$${savingsUsd}`}
                                     moreInfoText={
                                         currency.code.toUpperCase() === 'BRL'
-                                            ? 'Foreign cards pay IOF (~3.5%) plus an issuer FX markup (~3%). Peanut routes via PIX at the actual market rate.'
-                                            : 'Foreign cards apply the BCRA official rate plus an issuer FX markup. Peanut routes via MercadoPago at the market (MEP) rate.'
+                                            ? 'Foreign cards pay IOF (~3.5%) plus a typical ~3% issuer FX fee. Peanut routes via PIX at the current market rate.'
+                                            : 'Foreign cards apply the official rate plus a typical ~3% issuer FX fee. Peanut routes via MercadoPago at the current market rate.'
                                     }
                                 />
                             )

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -24,7 +24,13 @@ import { useRainCardOverview } from '@/hooks/useRainCardOverview'
 import { rainSpendingPowerToWei } from '@/utils/balance.utils'
 import { isTxReverted, saveRedirectUrl, formatNumberForDisplay } from '@/utils/general.utils'
 import { getShakeClass, type ShakeIntensity } from '@/utils/perk.utils'
-import { calculateSavingsInCents, isArgentinaMantecaQrPayment, getSavingsMessage } from '@/utils/qr-payment.utils'
+import {
+    calculateSavingsInCents,
+    hasCardMarkupComparison,
+    isArgentinaMantecaQrPayment,
+    getSavingsMessage,
+} from '@/utils/qr-payment.utils'
+import { useCardMarkupRate } from '@/hooks/useCardMarkupRate'
 import ErrorAlert from '@/components/Global/ErrorAlert'
 import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
 import { PERK_HOLD_DURATION_MS } from '@/constants/general.consts'
@@ -307,6 +313,11 @@ export default function QRPayPage() {
             return paymentLock.paymentAgainstAmount
         }
     }, [paymentLock?.code, paymentLock?.paymentAgainstAmount, amount])
+
+    // Live card-vs-local-rail markup, driven by Manteca's rate + (for ARS)
+    // BCRA's official rate. Used by both the confirm-screen "Save vs card"
+    // row and the success-screen savings message — keeps them in sync.
+    const { data: cardMarkup } = useCardMarkupRate(currency?.code, currency?.price)
 
     // validate payment against user's limits
     // currency comes from payment lock — hook normalizes it internally
@@ -1057,9 +1068,11 @@ export default function QRPayPage() {
     if (isSuccess && paymentProcessor === 'MANTECA' && !qrPayment) {
         return null
     } else if (isSuccess && paymentProcessor === 'MANTECA') {
-        // Calculate savings for Argentina Manteca QR payments only
-        const savingsInCents = calculateSavingsInCents(usdAmount)
-        const showSavingsMessage = savingsInCents > 0 && isArgentinaMantecaQrPayment(qrType, paymentProcessor)
+        // Show "saved $X vs card" only for currencies with a meaningful
+        // card-vs-local-rail gap (ARS, BRL — see CARD_FX_MARKUP_BY_CURRENCY).
+        // Rate is live (BCRA for ARS) via useCardMarkupRate above.
+        const savingsInCents = calculateSavingsInCents(usdAmount, cardMarkup?.rate)
+        const showSavingsMessage = savingsInCents > 0 && hasCardMarkupComparison(currency?.code)
         const savingsMessage = showSavingsMessage ? getSavingsMessage(savingsInCents) : ''
 
         return (
@@ -1375,6 +1388,23 @@ export default function QRPayPage() {
                             value={`1 USD = ${currency.price} ${currency.code.toUpperCase()}`}
                             moreInfoText="Rate shown is current but may vary slightly (~$1-5 ARS) until payment is confirmed."
                         />
+                        {(() => {
+                            if (!hasCardMarkupComparison(currency.code)) return null
+                            const savingsInCents = calculateSavingsInCents(usdAmount, cardMarkup?.rate)
+                            if (savingsInCents <= 0) return null
+                            const savingsUsd = (savingsInCents / 100).toFixed(2)
+                            return (
+                                <PaymentInfoRow
+                                    label="Save vs card"
+                                    value={`~$${savingsUsd}`}
+                                    moreInfoText={
+                                        currency.code.toUpperCase() === 'BRL'
+                                            ? 'Foreign cards pay IOF (~3.5%) plus an issuer FX markup (~3%). Peanut routes via PIX at the actual market rate.'
+                                            : 'Foreign cards apply the BCRA official rate plus an issuer FX markup. Peanut routes via MercadoPago at the market (MEP) rate.'
+                                    }
+                                />
+                            )
+                        })()}
                         <PaymentInfoRow label="Peanut fee" value="Sponsored by Peanut!" hideBottomBorder />
                     </Card>
 

--- a/src/app/actions/__tests__/card-comparison.test.ts
+++ b/src/app/actions/__tests__/card-comparison.test.ts
@@ -1,0 +1,103 @@
+import { getCardMarkupRate } from '@/app/actions/card-comparison'
+
+jest.mock('@/app/actions/currency', () => ({
+    getCurrencyPrice: jest.fn(),
+}))
+
+const { getCurrencyPrice } = jest.requireMock('@/app/actions/currency')
+
+describe('getCardMarkupRate', () => {
+    const originalFetch = global.fetch
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        global.fetch = jest.fn() as any
+    })
+
+    afterAll(() => {
+        global.fetch = originalFetch
+    })
+
+    it('returns null for currencies outside the comparison set', async () => {
+        const result = await getCardMarkupRate('EUR', 1.05)
+        expect(result).toBeNull()
+    })
+
+    it('returns null for empty currency code', async () => {
+        const result = await getCardMarkupRate('', 100)
+        expect(result).toBeNull()
+    })
+
+    it('returns the static BRL rate without hitting the network', async () => {
+        const result = await getCardMarkupRate('BRL')
+        expect(result).toEqual({ rate: 0.07, source: 'static' })
+        expect(global.fetch).not.toHaveBeenCalled()
+        expect(getCurrencyPrice).not.toHaveBeenCalled()
+    })
+
+    it('returns a live ARS rate when both dolarapi and a Manteca price are available', async () => {
+        ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ venta: 1000 }),
+        })
+        // mantecaPrice=1100, bcra=1000, issuer=0.03
+        // effectiveCardRate = 1000 * 0.97 = 970
+        // rate = 1100/970 - 1 ≈ 0.1340
+        const result = await getCardMarkupRate('ARS', 1100)
+        expect(result?.source).toBe('live')
+        expect(result?.rate).toBeCloseTo(0.134, 3)
+    })
+
+    it('fetches Manteca itself when no price is passed (LocalRailNudge call shape)', async () => {
+        getCurrencyPrice.mockResolvedValueOnce({ sell: 1100, buy: 1080 })
+        ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ venta: 1000 }),
+        })
+        const result = await getCardMarkupRate('ARS')
+        expect(getCurrencyPrice).toHaveBeenCalledWith('ARS')
+        expect(result?.source).toBe('live')
+        expect(result?.rate).toBeGreaterThan(0)
+    })
+
+    it('falls back to the static ARS rate when dolarapi fails', async () => {
+        ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+            ok: false,
+            status: 503,
+            json: () => Promise.resolve({}),
+        })
+        const result = await getCardMarkupRate('ARS', 1100)
+        expect(result).toEqual({ rate: 0.0913, source: 'static' })
+    })
+
+    it('falls back to the static ARS rate when dolarapi throws', async () => {
+        ;(global.fetch as jest.Mock).mockRejectedValueOnce(new Error('network down'))
+        const result = await getCardMarkupRate('ARS', 1100)
+        expect(result).toEqual({ rate: 0.0913, source: 'static' })
+    })
+
+    it('falls back to the static ARS rate when dolarapi returns garbage', async () => {
+        ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ venta: 'not-a-number' }),
+        })
+        const result = await getCardMarkupRate('ARS', 1100)
+        expect(result).toEqual({ rate: 0.0913, source: 'static' })
+    })
+
+    it('falls back to static when the live calc produces a non-positive markup (manteca cheaper than BCRA)', async () => {
+        // Pathological case — BCRA above Manteca should never happen, but we
+        // guard against showing "-3% savings" if FX weirdness inverts it.
+        ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ venta: 2000 }),
+        })
+        const result = await getCardMarkupRate('ARS', 1100)
+        expect(result).toEqual({ rate: 0.0913, source: 'static' })
+    })
+
+    it('normalizes the currency code (lower-case input)', async () => {
+        const result = await getCardMarkupRate('brl')
+        expect(result).toEqual({ rate: 0.07, source: 'static' })
+    })
+})

--- a/src/app/actions/card-comparison.ts
+++ b/src/app/actions/card-comparison.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { CARD_FX_MARKUP_BY_CURRENCY } from '@/constants/payment.consts'
+import { getCurrencyPrice } from '@/app/actions/currency'
 
 /**
  * Typical foreign-issuer FX markup applied on top of the network rate. Visa/MC
@@ -17,14 +18,18 @@ export interface CardMarkup {
 }
 
 /**
- * Effective card markup vs paying directly via Peanut's local rail, for the
- * currencies where the comparison is meaningful (ARS, BRL today).
+ * Single source of truth for "how much extra does a foreign card cost vs
+ * Peanut's local rail" — shared by every card-comparison surface (the QR pay
+ * confirm + success screens, and the post-card-spend nudge on transaction
+ * receipts). Currencies where the comparison is meaningful: ARS, BRL today.
  *
  * - ARS: live. BCRA official rate via dolarapi.com (what a foreign card user
  *        actually gets in Argentina post-PAIS-elimination) compared to
  *        Manteca's MEP/blue-equivalent rate that Peanut delivers. Spread
  *        fluctuates daily — anywhere from ~5% to ~25% historically — which is
- *        why this can't be a constant.
+ *        why this can't be a constant. Note: Manteca's price has its own
+ *        spread baked in, so the returned rate reflects what Peanut actually
+ *        delivers vs what a card delivers, not a pure BCRA-vs-MEP gap.
  * - BRL: static. IOF on foreign card purchases (3.5% as of 2025, phasing to 0
  *        by 2028) + issuer FX markup ~3%. Statutory + contract — not moving
  *        on FX news.
@@ -32,32 +37,40 @@ export interface CardMarkup {
  * Returns null if the currency has no meaningful card-vs-local-rail gap.
  *
  * @param currencyCode ISO code, case-insensitive
- * @param mantecaPriceUsdToLocal Local currency per 1 USD that Peanut delivers
- *        (i.e. `currency.price` from the qr-pay state). Required for the live
- *        spread calc on ARS — not used for static-fallback currencies.
+ * @param mantecaPriceUsdToLocal Optional. If the caller already has Manteca's
+ *        rate (e.g. from a QR payment lock), pass it to avoid an extra fetch.
+ *        Otherwise the action fetches it itself. Unused for static-fallback
+ *        currencies (BRL).
  */
 export async function getCardMarkupRate(
     currencyCode: string,
-    mantecaPriceUsdToLocal: number | null | undefined
+    mantecaPriceUsdToLocal?: number | null
 ): Promise<CardMarkup | null> {
     const code = currencyCode?.toUpperCase()
     if (!code) return null
     const staticRate = CARD_FX_MARKUP_BY_CURRENCY[code]
     if (staticRate === undefined) return null
 
-    if (code === 'ARS' && mantecaPriceUsdToLocal && mantecaPriceUsdToLocal > 0) {
+    if (code === 'ARS') {
         try {
-            const res = await fetch('https://dolarapi.com/v1/dolares/oficial', {
-                next: { revalidate: 300 },
-            })
-            if (res.ok) {
-                const data = (await res.json()) as { venta?: number }
-                const bcraOfficial = Number(data?.venta)
-                if (Number.isFinite(bcraOfficial) && bcraOfficial > 0) {
-                    const effectiveCardRate = bcraOfficial * (1 - ISSUER_FX_FEE)
-                    const rate = mantecaPriceUsdToLocal / effectiveCardRate - 1
-                    if (Number.isFinite(rate) && rate > 0) {
-                        return { rate, source: 'live' }
+            let mantecaPrice = mantecaPriceUsdToLocal
+            if (!mantecaPrice || mantecaPrice <= 0) {
+                const { sell } = await getCurrencyPrice('ARS')
+                mantecaPrice = sell
+            }
+            if (mantecaPrice && mantecaPrice > 0) {
+                const res = await fetch('https://dolarapi.com/v1/dolares/oficial', {
+                    next: { revalidate: 300 },
+                })
+                if (res.ok) {
+                    const data = (await res.json()) as { venta?: number }
+                    const bcraOfficial = Number(data?.venta)
+                    if (Number.isFinite(bcraOfficial) && bcraOfficial > 0) {
+                        const effectiveCardRate = bcraOfficial * (1 - ISSUER_FX_FEE)
+                        const rate = mantecaPrice / effectiveCardRate - 1
+                        if (Number.isFinite(rate) && rate > 0) {
+                            return { rate, source: 'live' }
+                        }
                     }
                 }
             }

--- a/src/app/actions/card-comparison.ts
+++ b/src/app/actions/card-comparison.ts
@@ -1,0 +1,71 @@
+'use server'
+
+import { CARD_FX_MARKUP_BY_CURRENCY } from '@/constants/payment.consts'
+
+/**
+ * Typical foreign-issuer FX markup applied on top of the network rate. Visa/MC
+ * deliver near mid-market; the issuing bank adds 2–3% as a foreign-transaction
+ * fee. Used by the ARS dynamic calc on top of the BCRA official rate.
+ */
+const ISSUER_FX_FEE = 0.03
+
+export interface CardMarkup {
+    /** Savings as a fraction of the Peanut USD amount (i.e. usdAmount × rate = USD saved). */
+    rate: number
+    /** Whether the rate came from a live source or fell back to a static constant. */
+    source: 'live' | 'static'
+}
+
+/**
+ * Effective card markup vs paying directly via Peanut's local rail, for the
+ * currencies where the comparison is meaningful (ARS, BRL today).
+ *
+ * - ARS: live. BCRA official rate via dolarapi.com (what a foreign card user
+ *        actually gets in Argentina post-PAIS-elimination) compared to
+ *        Manteca's MEP/blue-equivalent rate that Peanut delivers. Spread
+ *        fluctuates daily — anywhere from ~5% to ~25% historically — which is
+ *        why this can't be a constant.
+ * - BRL: static. IOF on foreign card purchases (3.5% as of 2025, phasing to 0
+ *        by 2028) + issuer FX markup ~3%. Statutory + contract — not moving
+ *        on FX news.
+ *
+ * Returns null if the currency has no meaningful card-vs-local-rail gap.
+ *
+ * @param currencyCode ISO code, case-insensitive
+ * @param mantecaPriceUsdToLocal Local currency per 1 USD that Peanut delivers
+ *        (i.e. `currency.price` from the qr-pay state). Required for the live
+ *        spread calc on ARS — not used for static-fallback currencies.
+ */
+export async function getCardMarkupRate(
+    currencyCode: string,
+    mantecaPriceUsdToLocal: number | null | undefined
+): Promise<CardMarkup | null> {
+    const code = currencyCode?.toUpperCase()
+    if (!code) return null
+    const staticRate = CARD_FX_MARKUP_BY_CURRENCY[code]
+    if (staticRate === undefined) return null
+
+    if (code === 'ARS' && mantecaPriceUsdToLocal && mantecaPriceUsdToLocal > 0) {
+        try {
+            const res = await fetch('https://dolarapi.com/v1/dolares/oficial', {
+                next: { revalidate: 300 },
+            })
+            if (res.ok) {
+                const data = (await res.json()) as { venta?: number }
+                const bcraOfficial = Number(data?.venta)
+                if (Number.isFinite(bcraOfficial) && bcraOfficial > 0) {
+                    const effectiveCardRate = bcraOfficial * (1 - ISSUER_FX_FEE)
+                    const rate = mantecaPriceUsdToLocal / effectiveCardRate - 1
+                    if (Number.isFinite(rate) && rate > 0) {
+                        return { rate, source: 'live' }
+                    }
+                }
+            }
+        } catch {
+            // Swallow — fall through to static fallback below. Never block
+            // the payment flow on a third-party FX feed being down.
+        }
+    }
+
+    return { rate: staticRate, source: 'static' }
+}

--- a/src/components/TransactionDetails/__tests__/LocalRailNudge.test.tsx
+++ b/src/components/TransactionDetails/__tests__/LocalRailNudge.test.tsx
@@ -4,11 +4,21 @@
  * The nudge fires only for a Rain card spend whose merchant sits in a
  * country with a cheaper first-party rail (AR → QR, BR → Pix). Every other
  * country, and every non-card-spend transaction, must render nothing.
+ *
+ * The savings percentage now comes from useCardMarkupRate (single source
+ * shared with the QR-pay confirm/success surfaces). Tests mock the hook to
+ * return undefined so the static-fallback in CARD_FX_MARKUP_BY_CURRENCY is
+ * exercised — that's the path users see during the first paint and during
+ * any third-party FX outage.
  */
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { LocalRailNudge } from '../provider-rows/LocalRailNudge'
 import { type TransactionDetails } from '../transactionTransformer'
+
+jest.mock('@/hooks/useCardMarkupRate', () => ({
+    useCardMarkupRate: jest.fn(() => ({ data: undefined })),
+}))
 
 /** Minimal TransactionDetails shaped for the nudge's two inputs only. */
 function tx(transactionCardType: string, merchantCountry: string | null): TransactionDetails {
@@ -21,14 +31,21 @@ function tx(transactionCardType: string, merchantCountry: string | null): Transa
 }
 
 describe('LocalRailNudge', () => {
-    it('nudges Argentina card spends toward QR', () => {
+    it('nudges Argentina card spends toward QR (static fallback ≈ 9%)', () => {
         render(<LocalRailNudge transaction={tx('card_pay', 'AR')} />)
         expect(screen.getByText(/In Argentina, paying with QR costs around 9% less/)).toBeInTheDocument()
     })
 
-    it('nudges Brazil card spends toward Pix', () => {
+    it('nudges Brazil card spends toward Pix (static fallback ≈ 7%)', () => {
         render(<LocalRailNudge transaction={tx('card_pay', 'BR')} />)
-        expect(screen.getByText(/In Brazil, paying with Pix costs around 9% less/)).toBeInTheDocument()
+        expect(screen.getByText(/In Brazil, paying with Pix costs around 7% less/)).toBeInTheDocument()
+    })
+
+    it('uses the live rate when the hook resolves with data', () => {
+        const { useCardMarkupRate } = jest.requireMock('@/hooks/useCardMarkupRate')
+        useCardMarkupRate.mockReturnValueOnce({ data: { rate: 0.21, source: 'live' } })
+        render(<LocalRailNudge transaction={tx('card_pay', 'AR')} />)
+        expect(screen.getByText(/around 21% less/)).toBeInTheDocument()
     })
 
     it('recovers the country code from a city-joined value', () => {

--- a/src/components/TransactionDetails/provider-rows/LocalRailNudge.tsx
+++ b/src/components/TransactionDetails/provider-rows/LocalRailNudge.tsx
@@ -4,6 +4,8 @@ import Card from '@/components/Global/Card'
 import { Icon } from '@/components/Global/Icons/Icon'
 import { type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
 import { extractMerchantIso2 } from '@/components/TransactionDetails/transaction-details.utils'
+import { useCardMarkupRate } from '@/hooks/useCardMarkupRate'
+import { CARD_FX_MARKUP_BY_CURRENCY } from '@/constants/payment.consts'
 
 /**
  * Countries where Peanut has a first-party local payment rail that's cheaper
@@ -12,10 +14,12 @@ import { extractMerchantIso2 } from '@/components/TransactionDetails/transaction
  * light up the nudge for it — mirrors MANTECA_GEO_RAIL_MAP in peanut-api-ts.
  *
  * `rail` is the printable, user-facing rail name (reads as "pay with {rail}").
+ * `currency` drives the shared `useCardMarkupRate` lookup so this nudge stays
+ * in sync with the QR-pay confirm/success surfaces.
  */
-const LOCAL_RAIL_BY_COUNTRY: Record<string, { countryName: string; rail: string }> = {
-    AR: { countryName: 'Argentina', rail: 'QR' },
-    BR: { countryName: 'Brazil', rail: 'Pix' },
+const LOCAL_RAIL_BY_COUNTRY: Record<string, { countryName: string; rail: string; currency: string }> = {
+    AR: { countryName: 'Argentina', rail: 'QR', currency: 'ARS' },
+    BR: { countryName: 'Brazil', rail: 'Pix', currency: 'BRL' },
 }
 
 /**
@@ -23,9 +27,11 @@ const LOCAL_RAIL_BY_COUNTRY: Record<string, { countryName: string; rail: string 
  * country where Peanut has a cheaper local rail (Argentina → QR, Brazil →
  * Pix), let the user know they could pay a better way next time.
  *
- * Card spends route through Rain and cost ~9% more than the local rail (see
- * `calculateSavingsInCents` in qr-payment.utils — 9.13% vs card). Renders
- * nothing for any other country or for non-card-spend transactions.
+ * Percentage comes from `useCardMarkupRate` so confirm-screen "Save vs card"
+ * and this nudge are sourced identically — single number, two surfaces.
+ * Static-table fallback is used until the live value resolves to avoid a
+ * flash of missing nudge. Loose "around N%" copy stays — this is an
+ * educational nudge on a past transaction, not a pre-pay precision moment.
  */
 export function LocalRailNudge({ transaction }: { transaction: TransactionDetails }) {
     // Card spends only. Refunds map to a 'receive' card type, so gating on
@@ -36,6 +42,15 @@ export function LocalRailNudge({ transaction }: { transaction: TransactionDetail
     const local = iso2 ? LOCAL_RAIL_BY_COUNTRY[iso2.toUpperCase()] : undefined
     if (!local) return null
 
+    return <LocalRailNudgeBody local={local} />
+}
+
+function LocalRailNudgeBody({ local }: { local: (typeof LOCAL_RAIL_BY_COUNTRY)[string] }) {
+    const { data: cardMarkup } = useCardMarkupRate(local.currency)
+    const rate = cardMarkup?.rate ?? CARD_FX_MARKUP_BY_CURRENCY[local.currency]
+    const percent = rate && rate > 0 ? Math.round(rate * 100) : null
+    if (!percent) return null
+
     return (
         <Card position="single" className="px-4 py-4">
             <div className="flex items-center gap-3">
@@ -43,7 +58,8 @@ export function LocalRailNudge({ transaction }: { transaction: TransactionDetail
                 <div className="flex flex-col gap-1">
                     <span className="font-semibold text-gray-900">Pay like a local next time</span>
                     <span className="text-sm text-gray-600">
-                        In {local.countryName}, paying with {local.rail} costs around 9% less than using your card.
+                        In {local.countryName}, paying with {local.rail} costs around {percent}% less than using your
+                        card.
                     </span>
                 </div>
             </div>

--- a/src/constants/payment.consts.ts
+++ b/src/constants/payment.consts.ts
@@ -29,6 +29,28 @@ export const MIN_PIX_AMOUNT_BRL = 1
 export const BRIDGE_DEVELOPER_FEE_RATE = 0
 
 /**
+ * Static fallback for the card-vs-local-rail markup. The live source of truth
+ * is `getCardMarkupRate` in `app/actions/card-comparison.ts` — for ARS that
+ * fetches BCRA official live (the spread fluctuates daily), for BRL it just
+ * returns the value here (IOF is statutory, slow-moving). These constants
+ * cover the static cases AND the eligibility gate (`hasCardMarkupComparison`)
+ * — only currencies in this map render the "vs card" surfaces at all.
+ *
+ * - ARS: 9.13% — historical empirical figure for the BCRA-vs-MEP rate spread
+ *        + issuer markup. Used only when the live BCRA fetch fails.
+ * - BRL: 7% — IOF on foreign card purchases (3.5% as of 2025, phasing to 0
+ *        by 2028) + typical issuer FX markup ~3%. No live source today.
+ *
+ * Only currencies with a real card-vs-local-rail gap belong here. USD / EUR /
+ * GBP / MXN spend doesn't show a meaningful enough delta to be a marketing
+ * point and should NOT be added.
+ */
+export const CARD_FX_MARKUP_BY_CURRENCY: Record<string, number> = {
+    ARS: 0.0913,
+    BRL: 0.07,
+}
+
+/**
  * validate if amount meets minimum requirement for a payment method
  * @param amount - amount in USD
  * @param methodId - payment method identifier

--- a/src/hooks/useCardMarkupRate.ts
+++ b/src/hooks/useCardMarkupRate.ts
@@ -4,21 +4,24 @@ import { getCardMarkupRate, type CardMarkup } from '@/app/actions/card-compariso
 /**
  * Live card-vs-local-rail markup for the currencies where it's meaningful
  * (ARS dynamic via BCRA official; BRL static via IOF + issuer markup). See
- * `getCardMarkupRate` for sourcing rules.
+ * `getCardMarkupRate` for sourcing rules. Single source for every card-
+ * comparison surface — confirm/success rows and the post-spend nudge.
  *
  * Cached 5 minutes client-side; the underlying fetch is also cached 5 minutes
  * on the Next.js server. Returns undefined while loading or when the currency
  * has no meaningful comparison — callers should treat null/undefined as
  * "don't render the savings row".
+ *
+ * `mantecaPriceUsdToLocal` is optional: if the caller already has the price
+ * (qr-pay confirm screen does), pass it to avoid a second fetch on the
+ * server side. Other callers (e.g. the post-card-spend nudge) just pass the
+ * currency code and the action fetches Manteca itself.
  */
-export function useCardMarkupRate(
-    currencyCode: string | null | undefined,
-    mantecaPriceUsdToLocal: number | null | undefined
-) {
+export function useCardMarkupRate(currencyCode: string | null | undefined, mantecaPriceUsdToLocal?: number | null) {
     return useQuery<CardMarkup | null>({
-        queryKey: ['cardMarkup', currencyCode?.toUpperCase(), mantecaPriceUsdToLocal],
+        queryKey: ['cardMarkup', currencyCode?.toUpperCase(), mantecaPriceUsdToLocal ?? null],
         queryFn: () => getCardMarkupRate(currencyCode!, mantecaPriceUsdToLocal),
-        enabled: !!currencyCode && !!mantecaPriceUsdToLocal && mantecaPriceUsdToLocal > 0,
+        enabled: !!currencyCode,
         staleTime: 5 * 60 * 1000,
         gcTime: 10 * 60 * 1000,
         refetchOnWindowFocus: true,

--- a/src/hooks/useCardMarkupRate.ts
+++ b/src/hooks/useCardMarkupRate.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query'
+import { getCardMarkupRate, type CardMarkup } from '@/app/actions/card-comparison'
+
+/**
+ * Live card-vs-local-rail markup for the currencies where it's meaningful
+ * (ARS dynamic via BCRA official; BRL static via IOF + issuer markup). See
+ * `getCardMarkupRate` for sourcing rules.
+ *
+ * Cached 5 minutes client-side; the underlying fetch is also cached 5 minutes
+ * on the Next.js server. Returns undefined while loading or when the currency
+ * has no meaningful comparison — callers should treat null/undefined as
+ * "don't render the savings row".
+ */
+export function useCardMarkupRate(
+    currencyCode: string | null | undefined,
+    mantecaPriceUsdToLocal: number | null | undefined
+) {
+    return useQuery<CardMarkup | null>({
+        queryKey: ['cardMarkup', currencyCode?.toUpperCase(), mantecaPriceUsdToLocal],
+        queryFn: () => getCardMarkupRate(currencyCode!, mantecaPriceUsdToLocal),
+        enabled: !!currencyCode && !!mantecaPriceUsdToLocal && mantecaPriceUsdToLocal > 0,
+        staleTime: 5 * 60 * 1000,
+        gcTime: 10 * 60 * 1000,
+        refetchOnWindowFocus: true,
+    })
+}

--- a/src/utils/qr-payment.utils.ts
+++ b/src/utils/qr-payment.utils.ts
@@ -1,15 +1,31 @@
 import { formatNumberForDisplay } from './general.utils'
 import { EQrType } from '@/components/Global/DirectSendQR/utils'
+import { CARD_FX_MARKUP_BY_CURRENCY } from '@/constants/payment.consts'
 
 /**
- * Calculate savings amount (9.13% of transaction value) in cents
- * @param usdAmount Transaction amount in USD
- * @returns Savings amount in cents, or 0 if invalid
+ * Calculate savings in cents vs paying with a foreign card, given a markup
+ * rate (the fraction of the USD transaction value that a card user would
+ * lose). Caller is responsible for sourcing the markup — typically from
+ * `useCardMarkupRate`, which fetches live for ARS and falls back to a static
+ * constant for BRL.
  */
-export function calculateSavingsInCents(usdAmount: string | null | undefined): number {
-    if (!usdAmount) return 0
-    const savingsAmount = parseFloat(usdAmount) * 0.0913
+export function calculateSavingsInCents(
+    usdAmount: string | null | undefined,
+    markupRate: number | null | undefined
+): number {
+    if (!usdAmount || !markupRate || markupRate <= 0) return 0
+    const savingsAmount = parseFloat(usdAmount) * markupRate
     return Math.round(savingsAmount * 100)
+}
+
+/**
+ * Whether a "vs card" comparison is meaningful for this currency. Only true
+ * for currencies with a real card-vs-local-rail gap (ARS, BRL today). Gates
+ * rendering of the comparison row before the live markup has resolved.
+ */
+export function hasCardMarkupComparison(currencyCode: string | null | undefined): boolean {
+    if (!currencyCode) return false
+    return CARD_FX_MARKUP_BY_CURRENCY[currencyCode.toUpperCase()] !== undefined
 }
 
 /**


### PR DESCRIPTION
## Summary

A single live source for "how much does a foreign card cost vs Peanut's local rail", shared by **every** card-comparison surface. Replaces the hardcoded 9.13% — the BCRA-vs-MEP spread fluctuates ~5–25% in practice, so the launch-day snapshot was wrong most days.

- New server action [`getCardMarkupRate`](src/app/actions/card-comparison.ts) — **single source of truth**:
  - **ARS live** via `dolarapi.com/v1/dolares/oficial` (free, public, the de facto AR FX source). Markup = `mantecaPrice / (bcraOfficial × 0.97) − 1`. The 3% factor is a typical issuer FX fee on top of the network rate. Cached 5 min server-side + 5 min client via React Query.
  - **BRL static** at 7% (IOF 3.5% + issuer ~3%). Statutory + slow-moving, no live source needed. Same hook surface so swapping in a live feed later is trivial.
  - Falls back to the static constant if the live fetch fails — payment flow never blocks on a third-party feed.
  - **Self-sufficient**: callers without a Manteca rate (e.g. LocalRailNudge) just pass a currency code; the action fetches Manteca itself.

- Wires **three** surfaces to the same hook so they can't drift:
  1. QR pay **confirm** screen — new `"Save vs card ~$X"` row between Exchange Rate and Peanut fee (this surface previously had no comparison at all).
  2. QR pay **success** screen — existing "saved ~\$X compared to card!" message, now live and extended to BRL (was ARS-only).
  3. **LocalRailNudge** on Rain-card-spend receipts — was `"around 9% less"` hardcoded (anchored to the old 9.13% in `calculateSavingsInCents` per its commit message); now `"around {N}% less"` where N comes from the same hook. Loose "around" copy stays — it's a post-hoc educational nudge, not a precision moment.

- `calculateSavingsInCents` now takes a markup *rate* instead of a currency code — decoupled from any static table; the table is fallback + eligibility gate only.

## Why this shape

Juan José's commit message for [LocalRailNudge](src/components/TransactionDetails/provider-rows/LocalRailNudge.tsx) (5333032, 2026-05-21) is explicit:

> The ~9% figure is the same delta `calculateSavingsInCents` already uses (9.13% vs card).

That intent — **one figure across surfaces** — was load-bearing. This PR preserves it while fixing the staleness. A first revision of this PR went live-rate on the QR-pay surfaces but left LocalRailNudge unchanged, which would have created drift between two surfaces that were meant to agree. Fixed.

## Honest framings

- Manteca's ARS price has its own spread baked in. The live `mantecaPrice / (bcraOfficial × 0.97) − 1` calc reflects "what Peanut actually delivers vs what a card delivers", **not** a pure BCRA-vs-MEP gap. That's the right thing to display (it's what the user gets), but the variable name shouldn't oversell as a pure spread.
- 3% issuer fee is a constant in [`card-comparison.ts:10`](src/app/actions/card-comparison.ts) (`ISSUER_FX_FEE`). Same drift class as the 9.13% it replaces — just moved. Product/marketing should know it lives here.
- BRL doesn't really gain from the dynamic path today (returns the static value). The infrastructure pays for itself the day IOF steps down or we wire in a live BRL source. Until then it's "free" cost (~10 LOC).

## Test plan

- [x] `npm test` — new `card-comparison.test.ts` (10 cases, covering eligibility, live ARS, static BRL, all dolarapi failure modes, the no-Manteca-price branch, and inverted-spread guards)
- [x] `npm test` — `qr-pay-states.test.tsx` (22/22 active, no regressions)
- [x] `npm test` — `LocalRailNudge.test.tsx` refreshed (live-rate path tested, static fallbacks updated to per-currency: AR 9%, BR 7%)
- [x] `tsc --noEmit` — clean on the touched files
- [ ] Manual: scan a MercadoPago/QR3 ARS QR on the preview, verify "Save vs card" amount tracks today's BCRA-vs-MEP (cross-check against `dolarapi.com/v1/dolares/oficial`)
- [ ] Manual: scan a PIX BRL QR, verify ~7% of USD value
- [ ] Manual: open a past Rain card-spend receipt in AR/BR, verify the nudge percentage now matches the QR-pay surface (no drift)
