### PR TITLE
feat(card): tweak win + rejection share captions

### DIFF
--- a/src/components/Card/share-asset/rejectionCaptions.ts
+++ b/src/components/Card/share-asset/rejectionCaptions.ts
@@ -9,16 +9,17 @@
  */
 
 export const REJECTION_CAPTIONS: readonly string[] = [
-    'rejected by @joinpeanut 🚫 the door policy is insane. i WILL be back.',
+    'rejected by @joinpeanut 🚫 the door policy is insane.',
+    '@joinpeanut has a bouncer now??',
     "@joinpeanut told me i'm not on the list 💀 the AUDACITY",
     "the @joinpeanut bouncer said come back when i'm somebody. ok bet.",
     'got read for filth by the @joinpeanut door',
-    'officially rejected by @joinpeanut. honestly an honor 🥜🚫',
+    'officially rejected by @joinpeanut.',
     'collected my first @joinpeanut badge: REJECTED 💀',
     'took an L at the @joinpeanut door. building my comeback arc.',
     "denied at the @joinpeanut door. the bouncer didn't even blink 🚫",
-    "@joinpeanut said NOT TONIGHT. guess i'll fix my whole life and come back",
-    'turned away from @joinpeanut 💀 most exclusive door in crypto fr',
+    "@joinpeanut said NOT TONIGHT. guess i'll fix my whole life",
+    'turned away from @joinpeanut 💀',
     "couldn't get past the @joinpeanut velvet rope. humbling.",
     '@joinpeanut rejection #1. framing this one.',
     'the @joinpeanut door looked me up and down and said no. respect.',
@@ -31,6 +32,8 @@ export const REJECTION_CAPTIONS: readonly string[] = [
     'tried the @joinpeanut door. NOT TONIGHT. comeback arc loading.',
     "@joinpeanut rejected me and i've never wanted in more 💀",
     'took an L at the @joinpeanut door tonight. tomorrow we ride again.',
+    "remember @joinpeanut from devconnect?? they've rejected me from their beta programme omg",
+    "rember @joinpeanut from devconnect?? seems they're back but also they don't want users ??? WHAT?",
 ]
 
 /** Pick a random caption. Browser-only (Math.random) — fine at share time. */

--- a/src/components/Card/share-asset/winCaptions.ts
+++ b/src/components/Card/share-asset/winCaptions.ts
@@ -26,6 +26,8 @@ export const WIN_CAPTIONS: readonly string[] = [
     'banked by @joinpeanut. unbothered.',
     "who needs a bank? i've got @joinpeanut.",
     "broke up with my bank. it's @joinpeanut now.",
+    "remember @joinpeanut from argentina? they're global now. just got into their closed beta",
+    "saw @joinpeanut in argentina. they went global — and i'm in the closed beta.",
 ]
 
 /** Pick a random caption. Browser-only (Math.random) — fine at share time. */


### PR DESCRIPTION
Copy-only follow-up to #2274, **stacked on `feat/card-share-sticker-collage`** (retarget to `dev` once #2274 merges).

Touches only the two caption pools — no logic, no asset changes. All captions keep the `@joinpeanut` tag (the file invariant).

### Rejection pool (`rejectionCaptions.ts`)
- Punchier — dropped trailing justifications:
  - `…the door policy is insane. i WILL be back.` → `…the door policy is insane.`
  - `officially rejected by @joinpeanut. honestly an honor 🥜🚫` → `officially rejected by @joinpeanut.`
  - `…guess i'll fix my whole life and come back` → `…guess i'll fix my whole life`
  - `turned away from @joinpeanut 💀 most exclusive door in crypto fr` → `turned away from @joinpeanut 💀`
- New lines:
  - `@joinpeanut has a bouncer now??`
  - `remember @joinpeanut from devconnect?? they've rejected me from their beta programme omg`
  - `rember @joinpeanut from devconnect?? seems they're back but also they don't want users ??? WHAT?` (`rember` typo intentional)

### Win pool (`winCaptions.ts`)
- Added an Argentina/global callback (tagged to match this branch's all-`@joinpeanut` convention):
  - `remember @joinpeanut from argentina? they're global now. just got into their closed beta`
  - `saw @joinpeanut in argentina. they went global — and i'm in the closed beta.`

### Checks
- `pnpm prettier --check` ✓ · typecheck (no new errors) ✓ · `jest src/components/Card/share-asset` 24/24 ✓