### PR TITLE
fix(card): guest claim-to-bank under maintenance (grey + SOON)

### DIFF
--- a/src/components/Claim/Link/SendLinkActionList.tsx
+++ b/src/components/Claim/Link/SendLinkActionList.tsx
@@ -108,12 +108,18 @@ export default function SendLinkActionList({
         return claimType === BankClaimType.GuestKycNeeded || claimType === BankClaimType.ReceiverKycNeeded
     }, [claimType])
 
+    // Guest claim-to-bank (claimer unverified, but the sender can receive a bank
+    // off-ramp) is under maintenance: the BE 503s POST /bridge/offramp/create-for-guest.
+    // Render the bank option greyed + "Soon!" so guests can't enter a flow that would
+    // fail. The authenticated self off-ramp (UserBankClaim) is unaffected.
+    const isGuestBankClaim = claimType === BankClaimType.GuestBankClaim
+
     // filter and sort payment methods based on geolocation
     const { filteredMethods: sortedActionMethods, isLoading: isGeoLoading } = useGeoFilteredPaymentOptions({
         sortUnavailable: true,
         isMethodUnavailable: (method) =>
             method.soon ||
-            (method.id === 'bank' && requiresVerification) ||
+            (method.id === 'bank' && (requiresVerification || isGuestBankClaim)) ||
             (['mercadopago', 'pix'].includes(method.id) && !isMantecaPayEnabled),
         methods: showDevconnectMethod
             ? DEVCONNECT_CLAIM_METHODS.filter((method) => method.id !== 'devconnect')
@@ -273,6 +279,7 @@ export default function SendLinkActionList({
                             key={method.id}
                             method={method}
                             requiresVerification={methodRequiresVerification}
+                            soon={method.id === 'bank' && isGuestBankClaim}
                         />
                     )
                 })}
