### PR TITLE
test(add-money): cover the reported Manteca back-button path in e2e

### DIFF
--- a/e2e/flows/add-money.spec.ts
+++ b/e2e/flows/add-money.spec.ts
@@ -115,4 +115,35 @@ test.describe('Add money flow', () => {
         consoleLogs.flush(testInfo, 'add-money-ar-bank-back')
         await context.close()
     })
+
+    // Same regression, the originally-reported flow: Manteca (MP) AR deposit at
+    // /add-money/argentina/manteca. Both add-money amount screens shared the
+    // { history: 'push' } bug; this covers the reported variant directly.
+    test('add-money/argentina/manteca — back button leaves the amount screen after typing (verified-ar)', async ({
+        browser,
+    }, testInfo) => {
+        const context = await browser.newContext({ ...devices['Pixel 7'] })
+        await usePersona(context, 'verified-ar')
+
+        const page = await context.newPage()
+        const consoleLogs = collectConsoleLogs(page)
+        await installApiMocks(page)
+
+        await page.goto('/add-money/argentina/manteca')
+
+        // amount step renders (verified persona; currency rate is mocked)
+        const amountInput = page.locator('input[inputmode="decimal"]').first()
+        await amountInput.waitFor({ state: 'visible', timeout: 15000 })
+
+        await amountInput.fill('100')
+        await captureStep(page, testInfo, { name: '01-add-money-manteca-amount-typed' })
+
+        // one tap must exit to the country page, not linger on /manteca with a stale amount
+        await page.locator('[data-testid="nav-back"]').first().click()
+        await expect(page).toHaveURL(/\/add-money\/argentina(?:\?.*)?$/)
+        await captureStep(page, testInfo, { name: '02-add-money-manteca-back-left-screen' })
+
+        consoleLogs.flush(testInfo, 'add-money-manteca-back')
+        await context.close()
+    })
 })


### PR DESCRIPTION
Follow-up to #2254. That PR fixed the dead back button on **both** add-money amount screens (Manteca AR/BR and Bridge bank), but the Playwright regression only drove the **bank** variant (`/add-money/AR/bank`). The bug was originally reported on the **Manteca (MP)** flow, so this adds the same assertion directly on `/add-money/argentina/manteca`:

- type an amount (writes `?amount=` — the per-keystroke write that used to poison the back stack), then
- one tap on the `nav-back` button must leave for `/add-money/argentina` (not linger on `/manteca` with a stale amount).

**Test-only** — no source changes. Mirrors the existing bank back-test (same `verified-ar` persona + `installApiMocks`). Verified: prettier clean, both back tests register on mobile + desktop (`add-money.spec.ts:89` bank, `:122` manteca). e2e executes in CI.