### PR TITLE
fix(pix): canonicalize +55 phone keys that already carry a + prefix

### DIFF
--- a/src/utils/__tests__/withdraw.utils.test.ts
+++ b/src/utils/__tests__/withdraw.utils.test.ts
@@ -79,6 +79,9 @@ describe('Withdraw Utilities', () => {
             // Should keep existing + prefix
             ['+5511999999999', '+5511999999999'],
             ['+551199999999', '+551199999999'],
+            // Should strip separators even when the + prefix is already present
+            ['+55-11-99999-9999', '+5511999999999'],
+            ['+55 11 99999 9999', '+5511999999999'],
             // Should not modify non-phone formats
             ['12345678901', '12345678901'], // CPF
             ['12345678901234', '12345678901234'], // CNPJ

--- a/src/utils/withdraw.utils.ts
+++ b/src/utils/withdraw.utils.ts
@@ -212,10 +212,11 @@ export const isPixPhoneNumber = (pixKey: string): boolean => {
  */
 export const normalizePixPhoneNumber = (pixKey: string): string => {
     const cleaned = pixKey.replace(/[\s-]/g, '')
-    if (isPixPhoneNumber(cleaned) && !cleaned.startsWith('+')) {
-        return '+' + cleaned
-    }
-    return pixKey
+    if (!isPixPhoneNumber(cleaned)) return pixKey
+    // Always return the separator-free +55 form. The old code returned the raw
+    // input untouched when it already started with '+', so inputs like
+    // '+55-11-99999-9999' kept their separators and stayed non-canonical.
+    return cleaned.startsWith('+') ? cleaned : '+' + cleaned
 }
 
 /**


### PR DESCRIPTION
From the release-PR (#2236) CodeRabbit triage. `normalizePixPhoneNumber` returned the **raw** input when the cleaned value already started with `+`, so `+55-11-99999-9999` kept its separators → non-canonical PIX key (risking key-match failures). Now always returns the separator-free `+55` form. Adds the separator-with-`+` regression cases (the existing `+`-prefix tests had no separators, so they never caught it). Non-phone inputs unchanged.