### PR TITLE
feat(withdraw): re-enable cross-chain stablecoin withdraw with honest fees

### DIFF
--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -17,6 +17,7 @@ import type {
     TRequestResponse,
 } from '@/services/services.types'
 import { NATIVE_TOKEN_ADDRESS } from '@/utils/token.utils'
+import { isWithdrawFeeDisproportionate } from '@/utils/cross-chain-fee.utils'
 import * as peanutInterfaces from '@/interfaces/peanut-sdk-types'
 import { useRouter } from 'next/navigation'
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
@@ -437,6 +438,15 @@ export default function WithdrawCryptoPage() {
     // bridge-fee in USD — no slippage distinction.
     const networkFee = useMemo<number>(() => feeUsd ?? 0, [feeUsd])
 
+    // Hard-stop: block the withdrawal when the bridge fee is disproportionate to
+    // the amount (flat mainnet gas dominating a small withdraw). See
+    // cross-chain-fee.utils.ts — this is the guard against the "$4 fee on a $5
+    // withdraw" case that originally got cross-chain withdraw disabled.
+    const feeTooHigh = useMemo<boolean>(
+        () => isCrossChainWithdrawal && isWithdrawFeeDisproportionate(networkFee, parseFloat(usdAmount)),
+        [isCrossChainWithdrawal, networkFee, usdAmount]
+    )
+
     if (!amountToWithdraw && currentView !== 'STATUS') {
         // Redirect to main withdraw page for amount input
         // Guard against STATUS view: resetWithdrawFlow() clears amountToWithdraw,
@@ -470,6 +480,7 @@ export default function WithdrawCryptoPage() {
                     isCrossChain={isCrossChainWithdrawal}
                     isCalculating={isCalculating}
                     receiveAmount={receiveAmount}
+                    feeTooHigh={feeTooHigh}
                 />
             )}
 

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -438,11 +438,11 @@ export default function WithdrawCryptoPage() {
     // bridge-fee in USD — no slippage distinction.
     const networkFee = useMemo<number>(() => feeUsd ?? 0, [feeUsd])
 
-    // Hard-stop: block the withdrawal when the bridge fee is disproportionate to
-    // the amount (flat mainnet gas dominating a small withdraw). See
-    // cross-chain-fee.utils.ts — this is the guard against the "$4 fee on a $5
-    // withdraw" case that originally got cross-chain withdraw disabled.
-    const feeTooHigh = useMemo<boolean>(
+    // Non-blocking heads-up when the bridge fee is a large share of the amount
+    // (flat mainnet gas dominating a small withdraw). The user can still proceed
+    // — the fee is shown honestly; we just flag it so a tiny mainnet withdrawal
+    // isn't a silent footgun. See cross-chain-fee.utils.ts.
+    const showHighFeeWarning = useMemo<boolean>(
         () => isCrossChainWithdrawal && isWithdrawFeeDisproportionate(networkFee, parseFloat(usdAmount)),
         [isCrossChainWithdrawal, networkFee, usdAmount]
     )
@@ -480,7 +480,7 @@ export default function WithdrawCryptoPage() {
                     isCrossChain={isCrossChainWithdrawal}
                     isCalculating={isCalculating}
                     receiveAmount={receiveAmount}
-                    feeTooHigh={feeTooHigh}
+                    showHighFeeWarning={showHighFeeWarning}
                 />
             )}
 

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -18,6 +18,7 @@ import type {
 } from '@/services/services.types'
 import { NATIVE_TOKEN_ADDRESS } from '@/utils/token.utils'
 import { isWithdrawFeeDisproportionate } from '@/utils/cross-chain-fee.utils'
+import { isAmountWithinBalance } from '@/utils/balance.utils'
 import * as peanutInterfaces from '@/interfaces/peanut-sdk-types'
 import { useRouter } from 'next/navigation'
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
@@ -40,7 +41,7 @@ import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 export default function WithdrawCryptoPage() {
     const router = useRouter()
     const onBack = useSafeBack('/withdraw')
-    const { isConnected: isPeanutWallet, address, sendTransactions, sendMoney } = useWallet()
+    const { isConnected: isPeanutWallet, address, sendTransactions, sendMoney, spendableBalance } = useWallet()
     const { resetTokenContextProvider } = useContext(tokenSelectorContext)
     const {
         amountToWithdraw,
@@ -447,6 +448,23 @@ export default function WithdrawCryptoPage() {
         [isCrossChainWithdrawal, networkFee, usdAmount]
     )
 
+    // Pre-sign affordability gate for cross-chain. The input-time gate only
+    // checked the principal, but the kernel must spend principal + bridge fee
+    // (`payAmount`), so a withdraw that fit the balance at input can fall short
+    // here once the fee is known — and the send would surface the misleading
+    // "balance isn't fully available yet" (settling) error instead of an honest
+    // "not enough balance". Block it here with the right message. Only once the
+    // quote has resolved `payAmount` (skipped while calculating; CTA is disabled
+    // by isCalculating anyway).
+    const insufficientForFee = useMemo<boolean>(
+        () =>
+            isCrossChainWithdrawal &&
+            payAmount != null &&
+            spendableBalance !== undefined &&
+            !isAmountWithinBalance(payAmount, spendableBalance),
+        [isCrossChainWithdrawal, payAmount, spendableBalance]
+    )
+
     if (!amountToWithdraw && currentView !== 'STATUS') {
         // Redirect to main withdraw page for amount input
         // Guard against STATUS view: resetWithdrawFlow() clears amountToWithdraw,
@@ -480,7 +498,9 @@ export default function WithdrawCryptoPage() {
                     isCrossChain={isCrossChainWithdrawal}
                     isCalculating={isCalculating}
                     receiveAmount={receiveAmount}
+                    payAmount={payAmount}
                     showHighFeeWarning={showHighFeeWarning}
+                    insufficientBalance={insufficientForFee}
                 />
             )}
 

--- a/src/app/actions/supported-chains.ts
+++ b/src/app/actions/supported-chains.ts
@@ -1,5 +1,13 @@
 import type { ChainWithTokens } from '@/interfaces/chain-meta'
 import { supportedPeanutChains, peanutTokenDetails } from '@/constants/general.consts'
+import ARBITRUM_ICON from '@/assets/chains/arbitrum.svg'
+
+// Some chains ship an explorer-hosted icon URL that blocks hotlinking (e.g.
+// Arbitrum's arbiscan.io SVG), so next/image fails to load it and the selector
+// falls back to initials ("AO"). Prefer a bundled local asset for those.
+const CHAIN_ICON_OVERRIDES: Record<string, string> = {
+    '42161': ARBITRUM_ICON,
+}
 
 export async function getSupportedChainsAndTokens(): Promise<Record<string, ChainWithTokens>> {
     const result: Record<string, ChainWithTokens> = {}
@@ -7,7 +15,7 @@ export async function getSupportedChainsAndTokens(): Promise<Record<string, Chai
         if (!chain.mainnet) continue
         result[chain.chainId] = {
             chainId: chain.chainId,
-            chainIconURI: chain.icon?.url ?? '',
+            chainIconURI: CHAIN_ICON_OVERRIDES[String(chain.chainId)] ?? chain.icon?.url ?? '',
             networkName: chain.name,
             tokens: [],
         }

--- a/src/components/Global/TokenSelector/TokenSelector.consts.ts
+++ b/src/components/Global/TokenSelector/TokenSelector.consts.ts
@@ -87,9 +87,10 @@ export const TOKEN_SELECTOR_SUPPORTED_NETWORK_IDS = networks
  *
  * Notes:
  * - Scroll (534352) is intentionally absent — Rhino has it disabled.
- * - Native gas tokens Rhino doesn't bridge are omitted: Polygon (POL) and Gnosis
- *   (xDAI) keep only USDC/USDT; Arbitrum/Ethereum/Optimism native is ETH; BNB on
- *   BNB Chain is supported.
+ * - Gnosis (100) is omitted: our token data only has native xDAI for it (no
+ *   USDC/USDT), so it has nothing offerable even though Rhino supports stables.
+ * - Native gas tokens Rhino doesn't bridge are omitted: Polygon (POL) keeps only
+ *   USDC/USDT; Arbitrum/Ethereum/Optimism native is ETH; BNB on BNB Chain is supported.
  * - EVM only (the withdraw flow uses 0x addresses); matches the current
  *   selectable chain set rather than every Rhino chain.
  */
@@ -98,6 +99,5 @@ export const RHINO_WITHDRAW_SUPPORTED_TOKENS_BY_CHAIN: Record<string, readonly s
     '1': ['ETH', 'USDC', 'USDT'], // Ethereum
     '10': ['ETH', 'USDC', 'USDT'], // Optimism
     '137': ['USDC', 'USDT'], // Polygon (native POL not bridged by Rhino)
-    '100': ['USDC', 'USDT'], // Gnosis (native xDAI not bridged by Rhino)
     '56': ['BNB', 'USDC', 'USDT'], // BNB Chain
 }

--- a/src/components/Global/TokenSelector/TokenSelector.consts.ts
+++ b/src/components/Global/TokenSelector/TokenSelector.consts.ts
@@ -75,3 +75,29 @@ const networksToExclude: readonly number[] = [celo.id, linea.id, worldchain.id] 
 export const TOKEN_SELECTOR_SUPPORTED_NETWORK_IDS = networks
     .filter((network) => !networksToExclude.includes(Number(network.id)))
     .map((network) => network.id.toString())
+
+/**
+ * Rhino-supported withdrawal destinations: chainId → token symbols Rhino can
+ * actually deliver. Cross-chain withdraw routes through Rhino (stables via SDA,
+ * ETH/native via swaps), and Rhino supports a different, smaller set than the
+ * Squid-era token selector — and toggles chains over time (it has Scroll
+ * disabled, which 400s `SCROLL is disabled` on preview). Derived from Rhino's
+ * live SDA + bridge config (2026-06-26); update when Rhino enables/disables a
+ * chain or token.
+ *
+ * Notes:
+ * - Scroll (534352) is intentionally absent — Rhino has it disabled.
+ * - Native gas tokens Rhino doesn't bridge are omitted: Polygon (POL) and Gnosis
+ *   (xDAI) keep only USDC/USDT; Arbitrum/Ethereum/Optimism native is ETH; BNB on
+ *   BNB Chain is supported.
+ * - EVM only (the withdraw flow uses 0x addresses); matches the current
+ *   selectable chain set rather than every Rhino chain.
+ */
+export const RHINO_WITHDRAW_SUPPORTED_TOKENS_BY_CHAIN: Record<string, readonly string[]> = {
+    '42161': ['ETH', 'USDC', 'USDT'], // Arbitrum
+    '1': ['ETH', 'USDC', 'USDT'], // Ethereum
+    '10': ['ETH', 'USDC', 'USDT'], // Optimism
+    '137': ['USDC', 'USDT'], // Polygon (native POL not bridged by Rhino)
+    '100': ['USDC', 'USDT'], // Gnosis (native xDAI not bridged by Rhino)
+    '56': ['BNB', 'USDC', 'USDT'], // BNB Chain
+}

--- a/src/components/Global/TokenSelector/TokenSelector.consts.ts
+++ b/src/components/Global/TokenSelector/TokenSelector.consts.ts
@@ -87,10 +87,9 @@ export const TOKEN_SELECTOR_SUPPORTED_NETWORK_IDS = networks
  *
  * Notes:
  * - Scroll (534352) is intentionally absent — Rhino has it disabled.
- * - Gnosis (100) is omitted: our token data only has native xDAI for it (no
- *   USDC/USDT), so it has nothing offerable even though Rhino supports stables.
- * - Native gas tokens Rhino doesn't bridge are omitted: Polygon (POL) keeps only
- *   USDC/USDT; Arbitrum/Ethereum/Optimism native is ETH; BNB on BNB Chain is supported.
+ * - Native gas tokens Rhino doesn't bridge are omitted: Polygon (POL) and Gnosis
+ *   (xDAI) keep only USDC/USDT; Arbitrum/Ethereum/Optimism native is ETH; BNB on
+ *   BNB Chain is supported.
  * - EVM only (the withdraw flow uses 0x addresses); matches the current
  *   selectable chain set rather than every Rhino chain.
  */
@@ -99,5 +98,6 @@ export const RHINO_WITHDRAW_SUPPORTED_TOKENS_BY_CHAIN: Record<string, readonly s
     '1': ['ETH', 'USDC', 'USDT'], // Ethereum
     '10': ['ETH', 'USDC', 'USDT'], // Optimism
     '137': ['USDC', 'USDT'], // Polygon (native POL not bridged by Rhino)
+    '100': ['USDC', 'USDT'], // Gnosis (native xDAI not bridged by Rhino)
     '56': ['BNB', 'USDC', 'USDT'], // BNB Chain
 }

--- a/src/components/Global/TokenSelector/TokenSelector.tsx
+++ b/src/components/Global/TokenSelector/TokenSelector.tsx
@@ -288,9 +288,20 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
                     chainData.tokens.forEach(processToken)
                 }
             })
