### PR TITLE
fix: actionable UX + telemetry for WebAuthn NotAllowedError during signing

### DIFF
--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -201,6 +201,11 @@ export const ANALYTICS_EVENTS = {
     CARD_WITHDRAW_ATTEMPTED: 'card_withdraw_attempted',
     CARD_WITHDRAW_SUCCEEDED: 'card_withdraw_succeeded',
     CARD_WITHDRAW_FAILED: 'card_withdraw_failed',
+
+    // WebAuthn ceremony failed while signing a transaction (userOp / EIP-712).
+    // `error_name` is the DOMException name (NotAllowedError = provider
+    // refused/wedged, e.g. 1Password on iOS), `context` is the signing call site.
+    PASSKEY_SIGN_FAILED: 'passkey_sign_failed',
 } as const
 
 /**

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -9,6 +9,7 @@ import { zerodevActions } from '@/redux/slices/zerodev-slice'
 import { getFromCookie, removeFromCookie, saveToCookie } from '@/utils/general.utils'
 import { clearAuthState } from '@/utils/auth.utils'
 import { isStaleKeyError, createStaleSessionError } from '@/utils/walletCredential.utils'
+import { capturePasskeySignFailure } from '@/utils/webauthn.utils'
 import { toWebAuthnKey, WebAuthnMode } from '@zerodev/passkey-validator'
 import { useCallback, useContext } from 'react'
 import type { TransactionReceipt, Hex, Hash } from 'viem'
@@ -196,6 +197,7 @@ export const useZeroDev = () => {
                 })
             } catch (error) {
                 console.error('Error sending UserOp:', error)
+                capturePasskeySignFailure(error, 'send-user-op')
 
                 // Detect stale webAuthnKey errors (AA24, wapk) and force a clean
                 // re-auth. A stale session can't recover by retrying — the only

--- a/src/hooks/wallet/useSignUserOp.ts
+++ b/src/hooks/wallet/useSignUserOp.ts
@@ -13,6 +13,7 @@ import { parseUnits, encodeFunctionData, erc20Abi } from 'viem'
 import type { Hex, Address } from 'viem'
 import type { SignUserOperationReturnType } from '@zerodev/sdk/actions'
 import { captureException } from '@sentry/nextjs'
+import { capturePasskeySignFailure } from '@/utils/webauthn.utils'
 
 export interface SignedUserOpData {
     signedUserOp: SignUserOperationReturnType
@@ -54,6 +55,7 @@ export const useSignUserOp = () => {
                 }
             } catch (error) {
                 console.error('[useSignUserOp] Error signing calls UserOperation:', error)
+                capturePasskeySignFailure(error, 'sign-user-op')
                 captureException(error, {
                     tags: { feature: 'sign-user-op' },
                     extra: { callCount: calls.length, chainId },

--- a/src/utils/__tests__/friendly-error.utils.test.tsx
+++ b/src/utils/__tests__/friendly-error.utils.test.tsx
@@ -48,6 +48,25 @@ describe('ErrorHandler', () => {
         })
     })
 
+    describe('WebAuthn NotAllowedError (passkey ceremony refused)', () => {
+        test('maps the verbatim iOS Safari message to retry/unlock guidance', () => {
+            // Verbatim DOMException message from prod (user ariel, 2026-06-06,
+            // TASK-20000): 1Password as iOS credential provider wedged and
+            // refused every signing assertion. Previously fell through to the
+            // generic "contact support" fallback even though a retry after
+            // unlocking the provider (or rebooting) succeeds.
+            const webAuthnRefused = Object.assign(
+                new Error(
+                    'The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.'
+                ),
+                { name: 'NotAllowedError' }
+            )
+            expect(ErrorHandler(webAuthnRefused)).toBe(
+                "Your device didn't complete the passkey confirmation. Try again — if it keeps failing, unlock your password manager (e.g. 1Password) or restart your device."
+            )
+        })
+    })
+
     test('unknown errors still fall through to the support fallback', () => {
         expect(ErrorHandler(new Error('something nobody mapped'))).toBe(
             'There was an issue with your request. Please contact support.'

--- a/src/utils/__tests__/webauthn.utils.test.ts
+++ b/src/utils/__tests__/webauthn.utils.test.ts
@@ -1,0 +1,38 @@
+import posthog from 'posthog-js'
+import { capturePasskeySignFailure } from '../webauthn.utils'
+
+jest.mock('posthog-js', () => ({
+    __esModule: true,
+    default: { capture: jest.fn() },
+}))
+
+jest.mock('@sentry/nextjs', () => ({
+    captureMessage: jest.fn(),
+}))
+
+describe('capturePasskeySignFailure', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    test('captures passkey_sign_failed for a WebAuthn DOMException name', () => {
+        const webAuthnRefused = Object.assign(
+            new Error('The request is not allowed by the user agent or the platform in the current context.'),
+            { name: 'NotAllowedError' }
+        )
+        capturePasskeySignFailure(webAuthnRefused, 'send-user-op')
+        expect(posthog.capture).toHaveBeenCalledWith('passkey_sign_failed', {
+            error_name: 'NotAllowedError',
+            context: 'send-user-op',
+        })
+    })
+
+    test('ignores non-WebAuthn errors so signing catches can call it unconditionally', () => {
+        // The signing catch blocks see every failure (insufficient funds,
+        // bundler timeouts, …) — only WebAuthn ceremony errors may emit the
+        // event, or the metric becomes generic failure noise.
+        capturePasskeySignFailure(new Error('insufficient funds'), 'send-user-op')
+        capturePasskeySignFailure('not even an Error', 'send-user-op')
+        expect(posthog.capture).not.toHaveBeenCalled()
+    })
+})

--- a/src/utils/friendly-error.utils.tsx
+++ b/src/utils/friendly-error.utils.tsx
@@ -92,7 +92,10 @@ export const ErrorHandler = (error: unknown): string => {
     // completes. Third-party credential providers (1Password) can wedge and
     // refuse every assertion until unlocked or the device restarts
     // (TASK-20000) — retrying after that works, so don't dead-end on the
-    // generic "contact support" fallback.
+    // generic "contact support" fallback. Matched on message text rather
+    // than error.name: NotAllowedError is also thrown by camera/clipboard
+    // APIs (the QR scanner raises one), and wrapped signing errors keep the
+    // text but lose the name.
     if (text.includes('not allowed by the user agent'))
         return "Your device didn't complete the passkey confirmation. Try again — if it keeps failing, unlock your password manager (e.g. 1Password) or restart your device."
     if (text.includes('Wrong password or invalid transaction.') || text.includes('transaction may fail'))

--- a/src/utils/friendly-error.utils.tsx
+++ b/src/utils/friendly-error.utils.tsx
@@ -88,6 +88,13 @@ export const ErrorHandler = (error: unknown): string => {
         return 'Failed to switch network. Try switching to the correct network manually.'
     if (text.includes('Insufficient balance')) return "You don't have enough balance."
     if (text.includes('The operation either timed out or was not allowed')) return 'Please confirm the transaction.'
+    // iOS Safari's NotAllowedError copy when the passkey ceremony never
+    // completes. Third-party credential providers (1Password) can wedge and
+    // refuse every assertion until unlocked or the device restarts
+    // (TASK-20000) — retrying after that works, so don't dead-end on the
+    // generic "contact support" fallback.
+    if (text.includes('not allowed by the user agent'))
+        return "Your device didn't complete the passkey confirmation. Try again — if it keeps failing, unlock your password manager (e.g. 1Password) or restart your device."
     if (text.includes('Wrong password or invalid transaction.') || text.includes('transaction may fail'))
         return 'Could not claim link, please refresh page. If problem persist confirm link with sender'
     if (text.includes('Send link already claimed')) return 'Send link already claimed'

--- a/src/utils/webauthn.utils.ts
+++ b/src/utils/webauthn.utils.ts
@@ -1,4 +1,6 @@
 import * as Sentry from '@sentry/nextjs'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 /**
  * Retry configuration for WebAuthn operations
@@ -135,10 +137,15 @@ export const PASSKEY_TROUBLESHOOTING_STEPS = {
     },
     ios: {
         NotAllowedError: [
+            // First because it's the dominant field case: a wedged third-party
+            // credential provider refuses every assertion until unlocked or the
+            // device restarts (TASK-20000).
+            'If you use a password manager like 1Password, open it and unlock it first',
             'Exit Private Browsing - use regular Safari',
             'Enable Face ID/Touch ID in Settings',
             'Enable iCloud Keychain in Settings',
             'Turn off VPN temporarily',
+            'Restart your device',
         ],
     },
     web: {
@@ -160,3 +167,18 @@ export const PASSKEY_WARNINGS = {
         NotAllowedError: 'Lower end Android devices may require recent security updates for passkeys to work properly.',
     },
 } as const
+
+/**
+ * Records a WebAuthn ceremony failure during transaction signing (userOp /
+ * EIP-712) as a dedicated PostHog event, so the trend is watchable without
+ * mining `$exception` by message substring. NotAllowedError dominates: iOS
+ * third-party credential providers (1Password) can wedge and refuse every
+ * assertion until unlocked or the device restarts (TASK-20000, ~45 users in
+ * the 30 days to 2026-06-10). No-ops for non-WebAuthn errors so signing
+ * catch blocks can call it without pre-filtering.
+ */
+export function capturePasskeySignFailure(error: unknown, context: string): void {
+    const errorName = error instanceof Error ? error.name : ''
+    if (!Object.values(WebAuthnErrorName).includes(errorName as WebAuthnErrorName)) return
+    posthog.capture(ANALYTICS_EVENTS.PASSKEY_SIGN_FAILED, { error_name: errorName, context })
+}

