### PR TITLE
fix(send): hide 'Exchange or Wallet' dead-button card in direct-send flow

### DIFF
--- a/src/features/payments/shared/components/PaymentMethodActionList.tsx
+++ b/src/features/payments/shared/components/PaymentMethodActionList.tsx
@@ -59,6 +59,15 @@ export function PaymentMethodActionList({
         methods: ACTION_METHODS,
     })
 
+    // The "Exchange or Wallet" card only does anything when the caller passes an
+    // external-wallet handler (semantic-request flow). The direct-send flow has
+    // no external-wallet path, so without this filter the card renders enabled
+    // but its tap is a silent no-op — a dead button. Only offer it when we can
+    // actually honor it.
+    const visibleMethods = onPayWithExternalWallet
+        ? sortedMethods
+        : sortedMethods.filter((method) => method.id !== 'exchange-or-wallet')
+
     const handleMethodClick = (method: PaymentMethod) => {
         // for all methods, save current url and redirect to setup with add-money as final destination
         // verification will be handled in the add-money flow after login
@@ -87,7 +96,7 @@ export function PaymentMethodActionList({
         <div className="space-y-2">
             {showDivider && <Divider text="or" />}
             <div className="space-y-2">
-                {sortedMethods.map((method) => {
+                {visibleMethods.map((method) => {
                     // does this method's gate require identity verification (badge display only)?
                     const qrMethodNeedsUnlock = ['mercadopago', 'pix'].includes(method.id) && !isQrPayEnabled
                     const bankMethodNeedsUnlock = method.id === 'bank' && !isBankEnabled

--- a/src/features/payments/shared/components/__tests__/PaymentMethodActionList.test.tsx
+++ b/src/features/payments/shared/components/__tests__/PaymentMethodActionList.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * PaymentMethodActionList — "Exchange or Wallet" visibility
+ *
+ * Regression: the direct-send flow rendered the "Exchange or Wallet" card
+ * without an onPayWithExternalWallet handler, so it was enabled but its tap was
+ * a silent no-op (dead button). The card must only render when the caller can
+ * honor it (i.e. provides the handler — the semantic-request flow does).
+ */
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+const mockRouterPush = jest.fn()
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ push: mockRouterPush }),
+}))
+
+// Return a fixed method list so the filter is the only thing under test.
+const METHODS = [
+    { id: 'bank', title: 'Bank', description: 'd', icons: [], soon: false },
+    { id: 'exchange-or-wallet', title: 'Exchange or Wallet', description: 'd', icons: [], soon: false },
+]
+jest.mock('@/hooks/useGeoFilteredPaymentOptions', () => ({
+    useGeoFilteredPaymentOptions: () => ({ filteredMethods: METHODS, isLoading: false }),
+}))
+
+jest.mock('@/hooks/useCapabilities', () => ({
+    useCapabilities: () => ({ canDo: () => true, bankRails: () => [] }),
+}))
+
+jest.mock('@/utils/general.utils', () => ({ saveRedirectUrl: jest.fn() }))
+
+jest.mock('@/components/0_Bruddle/Divider', () => ({ __esModule: true, default: () => <div /> }))
+jest.mock('@/components/Global/IconStack', () => ({ __esModule: true, default: () => <div /> }))
+jest.mock('@/components/Global/Loading', () => ({ __esModule: true, default: () => <div /> }))
+jest.mock('@/components/Global/Badges/StatusBadge', () => ({ __esModule: true, default: () => <div /> }))
+jest.mock('@/components/ActionListCard', () => ({
+    ActionListCard: (props: { title: React.ReactNode; onClick: () => void; isDisabled?: boolean }) => (
+        <button onClick={props.onClick} disabled={props.isDisabled}>
+            {props.title}
+        </button>
+    ),
+}))
+
+import { PaymentMethodActionList } from '../PaymentMethodActionList'
+
+beforeEach(() => jest.clearAllMocks())
+
+describe('PaymentMethodActionList — Exchange or Wallet card', () => {
+    it('is hidden when no onPayWithExternalWallet handler is provided (direct-send)', () => {
+        render(<PaymentMethodActionList isAmountEntered={true} />)
+        expect(screen.queryByText('Exchange or Wallet')).not.toBeInTheDocument()
+        // other methods still render
+        expect(screen.getByText('Bank')).toBeInTheDocument()
+    })
+
+    it('is shown and invokes the handler when onPayWithExternalWallet is provided (semantic-request)', () => {
+        const onPay = jest.fn()
+        render(<PaymentMethodActionList isAmountEntered={true} onPayWithExternalWallet={onPay} />)
+        const card = screen.getByText('Exchange or Wallet')
+        expect(card).toBeInTheDocument()
+        fireEvent.click(card)
+        expect(onPay).toHaveBeenCalledTimes(1)
+        // the external-wallet handler short-circuits — no /setup redirect
+        expect(mockRouterPush).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
## Why
A guest on `/send` who enters an amount sees an **'Exchange or Wallet'** card (`soon:false`, enabled) that does **nothing** when tapped. `PaymentMethodActionList` only acts on that card when the caller passes `onPayWithExternalWallet`; the semantic-request flow does, but **direct-send** (`SendInputView`) does not — and direct-send has **no external-wallet path** (only Input/Status/Success views). Dead button. Found by the dead-button-class audit (HIGH), same family as the withdraw Continue throw (#2224).

## Fix
Filter the `exchange-or-wallet` card out of `PaymentMethodActionList` unless an `onPayWithExternalWallet` handler is provided — correct-by-construction: no caller can render a card it can't honor. Semantic-request unchanged (still passes the handler, card still shows). Not wiring a handler into direct-send because that flow has no external-wallet machinery — that would be a feature, not a bug fix.

## Test
Adds the component's first tests: card hidden without handler (+ other methods still render), shown + invokes handler (no /setup redirect) with handler. 2/2 pass.

## Risk
Low, UI-only. Removes a non-functional option from the guest direct-send view; no behavior change for logged-in users or the request flow.