### PR TITLE
fix(add-money): skip the redundant second bank/method selection

### DIFF
--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -989,12 +989,14 @@ describe('GROUP 1: Landing / Method Selection', () => {
         expect(screen.getByText('Select your country')).toBeInTheDocument()
     })
 
-    test('selecting a country from list navigates to country page', () => {
+    test('selecting a country (already in bank flow) navigates straight to the bank step', () => {
         resetQueryState({ method: 'bank' })
         renderWithProviders(<AddMoneyPage />)
 
         fireEvent.click(screen.getByTestId('country-argentina'))
-        expect(mockRouterPush).toHaveBeenCalledWith('/add-money/argentina')
+        // Method was already chosen ('bank'), so skip the redundant per-country
+        // method picker and go straight to the bank step.
+        expect(mockRouterPush).toHaveBeenCalledWith('/add-money/argentina/bank')
     })
 
     test('back from method selection navigates to /home', () => {

--- a/src/app/(mobile-ui)/add-money/page.tsx
+++ b/src/app/(mobile-ui)/add-money/page.tsx
@@ -17,7 +17,7 @@ import { useQueryState, parseAsStringEnum } from 'nuqs'
 import { checkIfInternalNavigation, getRedirectUrl, clearRedirectUrl, getFromLocalStorage } from '@/utils/general.utils'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
-import { addMoneyCountryUrl } from '@/utils/native-routes'
+import { addMoneyBankUrl } from '@/utils/native-routes'
 
 export default function AddMoneyPage() {
     const router = useRouter()
@@ -68,7 +68,10 @@ export default function AddMoneyPage() {
             method_type: 'bank',
             country: country.path,
         })
-        router.push(addMoneyCountryUrl(country.path))
+        // User already chose Bank Transfer (this handler only renders in the bank
+        // branch), so go straight to the bank step — don't re-show the method
+        // picker on /add-money/[country] (that was the double "select bank twice").
+        router.push(addMoneyBankUrl(country.path))
     }
 
     // native app: render sub-views based on query params

--- a/src/utils/__tests__/native-routes.test.ts
+++ b/src/utils/__tests__/native-routes.test.ts
@@ -17,6 +17,7 @@ import {
     chargePayUrl,
     requestPotUrl,
     addMoneyCountryUrl,
+    addMoneyBankUrl,
     withdrawCountryUrl,
     withdrawBankUrl,
     rewriteMethodPath,
@@ -65,6 +66,12 @@ describe('native-routes', () => {
         describe('addMoneyCountryUrl', () => {
             it('should return /add-money with country query param', () => {
                 expect(addMoneyCountryUrl('belgium')).toBe('/add-money?country=belgium')
+            })
+        })
+
+        describe('addMoneyBankUrl', () => {
+            it('should return /add-money with country + view=bank (skips the method picker)', () => {
+                expect(addMoneyBankUrl('belgium')).toBe('/add-money?country=belgium&view=bank')
             })
         })
 
@@ -196,6 +203,12 @@ describe('native-routes', () => {
         describe('qrSuccessUrl', () => {
             it('should return /qr/{code}/success path', () => {
                 expect(qrSuccessUrl('abc123')).toBe('/qr/abc123/success')
+            })
+        })
+
+        describe('addMoneyBankUrl', () => {
+            it('should return /add-money/{country}/bank path (skips the method picker)', () => {
+                expect(addMoneyBankUrl('belgium')).toBe('/add-money/belgium/bank')
             })
         })
 

--- a/src/utils/native-routes.ts
+++ b/src/utils/native-routes.ts
@@ -39,6 +39,15 @@ export function addMoneyCountryUrl(countryPath: string): string {
     return isCapacitor() ? `/add-money?country=${encodeURIComponent(countryPath)}` : `/add-money/${countryPath}`
 }
 
+// Straight to the bank step, skipping the redundant per-country method picker —
+// mirrors withdrawBankUrl. Used when the user already chose "Bank Transfer" up
+// front, so re-showing the method list on the country page is a double-select.
+export function addMoneyBankUrl(countryPath: string): string {
+    return isCapacitor()
+        ? `/add-money?country=${encodeURIComponent(countryPath)}&view=bank`
+        : `/add-money/${countryPath}/bank`
+}
+
 export function withdrawCountryUrl(countryPath: string, queryParams?: string): string {
     if (isCapacitor()) {
         const qs = queryParams ? `&${queryParams.replace('?', '')}` : ''


### PR DESCRIPTION
## Why
Adding money via bank made the user **pick the method twice**:
1. `/add-money` → "Bank Transfer" (`AddMoneyMethodSelection` → `method=bank`)
2. pick a country
3. `/add-money/[country]` → `AddWithdrawCountriesList` renders the per-country **method picker again** → "From Bank"
4. `/add-money/[country]/bank` → amount

The **withdraw** flow doesn't have this — its country click goes straight to the bank step via `withdrawBankUrl` (withdraw/page.tsx). Add-money had no equivalent helper and used `addMoneyCountryUrl` → the method picker.

## What
- Add `addMoneyBankUrl` (mirrors `withdrawBankUrl`): web → `/add-money/[country]/bank`, native → `?country=…&view=bank`.
- Use it in `handleCountryClick` — which only renders in the bank branch (`method === 'bank'`), so the method is already chosen; going straight to the bank step is correct and removes the second selection.

## Tests
`native-routes.test.ts`: `addMoneyBankUrl` web + capacitor. Full suite 51/51.

## Scope
Just the double-selection. **Not** included (separate, reported by Hugo — need their own tickets/design input):
- amount input not autofocused on mobile (`AmountInput` only autofocuses on WEB)
- post-unlock UX nits: no celebration after unlock, no loading state, and the "Almost there" vs "all set" modal
