### PR TITLE
feat(merchant-lp): card-vs-Peanut savings + drop fabricated item descriptions

### DIFF
--- a/src/app/m/[slug]/MerchantLandingPage.tsx
+++ b/src/app/m/[slug]/MerchantLandingPage.tsx
@@ -4,12 +4,39 @@ import { Fragment, useMemo, useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { motion } from 'framer-motion'
+import { useQuery } from '@tanstack/react-query'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Marquee } from '@/components/LandingPage'
 import { FAQsPanel } from '@/components/Global/FAQs'
 import { useExchangeRate } from '@/hooks/useExchangeRate'
 import { Sparkle, Star } from '@/assets/illustrations'
+import { getArsCardMarkup } from './card-comparison'
 import type { Merchant, MenuItem } from './merchants'
+
+/** Documented empirical ARS card-vs-Peanut spread + issuer markup — used
+ *  as the immediate render value and the fallback when the live fetch fails.
+ *  Mirrors `CARD_FX_MARKUP_BY_CURRENCY.ARS` from PR #2108. */
+const ARS_CARD_MARKUP_FALLBACK = 0.0913
+
+/**
+ * Client wrapper around the `getArsCardMarkup` server action — keeps the
+ * third-party dolarapi.com call off the client and lets Next edge-cache the
+ * response for 5min. React-query layers an additional 5min client cache and
+ * re-fetches on focus so the displayed savings stays fresh without us having
+ * to think about it. Returns the static fallback while loading so the menu
+ * cards and banner can render unconditionally.
+ */
+function useCardMarkupArs(criptoUsdToArs: number): number {
+    const { data } = useQuery({
+        queryKey: ['merchantLpArsCardMarkup', criptoUsdToArs > 0 ? Math.round(criptoUsdToArs) : 0],
+        queryFn: () => getArsCardMarkup(criptoUsdToArs),
+        staleTime: 5 * 60 * 1000,
+        gcTime: 10 * 60 * 1000,
+        refetchOnWindowFocus: true,
+        enabled: criptoUsdToArs > 0,
+    })
+    return data?.rate ?? ARS_CARD_MARKUP_FALLBACK
+}
 
 const ctaButtonClassName =
     '!w-auto bg-white px-7 py-3 text-base font-extrabold hover:bg-white/90 md:px-9 md:py-8 md:text-xl'
@@ -266,6 +293,7 @@ function MenuFold({ fold }: { fold: Extract<Merchant['fold2'], { type: 'menu' }>
         enabled: fold.showLiveRate,
     })
     const arsPerUnit = currency === 'USD' ? usdArs : eurArs
+    const cardMarkup = useCardMarkupArs(usdArs)
 
     return (
         <section id="menu" className="relative overflow-hidden bg-secondary-1 px-4 py-24 text-center text-n-1 md:py-32">
@@ -293,11 +321,17 @@ function MenuFold({ fold }: { fold: Extract<Merchant['fold2'], { type: 'menu' }>
                     ))}
                 </div>
 
-                {fold.showLiveRate && <LiveRateBanner usdArs={usdArs} />}
+                {fold.showLiveRate && <LiveRateBanner usdArs={usdArs} cardMarkup={cardMarkup} />}
 
                 <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-2">
                     {fold.items.map((item) => (
-                        <MenuItemCard key={item.name} item={item} currency={currency} arsPerUnit={arsPerUnit} />
+                        <MenuItemCard
+                            key={item.name}
+                            item={item}
+                            currency={currency}
+                            arsPerUnit={arsPerUnit}
+                            cardMarkup={cardMarkup}
+                        />
                     ))}
                 </div>
             </div>
