### PR TITLE
fix(recover-wallet): show prefilled destination instead of hiding it

### DIFF
--- a/src/app/recover-wallet/page.tsx
+++ b/src/app/recover-wallet/page.tsx
@@ -91,7 +91,11 @@ function RecoverWalletInner() {
             setFatal('This recovery link is invalid or has expired. Please ask support for a fresh one.')
             return
         }
-        if (recoveryKey.to) setRecipient({ address: recoveryKey.to, name: '' })
+        // name MUST be undefined, not '' — GeneralRecipientInput shows
+        // `recipient.name ?? recipient.address`, and ?? only falls through on
+        // null/undefined, so an empty-string name would hide the prefilled
+        // destination while still enabling the button (invisible target).
+        if (recoveryKey.to) setRecipient({ address: recoveryKey.to, name: undefined })
 
         let cancelled = false
         ;(async () => {


### PR DESCRIPTION
Follow-up to #2246 (found while smoke-testing the live page on prod).

## Bug
On `/recover-wallet`, the destination field rendered **empty** while the "Recover funds" button was **enabled** — a click would have swept the full balance to a destination the user never saw.

## Root cause
`GeneralRecipientInput` controls its field with `value={recipient.name ?? recipient.address}`. The page prefilled the recipient with `name: ''`, and `??` only falls through on `null`/`undefined` (not empty string), so the field showed `''` while `recipient.address` held the target — enabling the button with an invisible destination.

## Fix
Prefill with `name: undefined` so the destination address is visible before the user confirms. One line.

## Verified
- Reproduced live on peanut.me (button enabled, field empty) before the fix.
- typecheck ✅ · eslint (my file) ✅ · jest 22/22 ✅.
- Will re-verify on prod after deploy that the field shows the prefilled address.