### PR TITLE
feat(bridge): pass claimer details for travel rule in guest claims

### DIFF
--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -257,6 +257,23 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                     externalAccountId,
                 },
                 features: { allowAnyFromAddress: true },
+                // travel rule: pass claimer details for third-party guest claims
+                ...(isGuestFlow &&
+                    account.firstName &&
+                    account.lastName && {
+                        beneficiaryName: `${account.firstName} ${account.lastName}`,
+                        ...(account.street &&
+                            account.city &&
+                            account.country && {
+                                beneficiaryAddress: {
+                                    street: account.street,
+                                    city: account.city,
+                                    country: account.country,
+                                    state: account.state || undefined,
+                                    postalCode: account.postalCode || undefined,
+                                },
+                            }),
+                    }),
             }
 
             const offrampResponse = isGuestFlow

--- a/src/services/services.types.ts
+++ b/src/services/services.types.ts
@@ -273,6 +273,15 @@ export interface TCreateOfframpRequest {
     features?: {
         allowAnyFromAddress?: boolean
     }
+    // travel rule: claimer (beneficiary) details for third-party guest claims
+    beneficiaryName?: string
+    beneficiaryAddress?: {
+        street: string
+        city: string
+        country: string
+        state?: string
+        postalCode?: string
+    }
 }
 
 export interface TCreateOfframpResponse {


### PR DESCRIPTION
- contributes to TASK-19569

## Summary

- Add `beneficiaryName` and `beneficiaryAddress` optional fields to `TCreateOfframpRequest`
- In guest claim flow (`BankFlowManager`), forward claimer's name + address to the offramp creation request
- Address block only included when all required fields (street, city, country) are present
- Backend uses these as `beneficiary.is_self=false` travel rule data for Bridge compliance

## Test plan

- [ ] Guest claim flow: claimer fills bank form, verify beneficiaryName + beneficiaryAddress are sent in the offramp request
- [ ] First-party withdraw: verify no beneficiary fields are sent (is_self=true path)
- [ ] Guest claim with missing address fields: verify address block is omitted, not sent with empty strings

Companion to backend PR: peanutprotocol/peanut-api-ts#1050

ref: https://apidocs.bridge.xyz/get-started/guides/move-money/crypto-travel-rule