### PR TITLE
chore(kyc): add bridge-uplift to KycActionType

### DIFF
--- a/src/app/actions/types/sumsub.types.ts
+++ b/src/app/actions/types/sumsub.types.ts
@@ -1,4 +1,8 @@
-export type KycActionType = 'manteca' | 'bridge-direct' | 'unsupported-region'
+// 'bridge-uplift': cross-region EU/NA tap by an applicant whose base verification
+// completed on a non-Bridge level — BE returns an applicant-action token that
+// collects the Bridge data delta (email + questionnaire). Handled generically
+// (token → SDK opens), same as 'manteca'.
+export type KycActionType = 'manteca' | 'bridge-direct' | 'bridge-uplift' | 'unsupported-region'
 
 export interface InitiateSumsubKycResponse {
     token: string | null // null when user is already APPROVED or bridge-direct

--- a/src/app/actions/types/sumsub.types.ts
+++ b/src/app/actions/types/sumsub.types.ts
@@ -1,7 +1,7 @@
 // 'bridge-uplift': cross-region EU/NA tap by an applicant whose base verification
-// completed on a non-Bridge level — BE returns an applicant-action token that
-// collects the Bridge data delta (email + questionnaire). Handled generically
-// (token → SDK opens), same as 'manteca'.
+// completed on a non-Bridge level — BE moves the applicant to bridge-requirements
+// and returns a token for the delta steps (email + Bridge questionnaire). Handled
+// generically (token → SDK opens), same as 'manteca'.
 export type KycActionType = 'manteca' | 'bridge-direct' | 'bridge-uplift' | 'unsupported-region'
 
 export interface InitiateSumsubKycResponse {


### PR DESCRIPTION
Companion to peanutprotocol/peanut-api-ts#1013 — the BE now returns `actionType: 'bridge-uplift'` (with an SDK token) when an EU/NA cross-region tap comes from an applicant that never completed `bridge-requirements`. The hook already handles any token-bearing actionType generically (token → SDK opens, `setIsActionFlow`), so this is type-only with no deploy coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)