### PR TITLE
feat(card): /card-recovery page for deleted-Rain-user collateral recovery

### DIFF
--- a/src/app/(mobile-ui)/card-recovery/page.tsx
+++ b/src/app/(mobile-ui)/card-recovery/page.tsx
@@ -1,0 +1,215 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import type { Address, Hex } from 'viem'
+import { Button } from '@/components/0_Bruddle/Button'
+import { Card } from '@/components/0_Bruddle/Card'
+import ErrorAlert from '@/components/Global/ErrorAlert'
+import NavHeader from '@/components/Global/NavHeader'
+import PeanutLoading from '@/components/Global/PeanutLoading'
+import { useKernelClient } from '@/context/kernelClient.context'
+import {
+    RAIN_WITHDRAW_EIP712_DOMAIN_NAME,
+    RAIN_WITHDRAW_EIP712_DOMAIN_VERSION,
+    rainWithdrawEip712Types,
+} from '@/constants/rain.consts'
+import { PEANUT_WALLET_CHAIN } from '@/constants/zerodev.consts'
+import { rainApi, type RecoverFundsPreviewResponse } from '@/services/rain'
+import { getExplorerUrl } from '@/utils/general.utils'
+
+type Step = 'preview' | 'confirm' | 'signing' | 'submitting' | 'done'
+
+/**
+ * Card collateral recovery flow.
+ *
+ * For the deleted-Rain-user case: a user's collateral USDC is sitting on-chain
+ * in the Rain coordinator's proxy, but Rain's balance endpoint won't return it
+ * because their Rain user record was deleted. The normal /withdraw flow can't
+ * see the balance, so we have a dedicated recovery endpoint pair on the
+ * backend that reads the on-chain balance directly and asks Rain for a
+ * signature for that exact amount, paid to the user's own smart wallet.
+ *
+ * This page wires that flow: preview → confirm → kernel-sign EIP-712 →
+ * submit. The destination address is decided by the backend and shown here
+ * for transparency; the FE cannot influence it.
+ *
+ * Not linked from anywhere in the main app — accessed by URL only. It's safe
+ * to share the URL with a user who needs to recover funds: the JWT cookie is
+ * the only auth, the recipient is server-locked, and the signing step still
+ * requires the user's passkey.
+ */
+export default function CardRecoveryPage() {
+    const router = useRouter()
+    const { getClientForChain } = useKernelClient()
+
+    const [step, setStep] = useState<Step>('preview')
+    const [preview, setPreview] = useState<RecoverFundsPreviewResponse | null>(null)
+    const [error, setError] = useState<string | null>(null)
+    const [txHash, setTxHash] = useState<Hex | null>(null)
+
+    useEffect(() => {
+        let cancelled = false
+        ;(async () => {
+            try {
+                const data = await rainApi.getRecoverFundsPreview()
+                if (!cancelled) setPreview(data)
+            } catch (e) {
+                if (!cancelled) setError((e as Error).message || 'Could not load recovery preview')
+            }
+        })()
+        return () => {
+            cancelled = true
+        }
+    }, [])
+
+    const handleRecover = useCallback(async () => {
+        setError(null)
+        setStep('signing')
+        try {
+            // Prepare locks in the amount + recipient server-side. Even if the
+            // page were tampered with at runtime, the backend signs over the
+            // values it computed itself.
+            const prep = await rainApi.prepareRecoverFunds()
+
+            const chainIdStr = String(PEANUT_WALLET_CHAIN.id)
+            const chainIdNum = Number(prep.chainId)
+            const kernelClient = getClientForChain(chainIdStr)
+
+            const adminSignature = (await kernelClient.account!.signTypedData({
+                domain: {
+                    name: RAIN_WITHDRAW_EIP712_DOMAIN_NAME,
+                    version: RAIN_WITHDRAW_EIP712_DOMAIN_VERSION,
+                    chainId: chainIdNum,
+                    verifyingContract: prep.collateralProxy as Address,
+                    salt: prep.adminSalt as Hex,
+                },
+                types: rainWithdrawEip712Types,
+                primaryType: 'Withdraw',
+                message: {
+                    user: prep.adminAddress as Address,
+                    asset: prep.tokenAddress as Address,
+                    amount: BigInt(prep.amount),
+                    recipient: prep.recipientAddress as Address,
+                    nonce: BigInt(prep.adminNonce),
+                },
+            })) as Hex
+
+            setStep('submitting')
+            const { txHash: hash } = await rainApi.submitWithdrawal({
+                preparationId: prep.preparationId,
+                amount: prep.amount,
+                recipientAddress: prep.recipientAddress,
+                directTransfer: prep.directTransfer,
+                adminSalt: prep.adminSalt,
+                adminNonce: prep.adminNonce,
+                adminSignature,
+                executorSignature: prep.executorSignature,
+                executorSalt: prep.executorSalt,
+                expiresAt: prep.expiresAt,
+            })
+            setTxHash(hash as Hex)
+            setStep('done')
+        } catch (e) {
+            setError((e as Error).message || 'Recovery failed — please try again')
+            setStep('preview')
+        }
+    }, [getClientForChain])
+
+    if (!preview && !error) return <PeanutLoading />
+
+    return (
+        <div className="flex min-h-[inherit] flex-col gap-8">
+            <NavHeader title="Recover card funds" onPrev={() => router.push('/home')} />
+            <div className="my-auto flex flex-col gap-6">
+                {error && <ErrorAlert description={error} />}
+
+                {step === 'done' && txHash ? (
+                    <Card className="flex flex-col gap-3 p-6">
+                        <h2 className="text-h7 font-bold">Funds sent to your wallet.</h2>
+                        <p className="text-sm text-grey-1">
+                            ${formatCents(preview!.amountCents)} USDC has been returned to your peanut wallet.
+                        </p>
+                        <a
+                            className="text-black underline"
+                            target="_blank"
+                            rel="noreferrer"
+                            href={`${getExplorerUrl(String(PEANUT_WALLET_CHAIN.id)) ?? ''}/tx/${txHash}`}
+                        >
+                            View transaction
+                        </a>
+                    </Card>
+                ) : (
+                    preview && (
+                        <>
+                            <Card className="flex flex-col gap-3 p-6">
+                                <h2 className="text-h7 font-bold">
+                                    {preview.hasRecoverableCard ? 'Recover your card collateral' : 'No card on file'}
+                                </h2>
+                                <p className="text-sm text-grey-1">
+                                    This pulls every USDC currently held in your card collateral contract back to your
+                                    peanut wallet. Auto-balance is turned off as part of recovery so the rebalancer
+                                    can't top up between now and the transfer.
+                                </p>
+
+                                <Row label="Recoverable" value={`$${formatCents(preview.amountCents)} USDC`} />
+                                <Row label="Destination" value={shorten(preview.recipient)} />
+                                {BigInt(preview.dustWei) > 0n && (
+                                    <Row label="Dust left in contract" value={`${preview.dustWei} wei (< $0.01)`} />
+                                )}
+                                <Row
+                                    label="Auto-balance"
+                                    value={preview.autoBalanceEnabled ? 'on — will be turned off' : 'off'}
+                                />
+                            </Card>
+
+                            <Button
+                                variant="purple"
+                                shadowSize="4"
+                                className="w-full"
+                                disabled={
+                                    step === 'signing' ||
+                                    step === 'submitting' ||
+                                    BigInt(preview.amountCents) <= 0n ||
+                                    !preview.hasRecoverableCard
+                                }
+                                loading={step === 'signing' || step === 'submitting'}
+                                onClick={handleRecover}
+                            >
+                                {step === 'signing'
+                                    ? 'Sign with passkey…'
+                                    : step === 'submitting'
+                                      ? 'Submitting…'
+                                      : 'Recover funds'}
+                            </Button>
+                        </>
+                    )
+                )}
+            </div>
+        </div>
+    )
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+    return (
+        <div className="flex items-center justify-between">
+            <span className="text-sm text-grey-1">{label}</span>
+            <span className="text-sm font-medium text-n-1">{value}</span>
+        </div>
+    )
+}
+
+// Render Rain cents (2 dp) as a fixed-precision USD amount with thousand
+// separators. Cents are bigint-string from the wire — never Number() them
+// directly; > 2^53 risks lossy display on whales.
+function formatCents(centsStr: string): string {
+    const cents = BigInt(centsStr)
+    const dollars = cents / 100n
+    const remainder = (cents % 100n).toString().padStart(2, '0')
+    return `${dollars.toLocaleString('en-US')}.${remainder}`
+}
+
+function shorten(addr: string): string {
+    if (addr.length <= 12) return addr
+    return `${addr.slice(0, 6)}…${addr.slice(-4)}`
+}

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -43,6 +43,7 @@ export const DEDICATED_ROUTES = [
     'limits',
     'notifications',
     'recover-funds',
+    'card-recovery',
 
     // Public pages (existing)
     'm', // merchant landing pages (/m/[slug]) — added on main; register so the catch-all never treats it as a recipient

--- a/src/services/rain.ts
+++ b/src/services/rain.ts
@@ -136,6 +136,33 @@ export interface SubmitRainWithdrawalResponse {
     txHash: string
 }
 
+// ─── Funds-recovery types ────────────────────────────────────────────────────
+//
+// Recovery is for the deleted-Rain-user case: Rain's balance endpoint stops
+// returning the collateral, but the on-chain USDC is still there and Rain's
+// signature endpoint still works. The server determines amount + recipient;
+// the FE just signs the admin EIP-712 over what the server gives it. See
+// peanut-api-ts/src/routes/rain/recover-funds.ts for the contract.
+
+export interface RecoverFundsPreviewResponse {
+    collateralProxy: string
+    /** The user's own smart-wallet address — the only allowed recipient. */
+    recipient: string
+    /** Full on-chain USDC balance in token smallest units (6 dp). */
+    amountWei: string
+    /** Recoverable amount in Rain cents (2 dp). */
+    amountCents: string
+    /** Wei below one cent — stays in the contract after recovery. */
+    dustWei: string
+    autoBalanceEnabled: boolean
+    hasRecoverableCard: boolean
+}
+
+export interface PrepareRecoverFundsResponse extends PrepareRainWithdrawalResponse {
+    amountCents: string
+    dustWei: string
+}
+
 // ─── Types for card management endpoints ────────────────────────────────────
 
 export interface RainCardDetailsResponse {
@@ -358,6 +385,37 @@ export const rainApi = {
             method: 'POST',
             path: '/rain/cards/withdraw/submit',
             body: input,
+        })
+    },
+
+    /**
+     * Read-only preview of what would be recovered: on-chain USDC balance,
+     * the user's smart-wallet recipient, and the current autoBalanceEnabled
+     * flag. Backed by GET /rain/cards/recover-funds/preview — no side
+     * effects, so safe to call on page mount and on refresh.
+     */
+    getRecoverFundsPreview: async (): Promise<RecoverFundsPreviewResponse> => {
+        return rainRequest<RecoverFundsPreviewResponse>({
+            method: 'GET',
+            path: '/rain/cards/recover-funds/preview',
+            noStore: true,
+        })
+    },
+
+    /**
+     * Side-effectful: flips autoBalanceEnabled to false, reads on-chain
+     * balance, fetches Rain's executor signature for the FULL cent-aligned
+     * amount payable to the user's smart wallet, creates a TransactionIntent.
+     * Returns the prepared payload the caller signs with their kernel and
+     * submits to /rain/cards/withdraw/submit (unchanged).
+     *
+     * Empty body on purpose — amount and recipient are server-locked.
+     */
+    prepareRecoverFunds: async (): Promise<PrepareRecoverFundsResponse> => {
+        return rainRequest<PrepareRecoverFundsResponse>({
+            method: 'POST',
+            path: '/rain/cards/recover-funds/prepare',
+            body: {},
         })
     },
 


