### PR TITLE
feat(card): host Rain card legal pages + wire onboarding links

### DIFF
--- a/src/app/[locale]/(marketing)/card-privacy/page.tsx
+++ b/src/app/[locale]/(marketing)/card-privacy/page.tsx
@@ -1,0 +1,83 @@
+import { notFound } from 'next/navigation'
+import { type Metadata } from 'next'
+import { generateMetadata as metadataHelper } from '@/app/metadata'
+import { SUPPORTED_LOCALES, getAlternates, isValidLocale } from '@/i18n/config'
+import { getTranslations } from '@/i18n'
+import { ContentPage } from '@/components/Marketing/ContentPage'
+import { readPageContentLocalized } from '@/lib/content'
+import { renderContent } from '@/lib/mdx'
+
+interface PageProps {
+    params: Promise<{ locale: string }>
+}
+
+interface LegalFrontmatter {
+    title: string
+    description: string
+    slug: string
+    published?: boolean
+    last_updated?: string
+}
+
+const SLUG = 'card-privacy'
+
+export async function generateStaticParams() {
+    return SUPPORTED_LOCALES.map((locale) => ({ locale }))
+}
+export const dynamicParams = false
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { locale } = await params
+    if (!isValidLocale(locale)) return {}
+
+    const mdxContent = readPageContentLocalized<LegalFrontmatter>('legal', SLUG, locale)
+    if (!mdxContent || mdxContent.frontmatter.published === false) return {}
+
+    return {
+        ...metadataHelper({
+            title: mdxContent.frontmatter.title,
+            description: mdxContent.frontmatter.description,
+            canonical: `/${locale}/${SLUG}`,
+        }),
+        alternates: {
+            canonical: `/${locale}/${SLUG}`,
+            languages: getAlternates(SLUG),
+        },
+    }
+}
+
+export default async function CardPrivacyPage({ params }: PageProps) {
+    const { locale } = await params
+    if (!isValidLocale(locale)) notFound()
+
+    const mdxSource = readPageContentLocalized<LegalFrontmatter>('legal', SLUG, locale)
+    if (!mdxSource || mdxSource.frontmatter.published === false) notFound()
+
+    const { content } = await renderContent(mdxSource.body)
+    const i18n = getTranslations(locale)
+
+    const displayTitle = mdxSource.frontmatter.title.replace(/\s*\|\s*Peanut$/, '')
+    const url = `/${locale}/${SLUG}`
+
+    return (
+        <ContentPage
+            locale={locale}
+            breadcrumbs={[
+                { name: i18n.home, href: `/${locale}` },
+                { name: displayTitle, href: url },
+            ]}
+            article={
+                mdxSource.frontmatter.last_updated
+                    ? {
+                          title: mdxSource.frontmatter.title,
+                          description: mdxSource.frontmatter.description,
+                          url,
+                          datePublished: mdxSource.frontmatter.last_updated,
+                      }
+                    : undefined
+            }
+        >
+            {content}
+        </ContentPage>
+    )
+}

--- a/src/app/[locale]/(marketing)/card-prohibited-activities/page.tsx
+++ b/src/app/[locale]/(marketing)/card-prohibited-activities/page.tsx
@@ -1,0 +1,83 @@
+import { notFound } from 'next/navigation'
+import { type Metadata } from 'next'
+import { generateMetadata as metadataHelper } from '@/app/metadata'
+import { SUPPORTED_LOCALES, getAlternates, isValidLocale } from '@/i18n/config'
+import { getTranslations } from '@/i18n'
+import { ContentPage } from '@/components/Marketing/ContentPage'
+import { readPageContentLocalized } from '@/lib/content'
+import { renderContent } from '@/lib/mdx'
+
+interface PageProps {
+    params: Promise<{ locale: string }>
+}
+
+interface LegalFrontmatter {
+    title: string
+    description: string
+    slug: string
+    published?: boolean
+    last_updated?: string
+}
+
+const SLUG = 'card-prohibited-activities'
+
+export async function generateStaticParams() {
+    return SUPPORTED_LOCALES.map((locale) => ({ locale }))
+}
+export const dynamicParams = false
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { locale } = await params
+    if (!isValidLocale(locale)) return {}
+
+    const mdxContent = readPageContentLocalized<LegalFrontmatter>('legal', SLUG, locale)
+    if (!mdxContent || mdxContent.frontmatter.published === false) return {}
+
+    return {
+        ...metadataHelper({
+            title: mdxContent.frontmatter.title,
+            description: mdxContent.frontmatter.description,
+            canonical: `/${locale}/${SLUG}`,
+        }),
+        alternates: {
+            canonical: `/${locale}/${SLUG}`,
+            languages: getAlternates(SLUG),
+        },
+    }
+}
+
+export default async function CardProhibitedActivitiesPage({ params }: PageProps) {
+    const { locale } = await params
+    if (!isValidLocale(locale)) notFound()
+
+    const mdxSource = readPageContentLocalized<LegalFrontmatter>('legal', SLUG, locale)
+    if (!mdxSource || mdxSource.frontmatter.published === false) notFound()
+
+    const { content } = await renderContent(mdxSource.body)
+    const i18n = getTranslations(locale)
+
+    const displayTitle = mdxSource.frontmatter.title.replace(/\s*\|\s*Peanut$/, '')
+    const url = `/${locale}/${SLUG}`
+
+    return (
+        <ContentPage
+            locale={locale}
+            breadcrumbs={[
+                { name: i18n.home, href: `/${locale}` },
+                { name: displayTitle, href: url },
+            ]}
+            article={
+                mdxSource.frontmatter.last_updated
+                    ? {
+                          title: mdxSource.frontmatter.title,
+                          description: mdxSource.frontmatter.description,
+                          url,
+                          datePublished: mdxSource.frontmatter.last_updated,
+                      }
+                    : undefined
+            }
+        >
+            {content}
+        </ContentPage>
+    )
+}

