### PR TITLE
fix(kyc): honest message for unsupported-region (ROW) cross-region — FE consumer of API #985

### DIFF
--- a/src/app/actions/types/sumsub.types.ts
+++ b/src/app/actions/types/sumsub.types.ts
@@ -1,4 +1,4 @@
-export type KycActionType = 'manteca' | 'bridge-direct'
+export type KycActionType = 'manteca' | 'bridge-direct' | 'unsupported-region'
 
 export interface InitiateSumsubKycResponse {
     token: string | null // null when user is already APPROVED or bridge-direct

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -1,0 +1,67 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { useSumsubKycFlow } from '@/hooks/useSumsubKycFlow'
+import { initiateSumsubKyc } from '@/app/actions/sumsub'
+
+// useSumsubKycFlow wires a websocket, redux, the router and three server actions.
+// Stub everything except the one action the cross-region branch reads so the test
+// asserts hook behaviour (does onKycSuccess fire? is an error surfaced?) and nothing else.
+jest.mock('@/app/actions/sumsub', () => ({
+    initiateSumsubKyc: jest.fn(),
+    initiateSelfHealResubmission: jest.fn(),
+    restartIdentityVerification: jest.fn(),
+}))
+jest.mock('@/hooks/useWebSocket', () => ({ useWebSocket: jest.fn() }))
+jest.mock('@/redux/hooks', () => ({ useUserStore: () => ({ user: { user: { username: 'test' } } }) }))
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn(), replace: jest.fn() }) }))
+jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => false }))
+
+const mockInitiate = initiateSumsubKyc as jest.MockedFunction<typeof initiateSumsubKyc>
+
+describe('useSumsubKycFlow — cross-region routing', () => {
+    beforeEach(() => {
+        mockInitiate.mockReset()
+    })
+
+    // Regression for the "Unlock {region}" no-op loop (ROW). The BE approves identity
+    // but can't enroll any first-party bank rail for rest-of-world, so it returns
+    // actionType: 'unsupported-region' (status APPROVED, no token). The hook MUST show
+    // an honest message and MUST NOT fire onKycSuccess — firing it loops the user back
+    // through the "all set" success path with nothing actually unlocked.
+    it('unsupported-region → surfaces an honest error and does NOT fire onKycSuccess', async () => {
+        mockInitiate.mockResolvedValue({
+            data: { token: null, applicantId: 'app_1', status: 'APPROVED', actionType: 'unsupported-region' },
+        })
+        const onKycSuccess = jest.fn()
+
+        // regionIntent undefined → the mount-time status fetch short-circuits, so the
+        // only initiateSumsubKyc call is the one handleInitiateKyc drives below.
+        const { result } = renderHook(() => useSumsubKycFlow({ onKycSuccess }))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('ROW', undefined, true)
+        })
+
+        expect(result.current.error).toMatch(/region/i)
+        expect(result.current.showWrapper).toBe(false)
+        // give any queued status-transition effect a chance to (wrongly) fire.
+        await waitFor(() => expect(onKycSuccess).not.toHaveBeenCalled())
+    })
+
+    // Control: the sibling cross-region success path must still fire onKycSuccess and
+    // stay error-free — proves the new branch was inserted without breaking bridge-direct.
+    it('bridge-direct → fires onKycSuccess with no error', async () => {
+        mockInitiate.mockResolvedValue({
+            data: { token: null, applicantId: 'app_2', status: 'APPROVED', actionType: 'bridge-direct' },
+        })
+        const onKycSuccess = jest.fn()
+
+        const { result } = renderHook(() => useSumsubKycFlow({ onKycSuccess }))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('EU', undefined, true)
+        })
+
+        expect(result.current.error).toBeNull()
+        await waitFor(() => expect(onKycSuccess).toHaveBeenCalledTimes(1))
+    })
+})

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -5,12 +5,19 @@ import { initiateSumsubKyc } from '@/app/actions/sumsub'
 // useSumsubKycFlow wires a websocket, redux, the router and three server actions.
 // Stub everything except the one action the cross-region branch reads so the test
 // asserts hook behaviour (does onKycSuccess fire? is an error surfaced?) and nothing else.
+// The websocket mock captures the status-update handler so a test can simulate a
+// late/stale APPROVED event arriving after the flow has resolved.
+const mockWs: { handler?: (status: string, labels?: string[]) => void } = {}
 jest.mock('@/app/actions/sumsub', () => ({
     initiateSumsubKyc: jest.fn(),
     initiateSelfHealResubmission: jest.fn(),
     restartIdentityVerification: jest.fn(),
 }))
-jest.mock('@/hooks/useWebSocket', () => ({ useWebSocket: jest.fn() }))
+jest.mock('@/hooks/useWebSocket', () => ({
+    useWebSocket: (opts: { onSumsubKycStatusUpdate?: (status: string, labels?: string[]) => void }) => {
+        mockWs.handler = opts.onSumsubKycStatusUpdate
+    },
+}))
 jest.mock('@/redux/hooks', () => ({ useUserStore: () => ({ user: { user: { username: 'test' } } }) }))
 jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn(), replace: jest.fn() }) }))
 jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => false }))
