### PR TITLE
fix(card): gate card-unlock history row on an issued card, not access

### DIFF
--- a/src/components/Card/__tests__/cardUnlock.types.test.ts
+++ b/src/components/Card/__tests__/cardUnlock.types.test.ts
@@ -1,0 +1,71 @@
+import { deriveCardUnlockEntry, isCardUnlockHistoryItem } from '../cardUnlock.types'
+
+describe('deriveCardUnlockEntry', () => {
+    const earnedAt = '2025-10-12T00:00:00.000Z'
+
+    it('returns null for an access-only user with NO issued card (the gabby/dragon bug)', () => {
+        // Holds the OG skip badge → hasCardAccess, but never got a card.
+        // Pre-fix this surfaced a "You skipped the line" share asset to
+        // ~33% of users. Gating on hasIssuedCard kills it.
+        expect(
+            deriveCardUnlockEntry({
+                hasIssuedCard: false,
+                hasCardAccess: true,
+                cardAccessGrantedAt: null,
+                skipBadges: ['OG_2025_10_12'],
+                userBadges: [{ code: 'OG_2025_10_12', earnedAt }],
+            })
+        ).toBeNull()
+    })
+
+    it('returns null for an admin-granted user with no issued card', () => {
+        expect(
+            deriveCardUnlockEntry({
+                hasIssuedCard: false,
+                hasCardAccess: true,
+                cardAccessGrantedAt: '2026-06-01T00:00:00.000Z',
+                skipBadges: [],
+            })
+        ).toBeNull()
+    })
+
+    it('returns a badge entry once the user actually has a card', () => {
+        const entry = deriveCardUnlockEntry({
+            hasIssuedCard: true,
+            hasCardAccess: true,
+            cardAccessGrantedAt: null,
+            skipBadges: ['OG_2025_10_12'],
+            userBadges: [{ code: 'OG_2025_10_12', earnedAt }],
+        })
+        expect(entry).not.toBeNull()
+        expect(entry?.via).toBe('badge')
+        expect(entry?.badgeCode).toBe('OG_2025_10_12')
+        expect(entry?.timestamp).toBe(earnedAt)
+        expect(isCardUnlockHistoryItem(entry)).toBe(true)
+    })
+
+    it('returns an admin entry (no badge) when granted + card issued', () => {
+        const grantedAt = '2026-06-01T00:00:00.000Z'
+        const entry = deriveCardUnlockEntry({
+            hasIssuedCard: true,
+            hasCardAccess: true,
+            cardAccessGrantedAt: grantedAt,
+            skipBadges: [],
+        })
+        expect(entry?.via).toBe('admin')
+        expect(entry?.timestamp).toBe(grantedAt)
+    })
+
+    it('returns null when a card exists but no derivable timestamp', () => {
+        // hasIssuedCard but no grant + no skip-badge earnedAt → nothing to
+        // anchor the row to; don't fabricate one.
+        expect(
+            deriveCardUnlockEntry({
+                hasIssuedCard: true,
+                hasCardAccess: true,
+                cardAccessGrantedAt: null,
+                skipBadges: [],
+            })
+        ).toBeNull()
+    })
+})

--- a/src/components/Card/cardUnlock.types.ts
+++ b/src/components/Card/cardUnlock.types.ts
@@ -3,8 +3,9 @@
  * synthetic-entry pattern. Surfaces in the user's activity feed so they
  * can re-open the share asset they earned on the celebration moment.
  *
- * No DB table needed — derived client-side from the user's
- * cardAccessGrantedAt timestamp + the skip-badge they hold.
+ * No DB table needed — derived client-side. Only surfaces once the user
+ * has an issued card (see deriveCardUnlockEntry); the timestamp comes from
+ * their cardAccessGrantedAt or earliest skip-badge earnedAt.
  */
 
 export type CardUnlockVia = 'badge' | 'admin' | 'public-launch'
@@ -30,19 +31,29 @@ export const isCardUnlockHistoryItem = (entry: unknown): entry is CardUnlockHist
     )
 }
 