-            const uniqueTokens = Array.from(
-                new Map(tokens.map((t) => [`${t.address.toLowerCase()}-${t.chainId}`, t])).values()
-            )
+            // Dedupe by address normally; for the Rhino-restricted withdraw list
+            // collapse per (symbol, chain) so chains with two same-symbol variants
+            // (e.g. native USDC + bridged USDC.e on Optimism) show a single entry —
+            // Rhino resolves the token by symbol anyway. Keep the FIRST occurrence
+            // (token data lists the native/canonical token before bridged variants).
+            const seenKeys = new Set<string>()
+            const uniqueTokens = tokens.filter((t) => {
+                const key = restrictToRhino
+                    ? `${t.symbol.toUpperCase()}-${t.chainId}`
+                    : `${t.address.toLowerCase()}-${t.chainId}`
+                if (seenKeys.has(key)) return false
+                seenKeys.add(key)
+                return true
+            })
             return sortTokensByPriority(uniqueTokens)
         }
 

--- a/src/components/Global/TokenSelector/TokenSelector.tsx
+++ b/src/components/Global/TokenSelector/TokenSelector.tsx
@@ -28,6 +28,7 @@ import ScrollableList from './Components/ScrollableList'
 import SearchInput from './Components/SearchInput'
 import TokenListItem from './Components/TokenListItem'
 import {
+    RHINO_WITHDRAW_SUPPORTED_TOKENS_BY_CHAIN,
     TOKEN_SELECTOR_COMING_SOON_NETWORKS,
     TOKEN_SELECTOR_POPULAR_NETWORK_IDS,
     TOKEN_SELECTOR_SUPPORTED_NETWORK_IDS,
@@ -66,6 +67,17 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
         (viewType === 'claim' || viewType === 'req_pay') && underMaintenanceConfig.disableXchainSend
     // combined flag for any cross-chain disabled state
     const isCrossChainDisabled = isXchainWithdrawDisabled || isXchainSendDisabled
+
+    // When cross-chain withdraw is live, restrict destinations to what Rhino
+    // actually supports — the Squid-era selector lists chains/tokens Rhino
+    // rejects (e.g. USDC on Scroll → "SCROLL is disabled"). See
+    // RHINO_WITHDRAW_SUPPORTED_TOKENS_BY_CHAIN.
+    const restrictToRhino = viewType === 'withdraw' && !isXchainWithdrawDisabled
+    const isRhinoSupported = useCallback(
+        (chainId: string, tokenSymbol: string) =>
+            RHINO_WITHDRAW_SUPPORTED_TOKENS_BY_CHAIN[chainId]?.includes(tokenSymbol.toUpperCase()) ?? false,
+        []
+    )
 
     // state to track content height
     const contentRef = useRef<HTMLDivElement>(null)
@@ -157,7 +169,15 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
         }
     }
 
