### PR TITLE
fix(rain-cooldown): mount intro modal globally + track swallowed cooldowns

### DIFF
--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -15,7 +15,6 @@ import '../../styles/globals.css'
 import QRScannerOverlay from '@/components/Global/QRScannerOverlay'
 import SecurityVerificationOverlay from '@/components/Global/SecurityVerificationOverlay'
 import SupportDrawer from '@/components/Global/SupportDrawer'
-import RainCooldownIntroModal from '@/components/Global/RainCooldown/IntroModal'
 import JoinWaitlistPage from '@/components/Invites/JoinWaitlistPage'
 import { useRouter } from 'next/navigation'
 import { Banner } from '@/components/Global/Banner'
@@ -225,8 +224,6 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
             <GuestLoginModal />
 
             <SupportDrawer />
-
-            <RainCooldownIntroModal />
 
             <QRScannerOverlay />
 

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -20,7 +20,6 @@ import { useWallet } from '@/hooks/wallet/useWallet'
 import { useSignSpendBundle } from '@/hooks/wallet/useSignSpendBundle'
 import { useStaleSessionGuard } from '@/hooks/wallet/useStaleSessionGuard'
 import { InsufficientSpendableError, SessionKeyGrantRequiredError } from '@/hooks/wallet/useSpendBundle'
-import { RainCooldownError } from '@/services/rain'
 import { rainCollateralErrorMessage } from '@/utils/friendly-error.utils'
 import { useRainCardOverview } from '@/hooks/useRainCardOverview'
 import { rainCentsToUsdcUnits } from '@/utils/balance.utils'
