### PR TITLE
fix(kyc): correct DUPLICATE_EMAIL copy — sign in / contact support

### DIFF
--- a/src/constants/sumsub-reject-labels.consts.ts
+++ b/src/constants/sumsub-reject-labels.consts.ts
@@ -275,7 +275,7 @@ const REJECT_LABEL_MAP: Record<string, RejectLabelInfo> = {
     DUPLICATE_EMAIL: {
         title: 'Email already in use',
         description:
-            'The email you entered is already associated with another account. Please verify again with a different email.',
+            'This email is already linked to another Peanut account. If it’s yours, sign in to that account to continue — otherwise contact support.',
     },
 }
 


### PR DESCRIPTION
## Summary

The `DUPLICATE_EMAIL` reject-label copy told users to *"verify again with a different email."* That's the wrong action: the collision is almost always the user's **own earlier account**, which the backend now auto-resolves (peanut-api-ts #1040). The cases that still surface this message are genuine conflicts where the right action is to **sign into the other account or contact support** — not re-enter a different email.

Before: *"The email you entered is already associated with another account. Please verify again with a different email."*
After: *"This email is already linked to another Peanut account. If it's yours, sign in to that account to continue — otherwise contact support."*

## Risk
Copy-only, one line in `src/constants/sumsub-reject-labels.consts.ts`. Renders in the existing `KycActionRequired` / `RejectLabelsList` path. No logic change.

## Cross-repo
Companion to **peanut-api-ts #1040** (drops the Sumsub data-wipe + adds dormant-account email reclaim). **Independent and order-agnostic** — this is just copy; ship either first.

## QA
Trigger an `ACTION_REQUIRED` KYC state carrying `rejectLabels: ["DUPLICATE_EMAIL"]` → the drawer shows the new copy. No test asserts this string today (pure content constant).