### PR TITLE
fix: auto-recover from chunk-load failures instead of dead-ending

### DIFF
--- a/src/app/[...recipient]/error.tsx
+++ b/src/app/[...recipient]/error.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { useModalsContext } from '@/context/ModalsContext'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Card } from '@/components/0_Bruddle/Card'
+import { recoverFromChunkError } from '@/utils/chunk-error-recovery'
 
 export default function PaymentError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
     const router = useRouter()
@@ -12,6 +13,9 @@ export default function PaymentError({ error, reset }: { error: Error & { digest
 
     useEffect(() => {
         console.error(error)
+        // "Try again" re-renders against the same dead deployment under skew —
+        // for chunk errors only a reload (re-pin to current deployment) works.
+        recoverFromChunkError(error)
     }, [error])
 
     return (

--- a/src/app/[locale]/(marketing)/error.tsx
+++ b/src/app/[locale]/(marketing)/error.tsx
@@ -2,10 +2,14 @@
 
 import { useEffect } from 'react'
 import Link from 'next/link'
+import { recoverFromChunkError } from '@/utils/chunk-error-recovery'
 
 export default function MarketingError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
     useEffect(() => {
         console.error(error)
+        // "Try again" re-renders against the same dead deployment under skew —
+        // for chunk errors only a reload (re-pin to current deployment) works.
+        recoverFromChunkError(error)
     }, [error])
 
     return (

--- a/src/app/global-error.jsx
+++ b/src/app/global-error.jsx
@@ -3,11 +3,15 @@
 import * as Sentry from '@sentry/nextjs'
 import Error from 'next/error'
 import { useEffect } from 'react'
+import { recoverFromChunkError } from '@/utils/chunk-error-recovery'
 
 export default function GlobalError({ error }) {
     if (process.env.NODE_ENV !== 'development') {
         useEffect(() => {
             Sentry.captureException(error)
+            // Caught chunk errors never reach the inline window-level recovery
+            // script — attempt the same guarded one-time reload from here.
+            recoverFromChunkError(error)
         }, [error])
     }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -158,13 +158,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 {/* Prefetch /qr-pay route - disabled in dev to avoid 9s+ compile time */}
                 {process.env.NODE_ENV !== 'development' && <link rel="prefetch" href="/qr-pay" />}
 
-                {/* Chunk-load failure recovery: MUST be inline — error boundaries are lazy
-                    chunks themselves and fail to load in the exact conditions that need them
-                    (see src/utils/chunk-error-recovery.ts) */}
+                {/* Chunk-load failure recovery: MUST be a raw inline script — error boundaries
+                    are lazy chunks themselves and fail to load in the exact conditions that need
+                    them, and even next/script beforeInteractive only queues into self.__next_s
+                    for Next's bootstrap CHUNK to execute (see src/utils/chunk-error-recovery.ts) */}
                 {process.env.NODE_ENV !== 'development' && (
-                    <Script id="chunk-error-recovery" strategy="beforeInteractive">
-                        {CHUNK_ERROR_RECOVERY_SCRIPT}
-                    </Script>
+                    <script
+                        id="chunk-error-recovery"
+                        dangerouslySetInnerHTML={{ __html: CHUNK_ERROR_RECOVERY_SCRIPT }}
+                    />
                 )}
 
                 {/* Service Worker Registration: Register early for offline support and caching */}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import localFont from 'next/font/local'
 import Script from 'next/script'
 import '../styles/globals.css'
 import { PEANUT_API_URL, BASE_URL } from '@/constants/general.consts'
+import { CHUNK_ERROR_RECOVERY_SCRIPT } from '@/utils/chunk-error-recovery'
 import { type Metadata } from 'next'
 
 const baseUrl = BASE_URL || 'https://peanut.me'
@@ -156,6 +157,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
                 {/* Prefetch /qr-pay route - disabled in dev to avoid 9s+ compile time */}
                 {process.env.NODE_ENV !== 'development' && <link rel="prefetch" href="/qr-pay" />}
+
+                {/* Chunk-load failure recovery: MUST be inline — error boundaries are lazy
+                    chunks themselves and fail to load in the exact conditions that need them
+                    (see src/utils/chunk-error-recovery.ts) */}
+                {process.env.NODE_ENV !== 'development' && (
+                    <Script id="chunk-error-recovery" strategy="beforeInteractive">
+                        {CHUNK_ERROR_RECOVERY_SCRIPT}
+                    </Script>
+                )}
 
                 {/* Service Worker Registration: Register early for offline support and caching */}
                 {/* CRITICAL: Must run before React hydration to enable offline-first PWA */}

--- a/src/components/Global/LazyLoadErrorBoundary/index.tsx
+++ b/src/components/Global/LazyLoadErrorBoundary/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React from 'react'
+import { recoverFromChunkError } from '@/utils/chunk-error-recovery'
 
 interface LazyLoadErrorBoundaryProps {
     children: React.ReactNode
@@ -30,6 +31,10 @@ class LazyLoadErrorBoundary extends React.Component<LazyLoadErrorBoundaryProps, 
     componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
         console.error('LazyLoad Error Boundary caught error:', error, errorInfo)
         this.props.onError?.(error)
+        // A swallowed chunk failure means UI silently never appears (e.g. the
+        // transaction-details drawer); a one-time reload re-pins to the current
+        // deployment and restores it.
+        recoverFromChunkError(error)
     }
 
     render() {

--- a/src/components/Marketing/MarketingErrorBoundary.tsx
+++ b/src/components/Marketing/MarketingErrorBoundary.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Component, type ReactNode } from 'react'
+import { recoverFromChunkError } from '@/utils/chunk-error-recovery'
 
 interface Props {
     children: ReactNode
@@ -23,6 +24,9 @@ export class MarketingErrorBoundary extends Component<Props, State> {
 
     componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
         console.error('MDX rendering error:', error, errorInfo)
+        // The fallback says "try refreshing" — do it for them when the cause
+        // is a failed chunk (one-time, sessionStorage-guarded).
+        recoverFromChunkError(error)
     }
 
     render() {

--- a/src/utils/__tests__/chunk-error-recovery.test.ts
+++ b/src/utils/__tests__/chunk-error-recovery.test.ts
@@ -1,0 +1,149 @@
+import { CHUNK_ERROR_RECOVERY_SCRIPT, isChunkLoadError, recoverFromChunkError } from '../chunk-error-recovery'
+
+type Listener = (event: { reason?: unknown; error?: unknown; message?: string }) => void
+
+/**
+ * Executes the inline script string against shadowed globals so we test the
+ * exact code that ships in the HTML, without fighting jsdom's read-only
+ * window.location.
+ */
+function bootScript({
+    standalone = false,
+    brokenStorage = false,
+}: { standalone?: boolean; brokenStorage?: boolean } = {}) {
+    const listeners: Record<string, Listener[]> = {}
+    const reload = jest.fn()
+    const store = new Map<string, string>()
+    const win = {
+        addEventListener: (type: string, fn: Listener) => {
+            ;(listeners[type] = listeners[type] || []).push(fn)
+        },
+        matchMedia: (_query: string) => ({ matches: standalone }),
+        location: { reload },
+    }
+    const sessionStorage = brokenStorage
+        ? {
+              getItem: () => {
+                  throw new Error('denied')
+              },
+              setItem: () => {
+                  throw new Error('denied')
+              },
+          }
+        : {
+              getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+              setItem: (k: string, v: string) => {
+                  store.set(k, v)
+              },
+          }
+    new Function('window', 'sessionStorage', 'navigator', CHUNK_ERROR_RECOVERY_SCRIPT)(win, sessionStorage, {})
+
+    const emitRejection = (reason: unknown) => listeners['unhandledrejection'].forEach((fn) => fn({ reason }))
+    const emitError = (event: { error?: unknown; message?: string }) => listeners['error'].forEach((fn) => fn(event))
+    return { reload, store, emitRejection, emitError }
+}
+
+const chunkError = () =>
+    Object.assign(new Error('Loading chunk 110 failed.\n(error: https://peanut.me/_next/static/chunks/110-x.js)'), {
+        name: 'ChunkLoadError',
+    })
+
+describe('CHUNK_ERROR_RECOVERY_SCRIPT', () => {
+    it('reloads once on an unhandled ChunkLoadError rejection', () => {
+        const { reload, emitRejection } = bootScript()
+        emitRejection(chunkError())
+        expect(reload).toHaveBeenCalledTimes(1)
+    })
+
+    it('matches by message when the error name is lost (minified rethrow)', () => {
+        const { reload, emitRejection } = bootScript()
+        emitRejection(new Error('Loading chunk 5142 failed.\n(timeout: https://peanut.me/_next/static/chunks/x.js)'))
+        expect(reload).toHaveBeenCalledTimes(1)
+    })
+
+    it('catches chunk errors surfaced through window.onerror', () => {
+        const { reload, emitError } = bootScript()
+        emitError({ message: 'Uncaught ChunkLoadError: Loading CSS chunk 42 failed' })
+        expect(reload).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not reload again within the guard window (no reload loop)', () => {
+        const { reload, emitRejection } = bootScript()
+        emitRejection(chunkError())
+        emitRejection(chunkError())
+        expect(reload).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores non-chunk errors', () => {
+        const { reload, emitRejection, emitError } = bootScript()
+        emitRejection(new Error('Failed to fetch'))
+        emitRejection('some string rejection')
+        emitRejection(undefined)
+        emitError({ message: 'ResizeObserver loop limit exceeded' })
+        expect(reload).not.toHaveBeenCalled()
+    })
+
+    it('does not auto-reload in standalone PWA mode (Android redirect-loop hazard)', () => {
+        const { reload, emitRejection } = bootScript({ standalone: true })
+        emitRejection(chunkError())
+        expect(reload).not.toHaveBeenCalled()
+    })
+
+    it('does not auto-reload when sessionStorage is unavailable (no loop protection)', () => {
+        const { reload, emitRejection } = bootScript({ brokenStorage: true })
+        emitRejection(chunkError())
+        expect(reload).not.toHaveBeenCalled()
+    })
+})
+
+describe('isChunkLoadError', () => {
+    it.each([
+        ['ChunkLoadError by name', chunkError()],
+        ['message-only chunk failure', new Error('Loading chunk 9654 failed.\n(error: https://x/9654.js)')],
+        ['CSS chunk failure', new Error('Loading CSS chunk 42 failed')],
+        ['dynamic import failure', new Error('Failed to fetch dynamically imported module: https://x/y.js')],
+        ['string form', 'ChunkLoadError: Loading chunk 1 failed'],
+    ])('matches %s', (_label, error) => {
+        expect(isChunkLoadError(error)).toBe(true)
+    })
+
+    it.each([
+        ['plain fetch failure', new Error('Failed to fetch')],
+        ['undefined', undefined],
+        ['null', null],
+        ['unrelated string', 'something broke'],
+    ])('rejects %s', (_label, error) => {
+        expect(isChunkLoadError(error)).toBe(false)
+    })
+})
+
+describe('recoverFromChunkError', () => {
+    const originalLocation = window.location
+    let reload: jest.Mock
+
+    beforeEach(() => {
+        sessionStorage.clear()
+        reload = jest.fn()
+        Object.defineProperty(window, 'location', { value: { ...originalLocation, reload }, writable: true })
+    })
+
+    afterEach(() => {
+        Object.defineProperty(window, 'location', { value: originalLocation, writable: true })
+    })
+
+    it('reloads once for a chunk error and returns true', () => {
+        expect(recoverFromChunkError(chunkError())).toBe(true)
+        expect(reload).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns false and skips reload for non-chunk errors', () => {
+        expect(recoverFromChunkError(new Error('Failed to fetch'))).toBe(false)
+        expect(reload).not.toHaveBeenCalled()
+    })
+
+    it('shares the guard with the inline script (no second reload within 60s)', () => {
+        expect(recoverFromChunkError(chunkError())).toBe(true)
+        expect(recoverFromChunkError(chunkError())).toBe(false)
+        expect(reload).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/utils/chunk-error-recovery.ts
+++ b/src/utils/chunk-error-recovery.ts
@@ -1,0 +1,113 @@
+/**
+ * Recovery for chunk-load failures.
+ *
+ * When a webpack chunk fails to load — deploy skew (the open page is pinned to
+ * a deployment whose assets are gone) or a transient network failure — Next.js
+ * throws a ChunkLoadError. Depending on where it surfaces the user either
+ * dead-ends on the static "Application error: a client-side exception has
+ * occurred" screen, gets an error boundary whose "Try again" re-renders
+ * against the same dead deployment (can never succeed under skew), or — for
+ * lazy components behind LazyLoadErrorBoundary — UI that silently vanishes.
+ * Reloading the page is the one real fix: refetching the HTML re-pins to the
+ * current deployment, so its chunks resolve.
+ *
+ * Two delivery mechanisms for the same logic, because one cannot cover both:
+ *
+ * 1. CHUNK_ERROR_RECOVERY_SCRIPT — inline beforeInteractive <Script> in the
+ *    root layout, for UNCAUGHT chunk errors. It must be inline: error.tsx /
+ *    global-error.jsx are themselves lazy chunks and fail to load under the
+ *    exact same conditions (PostHog $exception, 2026-05-26 spike: the top
+ *    failing chunks WERE the error pages). Inline-with-the-HTML is the only
+ *    code guaranteed to be in memory at error time.
+ * 2. recoverFromChunkError() — for chunk errors CAUGHT by a React error
+ *    boundary (those never reach the window listeners). Called from the
+ *    error boundaries; bundled code is fine there because the boundary
+ *    demonstrably loaded.
+ *
+ * Both share the same sessionStorage guard (one auto-reload per 60s) so they
+ * can't compound into a reload loop; when the guard blocks, behavior degrades
+ * to exactly what it was before this existed. Standalone PWA mode is excluded
+ * because window.location.reload() there can bounce the user out to the
+ * browser (see the sw-registration script in layout.tsx).
+ */
+
+const GUARD_KEY = 'peanut-chunk-reload-at'
+const GUARD_MS = 60_000
+const CHUNK_ERROR_RE = /ChunkLoadError|Loading chunk \S+ failed|Loading CSS chunk|dynamically imported module/
+
+export function isChunkLoadError(error: unknown): boolean {
+    if (!error) return false
+    if (typeof error === 'string') return CHUNK_ERROR_RE.test(error)
+    const candidate = error as { name?: unknown; message?: unknown }
+    return candidate.name === 'ChunkLoadError' || CHUNK_ERROR_RE.test(String(candidate.message ?? ''))
+}
+
+/**
+ * Reload-once recovery for chunk errors caught by React error boundaries.
+ * No-op for non-chunk errors. Returns true if a reload was triggered (callers
+ * can keep their fallback UI for the false case).
+ */
+export function recoverFromChunkError(error: unknown): boolean {
+    if (typeof window === 'undefined' || !isChunkLoadError(error)) return false
+    let isStandalone = false
+    try {
+        isStandalone =
+            window.matchMedia('(display-mode: standalone)').matches ||
+            (navigator as Navigator & { standalone?: boolean }).standalone === true
+    } catch {
+        // matchMedia unavailable -> assume not standalone
+    }
+    if (isStandalone) return false
+    try {
+        const last = Number(sessionStorage.getItem(GUARD_KEY) || 0)
+        if (Date.now() - last < GUARD_MS) return false
+        sessionStorage.setItem(GUARD_KEY, String(Date.now()))
+    } catch {
+        // no sessionStorage -> no loop protection -> don't auto-reload
+        return false
+    }
+    window.location.reload()
+    return true
+}
+
+export const CHUNK_ERROR_RECOVERY_SCRIPT = `
+(function () {
+    var GUARD_KEY = '${GUARD_KEY}';
+    var GUARD_MS = ${GUARD_MS};
+    var CHUNK_ERROR_RE = /${CHUNK_ERROR_RE.source}/;
+
+    function isChunkError(err) {
+        if (!err) return false;
+        if (typeof err === 'string') return CHUNK_ERROR_RE.test(err);
+        return err.name === 'ChunkLoadError' || CHUNK_ERROR_RE.test(String(err.message || ''));
+    }
+
+    function recover() {
+        var isStandalone = false;
+        try {
+            isStandalone = window.matchMedia('(display-mode: standalone)').matches || navigator.standalone === true;
+        } catch (e) {}
+        if (isStandalone) return;
+        try {
+            var last = Number(sessionStorage.getItem(GUARD_KEY) || 0);
+            if (Date.now() - last < GUARD_MS) return;
+            sessionStorage.setItem(GUARD_KEY, String(Date.now()));
+        } catch (e) {
+            // no sessionStorage -> no loop protection -> don't auto-reload
+            return;
+        }
+        window.location.reload();
+    }
+
+    window.addEventListener('unhandledrejection', function (event) {
+        if (isChunkError(event.reason)) recover();
+    });
+    window.addEventListener(
+        'error',
+        function (event) {
+            if (isChunkError(event.error || event.message)) recover();
+        },
+        true
+    );
+})();
+`


### PR DESCRIPTION
## Summary

**TASK-19993 ("Vraj 500 error")** — a user on `/withdraw/germany/bank` hit an uncaught `ChunkLoadError` after entering the withdrawal amount and dead-ended on Next's static **"Application error: a client-side exception has occurred"** screen. He could not withdraw at all. This isn't one user: PostHog `$exception` shows ChunkLoadErrors **every day** (a few users/day background from flaky networks) plus **deploy-day spikes** (2026-05-26: 37 users in ~2.5h, all pinned to one superseded deployment).

The only real fix for a failed chunk is **reloading the page** — refetching the HTML re-pins to the current deployment, whose chunks resolve. This PR adds that recovery on both surfaces where the error can land:

1. **Uncaught** → inline `beforeInteractive` script in the root layout (`CHUNK_ERROR_RECOVERY_SCRIPT`). It must be inline: the May-26 data shows the **error-boundary chunks themselves** (`global-error-*.js`, `(marketing)/error-*.js`) were among the top failures — boundary-based recovery can't load when chunk loading is what's broken. Inline-with-the-HTML code is the only code guaranteed to be in memory at error time.
2. **Caught by a boundary** (no window event fires) → `recoverFromChunkError()` from `LazyLoadErrorBoundary` (failed lazy chunks silently rendered `null` — e.g. the transaction-details drawer just never opened), `[...recipient]/error.tsx` + `(marketing)/error.tsx` ("Try again" `reset()` re-renders against the same dead deployment — can never succeed under skew), `MarketingErrorBoundary`, and `global-error.jsx`.

Safety: both paths share one sessionStorage guard — **max one auto-reload per 60s** — so they can't compound into a reload loop; when the guard blocks (e.g. hard-offline), behavior degrades to exactly today's. Standalone PWA is excluded (reload there can bounce the user out to the browser — same hazard the sw-registration script documents). Non-chunk errors are untouched.

## Risks / breaking changes

- **Low.** All additions are no-ops for non-chunk errors; the inline script only acts on uncaught chunk failures that today produce a guaranteed dead-end.
- An auto-reload mid-flow discards in-memory state — but the page was already broken, and URL-as-state means flows resume where they were. No reload happens while anything is healthy.
- No new deps; inline script is ES5, no CSP change (inline scripts already used in layout).

## QA

- `npm test` — 19 new tests cover the inline script (executed via `new Function` against shadowed globals — the exact string that ships) + `isChunkLoadError` + `recoverFromChunkError`: reload-once, guard window, standalone skip, broken-sessionStorage skip, non-chunk no-op.
- Manual repro: build + serve, then block a `_next/static/chunks/*.js` URL in DevTools and navigate — page reloads once instead of dead-ending; second failure within 60s shows the previous behavior.

Crisp ref: session_430d7370-f4ab-4c9c-9e61-e2c4d2b689f6