### PR TITLE
fix(analytics): make persons searchable by username in PostHog

### DIFF
--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -86,9 +86,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
             if (typeof window !== 'undefined' && window.gtag) {
                 window.gtag('set', { user_id: user.user.userId })
             }
-            // PostHog: identify user (stitches anonymous pre-login events to this user)
+            // PostHog: identify user (stitches anonymous pre-login events to this user).
+            // `name` duplicates username because PostHog's Persons-page search is
+            // hardcoded to email/name/distinct_id — username alone is not searchable.
             posthog.identify(user.user.userId, {
                 username: user.user.username,
+                name: user.user.username,
             })
             // Sentry: every error captured from here on inherits user context
             // as searchable Sentry tags. Closes the historical gap where FE


### PR DESCRIPTION
## Why

Konrad couldn't find any user by username in PostHog's Persons page. Root cause: PostHog's persons free-text search is **hardcoded** (`PersonStrategy.filter_conditions`) to match only `properties.email`, `properties.name`, person UUID, and `distinct_id`. We only set `username` on identify — and 0 of 2,658 persons have `email`/`name` — so search-by-username never worked for anyone. (Usernames *display* in the list because the display-name config includes `username`; display and search are separate code paths, which is the trap.)

## What

Duplicate `username` into `name` in the `posthog.identify` $set payload. `name` ranks before `username` in PostHog's display-name defaults and carries the same value, so nothing visibly changes — but the search box now matches.

## Backfill

Existing persons were backfilled (1,830 $set events via `mono/ops/scripts/posthog/backfill-person-name.mjs`), so this isn't waiting on user logins. Re-running the script is a no-op for already-backfilled persons; worth one re-run after this reaches prod to catch persons created in between.

## Testing

- `npm test`: 72/72 suites green
- `npm run typecheck`: no hits on changed file
- prettier: clean