### PR TITLE
fix(offramp): derive destination rail from account type, not country (PEANUT-API-5P/5M/5N)

### DIFF
--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -15,7 +15,7 @@ import useClaimLink from '../../useClaimLink'
 import { type AddBankAccountPayload } from '@/app/actions/types/users.types'
 import { useAuth } from '@/context/authContext'
 import { type TCreateOfframpRequest, type TCreateOfframpResponse } from '@/services/services.types'
-import { getOfframpCurrencyConfig } from '@/utils/bridge.utils'
+import { getOfframpConfigFromAccount } from '@/utils/bridge.utils'
 import { getBridgeChainName, getBridgeTokenName } from '@/utils/bridge-accounts.utils'
 import { generateKeysFromString, getParamsFromLink } from '@/utils/peanut-link.utils'
 import { getContractAddress } from '@/utils/peanut-claim.utils'
@@ -239,7 +239,13 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
 
             const externalAccountId = (account.bridgeAccountId ?? account.id) as string
 
-            const destination = getOfframpCurrencyConfig(account.country ?? selectedCountry!.id)
+            // Derive destination currency + rail from the SELECTED ACCOUNT's
+            // type, not from `selectedCountry`. Pairing a GB/GBP account with
+            // a SEPA destination is semantically impossible — Bridge rejects
+            // with "country is not supported for SEPA" (PEANUT-API-5P/5M/5N
+            // on 2026-06-02). The account's `type` already carries the right
+            // answer for every Bridge destination we support.
+            const destination = getOfframpConfigFromAccount(account)
 
             // handle offramp request creation
             const offrampRequestParams: TCreateOfframpRequest = {

--- a/src/utils/__tests__/bridge.utils.test.ts
+++ b/src/utils/__tests__/bridge.utils.test.ts
@@ -2,6 +2,7 @@ import { BRIDGE_DEVELOPER_FEE_RATE } from '@/constants/payment.consts'
 import {
     applyBridgeCrossCurrencyFee,
     getCurrencyConfig,
+    getOfframpConfigFromAccount,
     getOfframpCurrencyConfig,
     getPaymentRailDisplayName,
     getMinimumAmount,
@@ -138,6 +139,70 @@ describe('bridge.utils', () => {
         it('should return correct offramp configuration for other countries', () => {
             const config = getOfframpCurrencyConfig('FR')
             expect(config).toEqual({
+                currency: 'eur',
+                paymentRail: 'sepa',
+            })
+        })
+    })
+
+    describe('getOfframpConfigFromAccount (PEANUT-API-5P/5M/5N regression)', () => {
+        // The 2026-06-02 21:24 incident: a GB/GBP account got paired with
+        // EUR/SEPA because the picker used `account.country ?? selectedCountry`
+        // and the user-selected country fell through the "everything else →
+        // EUR/SEPA" default. These cases lock in the behavior that the account
+        // type alone is enough to pick the right rail.
+        it('GB account → GBP / faster_payments (was EUR/SEPA in the incident)', () => {
+            expect(getOfframpConfigFromAccount({ type: 'gb' })).toEqual({
+                currency: 'gbp',
+                paymentRail: 'faster_payments',
+            })
+        })
+
+        it('US account → USD / ach', () => {
+            expect(getOfframpConfigFromAccount({ type: 'us' })).toEqual({
+                currency: 'usd',
+                paymentRail: 'ach',
+            })
+        })
+
+        it('CLABE account → MXN / spei', () => {
+            expect(getOfframpConfigFromAccount({ type: 'clabe' })).toEqual({
+                currency: 'mxn',
+                paymentRail: 'spei',
+            })
+        })
+
+        it('IBAN account → EUR / sepa', () => {
+            expect(getOfframpConfigFromAccount({ type: 'iban' })).toEqual({
+                currency: 'eur',
+                paymentRail: 'sepa',
+            })
+        })
+
+        it('accepts BE Prisma-shape suffixes like BANK_IBAN / BANK_ACH_GB', () => {
+            expect(getOfframpConfigFromAccount({ type: 'BANK_IBAN' })).toEqual({
+                currency: 'eur',
+                paymentRail: 'sepa',
+            })
+            expect(getOfframpConfigFromAccount({ type: 'bank_account_gb' })).toEqual({
+                currency: 'gbp',
+                paymentRail: 'faster_payments',
+            })
+        })
+
+        it('throws on Manteca account type — must use the Manteca offramp path', () => {
+            expect(() => getOfframpConfigFromAccount({ type: 'manteca' })).toThrow(
+                'Manteca accounts route through a separate offramp path'
+            )
+        })
+
+        it('falls back to country-based picking when type is missing', () => {
+            expect(getOfframpConfigFromAccount({ country: 'US' })).toEqual({
+                currency: 'usd',
+                paymentRail: 'ach',
+            })
+            // Unknown country → EU/SEPA default, mirrors prior behavior
+            expect(getOfframpConfigFromAccount({ country: 'XYZ' })).toEqual({
                 currency: 'eur',
                 paymentRail: 'sepa',
             })

--- a/src/utils/bridge.utils.ts
+++ b/src/utils/bridge.utils.ts
@@ -82,6 +82,37 @@ export const getOfframpCurrencyConfig = (countryId: string): CurrencyConfig => {
 }
 
 /**
+ * Derive the offramp destination currency + payment rail from the bank
+ * account's actual `type`, falling back to country only when the type is
+ * unknown.
+ *
+ * Why: `getOfframpCurrencyConfig(country)` defaults *any* unknown country to
+ * EUR+SEPA. Pairing that default with a GBP/UK account caused Bridge to 400
+ * with "country is not supported for SEPA" (PEANUT-API-5P/5M/5N, 2026-06-02
+ * 21:24 UTC) — Bridge can't SEPA-credit a GBP account. The bank account's
+ * `type` already carries the right answer for every Bridge destination we
+ * support (`us`/`gb`/`clabe`/`iban`), so derive from it directly.
+ *
+ * Manteca-type accounts use a non-Bridge rail; the caller must NOT route
+ * those through this helper. We throw rather than silently misclassify.
+ */
+export const getOfframpConfigFromAccount = (account: {
+    type?: string | AccountType | null
+    country?: string | null
+}): CurrencyConfig => {
+    const t = account.type?.toString().toLowerCase()
+    if (t === AccountType.US || t?.endsWith('ach') || t?.endsWith('us')) return getCurrencyConfig('US', 'offramp')
+    if (t === AccountType.GB || t?.endsWith('gb')) return getCurrencyConfig('GB', 'offramp')
+    if (t === AccountType.CLABE || t?.endsWith('clabe')) return getCurrencyConfig('MX', 'offramp')
+    if (t === AccountType.IBAN || t?.endsWith('iban')) return getCurrencyConfig('EU', 'offramp')
+    if (t === AccountType.MANTECA || t?.endsWith('manteca')) {
+        throw new Error('Manteca accounts route through a separate offramp path, not Bridge.')
+    }
+    // type missing / unknown — fall back to country, preserving prior behavior.
+    return getOfframpCurrencyConfig(account.country ?? 'EU')
+}
+
+/**
  * Map ISO fiat currency → Bridge bank AccountType. Used by onramp quote
  * + exchange-rate callers that only have the currency string in hand.
  */


### PR DESCRIPTION
## Why

**2026-06-02 21:24 UTC. PEANUT-API-5P/5M/5N + Discord on-call page.**

A user with a UK GBP bank account tried to offramp USDC → EUR via SEPA. Bridge correctly rejected:
\`\`\`
country is not supported for SEPA
\`\`\`
SEPA only credits EUR-denominated Eurozone accounts. You can't SEPA-credit a GBP account.

## Root cause (FE)

\`BankFlowManager.handleCreateOfframpAndClaim\` picked the destination from country, not from the bank account's actual type:

\`\`\`ts
const destination = getOfframpCurrencyConfig(
    account.country ?? selectedCountry!.id
)
\`\`\`

When \`account.country\` is missing or doesn't match, the picker falls through to \`selectedCountry\`. \`getOfframpCurrencyConfig\`'s "everything unknown → EUR/SEPA" default then fires — even for a clearly GBP/UK account. Result: a GB account was paired with EUR/SEPA → Bridge 400.

The bank account's own \`type\` already carries the right answer for every Bridge destination we support (\`us\` / \`gb\` / \`clabe\` / \`iban\`). Deriving directly from type closes this class of bug at the source.

## What this PR does

New helper \`getOfframpConfigFromAccount(account)\` in \`src/utils/bridge.utils.ts\`:

| account.type | currency | paymentRail |
|---|---|---|
| \`us\` | usd | ach |
| \`gb\` | gbp | faster_payments |
| \`clabe\` | mxn | spei |
| \`iban\` | eur | sepa |
| \`manteca\` | **throws** (must use the Manteca offramp path, not Bridge) |
| missing/unknown | falls back to country-based picking (prior behavior) |

Also accepts BE Prisma-shape suffixes (\`BANK_IBAN\`, \`BANK_ACCOUNT_GB\`, …) so it works regardless of which side of the API the account row came from.

Use site: \`BankFlowManager.view.tsx:248\` — the only call site for the offramp destination picker on this code path.

## Tests

\`src/utils/__tests__/bridge.utils.test.ts\` — 7 new cases under \`getOfframpConfigFromAccount (PEANUT-API-5P/5M/5N regression)\`:

- ✅ **GB account → GBP/faster_payments** (was EUR/SEPA in the incident — locked in)
- ✅ US → USD/ach, CLABE → MXN/spei, IBAN → EUR/sepa
- ✅ BE Prisma-suffix shapes (\`BANK_IBAN\`, \`BANK_ACCOUNT_GB\`)
- ✅ Manteca throws to surface a wrong-path call early
- ✅ Missing-type fallback to country picking still works

**71 tests passing** in the file (was 64 before).

## What this PR does NOT do (deliberate)

- The companion BE PR fixes error surfacing + Discord pager filter: [peanut-api-ts #964](https://github.com/peanutprotocol/peanut-api-ts/pull/964). Even after this FE fix, *other* user-input mistakes (e.g. a Bridge customer status change mid-flow) shouldn't page on-call.
- Doesn't audit every other call site of \`getOfframpCurrencyConfig\`. The \`withdraw/[country]/bank/page.tsx\` flow uses the URL country, which by design matches the account type — out of scope here.

## Test plan

- [x] Unit tests cover the regression scenarios (above).
- [x] Typecheck clean for changed files.
- [x] Prettier clean.
- [ ] Post-merge: watch Sentry — \`country is not supported for SEPA\` should drop to zero from non-test traffic.