### PR TITLE
fix(add-money): back button no longer dies on the amount screen

### DIFF
--- a/e2e/flows/add-money.spec.ts
+++ b/e2e/flows/add-money.spec.ts
@@ -81,4 +81,38 @@ test.describe('Add money flow', () => {
         consoleLogs.flush(testInfo, 'add-money-us-bank')
         await context.close()
     })
+
+    // Regression: the NavHeader back button must LEAVE the amount screen on the first tap.
+    // Before fix/addmoney-back-nuqs-replace the flow used nuqs { history: 'push' }, so every
+    // amount keystroke stacked a same-screen history entry and useSafeBack's router.back()
+    // only stepped through stale amounts — the back button looked dead (MP/bank reports).
+    test('add-money/AR/bank — back button leaves the amount screen after typing (verified-ar)', async ({
+        browser,
+    }, testInfo) => {
+        const context = await browser.newContext({ ...devices['Pixel 7'] })
+        await usePersona(context, 'verified-ar')
+
+        const page = await context.newPage()
+        const consoleLogs = collectConsoleLogs(page)
+        await installApiMocks(page)
+
+        await page.goto('/add-money/AR/bank')
+
+        // amount step renders (verified persona skips the "country not found" gate)
+        const amountInput = page.locator('input[inputmode="decimal"]').first()
+        await amountInput.waitFor({ state: 'visible', timeout: 15000 })
+
+        // typing writes ?amount= — with the old { history: 'push' } this stacked back-stack
+        // entries; with the default 'replace' it does not.
+        await amountInput.fill('100')
+        await captureStep(page, testInfo, { name: '01-add-money-ar-bank-amount-typed' })
+
+        // one tap must exit to the country page, not linger on /bank with a stale amount
+        await page.locator('[data-testid="nav-back"]').first().click()
+        await expect(page).toHaveURL(/\/add-money\/AR(?:\?.*)?$/)
+        await captureStep(page, testInfo, { name: '02-add-money-ar-bank-back-left-screen' })
+
+        consoleLogs.flush(testInfo, 'add-money-ar-bank-back')
+        await context.close()
+    })
 })

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -127,6 +127,16 @@ module.exports = [
                     message:
                         "window.history.length is the pre-useSafeBack idiom (history.length > 1 ? back : push). It misfires on cold-load from external referrers — useSafeBack's pushState counter is more accurate. See PR #1965.",
                 },
+                {
+                    // nuqs `history: 'push'` stacks a browser-history entry on every URL write.
+                    // For per-keystroke params (e.g. `amount`) that poisons the back stack:
+                    // useSafeBack → router.back() then steps through stale same-screen states
+                    // and the back button looks dead (add-money MP/bank reports, June 2026).
+                    selector:
+                        "CallExpression[callee.name=/^useQueryStates?$/] Property[key.name='history'][value.value='push']",
+                    message:
+                        "Don't pass { history: 'push' } to nuqs useQueryState(s) — a history entry per URL write breaks the back button (useSafeBack steps through same-screen states instead of leaving). Use the default 'replace'; the URL stays shareable. If a flow genuinely needs push-per-step, add a scoped file exemption with a comment (see useNativePlugins).",
+                },
             ],
         },
     },

