### PR TITLE
feat(offramp): persist in-flight state + recover via BE on reload

### DIFF
--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -46,6 +46,7 @@ import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { withdrawCountryUrl } from '@/utils/native-routes'
 import { useSafeBack } from '@/hooks/useSafeBack'
+import { useInflightOfframpRecovery } from '@/hooks/useInflightOfframpRecovery'
 
 type View = 'INITIAL' | 'SUCCESS'
 
@@ -75,10 +76,15 @@ export default function WithdrawBankPage() {
     const searchParams = useSearchParams()
     const [isLoading, setIsLoading] = useState(false)
     const [view, setView] = useState<View>('INITIAL')
-    // Set as soon as the on-chain wallet→Bridge tx confirms. If a subsequent
-    // confirmOfframp() call fails, this gates the UI into a "processing" state
-    // instead of showing a Retry button that would re-fire sendMoney().
-    const [submittedTxHash, setSubmittedTxHash] = useState<string | null>(null)
+    // In-flight off-ramp gate — replaces the previous local useState so the
+    // "Transfer processing" state survives page reload / app kill. Backed by
+    // localStorage + a BE recovery query (GET /bridge/transfers/by-tx-hash).
+    // See useInflightOfframpRecovery for the recovery contract.
+    const {
+        inflightTxHash: submittedTxHash,
+        markSubmitted: markOfframpSubmitted,
+        clearInflight: clearInflightOfframp,
+    } = useInflightOfframpRecovery()
     const params = useParams()
     // read country from path params (web) or query params (native/capacitor)
     const country = (params.country as string) || searchParams.get('country') || ''
@@ -284,7 +290,8 @@ export default function WithdrawBankPage() {
             // Mark the on-chain leg done BEFORE confirmOfframp. From this point on
             // any error path (including a confirm timeout) must NOT offer Retry —
             // re-running this handler would call sendMoney() again and double-pay.
-            setSubmittedTxHash(txIdentifier)
+            // Persisted to localStorage so reload doesn't surface a fresh form.
+            markOfframpSubmitted(data.transferId, txIdentifier)
 
             const confirmResult = await confirmOfframp(data.transferId, txIdentifier)
 
@@ -305,6 +312,9 @@ export default function WithdrawBankPage() {
             // 30s tanstack staleTime + Bridge polling cadence.
             queryClient.invalidateQueries({ queryKey: [TRANSACTIONS] })
 
+            // Confirm landed cleanly — drop the inflight entry so a future
+            // reload renders the fresh form, not the "processing" gate.
+            clearInflightOfframp(data.transferId)
             setView('SUCCESS')
             posthog.capture(ANALYTICS_EVENTS.WITHDRAW_COMPLETED, {
                 amount_usd: amountToWithdraw,

--- a/src/app/actions/offramp.ts
+++ b/src/app/actions/offramp.ts
@@ -93,6 +93,45 @@ export async function createOfframpForGuest(
  * @param txHash - The on-chain transaction hash from the user's deposit.
  * @returns An object containing either the successful response data or an error.
  */
+/**
+ * Look up an off-ramp intent by the on-chain tx hash the user submitted to
+ * confirm it. Backed by `GET /bridge/transfers/by-tx-hash/:txHash` — added in
+ * peanut-api-ts #929 as the recovery counterpart to /confirm's new idempotency.
+ *
+ * Use case: user reloaded the page (or app was killed) mid-flow after the
+ * on-chain leg fired. React state is gone, but the wallet still has the tx
+ * hash. We ask the BE "do you know this hash?" to surface the in-progress
+ * state instead of letting the user re-trigger a fresh withdraw and double-pay.
+ * Returns null on any 4xx (no match / not yours) — only logs unexpected errors.
+ */
+export type OfframpByTxHash = {
+    intentId: string
+    transferId: string
+    status: string
+    bridgeState: string | null
+    userSubmittedTxHash: string | null
+    updatedAt: string
+}
+
+export async function getOfframpByTxHash(txHash: string): Promise<OfframpByTxHash | null> {
+    try {
+        const response = await serverFetch(`/bridge/transfers/by-tx-hash/${encodeURIComponent(txHash)}`, {
+            method: 'GET',
+        })
+        if (response.status === 404) return null
+        if (!response.ok) {
+            console.warn(`getOfframpByTxHash: unexpected status ${response.status} for ${txHash}`)
+            return null
+        }
+        return (await response.json()) as OfframpByTxHash
+    } catch (error) {
+        // Network error / timeout — treat as "unknown" so callers can render
+        // the form normally instead of getting stuck on a recovery query.
+        console.error('Error calling getOfframpByTxHash:', error)
+        return null
+    }
+}
+
 export async function confirmOfframp(
     transferId: string,
     txHash: string

--- a/src/hooks/__tests__/useInflightOfframpRecovery.test.ts
+++ b/src/hooks/__tests__/useInflightOfframpRecovery.test.ts
@@ -1,0 +1,126 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useInflightOfframpRecovery } from '@/hooks/useInflightOfframpRecovery'
+import { getOfframpByTxHash } from '@/app/actions/offramp'
+
+jest.mock('@/app/actions/offramp', () => ({
+    getOfframpByTxHash: jest.fn(),
+}))
+
+const mockedGetOfframpByTxHash = getOfframpByTxHash as jest.MockedFunction<typeof getOfframpByTxHash>
+
+const STORAGE_KEY = 'peanut.inflightOfframps.v1'
+
+const makeBeState = (overrides: Partial<Awaited<ReturnType<typeof getOfframpByTxHash>>> = {}) => ({
+    intentId: 'intent-1',
+    transferId: 't-1',
+    status: 'PENDING',
+    bridgeState: 'AWAITING_FUNDS',
+    userSubmittedTxHash: '0xabc',
+    updatedAt: '2026-06-01T14:00:00Z',
+    ...overrides,
+})
+
+beforeEach(() => {
+    window.localStorage.clear()
+    mockedGetOfframpByTxHash.mockReset()
+})
+
+describe('useInflightOfframpRecovery', () => {
+    test('fresh mount with no localStorage entries: inflightTxHash stays null and skips BE query', async () => {
+        const { result } = renderHook(() => useInflightOfframpRecovery())
+        await waitFor(() => expect(result.current.isRecovering).toBe(false))
+        expect(result.current.inflightTxHash).toBeNull()
+        expect(mockedGetOfframpByTxHash).not.toHaveBeenCalled()
+    })
+
+    test('markSubmitted persists to localStorage and exposes the hash', () => {
+        const { result } = renderHook(() => useInflightOfframpRecovery())
+        act(() => result.current.markSubmitted('t-1', '0xaaa'))
+        expect(result.current.inflightTxHash).toBe('0xaaa')
+        const raw = window.localStorage.getItem(STORAGE_KEY)
+        expect(raw).not.toBeNull()
+        const parsed = JSON.parse(raw!)
+        expect(parsed).toHaveLength(1)
+        expect(parsed[0]).toMatchObject({ transferId: 't-1', txHash: '0xaaa' })
+        expect(typeof parsed[0].submittedAt).toBe('number')
+    })
+
+    test('on mount: recovers stored hash when BE confirms it (Konrad reload scenario)', async () => {
+        // The motivating case: user submitted, on-chain leg fired, confirm
+        // timed out, app was closed. Next session must restore the gate so
+        // the user can't re-trigger sendMoney().
+        window.localStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify([{ transferId: 't-1', txHash: '0xaaa', submittedAt: Date.now() }])
+        )
+        mockedGetOfframpByTxHash.mockResolvedValueOnce(makeBeState({ userSubmittedTxHash: '0xaaa' }))
+
+        const { result } = renderHook(() => useInflightOfframpRecovery())
+        await waitFor(() => expect(result.current.isRecovering).toBe(false))
+        expect(result.current.inflightTxHash).toBe('0xaaa')
+        expect(mockedGetOfframpByTxHash).toHaveBeenCalledWith('0xaaa')
+    })
+
+    test('BE returns null (404): entry is pruned and form renders normally', async () => {
+        // The on-chain leg never actually fired (or BE never saw the hash).
+        // Safe to clear so the user gets a fresh form next visit.
+        window.localStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify([{ transferId: 't-1', txHash: '0xaaa', submittedAt: Date.now() }])
+        )
+        mockedGetOfframpByTxHash.mockResolvedValueOnce(null)
+
+        const { result } = renderHook(() => useInflightOfframpRecovery())
+        await waitFor(() => expect(result.current.isRecovering).toBe(false))
+        expect(result.current.inflightTxHash).toBeNull()
+        expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY)!)).toHaveLength(0)
+    })
+
+    test('clearInflight removes the entry and reverts the hash', () => {
+        const { result } = renderHook(() => useInflightOfframpRecovery())
+        act(() => result.current.markSubmitted('t-1', '0xaaa'))
+        expect(result.current.inflightTxHash).toBe('0xaaa')
+        act(() => result.current.clearInflight('t-1'))
+        expect(result.current.inflightTxHash).toBeNull()
+        expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY)!)).toHaveLength(0)
+    })
+
+    test('entries older than 24h are pruned on mount without hitting BE', async () => {
+        const twentyFiveHoursAgo = Date.now() - 25 * 60 * 60 * 1000
+        window.localStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify([{ transferId: 't-stale', txHash: '0xold', submittedAt: twentyFiveHoursAgo }])
+        )
+        const { result } = renderHook(() => useInflightOfframpRecovery())
+        await waitFor(() => expect(result.current.isRecovering).toBe(false))
+        expect(result.current.inflightTxHash).toBeNull()
+        expect(mockedGetOfframpByTxHash).not.toHaveBeenCalled()
+        expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY)!)).toHaveLength(0)
+    })
+
+    test('multiple entries: restores the most recent that BE confirms', async () => {
+        const now = Date.now()
+        window.localStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify([
+                { transferId: 't-old', txHash: '0xold', submittedAt: now - 60_000 },
+                { transferId: 't-new', txHash: '0xnew', submittedAt: now - 1_000 },
+            ])
+        )
+        mockedGetOfframpByTxHash.mockResolvedValueOnce(makeBeState({ userSubmittedTxHash: '0xnew' }))
+
+        const { result } = renderHook(() => useInflightOfframpRecovery())
+        await waitFor(() => expect(result.current.isRecovering).toBe(false))
+        expect(result.current.inflightTxHash).toBe('0xnew')
+        // Most recent queried first; first match wins, older entry not queried.
+        expect(mockedGetOfframpByTxHash).toHaveBeenCalledTimes(1)
+        expect(mockedGetOfframpByTxHash).toHaveBeenCalledWith('0xnew')
+    })
+
+    test('corrupted localStorage is tolerated (does not throw)', async () => {
+        window.localStorage.setItem(STORAGE_KEY, '{ not valid json')
+        const { result } = renderHook(() => useInflightOfframpRecovery())
+        await waitFor(() => expect(result.current.isRecovering).toBe(false))
+        expect(result.current.inflightTxHash).toBeNull()
+    })
+})

