### PR TITLE
fix(claim): surface backend bank-account error verbatim [hotfix]

### DIFF
--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -396,7 +396,13 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                     payloadWithCountry
                 )
                 if ('error' in externalAccountResponse && externalAccountResponse.error) {
-                    throw new Error(String(externalAccountResponse.error))
+                    // The backend returns a curated, user-facing message for bank-account
+                    // validation failures (e.g. an unverifiable billing address). Surface it
+                    // verbatim — routing it through ErrorHandler would collapse it into the
+                    // generic "contact support" fallback, hiding the actionable detail. (TASK-20194)
+                    const accountError = String(externalAccountResponse.error)
+                    Sentry.captureException(new Error(`External account creation failed: ${accountError}`))
+                    return { error: accountError }
                 }
                 if (!('id' in externalAccountResponse)) {
                     throw new Error('Failed to create external account')


### PR DESCRIPTION
**Hotfix to main (prod)** — companion to peanut-api-ts hotfix #1052 (TASK-20194). Cherry-pick of dev fix #2271.

When adding a bank account for a send-link payout fails, the backend now returns a curated, user-facing message (e.g. *'We couldn't verify your bank account's billing address. Please double-check the city, state, and ZIP/postal code.'*). `BankFlowManager` routed it through `ErrorHandler`, which collapsed it into the generic *'contact support'* fallback. Surface `response.error` verbatim for this path; keep FE Sentry capture.

Tiny (4 lines, one branch), display-only, success path untouched. Typecheck clean.

⚠️ **Merge AFTER #1052** (this surfaces the BE message verbatim; with the old BE it would show the raw 'Bridge…' string).