### PR TITLE
fix(kyc): surface per-label reject copy in action-required drawer

### DIFF
--- a/src/components/Kyc/states/KycActionRequired.tsx
+++ b/src/components/Kyc/states/KycActionRequired.tsx
@@ -5,8 +5,12 @@ import { Button } from '@/components/0_Bruddle/Button'
 import type { IconName } from '@/components/Global/Icons/Icon'
 
 // this component shows the identity-verification status when more action is needed
-// from the user. Displays a friendly actionMessage when present, otherwise the
-// normalized reject labels (e.g. bad photo quality, expired doc).
+// from the user. Prefers the per-label copy when reject labels are present (e.g.
+// DUPLICATE_EMAIL → "Email already in use, sign in to that account or contact
+// support") and only falls back to the backend's generic actionMessage when there
+// are none. The backend always sends a generic "resubmit your documents"
+// actionMessage for action_required, so checking it first would mask the
+// specific, actionable copy.
 export const KycActionRequired = ({
     onResume,
     isLoading,
@@ -22,7 +26,9 @@ export const KycActionRequired = ({
         <div className="space-y-4 p-1">
             <KYCStatusDrawerItem status="pending" customText="Action needed" />
 
-            {actionMessage ? (
+            {rejectLabels?.length ? (
+                <RejectLabelsList rejectLabels={rejectLabels} />
+            ) : actionMessage ? (
                 <InfoCard variant="info" icon="alert" description={actionMessage} />
             ) : (
                 <RejectLabelsList rejectLabels={rejectLabels} />

--- a/src/components/Kyc/states/KycActionRequired.tsx
+++ b/src/components/Kyc/states/KycActionRequired.tsx
@@ -8,9 +8,11 @@ import type { IconName } from '@/components/Global/Icons/Icon'
 // from the user. Prefers the per-label copy when reject labels are present (e.g.
 // DUPLICATE_EMAIL → "Email already in use, sign in to that account or contact
 // support") and only falls back to the backend's generic actionMessage when there
-// are none. The backend always sends a generic "resubmit your documents"
-// actionMessage for action_required, so checking it first would mask the
-// specific, actionable copy.
+// are none. The backend (identity.ts → actionMessageFor) sends a fixed, generic
+// "resubmit your documents" message for every action_required state — it is never
+// label-specific — so checking it first would mask the actionable per-label copy.
+// RejectLabelsList already renders its own generic fallback for empty labels, so
+// the no-labels-no-actionMessage case lands there safely.
 export const KycActionRequired = ({
     onResume,
     isLoading,
@@ -26,9 +28,7 @@ export const KycActionRequired = ({
         <div className="space-y-4 p-1">
             <KYCStatusDrawerItem status="pending" customText="Action needed" />
 
-            {rejectLabels?.length ? (
-                <RejectLabelsList rejectLabels={rejectLabels} />
-            ) : actionMessage ? (
+            {!rejectLabels?.length && actionMessage ? (
                 <InfoCard variant="info" icon="alert" description={actionMessage} />
             ) : (
                 <RejectLabelsList rejectLabels={rejectLabels} />

--- a/src/components/Kyc/states/__tests__/KycActionRequired.rejectCopy.test.tsx
+++ b/src/components/Kyc/states/__tests__/KycActionRequired.rejectCopy.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+import { KycActionRequired } from '../KycActionRequired'
+
+// Integration-level companion to KycStates.test.tsx: that suite mocks
+// RejectLabelsList to assert branch selection. Here we render the REAL
+// RejectLabelsList + reject-label copy map so a regression in the
+// DUPLICATE_EMAIL → "Email already in use" mapping (the whole point of the
+// precedence fix) actually fails a test instead of shipping silently.
+
+jest.mock('use-haptic', () => ({
+    useHaptic: () => ({ triggerHaptic: jest.fn() }),
+}))
+
+jest.mock('@/hooks/useLongPress', () => ({
+    useLongPress: () => ({ isLongPressed: false, pressProgress: 0, handlers: {} }),
+}))
+
+jest.mock('../../KYCStatusDrawerItem', () => ({
+    KYCStatusDrawerItem: () => <div data-testid="kyc-status-drawer-item" />,
+}))
+
+// InfoCard is the leaf both branches render through; surface its text so we can
+// assert the actual copy. RejectLabelsList is intentionally NOT mocked.
+jest.mock('@/components/Global/InfoCard', () => ({
+    __esModule: true,
+    default: ({ title, description }: { title?: string; description?: string }) => (
+        <>
+            {title ? <div>{title}</div> : null}
+            {description ? <div>{description}</div> : null}
+        </>
+    ),
+}))
+
+describe('KycActionRequired — real reject-label copy', () => {
+    it('renders the DUPLICATE_EMAIL guidance, not the generic resubmit message', () => {
+        render(
+            <KycActionRequired
+                onResume={jest.fn()}
+                actionMessage="We need a bit more to verify your identity. Please resubmit your documents."
+                rejectLabels={['DUPLICATE_EMAIL']}
+            />
+        )
+
+        expect(screen.getByText(/already linked to another Peanut account/i)).toBeInTheDocument()
+        expect(screen.getByText(/sign in to that account/i)).toBeInTheDocument()
+        expect(screen.queryByText(/resubmit your documents/i)).not.toBeInTheDocument()
+    })
+})

--- a/src/components/Kyc/states/__tests__/KycStates.test.tsx
+++ b/src/components/Kyc/states/__tests__/KycStates.test.tsx
@@ -48,6 +48,31 @@ describe('KYC state cards', () => {
         expect(onResume).toHaveBeenCalledWith()
     })
 
+    it('shows per-label reject copy (not the generic actionMessage) when reject labels are present', () => {
+        // DUPLICATE_EMAIL regression: the backend always sends a generic
+        // "resubmit your documents" actionMessage for action_required, which used
+        // to mask the specific "Email already in use" reject-label copy.
+        render(
+            <KycActionRequired
+                onResume={jest.fn()}
+                actionMessage="We need a bit more to verify your identity. Please resubmit your documents."
+                rejectLabels={['DUPLICATE_EMAIL']}
+            />
+        )
+
+        expect(screen.getByTestId('reject-labels-list')).toBeInTheDocument()
+        expect(screen.queryByText(/resubmit your documents/i)).not.toBeInTheDocument()
+    })
+
+    it('falls back to the generic actionMessage when there are no reject labels', () => {
+        render(
+            <KycActionRequired onResume={jest.fn()} actionMessage="Please resubmit your documents." rejectLabels={[]} />
+        )
+
+        expect(screen.getByText('Please resubmit your documents.')).toBeInTheDocument()
+        expect(screen.queryByTestId('reject-labels-list')).not.toBeInTheDocument()
+    })
+
     it('does not pass the click event to failed retry', () => {
         const onRetry = jest.fn()
         render(<KycFailed onRetry={onRetry} />)


### PR DESCRIPTION
## Summary

The KYC **action-required drawer** (`KycActionRequired.tsx`) checked `actionMessage` first and only rendered `RejectLabelsList` as a fallback. But the backend (`identity.ts` → `actionMessageFor`) **always** sends a generic `action_required` message ("…Please resubmit your documents."), so the `actionMessage` branch always won and the **specific per-label copy was never reachable**.

Most visible with **`DUPLICATE_EMAIL`**: a user whose KYC passed at Sumsub (GREEN) but collided with an email already on another Peanut account was shown a generic "verify your ID / resubmit documents" prompt — misleading and non-actionable (re-uploading docs can't fix an email collision). The correct copy ("Email already in use → sign in to that account or contact support", added in #2265) existed but was masked.

**Fix:** prefer `RejectLabelsList` when reject labels are present; fall back to the generic `actionMessage` only when there are none. Also improves every other soft-reject (bad photo, expired doc) — they now show their specific copy instead of the generic line.

## Risk
Low — single presentational component, no logic/data/contract change. The drawer modal variant (`KycActionRequiredModal`) already rendered `RejectLabelsList` directly and is unaffected. No backend change.

## QA
- KYC drawer in `action_required` with `rejectLabels: ['DUPLICATE_EMAIL']` → shows "Email already in use…", not the generic resubmit message.
- `action_required` with no reject labels → still shows the generic `actionMessage`.
- Covered by 2 new unit tests in `KycStates.test.tsx` (4/4 passing).

## Context
Surfaced from a live support case (US-passport user in Argentina, QR payment): Sumsub GREEN but our verification stuck `ACTION_REQUIRED` with `DUPLICATE_EMAIL`; the Manteca QR rail was already ENABLED, so the only blocker was the masked KYC copy.