--- a/src/hooks/useInflightOfframpRecovery.ts
+++ b/src/hooks/useInflightOfframpRecovery.ts
@@ -1,0 +1,143 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { getOfframpByTxHash } from '@/app/actions/offramp'
+import * as Sentry from '@sentry/nextjs'
+
+/**
+ * In-flight off-ramp recovery.
+ *
+ * Reason this exists: PR #2147 added a `submittedTxHash` React state to the
+ * withdraw bank page to prevent showing a Retry button after the on-chain
+ * leg fired (Sentry PEANUT-UI-QH9 / 2026-06-01). That defuse is correct
+ * within a single React session — but if the user reloads mid-flow (or the
+ * mobile app gets killed), React state is gone and they're back to a clean
+ * form. Submitting again would call sendMoney() twice → double-pay.
+ *
+ * This hook persists the in-flight {transferId, txHash} pair to localStorage
+ * keyed by transferId. On mount, it restores any pending entries and queries
+ * the BE recovery endpoint (GET /bridge/transfers/by-tx-hash/:txHash, added
+ * in peanut-api-ts #929) to confirm the BE knows about each one. If the BE
+ * has it recorded (or in any post-AWAITING_FUNDS state), the hook surfaces
+ * `inflightTxHash` so the consumer renders the "Transfer processing" gate
+ * instead of the form.
+ *
+ * Entries are cleared on:
+ *   - explicit `clearInflight()` call (consumer signals done — usually on
+ *     SUCCESS view).
+ *   - BE 404 (the hash was never recorded — likely the on-chain leg never
+ *     actually fired; safe to clear so the form re-renders).
+ *   - TTL expiry (24h) — defensive against stale storage if the user just
+ *     never came back. Bridge offramps that haven't completed in 24h are
+ *     either resolved (we'd have had a separate update) or stuck and need
+ *     ops intervention regardless.
+ */
+
+const STORAGE_KEY = 'peanut.inflightOfframps.v1'
+const TTL_MS = 24 * 60 * 60 * 1000 // 24h
+
+type InflightEntry = {
+    transferId: string
+    txHash: string
+    submittedAt: number // Date.now()
+}
+
+function readAll(): InflightEntry[] {
+    if (typeof window === 'undefined') return []
+    try {
+        const raw = window.localStorage.getItem(STORAGE_KEY)
+        if (!raw) return []
+        const parsed = JSON.parse(raw)
+        if (!Array.isArray(parsed)) return []
+        return parsed.filter(
+            (e): e is InflightEntry =>
+                e &&
+                typeof e === 'object' &&
+                typeof e.transferId === 'string' &&
+                typeof e.txHash === 'string' &&
+                typeof e.submittedAt === 'number'
+        )
+    } catch {
+        return []
+    }
+}
+
+function writeAll(entries: InflightEntry[]): void {
+    if (typeof window === 'undefined') return
+    try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries))
+    } catch {
+        // Quota exceeded / private mode — non-fatal. Worst case we lose
+        // recovery for this flow, which is the pre-hook behavior.
+    }
+}
+
+export interface UseInflightOfframpRecoveryResult {
+    /** The on-chain tx hash for the currently in-flight transfer, if any. */
+    inflightTxHash: string | null
+    /** True while we're checking localStorage + BE on mount. */
+    isRecovering: boolean
+    /** Call when the consumer kicks off a new offramp confirm attempt. */
+    markSubmitted: (transferId: string, txHash: string) => void
+    /** Call from the consumer when the flow reaches a terminal SUCCESS state. */
+    clearInflight: (transferId: string) => void
+}
+
+export function useInflightOfframpRecovery(): UseInflightOfframpRecoveryResult {
+    const [inflightTxHash, setInflightTxHash] = useState<string | null>(null)
+    const [isRecovering, setIsRecovering] = useState(true)
+
+    // Recovery on mount: prune expired, then ask the BE about each remaining
+    // entry. First confirmed in-flight wins (we only have one form per page).
+    useEffect(() => {
+        let cancelled = false
+        const run = async () => {
+            const now = Date.now()
+            const entries = readAll()
+            const fresh = entries.filter((e) => now - e.submittedAt < TTL_MS)
+            if (fresh.length !== entries.length) writeAll(fresh)
+            if (fresh.length === 0) {
+                if (!cancelled) setIsRecovering(false)
+                return
+            }
+            // Most recent first — restore that one if BE knows about it.
+            fresh.sort((a, b) => b.submittedAt - a.submittedAt)
+            for (const entry of fresh) {
+                const beState = await getOfframpByTxHash(entry.txHash)
+                if (cancelled) return
+                if (beState) {
+                    setInflightTxHash(entry.txHash)
+                    setIsRecovering(false)
+                    return
+                }
+                // 404 from BE — that hash was never recorded. The on-chain
+                // leg may have failed before /confirm was reached. Drop the
+                // entry so the form renders normally on next visit.
+                writeAll(readAll().filter((e) => e.transferId !== entry.transferId))
+            }
+            setIsRecovering(false)
+        }
+        run().catch((err) => {
+            Sentry.captureException(err, { tags: { area: 'inflight-offramp-recovery' } })
+            if (!cancelled) setIsRecovering(false)
+        })
+        return () => {
+            cancelled = true
+        }
+    }, [])
+
+    const markSubmitted = useCallback((transferId: string, txHash: string) => {
+        const entries = readAll().filter((e) => e.transferId !== transferId)
+        entries.push({ transferId, txHash, submittedAt: Date.now() })
+        writeAll(entries)
+        setInflightTxHash(txHash)
+    }, [])
+
+    const clearInflight = useCallback((transferId: string) => {
+        const entries = readAll().filter((e) => e.transferId !== transferId)
+        writeAll(entries)
+        setInflightTxHash(null)
+    }, [])
+
+    return { inflightTxHash, isRecovering, markSubmitted, clearInflight }
+}


