### PR TITLE
chore: back-merge main → dev (2026-06-10, post #2199/#2202/#2204)

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -422,7 +422,8 @@ export default function OnrampBankPage() {
                             await sumsubFlow.handleInitiateKyc(
                                 getRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
                                 undefined,
-                                gate.kind === 'needs-enrollment' || undefined
+                                gate.kind === 'needs-enrollment' || undefined,
+                                selectedCountry?.id
                             )
                         }
                     }}

--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { type FC, useCallback, useEffect, useRef, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { notFound } from 'next/navigation'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
@@ -50,7 +50,6 @@ function markSkipCelebrationSeen(): void {
 // they don't re-see the gate after celebration / add-card transitions.
 
 const CardPage: FC = () => {
-    const router = useRouter()
     const queryClient = useQueryClient()
     const { user, fetchUser } = useAuth()
     const userId = user?.user?.userId
@@ -138,32 +137,37 @@ const CardPage: FC = () => {
         })()
     }, [pressDoorMode, pioneerLoading, cardInfo, queryClient])
 
-    // Outer gate: pre-public-launch, redirect users without /shhhhh early
-    // access back to the landing page so they don't see a half-baked /card
-    // shell. BE returns `flowEarlyAccess: false` in that case.
+    // Outer gate: pre-public-launch, the card campaign isn't fully online
+    // yet. Users without flow early access get a 404 — the page behaves as
+    // if it doesn't exist. The only ways in are (a) already holding a card
+    // / being mid-application, or (b) entering through the special /shhhhh
+    // page, which stamps `flowEarlyAccess` via ?press_door=1 before landing
+    // here. BE returns `flowEarlyAccess: false` for everyone else.
     //
