### PR TITLE
fix(claim): preserve send-link password across the auth/KYC redirect

### DIFF
--- a/src/components/Claim/Claim.tsx
+++ b/src/components/Claim/Claim.tsx
@@ -14,7 +14,13 @@ import { EHistoryUserRole } from '@/hooks/useTransactionHistory'
 import { useUserInteractions } from '@/hooks/useUserInteractions'
 import { useWallet } from '@/hooks/wallet/useWallet'
 import type { RecipientType } from '@/interfaces/interfaces'
-import { ESendLinkStatus, getParamsFromLink, sendLinksApi, type ClaimLinkData } from '@/services/sendLinks'
+import {
+    ESendLinkStatus,
+    getParamsFromLink,
+    resolveClaimLink,
+    sendLinksApi,
+    type ClaimLinkData,
+} from '@/services/sendLinks'
 import {
     getInitialsFromName,
     getTokenDetails,
@@ -408,7 +414,9 @@ export const Claim = ({}) => {
     useEffect(() => {
         const pageUrl = typeof window !== 'undefined' ? window.location.href : ''
         if (pageUrl) {
-            setLinkUrl(pageUrl) // TanStack Query will automatically fetch when linkUrl changes
+            // resolveClaimLink restores the pristine `#p=` password if an auth/KYC
+            // redirect mangled the current URL's fragment (TASK-20193).
+            setLinkUrl(resolveClaimLink(pageUrl)) // TanStack Query will automatically fetch when linkUrl changes
         }
     }, [])
 
@@ -526,7 +534,7 @@ export const Claim = ({}) => {
                     transaction={selectedTransaction}
                     setIsLoading={setisLinkCancelling}
                     isLoading={isLinkCancelling}
-                    onClose={() => setLinkUrl(window.location.href)}
+                    onClose={() => setLinkUrl(resolveClaimLink(window.location.href))}
                 />
             )}
         </PageContainer>

--- a/src/components/Claim/__tests__/claim-states.test.tsx
+++ b/src/components/Claim/__tests__/claim-states.test.tsx
@@ -157,6 +157,7 @@ jest.mock('@/services/sendLinks', () => ({
     },
     sendLinksApi: mockSendLinksApi,
     getParamsFromLink: (...args: any[]) => mockGetParamsFromLink(...args),
+    resolveClaimLink: (link: string) => link,
 }))
 
 jest.mock('@/utils/peanut-link.utils', () => ({

--- a/src/services/__tests__/resolveClaimLink.test.ts
+++ b/src/services/__tests__/resolveClaimLink.test.ts
@@ -1,0 +1,47 @@
+/** @jest-environment jsdom */
+import { resolveClaimLink } from '@/services/sendLinks'
+import { generateKeysFromString, getParamsFromLink } from '@/utils/peanut-link.utils'
+
+// A v4.4 Arbitrum claim link: c/v/i live in the query (survive the redirect),
+// the password lives in the `#p=` fragment (mangled by the redirect).
+const BASE = 'https://peanut.me/claim?c=42161&v=v4.4&i=181'
+const PRISTINE = `${BASE}#p=abcdef0123456789`
+// What the claim page looks like after the auth/KYC redirect remounts it with a
+// corrupted fragment — same deposit slot, different (wrong) password.
+const CORRUPTED = `${BASE}&step=bank#p=WRONGwrongWRONG`
+
+const pubKeyOf = (link: string) => generateKeysFromString(getParamsFromLink(link).password).address
+
+beforeEach(() => localStorage.clear())
+
+describe('resolveClaimLink (TASK-20193)', () => {
+    it('restores the pristine password after a redirect mangles the fragment', () => {
+        // 1) recipient first opens the link → pristine password is captured
+        expect(resolveClaimLink(PRISTINE)).toBe(PRISTINE)
+
+        // 2) the post-redirect remount arrives with a corrupted fragment, which
+        // on its own derives the wrong pubKey (the prod 404 root cause)...
+        expect(pubKeyOf(CORRUPTED)).not.toBe(pubKeyOf(PRISTINE))
+
+        // 3) ...but resolveClaimLink serves the pristine link, so the fetch uses
+        // the correct pubKey instead of 404ing.
+        const resolved = resolveClaimLink(CORRUPTED)
+        expect(resolved).toBe(PRISTINE)
+        expect(pubKeyOf(resolved)).toBe(pubKeyOf(PRISTINE))
+    })
+
+    it('first write wins — a later mangled load cannot overwrite a good capture', () => {
+        resolveClaimLink(PRISTINE)
+        resolveClaimLink(CORRUPTED)
+        expect(resolveClaimLink(`${BASE}#p=yetAnotherWrongOne`)).toBe(PRISTINE)
+    })
+
+    it('passes through links without a deposit slot untouched', () => {
+        const noSlot = 'https://peanut.me/claim#p=orphan'
+        expect(resolveClaimLink(noSlot)).toBe(noSlot)
+    })
+
+    it('passes through non-URL input without throwing', () => {
+        expect(resolveClaimLink('not a url')).toBe('not a url')
+    })
+})

--- a/src/services/sendLinks.ts
+++ b/src/services/sendLinks.ts
@@ -1,4 +1,4 @@
-import { jsonParse, jsonStringify } from '@/utils/general.utils'
+import { jsonParse, jsonStringify, getFromLocalStorage, saveToLocalStorage } from '@/utils/general.utils'
 import { generateKeysFromString, getParamsFromLink } from '@/utils/peanut-link.utils'
 import type { SendLink } from '@/services/services.types'
 import { serverFetch } from '@/utils/api-fetch'
@@ -11,6 +11,44 @@ export type { SendLinkStatus, SendLink } from '@/services/services.types'
 export { getParamsFromLink } from '@/utils/peanut-link.utils'
 
 export type ClaimLinkData = SendLink & { link: string; password: string }
+
+const CLAIM_LINK_SLOT_PREFIX = 'claim-link-slot'
+// KYC review between opening a link and returning to claim can span days.
+const CLAIM_LINK_TTL_SECONDS = 7 * 24 * 60 * 60
+
+/**
+ * Resolve the link used to fetch + claim a send link, hardened against the
+ * auth/KYC redirect mangling the URL's `#p=` password fragment (TASK-20193).
+ *
+ * The recipient opens `/claim?c=&v=&i=#p=<password>`; the password derives the
+ * deterministic pubKey the backend is keyed on. The guest → /setup → KYC →
+ * /claim flow fully remounts the page, and across that multi-hop redirect the
+ * fragment can come back corrupted while the `c/v/i` query survives — so the
+ * remounted page derives the WRONG pubKey and gets a 404 "Send link not found",
+ * dead-ending the claim.
+ *
+ * Fix: key the pristine link by its deposit slot (chain:version:index, which
+ * the redirect preserves) in localStorage when the link is first opened.
+ * First write wins, so the correct password stays authoritative even if a
+ * later remount arrives with a broken fragment.
+ */
+export const resolveClaimLink = (currentLink: string): string => {
+    if (typeof window === 'undefined') return currentLink
+    let params: ReturnType<typeof getParamsFromLink>
+    try {
+        params = getParamsFromLink(currentLink)
+    } catch {
+        return currentLink
+    }
+    // Without a real deposit slot we can't key the link — leave it untouched.
+    if (!params.chainId || Number.isNaN(params.depositIdx)) return currentLink
+
+    const key = `${CLAIM_LINK_SLOT_PREFIX}::${params.chainId}:${params.contractVersion}:${params.depositIdx}`
+    const stored = getFromLocalStorage(key)
+    if (typeof stored === 'string' && stored) return stored // pristine link wins
+    if (params.password) saveToLocalStorage(key, currentLink, CLAIM_LINK_TTL_SECONDS)
+    return currentLink
+}
 
 type CreateLinkBody = {
     pubKey: string

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -137,7 +137,9 @@ export const saveToLocalStorage = (key: string, data: any, expirySeconds?: numbe
         } else {
             localStorage.removeItem(`${key}-expiry`)
         }
-        console.log(`Saved ${key} to localStorage:`, data)
+        // key is passed as an argument (not interpolated into the format string)
+        // so a user-controlled key can't act as a console format string (CodeQL).
+        console.log('Saved to localStorage:', key, data)
     } catch (error) {
         Sentry.captureException(error)
         console.error('Error saving to localStorage:', error)


### PR DESCRIPTION
## Summary
New recipients who open a send link, register/KYC, and get redirected back to `/claim` hit a **404 "Send link not found"** and cannot claim (TASK-20193).

The claim pubKey is derived from the link's `#p=` password fragment. The guest → `/setup` → KYC → `/claim` flow fully remounts the page, and across that multi-hop redirect the **fragment comes back mangled** while the `c/v/i` query survives — so the remounted page derives the **wrong pubKey** and 404s.

**Proven in prod (2026-06-20, user tomast):** the failing `GET /send-links/0xf711…962` used a pubKey that does **not** exist in the DB, while the real link at the same deposit slot (`c=42161,v=v4.4,i=181`) exists and is `completed` (pubKey `0xAa97…dAd6`). Created 71s before the first 404 → not replication lag. Sibling Sentry issues: PEANUT-UI-QN8 (this 404), PEANUT-UI-QN9 (the follow-on bank step).

## Fix
`resolveClaimLink` keys the **pristine** link by its deposit slot (`chain:version:index`, which the redirect preserves) in localStorage when the link is first opened. **First write wins**, so the correct password stays authoritative even if a later remount arrives with a broken fragment.

- **Client-only + slot-local** — nothing new is exposed; the password never goes to the server (cookies would, by design we can't use them).
- **Graceful degradation** — if localStorage is unavailable/evicted, it returns the current URL, i.e. exactly today's behavior. It can only help, never make a working case worse.
- Reuses the same localStorage mechanism the existing `saveRedirectUrl` redirect already depends on (and which demonstrably survives this flow).

## Risks
- Low blast radius: one new helper + 3 call-site lines in `Claim.tsx`. No API/schema change, no cross-repo coupling.
- Does **not** isolate the exact hop that strips the fragment — this is a robust safety net by design (chosen approach).

## QA
- Unit: `src/services/__tests__/resolveClaimLink.test.ts` reproduces the bug (corrupted fragment → wrong pubKey) and asserts the pristine pubKey is restored; first-write-wins; pass-through for no-slot / non-URL. 4/4 pass.
- Manual: open a v4.4 claim link as a logged-out user → register/KYC → confirm return to `/claim` loads the link (no 404) and claim proceeds.