### PR TITLE
fix: string badge-icon fallback + reachable restart-identity modal (release-audit follow-ups)

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
             "node_modules/(?!(@wagmi|wagmi|viem|@viem|@walletconnect|@justaname\\.id|@zerodev|permissionless)/)"
         ],
         "moduleNameMapper": {
-            "\\.(svg|png|jpg|jpeg|gif|webp)$": "jest-transform-stub",
+            "\\.(svg|png|jpg|jpeg|gif|webp)$": "<rootDir>/src/utils/__mocks__/static-image.ts",
             "^@/config/wagmi\\.config$": "<rootDir>/src/utils/__mocks__/wagmi-config.ts",
             "^wagmi/chains$": "<rootDir>/src/utils/__mocks__/wagmi.ts",
             "^@justaname\\.id/react$": "<rootDir>/src/utils/__mocks__/justaname.ts",

--- a/src/app/[...recipient]/error.tsx
+++ b/src/app/[...recipient]/error.tsx
@@ -1,14 +1,12 @@
 'use client'
 
 import { useEffect } from 'react'
-import { useRouter } from 'next/navigation'
 import { useModalsContext } from '@/context/ModalsContext'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Card } from '@/components/0_Bruddle/Card'
 import { recoverFromChunkError } from '@/utils/chunk-error-recovery'
 
 export default function PaymentError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