@@ -323,12 +330,17 @@ const MethodCard = ({
     onClick,
     requiresVerification,
     isDisabled,
+    soon,
 }: {
     method: PaymentMethod
     onClick: () => void
     requiresVerification?: boolean
     isDisabled?: boolean
+    // forces the "Soon!" badge + greyed/non-interactive state even when the
+    // static method config has soon=false (e.g. guest claim-to-bank maintenance)
+    soon?: boolean
 }) => {
+    const showSoon = method.soon || soon
     return (
         <ActionListCard
             position="single"
@@ -337,7 +349,7 @@ const MethodCard = ({
             title={
                 <div className="flex items-center gap-2">
                     {method.title}
-                    {(method.soon || requiresVerification) && (
+                    {(showSoon || requiresVerification) && (
                         <StatusBadge
                             status={requiresVerification ? 'custom' : 'soon'}
                             customText={requiresVerification ? 'REQUIRES VERIFICATION' : ''}
@@ -346,7 +358,7 @@ const MethodCard = ({
                 </div>
             }
             onClick={onClick}
-            isDisabled={method.soon || isDisabled}
+            isDisabled={showSoon || isDisabled}
             rightContent={<IconStack icons={method.icons} iconSize={method.id === 'bank' ? 80 : 24} />}
         />
     )

--- a/src/components/Claim/Link/__tests__/SendLinkActionList.test.tsx
+++ b/src/components/Claim/Link/__tests__/SendLinkActionList.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * SendLinkActionList — guest claim-to-bank maintenance gating
+ *
+ * The GUEST claim-to-bank off-ramp is under maintenance (BE 503s
+ * POST /bridge/offramp/create-for-guest). The bank method must render greyed +
+ * "Soon!" and be non-interactive when the claim resolves to GuestBankClaim,
+ * while the authenticated self off-ramp (UserBankClaim) stays fully clickable.
+ */
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+// ---------- module-level mocks (before importing the component) ----------
+
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
+}))
+
+jest.mock('next/image', () => ({
+    __esModule: true,
+    default: (props: any) => {
+        const { priority, fill, ...rest } = props
+        return <img {...rest} />
+    },
+}))
+
+jest.mock('use-haptic', () => ({
+    useHaptic: () => ({ triggerHaptic: jest.fn() }),
+}))
+
+// Heavy leaf modals / CTAs that are not under test
+jest.mock('@/components/Global/ActionModal', () => ({
+    __esModule: true,
+    default: () => null,
+}))
+jest.mock('../../../Global/ConfirmInviteModal', () => ({
+    __esModule: true,
+    default: () => null,
+}))
+jest.mock('../../../Global/SupportCTA', () => ({
+    __esModule: true,
+    default: () => null,
+}))
+
+// Bank claim type — the value under test. `BankClaimType` mirrors the real enum.
+let mockClaimType = 'user-bank-claim'
+jest.mock('@/hooks/useDetermineBankClaimType', () => ({
+    BankClaimType: {
+        GuestBankClaim: 'guest-bank-claim',
+        UserBankClaim: 'user-bank-claim',
+        ReceiverKycNeeded: 'receiver-kyc-needed',
+        GuestKycNeeded: 'guest-kyc-needed',
+    },
+    useDetermineBankClaimType: () => ({ claimType: mockClaimType, setClaimType: jest.fn() }),
+}))
+
+const mockSetFlowStep = jest.fn()
+jest.mock('@/context/ClaimBankFlowContext', () => ({
+    ClaimBankFlowStep: {
+        SavedAccountsList: 'saved-accounts-list',
+        BankCountryList: 'bank-country-list',
+        BankDetailsForm: 'bank-details-form',
+        BankConfirmClaim: 'bank-confirm-claim',
+    },
+    useClaimBankFlow: () => ({
+        setClaimToExternalWallet: jest.fn(),
+        setFlowStep: mockSetFlowStep,
+        setShowVerificationModal: jest.fn(),
+        setClaimToMercadoPago: jest.fn(),
+        setRegionalMethodType: jest.fn(),
+        setHideTokenSelector: jest.fn(),
+    }),
+}))
+
+jest.mock('@/hooks/useSavedAccounts', () => ({
+    __esModule: true,
+    default: () => [],
+}))
+
+jest.mock('../../useClaimLink', () => ({
+    __esModule: true,
+    default: () => ({ addParamStep: jest.fn() }),
+}))
+
+jest.mock('@/hooks/useCapabilities', () => ({
+    useCapabilities: () => ({ canDo: () => false }),
+}))
+
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => ({ user: { user: { userId: 'me', hasAppAccess: true } } }),
+}))
+
+jest.mock('@/redux/hooks', () => ({
+    useAppDispatch: () => jest.fn(),
+}))
+
+jest.mock('@/context', () => ({
+    tokenSelectorContext: React.createContext({
+        setSelectedTokenAddress: jest.fn(),
+        setSelectedChainID: jest.fn(),
+        devconnectChainId: '',
+        devconnectRecipientAddress: '',
+        devconnectTokenAddress: '',
+    }),
+}))
+
+// Return a fixed method set so the test is independent of geolocation.
+const bankMethod = { id: 'bank', title: 'Bank', description: 'EUR, USD, MXN, ARS & more', icons: [], soon: false }
+const walletMethod = {
+    id: 'exchange-or-wallet',
+    title: 'Exchange or Wallet',
+    description: 'Binance, Metamask and more',
+    icons: [],
+    soon: false,
+}
+jest.mock('@/hooks/useGeoFilteredPaymentOptions', () => ({
+    useGeoFilteredPaymentOptions: () => ({ filteredMethods: [bankMethod, walletMethod], isLoading: false }),
+}))
+
+// ---------- import component under test AFTER mocks ----------
+import SendLinkActionList from '../SendLinkActionList'
+
+const claimLinkData = {
+    amount: BigInt(10000000), // 10 USDC — above the $5 bank minimum
+    tokenDecimals: 6,
+    sender: { userId: 'sender-123', username: 'alice' },
+} as any
+
+function renderList() {
+    return render(<SendLinkActionList claimLinkData={claimLinkData} isLoggedIn isInviteLink={false} />)
+}
+
+beforeEach(() => {
+    jest.clearAllMocks()
+})
+
+describe('SendLinkActionList — guest claim-to-bank maintenance', () => {
+    test('GuestBankClaim: bank option is greyed + "Soon!" and non-interactive', () => {
+        mockClaimType = 'guest-bank-claim'
+        renderList()
+
+        // SOON badge present on the bank option
+        expect(screen.getByText('Soon!')).toBeInTheDocument()
+
+        // clicking the disabled bank card does not start the bank flow
+        fireEvent.click(screen.getByText('Bank'))
+        expect(mockSetFlowStep).not.toHaveBeenCalled()
+    })
+
+    test('UserBankClaim: authenticated self off-ramp stays interactive (no "Soon!")', () => {
+        mockClaimType = 'user-bank-claim'
+        renderList()
+
+        expect(screen.queryByText('Soon!')).not.toBeInTheDocument()
+
+        // clicking the enabled bank card enters the bank flow
+        fireEvent.click(screen.getByText('Bank'))
+        expect(mockSetFlowStep).toHaveBeenCalledWith('bank-country-list')
+    })
+})


### PR DESCRIPTION
## What

When a claim resolves to **GuestBankClaim** (claimer is *not* KYC-verified, but the link sender *can* receive a bank off-ramp), the **Bank** option in the claim method-selection list is now rendered **greyed-out, non-interactive, with a "Soon!" badge**. Guests can no longer enter that flow.

No re-routing, no error surfaced — the option simply reads as not-yet-available.

## Why

The backend has put the guest off-ramp under maintenance: **POST `/bridge/offramp/create-for-guest` now returns 503** (pairs with backend PR #1073). Without this, an unverified claimer could still tap **Bank**, fill the form, and dead-end on a 503 at the final step. Greying the option up front is the graceful FE reflection of that maintenance window for the Monday Card launch.

## Scope / safety

- **Only** the guest/unverified-claimer bank path (`BankClaimType.GuestBankClaim`) is gated.
- The **authenticated self bank off-ramp** (`UserBankClaim` → `POST /users/accounts` + `POST /bridge/offramp/create`) is **untouched** and stays fully clickable. Verified-claimer KYC paths (`ReceiverKycNeeded` / `GuestKycNeeded`) keep their existing "Requires verification" treatment.

## Implementation

Surgical change in `src/components/Claim/Link/SendLinkActionList.tsx`:
- Derive `isGuestBankClaim` from the resolved claim type.
- Add it to the unavailable-sort predicate so the bank option sinks to the bottom, consistent with other unavailable methods.
- Pass a `soon` flag to the bank `MethodCard`; `MethodCard` now honours an explicit `soon` (forces the existing `StatusBadge status="soon"` + `ActionListCard isDisabled` greyed/non-interactive state) on top of the static `method.soon`.

Reuses the existing `StatusBadge` ("Soon!") + `ActionListCard` disabled styling (`bg-grey-4`, `onClick` removed) — no new design primitives.

## Tests

New `src/components/Claim/Link/__tests__/SendLinkActionList.test.tsx`:
- GuestBankClaim → bank shows "Soon!" and clicking it does **not** start the bank flow.
- UserBankClaim → no "Soon!", clicking enters the bank flow (authenticated path unaffected).

Local gate: prettier clean, `typecheck` clean for the changed files, full jest suite passes (the one unrelated `countryCurrencyMapping` flag-asset suite fails only because untracked `public/flags/*` assets are absent in a fresh worktree — generated in CI).

## Notes

- Branched off `origin/main` (prod hotfix). `main` and `dev` have diverged (~18/20 commits) — normal for the release flow; this targets `main` to ship with the backend hotfix, and should back-merge to `dev` afterward.