### PR TITLE
fix(card-apply): poll cheap readiness endpoint instead of POST /rain/cards

### DIFF
--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -8,7 +8,7 @@ import { cardApi, type CardInfoResponse } from '@/services/card'
 import { useAuth } from '@/context/authContext'
 import { RAIN_CARD_OVERVIEW_QUERY_KEY, useRainCardOverview } from '@/hooks/useRainCardOverview'
 import { computeCardState, findActiveCard, type CardTopLevelState } from '@/components/Card/cardState.utils'
-import { pollUntilApplyAdvances } from '@/components/Card/cardApply.utils'
+import { pollUntilApplyAdvances, pollUntilReady } from '@/components/Card/cardApply.utils'
 import AddCardEntryScreen from '@/components/Card/AddCardEntryScreen'
 import ApplicationStatusScreen from '@/components/Card/ApplicationStatusScreen'
 import CardTermsScreen from '@/components/Card/CardTermsScreen'
@@ -360,10 +360,36 @@ const CardPage: FC = () => {
         pollAbortRef.current = controller
 
         try {
+            // Two-stage poll. First wait for the webhook-stamped readiness flag
+            // (cheap, DB-only, safe at 1s cadence). Once Sumsub has reviewed
+            // rain-requirements GREEN, fall through to the existing apply poll.
+            //
+            // Previous behaviour: single-stage `pollUntilApplyAdvances` against
+            // POST /rain/cards — every iteration hit Sumsub for `moveToLevel` +
+            // `getApplicant` + `getQuestionnaireAnswers`. ~75 Sumsub round-trips
+            // per stuck user, AND the WebSDK got re-opened on every `incomplete`
+            // in the race window, showing the user "verification is taking
+            // longer than expected" (Barbara F-M's 2026-06-02 Crisp escalation).
+            const readyResult = await pollUntilReady({
+                fetchReadiness: () => rainApi.getCardApplyReadiness(),
+                intervalMs: 1000,
+                timeoutMs: 30000,
+                signal: controller.signal,
+            })
+            if (controller.signal.aborted) return
+            if (readyResult === false) {
+                setApplyError('Verification is taking longer than expected. Please try again.')
+                return
+            }
+
+            // Sumsub is GREEN — single apply call should now advance past
+            // `incomplete`. Keep `pollUntilApplyAdvances` as a thin safety net
+            // for the rare case where the webhook flag landed but the
+            // applicant state hasn't fully propagated (e.g. read-replica lag).
             const res = await pollUntilApplyAdvances({
                 fetchApply: () => rainApi.applyForCard({ termsAccepted: false }),
                 intervalMs: 1000,
-                timeoutMs: 15000,
+                timeoutMs: 5000,
                 signal: controller.signal,
             })
             if (controller.signal.aborted) return

--- a/src/components/Card/cardApply.utils.ts
+++ b/src/components/Card/cardApply.utils.ts
@@ -35,3 +35,46 @@ export async function pollUntilApplyAdvances<R extends { status: string }>({
         if (now() - start >= timeoutMs) return null
     }
 }
+
+/**
+ * Cheap poll-until-ready helper for the post-Sumsub-WebSDK-close window.
+ *
+ * Each `fetchReadiness` call reads a single webhook-stamped flag from our DB
+ * (no Sumsub round-trip), so it's safe to poll fast. Returns `true` when the
+ * backend reports `ready: true` (Sumsub finished reviewing rain-requirements
+ * GREEN), `false` on timeout, `null` on abort.
+ *
+ * Replaces the previous pattern of polling `POST /rain/cards` itself — each
+ * of those calls did `moveToLevel` + `getApplicant` + `getQuestionnaireAnswers`
+ * against Sumsub's API, costing ~5 round-trips per poll × 15 polls per stuck
+ * user.
+ */
+export async function pollUntilReady({
+    fetchReadiness,
+    intervalMs,
+    timeoutMs,
+    signal,
+    sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
+    now = () => Date.now(),
+}: {
+    fetchReadiness: () => Promise<{ ready: boolean }>
+    intervalMs: number
+    timeoutMs: number
+    signal?: AbortSignal
+    sleep?: (ms: number) => Promise<void>
+    now?: () => number
+}): Promise<boolean | null> {
+    const start = now()
+    while (true) {
+        if (signal?.aborted) return null
+        try {
+            const { ready } = await fetchReadiness()
+            if (ready) return true
+        } catch {
+            // Swallow transient fetch errors — the next poll iteration retries.
+        }
+        await sleep(intervalMs)
+        if (signal?.aborted) return null
+        if (now() - start >= timeoutMs) return false
+    }
+}

--- a/src/services/rain.ts
+++ b/src/services/rain.ts
@@ -406,6 +406,27 @@ export const rainApi = {
         })
     },
 
