### PR TITLE
feat(withdraw): route Brazil PIX sends through the QR-payment endpoint

### DIFF
--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -23,13 +23,7 @@ import { countryData } from '@/components/AddMoney/consts'
 import { getFlagUrl } from '@/constants/countryCurrencyMapping'
 import Image from 'next/image'
 import { formatAmount, formatNumberForDisplay } from '@/utils/general.utils'
-import {
-    validateCbuCvuAlias,
-    validatePixKey,
-    normalizePixPhoneNumber,
-    isPixPhoneNumber,
-    isPixEmvcoQr,
-} from '@/utils/withdraw.utils'
+import { validateCbuCvuAlias, validatePixKey, normalizePixInput, isPixEmvcoQr } from '@/utils/withdraw.utils'
 import ValidatedInput from '@/components/Global/ValidatedInput'
 import AmountInput from '@/components/Global/AmountInput'
 import { formatUnits, parseUnits } from 'viem'
@@ -785,15 +779,8 @@ function MantecaBankWithdrawFlow() {
                                 placeholder={countryConfig!.accountNumberLabel}
                                 onUpdate={(update) => {
                                     // Auto-normalize PIX keys for Brazil: strip whitespace and normalize phone numbers
-                                    let normalizedValue = update.value
-                                    if (countryPath === 'brazil') {
-                                        normalizedValue = isPixEmvcoQr(normalizedValue.trim())
-                                            ? normalizedValue.trim()
-                                            : normalizedValue.replace(/\s/g, '')
-                                        if (isPixPhoneNumber(normalizedValue)) {
-                                            normalizedValue = normalizePixPhoneNumber(normalizedValue)
-                                        }
-                                    }
+                                    const normalizedValue =
+                                        countryPath === 'brazil' ? normalizePixInput(update.value) : update.value
                                     setDestinationAddress(normalizedValue)
                                     setIsDestinationAddressValid(update.isValid)
                                     setIsDestinationAddressChanging(update.isChanging)

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -71,10 +71,26 @@ import { initiateIncreaseLimits } from '@/app/actions/increase-limits'
 import { SumsubKycWrapper } from '@/components/Kyc/SumsubKycWrapper'
 import { useLimits } from '@/hooks/useLimits'
 import { isVerifiedForCountry } from '@/utils/regions.utils'
+import PixKeySendView from '@/components/Withdraw/views/PixKeySend.view'
 
 type MantecaWithdrawStep = 'amountInput' | 'bankDetails' | 'review' | 'success' | 'failure'
 
 export default function MantecaWithdrawFlow() {
+    const searchParams = useSearchParams()
+    // Brazil PIX sends go through the Manteca QR-payment endpoint (send to any
+    // PIX key), not the offramp/withdraw endpoint. Delegate to the lightweight
+    // PIX-key entry, which wraps the key and hands off to /qr-pay. The gate
+    // there (canDo('pay', { provider: 'manteca' })) is broader than the full
+    // Manteca KYC the withdraw flow requires — so PIX-pay-capable users get
+    // through. All Brazil-PIX entry points funnel here, so this is the single
+    // chokepoint that flips the endpoint without touching the AR / bank paths.
+    if (searchParams.get('country') === 'brazil' && searchParams.get('method') === 'pix') {
+        return <PixKeySendView destinationParam={searchParams.get('destination')} />
+    }
+    return <MantecaBankWithdrawFlow />
+}
+
+function MantecaBankWithdrawFlow() {
     const flowId = useId() // Unique ID per flow instance to prevent cache collisions
     const [currencyAmount, setCurrencyAmount] = useState<string | undefined>(undefined)
     const [usdAmount, setUsdAmount] = useState<string | undefined>(undefined)

--- a/src/components/Global/QRScannerOverlay/index.tsx
+++ b/src/components/Global/QRScannerOverlay/index.tsx
@@ -14,7 +14,7 @@ import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { BASE_URL } from '@/constants/general.consts'
 import { serverFetch } from '@/utils/api-fetch'
 import { openExternalUrl } from '@/utils/capacitor'
-import { pixKeyToBRCode } from '@/utils/pix.utils'
+import { pixKeyToQrPayUrl } from '@/utils/pix.utils'
 import * as Sentry from '@sentry/nextjs'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import posthog from 'posthog-js'
@@ -300,10 +300,9 @@ export default function QRScannerOverlay() {
                 break
             case EQrType.PIX_KEY:
                 {
-                    const brCode = pixKeyToBRCode(data)
-                    if (brCode) {
-                        const timestamp = Date.now()
-                        redirectUrl = `/qr-pay?qrCode=${encodeURIComponent(brCode)}&t=${timestamp}&type=${EQrType.PIX}`
+                    const url = pixKeyToQrPayUrl(data)
+                    if (url) {
+                        redirectUrl = url
                     } else {
                         showModal(EModalType.UNRECOGNIZED)
                         return { success: true }

--- a/src/components/Withdraw/views/PixKeySend.view.tsx
+++ b/src/components/Withdraw/views/PixKeySend.view.tsx
@@ -8,7 +8,7 @@ import NavHeader from '@/components/Global/NavHeader'
 import ValidatedInput from '@/components/Global/ValidatedInput'
 import ErrorAlert from '@/components/Global/ErrorAlert'
 import { Icon } from '@/components/Global/Icons/Icon'
-import { isPixEmvcoQr, isPixPhoneNumber, normalizePixPhoneNumber, validatePixKey } from '@/utils/withdraw.utils'
+import { isPixEmvcoQr, normalizePixInput, validatePixKey } from '@/utils/withdraw.utils'
 import { pixKeyToQrPayUrl } from '@/utils/pix.utils'
 
 /**
@@ -57,15 +57,7 @@ export default function PixKeySendView({ destinationParam }: { destinationParam?
                             value={pixKey}
                             placeholder="PIX Key (Include +55 in case of phone number)"
                             onUpdate={(update) => {
-                                // Auto-normalize: strip whitespace and normalize phone numbers
-                                let normalized = update.value
-                                normalized = isPixEmvcoQr(normalized.trim())
-                                    ? normalized.trim()
-                                    : normalized.replace(/\s/g, '')
-                                if (isPixPhoneNumber(normalized)) {
-                                    normalized = normalizePixPhoneNumber(normalized)
-                                }
-                                setPixKey(normalized)
+                                setPixKey(normalizePixInput(update.value))
                                 setIsValid(update.isValid)
                                 setIsChanging(update.isChanging)
                                 if (update.isValid || update.value === '') {

--- a/src/components/Withdraw/views/PixKeySend.view.tsx
+++ b/src/components/Withdraw/views/PixKeySend.view.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useSafeBack } from '@/hooks/useSafeBack'
+import { Button } from '@/components/0_Bruddle/Button'
+import NavHeader from '@/components/Global/NavHeader'
+import ValidatedInput from '@/components/Global/ValidatedInput'
+import ErrorAlert from '@/components/Global/ErrorAlert'
+import { Icon } from '@/components/Global/Icons/Icon'
+import { isPixEmvcoQr, isPixPhoneNumber, normalizePixPhoneNumber, validatePixKey } from '@/utils/withdraw.utils'
+import { pixKeyToQrPayUrl } from '@/utils/pix.utils'
+
+/**
+ * Send to any PIX key via the Manteca QR-payment endpoint.
+ *
+ * Reached from the withdraw/send flow for Brazil PIX (replaces the
+ * offramp/withdraw endpoint). Collects the key, wraps it into a BR Code and
+ * hands off to `/qr-pay`, where the amount is entered and the capability gate
+ * (`canDo('pay', { provider: 'manteca' })`) is enforced — the same path the QR
+ * scanner uses for a pasted PIX key.
+ */
+export default function PixKeySendView({ destinationParam }: { destinationParam?: string | null }) {
+    const router = useRouter()
+    const onBack = useSafeBack('/send')
+    const [pixKey, setPixKey] = useState<string>(destinationParam ?? '')
+    const [isValid, setIsValid] = useState(false)
+    const [isChanging, setIsChanging] = useState(false)
+    const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+    const validatePixDestination = async (value: string): Promise<boolean> => {
+        const normalized = isPixEmvcoQr(value.trim()) ? value.trim() : value.replace(/\s/g, '')
+        const result = validatePixKey(normalized)
+        if (!result.valid) {
+            setErrorMessage(result.message ?? 'Invalid Pix key')
+        }
+        return result.valid
+    }
+
+    const handleContinue = () => {
+        const url = pixKeyToQrPayUrl(pixKey)
+        if (!url) {
+            setErrorMessage('Invalid Pix key')
+            return
+        }
+        router.push(url)
+    }
+
+    return (
+        <div className="flex min-h-[inherit] flex-col gap-8">
+            <NavHeader title="Send with Pix" onPrev={onBack} />
+            <div className="my-auto flex flex-col gap-6">
+                <div className="space-y-4">
+                    <h2 className="text-lg font-bold">Enter Pix key</h2>
+                    <div className="space-y-2">
+                        <ValidatedInput
+                            value={pixKey}
+                            placeholder="PIX Key (Include +55 in case of phone number)"
+                            onUpdate={(update) => {
+                                // Auto-normalize: strip whitespace and normalize phone numbers
+                                let normalized = update.value
+                                normalized = isPixEmvcoQr(normalized.trim())
+                                    ? normalized.trim()
+                                    : normalized.replace(/\s/g, '')
+                                if (isPixPhoneNumber(normalized)) {
+                                    normalized = normalizePixPhoneNumber(normalized)
+                                }
+                                setPixKey(normalized)
+                                setIsValid(update.isValid)
+                                setIsChanging(update.isChanging)
+                                if (update.isValid || update.value === '') {
+                                    setErrorMessage(null)
+                                }
+                            }}
+                            validate={validatePixDestination}
+                        />
+                        <div className="flex items-center gap-2 text-sm text-gray-600">
+                            <Icon name="info" size={16} />
+                            <span>Send to any Pix key — email, phone, CPF/CNPJ or random key.</span>
+                        </div>
+                    </div>
+
+                    <Button
+                        onClick={handleContinue}
+                        disabled={!isValid || isChanging}
+                        loading={isChanging}
+                        className="w-full"
+                        shadowSize="4"
+                    >
+                        Continue
+                    </Button>
+
+                    {errorMessage && <ErrorAlert description={errorMessage} />}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/utils/__tests__/pix.utils.test.ts
+++ b/src/utils/__tests__/pix.utils.test.ts
@@ -1,4 +1,4 @@
-import { pixKeyToBRCode } from '@/utils/pix.utils'
+import { pixKeyToBRCode, pixKeyToQrPayUrl } from '@/utils/pix.utils'
 
 jest.mock('@/assets', () => ({}))
 
@@ -89,6 +89,31 @@ describe('PIX Utilities', () => {
                 expect(result).not.toBeNull()
                 expect(result).toContain('user@example.com')
             })
+        })
+    })
+
+    describe('pixKeyToQrPayUrl', () => {
+        it('wraps a valid PIX key into a /qr-pay PIX redirect with the encoded BR Code', () => {
+            const url = pixKeyToQrPayUrl('user@example.com')
+            expect(url).not.toBeNull()
+            expect(url).toMatch(/^\/qr-pay\?qrCode=/)
+            expect(url).toContain('&type=PIX')
+            // The encoded BR Code round-trips back to what pixKeyToBRCode produced.
+            const qrCode = new URLSearchParams(url!.split('?')[1]).get('qrCode')
+            expect(qrCode).toBe(pixKeyToBRCode('user@example.com'))
+        })
+
+        it('passes an existing BR Code through unchanged', () => {
+            const brCode =
+                '00020126580014br.gov.bcb.pix0136123e4567-e12b-12d1-a456-4266554400005204000053039865802BR5913Fulano de Tal6008BRASILIA62070503***63041D3D'
+            const url = pixKeyToQrPayUrl(brCode)
+            const qrCode = new URLSearchParams(url!.split('?')[1]).get('qrCode')
+            expect(qrCode).toBe(brCode)
+        })
+
+        it('returns null for an invalid PIX key so callers can surface an error', () => {
+            expect(pixKeyToQrPayUrl('not-a-valid-key')).toBeNull()
+            expect(pixKeyToQrPayUrl('')).toBeNull()
         })
     })
 })

--- a/src/utils/__tests__/withdraw.utils.test.ts
+++ b/src/utils/__tests__/withdraw.utils.test.ts
@@ -3,6 +3,7 @@ import {
     isPixPhoneNumber,
     normalizePixPhoneNumber,
     isPixEmvcoQr,
+    normalizePixInput,
     validatePixKey,
 } from '@/utils/withdraw.utils'
 
@@ -278,10 +279,9 @@ describe('Withdraw Utilities', () => {
         })
 
         describe('Pasted values with whitespace (stripped before validation)', () => {
-            // The withdraw page strips all whitespace from non-QR PIX keys before validation.
+            // PIX-key inputs strip all whitespace from non-QR keys before validation.
             // EMVCo QR codes only get trimmed (internal whitespace is preserved).
-            const normalizePixInput = (value: string) =>
-                isPixEmvcoQr(value.trim()) ? value.trim() : value.replace(/\s/g, '')
+            // Exercises the shared normalizePixInput used by every PIX-key entry.
 
             it.each([
                 { raw: ' +5511999999999 ', desc: 'phone with leading/trailing spaces' },

--- a/src/utils/pix.utils.ts
+++ b/src/utils/pix.utils.ts
@@ -38,3 +38,19 @@ export const pixKeyToBRCode = (pixKey: string): string | null => {
 
     return pix.toBRCode()
 }
+
+/**
+ * Wraps a raw PIX key into a `/qr-pay` redirect URL — the Manteca QR-payment
+ * flow (send to any PIX key), as opposed to the offramp/withdraw endpoint.
+ * Returns null when the key is invalid so callers can surface an error.
+ *
+ * Single source of truth for the scanner's PIX_KEY branch and the
+ * withdraw/send PIX-key entry, so both reach the exact same `/qr-pay` flow.
+ */
+export const pixKeyToQrPayUrl = (pixKey: string): string | null => {
+    const brCode = pixKeyToBRCode(pixKey)
+    if (!brCode) return null
+    const timestamp = Date.now()
+    // type=PIX mirrors EQrType.PIX; qr-pay routes it to the Manteca PIX rail.
+    return `/qr-pay?qrCode=${encodeURIComponent(brCode)}&t=${timestamp}&type=PIX`
+}

--- a/src/utils/withdraw.utils.ts
+++ b/src/utils/withdraw.utils.ts
@@ -229,6 +229,16 @@ export const isPixEmvcoQr = (pixKey: string): boolean => {
 }
 
 /**
+ * Normalizes a raw PIX key as the user types: keep an EMVCo QR verbatim,
+ * otherwise strip whitespace and canonicalize a phone number to its +55 form.
+ * Shared by every PIX-key input so they can't drift.
+ */
+export const normalizePixInput = (value: string): string => {
+    const normalized = isPixEmvcoQr(value.trim()) ? value.trim() : value.replace(/\s/g, '')
+    return isPixPhoneNumber(normalized) ? normalizePixPhoneNumber(normalized) : normalized
+}
+
+/**
  * Validates a PIX key based on Brazilian Central Bank standards
  * Supports: Phone, CPF, CNPJ, Email, Random Key (UUID), and EMVCo QR Code
  * @param pixKey - The PIX key to validate


### PR DESCRIPTION
## Summary

Make "send to any PIX key" — the flow you already get by pasting a PIX key into the QR scanner — reachable from the **withdraw/send** screen, gated so anyone with a PIX **pay** capability (a PIX rail) can use it.

Brazil PIX sends previously went to the **offramp/withdraw** endpoint (`mantecaApi.initiateWithdraw`), gated on **full Manteca KYC** (a rail carrying `mantecaUserId`). The QR-payment endpoint (`/qr-pay` → `initiateQrPayment`) only needs `canDo('pay', { provider: 'manteca' })` — a strictly broader cohort. So PIX-pay-capable users who lacked full Manteca KYC could reach the PIX entry but hit a verification wall they couldn't clear, despite already being able to pay any PIX key via the scanner.

**This PR routes Brazil PIX sends through the QR endpoint instead** (decision: *replace for everyone, Brazil PIX only*).

### How
- All Brazil-PIX **send** entry points funnel through `/withdraw/manteca?country=brazil&method=pix`, so a single delegation at the top of that page flips the endpoint — no changes to the Argentina (MercadoPago/CBU) or bank flows.
- `pixKeyToQrPayUrl()` — new shared helper that wraps a PIX key into a BR Code and builds the `/qr-pay?...&type=PIX` URL. Now the **single source of truth** for both the scanner overlay and the new entry (de-dupes the scanner's PIX_KEY branch).
- `PixKeySend.view.tsx` — lightweight key-entry surface; on submit it hands off to `/qr-pay`, where the amount is entered and the capability gate is enforced (same as the scanner-paste path).

## Risks / breaking changes
- **Behavior shift (intended):** Brazil PIX sends become `qr-payment` intents, not `OFFRAMP`. Different transaction-history label, limits path (server-side via `initiateQrPayment` vs `useLimitsValidation({flowType:'offramp'})`), fees, and perk eligibility. This is the existing scanner-paste capability, now reachable by typing — not a new code path on the backend.
- **No backend changes.** `/manteca/qr-payment/*` already handles arbitrary wrapped PIX keys.
- The **saved-account** withdraw path (routes without `method=pix`) intentionally stays on the withdraw endpoint — full-KYC users withdrawing to a saved account are unaffected.
- No cross-repo coordination required.

## QA (sandbox)
1. As a BR user with the PIX **pay** capability but **without** full Manteca KYC: Send → PIX → enter a PIX key → lands on `/qr-pay` → enter amount → pay. (Previously: blocked at the KYC wall.)
2. As a full-KYC BR user: same path still works (pay capability is a superset).
3. Paste a PIX key into the **QR scanner** → unchanged (now goes through the shared `pixKeyToQrPayUrl`).
4. Argentina MercadoPago / CBU and bank withdrawals → unchanged.

## Tests
- Unit: `pixKeyToQrPayUrl` (valid wrap, BR-Code passthrough, invalid→null) added to `pix.utils.test.ts`.
- Pre-existing unrelated red: `add-money-states` GROUP 3 ("10,000 USD") fails identically on pristine `origin/dev` — not introduced here.