### PR TITLE
fix(card): surface real readiness errors + show actually-recovered amount

### DIFF
--- a/src/app/(mobile-ui)/card-recovery/page.tsx
+++ b/src/app/(mobile-ui)/card-recovery/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
 import type { Address, Hex } from 'viem'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Card } from '@/components/0_Bruddle/Card'
@@ -9,6 +8,7 @@ import ErrorAlert from '@/components/Global/ErrorAlert'
 import NavHeader from '@/components/Global/NavHeader'
 import PeanutLoading from '@/components/Global/PeanutLoading'
 import { useKernelClient } from '@/context/kernelClient.context'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import {
     RAIN_WITHDRAW_EIP712_DOMAIN_NAME,
     RAIN_WITHDRAW_EIP712_DOMAIN_VERSION,
@@ -40,13 +40,17 @@ type Step = 'preview' | 'confirm' | 'signing' | 'submitting' | 'done'
  * requires the user's passkey.
  */
 export default function CardRecoveryPage() {
-    const router = useRouter()
+    const onBack = useSafeBack('/home')
     const { getClientForChain } = useKernelClient()
 
     const [step, setStep] = useState<Step>('preview')
     const [preview, setPreview] = useState<RecoverFundsPreviewResponse | null>(null)
     const [error, setError] = useState<string | null>(null)
     const [txHash, setTxHash] = useState<Hex | null>(null)
+    // The amount actually prepared + signed + submitted. The mount-time `preview`
+    // can be stale by the time the user confirms (collateral can change), so the
+    // completion screen must report what was really recovered, not the preview.
+    const [recoveredCents, setRecoveredCents] = useState<string | null>(null)
 
     useEffect(() => {
         let cancelled = false
@@ -71,6 +75,8 @@ export default function CardRecoveryPage() {
             // page were tampered with at runtime, the backend signs over the
             // values it computed itself.
             const prep = await rainApi.prepareRecoverFunds()
+            // Lock in the real prepared amount for the completion screen.
+            setRecoveredCents(prep.amountCents)
 
             const chainIdStr = String(PEANUT_WALLET_CHAIN.id)
             const chainIdNum = Number(prep.chainId)
@@ -120,7 +126,7 @@ export default function CardRecoveryPage() {
 
     return (
         <div className="flex min-h-[inherit] flex-col gap-8">
-            <NavHeader title="Recover card funds" onPrev={() => router.push('/home')} />
+            <NavHeader title="Recover card funds" onPrev={onBack} />
             <div className="my-auto flex flex-col gap-6">
                 {error && <ErrorAlert description={error} />}
 
@@ -128,7 +134,8 @@ export default function CardRecoveryPage() {
                     <Card className="flex flex-col gap-3 p-6">
                         <h2 className="text-h7 font-bold">Funds sent to your wallet.</h2>
                         <p className="text-sm text-grey-1">
-                            ${formatCents(preview!.amountCents)} USDC has been returned to your peanut wallet.
+                            ${formatCents(recoveredCents ?? preview!.amountCents)} USDC has been returned to your peanut
+                            wallet.
                         </p>
                         <a
                             className="text-black underline"

--- a/src/components/Card/__tests__/cardApply.utils.test.ts
+++ b/src/components/Card/__tests__/cardApply.utils.test.ts
@@ -1,4 +1,4 @@
-import { pollUntilApplyAdvances } from '@/components/Card/cardApply.utils'
+import { pollUntilApplyAdvances, pollUntilReady } from '@/components/Card/cardApply.utils'
 
 const noSleep = async () => {}
 
@@ -107,5 +107,93 @@ describe('pollUntilApplyAdvances', () => {
 
         expect(result).toBeNull()
         expect(fetchApply).not.toHaveBeenCalled()
+    })
+})
+
+describe('pollUntilReady', () => {
+    const noSleep = async () => {}
+
+    it('returns true once the backend reports ready', async () => {
+        const fetchReadiness = jest.fn().mockResolvedValueOnce({ ready: false }).mockResolvedValueOnce({ ready: true })
+
+        const result = await pollUntilReady({ fetchReadiness, intervalMs: 0, timeoutMs: 10_000, sleep: noSleep })
+
+        expect(result).toBe(true)
+        expect(fetchReadiness).toHaveBeenCalledTimes(2)
+    })
+
+    it('returns false on a clean timeout (backend healthy, never went ready)', async () => {
+        const fetchReadiness = jest.fn().mockResolvedValue({ ready: false })
+        let clock = 0
+
+        const result = await pollUntilReady({
+            fetchReadiness,
+            intervalMs: 1000,
+            timeoutMs: 3000,
+            sleep: async (ms) => {
+                clock += ms
+            },
+            now: () => clock,
+        })
+
+        expect(result).toBe(false)
+    })
+
+    // The fix: a PERSISTENT failure (auth / 5xx) must surface its real reason on
+    // timeout instead of being collapsed into a misleading `false` ("taking longer").
+    it('throws the last error when the most recent poll keeps failing', async () => {
+        const fetchReadiness = jest.fn().mockRejectedValue(new Error('401 session expired'))
+        let clock = 0
+
+        await expect(
+            pollUntilReady({
+                fetchReadiness,
+                intervalMs: 1000,
+                timeoutMs: 3000,
+                sleep: async (ms) => {
+                    clock += ms
+                },
+                now: () => clock,
+            })
+        ).rejects.toThrow('401 session expired')
+    })
+
+    // A transient blip that recovers must NOT surface a stale error: if the latest
+    // poll was a clean (not-ready) response, timeout returns false, not the old error.
+    it('does not throw a stale error after recovery — returns false on clean timeout', async () => {
+        const fetchReadiness = jest
+            .fn()
+            .mockRejectedValueOnce(new Error('transient 503'))
+            .mockResolvedValue({ ready: false })
+        let clock = 0
+
+        const result = await pollUntilReady({
+            fetchReadiness,
+            intervalMs: 1000,
+            timeoutMs: 3000,
+            sleep: async (ms) => {
+                clock += ms
+            },
+            now: () => clock,
+        })
+
+        expect(result).toBe(false)
+    })
+
+    it('returns null when the signal is already aborted', async () => {
+        const controller = new AbortController()
+        controller.abort()
+        const fetchReadiness = jest.fn()
+
+        const result = await pollUntilReady({
+            fetchReadiness,
+            intervalMs: 0,
+            timeoutMs: 10_000,
+            signal: controller.signal,
+            sleep: noSleep,
+        })
+
+        expect(result).toBeNull()
+        expect(fetchReadiness).not.toHaveBeenCalled()
     })
 })

--- a/src/components/Card/cardApply.utils.ts
+++ b/src/components/Card/cardApply.utils.ts
@@ -42,7 +42,10 @@ export async function pollUntilApplyAdvances<R extends { status: string }>({
  * Each `fetchReadiness` call reads a single webhook-stamped flag from our DB
  * (no Sumsub round-trip), so it's safe to poll fast. Returns `true` when the
  * backend reports `ready: true` (Sumsub finished reviewing rain-requirements
- * GREEN), `false` on timeout, `null` on abort.
+ * GREEN), `false` on a clean timeout (backend healthy but never went ready),
+ * `null` on abort. If the MOST RECENT poll failed (persistent auth/5xx), it
+ * re-throws that error on timeout so the caller surfaces the real reason
+ * instead of a misleading "taking longer than expected".
  *
  * Replaces the previous pattern of polling `POST /rain/cards` itself — each
  * of those calls did `moveToLevel` + `getApplicant` + `getQuestionnaireAnswers`
@@ -65,16 +68,26 @@ export async function pollUntilReady({
     now?: () => number
 }): Promise<boolean | null> {
     const start = now()
+    let lastError: unknown
     while (true) {
         if (signal?.aborted) return null
         try {
             const { ready } = await fetchReadiness()
             if (ready) return true
-        } catch {
-            // Swallow transient fetch errors — the next poll iteration retries.
+            // a clean (not-yet-ready) response means the backend is healthy —
+            // clear any earlier transient error so we don't surface a stale one.
+            lastError = undefined
+        } catch (err) {
+            // Swallow transient fetch errors mid-poll and retry, but remember the
+            // most recent one: a persistent failure (auth, 5xx) should surface its
+            // real reason on timeout instead of a misleading "taking longer".
+            lastError = err
         }
         await sleep(intervalMs)
         if (signal?.aborted) return null
-        if (now() - start >= timeoutMs) return false
+        if (now() - start >= timeoutMs) {
+            if (lastError) throw lastError
+            return false
+        }
     }
 }


### PR DESCRIPTION
## Summary

Two card-flow fixes surfaced by CodeRabbit on the `main→dev` back-merge (#2190). **Both pre-existing in prod — not introduced by that PR.** Bundled here as one PR since they're the same card domain (and it's one repo).

### 1. `pollUntilReady` masked terminal failures as a fake timeout
The post-Sumsub readiness poll swallowed **every** `fetchReadiness()` error and, on deadline, returned `false` → the user always got *"Verification is taking longer than expected,"* hiding persistent auth/5xx failures.

Now it remembers the **most-recent** error and re-throws it on a failed-poll timeout — the card page's existing `catch` then surfaces the real message and captures `CARD_APPLY_FAILED` with it. A clean *healthy-but-not-ready* timeout still returns `false`, and a transient blip that recovers does **not** surface a stale error.

### 2. Card-recovery completion showed a stale amount
The completion screen rendered the mount-time `preview.amountCents`. `prepareRecoverFunds()` re-reads on-chain collateral and returns the **actual** cent-aligned amount being recovered, so if collateral changed between preview and the signed submission, the screen confirmed the tx and then showed the **wrong** number (the on-chain tx itself was always correct).

Now it renders `prep.amountCents` — the amount actually prepared, signed, and submitted.

## Tests
- `cardApply.utils.test.ts` — `pollUntilReady`: returns true when ready; `false` on clean timeout; **throws the last error on a persistent-failure timeout**; does **not** throw a stale error after recovery; null on abort. (5 new cases.)
- Full suite green locally (77 suites, 1319 passed), typecheck + prettier clean.

## Risk
Low. `pollUntilReady`'s contract change (throw-on-failed-timeout vs return-false) is absorbed by the **existing** caller `try/catch` in `card/page.tsx` — no caller change needed. The recovery change is a display value swap.

## Also
Cleared the pre-existing `useSafeBack` eslint error in `card-recovery` (NavHeader back action `router.push('/home')` → `useSafeBack('/home')`, matching the `/card` page) — CodeRabbit finding #4.