--- a/src/utils/webauthn.utils.ts
+++ b/src/utils/webauthn.utils.ts
@@ -177,8 +177,9 @@ export const PASSKEY_WARNINGS = {
  * the 30 days to 2026-06-10). No-ops for non-WebAuthn errors so signing
  * catch blocks can call it without pre-filtering.
  */
+const WEBAUTHN_ERROR_NAMES = new Set<string>(Object.values(WebAuthnErrorName))
+
 export function capturePasskeySignFailure(error: unknown, context: string): void {
-    const errorName = error instanceof Error ? error.name : ''
-    if (!Object.values(WebAuthnErrorName).includes(errorName as WebAuthnErrorName)) return
-    posthog.capture(ANALYTICS_EVENTS.PASSKEY_SIGN_FAILED, { error_name: errorName, context })
+    if (!(error instanceof Error) || !WEBAUTHN_ERROR_NAMES.has(error.name)) return
+    posthog.capture(ANALYTICS_EVENTS.PASSKEY_SIGN_FAILED, { error_name: error.name, context })
 }


### PR DESCRIPTION
## Summary

When an iOS third-party credential provider (1Password) wedges, every passkey assertion during transaction signing throws `NotAllowedError` until the provider is unlocked or the device restarts. Users hitting this mid-send saw the generic **"There was an issue with your request. Please contact support."** — a dead end for a failure that a retry (after unlocking/rebooting) fixes. **45 users hit this in the last 30 days, 40 confirmed iOS** (TASK-20000, Crisp user `ariel`: 4 failed send attempts on 2026-06-06, QR payment succeeded on a later retry).

