### PR TITLE
fix(crisp): gate native Crisp open on token, closing the same bleed on Capacitor

### DIFF
--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -3,20 +3,32 @@
  *
  * The bug this guards against: a logged-in user briefly seeing a *different*
  * Peanut user's chat history. The Crisp token is derived asynchronously from
- * the userId (SHA-256), so for one render it is undefined. If we mount the
- * crisp-proxy iframe in that window, Crisp loads with no token and falls back
- * to the anonymous session persisted on client.crisp.chat — which, on a browser
- * that has hosted more than one account, is the previous user's conversation.
+ * the userId (SHA-256), so for one render it is undefined. If we open Crisp in
+ * that window with no token, it falls back to the shared/device-local anonymous
+ * session — which, where more than one account has been used, is the previous
+ * user's conversation.
  *
- * The gate: while a logged-in user's token is still resolving, the iframe must
- * not render. Anonymous visitors (no userId, no token by design) load right away.
+ * The gate (`isAwaitingToken`) covers both surfaces:
+ *  - web: the crisp-proxy iframe must not mount until the token resolves.
+ *  - native (Capacitor): openMessenger() must not fire until the token resolves.
+ * Anonymous visitors (no userId, no token by design) proceed immediately.
  */
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, act, waitFor } from '@testing-library/react'
 import SupportDrawer from '../index'
+import { isCapacitor } from '@/utils/capacitor'
 
 const mockUseCrispUserData = jest.fn()
 const mockUseCrispTokenId = jest.fn()