--- a/src/app/[locale]/(marketing)/card-terms-international/page.tsx
+++ b/src/app/[locale]/(marketing)/card-terms-international/page.tsx
@@ -1,0 +1,83 @@
+import { notFound } from 'next/navigation'
+import { type Metadata } from 'next'
+import { generateMetadata as metadataHelper } from '@/app/metadata'
+import { SUPPORTED_LOCALES, getAlternates, isValidLocale } from '@/i18n/config'
+import { getTranslations } from '@/i18n'
+import { ContentPage } from '@/components/Marketing/ContentPage'
+import { readPageContentLocalized } from '@/lib/content'
+import { renderContent } from '@/lib/mdx'
+
+interface PageProps {
+    params: Promise<{ locale: string }>
+}
+
+interface LegalFrontmatter {
+    title: string
+    description: string
+    slug: string
+    published?: boolean
+    last_updated?: string
+}
+
+const SLUG = 'card-terms-international'
+
+export async function generateStaticParams() {
+    return SUPPORTED_LOCALES.map((locale) => ({ locale }))
+}
+export const dynamicParams = false
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { locale } = await params
+    if (!isValidLocale(locale)) return {}
+
+    const mdxContent = readPageContentLocalized<LegalFrontmatter>('legal', SLUG, locale)
+    if (!mdxContent || mdxContent.frontmatter.published === false) return {}
+
+    return {
+        ...metadataHelper({
+            title: mdxContent.frontmatter.title,
+            description: mdxContent.frontmatter.description,
+            canonical: `/${locale}/${SLUG}`,
+        }),
+        alternates: {
+            canonical: `/${locale}/${SLUG}`,
+            languages: getAlternates(SLUG),
+        },
+    }
+}
+
+export default async function CardTermsInternationalPage({ params }: PageProps) {
+    const { locale } = await params
+    if (!isValidLocale(locale)) notFound()
+
+    const mdxSource = readPageContentLocalized<LegalFrontmatter>('legal', SLUG, locale)
+    if (!mdxSource || mdxSource.frontmatter.published === false) notFound()
+
+    const { content } = await renderContent(mdxSource.body)
+    const i18n = getTranslations(locale)
+
+    const displayTitle = mdxSource.frontmatter.title.replace(/\s*\|\s*Peanut$/, '')
+    const url = `/${locale}/${SLUG}`
+
+    return (
+        <ContentPage
+            locale={locale}
+            breadcrumbs={[
+                { name: i18n.home, href: `/${locale}` },
+                { name: displayTitle, href: url },
+            ]}
+            article={
+                mdxSource.frontmatter.last_updated
+                    ? {
+                          title: mdxSource.frontmatter.title,
+                          description: mdxSource.frontmatter.description,
+                          url,
+                          datePublished: mdxSource.frontmatter.last_updated,
+                      }
+                    : undefined
+            }
+        >
+            {content}
+        </ContentPage>
+    )
+}

