### PR TITLE
chore: back-merge main → dev (2026-06-07, post #2194)

### DIFF
--- a/src/app/actions/types/sumsub.types.ts
+++ b/src/app/actions/types/sumsub.types.ts
@@ -1,4 +1,4 @@
-export type KycActionType = 'manteca' | 'bridge-direct'
+export type KycActionType = 'manteca' | 'bridge-direct' | 'unsupported-region'
 
 export interface InitiateSumsubKycResponse {
     token: string | null // null when user is already APPROVED or bridge-direct

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -1,0 +1,67 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { useSumsubKycFlow } from '@/hooks/useSumsubKycFlow'
+import { initiateSumsubKyc } from '@/app/actions/sumsub'
+
+// useSumsubKycFlow wires a websocket, redux, the router and three server actions.
+// Stub everything except the one action the cross-region branch reads so the test
+// asserts hook behaviour (does onKycSuccess fire? is an error surfaced?) and nothing else.
+jest.mock('@/app/actions/sumsub', () => ({
+    initiateSumsubKyc: jest.fn(),
+    initiateSelfHealResubmission: jest.fn(),
+    restartIdentityVerification: jest.fn(),
+}))
+jest.mock('@/hooks/useWebSocket', () => ({ useWebSocket: jest.fn() }))
+jest.mock('@/redux/hooks', () => ({ useUserStore: () => ({ user: { user: { username: 'test' } } }) }))
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn(), replace: jest.fn() }) }))
+jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => false }))
+
+const mockInitiate = initiateSumsubKyc as jest.MockedFunction<typeof initiateSumsubKyc>
+
+describe('useSumsubKycFlow — cross-region routing', () => {
+    beforeEach(() => {
+        mockInitiate.mockReset()
+    })
+
+    // Regression for the "Unlock {region}" no-op loop (ROW). The BE approves identity
+    // but can't enroll any first-party bank rail for rest-of-world, so it returns
+    // actionType: 'unsupported-region' (status APPROVED, no token). The hook MUST show
+    // an honest message and MUST NOT fire onKycSuccess — firing it loops the user back
+    // through the "all set" success path with nothing actually unlocked.
+    it('unsupported-region → surfaces an honest error and does NOT fire onKycSuccess', async () => {
+        mockInitiate.mockResolvedValue({
+            data: { token: null, applicantId: 'app_1', status: 'APPROVED', actionType: 'unsupported-region' },
+        })
+        const onKycSuccess = jest.fn()
+
+        // regionIntent undefined → the mount-time status fetch short-circuits, so the
+        // only initiateSumsubKyc call is the one handleInitiateKyc drives below.
+        const { result } = renderHook(() => useSumsubKycFlow({ onKycSuccess }))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('ROW', undefined, true)
+        })
+
+        expect(result.current.error).toMatch(/region/i)
+        expect(result.current.showWrapper).toBe(false)
+        // give any queued status-transition effect a chance to (wrongly) fire.
+        await waitFor(() => expect(onKycSuccess).not.toHaveBeenCalled())
+    })
+
+    // Control: the sibling cross-region success path must still fire onKycSuccess and
+    // stay error-free — proves the new branch was inserted without breaking bridge-direct.
+    it('bridge-direct → fires onKycSuccess with no error', async () => {
+        mockInitiate.mockResolvedValue({
+            data: { token: null, applicantId: 'app_2', status: 'APPROVED', actionType: 'bridge-direct' },
+        })
+        const onKycSuccess = jest.fn()
+
+        const { result } = renderHook(() => useSumsubKycFlow({ onKycSuccess }))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('EU', undefined, true)
+        })
+
+        expect(result.current.error).toBeNull()
+        await waitFor(() => expect(onKycSuccess).toHaveBeenCalledTimes(1))
+    })
+})

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -5,12 +5,19 @@ import { initiateSumsubKyc } from '@/app/actions/sumsub'
 // useSumsubKycFlow wires a websocket, redux, the router and three server actions.
 // Stub everything except the one action the cross-region branch reads so the test
 // asserts hook behaviour (does onKycSuccess fire? is an error surfaced?) and nothing else.
+// The websocket mock captures the status-update handler so a test can simulate a
+// late/stale APPROVED event arriving after the flow has resolved.
+const mockWs: { handler?: (status: string, labels?: string[]) => void } = {}
 jest.mock('@/app/actions/sumsub', () => ({
     initiateSumsubKyc: jest.fn(),
     initiateSelfHealResubmission: jest.fn(),
     restartIdentityVerification: jest.fn(),
 }))
