### PR TITLE
fix(card): raise apply-for-card fetch timeout to 60s

### DIFF
--- a/src/services/rain.ts
+++ b/src/services/rain.ts
@@ -485,6 +485,13 @@ export const rainApi = {
             method: 'POST',
             path: '/rain/cards',
             body,
+            // The first-time-application path runs 7 sequential Sumsub calls, a
+            // deliberate 2.5s readiness sleep, the Rain createApplication call,
+            // and an optional inline issueCard — routinely 7-13s. The default
+            // 10s fetch timeout clips that tail, aborting client-side while the
+            // backend completes (user sees a false failure on a card that was
+            // actually submitted). Give this one call generous headroom.
+            timeoutMs: 60_000,
         })
     },
 


### PR DESCRIPTION
## Why

The first-time Rain card application path (`POST /rain/cards`) is **structurally 7–13s**:

- 7 sequential Sumsub calls (`getCollectedDocTypes` → `getApplicant` → `moveToLevel` ×2 → `checkRainReadiness` → `generateShareToken`)
- a deliberate `setTimeout(2_500)` readiness sleep (`apply.ts:585`) waiting for Sumsub's async review to flip GREEN
- `rainService.createApplication` (Rain API)
- an optional **inline** `issueCard` when Rain approves synchronously

The global 10s `fetchWithSentry` default (`src/utils/sentry.utils.ts`) aborts that tail **client-side** while the backend keeps running to completion. The user sees a false `card application failed` error on a card application that was actually submitted — and a retry can resubmit.

## Impact (PostHog, prod)

- `rain/cards … timed out after 10000ms` exception fires **~280×/week across ~40 distinct users**.
- Of **120 users** who hit it in the last 30d, only **28** reached `card_apply_succeeded`.

## Change

Override `timeoutMs: 60_000` on the `applyForCard` call **only**. This is a browser→`api.peanut.me` fetch, so the "10s because Vercel's function limit is 15s" rationale that caps the global default does not apply here. `rainRequest` already threads `opts.timeoutMs`; nothing else changes.

## Not in scope (follow-up)

This is a band-aid. The durable fix is backend: parallelize the independent Sumsub calls and/or make issuance async (return `processing`, finish via the `card_webhook_user_updated` path) so users aren't blocked on a 13s spinner. Also worth confirming `createApplication`/`issueCard` idempotency given the retry-after-timeout pattern.

## Risk

Low — single per-call timeout override, no behavior change on the happy path. Worst case a genuinely hung request now holds the spinner up to 60s instead of 10s before surfacing the same error.