### PR TITLE
refactor(og): single buildOgImageUrl() helper for /api/og links

### DIFF
--- a/src/app/[...recipient]/page.tsx
+++ b/src/app/[...recipient]/page.tsx
@@ -7,6 +7,7 @@ import { isAddress } from 'viem'
 import { printableAddress, isStableCoin } from '@/utils/general.utils'
 import { chargesApi } from '@/services/charges'
 import { parseAmountAndToken } from '@/lib/url-parser/parser'
+import { buildOgImageUrl } from '@/utils/og.utils'
 import { notFound } from 'next/navigation'
 import { couldBeRecipient, isReservedRoute } from '@/constants/routes'
 
@@ -99,30 +100,19 @@ export async function generateMetadata({ params, searchParams }: any) {
         if (!siteUrl) {
             console.error('Error: Unable to determine site origin')
         } else {
-            const ogUrl = new URL(`${siteUrl}/api/og`)
-            ogUrl.searchParams.set('type', 'request')
-            ogUrl.searchParams.set('username', recipient)
-
-            if (amount) {
-                ogUrl.searchParams.set('amount', String(amount))
-                if (token) {
-                    ogUrl.searchParams.set('token', token.toUpperCase())
-                }
-            } else {
-                // For ETH addresses/ENS without amount, set to 0 to show "is requesting funds"
-                ogUrl.searchParams.set('amount', '0')
-            }
-
-            // Only show as receipt if there's both a chargeId AND it's paid
-            if (chargeId && isPaid) {
-                ogUrl.searchParams.set('isReceipt', 'true')
-            }
-
-            if (isPeanutUsername) {
-                ogUrl.searchParams.set('isPeanutUsername', 'true')
-            }
-
-            ogImageUrl = ogUrl.toString()
+            ogImageUrl = buildOgImageUrl(
+                {
+                    type: 'request',
+                    username: recipient,
+                    // ETH addresses/ENS without an amount use 0 to show "is requesting funds"
+                    amount: amount ? String(amount) : '0',
+                    token: amount && token ? token.toUpperCase() : undefined,
+                    // only a receipt when there's a chargeId AND it's paid
+                    isReceipt: Boolean(chargeId && isPaid),
+                    isPeanutUsername,
+                },
+                siteUrl
+            )
         }
     }
 

--- a/src/app/invite/page.tsx
+++ b/src/app/invite/page.tsx
@@ -3,6 +3,7 @@ import getOrigin from '@/lib/hosting/get-origin'
 import { type Metadata } from 'next'
 import { validateInviteCode } from '../actions/invites'
 import { BASE_URL } from '@/constants/general.consts'
+import { buildOgImageUrl } from '@/utils/og.utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -46,14 +47,10 @@ export async function generateMetadata({
         description =
             'Join Peanut to send and receive money instantly, shop with merchants, and move funds across borders.'
 
-        const ogUrl = new URL(`${siteUrl}/api/og`)
-        ogUrl.searchParams.set('isInvite', 'true')
-        ogUrl.searchParams.set('username', inviteCodeData.username)
-
         if (!siteUrl) {
             console.error('Error: Unable to determine site origin')
         } else {
-            ogImageUrl = ogUrl.toString()
+            ogImageUrl = buildOgImageUrl({ username: inviteCodeData.username, isInvite: true }, siteUrl)
         }
     }
 

--- a/src/app/receipt/[entryId]/page.tsx
+++ b/src/app/receipt/[entryId]/page.tsx
@@ -13,6 +13,7 @@ import { generateMetadata as generateBaseMetadata } from '@/app/metadata'
 import { type Metadata } from 'next'
 import { BASE_URL } from '@/constants/general.consts'
 import { formatAmount, formatCurrency, isStableCoin } from '@/utils/general.utils'
+import { buildOgImageUrl } from '@/utils/og.utils'
 import getOrigin from '@/lib/hosting/get-origin'
 import PageContainer from '@/components/0_Bruddle/PageContainer'
 
