### PR TITLE
fix(card): bulletproof share-asset capture — faithful shadows + deterministic ready gate

### DIFF
--- a/e2e/flows/share-asset-capture.spec.ts
+++ b/e2e/flows/share-asset-capture.spec.ts
@@ -15,17 +15,18 @@
  *      Share/Save buttons use).
  *   2. Save stays disabled until the card face signals ready — we wait for it
  *      to enable (proves the gate releases only after the canvas mounts).
- *   3. We click Save, intercept the downloaded PNG, decode it, and sample a
- *      region in the CENTRE of the card — the hand's territory, away from the
- *      top-left logo and bottom-left card number. If that region is ENTIRELY
- *      the card pink (#FF90E8) the hand never rendered → the blank-card bug.
- *      We assert it contains non-background pixels (the hand was captured).
+ *   3. We click Save, intercept the downloaded PNG, decode it IN-BROWSER (an
+ *      <img> + <canvas>.getImageData — no extra Node dep), and sample a region
+ *      in the CENTRE of the card — the hand's territory, away from the top-left
+ *      logo and bottom-left card number. If that region is ENTIRELY the card
+ *      pink (#FF90E8) the hand never rendered → the blank-card bug. We assert
+ *      it contains non-background pixels (the hand was captured).
  *
  * No harness auth needed — /dev/share-builder is a pure client-render dev page.
  */
 
 import { test, expect } from '@playwright/test'
-import sharp from 'sharp'
+import { readFileSync } from 'fs'
 
 // Asset + card geometry — mirror of shareAssetLayout.ts (CANVAS_W/H, CARD_*).
 // Hardcoded (not imported) to match the e2e convention of not pulling app code
@@ -33,10 +34,10 @@ import sharp from 'sharp'
 const CANVAS_W = 1200
 const CANVAS_H = 900
 
-// Card-pink (PixelatedCardFace background) and asset-blue (ShareAssetD3 bg).
-// "Background" = either of these; the hand is neither.
-const CARD_PINK = { r: 0xff, g: 0x90, b: 0xe8 }
-const ASSET_BLUE = { r: 0x90, g: 0xa8, b: 0xed }
+// Card-pink (PixelatedCardFace background) and asset-blue (ShareAssetD3 bg) as
+// [r,g,b]. "Background" = either of these; the hand is neither.
+const CARD_PINK: [number, number, number] = [0xff, 0x90, 0xe8]
+const ASSET_BLUE: [number, number, number] = [0x90, 0xa8, 0xed]
 const COLOR_TOL = 12
 
 // Central card region in 1200×900 canvas coords. The card is centred
@@ -47,12 +48,7 @@ const COLOR_TOL = 12
 // present → many non-background pixels. Small enough that the card's -8°
 // final rotation can't rotate any background (blue) into it.
 const REGION = { x0: 430, y0: 330, x1: 770, y1: 570 }
-
-function isBackground(r: number, g: number, b: number): boolean {
-    const near = (c: { r: number; g: number; b: number }): boolean =>
-        Math.abs(r - c.r) <= COLOR_TOL && Math.abs(g - c.g) <= COLOR_TOL && Math.abs(b - c.b) <= COLOR_TOL
-    return near(CARD_PINK) || near(ASSET_BLUE)
-}
+const SAMPLE_STEP = 6 // sample every 6th canvas-px → a dense grid
 
 test.describe('Share-asset capture (card face is not blank)', () => {
     test('captured PNG card region contains the hand, not just background', async ({ page }, testInfo) => {
@@ -79,36 +75,71 @@ test.describe('Share-asset capture (card face is not blank)', () => {
         const pngPath = testInfo.outputPath('share-asset-capture.png')
         await download.saveAs(pngPath)
 
-        // Decode the captured PNG to raw RGBA and sample the central card window.
-        const { data, info } = await sharp(pngPath).ensureAlpha().raw().toBuffer({ resolveWithObject: true })
-        const { width, height, channels } = info
+        // Decode + sample IN-BROWSER: load the PNG into an <img>, paint it to a
+        // <canvas>, read it back with getImageData, and count non-background
+        // pixels in the central card window. Done in the page (not Node) so we
+        // need no PNG-decoder dependency.
+        const base64 = readFileSync(pngPath).toString('base64')
+        const result = await page.evaluate(
+            async ({ b64, canvasW, canvasH, region, pink, blue, tol, step }) => {
+                const img = new Image()
+                img.src = `data:image/png;base64,${b64}`
+                await img.decode()
 
-        // Output is captured at pixelRatio 2 (≈2400×1800) — scale canvas coords
-        // into output pixels.
-        const sx = width / CANVAS_W
-        const sy = height / CANVAS_H
+                const cv = document.createElement('canvas')
+                cv.width = img.naturalWidth
+                cv.height = img.naturalHeight
+                const ctx = cv.getContext('2d')
+                if (!ctx) throw new Error('no 2d context')
+                ctx.drawImage(img, 0, 0)
 
-        let sampled = 0
-        let nonBackground = 0
-        const STEP = 6 // sample every 6th canvas-px → a dense grid, fast decode
-        for (let cy = REGION.y0; cy <= REGION.y1; cy += STEP) {
-            for (let cx = REGION.x0; cx <= REGION.x1; cx += STEP) {
-                const px = Math.min(width - 1, Math.round(cx * sx))
-                const py = Math.min(height - 1, Math.round(cy * sy))
-                const idx = (py * width + px) * channels
-                sampled++
-                if (!isBackground(data[idx], data[idx + 1], data[idx + 2])) nonBackground++
+                const width = cv.width
+                const height = cv.height
+                const buf = ctx.getImageData(0, 0, width, height).data
+
+                // Output is captured at pixelRatio 2 (≈2400×1800) — scale canvas
+                // coords into output pixels.
+                const sx = width / canvasW
+                const sy = height / canvasH
+                const near = (r: number, g: number, b: number, c: number[]): boolean =>
+                    Math.abs(r - c[0]) <= tol && Math.abs(g - c[1]) <= tol && Math.abs(b - c[2]) <= tol
+
+                let sampled = 0
+                let nonBackground = 0
+                for (let cy = region.y0; cy <= region.y1; cy += step) {
+                    for (let cx = region.x0; cx <= region.x1; cx += step) {
+                        const px = Math.min(width - 1, Math.round(cx * sx))
+                        const py = Math.min(height - 1, Math.round(cy * sy))
+                        const idx = (py * width + px) * 4
+                        const r = buf[idx]
+                        const g = buf[idx + 1]
+                        const b = buf[idx + 2]
+                        sampled++
+                        if (!(near(r, g, b, pink) || near(r, g, b, blue))) nonBackground++
+                    }
+                }
+                return { width, height, sampled, nonBackground }
+            },
+            {
+                b64: base64,
+                canvasW: CANVAS_W,
+                canvasH: CANVAS_H,
+                region: REGION,
+                pink: CARD_PINK as number[],
+                blue: ASSET_BLUE as number[],
+                tol: COLOR_TOL,
+                step: SAMPLE_STEP,
             }
-        }
+        )
 
-        const fraction = nonBackground / sampled
+        const fraction = result.nonBackground / result.sampled
         // Blank card → fraction ≈ 0 (pure pink). Hand present → a large chunk of
         // the centre is non-pink. A 2% floor cleanly separates the two while
         // staying far below the hand's real coverage (avoids flake).
         expect(
             fraction,
             `card centre is ${(fraction * 100).toFixed(1)}% non-background ` +
-                `(${nonBackground}/${sampled} px; output ${width}×${height}). ` +
+                `(${result.nonBackground}/${result.sampled} px; output ${result.width}×${result.height}). ` +
                 `≈0% means the pixelated hand never rendered — the blank-card capture bug.`
         ).toBeGreaterThan(0.02)
     })

--- a/e2e/flows/share-asset-capture.spec.ts
+++ b/e2e/flows/share-asset-capture.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Share-asset capture regression — the card face must NOT be blank.
+ *
+ * The launch-day bug: <PixelatedCardFace /> paints its pixelated hand into a
+ * <canvas> appended ASYNCHRONOUSLY (new Image() → onload → appendChild). If a
+ * capture fired before that canvas mounted, html-to-image snapshotted a blank
+ * pink card — and the capture SUCCEEDED, so nothing reached Sentry.
+ *
+ * The deterministic fix gates the Save/Share buttons on PixelatedCardFace's
+ * `onReady` (the hand canvas mounting), so a capture can never fire early.
+ *
+ * This spec proves the guard end-to-end against the real html-to-image path:
+ *   1. /dev/share-builder renders <ShareAssetD3 /> and wires "Save image" to
+ *      captureShareAsset + downloadBlob (the same capture code the in-app
+ *      Share/Save buttons use).
+ *   2. Save stays disabled until the card face signals ready — we wait for it
+ *      to enable (proves the gate releases only after the canvas mounts).
+ *   3. We click Save, intercept the downloaded PNG, decode it, and sample a
+ *      region in the CENTRE of the card — the hand's territory, away from the
+ *      top-left logo and bottom-left card number. If that region is ENTIRELY
+ *      the card pink (#FF90E8) the hand never rendered → the blank-card bug.
+ *      We assert it contains non-background pixels (the hand was captured).
+ *
+ * No harness auth needed — /dev/share-builder is a pure client-render dev page.
+ */
+
+import { test, expect } from '@playwright/test'
+import sharp from 'sharp'
+
+// Asset + card geometry — mirror of shareAssetLayout.ts (CANVAS_W/H, CARD_*).
+// Hardcoded (not imported) to match the e2e convention of not pulling app code
+// through the '@/' alias into the Playwright tsconfig.
+const CANVAS_W = 1200
+const CANVAS_H = 900
+
+// Card-pink (PixelatedCardFace background) and asset-blue (ShareAssetD3 bg).
+// "Background" = either of these; the hand is neither.
+const CARD_PINK = { r: 0xff, g: 0x90, b: 0xe8 }
+const ASSET_BLUE = { r: 0x90, g: 0xa8, b: 0xed }
+const COLOR_TOL = 12
+
+// Central card region in 1200×900 canvas coords. The card is centred
+// (CARD_LEFT 220, CARD_TOP 210, CARD_W 760, CARD_H ≈ 479 → centre ≈ 600,449).
+// This window sits well inside the card and is HAND-ONLY: it excludes the
+// peanut logo (top-left ~248–300 px) and the "????" number (bottom-left,
+// canvas-y ≳ 615). So a blank card → this window is pure pink; the hand
+// present → many non-background pixels. Small enough that the card's -8°
+// final rotation can't rotate any background (blue) into it.
+const REGION = { x0: 430, y0: 330, x1: 770, y1: 570 }
+
+function isBackground(r: number, g: number, b: number): boolean {
+    const near = (c: { r: number; g: number; b: number }): boolean =>
+        Math.abs(r - c.r) <= COLOR_TOL && Math.abs(g - c.g) <= COLOR_TOL && Math.abs(b - c.b) <= COLOR_TOL
+    return near(CARD_PINK) || near(ASSET_BLUE)
+}
+
+test.describe('Share-asset capture (card face is not blank)', () => {
+    test('captured PNG card region contains the hand, not just background', async ({ page }, testInfo) => {
+        await page.goto('/dev/share-builder', { waitUntil: 'domcontentloaded' })
+
+        const saveBtn = page.getByTestId('save-image')
+
+        // The readiness gate: Save is disabled until the card face's async hand
+        // <canvas> mounts (onReady). If it never enables, the gate is broken OR
+        // the card never painted — both are failures this spec must catch.
+        await expect(saveBtn, 'Save must enable once the card face signals ready').toBeEnabled({ timeout: 60_000 })
+
+        // Let the card-slide / sticker-drop animations settle to their final
+        // frame so the card sits at its designed (centred, -8°) position before
+        // we capture. The capture itself overrides only the root scale; the
+        // card's own transform is whatever frame it's on.
+        await page.waitForTimeout(2_500)
+
+        // Click Save → captureShareAsset(node) → downloadBlob() fires a real
+        // download of the native-resolution PNG.
+        const downloadPromise = page.waitForEvent('download', { timeout: 30_000 })
+        await saveBtn.click()
+        const download = await downloadPromise
+        const pngPath = testInfo.outputPath('share-asset-capture.png')
+        await download.saveAs(pngPath)
+
+        // Decode the captured PNG to raw RGBA and sample the central card window.
+        const { data, info } = await sharp(pngPath).ensureAlpha().raw().toBuffer({ resolveWithObject: true })
+        const { width, height, channels } = info
+
+        // Output is captured at pixelRatio 2 (≈2400×1800) — scale canvas coords
+        // into output pixels.
+        const sx = width / CANVAS_W
+        const sy = height / CANVAS_H
+
+        let sampled = 0
+        let nonBackground = 0
+        const STEP = 6 // sample every 6th canvas-px → a dense grid, fast decode
+        for (let cy = REGION.y0; cy <= REGION.y1; cy += STEP) {
+            for (let cx = REGION.x0; cx <= REGION.x1; cx += STEP) {
+                const px = Math.min(width - 1, Math.round(cx * sx))
+                const py = Math.min(height - 1, Math.round(cy * sy))
+                const idx = (py * width + px) * channels
+                sampled++
+                if (!isBackground(data[idx], data[idx + 1], data[idx + 2])) nonBackground++
+            }
+        }
+
+        const fraction = nonBackground / sampled
+        // Blank card → fraction ≈ 0 (pure pink). Hand present → a large chunk of
+        // the centre is non-pink. A 2% floor cleanly separates the two while
+        // staying far below the hand's real coverage (avoids flake).
+        expect(
+            fraction,
+            `card centre is ${(fraction * 100).toFixed(1)}% non-background ` +
+                `(${nonBackground}/${sampled} px; output ${width}×${height}). ` +
+                `≈0% means the pixelated hand never rendered — the blank-card capture bug.`
+        ).toBeGreaterThan(0.02)
+    })
+})

--- a/src/app/(mobile-ui)/dev/share-builder/page.tsx
+++ b/src/app/(mobile-ui)/dev/share-builder/page.tsx
@@ -14,12 +14,13 @@
  * the same user (otherwise deterministic from username).
  */
 
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import NavHeader from '@/components/Global/NavHeader'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Checkbox } from '@/components/0_Bruddle/Checkbox'
 import ShareAssetD3 from '@/components/Card/share-asset/ShareAssetD3'
 import type { HeroVariant, UsernameBg } from '@/components/Card/share-asset/shareAsset.types'
+import { captureShareAsset, downloadBlob } from '@/components/Card/share-asset/captureShareAsset'
 import { BADGE_CODES, getBadgeDisplayName } from '@/components/Badges/badge.utils'
 import { CANVAS_W, CANVAS_H } from '@/components/Card/share-asset/shareAssetLayout'
 
@@ -42,6 +43,28 @@ export default function ShareBuilderPage() {
     const [seedNonce, setSeedNonce] = useState(0)
     const [previewScale, setPreviewScale] = useState(0.8)
     const [hideUsername, setHideUsername] = useState(false)
+
+    // ─── Capture (Save image) ────────────────────────────────────────────
+    // Ref points at the native-size asset node (the pre-scale div) so the
+    // capture renders at full 1200×900 fidelity. `assetReady` flips once the
+    // card face's async hand <canvas> mounts (ShareAssetD3.onReady) — Save is
+    // disabled until then so a capture can never snapshot a blank card.
+    const assetRef = useRef<HTMLDivElement>(null)
+    const [assetReady, setAssetReady] = useState(false)
+    const [saving, setSaving] = useState(false)
+    const handleSave = async () => {
+        const node = assetRef.current
+        if (!node) return
+        setSaving(true)
+        try {
+            const blob = await captureShareAsset(node)
+            downloadBlob(blob, 'peanut-card.png')
+        } catch (err) {
+            console.error('[share-builder] save failed', err)
+        } finally {
+            setSaving(false)
+        }
+    }
 
     // ─── Hero "I got in" message sticker ─────────────────────────────────
     const [heroVariant, setHeroVariant] = useState<HeroVariant | 'none'>('burst')
@@ -298,7 +321,11 @@ export default function ShareBuilderPage() {
                                 variant="purple"
                                 shadowSize="4"
                                 className="flex-1"
-                                onClick={() => setSeedNonce((n) => n + 1)}
+                                onClick={() => {
+                                    // Remounts ShareAssetD3 (key) → card face repaints; re-gate Save.
+                                    setAssetReady(false)
+                                    setSeedNonce((n) => n + 1)
+                                }}
                             >
                                 Reroll seed
                             </Button>
@@ -306,7 +333,10 @@ export default function ShareBuilderPage() {
                                 variant="stroke"
                                 shadowSize="4"
                                 className="flex-1"
-                                onClick={() => setAnimate((a) => !a)}
+                                onClick={() => {
+                                    setAssetReady(false)
+                                    setAnimate((a) => !a)
+                                }}
                             >
                                 {animate ? '✓ Animate' : 'Animate off'}
                             </Button>
@@ -343,6 +373,7 @@ export default function ShareBuilderPage() {
                             }}
                         >
                             <div
+                                ref={assetRef}
                                 style={{
                                     width: CANVAS_W,
                                     height: CANVAS_H,
@@ -362,6 +393,7 @@ export default function ShareBuilderPage() {
                                     usernameStyle={usernameStyle}
                                     hideUsername={hideUsername}
                                     animate={animate}
+                                    onReady={() => setAssetReady(true)}
                                 />
                             </div>
                         </div>
@@ -383,7 +415,14 @@ export default function ShareBuilderPage() {
                         <Button variant="purple" shadowSize="4" className="w-full">
                             Share
                         </Button>
-                        <Button variant="stroke" className="w-full">
+                        <Button
+                            data-testid="save-image"
+                            variant="stroke"
+                            className="w-full"
+                            onClick={handleSave}
+                            loading={saving}
+                            disabled={!assetReady || saving}
+                        >
                             Save image
                         </Button>
                     </div>

--- a/src/components/Card/BadgeSkipCelebration.tsx
+++ b/src/components/Card/BadgeSkipCelebration.tsx
@@ -61,6 +61,9 @@ type Phase = 'looking-up' | 'shaking' | 'revealed'
 const BadgeSkipCelebration: FC<Props> = ({ badgeCode, username, badges, stats, tier, pointsBalance, onContinue }) => {
     const [phase, setPhase] = useState<Phase>('looking-up')
     const [hideUsername, setHideUsername] = useState(false)
+    // Gate the Share/Save buttons until the card face's async hand <canvas>
+    // mounts — otherwise an early capture snapshots a blank card.
+    const [assetReady, setAssetReady] = useState(false)
     const { triggerHaptic } = useHaptic()
     const captureRef = useRef<HTMLDivElement | null>(null)
     const hasBadge = !!badgeCode
@@ -165,6 +168,7 @@ const BadgeSkipCelebration: FC<Props> = ({ badgeCode, username, badges, stats, t
                                 cardLast4="0420"
                                 hideUsername={hideUsername}
                                 animate={phase === 'revealed'}
+                                onReady={() => setAssetReady(true)}
                             />
                         </motion.div>
                     )}
@@ -184,7 +188,7 @@ const BadgeSkipCelebration: FC<Props> = ({ badgeCode, username, badges, stats, t
                     value={hideUsername}
                     onChange={(e) => setHideUsername(e.target.checked)}
                 />
-                <ShareAssetActions captureRef={captureRef} source="celebration" />
+                <ShareAssetActions captureRef={captureRef} source="celebration" ready={assetReady} />
                 <Button onClick={onContinue} variant="stroke" className="w-full">
                     Continue to your card
                 </Button>

--- a/src/components/Card/CardUnlockDrawer.tsx
+++ b/src/components/Card/CardUnlockDrawer.tsx
@@ -33,6 +33,9 @@ interface Props {
 export const CardUnlockDrawer: FC<Props> = ({ isOpen, onClose, entry, username, badges }) => {
     const captureRef = useRef<HTMLDivElement | null>(null)
     const [hideUsername, setHideUsername] = useState(false)
+    // Gate the Share/Save buttons until the card face's async hand <canvas>
+    // mounts — otherwise an early capture snapshots a blank card.
+    const [assetReady, setAssetReady] = useState(false)
 
     useEffect(() => {
         if (!isOpen) return
@@ -68,6 +71,7 @@ export const CardUnlockDrawer: FC<Props> = ({ isOpen, onClose, entry, username, 
                             cardLast4="0420"
                             hideUsername={hideUsername}
                             animate={false}
+                            onReady={() => setAssetReady(true)}
                         />
                     </div>
                     <div className="mx-auto flex w-full max-w-md flex-col gap-2">
@@ -78,7 +82,7 @@ export const CardUnlockDrawer: FC<Props> = ({ isOpen, onClose, entry, username, 
                             value={hideUsername}
                             onChange={(e) => setHideUsername(e.target.checked)}
                         />
-                        <ShareAssetActions captureRef={captureRef} source="history-replay" />
+                        <ShareAssetActions captureRef={captureRef} source="history-replay" ready={assetReady} />
                     </div>
                 </div>
             </DrawerContent>

--- a/src/components/Card/share-asset/PixelatedCardFace.tsx
+++ b/src/components/Card/share-asset/PixelatedCardFace.tsx
@@ -46,9 +46,10 @@ export interface PixelatedCardFaceProps {
      *  number — the share-asset rendering deliberately ignores this and
      *  always shows "????" so a screenshot can't leak the PAN. */
     last4?: string
-    /** Extra classes for the outer card div (the pink rounded box). */
+    /** Extra classes for the pink rounded card face. Sizing is fixed at
+     *  CARD_W×CARD_H on the wrapper — scale via <ScaledPixelatedCardFace />. */
     className?: string
-    /** Extra inline styles merged on top of the defaults (width/height/shadow). */
+    /** Extra inline styles merged onto the pink card face (e.g. background). */
     style?: CSSProperties
     /** When true, every element on the card (logos, number, pill) is run
      *  through the same canvas-rasterisation pipeline as the hand so the
@@ -58,6 +59,11 @@ export interface PixelatedCardFaceProps {
      *  display the Visa wordmark for compliance reasons (it renders crisp
      *  there since the share asset is the one surface that doesn't `blurAll`). */
     hideVisa?: boolean
+    /** Fires once the async-rasterised hand <canvas> has been appended to the
+     *  DOM — i.e. the card face is fully painted. Capture surfaces gate the
+     *  Share/Save buttons on this so a snapshot can never fire before the
+     *  hand mounts (the launch-day "blank card" bug). */
+    onReady?: () => void
 }
 
 export const PixelatedCardFace: FC<PixelatedCardFaceProps> = ({
@@ -65,39 +71,50 @@ export const PixelatedCardFace: FC<PixelatedCardFaceProps> = ({
     style,
     blurAll = false,
     hideVisa = false,
+    onReady,
 }) => (
-    <div
-        className={`relative overflow-hidden rounded-3xl border-[4px] border-black ${className ?? ''}`}
-        style={{
-            background: '#FF90E8',
-            width: CARD_W,
-            height: CARD_H,
-            boxShadow: '0.625rem 0.625rem 0 #000',
-            ...style,
-        }}
-    >
-        <PixelatedHand />
+    // The drop-shadow is an offset sibling, NOT a CSS box-shadow: html-to-image
+    // renders box-shadow on a rounded element as a SQUARE block, so the captured
+    // PNG showed a square shadow behind the rounded card. A real black rounded
+    // element shifted by the shadow distance captures faithfully.
+    <div className="relative" style={{ width: CARD_W, height: CARD_H }}>
+        <div
+            aria-hidden
+            className="pointer-events-none absolute rounded-3xl"
+            style={{ inset: 0, background: '#000', transform: 'translate(0.625rem, 0.625rem)' }}
+        />
+        <div
+            className={`relative h-full w-full overflow-hidden rounded-3xl border-[4px] border-black ${className ?? ''}`}
+            style={{
+                background: '#FF90E8',
+                ...style,
+            }}
+        >
+            <PixelatedHand onReady={onReady} />
 
-        {/* Top row: peanut logo (left) + visa logo (right) */}
-        <div className="absolute flex items-start justify-between" style={{ top: 24, left: 28, right: 28, zIndex: 2 }}>
-            {blurAll ? (
-                <PixelatedImg src={ASSET_PEANUTMAN_LOGO} displayW={52} displayH={52} />
-            ) : (
-                <img src={ASSET_PEANUTMAN_LOGO} alt="" aria-hidden style={{ height: 52, width: 'auto' }} />
-            )}
-            {!hideVisa &&
-                (blurAll ? (
-                    <PixelatedImg src={ASSET_VISA_BRAND} displayW={80} displayH={32} invert />
+            {/* Top row: peanut logo (left) + visa logo (right) */}
+            <div
+                className="absolute flex items-start justify-between"
+                style={{ top: 24, left: 28, right: 28, zIndex: 2 }}
+            >
+                {blurAll ? (
+                    <PixelatedImg src={ASSET_PEANUTMAN_LOGO} displayW={52} displayH={52} />
                 ) : (
-                    <img
-                        src={ASSET_VISA_BRAND}
-                        alt="Visa"
-                        style={{ height: 32, width: 'auto', filter: 'brightness(0) invert(1)' }}
-                    />
-                ))}
-        </div>
+                    <img src={ASSET_PEANUTMAN_LOGO} alt="" aria-hidden style={{ height: 52, width: 'auto' }} />
+                )}
+                {!hideVisa &&
+                    (blurAll ? (
+                        <PixelatedImg src={ASSET_VISA_BRAND} displayW={80} displayH={32} invert />
+                    ) : (
+                        <img
+                            src={ASSET_VISA_BRAND}
+                            alt="Visa"
+                            style={{ height: 32, width: 'auto', filter: 'brightness(0) invert(1)' }}
+                        />
+                    ))}
+            </div>
 
-        {/* Bottom: card number — same `•••• ????` pattern in both modes.
+            {/* Bottom: card number — same `•••• ????` pattern in both modes.
             The share asset deliberately obscures the real PAN so a
             screenshot can't leak it; the eligibility-check tease uses
             the same string for visual continuity. (The `last4` prop is
@@ -105,28 +122,29 @@ export const PixelatedCardFace: FC<PixelatedCardFaceProps> = ({
             card face — share-asset + tease callers just don't pass it.)
             Lowered toward the card edge now that the Virtual pill is
             gone — gives the layout room to breathe. */}
-        <div className="absolute" style={{ bottom: 32, left: 28, zIndex: 2 }}>
-            {blurAll ? (
-                <PixelatedText
-                    text="????"
-                    displayW={140}
-                    displayH={42}
-                    font="1000 42px Roboto, sans-serif"
-                    color="#000"
-                />
-            ) : (
-                <div
-                    style={{
-                        fontFamily: 'var(--font-roboto), sans-serif',
-                        fontWeight: 1000,
-                        letterSpacing: '0.06em',
-                        fontSize: 42,
-                        lineHeight: 1,
-                    }}
-                >
-                    ????
-                </div>
-            )}
+            <div className="absolute" style={{ bottom: 32, left: 28, zIndex: 2 }}>
+                {blurAll ? (
+                    <PixelatedText
+                        text="????"
+                        displayW={140}
+                        displayH={42}
+                        font="1000 42px Roboto, sans-serif"
+                        color="#000"
+                    />
+                ) : (
+                    <div
+                        style={{
+                            fontFamily: 'var(--font-roboto), sans-serif',
+                            fontWeight: 1000,
+                            letterSpacing: '0.06em',
+                            fontSize: 42,
+                            lineHeight: 1,
+                        }}
+                    >
+                        ????
+                    </div>
+                )}
+            </div>
         </div>
     </div>
 )
@@ -268,7 +286,7 @@ const PixelatedText: FC<PixelatedTextProps> = ({ text, displayW, displayH, font,
 // silhouette stays recognisable.
 // ---------------------------------------------------------------------------
 
-const PixelatedHand: FC = () => (
+const PixelatedHand: FC<{ onReady?: () => void }> = ({ onReady }) => (
     <div
         ref={(node) => {
             if (!node || node.firstChild) return
@@ -280,6 +298,8 @@ const PixelatedHand: FC = () => (
                 canvas.style.height = '100%'
                 canvas.style.imageRendering = 'pixelated'
                 node.appendChild(canvas)
+                // Card face is now painted — let capture surfaces unblock.
+                onReady?.()
             })
         }}
         className="pointer-events-none absolute select-none"

--- a/src/components/Card/share-asset/ShareAssetActions.tsx
+++ b/src/components/Card/share-asset/ShareAssetActions.tsx
@@ -69,9 +69,14 @@ interface Props {
     source: string
     /** Optional filename for the downloaded PNG. */
     filename?: string
+    /** Whether the share asset has finished painting its card face (the async
+     *  hand <canvas> has mounted — see PixelatedCardFace.onReady). Until then,
+     *  capturing would snapshot a blank card, so both buttons stay disabled.
+     *  Defaults to true so callers that don't wire the signal aren't blocked. */
+    ready?: boolean
 }
 
-export const ShareAssetActions: FC<Props> = ({ captureRef, source, filename = 'peanut-card.png' }) => {
+export const ShareAssetActions: FC<Props> = ({ captureRef, source, filename = 'peanut-card.png', ready = true }) => {
     const [isSharing, setIsSharing] = useState(false)
     const [isSaving, setIsSaving] = useState(false)
     const [error, setError] = useState<string | null>(null)
@@ -163,7 +168,7 @@ export const ShareAssetActions: FC<Props> = ({ captureRef, source, filename = 'p
                 shadowSize="4"
                 className="w-full"
                 loading={isSharing}
-                disabled={isSharing || isSaving}
+                disabled={isSharing || isSaving || !ready}
                 icon={<Icon name="share" size={18} />}
             >
                 Share
@@ -173,7 +178,7 @@ export const ShareAssetActions: FC<Props> = ({ captureRef, source, filename = 'p
                 variant="stroke"
                 className="w-full"
                 loading={isSaving}
-                disabled={isSharing || isSaving}
+                disabled={isSharing || isSaving || !ready}
                 icon={<Icon name="download" size={18} />}
             >
                 Save image

--- a/src/components/Card/share-asset/ShareAssetD3.tsx
+++ b/src/components/Card/share-asset/ShareAssetD3.tsx
@@ -100,6 +100,7 @@ const ShareAssetD3: FC<ShareAssetD3Props> = ({
     usernameStyle,
     hideUsername = false,
     animate = true,
+    onReady,
 }) => {
     const safeUsername = (username || '').trim() || 'anon'
     const safeLast4 = (cardLast4 || '').trim().padStart(4, '•').slice(-4) || '5695'
@@ -219,7 +220,7 @@ const ShareAssetD3: FC<ShareAssetD3Props> = ({
                         : 'none',
                 }}
             >
-                <PixelatedCardFace last4={safeLast4} hideVisa />
+                <PixelatedCardFace last4={safeLast4} hideVisa onReady={onReady} />
             </div>
 
             {/* ─── Stickers (z-index 4) — raw badge art collaged ON TOP of the
@@ -256,26 +257,36 @@ const ShareAssetD3: FC<ShareAssetD3Props> = ({
                     animation: animate ? `fadeUp 600ms ease-out ${ANIM_ATTRIBUTION_DELAY}ms both` : 'none',
                 }}
             >
-                <span
-                    className="inline-flex items-baseline rounded-full border-[5px] border-black"
-                    style={{
-                        backgroundColor: uBg,
-                        padding: '10px 40px',
-                        textTransform: 'lowercase',
-                        boxShadow: '0.375rem 0.375rem 0 #000',
-                        whiteSpace: 'nowrap',
-                        maxWidth: PILL_MAX_W,
-                        overflow: 'hidden',
-                        lineHeight: 1.05,
-                        transform: 'rotate(-3deg)',
-                        gap: 1,
-                    }}
-                >
-                    <span style={{ fontSize: uPrefixSize, fontWeight: 800 }}>peanut.me/</span>
-                    <span style={{ fontSize: uHandleSize, fontWeight: 1000, letterSpacing: `${uTracking}em` }}>
-                        {safeUsername}
+                {/* The pill's drop-shadow is an offset sibling, NOT a CSS
+                    box-shadow: html-to-image renders box-shadow on a `rounded-full`
+                    element as a SQUARE block, so the captured PNG showed a square
+                    shadow behind the rounded pill. The rotation lives on the
+                    wrapper so the black rounded shadow tracks the pill's tilt. */}
+                <div className="relative inline-flex" style={{ transform: 'rotate(-3deg)', maxWidth: PILL_MAX_W }}>
+                    <div
+                        aria-hidden
+                        className="pointer-events-none absolute rounded-full"
+                        style={{ inset: 0, background: '#000', transform: 'translate(0.375rem, 0.375rem)' }}
+                    />
+                    <span
+                        className="relative inline-flex items-baseline rounded-full border-[5px] border-black"
+                        style={{
+                            backgroundColor: uBg,
+                            padding: '10px 40px',
+                            textTransform: 'lowercase',
+                            whiteSpace: 'nowrap',
+                            maxWidth: PILL_MAX_W,
+                            overflow: 'hidden',
+                            lineHeight: 1.05,
+                            gap: 1,
+                        }}
+                    >
+                        <span style={{ fontSize: uPrefixSize, fontWeight: 800 }}>peanut.me/</span>
+                        <span style={{ fontSize: uHandleSize, fontWeight: 1000, letterSpacing: `${uTracking}em` }}>
+                            {safeUsername}
+                        </span>
                     </span>
-                </span>
+                </div>
             </div>
 
             {/* ─── Hero "I got in" message sticker (top, z-index 5 — above the

--- a/src/components/Card/share-asset/shareAsset.types.ts
+++ b/src/components/Card/share-asset/shareAsset.types.ts
@@ -105,4 +105,12 @@ export interface ShareAssetD3Props {
      * snapshots / image export so the final frame renders deterministically.
      */
     animate?: boolean
+
+    /**
+     * Fires once the card face's async hand <canvas> has mounted (forwarded
+     * straight to <PixelatedCardFace onReady />). Capture surfaces gate the
+     * Share/Save buttons on this so a snapshot can never fire before the card
+     * face paints — the deterministic fix for the blank-card capture bug.
+     */
+    onReady?: () => void
 }


### PR DESCRIPTION
## Why

The card launched **today** (`main` = prod). The share asset users capture-and-post had two capture bugs, plus a test gap.

## 1. Square-shadow bug

`html-to-image` renders CSS `box-shadow` on a **rounded** element as a **square** block, so the captured PNG showed square shadows behind:
- the `peanut.me/<user>` username pill (`rounded-full`) in `ShareAssetD3`
- the card drop-shadow (`rounded-3xl`) in `PixelatedCardFace`

**Fix:** replace each `box-shadow` with an **offset black sibling element** that shares the same `border-radius`, shifted by the shadow distance and layered behind. `html-to-image` renders these faithfully (rounded, not square). The pill's rotation now lives on a wrapper so the shadow tracks the tilt.

Hero stickers use `filter: drop-shadow(...)` — those capture fine and are left untouched.

## 2. Deterministic blank-card gate

`PixelatedCardFace` paints its pixelated hand into a `<canvas>` appended **asynchronously** (`new Image().onload → appendChild`). A capture firing before that canvas mounted snapshotted a **blank** pink card — and the capture *succeeded*, so nothing reached Sentry. The bounded `waitForAssetReady` wait (#2302) can **time out under load** → still blank.

**Fix (deterministic):** `PixelatedCardFace` fires an `onReady` callback once the hand canvas mounts. It threads up `ScaledPixelatedCardFace` / `ShareAssetD3` / `ScaledShareAsset` (via the existing prop spreads) to `ShareAssetActions`, which **disables Share/Save until the asset signals ready** — a capture can never fire before the card face paints. `waitForAssetReady` stays as a belt-and-suspenders fallback.

## 3. Test surface + regression guard

- Wired the `/dev/share-builder` **"Save image"** button (previously a dummy `<Button>` with no `onClick`) to the real `captureShareAsset` + `downloadBlob` path, gated on the same `onReady` signal.
- Added `e2e/flows/share-asset-capture.spec.ts`: loads `/dev/share-builder`, waits for the Save button to **enable** (proves the ready gate releases only after the canvas mounts), clicks Save, intercepts the downloaded PNG, decodes it with `sharp`, and samples the **centre of the card** (the hand's territory — away from the top-left logo and bottom-left number). It **fails if that region is entirely background** (card-pink `#FF90E8` / asset-blue `#90A8ED`), i.e. the hand never rendered.

## Files
- `src/components/Card/share-asset/PixelatedCardFace.tsx` — card offset-shadow sibling; `onReady` fired from `PixelatedHand` after the canvas appends.
- `src/components/Card/share-asset/ShareAssetD3.tsx` — pill offset-shadow sibling; forwards `onReady` to `PixelatedCardFace`.
- `src/components/Card/share-asset/shareAsset.types.ts` — `onReady?: () => void` on `ShareAssetD3Props`.
- `src/components/Card/share-asset/ShareAssetActions.tsx` — `ready?` prop gates both buttons.
- `src/components/Card/BadgeSkipCelebration.tsx`, `CardUnlockDrawer.tsx` — track `assetReady`, pass `onReady` → `ready`.
- `src/app/(mobile-ui)/dev/share-builder/page.tsx` — wired Save button + `onReady` gating.
- `e2e/flows/share-asset-capture.spec.ts` — new regression guard.

## Verification
- `pnpm prettier --check` ✅ · `npm run typecheck` ✅ · `npm test` ✅ (103 suites, 1602 passed, 3 skipped)
- e2e decode/sample logic validated against synthetic PNGs (blank → 0% non-bg → fails; hand → 45% → passes). **Playwright not run locally** (the `(mobile-ui)` layout redirects unauthenticated users to `/setup`; the spec needs the authenticated harness, which CI provides) — relies on CI for the browser run.
