### PR TITLE
fix: show actionable Pix-minimum error on below-minimum charges

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
+++ b/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
@@ -1176,7 +1176,7 @@ describe('GROUP 5: Error States', () => {
     })
 
     test('Below-minimum Pix charge shows the Pix minimum-amount error', async () => {
-        mockMantecaApi.initiateQrPayment.mockRejectedValue(new Error('PAYMENT_DESTINATION_BELOW_MINIMUM'))
+        mockMantecaApi.initiateQrPayment.mockRejectedValue(new Error('PIX_MIN_AMOUNT'))
 
         renderQrPay({ qrCode: 'pix://payment?id=123', type: 'PIX', t: '1' })
 

--- a/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
+++ b/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
@@ -1175,6 +1175,16 @@ describe('GROUP 5: Error States', () => {
         })
     })
 
+    test('Below-minimum Pix charge shows the Pix minimum-amount error', async () => {
+        mockMantecaApi.initiateQrPayment.mockRejectedValue(new Error('PAYMENT_DESTINATION_BELOW_MINIMUM'))
+
+        renderQrPay({ qrCode: 'pix://payment?id=123', type: 'PIX', t: '1' })
+
+        await waitFor(() => {
+            expect(screen.getByText(/BRL minimum for Pix payments/i)).toBeInTheDocument()
+        })
+    })
+
     test('Manteca API error shows generic error', async () => {
         mockMantecaApi.initiateQrPayment.mockRejectedValue(new Error('Network timeout'))
 

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -533,6 +533,12 @@ export default function QRPayPage() {
                 )
                 posthog.capture(ANALYTICS_EVENTS.QR_DECODING_ERROR_SHOWN, { qr_type: qrType })
                 setWaitingForMerchantAmount(false)
+            } else if (error.message.includes('PAYMENT_DESTINATION_BELOW_MINIMUM')) {
+                // no need to wait for merchant here since we know the amount is too low — just show an error with next steps
+                setWaitingForMerchantAmount(false)
+                setErrorInitiatingPayment(
+                    `This Pix charge is below the ${MIN_PIX_AMOUNT_BRL} BRL minimum for Pix payments.`
+                )
             } else {
                 // Network/timeout errors after all retries exhausted
                 setErrorInitiatingPayment(

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -76,6 +76,10 @@ import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 const MAX_QR_PAYMENT_AMOUNT = '2000'
 const MIN_QR_PAYMENT_AMOUNT = '0.1'
 
+// Deterministic provider rejections — retrying the payment-lock query can't
+// change the outcome, so fail fast instead of burning the 3-attempt budget.
+const NON_RETRYABLE_QR_PAY_ERRORS = ['PAYMENT_DESTINATION_DECODING_ERROR', 'PIX_MIN_AMOUNT']
+
 type PaymentProcessor = 'MANTECA'
 
 export default function QRPayPage() {
@@ -489,7 +493,7 @@ export default function QRPayPage() {
             !shouldBlockPay,
         retry: (failureCount, error: any) => {
             // Don't retry provider-specific errors
-            if (error?.message?.includes('PAYMENT_DESTINATION_DECODING_ERROR')) {
+            if (NON_RETRYABLE_QR_PAY_ERRORS.some((code) => error?.message?.includes(code))) {
                 return false
             }
             // Retry network/timeout errors up to 2 times (3 total attempts)

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -80,6 +80,11 @@ const MIN_QR_PAYMENT_AMOUNT = '0.1'
 // change the outcome, so fail fast instead of burning the 3-attempt budget.
 const NON_RETRYABLE_QR_PAY_ERRORS = ['PAYMENT_DESTINATION_DECODING_ERROR', 'PIX_MIN_AMOUNT']
 
+// Shown wherever the backend rejects a Pix payment below the rail minimum
+// (typed 400 PIX_MIN_AMOUNT — fires at lock-init for merchant-encoded amounts
+// and at re-init for user-entered amounts on open-amount QRs).
+const PIX_MIN_AMOUNT_ERROR_MESSAGE = `This Pix charge is below the ${MIN_PIX_AMOUNT_BRL} BRL minimum for Pix payments.`
+
 type PaymentProcessor = 'MANTECA'
 
 export default function QRPayPage() {
@@ -538,11 +543,10 @@ export default function QRPayPage() {
                 posthog.capture(ANALYTICS_EVENTS.QR_DECODING_ERROR_SHOWN, { qr_type: qrType })
                 setWaitingForMerchantAmount(false)
             } else if (error.message.includes('PIX_MIN_AMOUNT')) {
-                // no need to wait for merchant here since we know the amount is too low — just show an error with next steps
+                // Deterministic rejection — the merchant-encoded amount is below
+                // the rail minimum, so there's no merchant amount to wait for.
                 setWaitingForMerchantAmount(false)
-                setErrorInitiatingPayment(
-                    `This Pix charge is below the ${MIN_PIX_AMOUNT_BRL} BRL minimum for Pix payments.`
-                )
+                setErrorInitiatingPayment(PIX_MIN_AMOUNT_ERROR_MESSAGE)
             } else {
                 // Network/timeout errors after all retries exhausted
                 setErrorInitiatingPayment(
@@ -581,8 +585,14 @@ export default function QRPayPage() {
                 })
                 setPaymentLock(finalPaymentLock)
             } catch (error) {
-                captureException(error)
-                setErrorMessage('Could not initiate payment due to unexpected error. Please contact support')
+                if (error instanceof Error && error.message.includes('PIX_MIN_AMOUNT')) {
+                    // Deterministic rejection (user-entered amount below the rail
+                    // minimum) — actionable copy, not a Sentry-worthy surprise.
+                    setErrorMessage(PIX_MIN_AMOUNT_ERROR_MESSAGE)
+                } else {
+                    captureException(error)
+                    setErrorMessage('Could not initiate payment due to unexpected error. Please contact support')
+                }
                 setIsSuccess(false)
                 setLoadingState('Idle')
                 return

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -533,7 +533,7 @@ export default function QRPayPage() {
                 )
                 posthog.capture(ANALYTICS_EVENTS.QR_DECODING_ERROR_SHOWN, { qr_type: qrType })
                 setWaitingForMerchantAmount(false)
-            } else if (error.message.includes('PAYMENT_DESTINATION_BELOW_MINIMUM')) {
+            } else if (error.message.includes('PIX_MIN_AMOUNT')) {
                 // no need to wait for merchant here since we know the amount is too low — just show an error with next steps
                 setWaitingForMerchantAmount(false)
                 setErrorInitiatingPayment(


### PR DESCRIPTION
## Summary
A below-minimum Pix charge previously fell through to the generic "something went wrong" error, so the user had no idea why their payment failed or what to do next. This detects the `PAYMENT_DESTINATION_BELOW_MINIMUM` error from Manteca and shows a clear message stating the BRL minimum for Pix payments.

## Risk
Low / FE-only. Single `else if` branch in the qr-pay error handler — no API, schema, or shared-state changes. No cross-repo impact.

## QA
1. Initiate a QR/Pix payment whose destination is below the Pix minimum (sandbox).
2. Expect the error: "This Pix charge is below the {MIN_PIX_AMOUNT_BRL} BRL minimum for Pix payments." instead of the generic error.
3. Covered by unit test `Below-minimum Pix charge shows the Pix minimum-amount error` in `qr-pay-states.test.tsx`.