### PR TITLE
feat(shhhhh): /shhhhh?campaign=skip — full Skip Pass bypass via the marketing landing

### DIFF
--- a/src/app/shhhhh/ShhhhhLandingPage.tsx
+++ b/src/app/shhhhh/ShhhhhLandingPage.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image'
 import { useEffect, useRef, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useQueryClient } from '@tanstack/react-query'
 import posthog from 'posthog-js'
@@ -12,9 +12,18 @@ import { useAuth } from '@/context/authContext'
 import { PixelatedCardFace } from '@/components/Card/share-asset/PixelatedCardFace'
 import { Sparkle, Star } from '@/assets/illustrations'
 import { cardApi } from '@/services/card'
+import { invitesApi } from '@/services/invites'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { saveToCookie } from '@/utils/general.utils'
 
 const marqueeMessages = ['IYKYK', 'WORD TRAVELS', 'CLOSED BETA', 'SHHHH', 'PEANUT CLUB']
+
+// /shhhhh?campaign=skip — friends-of-Peanut land on the marketing page but get
+// the full Skip Pass bypass (badge + hasAppAccess + flowEarlyAccess) when they
+// press the door, instead of only the flowEarlyAccess flip the bare press grants.
+// Mirrors the /invite?campaign=skip path's contract — same BE call, same cookie
+// shape for post-signup pickup by useZeroDev.
+const SKIP_CAMPAIGN = 'skip'
 
 const stats: Array<{ value: string; label: string }> = [
     { value: '150M+', label: 'Visa-accepting merchants' },
@@ -135,12 +144,47 @@ function StickyShhhhhCTA({ onClick }: { onClick: () => void }) {
 }
 
 export default function ShhhhhLandingPage() {
-    const { user } = useAuth()
+    const { user, fetchUser } = useAuth()
     const router = useRouter()
     const queryClient = useQueryClient()
+    const searchParams = useSearchParams()
+    const isSkipCampaign = searchParams.get('campaign')?.toLowerCase() === SKIP_CAMPAIGN
 
     const handleCTA = async () => {
-        posthog.capture(ANALYTICS_EVENTS.DOOR_TRY, { signed_in: !!user })
+        posthog.capture(ANALYTICS_EVENTS.DOOR_TRY, {
+            signed_in: !!user,
+            campaign: isSkipCampaign ? SKIP_CAMPAIGN : null,
+        })
+
+        // /shhhhh?campaign=skip — Skip Pass bypass instead of the bare door
+        // press. Awards the badge (which flips hasAppAccess + flowEarlyAccess
+        // on the BE in one call), then routes to /home with full access.
+        if (isSkipCampaign) {
+            if (!user) {
+                // Carry the campaign through signup. useZeroDev's
+                // else-if(campaignTag) branch awards the skip badge once the
+                // account exists, same path as /invite?campaign=skip uses.
+                saveToCookie('campaignTag', SKIP_CAMPAIGN)
+                router.push('/setup?step=signup')
+                return
+            }
+            try {
+                await invitesApi.awardBadge(SKIP_CAMPAIGN)
+                posthog.capture(ANALYTICS_EVENTS.INVITE_ACCEPTED, { campaign_tag: SKIP_CAMPAIGN })
+            } catch (err) {
+                console.error('[shhhhh] awardBadge(skip) failed:', err)
+            }
+            // Refresh the user so the local cache reflects the new hasAppAccess
+            // + badge — keeps /home from flashing the jail screen on arrival.
+            try {
+                await fetchUser()
+            } catch (err) {
+                console.error('[shhhhh] fetchUser after skip failed:', err)
+            }
+            router.push('/home')
+            return
+        }
+
         if (!user) {
             // After signup, drop the user STRAIGHT into the card flow — not
             // back here. The `press_door=1` flag tells /card to call


### PR DESCRIPTION
## Why

\`/shhhhh\` and \`/invite?campaign=skip\` serve different audiences today: marketing-pitch landing vs. instant unlock. The bare door press on \`/shhhhh\` only stamps \`cardFlowEarlyAccessAt\` — a user also waitlisted at the app level still bounces to "Peanut jail" elsewhere, and a non-badged user still queues on \`/card\`.

For the broadcast we want ONE URL that does both: marketing pitch (scarcity counter, FAQ, card preview) AND the full waitlist bypass. This wires it.

## What changes

\`ShhhhhLandingPage.handleCTA\` now branches on \`?campaign=skip\`:

| Path | Logged-in | Logged-out |
|---|---|---|
| no campaign | door press → \`grantFlowEarlyAccess\` → \`/card\` (unchanged) | \`/setup?redirect_uri=/card?press_door=1\` (unchanged) |
| \`?campaign=skip\` | door press → \`invitesApi.awardBadge('skip')\` → \`fetchUser\` → \`/home\` | save \`campaignTag\` cookie → \`/setup?step=signup\` (useZeroDev awards post-signup) |

The badge award on the BE flips \`hasAppAccess\` + \`cardFlowEarlyAccessAt\` + adds \`WAITLIST_SKIP\` (the Skip Pass badge is in \`SKIP_BADGE_CODES\` so the card-waitlist inner gate also passes passively). All idempotent.

The logged-out branch carries the campaign via cookie — the same shape \`/invite?campaign=skip\` uses since #2159 generalized \`useZeroDev\`'s \`else if (campaignTag?.toLowerCase() === 'skip')\` to \`else if (campaignTag)\`.

## Net diff

\`+47 / -3\` in one file — \`ShhhhhLandingPage.tsx\`. New \`SKIP_CAMPAIGN\` constant mirrors the InvitesPage pattern. No new APIs, no BE changes.

## Behavior matrix verified

| Scenario | Outcome |
|---|---|
| \`/shhhhh\` press door (logged in, no skip) | unchanged — flowEarlyAccess flipped, \`/card\` |
| \`/shhhhh\` press door (logged out, no skip) | unchanged — \`/setup\` with redirect to \`/card?press_door=1\` |
| \`/shhhhh?campaign=skip\` (logged in, app-waitlisted) | badge award flips \`hasAppAccess\` + \`flowEarlyAccess\` → \`/home\` ✓ |
| \`/shhhhh?campaign=skip\` (logged in, already has access) | badge award is idempotent → still gets WAITLIST_SKIP badge → \`/home\` ✓ |
| \`/shhhhh?campaign=skip\` (logged out) | \`campaignTag\` cookie → signup → \`useZeroDev\` awards skip → in-app ✓ |

## Test plan

- [x] prettier clean
- [x] eslint clean (touched file)
- [x] typecheck clean (touched file)
- [ ] CI: full unit + e2e + Deploy-Preview
- [ ] After deploy: manual smoke of \`peanut.me/shhhhh?campaign=skip\` (logged-out + logged-in jailed) on the preview URL before merge

## Related

- Backend Skip Pass: peanutprotocol/peanut-api-ts#949 (merged)
- /invite?campaign=skip FE: #2158 (merged)
- DRY refactor that generalized useZeroDev's campaignTag branch: #2159 (merged)