### PR TITLE
fix(wallet): reject mismatched kernel client at the sign choke point + force re-auth

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -18,6 +18,7 @@ import CyclingLoading from '@/components/Global/PeanutLoading/CyclingLoading'
 import AmountInput from '@/components/Global/AmountInput'
 import { useWallet } from '@/hooks/wallet/useWallet'
 import { useSignSpendBundle } from '@/hooks/wallet/useSignSpendBundle'
+import { useStaleSessionGuard } from '@/hooks/wallet/useStaleSessionGuard'
 import { InsufficientSpendableError, SessionKeyGrantRequiredError } from '@/hooks/wallet/useSpendBundle'
 import { rainCollateralErrorMessage } from '@/utils/friendly-error.utils'
 import { useRainCardOverview } from '@/hooks/useRainCardOverview'
@@ -89,6 +90,7 @@ export default function QRPayPage() {
     const qrType = searchParams.get('type')
     const { spendableBalance: balance, sendMoney } = useWallet()
     const { signSpend } = useSignSpendBundle()
+    const handleStaleSession = useStaleSessionGuard()
     const { overview: rainCardOverview } = useRainCardOverview()
     const [isSuccess, setIsSuccess] = useState(false)
     const [errorMessage, setErrorMessage] = useState<string | null>(null)
@@ -681,6 +683,9 @@ export default function QRPayPage() {
                 clearTimeout(payingStateTimerRef.current)
                 payingStateTimerRef.current = null
             }
+            // Wrong-passkey session: backend rejected the signed UserOp with
+            // AA24 / wapk. Unrecoverable without re-auth — force a clean logout.
+            if (handleStaleSession(error)) return
             captureException(error)
             const errorMsg = (error as Error).message || 'Could not complete payment'
 
@@ -704,7 +709,17 @@ export default function QRPayPage() {
         } finally {
             setLoadingState('Idle')
         }
-    }, [paymentLock, signSpend, balance, rainCardOverview, qrCode, currencyAmount, setLoadingState, qrType])
+    }, [
+        paymentLock,
+        signSpend,
+        balance,
+        rainCardOverview,
+        qrCode,
+        currencyAmount,
+        setLoadingState,
+        qrType,
+        handleStaleSession,
+    ])
 
     const payQR = useCallback(async () => {
         if (paymentProcessor === 'MANTECA') {

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -2,6 +2,7 @@
 
 import { useWallet } from '@/hooks/wallet/useWallet'
 import { useSignSpendBundle } from '@/hooks/wallet/useSignSpendBundle'
+import { useStaleSessionGuard } from '@/hooks/wallet/useStaleSessionGuard'
 import { InsufficientSpendableError, SessionKeyGrantRequiredError } from '@/hooks/wallet/useSpendBundle'
 import { rainCollateralErrorMessage } from '@/utils/friendly-error.utils'
 import { rainCentsToUsdcUnits } from '@/utils/balance.utils'
@@ -96,6 +97,7 @@ export default function MantecaWithdrawFlow() {
     const router = useRouter()
     const { spendableBalance: balance, balance: smartBalance } = useWallet()
     const { signSpend } = useSignSpendBundle()
+    const handleStaleSession = useStaleSessionGuard()
     const { overview: rainCardOverview } = useRainCardOverview()
     const { isLoading, loadingState, setLoadingState } = useContext(loadingStateContext)
     const { setIsSupportModalOpen, openSupportWithMessage } = useModalsContext()
@@ -410,6 +412,10 @@ export default function MantecaWithdrawFlow() {
                     error_message: result.error,
                 })
 
+                // Wrong-passkey session: backend rejected the signed UserOp with
+                // AA24 / wapk. Unrecoverable without re-auth — force a clean logout.
+                if (handleStaleSession(result.message ?? result.error)) return
+
                 // handle onboarding-incomplete errors by redirecting to complete profile
                 if (await handleOnboardingError(result.message ?? result.error)) return
 
@@ -433,6 +439,7 @@ export default function MantecaWithdrawFlow() {
             })
         } catch (error) {
             console.error('Manteca withdraw error:', error)
+            if (handleStaleSession(error)) return
             posthog.capture(ANALYTICS_EVENTS.WITHDRAW_FAILED, {
                 method_type: 'manteca',
                 error_message: 'Withdraw failed unexpectedly',

--- a/src/context/kernelClient.context.tsx
+++ b/src/context/kernelClient.context.tsx
@@ -168,27 +168,6 @@ export const createKernelClientForChain = async <C extends Chain>(
             webAuthnKey,
             PasskeyValidatorContractVersion.V0_0_2_UNPATCHED
         )
-
-        // A migration account's address is injected (from the backend user
-        // record), not derived from the key — so the access-time guard in the
-        // provider can't tell whether this passkey actually owns it. Derive the
-        // address this key maps to (the same derivation the SDK does internally
-        // when no address is passed) and require it to match. A mismatch means
-        // the session is paired with the wrong passkey; signing would produce a
-        // wrong-owner signature the EntryPoint rejects (AA24). Bail to re-auth.
-        const keyDerivedAccount = await createKernelAccount(publicClient, {
-            plugins: { sudo: oldValidator },
-            entryPoint: USER_OP_ENTRY_POINT,
-            kernelVersion: ZERODEV_KERNEL_VERSION,
-        })
-        if (isStaleClientForUser(keyDerivedAccount.address, address)) {
-            console.error('[KernelClient] passkey does not own the migration account — stale credential', {
-                keyDerivedAddress: keyDerivedAccount.address,
-                expectedAddress: address,
-            })
-            throw createStaleSessionError()
-        }
-
         kernelAccount = await createKernelMigrationAccount(publicClient, {
             address,
             plugins: {
@@ -451,13 +430,7 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
             }
         }
 
-        retryAsync(initializeClients, {
-            maxRetries: 2,
-            baseDelay: 1000,
-            maxDelay: 5000,
-            // A stale-credential error is deterministic — don't burn retries on it.
-            shouldRetry: (error) => !isStaleKeyError(error),
-        }).catch(() => {
+        retryAsync(initializeClients, { maxRetries: 2, baseDelay: 1000, maxDelay: 5000 }).catch(() => {
             if (isMounted) {
                 console.error('[KernelClient] Primary chain client failed after retries — forcing logout')
                 dispatch(zerodevActions.setIsRegistering(false))

--- a/src/context/kernelClient.context.tsx
+++ b/src/context/kernelClient.context.tsx
@@ -26,6 +26,7 @@ import type { Address } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { captureException } from '@sentry/nextjs'
 import { retryAsync } from '@/utils/retry.utils'
+import { isStaleClientForUser } from '@/utils/walletCredential.utils'
 import { isAndroidNative, getNativeRpId } from '@/utils/capacitor'
 import { createNativeSignMessageCallback } from '@/utils/native-webauthn'
 import { PUBLIC_CLIENTS_BY_CHAIN } from '@/app/actions/clients'
@@ -459,6 +460,39 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
         }
     }, [clientsByChain])
 
+    // Refuse to hand out a kernel client whose smart-account address doesn't
+    // match the logged-in user, then force a clean re-auth. On a shared device
+    // with two passkeys for the same RP, the restore path can pair this session
+    // with the OTHER account's credential; signing with it yields a wrong-owner
+    // signature the EntryPoint rejects (AA24) — or Rain's ERC-1271 check rejects
+    // as invalid admin signature. Every sign site reads through here, so one
+    // check covers them all (and the next one written). Skipped when the user
+    // has no smart-wallet account yet (mid-registration); also a no-op for
+    // pre-migration accounts, whose address is injected rather than derived from
+    // the key, so a mismatch can't be detected here for them.
+    const assertClientOwnedByUser = useCallback(
+        (client: GenericSmartAccountClient): GenericSmartAccountClient => {
+            const expectedAddress = user?.accounts.find((a) => a.type === AccountType.PEANUT_WALLET)?.identifier
+            const derivedAddress = client.account?.address
+            if (isStaleClientForUser(derivedAddress, expectedAddress)) {
+                console.error('[KernelClient] active client does not match logged-in user — forcing logout', {
+                    userId: user?.user.userId,
+                    derivedAddress,
+                    expectedAddress,
+                })
+                if (user?.user.userId) updateUserPreferences(user.user.userId, { webAuthnKey: undefined })
+                logoutUser()
+                const staleError = new Error('Your session has expired. Please log in again.') as Error & {
+                    isStaleKeyError?: boolean
+                }
+                staleError.isStaleKeyError = true
+                throw staleError
+            }
+            return client
+        },
+        [user, logoutUser]
+    )
+
     const getClientForChain = useCallback(
         (chainId: string) => {
             const client = clientsByChain[chainId]
@@ -471,18 +505,18 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
                     `No client found for chain ${chainId}. This chain may not be configured for wallet operations.`
                 )
             }
-            return client
+            return assertClientOwnedByUser(client)
         },
-        [clientsByChain]
+        [clientsByChain, assertClientOwnedByUser]
     )
 
     const ensureClientForChain = useCallback(
         async (chainId: string): Promise<GenericSmartAccountClient> => {
             const cached = clientsByChain[chainId]
-            if (cached) return cached
+            if (cached) return assertClientOwnedByUser(cached)
 
             const inFlight = inFlightRef.current.get(chainId)
-            if (inFlight) return inFlight
+            if (inFlight) return inFlight.then(assertClientOwnedByUser)
 
             if (!webAuthnKey) {
                 throw new Error(`Cannot build kernel client for chain ${chainId}: not authenticated`)
@@ -508,7 +542,7 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
             )
                 .then((kernelClient) => {
                     setClientsByChain((prev) => ({ ...prev, [chainId]: kernelClient }))
-                    return kernelClient
+                    return assertClientOwnedByUser(kernelClient)
                 })
                 .catch((error) => {
                     console.error(`Error lazy-building kernel client for chain ${chainId}:`, error)
@@ -522,7 +556,7 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
             inFlightRef.current.set(chainId, promise)
             return promise
         },
-        [clientsByChain, webAuthnKey, isAfterZeroDevMigration, user]
+        [clientsByChain, webAuthnKey, isAfterZeroDevMigration, user, assertClientOwnedByUser]
     )
 
     return (

--- a/src/context/kernelClient.context.tsx
+++ b/src/context/kernelClient.context.tsx
@@ -26,7 +26,7 @@ import type { Address } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { captureException } from '@sentry/nextjs'
 import { retryAsync } from '@/utils/retry.utils'
-import { isStaleClientForUser } from '@/utils/walletCredential.utils'
+import { isStaleClientForUser, isStaleKeyError, createStaleSessionError } from '@/utils/walletCredential.utils'
 import { isAndroidNative, getNativeRpId } from '@/utils/capacitor'
 import { createNativeSignMessageCallback } from '@/utils/native-webauthn'
 import { PUBLIC_CLIENTS_BY_CHAIN } from '@/app/actions/clients'
@@ -168,6 +168,27 @@ export const createKernelClientForChain = async <C extends Chain>(
             webAuthnKey,
             PasskeyValidatorContractVersion.V0_0_2_UNPATCHED
         )
+
+        // A migration account's address is injected (from the backend user
+        // record), not derived from the key — so the access-time guard in the
+        // provider can't tell whether this passkey actually owns it. Derive the
+        // address this key maps to (the same derivation the SDK does internally
+        // when no address is passed) and require it to match. A mismatch means
+        // the session is paired with the wrong passkey; signing would produce a
+        // wrong-owner signature the EntryPoint rejects (AA24). Bail to re-auth.
+        const keyDerivedAccount = await createKernelAccount(publicClient, {
+            plugins: { sudo: oldValidator },
+            entryPoint: USER_OP_ENTRY_POINT,
+            kernelVersion: ZERODEV_KERNEL_VERSION,
+        })
+        if (isStaleClientForUser(keyDerivedAccount.address, address)) {
+            console.error('[KernelClient] passkey does not own the migration account — stale credential', {
+                keyDerivedAddress: keyDerivedAccount.address,
+                expectedAddress: address,
+            })
+            throw createStaleSessionError()
+        }
+
         kernelAccount = await createKernelMigrationAccount(publicClient, {
             address,
             plugins: {
@@ -430,7 +451,13 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
             }
         }
 
-        retryAsync(initializeClients, { maxRetries: 2, baseDelay: 1000, maxDelay: 5000 }).catch(() => {
+        retryAsync(initializeClients, {
+            maxRetries: 2,
+            baseDelay: 1000,
+            maxDelay: 5000,
+            // A stale-credential error is deterministic — don't burn retries on it.
+            shouldRetry: (error) => !isStaleKeyError(error),
+        }).catch(() => {
             if (isMounted) {
                 console.error('[KernelClient] Primary chain client failed after retries — forcing logout')
                 dispatch(zerodevActions.setIsRegistering(false))
@@ -482,11 +509,7 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
                 })
                 if (user?.user.userId) updateUserPreferences(user.user.userId, { webAuthnKey: undefined })
                 logoutUser()
-                const staleError = new Error('Your session has expired. Please log in again.') as Error & {
-                    isStaleKeyError?: boolean
-                }
-                staleError.isStaleKeyError = true
-                throw staleError
+                throw createStaleSessionError()
             }
             return client
         },
@@ -546,7 +569,11 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
                 })
                 .catch((error) => {
                     console.error(`Error lazy-building kernel client for chain ${chainId}:`, error)
-                    captureException(error)
+                    if (isStaleKeyError(error)) {
+                        logoutUser()
+                    } else {
+                        captureException(error)
+                    }
                     throw error
                 })
                 .finally(() => {
@@ -556,7 +583,7 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
             inFlightRef.current.set(chainId, promise)
             return promise
         },
-        [clientsByChain, webAuthnKey, isAfterZeroDevMigration, user, assertClientOwnedByUser]
+        [clientsByChain, webAuthnKey, isAfterZeroDevMigration, user, assertClientOwnedByUser, logoutUser]
     )
 
     return (

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -53,7 +53,7 @@ const isStaleKeyError = (error: unknown): boolean => {
 
 export const useZeroDev = () => {
     const dispatch = useAppDispatch()
-    const { user } = useAuth()
+    const { user, logoutUser } = useAuth()
     const { isKernelClientReady, isRegistering, isLoggingIn, isSendingUserOp, address } = useZerodevStore()
     const { setWebAuthnKey, getClientForChain, ensureClientForChain } = useKernelClient()
     const { setLoadingState } = useContext(loadingStateContext)
@@ -210,8 +210,11 @@ export const useZeroDev = () => {
             } catch (error) {
                 console.error('Error sending UserOp:', error)
 
-                // Detect stale webAuthnKey errors (AA24, wapk) and provide user feedback
-                // NOTE: Don't auto-clear here - user is mid-transaction, avoid data loss
+                // Detect stale webAuthnKey errors (AA24, wapk) and force a clean
+                // re-auth. A stale session can't recover by retrying — the only
+                // exit is logging out and back in, so surface the message AND
+                // force the logout (showing the toast alone left users stuck in a
+                // signed-in-but-broken state).
                 if (isStaleKeyError(error)) {
                     console.error('Detected stale webAuthnKey error - session is invalid')
                     captureException(error, {
@@ -229,6 +232,7 @@ export const useZeroDev = () => {
                     ;(enhancedError as any).cause = error
                     ;(enhancedError as any).isStaleKeyError = true
                     dispatch(zerodevActions.setIsSendingUserOp(false))
+                    logoutUser()
                     throw enhancedError
                 }
 
@@ -259,7 +263,7 @@ export const useZeroDev = () => {
                 receipt: userOpReceipt.receipt,
             }
         },
-        [getClientForChain, ensureClientForChain]
+        [getClientForChain, ensureClientForChain, logoutUser]
     )
 
     return {

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -8,6 +8,7 @@ import { useAppDispatch, useSetupStore, useZerodevStore } from '@/redux/hooks'
 import { zerodevActions } from '@/redux/slices/zerodev-slice'
 import { getFromCookie, removeFromCookie, saveToCookie } from '@/utils/general.utils'
 import { clearAuthState } from '@/utils/auth.utils'
+import { isStaleKeyError, createStaleSessionError } from '@/utils/walletCredential.utils'
 import { toWebAuthnKey, WebAuthnMode } from '@zerodev/passkey-validator'
 import { useCallback, useContext } from 'react'
 import type { TransactionReceipt, Hex, Hash } from 'viem'
@@ -36,20 +37,6 @@ class PasskeyError extends Error {
 }
 
 const WEB_AUTHN_COOKIE_KEY = 'web-authn-key'
-
-/**
- * Detects if an error is due to stale/invalid webAuthnKey
- * AA24 = EntryPoint signature verification failed
- * wapk = WebAuthn Public Key unauthorized (ZeroDev-specific)
- *
- * Note: Intentionally strict to avoid false positives on generic auth errors
- */
-const isStaleKeyError = (error: unknown): boolean => {
-    const errorStr = String(error).toLowerCase()
-    // AA24 = ERC-4337 EntryPoint signature verification failed
-    // wapk + unauthorized = ZeroDev's specific WebAuthn key error (not generic 401)
-    return errorStr.includes('aa24') || (errorStr.includes('wapk') && errorStr.includes('unauthorized'))
-}
 
 export const useZeroDev = () => {
     const dispatch = useAppDispatch()
@@ -225,15 +212,9 @@ export const useZeroDev = () => {
                             userId: user?.user.userId,
                         },
                     })
-                    // Enhance error message for user feedback
-                    const enhancedError = new Error(
-                        'Your session has expired. Please refresh the page and log in again.'
-                    )
-                    ;(enhancedError as any).cause = error
-                    ;(enhancedError as any).isStaleKeyError = true
                     dispatch(zerodevActions.setIsSendingUserOp(false))
                     logoutUser()
-                    throw enhancedError
+                    throw createStaleSessionError(error)
                 }
 
                 dispatch(zerodevActions.setIsSendingUserOp(false))

--- a/src/hooks/wallet/useStaleSessionGuard.ts
+++ b/src/hooks/wallet/useStaleSessionGuard.ts
@@ -1,0 +1,28 @@
+'use client'
+
+import { useCallback } from 'react'
+import { useAuth } from '@/context/authContext'
+import { isStaleKeyError } from '@/utils/walletCredential.utils'
+
+/**
+ * Reactive stale-credential guard for sign-then-broadcast flows. The UserOp is
+ * signed on the client and broadcast by the backend, so a wrong-passkey session
+ * surfaces as an AA24 / `wapk` error in the API *response* rather than a thrown
+ * client error — the access-point guard in KernelClientProvider never sees it
+ * for migration accounts (their address is injected, not key-derived).
+ *
+ * A stale session can't recover by retrying; the only exit is a clean re-auth.
+ * Pass the API error/message here: when it's a stale-credential error it forces
+ * logout and returns true so the caller can stop.
+ */
+export const useStaleSessionGuard = () => {
+    const { logoutUser } = useAuth()
+    return useCallback(
+        (error: unknown): boolean => {
+            if (!isStaleKeyError(error)) return false
+            logoutUser()
+            return true
+        },
+        [logoutUser]
+    )
+}

--- a/src/utils/__tests__/walletCredential.utils.test.ts
+++ b/src/utils/__tests__/walletCredential.utils.test.ts
@@ -1,4 +1,4 @@
-import { isStaleClientForUser } from '@/utils/walletCredential.utils'
+import { isStaleClientForUser, isStaleKeyError, createStaleSessionError } from '@/utils/walletCredential.utils'
 
 describe('isStaleClientForUser', () => {
     const accountA = '0xAAAAaaAAaAAAAAaaAAaaAAaaaAAAAAaAAaAAaAaa'
@@ -22,5 +22,27 @@ describe('isStaleClientForUser', () => {
 
     it('does not flag when the client has no derived address', () => {
         expect(isStaleClientForUser(undefined, accountB)).toBe(false)
+    })
+})
+
+describe('isStaleKeyError', () => {
+    it('recognises an error we tagged ourselves', () => {
+        expect(isStaleKeyError(createStaleSessionError())).toBe(true)
+    })
+
+    it('recognises an on-chain AA24 signature error', () => {
+        expect(isStaleKeyError(new Error('UserOperation reverted with reason: AA24 signature error'))).toBe(true)
+    })
+
+    it('recognises ZeroDev wapk-unauthorized', () => {
+        expect(isStaleKeyError('wapk: unauthorized')).toBe(true)
+    })
+
+    it('does not flag a generic unauthorized / 401', () => {
+        expect(isStaleKeyError(new Error('401 unauthorized'))).toBe(false)
+    })
+
+    it('does not flag an unrelated error', () => {
+        expect(isStaleKeyError(new Error('network request failed'))).toBe(false)
     })
 })

--- a/src/utils/__tests__/walletCredential.utils.test.ts
+++ b/src/utils/__tests__/walletCredential.utils.test.ts
@@ -1,0 +1,26 @@
+import { isStaleClientForUser } from '@/utils/walletCredential.utils'
+
+describe('isStaleClientForUser', () => {
+    const accountA = '0xAAAAaaAAaAAAAAaaAAaaAAaaaAAAAAaAAaAAaAaa'
+    const accountB = '0xBBBBbbBBbBBBBBbbBBbbBBbbbBBBBBbBBbBBbBbb'
+
+    it('flags a client whose address differs from the user (wrong passkey)', () => {
+        expect(isStaleClientForUser(accountA, accountB)).toBe(true)
+    })
+
+    it('accepts a client whose address matches the user', () => {
+        expect(isStaleClientForUser(accountA, accountA)).toBe(false)
+    })
+
+    it('matches case-insensitively (EIP-55 checksum vs lowercase)', () => {
+        expect(isStaleClientForUser(accountA.toLowerCase(), accountA)).toBe(false)
+    })
+
+    it('does not flag when the user has no smart-wallet address yet (mid-registration)', () => {
+        expect(isStaleClientForUser(accountA, undefined)).toBe(false)
+    })
+
+    it('does not flag when the client has no derived address', () => {
+        expect(isStaleClientForUser(undefined, accountB)).toBe(false)
+    })
+})

--- a/src/utils/walletCredential.utils.ts
+++ b/src/utils/walletCredential.utils.ts
@@ -5,9 +5,8 @@
  * ERC-1271 admin signature for Rain card withdraws).
  *
  * Returns false (treat as fine) when either address is missing: mid-registration
- * the user has no smart-wallet account yet, and pre-migration accounts inject
- * the address rather than derive it from the key — so an address comparison
- * can't detect a mismatch for them.
+ * the user has no smart-wallet account yet, and the comparison only makes sense
+ * when we have both a derived and an expected address.
  */
 export const isStaleClientForUser = (
     derivedAddress: string | undefined,
@@ -15,4 +14,33 @@ export const isStaleClientForUser = (
 ): boolean => {
     if (!derivedAddress || !expectedAddress) return false
     return derivedAddress.toLowerCase() !== expectedAddress.toLowerCase()
+}
+
+/**
+ * Recognises a stale-credential failure: either one we threw ourselves (tagged
+ * `isStaleKeyError`) or the on-chain/bundler symptoms of signing with the wrong
+ * passkey — AA24 (EntryPoint signature check failed) or ZeroDev's `wapk
+ * unauthorized` (WebAuthn key not authorised; deliberately paired with
+ * "unauthorized" so a generic 401 doesn't match).
+ */
+export const isStaleKeyError = (error: unknown): boolean => {
+    if (error && typeof error === 'object' && (error as { isStaleKeyError?: unknown }).isStaleKeyError === true) {
+        return true
+    }
+    const errorStr = String(error).toLowerCase()
+    return errorStr.includes('aa24') || (errorStr.includes('wapk') && errorStr.includes('unauthorized'))
+}
+
+/**
+ * Builds the user-facing stale-session error. Tagged with `isStaleKeyError` so
+ * downstream handlers can detect it and force a clean re-auth.
+ */
+export const createStaleSessionError = (cause?: unknown): Error => {
+    const error = new Error('Your session has expired. Please log in again.') as Error & {
+        isStaleKeyError: boolean
+        cause?: unknown
+    }
+    error.isStaleKeyError = true
+    if (cause !== undefined) error.cause = cause
+    return error
 }

--- a/src/utils/walletCredential.utils.ts
+++ b/src/utils/walletCredential.utils.ts
@@ -1,0 +1,18 @@
+/**
+ * True when the active kernel client's smart-account address doesn't belong to
+ * the logged-in user — i.e. the session is paired with the wrong passkey, so
+ * any signature it produces will be rejected (AA24 on-chain, or an invalid
+ * ERC-1271 admin signature for Rain card withdraws).
+ *
+ * Returns false (treat as fine) when either address is missing: mid-registration
+ * the user has no smart-wallet account yet, and pre-migration accounts inject
+ * the address rather than derive it from the key — so an address comparison
+ * can't detect a mismatch for them.
+ */
+export const isStaleClientForUser = (
+    derivedAddress: string | undefined,
+    expectedAddress: string | undefined
+): boolean => {
+    if (!derivedAddress || !expectedAddress) return false
+    return derivedAddress.toLowerCase() !== expectedAddress.toLowerCase()
+}


### PR DESCRIPTION
## Summary

On a shared device with two passkeys for the same RP, the credential-restore path in `KernelClientProvider` can pair a session with the **other** account's passkey (a stale key restored from the global cookie against the JWT identity). Every signing site reads the kernel client through `getClientForChain`, but nothing verified the client's smart-account address belonged to the logged-in user — so a wrong-owner signature gets produced and rejected downstream (`AA24 signature error` on-chain, or an invalid ERC-1271 admin signature for Rain).

Six signing sites, all reading through the same accessor: `useSignUserOp`, `useZeroDev.handleSendUserOpEncoded`, `useSignSpendBundle`, `useSpendBundle`, `card-recovery`, `useGrantSessionKey`.

## Changes

- **Post-migration — proactive guard at the choke point.** `getClientForChain` / `ensureClientForChain` run `assertClientOwnedByUser`: if the client's `account.address` ≠ the user's `PEANUT_WALLET` identifier, purge the key, force logout, throw. One check covers all six sites. This is safe to enforce because a post-migration address is *derived from the passkey* — the same derivation used to build the working client every day — so it cannot false-positive on a working account.
- **Pre-migration — reactive detection.** A migration account's address is *injected* from the backend record, not derived, so the proactive comparison is tautological for them. We deliberately do **not** add a separate derivation to compare against: if it were ever wrong it would throw a legitimate user into an unrecoverable logout loop (every re-auth re-derives the same wrong address; each passkey is an account, so there's no other key to escape with). Instead we detect the **actual** AA24 / `wapk` failure and force a clean re-auth — this can only fire on a real failure, so no false-positive lockout.
- **Reactive force-logout wired in two places:** `useZeroDev` (direct-broadcast UserOps — previously showed the "session expired" toast but left the user signed in) and **both** sign-then-broadcast flows (Manteca **withdraw** and **QR pay**, where the backend surfaces the broadcast error) via a new reusable `useStaleSessionGuard` hook.
- **Shared plumbing + tests:** `isStaleClientForUser`, `isStaleKeyError`, `createStaleSessionError` in `utils/walletCredential.utils.ts` (deduped from `useZeroDev`), with unit tests covering match/mismatch/case-insensitivity, the mid-registration carve-out, and the AA24 / wapk / generic-401 detection boundary.

## Notes

- Reactive coverage on the withdraw path surfaces the backend AA24 only when broadcast-first ordering is enabled (see peanut-api-ts #996). Direct-broadcast flows surface it unconditionally.

## Test plan

- `npm run typecheck` ✅
- `npx jest src/utils/__tests__/walletCredential.utils.test.ts` ✅ (10/10); hooks suites ✅ (96/96)
- Full suite green except a pre-existing, unrelated `add-money-states` limit-string assertion (fails on `main` too; imports none of the changed modules).
- Manual: account A → logout → account B on same device → signed action → expect forced logout + re-auth (post-migration proactively; pre-migration on the AA24 that comes back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
