### PR TITLE
fix(claim): restore dynamic social-preview metadata for claim links

### DIFF
--- a/src/app/(mobile-ui)/claim/page.tsx
+++ b/src/app/(mobile-ui)/claim/page.tsx
@@ -1,4 +1,32 @@
 import { Claim } from '@/components'
+import { BASE_URL } from '@/constants/general.consts'
+import getOrigin from '@/lib/hosting/get-origin'
+import { buildClaimMetadata, getClaimLinkData } from '@/utils/claim-metadata.utils'
+import { type Metadata } from 'next'
+
+// Claim previews are resolved per-request from the link's query params, so the
+// page must render dynamically on the web. The native (Capacitor static-export)
+// build strips this export — scripts/native-build.js replaces this file with a
+// metadata-free stub at build time, so SSR-only concerns never reach native.
+export const dynamic = 'force-dynamic'
+
+export async function generateMetadata({
+    searchParams,
+}: {
+    searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}): Promise<Metadata> {
+    const resolvedSearchParams = await searchParams
+
+    let siteUrl = BASE_URL
+    try {
+        siteUrl = (await getOrigin()) || BASE_URL
+    } catch {
+        // getOrigin throws on a missing/invalid host header — fall back to BASE_URL
+    }
+
+    const claimData = await getClaimLinkData(resolvedSearchParams, siteUrl)
+    return buildClaimMetadata({ claimData, siteUrl })
+}
 
 export default function ClaimPage() {
     return <Claim />

--- a/src/app/(mobile-ui)/claim/page.tsx
+++ b/src/app/(mobile-ui)/claim/page.tsx
@@ -1,4 +1,4 @@
-import { Claim } from '@/components'
+import { Claim } from '@/components/Claim'
 import { BASE_URL } from '@/constants/general.consts'
 import getOrigin from '@/lib/hosting/get-origin'
 import { buildClaimMetadata, getClaimLinkData } from '@/utils/claim-metadata.utils'

--- a/src/utils/__tests__/claim-metadata.utils.test.ts
+++ b/src/utils/__tests__/claim-metadata.utils.test.ts
@@ -1,0 +1,83 @@
+import { buildClaimMetadata, getClaimLinkData, type ClaimLinkData } from '@/utils/claim-metadata.utils'
+
+const SITE_URL = 'https://peanut.me'
+
+const ogImageUrl = (metadata: ReturnType<typeof buildClaimMetadata>): string => {
+    const image = (metadata.openGraph?.images as Array<{ url: string }>)?.[0]
+    return image?.url ?? ''
+}
+
+const unclaimed = (
+    overrides: Partial<ClaimLinkData['linkDetails']> = {},
+    username: string | null = null
+): ClaimLinkData => ({
+    username,
+    linkDetails: {
+        senderAddress: '0x1111111111111111111111111111111111111111',
+        tokenAmount: '100',
+        tokenSymbol: 'USDC',
+        claimed: false,
+        ...overrides,
+    },
+})
+
+describe('buildClaimMetadata', () => {
+    it('falls back to the generic Peanut preview when the link cannot be resolved', () => {
+        const metadata = buildClaimMetadata({ claimData: null, siteUrl: SITE_URL })
+
+        expect(metadata.title).toBe('Claim Payment | Peanut')
+        // Regression guard: the bug shipped exactly this generic image for real links.
+        expect(ogImageUrl(metadata)).toBe('/metadata-img.png')
+        expect(metadata.description).toBe('Tap the link to receive instantly and without fees.')
+    })
+
+    it('uses the sender username + amount when the link is unclaimed', () => {
+        const metadata = buildClaimMetadata({ claimData: unclaimed({}, 'kkonrad'), siteUrl: SITE_URL })
+
+        expect(metadata.title).toBe('kkonrad sent you $100 via Peanut')
+
+        const url = new URL(ogImageUrl(metadata))
+        expect(url.origin + url.pathname).toBe('https://peanut.me/api/og')
+        expect(url.searchParams.get('type')).toBe('send')
+        expect(url.searchParams.get('username')).toBe('kkonrad')
+        expect(url.searchParams.get('amount')).toBe('100')
+        expect(url.searchParams.get('token')).toBe('USDC')
+        expect(url.searchParams.get('isReceipt')).toBeNull()
+    })
+
+    it('falls back to the sender address + token when there is no username', () => {
+        const metadata = buildClaimMetadata({ claimData: unclaimed(), siteUrl: SITE_URL })
+
+        expect(metadata.title).toBe('You received 100 in USDC!')
+        expect(new URL(ogImageUrl(metadata)).searchParams.get('username')).toBe(
+            '0x1111111111111111111111111111111111111111'
+        )
+    })
+
+    it('says "some" for dust amounts under a cent', () => {
+        const metadata = buildClaimMetadata({ claimData: unclaimed({ tokenAmount: '0.004' }), siteUrl: SITE_URL })
+        expect(metadata.title).toBe('You received some USDC!')
+    })
+
+    it('renders the receipt variant for a claimed link', () => {
+        const metadata = buildClaimMetadata({
+            claimData: unclaimed({ claimed: true }, 'kkonrad'),
+            siteUrl: SITE_URL,
+        })
+
+        expect(metadata.title).toBe('This link has been claimed')
+        expect(metadata.description).toBe('This payment link has already been claimed.')
+
+        const url = new URL(ogImageUrl(metadata))
+        expect(url.searchParams.get('isReceipt')).toBe('true')
+        expect(url.searchParams.get('amount')).toBeNull()
+    })
+})
+
+describe('getClaimLinkData', () => {
+    it('returns null without hitting the API when chainId or depositIdx is missing', async () => {
+        await expect(getClaimLinkData({}, SITE_URL)).resolves.toBeNull()
+        await expect(getClaimLinkData({ c: '42161' }, SITE_URL)).resolves.toBeNull()
+        await expect(getClaimLinkData({ i: '159' }, SITE_URL)).resolves.toBeNull()
+    })
+})

--- a/src/utils/__tests__/claim-metadata.utils.test.ts
+++ b/src/utils/__tests__/claim-metadata.utils.test.ts
@@ -1,4 +1,5 @@
 import { buildClaimMetadata, getClaimLinkData, type ClaimLinkData } from '@/utils/claim-metadata.utils'
+import { sendLinksApi } from '@/services/sendLinks'
 
 const SITE_URL = 'https://peanut.me'
 
@@ -76,8 +77,13 @@ describe('buildClaimMetadata', () => {
 
 describe('getClaimLinkData', () => {
     it('returns null without hitting the API when chainId or depositIdx is missing', async () => {
+        const getByParamsSpy = jest.spyOn(sendLinksApi, 'getByParams')
+
         await expect(getClaimLinkData({}, SITE_URL)).resolves.toBeNull()
         await expect(getClaimLinkData({ c: '42161' }, SITE_URL)).resolves.toBeNull()
         await expect(getClaimLinkData({ i: '159' }, SITE_URL)).resolves.toBeNull()
+
+        expect(getByParamsSpy).not.toHaveBeenCalled()
+        getByParamsSpy.mockRestore()
     })
 })

--- a/src/utils/claim-metadata.utils.ts
+++ b/src/utils/claim-metadata.utils.ts
@@ -1,0 +1,132 @@
+import { PEANUT_WALLET_TOKEN_DECIMALS, PEANUT_WALLET_TOKEN_SYMBOL } from '@/constants/zerodev.consts'
+import { sendLinksApi } from '@/services/sendLinks'
+import { resolveAddressToUsername } from '@/utils/ens.utils'
+import { formatAmount } from '@/utils/general.utils'
+import { type Metadata } from 'next'
+import { formatUnits } from 'viem'
+
+export type ClaimLinkDetails = {
+    senderAddress: string
+    tokenAmount: string
+    tokenSymbol: string
+    claimed: boolean
+}
+
+export type ClaimLinkData = {
+    linkDetails: ClaimLinkDetails
+    username: string | null
+}
+
+/**
+ * Fetches the data needed to render a claim link's social preview from its
+ * query params (`?c=<chainId>&v=<contractVersion>&i=<depositIdx>`).
+ *
+ * Uses the password-less `/send-links` lookup (DB + on-chain fallback) so it
+ * can run during SSR metadata generation. Returns `null` when the link can't
+ * be resolved — the caller then falls back to the generic Peanut preview.
+ */
+export async function getClaimLinkData(
+    searchParams: { [key: string]: string | string[] | undefined },
+    siteUrl: string
+): Promise<ClaimLinkData | null> {
+    const chainId = typeof searchParams.c === 'string' ? searchParams.c : undefined
+    const depositIdx = typeof searchParams.i === 'string' ? searchParams.i : undefined
+    if (!chainId || !depositIdx) return null
+
+    try {
+        const contractVersion = (typeof searchParams.v === 'string' && searchParams.v) || 'v4.3'
+        const sendLink = await sendLinksApi.getByParams({ chainId, depositIdx, contractVersion })
+
+        const tokenDecimals = sendLink.tokenDecimals ?? PEANUT_WALLET_TOKEN_DECIMALS
+        const tokenSymbol = sendLink.tokenSymbol ?? PEANUT_WALLET_TOKEN_SYMBOL
+
+        const linkDetails: ClaimLinkDetails = {
+            senderAddress: sendLink.senderAddress,
+            tokenAmount: formatUnits(sendLink.amount, tokenDecimals),
+            tokenSymbol,
+            claimed: sendLink.status === 'CLAIMED' || sendLink.status === 'CANCELLED',
+        }
+
+        let username = sendLink.sender?.username || null
+
+        // Fall back to ENS reverse-resolution when the sender has no Peanut
+        // handle. Race a 3s timeout so a slow ENS lookup never stalls metadata.
+        if (!username && linkDetails.senderAddress) {
+            const timeout = new Promise<null>((resolve) => setTimeout(() => resolve(null), 3000))
+            const resolved = resolveAddressToUsername(linkDetails.senderAddress, siteUrl).catch(() => null)
+            username = await Promise.race([resolved, timeout])
+        }
+
+        return { linkDetails, username }
+    } catch {
+        return null
+    }
+}
+
+/**
+ * Builds the Open Graph / Twitter metadata for a claim link from already
+ * fetched data. Pure + synchronous so the title and OG-image logic is unit
+ * testable — this is the exact behaviour that silently regressed when the
+ * claim page's `generateMetadata` was stripped for the native build.
+ */
+export function buildClaimMetadata({
+    claimData,
+    siteUrl,
+}: {
+    claimData: ClaimLinkData | null
+    siteUrl: string
+}): Metadata {
+    let title = 'Claim Payment | Peanut'
+    let ogImageUrl = '/metadata-img.png'
+
+    if (claimData) {
+        const { linkDetails, username } = claimData
+        const amount = Number(linkDetails.tokenAmount)
+
+        if (linkDetails.claimed) {
+            title = 'This link has been claimed'
+        } else if (username) {
+            title = `${username} sent you $${formatAmount(amount)} via Peanut`
+        } else {
+            title = `You received ${amount < 0.01 ? 'some ' : `${formatAmount(amount)} in `}${linkDetails.tokenSymbol}!`
+        }
+
+        const ogUrl = new URL('/api/og', siteUrl)
+        ogUrl.searchParams.set('type', 'send')
+        ogUrl.searchParams.set('username', username || linkDetails.senderAddress)
+        if (linkDetails.claimed) {
+            // claimed links show the "receipt" variant of the OG image
+            ogUrl.searchParams.set('isReceipt', 'true')
+        } else {
+            ogUrl.searchParams.set('amount', linkDetails.tokenAmount)
+            ogUrl.searchParams.set('token', linkDetails.tokenSymbol)
+        }
+        ogImageUrl = ogUrl.toString()
+    }
+
+    const description = claimData?.linkDetails.claimed
+        ? 'This payment link has already been claimed.'
+        : 'Tap the link to receive instantly and without fees.'
+
+    return {
+        title,
+        description,
+        metadataBase: new URL(siteUrl),
+        icons: { icon: '/favicon.ico' },
+        openGraph: {
+            title,
+            description,
+            images: [{ url: ogImageUrl, width: 1200, height: 630 }],
+            type: 'website',
+            siteName: 'Peanut',
+        },
+        twitter: {
+            card: 'summary_large_image',
+            site: '@PeanutProtocol',
+            creator: '@PeanutProtocol',
+            title,
+            description,
+            images: [{ url: ogImageUrl }],
+        },
+    }
+}

--- a/src/utils/claim-metadata.utils.ts
+++ b/src/utils/claim-metadata.utils.ts
@@ -52,9 +52,16 @@ export async function getClaimLinkData(
         // Fall back to ENS reverse-resolution when the sender has no Peanut
         // handle. Race a 3s timeout so a slow ENS lookup never stalls metadata.
         if (!username && linkDetails.senderAddress) {
-            const timeout = new Promise<null>((resolve) => setTimeout(() => resolve(null), 3000))
+            let timeoutId: ReturnType<typeof setTimeout> | undefined
+            const timeout = new Promise<null>((resolve) => {
+                timeoutId = setTimeout(() => resolve(null), 3000)
+            })
             const resolved = resolveAddressToUsername(linkDetails.senderAddress, siteUrl).catch(() => null)
-            username = await Promise.race([resolved, timeout])
+            try {
+                username = await Promise.race([resolved, timeout])
+            } finally {
+                clearTimeout(timeoutId)
+            }
         }
 
         return { linkDetails, username }


### PR DESCRIPTION
## Summary

Claim-link social previews (Telegram/WhatsApp/X) regressed to the **generic** Peanut card — title *"Peanut - Instant Global P2P Payments…"* + `metadata-img.png` — instead of the dynamic *"X sent you $Y via Peanut"* preview with the per-link OG image.

**Root cause:** `d2049447f` (Apr 17, "page changes for native app — server feature removal") permanently stripped `generateMetadata` + `force-dynamic` from `src/app/(mobile-ui)/claim/page.tsx`. That strip was **redundant**: `scripts/native-build.js` (`P0_TRANSFORMS`) *already* replaces this page with a metadata-free stub at native-build time and restores the original afterwards — so the source-level removal only degraded the **web** (Vercel SSR) build, which never needed it. It's been broken ~2 months and was invisible to Sentry/Vercel/PostHog (missing metadata throws nothing — silent fallback).

## Fix

- Restore `generateMetadata` + `export const dynamic = 'force-dynamic'` to the claim page.
- Extract the data-fetch + OG-image construction into `src/utils/claim-metadata.utils.ts` (`getClaimLinkData`, pure `buildClaimMetadata`) per repo rules (logic out of routes; testable).
- New unit test `claim-metadata.utils.test.ts` (6 cases) — incl. the exact regression guard (null link → generic fallback) that would have caught this.
- **Native build is unaffected** — its `P0_TRANSFORMS` replaces this page by path, so the restored exports get stripped automatically at native build time.

## Risks / breaking changes

- **None cross-repo.** Web-only change. `/claim` becomes a dynamic (SSR) route again (build confirms `ƒ /claim`) — same as its pre-Apr-17 behavior. `generateMetadata` does a password-less `/send-links` lookup per request (DB + on-chain fallback, already used elsewhere) with a 3s ENS timeout race; failures fall back to the generic preview.
- Native (Capacitor) static export verified safe by design (path-based stub replacement).

## QA

1. After deploy to staging, crawl a real claim link as a bot:
   `curl -A "facebookexternalhit/1.1" "https://staging.peanut.me/claim?c=...&v=...&i=..." | grep -E 'og:title|og:image'`
   → expect `og:title="<sender> sent you $<amt> via Peanut"` and `og:image=…/api/og?type=send&username=…&amount=…&token=…`.
2. Claimed link → `og:title="This link has been claimed"`, `og:image` carries `isReceipt=true`.
3. Unit: `npm test src/utils/__tests__/claim-metadata.utils.test.ts` (6/6).

Local gate: prettier ✅ · typecheck ✅ · unit 90/90 ✅ · `next build` ✅ (`/claim` = dynamic).
