### PR TITLE
feat(add-money): flag BRL-via-PIX onramp as under maintenance (warn-only)

### DIFF
--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -1503,6 +1503,27 @@ describe('GROUP 8: InputAmountStep Component', () => {
         expect(screen.getByText('Continue')).not.toBeDisabled()
     })
 
+    test('renders maintenanceBanner and keeps Continue enabled (warn-only)', () => {
+        renderWithProviders(
+            <InputAmountStep
+                tokenAmount="100"
+                setTokenAmount={jest.fn()}
+                onSubmit={jest.fn()}
+                isLoading={false}
+                error={null}
+                setCurrencyAmount={jest.fn()}
+                limitsValidation={{ isBlocking: false, isWarning: false, currency: 'USD' }}
+                limitsCurrency="USD"
+                onBack={jest.fn()}
+                maintenanceBanner={<div data-testid="pix-maintenance">PIX deposits are under maintenance</div>}
+            />
+        )
+
+        expect(screen.getByTestId('pix-maintenance')).toBeInTheDocument()
+        // warn-only: the banner is informational and must not block submission
+        expect(screen.getByText('Continue')).not.toBeDisabled()
+    })
+
     test('Continue disabled when limits blocking', () => {
         const { getLimitsWarningCardProps } = require('@/features/limits/utils')
         getLimitsWarningCardProps.mockReturnValue({

--- a/src/components/AddMoney/components/InputAmountStep.tsx
+++ b/src/components/AddMoney/components/InputAmountStep.tsx
@@ -30,6 +30,8 @@ interface InputAmountStepProps {
     // required - must be provided by caller based on the payment flow's currency (ARS, BRL, USD)
     limitsCurrency: LimitCurrency
     onBack: () => void
+    // optional warning banner rendered at the top of the step (e.g. PIX-under-maintenance)
+    maintenanceBanner?: React.ReactNode
 }
 
 const InputAmountStep = ({
@@ -46,6 +48,7 @@ const InputAmountStep = ({
     limitsValidation,
     limitsCurrency,
     onBack,
+    maintenanceBanner,
 }: InputAmountStepProps) => {
     if (currencyData?.isLoading) {
         return <PeanutLoading />
@@ -63,6 +66,7 @@ const InputAmountStep = ({
         <div className="flex min-h-[inherit] flex-col justify-start space-y-8">
             <NavHeader title="Add Money" onPrev={onBack} />
             <div className="my-auto flex flex-grow flex-col justify-center gap-4 md:my-0">
+                {maintenanceBanner}
                 <div className="text-sm font-bold">How much do you want to add?</div>
 
                 <AmountInput

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -25,6 +25,8 @@ import { useQueryStates, parseAsString, parseAsStringEnum } from 'nuqs'
 import { useLimitsValidation } from '@/features/limits/hooks/useLimitsValidation'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import InfoCard from '@/components/Global/InfoCard'
+import underMaintenanceConfig, { PIX_BRAZIL_ONRAMP_MAINTENANCE } from '@/config/underMaintenance.config'
 
 // Step type for URL state
 type MantecaStep = 'inputAmount' | 'depositDetails'
@@ -70,6 +72,9 @@ const MantecaAddMoney: FC = () => {
         return countryData.find((country) => country.type === 'country' && country.path === selectedCountryPath)
     }, [selectedCountryPath])
     const onBack = useSafeBack(addMoneyCountryUrl(selectedCountryPath))
+    // BRL-via-PIX onramp warn-only maintenance flag (see underMaintenance.config.ts).
+    // Brazil-scoped so the Argentina/ARS Manteca onramp is unaffected.
+    const showPixMaintenance = selectedCountry?.id === 'BR' && underMaintenanceConfig.pixBrazilOnrampMaintenance
     // The pool→full upgrade gate asks "did the user clear ID verification?",
     // not "do they have an enabled rail elsewhere?" — read the identity
     // signal directly (Sumsub-cleared the human) instead of the old
@@ -280,6 +285,16 @@ const MantecaAddMoney: FC = () => {
                     limitsValidation={limitsValidation}
                     limitsCurrency={limitsValidation.currency}
                     onBack={onBack}
+                    maintenanceBanner={
+                        showPixMaintenance ? (
+                            <InfoCard
+                                variant="warning"
+                                icon="alert"
+                                title={PIX_BRAZIL_ONRAMP_MAINTENANCE.title}
+                                description={PIX_BRAZIL_ONRAMP_MAINTENANCE.description}
+                            />
+                        ) : undefined
+                    }
                 />
             </>
         )

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -35,6 +35,7 @@ import { getRegionIntent } from '@/utils/regions.utils'
 import { useTosGuard } from '@/hooks/useTosGuard'
 import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
 import { useModalsContext } from '@/context/ModalsContext'
+import underMaintenanceConfig, { PIX_BRAZIL_ONRAMP_MAINTENANCE } from '@/config/underMaintenance.config'
 
 interface AddWithdrawCountriesListProps {
     flow: 'add' | 'withdraw'
@@ -426,58 +427,76 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
             <div className="space-y-2">
                 <h2 className="text-base font-bold">{title}</h2>
                 <div className="flex flex-col">
-                    {paymentMethods.map((method, index) => (
-                        <ActionListCard
-                            key={method.id}
-                            isDisabled={method.isSoon}
-                            title={method.title}
-                            description={method.description}
-                            descriptionClassName={'text-xs'}
-                            leftIcon={
-                                typeof method.icon === 'string' || method.icon === undefined ? (
-                                    <AvatarWithBadge
-                                        icon={method.icon as IconName}
-                                        name={method.title ?? method.id}
-                                        size="extra-small"
-                                        inlineStyle={{
-                                            backgroundColor:
-                                                method.icon === ('bank' as IconName)
-                                                    ? '#FFC900'
-                                                    : method.id === 'crypto-add' || method.id === 'crypto-withdraw'
-                                                      ? '#FFC900'
-                                                      : getColorForUsername(method.title).lightShade,
-                                            color: method.icon === ('bank' as IconName) ? 'black' : 'black',
-                                        }}
-                                    />
-                                ) : (
-                                    <Image
-                                        src={method.icon as StaticImageData}
-                                        alt={method.id}
-                                        className="h-8 w-8 rounded-full"
-                                        width={32}
-                                        height={32}
-                                    />
-                                )
-                            }
-                            rightContent={method.isSoon ? <StatusBadge status="soon" size="small" /> : null}
-                            onClick={() => {
-                                if (flow === 'withdraw') {
-                                    handleWithdrawMethodClick(method)
-                                } else if (method.path) {
-                                    handleAddMethodClick(method)
+                    {paymentMethods.map((method, index) => {
+                        // BRL-via-PIX onramp is warn-only under maintenance: tag the Pix option but
+                        // keep it clickable (do not set isDisabled).
+                        const isPixOnrampUnderMaintenance =
+                            flow === 'add' &&
+                            method.id === 'pix-add' &&
+                            underMaintenanceConfig.pixBrazilOnrampMaintenance
+                        return (
+                            <ActionListCard
+                                key={method.id}
+                                isDisabled={method.isSoon}
+                                title={method.title}
+                                description={method.description}
+                                descriptionClassName={'text-xs'}
+                                leftIcon={
+                                    typeof method.icon === 'string' || method.icon === undefined ? (
+                                        <AvatarWithBadge
+                                            icon={method.icon as IconName}
+                                            name={method.title ?? method.id}
+                                            size="extra-small"
+                                            inlineStyle={{
+                                                backgroundColor:
+                                                    method.icon === ('bank' as IconName)
+                                                        ? '#FFC900'
+                                                        : method.id === 'crypto-add' || method.id === 'crypto-withdraw'
+                                                          ? '#FFC900'
+                                                          : getColorForUsername(method.title).lightShade,
+                                                color: method.icon === ('bank' as IconName) ? 'black' : 'black',
+                                            }}
+                                        />
+                                    ) : (
+                                        <Image
+                                            src={method.icon as StaticImageData}
+                                            alt={method.id}
+                                            className="h-8 w-8 rounded-full"
+                                            width={32}
+                                            height={32}
+                                        />
+                                    )
                                 }
-                            }}
-                            position={
-                                paymentMethods.length === 1
-                                    ? 'single'
-                                    : index === 0
-                                      ? 'first'
-                                      : index === paymentMethods.length - 1
-                                        ? 'last'
-                                        : 'middle'
-                            }
-                        />
-                    ))}
+                                rightContent={
+                                    method.isSoon ? (
+                                        <StatusBadge status="soon" size="small" />
+                                    ) : isPixOnrampUnderMaintenance ? (
+                                        <StatusBadge
+                                            status="pending"
+                                            customText={PIX_BRAZIL_ONRAMP_MAINTENANCE.badge}
+                                            size="small"
+                                        />
+                                    ) : null
+                                }
+                                onClick={() => {
+                                    if (flow === 'withdraw') {
+                                        handleWithdrawMethodClick(method)
+                                    } else if (method.path) {
+                                        handleAddMethodClick(method)
+                                    }
+                                }}
+                                position={
+                                    paymentMethods.length === 1
+                                        ? 'single'
+                                        : index === 0
+                                          ? 'first'
+                                          : index === paymentMethods.length - 1
+                                            ? 'last'
+                                            : 'middle'
+                                }
+                            />
+                        )
+                    })}
                 </div>
             </div>
         )

--- a/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
+++ b/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
@@ -15,8 +15,9 @@
  * gate is NOT ready — so the fix didn't just delete the guard wholesale.
  */
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
 import AddWithdrawCountriesList from '../AddWithdrawCountriesList'
+import underMaintenanceConfig from '@/config/underMaintenance.config'
 
 // ---- routing ----
 const mockPush = jest.fn()
@@ -40,6 +41,13 @@ jest.mock('@/components/AddMoney/consts', () => ({
                     description: 'Add via bank transfer',
                     icon: 'bank',
                     path: '/add-money/testland/bank',
+                },
+                {
+                    id: 'pix-add',
+                    title: 'Pix',
+                    description: 'Instant transfers',
+                    icon: 'pix',
+                    path: '/add-money/brazil/manteca',
                 },
             ],
             // id contains 'default-bank-withdraw' → routes through checkBridgeGate
@@ -128,8 +136,13 @@ jest.mock('@/utils/regions.utils', () => ({ getRegionIntent: () => 'STANDARD' })
 
 jest.mock('@/components/ActionListCard', () => ({
     ActionListCard: (props: any) => (
-        <button data-testid={`method-${props.title?.toLowerCase()}`} onClick={props.onClick}>
+        <button
+            data-testid={`method-${props.title?.toLowerCase()}`}
+            onClick={props.isDisabled ? undefined : props.onClick}
+            disabled={props.isDisabled}
+        >
             {props.title}
+            {props.rightContent}
         </button>
     ),
 }))
@@ -137,7 +150,10 @@ jest.mock('@/components/Global/NavHeader', () => ({
     __esModule: true,
     default: () => <div data-testid="nav-header" />,
 }))
-jest.mock('@/components/Global/Badges/StatusBadge', () => ({ __esModule: true, default: () => <span /> }))
+jest.mock('@/components/Global/Badges/StatusBadge', () => ({
+    __esModule: true,
+    default: (props: any) => <span data-testid="status-badge">{props.customText ?? props.status}</span>,
+}))
 jest.mock('@/components/Profile/AvatarWithBadge', () => ({ __esModule: true, default: () => <span /> }))
 jest.mock('@/components/Global/EmptyStates/EmptyState', () => ({ __esModule: true, default: () => <div /> }))
 jest.mock('@/components/AddWithdraw/DynamicBankAccountForm', () => ({ DynamicBankAccountForm: () => <div /> }))
@@ -218,5 +234,43 @@ describe('AddWithdrawCountriesList — bank gate', () => {
 
         expect(mockPush).not.toHaveBeenCalled()
         expect(screen.getByTestId('initiate-kyc-modal')).toBeInTheDocument()
+    })
+})
+
+/**
+ * BRL-via-PIX onramp is unstable, so the Pix option is flagged "under maintenance"
+ * (config: pixBrazilOnrampMaintenance) — warn-only: it stays visible and clickable.
+ */
+describe('AddWithdrawCountriesList — PIX onramp maintenance tag', () => {
+    beforeEach(() => {
+        mockPush.mockClear()
+        // a ready gate so a click can navigate — proving the option is not blocked
+        setCapabilities('ready', [{ status: 'enabled', channel: 'bank', country: 'US' }])
+    })
+
+    afterEach(() => {
+        underMaintenanceConfig.pixBrazilOnrampMaintenance = true
+    })
+
+    it('tags the Pix option "Maintenance" but keeps it clickable (warn-only)', () => {
+        underMaintenanceConfig.pixBrazilOnrampMaintenance = true
+
+        render(<AddWithdrawCountriesList flow="add" />)
+
+        const pixCard = screen.getByTestId('method-pix')
+        expect(within(pixCard).getByText('Maintenance')).toBeInTheDocument()
+
+        // warn-only: still navigates into the deposit flow
+        fireEvent.click(pixCard)
+        expect(mockPush).toHaveBeenCalledWith('/add-money/brazil/manteca')
+    })
+
+    it('shows no maintenance tag when the flag is off, and never tags non-Pix methods', () => {
+        underMaintenanceConfig.pixBrazilOnrampMaintenance = false
+
+        render(<AddWithdrawCountriesList flow="add" />)
+
+        expect(within(screen.getByTestId('method-pix')).queryByText('Maintenance')).toBeNull()
+        expect(within(screen.getByTestId('method-bank')).queryByText('Maintenance')).toBeNull()
     })
 })

--- a/src/config/underMaintenance.config.ts
+++ b/src/config/underMaintenance.config.ts
@@ -34,6 +34,12 @@
  *    - card pioneer modal, carousel cta, and perk rewards hidden from home
  *    - set to false to enable the feature
  *
+ * 7. pixBrazilOnrampMaintenance: warn-only flag for the BRL-via-PIX onramp (Manteca Brazil deposit)
+ *    - shows a "Maintenance" tag on the Pix option in /add-money/brazil
+ *    - shows a warning banner inside the deposit flow (/add-money/brazil/manteca)
+ *    - does NOT block deposits — the option stays usable (warn-only)
+ *    - set to false when PIX deposits are stable again
+ *
  * note: if either mode is enabled, the maintenance banner will show everywhere
  *
  * I HOPE WE NEVER NEED TO USE THIS...
@@ -49,6 +55,7 @@ interface MaintenanceConfig {
     disableXchainWithdraw: boolean
     disableXchainSend: boolean
     disableCardPioneers: boolean
+    pixBrazilOnrampMaintenance: boolean
 }
 
 const underMaintenanceConfig: MaintenanceConfig = {
@@ -58,10 +65,20 @@ const underMaintenanceConfig: MaintenanceConfig = {
     disableXchainWithdraw: true, // set to true to disable cross-chain withdrawals (only allows USDC on Arbitrum)
     disableXchainSend: true, // set to true to disable cross-chain sends (claim, request payments - only allows USDC on Arbitrum)
     disableCardPioneers: true, // set to false to enable the Card Pioneers waitlist feature
+    pixBrazilOnrampMaintenance: true, // set to false when BRL-via-PIX deposits are stable again
 }
 
 // shared user-facing copy for cross-chain disabled paths — keep wording aligned with TokenSelector banner
 export const CROSS_CHAIN_DISABLED_MESSAGE =
     'Cross-chain claims are temporarily unavailable. Try claiming to an external wallet on the same chain as the link, or try again later.'
+
+// shared user-facing copy for the BRL-via-PIX onramp maintenance warning — keep the list tag and
+// the in-flow banner aligned
+export const PIX_BRAZIL_ONRAMP_MAINTENANCE = {
+    badge: 'Maintenance',
+    title: 'PIX deposits are under maintenance',
+    description:
+        'PIX deposits are currently unstable and may be delayed or fail. You can still continue, but service may be unreliable until this is resolved.',
+}
 
 export default underMaintenanceConfig


### PR DESCRIPTION
## Why
BRL deposits via PIX (the Manteca Brazil onramp) are currently **unstable / intermittently unavailable**. We want users to still see and use the option, but to clearly know it may be delayed or fail.

## What
A new **warn-only**, Brazil-scoped config lever — `underMaintenanceConfig.pixBrazilOnrampMaintenance` (`src/config/underMaintenance.config.ts`):

- **List tag** — a "Maintenance" badge on the **Pix** option in `/add-money/brazil`. The option stays **clickable** (warn-only).
- **In-flow banner** — a warning `InfoCard` at the top of the deposit screen (`/add-money/brazil/manteca`), shown only for Brazil (`selectedCountry.id === 'BR'`).

Why a new lever instead of the existing `disabledPaymentProviders: ['MANTECA']`: that one is too coarse — it would also kill the Argentina/ARS Manteca onramp **and** Manteca QR pay, and it hard-blocks rather than warns.

## Scope / notes
- **Frontend-only.** The API still accepts PIX deposits by design (warn-only). If a hard server-side stop is ever needed, that's a separate change.
- **To turn off** when PIX recovers: flip `pixBrazilOnrampMaintenance` to `false` in `underMaintenance.config.ts`.
- Shared copy (`PIX_BRAZIL_ONRAMP_MAINTENANCE`) keeps the badge + banner wording aligned.

## Base / history
Single commit, cut **clean onto `main`** (hotfix — the onramp is degraded now). This supersedes #2261, whose base got flipped dev→main and swelled to the whole dev→main delta (45 files); this PR is just the one intended change (6 files). main→dev back-merge tracked.

## Tests
- `InputAmountStep` renders the `maintenanceBanner` and keeps **Continue enabled** (warn-only).
- `AddWithdrawCountriesList` tags the Pix option "Maintenance" and it **still navigates** into the flow; no tag when the flag is off; non-Pix methods never tagged.
- Local gate: `prettier` ✓, `tsc` ✓ (0 errors), `jest` ✓ (add-money-states + AddWithdrawCountriesList + qr-pay-states, 73 passed). `next build` left to CI (authoritative; runs with submodules + env).
