### PR TITLE
hotfix(add-money): country-scope the bank-deposit gate

### DIFF
--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -117,10 +117,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
     const { isKycApproved, gateFor, bankRails } = useCapabilities()
     const isUserKycApproved = isKycApproved
     const bankCountry = useMemo(() => railJurisdictionForBank(currentCountry?.id), [currentCountry?.id])
-    const gate = useMemo(
-        () => gateFor('deposit', { channel: 'bank', country: bankCountry }),
-        [gateFor, bankCountry]
-    )
+    const gate = useMemo(() => gateFor('deposit', { channel: 'bank', country: bankCountry }), [gateFor, bankCountry])
     const isBankRailUnderReview = useMemo(() => bankRails().some((rail) => rail.status === 'pending'), [bankRails])
     const { guardWithTos, showBridgeTos, hideTos } = useTosGuard()
     const { setIsSupportModalOpen } = useModalsContext()

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -31,6 +31,7 @@ import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { getKycModalVariant, getGateUserMessage } from '@/utils/capability-gate'
+import { railJurisdictionForBank } from '@/utils/bridge.utils'
 import { useTosGuard } from '@/hooks/useTosGuard'
 import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
 import { useModalsContext } from '@/context/ModalsContext'
@@ -89,26 +90,6 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
     const formRef = useRef<{ handleSubmit: () => void }>(null)
     const [isSupportedTokensModalOpen, setIsSupportedTokensModalOpen] = useState(false)
 
-    // Provider-blind bank-channel deposit gate + "any bank rail pending"
-    // signal (used to open the under-review status modal AFTER the gate
-    // already returned `ready`). Reads through useCapabilities's role-aware
-    // primitives — see utils/capability-gate.ts + utils/rail-channel.ts.
-    const { isKycApproved, gateFor, bankRails } = useCapabilities()
-    const isUserKycApproved = isKycApproved
-    const gate = useMemo(() => gateFor('deposit', { channel: 'bank' }), [gateFor])
-    const isBankRailUnderReview = useMemo(() => bankRails().some((rail) => rail.status === 'pending'), [bankRails])
-    const { guardWithTos, showBridgeTos, hideTos } = useTosGuard()
-    const { setIsSupportModalOpen } = useModalsContext()
-    const [showKycStatusModal, setShowKycStatusModal] = useState(false)
-
-    // stores the callback to replay after tos acceptance in the list view
-    const pendingAfterTosRef = useRef<(() => void) | null>(null)
-
-    // close kyc modal when sumsub sdk opens
-    useEffect(() => {
-        if (sumsubFlow.showWrapper) setIsKycModalOpen(false)
-    }, [sumsubFlow.showWrapper])
-
     // read country from path params (web: /add-money/india) or query params (native: /add-money?country=india)
     const countryFromQuery = searchParams.get('country')
     const viewFromQuery = searchParams.get('view')
@@ -121,6 +102,37 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
     const currentCountry = countryData.find(
         (country) => country.type === 'country' && country.path === countrySlugFromUrl
     )
