### PR TITLE
test(invites): preserve campaign→BADGES guard test (rescued from stale sync #2155)

### DIFF
--- a/src/components/Invites/InvitesPage.tsx
+++ b/src/components/Invites/InvitesPage.tsx
@@ -19,25 +19,7 @@ import UnsupportedBrowserModal from '../Global/UnsupportedBrowserModal'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { profileUrl } from '@/utils/native-routes'
-
-// mapping of special invite codes to their campaign tags
-// when these invite codes are used, the corresponding campaign tag is automatically applied
-const INVITE_CODE_TO_CAMPAIGN_MAP: Record<string, string> = {
-    arbiverseinvitesyou: 'ARBIVERSE_DEVCONNECT_BA_2025',
-    squirrelinvitesyou: 'ARBIVERSE_DEVCONNECT_BA_2025', // temporary: maps to arbiverse until 12pm noon tomorrow
-    founderhaus: 'FOUNDER_HOUSE',
-    survivor: 'SUPPORT_SURVIVOR',
-}
-
-// Map inbound `utm_campaign` values to the badge codes the backend whitelists.
-// Lets marketing/event links use a single UTM-shaped URL — PostHog auto-captures
-// utm_* on $pageview so the same string also flows into the analytics funnel.
-// Backend whitelist lives in peanut-api-ts/src/routes/badge.ts + invite.ts; keep
-// in sync when adding a new entry here.
-const UTM_CAMPAIGN_TO_BADGE_MAP: Record<string, string> = {
-    'token-nation-2026': 'TOKEN_NATION_SP_2026',
-    ethfloripa: 'ETHFLORIPA_HUB',
-}
+import { INVITE_CODE_TO_CAMPAIGN_MAP, UTM_CAMPAIGN_TO_BADGE_MAP } from './campaign-maps'
 
 // /invite?campaign=skip — bypasses the waitlist with no invite code. The backend
 // /badge/award endpoint flips hasAppAccess + cardFlowEarlyAccessAt and adds the

--- a/src/components/Invites/campaign-maps.test.ts
+++ b/src/components/Invites/campaign-maps.test.ts
@@ -1,0 +1,28 @@
+import { BADGES } from '@/components/Badges/badge.utils'
+import { INVITE_CODE_TO_CAMPAIGN_MAP, UTM_CAMPAIGN_TO_BADGE_MAP } from './campaign-maps'
+
+// Regression guard. The /invite flow resolves an inbound invite code / utm_campaign
+// to one of these badge codes, carries it through signup, and the UI renders
+// BADGES[code] for the awarded badge. If a code here has no BADGES entry, getBadgeIcon
+// falls back to the Peanutman logo and getBadgeDisplayName returns the raw backend
+// name — a silent visual regression with no conflict, no type error, no runtime throw.
+//
+// This is exactly how TOKEN_NATION_SP_2026 + ETHFLORIPA_HUB fell out of dev (the
+// May 29 event-badge hotfixes were written against the old parallel-map shape and
+// their additions evaporated when merged across the May 23 single-BADGES refactor),
+// and later out of main (regressed on release, fixed by 32699f171). This test fails
+// the moment a campaign code points at a badge the FE can't render.
+const badgeCodes = new Set(Object.keys(BADGES))
+
+describe('campaign maps reference real BADGES codes', () => {
+    it.each(Object.entries(UTM_CAMPAIGN_TO_BADGE_MAP))('utm_campaign "%s" → "%s" exists in BADGES', (_utm, code) => {
+        expect(badgeCodes).toContain(code)
+    })
+
+    it.each(Object.entries(INVITE_CODE_TO_CAMPAIGN_MAP))(
+        'invite code "%s" → "%s" exists in BADGES',
+        (_invite, code) => {
+            expect(badgeCodes).toContain(code)
+        }
+    )
+})

--- a/src/components/Invites/campaign-maps.ts
+++ b/src/components/Invites/campaign-maps.ts
@@ -1,0 +1,24 @@
+// Inbound campaign-resolution maps for /invite. Pure data, kept out of the
+// InvitesPage client component so they can be unit-tested in isolation: every
+// value here is a badge code, and if it isn't present in BADGES the awarded
+// badge silently renders the Peanutman fallback + raw backend name (the
+// parallel-maps→single-record regression). campaign-maps.test.ts guards that.
+
+// mapping of special invite codes to their campaign tags
+// when these invite codes are used, the corresponding campaign tag is automatically applied
+export const INVITE_CODE_TO_CAMPAIGN_MAP: Record<string, string> = {
+    arbiverseinvitesyou: 'ARBIVERSE_DEVCONNECT_BA_2025',
+    squirrelinvitesyou: 'ARBIVERSE_DEVCONNECT_BA_2025', // temporary: maps to arbiverse until 12pm noon tomorrow
+    founderhaus: 'FOUNDER_HOUSE',
+    survivor: 'SUPPORT_SURVIVOR',
+}
+
+// Map inbound `utm_campaign` values to the badge codes the backend whitelists.
+// Lets marketing/event links use a single UTM-shaped URL — PostHog auto-captures
+// utm_* on $pageview so the same string also flows into the analytics funnel.
+// Backend whitelist lives in peanut-api-ts/src/routes/badge.ts + invite.ts; keep
+// in sync when adding a new entry here.
+export const UTM_CAMPAIGN_TO_BADGE_MAP: Record<string, string> = {
+    'token-nation-2026': 'TOKEN_NATION_SP_2026',
+    ethfloripa: 'ETHFLORIPA_HUB',
+}


### PR DESCRIPTION
## Summary
Cherry-picks the **one unique commit** stranded on the abandoned sync branch `chore/sync-main-into-dev-0601` (PR #2155): a guard test (+ extracted `campaign-maps.ts`) ensuring every invite/utm campaign code resolves to a real `BADGES` entry.

This commit (`6800def7e`) was in **neither main nor dev** — it would have been lost when #2155 is closed. The behavior fix it guards (`32699f171`) is already in main; this adds the **CI tripwire** so the badge-registry silent-drop can't regress again (it bit dev+main twice).

## Changes
- `src/components/Invites/campaign-maps.ts` — extracts the campaign→BADGES mapping
- `src/components/Invites/campaign-maps.test.ts` — asserts each code resolves to a defined BADGES entry (fails on a dangling code)
- `src/components/Invites/InvitesPage.tsx` — uses the extracted map

## Tests
6/6 pass; typecheck + prettier + eslint clean.

## Why
Lossless closure of stale sync PR #2155 — certification showed it carried this unique work. Once this merges, #2155 is safe to close.