### PR TITLE
hotfix(offramp): prevent double-pay after Bridge confirm timeout

### DIFF
--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -49,6 +49,15 @@ import { useSafeBack } from '@/hooks/useSafeBack'
 
 type View = 'INITIAL' | 'SUCCESS'
 
+// Copy shown when the on-chain deposit to the Bridge address succeeded but the
+// subsequent `/bridge/transfers/:id/confirm` call failed (most often a
+// fetchWithSentry timeout). The Bridge transfer row exists on the BE; the
+// poller / Bridge webhook will eventually complete it. We MUST NOT show a
+// Retry button in this state — retrying re-runs sendMoney() and would send
+// funds to the deposit address a second time (Sentry PEANUT-UI-QH9, 2026-06-01).
+const CONFIRM_PENDING_COPY =
+    'Your transfer is processing. Funds were sent on-chain successfully — this can take a few minutes to confirm. If you don’t see the withdrawal in your activity within 30 minutes, please contact support.'
+
 export default function WithdrawBankPage() {
     const {
         amountToWithdraw,
@@ -66,6 +75,10 @@ export default function WithdrawBankPage() {
     const searchParams = useSearchParams()
     const [isLoading, setIsLoading] = useState(false)
     const [view, setView] = useState<View>('INITIAL')
+    // Set as soon as the on-chain wallet→Bridge tx confirms. If a subsequent
+    // confirmOfframp() call fails, this gates the UI into a "processing" state
+    // instead of showing a Retry button that would re-fire sendMoney().
+    const [submittedTxHash, setSubmittedTxHash] = useState<string | null>(null)
     const params = useParams()
     // read country from path params (web) or query params (native/capacitor)
     const country = (params.country as string) || searchParams.get('country') || ''
@@ -267,15 +280,22 @@ export default function WithdrawBankPage() {
             // chain tx hash, and the BE rejects it.
             const txIdentifier = receipt?.transactionHash ?? txHash ?? userOpHash
             if (!txIdentifier) throw new Error('No transaction identifier returned from sendMoney')
+
+            // Mark the on-chain leg done BEFORE confirmOfframp. From this point on
+            // any error path (including a confirm timeout) must NOT offer Retry —
+            // re-running this handler would call sendMoney() again and double-pay.
+            setSubmittedTxHash(txIdentifier)
+
             const confirmResult = await confirmOfframp(data.transferId, txIdentifier)
 
             if (confirmResult.error) {
-                // This is a tricky state. The on-chain tx succeeded, but the backend failed to record it.
-                // For now, we'll show a detailed error. A more robust solution could involve a retry mechanism
-                // or flagging this for support.
+                // On-chain tx succeeded, backend confirm failed. Bridge will still
+                // process the deposit (the funds are at the deposit address and the
+                // BE has the transfer row). Show a processing state, NOT an error
+                // with a Retry button — see CONFIRM_PENDING_COPY + the gate below.
                 setError({
                     showError: true,
-                    errorMessage: `Your funds were sent, but there was an issue confirming the transfer. Please contact support.`,
+                    errorMessage: CONFIRM_PENDING_COPY,
                 })
                 throw new Error(confirmResult.error)
             }
@@ -425,7 +445,23 @@ export default function WithdrawBankPage() {
                         <PaymentInfoRow hideBottomBorder label="Fee" value={`$ 0.00`} />
                     </Card>
 
-                    {error.showError ? (
+                    {submittedTxHash ? (
+                        // On-chain leg already fired. Even if confirmOfframp failed
+                        // we must NOT offer Retry — it would re-run sendMoney() and
+                        // double-pay (Sentry PEANUT-UI-QH9). Surface the in-progress
+                        // state and a Done button that takes the user home.
+                        <Button
+                            shadowSize="4"
+                            className="w-full"
+                            onClick={() => {
+                                router.push('/home')
+                                setAmountToWithdraw('')
+                                setSelectedMethod(null)
+                            }}
+                        >
+                            Done
+                        </Button>
+                    ) : error.showError ? (
                         <Button
                             disabled={isLoading}
                             onClick={handleCreateAndInitiateOfframp}
@@ -450,7 +486,16 @@ export default function WithdrawBankPage() {
                             Withdraw
                         </Button>
                     )}
-                    {error.showError && <ErrorAlert description={error.errorMessage} />}
+                    {submittedTxHash ? (
+                        <InfoCard
+                            variant="info"
+                            icon="info"
+                            title="Transfer processing"
+                            description={CONFIRM_PENDING_COPY}
+                        />
+                    ) : (
+                        error.showError && <ErrorAlert description={error.errorMessage} />
+                    )}
                     {balanceErrorMessage && <ErrorAlert description={balanceErrorMessage} />}
                 </div>
             )}

--- a/src/app/actions/offramp.ts
+++ b/src/app/actions/offramp.ts
@@ -80,6 +80,15 @@ export async function createOfframpForGuest(
  * this calls the `/bridge/transfers/:transferId/confirm` API endpoint, providing
  * the on-chain transaction hash. This makes the transfer visible in the user's history.
  *
+ * NOTE: this is called AFTER the on-chain deposit has already succeeded — the
+ * user's money is already at the Bridge deposit address. A timeout here is
+ * NOT safe to blindly retry from the wallet side (that would re-send funds).
+ * We bump the timeout well above the 10s default so the BE has time to write
+ * the transfer row + send confirmation, matching the long-running confirm
+ * pattern used by manteca.ts / rain.ts. Callers must additionally distinguish
+ * "on-chain succeeded, confirm failed" from "on-chain never happened" before
+ * surfacing a Retry action.
+ *
  * @param transferId - The ID of the transfer to confirm.
  * @param txHash - The on-chain transaction hash from the user's deposit.
  * @returns An object containing either the successful response data or an error.
@@ -92,6 +101,7 @@ export async function confirmOfframp(
         const response = await serverFetch(`/bridge/transfers/${transferId}/confirm`, {
             method: 'POST',
             body: JSON.stringify({ txHash }),
+            timeoutMs: 60_000,
         })
 
         if (!response.ok) {

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -119,6 +119,11 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
      */
     const handleConfirmClaim = useCallback(
         async (details: TCreateOfframpResponse) => {
+            // Track whether the on-chain claim already succeeded. Once true, a
+            // failure of the subsequent confirmOfframp() must NOT bubble back to
+            // ConfirmBankClaimView as a retryable error — `onConfirm` would call
+            // claimLink() again and try to send funds twice (Sentry PEANUT-UI-QH9).
+            let claimTxSubmitted = false
             try {
                 const claimTx = await claimLink({
                     address: details.depositInstructions.toAddress,
@@ -129,6 +134,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                 if (!claimTx) {
                     throw new Error('Failed to claim link - no transaction hash returned')
                 }
+                claimTxSubmitted = true
 
                 // if a user is logged in, associate the claim with their account.
                 // this helps track their activity correctly.
@@ -141,10 +147,29 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                     }
                 }
                 setTransactionHash(claimTx)
-                await confirmOfframp(details.transferId, claimTx)
+
+                try {
+                    await confirmOfframp(details.transferId, claimTx)
+                } catch (confirmErr: any) {
+                    // On-chain claim already executed; the BE has the transfer row
+                    // and Bridge will process the deposit. Log + fall through to the
+                    // SUCCESS view rather than throwing — re-confirming retries are
+                    // safe to drop since the BE poller/webhook will reconcile.
+                    Sentry.captureException(confirmErr)
+                    console.error('confirmOfframp failed after on-chain claim succeeded', confirmErr)
+                }
+
                 if (setClaimType) setClaimType('claim-bank')
                 onCustom('SUCCESS')
             } catch (e: any) {
+                if (claimTxSubmitted) {
+                    // Defensive: even if a post-claim step throws (e.g.
+                    // setClaimType), do not surface a retryable error — the funds
+                    // are already on-chain. Log + show SUCCESS.
+                    Sentry.captureException(e)
+                    onCustom('SUCCESS')
+                    return
+                }
                 const errorString = ErrorHandler(e)
                 setError(errorString)
                 Sentry.captureException(e)

--- a/src/utils/__tests__/friendly-error.utils.test.tsx
+++ b/src/utils/__tests__/friendly-error.utils.test.tsx
@@ -25,6 +25,20 @@ describe('ErrorHandler', () => {
             )
         })
 
+        test('maps fetchWithSentry AbortError copy ("timed out after <ms>ms")', () => {
+            // Verbatim shape from sentry.utils.ts AbortError path. The Bridge
+            // offramp `/confirm` 10s timeout (Konrad, 2026-06-01, PEANUT-UI-QH9)
+            // would otherwise fall through to the generic "contact support"
+            // copy and surface a Retry button next to an on-chain leg that
+            // already fired — risking a double-pay.
+            const fetchTimeoutError = new Error(
+                'Request to https://api.peanut.me/bridge/transfers/01e7a858-a849-4daa-9df7-e680d47bcfc1/confirm timed out after 10000ms'
+            )
+            expect(ErrorHandler(fetchTimeoutError)).toBe(
+                'The network is busy and your request timed out. Please try again in a moment.'
+            )
+        })
+
         test('does NOT hijack the WebAuthn "operation either timed out" message', () => {
             // Ordering guard: the passkey-prompt timeout has its own copy and is
             // matched earlier; the generic timeout matcher must not swallow it.

--- a/src/utils/friendly-error.utils.tsx
+++ b/src/utils/friendly-error.utils.tsx
@@ -96,7 +96,16 @@ export const ErrorHandler = (error: unknown): string => {
     // viem transport timeout — most often a slow ZeroDev paymaster/bundler RPC
     // (`zd_sponsorUserOperation`) on a busy network. Transient + retryable, so
     // tell the user to try again instead of the generic "contact support".
-    if (text.includes('took too long to respond') || text.includes('The request timed out'))
+    // `timed out after` also covers our own `fetchWithSentry` AbortError copy
+    // ("Request to <url> timed out after <ms>ms") — without it, every server
+    // fetch timeout fell through to the generic "contact support" fallback
+    // (Sentry PEANUT-UI-QH9, Bridge offramp /confirm). Callers that move money
+    // must still gate Retry separately — see WithdrawBankPage.
+    if (
+        text.includes('took too long to respond') ||
+        text.includes('The request timed out') ||
+        text.includes('timed out after')
+    )
         return 'The network is busy and your request timed out. Please try again in a moment.'
     return 'There was an issue with your request. Please contact support.'
 }


### PR DESCRIPTION
## P0 hotfix — Sentry PEANUT-UI-QH9 (Konrad, 2026-06-01)

### The bug (user perspective)

A user (Konrad, in this case) withdraws ~\$5 to a Polish IBAN via Bridge offramp:

1. BE creates the Bridge transfer fine (state `awaiting_funds`).
2. FE fires the on-chain leg — wallet sends USDC to the Bridge deposit address. **Money already left the wallet.**
3. FE calls `POST /bridge/transfers/:id/confirm` to record the txHash.
4. **That call timed out at exactly 10000ms on the FE side** (`fetchWithSentry`'s default).
5. The thrown timeout (`"Request to <url> timed out after 10000ms"`) didn't match either of `ErrorHandler`'s timeout substring matchers, so it fell through to the generic `"There was an issue with your request. Please contact support."` fallback.
6. The UI rendered a big pink **Retry** button next to that error.

If the user clicks Retry, the on-chain wallet→Bridge tx fires AGAIN — **double-pay, real money lost**.

### What this PR does

Three fixes, in order of how badly we need each. (1) is the actual defuse; (2)(3) are belt-and-braces.

**1. Gate the Retry button on the in-flight on-chain leg.**

- `src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx` — new `submittedTxHash` state is set as soon as the wallet→Bridge tx confirms (before `confirmOfframp`). While set, the UI shows a **Done** button + an InfoCard ("your transfer is processing, contact support if it doesn't show in 30 min") instead of the **Retry** button. The on-chain leg is irreversible from the FE side; Bridge and the BE poller reconcile.
- `src/components/Claim/Link/views/BankFlowManager.view.tsx` (claim-link → bank flow) — same risk via `claimLink`. `handleConfirmClaim` now swallows `confirmOfframp` errors that fire after the on-chain claim succeeded and routes to the SUCCESS view, instead of bubbling a retryable error back into `ConfirmBankClaimView` (whose CTA re-runs `claimLink`).

**2. Bump `confirmOfframp` timeout 10s → 60s** (`src/app/actions/offramp.ts`). Matches the long-running confirm pattern used by `services/manteca.ts` and `services/rain.ts` (both 120s for similar BE-heavy confirm endpoints). The BE-side investigation of why the confirm write takes >10s is tracked separately — this PR is FE-only.

**3. Add `"timed out after"` to ErrorHandler's timeout matcher list** (`src/utils/friendly-error.utils.tsx`). Our own `fetchWithSentry` AbortError copy (\`Request to <url> timed out after <ms>ms\`) didn't match either of the existing `"took too long to respond"` / `"The request timed out"` substrings. This is a backstop for the non-offramp endpoints — fixes 1+2 are what actually defuses the double-pay; this just means timeouts on other endpoints get the friendly "network is busy" copy rather than the alarming "contact support" one.

### Test plan

- [x] `pnpm prettier --check` on changed files — clean
- [x] `npm run typecheck` — only the pre-existing SEOFooter / submodule errors; zero hits on touched files
- [x] `npm test` — only the pre-existing `content.test.ts` + `countryCurrencyMapping.test.ts` flag-asset failures from uninitialized submodules / public/flags (worktree gotcha called out in CLAUDE.md). All 1236 other tests pass.
- [x] New unit test in `src/utils/__tests__/friendly-error.utils.test.tsx`: verbatim Konrad-shape error message ("Request to https://api.peanut.me/bridge/transfers/01e7a858-…/confirm timed out after 10000ms") maps to the friendly "network busy" copy.
- [ ] **Manual QA before merge** (Hugo / on-call):
  - Force `confirmOfframp` to time out (e.g. point at a stub BE that hangs) on the withdraw → IBAN flow. Verify:
    - The big pink "Retry" button does NOT appear.
    - A "Done" button appears instead, plus the "Transfer processing" InfoCard.
    - Tapping "Done" navigates home cleanly.
  - Repeat in the claim-link → bank flow (BankFlowManager). Verify the user lands on the SUCCESS screen, not the retryable error state.
  - Sanity: a *pre-on-chain* failure (e.g. `createOfframp` 500) still shows Retry — we only suppress retries after `setSubmittedTxHash`.

### Risks / what NOT to merge without

- This is FE-only. BE behavior is unchanged.
- One subtle behavioral change in BankFlowManager: even pre-existing `confirmOfframp` errors after a successful claim now route to SUCCESS instead of showing the error inline. This is the *correct* behavior (funds are at the deposit address; Bridge will process), but it changes the visible UX for that error class. Worth a one-line callout when merging.

### Out of scope (do separately)

- Why the BE `/confirm` write takes >10s in the first place. This PR buys us 60s and a safe UX; root cause work is BE-side.
- Other endpoints that move money + use the 10s default. We should audit, but not in this hotfix.

Fixes Sentry PEANUT-UI-QH9.