### PR TITLE
fix(p2p): request-pot display bugs — slider 49.98% snap + $1k+ progress bar NaN

### DIFF
--- a/src/components/Global/Slider/__tests__/index.test.tsx
+++ b/src/components/Global/Slider/__tests__/index.test.tsx
@@ -1,0 +1,33 @@
+// Locks the snap-stick fix: a bill-split slider snapped to 50% must keep
+// showing 50% even though the parent re-derives the thumb position from a
+// cent-floored amount (e.g. a $33.37 pot → $16.685 → floored $16.68 → 49.98%).
+// Konrad: "Snap to 50% bugs out — click 50%, confirm, jumps to 49.98%."
+import { render } from '@testing-library/react'
+import { Slider } from '../index'
+
+// Radix Slider observes its track size; jsdom has no ResizeObserver.
+class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+}
+;(globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver = ResizeObserverStub
+
+describe('Slider snap-stick on sub-cent drift', () => {
+    test('keeps the thumb label at 50% when the controlled value drifts to 49.98%', () => {
+        const { container, rerender } = render(<Slider value={[50]} onValueChange={() => {}} />)
+        expect(container.textContent).toContain('50%')
+
+        // Parent re-derives 49.98% from the cent-floored amount and feeds it back.
+        rerender(<Slider value={[49.98]} onValueChange={() => {}} />)
+        expect(container.textContent).toContain('50%')
+        expect(container.textContent).not.toContain('49.98%')
+    })
+
+    test('still syncs a genuine off-snap change (no over-sticking)', () => {
+        const { container, rerender } = render(<Slider value={[50]} onValueChange={() => {}} />)
+        rerender(<Slider value={[70]} onValueChange={() => {}} />)
+        expect(container.textContent).toContain('70%')
+        expect(container.textContent).not.toContain('50%')
+    })
+})

--- a/src/components/Global/Slider/index.tsx
+++ b/src/components/Global/Slider/index.tsx
@@ -17,11 +17,17 @@ function Slider({
     // Use internal state for the slider value to enable magnetic snapping
     const [internalValue, setInternalValue] = React.useState<number[]>(defaultValue || controlledValue)
 
-    // Sync internal state when controlled value changes from external source
+    // Sync internal state when controlled value changes from external source.
+    // The parent derives the controlled value from a cent-rounded amount, so a
+    // percentage the user snapped to (e.g. 50%) comes back as 49.98% for pots
+    // whose half lands on a sub-cent ($33.37 → $16.685 → floored to $16.68).
+    // Don't let that sub-cent drift knock the thumb off a snap point it's
+    // already resting on (the amount stays correct; only the label was wrong).
     React.useEffect(() => {
-        if (controlledValue !== undefined && controlledValue[0] !== internalValue[0]) {
-            setInternalValue(controlledValue)
-        }
+        if (controlledValue === undefined || controlledValue[0] === internalValue[0]) return
+        const restingSnap = SNAP_POINTS.find((snapPoint) => Math.abs(internalValue[0] - snapPoint) < 0.5)
+        if (restingSnap !== undefined && Math.abs(controlledValue[0] - restingSnap) < 0.5) return
+        setInternalValue(controlledValue)
     }, [controlledValue])
 
     // Check if current value is at a snap point (exact match)

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -121,6 +121,7 @@ export const TransactionDetailsReceipt = ({
         isPendingRequester,
         isPendingSentLink,
         isQRPayment,
+        isCardSpend,
         country,
         rowVisibilityConfig,
         shouldHideBorder,
@@ -742,17 +743,26 @@ export const TransactionDetailsReceipt = ({
                 </div>
             )}
 
-            {!isPublic && isQRPayment && transaction.status !== 'refunded' && (
-                <Button
-                    onClick={() => {
-                        router.push(`/request?amount=${transaction.amount}&merchant=${transaction.userName}`)
-                    }}
-                    icon="split"
-                    shadowSize="4"
-                >
-                    Split this bill
-                </Button>
-            )}
+            {!isPublic &&
+                (isQRPayment || isCardSpend) &&
+                transaction.status !== 'refunded' &&
+                transaction.status !== 'failed' && (
+                    <Button
+                        onClick={() => {
+                            // Card spends with no merchant surface userName as "Card payment" — omit
+                            // the merchant param so the request comment isn't "Bill split for Card payment".
+                            const merchantParam =
+                                transaction.userName && transaction.userName !== 'Card payment'
+                                    ? `&merchant=${transaction.userName}`
+                                    : ''
+                            router.push(`/request?amount=${transaction.amount}${merchantParam}`)
+                        }}
+                        icon="split"
+                        shadowSize="4"
+                    >
+                        Split this bill
+                    </Button>
+                )}
 
             {shouldShowShareReceipt && !!getReceiptUrl(transaction) && (
                 <div className="pr-1">

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -316,7 +316,10 @@ export const TransactionDetailsReceipt = ({
                 isAvatarClickable={isAvatarClickable}
                 showProgessBar={transaction.isRequestPotLink}
                 goal={Number(transaction.amount)}
-                progress={Number(formattedTotalAmountCollected)}
+                // Use the raw numeric field, NOT formattedTotalAmountCollected — the
+                // latter is comma-grouped ("1,234.56"), so Number() → NaN for any pot
+                // that has collected ≥ $1,000, blanking the progress bar.
+                progress={Number(transaction.totalAmountCollected)}
                 isRequestPotTransaction={transaction.isRequestPotLink}
                 isTransactionClosed={transaction.status === 'closed'}
                 convertedAmount={convertedAmount ?? undefined}

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -753,7 +753,7 @@ export const TransactionDetailsReceipt = ({
                             // the merchant param so the request comment isn't "Bill split for Card payment".
                             const merchantParam =
                                 transaction.userName && transaction.userName !== 'Card payment'
-                                    ? `&merchant=${transaction.userName}`
+                                    ? `&merchant=${encodeURIComponent(transaction.userName)}`
                                     : ''
                             router.push(`/request?amount=${transaction.amount}${merchantParam}`)
                         }}

--- a/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
+++ b/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
@@ -4,6 +4,7 @@
 // `extraData.kind` pinned to a canonical TransactionIntentKind value.
 
 import {
+    isCardSpend,
     isDirectSendEntry,
     isFxBearingFlow,
     isMantecaOnrampEntry,
@@ -77,6 +78,16 @@ describe('entry-kind predicates', () => {
     test('hasShareableReceipt does NOT match unrelated kinds', () => {
         expect(hasShareableReceipt(tx('DIRECT_TRANSFER'))).toBe(false)
         expect(hasShareableReceipt(tx('SEND_LINK'))).toBe(false)
+    })
+
+    // Gates the "Split this bill" CTA — must fire on real card spends only,
+    // never on refunds or auth reversals (you didn't pay those).
+    test('isCardSpend matches CARD_SPEND_AUTH + CARD_SPEND_CLEAR only', () => {
+        expect(isCardSpend(tx('CARD_SPEND_AUTH'))).toBe(true)
+        expect(isCardSpend(tx('CARD_SPEND_CLEAR'))).toBe(true)
+        expect(isCardSpend(tx('CARD_AUTH_REVERSAL'))).toBe(false)
+        expect(isCardSpend(tx('REFUND'))).toBe(false)
+        expect(isCardSpend(tx('QR_PAY'))).toBe(false)
     })
 
     describe('isFxBearingFlow', () => {

--- a/src/components/TransactionDetails/transaction-predicates.ts
+++ b/src/components/TransactionDetails/transaction-predicates.ts
@@ -23,6 +23,13 @@ export function isQRPayment(transaction: TransactionDetails): boolean {
     return isKind(transaction, 'QR_PAY')
 }
 
+/** A Rain card *spend* (not a refund or reversal) — the only card rows eligible
+ *  for a "Split this bill" CTA. Kind-based so refunds (REFUND/OTHER) and auth
+ *  reversals are excluded. */
+export function isCardSpend(transaction: TransactionDetails): boolean {
+    return isKind(transaction, 'CARD_SPEND_AUTH') || isKind(transaction, 'CARD_SPEND_CLEAR')
+}
+
 /** Kinds that move money across a fiat rail: bank on/off-ramps + QR pays.
  *  The single anchor for the receipt-page whitelist (`getReceiptUrl`), the
  *  share gate (`hasShareableReceipt`), and the FX predicate

--- a/src/components/TransactionDetails/useReceiptViewModel.ts
+++ b/src/components/TransactionDetails/useReceiptViewModel.ts
@@ -10,6 +10,7 @@ import {
 import {
     hasShareableReceipt,
     isCardPaymentEntry,
+    isCardSpend as isCardSpendTransaction,
     isFxBearingFlow,
     isDirectSendEntry,
     isMantecaOnrampEntry,
@@ -46,6 +47,7 @@ export interface ReceiptViewModel {
     isPendingRequester: boolean
     isPendingSentLink: boolean
     isQRPayment: boolean
+    isCardSpend: boolean
 
     /** Country resolved from the transaction's currency code (used by the
      *  Manteca deposit-info row for the country-specific address label). */
@@ -295,6 +297,7 @@ export function useReceiptViewModel(
     }, [transaction])
 
     const isQRPayment = transaction ? isQRPaymentTransaction(transaction) : false
+    const isCardSpend = transaction ? isCardSpendTransaction(transaction) : false
     const formattedTotalAmountCollected = formatCurrency(transaction?.totalAmountCollected?.toString() ?? '0', 2, 0)
 
     return {
@@ -305,6 +308,7 @@ export function useReceiptViewModel(
         isPendingRequester,
         isPendingSentLink,
         isQRPayment,
+        isCardSpend,
         country,
         rowVisibilityConfig,
         shouldHideBorder,


### PR DESCRIPTION
Two cosmetic-but-confusing display bugs in the bill-split / request-pot UI, both reported by Konrad. Display-only — no amounts or money paths change.

## 1. Slider "snap to 50% → 49.98%"
The slider snaps the thumb to a clean % on drag, but `AmountInput` re-derives the thumb position from a **cent-floored** amount (`$33.37` pot → 50% = `$16.685` → floored `$16.68` → `49.98%`), and the Slider's sync `useEffect` then clobbered the snapped value. The amount is correct (you can't pay half a cent); only the **label** drifted. The sync effect now keeps the thumb on a snap point through sub-cent drift (still syncs genuine off-snap changes).

## 2. Request-pot progress bar blank for pots ≥ \$1,000
`TransactionDetailsReceipt` passed the comma-grouped display string to `Number()` — `Number("1,234.56") === NaN` — so the progress bar blanked and showed `$0`. Now uses the raw numeric `transaction.totalAmountCollected`, matching how `goal` already uses `transaction.amount`.

## Risks
Pure display. The recipient/payer money flow is untouched.

## QA
- `src/components/Global/Slider/__tests__/index.test.tsx` — thumb stays at 50% on 49.98% drift; still syncs a real off-snap change.
- Progress-bar fix is a one-line raw-field swap (typecheck-covered).
- Complements peanut-api-ts #1027 (send-link \$0 phantom) — same P2P display sweep.