### PR TITLE
feat(kyc): wire contact-support gate → Crisp deep-link with failure context

### DIFF
--- a/src/components/Home/ActivationCTAs.tsx
+++ b/src/components/Home/ActivationCTAs.tsx
@@ -11,6 +11,8 @@ import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { useIdentityVerification } from '@/hooks/useIdentityVerification'
+import { useAuth } from '@/context/authContext'
+import { buildContactSupportMessage } from '@/utils/contact-support.utils'
 
 interface ActivationCTAsProps {
     activationStep: ActivationStep
@@ -72,8 +74,9 @@ const STEPS: Record<Exclude<ActivationStep, 'completed'>, StepConfig> = {
  */
 export default function ActivationCTAs({ activationStep, onDismissCard }: ActivationCTAsProps) {
     const router = useRouter()
-    const { setIsQRScannerOpen, setIsSupportModalOpen } = useModalsContext()
+    const { setIsQRScannerOpen, openSupportWithMessage } = useModalsContext()
     const { rails, channelOf } = useCapabilities()
+    const { user } = useAuth()
     // Suppress the "Unlock payments" verify CTA while identity is mid-flight
     // (Sumsub processing / action_required). The user already took the verify
     // action; the identity-verification page surfaces the in-progress modal,
@@ -84,17 +87,18 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
     // qr-only channels — never through card. Top-level status (not per-op
     // refinement): Manteca's pool tier reads `enabled` at the rail level even when
     // deposit/withdraw individually need an upgrade — that's not a rejection.
-    const { hasFixableRejection, hasBlockedRejection, primaryRejectionMessage } = useMemo(() => {
+    const { hasFixableRejection, hasBlockedRejection, primaryRejectionMessage, blockedRail } = useMemo(() => {
         const rejectableRails = rails.filter((rail) => {
             const channel = channelOf(rail)
             return channel === 'bank' || channel === 'qr-only'
         })
         const fixableRail = rejectableRails.find((rail) => rail.status === 'requires-info')
-        const blockedRail = rejectableRails.find((rail) => rail.status === 'blocked')
+        const blocked = rejectableRails.find((rail) => rail.status === 'blocked')
         return {
             hasFixableRejection: !!fixableRail,
-            hasBlockedRejection: !!blockedRail,
-            primaryRejectionMessage: (fixableRail ?? blockedRail)?.reason?.userMessage ?? null,
+            hasBlockedRejection: !!blocked,
+            primaryRejectionMessage: (fixableRail ?? blocked)?.reason?.userMessage ?? null,
+            blockedRail: blocked,
         }
     }, [rails, channelOf])
 
@@ -171,7 +175,16 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
                     className="mt-2 w-full"
                     onClick={() => {
                         if (hasProviderRejection && hasBlockedRejection && !hasFixableRejection) {
-                            setIsSupportModalOpen(true)
+                            // REQUIRES_SUPPORT class (or any blocked rail) — pre-fill Crisp
+                            // with the failure context so support can dispatch without
+                            // re-investigating the user's state.
+                            openSupportWithMessage(
+                                buildContactSupportMessage({
+                                    reason: blockedRail?.reason,
+                                    railId: blockedRail?.id,
+                                    userId: user?.user?.userId,
+                                })
+                            )
                         } else if (activationStep === 'outbound' && !hasProviderRejection) {
                             setIsQRScannerOpen(true)
                         } else {

--- a/src/types/capabilities.ts
+++ b/src/types/capabilities.ts
@@ -40,6 +40,12 @@ export type RailId = `${ProviderCode}.${string}`
 export interface CapabilityReason {
     code: string // normalized: 'proof_of_address' | 'manteca_us_nationality' | 'document_rejected' | …
     userMessage: string // friendly, display-ready
+    /**
+     * Optional technical detail captured from a provider response or a
+     * pipeline-side failure (REQUIRES_SUPPORT). Not user-facing copy — the FE
+     * forwards it to the Crisp pre-fill so the support agent sees what broke.
+     */
+    details?: string
 }
 
 /**

--- a/src/utils/contact-support.utils.ts
+++ b/src/utils/contact-support.utils.ts
@@ -1,0 +1,35 @@
+/**
+ * Build a Crisp pre-fill message for the `contact-support` NextAction that the
+ * BE emits when a rail lands in REQUIRES_SUPPORT (our pipeline broke en route
+ * to the provider — Bridge 5xx after retries, missing user email, etc).
+ *
+ * The user-facing copy stays generic ("we hit a snag on our side"); the
+ * machine-readable details (failureReason, railId, userId) are appended so the
+ * support agent can dispatch the right recovery script without re-investigating.
+ *
+ * Shape is deliberately simple plaintext — Crisp's prefill renders it as the
+ * user's first message in the conversation. The "Hi support" framing is the
+ * voice the user "sends"; the bracketed block reads as machine-attached
+ * context that the agent can copy/paste into their ops tooling.
+ */
+import type { CapabilityReason } from '@/types/capabilities'
+
+export function buildContactSupportMessage(args: {
+    reason?: CapabilityReason
+    railId?: string
+    userId?: string
+}): string {
+    const { reason, railId, userId } = args
+    const lines: string[] = []
+    lines.push(
+        reason?.userMessage ??
+            'Hi! I tried to finish my verification but something went wrong on the app side — could you help me sort this out?'
+    )
+    lines.push('')
+    lines.push('— context for support —')
+    if (reason?.code) lines.push(`reason: ${reason.code}`)
+    if (reason?.details) lines.push(`details: ${reason.details}`)
+    if (railId) lines.push(`rail: ${railId}`)
+    if (userId) lines.push(`user: ${userId}`)
+    return lines.join('\n')
+}


### PR DESCRIPTION
Companion to peanut-api-ts \`feat/requires-support\`. The BE now emits a contact-support NextAction when a rail lands in REQUIRES_SUPPORT — i.e., our pipeline silently failed mid-flow (no email, no docs found, Bridge 5xx after retries). The \`reason\` carries both a user-facing \`userMessage\` and an optional \`details\` field holding the technical failureReason captured at the failure site.

This PR:
- Adds \`details?: string\` to \`CapabilityReason\` (mirror of the BE TypeBox / openapi change in peanut-api-ts).
- New \`src/utils/contact-support.utils.ts:buildContactSupportMessage\` — composes a Crisp pre-fill string from \`reason\` + \`railId\` + \`userId\` so the support agent receives the technical context inline with the user's opening message and can dispatch the right ops script without re-investigating.
- \`ActivationCTAs.tsx\` blocked-rejection branch now calls \`openSupportWithMessage(buildContactSupportMessage(...))\` instead of raw \`setIsSupportModalOpen(true)\`.

## Verification

- tsc clean
- 1171/1175 unit tests pass (4 pre-existing skips)

## Sequencing

Lands AFTER the BE PR merges. Until then the FE side is dormant — \`details\` is just an optional field that won't be present yet, and \`blockedRail.reason\` already exists on blocked rails so the helper is a no-op upgrade for existing blocked-rail paths.

## Follow-ups (out of scope for this PR — separate PRs)

Hugo's EEA QA also flagged:
- **EEA Bug #1**: SecurityVerificationOverlay leaking into additional-docs flow (Jota's component from #2057). Trace + gate.
- **EEA Bug #2**: \"Read more\" link in EEA modal → help desk. One-liner copy.
- **EEA Bug #3**: longer / animated success state, reusing existing primitives. Audit the celebration components first.
- **EEA Bug #5**: \"add-money / showing withdraw\" page mismatch — provider-blind \`gateFor('deposit', { channel: 'bank' })\` likely picking the wrong rail for cross-region users; needs country-scoped gate.