### PR TITLE
hotfix(add-money): revert bank-step shortcut (AR/BR shown Euro selector)

### DIFF
--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -989,14 +989,12 @@ describe('GROUP 1: Landing / Method Selection', () => {
         expect(screen.getByText('Select your country')).toBeInTheDocument()
     })
 
-    test('selecting a country (already in bank flow) navigates straight to the bank step', () => {
+    test('selecting a country from list navigates to country page', () => {
         resetQueryState({ method: 'bank' })
         renderWithProviders(<AddMoneyPage />)
 
         fireEvent.click(screen.getByTestId('country-argentina'))
-        // Method was already chosen ('bank'), so skip the redundant per-country
-        // method picker and go straight to the bank step.
-        expect(mockRouterPush).toHaveBeenCalledWith('/add-money/argentina/bank')
+        expect(mockRouterPush).toHaveBeenCalledWith('/add-money/argentina')
     })
 
     test('back from method selection navigates to /home', () => {

--- a/src/app/(mobile-ui)/add-money/page.tsx
+++ b/src/app/(mobile-ui)/add-money/page.tsx
@@ -17,7 +17,7 @@ import { useQueryState, parseAsStringEnum } from 'nuqs'
 import { checkIfInternalNavigation, getRedirectUrl, clearRedirectUrl, getFromLocalStorage } from '@/utils/general.utils'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
-import { addMoneyBankUrl } from '@/utils/native-routes'
+import { addMoneyCountryUrl } from '@/utils/native-routes'
 
 export default function AddMoneyPage() {
     const router = useRouter()
@@ -68,10 +68,7 @@ export default function AddMoneyPage() {
             method_type: 'bank',
             country: country.path,
         })
-        // User already chose Bank Transfer (this handler only renders in the bank
-        // branch), so go straight to the bank step — don't re-show the method
-        // picker on /add-money/[country] (that was the double "select bank twice").
-        router.push(addMoneyBankUrl(country.path))
+        router.push(addMoneyCountryUrl(country.path))
     }
 
     // native app: render sub-views based on query params

--- a/src/utils/__tests__/native-routes.test.ts
+++ b/src/utils/__tests__/native-routes.test.ts
@@ -17,7 +17,6 @@ import {
     chargePayUrl,
     requestPotUrl,
     addMoneyCountryUrl,
-    addMoneyBankUrl,
     withdrawCountryUrl,
     withdrawBankUrl,
     rewriteMethodPath,
@@ -66,12 +65,6 @@ describe('native-routes', () => {
         describe('addMoneyCountryUrl', () => {
             it('should return /add-money with country query param', () => {
                 expect(addMoneyCountryUrl('belgium')).toBe('/add-money?country=belgium')
-            })
-        })
-
-        describe('addMoneyBankUrl', () => {
-            it('should return /add-money with country + view=bank (skips the method picker)', () => {
-                expect(addMoneyBankUrl('belgium')).toBe('/add-money?country=belgium&view=bank')
             })
         })
 
@@ -203,12 +196,6 @@ describe('native-routes', () => {
         describe('qrSuccessUrl', () => {
             it('should return /qr/{code}/success path', () => {
                 expect(qrSuccessUrl('abc123')).toBe('/qr/abc123/success')
-            })
-        })
-
-        describe('addMoneyBankUrl', () => {
-            it('should return /add-money/{country}/bank path (skips the method picker)', () => {
-                expect(addMoneyBankUrl('belgium')).toBe('/add-money/belgium/bank')
             })
         })
 

--- a/src/utils/native-routes.ts
+++ b/src/utils/native-routes.ts
@@ -39,15 +39,6 @@ export function addMoneyCountryUrl(countryPath: string): string {
     return isCapacitor() ? `/add-money?country=${encodeURIComponent(countryPath)}` : `/add-money/${countryPath}`
 }
 
-// Straight to the bank step, skipping the redundant per-country method picker —
-// mirrors withdrawBankUrl. Used when the user already chose "Bank Transfer" up
-// front, so re-showing the method list on the country page is a double-select.
-export function addMoneyBankUrl(countryPath: string): string {
-    return isCapacitor()
-        ? `/add-money?country=${encodeURIComponent(countryPath)}&view=bank`
-        : `/add-money/${countryPath}/bank`
-}
-
 export function withdrawCountryUrl(countryPath: string, queryParams?: string): string {
     if (isCapacitor()) {
         const qs = queryParams ? `&${queryParams.replace('?', '')}` : ''


### PR DESCRIPTION
## 🚨 Prod regression
#2276 (merged to dev, now on `main` via release #2245) made add-money country-click go straight to `/add-money/[country]/bank`. That route is the **Bridge (EUR/SEPA)** bank page. **Argentina/Brazil** bank deposits go through **Manteca** (Pix/CBU), which the per-country method picker on `/add-money/[country]` was correctly resolving.

Skipping that picker forced **every** country into the Bridge bank page → **AR/BR users see a Euro selector** when adding money.

## Fix
Revert `handleCountryClick` to `addMoneyCountryUrl` (the method picker) and remove the `addMoneyBankUrl` helper + its tests. Restores correct per-country routing.

## Scope
Pure revert of #2276's behavior change — these 4 files return to their pre-#2276 state. The double-selection UX nit #2276 tried to fix is separate/lower-priority; a correct fix must be per-country (skip the picker only for single-bank EU/NA countries), not a blanket shortcut.

## Tests
`native-routes` + `add-money-states` restored to pre-#2276 assertions; pass. (Pre-existing local-only EVM-deposit test failure is unrelated — CI passes it.)

## Follow-up
`dev` also carries #2276 — the post-release `main`→`dev` back-merge will carry this revert, or cherry-pick if dev ships first.