-    // IMPORTANT: skip the redirect if the user already has a non-canceled
-    // card. Legacy Pioneers + admin-granted users issued cards before
-    // /shhhhh existed and have no flowEarlyAccess stamp — they must still
-    // reach YourCardScreen. The computeCardState() precedence below mirrors
-    // this rule (active-card before no-flow-access). Also skip while
-    // pressDoorMode is in flight: the stamp is about to land any tick now,
-    // and bouncing to /shhhhh mid-stamp creates a momentary flash.
+    // IMPORTANT: skip the 404 if the user already has a non-canceled card.
+    // Legacy Pioneers + admin-granted users issued cards before /shhhhh
+    // existed and have no flowEarlyAccess stamp — they must still reach
+    // YourCardScreen. The computeCardState() precedence below mirrors this
+    // rule (active-card before no-flow-access). Also skip while pressDoorMode
+    // is in flight: the stamp is about to land any tick now, and 404-ing
+    // mid-stamp would wrongly bounce a legit /shhhhh entrant.
+    //
+    // notFound() thrown synchronously inside the effect bubbles to Next's
+    // not-found boundary just like a render-time call.
     useEffect(() => {
         if (pressDoorMode) return
         if (pioneerLoading || pioneerError) return
         if (!cardInfo) return
         if (cardInfo.flowEarlyAccess) return
         // CR FE#1: wait for overview before checking issued cards — otherwise
-        // legacy card-holders (overview still loading) get incorrectly bounced
-        // to /shhhhh because `overview?.cards.some(...)` returns false on
-        // undefined input.
+        // legacy card-holders (overview still loading) get incorrectly 404'd
+        // because `overview?.cards.some(...)` returns false on undefined input.
         if (overviewLoading || !overview) return
         const hasIssuedCard = overview.cards.some((c) => c.status !== 'CANCELED')
         if (hasIssuedCard) return
         posthog.capture(ANALYTICS_EVENTS.CARD_FLOW_GATED)
-        router.replace('/shhhhh')
-    }, [router, pioneerLoading, pioneerError, cardInfo, overview, overviewLoading, pressDoorMode])
+        notFound()
+    }, [pioneerLoading, pioneerError, cardInfo, overview, overviewLoading, pressDoorMode])
 
     const state = computeCardState({
         overview,
@@ -434,8 +438,9 @@ const CardPage: FC = () => {
         return ''
     }, [invalidateOverview])
 
-    // Outer-gate fail — we already kicked off the redirect to /shhhhh in
-    // the useEffect above; render nothing here so the page doesn't flash.
+    // Outer-gate fail — the useEffect above fires notFound() to render the
+    // 404 boundary; render nothing here so the page doesn't flash for the
+    // one frame before that lands.
     if (state === 'no-flow-access') {
         return null
     }

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -18,6 +18,7 @@ import CyclingLoading from '@/components/Global/PeanutLoading/CyclingLoading'
 import AmountInput from '@/components/Global/AmountInput'
 import { useWallet } from '@/hooks/wallet/useWallet'
 import { useSignSpendBundle } from '@/hooks/wallet/useSignSpendBundle'
+import { useStaleSessionGuard } from '@/hooks/wallet/useStaleSessionGuard'
 import { InsufficientSpendableError, SessionKeyGrantRequiredError } from '@/hooks/wallet/useSpendBundle'
 import { rainCollateralErrorMessage } from '@/utils/friendly-error.utils'
 import { useRainCardOverview } from '@/hooks/useRainCardOverview'
@@ -89,6 +90,7 @@ export default function QRPayPage() {
     const qrType = searchParams.get('type')
     const { spendableBalance: balance, sendMoney } = useWallet()
     const { signSpend } = useSignSpendBundle()
+    const handleStaleSession = useStaleSessionGuard()
     const { overview: rainCardOverview } = useRainCardOverview()
     const [isSuccess, setIsSuccess] = useState(false)
     const [errorMessage, setErrorMessage] = useState<string | null>(null)
@@ -681,6 +683,9 @@ export default function QRPayPage() {
                 clearTimeout(payingStateTimerRef.current)
                 payingStateTimerRef.current = null
             }
+            // Wrong-passkey session: backend rejected the signed UserOp with
+            // AA24 / wapk. Unrecoverable without re-auth — force a clean logout.
+            if (handleStaleSession(error)) return
             captureException(error)
             const errorMsg = (error as Error).message || 'Could not complete payment'
 
@@ -704,7 +709,17 @@ export default function QRPayPage() {
         } finally {
             setLoadingState('Idle')
         }
-    }, [paymentLock, signSpend, balance, rainCardOverview, qrCode, currencyAmount, setLoadingState, qrType])
+    }, [
+        paymentLock,
+        signSpend,
+        balance,
+        rainCardOverview,
+        qrCode,
+        currencyAmount,
+        setLoadingState,
+        qrType,
+        handleStaleSession,
+    ])
 
     const payQR = useCallback(async () => {
         if (paymentProcessor === 'MANTECA') {

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -535,7 +535,8 @@ export default function WithdrawBankPage() {
                         await sumsubFlow.handleInitiateKyc(
                             getRegionIntent(getCountryFromPath(country)?.region ?? 'rest-of-the-world'),
                             undefined,
-                            gate.kind === 'needs-enrollment' || undefined
+                            gate.kind === 'needs-enrollment' || undefined,
+                            getCountryFromPath(country)?.id
                         )
                     }
                 }}

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -2,6 +2,7 @@
 
 import { useWallet } from '@/hooks/wallet/useWallet'
 import { useSignSpendBundle } from '@/hooks/wallet/useSignSpendBundle'
+import { useStaleSessionGuard } from '@/hooks/wallet/useStaleSessionGuard'
 import { InsufficientSpendableError, SessionKeyGrantRequiredError } from '@/hooks/wallet/useSpendBundle'
 import { rainCollateralErrorMessage } from '@/utils/friendly-error.utils'
 import { rainCentsToUsdcUnits } from '@/utils/balance.utils'
@@ -96,6 +97,7 @@ export default function MantecaWithdrawFlow() {
     const router = useRouter()
     const { spendableBalance: balance, balance: smartBalance } = useWallet()
     const { signSpend } = useSignSpendBundle()
+    const handleStaleSession = useStaleSessionGuard()
     const { overview: rainCardOverview } = useRainCardOverview()
     const { isLoading, loadingState, setLoadingState } = useContext(loadingStateContext)
     const { setIsSupportModalOpen, openSupportWithMessage } = useModalsContext()
@@ -410,6 +412,10 @@ export default function MantecaWithdrawFlow() {
                     error_message: result.error,
                 })
 
+                // Wrong-passkey session: backend rejected the signed UserOp with
+                // AA24 / wapk. Unrecoverable without re-auth — force a clean logout.
+                if (handleStaleSession(result.message ?? result.error)) return
+
                 // handle onboarding-incomplete errors by redirecting to complete profile
                 if (await handleOnboardingError(result.message ?? result.error)) return
 
@@ -433,6 +439,7 @@ export default function MantecaWithdrawFlow() {
             })
         } catch (error) {
             console.error('Manteca withdraw error:', error)
+            if (handleStaleSession(error)) return
             posthog.capture(ANALYTICS_EVENTS.WITHDRAW_FAILED, {
                 method_type: 'manteca',
                 error_message: 'Withdraw failed unexpectedly',

--- a/src/app/[locale]/(marketing)/card-esign/page.tsx
+++ b/src/app/[locale]/(marketing)/card-esign/page.tsx
@@ -1,0 +1,83 @@
+import { notFound } from 'next/navigation'
+import { type Metadata } from 'next'
+import { generateMetadata as metadataHelper } from '@/app/metadata'
+import { SUPPORTED_LOCALES, getAlternates, isValidLocale } from '@/i18n/config'
+import { getTranslations } from '@/i18n'
+import { ContentPage } from '@/components/Marketing/ContentPage'
+import { readPageContentLocalized } from '@/lib/content'
+import { renderContent } from '@/lib/mdx'
+
+interface PageProps {
+    params: Promise<{ locale: string }>
+}
+
+interface LegalFrontmatter {
+    title: string
+    description: string
+    slug: string
+    published?: boolean
+    last_updated?: string
+}
+
+const SLUG = 'card-esign'
+
+export async function generateStaticParams() {
+    return SUPPORTED_LOCALES.map((locale) => ({ locale }))
+}
+export const dynamicParams = false
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { locale } = await params
+    if (!isValidLocale(locale)) return {}
+
+    const mdxContent = readPageContentLocalized<LegalFrontmatter>('legal', SLUG, locale)
+    if (!mdxContent || mdxContent.frontmatter.published === false) return {}
+
+    return {
+        ...metadataHelper({
+            title: mdxContent.frontmatter.title,
+            description: mdxContent.frontmatter.description,
+            canonical: `/${locale}/${SLUG}`,
+        }),
+        alternates: {
+            canonical: `/${locale}/${SLUG}`,
+            languages: getAlternates(SLUG),
+        },
+    }
+}
+
+export default async function CardEsignPage({ params }: PageProps) {
+    const { locale } = await params
+    if (!isValidLocale(locale)) notFound()
+
+    const mdxSource = readPageContentLocalized<LegalFrontmatter>('legal', SLUG, locale)
+    if (!mdxSource || mdxSource.frontmatter.published === false) notFound()
+
+    const { content } = await renderContent(mdxSource.body)
+    const i18n = getTranslations(locale)
+
+    const displayTitle = mdxSource.frontmatter.title.replace(/\s*\|\s*Peanut$/, '')
+    const url = `/${locale}/${SLUG}`
+
+    return (
+        <ContentPage
+            locale={locale}
+            breadcrumbs={[
+                { name: i18n.home, href: `/${locale}` },
+                { name: displayTitle, href: url },
+            ]}
+            article={
+                mdxSource.frontmatter.last_updated
+                    ? {
+                          title: mdxSource.frontmatter.title,
+                          description: mdxSource.frontmatter.description,
+                          url,
+                          datePublished: mdxSource.frontmatter.last_updated,
+                      }
+                    : undefined
+            }
+        >
+            {content}
+        </ContentPage>
+    )
+}

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -229,7 +229,12 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
         // scenario (2): if the user hasn't completed kyc yet
         // name and email are now collected by sumsub sdk — no need to save them beforehand
         if (!isUserKycApproved) {
-            await sumsubFlow.handleInitiateKyc(getRegionIntent(currentCountry?.region ?? 'rest-of-the-world'))
+            await sumsubFlow.handleInitiateKyc(
+                getRegionIntent(currentCountry?.region ?? 'rest-of-the-world'),
+                undefined,
+                undefined,
+                currentCountry?.id
+            )
         }
 
         return {}
@@ -338,7 +343,8 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                         await sumsubFlow.handleInitiateKyc(
                             getRegionIntent(currentCountry?.region ?? 'rest-of-the-world'),
                             undefined,
-                            gate.kind === 'needs-enrollment' || undefined
+                            gate.kind === 'needs-enrollment' || undefined,
+                            currentCountry?.id
                         )
                     }
                 }}

