### PR TITLE
fix(sentry): don't report qr-payment/init 422 as a client error

### DIFF
--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -12,7 +12,10 @@ const SKIP_REPORTING: Array<{ pattern: string | RegExp; statuses: number[] }> = 
     { pattern: /\/get-user(?:\b|$)/, statuses: [400, 401, 403, 404] },
     { pattern: /users/, statuses: [400, 401, 403, 404] },
     { pattern: /perks/, statuses: [400, 401, 403, 404] },
-    { pattern: /qr-payment\/init/, statuses: [400] },
+    // qr-payment/init: 400 = open QR awaiting merchant amount; 422 = a QR the
+    // provider can't decode (bad/expired/unsupported) — both are user-input
+    // outcomes shown to the user, not server bugs. (BE peanut-api-ts #1041.)
+    { pattern: /qr-payment\/init/, statuses: [400, 422] },
     // Rain card secrets endpoints are intentionally rate-limited (5/min) — a
     // 429 here is an expected outcome surfaced to the user, not a server bug.
     { pattern: /\/rain\/cards\/[^/]+\/details/, statuses: [429] },


### PR DESCRIPTION
## Summary
Companion to **peanut-api-ts #1041**, which made `POST /manteca/qr-payment/init` return **422** (instead of 500) when the provider can't decode a scanned QR — a user-input outcome, not a server bug.

This adds `422` to the `qr-payment/init` Sentry skip-list (`src/utils/sentry.utils.ts`) alongside the existing `400`, so a user scanning a bad/expired QR no longer generates Sentry warning noise — matching how the `400` (open QR awaiting merchant amount) is already skipped.

## Risk
**None functional.** Observability-only — `SKIP_REPORTING` controls whether a non-2xx is forwarded to Sentry, not any app behavior. The FE already shows the user-facing "couldn't read this QR" message + doesn't retry decoding errors. Genuine 500/502 from this route stay reported.

## Deploy order
No dependency. BE #1041 is already live in prod (422 served now); until this FE change reaches prod those 422s log as a low-severity Sentry *warning* (not error). This just silences that residual noise.

## QA
`npx jest src/utils/__tests__/sentry.utils.test.ts` (existing suite green). `shouldSkipReporting` is a private helper (no export added — config-array change only).