### PR TITLE
chore(add-money): PIX-BR onramp recovery toggle + maintenance-flag cleanup

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
+++ b/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
@@ -866,8 +866,8 @@ describe('GROUP 2: Payment Form States', () => {
     })
 
     test('Provider maintenance shows maintenance banner', async () => {
-        const maintenanceConfig = require('@/config/underMaintenance.config').default
-        maintenanceConfig.disabledPaymentProviders = ['MANTECA']
+        const underMaintenanceConfig = require('@/config/underMaintenance.config').default
+        underMaintenanceConfig.disabledPaymentProviders = ['MANTECA']
 
         setupMantecaPayment()
 
@@ -878,7 +878,7 @@ describe('GROUP 2: Payment Form States', () => {
         })
 
         // Clean up
-        maintenanceConfig.disabledPaymentProviders = []
+        underMaintenanceConfig.disabledPaymentProviders = []
     })
 })
 

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -61,7 +61,7 @@ import { PointsAction } from '@/services/services.types'
 import { usePointsConfetti } from '@/hooks/usePointsConfetti'
 import { usePointsCalculation } from '@/hooks/usePointsCalculation'
 import { useModalsContext } from '@/context/ModalsContext'
-import maintenanceConfig from '@/config/underMaintenance.config'
+import underMaintenanceConfig from '@/config/underMaintenance.config'
 import PointsCard from '@/components/Common/PointsCard'
 import { TRANSACTIONS } from '@/constants/query.consts'
 import { useLimitsValidation } from '@/features/limits/hooks/useLimitsValidation'
@@ -141,7 +141,7 @@ export default function QRPayPage() {
 
     // Check if this payment provider is under maintenance
     const isProviderDisabled = useMemo(() => {
-        return paymentProcessor ? maintenanceConfig.disabledPaymentProviders.includes(paymentProcessor) : false
+        return paymentProcessor ? underMaintenanceConfig.disabledPaymentProviders.includes(paymentProcessor) : false
     }, [paymentProcessor])
 
     // MIGRATION-REVIEW: QR-pay KYC gate, formerly useQrKycGate + useKycStatus.

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -26,7 +26,7 @@ import { useLimitsValidation } from '@/features/limits/hooks/useLimitsValidation
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import InfoCard from '@/components/Global/InfoCard'
-import underMaintenanceConfig, { PIX_BRAZIL_ONRAMP_MAINTENANCE } from '@/config/underMaintenance.config'
+import { PIX_BRAZIL_ONRAMP_MAINTENANCE, isPixBrazilOnrampUnderMaintenance } from '@/config/underMaintenance.config'
 
 // Step type for URL state
 type MantecaStep = 'inputAmount' | 'depositDetails'
@@ -72,9 +72,9 @@ const MantecaAddMoney: FC = () => {
         return countryData.find((country) => country.type === 'country' && country.path === selectedCountryPath)
     }, [selectedCountryPath])
     const onBack = useSafeBack(addMoneyCountryUrl(selectedCountryPath))
-    // BRL-via-PIX onramp warn-only maintenance flag (see underMaintenance.config.ts).
+    // BRL-via-PIX onramp warn-only maintenance banner (see underMaintenance.config.ts).
     // Brazil-scoped so the Argentina/ARS Manteca onramp is unaffected.
-    const showPixMaintenance = selectedCountry?.id === 'BR' && underMaintenanceConfig.pixBrazilOnrampMaintenance
+    const showPixMaintenanceBanner = selectedCountry?.id === 'BR' && isPixBrazilOnrampUnderMaintenance()
     // The pool→full upgrade gate asks "did the user clear ID verification?",
     // not "do they have an enabled rail elsewhere?" — read the identity
     // signal directly (Sumsub-cleared the human) instead of the old
