### PR TITLE
feat: advertise ETH on the crypto deposit screen (EVM only)

### DIFF
--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -268,8 +268,9 @@ jest.mock('@/constants/rhino.consts', () => ({
     getSupportedTokens: jest.fn(() => [
         { name: 'USDC', logoUrl: '/usdc.png' },
         { name: 'USDT', logoUrl: '/usdt.png' },
+        { name: 'ETH', logoUrl: '/eth-token.png' },
     ]),
-    TOKEN_LOGOS: { USDC: '/usdc.png', USDT: '/usdt.png' },
+    TOKEN_LOGOS: { USDC: '/usdc.png', USDT: '/usdt.png', ETH: '/eth-token.png' },
 }))
 
 jest.mock('@/constants/zerodev.consts', () => ({

--- a/src/constants/__tests__/rhino.consts.test.ts
+++ b/src/constants/__tests__/rhino.consts.test.ts
@@ -1,0 +1,26 @@
+import { RHINO_SUPPORTED_TOKENS, getSupportedTokens } from '@/constants/rhino.consts'
+
+// A token advertised on a network Rhino's SDA doesn't accept means silent,
+// permanent loss for the user (no webhook fires). These lists must mirror
+// Rhino's live `depositAddresses.getSupportedConfigs()` response.
+describe('getSupportedTokens', () => {
+    const names = (network: 'EVM' | 'SOL' | 'TRON') => getSupportedTokens(network).map((t) => t.name)
+
+    test('offers ETH on EVM networks only', () => {
+        expect(names('EVM')).toEqual(['USDT', 'USDC', 'ETH'])
+        expect(names('SOL')).not.toContain('ETH')
+        expect(names('TRON')).not.toContain('ETH')
+    })
+
+    test('keeps Solana to stablecoins and Tron to USDT only', () => {
+        expect(names('SOL')).toEqual(['USDT', 'USDC'])
+        expect(names('TRON')).toEqual(['USDT'])
+    })
+
+    test('every advertised token has a logo', () => {
+        expect(RHINO_SUPPORTED_TOKENS.map((t) => t.name)).toEqual(['USDT', 'USDC', 'ETH'])
+        for (const token of RHINO_SUPPORTED_TOKENS) {
+            expect(token.logoUrl).toMatch(/^https:\/\//)
+        }
+    })
+})

--- a/src/constants/rhino.consts.ts
+++ b/src/constants/rhino.consts.ts
@@ -82,7 +82,7 @@ const SUPPORTED_TOKENS_BY_NETWORK: Record<RhinoChainType, TokenName[]> = {
 }
 
 /** returns supported tokens (with logos) for a given chain type */
-export const getSupportedTokens = (network: RhinoChainType) =>
+export const getSupportedTokens = (network: RhinoChainType): Array<{ name: TokenName; logoUrl: string }> =>
     SUPPORTED_TOKENS_BY_NETWORK[network].map((name) => ({ name, logoUrl: TOKEN_LOGOS[name] }))
 
 /** Rhino-supported tokens with their logos */

--- a/src/constants/rhino.consts.ts
+++ b/src/constants/rhino.consts.ts
@@ -20,6 +20,7 @@ export const CHAIN_LOGOS = {
 export const TOKEN_LOGOS = {
     USDT: 'https://assets.coingecko.com/coins/images/325/standard/Tether.png?1696501661',
     USDC: 'https://assets.coingecko.com/coins/images/6319/small/USD_Coin_icon.png',
+    ETH: 'https://assets.coingecko.com/coins/images/279/standard/ethereum.png?1696501628',
 } as const
 
 export type ChainName = keyof typeof CHAIN_LOGOS
@@ -67,9 +68,22 @@ export const NETWORK_LOGOS: Record<RhinoChainType, string> = {
     TRON: CHAIN_LOGOS.TRON,
 }
 
-/** returns supported tokens for a given chain type (TRON has no USDC) */
+/**
+ * Tokens we advertise per chain type — mirrors Rhino's live SDA config
+ * (`depositAddresses.getSupportedConfigs()`). A token sent to an SDA that
+ * Rhino doesn't accept on that chain is silently lost (no webhook, no
+ * intent), so never list a token here without confirming Rhino accepts it.
+ * ETH is EVM-only; TRON is USDT-only (no USDC on Tron).
+ */
+const SUPPORTED_TOKENS_BY_NETWORK: Record<RhinoChainType, TokenName[]> = {
+    EVM: ['USDT', 'USDC', 'ETH'],
+    SOL: ['USDT', 'USDC'],
+    TRON: ['USDT'],
+}
+
+/** returns supported tokens (with logos) for a given chain type */
 export const getSupportedTokens = (network: RhinoChainType) =>
-    RHINO_SUPPORTED_TOKENS.filter((token) => (network === 'TRON' ? token.name !== 'USDC' : true))
+    SUPPORTED_TOKENS_BY_NETWORK[network].map((name) => ({ name, logoUrl: TOKEN_LOGOS[name] }))
 
 /** Rhino-supported tokens with their logos */
 export const RHINO_SUPPORTED_TOKENS = (Object.keys(TOKEN_LOGOS) as TokenName[]).map((name) => ({

--- a/src/constants/rhino.consts.ts
+++ b/src/constants/rhino.consts.ts
@@ -85,11 +85,10 @@ const SUPPORTED_TOKENS_BY_NETWORK: Record<RhinoChainType, TokenName[]> = {
 export const getSupportedTokens = (network: RhinoChainType): Array<{ name: TokenName; logoUrl: string }> =>
     SUPPORTED_TOKENS_BY_NETWORK[network].map((name) => ({ name, logoUrl: TOKEN_LOGOS[name] }))
 
-/** Rhino-supported tokens with their logos */
-export const RHINO_SUPPORTED_TOKENS = (Object.keys(TOKEN_LOGOS) as TokenName[]).map((name) => ({
-    name,
-    logoUrl: TOKEN_LOGOS[name],
-}))
+/** Union of every token advertised on at least one network (with logos) — for generic "supported tokens" surfaces */
+export const RHINO_SUPPORTED_TOKENS = (Object.keys(TOKEN_LOGOS) as TokenName[])
+    .filter((name) => Object.values(SUPPORTED_TOKENS_BY_NETWORK).some((tokens) => tokens.includes(name)))
+    .map((name) => ({ name, logoUrl: TOKEN_LOGOS[name] }))
 
 /**
  * EVM numeric chainId → Rhino chain-name mapping. Source of truth: Rhino's


### PR DESCRIPTION
## Summary

[TASK-19911](https://app.notion.com/p/peanutprotocol/3738381175798183bf56e02cb2a8e874) — ETH deposits already work end-to-end (Rhino inflow SDAs bridge ETH to Arbitrum USDC and the backend credits it), but the deposit screen only advertised USDC/USDT, so users never knew they could send ETH.

This adds ETH to the supported-token chips on every Rhino deposit surface (CryptoDeposit view, RhinoDeposit view / request-fulfilment, TokenAndNetworkConfirmationModal), **EVM only**.

**Verified against Rhino's live `depositAddresses.getSupportedConfigs()`** (read-only probe, 2026-06-10): ETH is accepted on the EVM SDA chains (Arbitrum, Base, BNB, Ethereum, Katana, Mantle, Polygon, Optimism, Unichain) but **not** on Solana or Tron. A token sent to an SDA that Rhino doesn't accept is silently lost (no webhook, no intent), so the token list moves from a flat list with a TRON special-case to an explicit per-network map, with a unit test guarding that ETH never leaks to SOL/TRON.

Side benefit: `TOKEN_LOGOS.ETH` means ETH deposit history/status rows now resolve a proper ETH icon instead of the USDT fallback (`add-money/crypto/page.tsx`, `getTokenLogo`).

## Risks / breaking changes

- Display-only change; no backend or API contract impact.
- **Known imprecision (accepted):** the EVM screen shows one flat token list for all EVM chains, but Rhino does not accept ETH on Gnosis/Celo (live config). Practically unreachable — exchanges/wallets don't offer native-ETH withdrawals on those chains — and the existing screen has the same flat-list semantics today.
- ⚠️ **Pre-existing drift flagged (NOT fixed here):** Rhino's live SDA config no longer lists **Scroll** at all, but `SUPPORTED_EVM_CHAINS` still advertises it on the deposit screen. If Rhino really dropped Scroll, a USDC/USDT deposit on Scroll today would be silently lost. Follow-up needed (confirm with Rhino, then drop the chip).

## QA

- `npm run typecheck` ✅ · `npm test` 81/81 suites (1381 passed) ✅ · `npm run build` ✅ · prettier ✅
- New test: `src/constants/__tests__/rhino.consts.test.ts` (ETH EVM-only; TRON USDT-only; SOL stablecoins-only).
- Manual: Add Money → From Crypto → EVM shows USDT/USDC/ETH chips; Solana/Tron tabs unchanged.