### PR TITLE
fix(card): prioritize smart-account balance over Rain collateral for spends

### DIFF
--- a/src/hooks/wallet/__tests__/useSpendBundle.test.ts
+++ b/src/hooks/wallet/__tests__/useSpendBundle.test.ts
@@ -4,7 +4,7 @@
  * The hook itself orchestrates kernel clients, Rain API calls, and the
  * session-key grant flow — those paths are covered by integration + manual
  * testing on sandbox. These tests lock down the deterministic pieces:
- *   - `computeSpendStrategy` routing (collateral → smart → mixed → insufficient)
+ *   - `computeSpendStrategy` routing (smart → collateral → mixed → insufficient)
  *   - `usdcUnitsToRainCents` amount conversion at the Rain API boundary
  */
 
@@ -45,8 +45,17 @@ import { computeSpendStrategy } from '../useSpendBundle'
 describe('computeSpendStrategy', () => {
     const amount = 1000n
 
-    it('prefers collateral-only when allowed and rain covers the amount', () => {
+    it('prefers smart-only when smart covers the amount, even if collateral-only is allowed', () => {
+        // Smart account is spent first so the payment never touches the Rain
+        // collateral (and its per-account withdrawal-signature cooldown) when
+        // smart-account USDC already covers it.
         expect(computeSpendStrategy({ smart: 5000n, rain: 10_000n, amount, collateralOnlyAllowed: true })).toBe(
+            'smart-only'
+        )
+    })
+
+    it('uses collateral-only when smart cannot cover but collateral can (allowed)', () => {
+        expect(computeSpendStrategy({ smart: 100n, rain: 10_000n, amount, collateralOnlyAllowed: true })).toBe(
             'collateral-only'
         )
     })

--- a/src/hooks/wallet/useSpendBundle.ts
+++ b/src/hooks/wallet/useSpendBundle.ts
@@ -104,9 +104,13 @@ export class SessionKeyGrantRequiredError extends Error {
 
 /**
  * Pure routing helper — decides which bucket(s) a spend will pull from.
- * Priority: collateral → smart → mixed. Collateral-only requires a single
- * recipient AND no subsequent kernel calls (Rain's coordinator transfers
- * tokens directly; nothing follows).
+ * Priority: smart → collateral → mixed. The smart account is spent first
+ * whenever it can cover the whole amount, so a payment never touches the
+ * Rain collateral — and Rain's per-account withdrawal-signature cooldown —
+ * if the user's smart-account USDC already covers it. Collateral is the
+ * fallback (single recipient AND no subsequent kernel calls, since Rain's
+ * coordinator transfers tokens directly with nothing following), and `mixed`
+ * tops up the shortfall from collateral when smart alone can't cover it.
  */
 export function computeSpendStrategy(input: {
     smart: bigint
@@ -114,8 +118,8 @@ export function computeSpendStrategy(input: {
     amount: bigint
     collateralOnlyAllowed: boolean
 }): SpendStrategy {
-    if (input.collateralOnlyAllowed && input.rain >= input.amount) return 'collateral-only'
     if (input.smart >= input.amount) return 'smart-only'
+    if (input.collateralOnlyAllowed && input.rain >= input.amount) return 'collateral-only'
     if (input.smart + input.rain >= input.amount) return 'mixed'
     return 'insufficient'
 }


### PR DESCRIPTION
## Summary

Back-merge of hotfix **#2230** (already reviewed + merged to \`main\`, commit \`0e3899971\`) into \`dev\`, so the next release PR doesn't conflict and `dev` carries the fix.

In-app card payments routed through \`computeSpendStrategy\` were **collateral-first**: any single-recipient send whose Rain collateral could cover the amount returned \`collateral-only\` without consulting the smart-account balance. That path goes through \`coordinator.withdrawAsset\`, subject to Rain's per-account withdrawal-signature cooldown (~3 min) → two rapid payments, the second blocked even with ample smart-account USDC.

Reorders to **smart-first** (smart → collateral → mixed): spend from the smart account whenever it covers the amount (plain kernel UserOp, no Rain, no cooldown); collateral becomes the fallback, mixed covers the shortfall.

## Risk

Low / contained. Pure strategy reorder in one hook (\`useSpendBundle.ts\`); no API or schema change. Already live on \`main\` since #2230 — this only propagates it to \`dev\`.

## QA

- \`useSpendBundle\` unit tests updated + passing (8/8): smart-only preference, collateral fallback, mixed, boundary/exact-match, rain-disallowed.
- Full local suite green (flag-asset suite needs \`postinstall\` copy-flags, which CI runs).

Cherry-pick — identical diff to #2230, no new code.