### PR TITLE
feat(kyc): expand KYCRegionIntent to 4 buckets (LATAM/ROW/EU/NA)

### DIFF
--- a/src/app/actions/types/sumsub.types.ts
+++ b/src/app/actions/types/sumsub.types.ts
@@ -16,4 +16,16 @@ export type SumsubKycStatus =
     | 'ACTION_REQUIRED'
     | 'REVERIFYING'
 
-export type KYCRegionIntent = 'STANDARD' | 'LATAM'
+/**
+ * User-facing region-intent bucket. One of four picker buttons:
+ *   - LATAM → backend mints `general` Sumsub level (Sumsub branches to
+ *             `manteca-requirements` for AR/BR applicants)
+ *   - ROW   → same as LATAM (pool-tier rails post-approval, no provider submission)
+ *   - EU    → `bridge-requirements` (Bridge SEPA / Faster Payments)
+ *   - NA    → `bridge-requirements` (Bridge ACH / Wire / SPEI)
+ *
+ * Legacy `STANDARD` is still accepted by the BE during this rollout (it maps to
+ * `general`); hardcoded callers that haven't been migrated to the country-aware
+ * pattern keep sending it. Remove once every call site sends one of the four.
+ */
+export type KYCRegionIntent = 'LATAM' | 'ROW' | 'EU' | 'NA' | 'STANDARD'

--- a/src/components/Profile/views/UnlockedRegions.view.tsx
+++ b/src/components/Profile/views/UnlockedRegions.view.tsx
@@ -25,9 +25,11 @@ import { type KYCRegionIntent } from '@/app/actions/types/sumsub.types'
 type ModalVariant = 'start' | 'processing' | 'action_required' | 'rejected'
 
 // the provider whose rail backs identity verification for a clicked region.
-// LATAM is served by Manteca; everything else (NA/EU/RoW) by Bridge.
+//   LATAM / ROW / STANDARD(legacy) → Manteca (general level; pool-tier pay rails
+//                                   post-approval, Manteca submission only for AR/BR)
+//   EU / NA                        → Bridge  (bridge-requirements level)
 const providerForRegionIntent = (intent: KYCRegionIntent | undefined): ProviderCode =>