--- a/src/app/[locale]/(marketing)/card-terms-us/page.tsx
+++ b/src/app/[locale]/(marketing)/card-terms-us/page.tsx
@@ -1,0 +1,83 @@
+import { notFound } from 'next/navigation'
+import { type Metadata } from 'next'
+import { generateMetadata as metadataHelper } from '@/app/metadata'
+import { SUPPORTED_LOCALES, getAlternates, isValidLocale } from '@/i18n/config'
+import { getTranslations } from '@/i18n'
+import { ContentPage } from '@/components/Marketing/ContentPage'
+import { readPageContentLocalized } from '@/lib/content'
+import { renderContent } from '@/lib/mdx'
+
+interface PageProps {
+    params: Promise<{ locale: string }>
+}
+
+interface LegalFrontmatter {
+    title: string
+    description: string
+    slug: string
+    published?: boolean
+    last_updated?: string
+}
+
+const SLUG = 'card-terms-us'
+
+export async function generateStaticParams() {
+    return SUPPORTED_LOCALES.map((locale) => ({ locale }))
+}
+export const dynamicParams = false
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { locale } = await params
+    if (!isValidLocale(locale)) return {}
+
+    const mdxContent = readPageContentLocalized<LegalFrontmatter>('legal', SLUG, locale)
+    if (!mdxContent || mdxContent.frontmatter.published === false) return {}
+
+    return {
+        ...metadataHelper({
+            title: mdxContent.frontmatter.title,
+            description: mdxContent.frontmatter.description,
+            canonical: `/${locale}/${SLUG}`,
+        }),
+        alternates: {
+            canonical: `/${locale}/${SLUG}`,
+            languages: getAlternates(SLUG),
+        },
+    }
+}
+
+export default async function CardTermsUsPage({ params }: PageProps) {
+    const { locale } = await params
+    if (!isValidLocale(locale)) notFound()
+
+    const mdxSource = readPageContentLocalized<LegalFrontmatter>('legal', SLUG, locale)
+    if (!mdxSource || mdxSource.frontmatter.published === false) notFound()
+
+    const { content } = await renderContent(mdxSource.body)
+    const i18n = getTranslations(locale)
+
+    const displayTitle = mdxSource.frontmatter.title.replace(/\s*\|\s*Peanut$/, '')
+    const url = `/${locale}/${SLUG}`
+
+    return (
+        <ContentPage
+            locale={locale}
+            breadcrumbs={[
+                { name: i18n.home, href: `/${locale}` },
+                { name: displayTitle, href: url },
+            ]}
+            article={
+                mdxSource.frontmatter.last_updated
+                    ? {
+                          title: mdxSource.frontmatter.title,
+                          description: mdxSource.frontmatter.description,
+                          url,
+                          datePublished: mdxSource.frontmatter.last_updated,
+                      }
+                    : undefined
+            }
+        >
+            {content}
+        </ContentPage>
+    )
+}

