### PR TITLE
fix(seo): content-gate loaders + receive-from sources to kill live 404s

### DIFF
--- a/scripts/verify-content.ts
+++ b/scripts/verify-content.ts
@@ -83,6 +83,17 @@ function listDirs(dir: string): string[] {
         .map((d) => d.name)
 }
 
+/**
+ * Receive-money-from pages render only for corridor origins that actually have
+ * a receive-from article. Mirrors RECEIVE_SOURCES in src/data/seo/corridors.ts.
+ * Without this gate, both the route index and the sitemap "expected URLs" would
+ * agree with each other on a slug that 404s at runtime (e.g. colombia, mexico).
+ */
+function gateReceiveSources(corridors: Array<{ from: string; to: string }>): string[] {
+    const origins = [...new Set(corridors.map((c) => c.from))]
+    return origins.filter((slug) => fs.existsSync(path.join(CONTENT_DIR, 'receive-from', slug, 'en.md')))
+}
+
 function getAllMdFiles(dir: string): string[] {
     const results: string[] = []
     if (!fs.existsSync(dir)) return results
@@ -192,7 +203,7 @@ function discoverRoutes(): Set<string> {
             corridors.push({ to: dest, from: origin })
         }
     }
-    const receiveSources = [...new Set(corridors.map((c) => c.from))]
+    const receiveSources = gateReceiveSources(corridors)
 
     // Check which routes actually have page.tsx files
     const hasRoute = (routePath: string) => {
@@ -704,7 +715,7 @@ function expectedSitemapUrls(): string[] {
         const fromDir = path.join(CONTENT_DIR, 'send-to', dest, 'from')
         for (const origin of listDirs(fromDir)) corridors.push({ from: origin, to: dest })
     }
-    const receiveSources = [...new Set(corridors.map((c) => c.from))]
+    const receiveSources = gateReceiveSources(corridors)
 
     for (const locale of SUPPORTED_LOCALES) {
         for (const slug of countrySlugs) {

--- a/src/app/[locale]/(marketing)/receive-money-from/[country]/page.tsx
+++ b/src/app/[locale]/(marketing)/receive-money-from/[country]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation'
 import { type Metadata } from 'next'
 import { generateMetadata as metadataHelper } from '@/app/metadata'
-import { CORRIDORS, getCountryName } from '@/data/seo'
+import { RECEIVE_SOURCES, getCountryName } from '@/data/seo'
 import { SUPPORTED_LOCALES, getAlternates, isValidLocale } from '@/i18n/config'
 import type { Locale } from '@/i18n/types'
 import { getTranslations, t } from '@/i18n'
@@ -13,21 +13,15 @@ interface PageProps {
     params: Promise<{ locale: string; country: string }>
 }
 
-/** Unique sending countries */
-function getReceiveSources(): string[] {
-    return [...new Set(CORRIDORS.map((c) => c.from))]
-}
-
 export async function generateStaticParams() {
-    const sources = getReceiveSources()
-    return SUPPORTED_LOCALES.flatMap((locale) => sources.map((country) => ({ locale, country })))
+    return SUPPORTED_LOCALES.flatMap((locale) => RECEIVE_SOURCES.map((country) => ({ locale, country })))
 }
 export const dynamicParams = false
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { locale, country } = await params
     if (!isValidLocale(locale)) return {}
-    if (!getReceiveSources().includes(country)) return {}
+    if (!RECEIVE_SOURCES.includes(country)) return {}
 
     const mdxContent = readPageContentLocalized('receive-from', country, locale)
     if (!mdxContent || mdxContent.frontmatter.published === false) return {}
@@ -51,7 +45,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function ReceiveMoneyPage({ params }: PageProps) {
     const { locale, country } = await params
     if (!isValidLocale(locale)) notFound()
-    if (!getReceiveSources().includes(country)) notFound()
+    if (!RECEIVE_SOURCES.includes(country)) notFound()
 
     const mdxSource = readPageContentLocalized('receive-from', country, locale)
     if (!mdxSource || mdxSource.frontmatter.published === false) notFound()

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,14 @@
 import { type MetadataRoute } from 'next'
 import { BASE_URL } from '@/constants/general.consts'
-import { COUNTRIES_SEO, CORRIDORS, COMPETITORS, EXCHANGES, DEPOSIT_RAILS, PAYMENT_METHOD_SLUGS } from '@/data/seo'
+import {
+    COUNTRIES_SEO,
+    CORRIDORS,
+    RECEIVE_SOURCES,
+    COMPETITORS,
+    EXCHANGES,
+    DEPOSIT_RAILS,
+    PAYMENT_METHOD_SLUGS,
+} from '@/data/seo'
 import { SUPPORTED_LOCALES } from '@/i18n/config'
 import { listContentSlugs, listPublishedSlugs } from '@/lib/content'
 
@@ -62,9 +70,8 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
             })
         }
 
-        // Receive money pages (unique sending countries from corridors)
-        const receiveSources = [...new Set(CORRIDORS.map((c) => c.from))]
-        for (const source of receiveSources) {
+        // Receive money pages — corridor origins that have a receive-from article
+        for (const source of RECEIVE_SOURCES) {
             pages.push({
                 path: `/${locale}/receive-money-from/${source}`,
                 priority: 0.7 * basePriority,

--- a/src/components/LandingPage/Footer.tsx
+++ b/src/components/LandingPage/Footer.tsx
@@ -63,18 +63,18 @@ const Footer = ({ showSiteDirectory = true, locale = 'en' }: { showSiteDirectory
                         <a className="text-xl font-bold text-white" href="/support">
                             Support
                         </a>
-                        <a className="text-xl font-bold text-white" href="/en/content">
+                        <Link className="text-xl font-bold text-white" href={`/${locale}/content`}>
                             Content
-                        </a>
-                        <a className="text-xl font-bold text-white" href="/en/help">
+                        </Link>
+                        <Link className="text-xl font-bold text-white" href={`/${locale}/help`}>
                             Docs
-                        </a>
-                        <a className="text-xl font-bold text-white" href="/en/terms">
+                        </Link>
+                        <Link className="text-xl font-bold text-white" href={`/${locale}/terms`}>
                             Terms
-                        </a>
-                        <a className="text-xl font-bold text-white" href="/en/privacy">
+                        </Link>
+                        <Link className="text-xl font-bold text-white" href={`/${locale}/privacy`}>
                             Privacy
-                        </a>
+                        </Link>
                         <a
                             className="text-xl font-bold text-white"
                             href="https://peanutprotocol.notion.site/Career-b351de56d92e405e962f0027b3a60f52"

--- a/src/data/seo/comparisons.ts
+++ b/src/data/seo/comparisons.ts
@@ -19,9 +19,10 @@ export interface Competitor {
 function loadCompetitors(): Record<string, Competitor> {
     const result: Record<string, Competitor> = {}
     for (const slug of listContentSlugs('compare')) {
+        // Skip slug dirs with no en.md — /compare/peanut-vs-{slug} would 404.
         const content = readPageContent<{ name?: unknown; published?: boolean }>('compare', slug, 'en')
-        if (content && content.frontmatter.published === false) continue
-        result[slug] = { name: displayNameFromContent(slug, content?.frontmatter) }
+        if (!content || content.frontmatter.published === false) continue
+        result[slug] = { name: displayNameFromContent(slug, content.frontmatter) }
     }
     return result
 }

--- a/src/data/seo/corridors.test.ts
+++ b/src/data/seo/corridors.test.ts
@@ -1,0 +1,32 @@
+import fs from 'fs'
+import path from 'path'
+import { CORRIDORS, RECEIVE_SOURCES } from './corridors'
+
+const RECEIVE_FROM_DIR = path.join(process.cwd(), 'src/content/content/receive-from')
+
+// Regression guard for the May 2026 live 404s: receive-money-from rendered for
+// every corridor origin, but origins lacking a receive-from article (colombia,
+// mexico) 404ed. RECEIVE_SOURCES must be CORRIDORS.from gated by content.
+describe('RECEIVE_SOURCES', () => {
+    it('only contains corridor origins', () => {
+        const origins = new Set(CORRIDORS.map((c) => c.from))
+        for (const slug of RECEIVE_SOURCES) {
+            expect(origins.has(slug)).toBe(true)
+        }
+    })
+
+    it('only contains origins that have a receive-from article (no 404s)', () => {
+        for (const slug of RECEIVE_SOURCES) {
+            const enFile = path.join(RECEIVE_FROM_DIR, slug, 'en.md')
+            expect(fs.existsSync(enFile)).toBe(true)
+        }
+    })
+
+    it('drops corridor origins with no receive-from article', () => {
+        const origins = [...new Set(CORRIDORS.map((c) => c.from))]
+        for (const slug of origins) {
+            const hasArticle = fs.existsSync(path.join(RECEIVE_FROM_DIR, slug, 'en.md'))
+            expect(RECEIVE_SOURCES.includes(slug)).toBe(hasArticle)
+        }
+    })
+})

--- a/src/data/seo/corridors.ts
+++ b/src/data/seo/corridors.ts
@@ -16,7 +16,13 @@
 // — now render the MDX body directly. We keep only the slug list and the
 // display-name resolver.
 
-import { listContentSlugs, listCorridorOrigins, readPageContent, readPageContentLocalized } from '@/lib/content'
+import {
+    listContentSlugs,
+    listCorridorOrigins,
+    readCorridorContent,
+    readPageContent,
+    readPageContentLocalized,
+} from '@/lib/content'
 import type { Locale } from '@/i18n/types'
 import { displayNameFromContent } from './utils'
 
@@ -32,9 +38,11 @@ export interface Corridor {
 function loadCountries(): Record<string, CountrySEO> {
     const result: Record<string, CountrySEO> = {}
     for (const slug of listContentSlugs('countries')) {
+        // A slug directory with no en.md has no render target — the route
+        // would 404. Gate on content presence, not just directory existence.
         const content = readPageContent<{ name?: unknown; published?: boolean }>('countries', slug, 'en')
-        if (content && content.frontmatter.published === false) continue
-        result[slug] = { name: displayNameFromContent(slug, content?.frontmatter) }
+        if (!content || content.frontmatter.published === false) continue
+        result[slug] = { name: displayNameFromContent(slug, content.frontmatter) }
     }
     return result
 }
@@ -44,6 +52,9 @@ function loadCorridors(): Corridor[] {
     const corridors: Corridor[] = []
     for (const dest of listContentSlugs('send-to')) {
         for (const origin of listCorridorOrigins(dest)) {
+            // Skip corridor dirs with no en.md — send-money-from would 404.
+            const content = readCorridorContent<{ published?: boolean }>(dest, origin, 'en')
+            if (!content || content.frontmatter.published === false) continue
             const key = `${origin}→${dest}`
             if (seen.has(key)) continue
             seen.add(key)
@@ -53,8 +64,25 @@ function loadCorridors(): Corridor[] {
     return corridors
 }
 
+/**
+ * Origins for the receive-money-from pages. The set is the corridor origins,
+ * but only those that actually have a receive-from article — an origin present
+ * in CORRIDORS.from but missing content/receive-from/{slug}/en.md would 404
+ * (this is how colombia & mexico shipped as live 404s in May 2026). The
+ * receive-from content tree is authored independently of corridors, so the two
+ * sets don't line up automatically.
+ */
+function loadReceiveSources(corridors: Corridor[]): string[] {
+    const origins = [...new Set(corridors.map((c) => c.from))]
+    return origins.filter((slug) => {
+        const content = readPageContent<{ published?: boolean }>('receive-from', slug, 'en')
+        return content !== null && content.frontmatter.published !== false
+    })
+}
+
 export const COUNTRIES_SEO: Record<string, CountrySEO> = loadCountries()
 export const CORRIDORS: Corridor[] = loadCorridors()
+export const RECEIVE_SOURCES: string[] = loadReceiveSources(CORRIDORS)
 
 /**
  * Get the country display name for a slug at the given locale. Reads

--- a/src/data/seo/exchanges.ts
+++ b/src/data/seo/exchanges.ts
@@ -53,11 +53,12 @@ function loadExchanges(): Record<string, Exchange> {
     const result: Record<string, Exchange> = {}
     for (const slug of listContentSlugs('deposit')) {
         if (RAIL_SLUGS.has(slug)) continue
+        // Skip slug dirs with no en.md — /deposit/from-{slug} would 404.
         const content = readPageContent<DepositFrontmatter>('deposit', slug, 'en')
-        if (content && content.frontmatter.published === false) continue
+        if (!content || content.frontmatter.published === false) continue
         result[slug] = {
-            name: displayNameFromContent(slug, content?.frontmatter),
-            recommendedNetwork: pickRecommendedNetwork(content?.frontmatter),
+            name: displayNameFromContent(slug, content.frontmatter),
+            recommendedNetwork: pickRecommendedNetwork(content.frontmatter),
         }
     }
     return result

--- a/src/data/seo/index.ts
+++ b/src/data/seo/index.ts
@@ -1,4 +1,4 @@
-export { COUNTRIES_SEO, CORRIDORS, getCountryName } from './corridors'
+export { COUNTRIES_SEO, CORRIDORS, RECEIVE_SOURCES, getCountryName } from './corridors'
 
 export { COMPETITORS } from './comparisons'
 

--- a/src/data/seo/payment-methods.ts
+++ b/src/data/seo/payment-methods.ts
@@ -20,9 +20,10 @@ export interface PaymentMethod {
 function loadPaymentMethods(): Record<string, PaymentMethod> {
     const result: Record<string, PaymentMethod> = {}
     for (const slug of listContentSlugs('pay-with')) {
+        // Skip slug dirs with no en.md — /pay-with/{slug} would 404.
         const content = readPageContent<{ name?: unknown; published?: boolean }>('pay-with', slug, 'en')
-        if (content && content.frontmatter.published === false) continue
-        result[slug] = { slug, name: displayNameFromContent(slug, content?.frontmatter) }
+        if (!content || content.frontmatter.published === false) continue
+        result[slug] = { slug, name: displayNameFromContent(slug, content.frontmatter) }
     }
     return result
 }

--- a/src/data/seo/utils.test.ts
+++ b/src/data/seo/utils.test.ts
@@ -1,0 +1,28 @@
+import { displayNameFromContent, titleCaseSlug } from './utils'
+
+describe('displayNameFromContent', () => {
+    it('returns the frontmatter name when present', () => {
+        expect(displayNameFromContent('wise', { name: 'Wise' })).toBe('Wise')
+    })
+
+    it('trims surrounding whitespace from the frontmatter name', () => {
+        // Validated with .trim() but used to return the raw value — whitespace
+        // leaked into breadcrumbs / link text.
+        expect(displayNameFromContent('wise', { name: '  Wise  ' })).toBe('Wise')
+        expect(displayNameFromContent('wise', { name: 'Wise\n' })).toBe('Wise')
+    })
+
+    it('falls back to title-cased slug for missing / blank / non-string names', () => {
+        expect(displayNameFromContent('western-union', undefined)).toBe('Western Union')
+        expect(displayNameFromContent('western-union', { name: '   ' })).toBe('Western Union')
+        expect(displayNameFromContent('western-union', { name: 42 })).toBe('Western Union')
+        expect(displayNameFromContent('western-union', null)).toBe('Western Union')
+    })
+})
+
+describe('titleCaseSlug', () => {
+    it('title-cases a kebab slug', () => {
+        expect(titleCaseSlug('united-kingdom')).toBe('United Kingdom')
+        expect(titleCaseSlug('binance-p2p')).toBe('Binance P2p')
+    })
+})

--- a/src/data/seo/utils.ts
+++ b/src/data/seo/utils.ts
@@ -16,7 +16,7 @@ interface Named {
  */
 export function displayNameFromContent(slug: string, frontmatter: Named | null | undefined): string {
     const name = frontmatter?.name
-    if (typeof name === 'string' && name.trim().length > 0) return name
+    if (typeof name === 'string' && name.trim().length > 0) return name.trim()
     return titleCaseSlug(slug)
 }
 


### PR DESCRIPTION
Followup to #2115 (the Konrad 1-commit list). Bases on `main` because it edits main-only code (Hugo's verify-content Pass 11 from #2115, and the `Footer` `locale` prop from the SEOFooter dedup) and fixes **live** 404s — same hotfix lane as #2114/#2115. dev gets it via the usual main→dev sync.

## The bug class

SEO loaders register a slug whenever its content **directory** exists, even when `en.md` is missing — the route then 404s at render (the page calls `notFound()` when content resolves to null). CodeRabbit flagged 4 instances of this on #2115.

## Live symptom — 10 prod 404s

`/{locale}/receive-money-from/{colombia,mexico}` × 5 locales. Both are corridor origins (so they're in `CORRIDORS.from`), but neither has a `content/receive-from/{slug}/` article. `getReceiveSources()` derived purely from `CORRIDORS.from`, so it generated static params that 404. Both `sitemap.ts` and verify-content's Pass 11 derived receive-from the same ungated way, so CI agreed with itself and never caught it.

## Changes

1. **`corridors.ts`** — new gated `RECEIVE_SOURCES` = corridor origins ∩ origins that actually have a `receive-from/{slug}/en.md`. The page and `sitemap.ts` both consume it, so route set ⇔ sitemap ⇔ CI now agree. Also gate `loadCountries` / `loadCorridors` on `en.md` presence.
2. **`exchanges.ts`, `payment-methods.ts`, `comparisons.ts`** — same `en.md` gate (the CodeRabbit fragility class). No-op on today's content; stops the next missing-`en.md` dir from shipping a 404. (`comparisons.ts` wasn't in the original list but is the identical pattern — fixed for consistency.)
3. **`utils.ts`** — `displayNameFromContent` returned the **un-trimmed** name despite validating with `.trim()`; whitespace leaked into breadcrumbs/link text. Now returns `name.trim()`.
4. **`Footer.tsx`** — 4 hardcoded `/en/{content,help,terms,privacy}` bare `<a>` → localized `<Link href={`/${locale}/...`}>`. The `locale` prop already existed; non-en visitors were bounced to English (and full page reloads).
5. **`verify-content.ts` Pass 11** — gate receive sources by `receive-from/{slug}/en.md` in both the route index and the expected-sitemap set, so CI reflects runtime instead of agreeing with itself on a 404ing slug.

## Verification

- `pnpm typecheck` ✅
- `pnpm validate-links` ✅ — `Pass 11 — Sitemap coverage: all 1080 expected URLs have routes` (was emitting the 10 colombia/mexico 404s before)
- `pnpm test` ✅ — 57 suites; added `src/data/seo/{utils,corridors}.test.ts` as regression guards (trim + the receive-from content gate)
- Runtime check: `RECEIVE_SOURCES` now excludes `colombia`, `mexico`

🤖 Generated with [Claude Code](https://claude.com/claude-code)