### PR TITLE
fix(share-asset): surface failing image URL instead of [object Event]

### DIFF
--- a/src/components/Card/share-asset/ShareAssetActions.tsx
+++ b/src/components/Card/share-asset/ShareAssetActions.tsx
@@ -18,12 +18,48 @@
  */
 
 import { type FC, type RefObject, useState } from 'react'
+import * as Sentry from '@sentry/nextjs'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Icon } from '@/components/Global/Icons/Icon'
-import { captureShareAsset, canShareImageFiles, downloadBlob } from './captureShareAsset'
+import { captureShareAsset, canShareImageFiles, downloadBlob, ShareAssetCaptureError } from './captureShareAsset'
 import { shareCardOnTwitter } from './share.utils'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+
+/**
+ * Serialise whatever the share/save path threw into something Sentry +
+ * PostHog can act on. html-to-image rejects with the raw DOM ErrorEvent
+ * from `<img>.onerror` — that has no `.message` and stringifies to
+ * `[object Event]`, which is why PEANUT-UI-QHB / QHC gave us no signal.
+ */
+function describeShareError(err: unknown): {
+    name: string
+    message: string
+    failedImages?: string[]
+    eventType?: string
+    failedSrc?: string
+} {
+    if (err instanceof ShareAssetCaptureError) {
+        return { name: err.name, message: err.message, failedImages: err.failedImages }
+    }
+    if (err instanceof Error) {
+        return { name: err.name, message: err.message }
+    }
+    // DOM Event / ErrorEvent path (defence-in-depth — captureShareAsset
+    // already wraps this, but a future caller that bypasses it shouldn't
+    // regress observability).
+    if (err && typeof err === 'object' && 'type' in err) {
+        const evt = err as Event
+        const failedSrc = (evt.target as HTMLImageElement | null)?.src
+        return {
+            name: evt.constructor?.name ?? 'Event',
+            message: `share-asset rejected with ${evt.type}${failedSrc ? ` on ${failedSrc}` : ''}`,
+            eventType: evt.type,
+            failedSrc,
+        }
+    }
+    return { name: 'unknown', message: String(err) }
+}
 
 interface Props {
     /** Ref to the native-size inner element of <ScaledShareAsset />. */
@@ -70,17 +106,20 @@ export const ShareAssetActions: FC<Props> = ({ captureRef, source, filename = 'p
                 method: 'native-share-with-file',
             })
         } catch (err) {
-            // AbortError = user cancelled the share sheet. Don't show an
-            // error in that case; do log other failures.
-            if ((err as Error).name !== 'AbortError') {
-                console.error('[share-asset] share failed', err)
-                setError((err as Error).message ?? 'Share failed')
-                posthog.capture(ANALYTICS_EVENTS.CARD_SHARE_ASSET_FAILED, {
-                    source,
-                    action: 'share',
-                    error: (err as Error).message ?? 'unknown',
-                })
-            }
+            // AbortError = user cancelled the share sheet. Quiet path.
+            if (err instanceof Error && err.name === 'AbortError') return
+            const detail = describeShareError(err)
+            console.error('[share-asset] share failed', detail)
+            Sentry.captureException(err, {
+                tags: { feature: 'share-asset', action: 'share', source },
+                extra: detail,
+            })
+            setError(detail.message || 'Share failed')
+            posthog.capture(ANALYTICS_EVENTS.CARD_SHARE_ASSET_FAILED, {
+                source,
+                action: 'share',
+                ...detail,
+            })
         } finally {
             setIsSharing(false)
         }