@@ -20,6 +27,7 @@ const mockInitiate = initiateSumsubKyc as jest.MockedFunction<typeof initiateSum
 describe('useSumsubKycFlow — cross-region routing', () => {
     beforeEach(() => {
         mockInitiate.mockReset()
+        mockWs.handler = undefined
     })
 
     // Regression for the "Unlock {region}" no-op loop (ROW). The BE approves identity
@@ -44,6 +52,31 @@ describe('useSumsubKycFlow — cross-region routing', () => {
         expect(result.current.error).toMatch(/region/i)
         expect(result.current.showWrapper).toBe(false)
         // give any queued status-transition effect a chance to (wrongly) fire.
+        await waitFor(() => expect(onKycSuccess).not.toHaveBeenCalled())
+    })
+
+    // The race the loop-fix has to survive: the user is already APPROVED, so a stale /
+    // connect-time websocket APPROVED event can land AFTER the unsupported-region error.
+    // If the branch left userInitiatedRef set, that event trips the status-transition
+    // effect into firing onKycSuccess — re-opening "all set" on top of the error.
+    it('unsupported-region → stale websocket APPROVED after the error still does NOT fire onKycSuccess', async () => {
+        mockInitiate.mockResolvedValue({
+            data: { token: null, applicantId: 'app_1', status: 'APPROVED', actionType: 'unsupported-region' },
+        })
+        const onKycSuccess = jest.fn()
+
+        const { result } = renderHook(() => useSumsubKycFlow({ onKycSuccess }))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('ROW', undefined, true)
+        })
+        expect(result.current.error).toMatch(/region/i)
+
+        // simulate a late websocket status push (APPROVED) arriving after the terminal error
+        await act(async () => {
+            mockWs.handler?.('APPROVED')
+        })
+
         await waitFor(() => expect(onKycSuccess).not.toHaveBeenCalled())
     })
 

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -173,8 +173,12 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 // silent no-op. surface an honest, terminal message and bail BEFORE the
                 // status sync below — syncing APPROVED here would trip the transition
                 // effect into firing onKycSuccess, looping the user back to "all set".
+                //
+                // clear userInitiatedRef so a late/stale websocket APPROVED event can't
+                // satisfy the transition-effect guard and fire onKycSuccess after this
+                // terminal error (the user is approved but has no rail — NOT a success).
                 if (response.data?.actionType === 'unsupported-region') {
-                    if (crossRegion) prevStatusRef.current = savedPrevStatus
+                    userInitiatedRef.current = false
                     setError(
                         "Bank deposits aren't available in your region yet. We'll let you know as soon as they go live."
                     )

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -167,6 +167,20 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                     return
                 }
 
+                // cross-region into a region no first-party bank provider serves (ROW).
+                // the backend approved identity but can't auto-enroll any rail, so it
+                // signals 'unsupported-region' (status APPROVED, no token) instead of a
+                // silent no-op. surface an honest, terminal message and bail BEFORE the
+                // status sync below — syncing APPROVED here would trip the transition
+                // effect into firing onKycSuccess, looping the user back to "all set".
+                if (response.data?.actionType === 'unsupported-region') {
+                    if (crossRegion) prevStatusRef.current = savedPrevStatus
+                    setError(
+                        "Bank deposits aren't available in your region yet. We'll let you know as soon as they go live."
+                    )
+                    return
+                }
+
                 // sync status from api response, but skip when a token is returned
                 // alongside APPROVED — that means the SDK should open (e.g. additional-docs flow),
                 // not that kyc is finished. syncing APPROVED here would trigger the useEffect


### PR DESCRIPTION
## Summary

The frontend half of the **\"Unlock {region}\" no-op loop** fix. Pairs with **peanut-api-ts #985** (the systemic BE source-of-truth + `unsupported-region` signal).

When a user who's already verified with one provider taps **Unlock {region}** for a *rest-of-world* region that **no first-party bank provider serves** (not Bridge EU/NA, not Manteca LATAM), the BE approves identity but has nothing to auto-enroll. It now returns `actionType: 'unsupported-region'` (status `APPROVED`, no token) instead of a silent no-op.

This PR makes the FE **consume that signal honestly**: show a clear terminal message and stop, instead of looping the user back through *\"You're all set\"* with nothing actually unlocked.

## Why it looped before

Without an explicit branch, an `APPROVED` + no-token response fell through to the generic *\"already approved, no token → done\"* path, which fires `onKycSuccess` → resets the region selection → user lands back on the same locked region. Infinite \"all set\" with no unlock.

## The fix

- `KycActionType` gains `'unsupported-region'` (`src/app/actions/types/sumsub.types.ts`).
- `useSumsubKycFlow` handles it **before the status-sync** — critical: syncing `APPROVED` into `liveKycStatus` would trip the status-transition effect into re-firing `onKycSuccess`, re-introducing the loop. We set an honest error and bail.
- Message: *\"Bank deposits aren't available in your region yet. We'll let you know as soon as they go live.\"* (renders via the existing `flow.error` surface in `UnlockedRegions.view`).

## Risk / blast radius

- **Low.** One new early-return branch keyed on a brand-new actionType the BE only emits for ROW cross-region. Existing paths (`bridge-direct`, `manteca`, APPROVED-no-token, token→SDK) are untouched.
- **Deploy order (cross-repo): ship API #985 first.** This FE branch is inert until the BE emits `unsupported-region`; shipping FE-first is safe (no-op), but the user-visible fix only lands once both are live.

## Tests

- New `src/hooks/__tests__/useSumsubKycFlow.test.ts`:
  - `unsupported-region` → surfaces an honest error **and does NOT fire `onKycSuccess`** (the loop guard).
  - control: `bridge-direct` → still fires `onKycSuccess`, no error (proves the branch was inserted without breaking the sibling success path).
- Full suite green locally (78 suites, 1316 passed), typecheck clean, prettier clean, new code lints clean.

## Context

- Incident: \"Unlock {region}\" dead-end reported via Crisp (Bulgaria/EU was the contract-drift variant, hotfixed in API #982; this PR closes the **ROW** gap).
- Sibling: peanut-api-ts #985 (systemic `crossRegionProvider` source-of-truth + cross-repo contract tripwire test).