@@ -309,29 +343,41 @@ function MenuItemCard({
     item,
     currency,
     arsPerUnit,
+    cardMarkup,
 }: {
     item: MenuItem
     currency: Currency
     /** ARS per 1 unit of the selected currency. 0 until the live rate loads. */
     arsPerUnit: number
+    /** Card-vs-Peanut markup (fraction). card price = peanut × (1 + cardMarkup). */
+    cardMarkup: number
 }) {
     const symbol = currency === 'USD' ? '$' : '€'
-    const price = arsPerUnit > 0 ? (item.priceARS / arsPerUnit).toFixed(2) : null
+    const peanutPrice = arsPerUnit > 0 ? item.priceARS / arsPerUnit : null
+    const peanutFmt = peanutPrice !== null ? peanutPrice.toFixed(2) : null
+    const cardFmt = peanutPrice !== null && cardMarkup > 0 ? (peanutPrice * (1 + cardMarkup)).toFixed(2) : null
 
     return (
         <div className="flex items-start justify-between gap-4 rounded-sm border-2 border-n-1 bg-white p-5 text-left shadow-[4px_4px_0_#000]">
             <div className="min-w-0 flex-1">
                 <div className="text-lg font-extraBlack md:text-xl">{item.name}</div>
-                <div className="mt-1 text-sm font-medium leading-snug opacity-70">{item.desc}</div>
             </div>
             <div className="flex flex-col items-end whitespace-nowrap pt-1">
-                <div className="font-roboto-flex-extrabold text-3xl font-extraBlack leading-none">
-                    {price === null ? (
+                {cardFmt !== null && (
+                    <div className="font-roboto-flex-extrabold text-base font-extraBlack leading-none line-through opacity-45">
+                        {symbol}
+                        {cardFmt}
+                    </div>
+                )}
+                <div
+                    className={`font-roboto-flex-extrabold text-3xl font-extraBlack leading-none ${cardFmt !== null ? 'mt-1' : ''}`}
+                >
+                    {peanutFmt === null ? (
                         <span className="opacity-30">{symbol}··</span>
                     ) : (
                         <>
                             {symbol}
-                            {price}
+                            {peanutFmt}
                             <span className="ml-1 text-[11px] font-extraBlack tracking-wider opacity-60">
                                 {currency}
                             </span>
@@ -343,10 +389,11 @@ function MenuItemCard({
     )
 }
 
-function LiveRateBanner({ usdArs }: { usdArs: number }) {
+function LiveRateBanner({ usdArs, cardMarkup }: { usdArs: number; cardMarkup: number }) {
     const isLive = usdArs > 0
+    const savingsPct = cardMarkup > 0 ? Math.round(cardMarkup * 100) : 0
     const copy = isLive
-        ? `Live · 1 USD = ${Math.round(usdArs).toLocaleString('en-US')} ARS`
+        ? `Live · 1 USD = ${Math.round(usdArs).toLocaleString('en-US')} ARS${savingsPct > 0 ? ` · save ~${savingsPct}% vs card` : ''}`
         : 'Loading live cripto-dólar rate…'
 
     return (

--- a/src/app/m/[slug]/card-comparison.ts
+++ b/src/app/m/[slug]/card-comparison.ts
@@ -1,0 +1,72 @@
+'use server'
+
+/**
+ * Local copy of the ARS card-vs-Peanut markup service.
+ *
+ * Mirrors `getCardMarkupRate` in `src/app/actions/card-comparison.ts` from
+ * PR #2108 (qr-pay live card savings) — same formula, same constants, same
+ * graceful-fallback contract. Lives here temporarily so the Stain landing
+ * page can ship with live data ahead of #2108 merging. When that PR lands:
+ * swap the import in `MerchantLandingPage.tsx` for the shared action and
+ * delete this file.
+ *
+ * Why server-side: keeps the third-party dolarapi.com call off the client
+ * (no CORS, no per-visitor hit), and Next's `revalidate: 300` caches the
+ * response at the edge for 5 minutes — so a viral pilot day doesn't pelt
+ * dolarapi from every browser.
+ *
+ * Why the comparison exists at all: Peanut delivers the cripto/MEP rate
+ * (via Manteca), while a foreign card in Argentina gets the BCRA-official
+ * rate minus an issuer FX fee. The spread fluctuates daily (historically
+ * 5–25%), which is why we compute live rather than hardcoding a single
+ * marketing number. The 9.13% fallback is the documented BCRA-vs-MEP +
+ * issuer empirical average — used only when the live fetch is unavailable.
+ */
+
+/** Documented empirical ARS card-vs-local-rail spread + issuer markup. */
+const ARS_STATIC_MARKUP = 0.0913
+/** Foreign-issuer FX fee on top of the network rate — Visa/MC ~mid-market, bank adds 2–3%. */
+const ISSUER_FX_FEE = 0.03
+
+export interface CardMarkup {
+    /** Markup as a fraction: card_price = peanut_price × (1 + rate). */
+    rate: number
+    /** Whether the live BCRA feed succeeded ('live') or we fell back to the static constant ('static'). */
+    source: 'live' | 'static'
+}
+
+/**
+ * Live ARS card-vs-Peanut markup. Never throws — always returns a defensible
+ * value so the caller (the menu fold + the live-rate banner) can render
+ * unconditionally.
+ *
+ * @param criptoUsdToArs ARS per 1 USD that Peanut delivers (Manteca effectiveSell).
+ *                       Required for the live spread calc; with no cripto baseline
+ *                       we can't compute a meaningful markup, so we return static.
+ */
+export async function getArsCardMarkup(criptoUsdToArs: number): Promise<CardMarkup> {
+    if (!Number.isFinite(criptoUsdToArs) || criptoUsdToArs <= 0) {
+        return { rate: ARS_STATIC_MARKUP, source: 'static' }
+    }
+
+    try {
+        const res = await fetch('https://dolarapi.com/v1/dolares/oficial', {
+            next: { revalidate: 300 }, // 5min edge cache so we don't hit dolarapi per visitor
+        })
+        if (res.ok) {
+            const data = (await res.json()) as { venta?: number }
+            const bcraOfficial = Number(data?.venta)
+            if (Number.isFinite(bcraOfficial) && bcraOfficial > 0) {
+                const effectiveCardRate = bcraOfficial * (1 - ISSUER_FX_FEE)
+                const rate = criptoUsdToArs / effectiveCardRate - 1
+                if (Number.isFinite(rate) && rate > 0) {
+                    return { rate, source: 'live' }
+                }
+            }
+        }
+    } catch {
+        // Swallow — never block the page on a third-party FX feed being down.
+    }
+
+    return { rate: ARS_STATIC_MARKUP, source: 'static' }
+}

--- a/src/app/m/[slug]/merchants.ts
+++ b/src/app/m/[slug]/merchants.ts
@@ -10,7 +10,6 @@
 
 export type MenuItem = {
     name: string
-    desc: string
     /** Base price in ARS — the merchant's local currency. Converted to USD/EUR client-side. */
     priceARS: number
 }
@@ -111,29 +110,21 @@ export const MERCHANTS: Record<string, Merchant> = {
             heading: 'THE MENU.',
             tagline: 'Pick your currency. The app handles the rest.',
             showLiveRate: true,
+            // Items + prices verified against Stain's authoritative menu
+            // (EN translation). Name + price only — original descriptions were
+            // AI-fabricated for items the source had blank desc cells for, so
+            // dropped wholesale rather than carry invented marketing copy.
             items: [
-                { name: 'Medialuna', desc: 'Classic Argentine croissant.', priceARS: ARS(4400) },
-                {
-                    name: 'Honey Butter Toast',
-                    desc: 'Honey, butter, muscovado sugar, sourdough.',
-                    priceARS: ARS(6200),
-                },
-                { name: 'Flat White', desc: 'Double ristretto, micro-foamed milk.', priceARS: ARS(5900) },
-                { name: 'Cappuccino', desc: 'Espresso, steamed milk, foam.', priceARS: ARS(6000) },
-                { name: 'Cold Brew', desc: 'Slow-steeped, served over ice.', priceARS: ARS(6200) },
-                { name: 'Iced Matcha Latte', desc: 'Ceremonial matcha over ice.', priceARS: ARS(6500) },
-                { name: 'Salted Caramel Latte', desc: 'House salted caramel, espresso, milk.', priceARS: ARS(7000) },
-                { name: 'Cinnamon Roll', desc: 'Baked fresh daily.', priceARS: ARS(5500) },
-                {
-                    name: 'Creamy Scrambled Eggs',
-                    desc: 'Eggs, mascarpone cheese, sourdough bread.',
-                    priceARS: ARS(10000),
-                },
-                {
-                    name: 'Avocado Toast',
-                    desc: 'Pea spread, avocado, mixed greens, hazelnuts.',
-                    priceARS: ARS(11500),
-                },
+                { name: 'Medialuna', priceARS: ARS(4400) },
+                { name: 'Cinnamon Roll', priceARS: ARS(5500) },
+                { name: 'Honey Butter Toast', priceARS: ARS(6200) },
+                { name: 'Flat White', priceARS: ARS(5900) },
+                { name: 'Cappuccino', priceARS: ARS(6000) },
+                { name: 'Cold Brew', priceARS: ARS(6200) },
+                { name: 'Iced Matcha Latte', priceARS: ARS(6500) },
+                { name: 'Salted Caramel Latte', priceARS: ARS(7000) },
+                { name: 'Creamy Scrambled Eggs', priceARS: ARS(10000) },
+                { name: 'Avocado Toast', priceARS: ARS(11500) },
             ],
         },
         install: { sub: '60 seconds. Skip the waitlist. Free coffee.' },


### PR DESCRIPTION
Follow-up to #2121 (Stain LP), now merged. Two related changes shipped together.

## Card-vs-Peanut savings UI
Each menu item now shows the **card price struck through** above the Peanut price, and the live-rate banner appends **"save ~X% vs card"**.

Sourced from a new server action — `src/app/m/[slug]/card-comparison.ts` (`'use server'`) — that fetches BCRA-official from dolarapi.com **server-side**, with Next \`revalidate: 300\` (5-min edge cache). The browser never touches dolarapi: it calls the server action via react-query, which adds another 5-min client cache. Two cache layers + a documented \`0.0913\` static fallback at every failure path — graceful by construction, never throws.

Mirrors **PR #2108**'s \`getCardMarkupRate\` formula and contract exactly. Local copy under \`src/app/m/[slug]/\` (rather than \`src/app/actions/\`) so it doesn't collide with that PR landing the canonical version. **When #2108 merges:** swap the import in \`MerchantLandingPage.tsx\` and delete \`card-comparison.ts\` — one-line follow-up, called out in the file's JSDoc.

## Drop \`MenuItem.desc\`
Original 10 Stain items had ~6 AI-fabricated descriptions (the authoritative menu xlsx has blank desc cells for most items — I'd invented copy like *"Double ristretto"* for Flat White or *"Ceremonial matcha"* for the Iced Matcha that we can't verify and shouldn't ship on a co-branded page). Dropping the field entirely is honest and unblocks restoring the recognizable items (Flat White, Cold Brew, Iced Matcha, etc.) without inventing descriptions for them.

Item names + prices remain **verbatim** from the source xlsx.

## Scope / blast radius
- BA Digital Nomads (`fold2: 'faq'`, no menu items) is **completely untouched** — the type change doesn't affect them.
- No other files touched. Diff is the new server action + the page + the stain items in `merchants.ts`.

## QA
- `/m/stain` menu shows the strikethrough card price + Peanut price; banner shows "save ~X% vs card"
- USD/EUR toggle still works; rate live, savings live
- `/m/badigitalnomads` unaffected (still renders normally)
- Server action runs server-side (verify the browser's network tab — no \`dolarapi.com\` requests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)