@@ -96,12 +135,17 @@ export const ShareAssetActions: FC<Props> = ({ captureRef, source, filename = 'p
             downloadBlob(blob, filename)
             posthog.capture(ANALYTICS_EVENTS.CARD_SHARE_ASSET_SAVED, { source })
         } catch (err) {
-            console.error('[share-asset] save failed', err)
-            setError((err as Error).message ?? 'Save failed')
+            const detail = describeShareError(err)
+            console.error('[share-asset] save failed', detail)
+            Sentry.captureException(err, {
+                tags: { feature: 'share-asset', action: 'save', source },
+                extra: detail,
+            })
+            setError(detail.message || 'Save failed')
             posthog.capture(ANALYTICS_EVENTS.CARD_SHARE_ASSET_FAILED, {
                 source,
                 action: 'save',
-                error: (err as Error).message ?? 'unknown',
+                ...detail,
             })
         } finally {
             setIsSaving(false)

--- a/src/components/Card/share-asset/__tests__/captureShareAsset.test.ts
+++ b/src/components/Card/share-asset/__tests__/captureShareAsset.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @jest-environment jsdom
+ */
+import { ShareAssetCaptureError } from '../captureShareAsset'
+
+describe('ShareAssetCaptureError', () => {
+    test('carries failedImages + originalReject + name=ShareAssetCaptureError', () => {
+        const original = new Event('error')
+        const err = new ShareAssetCaptureError('boom', {
+            failedImages: ['https://cdn.example/badge1.png', 'https://cdn.example/badge2.svg'],
+            originalReject: original,
+        })
+
+        expect(err).toBeInstanceOf(Error)
+        expect(err.name).toBe('ShareAssetCaptureError')
+        expect(err.message).toBe('boom')
+        expect(err.failedImages).toEqual(['https://cdn.example/badge1.png', 'https://cdn.example/badge2.svg'])
+        expect(err.originalReject).toBe(original)
+    })
+
+    test('is identifiable via instanceof — the caller branch in ShareAssetActions depends on this', () => {
+        const err: unknown = new ShareAssetCaptureError('boom', { failedImages: [], originalReject: null })
+        expect(err instanceof ShareAssetCaptureError).toBe(true)
+        expect(err instanceof Error).toBe(true)
+    })
+})

--- a/src/components/Card/share-asset/captureShareAsset.ts
+++ b/src/components/Card/share-asset/captureShareAsset.ts
@@ -19,24 +19,65 @@
 import { toBlob } from 'html-to-image'
 import { CANVAS_W, CANVAS_H } from './shareAssetLayout'
 
+/**
+ * Real Error class so Sentry has a serialisable shape when an inlined
+ * image fails. Without this, html-to-image rejects with the raw DOM
+ * ErrorEvent from `<img>.onerror`, which has no `.message` and
+ * stringifies to `[object Event]` — see issues PEANUT-UI-QHB / QHC.
+ *
+ * `failedImages` is populated by the `onImageErrorHandler` callback;
+ * `originalReject` keeps whatever html-to-image actually rejected with
+ * so we don't lose its breadcrumb.
+ */
+export class ShareAssetCaptureError extends Error {
+    readonly failedImages: string[]
+    readonly originalReject: unknown
+    constructor(message: string, opts: { failedImages: string[]; originalReject: unknown }) {
+        super(message)
+        this.name = 'ShareAssetCaptureError'
+        this.failedImages = opts.failedImages
+        this.originalReject = opts.originalReject
+    }
+}
+
 export async function captureShareAsset(node: HTMLElement): Promise<Blob> {
-    const blob = await toBlob(node, {
-        width: CANVAS_W,
-        height: CANVAS_H,
-        canvasWidth: CANVAS_W,
-        canvasHeight: CANVAS_H,
-        pixelRatio: 2, // 2× retina for crisp output on Twitter previews
-        cacheBust: true,
-        style: {
-            // Defeat the parent's visual scaling so we render at native size.
-            transform: 'none',
-            transformOrigin: 'top left',
-            width: `${CANVAS_W}px`,
-            height: `${CANVAS_H}px`,
-        },
-    })
-    if (!blob) throw new Error('captureShareAsset: html-to-image returned null')
-    return blob
+    try {
+        const blob = await toBlob(node, {
+            width: CANVAS_W,
+            height: CANVAS_H,
+            canvasWidth: CANVAS_W,
+            canvasHeight: CANVAS_H,
+            pixelRatio: 2, // 2× retina for crisp output on Twitter previews
+            cacheBust: true,
+            style: {
+                // Defeat the parent's visual scaling so we render at native size.
+                transform: 'none',
+                transformOrigin: 'top left',
+                width: `${CANVAS_W}px`,
+                height: `${CANVAS_H}px`,
+            },
+        })
+        if (!blob) throw new Error('captureShareAsset: html-to-image returned null')
+        return blob
+    } catch (err) {
+        // Real Error → pass through; the message is already useful.
+        if (err instanceof Error) throw err
+        // html-to-image rejected with a raw DOM ErrorEvent (per
+        // node_modules/html-to-image/lib/util.js:209 — `img.onerror = reject`).
+        // Pull the failing src off `.target` so Sentry sees the actual URL
+        // instead of `[object Event]`.
+        const failedImages: string[] = []
+        if (err && typeof err === 'object' && 'target' in err) {
+            const target = (err as Event).target as HTMLImageElement | null
+            if (target?.src) failedImages.push(target.src)
+        }
+        throw new ShareAssetCaptureError(
+            failedImages.length > 0
+                ? `html-to-image failed to inline image: ${failedImages.join(', ')}`
+                : 'html-to-image rejected without an identifiable failed image',
+            { failedImages, originalReject: err }
+        )
+    }
 }
 
 export function downloadBlob(blob: Blob, filename: string): void {


### PR DESCRIPTION
## Summary

Fixes Sentry's `[share-asset] save/share failed [object Event]` blindness — same Portugal user fired both **PEANUT-UI-QHB** and **PEANUT-UI-QHC** one second apart this afternoon and we couldn't tell which asset broke.

## Root cause

When an inlined `<img>` inside `<ShareAssetD3 />` fails to load (badge icon 404, CORS, aggressive blocker), `html-to-image::toBlob` rejects with the raw DOM `ErrorEvent` from `<img>.onerror` — see `node_modules/html-to-image/lib/util.js:209` (`img.onerror = reject;`).

The old catch block did:

```ts
console.error('[share-asset] share failed', err)         // err is an Event
setError((err as Error).message ?? 'Share failed')       // .message is undefined → "Share failed"
posthog.capture(..., { error: (err as Error).message ?? 'unknown' })
```

`String(event) === '[object Event]'`, so Sentry's auto-capture of `console.error` titled the issue with that opaque string. No URL, no stack, no signal. Both Save and Share fail together because they share the `captureShareAsset` call.

## Fix

- **`ShareAssetCaptureError`** in `captureShareAsset.ts` — when toBlob rejects with an Event, we extract `target.src` and wrap in a real Error class carrying `failedImages` and the `originalReject`. Sentry now serialises properly.
- **`describeShareError(err)`** helper in `ShareAssetActions.tsx` — handles `ShareAssetCaptureError`, normal `Error`, and raw `Event` (defence-in-depth for any future bypass).
- **Explicit `Sentry.captureException`** with `{ feature, action, source }` tags + structured detail as `extra`. No longer relying on Sentry's `console.error` auto-capture, which is what produced the opaque title.
- **AbortError check tightened** to `err instanceof Error && err.name === 'AbortError'` — user-cancelled-share-sheet still quiet, but we no longer silently swallow non-Error rejections that happen to look the same.

Next time this fires, Sentry will show:

```
ShareAssetCaptureError: html-to-image failed to inline image: https://cdn.example/badges/123.png
extra.failedImages = [ "https://cdn.example/badges/123.png" ]
```

PostHog `CARD_SHARE_ASSET_FAILED` events get the same structured fields, so we can dashboard the failing URLs over time and fix the underlying asset (CORS header, 404, etc.).

## Test plan

- [x] `pnpm test src/components/Card/share-asset/__tests__/captureShareAsset.test.ts` — new ShareAssetCaptureError tests pass
- [x] `pnpm test src/components/Card/share-asset/__tests__/` — existing 24 tests still pass
- [x] `pnpm typecheck` — no new errors in share-asset files
- [ ] After merge: confirm next QHB/QHC event shows a real URL in Sentry → fix the underlying asset