### PR TITLE
fix(card): prioritize smart-account balance over Rain collateral for spends

### DIFF
--- a/src/hooks/wallet/__tests__/useSpendBundle.test.ts
+++ b/src/hooks/wallet/__tests__/useSpendBundle.test.ts
@@ -4,7 +4,7 @@
  * The hook itself orchestrates kernel clients, Rain API calls, and the
  * session-key grant flow — those paths are covered by integration + manual
  * testing on sandbox. These tests lock down the deterministic pieces:
- *   - `computeSpendStrategy` routing (collateral → smart → mixed → insufficient)
+ *   - `computeSpendStrategy` routing (smart → collateral → mixed → insufficient)
  *   - `usdcUnitsToRainCents` amount conversion at the Rain API boundary
  */
 
@@ -45,8 +45,17 @@ import { computeSpendStrategy } from '../useSpendBundle'
 describe('computeSpendStrategy', () => {
     const amount = 1000n
 
-    it('prefers collateral-only when allowed and rain covers the amount', () => {
+    it('prefers smart-only when smart covers the amount, even if collateral-only is allowed', () => {
+        // Smart account is spent first so the payment never touches the Rain
+        // collateral (and its per-account withdrawal-signature cooldown) when
+        // smart-account USDC already covers it.
         expect(computeSpendStrategy({ smart: 5000n, rain: 10_000n, amount, collateralOnlyAllowed: true })).toBe(
+            'smart-only'
+        )
+    })
+
+    it('uses collateral-only when smart cannot cover but collateral can (allowed)', () => {
+        expect(computeSpendStrategy({ smart: 100n, rain: 10_000n, amount, collateralOnlyAllowed: true })).toBe(
             'collateral-only'
         )
     })

--- a/src/hooks/wallet/useSpendBundle.ts
+++ b/src/hooks/wallet/useSpendBundle.ts
@@ -104,9 +104,13 @@ export class SessionKeyGrantRequiredError extends Error {
 
 /**
  * Pure routing helper — decides which bucket(s) a spend will pull from.
- * Priority: collateral → smart → mixed. Collateral-only requires a single
- * recipient AND no subsequent kernel calls (Rain's coordinator transfers
- * tokens directly; nothing follows).
+ * Priority: smart → collateral → mixed. The smart account is spent first
+ * whenever it can cover the whole amount, so a payment never touches the
+ * Rain collateral — and Rain's per-account withdrawal-signature cooldown —
+ * if the user's smart-account USDC already covers it. Collateral is the
+ * fallback (single recipient AND no subsequent kernel calls, since Rain's
+ * coordinator transfers tokens directly with nothing following), and `mixed`
+ * tops up the shortfall from collateral when smart alone can't cover it.
  */
 export function computeSpendStrategy(input: {
     smart: bigint
@@ -114,8 +118,8 @@ export function computeSpendStrategy(input: {
     amount: bigint
     collateralOnlyAllowed: boolean
 }): SpendStrategy {
-    if (input.collateralOnlyAllowed && input.rain >= input.amount) return 'collateral-only'
     if (input.smart >= input.amount) return 'smart-only'
+    if (input.collateralOnlyAllowed && input.rain >= input.amount) return 'collateral-only'
     if (input.smart + input.rain >= input.amount) return 'mixed'
     return 'insufficient'
 }


### PR DESCRIPTION
## Summary
In-app card payments route through `computeSpendStrategy` (`src/hooks/wallet/useSpendBundle.ts`), which was **collateral-first**: any single-recipient send whose Rain collateral could cover the amount returned `collateral-only` **without consulting the smart-account balance**. That path executes via `coordinator.withdrawAsset`, which is subject to Rain's per-account **withdrawal-signature cooldown** (~3 min). So two rapid payments → the second is blocked with a cooldown, even when the user has ample smart-account USDC.

Reorder to **smart-first** (`smart → collateral → mixed`): spend from the smart account whenever it covers the amount (plain kernel UserOp — no Rain, no signature, no cooldown); use collateral only when smart can't cover, and `mixed` for the shortfall. Collateral is now the fallback, not the default.

**Repro (prod):** user `kkonrad` paid \$66.60 then \$13.37 seconds apart on 2026-06-15; both were drawn from collateral (negative collateral webhooks) and the second settled ~4 min late due to the Rain lockout, despite ~\$1700 in the smart account.

## Risk
- **Behavior change (intended):** card users with smart-account funds now deplete that balance first and leave collateral full, instead of the reverse. The old collateral-first ordering was deliberate — flagging for team awareness; confirmed desired.
- Blast radius is one pure function. `useSignSpendBundle` imports the same helper, so it inherits the change (single source of truth). No backend change — the collateral/mixed execution paths are unchanged, just selected less often. No cross-repo deploy ordering.

## QA
- Unit: `npx jest src/hooks/wallet` — `computeSpendStrategy` now returns `smart-only` when smart covers (even if collateral-only is eligible), `collateral-only` when smart can't cover but collateral can, `mixed` for the shortfall.
- Sandbox: as a card user with smart-account USDC ≥ amount, make two payments back-to-back → both go through immediately as smart-account UserOps, no cooldown modal. Drain smart below the amount → falls back to collateral/mixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)