### PR TITLE
fix(ui): harden 4 dead-button / silent-no-op handlers (card-setup lockout, KYC region verify, cancel-deposit, ToS confirm)

### DIFF
--- a/src/components/Home/EnableAutoBalanceBanner.tsx
+++ b/src/components/Home/EnableAutoBalanceBanner.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import ActionModal from '@/components/Global/ActionModal'
+import { useState } from 'react'
+import ActionModal, { type ActionModalButtonProps } from '@/components/Global/ActionModal'
 import { useRainCardOverview } from '@/hooks/useRainCardOverview'
 import { useGrantSessionKey } from '@/hooks/wallet/useGrantSessionKey'
 
@@ -14,13 +15,18 @@ import { useGrantSessionKey } from '@/hooks/wallet/useGrantSessionKey'
  * proxy + coordinator already provisioned by Rain) — otherwise the
  * passkey tap would throw `no-contracts`.
  *
- * Non-dismissible by design: no close button, no backdrop dismiss. The
- * modal hides itself once `grant()` succeeds and the overview refetch
- * flips `hasWithdrawApproval` to true.
+ * Blocking on the happy path (no close button, no backdrop dismiss); hides
+ * itself once `grant()` succeeds and the overview refetch flips
+ * `hasWithdrawApproval` to true. BUT: once a grant FAILS we surface the
+ * error and add a "Skip for now" escape — a passkey can fail or be
+ * cancelled (very common on iOS / 1Password), and a non-dismissible modal
+ * whose CTA silently does nothing is a hard lockout. Skipping is safe: the
+ * grant is re-prompted on the first card spend regardless.
  */
 export default function EnableAutoBalanceBanner() {
     const { overview } = useRainCardOverview()
-    const { grant, isGranting } = useGrantSessionKey()
+    const { grant, isGranting, lastError } = useGrantSessionKey()
+    const [dismissed, setDismissed] = useState(false)
 
     const card = overview?.cards?.[0]
     const shouldShow =
@@ -29,27 +35,48 @@ export default function EnableAutoBalanceBanner() {
         !!overview?.status?.contractAddress &&
         !!overview?.status?.coordinatorAddress
 
+    // `user-cancelled` just means the passkey sheet was dismissed — not a real
+    // error, the user simply taps Continue again. Any other failure gets a
+    // recoverable message.
+    const hardError = !!lastError && lastError.kind !== 'user-cancelled'
+
+    const ctas: ActionModalButtonProps[] = [
+        {
+            text: isGranting ? 'Working…' : hardError ? 'Try again' : 'Continue',
+            variant: 'purple',
+            shadowSize: '4',
+            disabled: isGranting,
+            onClick: () => {
+                void grant()
+            },
+        },
+    ]
+    // Escape hatch, shown only once a grant has failed, so the user is never
+    // trapped behind this non-dismissible modal.
+    if (lastError) {
+        ctas.push({
+            text: 'Skip for now',
+            variant: 'stroke',
+            disabled: isGranting,
+            onClick: () => setDismissed(true),
+        })
+    }
+
     return (
         <ActionModal
-            visible={shouldShow}
+            visible={shouldShow && !dismissed}
             onClose={() => {}}
             preventClose
             hideModalCloseButton
             icon="credit-card"
             iconContainerClassName="bg-yellow-1"
             title="Finish setting up your card"
-            description="One passkey tap to start using your card."
-            ctas={[
-                {
-                    text: isGranting ? 'Working…' : 'Continue',
-                    variant: 'purple',
-                    shadowSize: '4',
-                    disabled: isGranting,
-                    onClick: () => {
-                        void grant()
-                    },
-                },
-            ]}
+            description={
+                hardError
+                    ? "We couldn't finish setting up your card. Please try again, or skip for now — we'll prompt you again on your first card payment."
+                    : 'One passkey tap to start using your card.'
+            }
+            ctas={ctas}
         />
     )
 }

--- a/src/components/Home/__tests__/EnableAutoBalanceBanner.test.tsx
+++ b/src/components/Home/__tests__/EnableAutoBalanceBanner.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * EnableAutoBalanceBanner — escape-hatch regression
+ *
+ * The modal is preventClose + hideModalCloseButton. Before this fix `void grant()`
+ * discarded the result, so a cancelled/failed passkey left the user trapped with a
+ * button that appeared to do nothing. The fix surfaces the error and adds a "Skip
+ * for now" escape once a grant has failed.
+ */
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { GrantSessionKeyError } from '@/hooks/wallet/useGrantSessionKey'
+
+const mockGrant = jest.fn()
+let mockLastError: GrantSessionKeyError | null = null
+jest.mock('@/hooks/wallet/useGrantSessionKey', () => ({
+    useGrantSessionKey: () => ({ grant: mockGrant, isGranting: false, lastError: mockLastError }),
+}))
+
+jest.mock('@/hooks/useRainCardOverview', () => ({
+    useRainCardOverview: () => ({
+        overview: {
+            cards: [{ status: 'ACTIVE', hasWithdrawApproval: false }],
+            status: { contractAddress: '0xabc', coordinatorAddress: '0xdef' },
+        },
+    }),
+}))
+
+jest.mock('@/components/Global/ActionModal', () => ({
+    __esModule: true,
+    default: (props: { visible: boolean; description?: string; ctas?: { text: string; onClick: () => void }[] }) =>
+        props.visible ? (
+            <div data-testid="modal">
+                <p>{props.description}</p>
+                {props.ctas?.map((c) => (
+                    <button key={c.text} onClick={c.onClick}>
+                        {c.text}
+                    </button>
+                ))}
+            </div>
+        ) : null,
+}))
+
+import EnableAutoBalanceBanner from '../EnableAutoBalanceBanner'
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    mockLastError = null
+})
+
+describe('EnableAutoBalanceBanner', () => {
+    it('shows only Continue (no escape) before any error', () => {
+        render(<EnableAutoBalanceBanner />)
+        expect(screen.getByText('Continue')).toBeInTheDocument()
+        expect(screen.queryByText('Skip for now')).not.toBeInTheDocument()
+    })
+
+    it('after a cancelled/failed passkey, surfaces an escape so the non-dismissible modal cannot trap the user', () => {
+        mockLastError = { kind: 'user-cancelled' }
+        render(<EnableAutoBalanceBanner />)
+        const skip = screen.getByText('Skip for now')
+        expect(skip).toBeInTheDocument()
+        fireEvent.click(skip)
+        expect(screen.queryByTestId('modal')).not.toBeInTheDocument()
+    })
+
+    it('surfaces a recoverable message + Try again on a hard error', () => {
+        mockLastError = { kind: 'unexpected', message: 'boom' }
+        render(<EnableAutoBalanceBanner />)
+        expect(screen.getByText(/couldn't finish setting up your card/i)).toBeInTheDocument()
+        expect(screen.getByText('Try again')).toBeInTheDocument()
+    })
+})

--- a/src/components/Profile/views/UnlockedRegions.view.tsx
+++ b/src/components/Profile/views/UnlockedRegions.view.tsx
@@ -174,6 +174,11 @@ const UnlockedRegions = () => {
         await handleStartKyc()
     }, [handleStartKyc])
 
+    // ROW (rest-of-world) regions have no provider/rail, so an initiate there is a
+    // terminal "not available in your region yet" — not a transient failure. Only
+    // offer "Try again" for regions that can actually succeed on a retry.
+    const failedRegionRetriable = providerForRegionIntent(activeRegionIntent) !== null
+
     return (
         <div className="flex min-h-[inherit] flex-col space-y-8">
             <NavHeader title="Unlocked regions" onPrev={onBack} titleClassName="text-xl md:text-2xl" />
@@ -289,29 +294,40 @@ const UnlockedRegions = () => {
             <ActionModal
                 visible={!!flow.error && !errorAcknowledged}
                 onClose={() => setErrorAcknowledged(true)}
-                title="Verification couldn't start"
+                title={failedRegionRetriable ? "Verification couldn't start" : 'Not available yet'}
                 description={flow.error || 'Something went wrong. Please try again or contact support.'}
                 icon="alert"
                 iconContainerClassName="bg-yellow-1"
-                ctas={[
-                    {
-                        text: 'Try again',
-                        variant: 'purple',
-                        shadowSize: '4',
-                        disabled: flow.isLoading,
-                        onClick: () => {
-                            void flow.handleInitiateKyc(activeRegionIntent, undefined, true)
-                        },
-                    },
-                    {
-                        text: 'Contact support',
-                        variant: 'stroke',
-                        onClick: () => {
-                            setErrorAcknowledged(true)
-                            setIsSupportModalOpen(true)
-                        },
-                    },
-                ]}
+                ctas={
+                    failedRegionRetriable
+                        ? [
+                              {
+                                  text: 'Try again',
+                                  variant: 'purple',
+                                  shadowSize: '4',
+                                  disabled: flow.isLoading,
+                                  onClick: () => {
+                                      void flow.handleInitiateKyc(activeRegionIntent, undefined, true)
+                                  },
+                              },
+                              {
+                                  text: 'Contact support',
+                                  variant: 'stroke',
+                                  onClick: () => {
+                                      setErrorAcknowledged(true)
+                                      setIsSupportModalOpen(true)
+                                  },
+                              },
+                          ]
+                        : [
+                              {
+                                  text: 'Got it',
+                                  variant: 'purple',
+                                  shadowSize: '4',
+                                  onClick: () => setErrorAcknowledged(true),
+                              },
+                          ]
+                }
             />
 
             <SumsubKycModals flow={flow} autoStartSdk={autoStartSdk} />

--- a/src/components/Profile/views/UnlockedRegions.view.tsx
+++ b/src/components/Profile/views/UnlockedRegions.view.tsx
@@ -81,6 +81,10 @@ const UnlockedRegions = () => {
     const [activeRegionIntent, setActiveRegionIntent] = useState<KYCRegionIntent | undefined>(undefined)
     // skip StartVerificationView when re-submitting (user already consented)
     const [autoStartSdk, setAutoStartSdk] = useState(false)
+    // when an initiate fails, flow.error is set but the modal that triggered it
+    // has already closed — show a dismissible error modal so the user isn't left
+    // staring at a screen where "verify now" appeared to do nothing.
+    const [errorAcknowledged, setErrorAcknowledged] = useState(false)
 
     // MIGRATION-REVIEW + CONTRACT GAP: KycFailedModal's terminal-rejection heuristic used
     // sumsubRejectLabels / sumsubRejectType / a rejected-SUMSUB-verification count, all read
@@ -150,6 +154,7 @@ const UnlockedRegions = () => {
     const handleStartKyc = useCallback(async () => {
         const intent = selectedRegion ? getRegionIntent(selectedRegion.path) : undefined
         if (intent) setActiveRegionIntent(intent)
+        setErrorAcknowledged(false)
         setSelectedRegion(null)
         // A locked region by definition has no functional rail backing it, so
         // clicking one is ALWAYS a cross-region request — send crossRegion
@@ -281,7 +286,33 @@ const UnlockedRegions = () => {
                 ]}
             />
 
-            {flow.error && <p className="text-red-500 mt-2 text-sm">{flow.error}</p>}
+            <ActionModal
+                visible={!!flow.error && !errorAcknowledged}
+                onClose={() => setErrorAcknowledged(true)}
+                title="Verification couldn't start"
+                description={flow.error || 'Something went wrong. Please try again or contact support.'}
+                icon="alert"
+                iconContainerClassName="bg-yellow-1"
+                ctas={[
+                    {
+                        text: 'Try again',
+                        variant: 'purple',
+                        shadowSize: '4',
+                        disabled: flow.isLoading,
+                        onClick: () => {
+                            void flow.handleInitiateKyc(activeRegionIntent, undefined, true)
+                        },
+                    },
+                    {
+                        text: 'Contact support',
+                        variant: 'stroke',
+                        onClick: () => {
+                            setErrorAcknowledged(true)
+                            setIsSupportModalOpen(true)
+                        },
+                    },
+                ]}
+            />
 
             <SumsubKycModals flow={flow} autoStartSdk={autoStartSdk} />
         </div>

--- a/src/components/TransactionDetails/provider-actions/CancelDepositActions.tsx
+++ b/src/components/TransactionDetails/provider-actions/CancelDepositActions.tsx
@@ -1,6 +1,8 @@
 'use client'
 
+import { useState, type ReactNode } from 'react'
 import { Button } from '@/components/0_Bruddle/Button'
+import ErrorAlert from '@/components/Global/ErrorAlert'
 import { Icon } from '@/components/Global/Icons/Icon'
 import { type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
 import { isMantecaOnrampEntry, isRequestEntry } from '@/components/TransactionDetails/transaction-predicates'
@@ -37,6 +39,7 @@ export function CancelDepositActions({
     onClose: (() => void) | undefined
 }) {
     const queryClient = useQueryClient()
+    const [error, setError] = useState<string | null>(null)
     if (!setIsLoading || !onClose) return null
 
     const refetchAndClose = () =>
@@ -47,15 +50,26 @@ export function CancelDepositActions({
 
     const wrapAction = async (run: () => Promise<void>) => {
         setIsLoading(true)
+        setError(null)
         try {
             await run()
             await refetchAndClose()
-        } catch (error) {
-            captureException(error)
-            console.error('Error canceling deposit:', error)
+        } catch (err) {
+            captureException(err)
+            // A cancel that fails silently makes the user believe the deposit is
+            // cancelled when it isn't — surface it instead of only logging.
+            setError("We couldn't cancel this deposit. Please try again or contact support.")
             setIsLoading(false)
         }
     }
+
+    // Render the active cancel button (if any) alongside any failure message.
+    const withError = (button: ReactNode) => (
+        <div className="flex w-full flex-col gap-2">
+            {button}
+            {error && <ErrorAlert description={error} />}
+        </div>
+    )
 
     // 1. Bridge onramp pending — generic bank deposit cancel. Excludes REQUEST
     // rows (those take the dedicated request-cancel branch below).
@@ -66,7 +80,7 @@ export function CancelDepositActions({
         !!transaction.extraDataForDrawer?.depositInstructions
 
     if (showBridgeOnrampCancel) {
-        return (
+        return withError(
             <CancelButton
                 disabled={!!isLoading}
                 onClick={() =>
@@ -83,7 +97,7 @@ export function CancelDepositActions({
     const showMantecaCancel = isMantecaOnrampEntry(transaction) && transaction.status === 'pending'
 
     if (showMantecaCancel) {
-        return (
+        return withError(
             <CancelButton
                 disabled={!!isLoading}
                 onClick={() =>
@@ -103,7 +117,7 @@ export function CancelDepositActions({
         isPendingBankRequest && transaction.extraDataForDrawer?.originalUserRole === EHistoryUserRole.SENDER
 
     if (showPendingBankRequestCancel) {
-        return (
+        return withError(
             <div className="pr-1">
                 <CancelButton
                     label="Cancel Request"

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -336,8 +336,16 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
                 posthog.capture(ANALYTICS_EVENTS.KYC_TOS_ACCEPTED)
                 // show loading state while confirming + polling
                 setModalPhase('preparing')
-                await confirmBridgeTosAndAwaitRails(fetchUser)
-                completeFlow()
+                try {
+                    await confirmBridgeTosAndAwaitRails(fetchUser)
+                    completeFlow()
+                } catch {
+                    // Don't leave the modal frozen on 'preparing' with no feedback
+                    // if the confirm POST / rails poll throws — surface the
+                    // timed-out recovery state immediately instead of a ~30s dead
+                    // modal. (BridgeTosStep wraps the same call in try/catch.)
+                    setPreparingTimedOut(true)
+                }
             }
             // if manual close, stay on bridge_tos phase (user can try again)
         },


### PR DESCRIPTION
Follow-up to the withdraw + Send dead-button fixes. The dead-button audit's 4 remaining actionable findings — handlers whose failure path leaves an unresponsive control with no feedback.

| # | Sev | Where | Symptom | Fix |
|---|---|---|---|---|
| 2 | **HIGH** | `EnableAutoBalanceBanner` | non-dismissible 'Finish setting up your card' modal; `void grant()` discards error → cancelled/failed passkey **traps** the user | surface error + 'Skip for now' escape on failure (grant re-prompts on first card spend) — **+ tests** |
| 5 | **HIGH** | `UnlockedRegions` | 'verify now' closes the modal before the await; initiate errors land in an off-screen inline `<p>` → 'nothing happens' (**customer-reported, Federico; blocks EU onboarding**) | dismissible error modal (Try again + Contact support) on `flow.error` |
| 3 | MED | `CancelDepositActions` | cancel failures only `console.error`'d → user thinks deposit cancelled when it isn't | error state + `ErrorAlert` |
| 1 | MED | `useMultiPhaseKycFlow` | ToS-confirm await has no try/catch → ~30s frozen 'preparing' modal | try/catch → surface recovery state immediately (mirrors `BridgeTosStep`) |

**Not fixed:** `payQR` non-MANTECA no-op — currently unreachable (the pay screen only renders for MANTECA); adding handling to an impossible path is the opposite anti-pattern. Documented only.

**Risk:** low — all changes are additive error-handling on failure paths; happy paths unchanged. Verified: prettier ✓, typecheck ✓, eslint not-worsened (0 new errors), unit tests pass.