### PR TITLE
feat(card-details): render Rain dispute status in receipt drawer

### DIFF
--- a/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
+++ b/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
@@ -3,7 +3,7 @@
 import Image from 'next/image'
 import { type ReactNode } from 'react'
 import { PaymentInfoRow } from '@/components/Payment/PaymentInfoRow'
-import { type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
+import { type DisputeStatus, type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
 import { friendlyDeclineReason } from '@/utils/cardDeclineReason'
 import { getFlagUrl } from '@/constants/countryCurrencyMapping'
 import { extractMerchantIso2 } from '@/components/TransactionDetails/transaction-details.utils'
@@ -25,6 +25,30 @@ function parseCents(value: string | null | undefined): number | null {
     if (value == null) return null
     const n = Number(value)
     return Number.isFinite(n) ? n : null
+}
+
+/**
+ * Friendly copy for the dispute status row. The drawer shows ONE row labeled
+ * "Dispute" with the status-mapped text. Keep terminal-state copy actionable:
+ * "Resolved by merchant refund" / "Accepted (refund issued)" both signal that
+ * money has been returned (or is being returned), which is the user's actual
+ * concern at that point.
+ */
+export function disputeStatusLabel(status: DisputeStatus): string {
+    switch (status) {
+        case 'pending':
+            return 'Disputed — Awaiting review'
+        case 'inReview':
+            return 'Disputed — In review'
+        case 'accepted':
+            return 'Disputed — Accepted (refund issued)'
+        case 'rejected':
+            return 'Disputed — Rejected'
+        case 'canceled':
+            return 'Disputed — Cancelled'
+        case 'resolvedByMerchant':
+            return 'Disputed — Resolved by merchant refund'
+    }
 }
 
 /**
@@ -65,6 +89,7 @@ export function hasCardPaymentRowsContent(transaction: TransactionDetails): bool
     if (card.cancellationReason === 'auth_reversed' || card.cancellationReason === 'auth_expired_uncaptured') {
         return true
     }
+    if (card.dispute) return true
     return false
 }
 
@@ -198,12 +223,34 @@ export function CardPaymentRows({
         card.cancellationReason === 'auto_closed' ||
         card.cancellationReason === 'auth_reversed' ||
         card.cancellationReason === 'auth_expired_uncaptured'
-    if (transaction.status === 'pending' && !card.isRefund && !hasCancellationNote) {
+    // Active disputes flip the pill to pending too (see transactionTransformer),
+    // but the dispute row IS the status — the spend already settled, so
+    // "Authorized, awaiting settlement" is a lie next to "Disputed — In review".
+    const hasActiveDispute = card.dispute?.status === 'pending' || card.dispute?.status === 'inReview'
+    if (transaction.status === 'pending' && !card.isRefund && !hasCancellationNote && !hasActiveDispute) {
         subRows.push({
             key: 'pendingNote',
             label: 'Status',
             value: 'Authorized, awaiting settlement or reversal',
         })
+    }
+
+    // Dispute lifecycle. One row for the status; an additional row when Rain
+    // has requested evidence so the user knows to upload it. Both render
+    // regardless of the spend's status — disputes outlive the spend lifecycle.
+    if (card.dispute) {
+        subRows.push({
+            key: 'disputeStatus',
+            label: 'Dispute',
+            value: disputeStatusLabel(card.dispute.status),
+        })
+        if (card.dispute.evidenceRequestedMessage) {
+            subRows.push({
+                key: 'disputeEvidenceRequest',
+                label: 'Evidence requested',
+                value: card.dispute.evidenceRequestedMessage,
+            })
+        }
     }
 
     if (subRows.length === 0) return null

--- a/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
+++ b/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
@@ -244,11 +244,15 @@ export function CardPaymentRows({
             label: 'Dispute',
             value: disputeStatusLabel(card.dispute.status),
         })
-        if (card.dispute.evidenceRequestedMessage) {
+        // Rain prompt text is free-form prose; the same nonBlank gate the
+        // decline-reason row uses keeps whitespace-only payloads from
+        // rendering an empty "Evidence requested" row.
+        const evidenceMessage = nonBlank(card.dispute.evidenceRequestedMessage)
+        if (evidenceMessage) {
             subRows.push({
                 key: 'disputeEvidenceRequest',
                 label: 'Evidence requested',
-                value: card.dispute.evidenceRequestedMessage,
+                value: evidenceMessage,
             })
         }
     }

--- a/src/components/TransactionDetails/provider-rows/__tests__/dispute-label.test.ts
+++ b/src/components/TransactionDetails/provider-rows/__tests__/dispute-label.test.ts
@@ -1,0 +1,21 @@
+// Locks in the Disputed-status row copy. Keep changes here in sync with the
+// BE's dispute event handler in src/ledger/rain-mapper.ts so the FE label
+// always covers every status string the BE may write.
+
+import { disputeStatusLabel } from '../CardPaymentRows'
+import { type DisputeStatus } from '@/components/TransactionDetails/transactionTransformer'
+
+const CASES: Array<[DisputeStatus, string]> = [
+    ['pending', 'Disputed — Awaiting review'],
+    ['inReview', 'Disputed — In review'],
+    ['accepted', 'Disputed — Accepted (refund issued)'],
+    ['rejected', 'Disputed — Rejected'],
+    ['canceled', 'Disputed — Cancelled'],
+    ['resolvedByMerchant', 'Disputed — Resolved by merchant refund'],
+]
+
+describe('disputeStatusLabel', () => {
+    test.each(CASES)('%s → %s', (status: DisputeStatus, label: string) => {
+        expect(disputeStatusLabel(status)).toBe(label)
+    })
+})

--- a/src/components/TransactionDetails/transactionTransformer.ts
+++ b/src/components/TransactionDetails/transactionTransformer.ts
@@ -21,6 +21,19 @@ import { dispatchStrategy, isIntentKind, type IntentKind } from './strategies/re
 /** Rain dispute lifecycle status values. Source: Rain dispute.* webhooks. */
 export type DisputeStatus = 'pending' | 'inReview' | 'accepted' | 'rejected' | 'canceled' | 'resolvedByMerchant'
 
+const DISPUTE_STATUSES: ReadonlySet<string> = new Set([
+    'pending',
+    'inReview',
+    'accepted',
+    'rejected',
+    'canceled',
+    'resolvedByMerchant',
+])
+
+function isDisputeStatus(value: unknown): value is DisputeStatus {
+    return typeof value === 'string' && DISPUTE_STATUSES.has(value)
+}
+
 // Mirror of peanut-api-ts `enum TransactionProvider`. Receipts that branch
 // on provider (e.g. Manteca-specific deposit-info row) use this typed
 // value via `extraDataForDrawer.provider` for positive identity rather
@@ -608,10 +621,12 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
                           dispute: (() => {
                               const d = entry.extraData?.dispute as Record<string, unknown> | null | undefined
                               if (!d || typeof d !== 'object') return null
-                              const status = d.status as DisputeStatus | undefined
-                              if (!status) return null
+                              // Type-guard d.status — any non-DisputeStatus string from
+                              // the wire (sandbox drift, schema bump) should drop the
+                              // whole block rather than leak through.
+                              if (!isDisputeStatus(d.status)) return null
                               return {
-                                  status,
+                                  status: d.status,
                                   type: (d.type as string | undefined) ?? null,
                                   resolvedAt: (d.resolvedAt as string | undefined) ?? null,
                                   textEvidence: (d.textEvidence as string | undefined) ?? null,

--- a/src/components/TransactionDetails/transactionTransformer.ts
+++ b/src/components/TransactionDetails/transactionTransformer.ts
@@ -18,6 +18,9 @@ import { PEANUT_WALLET_CHAIN } from '@/constants/zerodev.consts'
 import { type HistoryEntryPerkReward, type ChargeEntry } from '@/services/services.types'
 import { dispatchStrategy, isIntentKind, type IntentKind } from './strategies/registry'
 
+/** Rain dispute lifecycle status values. Source: Rain dispute.* webhooks. */
+export type DisputeStatus = 'pending' | 'inReview' | 'accepted' | 'rejected' | 'canceled' | 'resolvedByMerchant'
+
 // Mirror of peanut-api-ts `enum TransactionProvider`. Receipts that branch
 // on provider (e.g. Manteca-specific deposit-info row) use this typed
 // value via `extraDataForDrawer.provider` for positive identity rather
@@ -374,6 +377,17 @@ export interface TransactionDetails {
             parentRainTxId: string | null
             rainTransactionId: string | null
             isRefund: boolean
+            /** Populated when Rain has fired any dispute.* webhook for this
+             *  spend. Status drives the drawer's "Disputed — <label>" badge;
+             *  evidenceRequestedMessage prompts the user to upload docs. */
+            dispute: {
+                status: DisputeStatus
+                type: string | null
+                resolvedAt: string | null
+                textEvidence: string | null
+                evidenceRequestedMessage: string | null
+                chargebackRainTxId: string | null
+            } | null
         }
     }
     sourceView?: 'status' | 'history'
@@ -458,6 +472,19 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
     // Strategy uiStatus wins (e.g. SEND_LINK BOTH → 'cancelled'); otherwise
     // map raw entry.status via the shared helper.
     if (!strategyOverrodeUiStatus) uiStatus = mapEntryStatusToUiStatus(entry, direction)
+
+    // Active dispute trumps the underlying spend's status — a card spend
+    // that's been contested isn't really "completed" from the user's POV,
+    // even though Rain settled it. Flip the pill to `pending` while the
+    // dispute is open. Terminal dispute states (accepted / resolvedByMerchant
+    // / rejected / canceled) restore the underlying status: the chargeback
+    // for accepted disputes arrives as a separate credit transaction; the
+    // others left the original spend standing. Status discrimination beyond
+    // the pill lives on the "Disputed — <label>" sub-row.
+    const disputeStatus = (entry.extraData?.dispute as { status?: string } | null | undefined)?.status
+    if (disputeStatus === 'pending' || disputeStatus === 'inReview') {
+        uiStatus = 'pending'
+    }
 
     // parse the amount from the usdamount string in extradata
     const amount = entry.extraData?.usdAmount
@@ -576,6 +603,22 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
                           parentRainTxId: entry.extraData?.parentRainTxId as string | null,
                           rainTransactionId: entry.extraData?.rainTransactionId as string | null,
                           isRefund: !!entry.extraData?.parentRainTxId,
+                          // Dispute lifecycle — null when Rain hasn't fired
+                          // any dispute.* webhook for this spend.
+                          dispute: (() => {
+                              const d = entry.extraData?.dispute as Record<string, unknown> | null | undefined
+                              if (!d || typeof d !== 'object') return null
+                              const status = d.status as DisputeStatus | undefined
+                              if (!status) return null
+                              return {
+                                  status,
+                                  type: (d.type as string | undefined) ?? null,
+                                  resolvedAt: (d.resolvedAt as string | undefined) ?? null,
+                                  textEvidence: (d.textEvidence as string | undefined) ?? null,
+                                  evidenceRequestedMessage: (d.evidenceRequestedMessage as string | undefined) ?? null,
+                                  chargebackRainTxId: (d.chargebackRainTxId as string | undefined) ?? null,
+                              }
+                          })(),
                       }
                     : undefined,
             perkReward: entry.extraData?.perkReward as HistoryEntryPerkReward | undefined,

--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -137,6 +137,21 @@ export interface HistoryEntryExtraData {
     merchantLogo?: string | null
     merchantId?: string | null
 
+    // Dispute lifecycle. Set when Rain has fired any dispute.* webhook for
+    // the spend. Transformer narrows into TransactionDetails.cardPayment.dispute.
+    dispute?: {
+        rainDisputeId?: string
+        status?: 'pending' | 'inReview' | 'accepted' | 'rejected' | 'canceled' | 'resolvedByMerchant'
+        type?: string
+        createdAt?: string
+        resolvedAt?: string | null
+        textEvidence?: string | null
+        evidenceRequestedMessage?: string | null
+        evidenceRequestedAt?: string | null
+        chargebackRainTxId?: string | null
+        chargebackCreatedAt?: string | null
+    } | null
+
     // Perk reward + claim metadata. Shapes match
     // TransactionDetails.extraDataForDrawer.perk* — kept loose here to
     // avoid a cross-import; transformer narrows.


### PR DESCRIPTION
## Summary

Companion to **peanut-api-ts#1037** (Rain dispute webhook handling).

The BE PR stamps `metadata.dispute` on the `CARD_SPEND_AUTH` intent whenever Rain fires any `dispute.*` webhook. This PR makes that visible:

- Plumb `extraData.dispute` through `history.utils.ts` → `transactionTransformer` → `cardPayment.dispute`.
- Render a "Disputed — <label>" row in the receipt drawer's `CardPaymentRows`, under the existing decline / cancellation / pending notes.
- Append an "Evidence requested" sub-row when Rain has prompted the user for docs.
- **Pill override:** while the dispute is `pending` or `inReview`, the spend's status pill flips to PENDING — a settled spend that's actively contested isn't really COMPLETED from the user's POV. Terminal dispute states (`accepted` / `resolvedByMerchant` / `rejected` / `canceled`) restore the underlying status.
- Suppress the existing "Authorized, awaiting settlement or reversal" sub-row when an active dispute is the reason for the pending pill — the dispute row IS the status story there, the auth-awaiting message is a lie.

## Risks

- **Cross-repo dependency.** Without the BE PR deployed, `extraData.dispute` is null and the UI just doesn't render anything new. Safe to deploy either order.
- **Status pill semantics overload.** PENDING now means either "auth held, awaiting settlement" or "spend contested" — but the sub-row immediately disambiguates ("Authorized, awaiting settlement…" vs "Disputed — In review"). If this turns out to confuse, a dedicated `disputed` pill variant is the follow-up (deferred to keep design-system surface area zero in this PR).
- **No upload-evidence CTA** on the "Evidence requested" row. The user sees the prompt but can't act on it from inside the app — they need to use Rain's portal. Follow-up if we want the in-app flow.
- **No push notifications on dispute status changes.** Surface is receipt drawer only.

## Test plan

- [ ] Trigger BE `dispute.created` on jotest090's last spend → pill flips to PENDING, "Disputed — Awaiting review" sub-row appears, "Authorized, awaiting settlement" sub-row gone.
- [ ] BE `dispute.updated` to `inReview` → label flips to "Disputed — In review".
- [ ] BE `dispute.evidenceRequested` with message → "Evidence requested" row with the prompt.
- [ ] BE `dispute.chargebackCreated` → pill back to COMPLETED, label "Disputed — Accepted (refund issued)".
- [ ] `dispute.status = canceled` / `rejected` → pill back to COMPLETED, label matches.
- [ ] Non-disputed card spend renders unchanged.

Local gate: `pnpm typecheck` ✅, `npm test` 125/125 ✅ (TransactionDetails + new dispute-label suite).