### PR TITLE
fix(rain): 120s timeout on collateral withdraw submit (was 10s default → duplicate sends)

### DIFF
--- a/src/services/rain.ts
+++ b/src/services/rain.ts
@@ -392,12 +392,23 @@ export const rainApi = {
      * Submit a prepared withdrawal with the user's admin signature. Backend
      * verifies via ERC-1271 against the user's kernel and broadcasts the
      * coordinator call through the shared admin relayer.
+     *
+     * `/submit` is SYNCHRONOUS: it broadcasts AND awaits on-chain confirmation
+     * (`waitForUserOperationReceipt` + `confirmIntentByTxHash`) before
+     * responding, and for a request/charge it settles the charge in the same
+     * call. That round-trip routinely exceeds the default 10s fetch budget, so
+     * pass 120s — the same budget the verified-withdrawal path already uses for
+     * this exact reason (see line ~525). With the 10s default the FE aborts
+     * while the tx still lands + the charge settles: the user sees an error on a
+     * payment that actually succeeded, retries, and double-sends. (#2245 routed
+     * request payments through this path for the first time → the regression.)
      */
     submitWithdrawal: async (input: SubmitRainWithdrawalInput): Promise<SubmitRainWithdrawalResponse> => {
         return rainRequest<SubmitRainWithdrawalResponse>({
             method: 'POST',
             path: '/rain/cards/withdraw/submit',
             body: input,
+            timeoutMs: 120_000,
         })
     },
 


### PR DESCRIPTION
## Hotfix — request payments via Rain card collateral double-send

### Symptom (prod, post-#2245)
Paying a request / direct-send via **Rain card collateral** shows the payer **"there was an issue with your request"** *after they sign* — **even though the payment succeeds on-chain**. The payer retries → **the retry also lands → duplicate send.**

Observed: one payer → same recipient **×3** ($1 each) for a single intended $1 payment (tx `0x0ce1…` confirmed at 23:20:54 while the FE showed an error).

### Root cause
`POST /rain/cards/withdraw/submit` is **synchronous**: it broadcasts **and awaits on-chain confirmation** (`waitForUserOperationReceipt` + `confirmIntentByTxHash`), and for a request/charge it settles the charge in the same call. The FE's `submitWithdrawal` sent it with **no `timeoutMs` → `fetchWithSentry`'s default 10s**. When confirmation exceeds 10s the FE **aborts** while the tx still lands and the charge settles → false error → retry → duplicate.

**Why now:** `#2245` (`73f73bc53`) routed **request payments through this submit path for the first time**. Card withdrawals already used it; request-pays — much higher frequency — only started hitting the 10s cap at go-live. Direct Sentry fingerprint: **`PEANUT-UI-QP5: rain/cards/withdraw/submit timed out after 10000ms`** (first seen at deploy).

### Fix
Give `submitWithdrawal` a **120s** budget — the same value the verified-withdrawal path (`rain.ts:~525`) already uses for this exact synchronous-confirm reason. One line + an explanatory comment.

### Scope / risk
- 1 file, `src/services/rain.ts`. No behavior change except the client wait budget on this one money-path call.
- Branched off `main` (prod) as a mini-hotfix.

### Verification
- typecheck ✅ · prettier ✅
- Behavioral: a >10s collateral submit now resolves to the real success instead of a false abort. A unit test here would only assert "fetch called with 120000" (mock-was-called anti-pattern); recommend a Nutcracker scenario (slow-confirm collateral request-pay) as follow-up coverage instead.

### Not in this PR (follow-ups)
- The stuck-PENDING attempts (no tx) look like Rain's per-account **signature cooldown** from rapid retries — largely self-resolves once the false errors stop driving retries; worth a separate look.
- DRY: 5+ call sites still each remember "collateral-only ⇒ skip recordPayment" — consolidate behind one `payCharge` primitive.
- **Back-merge / cherry-pick this commit to `dev`** so the next release doesn't regress it.