@@ -614,12 +613,6 @@ export default function QRPayPage() {
             } else if (error instanceof SessionKeyGrantRequiredError) {
                 setErrorMessage("One-time card authorization needed. You'll be asked to confirm once.")
             } else if (rainMsg) {
-                if (error instanceof RainCooldownError) {
-                    posthog.capture(ANALYTICS_EVENTS.RAIN_COOLDOWN_HIT, {
-                        flow: 'qr_pay',
-                        retry_after_sec: error.retryAfterSec,
-                    })
-                }
                 setErrorMessage(rainMsg)
             } else if ((error as Error).toString().includes('not allowed')) {
                 setErrorMessage('Please confirm the transaction.')

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -20,6 +20,7 @@ import { useWallet } from '@/hooks/wallet/useWallet'
 import { useSignSpendBundle } from '@/hooks/wallet/useSignSpendBundle'
 import { useStaleSessionGuard } from '@/hooks/wallet/useStaleSessionGuard'
 import { InsufficientSpendableError, SessionKeyGrantRequiredError } from '@/hooks/wallet/useSpendBundle'
+import { RainCooldownError } from '@/services/rain'
 import { rainCollateralErrorMessage } from '@/utils/friendly-error.utils'
 import { useRainCardOverview } from '@/hooks/useRainCardOverview'
 import { rainCentsToUsdcUnits } from '@/utils/balance.utils'
@@ -613,6 +614,12 @@ export default function QRPayPage() {
             } else if (error instanceof SessionKeyGrantRequiredError) {
                 setErrorMessage("One-time card authorization needed. You'll be asked to confirm once.")
             } else if (rainMsg) {
+                if (error instanceof RainCooldownError) {
+                    posthog.capture(ANALYTICS_EVENTS.RAIN_COOLDOWN_HIT, {
+                        flow: 'qr_pay',
+                        retry_after_sec: error.retryAfterSec,
+                    })
+                }
                 setErrorMessage(rainMsg)
             } else if ((error as Error).toString().includes('not allowed')) {
                 setErrorMessage('Please confirm the transaction.')

--- a/src/app/ClientProviders.tsx
+++ b/src/app/ClientProviders.tsx
@@ -7,6 +7,7 @@
  * the root layout (server component) renders this single client boundary.
  */
 import { ConsoleGreeting } from '@/components/Global/ConsoleGreeting'
+import RainCooldownIntroModal from '@/components/Global/RainCooldown/IntroModal'
 import { ScreenOrientationLocker } from '@/components/Global/ScreenOrientationLocker'
 import { TranslationSafeWrapper } from '@/components/Global/TranslationSafeWrapper'
 import { PeanutProvider } from '@/config'
@@ -40,6 +41,10 @@ export function ClientProviders({ children }: { children: React.ReactNode }) {
                             <ConsoleGreeting />
                             <ScreenOrientationLocker />
                             <PeanutDebug />
+                            {/* Mounted here (not in a route-group layout) so the cooldown
+                                explainer also covers public pay/send/request pages —
+                                the rain:cooldown event fires on every spend path. */}
+                            <RainCooldownIntroModal />
                             {HarnessBootstrap && (
                                 <Suspense fallback={null}>
                                     <HarnessBootstrap />

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -201,6 +201,9 @@ export const ANALYTICS_EVENTS = {
     CARD_WITHDRAW_ATTEMPTED: 'card_withdraw_attempted',
     CARD_WITHDRAW_SUCCEEDED: 'card_withdraw_succeeded',
     CARD_WITHDRAW_FAILED: 'card_withdraw_failed',
+    // Rain withdrawal-signature cooldown tripped during a spend. Handled
+    // gracefully in-flow (no captureException), so this is the only telemetry.
+    RAIN_COOLDOWN_HIT: 'rain_cooldown_hit',
 } as const
 
 /**

--- a/src/services/rain.ts
+++ b/src/services/rain.ts
@@ -8,6 +8,8 @@
  */
 
 import Cookies from 'js-cookie'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { PEANUT_API_KEY, PEANUT_API_URL } from '@/constants/general.consts'
 import { fetchWithSentry } from '@/utils/sentry.utils'
 import type { SignedRainWithdrawal } from '@/hooks/wallet/useSignSpendBundle'
@@ -315,12 +317,20 @@ async function rainRequest<T>(opts: RequestOpts): Promise<T> {
                 : null
         const message =
             err.error || err.message || 'A previous withdrawal is still active for this card. Try again shortly.'
-        if (retryAfterSec !== null && typeof window !== 'undefined') {
-            window.dispatchEvent(
-                new CustomEvent<RainCooldownEventDetail>('rain:cooldown', {
-                    detail: { retryAfterSec, message },
-                })
-            )
+        if (typeof window !== 'undefined') {
+            // Captured here — the single point every spend path's cooldown 425
+            // flows through — so all flows get telemetry, including the
+            // retryAfterSec-less shape that shows no cooldown UI at all
+            // (the PEANUT-UI-QJ1 blind spot). Flow context comes from
+            // PostHog's auto-captured $pathname.
+            posthog.capture(ANALYTICS_EVENTS.RAIN_COOLDOWN_HIT, { retry_after_sec: retryAfterSec })
+            if (retryAfterSec !== null) {
+                window.dispatchEvent(
+                    new CustomEvent<RainCooldownEventDetail>('rain:cooldown', {
+                        detail: { retryAfterSec, message },
+                    })
+                )
+            }
         }
         throw new RainCooldownError(message, retryAfterSec)
     }


### PR DESCRIPTION
## Summary

The Rain cooldown explainer modal was mounted only in the `(mobile-ui)` layout, but the `rain:cooldown` event fires from **every** spend path — including public pay/send/request pages (`/send/<user>`, `/<user>/<amount>`) that live outside that route group. A user paying a request from one of those pages got a bare inline error with no modal (Sentry [PEANUT-UI-QJ1](https://peanut-c34d84c05.sentry.io/issues/PEANUT-UI-QJ1), June 4–5). The `RainCooldownProvider` + ToastProvider already live at the root via `ClientProviders`; the modal now mounts beside them so coverage can't drift per route group.

Second part: a `rain_cooldown_hit` PostHog event captured in `rainRequest`'s 425 branch (services/rain.ts) — the single choke point every spend surface's cooldown flows through. Fires for **both** shapes, including the `retryAfterSec: null` one that shows no cooldown UI (the QJ1 blind spot, previously zero telemetry: the qr-pay catch handles these gracefully with no `captureException`). Flow context comes from PostHog's auto-captured `$pathname`.

## Risks / breaking changes

- Low blast radius: mount-point move (modal portals to `document.body`, so stacking is unchanged) + one analytics event. No API contract changes.
- First `posthog` usage inside `src/services/` — deliberate: per-callsite captures would undercount the other 10+ spend surfaces and were coupled to the `rainMsg` substring match.
- Companion BE PR peanutprotocol/peanut-api-ts#1008 makes `retryAfterSec` always present so the countdown/modal engage on every cooldown shape — independent, no deploy-order requirement.

## QA

- `npm test` — 1378 passed. Typecheck, prettier, `npm run build` clean (re-run after each review fix).
- Existing `RainCooldownContext` tests cover modal-trigger behavior; mount move is structural (verified: single root layout wraps all route groups in `ClientProviders`).
- Manual: dispatch `window.dispatchEvent(new CustomEvent('rain:cooldown', { detail: { retryAfterSec: 120, message: 'x' } }))` on a public `/send/<user>` page → intro modal + countdown toast now appear.
