### PR TITLE
perf(currency): cache getCurrencyPrice for 10min

### DIFF
--- a/src/app/actions/currency.ts
+++ b/src/app/actions/currency.ts
@@ -1,42 +1,49 @@
 import { getExchangeRate } from './exchange-rate'
 import { AccountType } from '@/interfaces'
 import { mantecaApi } from '@/services/manteca'
+import { unstable_cache } from '@/utils/no-cache'
 
 const MANTECA_CURRENCIES = ['ARS', 'BRL', 'COP', 'CRC', 'PUSD', 'GTQ', 'PHP', 'BOB']
 
-export const getCurrencyPrice = async (currencyCode: string): Promise<{ buy: number; sell: number }> => {
-    let buy: number
-    let sell: number
-    currencyCode = currencyCode.toUpperCase()
-    if (currencyCode === 'USD') {
-        buy = 1
-        sell = 1
-    } else if (['EUR', 'MXN', 'GBP'].includes(currencyCode)) {
-        let accountType: AccountType
-        if (currencyCode === 'EUR') {
-            accountType = AccountType.IBAN
-        } else if (currencyCode === 'MXN') {
-            accountType = AccountType.CLABE
-        } else if (currencyCode === 'GBP') {
-            accountType = AccountType.GB
+const fetchCurrencyPrice = unstable_cache(
+    async (currencyCode: string): Promise<{ buy: number; sell: number }> => {
+        let buy: number
+        let sell: number
+        if (currencyCode === 'USD') {
+            buy = 1
+            sell = 1
+        } else if (['EUR', 'MXN', 'GBP'].includes(currencyCode)) {
+            let accountType: AccountType
+            if (currencyCode === 'EUR') {
+                accountType = AccountType.IBAN
+            } else if (currencyCode === 'MXN') {
+                accountType = AccountType.CLABE
+            } else if (currencyCode === 'GBP') {
+                accountType = AccountType.GB
+            } else {
+                throw new Error('Invalid currency code')
+            }
+            const { data, error } = await getExchangeRate(accountType)
+            if (error) {
+                throw new Error('Failed to fetch exchange rate from bridge')
+            }
+            if (!data) {
+                throw new Error('No data returned from exchange rate API')
+            }
+            buy = parseFloat(data.buy_rate)
+            sell = parseFloat(data.sell_rate)
+        } else if (MANTECA_CURRENCIES.includes(currencyCode)) {
+            const response = await mantecaApi.getPrices({ asset: 'USDC', against: currencyCode })
+            buy = Number(response.effectiveBuy)
+            sell = Number(response.effectiveSell)
         } else {
             throw new Error('Invalid currency code')
         }
-        const { data, error } = await getExchangeRate(accountType)
-        if (error) {
-            throw new Error('Failed to fetch exchange rate from bridge')
-        }
-        if (!data) {
-            throw new Error('No data returned from exchange rate API')
-        }
-        buy = parseFloat(data.buy_rate)
-        sell = parseFloat(data.sell_rate)
-    } else if (MANTECA_CURRENCIES.includes(currencyCode)) {
-        const response = await mantecaApi.getPrices({ asset: 'USDC', against: currencyCode })
-        buy = Number(response.effectiveBuy)
-        sell = Number(response.effectiveSell)
-    } else {
-        throw new Error('Invalid currency code')
-    }
-    return { buy, sell }
-}
+        return { buy, sell }
+    },
+    ['getCurrencyPrice'],
+    { revalidate: 10 * 60 }
+)
+
+export const getCurrencyPrice = (currencyCode: string): Promise<{ buy: number; sell: number }> =>
+    fetchCurrencyPrice(currencyCode.toUpperCase())


### PR DESCRIPTION
## Why

The currency widget (ARS and other Manteca/Bridge-priced currencies) loads slowly because every `getCurrencyPrice` call goes out to Manteca/Bridge live. The upstream provider request was never cached — only the `/api/exchange-rate` **route response** carried `s-maxage=300, stale-while-revalidate=600`, which only helps on repeat hits behind the CDN. Cold edge calls and the Capacitor client path (which calls `getCurrencyPrice` directly) always paid the full round-trip.

## What

Wrap `getCurrencyPrice` in the existing `unstable_cache` shim (`@/utils/no-cache`), keyed on the normalized currency code, with a 10-minute TTL. Repeat lookups within the window serve from process memory instead of re-hitting the provider.

This matches how `tokens.ts`, `ens.ts`, and `bridge/get-customer.ts` already cache server-action data — no new infra.

## Notes / tradeoffs

- The shim is **per-process in-memory** (not Redis/durable), so on serverless each cold instance still pays one provider call before warming. That was a deliberate choice — a shared cache would need KV infra and isn't warranted here.
- Staleness is bounded at 10 min, fine for an FX widget.
- USD short-circuit (`{ buy: 1, sell: 1 }`) is unchanged behaviour; caching it is harmless.
- Errors are not cached (the shim only stores resolved values), so a provider blip won't get pinned for 10 min.

## Test

- `npm test` — `api-headers`, `api-headers-extended`, `qr-pay-states` suites pass (they exercise `getCurrencyPrice`).
- `prettier --check` clean.