### PR TITLE
feat(card): show registered cardholder name on reveal

### DIFF
--- a/src/components/Card/CardFace.tsx
+++ b/src/components/Card/CardFace.tsx
@@ -11,6 +11,9 @@ export interface RevealedCardDetails {
     cvv: string
     expiryMonth: number
     expiryYear: number
+    /** Registered cardholder name from Rain. Optional — the backend resolves it
+     *  best-effort, so a Rain hiccup leaves it absent and the field is hidden. */
+    cardholderName?: string
 }
 
 interface Props {
@@ -125,6 +128,13 @@ const CardFace: FC<Props> = ({
                                     </button>
                                 )}
                             </div>
+                            {/* Registered cardholder name — PII, kept out of session
+                             * recordings like the other revealed fields. */}
+                            {revealed.cardholderName && (
+                                <span className="ph-no-capture mt-1 text-sm font-bold uppercase tracking-wide">
+                                    {revealed.cardholderName}
+                                </span>
+                            )}
                             <div className="flex items-end justify-between">
                                 <div className="text-s flex gap-6">
                                     <div>

--- a/src/components/Card/CardFace.tsx
+++ b/src/components/Card/CardFace.tsx
@@ -138,7 +138,7 @@ const CardFace: FC<Props> = ({
                             <div className="flex items-end justify-between">
                                 <div className="text-s flex gap-6">
                                     <div>
-                                        <div className="opacity-70">Expiry</div>
+                                        {/* "Expiry" label dropped — value row stays one line so PAN/name clear the artwork */}
                                         {/* ph-no-capture: expiry digits out of recordings. */}
                                         <div className="ph-no-capture font-bold">
                                             {String(revealed.expiryMonth).padStart(2, '0')}/
@@ -147,7 +147,7 @@ const CardFace: FC<Props> = ({
                                     </div>
                                     <div className="flex items-end gap-1">
                                         <div>
-                                            <div className="opacity-70">CVV</div>
+                                            {/* "CVV" label dropped — value only */}
                                             {/* ph-no-capture: CVV out of recordings. */}
                                             <div className="ph-no-capture font-bold">{revealed.cvv}</div>
                                         </div>
@@ -180,11 +180,11 @@ const CardFace: FC<Props> = ({
                             <div className="h-7 w-56 animate-pulse rounded bg-white/40" />
                             <div className="mt-2 flex items-end gap-6 text-xs">
                                 <div>
-                                    <div className="opacity-70">Expiry</div>
+                                    {/* label dropped to match the revealed layout — no height jump on reveal */}
                                     <div className="mt-1 h-4 w-12 animate-pulse rounded bg-white/40" />
                                 </div>
                                 <div>
-                                    <div className="opacity-70">CVV</div>
+                                    {/* label dropped to match the revealed layout */}
                                     <div className="mt-1 h-4 w-10 animate-pulse rounded bg-white/40" />
                                 </div>
                             </div>

--- a/src/components/Card/__tests__/CardFace.test.tsx
+++ b/src/components/Card/__tests__/CardFace.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * CardFace — registered cardholder name.
+ *
+ * The name comes from Rain (best-effort) and is shown ONLY in the revealed
+ * state, alongside PAN/CVV/expiry. It must never appear on the masked card, and
+ * the card must still render when the reveal payload omits the name (backend
+ * degraded the Rain lookup).
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import CardFace, { type RevealedCardDetails } from '@/components/Card/CardFace'
+
+const revealed: RevealedCardDetails = {
+    pan: '4111111111111234',
+    cvv: '123',
+    expiryMonth: 12,
+    expiryYear: 2030,
+    cardholderName: 'Jane Doe',
+}
+
+describe('CardFace cardholder name', () => {
+    it('shows the registered name when the card is revealed', () => {
+        render(<CardFace last4="1234" revealed={revealed} />)
+        expect(screen.getByText('Jane Doe')).toBeInTheDocument()
+    })
+
+    it('hides the name when the card is masked (not revealed)', () => {
+        render(<CardFace last4="1234" revealed={null} />)
+        expect(screen.queryByText('Jane Doe')).not.toBeInTheDocument()
+    })
+
+    it('still renders the revealed card when the name is absent', () => {
+        const { cardholderName: _omitted, ...withoutName } = revealed
+        render(<CardFace last4="1234" revealed={withoutName} />)
+        expect(screen.queryByText('Jane Doe')).not.toBeInTheDocument()
+        // PAN still renders, proving reveal works without the name.
+        expect(screen.getByText('4111 1111 1111 1234')).toBeInTheDocument()
+    })
+})

--- a/src/components/Card/__tests__/CardFace.test.tsx
+++ b/src/components/Card/__tests__/CardFace.test.tsx
@@ -21,7 +21,11 @@ const revealed: RevealedCardDetails = {
 describe('CardFace cardholder name', () => {
     it('shows the registered name when the card is revealed', () => {
         render(<CardFace last4="1234" revealed={revealed} />)
-        expect(screen.getByText('Jane Doe')).toBeInTheDocument()
+        const name = screen.getByText('Jane Doe')
+        expect(name).toBeInTheDocument()
+        // PII guard: the name must stay inside the ph-no-capture wrapper so it's
+        // kept out of session recordings — assert the class, not just the text.
+        expect(name).toHaveClass('ph-no-capture')
     })
 
     it('hides the name when the card is masked (not revealed)', () => {

--- a/src/services/rain.ts
+++ b/src/services/rain.ts
@@ -174,6 +174,9 @@ export interface RainCardDetailsResponse {
     expiryYear: number
     last4: string
     network: string
+    /** Registered cardholder name from Rain. Best-effort on the backend, so it
+     *  may be absent if the Rain user lookup failed. */
+    cardholderName?: string
 }
 
 export type RainLimitFrequency = 'perAuthorization' | 'per24HourPeriod' | 'per30DayPeriod' | 'perAllTime'


### PR DESCRIPTION
## Summary
Render the Rain-registered cardholder name on the card face, only in the revealed state (alongside
PAN/CVV/expiry), `ph-no-capture` since it's PII.

## Risks / cross-repo
⚠️ **Depends on peanut-api-ts#1038**, which returns the optional `cardholderName` on
`GET /rain/cards/:cardId/details`. Deploy **backend first**; the field is optional so the FE degrades
gracefully if the BE isn't live yet.

## QA
- Unit: `CardFace.test.tsx` (name shown revealed / hidden masked / renders when name absent) +
  `useCardReveal` passthrough. Typecheck + prettier clean.
- Sandbox: reveal shows the name; masked shows none.

## Follow-up (not blocking)
- Refresh the OpenAPI snapshot (`api.openapi.json` + `api.generated.ts`) to include `cardholderName` via
  `pnpm gen:api:live` against the updated backend. Runtime works without it (FE uses the hand-written
  `RainCardDetailsResponse`); `check:api` stays green (snapshot self-consistent).
