### PR TITLE
fix(qr-pay): refetch + skip Sumsub modal when QR-pool already enabled

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -78,6 +78,36 @@ const MIN_QR_PAYMENT_AMOUNT = '0.1'
 
 type PaymentProcessor = 'MANTECA'
 
+/**
+ * Has the user's account been transitioned to a state where they can ALREADY
+ * do QR payments via the Manteca corporate pool account (`tier:qr-pool`)?
+ *
+ * Used by the gate-modal CTAs to avoid (re-)triggering Sumsub identity
+ * verification on top of a user whose QR access has already been unlocked
+ * server-side (backfill / handleKycApproval / the LATAM-reentry hotfix that
+ * calls enableQrPoolRails up front) since the last poll. Reads from a fresh
+ * fetchUser() result rather than the reactive `canDo()` snapshot so the
+ * onClick callback isn't trapped in a stale closure.
+ */
+function mantecaQrPoolPaymentEnabled(
+    user:
+        | {
+              capabilities?: {
+                  rails?: Array<{ provider: string; method: string; status: string; operations?: { pay?: string } }>
+              }
+          }
+        | null
+        | undefined
+): boolean {
+    const rails = user?.capabilities?.rails ?? []
+    return rails.some(
+        (rail) =>
+            rail.provider === 'manteca' &&
+            (rail.method === 'PIX_BR' || rail.method === 'MERCADOPAGO_QR_AR') &&
+            (rail.operations?.pay ?? rail.status) === 'enabled'
+    )
+}
+
 export default function QRPayPage() {
     const searchParams = useSearchParams()
     const router = useRouter()
@@ -1021,13 +1051,25 @@ export default function QRPayPage() {
                     ctas={[
                         {
                             text: 'Unlock now',
-                            onClick: () =>
+                            onClick: async () => {
+                                // Defensive: refetch user before triggering the KYC flow.
+                                // A sibling flow (e.g. a backfill / handleKycApproval re-run / the
+                                // /users/identity LATAM hotfix that calls enableQrPoolRails up front)
+                                // may have enabled the Manteca×PIX_BR + Manteca×MERCADOPAGO_QR_AR
+                                // rails since the last poll. If so, the gate transitions to
+                                // PROCEED_TO_PAY on the next render and this modal auto-closes —
+                                // we should NOT pop the Sumsub SDK on top of an already-unlocked
+                                // user. Reads from the fresh fetch result to avoid the stale
+                                // closure trap (canDo() from useCapabilities updates async).
+                                const refreshed = await fetchUser()
+                                if (mantecaQrPoolPaymentEnabled(refreshed)) return
                                 sumsubFlow.handleInitiateKyc(
                                     'LATAM',
                                     undefined,
                                     isKycApproved || undefined,
                                     targetMantecaCountry
-                                ),
+                                )
+                            },
                             variant: 'purple',
                             shadowSize: '4',
                             icon: 'check-circle',
@@ -1044,13 +1086,19 @@ export default function QRPayPage() {
                     ctas={[
                         {
                             text: 'Continue',
-                            onClick: () =>
+                            onClick: async () => {
+                                // Same defensive refetch as the REQUIRES_IDENTITY_VERIFICATION
+                                // CTA above — if a backfill / hotfix transitioned the rails
+                                // since the last poll, skip re-initiating Sumsub.
+                                const refreshed = await fetchUser()
+                                if (mantecaQrPoolPaymentEnabled(refreshed)) return
                                 sumsubFlow.handleInitiateKyc(
                                     'LATAM',
                                     undefined,
                                     isKycApproved || undefined,
                                     targetMantecaCountry
-                                ),
+                                )
+                            },
                             variant: 'purple',
                             shadowSize: '4',
                             icon: 'check-circle',


### PR DESCRIPTION
## Summary
- The "Unlock QR payments" / "Almost there" gate-modal CTAs on `/qr-pay` now `await fetchUser()` first and short-circuit if Manteca×PIX_BR or Manteca×MERCADOPAGO_QR_AR is already in `operations.pay === 'enabled'` (or `status === 'enabled'`) state.
- Prevents firing `sumsubFlow.handleInitiateKyc('LATAM', ...)` on top of a user whose QR access has already been unlocked server-side. Gate transitions to PROCEED_TO_PAY on the next render and the modal closes naturally.

## Why
FE-side follow-up to two BE changes shipped today (2026-06-01):

1. **Prod backfill** (`scripts/backfill-qr-pool-rails.ts --apply`): 4,015 user_rail rows touched across 2,492 Sumsub-approved users — all now have `tier:qr-pool` Manteca rails ENABLED.
2. **BE hotfix** (peanutprotocol/peanut-api-ts#920): `/users/identity` LATAM re-entry path now calls `enableQrPoolRails()` up front, before the Manteca-action creation.

In both cases the user's QR access is unlocked server-side, but cached FE state (esp. before the next `useUserAutoRefresh` ~4s poll) can still show `kycGateState === REQUIRES_IDENTITY_VERIFICATION`. The pre-existing onClick fired the LATAM Sumsub flow unconditionally → the user got a Manteca KYC modal even though they were already unlocked.

The defensive refetch closes this race: the fresh `fetchUser()` result is read directly (avoids the stale-closure trap of `canDo()` from `useCapabilities()` that updates async via React Query).

## Helper

```ts
function mantecaQrPoolPaymentEnabled(user) {
    const rails = user?.capabilities?.rails ?? []
    return rails.some(
        (rail) =>
            rail.provider === 'manteca' &&
            (rail.method === 'PIX_BR' || rail.method === 'MERCADOPAGO_QR_AR') &&
            (rail.operations?.pay ?? rail.status) === 'enabled'
    )
}
```

Reads `operations.pay` with fallback to `rail.status` — matches the resolver's documented `operations?.[op] ?? status` semantics (`src/types/capabilities.ts:69`).

## Companion PR
- BE: peanutprotocol/peanut-api-ts#920 — `enableQrPoolRails` on `/users/identity` LATAM re-entry path.

## Test plan
- [x] tsc clean on the touched file
- [x] prettier formatted
- [ ] Manual on staging: log in as a Sumsub-approved user without Manteca KYC → tap "Unlock now" → confirm no Manteca Sumsub modal pops on top of an already-unlocked account.
- [ ] Manual on staging: log in as a user with NO Manteca QR rails enabled (still genuinely needs to start KYC) → tap "Unlock now" → confirm Sumsub SDK opens as today (no regression).