### PR TITLE
perf(currency): split FX cache — commit paths live, display paths 60s TTL

### DIFF
--- a/src/app/actions/__tests__/currency.test.ts
+++ b/src/app/actions/__tests__/currency.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for getCurrencyPrice (live) and getCachedCurrencyPrice (60s TTL).
+ *
+ * The cache shim in @/utils/no-cache is module-scoped, so we jest.resetModules()
+ * between tests and re-require the SUT to start each test with a cold cache.
+ */
+
+import { AccountType } from '@/interfaces'
+
+const mantecaGetPrices = jest.fn()
+const getExchangeRateMock = jest.fn()
+
+jest.mock('@/services/manteca', () => ({
+    mantecaApi: { getPrices: (...args: unknown[]) => mantecaGetPrices(...args) },
+}))
+jest.mock('../exchange-rate', () => ({
+    getExchangeRate: (...args: unknown[]) => getExchangeRateMock(...args),
+}))
+
+type CurrencyModule = typeof import('../currency')
+
+const loadModule = (): CurrencyModule => {
+    let mod!: CurrencyModule
+    jest.isolateModules(() => {
+        mod = require('../currency')
+    })
+    return mod
+}
+
+beforeEach(() => {
+    mantecaGetPrices.mockReset()
+    getExchangeRateMock.mockReset()
+    jest.useRealTimers()
+})
+
+describe('getCurrencyPrice (uncached, commit-path)', () => {
+    it('returns 1:1 for USD without calling any provider', async () => {
+        const { getCurrencyPrice } = loadModule()
+        await expect(getCurrencyPrice('USD')).resolves.toEqual({ buy: 1, sell: 1 })
+        expect(mantecaGetPrices).not.toHaveBeenCalled()
+        expect(getExchangeRateMock).not.toHaveBeenCalled()
+    })
+
+    it('normalizes lowercase currency codes to uppercase', async () => {
+        mantecaGetPrices.mockResolvedValue({ effectiveBuy: '1200', effectiveSell: '1180' })
+        const { getCurrencyPrice } = loadModule()
+        await getCurrencyPrice('ars')
+        expect(mantecaGetPrices).toHaveBeenCalledWith({ asset: 'USDC', against: 'ARS' })
+    })
+
+    it('routes EUR through Bridge with IBAN account type', async () => {
+        getExchangeRateMock.mockResolvedValue({ data: { buy_rate: '0.92', sell_rate: '0.90' }, error: null })
+        const { getCurrencyPrice } = loadModule()
+        await expect(getCurrencyPrice('EUR')).resolves.toEqual({ buy: 0.92, sell: 0.9 })
+        expect(getExchangeRateMock).toHaveBeenCalledWith(AccountType.IBAN)
+    })
+
+    it('routes Manteca currencies through mantecaApi.getPrices', async () => {
+        mantecaGetPrices.mockResolvedValue({ effectiveBuy: '1200', effectiveSell: '1180' })
+        const { getCurrencyPrice } = loadModule()
+        await expect(getCurrencyPrice('ARS')).resolves.toEqual({ buy: 1200, sell: 1180 })
+    })
+
+    it('throws on unknown currency code', async () => {
+        const { getCurrencyPrice } = loadModule()
+        await expect(getCurrencyPrice('XYZ')).rejects.toThrow('Invalid currency code')
+    })
+
+    it('throws when Bridge returns an error', async () => {
+        getExchangeRateMock.mockResolvedValue({ data: null, error: 'down' })
+        const { getCurrencyPrice } = loadModule()
+        await expect(getCurrencyPrice('EUR')).rejects.toThrow('Failed to fetch exchange rate from bridge')
+    })
+
+    it('throws when Manteca returns a non-numeric rate (NaN)', async () => {
+        mantecaGetPrices.mockResolvedValue({ effectiveBuy: 'not-a-number', effectiveSell: '1180' })
+        const { getCurrencyPrice } = loadModule()
+        await expect(getCurrencyPrice('ARS')).rejects.toThrow(/Invalid buy rate/)
+    })
+
+    it('throws when Manteca returns a zero rate', async () => {
+        mantecaGetPrices.mockResolvedValue({ effectiveBuy: '0', effectiveSell: '1180' })
+        const { getCurrencyPrice } = loadModule()
+        await expect(getCurrencyPrice('ARS')).rejects.toThrow(/Invalid buy rate/)
+    })
+
+    it('throws when Bridge returns a negative rate', async () => {
+        getExchangeRateMock.mockResolvedValue({ data: { buy_rate: '-0.5', sell_rate: '0.9' }, error: null })
+        const { getCurrencyPrice } = loadModule()
+        await expect(getCurrencyPrice('EUR')).rejects.toThrow(/Invalid buy rate/)
+    })
+
+    it('hits the provider on every call (no caching on the commit path)', async () => {
+        mantecaGetPrices.mockResolvedValue({ effectiveBuy: '1200', effectiveSell: '1180' })
+        const { getCurrencyPrice } = loadModule()
+        await getCurrencyPrice('ARS')
+        await getCurrencyPrice('ARS')
+        await getCurrencyPrice('ARS')
+        expect(mantecaGetPrices).toHaveBeenCalledTimes(3)
+    })
+})
+
+describe('getCachedCurrencyPrice (60s TTL, display path)', () => {
+    it('hits the provider once within the TTL window', async () => {
+        mantecaGetPrices.mockResolvedValue({ effectiveBuy: '1200', effectiveSell: '1180' })
+        const { getCachedCurrencyPrice } = loadModule()
+        const first = await getCachedCurrencyPrice('ARS')
+        const second = await getCachedCurrencyPrice('ARS')
+        expect(first).toEqual({ buy: 1200, sell: 1180 })
+        expect(second).toEqual({ buy: 1200, sell: 1180 })
+        expect(mantecaGetPrices).toHaveBeenCalledTimes(1)
+    })
+
+    it('treats normalized codes as the same cache key', async () => {
+        mantecaGetPrices.mockResolvedValue({ effectiveBuy: '1200', effectiveSell: '1180' })
+        const { getCachedCurrencyPrice } = loadModule()
+        await getCachedCurrencyPrice('ars')
+        await getCachedCurrencyPrice('ARS')
+        await getCachedCurrencyPrice('Ars')
+        expect(mantecaGetPrices).toHaveBeenCalledTimes(1)
+    })
+
+    it('refetches after the 60s TTL expires', async () => {
+        jest.useFakeTimers({ now: 0 })
+        mantecaGetPrices
+            .mockResolvedValueOnce({ effectiveBuy: '1200', effectiveSell: '1180' })
+            .mockResolvedValueOnce({ effectiveBuy: '1300', effectiveSell: '1280' })
+        const { getCachedCurrencyPrice } = loadModule()
+
+        const first = await getCachedCurrencyPrice('ARS')
+        jest.setSystemTime(61_000) // past 60s TTL
+        const second = await getCachedCurrencyPrice('ARS')
+
+        expect(first).toEqual({ buy: 1200, sell: 1180 })
+        expect(second).toEqual({ buy: 1300, sell: 1280 })
+        expect(mantecaGetPrices).toHaveBeenCalledTimes(2)
+    })
+
+    it('does NOT cache thrown errors — next call retries the provider', async () => {
+        mantecaGetPrices
+            .mockRejectedValueOnce(new Error('provider blip'))
+            .mockResolvedValueOnce({ effectiveBuy: '1200', effectiveSell: '1180' })
+        const { getCachedCurrencyPrice } = loadModule()
+
+        await expect(getCachedCurrencyPrice('ARS')).rejects.toThrow('provider blip')
+        await expect(getCachedCurrencyPrice('ARS')).resolves.toEqual({ buy: 1200, sell: 1180 })
+        expect(mantecaGetPrices).toHaveBeenCalledTimes(2)
+    })
+
+    it('does NOT cache invalid rates (NaN) — they throw, next call retries', async () => {
+        mantecaGetPrices
+            .mockResolvedValueOnce({ effectiveBuy: 'garbage', effectiveSell: '1180' })
+            .mockResolvedValueOnce({ effectiveBuy: '1200', effectiveSell: '1180' })
+        const { getCachedCurrencyPrice } = loadModule()
+
+        await expect(getCachedCurrencyPrice('ARS')).rejects.toThrow(/Invalid buy rate/)
+        await expect(getCachedCurrencyPrice('ARS')).resolves.toEqual({ buy: 1200, sell: 1180 })
+        expect(mantecaGetPrices).toHaveBeenCalledTimes(2)
+    })
+
+    it('serves USD from cache without hitting providers', async () => {
+        const { getCachedCurrencyPrice } = loadModule()
+        await expect(getCachedCurrencyPrice('USD')).resolves.toEqual({ buy: 1, sell: 1 })
+        expect(mantecaGetPrices).not.toHaveBeenCalled()
+        expect(getExchangeRateMock).not.toHaveBeenCalled()
+    })
+})

