### PR TITLE
fix(saved-accounts): include Manteca (AR/BR) accounts in useSavedAccounts

### DIFF
--- a/src/hooks/__tests__/useSavedAccounts.test.ts
+++ b/src/hooks/__tests__/useSavedAccounts.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react'
 import useSavedAccounts from '@/hooks/useSavedAccounts'
-import { AccountType } from '@/interfaces'
+import { AccountType } from '@/interfaces/interfaces'
 
 const mockUseAuth = jest.fn()
 jest.mock('@/context/authContext', () => ({

--- a/src/hooks/__tests__/useSavedAccounts.test.ts
+++ b/src/hooks/__tests__/useSavedAccounts.test.ts
@@ -1,0 +1,46 @@
+import { renderHook } from '@testing-library/react'
+import useSavedAccounts from '@/hooks/useSavedAccounts'
+import { AccountType } from '@/interfaces'
+
+const mockUseAuth = jest.fn()
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => mockUseAuth(),
+}))
+
+const acct = (type: AccountType, identifier: string) => ({ type, identifier, id: identifier })
+
+beforeEach(() => mockUseAuth.mockReset())
+
+describe('useSavedAccounts', () => {
+    it('returns [] when there is no user', () => {
+        mockUseAuth.mockReturnValue({ user: undefined })
+        const { result } = renderHook(() => useSavedAccounts())
+        expect(result.current).toEqual([])
+    })
+
+    it('includes Manteca (AR CBU/CVU, BR PIX) accounts alongside Bridge bank types', () => {
+        // Regression: Manteca accounts (projected by the backend as type
+        // 'manteca') were dropped, so AR/BR users saw an empty saved-accounts
+        // list and had to re-enter their bank account every time.
+        mockUseAuth.mockReturnValue({
+            user: {
+                accounts: [
+                    acct(AccountType.PEANUT_WALLET, '0xabc'),
+                    acct(AccountType.EVM_ADDRESS, '0xdef'),
+                    acct(AccountType.IBAN, 'DE00'),
+                    acct(AccountType.MANTECA, '0070075730004135153296'),
+                ],
+            },
+        })
+        const { result } = renderHook(() => useSavedAccounts())
+        expect(result.current.map((a) => a.type)).toEqual([AccountType.IBAN, AccountType.MANTECA])
+    })
+
+    it('excludes wallets and other non-bank account types', () => {
+        mockUseAuth.mockReturnValue({
+            user: { accounts: [acct(AccountType.PEANUT_WALLET, '0xabc'), acct(AccountType.EVM_ADDRESS, '0xdef')] },
+        })
+        const { result } = renderHook(() => useSavedAccounts())
+        expect(result.current).toEqual([])
+    })
+})

--- a/src/hooks/useSavedAccounts.tsx
+++ b/src/hooks/useSavedAccounts.tsx
@@ -5,14 +5,18 @@ import { AccountType } from '@/interfaces'
 import { useMemo } from 'react'
 
 /**
- * Used to get the user's saved accounts, for now limited to bank accounts with (IBAN, US, and CLABE)
+ * Used to get the user's saved bank accounts (IBAN, US/ACH, CLABE, GB sort-code,
+ * and Manteca LATAM accounts — AR CBU/CVU, BR PIX — which the backend projects
+ * under the single 'manteca' type).
  * NOTE: This hook can be extended to support more account types in the future based on requirements
  * @returns {array} An array of the user's saved bank accounts
  */
 export default function useSavedAccounts() {
     const { user } = useAuth()
 
-    // filter out accounts that are not IBAN, US, or CLABE
+    // keep only saved bank accounts. Manteca (AR/BR) was previously omitted, so
+    // Manteca users' saved bank accounts never appeared in the claim/send-link
+    // bank flows — they had to re-enter their CBU/CVU/PIX every time.
     const savedAccounts = useMemo(() => {
         return (
             user?.accounts.filter(
@@ -20,7 +24,8 @@ export default function useSavedAccounts() {
                     acc.type === AccountType.IBAN ||
                     acc.type === AccountType.US ||
                     acc.type === AccountType.CLABE ||
-                    acc.type === AccountType.GB
+                    acc.type === AccountType.GB ||
+                    acc.type === AccountType.MANTECA
             ) ?? []
         )
     }, [user])

--- a/src/hooks/useSavedAccounts.tsx
+++ b/src/hooks/useSavedAccounts.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useAuth } from '@/context/authContext'
-import { AccountType } from '@/interfaces'
+import { AccountType } from '@/interfaces/interfaces'
 import { useMemo } from 'react'
 
 /**


### PR DESCRIPTION
## What

The claim / send-link "to bank" flows showed an **empty** saved-accounts list for Manteca (AR/BR) users, forcing them to re-enter their CBU/CVU/PIX every time. (Same Crisp report from `jani` as the BE PR.)

## Root cause

`useSavedAccounts` filtered saved accounts to `IBAN/US/CLABE/GB` only and omitted `AccountType.MANTECA` — the type the backend projects Manteca (AR/BR) accounts under. The withdraw router (`AddWithdrawRouterView`) already includes `MANTECA` in its own local filter; this brings the shared hook (used by the claim/send-link bank flows) to parity.

## Fix

Add `AccountType.MANTECA` to the `useSavedAccounts` filter.

## Cross-repo

Depends on peanut-api-ts `hotfix/manteca-account-details`, which makes the backend emit `type:'manteca'` for AR/BR bank accounts. **Safe in either deploy order** — until the BE ships, no account has type `'manteca'`, so this filter change is a no-op.

## Tests

NEW `src/hooks/__tests__/useSavedAccounts.test.ts` — Manteca accounts included alongside Bridge bank types; wallets/non-bank types excluded. **3/3 green**, prettier + tsc clean.

## Note

`useSavedAccounts` (this hook) and `AddWithdrawRouterView`'s local account filter duplicate the same bank-type list. Out of scope here, but worth consolidating into one shared predicate in a follow-up.

⚠️ Back-merge main→dev after merge.