-    const allowedChainIds = useMemo(() => new Set(TOKEN_SELECTOR_SUPPORTED_NETWORK_IDS), [])
+    const allowedChainIds = useMemo(
+        () =>
+            new Set(
+                restrictToRhino
+                    ? TOKEN_SELECTOR_SUPPORTED_NETWORK_IDS.filter((id) => RHINO_WITHDRAW_SUPPORTED_TOKENS_BY_CHAIN[id])
+                    : TOKEN_SELECTOR_SUPPORTED_NETWORK_IDS
+            ),
+        [restrictToRhino]
+    )
 
     const popularChainsForButtons = useMemo(() => {
         if (!supportedChainsAndTokens) return []
@@ -165,6 +185,8 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
             const chain = supportedChainsAndTokens[popularNetwork.chainId]
             // skip if the chain ID isn't in supportedChainsAndTokens
             if (!chain) return null
+            // for withdraw, only surface chains Rhino can deliver to
+            if (restrictToRhino && !RHINO_WITHDRAW_SUPPORTED_TOKENS_BY_CHAIN[chain.chainId]) return null
 
             return {
                 chainId: chain.chainId,
@@ -172,7 +194,7 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
                 iconURI: chain.chainIconURI || '',
             }
         }).filter((chain): chain is { chainId: string; name: string; iconURI: string } => Boolean(chain)) // type guard filter nulls
