### PR TITLE
fix(crisp): isolate support chat per account, stop cross-user history bleed

### DIFF
--- a/src/app/crisp-proxy/page.tsx
+++ b/src/app/crisp-proxy/page.tsx
@@ -128,7 +128,7 @@ function CrispProxyContent() {
                 {`
                     window.$crisp=[];
                     window.CRISP_WEBSITE_ID="${CRISP_WEBSITE_ID}";
-                    window.CRISP_RUNTIME_CONFIG={lock_maximized:true,lock_full_view:true,cross_origin_cookies:true,session_merge:true};
+                    window.CRISP_RUNTIME_CONFIG={lock_maximized:true,lock_full_view:true,cross_origin_cookies:true};
                     (function(){
                         var t=new URLSearchParams(window.location.search).get("crisp_token_id");
                         if(t) window.CRISP_TOKEN_ID=t;

--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * SupportDrawer — Crisp session isolation gate.
+ *
+ * The bug this guards against: a logged-in user briefly seeing a *different*
+ * Peanut user's chat history. The Crisp token is derived asynchronously from
+ * the userId (SHA-256), so for one render it is undefined. If we mount the
+ * crisp-proxy iframe in that window, Crisp loads with no token and falls back
+ * to the anonymous session persisted on client.crisp.chat — which, on a browser
+ * that has hosted more than one account, is the previous user's conversation.
+ *
+ * The gate: while a logged-in user's token is still resolving, the iframe must
+ * not render. Anonymous visitors (no userId, no token by design) load right away.
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import SupportDrawer from '../index'
+
+const mockUseCrispUserData = jest.fn()
+const mockUseCrispTokenId = jest.fn()
+
+jest.mock('@/context/ModalsContext', () => ({
+    useModalsContext: () => ({
+        isSupportModalOpen: true,
+        setIsSupportModalOpen: jest.fn(),
+        supportPrefilledMessage: undefined,
+    }),
+}))
+jest.mock('@/hooks/useCrispUserData', () => ({
+    useCrispUserData: () => mockUseCrispUserData(),
+}))
+jest.mock('@/hooks/useCrispTokenId', () => ({
+    useCrispTokenId: () => mockUseCrispTokenId(),
+}))
+jest.mock('@/hooks/useCrispProxyUrl', () => ({
+    useCrispProxyUrl: (_data: unknown, _msg: unknown, tokenId?: string) =>
+        tokenId ? `/crisp-proxy?crisp_token_id=${tokenId}` : '/crisp-proxy',
+}))
+jest.mock('../../PeanutLoading', () => ({
+    __esModule: true,
+    default: () => <div data-testid="peanut-loading" />,
+}))
+jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => false }))
+
+const supportIframe = () => screen.queryByTitle('Support Chat')
+
+describe('SupportDrawer Crisp session gate', () => {
+    beforeEach(() => {
+        mockUseCrispUserData.mockReset()
+        mockUseCrispTokenId.mockReset()
+    })
+
+    it('does NOT mount the proxy iframe while a logged-in user’s token is still resolving', () => {
+        mockUseCrispUserData.mockReturnValue({ userId: 'user-abc', email: 'a@b.com' })
+        mockUseCrispTokenId.mockReturnValue(undefined)
+
+        render(<SupportDrawer />)
+
+        expect(supportIframe()).not.toBeInTheDocument()
+        expect(screen.getByTestId('peanut-loading')).toBeInTheDocument()
+    })
+
+    it('mounts a token-bound iframe once the logged-in user’s token resolves', () => {
+        mockUseCrispUserData.mockReturnValue({ userId: 'user-abc', email: 'a@b.com' })
+        mockUseCrispTokenId.mockReturnValue('token-abc')
+
+        render(<SupportDrawer />)
+
+        const iframe = supportIframe()
+        expect(iframe).toBeInTheDocument()
+        expect(iframe).toHaveAttribute('src', '/crisp-proxy?crisp_token_id=token-abc')
+    })
+
+    it('mounts the anonymous proxy immediately for a logged-out visitor (no userId, no token)', () => {
+        mockUseCrispUserData.mockReturnValue({ userId: undefined, email: undefined })
+        mockUseCrispTokenId.mockReturnValue(undefined)
+
+        render(<SupportDrawer />)
+
+        const iframe = supportIframe()
+        expect(iframe).toBeInTheDocument()
+        expect(iframe).toHaveAttribute('src', '/crisp-proxy')
+    })
+})

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -119,7 +119,8 @@ const SupportDrawer = () => {
                 aria-hidden="true"
             />
 
-            {/* slide-up panel — always mounted so the iframe never unmounts */}
+            {/* slide-up panel — always mounted to preserve drag state; the iframe inside
+                mounts only once the token resolves for logged-in users (isAwaitingToken gate) */}
             <div
                 ref={panelRef}
                 role="dialog"

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -18,6 +18,14 @@ const SupportDrawer = () => {
 
     const crispProxyUrl = useCrispProxyUrl(userData, prefilledMessage, crispTokenId)
 
+    // A logged-in user's token is computed asynchronously (SHA-256 of their userId).
+    // Until it resolves we must NOT load the proxy: a token-less load makes Crisp fall
+    // back to the shared anonymous session persisted on client.crisp.chat, which on a
+    // browser that has hosted more than one Peanut account surfaces the *previous*
+    // user's conversation. Anonymous visitors (no userId) have no token by design and
+    // load immediately.
+    const isAwaitingToken = Boolean(userData.userId) && !crispTokenId
+
     // in capacitor, open native crisp messenger instead of iframe
     useEffect(() => {
         if (!isSupportModalOpen || !isCapacitor()) return
@@ -137,19 +145,21 @@ const SupportDrawer = () => {
 
                 <div className="flex w-full justify-center">
                     <div className="relative h-[80vh] w-full overflow-auto md:max-w-xl">
-                        {!isCrispReady && (
+                        {(!isCrispReady || isAwaitingToken) && (
                             <div className="absolute inset-0 z-10 flex items-center justify-center bg-background">
                                 <PeanutLoading />
                             </div>
                         )}
-                        <iframe
-                            src={crispProxyUrl}
-                            className="h-full w-full"
-                            allow="storage-access *"
-                            sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals allow-storage-access-by-user-activation"
-                            title="Support Chat"
-                            tabIndex={isSupportModalOpen ? 0 : -1}
-                        />
+                        {!isAwaitingToken && (
+                            <iframe
+                                src={crispProxyUrl}
+                                className="h-full w-full"
+                                allow="storage-access *"
+                                sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals allow-storage-access-by-user-activation"
+                                title="Support Chat"
+                                tabIndex={isSupportModalOpen ? 0 : -1}
+                            />
+                        )}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## What & why

**Reported:** Aleksander (`ab`) opened support on his Samsung S24 (Android) and saw **thyy's** conversation in his chat history — an account he'd never logged into on that device. ([TASK-19988](https://app.notion.com/p/37983811757980adb154fc1fc9cdcd5c), Discord thread.)

### Root cause — two interacting defects

**1. `session_merge: true` is a permanent cross-user bleed vector.**
Added 2026-03-12 (`4268f96c`) as a *one-off* aid to migrate pre-token cookie sessions into the new token sessions. It was never removed. It tells Crisp to fold the browser's lingering **anonymous** session into whatever token session loads next. On a browser that has hosted more than one Peanut account — exactly our QA/deployment setup, and Aleksander tests several accounts — the previous user's conversation merges into the next user's chat.

**2. Token race → token-less proxy load.**
The per-user Crisp token is `SHA-256(salt:userId)`, computed **asynchronously**, so for the first render `crispTokenId` is `undefined`. `SupportDrawer`'s iframe is *always mounted* (it sits in the mobile-ui layout on every logged-in page), so it boots `crisp-proxy` **token-less** in that window. With no token, Crisp falls back to the shared anonymous session persisted on `client.crisp.chat` — the same bleed surface, triggered on every page load, not just when the drawer opens.

The two compound: a token-less load attaches the shared anonymous session, and `session_merge` then folds it into the account's token session.

### Fix
- **Drop `session_merge`** from `CRISP_RUNTIME_CONFIG`. Its migration window closed ~3 months ago; the deterministic per-user token is now the sole session key.
- **Gate the iframe**: a logged-in user (`userId` present) never loads the proxy until their token resolves, so it is always token-bound. Anonymous visitors (no `userId`, no token by design) still load immediately.

### Guarantee after this change
For any **logged-in account**, the token is deterministic and device-independent, always passed before Crisp loads, and nothing is merged into it → **one account = exactly one Crisp session, stable across devices.** No server-side cleanup needed: the three conversations involved have distinct `people_id`s, so the leak was a client-side *display* of the lingering session, not a persisted merge.

**Out of scope (inherent to Crisp, no account identity):** two *logged-out* visitors on the same browser still share one anonymous thread; pre-login anonymous messages no longer carry into the account after login (that was `session_merge`'s job — and the exact bleed vector).

## Tests
`SupportDrawer.test.tsx` — gate states: token resolving (no iframe, loader shown) / resolved (token-bound iframe) / anonymous (immediate iframe).

## Verification
- `jest src/components/Global/SupportDrawer` → 3/3 pass
- `tsc --noEmit` → clean for changed files
- `prettier --check` → clean