### PR TITLE
fix(qr-pay): auto-dismiss Sumsub flow when QR-pool unlocks mid-flight

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -211,6 +211,26 @@ export default function QRPayPage() {
     const shouldBlockPay = kycGateState !== QrKycState.PROCEED_TO_PAY
 
     const sumsubFlow = useMultiPhaseKycFlow({})
+
+    // Auto-dismiss the Sumsub flow if the user's QR-pool rails become enabled
+    // server-side while a flow is mid-air. Two known sources:
+    //   1. The `/users/identity` LATAM re-entry path now calls
+    //      `enableQrPoolRails()` BEFORE returning the Manteca action token
+    //      (peanut-api-ts #920) — so the BE can hand back a Sumsub token AND
+    //      have just unlocked QR access in the same request. Without this,
+    //      the SDK pops on top of an already-unlocked user.
+    //   2. Out-of-band capability updates (sibling-tab refresh, manual
+    //      backfill, etc.) flip the gate to PROCEED_TO_PAY while the modal
+    //      is still open. Same outcome — close it.
+    // Cheap watcher, zero added latency on the happy path: relies on the
+    // existing useUserAutoRefresh / fetchUser polling already in place.
+    useEffect(() => {
+        if (kycGateState !== QrKycState.PROCEED_TO_PAY) return
+        if (sumsubFlow.showWrapper || sumsubFlow.isModalOpen) {
+            sumsubFlow.completeFlow()
+        }
+    }, [kycGateState, sumsubFlow.showWrapper, sumsubFlow.isModalOpen, sumsubFlow.completeFlow])
+
     const queryClient = useQueryClient()
     const [isShaking, setIsShaking] = useState(false)
     const [shakeIntensity, setShakeIntensity] = useState<ShakeIntensity>('none')


### PR DESCRIPTION
## Summary
A 20-line reactive `useEffect` that watches `kycGateState` and dismisses the in-flight Sumsub flow if QR-pool rails get enabled server-side while the modal is open. Zero added latency.

## Why
Replaces closed PR #2141 (defensive `await fetchUser()` on every CTA click). That added ~hundreds of ms to every "Unlock now" tap to fix a narrow race — bad cost/benefit.

This version triggers only when:
1. `kycGateState` flips to `PROCEED_TO_PAY` (i.e. `canDo('pay', manteca)` became true via the next `useUserAutoRefresh` poll), AND
2. The Sumsub SDK / multi-phase modal is currently open

When both are true, calls `sumsubFlow.completeFlow()` to dismiss. Common-case "Unlock now" tap → unchanged.

## What it catches

1. **peanut-api-ts #920** — `/users/identity` LATAM re-entry now calls `enableQrPoolRails()` BEFORE returning the Manteca action token. The BE can hand back a Sumsub token AND have just unlocked QR access in the same request → SDK pops on top of an already-unlocked user. The watcher dismisses it on the next poll cycle.
2. **Out-of-band capability updates** — sibling-tab refresh, manual backfill, support tooling — anything that flips the gate to `PROCEED_TO_PAY` while a modal is open.

## Companion PR
- BE: [peanutprotocol/peanut-api-ts#920](https://github.com/peanutprotocol/peanut-api-ts/pull/920) — `enableQrPoolRails` on initiate-kyc LATAM re-entry

## Test plan
- [x] tsc clean
- [x] prettier formatted
- [ ] Manual on staging: trigger BE #920 path (already-Sumsub-approved user with no Manteca taps "Unlock now") → confirm Sumsub SDK opens briefly, then auto-dismisses within ~4s when the poll picks up the enabled rails.
- [ ] Regression: user who genuinely needs to start Sumsub from scratch (no QR-pool, no Sumsub APPROVED) → confirm SDK opens normally, watcher does nothing.