### PR TITLE
fix(capabilities): hoist `ready` above blocked/accept-tos/fixable in deriveGate

### DIFF
--- a/src/utils/capability-gate.test.ts
+++ b/src/utils/capability-gate.test.ts
@@ -315,3 +315,97 @@ describe('deriveGate — restart-identity vs contact-support split for blocked r
         expect(getKycModalVariant(gate.kind)).toBe('blocked')
     })
 })
+
+describe('deriveGate — ready-first ordering (Alexandre fix)', () => {
+    const tosAction: NextAction = { key: 'bridge.tos', kind: 'accept-tos', purpose: 'bridge-tos' }
+    const sumsubAction: NextAction = { key: 'bridge.rfi', kind: 'sumsub', purpose: 'bridge-rfi' }
+
+    test('Alexandre case: PIX_BR ENABLED + Bridge × US/GB/EU/MX stuck on ToS → ready (no modal)', () => {
+        const pixBr = bankRail({
+            id: 'manteca.pix_br',
+            provider: 'manteca',
+            method: 'PIX_BR',
+            country: 'BR',
+            currency: 'BRL',
+            status: 'enabled',
+        })
+        const stuck = (id: `bridge.${string}`, country: string, currency: string, method: string): RailCapability =>
+            bankRail({
+                id,
+                provider: 'bridge',
+                method,
+                country,
+                currency,
+                status: 'requires-info',
+                blockingActions: ['bridge.tos'],
+                reason: { code: 'bridge_tos_v2_required', userMessage: 'Accept terms' },
+            })
+        const rails = [
+            pixBr,
+            stuck('bridge.ach_us', 'US', 'USD', 'ACH_US'),
+            stuck('bridge.faster_payments_gb', 'GB', 'GBP', 'FASTER_PAYMENTS_GB'),
+            stuck('bridge.sepa_eu', 'EU', 'EUR', 'SEPA_EU'),
+            stuck('bridge.spei_mx', 'MX', 'MXN', 'SPEI_MX'),
+        ]
+
+        const gate = deriveGate(state(rails, [tosAction]), 'deposit', { channel: 'bank' })
+        expect(gate.kind).toBe('ready')
+    })
+
+    test('ready beats blocked-rejection — working rail trumps unrelated blocked one', () => {
+        const ready = bankRail({ id: 'manteca.pix_br', provider: 'manteca', country: 'BR', status: 'enabled' })
+        const blockedTerminal = bankRail({
+            id: 'bridge.ach_us',
+            status: 'blocked',
+            reason: { code: 'kyc_rejected_terminal', userMessage: 'Verification failed' },
+        })
+
+        const gate = deriveGate(state([ready, blockedTerminal]), 'deposit', { channel: 'bank' })
+        expect(gate.kind).toBe('ready')
+    })
+
+    test('ready beats fixable-rejection — RFI on another rail does not gate', () => {
+        const ready = bankRail({ id: 'manteca.pix_br', provider: 'manteca', country: 'BR', status: 'enabled' })
+        const rfi = bankRail({ id: 'bridge.ach_us', status: 'requires-info', blockingActions: ['bridge.rfi'] })
+
+        const gate = deriveGate(state([ready, rfi], [sumsubAction]), 'deposit', { channel: 'bank' })
+        expect(gate.kind).toBe('ready')
+    })
+
+    test('ready beats restart-identity — self-fixable blocked rail does not gate', () => {
+        const ready = bankRail({ id: 'manteca.pix_br', provider: 'manteca', country: 'BR', status: 'enabled' })
+        const restartable = bankRail({
+            id: 'bridge.ach_us',
+            status: 'blocked',
+            blockingActions: ['bridge.restart'],
+        })
+        const restartAction: NextAction = { key: 'bridge.restart', kind: 'restart-identity', purpose: 'restart' }
+
+        const gate = deriveGate(state([ready, restartable], [restartAction]), 'deposit', { channel: 'bank' })
+        expect(gate.kind).toBe('ready')
+    })
+
+    test('no ready rail → falls through to existing blocked / accept-tos / fixable order', () => {
+        const tosRail = bankRail({
+            id: 'bridge.ach_us',
+            status: 'requires-info',
+            blockingActions: ['bridge.tos'],
+            reason: { code: 'bridge_tos_required', userMessage: 'Accept terms' },
+        })
+
+        const gate = deriveGate(state([tosRail], [tosAction]), 'deposit', { channel: 'bank' })
+        expect(gate.kind).toBe('accept-tos')
+    })
+
+    test('per-op enabled status (not rail-level) is what matters', () => {
+        const railWithEnabledOp = bankRail({
+            id: 'bridge.ach_us',
+            status: 'requires-info',
+            operations: { deposit: 'enabled', withdraw: 'requires-info' },
+            blockingActions: ['bridge.rfi'],
+        })
+
+        const gate = deriveGate(state([railWithEnabledOp], [sumsubAction]), 'deposit', { channel: 'bank' })
+        expect(gate.kind).toBe('ready')
+    })
+})

