### PR TITLE
test(split-bill): lock the Split-this-bill CTA URL builder

### DIFF
--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -52,6 +52,7 @@ import {
     usesCompletedTimestampLabel,
 } from './transaction-predicates'
 import { useReceiptViewModel } from './useReceiptViewModel'
+import { buildSplitBillRequestUrl } from './splitBill.utils'
 import { CardPaymentRows } from './provider-rows/CardPaymentRows'
 import { LocalRailNudge } from './provider-rows/LocalRailNudge'
 import { MantecaDepositInfo } from './provider-rows/MantecaDepositInfo'
@@ -748,15 +749,7 @@ export const TransactionDetailsReceipt = ({
                 transaction.status !== 'refunded' &&
                 transaction.status !== 'failed' && (
                     <Button
-                        onClick={() => {
-                            // Card spends with no merchant surface userName as "Card payment" — omit
-                            // the merchant param so the request comment isn't "Bill split for Card payment".
-                            const merchantParam =
-                                transaction.userName && transaction.userName !== 'Card payment'
-                                    ? `&merchant=${encodeURIComponent(transaction.userName)}`
-                                    : ''
-                            router.push(`/request?amount=${transaction.amount}${merchantParam}`)
-                        }}
+                        onClick={() => router.push(buildSplitBillRequestUrl(transaction.amount, transaction.userName))}
                         icon="split"
                         shadowSize="4"
                     >

--- a/src/components/TransactionDetails/__tests__/splitBill.utils.test.ts
+++ b/src/components/TransactionDetails/__tests__/splitBill.utils.test.ts
@@ -1,0 +1,23 @@
+// Locks the "Split this bill" CTA URL build — the merchant fallback + URL-encoding
+// (the latter was a CodeRabbit finding: "Tigers & Lions" must not break the query).
+import { buildSplitBillRequestUrl } from '../splitBill.utils'
+
+describe('buildSplitBillRequestUrl', () => {
+    test('includes amount + merchant for a normal merchant', () => {
+        expect(buildSplitBillRequestUrl(15, 'Cafe Tortoni')).toBe('/request?amount=15&merchant=Cafe%20Tortoni')
+    })
+
+    test('URL-encodes reserved characters in the merchant name', () => {
+        expect(buildSplitBillRequestUrl(20, 'Tigers & Lions')).toBe('/request?amount=20&merchant=Tigers%20%26%20Lions')
+    })
+
+    test('omits the merchant param for the "Card payment" fallback', () => {
+        expect(buildSplitBillRequestUrl(12.5, 'Card payment')).toBe('/request?amount=12.5')
+    })
+
+    test('omits the merchant param when there is no merchant name', () => {
+        expect(buildSplitBillRequestUrl(8)).toBe('/request?amount=8')
+        expect(buildSplitBillRequestUrl(8, null)).toBe('/request?amount=8')
+        expect(buildSplitBillRequestUrl(8, '')).toBe('/request?amount=8')
+    })
+})

--- a/src/components/TransactionDetails/splitBill.utils.ts
+++ b/src/components/TransactionDetails/splitBill.utils.ts
@@ -1,0 +1,16 @@
+/**
+ * Build the `/request` prefill URL for the "Split this bill" CTA (shown on QR
+ * payments and card spends). The request screen reads `amount` + `merchant`
+ * from the query to seed a bill-split request.
+ *
+ * Two rules baked in (both had real bugs):
+ *  - Omit `merchant` for the "Card payment" fallback (a card spend with no
+ *    merchant name) so the request comment isn't "Bill split for Card payment".
+ *  - URL-encode the merchant so reserved chars (e.g. "Tigers & Lions") can't
+ *    break the query string.
+ */
+export function buildSplitBillRequestUrl(amount: number | bigint | string, merchantName?: string | null): string {
+    const merchantParam =
+        merchantName && merchantName !== 'Card payment' ? `&merchant=${encodeURIComponent(merchantName)}` : ''
+    return `/request?amount=${amount}${merchantParam}`
+}

--- a/src/components/TransactionDetails/splitBill.utils.ts
+++ b/src/components/TransactionDetails/splitBill.utils.ts
@@ -12,5 +12,5 @@
 export function buildSplitBillRequestUrl(amount: number | bigint | string, merchantName?: string | null): string {
     const merchantParam =
         merchantName && merchantName !== 'Card payment' ? `&merchant=${encodeURIComponent(merchantName)}` : ''
-    return `/request?amount=${amount}${merchantParam}`
+    return `/request?amount=${encodeURIComponent(String(amount))}${merchantParam}`
 }


### PR DESCRIPTION
Follow-up coverage for the split-bill CTA (#2235, now merged). Extracts the CTA's `/request` URL build into `buildSplitBillRequestUrl` and unit-tests the two bug-prone rules: URL-encoding the merchant (CodeRabbit finding — "Tigers & Lions" must not break the query) and omitting the merchant param for the "Card payment" fallback. **Pure refactor + tests, no behavior change.** Runs in jest (verified locally, 4/4).