### PR TITLE
kyc(EEA #5): branch onKycSuccess routing on flow — fix 'Add Money' showing withdraw form

### DIFF
--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -62,6 +62,22 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
     const sumsubFlow = useMultiPhaseKycFlow({
         onKycSuccess: () => {
             setIsKycModalOpen(false)
+            // The `view: 'form'` branch below renders DynamicBankAccountForm —
+            // the offramp/withdraw bank-account input form. That's correct for
+            // `flow === 'withdraw'` (user enters THEIR bank account to receive
+            // funds) but completely wrong for `flow === 'add'`, which needs
+            // Bridge's deposit instructions (an account belonging to Bridge
+            // that the user wires TO). Pre-fix this unconditional setView
+            // surfaced the withdraw form under an "Add money" title — the
+            // EEA QA Bug #5 ("Submitted, but still asking for account holder
+            // details when I'm trying to add money"). Route add-money users
+            // to /add-money/[country]/bank instead, which mounts
+            // AddMoneyBankDetails (deposit-instructions display).
+            if (flow === 'add') {
+                const countrySlug = currentCountry?.path
+                router.push(countrySlug ? `/add-money/${countrySlug}/bank` : '/add-money')
+                return
+            }
             setView('form')
         },
         onManualClose: () => setIsKycModalOpen(false),


### PR DESCRIPTION
## Summary

**Fixes EEA QA bug #5** from your Notion list: user on **Add Money** flow completes KYC, then sees the screen titled \"Add Money\" with the **withdraw** bank-account input form (account holder name, IBAN, etc.) — instead of Bridge's deposit instructions.

## Root cause

\`AddWithdrawCountriesList\` is a shared component mounted for BOTH flows:
- \`/add-money\` → \`<AddWithdrawCountriesList flow=\"add\" />\` (per \`app/(mobile-ui)/add-money/page.tsx\` + \`[country]/page.tsx\`)
- \`/withdraw\` → \`<AddWithdrawCountriesList flow=\"withdraw\" />\`

Its post-Sumsub-success handler at line 62 unconditionally flipped an internal view state to \`'form'\`:

\`\`\`ts
const sumsubFlow = useMultiPhaseKycFlow({
    onKycSuccess: () => {
        setIsKycModalOpen(false)
        setView('form')   // ← unconditional, regardless of flow
    },
})
\`\`\`

The \`view === 'form'\` branch (line 352) renders \`<DynamicBankAccountForm>\` — the offramp form asking the user for THEIR bank account. Correct for withdraw, wrong for add (which needs Bridge's deposit-instructions display from \`AddMoneyBankDetails\` at \`/add-money/[country]/bank\`).

The NavHeader stays correct (\`title={flow === 'withdraw' ? 'Withdraw' : 'Add money'}\`) — only the inner form was wrong, hence the confusing UX of \"Add Money\" + withdraw fields.

**Why it slipped past coverage**: initial \`useState\` for \`view\` at line 71 already guards (\`flow === 'withdraw' && amountToWithdraw ? 'form' : 'list'\`), so add-money never hits the bad state on initial mount. The bug only surfaces in the post-KYC transition path — exactly the EEA flow.

## Fix

Branch on \`flow\` inside \`onKycSuccess\`:
- \`flow === 'add'\` → \`router.push('/add-money/[country]/bank')\` (deposit-instructions page)
- \`flow === 'withdraw'\` → \`setView('form')\` (unchanged — correct destination for offramp)

16 lines including comment. Single touched file.

## Systemic audit (you asked)

**NOT systemic.** \`AddWithdrawCountriesList\` is the ONLY component used for both add + withdraw flows. Audited every other \`useMultiPhaseKycFlow\` consumer:

| Consumer | Verdict |
|---|---|
| \`AddWithdrawCountriesList\` | 🔴 THIS bug |
| \`add-money/[country]/bank\` | ✅ single-flow, sets \`step\` within the page |
| \`withdraw/[country]/bank\` + \`withdraw/manteca\` + qr-pay | ✅ withdraw/pay-only, empty handlers |
| \`MantecaAddMoney\` + \`MantecaFlowManager\` + \`BankFlowManager\` (claim) | ✅ single-flow or empty handlers |
| \`UnlockedRegions\`, \`KycStatusDrawer\` | ✅ separate concerns |
| Card flow | ✅ no \`useMultiPhaseKycFlow\` consumer |

So send, withdraw, pay-QR, and card flows are unaffected.

## Test plan

- [x] \`pnpm typecheck\` clean (only pre-existing SVG/asset import errors that are Next.js worktree quirk)
- [x] \`pnpm prettier --check\` clean
- [ ] Manual on staging:
  - User without KYC clicks Add Money → picks a country → hits KYC modal → completes Sumsub → verifies they land on \`/add-money/[country]/bank\` showing Bridge's deposit instructions, NOT the withdraw form
  - User without KYC clicks Withdraw → picks a country with amount → hits KYC → completes Sumsub → verifies they land on the bank-details form (unchanged behavior)
  - PostHog session recording: pull a session matching the original report to confirm the bug + then re-run on the fixed build

## Notes

- 10-LoC behavioral change inside a single hook config callback. Unit testing the component would require mocking 15+ hooks (auth, withdraw flow, capabilities, ToS guard, modals, dispatch, etc.) — disproportionate scaffolding for one branched-callback assertion. If CR pushes back, happy to add a lightweight test that extracts the routing decision into a pure helper.
- Companion to recently-merged #906 (BE Bridge vocabulary) + #2132 (FE wait:bridge gate). Those addressed EEA Bug #4 ("Submitted, but still asking"). This addresses #5.