### PR TITLE
fix(deposit): stop offering Scroll deposits (silently lost) + drop stale Avalanche FAQ

### DIFF
--- a/src/app/m/[slug]/merchants.ts
+++ b/src/app/m/[slug]/merchants.ts
@@ -187,7 +187,7 @@ export const MERCHANTS: Record<string, Merchant> = {
                 {
                     id: 'funding',
                     question: 'How do I fund it?',
-                    answer: 'Two ways. Crypto: USDC or USDT on Solana, Arbitrum, Base, Tron, Avalanche, Polygon, or Ethereum, and we cover the network fees. Bank: SEPA, ACH, or wire from any country. No Argentine bank account needed.',
+                    answer: 'Two ways. Crypto: USDC or USDT on Solana, Arbitrum, Base, Tron, Polygon, or Ethereum, and we cover the network fees. Bank: SEPA, ACH, or wire from any country. No Argentine bank account needed.',
                 },
                 {
                     id: 'receiving',

--- a/src/components/Global/TokenAndNetworkConfirmationModal/index.tsx
+++ b/src/components/Global/TokenAndNetworkConfirmationModal/index.tsx
@@ -2,11 +2,13 @@ import ActionModal from '@/components/Global/ActionModal'
 import { Slider } from '@/components/Slider'
 import ChainChip from '@/components/AddMoney/components/ChainChip'
 import {
-    RHINO_SUPPORTED_CHAINS,
     RHINO_SUPPORTED_EVM_CHAINS,
     RHINO_SUPPORTED_OTHER_CHAINS,
     RHINO_SUPPORTED_TOKENS,
 } from '@/constants/rhino.consts'
+
+const VISIBLE_EVM_CHAINS = 6
+const overflowEvmCount = RHINO_SUPPORTED_EVM_CHAINS.length - VISIBLE_EVM_CHAINS
 
 export default function TokenAndNetworkConfirmationModal({
     onClose,
@@ -38,14 +40,16 @@ export default function TokenAndNetworkConfirmationModal({
                             {RHINO_SUPPORTED_OTHER_CHAINS.map((chain) => (
                                 <ChainChip key={chain.name} chainName={chain.name} chainSymbol={chain.logoUrl} />
                             ))}
-                            {RHINO_SUPPORTED_EVM_CHAINS.slice(0, 6).map((chain) => (
+                            {RHINO_SUPPORTED_EVM_CHAINS.slice(0, VISIBLE_EVM_CHAINS).map((chain) => (
                                 <ChainChip key={chain.name} chainName={chain.name} chainSymbol={chain.logoUrl} />
                             ))}
-                            <ChainChip
-                                chainName={'+4 EVM'}
-                                logo="plus"
-                                logoClassName="bg-black rounded-full text-white"
-                            />
+                            {overflowEvmCount > 0 && (
+                                <ChainChip
+                                    chainName={`+${overflowEvmCount} EVM`}
+                                    logo="plus"
+                                    logoClassName="bg-black rounded-full text-white"
+                                />
+                            )}
                         </div>
                     </div>
 

--- a/src/constants/rhino.consts.ts
+++ b/src/constants/rhino.consts.ts
@@ -26,6 +26,9 @@ export const TOKEN_LOGOS = {
 export type ChainName = keyof typeof CHAIN_LOGOS
 export type TokenName = keyof typeof TOKEN_LOGOS
 
+// Mirrors Rhino's live SDA config (`depositAddresses.getSupportedConfigs()`).
+// Scroll was removed 2026-06-11: Rhino's live config no longer returns an SDA
+// entry for it, and a deposit on an unsupported chain is silently lost.
 export const SUPPORTED_EVM_CHAINS = [
     'ARBITRUM',
     'ETHEREUM',
@@ -34,7 +37,6 @@ export const SUPPORTED_EVM_CHAINS = [
     'BNB',
     'POLYGON',
     'KATANA',
-    'SCROLL',
     'GNOSIS',
     'CELO',
 ] as const


### PR DESCRIPTION
Salvages the still-needed **deposit-flow** half of #2216. The avalanche-**marketing** half (SEO routes, content, redirects, deposit-rails) already shipped via #2232, so #2216's content/exchanges/verify-content changes are now obsolete — this carries forward only the parts still live on dev.

## Changes
- **`rhino.consts.ts`** — remove `SCROLL` from `SUPPORTED_EVM_CHAINS`. Rhino's live config (`getSupportedConfigs()`) no longer returns an SDA for Scroll (audit 2026-06-11); a deposit on an unsupported chain is **silently lost**. The `534352 → SCROLL` chainId map is intentionally kept so any stray deposit stays identifiable for recovery.
- **`TokenAndNetworkConfirmationModal`** — compute the `+N EVM` overflow chip from the list length (was hardcoded `+4`, now wrong after the removal); drop the now-unused `RHINO_SUPPORTED_CHAINS` import.
- **`merchants.ts`** — drop "Avalanche" from the Argentina funding FAQ (false claim; matches the avalanche removal already shipped).

## Verified
prettier ✅ · typecheck ✅ (clean on changed files) · build running. No SCROLL in the offered EVM list; no Avalanche in merchants; unused import gone.

## Note
Supersedes **#2216** (draft, now conflicting + half-obsolete). Closing that in favor of this focused PR.