-/** Returns null if the user doesn't have card access yet. Otherwise picks
- *  the best available timestamp:
+/** Returns null unless the user has ACTUALLY been issued a card. Card
+ *  *access* (a skip badge or an admin grant) is NOT enough — it only means
+ *  the user is allowed a card, not that they ever entered the flow or got
+ *  one. Gating on access alone surfaced this share-asset row + "I got my
+ *  Peanut card" image to ~33% of users (every OG / Devconnect / Arbiverse /
+ *  Pioneer badge holder), the vast majority of whom never received a card.
+ *
+ *  Once gated on `hasIssuedCard`, picks the best available timestamp:
  *    1. Explicit `cardAccessGrantedAt` (admin grant / waitlist release).
  *    2. Earliest skip-badge `earnedAt` (badge-driven access — user has
  *       been "in" since they earned the badge, even if the BE never
  *       stamped a separate grant timestamp).
  *  If neither is present, returns null rather than fabricating one. */
 export function deriveCardUnlockEntry(args: {
+    /** True once the user has at least one Rain card row (the only
+     *  server-verifiable signal that they got through the card flow). */
+    hasIssuedCard: boolean
     hasCardAccess: boolean
     cardAccessGrantedAt: string | null | undefined
     skipBadges: string[]
     userBadges?: Array<{ code: string; earnedAt?: string | Date | null }>
 }): CardUnlockHistoryEntry | null {
+    if (!args.hasIssuedCard) return null
     if (!args.hasCardAccess) return null
 
     let timestamp = args.cardAccessGrantedAt ?? undefined

--- a/src/components/Home/HomeHistory.tsx
+++ b/src/components/Home/HomeHistory.tsx
@@ -21,6 +21,7 @@ import { buildKycHistoryEntry } from '@/utils/kyc-grouping.utils'
 import CardUnlockHistoryItem from '../Card/CardUnlockHistoryItem'
 import { deriveCardUnlockEntry, isCardUnlockHistoryItem, type CardUnlockHistoryEntry } from '../Card/cardUnlock.types'
 import { useCardPioneerInfo } from '@/hooks/useCardPioneerInfo'
+import { useRainCardOverview } from '@/hooks/useRainCardOverview'
 import { useWallet } from '@/hooks/wallet/useWallet'
 import { BadgeStatusItem } from '@/components/Badges/BadgeStatusItem'
 import { isBadgeHistoryItem } from '@/components/Badges/badge.types'
@@ -78,6 +79,11 @@ const HomeHistory = ({
     // entry. Mirrors how kyc derives from user state. Only meaningful when
     // viewing your own history.
     const { cardInfo } = useCardPioneerInfo()
+    // The card-unlock row gates on an ACTUALLY-issued card, not mere access.
+    // Same query key the wallet already loads on home → cache read, no extra
+    // fetch. Card *access* (skip badge / admin grant) is held by ~33% of
+    // users who never got a card; only an issued card means they got through.
+    const { overview: rainOverview } = useRainCardOverview()
 
     // WebSocket for real-time updates
     const { historyEntries: wsHistoryEntries } = useWebSocket({
@@ -236,6 +242,7 @@ const HomeHistory = ({
                 // badge.
                 if (isViewingOwnHistory && cardInfo) {
                     const unlock = deriveCardUnlockEntry({
+                        hasIssuedCard: (rainOverview?.cards.length ?? 0) > 0,
                         hasCardAccess: cardInfo.hasCardAccess,
                         cardAccessGrantedAt: cardInfo.waitlistReleasedAt,
                         skipBadges: cardInfo.skipBadges,
@@ -275,7 +282,7 @@ const HomeHistory = ({
             }
         }
         return undefined
-    }, [historyData, wsHistoryEntries, user, isLoading, isViewingOwnHistory, cardInfo])
+    }, [historyData, wsHistoryEntries, user, isLoading, isViewingOwnHistory, cardInfo, rainOverview])
 
     const pendingRequests = useMemo(() => {
         if (!combinedEntries.length) return []


### PR DESCRIPTION
## What

The synthetic **\"You skipped the line\"** card-unlock row (and its shareable *\"I got my Peanut card. shhhh.\"* asset) in the home activity feed was derived from `hasCardAccess` alone (`deriveCardUnlockEntry`). It now requires the user to have an **actually-issued Rain card**.

## Why

`hasCardAccess` is true for anyone holding a skip badge (`OG_2025_10_12`, `DEVCONNECT_BA_2025`, `ARBIVERSE_DEVCONNECT_BA_2025`, `CARD_PIONEER`) **or** an admin `cardAccessGrantedAt`. That means *allowed a card*, not *got through the flow*. There was no gate on entering `/card`, seeing the celebration, or holding a card.

**Prod blast radius (read-only query, 2026-06-01):**

| | count |
|---|---|
| Total users | 9,757 |
| Card **access** (badge or grant) | **3,230** |
| Users who ever got a real card | **9** |
| **Saw the bogus item** (access, no card) | **3,221** (~33% of all users) |

Reported case: user `dragon` (gabby) — holds `OG_2025_10_12`, `flowEarlyAccess=false` (never even entered the flow), 0 cards — yet saw the item.

## How

- `deriveCardUnlockEntry` takes `hasIssuedCard` and returns `null` unless true.
- `HomeHistory` passes `hasIssuedCard` from `useRainCardOverview()` — the **same query key the wallet already loads on home**, so it's a cache read (no extra fetch).
- **No DB change.** The badges are legitimate data; the bug was purely FE gating. Nothing is mutated or stripped.

## Test

- New `cardUnlock.types.test.ts` (5 cases incl. the gabby access-only → `null` regression).
- All 60 Card/Home suites pass; prettier clean; changed files typecheck clean.

## Notes

- Hotfix off `main` — **needs back-merge to `dev`** after merge (release-flow convention) so the next release PR doesn't conflict.
- Follow-ups (not in this PR): the celebration-seen marker is still localStorage-only (`card_skip_celebration_seen_v2`); the BE `cardWaitlistSkipCelebrationSeenAt` column exists but is unwired ("Phase 5"). And the share copy ("I got my Peanut card") slightly overclaims for skip-the-line/pre-card users.