### PR TITLE
feat(card): self-hosted Peanut E-Sign Consent page + onboarding link

### DIFF
--- a/src/app/[locale]/(marketing)/card-esign/page.tsx
+++ b/src/app/[locale]/(marketing)/card-esign/page.tsx
@@ -1,0 +1,83 @@
+import { notFound } from 'next/navigation'
+import { type Metadata } from 'next'
+import { generateMetadata as metadataHelper } from '@/app/metadata'
+import { SUPPORTED_LOCALES, getAlternates, isValidLocale } from '@/i18n/config'
+import { getTranslations } from '@/i18n'
+import { ContentPage } from '@/components/Marketing/ContentPage'
+import { readPageContentLocalized } from '@/lib/content'
+import { renderContent } from '@/lib/mdx'
+
+interface PageProps {
+    params: Promise<{ locale: string }>
+}
+
+interface LegalFrontmatter {
+    title: string
+    description: string
+    slug: string
+    published?: boolean
+    last_updated?: string
+}
+
+const SLUG = 'card-esign'
+
+export async function generateStaticParams() {
+    return SUPPORTED_LOCALES.map((locale) => ({ locale }))
+}
+export const dynamicParams = false
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { locale } = await params
+    if (!isValidLocale(locale)) return {}
+
+    const mdxContent = readPageContentLocalized<LegalFrontmatter>('legal', SLUG, locale)
+    if (!mdxContent || mdxContent.frontmatter.published === false) return {}
+
+    return {
+        ...metadataHelper({
+            title: mdxContent.frontmatter.title,
+            description: mdxContent.frontmatter.description,
+            canonical: `/${locale}/${SLUG}`,
+        }),
+        alternates: {
+            canonical: `/${locale}/${SLUG}`,
+            languages: getAlternates(SLUG),
+        },
+    }
+}
+
+export default async function CardEsignPage({ params }: PageProps) {
+    const { locale } = await params
+    if (!isValidLocale(locale)) notFound()
+
+    const mdxSource = readPageContentLocalized<LegalFrontmatter>('legal', SLUG, locale)
+    if (!mdxSource || mdxSource.frontmatter.published === false) notFound()
+
+    const { content } = await renderContent(mdxSource.body)
+    const i18n = getTranslations(locale)
+
+    const displayTitle = mdxSource.frontmatter.title.replace(/\s*\|\s*Peanut$/, '')
+    const url = `/${locale}/${SLUG}`
+
+    return (
+        <ContentPage
+            locale={locale}
+            breadcrumbs={[
+                { name: i18n.home, href: `/${locale}` },
+                { name: displayTitle, href: url },
+            ]}
+            article={
+                mdxSource.frontmatter.last_updated
+                    ? {
+                          title: mdxSource.frontmatter.title,
+                          description: mdxSource.frontmatter.description,
+                          url,
+                          datePublished: mdxSource.frontmatter.last_updated,
+                      }
+                    : undefined
+            }
+        >
+            {content}
+        </ContentPage>
+    )
+}

--- a/src/components/Card/CardTermsScreen.tsx
+++ b/src/components/Card/CardTermsScreen.tsx
@@ -19,7 +19,7 @@ const CARD_PARTNER_NAME = 'Peanut'
 
 // US and international cardholders accept different card-terms documents.
 const LINKS = {
-    eSign: 'https://legal.raincards.xyz/legal/electronic-communications-notice',
+    eSign: 'https://peanut.me/en/card-esign',
     issuerPrivacy: 'https://www.third-national.com/privacypolicy',
     cardTermsUs: 'https://peanut.me/en/card-terms-us',
     cardTermsInternational: 'https://peanut.me/en/card-terms-international',

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -24,6 +24,7 @@ export const ROUTE_SLUGS = [
     'card-terms-international',
     'card-privacy',
     'card-prohibited-activities',
+    'card-esign',
 ] as const
 
 export type RouteSlug = (typeof ROUTE_SLUGS)[number]


### PR DESCRIPTION
## Why
Rain's final-submission form requires a **partner-hosted** E-Sign Consent (their template with 'Rain' → your company name), and Rain's hosted page surfaces Rain branding + routes support to `support@rain.xyz` — which conflicts with our no-provider-names-to-customers posture. So we self-host a Peanut-branded version.

## What
- **New page** `peanut.me/[locale]/card-esign` — legal `ContentPage`, content from peanut-content@f204f50 (mono `content/legal/card-esign`). Faithful adaptation of Rain's Electronic Communications Notice: Rain→Peanut, `support@rain.xyz`→`help@peanut.me`, dropped the B2B Company-Administrator/User language (consumer card flow), and defined 'we/us' to include the card issuer for accuracy.
- **`ROUTE_SLUGS`** += `card-esign`
- **Onboarding link flip:** the E-Sign Consent checkbox in `CardTermsScreen` now points to `peanut.me/en/card-esign` instead of `legal.raincards.xyz`.

Page + link ship in the same PR → no broken-link window.

## ⚠️ Needs a legal eyeball before merge
This is a faithful but **mechanical** adaptation of Rain's template — Rain Legal reviews it on submission anyway, but two points to confirm: (1) self-hosting is what Guinea wants (she verbally OK'd linking Rain's), and (2) since the card terms call it *'the Issuer's E-Sign Notice'*, whether 'we/us' should read as Peanut or the Issuer. Hold the merge until that's confirmed.

Content-only + one route + one link. Page MDX-compiles; my files typecheck clean.