### PR TITLE
fix(split-bill): hide "Split this bill" only on reversed/refunded charges + guard negative amount

### DIFF
--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -49,6 +49,7 @@ import {
     isPerkReward as isPerkRewardTransaction,
     isRequestEntry,
     isSendLinkEntry,
+    isSplittable,
     usesCompletedTimestampLabel,
 } from './transaction-predicates'
 import { useReceiptViewModel } from './useReceiptViewModel'
@@ -122,7 +123,6 @@ export const TransactionDetailsReceipt = ({
         isPendingRequester,
         isPendingSentLink,
         isQRPayment,
-        isCardSpend,
         country,
         rowVisibilityConfig,
         shouldHideBorder,
@@ -744,18 +744,15 @@ export const TransactionDetailsReceipt = ({
                 </div>
             )}
 
-            {!isPublic &&
-                (isQRPayment || isCardSpend) &&
-                transaction.status !== 'refunded' &&
-                transaction.status !== 'failed' && (
-                    <Button
-                        onClick={() => router.push(buildSplitBillRequestUrl(transaction.amount, transaction.userName))}
-                        icon="split"
-                        shadowSize="4"
-                    >
-                        Split this bill
-                    </Button>
-                )}
+            {!isPublic && isSplittable(transaction) && (
+                <Button
+                    onClick={() => router.push(buildSplitBillRequestUrl(transaction.amount, transaction.userName))}
+                    icon="split"
+                    shadowSize="4"
+                >
+                    Split this bill
+                </Button>
+            )}
 
             {shouldShowShareReceipt && !!getReceiptUrl(transaction) && (
                 <div className="pr-1">

--- a/src/components/TransactionDetails/__tests__/splitBill.utils.test.ts
+++ b/src/components/TransactionDetails/__tests__/splitBill.utils.test.ts
@@ -20,4 +20,10 @@ describe('buildSplitBillRequestUrl', () => {
         expect(buildSplitBillRequestUrl(8, null)).toBe('/request?amount=8')
         expect(buildSplitBillRequestUrl(8, '')).toBe('/request?amount=8')
     })
+
+    test('strips a leading minus so the prefill amount is never negative', () => {
+        expect(buildSplitBillRequestUrl(-15, 'Cafe Tortoni')).toBe('/request?amount=15&merchant=Cafe%20Tortoni')
+        expect(buildSplitBillRequestUrl('-12.5')).toBe('/request?amount=12.5')
+        expect(buildSplitBillRequestUrl(-20n)).toBe('/request?amount=20')
+    })
 })

--- a/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
+++ b/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
@@ -12,6 +12,7 @@ import {
     isQRPayment,
     isRequestEntry,
     isSendLinkEntry,
+    isSplittable,
     hasShareableReceipt,
 } from '../transaction-predicates'
 import type { TransactionDetails } from '../transactionTransformer'
@@ -107,5 +108,47 @@ describe('entry-kind predicates', () => {
             expect(isFxBearingFlow(tx('SEND_LINK'))).toBe(false)
             expect(isFxBearingFlow(tx('CRYPTO_WITHDRAW'))).toBe(false)
         })
+    })
+})
+
+// Gates the "Split this bill" CTA: a QR payment, or a card spend that went
+// through. It's an in-the-moment action right after paying, so a freshly-
+// authorized (`pending`) card hold IS splittable — settlement takes days. Only
+// charges that didn't stick (refunded/failed/cancelled) are excluded.
+describe('isSplittable', () => {
+    const txWithStatus = (kind: string, status?: string): TransactionDetails =>
+        ({
+            status,
+            extraDataForDrawer: { originalType: 'TRANSACTION_INTENT', kind },
+        }) as unknown as TransactionDetails
+
+    test('QR payments are splittable unless refunded/failed (behaviour unchanged)', () => {
+        expect(isSplittable(txWithStatus('QR_PAY', 'completed'))).toBe(true)
+        expect(isSplittable(txWithStatus('QR_PAY', 'pending'))).toBe(true)
+        expect(isSplittable(txWithStatus('QR_PAY', 'refunded'))).toBe(false)
+        expect(isSplittable(txWithStatus('QR_PAY', 'failed'))).toBe(false)
+    })
+
+    test('a freshly-authorized (pending) card hold IS splittable — split in the moment, settlement takes days', () => {
+        expect(isSplittable(txWithStatus('CARD_SPEND_AUTH', 'pending'))).toBe(true)
+    })
+
+    test('settled card spends are splittable', () => {
+        expect(isSplittable(txWithStatus('CARD_SPEND_CLEAR', 'completed'))).toBe(true)
+        expect(isSplittable(txWithStatus('CARD_SPEND_AUTH', 'completed'))).toBe(true)
+    })
+
+    test('a cancelled (reversed/expired) card hold is NOT splittable — the charge never stuck', () => {
+        expect(isSplittable(txWithStatus('CARD_SPEND_AUTH', 'cancelled'))).toBe(false)
+    })
+
+    test('refunded/failed card spends are NOT splittable', () => {
+        expect(isSplittable(txWithStatus('CARD_SPEND_CLEAR', 'refunded'))).toBe(false)
+        expect(isSplittable(txWithStatus('CARD_SPEND_CLEAR', 'failed'))).toBe(false)
+    })
+
+    test('non-QR / non-card kinds are never splittable', () => {
+        expect(isSplittable(txWithStatus('DIRECT_TRANSFER', 'completed'))).toBe(false)
+        expect(isSplittable(txWithStatus('SEND_LINK', 'completed'))).toBe(false)
     })
 })

