### PR TITLE
fix(card): render failure-state rails instead of looping users back to add-card

### DIFF
--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -69,7 +69,7 @@ const CardPage: FC = () => {
 
     const { overview, isLoading: overviewLoading, error: overviewError } = useRainCardOverview()
     const { serializeGrant } = useGrantSessionKey()
-    const { railsForProvider } = useCapabilities()
+    const { railsForProvider, isLoading: capabilitiesLoading } = useCapabilities()
     const { setIsSupportModalOpen } = useModalsContext()
     const onBack = useSafeBack('/home')
 
@@ -516,6 +516,15 @@ const CardPage: FC = () => {
                 // capabilities read-model — `rail.reason.userMessage` is
                 // display-ready and provider-neutral by contract. The card
                 // provider serves exactly one rail, so [0] is the card rail.
+                // Overview and capabilities load independently — wait for
+                // capabilities so the screen never flashes without its reason.
+                if (capabilitiesLoading) {
+                    return (
+                        <div className="flex min-h-[inherit] w-full items-center justify-center">
+                            <Loading />
+                        </div>
+                    )
+                }
                 const cardRailReason = railsForProvider('rain')[0]?.reason?.userMessage
                 return (
                     <ApplicationStatusScreen

--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -23,6 +23,7 @@ import PageContainer from '@/components/0_Bruddle/PageContainer'
 import { SumsubKycWrapper } from '@/components/Kyc/SumsubKycWrapper'
 import { rainApi, type ApplyForCardResponse } from '@/services/rain'
 import { useGrantSessionKey } from '@/hooks/wallet/useGrantSessionKey'
+import { useCapabilities } from '@/hooks/useCapabilities'
 import { useModalsContext } from '@/context/ModalsContext'
 import { useSafeBack } from '@/hooks/useSafeBack'
 
@@ -68,6 +69,7 @@ const CardPage: FC = () => {
 
     const { overview, isLoading: overviewLoading, error: overviewError } = useRainCardOverview()
     const { serializeGrant } = useGrantSessionKey()
+    const { railsForProvider } = useCapabilities()
     const { setIsSupportModalOpen } = useModalsContext()
     const onBack = useSafeBack('/home')
 
@@ -509,6 +511,31 @@ const CardPage: FC = () => {
                 return <ApplicationStatusScreen variant="pending" onPrev={onBack} />
             case 'manual-review':
                 return <ApplicationStatusScreen variant="manual-review" onPrev={onBack} />
+            case 'requires-info': {
+                // Surface the structured remediation reason from the
+                // capabilities read-model — `rail.reason.userMessage` is
+                // display-ready and provider-neutral by contract. The card
+                // provider serves exactly one rail, so [0] is the card rail.
+                const cardRailReason = railsForProvider('rain')[0]?.reason?.userMessage
+                return (
+                    <ApplicationStatusScreen
+                        variant="requires-info"
+                        reasonMessage={cardRailReason}
+                        onContactSupport={() => setIsSupportModalOpen(true)}
+                        onPrev={onBack}
+                    />
+                )
+            }
+            case 'requires-support':
+                // Pipeline-side failure — nothing the user can re-submit.
+                // Same support deep-link as 'rejected' below.
+                return (
+                    <ApplicationStatusScreen
+                        variant="requires-support"
+                        onContactSupport={() => setIsSupportModalOpen(true)}
+                        onPrev={onBack}
+                    />
+                )
             case 'rejected':
                 // No retry CTA: Rain denials are terminal on our side. The
                 // only path forward is support reviewing the case manually

--- a/src/components/Card/ApplicationStatusScreen.tsx
+++ b/src/components/Card/ApplicationStatusScreen.tsx
@@ -5,10 +5,14 @@ import { PeanutCrying } from '@/assets/mascot'
 import NavHeader from '@/components/Global/NavHeader'
 import Loading from '@/components/Global/Loading'
 
-type Variant = 'pending' | 'manual-review' | 'rejected'
+type Variant = 'pending' | 'manual-review' | 'requires-info' | 'requires-support' | 'rejected'
 
 interface Props {
     variant: Variant
+    /** Display-ready reason from the capabilities read-model
+     *  (`rail.reason.userMessage`) — rendered above the generic body so the
+     *  user sees what specifically is missing. Provider-neutral by contract. */
+    reasonMessage?: string
     onContactSupport?: () => void
     onPrev?: () => void
 }
@@ -22,20 +26,31 @@ const COPY: Record<Variant, { title: string; body: string }> = {
         title: 'Manual review needed',
         body: "We need to do a manual review of your submission. This usually takes 1-2 days and we'll let you know when it's ready.",
     },
+    'requires-info': {
+        title: 'We need more information',
+        body: 'Our team will help you finish your card application — message support to continue.',
+    },
+    'requires-support': {
+        title: 'Something went wrong on our side',
+        body: "We hit a snag while processing your card application. Our team needs to take a look — message support and we'll get you sorted.",
+    },
     rejected: {
         title: "We couldn't issue you a card",
         body: "Your card application wasn't approved. This might be because of duplicate attempt, incomplete documents, information mismatch, or regional restrictions.",
     },
 }
 
-const ApplicationStatusScreen: FC<Props> = ({ variant, onContactSupport, onPrev }) => {
+/** Variants where support is the only path forward — these render the CTA. */
+const SUPPORT_VARIANTS: ReadonlySet<Variant> = new Set(['requires-info', 'requires-support', 'rejected'])
+
+const ApplicationStatusScreen: FC<Props> = ({ variant, reasonMessage, onContactSupport, onPrev }) => {
     const copy = COPY[variant]
     return (
         <div className="flex min-h-[inherit] flex-col gap-8">
             <NavHeader title="Add card" onPrev={onPrev} />
             <div className="my-auto flex flex-col items-center gap-6 text-center">
                 {variant === 'pending' && <Loading />}
-                {variant === 'rejected' && (
+                {(variant === 'rejected' || variant === 'requires-support') && (
                     <Image
                         src={PeanutCrying.src}
                         unoptimized
@@ -48,9 +63,10 @@ const ApplicationStatusScreen: FC<Props> = ({ variant, onContactSupport, onPrev 
                 )}
                 <div className="flex flex-col gap-3">
                     <h1 className="text-2xl font-extrabold text-n-1">{copy.title}</h1>
+                    {reasonMessage && <p className="text-grey-1">{reasonMessage}</p>}
                     <p className="text-grey-1">{copy.body}</p>
                 </div>
-                {variant === 'rejected' && onContactSupport && (
+                {SUPPORT_VARIANTS.has(variant) && onContactSupport && (
                     <button type="button" onClick={onContactSupport} className="text-black underline">
                         Contact support
                     </button>

--- a/src/components/Card/__tests__/cardState.utils.test.ts
+++ b/src/components/Card/__tests__/cardState.utils.test.ts
@@ -258,6 +258,20 @@ describe('computeCardState', () => {
                 })
             ).not.toBe('add-card')
         })
+
+        it('routes an UNKNOWN future railStatus to requires-support, never add-card (default-deny)', () => {
+            // A new backend RailStatus value must not silently fall through
+            // to add-card — an application exists, so re-applying would
+            // re-create the same infinite loop for the unknown state.
+            expect(
+                computeCardState({
+                    ...base,
+                    overview: withApp('SOME_FUTURE_STATUS' as never),
+                    cardInfo: cardInfo({ hasCardAccess: true }),
+                    skipCelebrationSeen: true,
+                })
+            ).toBe('requires-support')
+        })
     })
 
     it('returns active even when flowEarlyAccess is false (legacy card-holder regression)', () => {

--- a/src/components/Card/__tests__/cardState.utils.test.ts
+++ b/src/components/Card/__tests__/cardState.utils.test.ts
@@ -151,7 +151,7 @@ describe('computeCardState', () => {
         expect(
             computeCardState({
                 ...base,
-                overview: withApp('IN_REVIEW', 'needsVerification'),
+                overview: withApp('PENDING', 'needsVerification'),
                 cardInfo: cardInfo({ hasCardAccess: true }),
             })
         ).toBe('manual-review')
@@ -211,6 +211,53 @@ describe('computeCardState', () => {
                 skipCelebrationSeen: false,
             })
         ).toBe('waitlist-skip-celebration')
+    })
+
+    // Exhaustive over the backend RailStatus enum (peanut-api-ts prisma).
+    // If the BE adds a value, add a row here — any unmapped status falls
+    // through to the add-card branch, which is exactly the prod infinite
+    // loop (apply → "Application already submitted" → add-card → …) that
+    // hit REQUIRES_INFORMATION / FAILED / REQUIRES_SUPPORT users (2026-06-10).
+    describe('maps every backend RailStatus value to a real state', () => {
+        const cases: Array<{ railStatus: string; expected: string }> = [
+            { railStatus: 'PENDING', expected: 'pending' },
+            { railStatus: 'ENABLED', expected: 'add-card' },
+            { railStatus: 'REQUIRES_INFORMATION', expected: 'requires-info' },
+            { railStatus: 'REQUIRES_EXTRA_INFORMATION', expected: 'requires-info' },
+            { railStatus: 'REQUIRES_SUPPORT', expected: 'requires-support' },
+            { railStatus: 'REJECTED', expected: 'rejected' },
+            { railStatus: 'FAILED', expected: 'rejected' },
+        ]
+
+        it.each(cases)('$railStatus → $expected', ({ railStatus, expected }) => {
+            expect(
+                computeCardState({
+                    ...base,
+                    overview: withApp(railStatus),
+                    cardInfo: cardInfo({ hasCardAccess: true }),
+                    skipCelebrationSeen: true,
+                })
+            ).toBe(expected)
+        })
+
+        const failureStatuses = [
+            'REQUIRES_INFORMATION',
+            'REQUIRES_EXTRA_INFORMATION',
+            'REQUIRES_SUPPORT',
+            'REJECTED',
+            'FAILED',
+        ]
+
+        it.each(failureStatuses)('%s never resolves to add-card (infinite-loop regression)', (railStatus) => {
+            expect(
+                computeCardState({
+                    ...base,
+                    overview: withApp(railStatus),
+                    cardInfo: cardInfo({ hasCardAccess: true }),
+                    skipCelebrationSeen: true,
+                })
+            ).not.toBe('add-card')
+        })
     })
 
     it('returns active even when flowEarlyAccess is false (legacy card-holder regression)', () => {

--- a/src/components/Card/cardState.utils.ts
+++ b/src/components/Card/cardState.utils.ts
@@ -15,7 +15,8 @@ export function findActiveCard(overview: RainCardOverview | undefined): RainCard
  * Top-level state for the /card flow.
  *
  * Precedence (top wins) in `computeCardState`:
- *   loading → active → no-flow-access → rejected → pending/manual-review →
+ *   loading → active → no-flow-access → rejected (incl. FAILED) →
+ *   requires-support → requires-info → pending/manual-review →
  *   eligibility-check (first arrival, not yet held) → skip-celebration →
  *   add-card → waitlist
  *
@@ -38,6 +39,13 @@ export type CardTopLevelState =
     | 'add-card'
     | 'pending'
     | 'manual-review'
+    /** Provider needs more information from the user (rail REQUIRES_INFORMATION /
+     *  REQUIRES_EXTRA_INFORMATION). The capabilities read-model carries the
+     *  display-ready reason — the screen surfaces it. */
+    | 'requires-info'
+    /** Our pipeline broke en route to the provider (rail REQUIRES_SUPPORT).
+     *  Not self-fixable — support has to step in. */
+    | 'requires-support'
     | 'rejected'
     | 'active'
 
@@ -84,11 +92,24 @@ export function computeCardState({
     const rail = overview.status.railStatus
     const app = overview.status.applicationStatus
 
-    // Terminal rejection — always shows the rejection screen.
-    if (rail === 'REJECTED') return 'rejected'
+    // Terminal denial — always shows the rejection screen. FAILED is the
+    // webhook mapping for a locked/canceled application: same dead end,
+    // same screen.
+    if (rail === 'REJECTED' || rail === 'FAILED') return 'rejected'
+
+    // Our submission pipeline broke en route to the provider — re-applying
+    // just returns "Application already submitted". Support has to step in.
+    if (rail === 'REQUIRES_SUPPORT') return 'requires-support'
+
+    // Provider needs more information from the user. These rails HAVE an
+    // application, so falling through to add-card here caused the prod
+    // infinite loop (apply → "Application already submitted" → add-card → …).
+    if (rail === 'REQUIRES_INFORMATION' || rail === 'REQUIRES_EXTRA_INFORMATION') return 'requires-info'
 
     // Application still in flight on Rain's side → show status screen.
-    if (rail === 'PENDING' || rail === 'IN_REVIEW') {
+    // (railStatus is the raw backend RailStatus enum — 'IN_REVIEW' was never
+    // a value of it; the old comparison was dead code.)
+    if (rail === 'PENDING') {
         if (app === 'needsVerification' || app === 'needsInformation' || app === 'locked') {
             return 'manual-review'
         }

--- a/src/components/Card/cardState.utils.ts
+++ b/src/components/Card/cardState.utils.ts
@@ -116,6 +116,12 @@ export function computeCardState({
         return 'pending'
     }
 
+    // Default-deny for forward-compat: any other non-ENABLED railStatus means
+    // an application EXISTS in a state this build doesn't know. Falling
+    // through to add-card would re-create the apply loop ("Application
+    // already submitted" → add-card → …), so route unknowns to support.
+    if (rail && rail !== 'ENABLED') return 'requires-support'
+
     // First arrival from /shhhhh: gate everything else behind the press-and-hold
     // "see if you qualify" moment. Applies whether the user ultimately lands on
     // celebration or waitlist — the user explicitly engages the door before


### PR DESCRIPTION
## Why

`computeCardState` only understood `REJECTED` and `PENDING` (plus a dead `'IN_REVIEW'` branch that isn't a real `RailStatus`). A Rain rail in **REQUIRES_INFORMATION / REQUIRES_EXTRA_INFORMATION / FAILED / REQUIRES_SUPPORT** fell through to `add-card` → user taps Apply → backend answers "Application already submitted" → overview invalidates → `add-card` again. **Infinite loop with no remediation screen.** Real prod victims diagnosed today (2026-06-10), e.g. `barbara` (REQUIRES_INFORMATION, `INCORRECT_SOCIAL_NUMBER`).

## What

- `cardState.utils.ts`: all seven `RailStatus` values now resolve to a real state — `requires-info` (new, surfaces the capabilities `reason.userMessage`), `requires-support` (new, contact-support screen), FAILED reuses the existing rejection screen; dead `IN_REVIEW` branch removed (verified unreachable).
- `ApplicationStatusScreen`: two new variants + optional `reasonMessage`; support CTA via the existing Crisp-gated support drawer (PR #2130 pattern). No provider names in any copy.
- `card/page.tsx`: wires `useCapabilities` + the two new switch cases.

| RailStatus | Card state | Screen |
|---|---|---|
| REQUIRES_INFORMATION / REQUIRES_EXTRA_INFORMATION | `requires-info` (new) | "We need more information" + reason + support CTA |
| REQUIRES_SUPPORT | `requires-support` (new) | "Something went wrong on our side" + support CTA |
| FAILED | `rejected` (reused) | existing rejection screen |

## Notes

- Companion BE PR: peanutprotocol/peanut-api-ts#1006 (fixes the upstream causes: Rain missing-address 400, orphan applicant row, webhook crash, alert dedupe).
- Pre-existing gap left as-is: failure-state users without `flowEarlyAccess` and no card still hit the page-level `notFound()` first (also true for `rejected` before this PR).
- Follow-up opportunity (not in scope): dispatch the capabilities sumsub NextAction to re-open the WebSDK from `requires-info` instead of support-only.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 81 suites / 1395 green; new table-driven suite covers all 7 RailStatus values + a "failure states never resolve to add-card" regression guard (12 new tests)
- [x] prettier clean