### PR TITLE
fix(home): show "You're unlocked" modal once, off a milestone

### DIFF
--- a/src/app/(mobile-ui)/home/page.tsx
+++ b/src/app/(mobile-ui)/home/page.tsx
@@ -75,7 +75,7 @@ export default function Home() {
 
     const [showBalanceWarningModal, setShowBalanceWarningModal] = useState(false)
     const [isPostSignupActionModalVisible, setIsPostSignupActionModalVisible] = useState(false)
-    const [showKycModal, setShowKycModal] = useState(user?.user.showKycCompletedModal ?? false)
+    const [showKycModal, setShowKycModal] = useState(false)
 
     // Track if this is a fresh signup session - captured once on mount so it persists
     // even after NoMoreJailModal clears the sessionStorage key
@@ -89,12 +89,16 @@ export default function Home() {
         fetchUser()
     }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-    // sync modal state with user data when it changes
+    // Show the "You're unlocked" celebration exactly once: the user has a usable
+    // rail (isKycApproved) and has never dismissed it (activationCelebratedAt is
+    // null, stamped server-side on dismiss). A KYC re-approval can't resurface it
+    // — unlike the old showKycCompletedModal flag, which re-fired on every
+    // `→ approved` transition (e.g. the faster_payments endorsement backfill).
     useEffect(() => {
-        if (user?.user.showKycCompletedModal !== undefined) {
-            setShowKycModal(user.user.showKycCompletedModal)
+        if (isKycApproved && !user?.user.activationCelebratedAt) {
+            setShowKycModal(true)
         }
-    }, [user?.user.showKycCompletedModal])
+    }, [isKycApproved, user?.user.activationCelebratedAt])
 
     const userFullName = useMemo(() => {
         if (!user) return
@@ -256,7 +260,7 @@ export default function Home() {
                             if (user?.user.userId) {
                                 await updateUserById({
                                     userId: user.user.userId,
-                                    showKycCompletedModal: false,
+                                    dismissActivationCelebration: true,
                                 })
                                 // refetch user to ensure the modal doesn't reappear
                                 await fetchUser()

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -198,7 +198,9 @@ export interface User {
     activatedAt?: string | null
     activationMilestone?: 'registered' | 'verified' | 'funded' | 'activated'
     showFullName: boolean
-    showKycCompletedModal?: boolean
+    // Null until the user dismisses the "You're unlocked" celebration. The modal
+    // shows once, when KYC-approved (a rail is enabled) AND this is still null.
+    activationCelebratedAt?: string | null
     createdAt: string
     accounts: Account[]
     badges?: Array<{

--- a/src/types/api.generated.ts
+++ b/src/types/api.generated.ts
@@ -540,7 +540,7 @@ export interface paths {
                         showFullName?: boolean;
                         hasSeenEarlyUserModal?: boolean;
                         bridgeKycStatus?: "not_started" | "incomplete" | "under_review" | "approved" | "rejected";
-                        showKycCompletedModal?: boolean;
+                        dismissActivationCelebration?: boolean;
                     };
                 };
             };

--- a/src/types/api.openapi.json
+++ b/src/types/api.openapi.json
@@ -739,7 +739,7 @@
 											}
 										]
 									},
-									"showKycCompletedModal": {
+									"dismissActivationCelebration": {
 										"type": "boolean"
 									}
 								},


### PR DESCRIPTION
## Why

The "🎉 You're unlocked" modal re-appeared for long-time users (e.g. Konrad), listing rails they'd had for months. It was gated on the backend `showKycCompletedModal` flag, which was re-set on **every** KYC `→approved` transition — so re-approvals (the `faster_payments` endorsement backfill) re-showed it. The modal copy is a static bullet list, so it advertised old rails and didn't even mention the one rail he actually gained.

## What this does
Drives the modal off a **once-ever milestone** instead of a re-settable flag:
- Shows when `isKycApproved` (a rail is enabled) **AND** `user.activationCelebratedAt` is null.
- Dismissal calls `updateUserById({ dismissActivationCelebration: true })`; the **server** stamps `activationCelebratedAt` (monotonic — never overwritten), so the celebration can't resurface on a later re-approval.
- Removes `showKycCompletedModal` from the user interface + the update-user request type; `activationCelebratedAt` now flows from get-user.

## Tests / gates
- `npm run typecheck` ✅ (0 errors). `npm test` green except the pre-existing `countryCurrencyMapping` flag-asset suite (worktree has 0 of 433 `public/flags` SVGs — environmental, unrelated).

## ⚠️ Depends on peanut-api-ts #1034
Ship **after** the API migration + `backfill-activation-celebrated-at.ts` run, or already-unlocked users (~2,707) will all see the modal once. See #1034's deploy runbook.