--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -49,13 +49,15 @@ export default function OnrampBankPage() {
 
     // URL state - persisted in query params
     // Example: /add-money/mexico/bank?step=inputAmount&amount=500
-    const [urlState, setUrlState] = useQueryStates(
-        {
-            step: parseAsStringEnum<BridgeBankStep>(['inputAmount', 'showDetails']),
-            amount: parseAsString,
-        },
-        { history: 'push' }
-    )
+    // history stays at the nuqs default ('replace'): `amount` is rewritten on every
+    // keystroke, so 'push' would stack a browser-history entry per character and the
+    // NavHeader back button (useSafeBack → router.back()) would only step through stale
+    // amounts of this same screen instead of leaving it. The URL stays shareable either
+    // way. Enforced by the no-restricted-syntax guard in eslint.config.js.
+    const [urlState, setUrlState] = useQueryStates({
+        step: parseAsStringEnum<BridgeBankStep>(['inputAmount', 'showDetails']),
+        amount: parseAsString,
+    })
 
     // Amount from URL
     const rawTokenAmount = urlState.amount ?? ''

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -39,15 +39,17 @@ const MantecaAddMoney: FC = () => {
 
     // URL state - persisted in query params
     // Example: /add-money/argentina/manteca?step=inputAmount&amount=100&currency=ARS
-    // The `amount` is stored in whatever denomination `currency` specifies
-    const [urlState, setUrlState] = useQueryStates(
-        {
-            step: parseAsStringEnum<MantecaStep>(['inputAmount', 'depositDetails']),
-            amount: parseAsString,
-            currency: parseAsStringEnum<CurrencyDenomination>(['USD', 'ARS', 'BRL', 'MXN', 'EUR']),
-        },
-        { history: 'push' }
-    )
+    // The `amount` is stored in whatever denomination `currency` specifies.
+    // history stays at the nuqs default ('replace'): `amount` is rewritten on every
+    // keystroke, so 'push' would stack a browser-history entry per character and the
+    // NavHeader back button (useSafeBack → router.back()) would only step through stale
+    // amounts of this same screen instead of leaving it. The URL stays shareable either
+    // way. Enforced by the no-restricted-syntax guard in eslint.config.js.
+    const [urlState, setUrlState] = useQueryStates({
+        step: parseAsStringEnum<MantecaStep>(['inputAmount', 'depositDetails']),
+        amount: parseAsString,
+        currency: parseAsStringEnum<CurrencyDenomination>(['USD', 'ARS', 'BRL', 'MXN', 'EUR']),
+    })
 
     // Derive state from URL (with defaults)
     const step: MantecaStep = urlState.step ?? 'inputAmount'

--- a/src/components/Global/NavHeader/index.tsx
+++ b/src/components/Global/NavHeader/index.tsx
@@ -32,7 +32,7 @@ const NavHeader = ({
         <div className="relative flex w-full flex-row items-center justify-between md:block">
             {!onPrev ? (
                 <Link href={href ?? '/home'} className="md:hidden">
-                    <Button variant="stroke" className="h-7 w-7 p-0">
+                    <Button variant="stroke" className="h-7 w-7 p-0" data-testid="nav-back">
                         <Icon
                             name={icon}
                             size={20}
@@ -41,7 +41,13 @@ const NavHeader = ({
                     </Button>
                 </Link>
             ) : (
-                <Button variant="stroke" className="h-7 w-7 p-0" onClick={onPrev} disabled={disableBackBtn}>
+                <Button
+                    variant="stroke"
+                    className="h-7 w-7 p-0"
+                    onClick={onPrev}
+                    disabled={disableBackBtn}
+                    data-testid="nav-back"
+                >
                     <Icon
                         name={icon}
                         size={20}


### PR DESCRIPTION
## The bug
A user reported the **back button on the Add Money amount screen does nothing** (MP / Manteca AR flow). Confirmed by code: both add-money amount flows declared their nuqs URL state with `{ history: 'push' }`:

- `src/components/AddMoney/components/MantecaAddMoney.tsx` (Manteca AR/BR — the reported MP case)
- `src/app/(mobile-ui)/add-money/[country]/bank/page.tsx` (Bridge bank: SEPA/US/UK/MX — identical bug)

`amount` is rewritten on **every keystroke** (`setUrlState({ amount })`). With `history: 'push'`, each write pushes a **new browser-history entry for the same screen**. The NavHeader back button calls `useSafeBack → router.back()`, which steps back exactly **one** entry — landing on the same Add Money screen with a slightly different amount. Visually nothing changes, so the button looks dead. (Even at `0.00`: the denomination/`currency` write on mount already poisons the stack.)

## The fix
Drop the option so both flows use the nuqs default (`'replace'`). The URL still updates (`?amount=…` stays shareable / deep-linkable per the "URL as state" rule), but it no longer grows history — so `router.back()` leaves the screen on the first tap. Step navigation already has its own explicit handler (`setUrlState({ step })`), so it never needed `push` either.

## Systemic investigation (this was the ask: fix the class, not the instance)
- **nuqs `history:'push'` footgun:** exactly **2** sites, both add-money. Every other nuqs flow already uses `replace` (the two Exchange widgets set it explicitly). So the bug was contained, but nothing stopped it recurring.
- **Back-button anti-patterns:** the existing guard pack (PRs #1965/#1997) already bans `router.back()`, `router.push` in `onBack/onPrev`, and `window.history.length`. The remaining hits are intentionally exempted (`PublicProfile` referrer signal, `useNativePlugins` hardware back) or dev-showcase snippets. That pass caught the *call-shape* anti-patterns but **missed this config footgun**, which defeats `useSafeBack` from the other side.
- **Guard added:** a `no-restricted-syntax` rule now flags `{ history: 'push' }` inside `useQueryState(s)`, with a message pointing devs to the default. Verified firing on a fixture; the fixed files are clean.

## Why tests didn't catch it
`add-money-states.test.tsx` mocks `nuqs` as a plain object and `router.back` as `jest.fn()` (every `onBack={jest.fn()}`) — a render-matrix suite that structurally can't observe history-stack behavior. The proper guard is a real browser. Added a Playwright regression test (`e2e/flows/add-money.spec.ts`) + `data-testid="nav-back"` on NavHeader: it types an amount and asserts one back tap leaves `/bank` for the country page.

## Verification
- ✅ `typecheck` — zero errors in changed files
- ✅ `jest` — 47/47 (add-money matrix + useSafeBack), no regression
- ✅ `prettier --check` clean; `eslint` clean on changed files; new guard proven to fire
- ✅ Playwright spec compiles & registers (mobile + desktop)
- ⏳ Playwright **execution** runs in CI (its designed env). Local run was blocked by worktree tooling (Turbopack rejects symlinked `node_modules`), not by the change.

## Risk
Frontend-only, no backend. Behavior change: hardware/browser-back from the deposit-details step now returns to the country page instead of the amount step — the in-app back button on that step is unchanged and remains the primary affordance.