### PR TITLE
refactor(invite): DRY the Skip Pass into the shared claim flow (-67 LoC)

### DIFF
--- a/src/components/Invites/InvitesPage.tsx
+++ b/src/components/Invites/InvitesPage.tsx
@@ -39,13 +39,9 @@ const UTM_CAMPAIGN_TO_BADGE_MAP: Record<string, string> = {
     ethfloripa: 'ETHFLORIPA_HUB',
 }
 
-// Campaign that bypasses the waitlist with no invite code: /invite?campaign=skip.
-// Awarding the Skip Pass badge (backend /badge/award) also flips hasAppAccess.
-//
-// TODO(card-beta-open): collapse the skip flow (this constant, isSkipCampaign, the
-// auto-claim effect, handleClaimSkip, and the skip render branch) into the existing
-// invite-claim path. Kept WET on purpose — invite signup is a hot, untested code path;
-// duplication < refactor blast radius while Card Beta is live.
+// /invite?campaign=skip — bypasses the waitlist with no invite code. The backend
+// /badge/award endpoint flips hasAppAccess + cardFlowEarlyAccessAt and adds the
+// Skip Pass badge (which is also in SKIP_BADGE_CODES, so card-waitlist is bypassed).
 const SKIP_CAMPAIGN = 'skip'
 
 function InvitePageContent() {
@@ -66,7 +62,9 @@ function InvitePageContent() {
         (inviteCode ? INVITE_CODE_TO_CAMPAIGN_MAP[inviteCode] : undefined) ||
         (utmCampaignParam ? UTM_CAMPAIGN_TO_BADGE_MAP[utmCampaignParam] : undefined)
 
-    // skip-the-waitlist link: no invite code required, handled by its own flow below
+    // Skip-the-waitlist link: no invite code, ?campaign=skip. The auto-claim
+    // effect below treats it specially (fires even without hasAppAccess) since
+    // awarding the badge IS what grants access.
     const isSkipCampaign = !inviteCode && campaign?.toLowerCase() === SKIP_CAMPAIGN
 
     const dispatch = useAppDispatch()
@@ -74,7 +72,6 @@ function InvitePageContent() {
     const { handleLoginClick, isLoggingIn } = useLogin()
     const [isAwardingBadge, setIsAwardingBadge] = useState(false)
     const hasStartedAwardingRef = useRef(false)
-    const hasStartedSkipRef = useRef(false)
 
     // Track if we should show content (prevents flash)
     const [shouldShowContent, setShouldShowContent] = useState(false)
@@ -103,164 +100,97 @@ function InvitePageContent() {
 
     // determine if we should show content based on user state
     useEffect(() => {
-        // if still fetching user, don't show content yet
         if (isFetchingUser) {
             setShouldShowContent(false)
             return
         }
-
-        // if invite validation is still loading, don't show content yet
-        if (isLoading) {
+        // wait for the invite query if there is one
+        if (inviteCode && isLoading) {
             setShouldShowContent(false)
             return
         }
-
-        // if user has app access AND invite is valid, they'll be redirected
-        // don't show content in this case (show loading instead)
-        if (!redirectUri && user?.user?.hasAppAccess && inviteCodeData?.success) {
+        // a logged-in visitor on either claim path will be auto-routed by the
+        // effect below — keep the loading spinner so they don't see the CTA flash.
+        if (user?.user && (isSkipCampaign || (!redirectUri && user.user.hasAppAccess && inviteCodeData?.success))) {
             setShouldShowContent(false)
             return
         }
-
-        // otherwise, safe to show content (either error view or invite screen)
         setShouldShowContent(true)
-    }, [user, isFetchingUser, redirectUri, inviteCodeData, isLoading])
+    }, [user, isFetchingUser, redirectUri, inviteCodeData, isLoading, isSkipCampaign, inviteCode])
 
-    // redirect logged-in users who already have app access
-    // users without app access should stay on this page to claim the invite and get access
+    // Logged-in auto-claim: award the campaign badge then push /home, or fall
+    // back to the inviter's profile when there's a valid invite but no campaign.
+    // Fires on both the invite-code path (needs hasAppAccess) and the Skip Pass
+    // path (badge GRANTS access, so no hasAppAccess gate).
     useEffect(() => {
-        // wait for both user and invite data to be loaded
-        if (!user?.user || !inviteCodeData || isLoading || isFetchingUser) {
+        if (!user?.user || isFetchingUser || hasStartedAwardingRef.current) return
+        // wait for invite-code validation when there is one
+        if (inviteCode && (isLoading || !inviteCodeData)) return
+
+        const hasValidInvite = !!inviteCodeData?.success && !!inviteCodeData.username
+        const isInviteAutoClaim = !redirectUri && user.user.hasAppAccess && hasValidInvite
+        if (!isInviteAutoClaim && !isSkipCampaign) return
+
+        hasStartedAwardingRef.current = true
+
+        if (campaign) {
+            setIsAwardingBadge(true)
+            invitesApi
+                .awardBadge(campaign)
+                .catch((e) => console.error('Error awarding campaign badge', e))
+                .finally(async () => {
+                    await fetchUser()
+                    setIsAwardingBadge(false)
+                    router.push('/home')
+                })
             return
         }
 
-        // prevent running the effect multiple times (ref doesn't trigger re-renders)
-        if (hasStartedAwardingRef.current) {
-            return
+        // No campaign on a validated invite → route to inviter profile.
+        if (hasValidInvite) {
+            router.push(profileUrl(inviteCodeData!.username!))
         }
+    }, [
+        user,
+        inviteCodeData,
+        isLoading,
+        isFetchingUser,
+        router,
+        campaign,
+        redirectUri,
+        fetchUser,
+        isSkipCampaign,
+        inviteCode,
+    ])
 
-        // if user has app access and invite is valid, handle redirect
-        if (!redirectUri && user.user.hasAppAccess && inviteCodeData.success && inviteCodeData.username) {
-            // if campaign is present, award the badge and redirect to home
-            if (campaign) {
-                hasStartedAwardingRef.current = true
-                setIsAwardingBadge(true)
-                invitesApi
-                    .awardBadge(campaign)
-                    .then(async () => {
-                        // refetch user data to get the newly awarded badge
-                        await fetchUser()
-                        router.push('/home')
-                    })
-                    .catch(async () => {
-                        // if badge awarding fails, still refetch and redirect
-                        await fetchUser()
-                        router.push('/home')
-                    })
-                    .finally(() => {
-                        setIsAwardingBadge(false)
-                    })
-            } else {
-                // no campaign, just redirect to inviter's profile
-                router.push(profileUrl(inviteCodeData.username))
-            }
-        }
-    }, [user, inviteCodeData, isLoading, isFetchingUser, router, campaign, redirectUri, fetchUser])
+    const handleClaim = () => {
+        const eventTag = inviteCode || (isSkipCampaign ? SKIP_CAMPAIGN : undefined)
+        posthog.capture(ANALYTICS_EVENTS.INVITE_CLAIM_CLICKED, { invite_code: eventTag })
 
-    // skip-the-waitlist: a logged-in visitor (even one still in jail) claims immediately —
-    // awardBadge('skip') grants app access + the Skip Pass badge on the backend.
-    useEffect(() => {
-        if (!isSkipCampaign || isFetchingUser || hasStartedSkipRef.current) return
-        if (!user?.user) return // not logged in — handled by the claim CTA below
-
-        hasStartedSkipRef.current = true
-        setIsAwardingBadge(true)
-        invitesApi
-            .awardBadge(SKIP_CAMPAIGN)
-            .catch((e) => console.error('Error claiming skip pass', e))
-            .finally(async () => {
-                await fetchUser()
-                router.push('/home')
-            })
-    }, [isSkipCampaign, user, isFetchingUser, fetchUser, router])
-
-    const handleClaimSkip = () => {
-        posthog.capture(ANALYTICS_EVENTS.INVITE_CLAIM_CLICKED, { invite_code: SKIP_CAMPAIGN })
-        // carry the campaign through signup; useZeroDev awards it once the account exists
-        saveToCookie('campaignTag', SKIP_CAMPAIGN)
-        router.push('/setup?step=signup')
-    }
-
-    const handleClaimInvite = async () => {
         if (inviteCode) {
-            posthog.capture(ANALYTICS_EVENTS.INVITE_CLAIM_CLICKED, {
-                invite_code: inviteCode,
-            })
             dispatch(setupActions.setInviteCode(inviteCode))
             dispatch(setupActions.setInviteType(EInviteType.PAYMENT_LINK))
-            saveToCookie('inviteCode', inviteCode) // Save to cookies as well, so that if user installs PWA, they can still use the invite code
-            if (campaign) {
-                saveToCookie('campaignTag', campaign)
-            }
-            if (redirectUri) {
-                const encodedRedirectUri = encodeURIComponent(redirectUri)
-                router.push('/setup?step=signup&redirect_uri=' + encodedRedirectUri)
-            } else {
-                router.push('/setup?step=signup')
-            }
+            // Save to cookie so PWA-install + later signup still see the invite.
+            saveToCookie('inviteCode', inviteCode)
         }
+        if (campaign) {
+            // useZeroDev reads `campaignTag` post-signup and calls /badge/award.
+            saveToCookie('campaignTag', campaign)
+        }
+
+        const signupUrl = redirectUri
+            ? `/setup?step=signup&redirect_uri=${encodeURIComponent(redirectUri)}`
+            : '/setup?step=signup'
+        router.push(signupUrl)
     }
 
-    // skip-the-waitlist link (?campaign=skip, no invite code) — its own flow
-    if (isSkipCampaign) {
-        // logged-in visitors are auto-claimed by the effect above; show loading while it runs
-        if (user?.user || isAwardingBadge || isFetchingUser) {
-            return <PeanutLoading coverFullScreen />
-        }
-        // not logged in — create an account, then useZeroDev awards the skip on signup
-        return (
-            <InvitesPageLayout image={peanutAnim.src}>
-                <div
-                    className={twMerge(
-                        'flex flex-grow flex-col justify-between overflow-hidden bg-white px-6 pb-8 pt-6 md:h-[100dvh] md:justify-center md:space-y-4',
-                        'flex flex-col items-end justify-center gap-5 pt-8 '
-                    )}
-                >
-                    <div className="mx-auto w-full md:max-w-xs">
-                        <div className="flex h-full flex-col justify-between gap-4 md:gap-6 md:pt-5">
-                            <h1 className="text-xl font-extrabold">You&apos;re skipping the waitlist</h1>
-                            <p className="text-base font-medium">
-                                Someone at Peanut wants you in. Create your wallet and walk straight past the line — no
-                                invite code, no queue.
-                            </p>
-                            <Button onClick={handleClaimSkip} shadowSize="4">
-                                Claim your Skip Pass
-                            </Button>
-                            <Button
-                                disabled={isLoggingIn}
-                                loading={isLoggingIn}
-                                variant="primary-soft"
-                                onClick={handleLoginClick}
-                                shadowSize="4"
-                            >
-                                Already have an account? Log in!
-                            </Button>
-                        </div>
-                    </div>
-                </div>
-                <UnsupportedBrowserModal allowClose={false} />
-            </InvitesPageLayout>
-        )
-    }
-
-    // show loading if:
-    // 1. badge is being awarded
-    // 2. we determined content shouldn't be shown yet (covers user fetching + invite validation)
     if (isAwardingBadge || !shouldShowContent) {
         return <PeanutLoading coverFullScreen />
     }
 
-    if (isError || !inviteCodeData?.success) {
+    // Invalid invite code (only reachable when an invite code was supplied).
+    // The skip path has no invite code so it never falls here.
+    if (!isSkipCampaign && (isError || !inviteCodeData?.success)) {
         return (
             <div className="my-auto flex h-[100dvh] w-screen flex-col items-center justify-center space-y-4 px-6">
                 <ValidationErrorView
@@ -273,6 +203,12 @@ function InvitePageContent() {
         )
     }
 
+    const title = isSkipCampaign ? "You're skipping the waitlist" : `${inviteCodeData?.username} invited you to Peanut`
+    const description = isSkipCampaign
+        ? 'Someone at Peanut wants you in. Create your wallet and walk straight past the line — no invite code, no queue.'
+        : 'Members-only access. Use this invite to open your wallet and start sending and receiving money globally.'
+    const ctaLabel = isSkipCampaign ? 'Claim your Skip Pass' : 'Claim your spot'
+
     return (
         <InvitesPageLayout image={peanutAnim.src}>
             <div
@@ -283,13 +219,10 @@ function InvitePageContent() {
             >
                 <div className="mx-auto w-full md:max-w-xs">
                     <div className="flex h-full flex-col justify-between gap-4 md:gap-6 md:pt-5">
-                        <h1 className="text-xl font-extrabold">{inviteCodeData?.username} invited you to Peanut</h1>
-                        <p className="text-base font-medium">
-                            Members-only access. Use this invite to open your wallet and start sending and receiving
-                            money globally.
-                        </p>
-                        <Button onClick={handleClaimInvite} shadowSize="4">
-                            Claim your spot
+                        <h1 className="text-xl font-extrabold">{title}</h1>
+                        <p className="text-base font-medium">{description}</p>
+                        <Button onClick={handleClaim} shadowSize="4">
+                            {ctaLabel}
                         </Button>
 
                         {!user?.user && (

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -120,15 +120,16 @@ export const useZeroDev = () => {
                     })
                     console.error('Error accepting invite', e)
                 }
-            } else if (campaignTag?.toLowerCase() === 'skip') {
-                // skip-the-waitlist campaign (no invite code): awarding grants app access + the Skip Pass badge.
-                // TODO(card-beta-open): generalize to `else if (campaignTag)` once the skip path is folded
-                // into the invite-claim path (see InvitesPage SKIP_CAMPAIGN TODO).
+            } else if (campaignTag) {
+                // No invite code but a campaign tag — only InvitesPage's skip-path
+                // CTA reaches here today (it sets the cookie without an inviteCode).
+                // The BE whitelists which campaigns are claimable, so passing other
+                // values through is safe — anything not on the whitelist 400s.
                 try {
                     await invitesApi.awardBadge(campaignTag)
                     posthog.capture(ANALYTICS_EVENTS.INVITE_ACCEPTED, { campaign_tag: campaignTag })
                 } catch (e) {
-                    console.error('Error claiming skip pass', e)
+                    console.error('Error awarding campaign badge', e)
                 } finally {
                     removeFromCookie('campaignTag')
                 }


### PR DESCRIPTION
## Why

Konrad's #2120 shipped 79 lines of WET parallel skip-flow logic with an explicit \`TODO(card-beta-open): collapse the skip flow … into the existing invite-claim path\`. The duplication was a risk-aversion decision while the hot invite-signup path was untested. Skip Pass is now live on prod (#2158), the hot path is exercised — duplication paid off, now we collapse it.

## What changes

InvitesPage.tsx: **-145 / +78 lines**. No behavior change across the five paths:

| Path | Before | After |
|---|---|---|
| Logged-out, valid invite + campaign | claim CTA → signup, cookies set | unchanged |
| Logged-out, no invite, ?campaign=skip | dedicated skip render branch + handleClaimSkip | branched copy in shared render + shared handleClaim |
| Logged-in (no app access), ?campaign=skip | dedicated skip useEffect | extended shared auto-claim useEffect |
| Logged-in (has app access), valid invite + campaign | auto-claim effect | unchanged (effect now also fires for skip) |
| Logged-in (has app access), valid invite, no campaign | auto-claim effect → inviter profile | unchanged |

Dropped:
- \`SKIP_CAMPAIGN\` WET TODO comment (kept the constant — it's a meaningful name)
- \`hasStartedSkipRef\` (single \`hasStartedAwardingRef\` now serves both paths)
- dedicated skip \`useEffect\` (~14 lines)
- \`handleClaimSkip\` (~6 lines)
- dedicated \`if (isSkipCampaign)\` render branch (~40 lines)

Generalized:
- \`handleClaimInvite\` → \`handleClaim\` — handles no-invite-code skip case by saving \`campaignTag\` cookie (which useZeroDev picks up post-signup).
- Existing auto-claim \`useEffect\` — fires for both \`isInviteAutoClaim\` AND \`isSkipCampaign\`. The skip path bypasses the \`hasAppAccess\` gate because the badge GRANTS access on the BE.
- \`shouldShowContent\` — loading-spinner shown when EITHER auto-claim path will fire (skip OR existing invite path).

useZeroDev.ts: generalized \`else if (campaignTag?.toLowerCase() === 'skip')\` → \`else if (campaignTag)\`. BE whitelists which campaigns are claimable (anything else 400s), so passing other values is safe. Only InvitesPage's skip path currently sets \`campaignTag\` without an invite code, so behavior is unchanged today; the change is future-proofing for additional no-invite-code campaigns.

## Behavioral mapping verified

5 scenarios walked manually against the new code:

1. **Logged-out + ?code=foo + ?campaign=bar** → handleClaim saves both cookies → /setup?step=signup → useZeroDev's inviteCode branch fires acceptInvite ✓
2. **Logged-out + ?campaign=skip** → handleClaim saves only campaignTag → /setup → useZeroDev's else-if(campaignTag) branch fires awardBadge('skip') ✓
3. **Logged-in (jail) + ?campaign=skip** → auto-claim effect bypasses hasAppAccess gate → awardBadge('skip') → fetchUser → /home ✓
4. **Logged-in (access) + ?code=foo + ?campaign=bar** → auto-claim effect → awardBadge('bar') → /home ✓
5. **Logged-in (access) + ?code=foo only** → auto-claim effect → no campaign → router.push(profileUrl) ✓

## Test plan

- [x] \`npm test --testPathPattern=invite\` — 10/10 green
- [x] eslint clean on touched files
- [x] typecheck clean
- [ ] CI: full unit + e2e + Deploy-Preview
- [ ] After deploy: manual smoke of /invite?campaign=skip (logged-out + logged-in jailed) on the preview URL before merge

## Companion / related

- Original Skip Pass FE: peanutprotocol/peanut-ui#2158 (merged to main, deploy currently flaking on Vercel post-build upload — not a code issue)
- Original Skip Pass BE: peanutprotocol/peanut-api-ts#949 (merged to main)