### PR TITLE
fix(card): prioritize card CTA for eligible users over region-picker KYC

### DIFF
--- a/src/components/Profile/views/UnlockedRegions.view.tsx
+++ b/src/components/Profile/views/UnlockedRegions.view.tsx
@@ -21,6 +21,10 @@ import Image from 'next/image'
 import { useSafeBack } from '@/hooks/useSafeBack'
 import { useState, useCallback, useRef, useMemo } from 'react'
 import { type KYCRegionIntent } from '@/app/actions/types/sumsub.types'
+import { useRouter } from 'next/navigation'
+import { useCardInfo } from '@/hooks/useCardInfo'
+import { useRainCardOverview } from '@/hooks/useRainCardOverview'
+import { findActiveCard } from '@/components/Card/cardState.utils'
 
 type ModalVariant = 'start' | 'processing' | 'action_required' | 'rejected'
 
@@ -59,6 +63,14 @@ function getModalVariant(rail: RailCapability | undefined, hasSumsubAction: bool
 
 const UnlockedRegions = () => {
     const onBack = useSafeBack('/profile', { replace: true })
+    const router = useRouter()
+    // Card-priority guard: an eligible user (skip badge / admin grant →
+    // hasCardAccess) without an active card is steered to /card from the region
+    // picker (see handleStartKyc), regardless of region. `hasActiveCard` excludes
+    // users who already hold a card so they can still unlock bank regions here.
+    const { hasCardAccess } = useCardInfo()
+    const { overview } = useRainCardOverview()
+    const hasActiveCard = useMemo(() => !!findActiveCard(overview), [overview])
     const { rails, isKycApproved, railsForProvider, nextActionsForRail } = useCapabilities()
     // MIGRATION-REVIEW: unlockedRegions/lockedRegions previously came from
     // `useIdentityVerification` (raw rails + Sumsub flags). Now derived from the
@@ -152,6 +164,16 @@ const UnlockedRegions = () => {
     }, [])
 
     const handleStartKyc = useCallback(async () => {
+        // Card takes priority for eligible users: if the user has card access but
+        // no active card yet, send them to /card (KYC on rain-requirements — no
+        // regionIntent, no Bridge/Manteca rail enrollment) instead of starting
+        // region KYC, for ANY region they picked. Card-holders fall through and
+        // can still unlock bank regions here.
+        if (hasCardAccess === true && !hasActiveCard) {
+            setSelectedRegion(null)
+            router.push('/card')
+            return
+        }
         const intent = selectedRegion ? getRegionIntent(selectedRegion.path) : undefined
         if (intent) setActiveRegionIntent(intent)
         setErrorAcknowledged(false)
@@ -166,7 +188,7 @@ const UnlockedRegions = () => {
         // Fresh-KYC safe: the BE's cross-region branches all require an
         // APPROVED verification, so for first-time users the flag is a no-op.
         await flow.handleInitiateKyc(intent, undefined, true)
-    }, [flow.handleInitiateKyc, selectedRegion])
+    }, [flow.handleInitiateKyc, selectedRegion, hasCardAccess, hasActiveCard, router])
 
     // re-submission: skip StartVerificationView since user already consented
     const handleResubmitKyc = useCallback(async () => {

--- a/src/components/Profile/views/UnlockedRegions.view.tsx
+++ b/src/components/Profile/views/UnlockedRegions.view.tsx
@@ -70,7 +70,12 @@ const UnlockedRegions = () => {
     // users who already hold a card so they can still unlock bank regions here.
     const { hasCardAccess } = useCardInfo()
     const { overview } = useRainCardOverview()
-    const hasActiveCard = useMemo(() => !!findActiveCard(overview), [overview])
+    // Tri-state: undefined while the overview is still loading, so a card-holder
+    // isn't briefly treated as "no card" and bounced to /card before it resolves.
+    const hasActiveCard = useMemo<boolean | undefined>(() => {
+        if (!overview) return undefined
+        return !!findActiveCard(overview)
+    }, [overview])
     const { rails, isKycApproved, railsForProvider, nextActionsForRail } = useCapabilities()
     // MIGRATION-REVIEW: unlockedRegions/lockedRegions previously came from
     // `useIdentityVerification` (raw rails + Sumsub flags). Now derived from the
@@ -169,7 +174,7 @@ const UnlockedRegions = () => {
         // regionIntent, no Bridge/Manteca rail enrollment) instead of starting
         // region KYC, for ANY region they picked. Card-holders fall through and
         // can still unlock bank regions here.
-        if (hasCardAccess === true && !hasActiveCard) {
+        if (hasCardAccess === true && hasActiveCard === false) {
             setSelectedRegion(null)
             router.push('/card')
             return

--- a/src/hooks/useActivationStatus.ts
+++ b/src/hooks/useActivationStatus.ts
@@ -100,15 +100,26 @@ export function useActivationStatus(): ActivationStatus {
             }
         }
 
-        // Insert the card step between `deposit` and `outbound`: user has
-        // funded but hasn't taken the card yet. Skipped if they can't access
-        // the card flow, already have a card, or explicitly dismissed.
-        if (activationStep === 'outbound') {
-            const hasCardAccess = cardInfo?.hasCardAccess ?? false
-            const hasCard = !!findActiveCard(overview)
-            if (hasCardAccess && !hasCard && !cardDismissed) {
-                activationStep = 'card'
-            }
+        // Card takes priority for eligible users. An eligible user is one who
+        // holds a skip badge (e.g. WAITLIST_SKIP) or an explicit admin grant —
+        // both collapse into `cardInfo.hasCardAccess` on the BE, so gating here
+        // IS gating on the badge. If they don't yet hold a card and haven't
+        // dismissed the nudge, steer them straight to the card step (→ /card),
+        // overriding verify/deposit/outbound.
+        //
+        // Why this beats the old "insert between deposit and outbound" rule:
+        // the /card flow runs KYC on the `rain-requirements` Sumsub level,
+        // which does NOT send a regionIntent and does NOT enroll Bridge bank
+        // rails. The verify step instead routes to the region picker, where an
+        // EU/NA user gets `bridge-requirements` + auto-enrolled Bridge rails —
+        // the source of the "blocked by Bridge / proof of address" detours for
+        // users who only ever wanted a card. Surfacing card first keeps them
+        // off that path. Also fires for already-activated users who simply
+        // never took the card (the funnel would otherwise be `completed`).
+        const hasCardAccess = cardInfo?.hasCardAccess ?? false
+        const hasCard = !!findActiveCard(overview)
+        if (hasCardAccess && !hasCard && !cardDismissed) {
+            activationStep = 'card'
         }
 
         return { isActivated, activatedAt, activationStep }

--- a/src/hooks/useHomeCarouselCTAs.tsx
+++ b/src/hooks/useHomeCarouselCTAs.tsx
@@ -295,7 +295,13 @@ export const useHomeCarouselCTAs = () => {
             })
         }
 
-        if (!hasKycApproval && !isInFlight) {
+        // Don't push card-eligible users (skip badge / admin grant) to the
+        // region picker. This CTA routes to /profile/identity-verification,
+        // where EU/NA users get `bridge-requirements` + Bridge bank rails — the
+        // detour we steer eligible users away from (they go to /card instead,
+        // which KYCs on `rain-requirements`). `=== false` so we suppress while
+        // card-info is still loading too, mirroring the card-pioneer gate above.
+        if (!hasKycApproval && !isInFlight && hasCardAccessGranted === false) {
             _carouselCTAs.push({
                 id: 'kyc-prompt',
                 title: (


### PR DESCRIPTION
## Summary
Card-eligible users were being routed to the **region picker** before ever seeing the card. The home activation funnel only inserted the `card` step *after* the user was KYC-approved **and** funded, and the carousel `kyc-prompt` always pointed at `/profile/identity-verification`.

For **EU/NA** users that picker maps the region intent → `bridge-requirements` and auto-enrolls Bridge bank rails — whose database checks fail on many EU (e.g. Polish) addresses, surfacing as a *"blocked by Bridge / proof of address"* dead-end for people who only ever wanted a card.

This makes the card CTA take **priority for eligible users** and routes them to `/card`, whose KYC runs on the `rain-requirements` Sumsub level (no `regionIntent`, no Bridge rail enrollment).

- `useActivationStatus`: the `card` step now wins over `verify`/`deposit`/`outbound` (and fires for activated-but-cardless users), gated on `hasCardAccess && !hasCard && !dismissed`.
- `useHomeCarouselCTAs`: suppress the region-picker `kyc-prompt` for users who already have card access.

"Eligible" = `cardInfo.hasCardAccess` — a skip badge (e.g. `WAITLIST_SKIP`) or an admin grant. This is already phase-aware on the backend (`activeSkipBadgeCodes()`), so the gate widens automatically at public launch with no FE change.

## Risk
**Low / FE-only.** Changes which single home CTA shows; all routing targets already exist. Eligible users now see "Get your card" first instead of "Unlock payments"; non-eligible users are unchanged. No API/contract change.

> ⚠️ Base is **`main`** per request. The repo convention for features is `dev` — flagging in case this should retarget.

## QA (sandbox)
- Eligible user (skip badge / grant), no card → home shows **Get your card** → `/card` (rain-requirements KYC, **no region picker**).
- Eligible user taps **Maybe later** → falls back to the normal funnel.
- User with an active card → no card CTA.
- Non-eligible user → unchanged: sees verify / kyc-prompt → region picker.