### PR TITLE
feat(seo): register Faster Payments + SPEI as deposit rails (via-, not from-)

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -164,5 +164,15 @@
         "source": "/:locale/withdraw/avalanche",
         "destination": "/:locale/supported-networks",
         "permanent": true
+    },
+    {
+        "source": "/:locale/deposit/from-faster-payments",
+        "destination": "/:locale/deposit/via-faster-payments",
+        "permanent": true
+    },
+    {
+        "source": "/:locale/deposit/from-spei",
+        "destination": "/:locale/deposit/via-spei",
+        "permanent": true
     }
 ]

--- a/src/data/seo/deposit-rails.ts
+++ b/src/data/seo/deposit-rails.ts
@@ -18,6 +18,8 @@ export const DEPOSIT_RAILS: Record<string, string> = {
     ach: 'ACH Bank Transfer',
     sepa: 'SEPA Bank Transfer',
     wire: 'Wire Transfer',
+    'faster-payments': 'Faster Payments',
+    spei: 'SPEI Bank Transfer',
     arbitrum: 'Arbitrum',
     base: 'Base',
     ethereum: 'Ethereum',


### PR DESCRIPTION
## What
Registers **Faster Payments** (UK/GBP) and **SPEI** (Mexico/MXN) as deposit **rails** so they're served at `/deposit/via-{slug}` like SEPA/ACH/wire — instead of being mislabeled as exchanges at `/deposit/from-{slug}`.

## Why
Both are live deposit rails (via the card/service's GBP+MXN support) with content pages already written, but they were classified as exchanges. Not a 404 (both URL families currently 200), but the sitemap + internal links advertised the wrong `from-` taxonomy. The content gate (`verify-content`) and the network-claims-audit both treat the from-/via- split as a correctness rule.

## Changes
- `src/data/seo/deposit-rails.ts`: +`faster-payments`, +`spei` (single source of truth → routes + sitemap + gate all pick them up).
- `redirects.json`: 301 `/deposit/from-faster-payments` → `/deposit/via-faster-payments` and same for `spei` (old indexed/shared links).
- `src/content`: **358b6a6 → 5eb8453** — flips the 14 generated `<RelatedLink>` hrefs `from-`→`via-` (UK hub, send-to/UK, send-to/brazil/from/mexico, withdraw/{faster-payments,spei}) **and** adds FP/SPEI to the fiat-rail list in `content/_system/guidelines/intent-taxonomy.md` so regeneration keeps them as rails (durable input-layer fix, pushed to mono `8a061d5`).

## Verified locally
content gate ✅ · prettier ✅ · typecheck ✅ · `src/data` unit 7/7 ✅. Submodule bump carries exactly the 14-link content fix, nothing else.

## Notes
- Builds on the deposit-rails de-dup from #2232 (single source of truth makes this a 2-line code add).
- No app/money/auth behavior — SEO/marketing taxonomy only.