--- a/src/components/TransactionDetails/splitBill.utils.ts
+++ b/src/components/TransactionDetails/splitBill.utils.ts
@@ -8,9 +8,14 @@
  *    merchant name) so the request comment isn't "Bill split for Card payment".
  *  - URL-encode the merchant so reserved chars (e.g. "Tigers & Lions") can't
  *    break the query string.
+ *  - Strip a leading sign so the prefill can never be negative.
  */
 export function buildSplitBillRequestUrl(amount: number | bigint | string, merchantName?: string | null): string {
     const merchantParam =
         merchantName && merchantName !== 'Card payment' ? `&merchant=${encodeURIComponent(merchantName)}` : ''
-    return `/request?amount=${encodeURIComponent(String(amount))}${merchantParam}`
+    // A split request must never carry a negative amount — strip a leading sign
+    // so a stray "-15" can't seed `/request?amount=-15`. Done on the string form
+    // to stay exact for bigint/string inputs.
+    const positiveAmount = String(amount).replace(/^-/, '')
+    return `/request?amount=${encodeURIComponent(positiveAmount)}${merchantParam}`
 }

--- a/src/components/TransactionDetails/transaction-predicates.ts
+++ b/src/components/TransactionDetails/transaction-predicates.ts
@@ -23,11 +23,26 @@ export function isQRPayment(transaction: TransactionDetails): boolean {
     return isKind(transaction, 'QR_PAY')
 }
 
-/** A Rain card *spend* (not a refund or reversal) — the only card rows eligible
- *  for a "Split this bill" CTA. Kind-based so refunds (REFUND/OTHER) and auth
- *  reversals are excluded. */
+/** A Rain card *spend* (not a refund or reversal). Kind-based so refunds
+ *  (REFUND/OTHER) and auth reversals are excluded. Card-spend eligibility for
+ *  the "Split this bill" CTA layers a settled-status check on top — see
+ *  {@link isSplittable}. */
 export function isCardSpend(transaction: TransactionDetails): boolean {
     return isKind(transaction, 'CARD_SPEND_AUTH') || isKind(transaction, 'CARD_SPEND_CLEAR')
+}
+
+/** Eligible for the "Split this bill" CTA: a QR payment, or a card spend that
+ *  actually went through. This is an in-the-moment action right after paying,
+ *  so a freshly-authorized card hold (`pending`) IS splittable — settlement can
+ *  take days and we don't make users wait. The only card spends excluded are the
+ *  ones that didn't stick: refunded, failed, and `cancelled` (the auth was
+ *  reversed or expired — "Hold released, funds back on your card"). QR pays keep
+ *  their prior behaviour (splittable unless refunded/failed). */
+export function isSplittable(transaction: TransactionDetails): boolean {
+    if (transaction.status === 'refunded' || transaction.status === 'failed') return false
+    if (isQRPayment(transaction)) return true
+    if (isCardSpend(transaction)) return transaction.status !== 'cancelled'
+    return false
 }
 
 /** Kinds that move money across a fiat rail: bank on/off-ramps + QR pays.


### PR DESCRIPTION
Two fixes from the **dev→main release review** (#2245), both in the new card-spend "Split this bill" feature (TASK-19739). Targets `dev`.

### 1. Split CTA showed on a reversed/expired card hold
The eligibility gate was `(isQRPayment || isCardSpend) && status !== 'refunded' && status !== 'failed'`. A `cancelled` card spend (the auth was **reversed or expired** — `CardPaymentRows.tsx` renders "Hold released — funds back on your card") still passed the gate, so a user could tap "Split this bill" and ask friends to chip in for a charge that never actually cost them.

**Fix:** extracted the logic into a tested `isSplittable()` predicate in `transaction-predicates.ts`. The CTA is an **in-the-moment action right after paying**, so a freshly-authorized hold (`pending`) **stays splittable** — card settlement can take days and we don't make users wait. Only charges that **didn't stick** are excluded:
- QR pays — **unchanged** (splittable unless refunded/failed).
- Card spends — splittable while `pending` and once settled; excluded only when `refunded`, `failed`, or `cancelled` (reversed/expired).

This also closes the verify-gap that let it through: the eligibility gate had no test. Now covered.

### 2. Negative-amount prefill hardening
`buildSplitBillRequestUrl` did `String(amount)` with no sign guard — a negative amount would seed `/request?amount=-15`. Now strips a leading `-` (on the string form, exact for bigint/string inputs).

### Tests
- `transaction-predicates.test.ts` — `isSplittable` across QR/card × pending/cancelled/completed/refunded/failed (pending card = splittable, cancelled = not).
- `splitBill.utils.test.ts` — negative number / string / bigint all normalize to positive.
- Local gate: prettier clean, `tsc --noEmit` 0 errors, tests pass.

_Not addressed here (lower priority, noted in the review): the slider snap-stick 0.5% edge case and the `'Card payment'` magic-string coupling — left as follow-ups._
