### PR TITLE
fix(card): blank share asset — wait for the card-face canvas before capture

### DIFF
--- a/src/components/Card/share-asset/captureShareAsset.ts
+++ b/src/components/Card/share-asset/captureShareAsset.ts
@@ -40,8 +40,48 @@ export class ShareAssetCaptureError extends Error {
     }
 }
 
+/**
+ * Wait for the asset's content to be painted before we snapshot.
+ *
+ * The pink card + its drop-shadow are synchronous, but the card's pixelated
+ * hand is drawn into a <canvas> that PixelatedCardFace appends ASYNCHRONOUSLY
+ * (new Image() → onload → appendChild — see rasterImg / PixelatedHand). Unlike
+ * an <img>, html-to-image cannot wait for a not-yet-mounted <canvas>, so
+ * capturing too early yields a blank card — just the pink box + its floating
+ * shadow (the launch-day "blank share asset" bug; silent — capture succeeds,
+ * so nothing reaches Sentry). Gate on:
+ *   - document.fonts.ready (the hero/username use a web font)
+ *   - every <img> decoded (badge stickers + the card's small logo)
+ *   - the async hand <canvas> being mounted
+ * bounded by a timeout so a genuinely-stuck asset still captures (never hangs).
+ */
+const CAPTURE_READY_TIMEOUT_MS = 2500
+
+async function waitForAssetReady(node: HTMLElement): Promise<void> {
+    if (typeof document !== 'undefined' && document.fonts?.ready) {
+        try {
+            await document.fonts.ready
+        } catch {
+            // fonts.ready can reject in odd states — capture anyway.
+        }
+    }
+    await Promise.all(
+        Array.from(node.querySelectorAll('img')).map((img) =>
+            typeof img.decode === 'function' ? img.decode().catch(() => undefined) : Promise.resolve()
+        )
+    )
+    // Poll for the async hand canvas to mount (it's appended on image.onload,
+    // outside React's tree, so html-to-image can't wait for it on its own).
+    const start = typeof performance !== 'undefined' ? performance.now() : 0
+    const elapsed = (): number => (typeof performance !== 'undefined' ? performance.now() : Infinity) - start
+    while (!node.querySelector('canvas') && elapsed() < CAPTURE_READY_TIMEOUT_MS) {
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+    }
+}
+
 export async function captureShareAsset(node: HTMLElement): Promise<Blob> {
     try {
+        await waitForAssetReady(node)
         const blob = await toBlob(node, {
             width: CANVAS_W,
             height: CANVAS_H,


### PR DESCRIPTION
## Crit: blank share asset (launch day)
Influencers shared the "I'M IN!" card asset with a **blank card** (empty pink box + a floating drop-shadow); stickers, hero burst, and the `peanut.me/<handle>` pill rendered fine.

## Root cause
`PixelatedCardFace` paints the pixelated **hand into a `<canvas>` appended asynchronously** (`new Image()` → `onload` → `appendChild`; PixelatedCardFace.tsx rasterImg/PixelatedHand). `captureShareAsset` called html-to-image **without waiting** for it. html-to-image awaits `<img>` elements but **cannot wait for a not-yet-mounted `<canvas>`**, so a fast / first-share-of-session race captured the card before the hand mounted → blank card + its synchronous box-shadow floating behind it. **Silent** — capture *succeeds*, so nothing reached Sentry (confirmed: zero results).

## Fix (single file — captureShareAsset.ts)
Before `toBlob`, gate on: `document.fonts.ready` + every `<img>.decode()` + the hand `<canvas>` being mounted — bounded by a 2.5s timeout so a stuck asset still captures (never hangs).

## Blast radius
Win/celebration asset only (`CardUnlockDrawer` / `BadgeSkipCelebration` → `ShareAssetD3`). The rejection asset has no canvas and is unaffected. A first-share-of-session race (the `rasterCache` makes later shares synchronous), widened on launch day by cold caches.

## Follow-ups (not in this hotfix)
- Deterministic gate: disable Share/Save until the canvas signals ready (`ShareAssetActions`).
- Root-cause cleanup: render the hand as a synchronous pre-rasterised data-URI `<img>` (delete the async-canvas dependency html-to-image can't await).