-    const router = useRouter()
     const { setIsSupportModalOpen } = useModalsContext()
 
     useEffect(() => {

--- a/src/components/Badges/__tests__/badge.utils.test.ts
+++ b/src/components/Badges/__tests__/badge.utils.test.ts
@@ -1,0 +1,20 @@
+import { BADGES, getBadgeIcon } from '../badge.utils'
+
+// jest-transform-stub turns svg imports into a bare string, so mock the mascot
+// module to mirror the real StaticImageData shape — the fallback must unwrap .src.
+jest.mock('@/assets/mascot', () => ({
+    PEANUTMAN_LOGO: { src: '/peanut-logo-stub.svg' },
+}))
+
+describe('getBadgeIcon', () => {
+    it('returns the badge path for known codes', () => {
+        expect(getBadgeIcon('WAITLIST_SKIP')).toBe(BADGES.WAITLIST_SKIP.path)
+    })
+
+    it('falls back to a string URL for unknown codes (raw <img src> consumers)', () => {
+        // Unknown codes happen in prod when the FE BADGES map drops a code the BE
+        // still awards (the recurring badge-registry silent-drop incident).
+        expect(getBadgeIcon('NOT_A_REAL_BADGE')).toBe('/peanut-logo-stub.svg')
+        expect(getBadgeIcon(undefined)).toBe('/peanut-logo-stub.svg')
+    })
+})

--- a/src/components/Badges/__tests__/badge.utils.test.ts
+++ b/src/components/Badges/__tests__/badge.utils.test.ts
@@ -1,11 +1,5 @@
 import { BADGES, getBadgeIcon } from '../badge.utils'
 
-// jest-transform-stub turns svg imports into a bare string, so mock the mascot
-// module to mirror the real StaticImageData shape — the fallback must unwrap .src.
-jest.mock('@/assets/mascot', () => ({
-    PEANUTMAN_LOGO: { src: '/peanut-logo-stub.svg' },
-}))
-
 describe('getBadgeIcon', () => {
     it('returns the badge path for known codes', () => {
         expect(getBadgeIcon('WAITLIST_SKIP')).toBe(BADGES.WAITLIST_SKIP.path)
@@ -13,8 +7,10 @@ describe('getBadgeIcon', () => {
 
     it('falls back to a string URL for unknown codes (raw <img src> consumers)', () => {
         // Unknown codes happen in prod when the FE BADGES map drops a code the BE
-        // still awards (the recurring badge-registry silent-drop incident).
-        expect(getBadgeIcon('NOT_A_REAL_BADGE')).toBe('/peanut-logo-stub.svg')
-        expect(getBadgeIcon(undefined)).toBe('/peanut-logo-stub.svg')
+        // still awards (the recurring badge-registry silent-drop incident). The
+        // fallback must unwrap StaticImageData.src — never leak the object.
+        expect(typeof getBadgeIcon('NOT_A_REAL_BADGE')).toBe('string')
+        expect(getBadgeIcon('NOT_A_REAL_BADGE')).toBeTruthy()
+        expect(getBadgeIcon(undefined)).toBe(getBadgeIcon('NOT_A_REAL_BADGE'))
     })
 })

--- a/src/components/Badges/badge.utils.ts
+++ b/src/components/Badges/badge.utils.ts
@@ -195,8 +195,10 @@ export const BADGES: Record<string, BadgeMeta> = {
  *  list. Used by /dev/share-builder + /dev/debug for iteration. */
 export const BADGE_CODES: readonly string[] = Object.keys(BADGES)
 
-export function getBadgeIcon(code?: string) {
-    return (code && BADGES[code]?.path) || PEANUTMAN_LOGO
+export function getBadgeIcon(code?: string): string {
+    // .src: the svg import is StaticImageData (typed `any` by the module shim, so the
+    // annotation alone can't enforce this) — raw <img src> consumers need a string URL.
+    return (code && BADGES[code]?.path) || PEANUTMAN_LOGO.src
 }
 
 // returns the public-facing description for a badge code (third-person perspective)

--- a/src/components/Card/share-asset/__tests__/shareAssetLayout.test.ts
+++ b/src/components/Card/share-asset/__tests__/shareAssetLayout.test.ts
@@ -8,6 +8,13 @@
  * regress here.
  */
 
+// jest-transform-stub flattens svg imports to a bare string; getBadgeIcon unwraps
+// PEANUTMAN_LOGO.src, so mirror the real StaticImageData shape for the fallback path.
+jest.mock('@/assets/mascot', () => ({
+    ...jest.requireActual('@/assets/mascot'),
+    PEANUTMAN_LOGO: { src: '/peanut-logo-stub.svg' },
+}))
+
 import { SeededRandom } from '../seededRandom'
 import {
     CANVAS_W,

--- a/src/components/Card/share-asset/__tests__/shareAssetLayout.test.ts
+++ b/src/components/Card/share-asset/__tests__/shareAssetLayout.test.ts
@@ -8,13 +8,6 @@
  * regress here.
  */
 
-// jest-transform-stub flattens svg imports to a bare string; getBadgeIcon unwraps
-// PEANUTMAN_LOGO.src, so mirror the real StaticImageData shape for the fallback path.
-jest.mock('@/assets/mascot', () => ({
-    ...jest.requireActual('@/assets/mascot'),
-    PEANUTMAN_LOGO: { src: '/peanut-logo-stub.svg' },
-}))
-
 import { SeededRandom } from '../seededRandom'
 import {
     CANVAS_W,

--- a/src/components/Jobs/index.tsx
+++ b/src/components/Jobs/index.tsx
@@ -4,7 +4,7 @@ export function Careers() {
     return (
         <div className="flex h-full flex-col-reverse items-center justify-center lg:flex-row">
             <div className="w-4/5 md:w-1/2">
-                <img src={PeanutTooCool.src} className="h-full w-auto md:h-fit md:w-fit" />
+                <img src={PeanutTooCool.src} alt="" className="h-full w-auto md:h-fit md:w-fit" />
             </div>
             <div>
                 <div className="font-display text-xl lg:text-3xl">{'<'} Hey there! Want to work at Peanut?</div>

--- a/src/components/Profile/views/UnlockedRegions.view.tsx
+++ b/src/components/Profile/views/UnlockedRegions.view.tsx
@@ -117,7 +117,9 @@ const UnlockedRegions = () => {
         !!selectedRegion &&
         clickedRegionProvider !== null &&
         isSumsubApproved &&
-        (providerRejectionForRegion.state === 'fixable' || providerRejectionForRegion.state === 'blocked')
+        (providerRejectionForRegion.state === 'fixable' ||
+            providerRejectionForRegion.state === 'blocked' ||
+            providerRejectionForRegion.state === 'restart-identity')
     const modalVariant = hasProviderRejectionForRegion ? ('provider_rejection' as const) : baseModalVariant
 
     const handleFinalKycSuccess = useCallback(() => {

--- a/src/components/Profile/views/UnlockedRegions.view.tsx
+++ b/src/components/Profile/views/UnlockedRegions.view.tsx
@@ -117,9 +117,10 @@ const UnlockedRegions = () => {
         !!selectedRegion &&
         clickedRegionProvider !== null &&
         isSumsubApproved &&
-        (providerRejectionForRegion.state === 'fixable' ||
-            providerRejectionForRegion.state === 'blocked' ||
-            providerRejectionForRegion.state === 'restart-identity')
+        // Any non-happy state has a dedicated rendering in the ActionModal below.
+        // Derive from !== 'happy' so a new ProviderRejectionState member can't
+        // silently miss this gate again (restart-identity did exactly that).
+        providerRejectionForRegion.state !== 'happy'
     const modalVariant = hasProviderRejectionForRegion ? ('provider_rejection' as const) : baseModalVariant
 
     const handleFinalKycSuccess = useCallback(() => {

--- a/src/utils/__mocks__/static-image.ts
+++ b/src/utils/__mocks__/static-image.ts
@@ -1,0 +1,13 @@
+// Jest stand-in for Next.js static asset imports (svg/png/jpg/gif/webp).
+// Next yields StaticImageData ({ src, width, height, ... }), but the previous
+// jest-transform-stub flattened imports to a bare string — so any code reading
+// `.src` (the prod pattern, e.g. getBadgeIcon's fallback) tested against
+// fiction. Mirror the real shape so tests and prod agree.
+const staticImageStub = {
+    src: '/test-file-stub',
+    height: 1,
+    width: 1,
+    blurDataURL: '/test-file-stub',
+}
+
+export default staticImageStub


### PR DESCRIPTION
## Summary

Follow-ups from the release-audit + CodeRabbit pass on #2218 — all pre-existing (zero delta in the release), bundled here so the release PR stays clean.

1. **`getBadgeIcon` returns a string, always.** The fallback returned `PEANUTMAN_LOGO` (StaticImageData, typed `any` by the svg module shim — so typecheck never caught it) while `shareAssetLayout` types `iconUrl: string` and `ShareAssetD3` feeds it to a raw `<img src>`. An unknown badge code — exactly what the recurring FE-`BADGES`-drop incident produces — would render a broken stamp in the share asset. Now unwraps `.src`, with a `: string` annotation and a guard test pinning both branches.
2. **`restart-identity` reaches its own modal.** `UnlockedRegions`' provider-rejection override only promoted `fixable`/`blocked`; the dedicated restart-identity copy + `handleRestartIdentity` CTA already wired inside the `provider_rejection` ActionModal were unreachable from this predicate — those users fell back to the generic start flow. Predicate now includes `restart-identity`.
3. Lint nits from the same review: unused `useRouter` in the payment error boundary; `alt=""` on the careers mascot img.

Test changes: new `badge.utils.test.ts`; `shareAssetLayout.test.ts` gets a StaticImageData-shaped mascot mock (jest's svg stub flattens imports to a bare string, so the fallback path needs the real shape).

## Declined CodeRabbit findings (from #2218, for the record)
- `claim_external` sign flip — misread semantics: incoming claims take the `receive`/`+` branch; `claim_external` is the claim-to-external-wallet path.
- Case-insensitive WebAuthn text match — widens the matcher toward WebKit's getUserMedia denial message (same phrase); current casing matches the observed iOS variant.
- Merchant-name acronym handling, stale `?method=` param, repeated-`@` invite strip — valid minors, out of scope here; noted in TODO.

## Risks / breaking changes
None — FE-only, no contract changes, no migrations. Blast radius: badge icon fallback (share asset + badge lists), one KYC modal predicate, an error boundary, the careers page.

## QA
- `getBadgeIcon('NOT_A_REAL_BADGE')` → string URL (unit-tested).
- Profile → Unlocked regions: a user whose provider rejection is `restart-identity` now gets the "Verify with a different document" modal instead of the generic flow.
- typecheck 0 errors · jest 85/85 suites (1425 pass) · build green locally.

## /code-review findings + disposition (second commit)
- **Applied:** predicate → `state !== 'happy'` (enumeration is the bug class that caused the original miss); jest asset stub → StaticImageData shape at the `moduleNameMapper` level (`src/utils/__mocks__/static-image.ts`), deleting both per-file mascot mocks — `.src`-reading code no longer tests against fiction.
- **Key discovery:** `POST /users/identity/restart` and the `country_not_supported` reason exist **only in open api PR #914** — the restart-identity state is unreachable on today's backend, so the predicate change is inert until #914 merges, then becomes live with a working CTA. No 404 exposure.
- **Confirmed follow-up (post-#914):** `isSumsubApproved` here is an any-rail-enabled proxy (`useCapabilities.ts:184`), so a user whose only rails are blocked Manteca `country_not_supported` ones never reaches this modal — the gate should read the provider-agnostic `identityVerification` signal instead. In TODO.
- **Noted, pre-existing (not this PR):** the provider-rejection override can mask the `processing` variant (already true for fixable/blocked); restart-identity call sites run with `regionIntent=undefined` (shared pattern, BE pins the level); 4 surfaces hand-roll the same rejection-state ternary cascade (shared `deriveRejectionModalProps` follow-up in TODO).
- `jest-transform-stub` stays in devDependencies: removing it forces a lockfile re-resolve that moves Sentry onto different otel peers — deferred to a deps PR.
