### PR TITLE
chore(sync): back-merge main into dev — restore event badge catalog + guard regression

### DIFF
--- a/src/components/Badges/badge.utils.ts
+++ b/src/components/Badges/badge.utils.ts
@@ -94,6 +94,18 @@ export const BADGES: Record<string, BadgeMeta> = {
         description: '$1K swiped. They put their money where their card is.',
         // TODO(card-launch): award on cumulative card spend ≥ $1K
     },
+    // Event badges — assets shipped to main via the May 29 hotfix but the catalog
+    // entries were dropped when the parallel maps collapsed into this single BADGES
+    // record, so the backend codes fell back to the Peanutman logo + raw backend name.
+    TOKEN_NATION_SP_2026: {
+        path: '/badges/token_nation_2026.svg',
+        description: 'São Paulo, baby. They came, they claimed, they tagged the wall.',
+    },
+    ETHFLORIPA_HUB: {
+        path: '/badges/ethfloripa_hub.svg',
+        description: 'Ilha da Magia, baby. Coconuts and consensus.',
+        displayName: 'Ethereum Hub Floripa',
+    },
 }
 
 /** All known badge codes — derived from BADGES so we never duplicate the

--- a/src/components/Invites/InvitesPage.tsx
+++ b/src/components/Invites/InvitesPage.tsx
@@ -19,25 +19,7 @@ import UnsupportedBrowserModal from '../Global/UnsupportedBrowserModal'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { profileUrl } from '@/utils/native-routes'
-
-// mapping of special invite codes to their campaign tags
-// when these invite codes are used, the corresponding campaign tag is automatically applied
-const INVITE_CODE_TO_CAMPAIGN_MAP: Record<string, string> = {
-    arbiverseinvitesyou: 'ARBIVERSE_DEVCONNECT_BA_2025',
-    squirrelinvitesyou: 'ARBIVERSE_DEVCONNECT_BA_2025', // temporary: maps to arbiverse until 12pm noon tomorrow
-    founderhaus: 'FOUNDER_HOUSE',
-    survivor: 'SUPPORT_SURVIVOR',
-}
-
-// Map inbound `utm_campaign` values to the badge codes the backend whitelists.
-// Lets marketing/event links use a single UTM-shaped URL — PostHog auto-captures
-// utm_* on $pageview so the same string also flows into the analytics funnel.
-// Backend whitelist lives in peanut-api-ts/src/routes/badge.ts + invite.ts; keep
-// in sync when adding a new entry here.
-const UTM_CAMPAIGN_TO_BADGE_MAP: Record<string, string> = {
-    'token-nation-2026': 'TOKEN_NATION_SP_2026',
-    ethfloripa: 'ETHFLORIPA_HUB',
-}
+import { INVITE_CODE_TO_CAMPAIGN_MAP, UTM_CAMPAIGN_TO_BADGE_MAP } from './campaign-maps'
 
 function InvitePageContent() {
     const searchParams = useSearchParams()

--- a/src/components/Invites/campaign-maps.test.ts
+++ b/src/components/Invites/campaign-maps.test.ts
@@ -1,0 +1,28 @@
+import { BADGES } from '@/components/Badges/badge.utils'
+import { INVITE_CODE_TO_CAMPAIGN_MAP, UTM_CAMPAIGN_TO_BADGE_MAP } from './campaign-maps'
+
+// Regression guard. The /invite flow resolves an inbound invite code / utm_campaign
+// to one of these badge codes, carries it through signup, and the UI renders
+// BADGES[code] for the awarded badge. If a code here has no BADGES entry, getBadgeIcon
+// falls back to the Peanutman logo and getBadgeDisplayName returns the raw backend
+// name — a silent visual regression with no conflict, no type error, no runtime throw.
+//
+// This is exactly how TOKEN_NATION_SP_2026 + ETHFLORIPA_HUB fell out of dev (the
+// May 29 event-badge hotfixes were written against the old parallel-map shape and
+// their additions evaporated when merged across the May 23 single-BADGES refactor),
+// and later out of main (regressed on release, fixed by 32699f171). This test fails
+// the moment a campaign code points at a badge the FE can't render.
+const badgeCodes = new Set(Object.keys(BADGES))
+
+describe('campaign maps reference real BADGES codes', () => {
+    it.each(Object.entries(UTM_CAMPAIGN_TO_BADGE_MAP))('utm_campaign "%s" → "%s" exists in BADGES', (_utm, code) => {
+        expect(badgeCodes).toContain(code)
+    })
+
+    it.each(Object.entries(INVITE_CODE_TO_CAMPAIGN_MAP))(
+        'invite code "%s" → "%s" exists in BADGES',
+        (_invite, code) => {
+            expect(badgeCodes).toContain(code)
+        }
+    )
+})

--- a/src/components/Invites/campaign-maps.ts
+++ b/src/components/Invites/campaign-maps.ts
@@ -1,0 +1,24 @@
+// Inbound campaign-resolution maps for /invite. Pure data, kept out of the
+// InvitesPage client component so they can be unit-tested in isolation: every
+// value here is a badge code, and if it isn't present in BADGES the awarded
+// badge silently renders the Peanutman fallback + raw backend name (the
+// parallel-maps→single-record regression). campaign-maps.test.ts guards that.
+
+// mapping of special invite codes to their campaign tags
+// when these invite codes are used, the corresponding campaign tag is automatically applied
+export const INVITE_CODE_TO_CAMPAIGN_MAP: Record<string, string> = {
+    arbiverseinvitesyou: 'ARBIVERSE_DEVCONNECT_BA_2025',
+    squirrelinvitesyou: 'ARBIVERSE_DEVCONNECT_BA_2025', // temporary: maps to arbiverse until 12pm noon tomorrow
+    founderhaus: 'FOUNDER_HOUSE',
+    survivor: 'SUPPORT_SURVIVOR',
+}
+
+// Map inbound `utm_campaign` values to the badge codes the backend whitelists.
+// Lets marketing/event links use a single UTM-shaped URL — PostHog auto-captures
+// utm_* on $pageview so the same string also flows into the analytics funnel.
+// Backend whitelist lives in peanut-api-ts/src/routes/badge.ts + invite.ts; keep
+// in sync when adding a new entry here.
+export const UTM_CAMPAIGN_TO_BADGE_MAP: Record<string, string> = {
+    'token-nation-2026': 'TOKEN_NATION_SP_2026',
+    ethfloripa: 'ETHFLORIPA_HUB',
+}


### PR DESCRIPTION
Clean back-merge of `main` into `dev`, plus a regression guard so the underlying
codesmell can't bite a third time.

## Why
`dev` was missing `TOKEN_NATION_SP_2026` + `ETHFLORIPA_HUB` from the `BADGES`
catalog, so the live `/invite` award path renders those event badges with the
Peanutman fallback art + raw backend name. `main` already has the fix
(`32699f171`, the June 1 hotfix). This merge carries it to `dev`.

`git merge-tree` reports **zero conflicts**; the entire `dev↔main` delta is the
12-line `badge.utils.ts` block (plus `dev`-ahead `qr-pay` work, preserved).

## How the drop happened (narrative)
1. **May 23** — `551766bc0` collapses 3 parallel badge maps into one `BADGES`
   record on `dev`. Not yet released to `main`.
2. **May 29** — event-badge hotfixes ship to `main` (`#2133`), written against
   `main`'s **old parallel-map shape** (`CODE_TO_PATH` + `PUBLIC_DESCRIPTIONS`).
3. Those hotfixes reach `dev` via merge — but the parallel maps no longer exist
   there, so git auto-resolves the map-key additions as *deletion wins*. The
   `badge.utils.ts` entries **silently evaporate** (no conflict). The InvitesPage
   `utm_campaign` line + the SVG assets survive (refactor never touched them) —
   which is why `dev` today has the utm path + assets but not the catalog entries.
4. The same refactor later crosses into `main` on release, dropping `main`'s
   entries the same way → prod regression → hotfix `32699f171`.

Root cause: a hand-maintained FE badge registry refactored on one long-lived
branch while hotfixed on the other. Cross-branch merges don't conflict — they
drop keys whose target structure changed. Only signal was wrong art in prod.

## What's in this PR
- **Back-merge** `origin/main` → `dev` (the 12-line catalog re-add).
- **Extract** the `/invite` campaign maps out of the `InvitesPage` client
  component into pure-data `campaign-maps.ts` (import-only change in InvitesPage).
- **Guard test** `campaign-maps.test.ts`: asserts every value in
  `INVITE_CODE_TO_CAMPAIGN_MAP` + `UTM_CAMPAIGN_TO_BADGE_MAP` exists as a `BADGES`
  key. Verified it **fails** on the two dropped codes when the entries are absent,
  and passes (6/6) with the merge applied — i.e. it would have caught both the
  `dev` and `main` regressions at CI.

## Supersedes
Closes #2135 (`chore/sync-event-badges-to-dev`) — verified redundant: identical
SVG blobs already on `dev`, same `badge.utils.ts` entries, and its only
InvitesPage delta was comment re-wording (a downgrade — it drops the
"keep in sync with peanut-api-ts" note).

## Verification
- `git merge-tree origin/dev origin/main` → no conflicts
- `npx jest src/components/Invites/campaign-maps.test.ts` → 6/6 pass; proven to fail when entries removed
- typecheck clean on changed files; prettier clean
- BE side already in sync (peanut-api-ts `main ⊆ dev`; codes whitelisted+seeded on both)