### PR DESCRIPTION
## Summary

Follow-up to [peanut-ui #2147](https://github.com/peanutprotocol/peanut-ui/pull/2147) + [peanut-api-ts #929](https://github.com/peanutprotocol/peanut-api-ts/pull/929).

#2147 prevents double-pay within a single React session via local \`submittedTxHash\` state. This PR closes the **cross-session gap**: if the user reloads (or the mobile app is killed) after the on-chain leg fired but before \`/confirm\` completes, React state is gone and the form renders fresh — submitting again would call \`sendMoney()\` twice.

Targets \`main\` because it stacks on #2147 (already on main, not yet back-merged to dev).

## Changes

### 1. \`getOfframpByTxHash(txHash)\` — \`src/app/actions/offramp.ts\` (+39)

Consumer of the new BE \`GET /bridge/transfers/by-tx-hash/:txHash\` endpoint (peanut-api-ts #929). Auth-scoped; returns \`null\` on 404 (no match or not yours) instead of surfacing as an error. Treats network errors / timeouts as \"unknown\" so the form still renders.

### 2. \`useInflightOfframpRecovery()\` — \`src/hooks/useInflightOfframpRecovery.ts\` (new, +143)

Persists \`{ transferId, txHash, submittedAt }\` to \`localStorage\` keyed by transferId. Behavior:

- \`markSubmitted(transferId, txHash)\` — call after the on-chain leg confirms, before \`/confirm\`. Persists + exposes \`inflightTxHash\`.
- **On mount**: prunes expired entries (>24h), then queries BE for each remaining entry by tx hash. First confirmed match wins; older entries skipped. If BE 404s an entry, it's pruned (on-chain leg never reached BE → safe to render fresh form).
- \`clearInflight(transferId)\` — call on terminal SUCCESS so the next session renders a fresh form.

### 3. Wire into withdraw/[country]/bank/page.tsx (+20/-5)

Replaces the local \`useState<string | null>(null)\` from #2147 with the hook. Same \`submittedTxHash\` consumer-name preserved to keep the render branches untouched. Clears the inflight entry on the SUCCESS path.

### 4. Tests — 8 unit tests (+126)

- Fresh mount with no entries → no BE query
- \`markSubmitted\` persists to localStorage
- Recovery: BE confirms the hash → \`inflightTxHash\` restored (Konrad reload scenario)
- BE 404 → entry pruned, form renders normally
- \`clearInflight\` removes entry + reverts state
- 24h TTL prunes stale entries without hitting BE
- Multi-entry: most recent queried first, others skipped
- Corrupted \`localStorage\` tolerated without throwing

All 8 pass.

## What's NOT in this PR

- **claim-bank flow (\`BankFlowManager\`)**: has the same cross-session risk; intentionally left out to keep this PR's surface tight. A sibling commit applying the hook there is small (~15 LoC) — happy to add if you'd like.
- **The 4 other Konrad-shape flows** (crypto-withdraw, P2P send, request pay, contribute pot — all call \`recordPayment\` after \`sendMoney\` at 10s default): out of scope. These need a shared \`useOnChainThenAck\` primitive, not per-flow patches. Tracked as the natural next PR.

## Risk

- Touches the withdraw bank page's hot path. The render branches (\`{submittedTxHash ? ... : ...}\`) are unchanged — only the source of \`submittedTxHash\` changed.
- localStorage is per-origin; works in all browsers Peanut supports. Quota/private-mode failures are caught and degrade gracefully to pre-hook behavior (no recovery, but no error either).
- The hook is additive — disabling it would revert to #2147's single-session protection without breaking anything.

## Test plan

- [x] \`pnpm prettier --check\` on changed files — clean
- [x] \`npm test -- useInflightOfframpRecovery\` — 8/8 pass
- [ ] **Manual QA** before merge:
  - Kill the BE mid-\`/confirm\` (or block the FE call in DevTools) on the withdraw → IBAN flow. Verify the \"Done\" button appears.
  - **Reload the page.** Verify the \"Transfer processing\" state restores from BE — not a fresh form.
  - Complete the BE side. Reload again — verify the fresh form appears (no stale recovery banner).
  - Clear localStorage + reload — verify no error, fresh form.

## Stack order

Must merge in this order:
1. peanut-api-ts #929 (BE endpoint) → dev → next main release
2. THIS PR → main (depends on #929 being deployed)

If #929 isn't deployed when this lands, the recovery hook gracefully no-ops (BE returns 404 for the unknown route, entry gets pruned, form renders normally) — degraded but not broken.

## Context

- Triggering incident: [Sentry PEANUT-UI-QH9](https://peanut-c34d84c05.sentry.io/issues/PEANUT-UI-QH9) (Konrad, 2026-06-01). \$5 PL withdraw; on-chain leg succeeded; FE \`/confirm\` timed out; user saw \"Retry\" button next to an irreversible on-chain leg.
- #2147 defused the same-session case. This PR defuses the reload case.