--- a/src/utils/capability-gate.ts
+++ b/src/utils/capability-gate.ts
@@ -112,13 +112,18 @@ export interface CapabilityState {
  *
  * Priority (highest first):
  *   1. loading             — capability state not yet settled
- *   2. blocked-rejection   — any in-scope rail status: 'blocked'
- *   3. accept-tos          — requires-info + a `kind: 'accept-tos'` action
+ *   2. ready               — at least one in-scope rail has operationStatus(op) === 'enabled'.
+ *                            Hoisted to position 2 so a working rail (e.g. Manteca PIX_BR
+ *                            ENABLED) wins over stuck sibling rails (e.g. Bridge ACH_US
+ *                            terms_of_service_v2). The 2026-06-01 Alexandre incident
+ *                            (BR user blocked by Bridge ToS modal while their Manteca
+ *                            PIX_BR was ENABLED) was the latest customer-visible failure
+ *                            of the prior 'gate any sibling blocker first' order.
+ *   3. blocked-rejection   — any in-scope rail status: 'blocked', and no ready rail
+ *   4. accept-tos          — requires-info + a `kind: 'accept-tos'` action
  *                            (user-actionable, unblocks the scope)
- *   4. fixable-rejection   — requires-info + a `kind: 'sumsub'` action
+ *   5. fixable-rejection   — requires-info + a `kind: 'sumsub'` action
  *                            (user-actionable, unblocks the scope)
- *   5. ready               — at least one in-scope rail has operationStatus(op) === 'enabled'
- *                            (user can transact NOW)
  *   6. pending             — at least one in-scope rail status === 'pending' (we're provisioning)
  *   7. waiting-on-provider — only requires-info rails AND every one has only
  *                            `kind: 'wait'` actions (e.g. Bridge internal KYC
@@ -138,7 +143,14 @@ export function deriveGate(state: CapabilityState, op: RailOperation, scope: Gat
     const candidates = filterRailsByScope(state.rails, scope)
     const actionByKey = new Map(state.nextActions.map((action) => [action.key, action]))
 
-    // 2. blocked — split: if the rail carries a `restart-identity` action the
+    // 2. ready — per-op refinement wins over rail-level status. Hoisted
+    // above blocked / accept-tos / fixable-rejection because the user has
+    // a working path; a blocked sibling rail (different currency, KYC
+    // remediation pending) is not the user's problem right now.
+    const hasReady = candidates.some((rail) => operationStatus(rail, op) === 'enabled')
+    if (hasReady) return { kind: 'ready' }
+
+    // 3. blocked — split: if the rail carries a `restart-identity` action the
     // user can self-fix by re-verifying with a different document; otherwise
     // the only path is contact-support.
     const blocked = candidates.find((rail) => rail.status === 'blocked')
@@ -160,7 +172,7 @@ export function deriveGate(state: CapabilityState, op: RailOperation, scope: Gat
 
     const requiresInfoRails = candidates.filter((rail) => rail.status === 'requires-info')
 
-    // 3. accept-tos
+    // 4. accept-tos
     const tosRail = requiresInfoRails.find((rail) =>
         railActions(rail, actionByKey).some((action) => action.kind === 'accept-tos')
     )
@@ -174,7 +186,7 @@ export function deriveGate(state: CapabilityState, op: RailOperation, scope: Gat
         }
     }
 
-    // 4. fixable-rejection (Sumsub RFI / self-heal)
+    // 5. fixable-rejection (Sumsub RFI / self-heal)
     const fixableRail = requiresInfoRails.find((rail) =>
         railActions(rail, actionByKey).some((action) => action.kind === 'sumsub')
     )
@@ -185,10 +197,6 @@ export function deriveGate(state: CapabilityState, op: RailOperation, scope: Gat
             reason: fixableRail.reason,
         }
     }
-
-    // 5. ready — per-op refinement wins over rail-level status
-    const hasReady = candidates.some((rail) => operationStatus(rail, op) === 'enabled')
-    if (hasReady) return { kind: 'ready' }
 
     // 6. pending — BE is provisioning, no user action needed
     const hasPending = candidates.some((rail) => rail.status === 'pending')


### PR DESCRIPTION
## Summary

If any in-scope rail can transact NOW, the gate returns `ready` — period. A stuck sibling rail in a different currency or with KYC remediation pending is not the user's problem when they have a working path.

## Triggering incident — 2026-06-01 Alexandre case

User `xandovsk` (Alexandre Santarossa, BR, user_id `ee146cd6-…`) reported via Crisp: *"i can't deposit BRL with PIX, it keep me telling to accept terms with Bridge, which I already accepted"*.

His user_rails state at 16:39 UTC:

| Provider | Method | Country | Status |
|---|---|---|---|
| **MANTECA** | **PIX_BR** | **BR** | **✅ ENABLED** |
| MANTECA | MERCADOPAGO_QR_AR | AR | ENABLED |
| BRIDGE | ACH_US | US | REQUIRES_EXTRA_INFORMATION (terms_of_service_v2) |
| BRIDGE | FASTER_PAYMENTS_GB | GB | REQUIRES_EXTRA_INFORMATION (terms_of_service_v2) |
| BRIDGE | SEPA_EU | EU | REQUIRES_EXTRA_INFORMATION (terms_of_service_v2) |
| BRIDGE | SPEI_MX | MX | REQUIRES_EXTRA_INFORMATION (terms_of_service_v2) |

Manteca's PIX_BR was right there ENABLED. But the FE gate evaluated `accept-tos` (looking at the Bridge rails) before `ready` (looking at the Manteca rail), so he saw a "Accept Terms of Service" modal for a Bridge currency he wasn't depositing.

PostHog confirmed he landed on `/add-money/brazil` at 16:36:26, spent ~4 seconds, then bounced.

## Fix

Hoist the `ready` check from priority 5 to priority 2 in `deriveGate`:

```ts
// 2. ready — per-op refinement wins over rail-level status. Hoisted
// above blocked / accept-tos / fixable-rejection because the user has
// a working path; a blocked sibling rail (different currency, KYC
// remediation pending) is not the user's problem right now.
const hasReady = candidates.some((rail) => operationStatus(rail, op) === 'enabled')
if (hasReady) return { kind: 'ready' }
```

Everything else falls through to the existing order when no ready rail exists.

## Relationship to other PRs

- **#2145 (Jota's, merged 14:30 UTC)** — narrows the bank-deposit gate's scope to country when the URL carries one. Solves the cross-country leak. This PR closes the same anti-pattern at the within-scope layer: even if a blocked Bridge × BR rail existed in scope, a ready Manteca × PIX_BR alongside should win. Also fixes the picker case (`/add-money` with no country) where #2145 intentionally kept the channel-only scope.
- **peanut-api-ts #942 (sibling-agent BE, in flight)** — Bridge classifier splits future-dated `effectiveDate` requirements into advisory vs blocking. Solves a different incident (Hugo's SEPA case, `c511d99c-…`). Complementary defense-in-depth on the same anti-pattern at a different layer.

## Test plan

- [x] `npm test src/utils/capability-gate.test.ts` — 20/20 pass (14 prior + 6 new)
- [x] `npm test src/app/(mobile-ui)/add-money/__tests__` — 73/73 pass across gate + add-money + KYC suites
- [x] `npm run typecheck` clean
- [x] `prettier --check` clean
- [ ] After merge: confirm Alexandre's `/add-money/brazil` does not show the Bridge ToS modal (use Hugo's PWA-refresh path or verify a similar BR user).

## Regression risks

- **Old behavior preserved when no ready rail exists** — the "no ready → falls through to existing order" test pins this. Blocked / accept-tos / fixable-rejection / waiting-on-provider all still fire as before for users with no working rail.
- **One semantic change worth noting**: a user with a blocked Bridge rail + ready Manteca rail used to see `blocked-rejection` modal; now they see no modal and get the working flow. That's the *intent* — but if anyone was relying on the modal as a way to push users to remediate their Bridge KYC even though they have a working Manteca path, that pattern goes away. KYC remediation prompts still live in `/profile/identity-verification` independently.

## Files

- `src/utils/capability-gate.ts` — reorder, update JSDoc, add commentary on the Alexandre incident
- `src/utils/capability-gate.test.ts` — 6 new tests under `deriveGate — ready-first ordering (Alexandre fix)`