-    intent === 'LATAM' ? 'manteca' : 'bridge'
+    intent === 'EU' || intent === 'NA' ? 'bridge' : 'manteca'
 
 /**
  * Determine which verification modal to show for the clicked region, derived
@@ -127,7 +129,9 @@ const UnlockedRegions = () => {
 
     // override modal variant when sumsub is approved but a provider rejected the user
     // determines which provider is relevant based on the clicked region
-    const providerRejectionForRegion = clickedRegionIntent === 'LATAM' ? mantecaRejection : bridgeRejection
+    // EU/NA → Bridge; LATAM/ROW/STANDARD → Manteca (general level).
+    const providerRejectionForRegion =
+        clickedRegionIntent === 'EU' || clickedRegionIntent === 'NA' ? bridgeRejection : mantecaRejection
     const hasProviderRejectionForRegion =
         !!selectedRegion &&
         isSumsubApproved &&

--- a/src/components/Profile/views/UnlockedRegions.view.tsx
+++ b/src/components/Profile/views/UnlockedRegions.view.tsx
@@ -127,11 +127,10 @@ const UnlockedRegions = () => {
         : false
     const baseModalVariant = selectedRegion ? getModalVariant(clickedRegionRail, clickedRailHasSumsubAction) : null
 
-    // override modal variant when sumsub is approved but a provider rejected the user
-    // determines which provider is relevant based on the clicked region
-    // EU/NA → Bridge; LATAM/ROW/STANDARD → Manteca (general level).
+    // override modal variant when sumsub is approved but a provider rejected the user.
+    // Use the same provider→intent map as the cross-region check below for consistency.
     const providerRejectionForRegion =
-        clickedRegionIntent === 'EU' || clickedRegionIntent === 'NA' ? bridgeRejection : mantecaRejection
+        providerForRegionIntent(clickedRegionIntent) === 'bridge' ? bridgeRejection : mantecaRejection
     const hasProviderRejectionForRegion =
         !!selectedRegion &&
         isSumsubApproved &&
@@ -165,9 +164,19 @@ const UnlockedRegions = () => {
     const handleStartKyc = useCallback(async () => {
         const intent = selectedRegion ? getRegionIntent(selectedRegion.path) : undefined
         if (intent) setActiveRegionIntent(intent)
-        // only signal cross-region when user is switching to a different region
+        // Cross-region means "user has an identity for one provider, clicked a
+        // region served by a DIFFERENT provider". Compare PROVIDERS not raw
+        // intent strings: in the 4-bucket model both 'EU' and 'NA' route to
+        // Bridge, and both 'LATAM' / 'ROW' route to Manteca (`general` level),
+        // so 'STANDARD' !== 'EU' alone would misclassify a Bridge→Bridge flow
+        // as cross-region.
         const crossRegion =
-            sumsubVerificationRegionIntent && intent && intent !== sumsubVerificationRegionIntent ? true : undefined
+            sumsubVerificationRegionIntent &&
+            intent &&
+            providerForRegionIntent(sumsubVerificationRegionIntent as KYCRegionIntent) !==
+                providerForRegionIntent(intent)
+                ? true
+                : undefined
         setSelectedRegion(null)
         await flow.handleInitiateKyc(intent, undefined, crossRegion)
     }, [flow.handleInitiateKyc, selectedRegion, sumsubVerificationRegionIntent])

--- a/src/utils/__tests__/regions.utils.test.ts
+++ b/src/utils/__tests__/regions.utils.test.ts
@@ -1,0 +1,15 @@
+import { getRegionIntent } from '../regions.utils'
+
+describe('getRegionIntent', () => {
+    it('maps each picker path to its 4-bucket intent', () => {
+        expect(getRegionIntent('latam')).toBe('LATAM')
+        expect(getRegionIntent('rest-of-the-world')).toBe('ROW')
+        expect(getRegionIntent('europe')).toBe('EU')
+        expect(getRegionIntent('north-america')).toBe('NA')
+    })
+
+    it('falls back to ROW for unknown paths', () => {
+        expect(getRegionIntent('mars')).toBe('ROW')
+        expect(getRegionIntent('')).toBe('ROW')
+    })
+})

--- a/src/utils/regions.utils.ts
+++ b/src/utils/regions.utils.ts
@@ -81,9 +81,29 @@ const BRIDGE_SUPPORTED_LATAM_COUNTRIES: Region[] = [
     },
 ]
 
-/** maps a region path to the sumsub kyc template intent */
+/**
+ * Maps a region path to the KYC region intent. Four picker buttons map 1:1 to
+ * four intents; the BE then resolves the Sumsub level
+ * (`verificationLevelForIntent`):
+ *   - latam               → LATAM → general
+ *   - rest-of-the-world   → ROW   → general
+ *   - europe              → EU    → bridge-requirements
+ *   - north-america       → NA    → bridge-requirements
+ *
+ * Unknown paths fall back to ROW (the most conservative target).
+ */
 export const getRegionIntent = (regionPath: string): KYCRegionIntent => {
-    return regionPath === 'latam' ? 'LATAM' : 'STANDARD'
+    switch (regionPath) {
+        case 'latam':
+            return 'LATAM'
+        case 'europe':
+            return 'EU'
+        case 'north-america':
+            return 'NA'
+        case 'rest-of-the-world':
+        default:
+            return 'ROW'
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

Pairs with peanut-api-ts PR #913 which replaces the deprecated `resolveLevelName` with `verificationLevelForIntent` and routes 4 intent buckets to the current Sumsub levels:

| Intent | Sumsub level |
|---|---|
| LATAM | `general` |
| ROW   | `general` |
| EU    | `bridge-requirements` |
| NA    | `bridge-requirements` |
| STANDARD (legacy) | `general` (kept temporarily for hardcoded callers) |

The Sumsub `general` workflow branches internally to `manteca-requirements` for AR/BR applicants.

## Changes

- `KYCRegionIntent`: `'STANDARD' \| 'LATAM'` → `'LATAM' \| 'ROW' \| 'EU' \| 'NA' \| 'STANDARD'`. `STANDARD` kept temporarily so the hardcoded `handleInitiateKyc('STANDARD')` callers (AddWithdraw, BankFlowManager) keep working until they're migrated to country-aware patterns.
- `getRegionIntent`: maps all 4 picker paths to their distinct intents (`latam` → `LATAM`, `rest-of-the-world` → `ROW`, `europe` → `EU`, `north-america` → `NA`). Falls back to `ROW` for unknown paths.
- `UnlockedRegions.view.tsx`: `providerForRegionIntent` + `providerRejectionForRegion` now route `EU`/`NA` → Bridge and `LATAM`/`ROW`/`STANDARD` → Manteca (matches BE routing — LATAM and ROW both land on the manteca-flavored `general` level).

## Tests

2 unit tests for `getRegionIntent` in `src/utils/__tests__/regions.utils.test.ts`.

`pnpm typecheck` clean.

## Followups (out of scope here)

- Hardcoded `handleInitiateKyc('STANDARD' | 'LATAM')` callers — Add Money / Withdraw / Claim / Manteca flow managers — could be migrated to a country-aware pattern (mint `manteca-requirements` directly for AR/BR, `bridge-requirements` for MX/EU/US/GB). Lots of touch points; punted to a separate PR.
- Once every caller sends one of the 4 new buckets, drop the `STANDARD` legacy alias from both the FE type and BE `verificationLevelForIntent`.