### PR TITLE
fix(landing): stop currency widget from scrolling to top

### DIFF
--- a/src/components/Global/ExchangeRateWidget/index.tsx
+++ b/src/components/Global/ExchangeRateWidget/index.tsx
@@ -4,7 +4,7 @@ import { useDebounce } from '@/hooks/useDebounce'
 import { useExchangeRate } from '@/hooks/useExchangeRate'
 import { applyBridgeCrossCurrencyFee, reverseBridgeCrossCurrencyFee } from '@/utils/bridge.utils'
 import Image from 'next/image'
-import { useRouter, useSearchParams } from 'next/navigation'
+import { parseAsFloat, parseAsString, useQueryStates } from 'nuqs'
 import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Icon, type IconName } from '../Icons/Icon'
 import { Button } from '@/components/0_Bruddle/Button'
@@ -16,15 +16,21 @@ interface IExchangeRateWidgetProps {
 }
 
 const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, ctaAction }) => {
-    const searchParams = useSearchParams()
-    const router = useRouter()
+    // shallow + history:'replace' uses window.history.replaceState — bypasses
+    // Next.js navigation so URL updates don't (occasionally) scroll the page
+    // to the top through the parent Suspense boundary.
+    const [query, setQuery] = useQueryStates(
+        {
+            from: parseAsString.withDefault('USD'),
+            to: parseAsString.withDefault('EUR'),
+            amount: parseAsFloat.withDefault(10),
+        },
+        { shallow: true, history: 'replace', scroll: false }
+    )
 
-    // Get values from URL or use defaults
-    const sourceCurrency = searchParams.get('from') || 'USD'
-    const destinationCurrency = searchParams.get('to') || 'EUR'
-    const rawAmount = searchParams.get('amount')
-    const parsedAmount = rawAmount !== null ? Number(rawAmount) : 10
-    const urlSourceAmount = Number.isFinite(parsedAmount) && parsedAmount > 0 ? parsedAmount : 10
+    const sourceCurrency = query.from
+    const destinationCurrency = query.to
+    const urlSourceAmount = query.amount > 0 ? query.amount : 10
 
     // Exchange rate hook handles all the conversion logic
     const {
@@ -62,18 +68,11 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
         return netDestinationAmount.toFixed(2)
     }, [isEditingDestination, getDestinationDisplayValue, netDestinationAmount])
 
-    // Function to update URL parameters
     const updateUrlParams = useCallback(
         (params: { from?: string; to?: string; amount?: number }) => {
-            const newSearchParams = new URLSearchParams(searchParams.toString())
-
-            if (params.from) newSearchParams.set('from', params.from)
-            if (params.to) newSearchParams.set('to', params.to)
-            if (params.amount !== undefined) newSearchParams.set('amount', params.amount.toString())
-
-            router.replace(`?${newSearchParams.toString()}`, { scroll: false })
+            setQuery(params)
         },
-        [searchParams, router]
+        [setQuery]
     )
 
     // Setter functions that update URL

--- a/src/components/Marketing/mdx/ExchangeWidget.tsx
+++ b/src/components/Marketing/mdx/ExchangeWidget.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { Suspense, useEffect } from 'react'
-import { useRouter, useSearchParams } from 'next/navigation'
+import { useRouter } from 'next/navigation'
+import { parseAsString, useQueryStates } from 'nuqs'
 import ExchangeRateWidget from '@/components/Global/ExchangeRateWidget'
 import { Star } from '@/assets'
 import { CloudsCss } from '@/components/LandingPage/CloudsCss'
@@ -20,17 +21,17 @@ interface ExchangeWidgetProps {
 
 function ExchangeWidgetInner({ destinationCurrency, sourceCurrency = 'USD' }: ExchangeWidgetProps) {
     const router = useRouter()
-    const searchParams = useSearchParams()
+    const [{ from, to }, setQuery] = useQueryStates(
+        { from: parseAsString, to: parseAsString },
+        { shallow: true, history: 'replace', scroll: false }
+    )
 
-    // Set initial currencies in URL if not already set
+    // Seed the URL with the page's default destination currency on first mount.
     useEffect(() => {
-        if (destinationCurrency && !searchParams.get('to')) {
-            const params = new URLSearchParams(searchParams.toString())
-            params.set('to', destinationCurrency)
-            if (!params.get('from')) params.set('from', sourceCurrency)
-            router.replace(`?${params.toString()}`, { scroll: false })
+        if (destinationCurrency && !to) {
+            setQuery({ to: destinationCurrency, from: from ?? sourceCurrency })
         }
-    }, [destinationCurrency, sourceCurrency, searchParams, router])
+    }, [destinationCurrency, sourceCurrency, to, from, setQuery])
 
     return (
         <section className="relative my-8 w-full pb-14 pt-10 md:pb-18 md:pt-14" style={{ backgroundColor: '#90A8ED' }}>


### PR DESCRIPTION
## Summary
- Clicking a currency in the landing-page exchange widget would sometimes scroll the user back to the top.
- Root cause: `router.replace('?...', { scroll: false })` is flaky in Next.js 16 when there's a `<Suspense>` boundary above — search-param changes occasionally bubble a scroll reset through it. The landing page has Suspense at `src/app/page.tsx:38`, which is why the bug surfaced there.
- Fix: switch both `Global/ExchangeRateWidget` and its MDX wrapper `Marketing/mdx/ExchangeWidget` to `nuqs` with `shallow: true, history: 'replace', scroll: false`. nuqs goes through `window.history.replaceState` and never re-enters the Next.js router. Also brings these two files in line with the "use nuqs, never URLSearchParams" rule in CLAUDE.md.

## Test plan
- [ ] On `/` (and any SEO page that embeds `<ExchangeWidget destinationCurrency="ARS" />`), scroll down to the exchange widget and open either currency picker.
- [ ] Pick a different currency — the page should stay put, not jump to the hero.
- [ ] Swap currencies via the swap button — same: no scroll.
- [ ] Type a new source amount — no scroll on debounce.
- [ ] Reload with `?from=BRL&to=USD&amount=250` and confirm the widget restores those values.
- [ ] On an SEO page (e.g. `/en/send-to/argentina`), confirm the widget still seeds `to=ARS` on first mount when no query string is present.

---

Split out of #2109 — scroll fix only. Card-markup work is back in #2108.