--- a/src/components/Card/CardTermsScreen.tsx
+++ b/src/components/Card/CardTermsScreen.tsx
@@ -19,7 +19,7 @@ const CARD_PARTNER_NAME = 'Peanut'
 
 // US and international cardholders accept different card-terms documents.
 const LINKS = {
-    eSign: 'https://legal.raincards.xyz/legal/electronic-communications-notice',
+    eSign: 'https://peanut.me/en/card-esign',
     issuerPrivacy: 'https://www.third-national.com/privacypolicy',
     cardTermsUs: 'https://peanut.me/en/card-terms-us',
     cardTermsInternational: 'https://peanut.me/en/card-terms-international',

--- a/src/components/Claim/Link/MantecaFlowManager.tsx
+++ b/src/components/Claim/Link/MantecaFlowManager.tsx
@@ -147,7 +147,7 @@ const MantecaFlowManager: FC<MantecaFlowManagerProps> = ({ claimLinkData, amount
                     } else if (mantecaRejection.state === 'fixable') {
                         await sumsubFlow.handleSelfHealResubmit('MANTECA')
                     } else {
-                        await sumsubFlow.handleInitiateKyc('LATAM', undefined, true)
+                        await sumsubFlow.handleInitiateKyc('LATAM', undefined, true, selectedCountry?.id)
                     }
                     setShowKycModal(false)
                 }}

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -297,7 +297,12 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
         // scenario 1: receiver needs KYC
         // name and email are now collected by sumsub sdk — no need to save them beforehand
         if (bankClaimType === BankClaimType.ReceiverKycNeeded && !justCompletedKyc) {
-            await sumsubFlow.handleInitiateKyc(getRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'))
+            await sumsubFlow.handleInitiateKyc(
+                getRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
+                undefined,
+                undefined,
+                selectedCountry?.id
+            )
             return {}
         }
 
@@ -567,7 +572,8 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                                     await sumsubFlow.handleInitiateKyc(
                                         getRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
                                         undefined,
-                                        gate.kind === 'needs-enrollment' || undefined
+                                        gate.kind === 'needs-enrollment' || undefined,
+                                        selectedCountry?.id
                                     )
                                 }
                                 // only close if sdk opened — if it errored, keep modal open to show error

--- a/src/context/kernelClient.context.tsx
+++ b/src/context/kernelClient.context.tsx
@@ -168,27 +168,6 @@ export const createKernelClientForChain = async <C extends Chain>(
             webAuthnKey,
             PasskeyValidatorContractVersion.V0_0_2_UNPATCHED
         )
