### PR TITLE
fix(card): 404 the /card gate instead of redirecting to /shhhhh

### DIFF
--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { type FC, useCallback, useEffect, useRef, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { notFound } from 'next/navigation'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
@@ -50,7 +50,6 @@ function markSkipCelebrationSeen(): void {
 // they don't re-see the gate after celebration / add-card transitions.
 
 const CardPage: FC = () => {
-    const router = useRouter()
     const queryClient = useQueryClient()
     const { user, fetchUser } = useAuth()
     const userId = user?.user?.userId
@@ -138,32 +137,37 @@ const CardPage: FC = () => {
         })()
     }, [pressDoorMode, pioneerLoading, cardInfo, queryClient])
 
-    // Outer gate: pre-public-launch, redirect users without /shhhhh early
-    // access back to the landing page so they don't see a half-baked /card
-    // shell. BE returns `flowEarlyAccess: false` in that case.
+    // Outer gate: pre-public-launch, the card campaign isn't fully online
+    // yet. Users without flow early access get a 404 — the page behaves as
+    // if it doesn't exist. The only ways in are (a) already holding a card
+    // / being mid-application, or (b) entering through the special /shhhhh
+    // page, which stamps `flowEarlyAccess` via ?press_door=1 before landing
+    // here. BE returns `flowEarlyAccess: false` for everyone else.
     //
-    // IMPORTANT: skip the redirect if the user already has a non-canceled
-    // card. Legacy Pioneers + admin-granted users issued cards before
-    // /shhhhh existed and have no flowEarlyAccess stamp — they must still
-    // reach YourCardScreen. The computeCardState() precedence below mirrors
-    // this rule (active-card before no-flow-access). Also skip while
-    // pressDoorMode is in flight: the stamp is about to land any tick now,
-    // and bouncing to /shhhhh mid-stamp creates a momentary flash.
+    // IMPORTANT: skip the 404 if the user already has a non-canceled card.
+    // Legacy Pioneers + admin-granted users issued cards before /shhhhh
+    // existed and have no flowEarlyAccess stamp — they must still reach
+    // YourCardScreen. The computeCardState() precedence below mirrors this
+    // rule (active-card before no-flow-access). Also skip while pressDoorMode
+    // is in flight: the stamp is about to land any tick now, and 404-ing
+    // mid-stamp would wrongly bounce a legit /shhhhh entrant.
+    //
+    // notFound() thrown synchronously inside the effect bubbles to Next's
+    // not-found boundary just like a render-time call.
     useEffect(() => {
         if (pressDoorMode) return
         if (pioneerLoading || pioneerError) return
         if (!cardInfo) return
         if (cardInfo.flowEarlyAccess) return
         // CR FE#1: wait for overview before checking issued cards — otherwise
-        // legacy card-holders (overview still loading) get incorrectly bounced
-        // to /shhhhh because `overview?.cards.some(...)` returns false on
-        // undefined input.
+        // legacy card-holders (overview still loading) get incorrectly 404'd
+        // because `overview?.cards.some(...)` returns false on undefined input.
         if (overviewLoading || !overview) return
         const hasIssuedCard = overview.cards.some((c) => c.status !== 'CANCELED')
         if (hasIssuedCard) return
         posthog.capture(ANALYTICS_EVENTS.CARD_FLOW_GATED)
-        router.replace('/shhhhh')
-    }, [router, pioneerLoading, pioneerError, cardInfo, overview, overviewLoading, pressDoorMode])
+        notFound()
+    }, [pioneerLoading, pioneerError, cardInfo, overview, overviewLoading, pressDoorMode])
 
     const state = computeCardState({
         overview,
@@ -434,8 +438,9 @@ const CardPage: FC = () => {
         return ''
     }, [invalidateOverview])
 
-    // Outer-gate fail — we already kicked off the redirect to /shhhhh in
-    // the useEffect above; render nothing here so the page doesn't flash.
+    // Outer-gate fail — the useEffect above fires notFound() to render the
+    // 404 boundary; render nothing here so the page doesn't flash for the
+    // one frame before that lands.
     if (state === 'no-flow-access') {
         return null
     }


### PR DESCRIPTION
## Why

The card campaign isn't fully online yet. The outer gate on `/card` currently redirects ungated users to the `/shhhhh` closed-beta landing — which *advertises* the page's existence to anyone who pokes at `/card`. We don't want that yet.

## What

`/card`'s outer gate now calls `notFound()` instead of `router.replace('/shhhhh')`. To the ungated, `/card` behaves as if it doesn't exist (404), rather than leaking the beta landing.

- Swapped the redirect for `notFound()` in the gate `useEffect` (thrown synchronously inside the effect → bubbles to Next's not-found boundary, same pattern as the marketing pages).
- Removed the now-unused `useRouter`/`router`.
- Updated comments.

## Access rules are unchanged

| User | Result |
|---|---|
| Existing / in-progress card holder | ✅ passes — active-card precedence runs before the gate |
| Entered via `/shhhhh` | ✅ `?press_door=1` stamps `flowEarlyAccess` before `/card` mounts |
| Ungated, no card | 🚫 **404** (was: redirect to `/shhhhh`) |

`/shhhhh` itself stays **public and fully visible** — it's the intended (only) front door in. `CARD_FLOW_GATED` analytics still fires before the 404.

## Scope / risk

FE-only gating change in `peanut-ui`. No backend/contract impact. `computeCardState` is untouched (`no-flow-access` still computes identically) — only the page's reaction changed.

## Test

- `cardState.utils` unit tests pass (15/15).
- Typecheck clean for the changed file.