@@ -286,7 +286,7 @@ const MantecaAddMoney: FC = () => {
                     limitsCurrency={limitsValidation.currency}
                     onBack={onBack}
                     maintenanceBanner={
-                        showPixMaintenance ? (
+                        showPixMaintenanceBanner ? (
                             <InfoCard
                                 variant="warning"
                                 icon="alert"

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -26,7 +26,7 @@ import { useLimitsValidation } from '@/features/limits/hooks/useLimitsValidation
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import InfoCard from '@/components/Global/InfoCard'
-import { PIX_BRAZIL_ONRAMP_MAINTENANCE, isPixBrazilOnrampUnderMaintenance } from '@/config/underMaintenance.config'
+import underMaintenanceConfig, { PIX_ONRAMP_MAINTENANCE_COPY } from '@/config/underMaintenance.config'
 
 // Step type for URL state
 type MantecaStep = 'inputAmount' | 'depositDetails'
@@ -74,7 +74,8 @@ const MantecaAddMoney: FC = () => {
     const onBack = useSafeBack(addMoneyCountryUrl(selectedCountryPath))
     // BRL-via-PIX onramp warn-only maintenance banner (see underMaintenance.config.ts).
     // Brazil-scoped so the Argentina/ARS Manteca onramp is unaffected.
-    const showPixMaintenanceBanner = selectedCountry?.id === 'BR' && isPixBrazilOnrampUnderMaintenance()
+    const showPixMaintenanceBanner =
+        selectedCountry?.id === 'BR' && underMaintenanceConfig.enablePixOnrampMaintenanceWarning
     // The pool→full upgrade gate asks "did the user clear ID verification?",
     // not "do they have an enabled rail elsewhere?" — read the identity
     // signal directly (Sumsub-cleared the human) instead of the old
@@ -290,8 +291,8 @@ const MantecaAddMoney: FC = () => {
                             <InfoCard
                                 variant="warning"
                                 icon="alert"
-                                title={PIX_BRAZIL_ONRAMP_MAINTENANCE.title}
-                                description={PIX_BRAZIL_ONRAMP_MAINTENANCE.description}
+                                title={PIX_ONRAMP_MAINTENANCE_COPY.title}
+                                description={PIX_ONRAMP_MAINTENANCE_COPY.description}
                             />
                         ) : undefined
                     }

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -35,7 +35,7 @@ import { getRegionIntent } from '@/utils/regions.utils'
 import { useTosGuard } from '@/hooks/useTosGuard'
 import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
 import { useModalsContext } from '@/context/ModalsContext'
-import underMaintenanceConfig, { PIX_BRAZIL_ONRAMP_MAINTENANCE } from '@/config/underMaintenance.config'
+import { PIX_BRAZIL_ONRAMP_MAINTENANCE, isPixBrazilOnrampUnderMaintenance } from '@/config/underMaintenance.config'
 
 interface AddWithdrawCountriesListProps {
     flow: 'add' | 'withdraw'
@@ -429,11 +429,10 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                 <div className="flex flex-col">
                     {paymentMethods.map((method, index) => {
                         // BRL-via-PIX onramp is warn-only under maintenance: tag the Pix option but
-                        // keep it clickable (do not set isDisabled).
-                        const isPixOnrampUnderMaintenance =
-                            flow === 'add' &&
-                            method.id === 'pix-add' &&
-                            underMaintenanceConfig.pixBrazilOnrampMaintenance
+                        // keep it clickable (do not set isDisabled). The `pix-add` method is itself
+                        // Brazil-only (consts filter it to countryCode === 'BR').
+                        const showPixMaintenanceTag =
+                            flow === 'add' && method.id === 'pix-add' && isPixBrazilOnrampUnderMaintenance()
                         return (
                             <ActionListCard
                                 key={method.id}
@@ -470,7 +469,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                                 rightContent={
                                     method.isSoon ? (
                                         <StatusBadge status="soon" size="small" />
-                                    ) : isPixOnrampUnderMaintenance ? (
+                                    ) : showPixMaintenanceTag ? (
                                         <StatusBadge
                                             status="pending"
                                             customText={PIX_BRAZIL_ONRAMP_MAINTENANCE.badge}

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -35,7 +35,7 @@ import { getRegionIntent } from '@/utils/regions.utils'
 import { useTosGuard } from '@/hooks/useTosGuard'
 import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
 import { useModalsContext } from '@/context/ModalsContext'
-import { PIX_BRAZIL_ONRAMP_MAINTENANCE, isPixBrazilOnrampUnderMaintenance } from '@/config/underMaintenance.config'
+import underMaintenanceConfig, { PIX_ONRAMP_MAINTENANCE_COPY } from '@/config/underMaintenance.config'
 
 interface AddWithdrawCountriesListProps {
     flow: 'add' | 'withdraw'
@@ -432,7 +432,9 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                         // keep it clickable (do not set isDisabled). The `pix-add` method is itself
                         // Brazil-only (consts filter it to countryCode === 'BR').
                         const showPixMaintenanceTag =
-                            flow === 'add' && method.id === 'pix-add' && isPixBrazilOnrampUnderMaintenance()
+                            flow === 'add' &&
+                            method.id === 'pix-add' &&
+                            underMaintenanceConfig.enablePixOnrampMaintenanceWarning
                         return (
                             <ActionListCard
                                 key={method.id}
@@ -472,7 +474,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                                     ) : showPixMaintenanceTag ? (
                                         <StatusBadge
                                             status="pending"
-                                            customText={PIX_BRAZIL_ONRAMP_MAINTENANCE.badge}
+                                            customText={PIX_ONRAMP_MAINTENANCE_COPY.badge}
                                             size="small"
                                         />
                                     ) : null

--- a/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
+++ b/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
@@ -242,14 +242,19 @@ describe('AddWithdrawCountriesList — bank gate', () => {
  * (config: pixBrazilOnrampMaintenance) — warn-only: it stays visible and clickable.
  */
 describe('AddWithdrawCountriesList — PIX onramp maintenance tag', () => {
+    // snapshot/restore the shipped flag so each test can flip it without leaking state —
+    // and without coupling the restore to whatever the committed default happens to be
+    let originalPixMaintenance: boolean
+
     beforeEach(() => {
         mockPush.mockClear()
         // a ready gate so a click can navigate — proving the option is not blocked
         setCapabilities('ready', [{ status: 'enabled', channel: 'bank', country: 'US' }])
+        originalPixMaintenance = underMaintenanceConfig.pixBrazilOnrampMaintenance
     })
 
     afterEach(() => {
-        underMaintenanceConfig.pixBrazilOnrampMaintenance = true
+        underMaintenanceConfig.pixBrazilOnrampMaintenance = originalPixMaintenance
     })
 
     it('tags the Pix option "Maintenance" but keeps it clickable (warn-only)', () => {

--- a/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
+++ b/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
@@ -239,7 +239,7 @@ describe('AddWithdrawCountriesList — bank gate', () => {
 
 /**
  * BRL-via-PIX onramp is unstable, so the Pix option is flagged "under maintenance"
- * (config: pixBrazilOnrampMaintenance) — warn-only: it stays visible and clickable.
+ * (config: enablePixOnrampMaintenanceWarning) — warn-only: it stays visible and clickable.
  */
 describe('AddWithdrawCountriesList — PIX onramp maintenance tag', () => {
     // snapshot/restore the shipped flag so each test can flip it without leaking state —
@@ -250,15 +250,15 @@ describe('AddWithdrawCountriesList — PIX onramp maintenance tag', () => {
         mockPush.mockClear()
         // a ready gate so a click can navigate — proving the option is not blocked
         setCapabilities('ready', [{ status: 'enabled', channel: 'bank', country: 'US' }])
-        originalPixMaintenance = underMaintenanceConfig.pixBrazilOnrampMaintenance
+        originalPixMaintenance = underMaintenanceConfig.enablePixOnrampMaintenanceWarning
     })
 
     afterEach(() => {
-        underMaintenanceConfig.pixBrazilOnrampMaintenance = originalPixMaintenance
+        underMaintenanceConfig.enablePixOnrampMaintenanceWarning = originalPixMaintenance
     })
 
     it('tags the Pix option "Maintenance" but keeps it clickable (warn-only)', () => {
-        underMaintenanceConfig.pixBrazilOnrampMaintenance = true
+        underMaintenanceConfig.enablePixOnrampMaintenanceWarning = true
 
         render(<AddWithdrawCountriesList flow="add" />)
 
@@ -271,7 +271,7 @@ describe('AddWithdrawCountriesList — PIX onramp maintenance tag', () => {
     })
 
     it('shows no maintenance tag when the flag is off, and never tags non-Pix methods', () => {
-        underMaintenanceConfig.pixBrazilOnrampMaintenance = false
+        underMaintenanceConfig.enablePixOnrampMaintenanceWarning = false
 
         render(<AddWithdrawCountriesList flow="add" />)
 

--- a/src/components/Global/Banner/index.tsx
+++ b/src/components/Global/Banner/index.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react'
 import { usePathname } from 'next/navigation'
 import { MaintenanceBanner } from './MaintenanceBanner'
 import { MarqueeWrapper } from '../MarqueeWrapper'
-import maintenanceConfig from '@/config/underMaintenance.config'
+import underMaintenanceConfig from '@/config/underMaintenance.config'
 import { HandThumbsUp } from '@/assets'
 import Image from 'next/image'
 import { useModalsContext } from '@/context/ModalsContext'
@@ -16,7 +16,7 @@ export function Banner() {
     if (!pathname) return null
 
     // check if maintenance banner OR full maintenance is enabled - show on all pages
-    if (maintenanceConfig.enableMaintenanceBanner || maintenanceConfig.enableFullMaintenance) {
+    if (underMaintenanceConfig.enableMaintenanceBanner || underMaintenanceConfig.enableFullMaintenance) {
         return <MaintenanceBanner />
     }
 

--- a/src/config/underMaintenance.config.ts
+++ b/src/config/underMaintenance.config.ts
@@ -38,7 +38,8 @@
  *    - shows a "Maintenance" tag on the Pix option in /add-money/brazil
  *    - shows a warning banner inside the deposit flow (/add-money/brazil/manteca)
  *    - does NOT block deposits — the option stays usable (warn-only)
- *    - set to false when PIX deposits are stable again
+ *    - set to true when PIX deposits degrade again; both surfaces read it through
+ *      isPixBrazilOnrampUnderMaintenance() so they can never drift apart
  *
  * note: if either mode is enabled, the maintenance banner will show everywhere
  *
@@ -65,7 +66,7 @@ const underMaintenanceConfig: MaintenanceConfig = {
     disableXchainWithdraw: true, // set to true to disable cross-chain withdrawals (only allows USDC on Arbitrum)
     disableXchainSend: true, // set to true to disable cross-chain sends (claim, request payments - only allows USDC on Arbitrum)
     disableCardPioneers: true, // set to false to enable the Card Pioneers waitlist feature
-    pixBrazilOnrampMaintenance: true, // set to false when BRL-via-PIX deposits are stable again
+    pixBrazilOnrampMaintenance: false, // set to true when BRL-via-PIX deposits degrade again
 }
 
 // shared user-facing copy for cross-chain disabled paths — keep wording aligned with TokenSelector banner
@@ -79,6 +80,18 @@ export const PIX_BRAZIL_ONRAMP_MAINTENANCE = {
     title: 'PIX deposits are under maintenance',
     description:
         'PIX deposits are currently unstable and may be delayed or fail. You can still continue, but service may be unreliable until this is resolved.',
+}
+
+/**
+ * Whether the BRL-via-PIX onramp (Manteca Brazil deposit) is flagged warn-only under maintenance.
+ *
+ * Single source of truth for the two surfaces that warn about it — the "Maintenance" tag on the
+ * Pix option in the add-money country list, and the in-flow banner on /add-money/brazil/manteca.
+ * Callers add only their own context check (the `pix-add` method, or country `BR`); the maintenance
+ * determination lives here so the two surfaces can never drift apart.
+ */
+export function isPixBrazilOnrampUnderMaintenance(): boolean {
+    return underMaintenanceConfig.pixBrazilOnrampMaintenance
 }
 
 export default underMaintenanceConfig

--- a/src/config/underMaintenance.config.ts
+++ b/src/config/underMaintenance.config.ts
@@ -3,6 +3,12 @@
  *
  * to enable maintenance mode, simply toggle one or both of these keys:
  *
+ * naming convention — read the verb, not just the value:
+ *   - enable<Behavior>: true = turn that maintenance behavior ON (block / redirect / warn)
+ *   - disable<Feature>: true = turn that product feature OFF
+ *   `enableX: true` makes X happen; `disableY: true` makes Y stop. New flags MUST follow
+ *   one of these two shapes so the polarity is always obvious from the name.
+ *
  * 1. enableFullMaintenance: redirects ALL pages to /maintenance page
  *    - landing page (/) and support page (/support) remain accessible
  *    - maintenance banner shows on all pages (including landing and support)
@@ -34,12 +40,11 @@
  *    - card pioneer modal, carousel cta, and perk rewards hidden from home
  *    - set to false to enable the feature
  *
- * 7. pixBrazilOnrampMaintenance: warn-only flag for the BRL-via-PIX onramp (Manteca Brazil deposit)
+ * 7. enablePixOnrampMaintenanceWarning: warn-only flag for the PIX onramp (Manteca Brazil deposit)
  *    - shows a "Maintenance" tag on the Pix option in /add-money/brazil
  *    - shows a warning banner inside the deposit flow (/add-money/brazil/manteca)
  *    - does NOT block deposits — the option stays usable (warn-only)
- *    - set to true when PIX deposits degrade again; both surfaces read it through
- *      isPixBrazilOnrampUnderMaintenance() so they can never drift apart
+ *    - set to true when PIX deposits degrade again
  *
  * note: if either mode is enabled, the maintenance banner will show everywhere
  *
@@ -56,7 +61,7 @@ interface MaintenanceConfig {
     disableXchainWithdraw: boolean
     disableXchainSend: boolean
     disableCardPioneers: boolean
-    pixBrazilOnrampMaintenance: boolean
+    enablePixOnrampMaintenanceWarning: boolean
 }
 
 const underMaintenanceConfig: MaintenanceConfig = {
@@ -66,32 +71,20 @@ const underMaintenanceConfig: MaintenanceConfig = {
     disableXchainWithdraw: true, // set to true to disable cross-chain withdrawals (only allows USDC on Arbitrum)
     disableXchainSend: true, // set to true to disable cross-chain sends (claim, request payments - only allows USDC on Arbitrum)
     disableCardPioneers: true, // set to false to enable the Card Pioneers waitlist feature
-    pixBrazilOnrampMaintenance: false, // set to true when BRL-via-PIX deposits degrade again
+    enablePixOnrampMaintenanceWarning: false, // set to true when PIX (Manteca Brazil) deposits degrade again
 }
 
 // shared user-facing copy for cross-chain disabled paths — keep wording aligned with TokenSelector banner
 export const CROSS_CHAIN_DISABLED_MESSAGE =
     'Cross-chain claims are temporarily unavailable. Try claiming to an external wallet on the same chain as the link, or try again later.'
 
-// shared user-facing copy for the BRL-via-PIX onramp maintenance warning — keep the list tag and
+// shared user-facing copy for the PIX onramp maintenance warning — keep the list tag and
 // the in-flow banner aligned
-export const PIX_BRAZIL_ONRAMP_MAINTENANCE = {
+export const PIX_ONRAMP_MAINTENANCE_COPY = {
     badge: 'Maintenance',
     title: 'PIX deposits are under maintenance',
     description:
         'PIX deposits are currently unstable and may be delayed or fail. You can still continue, but service may be unreliable until this is resolved.',
-}
-
-/**
- * Whether the BRL-via-PIX onramp (Manteca Brazil deposit) is flagged warn-only under maintenance.
- *
- * Single source of truth for the two surfaces that warn about it — the "Maintenance" tag on the
- * Pix option in the add-money country list, and the in-flow banner on /add-money/brazil/manteca.
- * Callers add only their own context check (the `pix-add` method, or country `BR`); the maintenance
- * determination lives here so the two surfaces can never drift apart.
- */
-export function isPixBrazilOnrampUnderMaintenance(): boolean {
-    return underMaintenanceConfig.pixBrazilOnrampMaintenance
 }
 
 export default underMaintenanceConfig

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,7 +3,7 @@
 // https://nextjs.org/docs/messages/middleware-to-proxy
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
-import maintenanceConfig from '@/config/underMaintenance.config'
+import underMaintenanceConfig from '@/config/underMaintenance.config'
 
 export function proxy(request: NextRequest) {
     const { pathname } = request.nextUrl
@@ -15,7 +15,7 @@ export function proxy(request: NextRequest) {
     // }
 
     // check if full maintenance mode is enabled
-    if (maintenanceConfig.enableFullMaintenance) {
+    if (underMaintenanceConfig.enableFullMaintenance) {
         const allowedPaths = ['/', '/maintenance', '/apple-app-site-association', '/support']
         if (
             !allowedPaths.includes(pathname) &&


### PR DESCRIPTION
> **Draft — parked on purpose.** Merge this **when the BRL-via-PIX onramp (Manteca Brazil) is stable again.** Merging it flips PIX maintenance **off** in prod.

Follow-up to #2268.

## Why
#2268 shipped the warn-only "PIX under maintenance" tag + in-flow banner with the flag **on**. This is the matching recovery PR — ready in advance so flipping PIX back to normal is a one-merge action, not a scramble. It also cleans up two smells from the #2268 review.

## What
1. **Restore to not-under-maintenance** — `pixBrazilOnrampMaintenance: true → false` in `underMaintenance.config.ts`. The tag + banner disappear; the warn-only machinery stays in place, ready to flip back on (set the flag to `true`) if the onramp degrades again.
2. **One selector, no drift** — both surfaces (the list "Maintenance" tag and the in-flow banner) now read the maintenance state through a single `isPixBrazilOnrampUnderMaintenance()` selector instead of two separate `underMaintenanceConfig.pixBrazilOnrampMaintenance` reads. The maintenance determination lives in one place, so if the rule ever gains complexity (a time window, more regions) the two surfaces can't diverge. Each caller still keeps its own *context* check (the `pix-add` method / country `BR`).
3. **Robust test restore** — the maintenance test snapshots and restores the *shipped* flag value instead of hardcoding the `afterEach` restore to `true`. Previously, once the committed default became `false` (i.e. this PR), the old `afterEach` would have left the shared config singleton stuck at `true` for anything running after it.

## Base
Cut onto **`main`**, not `dev`: the `pixBrazilOnrampMaintenance` flag + UI only exist on `main` so far (the #2268 main→dev back-merge is still pending), so `main` is the only base where this is a clean, minimal diff. When the back-merge lands, this change rides along with it.

## Scope / notes
- **Frontend-only.** No API or schema changes.
- No behavior change while the flag is `false` beyond the maintenance UI being hidden — i.e. the pre-#2268 deposit experience.

## Tests (local gate, run in worktree)
- `prettier` ✓ (all 4 files unchanged after `--write`)
- `tsc` ✓ — 0 errors in changed files
- `jest` ✓ — `AddWithdrawCountriesList` (7) + `add-money-states` (41) pass; maintenance tests pass with the flag both on and off
- `next build` left to CI (authoritative — submodules + env)