- `ErrorHandler` now maps the iOS Safari message ("not allowed by the user agent…") to retry/unlock-your-password-manager guidance. Only the *timeout* variant was mapped before.
- iOS `PASSKEY_TROUBLESHOOTING_STEPS.NotAllowedError` now leads with the password-manager unlock hint and ends with device restart (the two fixes that actually work in the field).
- New `passkey_sign_failed` PostHog event (`error_name`, `context`) emitted from the two low-level signing entry points (`useZeroDev.handleSendUserOpEncoded`, `useSignUserOp.signCallsUserOp`) via `capturePasskeySignFailure`, which no-ops for non-WebAuthn errors. Spend-bundle EIP-712 failures already carry `error_kind` on `card_withdraw_failed`, so they're intentionally not double-captured.

## Risks / breaking changes

None expected. Copy + analytics only; no flow logic changed. No backend involvement. The new ErrorHandler branch sits after the existing WebAuthn-timeout matcher and before the generic fallback, so existing mappings are untouched (ordering covered by tests).

## QA

- `npm test` — new tests: verbatim prod error message → new copy; ordering guard for the existing timeout variant; `capturePasskeySignFailure` captures for `NotAllowedError` and ignores non-WebAuthn errors.
- `npm run typecheck`, `npm run build`, `pnpm prettier --check .` all green locally.
- Manual repro of the wedged-provider state isn't feasible in sandbox; the mapped string is the verbatim DOMException message captured in PostHog $exception events from prod.