--- a/src/components/Card/CardTermsScreen.tsx
+++ b/src/components/Card/CardTermsScreen.tsx
@@ -17,12 +17,13 @@ interface Props {
 // stands in for Peanut. Swap if the partnership agreement renames the card.
 const CARD_PARTNER_NAME = 'Peanut'
 
+// US and international cardholders accept different card-terms documents.
 const LINKS = {
     eSign: 'https://legal.raincards.xyz/legal/electronic-communications-notice',
     issuerPrivacy: 'https://www.third-national.com/privacypolicy',
-    // TODO: swap placeholders with the real links when Rain/partner share them.
-    cardTerms: '#',
-    accountOpeningPrivacy: '#',
+    cardTermsUs: 'https://peanut.me/en/card-terms-us',
+    cardTermsInternational: 'https://peanut.me/en/card-terms-international',
+    accountOpeningPrivacy: 'https://peanut.me/en/card-privacy',
 }
 
 interface Term {
@@ -36,49 +37,53 @@ const ExternalLink: FC<{ href: string; children: ReactNode }> = ({ href, childre
     </a>
 )
 
-const INT_TERMS: Term[] = [
-    {
-        id: 'esign',
-        label: (
-            <>
-                I accept the <ExternalLink href={LINKS.eSign}>E-Sign Consent</ExternalLink>
-            </>
-        ),
-    },
-    {
-        id: 'cardTermsIssuer',
-        label: (
-            <>
-                I accept the <ExternalLink href={LINKS.cardTerms}>{CARD_PARTNER_NAME} Card Terms</ExternalLink>
-                {', and the '}
-                <ExternalLink href={LINKS.issuerPrivacy}>Issuer Privacy Policy</ExternalLink>
-            </>
-        ),
-    },
-    {
-        id: 'accuracy',
-        label: `I certify that the information I have provided is accurate and that I will abide by all the rules and requirements related to my ${CARD_PARTNER_NAME} Spend Card.`,
-    },
-    {
-        id: 'solicitation',
-        label: `I acknowledge that applying for the ${CARD_PARTNER_NAME} Spend Card does not constitute unauthorized solicitation.`,
-    },
-]
+const esignTerm: Term = {
+    id: 'esign',
+    label: (
+        <>
+            I accept the <ExternalLink href={LINKS.eSign}>E-Sign Consent</ExternalLink>
+        </>
+    ),
+}
+
+const cardTermsIssuerTerm = (cardTermsHref: string): Term => ({
+    id: 'cardTermsIssuer',
+    label: (
+        <>
+            I accept the <ExternalLink href={cardTermsHref}>{CARD_PARTNER_NAME} Card Terms</ExternalLink>
+            {', and the '}
+            <ExternalLink href={LINKS.issuerPrivacy}>Issuer Privacy Policy</ExternalLink>
+        </>
+    ),
+})
+
+const accuracyTerm: Term = {
+    id: 'accuracy',
+    label: `I certify that the information I have provided is accurate and that I will abide by all the rules and requirements related to my ${CARD_PARTNER_NAME} Spend Card.`,
+}
+
+const solicitationTerm: Term = {
+    id: 'solicitation',
+    label: `I acknowledge that applying for the ${CARD_PARTNER_NAME} Spend Card does not constitute unauthorized solicitation.`,
+}
+
+const accountOpeningPrivacyTerm: Term = {
+    id: 'accountOpeningPrivacy',
+    label: (
+        <>
+            I accept the <ExternalLink href={LINKS.accountOpeningPrivacy}>Account Opening Privacy Notice</ExternalLink>
+        </>
+    ),
+}
+
+const INT_TERMS: Term[] = [esignTerm, cardTermsIssuerTerm(LINKS.cardTermsInternational), accuracyTerm, solicitationTerm]
 
 const US_TERMS: Term[] = [
-    INT_TERMS[0],
-    {
-        id: 'accountOpeningPrivacy',
-        label: (
-            <>
-                I accept the{' '}
-                <ExternalLink href={LINKS.accountOpeningPrivacy}>Account Opening Privacy Notice</ExternalLink>
-            </>
-        ),
-    },
-    INT_TERMS[1],
-    INT_TERMS[2],
-    INT_TERMS[3],
+    esignTerm,
+    accountOpeningPrivacyTerm,
+    cardTermsIssuerTerm(LINKS.cardTermsUs),
+    accuracyTerm,
+    solicitationTerm,
 ]
 
 const CardTermsScreen: FC<Props> = ({ isUsResident, onAccept, onPrev, submitError }) => {

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -20,6 +20,10 @@ export const ROUTE_SLUGS = [
     'supported-networks',
     'terms',
     'privacy',
+    'card-terms-us',
+    'card-terms-international',
+    'card-privacy',
+    'card-prohibited-activities',
 ] as const
 
 export type RouteSlug = (typeof ROUTE_SLUGS)[number]


### PR DESCRIPTION
## What
Hosts the four Rain card legal documents at stable URLs and wires them into the card onboarding terms screen, replacing the `'#'` placeholders.

New marketing routes (mirror the existing `/terms` + `/privacy` pattern):
- `/{locale}/card-terms-us` — U.S. consumer card terms
- `/{locale}/card-terms-international` — international consumer card terms
- `/{locale}/card-privacy` — account-opening privacy notice (U.S.)
- `/{locale}/card-prohibited-activities` — prohibited activities policy

## Changes
- `src/i18n/config.ts` — register the 4 slugs in `ROUTE_SLUGS`.
- 4 route `page.tsx` under `[locale]/(marketing)/` — identical to `terms/page.tsx`, reading `content/legal/<slug>`.
- `src/components/Card/CardTermsScreen.tsx` — replace the two `'#'` placeholders with the real hosted URLs. **US and international cardholders accept different card-terms documents**, so the card-terms link is now split by residency (`cardTermsUs` / `cardTermsInternational`). E-Sign still points at Rain's hosted notice; Issuer Privacy still points at Third National.

## Content dependency (ordering)
The page bodies are authored in **mono** `content/legal/card-*/en.md` and reach peanut-ui via the peanut-content mirror → `src/content` submodule bump. **These routes 404 until that content lands.** Merge the mono content first (or concurrently); this PR is the code side.

## Notes
- Legal text is English-only for now (`en.md`); links are pinned to `/en/…` to match what's submitted to Rain.
- Fees in the hosted docs are currently **0 / None** (see compliance watch-outs) — must match the fee form on file with Rain before launch.

## Test
- `tsc` clean on changed files (pre-existing SEOFooter/asset-decl noise only, unrelated).
- Routes render once the mono content mirror lands.