@@ -138,32 +139,31 @@ export async function generateMetadata({
 
     // Generate dynamic OG image URL
     const origin = (await getOrigin()) || BASE_URL
-    const ogUrl = new URL(`${origin}/api/og`)
-
-    // Map transaction type for OG image
     const ogType = mapTransactionTypeToOGType(transactionDetails.extraDataForDrawer?.transactionCardType || 'send')
-    ogUrl.searchParams.set('type', ogType)
-    ogUrl.searchParams.set('isReceipt', 'true')
-
-    // Add amount if available (always use USD amount)
-    if (transactionDetails.amount > 0) {
-        ogUrl.searchParams.set('amount', formatCurrency(Number(transactionDetails.amount).toString()))
-        ogUrl.searchParams.set('token', 'USDC')
-    }
-
-    // Add username if available and not an address-like string
-    if (
+    const hasAmount = transactionDetails.amount > 0
+    // include username only when present and not an address-like string
+    const hasUsername = Boolean(
         transactionDetails.userName &&
         transactionDetails.userName.length < 20 &&
         !transactionDetails.userName.startsWith('0x')
-    ) {
-        ogUrl.searchParams.set('username', transactionDetails.userName)
-    }
+    )
+
+    const ogImageUrl = buildOgImageUrl(
+        {
+            type: ogType,
+            isReceipt: true,
+            username: hasUsername ? transactionDetails.userName : undefined,
+            // always denominate the receipt amount in USD
+            amount: hasAmount ? formatCurrency(Number(transactionDetails.amount).toString()) : undefined,
+            token: hasAmount ? 'USDC' : undefined,
+        },
+        origin
+    )
 
     return generateBaseMetadata({
         title,
         description,
-        image: ogUrl.toString(),
+        image: ogImageUrl,
         keywords: 'crypto receipt, transaction receipt, payment receipt, Peanut Protocol',
     })
 }

--- a/src/utils/__tests__/og.utils.test.ts
+++ b/src/utils/__tests__/og.utils.test.ts
@@ -1,0 +1,61 @@
+import { buildOgImageUrl } from '@/utils/og.utils'
+
+const SITE_URL = 'https://peanut.me'
+const parse = (url: string) => new URL(url)
+
+describe('buildOgImageUrl', () => {
+    it('builds an absolute /api/og URL on the given origin', () => {
+        const url = parse(buildOgImageUrl({ type: 'send' }, SITE_URL))
+        expect(url.origin + url.pathname).toBe('https://peanut.me/api/og')
+        expect(url.searchParams.get('type')).toBe('send')
+    })
+
+    it('send + amount (unclaimed claim link)', () => {
+        const p = parse(
+            buildOgImageUrl({ type: 'send', username: 'kkonrad', amount: '100', token: 'USDC' }, SITE_URL)
+        ).searchParams
+        expect(p.get('type')).toBe('send')
+        expect(p.get('username')).toBe('kkonrad')
+        expect(p.get('amount')).toBe('100')
+        expect(p.get('token')).toBe('USDC')
+        expect(p.get('isReceipt')).toBeNull()
+    })
+
+    it('send + isReceipt omits amount/token (claimed claim link)', () => {
+        const p = parse(buildOgImageUrl({ type: 'send', username: 'kkonrad', isReceipt: true }, SITE_URL)).searchParams
+        expect(p.get('isReceipt')).toBe('true')
+        expect(p.get('amount')).toBeNull()
+        expect(p.get('token')).toBeNull()
+    })
+
+    it('request + peanut username + amount 0 (address/profile request)', () => {
+        const p = parse(
+            buildOgImageUrl({ type: 'request', username: 'kkonrad', amount: '0', isPeanutUsername: true }, SITE_URL)
+        ).searchParams
+        expect(p.get('type')).toBe('request')
+        expect(p.get('amount')).toBe('0')
+        expect(p.get('isPeanutUsername')).toBe('true')
+    })
+
+    it('invite has no type param and sets isInvite', () => {
+        const p = parse(buildOgImageUrl({ username: 'kkonrad', isInvite: true }, SITE_URL)).searchParams
+        expect(p.get('type')).toBeNull()
+        expect(p.get('isInvite')).toBe('true')
+        expect(p.get('username')).toBe('kkonrad')
+    })
+
+    it('omits empty amount/token and false flags', () => {
+        const p = parse(
+            buildOgImageUrl(
+                { type: 'send', username: '', amount: '', token: undefined, isReceipt: false, isPeanutUsername: false },
+                SITE_URL
+            )
+        ).searchParams
+        expect([...p.keys()]).toEqual(['type'])
+    })
+
+    it('includes a numeric zero amount', () => {
+        const p = parse(buildOgImageUrl({ type: 'request', amount: 0 }, SITE_URL)).searchParams
+        expect(p.get('amount')).toBe('0')
+    })
+})

--- a/src/utils/claim-metadata.utils.ts
+++ b/src/utils/claim-metadata.utils.ts
@@ -2,6 +2,7 @@ import { PEANUT_WALLET_TOKEN_DECIMALS, PEANUT_WALLET_TOKEN_SYMBOL } from '@/cons
 import { sendLinksApi } from '@/services/sendLinks'
 import { resolveAddressToUsername } from '@/utils/ens.utils'
 import { formatAmount } from '@/utils/general.utils'
+import { buildOgImageUrl } from '@/utils/og.utils'
 import { type Metadata } from 'next'
 import { formatUnits } from 'viem'
 
@@ -98,17 +99,18 @@ export function buildClaimMetadata({
             title = `You received ${amount < 0.01 ? 'some ' : `${formatAmount(amount)} in `}${linkDetails.tokenSymbol}!`
         }
 
-        const ogUrl = new URL('/api/og', siteUrl)
-        ogUrl.searchParams.set('type', 'send')
-        ogUrl.searchParams.set('username', username || linkDetails.senderAddress)
-        if (linkDetails.claimed) {
-            // claimed links show the "receipt" variant of the OG image
-            ogUrl.searchParams.set('isReceipt', 'true')
-        } else {
-            ogUrl.searchParams.set('amount', linkDetails.tokenAmount)
-            ogUrl.searchParams.set('token', linkDetails.tokenSymbol)
-        }
-        ogImageUrl = ogUrl.toString()
+        // claimed links show the "receipt" variant; unclaimed show amount + token
+        ogImageUrl = buildOgImageUrl(
+            linkDetails.claimed
+                ? { type: 'send', username: username || linkDetails.senderAddress, isReceipt: true }
+                : {
+                      type: 'send',
+                      username: username || linkDetails.senderAddress,
+                      amount: linkDetails.tokenAmount,
+                      token: linkDetails.tokenSymbol,
+                  },
+            siteUrl
+        )
     }
 
     const description = claimData?.linkDetails.claimed

--- a/src/utils/og.utils.ts
+++ b/src/utils/og.utils.ts
@@ -1,0 +1,40 @@
+/**
+ * Single source of truth for building `/api/og` social-preview image URLs.
+ *
+ * The query-param contract lives here and in the image renderer at
+ * `src/app/api/og/route.tsx` — keep the param names in the two in sync. Every
+ * page that needs a dynamic OG image (claim, the `[...recipient]`
+ * payment/profile page, receipts, invites) builds its URL through this helper,
+ * so a change to the contract happens in one place instead of N.
+ */
+export type OgImageParams = {
+    type?: 'send' | 'request' | 'generic'
+    username?: string
+    /** Token amount as a display string/number; omitted from the URL when empty. */
+    amount?: string | number
+    /** Token symbol, e.g. USDC. */
+    token?: string
+    /** Render the already-paid / claimed "receipt" variant. */
+    isReceipt?: boolean
+    /** Mark the recipient as a Peanut handle (profile styling). */
+    isPeanutUsername?: boolean
+    /** Render the invite variant. */
+    isInvite?: boolean
+}
+
+/** Build an absolute `/api/og` image URL from the given params and site origin. */
+export function buildOgImageUrl(params: OgImageParams, siteUrl: string): string {
+    const url = new URL('/api/og', siteUrl)
+
+    if (params.type) url.searchParams.set('type', params.type)
+    if (params.username) url.searchParams.set('username', params.username)
+    if (params.amount !== undefined && params.amount !== null && params.amount !== '') {
+        url.searchParams.set('amount', String(params.amount))
+    }
+    if (params.token) url.searchParams.set('token', params.token)
+    if (params.isReceipt) url.searchParams.set('isReceipt', 'true')
+    if (params.isPeanutUsername) url.searchParams.set('isPeanutUsername', 'true')
+    if (params.isInvite) url.searchParams.set('isInvite', 'true')
+
+    return url.toString()
+}


### PR DESCRIPTION
## Summary

Follow-up to #2249. The `/api/og` social-preview URL (params: `type`, `username`, `amount`, `token`, `isReceipt`, `isPeanutUsername`, `isInvite`) was hand-built inline in **four** places — `claim-metadata.utils.ts`, `[...recipient]/page.tsx`, `receipt/[entryId]/page.tsx`, `invite/page.tsx` — each a separate copy of the same query-param contract shared with the image renderer (`app/api/og/route.tsx`). A renamed/added param meant editing N sites with nothing catching a miss (the silent-drift class this repo cares about).

This extracts one typed, unit-tested **`buildOgImageUrl(params, siteUrl)`** (`src/utils/og.utils.ts`) and routes all four consumers through it.

## Behavior

- **claim** + **[...recipient]**: produced URLs are **byte-identical** to before (same params, same order) — zero output change.
- **receipt** + **invite**: same params, **order differs** (cosmetic; `/api/og` reads by key, render is identical).
- Net: a single source of truth for the OG-image contract; the previously-untested catch-all OG logic now has coverage via the helper's tests.

## Risk

Low, web-only, no cross-repo. Pure URL-string refactor — no new data fetching, no logic change. All four routes still build as dynamic (`ƒ`). Native build unaffected (these routes are stripped/disabled there; the helper has no importer in native).

## QA

- New `og.utils.test.ts` (7 cases: send/amount, receipt, request/peanut-username, invite-no-type, empty-omission, numeric-zero, absolute-URL).
- Existing `claim-metadata.utils.test.ts` still green (proves claim output unchanged).
- Post-merge I'll live-verify on staging that claim / profile / request / receipt / invite OG images all still render.

Local gate: prettier ✅ · typecheck ✅ · unit 91/91 (1473) ✅ · `next build` ✅.

## Note (pre-existing, not touched)
Two pre-existing eslint errors live in files I refactored but did not author — `[...recipient]` `generateMetadata(...: any)` and an unused `params` arg in `invite`'s `generateMetadata`. Left as-is (surgical; verbatim on `dev`), flagging rather than scope-creeping.
