### PR TITLE
fix(kyc): country-scope the bank-channel capability gate

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -21,7 +21,7 @@ import { formatUnits } from 'viem'
 import PeanutLoading from '@/components/Global/PeanutLoading'
 import EmptyState from '@/components/Global/EmptyStates/EmptyState'
 import AddMoneyBankDetails from '@/components/AddMoney/components/AddMoneyBankDetails'
-import { getCurrencyConfig, getCurrencySymbol, getMinimumAmount } from '@/utils/bridge.utils'
+import { getCurrencyConfig, getCurrencySymbol, getMinimumAmount, railJurisdictionForBank } from '@/utils/bridge.utils'
 import { OnrampConfirmationModal } from '@/components/AddMoney/components/OnrampConfirmationModal'
 import InfoCard from '@/components/Global/InfoCard'
 import { useQueryStates, parseAsString, parseAsStringEnum } from 'nuqs'
@@ -100,12 +100,15 @@ export default function OnrampBankPage() {
     // uk-specific check
     const isUK = isUKCountry(selectedCountryPath)
 
-    // Provider-blind bank-channel readiness gate. Country-scoping would tighten
-    // this further (each page route is country-specific) — kept open for now to
-    // exactly preserve the old `deriveBridgeGate`'s behavior on rails of ANY
-    // country. Follow-up: scope to `{ channel: 'bank', country: selectedCountryPath.toUpperCase() }`.
+    // Country-scoped bank-channel readiness gate. The scope narrows to the
+    // rail jurisdiction this page actually deposits into (PT/DE/FR/… → EU
+    // SEPA; US → US ACH; MX → SPEI; etc.), so a stuck PENDING rail in an
+    // unrelated jurisdiction (e.g. a ghost BANK_TRANSFER_AR row) can't keep
+    // this page in a "Setting up your account…" wait loop. Unknown country
+    // → undefined → falls back to channel-only filter.
     const { gateFor } = useCapabilities()
-    const gate = useMemo(() => gateFor('deposit', { channel: 'bank' }), [gateFor])
+    const bankCountry = useMemo(() => railJurisdictionForBank(selectedCountry?.id), [selectedCountry?.id])
+    const gate = useMemo(() => gateFor('deposit', { channel: 'bank', country: bankCountry }), [gateFor, bankCountry])
     const { guardWithTos, showBridgeTos, hideTos } = useTosGuard()
     const { setIsSupportModalOpen } = useModalsContext()
 

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -244,6 +244,7 @@ jest.mock('@/utils/bridge.utils', () => ({
         return map[currency] ?? currency
     }),
     getMinimumAmount: jest.fn(() => 1),
+    railJurisdictionForBank: jest.fn(() => 'EU'),
 }))
 
 // Country currency mappings

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -25,7 +25,7 @@ import { TRANSACTIONS } from '@/constants/query.consts'
 import PaymentSuccessView from '@/features/payments/shared/components/PaymentSuccessView'
 import { ErrorHandler } from '@/utils/friendly-error.utils'
 import { getBridgeChainName } from '@/utils/bridge-accounts.utils'
-import { getOfframpCurrencyConfig, getCountryFromPath } from '@/utils/bridge.utils'
+import { getOfframpCurrencyConfig, getCountryFromPath, railJurisdictionForBank } from '@/utils/bridge.utils'
 import { createOfframp, confirmOfframp } from '@/app/actions/offramp'
 import { useAuth } from '@/context/authContext'
 import { useTosGuard } from '@/hooks/useTosGuard'
