### PR TITLE
hotfix(kyc): derive region intent from destination country in bank flows

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -38,6 +38,7 @@ import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { addMoneyCountryUrl } from '@/utils/native-routes'
 import { useSafeBack } from '@/hooks/useSafeBack'
+import { getRegionIntent } from '@/utils/regions.utils'
 
 // Step type for URL state
 type BridgeBankStep = 'inputAmount' | 'showDetails'
@@ -71,7 +72,8 @@ export default function OnrampBankPage() {
 
     // inline sumsub kyc flow for bridge bank onramp
     // regionIntent is NOT passed here to avoid creating a backend record on mount.
-    // intent is passed at call time: handleInitiateKyc('STANDARD')
+    // intent is passed at call time, derived from the destination country
+    // (e.g. /add-money/usa → NA → bridge-requirements).
     const sumsubFlow = useMultiPhaseKycFlow({
         onKycSuccess: () => {
             setUrlState({ step: 'inputAmount' })
@@ -418,7 +420,7 @@ export default function OnrampBankPage() {
                             await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                         } else {
                             await sumsubFlow.handleInitiateKyc(
-                                'STANDARD',
+                                getRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
                                 undefined,
                                 gate.kind === 'needs-enrollment' || undefined
                             )

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -256,6 +256,7 @@ jest.mock('@/constants/countryCurrencyMapping', () => ({
     ],
     isNonEuroSepaCountry: jest.fn(() => false),
     isUKCountry: jest.fn(() => false),
+    getFlagUrl: jest.fn((iso2: string) => `/flags/${iso2}.svg`),
 }))
 
 // Rhino consts
@@ -681,6 +682,7 @@ jest.mock('@/components/AddMoney/consts', () => ({
         { type: 'country', id: 'XX', path: 'unknown', currency: 'USD', iso3: 'XXX' },
     ],
     ALL_COUNTRIES_ALPHA3_TO_ALPHA2: { ARG: 'AR', BRA: 'BR', USA: 'US', DEU: 'DE', MEX: 'MX', GBR: 'GB' },
+    BRIDGE_ALPHA3_TO_ALPHA2: { USA: 'US', DEU: 'DE', MEX: 'MX', GBR: 'GB' },
 }))
 
 jest.mock('@/components/TransactionDetails/transactionTransformer', () => ({}))

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -38,7 +38,7 @@ import { getKycModalVariant, getGateUserMessage } from '@/utils/capability-gate'
 import { useModalsContext } from '@/context/ModalsContext'
 import ExchangeRate from '@/components/ExchangeRate'
 import countryCurrencyMappings, { isNonEuroSepaCountry } from '@/constants/countryCurrencyMapping'
-import { isBridgeSupportedCountry } from '@/utils/regions.utils'
+import { isBridgeSupportedCountry, getRegionIntent } from '@/utils/regions.utils'
 import { PointsAction } from '@/services/services.types'
 import { usePointsCalculation } from '@/hooks/usePointsCalculation'
 import { parseUnits } from 'viem'
@@ -533,7 +533,7 @@ export default function WithdrawBankPage() {
                         await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                     } else {
                         await sumsubFlow.handleInitiateKyc(
-                            'STANDARD',
+                            getRegionIntent(getCountryFromPath(country)?.region ?? 'rest-of-the-world'),
                             undefined,
                             gate.kind === 'needs-enrollment' || undefined
                         )

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -32,6 +32,7 @@ import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { getKycModalVariant, getGateUserMessage } from '@/utils/capability-gate'
 import { railJurisdictionForBank } from '@/utils/bridge.utils'
+import { getRegionIntent } from '@/utils/regions.utils'
 import { useTosGuard } from '@/hooks/useTosGuard'
 import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
 import { useModalsContext } from '@/context/ModalsContext'
@@ -59,7 +60,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
 
     // inline sumsub kyc flow for bridge bank users who need verification
     // regionIntent is NOT passed here to avoid creating a backend record on mount.
-    // intent is passed at call time: handleInitiateKyc('STANDARD')
+    // intent is passed at call time, derived from the destination country.
     const sumsubFlow = useMultiPhaseKycFlow({
         onKycSuccess: () => {
             setIsKycModalOpen(false)
@@ -235,7 +236,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
         // scenario (2): if the user hasn't completed kyc yet
         // name and email are now collected by sumsub sdk — no need to save them beforehand
         if (!isUserKycApproved) {
-            await sumsubFlow.handleInitiateKyc('STANDARD')
+            await sumsubFlow.handleInitiateKyc(getRegionIntent(currentCountry?.region ?? 'rest-of-the-world'))
         }
 
         return {}
@@ -342,7 +343,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                         await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                     } else {
                         await sumsubFlow.handleInitiateKyc(
-                            'STANDARD',
+                            getRegionIntent(currentCountry?.region ?? 'rest-of-the-world'),
                             undefined,
                             gate.kind === 'needs-enrollment' || undefined
                         )

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -32,6 +32,7 @@ import { bankFormActions } from '@/redux/slices/bank-form-slice'
 import { sendLinksApi } from '@/services/sendLinks'
 import { useSearchParams } from 'next/navigation'
 import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
+import { getRegionIntent } from '@/utils/regions.utils'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { getKycModalVariant, getGateUserMessage } from '@/utils/capability-gate'
@@ -93,7 +94,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
 
     // inline sumsub kyc flow for users who need verification
     // regionIntent is NOT passed here to avoid creating a backend record on mount.
-    // intent is passed at call time: handleInitiateKyc('STANDARD')
+    // intent is passed at call time, derived from the destination country.
     const sumsubFlow = useMultiPhaseKycFlow({
         onKycSuccess: async () => {
             if (justCompletedKyc) return
@@ -296,7 +297,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
         // scenario 1: receiver needs KYC
         // name and email are now collected by sumsub sdk — no need to save them beforehand
         if (bankClaimType === BankClaimType.ReceiverKycNeeded && !justCompletedKyc) {
-            await sumsubFlow.handleInitiateKyc('STANDARD')
+            await sumsubFlow.handleInitiateKyc(getRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'))
             return {}
         }
 
@@ -564,7 +565,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                                     await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                                 } else {
                                     await sumsubFlow.handleInitiateKyc(
-                                        'STANDARD',
+                                        getRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
                                         undefined,
                                         gate.kind === 'needs-enrollment' || undefined
                                     )

--- a/src/components/Profile/views/UnlockedRegions.view.tsx
+++ b/src/components/Profile/views/UnlockedRegions.view.tsx
@@ -79,17 +79,20 @@ const UnlockedRegions = () => {
     const mantecaRejection = useMemo(() => deriveProviderRejection(rails, 'MANTECA'), [rails])
     const isSumsubApproved = isKycApproved
     // MIGRATION-REVIEW: the existing verification's region intent (was
-    // useUnifiedKycStatus.sumsubVerificationRegionIntent, read off raw kycVerifications
-    // metadata) is proxied from which provider the user already holds a functional rail
-    // for: a Manteca rail ⇒ they verified for LATAM, a Bridge rail ⇒ STANDARD. Used only
+    // Which provider the user already holds a functional rail for, used only
     // to detect a cross-region switch when starting a new verification.
-    const sumsubVerificationRegionIntent: string | null = useMemo(() => {
+    // We deliberately capture the PROVIDER directly rather than round-tripping
+    // through KYCRegionIntent: the legacy 'STANDARD' value used to stand in
+    // for "Bridge rail" here, but providerForRegionIntent maps STANDARD →
+    // manteca (it's in the general-bucket fallback), so a Bridge-→Bridge
+    // re-verification would have misclassified as cross-region.
+    const existingVerificationProvider: ProviderCode | null = useMemo(() => {
         const hasFunctional = (provider: ProviderCode) =>
             railsForProvider(provider).some(
                 (rail) => rail.status === 'enabled' || rail.status === 'pending' || rail.status === 'requires-info'
             )
-        if (hasFunctional('manteca')) return 'LATAM'
-        if (hasFunctional('bridge')) return 'STANDARD'
+        if (hasFunctional('manteca')) return 'manteca'
+        if (hasFunctional('bridge')) return 'bridge'
         return null
     }, [railsForProvider])
     const { setIsSupportModalOpen } = useModalsContext()
@@ -165,21 +168,17 @@ const UnlockedRegions = () => {
         const intent = selectedRegion ? getRegionIntent(selectedRegion.path) : undefined
         if (intent) setActiveRegionIntent(intent)
         // Cross-region means "user has an identity for one provider, clicked a
-        // region served by a DIFFERENT provider". Compare PROVIDERS not raw
-        // intent strings: in the 4-bucket model both 'EU' and 'NA' route to
-        // Bridge, and both 'LATAM' / 'ROW' route to Manteca (`general` level),
-        // so 'STANDARD' !== 'EU' alone would misclassify a Bridge→Bridge flow
-        // as cross-region.
+        // region served by a DIFFERENT provider". Compare PROVIDERS directly:
+        // in the 4-bucket model both 'EU' and 'NA' route to Bridge and both
+        // 'LATAM' / 'ROW' route to Manteca, so an intent-string compare would
+        // miss Bridge-EU → Bridge-NA same-provider flows.
         const crossRegion =
-            sumsubVerificationRegionIntent &&
-            intent &&
-            providerForRegionIntent(sumsubVerificationRegionIntent as KYCRegionIntent) !==
-                providerForRegionIntent(intent)
+            existingVerificationProvider && intent && existingVerificationProvider !== providerForRegionIntent(intent)
                 ? true
                 : undefined
         setSelectedRegion(null)
         await flow.handleInitiateKyc(intent, undefined, crossRegion)
-    }, [flow.handleInitiateKyc, selectedRegion, sumsubVerificationRegionIntent])
+    }, [flow.handleInitiateKyc, selectedRegion, existingVerificationProvider])
 
     // re-submission: skip StartVerificationView since user already consented
     const handleResubmitKyc = useCallback(async () => {


### PR DESCRIPTION
## Summary

PR #913 (BE) and #2136 (FE) replaced `resolveLevelName` with the 4-bucket `verificationLevelForIntent`:

- `EU` / `NA` → `bridge-requirements`
- `LATAM` / `ROW` / `STANDARD` / `undefined` → `general`

Every Bridge bank-flow call site kept the hardcoded literal `'STANDARD'` as the intent, which now falls through to the **`general`** catch-all. So every Bridge bank user (add-money OR withdraw) gets routed to `general` instead of `bridge-requirements` and sees the wrong KYC level when starting verification.

Triggering Crisp report (2026-06-01): user trying to withdraw to a US bank account got the `general` level + a "We couldn't unlock this — verification issue" modal. Stuck.

## Fix

Pass the destination country's region through `getRegionIntent(...)` so `/withdraw/usa` and `/add-money/usa` land on `NA` → `bridge-requirements`, `/add-money/germany` on `EU` → `bridge-requirements`, etc. Mirrors what Manteca pages already do with the hardcoded `'LATAM'` intent.

Six call sites across four files:

| File | Lines |
|---|---|
| `app/(mobile-ui)/withdraw/[country]/bank/page.tsx` | 1 |
| `app/(mobile-ui)/add-money/[country]/bank/page.tsx` | 1 |
| `components/AddWithdraw/AddWithdrawCountriesList.tsx` | 2 |
| `components/Claim/Link/views/BankFlowManager.view.tsx` | 2 |

Each file picks up `getRegionIntent` from `@/utils/regions.utils`; the call shape is `getRegionIntent(<country>?.region ?? 'rest-of-the-world')`. Stale comments referencing `'STANDARD'` updated to "derived from the destination country."

## Out of scope (follow-up)

`components/Profile/views/UnlockedRegions.view.tsx:92` returns `'STANDARD'` for "user already has a Bridge functional rail" — a legacy cross-region marker, not a routing intent. But `providerForRegionIntent('STANDARD')` returns `'manteca'`, so a Bridge → Bridge re-verification path may misclassify as cross-region. That's a separate fix; not bank-flow-specific and not covered here.

## Test plan

- [ ] `/withdraw/usa` as a non-verified Bridge user → KYC modal opens at `bridge-requirements` level, not `general`.
- [ ] `/add-money/germany` as a non-verified Bridge user → same.
- [ ] `/add-money/argentina` (Manteca country) → unchanged: still `general`/`LATAM` (Manteca routes don't go through these call sites).
- [ ] `/withdraw/mexico` for a user with SPEI-MX Bridge → KYC modal opens at `bridge-requirements`.
- [ ] Claim-link bank flow (`BankFlowManager`) → same as above.
- [ ] `tsc --noEmit` clean.