### PR TITLE
fix(claim): surface backend bank-account error verbatim

### DIFF
--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -396,7 +396,13 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                     payloadWithCountry
                 )
                 if ('error' in externalAccountResponse && externalAccountResponse.error) {
-                    throw new Error(String(externalAccountResponse.error))
+                    // The backend returns a curated, user-facing message for bank-account
+                    // validation failures (e.g. an unverifiable billing address). Surface it
+                    // verbatim — routing it through ErrorHandler would collapse it into the
+                    // generic "contact support" fallback, hiding the actionable detail. (TASK-20194)
+                    const accountError = String(externalAccountResponse.error)
+                    Sentry.captureException(new Error(`External account creation failed: ${accountError}`))
+                    return { error: accountError }
                 }
                 if (!('id' in externalAccountResponse)) {
                     throw new Error('Failed to create external account')


### PR DESCRIPTION
## Summary
Companion to peanut-api-ts PR (external-account friendly errors, TASK-20194). The backend now returns curated, user-facing messages when adding a bank account for a send-link payout fails (e.g. *"We couldn't verify your bank account's billing address. Please double-check the city, state, and ZIP/postal code."*).

But `BankFlowManager` threw that message through `ErrorHandler`, whose substring matchers don't match it → it collapsed into the generic *"There was an issue with your request. Please contact support."* fallback, hiding the actionable detail.

## What
For the external-account-creation error path only, surface `response.error` **verbatim** instead of routing it through `ErrorHandler`. FE Sentry capture is preserved. Other errors in the flow (thrown exceptions) still go through `ErrorHandler` unchanged.

## Risk
Tiny, display-only (4 lines, one branch). No logic/state/flow change. Depends on the backend PR for the *content* of the message, but is safe to ship independently (today the BE message is just shown verbatim too).

## QA
Typecheck clean. Manual: trigger a bank-account add failure (e.g. an address the bank service can't verify) → user sees the specific, actionable message instead of "contact support".