@@ -71,9 +71,13 @@ export default function WithdrawBankPage() {
     const country = (params.country as string) || searchParams.get('country') || ''
     const [balanceErrorMessage, setBalanceErrorMessage] = useState<string | null>(null)
     const { hasPendingTransactions } = usePendingTransactions()
-    // Provider-blind bank-channel withdraw gate. See utils/capability-gate.ts.
+    // Country-scoped bank-channel withdraw gate. Same rationale as the
+    // add-money/[country]/bank page: scope to the rail jurisdiction this page
+    // actually withdraws to (PT/DE/… → EU SEPA; US → ACH; etc.) so a stuck
+    // PENDING rail in an unrelated jurisdiction can't block this page.
     const { gateFor } = useCapabilities()
-    const gate = useMemo(() => gateFor('withdraw', { channel: 'bank' }), [gateFor])
+    const bankCountry = useMemo(() => railJurisdictionForBank(getCountryFromPath(country)?.id), [country])
+    const gate = useMemo(() => gateFor('withdraw', { channel: 'bank', country: bankCountry }), [gateFor, bankCountry])
     const sumsubFlow = useMultiPhaseKycFlow({})
     const [showKycModal, setShowKycModal] = useState(false)
     const { setIsSupportModalOpen } = useModalsContext()

--- a/src/app/(mobile-ui)/withdraw/__tests__/withdraw-states.test.tsx
+++ b/src/app/(mobile-ui)/withdraw/__tests__/withdraw-states.test.tsx
@@ -98,8 +98,9 @@ jest.mock('@/utils/general.utils', () => ({
 
 jest.mock('@/utils/bridge.utils', () => ({
     getCountryFromAccount: jest.fn(() => ({ iso2: 'US', path: 'us' })),
-    getCountryFromPath: jest.fn(() => ({ iso2: 'US' })),
+    getCountryFromPath: jest.fn(() => ({ iso2: 'US', id: 'US' })),
     getMinimumAmount: jest.fn(() => 1),
+    railJurisdictionForBank: jest.fn(() => 'US'),
 }))
 
 const mockUseGetExchangeRate = jest.fn()

--- a/src/utils/__tests__/bridge.utils.test.ts
+++ b/src/utils/__tests__/bridge.utils.test.ts
@@ -5,6 +5,7 @@ import {
     getOfframpCurrencyConfig,
     getPaymentRailDisplayName,
     getMinimumAmount,
+    railJurisdictionForBank,
     reverseBridgeCrossCurrencyFee,
 } from '../bridge.utils'
 
@@ -337,6 +338,49 @@ describe('bridge.utils', () => {
             expect(onrampConfig.paymentRail).toBe('sepa')
             expect(offrampConfig.paymentRail).toBe('sepa')
             expect(onrampConfig.currency).toBe(offrampConfig.currency)
+        })
+    })
+
+    describe('railJurisdictionForBank', () => {
+        it.each([
+            // US (both ISO2 + ISO3)
+            ['US', 'US'],
+            ['USA', 'US'],
+            // Mexico
+            ['MX', 'MX'],
+            ['MEX', 'MX'],
+            // UK
+            ['GB', 'GB'],
+            ['GBR', 'GB'],
+            // LATAM (Manteca rails are catalogued under user country)
+            ['AR', 'AR'],
+            ['ARG', 'AR'],
+            ['BR', 'BR'],
+            ['BRA', 'BR'],
+        ])('maps %s → %s', (input, expected) => {
+            expect(railJurisdictionForBank(input)).toBe(expected)
+        })
+
+        it('defaults SEPA-EUR countries to EU (Bridge catalogues SEPA as a single EU rail)', () => {
+            // The exact case that motivated this helper: Portugal user clicks
+            // "add money from bank" — we need to scope to the SEPA jurisdiction,
+            // not the literal ISO2 of Portugal.
+            expect(railJurisdictionForBank('PT')).toBe('EU')
+            expect(railJurisdictionForBank('PRT')).toBe('EU')
+            expect(railJurisdictionForBank('DE')).toBe('EU')
+            expect(railJurisdictionForBank('FR')).toBe('EU')
+            expect(railJurisdictionForBank('ES')).toBe('EU')
+        })
+
+        it('returns undefined for missing / empty input (gate falls back to no country filter)', () => {
+            expect(railJurisdictionForBank(undefined)).toBeUndefined()
+            expect(railJurisdictionForBank(null)).toBeUndefined()
+            expect(railJurisdictionForBank('')).toBeUndefined()
+        })
+
+        it('case-insensitive', () => {
+            expect(railJurisdictionForBank('us')).toBe('US')
+            expect(railJurisdictionForBank('pt')).toBe('EU')
         })
     })
 })

