### PR TITLE
feat(merchant-lp): typed UTM schema + builder; refactor LP CTAs

### DIFF
--- a/src/app/m/[slug]/MerchantLandingPage.tsx
+++ b/src/app/m/[slug]/MerchantLandingPage.tsx
@@ -10,8 +10,28 @@ import { Marquee } from '@/components/LandingPage'
 import { FAQsPanel } from '@/components/Global/FAQs'
 import { useExchangeRate } from '@/hooks/useExchangeRate'
 import { Sparkle, Star } from '@/assets/illustrations'
+import { UTM_MEDIUMS, UTM_SOURCES, withUtm } from '@/utils/utm.utils'
 import { getArsCardMarkup } from './card-comparison'
 import type { Merchant, MenuItem } from './merchants'
+
+/** Sticky invite code attached to every CTA on `/m/[slug]`. The UTM
+ *  taxonomy lives in `mono/strategy/utm-tracking.md` — `utm_campaign` is
+ *  the merchant slug, `utm_content` distinguishes the two CTAs so we can
+ *  split-test hero-vs-end-fold conversion. */
+const MERCHANT_INVITE_CODE = 'SQUIRRELINVITESYOU'
+
+function buildInviteHref(merchantSlug: string, content: 'hero' | 'end_fold'): string {
+    return withUtm(
+        '/invite',
+        {
+            source: UTM_SOURCES.MERCHANT_LANDING,
+            medium: UTM_MEDIUMS.MERCHANT,
+            campaign: merchantSlug,
+            content,
+        },
+        { code: MERCHANT_INVITE_CODE }
+    )
+}
 
 /** Documented empirical ARS card-vs-Peanut spread + issuer markup — used
  *  as the immediate render value and the fallback when the live fetch fails.
@@ -123,10 +143,7 @@ function Hero({ merchant }: { merchant: Merchant }) {
 
                     <div className="mt-8 flex flex-col items-center gap-5 md:flex-row md:items-center md:gap-6">
                         <div className="relative">
-                            <Link
-                                href={`/invite?code=SQUIRRELINVITESYOU&utm_medium=merchant&utm_source=m&utm_campaign=${merchant.slug}`}
-                                className="inline-block"
-                            >
+                            <Link href={buildInviteHref(merchant.slug, 'hero')} className="inline-block">
                                 <Button shadowSize="4" className={ctaButtonClassName}>
                                     {merchant.primaryCta}
                                 </Button>
@@ -469,10 +486,7 @@ function EndFold({ merchant }: { merchant: Merchant }) {
                     {merchant.install.sub}
                 </p>
                 <div className="mt-10 flex justify-center">
-                    <Link
-                        href={`/invite?code=SQUIRRELINVITESYOU&utm_medium=merchant&utm_source=m&utm_campaign=${merchant.slug}`}
-                        className="inline-block"
-                    >
+                    <Link href={buildInviteHref(merchant.slug, 'end_fold')} className="inline-block">
                         <Button shadowSize="4" className={ctaButtonClassName}>
                             INSTALL PEANUT
                         </Button>

--- a/src/app/m/[slug]/MerchantLandingPage.tsx
+++ b/src/app/m/[slug]/MerchantLandingPage.tsx
@@ -14,22 +14,22 @@ import { UTM_MEDIUMS, UTM_SOURCES, withUtm } from '@/utils/utm.utils'
 import { getArsCardMarkup } from './card-comparison'
 import type { Merchant, MenuItem } from './merchants'
 
-/** Sticky invite code attached to every CTA on `/m/[slug]`. The UTM
- *  taxonomy lives in `mono/strategy/utm-tracking.md` — `utm_campaign` is
- *  the merchant slug, `utm_content` distinguishes the two CTAs so we can
- *  split-test hero-vs-end-fold conversion. */
-const MERCHANT_INVITE_CODE = 'SQUIRRELINVITESYOU'
-
-function buildInviteHref(merchantSlug: string, content: 'hero' | 'end_fold'): string {
+/** Build a `/invite` URL with the merchant's vanity code + the UTM
+ *  attribution. The code (e.g. `STAIN`, `BANOMADS`) is registered in
+ *  peanut-api-ts/src/utils/invite.ts → SPECIAL_INVITE_CODES_MAP and
+ *  routes to the squirrel housekeeping inviter; the UTM taxonomy
+ *  (`utm_source=m`, `utm_medium=merchant`, `utm_campaign=<slug>`,
+ *  `utm_content=hero|end_fold`) lives in mono/strategy/utm-tracking.md. */
+function buildInviteHref(merchant: Merchant, content: 'hero' | 'end_fold'): string {
     return withUtm(
         '/invite',
         {
             source: UTM_SOURCES.MERCHANT_LANDING,
             medium: UTM_MEDIUMS.MERCHANT,
-            campaign: merchantSlug,
+            campaign: merchant.slug,
             content,
         },
-        { code: MERCHANT_INVITE_CODE }
+        { code: merchant.inviteCode }
     )
 }
 
@@ -143,7 +143,7 @@ function Hero({ merchant }: { merchant: Merchant }) {
 
                     <div className="mt-8 flex flex-col items-center gap-5 md:flex-row md:items-center md:gap-6">
                         <div className="relative">
-                            <Link href={buildInviteHref(merchant.slug, 'hero')} className="inline-block">
+                            <Link href={buildInviteHref(merchant, 'hero')} className="inline-block">
                                 <Button shadowSize="4" className={ctaButtonClassName}>
                                     {merchant.primaryCta}
                                 </Button>
@@ -486,7 +486,7 @@ function EndFold({ merchant }: { merchant: Merchant }) {
                     {merchant.install.sub}
                 </p>
                 <div className="mt-10 flex justify-center">
-                    <Link href={buildInviteHref(merchant.slug, 'end_fold')} className="inline-block">
+                    <Link href={buildInviteHref(merchant, 'end_fold')} className="inline-block">
                         <Button shadowSize="4" className={ctaButtonClassName}>
                             INSTALL PEANUT
                         </Button>

--- a/src/app/m/[slug]/merchants.ts
+++ b/src/app/m/[slug]/merchants.ts
@@ -26,6 +26,12 @@ export type Merchant = {
     name: string
     /** Meta description for SEO. */
     metaDescription: string
+    /** Merchant-specific invite code (e.g. `STAIN`, `BANOMADS`). Attached
+     *  to every CTA on the LP so a stain QR-sticker scan is attributable
+     *  separately from a BA Nomads share even when the URL is hand-typed
+     *  (and `utm_*` get stripped). Must be registered in
+     *  peanut-api-ts/src/utils/invite.ts → SPECIAL_INVITE_CODES_MAP. */
+    inviteCode: string
 
     // ===== Hero =====
     /** Big lowercase headline. Multi-line by default. */
@@ -95,6 +101,7 @@ const ARS = (n: number) => n
 export const MERCHANTS: Record<string, Merchant> = {
     stain: {
         slug: 'stain',
+        inviteCode: 'STAIN',
         name: 'Stain Coffee',
         metaDescription:
             'Your first $10 at Stain Coffee in Palermo Hollywood is on us. Pay with Peanut at the Mercado Pago QR.',
@@ -149,6 +156,7 @@ export const MERCHANTS: Record<string, Merchant> = {
 
     badigitalnomads: {
         slug: 'badigitalnomads',
+        inviteCode: 'BANOMADS',
         name: 'BA Digital Nomads',
         metaDescription:
             'Free $10 on your first Mercado Pago payment in Buenos Aires. No DNI, no Argentine bank account needed. For the BA Digital Nomads community.',

--- a/src/utils/utm.utils.ts
+++ b/src/utils/utm.utils.ts
@@ -1,0 +1,95 @@
+/**
+ * Typed builder + controlled vocabulary for `utm_*` parameters on outbound links.
+ *
+ * PostHog auto-captures these on `$pageview` and stamps `$initial_utm_*` on the
+ * anonymous distinct_id, so the values that flow through this builder become
+ * PostHog dimensions on every signup. Typos silently fork the funnel — funneling
+ * through `withUtm()` makes the typo a typecheck error instead.
+ *
+ * Team conventions + closed-enum rationale live in `mono/strategy/utm-tracking.md`.
+ * Read that before adding a new medium.
+ */
+
+/**
+ * Channel category — the analytical bucket we slice the funnel by.
+ *
+ * Keep this set small. Every new medium dilutes dashboards; adding one is a
+ * team conversation (see `mono/strategy/utm-tracking.md`).
+ */
+export const UTM_MEDIUMS = {
+    /** Co-branded merchant landing pages (`/m/[slug]`). */
+    MERCHANT: 'merchant',
+    /** Peer-to-peer share links emitted by an existing Peanut user. */
+    REFERRAL: 'referral',
+    /** Any email — newsletter, drip, transactional. */
+    EMAIL: 'email',
+    /** Organic social posts. */
+    SOCIAL: 'social',
+    /** Paid acquisition where we pay per click (Google ads, Meta ads). */
+    CPC: 'cpc',
+    /** Paid acquisition where we pay per impression. */
+    CPM: 'cpm',
+    /** Paid ambassador / creator partnership (distinct from organic referral). */
+    AMBASSADOR: 'ambassador',
+} as const
+
+/**
+ * Publishing surface — where the click physically came from.
+ *
+ * Add new sources here before using them in code so we keep one canonical list.
+ */
+export const UTM_SOURCES = {
+    /** `/m/[slug]` merchant landing pages. */
+    MERCHANT_LANDING: 'm',
+    /** In-app share buttons / native share sheets. */
+    APP_SHARE: 'app',
+    /** `/content/*` SEO hub. */
+    CONTENT_HUB: 'c',
+    /** Beehiiv-driven email. */
+    BEEHIIV: 'beehiiv',
+    TWITTER: 'twitter',
+    INSTAGRAM: 'instagram',
+    TIKTOK: 'tiktok',
+    TELEGRAM: 'telegram',
+    /** Google ads / search. */
+    GOOGLE: 'google',
+    /** Meta ads (Facebook + Instagram). */
+    META: 'meta',
+} as const
+
+export type UtmMedium = (typeof UTM_MEDIUMS)[keyof typeof UTM_MEDIUMS]
+export type UtmSource = (typeof UTM_SOURCES)[keyof typeof UTM_SOURCES]
+
+export type UtmParams = {
+    source: UtmSource
+    medium: UtmMedium
+    /** lowercase-kebab. For merchant landings: the merchant slug. */
+    campaign: string
+    /** CTA / placement / variant within a campaign. e.g. `hero`, `end_fold`. */
+    content?: string
+    /** Search keyword / audience segment. Rare outside paid search. */
+    term?: string
+}
+
+/**
+ * Build a URL with `utm_*` params appended.
+ *
+ * @param path  Path or full URL — query string is preserved.
+ * @param utm   The four mandatory + two optional UTM fields.
+ * @param extra Additional non-UTM query params (e.g. `code` for invite links).
+ *              These come first in the resulting query string to match the
+ *              existing convention on merchant LPs (`?code=…&utm_…`).
+ */
+export function withUtm(path: string, utm: UtmParams, extra?: Record<string, string>): string {
+    const params = new URLSearchParams()
+    if (extra) {
+        for (const [k, v] of Object.entries(extra)) params.set(k, v)
+    }
+    params.set('utm_source', utm.source)
+    params.set('utm_medium', utm.medium)
+    params.set('utm_campaign', utm.campaign)
+    if (utm.content) params.set('utm_content', utm.content)
+    if (utm.term) params.set('utm_term', utm.term)
+    const sep = path.includes('?') ? '&' : '?'
+    return `${path}${sep}${params.toString()}`
+}


### PR DESCRIPTION
## Summary

1. **Typed UTM schema** — `src/utils/utm.utils.ts` exports closed-enum `UTM_SOURCES` / `UTM_MEDIUMS` + a `withUtm(path, params, extra?)` builder. Replaces the two hardcoded `/invite?code=…&utm_*=…` URL templates on `/m/[slug]` so a typo becomes a typecheck error.
2. **Per-CTA dimension** — adds `utm_content=hero` vs `utm_content=end_fold` so hero-vs-end-fold conversion becomes a real split in PostHog.
3. **Per-merchant invite codes** — `Merchant` gains an `inviteCode` field; LP CTAs now ship `?code=STAIN` and `?code=BANOMADS` instead of the shared `SQUIRRELINVITESYOU`. The vanity codes are registered in peanut-api-ts PR #899 and route to the squirrel housekeeping inviter, mirroring the existing `arbiverseinvitesyou → squirrel` pattern.
4. **Doc** — conventions in [`mono/strategy/utm-tracking.md`](https://github.com/peanutprotocol/mono/blob/main/strategy/utm-tracking.md). UTM taxonomy spans email / social / paid / ambassador, not just the FE, so it lives in mono.

## Why per-merchant codes

`utm_campaign=<slug>` already gives PostHog the split at the LP click level, but the `code` is what survives:

- **QR stickers / hand-typed URLs** — `utm_*` get stripped, only `code` remains
- **Support tickets / Sentry breadcrumbs** — `code` is the user-visible identifier

`STAIN` / `BANOMADS` give us clean attribution in both cases.

## How tracking flows (unchanged)

PostHog auto-captures `utm_*` on `$pageview` and stamps `$initial_utm_*` on the distinct_id. When the user signs up and `posthog.identify(userId)` runs in `src/context/authContext.tsx`, those initial properties follow them. No new persistence layer.

## Resulting URLs

Before:
```
/invite?code=SQUIRRELINVITESYOU&utm_medium=merchant&utm_source=m&utm_campaign=stain
```

After (hero CTA on `/m/stain`):
```
/invite?code=STAIN&utm_source=m&utm_medium=merchant&utm_campaign=stain&utm_content=hero
```

After (end-fold CTA on `/m/badigitalnomads`):
```
/invite?code=BANOMADS&utm_source=m&utm_medium=merchant&utm_campaign=badigitalnomads&utm_content=end_fold
```

## Base branch

Targeting `main` because the merchant LP files (`src/app/m/[slug]/*`) currently only exist on `main`, not yet in `dev`. Matches the pattern of #2121, #2123, #2125 — and the companion BE PR #899 also goes to main for the same reason.

## Companion

peanut-api-ts PR #899 — registers `STAIN` / `BANOMADS` in `PROD_SPECIAL_INVITE_CODES_MAP` + `STAGING_SPECIAL_INVITE_CODES_MAP`. Must land before / together with this PR or the new codes 400 with "Invalid Invite".

## Test plan

- [x] `npm run typecheck` — no new errors (pre-existing image-module errors are env-only)
- [x] `npx jest src/utils/ src/app/m/` — 447/447 pass
- [x] Manual: `/m/stain` hero CTA → URL contains `code=STAIN` + `utm_content=hero`; install CTA → `utm_content=end_fold`
- [x] Manual: `/m/badigitalnomads` → `code=BANOMADS`
- [ ] Reviewer sanity-check (post-BE merge): `?code=STAIN` resolves to a valid invite (inviter username on the page = `squirrel`)
- [ ] Reviewer sanity-check: PostHog Live Events shows the new `utm_content` dimension on a fresh anonymous session
