### PR TITLE
fix(exchange-rate): short-circuit non-Bridge AccountTypes (PEANUT-UI-QHR)

### DIFF
--- a/src/hooks/__tests__/useGetExchangeRate.test.ts
+++ b/src/hooks/__tests__/useGetExchangeRate.test.ts
@@ -1,0 +1,63 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import useGetExchangeRate from '@/hooks/useGetExchangeRate'
+import { AccountType } from '@/interfaces'
+
+// `getExchangeRate` performs a server fetch in real use. We mock it to capture
+// whether it was called — the regression test for PEANUT-UI-QHR is that
+// non-Bridge AccountType values must NOT cause a network call.
+const getExchangeRateMock = jest.fn()
+jest.mock('@/app/actions/exchange-rate', () => ({
+    getExchangeRate: (...args: unknown[]) => getExchangeRateMock(...args),
+}))
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+    const client = new QueryClient({
+        defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+    })
+    return React.createElement(QueryClientProvider, { client }, children)
+}
+
+describe('useGetExchangeRate', () => {
+    beforeEach(() => {
+        getExchangeRateMock.mockReset()
+    })
+
+    it('returns 1 and skips the network call for AccountType.US (USD↔USD)', async () => {
+        const { result } = renderHook(() => useGetExchangeRate({ accountType: AccountType.US }), { wrapper })
+        await waitFor(() => expect(result.current.exchangeRate).toBe('1'))
+        expect(getExchangeRateMock).not.toHaveBeenCalled()
+    })
+
+    // PEANUT-UI-QHR regression: the BE `/bridge/exchange-rate` enum is
+    // {iban,us,clabe,gb}. Any other AccountType (MANTECA, EVM_ADDRESS,
+    // PEANUT_WALLET) would 400 — the hook must short-circuit instead of
+    // making the network call.
+    it.each([AccountType.MANTECA, AccountType.EVM_ADDRESS, AccountType.PEANUT_WALLET])(
+        'returns 1 and skips the network call for non-Bridge type: %s',
+        async (accountType) => {
+            const { result } = renderHook(() => useGetExchangeRate({ accountType }), { wrapper })
+            await waitFor(() => expect(result.current.exchangeRate).toBe('1'))
+            expect(getExchangeRateMock).not.toHaveBeenCalled()
+        }
+    )
+
+    it.each([AccountType.IBAN, AccountType.CLABE, AccountType.GB])(
+        'calls the network for Bridge FX type: %s and returns its sell_rate',
+        async (accountType) => {
+            getExchangeRateMock.mockResolvedValue({ data: { sell_rate: '1.05' } })
+            const { result } = renderHook(() => useGetExchangeRate({ accountType }), { wrapper })
+            await waitFor(() => expect(result.current.exchangeRate).toBe('1.05'))
+            expect(getExchangeRateMock).toHaveBeenCalledWith(accountType)
+        }
+    )
+
+    it('falls back to 1 when the network returns an error', async () => {
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+        getExchangeRateMock.mockResolvedValue({ error: 'upstream 500' })
+        const { result } = renderHook(() => useGetExchangeRate({ accountType: AccountType.IBAN }), { wrapper })
+        await waitFor(() => expect(result.current.exchangeRate).toBe('1'))
+        consoleErrorSpy.mockRestore()
+    })
+})

--- a/src/hooks/useGetExchangeRate.tsx
+++ b/src/hooks/useGetExchangeRate.tsx
@@ -11,12 +11,24 @@ export interface IExchangeRate {
  * Used to get exchange rate for a given account type using TanStack Query
  * @returns {string, boolean} The exchange rate for the given account type and a boolean indicating if the rate is being fetched
  */
+// `/bridge/exchange-rate` only serves Bridge bank-account types with a
+// non-trivial FX rate: IBAN (EUR), CLABE (MXN), GB (GBP). US is USD↔USD = 1
+// by definition. Other AccountType values (MANTECA, EVM_ADDRESS, PEANUT_WALLET)
+// aren't on the Bridge enum and 400 the endpoint (PEANUT-UI-QHR, 2026-06-02).
+// Treat those like US — '1' is a safe display fallback; consumers already
+// degrade gracefully on '1' (and the only consumer that needs a real Manteca
+// FX rate routes through `getCachedCurrencyPrice` in actions/currency.ts).
+// TODO: Manteca-currency display rates should route through that helper too
+// instead of returning '1'; separate PR.
+const BRIDGE_FX_ACCOUNT_TYPES: ReadonlySet<AccountType> = new Set([AccountType.IBAN, AccountType.CLABE, AccountType.GB])
+
 export default function useGetExchangeRate({ accountType, enabled = true }: IExchangeRate) {
     const { data: exchangeRate, isFetching: isFetchingRate } = useQuery({
         queryKey: ['exchangeRate', accountType],
         queryFn: async () => {
-            // US accounts have 1:1 exchange rate
-            if (accountType === AccountType.US) {
+            // Anything not on the Bridge FX set returns the passthrough rate.
+            // Includes AccountType.US (USD↔USD = 1).
+            if (!BRIDGE_FX_ACCOUNT_TYPES.has(accountType)) {
                 return '1'
             }
 


### PR DESCRIPTION
## Why

`useGetExchangeRate` was passing the raw `AccountType` enum value to the `/bridge/exchange-rate` endpoint. The BE schema validates against the **Bridge enum** \`{iban, us, clabe, gb}\`; passing any other value returns **400** with \`querystring/accountType must be equal to one of the allowed values\`.

Today (2026-06-02), 2 users hit this via the Manteca bank-account withdraw flow → **PEANUT-UI-QHR**. The FE \`AccountType\` enum is broader than the Bridge enum:

| FE \`AccountType\` | On Bridge enum? |
|---|---|
| IBAN | ✅ |
| US | ✅ (treated as USD↔USD = 1) |
| CLABE | ✅ |
| GB | ✅ |
| **MANTECA** | ❌ → 400 |
| **EVM_ADDRESS** | ❌ → 400 |
| **PEANUT_WALLET** | ❌ → 400 |

## Fix

The hook already short-circuited \`AccountType.US\` to return \`'1'\`. Generalise: short-circuit **any** \`accountType\` not on the Bridge FX set \`{IBAN, CLABE, GB}\`. US still returns \`'1'\` (existing behaviour); MANTECA / EVM_ADDRESS / PEANUT_WALLET now also return \`'1'\` instead of leaking to the 400.

\`'1'\` is a safe display fallback — the only consumer that needs a *real* Manteca FX rate routes through \`getCachedCurrencyPrice\` in \`app/actions/currency.ts\` (Manteca-aware via \`mantecaApi.getPrices\`), which is unaffected by this change.

## Test plan

- [x] Regression test: \`MANTECA\` / \`EVM_ADDRESS\` / \`PEANUT_WALLET\` return \`'1'\` and don't call \`getExchangeRate\`.
- [x] \`US\` still returns \`'1'\` (no regression).
- [x] \`IBAN\` / \`CLABE\` / \`GB\` still call the network and return the \`sell_rate\`.
- [x] Network error falls back to \`'1'\`.
- [x] All 8 tests passing locally.
- [x] Typecheck clean for the changed file.
- [x] Prettier clean.

## Follow-up (deliberate, not in this PR)

Manteca display rates should route through \`getCachedCurrencyPrice\` rather than being treated as 1:1. Marked as TODO in the file comment. Separate PR — it's a behavior change that needs UX review.

## Bug pattern

Same shape as the [\`api-contract\`](../tree/main/skills/api-contract) skill is designed to catch — silent enum drift between FE and BE where the FE enum is a superset of the BE enum it gets passed to.