--- a/src/utils/__tests__/bridge.utils.test.ts
+++ b/src/utils/__tests__/bridge.utils.test.ts
@@ -378,6 +378,16 @@ describe('bridge.utils', () => {
             expect(railJurisdictionForBank('')).toBeUndefined()
         })
 
+        it('maps unmapped countries to EU (SEPA default — mirrors getCurrencyConfig)', () => {
+            // Returning undefined here would re-introduce the original bug
+            // (unscoped gate sees stuck pending rails from unrelated
+            // jurisdictions). Every other country we serve via Bridge does
+            // so via SEPA, so 'EU' is the right scope.
+            expect(railJurisdictionForBank('JP')).toBe('EU')
+            expect(railJurisdictionForBank('IN')).toBe('EU')
+            expect(railJurisdictionForBank('XX')).toBe('EU')
+        })
+
         it('case-insensitive', () => {
             expect(railJurisdictionForBank('us')).toBe('US')
             expect(railJurisdictionForBank('pt')).toBe('EU')

--- a/src/utils/bridge.utils.ts
+++ b/src/utils/bridge.utils.ts
@@ -10,6 +10,33 @@ export interface CurrencyConfig {
 export type BridgeOperationType = 'onramp' | 'offramp'
 
 /**
+ * Map a country selection to the rail-jurisdiction code its bank rail uses
+ * in the capability model. Bridge SEPA rails are stored with country='EU'
+ * (one rail spans all 27 EU member states); ACH/SPEI/Faster Payments use
+ * their own ISO2. Manteca rails are stored under the user's country
+ * (BR/AR). Used by deposit/withdraw bank pages to country-scope the
+ * capability gate so a stuck PENDING rail in country X doesn't block
+ * country Y's flow (e.g. a ghost BANK_TRANSFER_AR rail shouldn't keep the
+ * Portugal-SEPA page in a "Setting up your account…" wait loop).
+ *
+ * Returns undefined for missing/unknown — caller should omit the country
+ * field from the gate scope so the filter falls back to channel-only.
+ */
+export const railJurisdictionForBank = (countryId: string | null | undefined): string | undefined => {
+    if (!countryId) return undefined
+    const upper = countryId.toUpperCase()
+    if (upper === 'US' || upper === 'USA') return 'US'
+    if (upper === 'MX' || upper === 'MEX') return 'MX'
+    if (upper === 'GB' || upper === 'GBR') return 'GB'
+    if (upper === 'AR' || upper === 'ARG') return 'AR'
+    if (upper === 'BR' || upper === 'BRA') return 'BR'
+    // Every other country we serve via Bridge does so via SEPA, which is
+    // catalogued as a single EU-jurisdiction rail (matches getCurrencyConfig
+    // default below).
+    return 'EU'
+}
+
+/**
  * Get currency configuration for a specific country and operation type
  * USA -> USD/ACH, Mexico -> MXN/SPEI, everything else -> EUR/SEPA
  * Payment rails differ between onramp and offramp operations

--- a/src/utils/bridge.utils.ts
+++ b/src/utils/bridge.utils.ts
@@ -19,8 +19,15 @@ export type BridgeOperationType = 'onramp' | 'offramp'
  * country Y's flow (e.g. a ghost BANK_TRANSFER_AR rail shouldn't keep the
  * Portugal-SEPA page in a "Setting up your account…" wait loop).
  *
- * Returns undefined for missing/unknown — caller should omit the country
- * field from the gate scope so the filter falls back to channel-only.
+ * Contract:
+ * - missing input (null/undefined/empty) → undefined; the gate falls back
+ *   to a channel-only scope.
+ * - recognized US/MX/GB/AR/BR → the matching ISO2 code.
+ * - anything else → 'EU'. This intentionally mirrors `getCurrencyConfig`'s
+ *   "everything else → SEPA/EUR" default. Returning undefined here would
+ *   re-introduce the original bug (unscoped gate sees stuck pending rails
+ *   from unrelated jurisdictions); Bridge serves every other country we
+ *   support via SEPA, so 'EU' is the right scope for any unmapped entry.
  */
 export const railJurisdictionForBank = (countryId: string | null | undefined): string | undefined => {
     if (!countryId) return undefined
@@ -30,9 +37,6 @@ export const railJurisdictionForBank = (countryId: string | null | undefined): s
     if (upper === 'GB' || upper === 'GBR') return 'GB'
     if (upper === 'AR' || upper === 'ARG') return 'AR'
     if (upper === 'BR' || upper === 'BRA') return 'BR'
-    // Every other country we serve via Bridge does so via SEPA, which is
-    // catalogued as a single EU-jurisdiction rail (matches getCurrencyConfig
-    // default below).
     return 'EU'
 }
 


### PR DESCRIPTION
## Summary
- New helper `railJurisdictionForBank(countryId)` in `src/utils/bridge.utils.ts` maps a country to the rail catalog's jurisdiction code (PT/DE/FR/… → `'EU'` since SEPA is a single EU-wide rail; US/MX/GB stay as ISO2; AR/BR map to themselves for Manteca rails).
- `add-money/[country]/bank/page.tsx` and `withdraw/[country]/bank/page.tsx` now pass `country` to `gateFor('deposit'/'withdraw', { channel: 'bank', country })`. A stuck PENDING rail in country X can no longer block country Y's bank page.
- Resolves the long-standing TODO in the gate-call comment.

## Why
`testaaakyc52` (staging, today) signed up, did KYC, then tried "add money from bank → Portugal". Stuck on "Setting up your account…" forever. Reason: the gate's `{channel: 'bank'}` scope included a leftover PENDING `BANK_TRANSFER_AR` rail (from the unfixed LATAM auto-enroll bug), so the gate kept returning `{kind: 'pending'}` regardless of which country page the user was on.

This PR is the defence-in-depth fix. The root-cause BE fix is the companion PR.

## Behaviour
| Country | Gate scope before | Gate scope after |
|---|---|---|
| Portugal / Germany / Spain | `{channel: 'bank'}` | `{channel: 'bank', country: 'EU'}` |
| United States | `{channel: 'bank'}` | `{channel: 'bank', country: 'US'}` |
| Mexico | `{channel: 'bank'}` | `{channel: 'bank', country: 'MX'}` |
| United Kingdom | `{channel: 'bank'}` | `{channel: 'bank', country: 'GB'}` |
| Argentina | `{channel: 'bank'}` | `{channel: 'bank', country: 'AR'}` |
| Brazil | `{channel: 'bank'}` | `{channel: 'bank', country: 'BR'}` |
| (missing/unknown country) | `{channel: 'bank'}` | `{channel: 'bank'}` (helper returns undefined → falls back to channel-only) |

## Not in scope
- `AddWithdrawCountriesList` and `BankFlowManager.view` also call `gateFor('deposit', { channel: 'bank' })` — left alone because they don't yet have a single country in scope (former is the picker itself; latter is for claim-link bank flow). Worth a follow-up if those surfaces show the same wait-spinner regression.

## Companion PR
- BE: peanutprotocol/peanut-api-ts#917 — removes `BANK_TRANSFER_AR` from `REGION_RAIL_MAP.LATAM` (root-cause fix).

## Test plan
- [x] Unit: 13 new tests in `src/utils/__tests__/bridge.utils.test.ts` covering US/USA, MX/MEX, GB/GBR, AR/ARG, BR/BRA, all EU SEPA countries → 'EU', missing/null input → undefined, case-insensitivity.
- [x] Existing 63 bridge.utils tests still pass.
- [ ] Manual on staging after deploy: `testaaakyc52` (already has stuck BANK_TRANSFER_AR) → "add money from bank → Portugal" no longer shows the spinner; instead surfaces `needs-enrollment` (cross-region KYC modal) as designed.