+    /**
+     * Cheap polling endpoint for the post-Sumsub WebSDK-close window.
+     *
+     * `applyForCard` is a heavy call — each invocation does `moveToLevel` +
+     * `getApplicant` + `getQuestionnaireAnswers` against Sumsub's API. Polling
+     * it every second for 15s during the async-review race adds up to ~75
+     * Sumsub round-trips per stuck user. This endpoint reads a single
+     * webhook-stamped flag from our DB instead, so it's safe to poll at high
+     * frequency without burning Sumsub rate budget.
+     */
+    getCardApplyReadiness: async (): Promise<{
+        ready: boolean
+        hasApplication: boolean
+        readyAt?: string
+    }> => {
+        return rainRequest<{ ready: boolean; hasApplication: boolean; readyAt?: string }>({
+            method: 'GET',
+            path: '/rain/cards/readiness',
+        })
+    },
+
     /** Activate a card (from locked or not-activated). Returns the new Rain status. */
     activateCard: async (cardId: string): Promise<string> => {
         const { status } = await rainRequest<{ status: string }>({


### PR DESCRIPTION
## Summary

Pairs with [peanut-api-ts#976](https://github.com/peanutprotocol/peanut-api-ts/pull/976). Targets `main` because #969 already merged there and both repos need this in lockstep.

After Sumsub's WebSDK closes, `handleSumsubComplete` now:

1. Polls **`GET /rain/cards/readiness`** at 1s/30s — DB-only, zero Sumsub round trips. Returns `ready: true` once the webhook in peanut-api-ts#976 stamps `rainSubmissionReadyAt` on the SUMSUB kycVerification row.
2. Fires **one** `POST /rain/cards` once readiness lands.
3. Keeps `pollUntilApplyAdvances` as a 5s safety net for read-replica lag between webhook landing and applicant state propagating fully.

### Old behaviour (the bug)

`pollUntilApplyAdvances` against `POST /rain/cards` at 1s/15s. Each iteration triggered `moveToLevel` + `getApplicant` + `getQuestionnaireAnswers` against Sumsub's API. ~75 round trips per stuck user, AND every `incomplete` re-opened the WebSDK against an already-approved applicant. Barbara F-M's 2026-06-02 ticket: "Start Secure Verification" interstitial after she'd already finished it.

## Risks

- Behind a feature path users only hit once (post-Sumsub WebSDK close on rain-requirements). Low blast radius.
- Cross-repo: needs peanut-api-ts#976 merged first. If FE deploys before BE, `getCardApplyReadiness` returns 404 and the FE shows the "Verification is taking longer than expected" message — same UX as the old race, no worse.

## Test plan

- [ ] FE typecheck + jest pass locally
- [ ] Manual sandbox: complete rain-requirements WebSDK, confirm FE settles on `complete` first try (network tab: one GET /rain/cards/readiness with `ready: true`, then one POST /rain/cards)
- [ ] Manual sandbox: throttle network to simulate webhook lag, confirm FE polls readiness up to 30s and surfaces friendly retry message on timeout
- [ ] peanut-api-ts#976 deployed first