+const mockIsCapacitor = isCapacitor as jest.Mock
+
+const nativeCrisp = {
+    setUser: jest.fn(),
+    setTokenID: jest.fn(),
+    setString: jest.fn(),
+    sendMessage: jest.fn(),
+    openMessenger: jest.fn(),
+}
 
 jest.mock('@/context/ModalsContext', () => ({
     useModalsContext: () => ({
@@ -39,14 +51,16 @@ jest.mock('../../PeanutLoading', () => ({
     __esModule: true,
     default: () => <div data-testid="peanut-loading" />,
 }))
-jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => false }))
+jest.mock('@/utils/capacitor', () => ({ isCapacitor: jest.fn() }))
+jest.mock('@capgo/capacitor-crisp', () => ({ CapacitorCrisp: nativeCrisp }))
 
 const supportIframe = () => screen.queryByTitle('Support Chat')
 
-describe('SupportDrawer Crisp session gate', () => {
+describe('SupportDrawer Crisp session gate — web iframe', () => {
     beforeEach(() => {
         mockUseCrispUserData.mockReset()
         mockUseCrispTokenId.mockReset()
+        mockIsCapacitor.mockReset().mockReturnValue(false)
     })
 
     it('does NOT mount the proxy iframe while a logged-in user’s token is still resolving', () => {
@@ -79,5 +93,49 @@ describe('SupportDrawer Crisp session gate', () => {
         const iframe = supportIframe()
         expect(iframe).toBeInTheDocument()
         expect(iframe).toHaveAttribute('src', '/crisp-proxy')
+    })
+})
+
+describe('SupportDrawer Crisp session gate — native (Capacitor)', () => {
+    beforeEach(() => {
+        mockUseCrispUserData.mockReset()
+        mockUseCrispTokenId.mockReset()
+        mockIsCapacitor.mockReset().mockReturnValue(true)
+        Object.values(nativeCrisp).forEach((fn) => fn.mockReset())
+    })
+
+    it('does NOT open the native messenger while a logged-in user’s token is still resolving', async () => {
+        mockUseCrispUserData.mockReturnValue({ userId: 'user-abc', email: 'a@b.com' })
+        mockUseCrispTokenId.mockReturnValue(undefined)
+
+        await act(async () => {
+            render(<SupportDrawer />)
+        })
+
+        expect(nativeCrisp.openMessenger).not.toHaveBeenCalled()
+    })
+
+    it('opens the native messenger with the token bound once it resolves', async () => {
+        mockUseCrispUserData.mockReturnValue({ userId: 'user-abc', email: 'a@b.com' })
+        mockUseCrispTokenId.mockReturnValue('token-abc')
+
+        await act(async () => {
+            render(<SupportDrawer />)
+        })
+
+        await waitFor(() => expect(nativeCrisp.openMessenger).toHaveBeenCalled())
+        expect(nativeCrisp.setTokenID).toHaveBeenCalledWith({ tokenID: 'token-abc' })
+    })
+
+    it('opens the native messenger immediately for a logged-out visitor (no token bound)', async () => {
+        mockUseCrispUserData.mockReturnValue({ userId: undefined, email: undefined })
+        mockUseCrispTokenId.mockReturnValue(undefined)
+
+        await act(async () => {
+            render(<SupportDrawer />)
+        })
+
+        await waitFor(() => expect(nativeCrisp.openMessenger).toHaveBeenCalled())
+        expect(nativeCrisp.setTokenID).not.toHaveBeenCalled()
     })
 })

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -26,9 +26,14 @@ const SupportDrawer = () => {
     // load immediately.
     const isAwaitingToken = Boolean(userData.userId) && !crispTokenId
 
-    // in capacitor, open native crisp messenger instead of iframe
+    // in capacitor, open native crisp messenger instead of iframe.
+    // Same token gate as the web iframe: for a logged-in user we must not
+    // openMessenger() before the token resolves — a token-less native open
+    // falls back to the device-local Crisp session, which on a shared device
+    // surfaces the previous user's conversation. The effect re-runs and opens
+    // once crispTokenId resolves (it's in the deps).
     useEffect(() => {
-        if (!isSupportModalOpen || !isCapacitor()) return
+        if (!isSupportModalOpen || !isCapacitor() || isAwaitingToken) return
 
         import('@capgo/capacitor-crisp').then(({ CapacitorCrisp }) => {
             // set user data before opening
@@ -57,7 +62,7 @@ const SupportDrawer = () => {
             // close our drawer since native UI takes over
             setIsSupportModalOpen(false)
         })
-    }, [isSupportModalOpen, userData, crispTokenId, prefilledMessage, setIsSupportModalOpen])
+    }, [isSupportModalOpen, isAwaitingToken, userData, crispTokenId, prefilledMessage, setIsSupportModalOpen])
 
     // drag-to-dismiss state
     const panelRef = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
## What & why
Follow-up to #2209 (cross-user Crisp history bleed). That PR closed the leak on **web** by gating the `crisp-proxy` iframe so a logged-in user never loads Crisp before their per-user token (`SHA-256(userId)`) resolves. The **native (Capacitor)** path had the identical gap:

```ts
if (crispTokenId) { CapacitorCrisp.setTokenID({ tokenID: crispTokenId }) }  // gated
...
CapacitorCrisp.openMessenger()                                              // NOT gated
```

So a logged-in user who tapped Support before the token resolved opened the native messenger with **no token bound** → Crisp falls back to the device-local session, which on a shared device is the previous user's conversation. Same class of leak, native surface.

## Fix
Reuse the existing `isAwaitingToken` guard from #2209 — bail the native effect until a logged-in user's token resolves. The effect re-runs and opens once `crispTokenId` lands (already in the deps). Anonymous visitors (no `userId`, no token by design) still open immediately, token-less.

One-line behavioural change; no new state, no new abstraction.

## Scope / risk
- FE-only, native path only. The web fix shipped in #2209 is unchanged.
- The native (Capacitor) app is **not currently shipped** (Android build rotted, iOS not started), so this is hardening ahead of the native revival rather than a live-user fix — but it removes the bug now while it's understood, so the native resurrection doesn't reintroduce the leak.

## Tests
`SupportDrawer.test.tsx` extended with a native describe block: messenger does **not** open while the token resolves, opens **token-bound** once it does, opens **immediately/token-less** for anonymous visitors. 6/6 pass (3 web + 3 native).