### PR TITLE
fix(badges): restore EthFloripa + Token Nation catalog entries on main

### DIFF
--- a/src/components/Badges/badge.utils.ts
+++ b/src/components/Badges/badge.utils.ts
@@ -94,6 +94,18 @@ export const BADGES: Record<string, BadgeMeta> = {
         description: '$1K swiped. They put their money where their card is.',
         // TODO(card-launch): award on cumulative card spend ≥ $1K
     },
+    // Event badges — assets shipped to main via the May 29 hotfix but the catalog
+    // entries were dropped when the parallel maps collapsed into this single BADGES
+    // record, so the backend codes fell back to the Peanutman logo + raw backend name.
+    TOKEN_NATION_SP_2026: {
+        path: '/badges/token_nation_2026.svg',
+        description: 'São Paulo, baby. They came, they claimed, they tagged the wall.',
+    },
+    ETHFLORIPA_HUB: {
+        path: '/badges/ethfloripa_hub.svg',
+        description: 'Ilha da Magia, baby. Coconuts and consensus.',
+        displayName: 'Ethereum Hub Floripa',
+    },
 }
 
 /** All known badge codes — derived from BADGES so we never duplicate the


### PR DESCRIPTION
## What's broken in prod
The **Ethereum Hub Floripa** badge renders wrong on `main`:
1. **Wrong name** — shows the raw backend-seeded name instead of "Ethereum Hub Floripa".
2. **Wrong asset** — shows the generic Peanutman logo instead of the EthFloripa art.

`TOKEN_NATION_SP_2026` has the **identical** regression (Peanutman fallback).

## Root cause
The May 29 event-badge hotfix (#2133 / `d72c7265a`) shipped the **assets** (`ethfloripa_hub.svg`, `token_nation_2026.svg`) and the InvitesPage `utm_campaign` map to `main`, but the badge **catalog entries** never landed in the single `BADGES` record. They lived in the pre-refactor parallel `CODE_TO_PATH` / `PUBLIC_DESCRIPTIONS` maps on the hotfix branch, and were lost when `main` collapsed those into the single `BADGES` source of truth (`551766bc0`).

With no `BADGES[code]` entry:
- `getBadgeIcon('ETHFLORIPA_HUB')` → no `path` → `PEANUTMAN_LOGO` fallback (the "swapped" asset)
- `getBadgeDisplayName('ETHFLORIPA_HUB', backendName)` → no override → raw backend name

`git log -S "ETHFLORIPA_HUB" -- src/components/Badges/badge.utils.ts` on `main` returns nothing, confirming the entry was never in the post-refactor catalog.

## Fix
Re-add both codes to `BADGES`. Assets already exist on `main`, so this is catalog-only:
- `TOKEN_NATION_SP_2026` → `token_nation_2026.svg` + copy
- `ETHFLORIPA_HUB` → `ethfloripa_hub.svg` + copy + **`displayName: 'Ethereum Hub Floripa'`**

The `displayName` override fixes the name regardless of what the backend seeded (same mechanism already used for `SUPPORT_SURVIVOR` → "Bug Whisperer").

## Why target `main`
Live prod regression on time-sensitive event badges — matches the original #2133 hotfix-to-`main` pattern. Verified all badge surfaces (`BadgesRow`, `BadgeStatusItem`, `BadgeStatusDrawer`, profile list, card share-asset) consume `getBadgeDisplayName` + `getBadgeIcon`, so the fix applies everywhere.

## Follow-up (not in this PR)
- Open dev PR **#2135** (`chore/sync-event-badges-to-dev`) adds these entries to `dev` but **without** the `displayName` — it should pick up `displayName: 'Ethereum Hub Floripa'` so the next `dev`→`main` release doesn't re-regress the name.
- If Token Nation's backend name is also wrong, it needs a `displayName` too (left off here since only EthFloripa's name was reported).

## Verification
- prettier: clean
- Type-safe additive entry conforming to `BadgeMeta`