### PR TITLE
feat(card): real FOMO door tally on rejection screen

### DIFF
--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -477,6 +477,8 @@ const CardPage: FC = () => {
                 return (
                     <CardRejectionScreen
                         username={user?.user?.username ?? undefined}
+                        waitlistTotal={cardInfo!.waitlistTotal}
+                        admittedTotal={cardInfo!.admittedTotal}
                         alreadyJoined={!!cardInfo!.waitlistJoinedAt}
                         onPrev={onBack}
                         onJoined={refetchCardInfo}

--- a/src/app/(mobile-ui)/dev/rejection-builder/page.tsx
+++ b/src/app/(mobile-ui)/dev/rejection-builder/page.tsx
@@ -13,6 +13,7 @@
 import { useState } from 'react'
 import NavHeader from '@/components/Global/NavHeader'
 import CardRejectionScreen from '@/components/Card/CardRejectionScreen'
+import { computeDoorTally } from '@/components/Card/doorTally.utils'
 import type { RejectionMascot } from '@/components/Card/share-asset/shareAsset.types'
 
 const MASCOTS: ReadonlyArray<[RejectionMascot, string]> = [
@@ -25,9 +26,13 @@ const MASCOTS: ReadonlyArray<[RejectionMascot, string]> = [
 export default function RejectionBuilderPage() {
     const [username, setUsername] = useState('kkonrad')
     const [mascot, setMascot] = useState<RejectionMascot>('cool')
-    const [applicants, setApplicants] = useState(213)
-    const [admitted, setAdmitted] = useState(7)
+    // The REAL backend counts (waitlistTotal / admittedTotal). The screen
+    // inflates "tried" for FOMO; the readout below shows what it renders.
+    const [waitlistTotal, setWaitlistTotal] = useState(120)
+    const [admittedTotal, setAdmittedTotal] = useState(7)
     const [alreadyJoined, setAlreadyJoined] = useState(false)
+
+    const tally = computeDoorTally(waitlistTotal, admittedTotal)
 
     return (
         <div className="flex min-h-screen flex-col">
@@ -76,45 +81,63 @@ export default function RejectionBuilderPage() {
                         </p>
                     </Section>
 
-                    <Section title="Door tally (screen copy, not on asset)">
-                        <Field label={`Applicants tonight (${applicants})`}>
+                    <Section title="Door tally — REAL backend counts">
+                        <Field label={`Waitlist size · real cardWaitlistJoinedAt count (${waitlistTotal})`}>
                             <input
                                 type="range"
-                                min={20}
+                                min={0}
                                 max={5000}
                                 step={1}
-                                value={applicants}
-                                onChange={(e) => setApplicants(Number(e.target.value))}
+                                value={waitlistTotal}
+                                onChange={(e) => setWaitlistTotal(Number(e.target.value))}
                                 className="w-full"
                             />
                         </Field>
-                        <Field label={`Admitted (${admitted})`}>
+                        <Field label={`Admitted · real cardAccessGrantedAt count (${admittedTotal})`}>
                             <input
                                 type="range"
-                                min={1}
-                                max={50}
+                                min={0}
+                                max={500}
                                 step={1}
-                                value={admitted}
-                                onChange={(e) => setAdmitted(Number(e.target.value))}
+                                value={admittedTotal}
+                                onChange={(e) => setAdmittedTotal(Number(e.target.value))}
                                 className="w-full"
                             />
                         </Field>
+                        <p className="rounded-sm border border-n-1 bg-grey-3 p-2 text-center text-xs font-bold text-n-1">
+                            renders as:{' '}
+                            <span className="text-primary-1">
+                                {tally.applicants.toLocaleString('en-US')} tried · {tally.admitted} got in
+                            </span>
+                            <br />
+                            <span className="font-normal text-grey-1">
+                                “tried” = waitlist × FOMO multiplier (floored); “got in” = real admitted
+                            </span>
+                        </p>
                         <div className="flex flex-wrap gap-2">
                             <PresetButton
                                 onClick={() => {
-                                    setApplicants(213)
-                                    setAdmitted(7)
+                                    setWaitlistTotal(0)
+                                    setAdmittedTotal(0)
                                 }}
                             >
-                                213 / 7
+                                empty (floor)
                             </PresetButton>
                             <PresetButton
                                 onClick={() => {
-                                    setApplicants(1842)
-                                    setAdmitted(11)
+                                    setWaitlistTotal(120)
+                                    setAdmittedTotal(7)
                                 }}
                             >
-                                1842 / 11
+                                early beta
+                            </PresetButton>
+                            <PresetButton
+                                onClick={() => {
+                                    setWaitlistTotal(1842)
+                                    setAdmittedTotal(140)
+                                }}
+                            >
+                                busy door
                             </PresetButton>
                         </div>
                     </Section>
@@ -148,8 +171,8 @@ export default function RejectionBuilderPage() {
                             <CardRejectionScreen
                                 username={username || 'anon'}
                                 mascot={mascot}
-                                applicants={applicants}
-                                admitted={admitted}
+                                waitlistTotal={waitlistTotal}
+                                admittedTotal={admittedTotal}
                                 alreadyJoined={alreadyJoined}
                                 onJoined={() => setAlreadyJoined(true)}
                             />

--- a/src/components/Card/CardRejectionScreen.tsx
+++ b/src/components/Card/CardRejectionScreen.tsx
@@ -26,15 +26,19 @@ import { ScaledRejectionAsset } from '@/components/Card/share-asset/ScaledReject
 import { captureShareAsset, canShareImageFiles } from '@/components/Card/share-asset/captureShareAsset'
 import { pickRejectionCaption } from '@/components/Card/share-asset/rejectionCaptions'
 import type { RejectionMascot } from '@/components/Card/share-asset/shareAsset.types'
+import { computeDoorTally } from '@/components/Card/doorTally.utils'
 import { cardApi } from '@/services/card'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 interface Props {
     username?: string
-    /** Door tally — scarcity flex, rendered as screen copy (not on the asset). */
-    applicants?: number
-    admitted?: number
+    /** Real waitlist size (total who joined). The screen inflates this for the
+     *  FOMO "tried" tally — mirrors the /shhhhh ScarcityCounter flex. Undefined
+     *  while /card is still loading → a sane floor renders. */
+    waitlistTotal?: number
+    /** Real number admitted (released/granted). Shown verbatim as "got in". */
+    admittedTotal?: number
     /** Which smug mascot the asset shows. */
     mascot?: RejectionMascot
     /** True once the user is already on the waitlist — swaps the "Join anyway"
@@ -48,13 +52,16 @@ interface Props {
 
 const CardRejectionScreen: FC<Props> = ({
     username,
-    applicants = 213,
-    admitted = 7,
+    waitlistTotal,
+    admittedTotal,
     mascot = 'cool',
     alreadyJoined = false,
     onPrev,
     onJoined,
 }) => {
+    // "tried" = real waitlist size, inflated for FOMO; "got in" = real admitted.
+    // Deterministic (pure fn of the counts) so it never jitters between renders.
+    const { applicants, admitted } = computeDoorTally(waitlistTotal, admittedTotal)
     const captureRef = useRef<HTMLDivElement | null>(null)
     const [sharing, setSharing] = useState(false)
     const [joining, setJoining] = useState(false)

--- a/src/components/Card/__tests__/doorTally.utils.test.ts
+++ b/src/components/Card/__tests__/doorTally.utils.test.ts
@@ -8,19 +8,25 @@ import {
 
 describe('inflateApplicants', () => {
     test('multiplies the real waitlist size by the FOMO factor', () => {
-        // 1000 * 3 = 3000, comfortably above the floor.
+        // 1000 * 5 = 5000, comfortably above the floor.
         expect(inflateApplicants(1000)).toBe(1000 * DOOR_TALLY_FOMO_MULTIPLIER)
     })
 
     test('clamps to the floor when the inflated value is small', () => {
-        // 10 * 3 = 30 < floor → floor wins.
+        // 10 * 5 = 50 < floor → floor wins.
         expect(inflateApplicants(10)).toBe(DOOR_TALLY_APPLICANTS_FLOOR)
     })
 
-    test('rounds to a whole number', () => {
-        // 71 * 3 = 213 (== floor here); use a value that rounds to confirm.
+    test('clears the 213 floor at the current prod waitlist size (~55)', () => {
+        // The whole point of ×5: 55 * 5 = 275 > 213, so the real (inflated)
+        // number renders instead of the masked floor.
+        expect(inflateApplicants(55)).toBe(275)
+    })
+
+    test('returns a whole number above the floor', () => {
         expect(Number.isInteger(inflateApplicants(101))).toBe(true)
-        expect(inflateApplicants(101)).toBe(303)
+        // 101 * 5 = 505.
+        expect(inflateApplicants(101)).toBe(505)
     })
 
     test.each([undefined, NaN, 0, -5, Infinity])('falls back to the floor for %p', (input) => {
@@ -34,7 +40,8 @@ describe('inflateApplicants', () => {
 
 describe('computeDoorTally', () => {
     test('inflates "tried" but shows "got in" verbatim', () => {
-        expect(computeDoorTally(500, 42)).toEqual({ applicants: 1500, admitted: 42 })
+        // 500 * 5 = 2500 tried; 42 admitted shown as-is.
+        expect(computeDoorTally(500, 42)).toEqual({ applicants: 2500, admitted: 42 })
     })
 
     test('uses loading fallbacks when counts are missing', () => {

--- a/src/components/Card/__tests__/doorTally.utils.test.ts
+++ b/src/components/Card/__tests__/doorTally.utils.test.ts
@@ -1,0 +1,50 @@
+import {
+    inflateApplicants,
+    computeDoorTally,
+    DOOR_TALLY_APPLICANTS_FLOOR,
+    DOOR_TALLY_ADMITTED_FALLBACK,
+    DOOR_TALLY_FOMO_MULTIPLIER,
+} from '../doorTally.utils'
+
+describe('inflateApplicants', () => {
+    test('multiplies the real waitlist size by the FOMO factor', () => {
+        // 1000 * 3 = 3000, comfortably above the floor.
+        expect(inflateApplicants(1000)).toBe(1000 * DOOR_TALLY_FOMO_MULTIPLIER)
+    })
+
+    test('clamps to the floor when the inflated value is small', () => {
+        // 10 * 3 = 30 < floor → floor wins.
+        expect(inflateApplicants(10)).toBe(DOOR_TALLY_APPLICANTS_FLOOR)
+    })
+
+    test('rounds to a whole number', () => {
+        // 71 * 3 = 213 (== floor here); use a value that rounds to confirm.
+        expect(Number.isInteger(inflateApplicants(101))).toBe(true)
+        expect(inflateApplicants(101)).toBe(303)
+    })
+
+    test.each([undefined, NaN, 0, -5, Infinity])('falls back to the floor for %p', (input) => {
+        expect(inflateApplicants(input as number)).toBe(DOOR_TALLY_APPLICANTS_FLOOR)
+    })
+
+    test('is deterministic — same input, same output (no jitter)', () => {
+        expect(inflateApplicants(742)).toBe(inflateApplicants(742))
+    })
+})
+
+describe('computeDoorTally', () => {
+    test('inflates "tried" but shows "got in" verbatim', () => {
+        expect(computeDoorTally(500, 42)).toEqual({ applicants: 1500, admitted: 42 })
+    })
+
+    test('uses loading fallbacks when counts are missing', () => {
+        expect(computeDoorTally(undefined, undefined)).toEqual({
+            applicants: DOOR_TALLY_APPLICANTS_FLOOR,
+            admitted: DOOR_TALLY_ADMITTED_FALLBACK,
+        })
+    })
+
+    test('admitted=0 is real and shown as 0 (not the fallback)', () => {
+        expect(computeDoorTally(1000, 0).admitted).toBe(0)
+    })
+})

--- a/src/components/Card/doorTally.utils.ts
+++ b/src/components/Card/doorTally.utils.ts
@@ -1,0 +1,55 @@
+/**
+ * Door-tally math for the Berghain rejection screen ("N tried · M got in").
+ *
+ * The backend (/card → waitlistTotal, admittedTotal) reports the REAL counts.
+ * "tried" gets inflated for FOMO — the same fake-scarcity flex the /shhhhh
+ * landing already does with its "only 20 a week" ScarcityCounter — while
+ * "got in" is shown verbatim (the real number admitted).
+ *
+ * The inflation is a pure function of the real count (a constant multiplier
+ * with a floor), so it's deterministic per render and never jitters between
+ * frames. No randomness on purpose.
+ */
+
+/** FOMO inflation factor applied to the real waitlist size for "tried". */
+export const DOOR_TALLY_FOMO_MULTIPLIER = 3
+
+/**
+ * Minimum "tried" — keeps the door looking busy when the real waitlist is
+ * still small, and doubles as the loading fallback. 213 mirrors the original
+ * hardcoded tally so the copy reads identically before counts land.
+ */
+export const DOOR_TALLY_APPLICANTS_FLOOR = 213
+
+/** Loading fallback for "got in" (real admitted count, before it lands). */
+export const DOOR_TALLY_ADMITTED_FALLBACK = 7
+
+export type DoorTally = {
+    /** Inflated "tried" count (FOMO). */
+    applicants: number
+    /** Real "got in" count, verbatim. */
+    admitted: number
+}
+
+/**
+ * Inflate the real waitlist size into the FOMO "tried" number. Falls back to
+ * the floor for missing/zero/invalid input (e.g. counts still loading).
+ */
+export function inflateApplicants(waitlistTotal?: number): number {
+    if (typeof waitlistTotal !== 'number' || !Number.isFinite(waitlistTotal) || waitlistTotal <= 0) {
+        return DOOR_TALLY_APPLICANTS_FLOOR
+    }
+    return Math.max(DOOR_TALLY_APPLICANTS_FLOOR, Math.round(waitlistTotal * DOOR_TALLY_FOMO_MULTIPLIER))
+}
+
+/**
+ * Build the door tally from the real backend counts: inflated "tried" + real
+ * "got in" (with sane fallbacks while the counts are loading).
+ */
+export function computeDoorTally(waitlistTotal?: number, admittedTotal?: number): DoorTally {
+    const admitted =
+        typeof admittedTotal === 'number' && Number.isFinite(admittedTotal) && admittedTotal >= 0
+            ? Math.round(admittedTotal)
+            : DOOR_TALLY_ADMITTED_FALLBACK
+    return { applicants: inflateApplicants(waitlistTotal), admitted }
+}

--- a/src/components/Card/doorTally.utils.ts
+++ b/src/components/Card/doorTally.utils.ts
@@ -11,8 +11,13 @@
  * frames. No randomness on purpose.
  */
 
-/** FOMO inflation factor applied to the real waitlist size for "tried". */
-export const DOOR_TALLY_FOMO_MULTIPLIER = 3
+/**
+ * FOMO inflation factor applied to the real waitlist size for "tried". ×5 (not
+ * ×3) so the real number clears the 213 floor at the current prod waitlist size
+ * (~55 → 55×5 = 275 > 213) — otherwise the floor masks the real count and the
+ * tally looks frozen at 213.
+ */
+export const DOOR_TALLY_FOMO_MULTIPLIER = 5
 
 /**
  * Minimum "tried" — keeps the door looking busy when the real waitlist is

--- a/src/services/card.ts
+++ b/src/services/card.ts
@@ -38,9 +38,13 @@ export interface CardInfoResponse {
     /** Global door-tally counts (same for every user) — power the Berghain
      *  rejection screen. `waitlistTotal` = total who joined the waitlist (the FE
      *  inflates it for the FOMO "tried"); `admittedTotal` = total released/granted
-     *  (shown verbatim as "got in"). */
-    waitlistTotal: number
-    admittedTotal: number
+     *  (shown verbatim as "got in").
+     *
+     *  OPTIONAL on purpose: the BE that returns these (peanut-api-ts) deploys
+     *  first, but during the rollout window — and for any older API — the FE
+     *  must tolerate `undefined`. `computeDoorTally` falls back to 213 / 7. */
+    waitlistTotal?: number
+    admittedTotal?: number
 }
 
 export interface WaitlistStateResponse {

--- a/src/services/card.ts
+++ b/src/services/card.ts
@@ -35,6 +35,12 @@ export interface CardInfoResponse {
     waitlistReleasedAt: string | null
     /** Skip-badge codes the user holds (subset of SKIP_BADGE_CODES on BE). */
     skipBadges: string[]
+    /** Global door-tally counts (same for every user) — power the Berghain
+     *  rejection screen. `waitlistTotal` = total who joined the waitlist (the FE
+     *  inflates it for the FOMO "tried"); `admittedTotal` = total released/granted
+     *  (shown verbatim as "got in"). */
+    waitlistTotal: number
+    admittedTotal: number
 }
 
 export interface WaitlistStateResponse {


### PR DESCRIPTION
## What

The Berghain "not tonight" card-rejection screen showed a **hardcoded** door tally — `CardRejectionScreen` defaulted `applicants = 213, admitted = 7` and `card/page.tsx` never passed real values, so the static defaults always rendered.

Now it's real / semi-real:
- **"tried"** = the real waitlist size (`/card` → `waitlistTotal`) **inflated for FOMO** — `max(213, round(waitlistTotal × 5))`. Mirrors how `/shhhhh`'s `ScarcityCounter` already fakes scarcity ("only 20 a week").
- **"got in"** = the real number admitted (`/card` → `admittedTotal`), shown verbatim.

The inflation lives in a new pure helper `src/components/Card/doorTally.utils.ts` (`inflateApplicants` / `computeDoorTally`), so it's **deterministic per render** (no `Math.random`, no jitter). A `213 / 7` fallback covers the still-loading window. Hardcoded `213`/`7` defaults removed from the component (props are now `waitlistTotal` / `admittedTotal`, both optional so existing mocks + the BE-deploys-first rollout tolerate `undefined`).

`/dev/rejection-builder` updated: sliders now drive the **real** backend counts and the panel previews the inflated "renders as: N tried · M got in".

## Design (3 lines)

- **Counts come from** `GET /card` → `waitlistTotal` (all who joined the queue) + `admittedTotal` (all released/granted).
- **Exaggeration**: `tried = max(213, round(waitlistTotal × 5))`; `got in = admittedTotal` (verbatim). ×5 (not ×3) so the real count clears the 213 floor at the current prod waitlist size (~55 → 275 > 213); below that the floor would mask it and the tally would look frozen at 213.
- **Deterministic**: pure fn of the API counts — same input, same output every render.

## Cross-repo — BE must deploy first

⚠️ Depends on **peanut-api-ts PR #1085** (`feat/door-tally-real-counts`), which adds `waitlistTotal` / `admittedTotal` to `GET /card`. **Merge + deploy that first.** Until then the FE reads `undefined` and renders the `213 / 7` fallback — safe (no crash, just the old static-looking copy), but not the real numbers.

## Tests

- `src/components/Card/__tests__/doorTally.utils.test.ts`: ×5 multiplier, floor clamp, "clears the floor at ~55" case, rounding, fallbacks (undefined/NaN/0/negative/Infinity), determinism, `admitted=0` is real (not the fallback). Full `tsc --noEmit` + full `npm test` green; prettier clean.

## eslint note

The repo-wide `eslint` check is red on pre-existing violations in files this PR does not touch (`add-money/*`, `dev/debug/page.tsx`). None of this PR's files appear in the eslint output, and the required `ci-success` aggregate passes regardless (eslint is advisory per the ruleset).
