### PR TITLE
fix(amount-input): reliably autofocus the amount field on desktop

### DIFF
--- a/src/components/Global/AmountInput/index.tsx
+++ b/src/components/Global/AmountInput/index.tsx
@@ -216,6 +216,14 @@ const AmountInput = ({
         }
     }, [displayValue])
 
+    // Autofocus the amount field on mount (desktop only). Done explicitly via the
+    // ref instead of React's `autoFocus` prop, which only fires at the exact moment
+    // of mount and silently no-ops when the input mounts after a client-side
+    // navigation/step transition (the add-money amount screen regressed this way).
+    useEffect(() => {
+        if (shouldAutoFocus) inputRef.current?.focus()
+    }, [shouldAutoFocus])
+
     return (
         <form
             className={`relative cursor-text rounded-sm border border-n-1 bg-white p-4 dark:border-white ${className}`}
@@ -229,7 +237,6 @@ const AmountInput = ({
                     {/* Input with fake caret */}
                     <div className="relative">
                         <input
-                            autoFocus={shouldAutoFocus}
                             className={`h-12 max-w-80 bg-transparent text-6xl font-black text-black caret-primary-1 outline-none transition-colors placeholder:text-h1 placeholder:text-gray-1 focus:border-primary-1 disabled:opacity-100 disabled:[-webkit-text-fill-color:black] dark:border-white dark:bg-n-1 dark:text-white dark:placeholder:text-white/75 dark:focus:border-primary-1 dark:disabled:[-webkit-text-fill-color:white]`}
                             placeholder={'0.00'}
                             onChange={(e) => {


### PR DESCRIPTION
## Summary
The amount input stopped auto-focusing when entering some flows (reported on **add money** — you have to click the field to start typing). It relied on React's `autoFocus` prop, which only fires at the exact moment the `<input>` mounts and silently no-ops when the input mounts *after* a client-side navigation / step transition (e.g. the add-money amount step). Replaced it with an explicit `inputRef.focus()` in a `useEffect` gated on the same desktop-only `shouldAutoFocus = deviceType === WEB` condition, so focus lands reliably regardless of mount timing.

## Risk
- **Low, FE-only, one file.** `AmountInput` is shared (send / withdraw / qr-pay / add-money / request). The change restores the *same intent* the `autoFocus` prop had (focus on desktop mount) but reliably — no new behavior.
- **Mobile unchanged:** autofocus stays OFF on iOS/Android by design (`shouldAutoFocus` is false there).
- Not related to #2266 (balance PR).

## QA
Desktop web: open **Add money → amount step** — the field is focused (blinking caret) without a click. Same for **Send**, **Withdraw**, **QR pay** amount screens. On mobile, the field is NOT auto-focused (unchanged). Full unit suite green.