### PR TITLE
test(card): regression guard for the blank share-asset capture

### DIFF
--- a/src/components/Card/share-asset/__tests__/captureShareAsset.test.ts
+++ b/src/components/Card/share-asset/__tests__/captureShareAsset.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { ShareAssetCaptureError } from '../captureShareAsset'
+import { ShareAssetCaptureError, waitForAssetReady } from '../captureShareAsset'
 
 describe('ShareAssetCaptureError', () => {
     test('carries failedImages + originalReject + name=ShareAssetCaptureError', () => {
@@ -22,5 +22,72 @@ describe('ShareAssetCaptureError', () => {
         const err: unknown = new ShareAssetCaptureError('boom', { failedImages: [], originalReject: null })
         expect(err instanceof ShareAssetCaptureError).toBe(true)
         expect(err instanceof Error).toBe(true)
+    })
+})
+
+/**
+ * Regression guard for the launch-day "blank share asset" bug: the card-face
+ * hand is an async-mounted <canvas>, and capturing before it mounts produced a
+ * blank card. waitForAssetReady must block the snapshot until that canvas is
+ * present (+ fonts ready + images decoded), bounded so it never hangs.
+ */
+describe('waitForAssetReady — share-asset capture readiness gate', () => {
+    const realRAF = global.requestAnimationFrame
+    beforeEach(() => {
+        // jsdom's RAF is ~16ms; make the poll prompt + deterministic.
+        global.requestAnimationFrame = ((cb: FrameRequestCallback) =>
+            setTimeout(() => cb(performance.now()), 0)) as unknown as typeof requestAnimationFrame
+    })
+    afterEach(() => {
+        global.requestAnimationFrame = realRAF
+    })
+
+    test('does NOT resolve until the card-face <canvas> has mounted (the blank-asset bug)', async () => {
+        const node = document.createElement('div') // pink box only — no canvas yet
+        let resolved = false
+        const pending = waitForAssetReady(node).then(() => {
+            resolved = true
+        })
+        await new Promise((r) => setTimeout(r, 40))
+        expect(resolved).toBe(false) // still gated — a snapshot here would be blank
+        node.appendChild(document.createElement('canvas')) // the hand mounts
+        await new Promise((r) => setTimeout(r, 40))
+        await pending
+        expect(resolved).toBe(true)
+    })
+
+    test('resolves (never hangs) if the canvas never mounts — bounded by the timeout', async () => {
+        const node = document.createElement('div')
+        await expect(waitForAssetReady(node, 40)).resolves.toBeUndefined()
+    })
+
+    test('awaits image decode for every <img> before snapshotting', async () => {
+        const node = document.createElement('div')
+        const img = document.createElement('img')
+        const decode = jest.fn().mockResolvedValue(undefined)
+        ;(img as unknown as { decode: unknown }).decode = decode
+        node.appendChild(img)
+        node.appendChild(document.createElement('canvas'))
+        await waitForAssetReady(node, 200)
+        expect(decode).toHaveBeenCalledTimes(1)
+    })
+
+    test('awaits document.fonts.ready before snapshotting', async () => {
+        let fontsReady = false
+        Object.defineProperty(document, 'fonts', {
+            configurable: true,
+            value: {
+                ready: new Promise<void>((resolve) =>
+                    setTimeout(() => {
+                        fontsReady = true
+                        resolve()
+                    }, 20)
+                ),
+            },
+        })
+        const node = document.createElement('div')
+        node.appendChild(document.createElement('canvas'))
+        await waitForAssetReady(node, 200)
+        expect(fontsReady).toBe(true)
     })
 })

--- a/src/components/Card/share-asset/captureShareAsset.ts
+++ b/src/components/Card/share-asset/captureShareAsset.ts
@@ -55,9 +55,14 @@ export class ShareAssetCaptureError extends Error {
  *   - the async hand <canvas> being mounted
  * bounded by a timeout so a genuinely-stuck asset still captures (never hangs).
  */
-const CAPTURE_READY_TIMEOUT_MS = 2500
+export const CAPTURE_READY_TIMEOUT_MS = 2500
 
-async function waitForAssetReady(node: HTMLElement): Promise<void> {
+// Exported for unit tests. `timeoutMs` is injectable so the bounded-wait
+// behaviour can be asserted without a 2.5s test.
+export async function waitForAssetReady(
+    node: HTMLElement,
+    timeoutMs: number = CAPTURE_READY_TIMEOUT_MS
+): Promise<void> {
     if (typeof document !== 'undefined' && document.fonts?.ready) {
         try {
             await document.fonts.ready
@@ -74,7 +79,7 @@ async function waitForAssetReady(node: HTMLElement): Promise<void> {
     // outside React's tree, so html-to-image can't wait for it on its own).
     const start = typeof performance !== 'undefined' ? performance.now() : 0
     const elapsed = (): number => (typeof performance !== 'undefined' ? performance.now() : Infinity) - start
-    while (!node.querySelector('canvas') && elapsed() < CAPTURE_READY_TIMEOUT_MS) {
+    while (!node.querySelector('canvas') && elapsed() < timeoutMs) {
         await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
     }
 }


### PR DESCRIPTION
Definitive verification + permanent guard for the blank-share-asset fix (#2302, merged).

The blank asset was a timing race: the card-face hand is an async-mounted `<canvas>`, and html-to-image can't wait for a not-yet-mounted canvas, so a fast/first-of-session capture snapshotted a blank card. That race can't be reproduced on-demand, so the definitive check is a unit test of the gate logic:

- Export `waitForAssetReady` with an injectable timeout (so the bounded-wait is testable without a 2.5s test).
- **`does NOT resolve until the card-face <canvas> has mounted`** — proves capture blocks until the hand canvas is present (a snapshot before it would be blank).
- never hangs (bounded timeout), awaits every `<img>.decode()`, awaits `document.fonts.ready`.

6/6 pass, prettier + typecheck clean. Off main; back-merge to dev.