+
+    // Provider-blind bank-channel deposit gate + "any bank rail pending"
+    // signal (used to open the under-review status modal AFTER the gate
+    // already returned `ready`). Reads through useCapabilities's role-aware
+    // primitives — see utils/capability-gate.ts + utils/rail-channel.ts.
+    //
+    // SCOPE: when the user is on /add-money/<country>, narrow the gate to
+    // that country's rail jurisdiction. Without this, a rejected rail in an
+    // unrelated jurisdiction (e.g. a Bridge BANK_TRANSFER_MX REJECTED row
+    // from the 2026-06-01 sync) trips `blocked-rejection` here and the user
+    // sees "We couldn't unlock this" on a country whose own rail is fine.
+    // Matches the scoping already in /add-money/[country]/bank/page.tsx.
+    const { isKycApproved, gateFor, bankRails } = useCapabilities()
+    const isUserKycApproved = isKycApproved
+    const bankCountry = useMemo(() => railJurisdictionForBank(currentCountry?.id), [currentCountry?.id])
+    const gate = useMemo(
+        () => gateFor('deposit', { channel: 'bank', country: bankCountry }),
+        [gateFor, bankCountry]
+    )
+    const isBankRailUnderReview = useMemo(() => bankRails().some((rail) => rail.status === 'pending'), [bankRails])
+    const { guardWithTos, showBridgeTos, hideTos } = useTosGuard()
+    const { setIsSupportModalOpen } = useModalsContext()
+    const [showKycStatusModal, setShowKycStatusModal] = useState(false)
+
+    // stores the callback to replay after tos acceptance in the list view
+    const pendingAfterTosRef = useRef<(() => void) | null>(null)
+
+    // close kyc modal when sumsub sdk opens
+    useEffect(() => {
+        if (sumsubFlow.showWrapper) setIsKycModalOpen(false)
+    }, [sumsubFlow.showWrapper])
 
     /** returns true if the user is gated (caller should return early) */
     const checkBridgeGate = useCallback(


### PR DESCRIPTION
## Summary

When viewing `/add-money/<country>`, narrow the bank-deposit gate to that country's rail jurisdiction. Today the gate is scoped `{ channel: 'bank' }` only, so a rejected rail in **any** country trips `blocked-rejection` and surfaces *"We couldn't unlock this — Verification issue"* even when the country the user is actually on has a healthy rail.

## Triggering incident — 2026-06-01

- A `sync-rails-from-providers` run flipped 1,595 users' `BANK_TRANSFER_MX BRIDGE` `user_rails` rows to `REJECTED`.
- `BANK_TRANSFER_MX` is a kyc-2.0 catalog seed artifact, not a real Bridge endorsement (Mexico is SPEI). The catalog row should be deactivated separately (`is_active=false` on rail `48def142-…`).
- Until the catalog row is deactivated, those REJECTED rows appear in capabilities. With the previous unscoped gate, any of those 1,595 users opening `/add-money/usa` (or any country) saw the blocked modal.

## Fix

Mirror the country-scoping already in `/add-money/[country]/bank/page.tsx`:

```ts
const bankCountry = useMemo(() => railJurisdictionForBank(currentCountry?.id), [currentCountry?.id])
const gate = useMemo(
    () => gateFor('deposit', { channel: 'bank', country: bankCountry }),
    [gateFor, bankCountry]
)
```

Country detection was already present in the same component — just moved above the gate so both can share it.

When `currentCountry` is null (the picker `/add-money` or `/withdraw` country list with no country yet), `bankCountry` is `undefined` and the gate falls back to channel-only filtering. That's the current behaviour, unchanged.

## Defense in depth

Two other actions for the full incident:

1. **Catalog deactivation** (one-row UPDATE on `app.rails`) — hides the 1,595 ghost REJECTED rows via the `isActive` filter on all user-facing reads.
2. **Sync-script audit** — the same run also wrote `REJECTED` on ~94 active-catalog rails (SEPA_EU/ACH_US/FASTER_PAYMENTS_GB/SPEI_MX) with empty `last_submission_error`. Bug to investigate + rollback.

This PR only addresses the FE gating regression. It is the broader guardrail so any future blocked-rail-in-unrelated-country can't break a working country's add-money screen.

## Test plan

- [ ] Manually open `/add-money/usa` as a user with a rejected MX bank rail — gate should be `ready`, no modal.
- [ ] Open `/add-money/mexico` as the same user — modal should still appear with the existing MX-flow copy (since the rejected rail IS in scope for MX). Behavior on MX is the only place the rejection should ever surface.
- [ ] Open `/add-money` (no country selected) — list of countries renders as before.
- [ ] Withdraw flow `/withdraw` and `/withdraw/<country>` work as before (component is shared via the `flow` prop).