### PR TITLE
fix(footer): responsive grid for SEO footer columns

### DIFF
--- a/src/components/LandingPage/SEOFooter.tsx
+++ b/src/components/LandingPage/SEOFooter.tsx
@@ -46,7 +46,7 @@ export function SEOFooter() {
 
     return (
         <nav aria-label="Site directory" className="bg-black px-8 py-8 md:px-20">
-            <div className="flex flex-wrap justify-between gap-y-8">
+            <div className="grid grid-cols-2 gap-x-6 gap-y-8 md:grid-cols-4">
                 {hasSendMoney && (
                     <div>
                         <h3 className="mb-3 text-xs font-bold text-white">Send Money</h3>


### PR DESCRIPTION
## What

The SEO footer link columns (Send Money / Compare / Learn More / Resources) used `flex flex-wrap justify-between gap-y-8`. With only a vertical gap and `justify-between` eating the horizontal whitespace, on narrow/medium widths the columns stayed jammed on one row with no gutter — labels like "Digital Nomads in LATAM" visually collided with the neighbouring column.

## Change

One-line className swap in `SEOFooter.tsx`:

```diff
- <div className="flex flex-wrap justify-between gap-y-8">
+ <div className="grid grid-cols-2 gap-x-6 gap-y-8 md:grid-cols-4">
```

- Breaks earlier: 2 columns below `md` (768px), 4 columns at `md`+.
- `gap-x-6` reserves a real horizontal gutter, so columns never touch.
- Long labels wrap inside their own cell instead of overrunning.

## Risk

Cosmetic / layout only. No logic, type, or data changes. Prettier clean.