### PR TITLE
feat(card): home card-launch CTA (fat /shhhhh-tone splash on launch day)

### DIFF
--- a/src/app/(mobile-ui)/home/page.tsx
+++ b/src/app/(mobile-ui)/home/page.tsx
@@ -26,6 +26,7 @@ import { useNotifications } from '@/hooks/useNotifications'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { useCardInfo } from '@/hooks/useCardInfo'
 import HomeCarouselCTA from '@/components/Home/HomeCarouselCTA'
+import CardLaunchCTA from '@/components/Home/CardLaunchCTA'
 import EnableAutoBalanceBanner from '@/components/Home/EnableAutoBalanceBanner'
 import InvitesIcon from '@/components/Home/InvitesIcon'
 import NavigationArrow from '@/components/Global/NavigationArrow'
@@ -208,6 +209,11 @@ export default function Home() {
 
                 <div className="space-y-2">
                     <EnableAutoBalanceBanner />
+                    {/* Public-launch splash. Self-gating (see CardLaunchCTA): shows post-
+                        launch to activated, geo-eligible, card-less, non-waitlisted users;
+                        dismiss/click hides it forever. Rendered above the carousel/activation
+                        CTAs so it leads the home stack on launch day. */}
+                    <CardLaunchCTA />
                     {isActivated ? (
                         <HomeCarouselCTA />
                     ) : (

--- a/src/components/Card/__tests__/cardState.utils.test.ts
+++ b/src/components/Card/__tests__/cardState.utils.test.ts
@@ -15,6 +15,7 @@ const cardInfo = (
     hasCardAccess: opts.hasCardAccess ?? false,
     isEligible: true,
     flowEarlyAccess: opts.flowEarlyAccess ?? true,
+    isPublicLaunched: true,
     waitlistJoinedAt: opts.waitlistJoinedAt ?? null,
     waitlistPosition: opts.waitlistPosition ?? null,
     waitlistReleasedAt: opts.waitlistReleasedAt ?? null,

--- a/src/components/Home/CardLaunchCTA/CardLaunchCTABanner.tsx
+++ b/src/components/Home/CardLaunchCTA/CardLaunchCTABanner.tsx
@@ -77,6 +77,7 @@ export default function CardLaunchCTABanner({ onTryDoor, onDismiss }: CardLaunch
                     variant="dark"
                     shadowSize="4"
                     className="mt-1 w-full"
+                    disableHaptics
                     onClick={(e) => {
                         e.stopPropagation()
                         handleTryDoor()

--- a/src/components/Home/CardLaunchCTA/CardLaunchCTABanner.tsx
+++ b/src/components/Home/CardLaunchCTA/CardLaunchCTABanner.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import Image from 'next/image'
+import { Icon } from '@/components/Global/Icons/Icon'
+import { Button } from '@/components/0_Bruddle/Button'
+import { Sparkle } from '@/assets/illustrations'
+import { useHaptic } from 'use-haptic'
+
+interface CardLaunchCTABannerProps {
+    /** Tap-through: routes the user into the /card eligibility flow. */
+    onTryDoor: () => void
+    /** Close (X): permanently hides the banner. */
+    onDismiss: () => void
+}
+
+/**
+ * Fat home launch banner for the Peanut Card public launch.
+ *
+ * Presentational only — gating + persistence live in the `CardLaunchCTA`
+ * container so this can be force-rendered in the /dev/home-ctas preview.
+ *
+ * Tone matches the /shhhhh teaser: pink, hard black border + shadow, extra-black
+ * uppercase headline, provocative "maybe it's for you" framing. The whole card
+ * is a tap target (parity with CarouselCTA); the X stops propagation.
+ */
+export default function CardLaunchCTABanner({ onTryDoor, onDismiss }: CardLaunchCTABannerProps) {
+    const { triggerHaptic } = useHaptic()
+
+    const handleTryDoor = () => {
+        triggerHaptic()
+        onTryDoor()
+    }
+
+    const handleDismiss = (e: React.MouseEvent) => {
+        e.stopPropagation()
+        onDismiss()
+    }
+
+    return (
+        <div
+            role="button"
+            tabIndex={0}
+            onClick={handleTryDoor}
+            className="relative cursor-pointer overflow-hidden rounded-sm border-2 border-n-1 bg-primary-1 p-5 shadow-[4px_4px_0_#000]"
+        >
+            <button
+                type="button"
+                aria-label="Dismiss launch announcement"
+                onClick={handleDismiss}
+                className="absolute right-2.5 top-2.5 z-10 cursor-pointer p-1 text-n-1 outline-none"
+            >
+                <Icon name="cancel" size={16} />
+            </button>
+
+            <Image
+                src={Sparkle}
+                alt=""
+                aria-hidden
+                width={56}
+                height={56}
+                className="pointer-events-none absolute -right-3 -top-3 w-12 select-none md:w-14"
+            />
+
+            <div className="relative z-[1] flex flex-col gap-3 pr-6">
+                <span className="font-roboto-flex-extrabold text-[11px] font-extraBlack uppercase tracking-[0.22em] text-n-1 opacity-60">
+                    shhhhh · it&apos;s out
+                </span>
+                <h3 className="font-roboto-flex-extrabold text-2xl font-extraBlack uppercase leading-[1.02] text-n-1">
+                    The card is out.
+                    <br />
+                    For you? Maybe.
+                </h3>
+                <p className="text-sm font-bold leading-snug text-n-1">
+                    We opened the door to everyone. Tap to find out if you&apos;re in.
+                </p>
+                <Button
+                    variant="dark"
+                    shadowSize="4"
+                    className="mt-1 w-full"
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        handleTryDoor()
+                    }}
+                >
+                    Try the door →
+                </Button>
+            </div>
+        </div>
+    )
+}

--- a/src/components/Home/CardLaunchCTA/__tests__/cardLaunchCTA.utils.test.ts
+++ b/src/components/Home/CardLaunchCTA/__tests__/cardLaunchCTA.utils.test.ts
@@ -1,0 +1,28 @@
+import { dismissCardLaunchCTA, isCardLaunchCTADismissed } from '../cardLaunchCTA.utils'
+
+describe('cardLaunchCTA dismiss persistence', () => {
+    beforeEach(() => {
+        localStorage.clear()
+    })
+
+    it('defaults to not dismissed', () => {
+        expect(isCardLaunchCTADismissed()).toBe(false)
+    })
+
+    it('persists a dismissal', () => {
+        dismissCardLaunchCTA()
+        expect(isCardLaunchCTADismissed()).toBe(true)
+    })
+
+    it('is permanent — a re-read still reports dismissed (no cooldown)', () => {
+        dismissCardLaunchCTA()
+        // simulate a later mount reading the flag again
+        expect(isCardLaunchCTADismissed()).toBe(true)
+    })
+
+    it('is idempotent', () => {
+        dismissCardLaunchCTA()
+        dismissCardLaunchCTA()
+        expect(isCardLaunchCTADismissed()).toBe(true)
+    })
+})

--- a/src/components/Home/CardLaunchCTA/cardLaunchCTA.utils.ts
+++ b/src/components/Home/CardLaunchCTA/cardLaunchCTA.utils.ts
@@ -1,0 +1,32 @@
+/**
+ * Permanent ("gone forever") dismissal for the home card-launch CTA.
+ *
+ * Mirrors useActivationStatus' `peanut_card_activation_dismissed` localStorage
+ * flag — NOT the carousel's `dismissedCarouselCTAs` map, which re-surfaces a CTA
+ * after a 7-day cooldown. The launch CTA is a one-shot splash: once the user
+ * clicks through OR closes it, it never comes back.
+ */
+
+const CARD_LAUNCH_CTA_DISMISSED_KEY = 'peanut_card_launch_cta_dismissed'
+
+/** True if the user has already clicked through or dismissed the launch CTA. */
+export function isCardLaunchCTADismissed(): boolean {
+    if (typeof window === 'undefined') return false
+    try {
+        return localStorage.getItem(CARD_LAUNCH_CTA_DISMISSED_KEY) === 'true'
+    } catch {
+        // Private-mode / storage-disabled browsers: treat as not-dismissed so the
+        // CTA still shows; worst case it re-appears on next mount (no crash).
+        return false
+    }
+}
+
+/** Permanently hide the launch CTA. Idempotent. */
+export function dismissCardLaunchCTA(): void {
+    if (typeof window === 'undefined') return
+    try {
+        localStorage.setItem(CARD_LAUNCH_CTA_DISMISSED_KEY, 'true')
+    } catch {
+        // No-op if storage is unavailable.
+    }
+}

--- a/src/components/Home/CardLaunchCTA/index.tsx
+++ b/src/components/Home/CardLaunchCTA/index.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import posthog from 'posthog-js'
+import { useAuth } from '@/context/authContext'
+import { useCardInfo } from '@/hooks/useCardInfo'
+import { useRainCardOverview } from '@/hooks/useRainCardOverview'
+import { useActivationStatus } from '@/hooks/useActivationStatus'
+import { findActiveCard } from '@/components/Card/cardState.utils'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import underMaintenanceConfig from '@/config/underMaintenance.config'
+import CardLaunchCTABanner from './CardLaunchCTABanner'
+import { dismissCardLaunchCTA, isCardLaunchCTADismissed } from './cardLaunchCTA.utils'
+
+/**
+ * Home launch CTA for the Peanut Card public launch (2026-06-29).
+ *
+ * Self-gating once `isPublicLaunched` flips. Audience = the active base who
+ * could plausibly want a card and haven't engaged yet: ACTIVATED users who are
+ * geo-eligible, have no active card, and aren't already on the waitlist (and
+ * haven't dismissed/clicked it). Non-activated users are left to the activation
+ * funnel; on-waitlist / card-holding / ineligible users are excluded so the
+ * "find out if you're in" tap never dead-ends.
+ *
+ * Gates on `/card`'s `isPublicLaunched` — NOT `hasCardAccess` (the inner gate
+ * that excludes most users). The point is to drive the eligible base to /card to
+ * "test if they can get their card"; /card itself does the final eligibility gate.
+ *
+ * Dismissal is permanent (localStorage flag, no cooldown): clicking through OR
+ * closing the X both hide it forever.
+ */
+export default function CardLaunchCTA() {
+    const router = useRouter()
+    const { user } = useAuth()
+    const { isPublicLaunched, isEligible, cardInfo, isLoading } = useCardInfo()
+    const { overview } = useRainCardOverview()
+    const { isActivated } = useActivationStatus()
+
+    // Read the permanent dismissal after mount to avoid a hydration mismatch —
+    // localStorage is client-only. Mirrors useActivationStatus.dismissCardStep.
+    const [dismissed, setDismissed] = useState(false)
+    useEffect(() => {
+        setDismissed(isCardLaunchCTADismissed())
+    }, [])
+
+    const hasActiveCard = !!findActiveCard(overview)
+    const isOnWaitlist = !!cardInfo?.waitlistJoinedAt
+    // Audience (per Hugo): the launch splash targets the active base who haven't engaged
+    // with the card yet. Activated-only (non-activated users have the activation funnel);
+    // exclude anyone who already has a card or already joined the waitlist; skip geo-
+    // ineligible users so the "find out if you're in" tap never dead-ends on "not your country".
+    const visible =
+        !!user &&
+        !isLoading &&
+        isPublicLaunched === true &&
+        isActivated &&
+        isEligible === true &&
+        !hasActiveCard &&
+        !isOnWaitlist &&
+        !dismissed &&
+        !underMaintenanceConfig.disableCardPioneers
+
+    // Fire "viewed" exactly once, when the banner first becomes visible.
+    const viewedRef = useRef(false)
+    useEffect(() => {
+        if (visible && !viewedRef.current) {
+            viewedRef.current = true
+            posthog.capture(ANALYTICS_EVENTS.CARD_LAUNCH_CTA_VIEWED)
+        }
+    }, [visible])
+
+    if (!visible) return null
+
+    const handleTryDoor = () => {
+        dismissCardLaunchCTA()
+        setDismissed(true)
+        posthog.capture(ANALYTICS_EVENTS.CARD_LAUNCH_CTA_CLICKED)
+        router.push('/card')
+    }
+
+    const handleDismiss = () => {
+        dismissCardLaunchCTA()
+        setDismissed(true)
+        posthog.capture(ANALYTICS_EVENTS.CARD_LAUNCH_CTA_DISMISSED)
+    }
+
+    return <CardLaunchCTABanner onTryDoor={handleTryDoor} onDismiss={handleDismiss} />
+}

--- a/src/components/Home/CardLaunchCTA/index.tsx
+++ b/src/components/Home/CardLaunchCTA/index.tsx
@@ -34,12 +34,13 @@ export default function CardLaunchCTA() {
     const router = useRouter()
     const { user } = useAuth()
     const { isPublicLaunched, isEligible, cardInfo, isLoading } = useCardInfo()
-    const { overview } = useRainCardOverview()
+    const { overview, isLoading: isOverviewLoading } = useRainCardOverview()
     const { isActivated } = useActivationStatus()
 
     // Read the permanent dismissal after mount to avoid a hydration mismatch —
-    // localStorage is client-only. Mirrors useActivationStatus.dismissCardStep.
-    const [dismissed, setDismissed] = useState(false)
+    // localStorage is client-only. Starts null (unknown) so a dismissed user
+    // never flashes the banner / fires VIEWED before hydration resolves.
+    const [dismissed, setDismissed] = useState<boolean | null>(null)
     useEffect(() => {
         setDismissed(isCardLaunchCTADismissed())
     }, [])
@@ -53,12 +54,13 @@ export default function CardLaunchCTA() {
     const visible =
         !!user &&
         !isLoading &&
+        !isOverviewLoading &&
+        dismissed === false &&
         isPublicLaunched === true &&
         isActivated &&
         isEligible === true &&
         !hasActiveCard &&
         !isOnWaitlist &&
-        !dismissed &&
         !underMaintenanceConfig.disableCardPioneers
 
     // Fire "viewed" exactly once, when the banner first becomes visible.

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -148,6 +148,12 @@ export const ANALYTICS_EVENTS = {
     CARD_FLOW_EARLY_ACCESS_GRANTED: 'card_flow_early_access_granted',
     // Outer-gate fail: user landed on /card without /shhhhh early access pre-launch.
     CARD_FLOW_GATED: 'card_flow_gated',
+    // Home launch CTA (shown to everyone post-public-launch who has no active card).
+    // viewed = banner became visible; clicked = tapped through to /card;
+    // dismissed = tapped the X. Click and dismiss both hide it permanently.
+    CARD_LAUNCH_CTA_VIEWED: 'card_launch_cta_viewed',
+    CARD_LAUNCH_CTA_CLICKED: 'card_launch_cta_clicked',
+    CARD_LAUNCH_CTA_DISMISSED: 'card_launch_cta_dismissed',
     // Eligibility-check screen — press-and-hold gate between /shhhhh and the
     // celebration/waitlist verdict.
     CARD_ELIGIBILITY_CHECK_VIEWED: 'card_eligibility_check_viewed',

--- a/src/hooks/useCardInfo.ts
+++ b/src/hooks/useCardInfo.ts
@@ -30,6 +30,7 @@ export const useCardInfo = () => {
         isEligible: query.isLoading ? undefined : (query.data?.isEligible ?? false),
         hasCardAccess: query.isLoading ? undefined : (query.data?.hasCardAccess ?? false),
         flowEarlyAccess: query.isLoading ? undefined : (query.data?.flowEarlyAccess ?? false),
+        isPublicLaunched: query.isLoading ? undefined : (query.data?.isPublicLaunched ?? false),
         skipBadges: query.data?.skipBadges ?? [],
     }
 }

--- a/src/services/card.ts
+++ b/src/services/card.ts
@@ -25,6 +25,11 @@ export interface CardInfoResponse {
     /** Outer gate. True iff user can ENTER the /card flow (via /shhhhh
      *  early access or post-public-launch). */
     flowEarlyAccess: boolean
+    /** True once the card flow is public for EVERYONE (now >= CARD_PUBLIC_LAUNCH_DATE).
+     *  Unlike `flowEarlyAccess`, this is NOT true pre-launch for /shhhhh-stamped or
+     *  badge-holding users — it flips for all users at the same instant. Drives the
+     *  home launch CTA. */
+    isPublicLaunched: boolean
     waitlistJoinedAt: string | null
     waitlistPosition: number | null
     waitlistReleasedAt: string | null


### PR DESCRIPTION
## What
A **fat home banner** shown to the active base on **public launch (Mon 2026-06-29)**, in the `/shhhhh` tone, driving them to `/card` to **"test if they can get their card."** Fills the real gap: activated users currently get **no** card CTA on home.

## Audience / gating (per Hugo's edge cases)
Shows only when **all** hold:
- **`isPublicLaunched`** — new `/card/info` field that flips for *everyone* at launch. (Not `hasCardAccess` — excludes most users; not `flowEarlyAccess` — true pre-launch for shhhhh/badge holders.)
- **activated** — non-activated users keep the activation funnel (avoids double-CTA).
- **geo-eligible** — so the "find out if you're in" tap never dead-ends on "not your country."
- **no active card** and **not already on the waitlist.**
- **not dismissed.**

**Dismissal is permanent** (one-shot localStorage flag, no cooldown): clicking through **or** closing the X both hide it forever — never nags.

## Decisions I made (flag for review)
- **Activated-only** (your "definitely activated; non-activated unsure"). Reason: non-activated users have the funnel, and a card needs KYC anyway. **One-line toggle** if you want non-activated too.
- **Exclude geo-ineligible** — to avoid a dead-end tap. Also a one-line toggle if you'd rather tease them.
- **Copy** (from the stopped agent, kept — it's on-tone): *"shhhhh · it's out / The card is out. For you? Maybe. / We opened the door to everyone. Tap to find out if you're in. / Try the door →"*. Easy to swap.

## ⚠️ Cross-repo dependency
Needs **peanut-api-ts #1075** (`isPublicLaunched` on `/card/info`). Without it the field is `undefined→false` and the CTA stays hidden. Both must ship for launch.

## Tests
Container/presentational split; permanent-dismiss util tested; card-info fixture updated. Typecheck + 32 unit tests green.

## Follow-up
Debug preview route (`/dev/home-ctas` — force-render every home CTA) is a **separate PR** (background agent).