-
-        // A migration account's address is injected (from the backend user
-        // record), not derived from the key — so the access-time guard in the
-        // provider can't tell whether this passkey actually owns it. Derive the
-        // address this key maps to (the same derivation the SDK does internally
-        // when no address is passed) and require it to match. A mismatch means
-        // the session is paired with the wrong passkey; signing would produce a
-        // wrong-owner signature the EntryPoint rejects (AA24). Bail to re-auth.
-        const keyDerivedAccount = await createKernelAccount(publicClient, {
-            plugins: { sudo: oldValidator },
-            entryPoint: USER_OP_ENTRY_POINT,
-            kernelVersion: ZERODEV_KERNEL_VERSION,
-        })
-        if (isStaleClientForUser(keyDerivedAccount.address, address)) {
-            console.error('[KernelClient] passkey does not own the migration account — stale credential', {
-                keyDerivedAddress: keyDerivedAccount.address,
-                expectedAddress: address,
-            })
-            throw createStaleSessionError()
-        }
-
         kernelAccount = await createKernelMigrationAccount(publicClient, {
             address,
             plugins: {
@@ -451,13 +430,7 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
             }
         }
 
-        retryAsync(initializeClients, {
-            maxRetries: 2,
-            baseDelay: 1000,
-            maxDelay: 5000,
-            // A stale-credential error is deterministic — don't burn retries on it.
-            shouldRetry: (error) => !isStaleKeyError(error),
-        }).catch(() => {
+        retryAsync(initializeClients, { maxRetries: 2, baseDelay: 1000, maxDelay: 5000 }).catch(() => {
             if (isMounted) {
                 console.error('[KernelClient] Primary chain client failed after retries — forcing logout')
                 dispatch(zerodevActions.setIsRegistering(false))

--- a/src/context/kernelClient.context.tsx
+++ b/src/context/kernelClient.context.tsx
@@ -26,6 +26,7 @@ import type { Address } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { captureException } from '@sentry/nextjs'
 import { retryAsync } from '@/utils/retry.utils'
+import { isStaleClientForUser } from '@/utils/walletCredential.utils'
 import { isAndroidNative, getNativeRpId } from '@/utils/capacitor'
 import { createNativeSignMessageCallback } from '@/utils/native-webauthn'
 import { PUBLIC_CLIENTS_BY_CHAIN } from '@/app/actions/clients'
@@ -459,6 +460,39 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
         }
     }, [clientsByChain])
 
+    // Refuse to hand out a kernel client whose smart-account address doesn't
+    // match the logged-in user, then force a clean re-auth. On a shared device
+    // with two passkeys for the same RP, the restore path can pair this session
+    // with the OTHER account's credential; signing with it yields a wrong-owner
+    // signature the EntryPoint rejects (AA24) — or Rain's ERC-1271 check rejects
+    // as invalid admin signature. Every sign site reads through here, so one
+    // check covers them all (and the next one written). Skipped when the user
+    // has no smart-wallet account yet (mid-registration); also a no-op for
+    // pre-migration accounts, whose address is injected rather than derived from
+    // the key, so a mismatch can't be detected here for them.
+    const assertClientOwnedByUser = useCallback(
+        (client: GenericSmartAccountClient): GenericSmartAccountClient => {
+            const expectedAddress = user?.accounts.find((a) => a.type === AccountType.PEANUT_WALLET)?.identifier
+            const derivedAddress = client.account?.address
+            if (isStaleClientForUser(derivedAddress, expectedAddress)) {
+                console.error('[KernelClient] active client does not match logged-in user — forcing logout', {
+                    userId: user?.user.userId,
+                    derivedAddress,
+                    expectedAddress,
+                })
+                if (user?.user.userId) updateUserPreferences(user.user.userId, { webAuthnKey: undefined })
+                logoutUser()
+                const staleError = new Error('Your session has expired. Please log in again.') as Error & {
+                    isStaleKeyError?: boolean
+                }
+                staleError.isStaleKeyError = true
+                throw staleError
+            }
+            return client
+        },
+        [user, logoutUser]
+    )
+
     const getClientForChain = useCallback(
         (chainId: string) => {
             const client = clientsByChain[chainId]
@@ -471,18 +505,18 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
                     `No client found for chain ${chainId}. This chain may not be configured for wallet operations.`
                 )
             }
-            return client
+            return assertClientOwnedByUser(client)
         },
-        [clientsByChain]
+        [clientsByChain, assertClientOwnedByUser]
     )
 
     const ensureClientForChain = useCallback(
         async (chainId: string): Promise<GenericSmartAccountClient> => {
             const cached = clientsByChain[chainId]
-            if (cached) return cached
+            if (cached) return assertClientOwnedByUser(cached)
 
             const inFlight = inFlightRef.current.get(chainId)
-            if (inFlight) return inFlight
+            if (inFlight) return inFlight.then(assertClientOwnedByUser)
 
             if (!webAuthnKey) {
                 throw new Error(`Cannot build kernel client for chain ${chainId}: not authenticated`)
@@ -508,7 +542,7 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
             )
                 .then((kernelClient) => {
                     setClientsByChain((prev) => ({ ...prev, [chainId]: kernelClient }))
-                    return kernelClient
+                    return assertClientOwnedByUser(kernelClient)
                 })
                 .catch((error) => {
                     console.error(`Error lazy-building kernel client for chain ${chainId}:`, error)
@@ -522,7 +556,7 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
             inFlightRef.current.set(chainId, promise)
             return promise
         },
-        [clientsByChain, webAuthnKey, isAfterZeroDevMigration, user]
+        [clientsByChain, webAuthnKey, isAfterZeroDevMigration, user, assertClientOwnedByUser]
     )
 
     return (

--- a/src/context/kernelClient.context.tsx
+++ b/src/context/kernelClient.context.tsx
@@ -26,7 +26,7 @@ import type { Address } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { captureException } from '@sentry/nextjs'
 import { retryAsync } from '@/utils/retry.utils'
-import { isStaleClientForUser } from '@/utils/walletCredential.utils'
+import { isStaleClientForUser, isStaleKeyError, createStaleSessionError } from '@/utils/walletCredential.utils'
 import { isAndroidNative, getNativeRpId } from '@/utils/capacitor'
 import { createNativeSignMessageCallback } from '@/utils/native-webauthn'
 import { PUBLIC_CLIENTS_BY_CHAIN } from '@/app/actions/clients'
@@ -168,6 +168,27 @@ export const createKernelClientForChain = async <C extends Chain>(
             webAuthnKey,
             PasskeyValidatorContractVersion.V0_0_2_UNPATCHED
         )
+
+        // A migration account's address is injected (from the backend user
+        // record), not derived from the key — so the access-time guard in the
+        // provider can't tell whether this passkey actually owns it. Derive the
+        // address this key maps to (the same derivation the SDK does internally
+        // when no address is passed) and require it to match. A mismatch means
+        // the session is paired with the wrong passkey; signing would produce a
+        // wrong-owner signature the EntryPoint rejects (AA24). Bail to re-auth.
+        const keyDerivedAccount = await createKernelAccount(publicClient, {
+            plugins: { sudo: oldValidator },
+            entryPoint: USER_OP_ENTRY_POINT,
+            kernelVersion: ZERODEV_KERNEL_VERSION,
+        })
+        if (isStaleClientForUser(keyDerivedAccount.address, address)) {
+            console.error('[KernelClient] passkey does not own the migration account — stale credential', {
+                keyDerivedAddress: keyDerivedAccount.address,
+                expectedAddress: address,
+            })
+            throw createStaleSessionError()
+        }
+
         kernelAccount = await createKernelMigrationAccount(publicClient, {
             address,
             plugins: {
@@ -430,7 +451,13 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
             }
         }
 
-        retryAsync(initializeClients, { maxRetries: 2, baseDelay: 1000, maxDelay: 5000 }).catch(() => {
+        retryAsync(initializeClients, {
+            maxRetries: 2,
+            baseDelay: 1000,
+            maxDelay: 5000,
+            // A stale-credential error is deterministic — don't burn retries on it.
+            shouldRetry: (error) => !isStaleKeyError(error),
+        }).catch(() => {
             if (isMounted) {
                 console.error('[KernelClient] Primary chain client failed after retries — forcing logout')
                 dispatch(zerodevActions.setIsRegistering(false))
@@ -482,11 +509,7 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
                 })
                 if (user?.user.userId) updateUserPreferences(user.user.userId, { webAuthnKey: undefined })
                 logoutUser()
-                const staleError = new Error('Your session has expired. Please log in again.') as Error & {
-                    isStaleKeyError?: boolean
-                }
-                staleError.isStaleKeyError = true
-                throw staleError
+                throw createStaleSessionError()
             }
             return client
         },
@@ -546,7 +569,11 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
                 })
                 .catch((error) => {
                     console.error(`Error lazy-building kernel client for chain ${chainId}:`, error)
-                    captureException(error)
+                    if (isStaleKeyError(error)) {
+                        logoutUser()
+                    } else {
+                        captureException(error)
+                    }
                     throw error
                 })
                 .finally(() => {
@@ -556,7 +583,7 @@ export const KernelClientProvider = ({ children }: { children: ReactNode }) => {
             inFlightRef.current.set(chainId, promise)
             return promise
         },
-        [clientsByChain, webAuthnKey, isAfterZeroDevMigration, user, assertClientOwnedByUser]
+        [clientsByChain, webAuthnKey, isAfterZeroDevMigration, user, assertClientOwnedByUser, logoutUser]
     )
 
     return (

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -124,6 +124,19 @@ describe('useSumsubKycFlow — targetCountry gating', () => {
         )
     })
 
+    it('uppercases a lowercase targetCountry (br → BR) before forwarding', async () => {
+        mockInitiate.mockResolvedValue({
+            data: { token: 'tok_1', applicantId: 'app_1', status: 'APPROVED', actionType: 'manteca' },
+        })
+        const { result } = renderHook(() => useSumsubKycFlow({}))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('LATAM', undefined, true, 'br')
+        })
+
+        expect(mockInitiate).toHaveBeenCalledWith(expect.objectContaining({ targetCountry: 'BR' }))
+    })
+
     it('drops a non-Manteca targetCountry (MX) instead of stamping a poisoned geo', async () => {
         mockInitiate.mockResolvedValue({
             data: { token: 'tok_1', applicantId: 'app_1', status: 'APPROVED', actionType: 'manteca' },

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -98,3 +98,122 @@ describe('useSumsubKycFlow — cross-region routing', () => {
         await waitFor(() => expect(onKycSuccess).toHaveBeenCalledTimes(1))
     })
 })
+
+describe('useSumsubKycFlow — targetCountry gating', () => {
+    beforeEach(() => {
+        mockInitiate.mockReset()
+        mockWs.handler = undefined
+    })
+
+    // The BE only ever consumes targetCountry as a Manteca geo, and an unsupported
+    // stamp poisons the verification metadata (first-write-wins). Call sites pass the
+    // raw country for every `latam`-region country, so the hook is the choke point
+    // that must forward AR/BR and drop everything else.
+    it('forwards a Manteca-supported targetCountry (AR) to the BE', async () => {
+        mockInitiate.mockResolvedValue({
+            data: { token: 'tok_1', applicantId: 'app_1', status: 'APPROVED', actionType: 'manteca' },
+        })
+        const { result } = renderHook(() => useSumsubKycFlow({}))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('LATAM', undefined, true, 'AR')
+        })
+
+        expect(mockInitiate).toHaveBeenCalledWith(
+            expect.objectContaining({ regionIntent: 'LATAM', crossRegion: true, targetCountry: 'AR' })
+        )
+    })
+
+    it('drops a non-Manteca targetCountry (MX) instead of stamping a poisoned geo', async () => {
+        mockInitiate.mockResolvedValue({
+            data: { token: 'tok_1', applicantId: 'app_1', status: 'APPROVED', actionType: 'manteca' },
+        })
+        const { result } = renderHook(() => useSumsubKycFlow({}))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('LATAM', undefined, true, 'MX')
+        })
+
+        expect(mockInitiate).toHaveBeenCalledWith(
+            expect.objectContaining({ regionIntent: 'LATAM', crossRegion: true, targetCountry: undefined })
+        )
+    })
+})
+
+describe('useSumsubKycFlow — terminal-error exits clear the user-initiated guard', () => {
+    beforeEach(() => {
+        mockInitiate.mockReset()
+        mockWs.handler = undefined
+    })
+
+    // Same race the unsupported-region branch closes, on the other terminal exits:
+    // restoring prevStatusRef while leaving userInitiatedRef set lets a late websocket
+    // event fire onKycSuccess on top of the rendered error. The PENDING→APPROVED
+    // two-event sequence isolates the userInitiatedRef guard — PENDING advances
+    // prevStatusRef first, so the prevStatus !== 'APPROVED' guard alone cannot save a
+    // regression that re-leaks the ref.
+    it('response.error → late PENDING→APPROVED websocket events do NOT fire onKycSuccess', async () => {
+        mockInitiate.mockResolvedValue({ error: 'region_not_supported' })
+        const onKycSuccess = jest.fn()
+
+        const { result } = renderHook(() => useSumsubKycFlow({ onKycSuccess }))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('LATAM', undefined, true, 'AR')
+        })
+        expect(result.current.error).toBe('region_not_supported')
+
+        await act(async () => {
+            mockWs.handler?.('PENDING')
+        })
+        await act(async () => {
+            mockWs.handler?.('APPROVED')
+        })
+
+        await waitFor(() => expect(onKycSuccess).not.toHaveBeenCalled())
+    })
+
+    it('thrown initiate → late PENDING→APPROVED websocket events do NOT fire onKycSuccess', async () => {
+        mockInitiate.mockRejectedValue(new Error('network down'))
+        const onKycSuccess = jest.fn()
+
+        const { result } = renderHook(() => useSumsubKycFlow({ onKycSuccess }))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('EU', undefined, true)
+        })
+        expect(result.current.error).toBe('network down')
+
+        await act(async () => {
+            mockWs.handler?.('PENDING')
+        })
+        await act(async () => {
+            mockWs.handler?.('APPROVED')
+        })
+
+        await waitFor(() => expect(onKycSuccess).not.toHaveBeenCalled())
+    })
+
+    // Control: a real flow that opens the SDK keeps the guard armed — the user
+    // completing KYC afterwards must still fire onKycSuccess via the transition effect.
+    it('successful SDK open keeps the guard armed: later APPROVED fires onKycSuccess', async () => {
+        mockInitiate.mockResolvedValue({
+            data: { token: 'tok_1', applicantId: 'app_1', status: 'PENDING' },
+        })
+        const onKycSuccess = jest.fn()
+
+        const { result } = renderHook(() => useSumsubKycFlow({ onKycSuccess }))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('EU')
+        })
+        expect(result.current.error).toBeNull()
+        expect(result.current.showWrapper).toBe(true)
+
+        await act(async () => {
+            mockWs.handler?.('APPROVED')
+        })
+
+        await waitFor(() => expect(onKycSuccess).toHaveBeenCalledTimes(1))
+    })
+})

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -151,8 +151,11 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
             // (MX, CL, …), but Manteca only serves AR/BR — an unsupported stamp
             // poisons the verification metadata (first-write-wins) and bails
             // every later geo resolution, so drop it at this choke point.