### PR DESCRIPTION
## Why

Pairs with peanut-api-ts PR [#977](https://github.com/peanutprotocol/peanut-api-ts/pull/977). When a Rain user is deleted, the on-chain collateral USDC stays where it is but Rain's balance endpoint stops reporting it, so the regular withdraw flow can't reach it. The BE PR adds a server-locked recovery endpoint pair; this PR adds the page that drives them.

Targets \`main\` to match the BE hotfix-target.

## Flow

1. **Preview** — \`GET /rain/cards/recover-funds/preview\` on mount. Shows recoverable amount in USDC, the destination (the user's own smart wallet, decided by the server), dust left in the contract, and the current auto-balance flag.
2. **Recover** — button click runs:
   - \`POST /rain/cards/recover-funds/prepare\` — backend flips \`autoBalanceEnabled=false\`, reads on-chain USDC balance, fetches Rain's executor sig for the full cent-aligned amount, returns the same payload shape as the regular \`/withdraw/prepare\`.
   - \`kernelClient.signTypedData(...)\` — user's passkey signs the admin EIP-712.
   - \`POST /rain/cards/withdraw/submit\` (existing, unchanged) — broadcasts.
3. **Done** — shows the tx hash with explorer link.

## Security model

- The destination is **server-determined** and merely displayed on the page. There is no input field that the page could hand to the backend; \`prepareRecoverFunds()\` sends an empty body.
- Even if the page or this file were tampered with at runtime, the backend signs over the amount + recipient it computed itself, and \`/submit\` re-binds them to the prepared intent — anything off-spec is rejected on the BE.
- The signing step still requires the user's passkey, so a stolen JWT alone cannot drain the collateral.

## Files

| File | What |
|---|---|
| \`src/app/(mobile-ui)/card-recovery/page.tsx\` (new) | Self-contained client page. Preview on mount, confirm button, kernel sign, submit, result. |
| \`src/services/rain.ts\` | Two new methods: \`getRecoverFundsPreview\` and \`prepareRecoverFunds\`. Two new exported types. No changes to existing methods. |
| \`src/constants/routes.ts\` | Added \`card-recovery\` to \`DEDICATED_ROUTES\` so the catch-all recipient route doesn't intercept the new URL. The colocated route test (\`routes.test.ts\`) verified this is needed. |

## Cross-repo dependency

**Needs peanut-api-ts [#977](https://github.com/peanutprotocol/peanut-api-ts/pull/977) deployed before this page works.** The page will throw \"Request failed: 404\" until the BE endpoints exist.

## Test plan
- [ ] \`pnpm typecheck\` (verified locally — clean).
- [ ] \`npm test\` — one pre-existing failure in \`add-money-states.test.tsx\` unrelated to this change; no new failures.
- [ ] After BE is deployed: hit \`/card-recovery\` as a user with collateral on-chain → page shows the right amount + destination + dust.
- [ ] Click \"Recover funds\" → passkey prompt → tx submitted → explorer link works → collateral lands in smart wallet.
- [ ] Verify \`autoBalanceEnabled\` flipped to \`false\` in the DB.
- [ ] Try as a user with no card → preview shows \"No card on file\", button disabled.
- [ ] Try as a user with < $0.01 collateral → button disabled (amount is 0 cents).

## Notes
- Page is not linked from anywhere in the main app. Shareable URL — JWT cookie auth + server-locked recipient + passkey required to sign keep it safe to hand out.
- Layout follows the \"centered content + CTA\" peanut-ui rule (NavHeader + \`my-auto\` flex group).