-jest.mock('@/hooks/useWebSocket', () => ({ useWebSocket: jest.fn() }))
+jest.mock('@/hooks/useWebSocket', () => ({
+    useWebSocket: (opts: { onSumsubKycStatusUpdate?: (status: string, labels?: string[]) => void }) => {
+        mockWs.handler = opts.onSumsubKycStatusUpdate
+    },
+}))
 jest.mock('@/redux/hooks', () => ({ useUserStore: () => ({ user: { user: { username: 'test' } } }) }))
 jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn(), replace: jest.fn() }) }))
 jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => false }))
@@ -20,6 +27,7 @@ const mockInitiate = initiateSumsubKyc as jest.MockedFunction<typeof initiateSum
 describe('useSumsubKycFlow — cross-region routing', () => {
     beforeEach(() => {
         mockInitiate.mockReset()
+        mockWs.handler = undefined
     })
 
     // Regression for the "Unlock {region}" no-op loop (ROW). The BE approves identity
@@ -44,6 +52,31 @@ describe('useSumsubKycFlow — cross-region routing', () => {
         expect(result.current.error).toMatch(/region/i)
         expect(result.current.showWrapper).toBe(false)
         // give any queued status-transition effect a chance to (wrongly) fire.
+        await waitFor(() => expect(onKycSuccess).not.toHaveBeenCalled())
+    })
+
+    // The race the loop-fix has to survive: the user is already APPROVED, so a stale /
+    // connect-time websocket APPROVED event can land AFTER the unsupported-region error.
+    // If the branch left userInitiatedRef set, that event trips the status-transition
+    // effect into firing onKycSuccess — re-opening "all set" on top of the error.
+    it('unsupported-region → stale websocket APPROVED after the error still does NOT fire onKycSuccess', async () => {
+        mockInitiate.mockResolvedValue({
+            data: { token: null, applicantId: 'app_1', status: 'APPROVED', actionType: 'unsupported-region' },
+        })
+        const onKycSuccess = jest.fn()
+
+        const { result } = renderHook(() => useSumsubKycFlow({ onKycSuccess }))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('ROW', undefined, true)
+        })
+        expect(result.current.error).toMatch(/region/i)
+
+        // simulate a late websocket status push (APPROVED) arriving after the terminal error
+        await act(async () => {
+            mockWs.handler?.('APPROVED')
+        })
+
         await waitFor(() => expect(onKycSuccess).not.toHaveBeenCalled())
     })
 

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -173,8 +173,12 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 // silent no-op. surface an honest, terminal message and bail BEFORE the
                 // status sync below — syncing APPROVED here would trip the transition
                 // effect into firing onKycSuccess, looping the user back to "all set".
+                //
+                // clear userInitiatedRef so a late/stale websocket APPROVED event can't
+                // satisfy the transition-effect guard and fire onKycSuccess after this
+                // terminal error (the user is approved but has no rail — NOT a success).
                 if (response.data?.actionType === 'unsupported-region') {
-                    if (crossRegion) prevStatusRef.current = savedPrevStatus
+                    userInitiatedRef.current = false
                     setError(
                         "Bank deposits aren't available in your region yet. We'll let you know as soon as they go live."
                     )

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -167,6 +167,20 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                     return
                 }
 
+                // cross-region into a region no first-party bank provider serves (ROW).
+                // the backend approved identity but can't auto-enroll any rail, so it
+                // signals 'unsupported-region' (status APPROVED, no token) instead of a
+                // silent no-op. surface an honest, terminal message and bail BEFORE the
+                // status sync below — syncing APPROVED here would trip the transition
+                // effect into firing onKycSuccess, looping the user back to "all set".
+                if (response.data?.actionType === 'unsupported-region') {
+                    if (crossRegion) prevStatusRef.current = savedPrevStatus
+                    setError(
+                        "Bank deposits aren't available in your region yet. We'll let you know as soon as they go live."
+                    )
+                    return
+                }
+
                 // sync status from api response, but skip when a token is returned
                 // alongside APPROVED — that means the SDK should open (e.g. additional-docs flow),
                 // not that kyc is finished. syncing APPROVED here would trigger the useEffect


### PR DESCRIPTION
Routine main→dev sync. Carries **#2194** (cross-region unsupported-region FE consumer) from main into dev. Clean merge (0 conflicts); typecheck green.