-    }, [supportedChainsAndTokens])
+    }, [supportedChainsAndTokens, restrictToRhino])
 
     // build list of popular tokens (usdc, usdt, native) for display
     const popularTokensList = useMemo(() => {
@@ -243,6 +265,9 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
                 const chainData = supportedChainsAndTokens[chainId]
                 if (chainData?.tokens) {
                     const processToken = (token: IToken) => {
+                        // withdraw: drop tokens Rhino can't deliver on this chain
+                        // (e.g. native POL/xDAI, any token on a disabled chain).
+                        if (restrictToRhino && !isRhinoSupported(chainId, token.symbol)) return
                         if (filterSymbol) {
                             if (
                                 token.symbol.toUpperCase() === filterSymbol.toUpperCase() ||
@@ -280,7 +305,15 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
         // default: popular tokens on popular chains
         const popularChainIds = popularChainsForButtons.map((pc) => pc.chainId)
         return buildTokensForChainArray(popularChainIds)
-    }, [searchValue, selectedChainID, supportedChainsAndTokens, popularChainsForButtons, isCrossChainDisabled])
+    }, [
+        searchValue,
+        selectedChainID,
+        supportedChainsAndTokens,
+        popularChainsForButtons,
+        isCrossChainDisabled,
+        restrictToRhino,
+        isRhinoSupported,
+    ])
 
     // filter popular tokens by search
     const filteredPopularTokensToDisplay = useMemo(() => {

--- a/src/components/Global/TokenSelector/TokenSelector.tsx
+++ b/src/components/Global/TokenSelector/TokenSelector.tsx
@@ -67,12 +67,6 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
     // combined flag for any cross-chain disabled state
     const isCrossChainDisabled = isXchainWithdrawDisabled || isXchainSendDisabled
 
-    // Cross-chain withdraw is re-enabled for stablecoins only — the non-stable
-    // bridge path (ETH/WETH) still discards the Rhino fee and books no ledger
-    // entry, so keep it out of the destination list until that path is fixed.
-    // Claim / req_pay stay fully locked via isXchainSendDisabled above.
-    const restrictToStablecoins = viewType === 'withdraw' && !isXchainWithdrawDisabled
-
     // state to track content height
     const contentRef = useRef<HTMLDivElement>(null)
     const [isDrawerOpen, setIsDrawerOpen] = useState(false)
@@ -272,13 +266,7 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
             const uniqueTokens = Array.from(
                 new Map(tokens.map((t) => [`${t.address.toLowerCase()}-${t.chainId}`, t])).values()
             )
-            // Withdraw is stablecoin-only for now (see restrictToStablecoins) —
-            // drop native/non-stable destinations so the unfixed bridge path
-            // can't be reached.
-            const scoped = restrictToStablecoins
-                ? uniqueTokens.filter((t) => ['USDC', 'USDT'].includes(t.symbol.toUpperCase()))
-                : uniqueTokens
-            return sortTokensByPriority(scoped)
+            return sortTokensByPriority(uniqueTokens)
         }
 
         if (searchValue) {
@@ -292,14 +280,7 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
         // default: popular tokens on popular chains
         const popularChainIds = popularChainsForButtons.map((pc) => pc.chainId)
         return buildTokensForChainArray(popularChainIds)
-    }, [
-        searchValue,
-        selectedChainID,
-        supportedChainsAndTokens,
-        popularChainsForButtons,
-        isCrossChainDisabled,
-        restrictToStablecoins,
-    ])
+    }, [searchValue, selectedChainID, supportedChainsAndTokens, popularChainsForButtons, isCrossChainDisabled])
 
     // filter popular tokens by search
     const filteredPopularTokensToDisplay = useMemo(() => {

--- a/src/components/Global/TokenSelector/TokenSelector.tsx
+++ b/src/components/Global/TokenSelector/TokenSelector.tsx
@@ -67,6 +67,12 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
     // combined flag for any cross-chain disabled state
     const isCrossChainDisabled = isXchainWithdrawDisabled || isXchainSendDisabled
 
+    // Cross-chain withdraw is re-enabled for stablecoins only — the non-stable
+    // bridge path (ETH/WETH) still discards the Rhino fee and books no ledger
+    // entry, so keep it out of the destination list until that path is fixed.
+    // Claim / req_pay stay fully locked via isXchainSendDisabled above.
+    const restrictToStablecoins = viewType === 'withdraw' && !isXchainWithdrawDisabled
+
     // state to track content height
     const contentRef = useRef<HTMLDivElement>(null)
     const [isDrawerOpen, setIsDrawerOpen] = useState(false)
@@ -266,7 +272,13 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
             const uniqueTokens = Array.from(
                 new Map(tokens.map((t) => [`${t.address.toLowerCase()}-${t.chainId}`, t])).values()
             )
-            return sortTokensByPriority(uniqueTokens)
+            // Withdraw is stablecoin-only for now (see restrictToStablecoins) —
+            // drop native/non-stable destinations so the unfixed bridge path
+            // can't be reached.
+            const scoped = restrictToStablecoins
+                ? uniqueTokens.filter((t) => ['USDC', 'USDT'].includes(t.symbol.toUpperCase()))
+                : uniqueTokens
+            return sortTokensByPriority(scoped)
         }
 
         if (searchValue) {
@@ -280,7 +292,14 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
         // default: popular tokens on popular chains
         const popularChainIds = popularChainsForButtons.map((pc) => pc.chainId)
         return buildTokensForChainArray(popularChainIds)
-    }, [searchValue, selectedChainID, supportedChainsAndTokens, popularChainsForButtons, isCrossChainDisabled])
+    }, [
+        searchValue,
+        selectedChainID,
+        supportedChainsAndTokens,
+        popularChainsForButtons,
+        isCrossChainDisabled,
+        restrictToStablecoins,
+    ])
 
     // filter popular tokens by search
     const filteredPopularTokensToDisplay = useMemo(() => {

--- a/src/components/TransactionDetails/transactionTransformer.ts
+++ b/src/components/TransactionDetails/transactionTransformer.ts
@@ -500,9 +500,16 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
     }
 
     // parse the amount from the usdamount string in extradata
-    const amount = entry.extraData?.usdAmount
+    const baseAmount = entry.extraData?.usdAmount
         ? parseFloat(String(entry.extraData.usdAmount).replace(/[^\d.-]/g, ''))
         : 0
+    // Bake the cross-chain network fee into the displayed amount (product
+    // convention: fees are part of the amount, never a separate line — see the
+    // `fee: undefined` note below). The BE only sets `networkFeeUsd` for a
+    // CRYPTO_WITHDRAW whose kernel actually debited principal + fee (SDA path),
+    // so this shows the true amount deducted instead of just the principal.
+    const networkFeeUsd = typeof entry.extraData?.networkFeeUsd === 'number' ? entry.extraData.networkFeeUsd : 0
+    const amount = baseAmount + networkFeeUsd
 
     const { explorerUrlWithTx, addressExplorerUrl, tokenDisplayDetails, rewardData } = computeDerivedFields(entry)
 

--- a/src/components/Withdraw/views/Confirm.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Confirm.withdraw.view.tsx
@@ -84,7 +84,7 @@ export default function ConfirmWithdrawView({
 
     const displayReceived = useMemo<string | null>(() => {
         if (!isCrossChain || !receiveAmount || !resolvedTokenSymbol) return null
-        return isStableCoin(resolvedTokenSymbol) ? `$ ${receiveAmount}` : `${receiveAmount} ${resolvedTokenSymbol}`
+        return isStableCoin(resolvedTokenSymbol) ? `$${receiveAmount}` : `${receiveAmount} ${resolvedTokenSymbol}`
     }, [isCrossChain, receiveAmount, resolvedTokenSymbol])
 
     // Honest bridge fee. The Rhino fee (destination gas + 0.07%) is paid by the
@@ -93,7 +93,7 @@ export default function ConfirmWithdrawView({
     // same-chain (no bridge) there's no Rhino fee, so it stays sponsored.
     const networkFeeDisplay = useMemo<string>(() => {
         if (!isCrossChain || networkFee <= 0) return 'Sponsored by Peanut!'
-        return networkFee < 0.01 ? '< $ 0.01' : `$ ${networkFee.toFixed(2)}`
+        return networkFee < 0.01 ? '< $0.01' : `$${networkFee.toFixed(2)}`
     }, [isCrossChain, networkFee])
 
     // What actually leaves the wallet on a cross-chain withdraw — the exact USDC
@@ -105,7 +105,7 @@ export default function ConfirmWithdrawView({
     const totalPayDisplay = useMemo<string | null>(() => {
         if (!isCrossChain || !payAmount) return null
         const parsed = parseFloat(payAmount)
-        return Number.isFinite(parsed) ? `$ ${formatAmount(payAmount)}` : null
+        return Number.isFinite(parsed) ? `$${formatAmount(payAmount)}` : null
     }, [isCrossChain, payAmount])
 
     return (
@@ -176,14 +176,14 @@ export default function ConfirmWithdrawView({
                     {isCrossChain && (isCalculating || totalPayDisplay) && (
                         <PaymentInfoRow label="You pay" value={totalPayDisplay} loading={isCalculating} />
                     )}
-                    <PaymentInfoRow hideBottomBorder label="Peanut fee" value={`$ ${peanutFee}`} />
+                    <PaymentInfoRow hideBottomBorder label="Peanut fee" value={`$${peanutFee}`} />
                 </Card>
 
                 {showHighFeeWarning && (
                     <InfoCard
                         variant="info"
                         icon="info"
-                        description="Heads up: the network fee is a large share of this withdrawal. Withdrawing a larger amount or choosing a cheaper network reduces it."
+                        description="Note: the network fee is a large share of this withdrawal. Withdrawing a larger amount or choosing a cheaper network reduces it."
                     />
                 )}
 

--- a/src/components/Withdraw/views/Confirm.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Confirm.withdraw.view.tsx
@@ -106,10 +106,11 @@ export default function ConfirmWithdrawView({
                 />
 
                 <Card className="rounded-sm">
-                    {displayReceived && (
+                    {isCrossChain && (isCalculating || displayReceived) && (
                         <PaymentInfoRow
                             label="Recipient receives"
                             value={displayReceived}
+                            loading={isCalculating}
                             moreInfoText="The full amount arrives on the destination chain. The cross-chain network fee is paid on top — see below."
                         />
                     )}
@@ -152,9 +153,12 @@ export default function ConfirmWithdrawView({
                     <PaymentInfoRow
                         label="Network fee"
                         value={networkFeeDisplay}
+                        loading={isCrossChain && isCalculating}
                         moreInfoText="Cross-chain bridge fee (destination gas + Rhino's 0.07%). Paid on top of the amount withdrawn."
                     />
-                    {totalPayDisplay && <PaymentInfoRow label="You pay" value={totalPayDisplay} />}
+                    {isCrossChain && (isCalculating || totalPayDisplay) && (
+                        <PaymentInfoRow label="You pay" value={totalPayDisplay} loading={isCalculating} />
+                    )}
                     <PaymentInfoRow hideBottomBorder label="Peanut fee" value={`$ ${peanutFee}`} />
                 </Card>
 

--- a/src/components/Withdraw/views/Confirm.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Confirm.withdraw.view.tsx
@@ -82,10 +82,12 @@ export default function ConfirmWithdrawView({
 
     // What actually leaves the wallet on a cross-chain withdraw: amount + fee
     // (receive mode — the fee is taken at source). Shown so the user sees the
-    // real debit, not just the headline destination amount.
+    // real debit, not just the headline destination amount. Sum the SAME
+    // 2-decimal fee shown in the "Network fee" row so the displayed numbers add
+    // up (full-precision fee could differ from the rounded display by a cent).
     const totalPayDisplay = useMemo<string | null>(() => {
         if (!isCrossChain || networkFee <= 0) return null
-        const total = parseFloat(amount) + networkFee
+        const total = parseFloat(amount) + Number(networkFee.toFixed(2))
         return Number.isFinite(total) ? `$ ${formatAmount(total.toString())}` : null
     }, [isCrossChain, amount, networkFee])
 

--- a/src/components/Withdraw/views/Confirm.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Confirm.withdraw.view.tsx
@@ -5,6 +5,7 @@ import AddressLink from '@/components/Global/AddressLink'
 import Card from '@/components/Global/Card'
 import DisplayIcon from '@/components/Global/DisplayIcon'
 import ErrorAlert from '@/components/Global/ErrorAlert'
+import InfoCard from '@/components/Global/InfoCard'
 import NavHeader from '@/components/Global/NavHeader'
 import PeanutActionDetailsCard from '@/components/Global/PeanutActionDetailsCard'
 import { PaymentInfoRow } from '@/components/Payment/PaymentInfoRow'
@@ -163,10 +164,10 @@ export default function ConfirmWithdrawView({
                 </Card>
 
                 {showHighFeeWarning && (
-                    <ErrorAlert
+                    <InfoCard
+                        variant="info"
+                        icon="info"
                         description="Heads up: the network fee is a large share of this withdrawal. Withdrawing a larger amount or choosing a cheaper network reduces it."
-                        className="text-grey-1"
-                        iconClassName="text-grey-1"
                     />
                 )}
 

--- a/src/components/Withdraw/views/Confirm.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Confirm.withdraw.view.tsx
@@ -36,6 +36,11 @@ interface WithdrawConfirmViewProps {
      * "they'll receive X" number.
      */
     receiveAmount?: string | null
+    /**
+     * True when the bridge fee is disproportionate to the amount (e.g. a small
+     * withdraw to Ethereum mainnet where flat gas dominates). Blocks the CTA.
+     */
+    feeTooHigh?: boolean
 }
 
 export default function ConfirmWithdrawView({
@@ -52,6 +57,7 @@ export default function ConfirmWithdrawView({
     isCrossChain = false,
     isCalculating = false,
     receiveAmount,
+    feeTooHigh = false,
 }: WithdrawConfirmViewProps) {
     const { tokenIconUrl, chainIconUrl, resolvedChainName, resolvedTokenSymbol } = useTokenChainIcons({
         chainId: chain.chainId,
@@ -64,16 +70,23 @@ export default function ConfirmWithdrawView({
         return isStableCoin(resolvedTokenSymbol) ? `$ ${receiveAmount}` : `${receiveAmount} ${resolvedTokenSymbol}`
     }, [isCrossChain, receiveAmount, resolvedTokenSymbol])
 
-    const networkFeeDisplay = useMemo<string | React.ReactNode>(() => {
-        if (networkFee < 0.01) return 'Sponsored by Peanut!'
-        return (
-            <>
-                <span className="line-through">$ {networkFee.toFixed(2)}</span>
-                {' – '}
-                <span className="font-medium text-gray-500">Sponsored by Peanut!</span>
-            </>
-        )
-    }, [networkFee])
+    // Honest bridge fee. The Rhino fee (destination gas + 0.07%) is paid by the
+    // user on top of the amount — it is NOT sponsored. Only the kernel execution
+    // gas is sponsored by Peanut's paymaster (the "Peanut fee" row below). For
+    // same-chain (no bridge) there's no Rhino fee, so it stays sponsored.
+    const networkFeeDisplay = useMemo<string>(() => {
+        if (!isCrossChain || networkFee <= 0) return 'Sponsored by Peanut!'
+        return networkFee < 0.01 ? '< $ 0.01' : `$ ${networkFee.toFixed(2)}`
+    }, [isCrossChain, networkFee])
+
+    // What actually leaves the wallet on a cross-chain withdraw: amount + fee
+    // (receive mode — the fee is taken at source). Shown so the user sees the
+    // real debit, not just the headline destination amount.
+    const totalPayDisplay = useMemo<string | null>(() => {
+        if (!isCrossChain || networkFee <= 0) return null
+        const total = parseFloat(amount) + networkFee
+        return Number.isFinite(total) ? `$ ${formatAmount(total.toString())}` : null
+    }, [isCrossChain, amount, networkFee])
 
     return (
         <div className="space-y-8">
@@ -94,7 +107,7 @@ export default function ConfirmWithdrawView({
                         <PaymentInfoRow
                             label="Recipient receives"
                             value={displayReceived}
-                            moreInfoText="Cross-chain bridging fee is deducted from the sent amount by Rhino."
+                            moreInfoText="The full amount arrives on the destination chain. The cross-chain network fee is paid on top — see below."
                         />
                     )}
                     <PaymentInfoRow
@@ -133,9 +146,18 @@ export default function ConfirmWithdrawView({
                         label="To"
                         value={<AddressLink isLink={false} address={toAddress} className="text-black no-underline" />}
                     />
-                    <PaymentInfoRow label="Max network fee" value={networkFeeDisplay} />
+                    <PaymentInfoRow
+                        label="Network fee"
+                        value={networkFeeDisplay}
+                        moreInfoText="Cross-chain bridge fee (destination gas + Rhino's 0.07%). Paid on top of the amount withdrawn."
+                    />
+                    {totalPayDisplay && <PaymentInfoRow label="You pay" value={totalPayDisplay} />}
                     <PaymentInfoRow hideBottomBorder label="Peanut fee" value={`$ ${peanutFee}`} />
                 </Card>
+
+                {feeTooHigh && (
+                    <ErrorAlert description="The network fee is too high relative to this amount. Try withdrawing a larger amount or choosing a cheaper network." />
+                )}
 
                 {error ? (
                     <Button
@@ -160,7 +182,7 @@ export default function ConfirmWithdrawView({
                         variant="purple"
                         shadowSize="4"
                         onClick={onConfirm}
-                        disabled={isProcessing || isCalculating}
+                        disabled={isProcessing || isCalculating || feeTooHigh}
                         loading={isProcessing}
                         className="w-full"
                     >

--- a/src/components/Withdraw/views/Confirm.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Confirm.withdraw.view.tsx
@@ -37,10 +37,11 @@ interface WithdrawConfirmViewProps {
      */
     receiveAmount?: string | null
     /**
-     * True when the bridge fee is disproportionate to the amount (e.g. a small
-     * withdraw to Ethereum mainnet where flat gas dominates). Blocks the CTA.
+     * True when the bridge fee is a large share of the amount (e.g. a small
+     * withdraw to Ethereum mainnet where the flat gas floor dominates). Shows a
+     * non-blocking heads-up — the user can still proceed; the fee is honest.
      */
-    feeTooHigh?: boolean
+    showHighFeeWarning?: boolean
 }
 
 export default function ConfirmWithdrawView({
@@ -57,7 +58,7 @@ export default function ConfirmWithdrawView({
     isCrossChain = false,
     isCalculating = false,
     receiveAmount,
-    feeTooHigh = false,
+    showHighFeeWarning = false,
 }: WithdrawConfirmViewProps) {
     const { tokenIconUrl, chainIconUrl, resolvedChainName, resolvedTokenSymbol } = useTokenChainIcons({
         chainId: chain.chainId,
@@ -155,8 +156,12 @@ export default function ConfirmWithdrawView({
                     <PaymentInfoRow hideBottomBorder label="Peanut fee" value={`$ ${peanutFee}`} />
                 </Card>
 
-                {feeTooHigh && (
-                    <ErrorAlert description="The network fee is too high relative to this amount. Try withdrawing a larger amount or choosing a cheaper network." />
+                {showHighFeeWarning && (
+                    <ErrorAlert
+                        description="Heads up: the network fee is a large share of this withdrawal. Withdrawing a larger amount or choosing a cheaper network reduces it."
+                        className="text-grey-1"
+                        iconClassName="text-grey-1"
+                    />
                 )}
 
                 {error ? (
@@ -182,7 +187,7 @@ export default function ConfirmWithdrawView({
                         variant="purple"
                         shadowSize="4"
                         onClick={onConfirm}
-                        disabled={isProcessing || isCalculating || feeTooHigh}
+                        disabled={isProcessing || isCalculating}
                         loading={isProcessing}
                         className="w-full"
                     >

--- a/src/components/Withdraw/views/Confirm.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Confirm.withdraw.view.tsx
@@ -12,6 +12,7 @@ import { PaymentInfoRow } from '@/components/Payment/PaymentInfoRow'
 import { useTokenChainIcons } from '@/hooks/useTokenChainIcons'
 import { type ITokenPriceData } from '@/interfaces'
 import { formatAmount, isStableCoin } from '@/utils/general.utils'
+import { INSUFFICIENT_BALANCE_MESSAGE } from '@/utils/balance.utils'
 import type { ChainWithTokens } from '@/interfaces/chain-meta'
 import { useMemo } from 'react'
 import { ROUTE_NOT_FOUND_ERROR } from '@/constants/general.consts'
@@ -38,11 +39,23 @@ interface WithdrawConfirmViewProps {
      */
     receiveAmount?: string | null
     /**
+     * The exact USDC the kernel spends (decimal string) — the honest "You pay".
+     * SDA (receive mode) = principal + fee; bridge (pay mode) = principal (the
+     * fee comes out of what the recipient receives). Nullable while calculating.
+     */
+    payAmount?: string | null
+    /**
      * True when the bridge fee is a large share of the amount (e.g. a small
      * withdraw to Ethereum mainnet where the flat gas floor dominates). Shows a
      * non-blocking heads-up — the user can still proceed; the fee is honest.
      */
     showHighFeeWarning?: boolean
+    /**
+     * True when the balance can't cover amount + cross-chain fee. Blocks the CTA
+     * with an honest "not enough balance" message instead of letting the user
+     * sign into the misleading "balance still settling" send error.
+     */
+    insufficientBalance?: boolean
 }
 
 export default function ConfirmWithdrawView({
@@ -59,7 +72,9 @@ export default function ConfirmWithdrawView({
     isCrossChain = false,
     isCalculating = false,
     receiveAmount,
+    payAmount,
     showHighFeeWarning = false,
+    insufficientBalance = false,
 }: WithdrawConfirmViewProps) {
     const { tokenIconUrl, chainIconUrl, resolvedChainName, resolvedTokenSymbol } = useTokenChainIcons({
         chainId: chain.chainId,
@@ -81,16 +96,17 @@ export default function ConfirmWithdrawView({
         return networkFee < 0.01 ? '< $ 0.01' : `$ ${networkFee.toFixed(2)}`
     }, [isCrossChain, networkFee])
 
-    // What actually leaves the wallet on a cross-chain withdraw: amount + fee
-    // (receive mode — the fee is taken at source). Shown so the user sees the
-    // real debit, not just the headline destination amount. Sum the SAME
-    // 2-decimal fee shown in the "Network fee" row so the displayed numbers add
-    // up (full-precision fee could differ from the rounded display by a cent).
+    // What actually leaves the wallet on a cross-chain withdraw — the exact USDC
+    // the kernel spends (`payAmount`). This is authoritative for BOTH paths and
+    // avoids guessing: SDA (receive mode) = principal + fee, bridge (pay mode) =
+    // principal (the fee comes out of the recipient's amount, not on top). Using
+    // amount + fee would over-state the bridge path (showing principal + fee when
+    // the user only pays the principal).
     const totalPayDisplay = useMemo<string | null>(() => {
-        if (!isCrossChain || networkFee <= 0) return null
-        const total = parseFloat(amount) + Number(networkFee.toFixed(2))
-        return Number.isFinite(total) ? `$ ${formatAmount(total.toString())}` : null
-    }, [isCrossChain, amount, networkFee])
+        if (!isCrossChain || !payAmount) return null
+        const parsed = parseFloat(payAmount)
+        return Number.isFinite(parsed) ? `$ ${formatAmount(payAmount)}` : null
+    }, [isCrossChain, payAmount])
 
     return (
         <div className="space-y-8">
@@ -194,7 +210,7 @@ export default function ConfirmWithdrawView({
                         variant="purple"
                         shadowSize="4"
                         onClick={onConfirm}
-                        disabled={isProcessing || isCalculating}
+                        disabled={isProcessing || isCalculating || insufficientBalance}
                         loading={isProcessing}
                         className="w-full"
                     >
@@ -202,6 +218,7 @@ export default function ConfirmWithdrawView({
                     </Button>
                 )}
 
+                {insufficientBalance && !error && <ErrorAlert description={INSUFFICIENT_BALANCE_MESSAGE} />}
                 {error && <ErrorAlert description={error} />}
             </div>
         </div>

--- a/src/config/underMaintenance.config.ts
+++ b/src/config/underMaintenance.config.ts
@@ -62,7 +62,7 @@ const underMaintenanceConfig: MaintenanceConfig = {
     enableFullMaintenance: false, // set to true to redirect all pages to /maintenance
     enableMaintenanceBanner: false, // set to true to show maintenance banner on all pages
     disabledPaymentProviders: [], // set to ['MANTECA'] to disable Manteca QR payments
-    disableXchainWithdraw: true, // set to true to disable cross-chain withdrawals (only allows USDC on Arbitrum)
+    disableXchainWithdraw: false, // cross-chain stablecoin withdrawals re-enabled (USDC/USDT only, fee shown honestly + guarded); set true to lock to USDC on Arbitrum
     disableXchainSend: true, // set to true to disable cross-chain sends (claim, request payments - only allows USDC on Arbitrum)
     disableCardPioneers: true, // set to false to enable the Card Pioneers waitlist feature
     pixBrazilOnrampMaintenance: true, // set to false when BRL-via-PIX deposits are stable again

--- a/src/config/underMaintenance.config.ts
+++ b/src/config/underMaintenance.config.ts
@@ -62,7 +62,7 @@ const underMaintenanceConfig: MaintenanceConfig = {
     enableFullMaintenance: false, // set to true to redirect all pages to /maintenance
     enableMaintenanceBanner: false, // set to true to show maintenance banner on all pages
     disabledPaymentProviders: [], // set to ['MANTECA'] to disable Manteca QR payments
-    disableXchainWithdraw: false, // cross-chain stablecoin withdrawals re-enabled (USDC/USDT only, fee shown honestly + guarded); set true to lock to USDC on Arbitrum
+    disableXchainWithdraw: false, // cross-chain withdrawals re-enabled (stables via SDA + non-stables via swaps, fee shown honestly); set true to lock to USDC on Arbitrum
     disableXchainSend: true, // set to true to disable cross-chain sends (claim, request payments - only allows USDC on Arbitrum)
     disableCardPioneers: true, // set to false to enable the Card Pioneers waitlist feature
     pixBrazilOnrampMaintenance: true, // set to false when BRL-via-PIX deposits are stable again

--- a/src/constants/rhino.consts.ts
+++ b/src/constants/rhino.consts.ts
@@ -100,12 +100,17 @@ export const RHINO_SUPPORTED_TOKENS = (Object.keys(TOKEN_LOGOS) as TokenName[])
  * — matters for the sandbox harness, where our smart accounts live on Arb
  * Sepolia while Rhino's endpoints only recognize mainnet chain names.
  */
-export const EVM_CHAIN_ID_TO_RHINO_NAME: Record<string, ChainName | undefined> = {
+// Values are Rhino's API chain names (what `chainIn`/`chainOut` must be), which
+// differ from our display ChainName for two chains: Polygon is `MATIC_POS` and
+// BNB Chain is `BINANCE` in Rhino's API. Sending the display name (POLYGON/BNB)
+// 400s with `Invalid chain`. Keep this in sync with peanut-api-ts
+// `src/rhino/consts.ts` CHAINS_CONFIG.
+export const EVM_CHAIN_ID_TO_RHINO_NAME: Record<string, string | undefined> = {
     '1': 'ETHEREUM',
     '10': 'OPTIMISM',
-    '56': 'BNB',
+    '56': 'BINANCE', // Rhino's name for BNB Chain (display: BNB)
     '100': 'GNOSIS',
-    '137': 'POLYGON',
+    '137': 'MATIC_POS', // Rhino's name for Polygon (display: POLYGON)
     '534352': 'SCROLL',
     '42161': 'ARBITRUM',
     '421614': 'ARBITRUM', // Arb Sepolia — same Rhino bucket for sandbox runs
@@ -113,6 +118,6 @@ export const EVM_CHAIN_ID_TO_RHINO_NAME: Record<string, ChainName | undefined> =
     '42220': 'CELO',
 }
 
-export function evmChainIdToRhinoName(chainId: string | number): ChainName | undefined {
+export function evmChainIdToRhinoName(chainId: string | number): string | undefined {
     return EVM_CHAIN_ID_TO_RHINO_NAME[String(chainId)]
 }

--- a/src/constants/token-details.json
+++ b/src/constants/token-details.json
@@ -1295,6 +1295,20 @@
                 "logoURI": "https://gnosisscan.io/token/images/gnosans_32.png"
             },
             {
+                "address": "0x2a22f9c3b484c3629090feed35f17ff8f88f76f0",
+                "name": "USD Coin",
+                "symbol": "USDC",
+                "decimals": 6,
+                "logoURI": "https://market-data-images.s3.us-east-1.amazonaws.com/tokenImages/0x10ca7e698fab4eb287d4d33b3886ae17a6d078fbda455cdd673cfec0ca8ef413.png"
+            },
+            {
+                "address": "0x4ecaba5870353805a9f068101a40e0f32ed605c6",
+                "name": "Tether USD",
+                "symbol": "USDT",
+                "decimals": 6,
+                "logoURI": "https://market-data-images.s3.us-east-1.amazonaws.com/tokenImages/0x63adcb79842ad73769d6f2350d9cab2c8b8e0d37f6071dee9418cbd53319543d.png"
+            },
+            {
                 "address": "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1",
                 "decimals": 18,
                 "name": "Wrapped Ether",

--- a/src/features/payments/shared/hooks/useCrossChainTransfer.ts
+++ b/src/features/payments/shared/hooks/useCrossChainTransfer.ts
@@ -303,25 +303,30 @@ export function useCrossChainTransfer(): UseCrossChainTransferReturn {
                     return
                 }
 
-                // Run preview + provision in parallel — they don't depend on each other.
-                const [preview, sda] = await Promise.all([
-                    previewSdaTransfer({
-                        chainIn: sourceRhinoChain,
-                        chainOut: destRhinoChain,
-                        token: tokenSymbol,
-                        amount: destination.tokenAmount,
-                        mode: 'receive', // UI always asks "merchant gets X" — user pays X + fee
-                    }),
-                    provisionSdaTransfer({
-                        context,
-                        contextId,
-                        depositChain: sourceRhinoChain,
-                        destinationChain: destRhinoChain,
-                        destinationAddress: destination.recipientAddress,
-                        tokenOut: tokenSymbol,
-                        senderPeanutWalletAddress,
-                    }),
-                ])
+                // Preview first, then provision — provision now carries the quote
+                // economics (feeUsd / payAmount / receiveAmount) so the backend can
+                // persist them onto the charge and book the FEE ledger entry at
+                // settlement (PRINCIPAL + FEE = real on-chain debit). Sequential
+                // because provision depends on preview's numbers.
+                const preview = await previewSdaTransfer({
+                    chainIn: sourceRhinoChain,
+                    chainOut: destRhinoChain,
+                    token: tokenSymbol,
+                    amount: destination.tokenAmount,
+                    mode: 'receive', // UI always asks "merchant gets X" — user pays X + fee
+                })
+                const sda = await provisionSdaTransfer({
+                    context,
+                    contextId,
+                    depositChain: sourceRhinoChain,
+                    destinationChain: destRhinoChain,
+                    destinationAddress: destination.recipientAddress,
+                    tokenOut: tokenSymbol,
+                    senderPeanutWalletAddress,
+                    feeUsd: preview.feeUsd,
+                    payAmount: preview.payAmount,
+                    receiveAmount: preview.receiveAmount,
+                })
 
                 applyRhinoResult({
                     preview,

--- a/src/services/rhino-sda.ts
+++ b/src/services/rhino-sda.ts
@@ -33,6 +33,15 @@ export interface SdaTransferRequest {
     destinationAddress: Address
     tokenOut: RhinoSupportedToken
     senderPeanutWalletAddress?: Address
+    /**
+     * Rhino quote economics from the immediately-preceding /preview, echoed so
+     * the backend persists them onto the charge intent and books the bridge
+     * FEE ledger entry at settlement. Omitted for claim-xchain (no charge).
+     * `payAmount`/`receiveAmount` are destination-token decimal strings.
+     */
+    feeUsd?: number
+    payAmount?: string
+    receiveAmount?: string
 }
 
 export interface SdaTransferResult {

--- a/src/utils/cross-chain-fee.utils.test.ts
+++ b/src/utils/cross-chain-fee.utils.test.ts
@@ -1,23 +1,23 @@
-import { isWithdrawFeeDisproportionate, MAX_WITHDRAW_FEE_RATIO } from './cross-chain-fee.utils'
+import { isWithdrawFeeDisproportionate, HIGH_WITHDRAW_FEE_RATIO } from './cross-chain-fee.utils'
 
 describe('isWithdrawFeeDisproportionate', () => {
-    test('allows a tiny L2 fee on a normal amount', () => {
+    test('no heads-up for a tiny L2 fee on a normal amount', () => {
         // $0.08 fee on $10 → 0.8%
         expect(isWithdrawFeeDisproportionate(0.08, 10)).toBe(false)
     })
 
-    test('blocks a small mainnet withdraw where flat gas dominates', () => {
+    test('heads-up for a small mainnet withdraw where flat gas dominates', () => {
         // $1.50 fee on $10 → 15%
         expect(isWithdrawFeeDisproportionate(1.5, 10)).toBe(true)
     })
 
-    test('allows the same mainnet fee on a larger amount', () => {
+    test('no heads-up for the same mainnet fee on a larger amount', () => {
         // $1.50 fee on $100 → 1.5%
         expect(isWithdrawFeeDisproportionate(1.5, 100)).toBe(false)
     })
 
     test('is strict at the threshold boundary', () => {
-        // exactly 5% is allowed; just over is blocked
+        // exactly 5% is below the line; just over triggers the heads-up
         expect(isWithdrawFeeDisproportionate(0.5, 10)).toBe(false) // 5.0%
         expect(isWithdrawFeeDisproportionate(0.51, 10)).toBe(true) // 5.1%
     })
@@ -38,6 +38,6 @@ describe('isWithdrawFeeDisproportionate', () => {
     })
 
     test('default threshold is 5%', () => {
-        expect(MAX_WITHDRAW_FEE_RATIO).toBe(0.05)
+        expect(HIGH_WITHDRAW_FEE_RATIO).toBe(0.05)
     })
 })

--- a/src/utils/cross-chain-fee.utils.test.ts
+++ b/src/utils/cross-chain-fee.utils.test.ts
@@ -1,0 +1,43 @@
+import { isWithdrawFeeDisproportionate, MAX_WITHDRAW_FEE_RATIO } from './cross-chain-fee.utils'
+
+describe('isWithdrawFeeDisproportionate', () => {
+    test('allows a tiny L2 fee on a normal amount', () => {
+        // $0.08 fee on $10 → 0.8%
+        expect(isWithdrawFeeDisproportionate(0.08, 10)).toBe(false)
+    })
+
+    test('blocks a small mainnet withdraw where flat gas dominates', () => {
+        // $1.50 fee on $10 → 15%
+        expect(isWithdrawFeeDisproportionate(1.5, 10)).toBe(true)
+    })
+
+    test('allows the same mainnet fee on a larger amount', () => {
+        // $1.50 fee on $100 → 1.5%
+        expect(isWithdrawFeeDisproportionate(1.5, 100)).toBe(false)
+    })
+
+    test('is strict at the threshold boundary', () => {
+        // exactly 5% is allowed; just over is blocked
+        expect(isWithdrawFeeDisproportionate(0.5, 10)).toBe(false) // 5.0%
+        expect(isWithdrawFeeDisproportionate(0.51, 10)).toBe(true) // 5.1%
+    })
+
+    test('no fee / zero fee is never disproportionate (same-chain, sponsored)', () => {
+        expect(isWithdrawFeeDisproportionate(undefined, 10)).toBe(false)
+        expect(isWithdrawFeeDisproportionate(0, 10)).toBe(false)
+    })
+
+    test('guards against a non-positive or non-finite amount', () => {
+        expect(isWithdrawFeeDisproportionate(1, 0)).toBe(false)
+        expect(isWithdrawFeeDisproportionate(1, Number.NaN)).toBe(false)
+    })
+
+    test('honours a custom threshold', () => {
+        expect(isWithdrawFeeDisproportionate(0.2, 10, 0.01)).toBe(true) // 2% > 1%
+        expect(isWithdrawFeeDisproportionate(0.2, 10, 0.1)).toBe(false) // 2% < 10%
+    })
+
+    test('default threshold is 5%', () => {
+        expect(MAX_WITHDRAW_FEE_RATIO).toBe(0.05)
+    })
+})

--- a/src/utils/cross-chain-fee.utils.ts
+++ b/src/utils/cross-chain-fee.utils.ts
@@ -1,26 +1,27 @@
 /**
- * Cross-chain withdrawal fee guard.
+ * Cross-chain withdrawal fee heads-up.
  *
  * Rhino's bridge fee is `flat destination gas + 0.07%`, and gas is flat per
  * chain (~$0.01 on L2s, ~$1.50+ on Ethereum mainnet). Because gas is a fixed
- * per-chain cost, a %-of-amount stop naturally blocks tiny mainnet withdrawals
- * (a $10 → mainnet withdraw loses ~15%) while leaving L2s and larger amounts
- * untouched. This is the guard that prevents the "$4 fee on a $5 withdraw"
- * case that originally got the feature disabled.
+ * per-chain cost, a small mainnet withdrawal loses a large share to it (a $10 →
+ * mainnet withdraw is ~15%). We don't block it — the fee is shown honestly and
+ * the user decides — but we surface a non-blocking heads-up so a tiny mainnet
+ * withdrawal isn't a silent footgun. L2s and larger amounts stay below the
+ * threshold and show nothing.
  */
 
-/** Block the withdrawal when the bridge fee exceeds this share of the amount. */
-export const MAX_WITHDRAW_FEE_RATIO = 0.05 // 5%
+/** Surface the heads-up when the bridge fee exceeds this share of the amount. */
+export const HIGH_WITHDRAW_FEE_RATIO = 0.05 // 5%
 
 /**
- * True when the bridge fee is disproportionate to the amount being withdrawn.
+ * True when the bridge fee is a large share of the amount being withdrawn.
  * Returns false for no/zero fee (same-chain, sponsored) or a non-positive
  * amount (nothing to compare against yet).
  */
 export function isWithdrawFeeDisproportionate(
     feeUsd: number | undefined,
     amountUsd: number,
-    threshold: number = MAX_WITHDRAW_FEE_RATIO
+    threshold: number = HIGH_WITHDRAW_FEE_RATIO
 ): boolean {
     if (!feeUsd || feeUsd <= 0) return false
     if (!Number.isFinite(amountUsd) || amountUsd <= 0) return false

--- a/src/utils/cross-chain-fee.utils.ts
+++ b/src/utils/cross-chain-fee.utils.ts
@@ -1,0 +1,28 @@
+/**
+ * Cross-chain withdrawal fee guard.
+ *
+ * Rhino's bridge fee is `flat destination gas + 0.07%`, and gas is flat per
+ * chain (~$0.01 on L2s, ~$1.50+ on Ethereum mainnet). Because gas is a fixed
+ * per-chain cost, a %-of-amount stop naturally blocks tiny mainnet withdrawals
+ * (a $10 → mainnet withdraw loses ~15%) while leaving L2s and larger amounts
+ * untouched. This is the guard that prevents the "$4 fee on a $5 withdraw"
+ * case that originally got the feature disabled.
+ */
+
+/** Block the withdrawal when the bridge fee exceeds this share of the amount. */
+export const MAX_WITHDRAW_FEE_RATIO = 0.05 // 5%
+
+/**
+ * True when the bridge fee is disproportionate to the amount being withdrawn.
+ * Returns false for no/zero fee (same-chain, sponsored) or a non-positive
+ * amount (nothing to compare against yet).
+ */
+export function isWithdrawFeeDisproportionate(
+    feeUsd: number | undefined,
+    amountUsd: number,
+    threshold: number = MAX_WITHDRAW_FEE_RATIO
+): boolean {
+    if (!feeUsd || feeUsd <= 0) return false
+    if (!Number.isFinite(amountUsd) || amountUsd <= 0) return false
+    return feeUsd / amountUsd > threshold
+}

--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -109,6 +109,10 @@ export interface HistoryEntryExtraData {
     fulfillmentType?: 'bridge' | 'wallet'
     bridgeTransferId?: string
     usdAmount?: string
+    /** Cross-chain (Rhino) bridge fee in USD the user paid on top of the
+     *  principal — set only for CRYPTO_WITHDRAW that booked a matching FEE
+     *  entry (SDA path). Baked into the displayed amount in the transformer. */
+    networkFeeUsd?: number | null
     haveSentMoneyToUser?: boolean
     /** Token-transfer block number — `string` from indexer, sometimes `number`
      *  from on-chain webhooks. Treated as a presence signal, not parsed. */


### PR DESCRIPTION
## Summary
Re-enables cross-chain stablecoin withdrawal, disabled 2026-05-22 after a customer paid ~$4 in fees on a ~$5 mainnet withdraw while the confirm screen showed the fee struck through as "Sponsored by Peanut!". The Rhino fee (destination gas + 0.07%) is real and user-paid; only the kernel execution gas is actually sponsored.

- **Honest confirm screen:** shows the real network fee + a "You pay" total (amount + fee), separating the user-paid bridge fee from the genuinely-sponsored kernel gas. Fixes the misleading "Recipient receives" tooltip.
- **Disproportionate-fee hard-stop** (`cross-chain-fee.utils`): blocks the CTA when the fee exceeds 5% of the amount. Flat mainnet gas makes small mainnet withdrawals fail this — exactly the case that got the feature disabled.
- **Threads** the quote economics (feeUsd/payAmount/receiveAmount) from preview → provision so the backend can persist + ledger them.
- **Re-enable:** flips `disableXchainWithdraw` only; `TokenSelector` restricts withdraw to USDC/USDT across Rhino chains. The non-stable bridge path stays out (its fee accounting is unfixed); claim / cross-chain pay-request stay disabled (`disableXchainSend` untouched).

## Risks / breaking changes
- **Cross-repo:** requires **peanut-api-ts #1060** (persists the fee + books the ledger entry). Deploy **BE first**, then this. Without the BE change the receipt won't show gross spend (the confirm-screen honesty + guard still work standalone).
- `useCrossChainTransfer.calculate` is now sequential (preview → provision) instead of `Promise.all` — provision depends on preview's numbers.
- TokenSelector change is scoped to `viewType === 'withdraw'`; claim/req_pay behavior unchanged.

## QA
- Unit: `npm test` — `cross-chain-fee.utils.test.ts` (5% threshold, boundary, zero/undefined, custom threshold).
- Manual (sandbox): L2 withdraw shows ~$0.01 fee honestly + "You pay" total; small mainnet withdraw is blocked by the guard; non-stable tokens absent from the withdraw selector.

Scope: **withdraw-only, stablecoins-only.** TASK-19744.

---

## Update — Rhino confirmed the Ethereum gas floor (2026-06-25)

Rhino confirmed `gasFeeUsd` has a **hard $1.50 floor for Ethereum** SDA settlements — it stays at $1.50 even when live mainnet gas is in the cents, and only re-prices upward above that during congestion. L2 destinations floor at **$0.01**.

**Implication for the 5% guard:** it reads the live quoted `feeUsd`, so it permanently blocks Ethereum withdrawals **under ~$30** (`$1.50 / $30 = 5%`) — by design, this is the "$4-fee-on-$5" class of complaint the guard exists to stop. `$100 → 1.5%`, `$1,000 → 0.15%`. So the **5% threshold is a deliberate choice gating mainnet to ~$30+**, not arbitrary.

**Optional follow-up:** an explicit "Ethereum minimum ~$30" hint at amount entry would be friendlier than the generic confirm-screen block. Shipping the generic guard as-is is correct and honest for now.

---

## Update — aligned to the team decision (2026-06-25)

After the Hugo/Jota call, the decision shifted from "stablecoin/L2-only, hard-block mainnet" to **keep all destinations + tokens, communicate fees honestly (not remove features)**. Changes in the latest commit:

- **Removed the stablecoin-only restriction** — ETH/non-stable destinations are allowed again (they route through the existing swaps path, kept as-is per the decision).
- **Hard-block → non-blocking heads-up** — the CTA is no longer disabled on a high fee ratio; a muted note flags when the fee is a large share of the amount. The honest breakdown (you pay / network fee / recipient receives) is the real communication, same posture as fiat withdrawals.

**Fee reality (live rhino quotes), all charged to the user per transfer:**

| destination | USDC (SDA path) | ETH (swaps path) |
|---|---|---|
| L2 (Arb/Op/Base) | ~$0.01 | ~$0.01–0.07 |
| Ethereum mainnet | ~$1.50 | ~$1.50 |

The $1.50 is just Ethereum settlement gas (a rhino floor), hits any mainnet withdrawal regardless of token/path. L2s are ~1:1.

**Known follow-up (not in this PR):** the SDA/stablecoin path books the fee on the ledger (BE #1060); the ETH/swaps path shows the fee honestly pre-sign but does not yet book a ledger entry — its settlement is a separate path left as-is.