--- a/src/app/actions/currency.ts
+++ b/src/app/actions/currency.ts
@@ -1,42 +1,62 @@
 import { getExchangeRate } from './exchange-rate'
 import { AccountType } from '@/interfaces'
 import { mantecaApi } from '@/services/manteca'
+import { unstable_cache } from '@/utils/no-cache'
 
 const MANTECA_CURRENCIES = ['ARS', 'BRL', 'COP', 'CRC', 'PUSD', 'GTQ', 'PHP', 'BOB']
-
-export const getCurrencyPrice = async (currencyCode: string): Promise<{ buy: number; sell: number }> => {
-    let buy: number
-    let sell: number
-    currencyCode = currencyCode.toUpperCase()
-    if (currencyCode === 'USD') {
-        buy = 1
-        sell = 1
-    } else if (['EUR', 'MXN', 'GBP'].includes(currencyCode)) {
-        let accountType: AccountType
-        if (currencyCode === 'EUR') {
-            accountType = AccountType.IBAN
-        } else if (currencyCode === 'MXN') {
-            accountType = AccountType.CLABE
-        } else if (currencyCode === 'GBP') {
-            accountType = AccountType.GB
-        } else {
-            throw new Error('Invalid currency code')
-        }
-        const { data, error } = await getExchangeRate(accountType)
-        if (error) {
-            throw new Error('Failed to fetch exchange rate from bridge')
-        }
-        if (!data) {
-            throw new Error('No data returned from exchange rate API')
-        }
-        buy = parseFloat(data.buy_rate)
-        sell = parseFloat(data.sell_rate)
-    } else if (MANTECA_CURRENCIES.includes(currencyCode)) {
-        const response = await mantecaApi.getPrices({ asset: 'USDC', against: currencyCode })
-        buy = Number(response.effectiveBuy)
-        sell = Number(response.effectiveSell)
-    } else {
-        throw new Error('Invalid currency code')
-    }
-    return { buy, sell }
+const BRIDGE_CURRENCIES = ['EUR', 'MXN', 'GBP']
+const BRIDGE_ACCOUNT_TYPE: Record<string, AccountType> = {
+    EUR: AccountType.IBAN,
+    MXN: AccountType.CLABE,
+    GBP: AccountType.GB,
 }
+
+const assertPositiveRate = (label: string, rate: number): number => {
+    if (!Number.isFinite(rate) || rate <= 0) {
+        throw new Error(`Invalid ${label} rate from provider: ${rate}`)
+    }
+    return rate
+}
+
+const fetchCurrencyPrice = async (currencyCode: string): Promise<{ buy: number; sell: number }> => {
+    if (currencyCode === 'USD') return { buy: 1, sell: 1 }
+
+    if (BRIDGE_CURRENCIES.includes(currencyCode)) {
+        const { data, error } = await getExchangeRate(BRIDGE_ACCOUNT_TYPE[currencyCode])
+        if (error) throw new Error('Failed to fetch exchange rate from bridge')
+        if (!data) throw new Error('No data returned from exchange rate API')
+        return {
+            buy: assertPositiveRate('buy', parseFloat(data.buy_rate)),
+            sell: assertPositiveRate('sell', parseFloat(data.sell_rate)),
+        }
+    }
+
+    if (MANTECA_CURRENCIES.includes(currencyCode)) {
+        const response = await mantecaApi.getPrices({ asset: 'USDC', against: currencyCode })
+        return {
+            buy: assertPositiveRate('buy', Number(response.effectiveBuy)),
+            sell: assertPositiveRate('sell', Number(response.effectiveSell)),
+        }
+    }
+
+    throw new Error('Invalid currency code')
+}
+
+/**
+ * Live FX quote — no caching. Use this on commit paths where the returned
+ * value is multiplied into an `amount` sent to a provider (on-ramp create,
+ * QR payment quote). A stale rate here translates directly into the user
+ * receiving more/less USDC than displayed.
+ */
+export const getCurrencyPrice = (currencyCode: string): Promise<{ buy: number; sell: number }> =>
+    fetchCurrencyPrice(currencyCode.toUpperCase())
+
+const cachedFetch = unstable_cache(fetchCurrencyPrice, ['getCurrencyPrice'], { revalidate: 60 })
+
+/**
+ * 60s in-memory cached FX quote. Use for display surfaces (currency picker,
+ * exchange-rate widget, history rows). Never use on a code path that
+ * forwards the result as an `amount` to a provider — use `getCurrencyPrice`.
+ */
+export const getCachedCurrencyPrice = (currencyCode: string): Promise<{ buy: number; sell: number }> =>
+    cachedFetch(currencyCode.toUpperCase())

--- a/src/app/api/exchange-rate/route.ts
+++ b/src/app/api/exchange-rate/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getCurrencyPrice } from '@/app/actions/currency'
+import { getCachedCurrencyPrice } from '@/app/actions/currency'
 
 interface ExchangeRateResponse {
     rate: number
@@ -41,7 +41,7 @@ export async function GET(request: NextRequest) {
         if (fromUc === 'USD' || toUc === 'USD') {
             const pairKey = `${fromUc}-${toUc}`
 
-            // Check if either currency uses getCurrencyPrice (Manteca or Bridge currencies)
+            // Check if either currency uses getCachedCurrencyPrice (Manteca or Bridge currencies)
             if (
                 MANTECA_CURRENCIES.has(fromUc) ||
                 MANTECA_CURRENCIES.has(toUc) ||
@@ -59,8 +59,8 @@ export async function GET(request: NextRequest) {
                         }
                     )
                 }
-                // Fall back to other providers if getCurrencyPrice fails
-                console.warn(`getCurrencyPrice failed for ${pairKey}, falling back to other providers`)
+                // Fall back to other providers if getCachedCurrencyPrice fails
+                console.warn(`getCachedCurrencyPrice failed for ${pairKey}, falling back to other providers`)
             }
 
             // Use Frankfurter for all other pairs or as fallback
@@ -104,7 +104,7 @@ export async function GET(request: NextRequest) {
 
 async function getExchangeRate(from: string, to: string): Promise<number | null> {
     try {
-        // Check if either currency uses getCurrencyPrice (Manteca or Bridge currencies)
+        // Check if either currency uses getCachedCurrencyPrice (Manteca or Bridge currencies)
         if (
             MANTECA_CURRENCIES.has(from) ||
             MANTECA_CURRENCIES.has(to) ||
@@ -123,21 +123,21 @@ async function getExchangeRate(from: string, to: string): Promise<number | null>
 }
 
 async function fetchFromCurrencyPrice(from: string, to: string): Promise<number | null> {
-    console.log('Fetching from getCurrencyPrice')
+    console.log('Fetching from getCachedCurrencyPrice')
     try {
         if (from === 'USD' && (MANTECA_CURRENCIES.has(to) || ['EUR', 'MXN', 'GBP'].includes(to))) {
             // USD → other currency: use sell rate (selling USD to get other currency)
-            const { sell } = await getCurrencyPrice(to)
+            const { sell } = await getCachedCurrencyPrice(to)
             if (!isFinite(sell) || sell <= 0) {
-                console.error(`Invalid sell rate from getCurrencyPrice for ${to}: ${sell}`)
+                console.error(`Invalid sell rate from getCachedCurrencyPrice for ${to}: ${sell}`)
                 return null
             }
             return sell
         } else if ((MANTECA_CURRENCIES.has(from) || ['EUR', 'MXN', 'GBP'].includes(from)) && to === 'USD') {
             // Other currency → USD: use buy rate (buying USD with other currency)
-            const { buy } = await getCurrencyPrice(from)
+            const { buy } = await getCachedCurrencyPrice(from)
             if (!isFinite(buy) || buy <= 0) {
-                console.error(`Invalid buy rate from getCurrencyPrice for ${from}: ${buy}`)
+                console.error(`Invalid buy rate from getCachedCurrencyPrice for ${from}: ${buy}`)
                 return null
             }
             return 1 / buy
@@ -146,8 +146,8 @@ async function fetchFromCurrencyPrice(from: string, to: string): Promise<number 
             (MANTECA_CURRENCIES.has(to) || ['EUR', 'MXN', 'GBP'].includes(to))
         ) {
             // Other currency → Other currency: convert through USD
-            const fromPrices = await getCurrencyPrice(from)
-            const toPrices = await getCurrencyPrice(to)
+            const fromPrices = await getCachedCurrencyPrice(from)
+            const toPrices = await getCachedCurrencyPrice(to)
 
             if (!isFinite(fromPrices.buy) || fromPrices.buy <= 0 || !isFinite(toPrices.sell) || toPrices.sell <= 0) {
                 console.error(`Invalid prices for ${from}-${to}: buy=${fromPrices.buy}, sell=${toPrices.sell}`)
@@ -160,11 +160,11 @@ async function fetchFromCurrencyPrice(from: string, to: string): Promise<number 
             return fromToUsd * usdToTo
         } else {
             // Unsupported conversion
-            console.warn(`Unsupported getCurrencyPrice conversion: ${from} → ${to}`)
+            console.warn(`Unsupported getCachedCurrencyPrice conversion: ${from} → ${to}`)
             return null
         }
     } catch (error) {
-        console.error(`getCurrencyPrice error for ${from}-${to}:`, error)
+        console.error(`getCachedCurrencyPrice error for ${from}-${to}:`, error)
         return null
     }
 }

--- a/src/hooks/useCurrency.ts
+++ b/src/hooks/useCurrency.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { getCurrencyPrice } from '@/app/actions/currency'
+import { getCachedCurrencyPrice } from '@/app/actions/currency'
 
 export const SYMBOLS_BY_CURRENCY_CODE: Record<string, string> = {
     ARS: 'ARS',
@@ -44,7 +44,7 @@ export const useCurrency = (currencyCode: string | null) => {
         }
 
         setIsLoading(true)
-        getCurrencyPrice(code)
+        getCachedCurrencyPrice(code)
             .then((price) => {
                 setSymbol(SYMBOLS_BY_CURRENCY_CODE[code])
                 setPrice(price)

--- a/src/hooks/useExchangeRate.ts
+++ b/src/hooks/useExchangeRate.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { useDebounce } from './useDebounce'
 import { useQuery } from '@tanstack/react-query'
 import { isCapacitor } from '@/utils/capacitor'
-import { getCurrencyPrice } from '@/app/actions/currency'
+import { getCachedCurrencyPrice } from '@/app/actions/currency'
 
 type InputValue = number | ''
 
@@ -93,7 +93,7 @@ export function useExchangeRate({
                 const to = destinationCurrency.toUpperCase()
                 if (from === to) return { rate: 1 }
                 try {
-                    const price = await getCurrencyPrice(from === 'USD' ? to : from)
+                    const price = await getCachedCurrencyPrice(from === 'USD' ? to : from)
                     const rate = from === 'USD' ? price.sell : 1 / price.buy
                     if (isFinite(rate) && rate > 0) return { rate }
                 } catch {}

--- a/src/utils/__tests__/history.utils.test.ts
+++ b/src/utils/__tests__/history.utils.test.ts
@@ -15,7 +15,7 @@
 import { completeHistoryEntry } from '../history.utils'
 import type { HistoryEntry } from '../history.utils'
 
-jest.mock('@/app/actions/currency', () => ({ getCurrencyPrice: jest.fn() }))
+jest.mock('@/app/actions/currency', () => ({ getCachedCurrencyPrice: jest.fn() }))
 jest.mock('@/utils/general.utils', () => ({
     getFromLocalStorage: jest.fn(() => null),
     getTokenDetails: jest.fn(() => ({ symbol: 'USDC', decimals: 6 })),

--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -4,7 +4,7 @@ import { getFromLocalStorage } from '@/utils/general.utils'
 import { formatUnits } from 'viem'
 import { type Hash } from 'viem'
 import { getTokenDetails } from '@/utils/general.utils'
-import { getCurrencyPrice } from '@/app/actions/currency'
+import { getCachedCurrencyPrice } from '@/app/actions/currency'
 import { type ChargeEntry } from '@/services/services.types'
 import { PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
 import { shareableUrl } from '@/utils/url.utils'
@@ -353,7 +353,7 @@ export async function completeHistoryEntry(entry: HistoryEntry): Promise<History
             }
             if (usdAmount === entry.currency?.amount && entry.currency?.code && entry.currency?.code !== 'USD') {
                 try {
-                    const price = await getCurrencyPrice(entry.currency.code)
+                    const price = await getCachedCurrencyPrice(entry.currency.code)
                     usdAmount = (Number(entry.currency.amount) / price.buy).toString()
                 } catch (error) {
                     console.error(
@@ -380,7 +380,7 @@ export async function completeHistoryEntry(entry: HistoryEntry): Promise<History
 
                 if (!hasCurrencyAmount || !isFinite(currNum) || approximatelyEqual) {
                     try {
-                        const price = await getCurrencyPrice(entry.currency.code)
+                        const price = await getCachedCurrencyPrice(entry.currency.code)
                         const converted = Number.isFinite(usdNum) && price?.sell ? usdNum * price.sell : usdNum
                         entry.currency.amount = converted.toString()
                     } catch (error) {


### PR DESCRIPTION
## Why

Replaces closed #2117. That PR cached \`getCurrencyPrice\` globally for 10 min, but the same function is used to compute the **wire amount** posted to \`/bridge/onramp/create\` and \`/bridge/onramp/create-for-guest\`. The backend forwards that amount to Bridge unchanged (\`peanut-api-ts/src/routes/bridge/onramp/create.ts:131-146\`) — no server-side FX recompute. A stale rate at quote time translates directly into the user receiving more/less USDC than displayed when Bridge settles the deposit at its live rate.

Same risk on the QR-pay path (\`qr-pay/page.tsx:282\` → \`paymentLock.paymentPrice\`).

## What

Split the public surface so the cache only touches display:

- **\`getCurrencyPrice(code)\`** — live, no cache. Source of truth for any code path that multiplies the rate into an \`amount\` sent to a provider. Used by:
  - \`src/app/actions/onramp.ts\`
  - \`src/hooks/useCreateOnramp.ts\`
  - \`src/app/(mobile-ui)/qr-pay/page.tsx\`
- **\`getCachedCurrencyPrice(code)\`** — 60s in-memory TTL. Used by:
  - \`src/app/api/exchange-rate/route.ts\` (display widget)
  - \`src/hooks/useCurrency.ts\` (currency picker)
  - \`src/hooks/useExchangeRate.ts\` (Capacitor fallback path; the route path already has TanStack 5min + CDN \`s-maxage=300\`)
  - \`src/utils/history.utils.ts\` (historic display rows)

## Safeguards added vs #2117

1. **Reject invalid rates at the source.** \`assertPositiveRate\` throws on \`NaN\`, zero, or negative. #2117's cache would have happily pinned a \`NaN\` from a malformed Manteca response for a full TTL.
2. **TTL dropped 10min → 60s.** 10 min is widget-only territory; 60s is consistent with how the Frankfurter fallback in this same route is tuned (\`next: { revalidate: 300 }\` is its own CDN layer).
3. **Errors still aren't cached** (unchanged from the shim's existing behaviour — only resolved values are stored).
4. **Tests.** New \`currency.test.ts\` covers: USD short-circuit, case normalization, TTL hit/miss boundary at 60s, no-cache-on-throw, no-cache-on-NaN/zero/negative, per-provider routing, no caching on the commit path.

## Why \`main\` and not \`dev\`

The stale-FX path quietly mis-quotes on-ramps already in prod via the existing \`/api/exchange-rate\` widget; the safeguard half of this PR (invalid-rate rejection) is independently a fix. Doesn't need to ride a dev cycle.

## Test

- \`npm run typecheck\` clean (pre-existing asset-import errors unrelated to this PR — same set on \`main\`).
- \`npm test\` — 1118/1125 pass; 3 failures are the known \`src/lib/content.test.ts\` set, 4 skipped.
- \`prettier --write\` ran on all touched files (no diffs).
- New suite \`currency.test.ts\` — 15/15 pass, covering all safeguards above.