+            const normalizedTargetCountry = rawTargetCountry?.toUpperCase()
             const targetCountry =
-                rawTargetCountry && isMantecaSupportedCountryCode(rawTargetCountry) ? rawTargetCountry : undefined
+                normalizedTargetCountry && isMantecaSupportedCountryCode(normalizedTargetCountry)
+                    ? normalizedTargetCountry
+                    : undefined
             userInitiatedRef.current = true
             initiatingRef.current = true
             selfHealProviderRef.current = null

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -4,6 +4,7 @@ import { useWebSocket } from '@/hooks/useWebSocket'
 import { useUserStore } from '@/redux/hooks'
 import { initiateSumsubKyc, initiateSelfHealResubmission, restartIdentityVerification } from '@/app/actions/sumsub'
 import { type KYCRegionIntent, type SumsubKycStatus } from '@/app/actions/types/sumsub.types'
+import { isMantecaSupportedCountryCode } from '@/constants/manteca.consts'
 import { isCapacitor } from '@/utils/capacitor'
 
 interface UseSumsubKycFlowOptions {
@@ -138,7 +139,20 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     }, [isVerificationProgressModalOpen])
 
     const handleInitiateKyc = useCallback(
-        async (overrideIntent?: KYCRegionIntent, levelName?: string, crossRegion?: boolean, targetCountry?: string) => {
+        async (
+            overrideIntent?: KYCRegionIntent,
+            levelName?: string,
+            crossRegion?: boolean,
+            rawTargetCountry?: string
+        ) => {
+            // targetCountry is only ever consumed by the BE as a Manteca geo
+            // (pendingMantecaGeo stamp + action externalId suffix). Call sites
+            // pass the raw destination country for EVERY `latam`-region country
+            // (MX, CL, …), but Manteca only serves AR/BR — an unsupported stamp
+            // poisons the verification metadata (first-write-wins) and bails
+            // every later geo resolution, so drop it at this choke point.
+            const targetCountry =
+                rawTargetCountry && isMantecaSupportedCountryCode(rawTargetCountry) ? rawTargetCountry : undefined
             userInitiatedRef.current = true
             initiatingRef.current = true
             selfHealProviderRef.current = null
@@ -162,6 +176,11 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 })
 
                 if (response.error) {
+                    // same race the unsupported-region branch closes below: restoring
+                    // prevStatusRef while leaving userInitiatedRef set lets a late/stale
+                    // websocket APPROVED event fire onKycSuccess on top of this error.
+                    // every terminal-error exit must clear the user-initiated guard.
+                    userInitiatedRef.current = false
                     if (crossRegion) prevStatusRef.current = savedPrevStatus
                     setError(response.error)
                     return
@@ -226,14 +245,19 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                         try {
                             const SNSMobileSDK = (window as any).SNSMobileSDK
                             if (!SNSMobileSDK) {
+                                userInitiatedRef.current = false
                                 setError('KYC SDK not available. Please update the app.')
                                 return
                             }
                             const effectiveRegionIntent = overrideIntent ?? regionIntent
                             const sdk = SNSMobileSDK.init(response.data.token, async () => {
+                                // keep parity with the web refreshToken below — dropping
+                                // targetCountry here would mint a token for a different
+                                // (suffix-less) applicant action than the one the user is in.
                                 const r = await initiateSumsubKyc({
                                     regionIntent: effectiveRegionIntent,
                                     levelName: levelNameRef.current,
+                                    targetCountry: targetCountryRef.current,
                                 })
                                 return r.data?.token || ''
                             })
@@ -256,6 +280,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                             }
                         } catch (nativeErr) {
                             console.error('[useSumsubKycFlow] native SDK error:', nativeErr)
+                            userInitiatedRef.current = false
                             setError('Verification failed. Please try again.')
                         }
                         return
@@ -265,9 +290,11 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                     setIsActionFlow(!!response.data.actionType)
                     setShowWrapper(true)
                 } else {
+                    userInitiatedRef.current = false
                     setError('Could not initiate verification. Please try again.')
                 }
             } catch (e: unknown) {
+                userInitiatedRef.current = false
                 if (crossRegion) prevStatusRef.current = savedPrevStatus
                 const message = e instanceof Error ? e.message : 'An unexpected error occurred'
                 setError(message)
@@ -351,6 +378,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         try {
             const response = await restartIdentityVerification()
             if (response.error) {
+                userInitiatedRef.current = false
                 setError(response.error)
                 return
             }
@@ -358,9 +386,11 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 setAccessToken(response.data.token)
                 setShowWrapper(true)
             } else {
+                userInitiatedRef.current = false
                 setError('Could not restart identity verification. Please try again.')
             }
         } catch (e: unknown) {
+            userInitiatedRef.current = false
             const message = e instanceof Error ? e.message : 'An unexpected error occurred'
             setError(message)
         } finally {
@@ -380,6 +410,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
             const response = await initiateSelfHealResubmission(provider)
 
             if (response.error) {
+                userInitiatedRef.current = false
                 selfHealProviderRef.current = null
                 setError(response.error)
                 return
@@ -389,10 +420,12 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 setAccessToken(response.data.token)
                 setShowWrapper(true)
             } else {
+                userInitiatedRef.current = false
                 selfHealProviderRef.current = null
                 setError('Could not initiate document resubmission. Please try again.')
             }
         } catch (e: unknown) {
+            userInitiatedRef.current = false
             selfHealProviderRef.current = null
             const message = e instanceof Error ? e.message : 'An unexpected error occurred'
             setError(message)

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -53,7 +53,7 @@ const isStaleKeyError = (error: unknown): boolean => {
 
 export const useZeroDev = () => {
     const dispatch = useAppDispatch()
-    const { user } = useAuth()
+    const { user, logoutUser } = useAuth()
     const { isKernelClientReady, isRegistering, isLoggingIn, isSendingUserOp, address } = useZerodevStore()
     const { setWebAuthnKey, getClientForChain, ensureClientForChain } = useKernelClient()
     const { setLoadingState } = useContext(loadingStateContext)
@@ -210,8 +210,11 @@ export const useZeroDev = () => {
             } catch (error) {
                 console.error('Error sending UserOp:', error)
 
-                // Detect stale webAuthnKey errors (AA24, wapk) and provide user feedback
-                // NOTE: Don't auto-clear here - user is mid-transaction, avoid data loss
+                // Detect stale webAuthnKey errors (AA24, wapk) and force a clean
+                // re-auth. A stale session can't recover by retrying — the only
+                // exit is logging out and back in, so surface the message AND
+                // force the logout (showing the toast alone left users stuck in a
+                // signed-in-but-broken state).
                 if (isStaleKeyError(error)) {
                     console.error('Detected stale webAuthnKey error - session is invalid')
                     captureException(error, {
@@ -229,6 +232,7 @@ export const useZeroDev = () => {
                     ;(enhancedError as any).cause = error
                     ;(enhancedError as any).isStaleKeyError = true
                     dispatch(zerodevActions.setIsSendingUserOp(false))
+                    logoutUser()
                     throw enhancedError
                 }
 
@@ -259,7 +263,7 @@ export const useZeroDev = () => {
                 receipt: userOpReceipt.receipt,
             }
         },
-        [getClientForChain, ensureClientForChain]
+        [getClientForChain, ensureClientForChain, logoutUser]
     )
 
     return {

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -8,6 +8,7 @@ import { useAppDispatch, useSetupStore, useZerodevStore } from '@/redux/hooks'
 import { zerodevActions } from '@/redux/slices/zerodev-slice'
 import { getFromCookie, removeFromCookie, saveToCookie } from '@/utils/general.utils'
 import { clearAuthState } from '@/utils/auth.utils'
+import { isStaleKeyError, createStaleSessionError } from '@/utils/walletCredential.utils'
 import { toWebAuthnKey, WebAuthnMode } from '@zerodev/passkey-validator'
 import { useCallback, useContext } from 'react'
 import type { TransactionReceipt, Hex, Hash } from 'viem'
@@ -36,20 +37,6 @@ class PasskeyError extends Error {
 }
 
 const WEB_AUTHN_COOKIE_KEY = 'web-authn-key'
-
-/**
- * Detects if an error is due to stale/invalid webAuthnKey
- * AA24 = EntryPoint signature verification failed
- * wapk = WebAuthn Public Key unauthorized (ZeroDev-specific)
- *
- * Note: Intentionally strict to avoid false positives on generic auth errors
- */
-const isStaleKeyError = (error: unknown): boolean => {
-    const errorStr = String(error).toLowerCase()
-    // AA24 = ERC-4337 EntryPoint signature verification failed
-    // wapk + unauthorized = ZeroDev's specific WebAuthn key error (not generic 401)
-    return errorStr.includes('aa24') || (errorStr.includes('wapk') && errorStr.includes('unauthorized'))
-}
 
 export const useZeroDev = () => {
     const dispatch = useAppDispatch()
@@ -225,15 +212,9 @@ export const useZeroDev = () => {
                             userId: user?.user.userId,
                         },
                     })
-                    // Enhance error message for user feedback
-                    const enhancedError = new Error(
-                        'Your session has expired. Please refresh the page and log in again.'
-                    )
-                    ;(enhancedError as any).cause = error
-                    ;(enhancedError as any).isStaleKeyError = true
                     dispatch(zerodevActions.setIsSendingUserOp(false))
                     logoutUser()
-                    throw enhancedError
+                    throw createStaleSessionError(error)
                 }
 
                 dispatch(zerodevActions.setIsSendingUserOp(false))

--- a/src/hooks/wallet/useStaleSessionGuard.ts
+++ b/src/hooks/wallet/useStaleSessionGuard.ts
@@ -1,0 +1,28 @@
+'use client'
+
+import { useCallback } from 'react'
+import { useAuth } from '@/context/authContext'
+import { isStaleKeyError } from '@/utils/walletCredential.utils'
+
+/**
+ * Reactive stale-credential guard for sign-then-broadcast flows. The UserOp is
+ * signed on the client and broadcast by the backend, so a wrong-passkey session
+ * surfaces as an AA24 / `wapk` error in the API *response* rather than a thrown
+ * client error — the access-point guard in KernelClientProvider never sees it
+ * for migration accounts (their address is injected, not key-derived).
+ *
+ * A stale session can't recover by retrying; the only exit is a clean re-auth.
+ * Pass the API error/message here: when it's a stale-credential error it forces
+ * logout and returns true so the caller can stop.
+ */
+export const useStaleSessionGuard = () => {
+    const { logoutUser } = useAuth()
+    return useCallback(
+        (error: unknown): boolean => {
+            if (!isStaleKeyError(error)) return false
+            logoutUser()
+            return true
+        },
+        [logoutUser]
+    )
+}

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -24,6 +24,7 @@ export const ROUTE_SLUGS = [
     'card-terms-international',
     'card-privacy',
     'card-prohibited-activities',
+    'card-esign',
 ] as const
 
 export type RouteSlug = (typeof ROUTE_SLUGS)[number]

--- a/src/utils/__tests__/walletCredential.utils.test.ts
+++ b/src/utils/__tests__/walletCredential.utils.test.ts
@@ -1,4 +1,4 @@
-import { isStaleClientForUser } from '@/utils/walletCredential.utils'
+import { isStaleClientForUser, isStaleKeyError, createStaleSessionError } from '@/utils/walletCredential.utils'
 
 describe('isStaleClientForUser', () => {
     const accountA = '0xAAAAaaAAaAAAAAaaAAaaAAaaaAAAAAaAAaAAaAaa'
@@ -22,5 +22,27 @@ describe('isStaleClientForUser', () => {
 
     it('does not flag when the client has no derived address', () => {
         expect(isStaleClientForUser(undefined, accountB)).toBe(false)
+    })
+})
+
+describe('isStaleKeyError', () => {
+    it('recognises an error we tagged ourselves', () => {
+        expect(isStaleKeyError(createStaleSessionError())).toBe(true)
+    })
+
+    it('recognises an on-chain AA24 signature error', () => {
+        expect(isStaleKeyError(new Error('UserOperation reverted with reason: AA24 signature error'))).toBe(true)
+    })
+
+    it('recognises ZeroDev wapk-unauthorized', () => {
+        expect(isStaleKeyError('wapk: unauthorized')).toBe(true)
+    })
+
+    it('does not flag a generic unauthorized / 401', () => {
+        expect(isStaleKeyError(new Error('401 unauthorized'))).toBe(false)
+    })
+
+    it('does not flag an unrelated error', () => {
+        expect(isStaleKeyError(new Error('network request failed'))).toBe(false)
     })
 })

--- a/src/utils/__tests__/walletCredential.utils.test.ts
+++ b/src/utils/__tests__/walletCredential.utils.test.ts
@@ -1,0 +1,26 @@
+import { isStaleClientForUser } from '@/utils/walletCredential.utils'
+
+describe('isStaleClientForUser', () => {
+    const accountA = '0xAAAAaaAAaAAAAAaaAAaaAAaaaAAAAAaAAaAAaAaa'
+    const accountB = '0xBBBBbbBBbBBBBBbbBBbbBBbbbBBBBBbBBbBBbBbb'
+
+    it('flags a client whose address differs from the user (wrong passkey)', () => {
+        expect(isStaleClientForUser(accountA, accountB)).toBe(true)
+    })
+
+    it('accepts a client whose address matches the user', () => {
+        expect(isStaleClientForUser(accountA, accountA)).toBe(false)
+    })
+
+    it('matches case-insensitively (EIP-55 checksum vs lowercase)', () => {
+        expect(isStaleClientForUser(accountA.toLowerCase(), accountA)).toBe(false)
+    })
+
+    it('does not flag when the user has no smart-wallet address yet (mid-registration)', () => {
+        expect(isStaleClientForUser(accountA, undefined)).toBe(false)
+    })
+
+    it('does not flag when the client has no derived address', () => {
+        expect(isStaleClientForUser(undefined, accountB)).toBe(false)
+    })
+})

--- a/src/utils/walletCredential.utils.ts
+++ b/src/utils/walletCredential.utils.ts
@@ -5,9 +5,8 @@
  * ERC-1271 admin signature for Rain card withdraws).
  *
  * Returns false (treat as fine) when either address is missing: mid-registration
- * the user has no smart-wallet account yet, and pre-migration accounts inject
- * the address rather than derive it from the key — so an address comparison
- * can't detect a mismatch for them.
+ * the user has no smart-wallet account yet, and the comparison only makes sense
+ * when we have both a derived and an expected address.
  */
 export const isStaleClientForUser = (
     derivedAddress: string | undefined,
@@ -15,4 +14,33 @@ export const isStaleClientForUser = (
 ): boolean => {
     if (!derivedAddress || !expectedAddress) return false
     return derivedAddress.toLowerCase() !== expectedAddress.toLowerCase()
+}
+
+/**
+ * Recognises a stale-credential failure: either one we threw ourselves (tagged
+ * `isStaleKeyError`) or the on-chain/bundler symptoms of signing with the wrong
+ * passkey — AA24 (EntryPoint signature check failed) or ZeroDev's `wapk
+ * unauthorized` (WebAuthn key not authorised; deliberately paired with
+ * "unauthorized" so a generic 401 doesn't match).
+ */
+export const isStaleKeyError = (error: unknown): boolean => {
+    if (error && typeof error === 'object' && (error as { isStaleKeyError?: unknown }).isStaleKeyError === true) {
+        return true
+    }
+    const errorStr = String(error).toLowerCase()
+    return errorStr.includes('aa24') || (errorStr.includes('wapk') && errorStr.includes('unauthorized'))
+}
+
+/**
+ * Builds the user-facing stale-session error. Tagged with `isStaleKeyError` so
+ * downstream handlers can detect it and force a clean re-auth.
+ */
+export const createStaleSessionError = (cause?: unknown): Error => {
+    const error = new Error('Your session has expired. Please log in again.') as Error & {
+        isStaleKeyError: boolean
+        cause?: unknown
+    }
+    error.isStaleKeyError = true
+    if (cause !== undefined) error.cause = cause
+    return error
 }

--- a/src/utils/walletCredential.utils.ts
+++ b/src/utils/walletCredential.utils.ts
@@ -1,0 +1,18 @@
+/**
+ * True when the active kernel client's smart-account address doesn't belong to
+ * the logged-in user — i.e. the session is paired with the wrong passkey, so
+ * any signature it produces will be rejected (AA24 on-chain, or an invalid
+ * ERC-1271 admin signature for Rain card withdraws).
+ *
+ * Returns false (treat as fine) when either address is missing: mid-registration
+ * the user has no smart-wallet account yet, and pre-migration accounts inject
+ * the address rather than derive it from the key — so an address comparison
+ * can't detect a mismatch for them.
+ */
+export const isStaleClientForUser = (
+    derivedAddress: string | undefined,
+    expectedAddress: string | undefined
+): boolean => {
+    if (!derivedAddress || !expectedAddress) return false
+    return derivedAddress.toLowerCase() !== expectedAddress.toLowerCase()
+}


### PR DESCRIPTION
## Summary
Routine back-merge so the next release PR doesn't conflict. Carries from main: #2194 (cross-region unsupported message), #2199 (targetCountry plumbing + hook hardening), #2202 (stale-credential guard), #2204 (card e-sign page), content bumps.

Merge was conflict-free (19 files).

## Gates
- typecheck clean
- full jest green (the 17 `countryCurrencyMapping` failures in a fresh worktree are the known missing-`public/flags` env artifact — pass with assets present)

## Risk
None beyond what already shipped on main.