### PR TITLE
ci(content): base auto-bump on dev + content-only auto-merge (stop the pile-up)

### DIFF
--- a/.github/workflows/update-content.yml
+++ b/.github/workflows/update-content.yml
@@ -13,7 +13,14 @@ jobs:
     update:
         runs-on: ubuntu-latest
         steps:
+            # Base the bump on `dev` (the PR target), NOT the repo default branch.
+            # Branching off a different branch than the base is what let unrelated
+            # code drift leak into the auto-PR (#2226) and made it conflict with dev
+            # once dev's content pointer moved (#2247). Off `dev`, the PR is
+            # content-only by construction and always cleanly mergeable.
             - uses: actions/checkout@v4
+              with:
+                  ref: dev
 
             - name: Init and update submodule
               env:
@@ -34,14 +41,19 @@ jobs:
                     echo "changed=true" >> "$GITHUB_OUTPUT"
                   fi
 
-            - name: Create PR
+            - name: Create PR + auto-merge (content-only)
               if: steps.check.outputs.changed == 'true'
+              # Prefer a PAT (CONTENT_BOT_TOKEN) so the PR triggers CI and auto-merge
+              # can fire on green checks. Falls back to GITHUB_TOKEN — the PR still
+              # opens, but GITHUB_TOKEN-created PRs don't trigger CI, so auto-merge
+              # won't fire until the PAT is configured (no regression vs today).
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ secrets.CONTENT_BOT_TOKEN || secrets.GITHUB_TOKEN }}
               run: |
+                  set -euo pipefail
                   BRANCH="auto/update-content-$(date -u +%Y%m%d-%H%M%S)"
                   SUBMODULE_SHA=$(git -C src/content rev-parse HEAD)
-                  PARENT=$(git rev-parse HEAD)
+                  PARENT=$(git rev-parse HEAD)   # dev tip — bump is content-only vs dev
                   BASE_TREE=$(gh api repos/${{ github.repository }}/git/commits/$PARENT --jq '.tree.sha')
                   # Create tree via API with updated submodule pointer
                   TREE=$(gh api repos/${{ github.repository }}/git/trees \
@@ -64,8 +76,18 @@ jobs:
                     --method POST \
                     -f "ref=refs/heads/$BRANCH" \
                     -f "sha=$COMMIT_SHA"
-                  gh pr create \
+                  PR_URL=$(gh pr create \
                     --head "$BRANCH" \
                     --base dev \
                     --title "Update content submodule" \
-                    --body "Auto-generated: updates content submodule to latest peanut-content main."
+                    --body "Auto-generated: bumps the content submodule to latest peanut-content main. Based on dev, so it's content-only and auto-merges once checks pass.")
+                  # Guard: only auto-merge when the PR touches NOTHING but the submodule
+                  # pointer. If anything else slipped in, leave it for a human.
+                  FILES=$(gh pr diff "$PR_URL" --name-only)
+                  if [ "$FILES" = "src/content" ]; then
+                    gh pr merge "$PR_URL" --auto --squash \
+                      || echo "::warning::auto-merge not enabled/permitted — left for manual merge ($PR_URL)"
+                  else
+                    echo "::warning::PR touches more than src/content — left for manual review:"
+                    echo "$FILES"
+                  fi


### PR DESCRIPTION
## Problem
The `update-content.yml` job opens "Update content submodule" PRs but **never merges them** — 9 piled up since June 3 (now closed). Two root causes:
1. It branched the bump off the **default branch (main)**, not the PR base (dev) → unrelated code drift polluted the PR (#2226) and it **conflicted** with dev once dev's content pointer moved (#2247).
2. The PRs aren't auto-merged, so content reaches peanut-content automatically but **stalls** at the peanut-ui bump until a human merges.

## Fix
- **Branch the bump off `dev`** (the PR base) → the PR is **content-only by construction** and always cleanly mergeable.
- **Auto-merge**, guarded so it only fires when the diff is **solely** `src/content` (anything else → left for human review — keeps the #2226 pollution from ever auto-merging).
- Create the PR with `CONTENT_BOT_TOKEN` (PAT) when present so the PR **triggers CI** and auto-merge can gate on green checks; **falls back to `GITHUB_TOKEN`** so there's no regression if the secret isn't set.

## One-time setup needed (repo admin — you)
1. Add repo secret **`CONTENT_BOT_TOKEN`** = a PAT with peanut-ui `contents` + `pull_requests` write (so the bot PR runs CI + can be merged).
2. Enable **Settings → General → Allow auto-merge**.
3. Ensure `dev` branch protection lets that bot/auto-merge through (required checks only, or allow the bot).

## Note
`repository_dispatch` runs the workflow from the **default branch (main)**, so this takes effect **once it reaches main** (via the next dev→main release) — not on merge to dev.

No app code touched; YAML validated.