### PR TITLE
fix(kernel): reject a restored passkey that belongs to a different account

### DIFF
--- a/src/context/kernelClient.context.tsx
+++ b/src/context/kernelClient.context.tsx
@@ -395,6 +395,29 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
                 inFlightRef.current.delete(primaryChainId)
             }
 
+            // Guard: the restored WebAuthnKey must belong to the logged-in user.
+            // On a shared device with two Peanut accounts (two passkeys for the
+            // same RP), the restore path can pair this session with the OTHER
+            // account's credential. The derived kernel address then differs from
+            // the user's real smart-wallet address, and any server-bound ERC-1271
+            // check (Rain card withdraw) rejects the signature as "invalid admin
+            // signature". Purge the poisoned key and force a clean re-auth rather
+            // than silently signing with the wrong credential. Skipped when the
+            // user has no smart-wallet account yet (mid-registration) and for
+            // pre-migration users (address is passed in, so it always matches).
+            const expectedAddress = user?.accounts.find((a) => a.type === AccountType.PEANUT_WALLET)?.identifier
+            const derivedAddress = kernelClient.account?.address
+            if (expectedAddress && derivedAddress && derivedAddress.toLowerCase() !== expectedAddress.toLowerCase()) {
+                console.error('[KernelClient] restored WebAuthnKey does not match the logged-in user — purging', {
+                    userId: user?.user.userId,
+                    derivedAddress,
+                    expectedAddress,
+                })
+                if (user?.user.userId) updateUserPreferences(user.user.userId, { webAuthnKey: undefined })
+                logoutUser()
+                return
+            }
+
             // Only update state after primary succeeds — avoids
             // registering→not→registering UI flicker between retries.
             if (isMounted) {


### PR DESCRIPTION
## Why

A user (`natalia`, smart wallet `0xa53f…`) had **every** Rain-card withdrawal fail with `[rain-verify] reject: invalid admin signature` since 2026-06-03 18:12 UTC, while other users succeeded through the same path.

Root cause (proven end-to-end via the temp logging in api PR #978 + offline replay):
- Her device has **two Peanut accounts** — `natalia` (passkey `c4f6…`) and `nnatalia` (passkey `52ca1e36…`), both passkeys for `peanut.me` in Google Password Manager.
- Her **kernel authorizes `c4f6…`** (confirmed on-chain: the WebAuthn validator stores exactly that key).
- But her browser **signed with `nnatalia`'s key** (recovered the signing pubkey from the assertion → `52ca1e36…`, which the `passkeys` table maps to account `nnatalia`). The kernel correctly returns `0xffffffff`.

The mechanism is in `kernelClient.context.tsx:277`:
```js
const storedWebAuthnKey = userPreferences?.webAuthnKey ?? getFromCookie(WEB_AUTHN_COOKIE_KEY)
```
The cookie fallback is **device-global**, and the restored key is used with **no check that it belongs to the current user** — and it then gets persisted back into the per-user pref (`:308–311`), poisoning it. On a 2-account device the session can end up paired with the other account's credential.

**Why only the card flow surfaced it:** every other flow is a UserOp the kernel signs for *its own* address (self-consistent — silently acts on whatever wallet the key controls). Rain withdraw is the only flow that verifies the signature against the **server-derived `adminAddress`**, so it's the only one that hard-fails on a mismatch.

## What (Layer 1 — validate the credential against the user)

After the primary kernel client builds, assert its **derived address equals the user's smart-wallet account identifier** (`accounts.find(PEANUT_WALLET).identifier`, already on the FE). On mismatch: purge the key (clear the per-user pref) and `logoutUser()` — which also clears the cookie (`authContext:184,187`) — forcing a clean, self-consistent re-auth. Never signs with the wrong credential.

This is correct **regardless of how the wrong key got cached** (cookie, poisoned pref, or switch-account race) and **self-heals** existing poisoned state on next load — which a cookie-fallback removal alone would not do.

- Skipped mid-registration (no wallet account yet → `expectedAddress` undefined).
- No-op for pre-migration users (address is passed into the build, so derived == expected by construction).

## Risk / scope
- One file, ~23 lines, in the primary-client build path. No backend change (uses data the FE already has).
- Worst case on mismatch is a forced re-login (a passkey tap), not a wrong-account action.

## Verification
- `npm run typecheck` ✓
- `npm test` — 1305/1306 pass; the single failure (`add-money-states` crypto-deposit limit assertion) is **pre-existing**, reproduced identically on clean `origin/main`, and unrelated to this change.
- `prettier` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)