### PR TITLE
fix(passkey): pin native signing ceremony to the kernel's own credential

### DIFF
--- a/src/context/kernelClient.context.tsx
+++ b/src/context/kernelClient.context.tsx
@@ -282,7 +282,13 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
             // the native capacitor plugin callback so signing works after restore.
             if (isAndroidNative() && !storedWebAuthnKey.signMessageCallback) {
                 const rpId = storedWebAuthnKey.rpID || getNativeRpId()
-                storedWebAuthnKey.signMessageCallback = createNativeSignMessageCallback(rpId)
+                // Pin the native assertion to THIS account's credential so the
+                // platform can't return another Peanut account's passkey for the
+                // same RP (would sign with the wrong key → "invalid admin signature").
+                storedWebAuthnKey.signMessageCallback = createNativeSignMessageCallback(
+                    rpId,
+                    storedWebAuthnKey.authenticatorId
+                )
             }
             // Only update if the key actually changed to avoid re-triggering kernel client init
             // Note: WebAuthnKey contains BigInt fields (pubX, pubY) which JSON.stringify cannot handle,

--- a/src/utils/native-webauthn.ts
+++ b/src/utils/native-webauthn.ts
@@ -134,7 +134,7 @@ const RIP7212_CHAIN_IDS = [137, 8453, 10, 42161] // polygon, base, optimism, arb
  * this callback is re-attached after restoring a WebAuthnKey from storage
  * since functions can't be serialized to cookies/localStorage.
  */
-export function createNativeSignMessageCallback(rpId: string) {
+export function createNativeSignMessageCallback(rpId: string, pinnedCredentialId?: string) {
     return async (
         message: SignableMessage,
         _rpId: string,
@@ -158,10 +158,25 @@ export function createNativeSignMessageCallback(rpId: string) {
         const messageBytes = new Uint8Array(formattedMessage.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16)))
         const challenge = bufferToBase64URL(messageBytes.buffer)
 
+        // Constrain the assertion to THIS kernel's credential. On a device with
+        // more than one peanut.me passkey (multiple Peanut accounts), an
+        // unconstrained get() lets the platform hand back a DIFFERENT account's
+        // passkey, whose signature the kernel then rejects ("invalid admin
+        // signature"). Honor a caller-supplied allow-list if present; otherwise
+        // fall back to the kernel's own credential id. This only ever *adds* the
+        // kernel's own credential to the allow-list, so a working signature
+        // (which already uses that credential) is never excluded.
+        const effectiveAllowCredentials =
+            allowCredentials && allowCredentials.length > 0
+                ? allowCredentials
+                : pinnedCredentialId
+                  ? [{ id: pinnedCredentialId, type: 'public-key' as const }]
+                  : undefined
+
         const assertionOptions = {
             challenge: messageBytes as BufferSource,
             rpId,
-            allowCredentials: allowCredentials?.map((cred) => ({
+            allowCredentials: effectiveAllowCredentials?.map((cred) => ({
                 id: base64URLToBytes(cred.id) as BufferSource,
                 type: 'public-key' as const,
             })),


### PR DESCRIPTION
## Why (follow-up to #2188)

#2188 made sure the kernel **client** holds the right credential. But Natalia *still* failed afterward (deployed 18h, no re-login): the recovery proved her kernel client was correct (`c4f6…`), yet her assertion was signed by her **second account's** key (`nnatalia`, `52ca1e36…`) — this time via the **native** surface.

Root cause: on Android native, signing goes through a custom `signMessageCallback` (`native-webauthn.ts`), and its `navigator.credentials.get()` was **unconstrained** — `allowCredentials` was only set if a caller supplied it, and ZeroDev doesn't for this shim. With two `peanut.me` passkeys on the device, the platform handed back the wrong account's passkey even though the client was right. The kernel then rejects it on-chain (`0xffffffff` → "invalid admin signature").

## What
Pin `allowCredentials` in the native callback to the kernel's **own** `authenticatorId`:
- `createNativeSignMessageCallback(rpId, pinnedCredentialId?)` defaults the get()'s allow-list to the kernel's credential **only when the caller didn't supply one**.
- Call site passes `storedWebAuthnKey.authenticatorId` (`kernelClient.context.tsx:285`).

## Safety (the key concern)
- **Native-only** — web signing goes through ZeroDev's own path and is untouched.
- It only **adds** the kernel's own credential to the allow-list. A working signature already uses that exact credential, so it can never be excluded → **a previously valid signature cannot become invalid.**
- **Worst case is a no-op:** if the `@capgo/capacitor-passkey` shim ignores `allowCredentials`, behavior is unchanged.

## Honest residual risk
Whether this *fixes* Natalia depends on the capacitor shim honoring `allowCredentials` for `get()` — needs a **real-device smoke test** (a 2-account Android device, or Natalia). If the shim honors it (expected), the platform is forced to her own passkey. If her own passkey isn't actually present on that device, signing will fail *cleanly* rather than substitute — which is correct, and points to recovery.

## Verification
- `npm run typecheck` ✓
- `npm test` — 1305/1306; the single failure (`add-money-states` crypto-deposit assertion) is pre-existing, reproduced on clean `origin/main`, unrelated.
- `prettier` ✓
- **Not yet device-tested** — please smoke on a 2-account Android build before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)