### PR TITLE
feat(kyc): mandatory EEA-uplift gate + funnel analytics

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -88,8 +88,11 @@ export default function OnrampBankPage() {
     } = useEeaUpliftFunnel('deposit')
 
     const sumsubFlow = useMultiPhaseKycFlow({
+        // Fire completed at Sumsub approval (verification submitted), not at
+        // end-of-flow — so it isn't lost if the user drops during the
+        // post-approval ToS / preparing steps.
+        onKycApproved: () => trackUpliftCompleted(),
         onKycSuccess: () => {
-            trackUpliftCompleted()
             setUrlState({ step: 'inputAmount' })
         },
         // Abandoned attempt: clear the pending start so a later unrelated KYC

--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -81,13 +81,20 @@ export default function OnrampBankPage() {
     // (e.g. /add-money/usa → NA → bridge-requirements).
     // EEA-uplift funnel events (PostHog): started on launch, completed on KYC
     // success. trackCompleted no-ops unless an uplift was started this session.
-    const { trackStarted: trackUpliftStarted, trackCompleted: trackUpliftCompleted } = useEeaUpliftFunnel('deposit')
+    const {
+        trackStarted: trackUpliftStarted,
+        trackCompleted: trackUpliftCompleted,
+        reset: resetUpliftFunnel,
+    } = useEeaUpliftFunnel('deposit')
 
     const sumsubFlow = useMultiPhaseKycFlow({
         onKycSuccess: () => {
             trackUpliftCompleted()
             setUrlState({ step: 'inputAmount' })
         },
+        // Abandoned attempt: clear the pending start so a later unrelated KYC
+        // success on this page can't mis-fire eea_uplift_completed.
+        onManualClose: resetUpliftFunnel,
     })
 
     // read country from path params (web) or query params (native/capacitor)

--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -36,6 +36,7 @@ import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
 import AdvisoryPreemptModal from '@/components/Kyc/AdvisoryPreemptModal'
 import { useAdvisoryPreempt } from '@/hooks/useAdvisoryPreempt'
+import { useEeaUpliftFunnel } from '@/hooks/useEeaUpliftFunnel'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { addMoneyCountryUrl } from '@/utils/native-routes'
@@ -78,8 +79,13 @@ export default function OnrampBankPage() {
     // regionIntent is NOT passed here to avoid creating a backend record on mount.
     // intent is passed at call time, derived from the destination country
     // (e.g. /add-money/usa → NA → bridge-requirements).
+    // EEA-uplift funnel events (PostHog): started on launch, completed on KYC
+    // success. trackCompleted no-ops unless an uplift was started this session.
+    const { trackStarted: trackUpliftStarted, trackCompleted: trackUpliftCompleted } = useEeaUpliftFunnel('deposit')
+
     const sumsubFlow = useMultiPhaseKycFlow({
         onKycSuccess: () => {
+            trackUpliftCompleted()
             setUrlState({ step: 'inputAmount' })
         },
     })
@@ -115,8 +121,9 @@ export default function OnrampBankPage() {
     const { gateFor } = useCapabilities()
     const bankCountry = useMemo(() => railJurisdictionForBank(selectedCountry?.id), [selectedCountry?.id])
     const gate = useMemo(() => gateFor('deposit', { channel: 'bank', country: bankCountry }), [gateFor, bankCountry])
-    // A ready bank rail can still carry a future-dated requirement (the gate's
-    // `advisory`). Offer it as a skippable pre-empt at the proceed step.
+    // A ready bank rail can still carry a pending Bridge requirement (the gate's
+    // `advisory`). Enforce it as a mandatory, non-skippable pre-empt at the
+    // proceed step — the deposit cannot continue until it's completed.
     const advisory = gate.kind === 'ready' ? gate.advisory : undefined
     const { intercept: advisoryIntercept, modalProps: advisoryModalProps } = useAdvisoryPreempt({
         advisory,
@@ -124,8 +131,11 @@ export default function OnrampBankPage() {
         // Route through the self-heal resubmit path (reheal-tagged action) so the
         // completed submission round-trips to Bridge. start-action mints a plain
         // token whose webhook completion has no Bridge relay → answers are dropped.
-        onCompleteNow: () =>
-            advisory ? sumsubFlow.handleSelfHealResubmit('BRIDGE', advisory.requirementKey) : Promise.resolve(),
+        onCompleteNow: () => {
+            if (!advisory) return Promise.resolve()
+            trackUpliftStarted(advisory)
+            return sumsubFlow.handleSelfHealResubmit('BRIDGE', advisory.requirementKey)
+        },
     })
     const { guardWithTos, showBridgeTos, hideTos } = useTosGuard()
     const { setIsSupportModalOpen } = useModalsContext()
@@ -247,10 +257,10 @@ export default function OnrampBankPage() {
             return
         }
 
-        // ready — offer the skippable advisory pre-empt once; on proceed (now, or
-        // after "Not now") record the amount-entered event and open the
-        // confirmation modal. Firing inside the proceed avoids double-counting if
-        // the user dismisses the advisory and re-clicks.
+        // ready — enforce the mandatory verification pre-empt. The proceed body
+        // (record the amount-entered event, open the confirmation modal) only
+        // runs once there's no pending requirement; while one exists the modal
+        // blocks and this never fires, so the event can't double-count.
         advisoryIntercept(() => {
             posthog.capture(ANALYTICS_EVENTS.DEPOSIT_AMOUNT_ENTERED, {
                 amount_usd: usdEquivalent,

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -32,6 +32,7 @@ import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
 import AdvisoryPreemptModal from '@/components/Kyc/AdvisoryPreemptModal'
 import { useAdvisoryPreempt } from '@/hooks/useAdvisoryPreempt'
+import { useEeaUpliftFunnel } from '@/hooks/useEeaUpliftFunnel'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { getKycModalVariant, getGateUserMessage } from '@/utils/capability-gate'
 import { useModalsContext } from '@/context/ModalsContext'
@@ -89,9 +90,14 @@ export default function WithdrawBankPage() {
     const { gateFor } = useCapabilities()
     const bankCountry = useMemo(() => railJurisdictionForBank(getCountryFromPath(country)?.id), [country])
     const gate = useMemo(() => gateFor('withdraw', { channel: 'bank', country: bankCountry }), [gateFor, bankCountry])
-    const sumsubFlow = useMultiPhaseKycFlow({})
-    // A ready bank rail can still carry a future-dated requirement (the gate's
-    // `advisory`). Offer it as a skippable pre-empt before the withdrawal.
+    // EEA-uplift funnel events (PostHog): started on launch, completed on KYC
+    // success. trackCompleted no-ops unless an uplift was started this session.
+    const { trackStarted: trackUpliftStarted, trackCompleted: trackUpliftCompleted } = useEeaUpliftFunnel('withdraw')
+
+    const sumsubFlow = useMultiPhaseKycFlow({ onKycSuccess: () => trackUpliftCompleted() })
+    // A ready bank rail can still carry a pending Bridge requirement (the gate's
+    // `advisory`). Enforce it as a mandatory, non-skippable pre-empt before the
+    // withdrawal — the offramp cannot proceed until it's completed.
     const advisory = gate.kind === 'ready' ? gate.advisory : undefined
     const { intercept: advisoryIntercept, modalProps: advisoryModalProps } = useAdvisoryPreempt({
         advisory,
@@ -99,8 +105,11 @@ export default function WithdrawBankPage() {
         // Route through the self-heal resubmit path (reheal-tagged action) so the
         // completed submission round-trips to Bridge. start-action mints a plain
         // token whose webhook completion has no Bridge relay → answers are dropped.
-        onCompleteNow: () =>
-            advisory ? sumsubFlow.handleSelfHealResubmit('BRIDGE', advisory.requirementKey) : Promise.resolve(),
+        onCompleteNow: () => {
+            if (!advisory) return Promise.resolve()
+            trackUpliftStarted(advisory)
+            return sumsubFlow.handleSelfHealResubmit('BRIDGE', advisory.requirementKey)
+        },
     })
     const [showKycModal, setShowKycModal] = useState(false)
     const { setIsSupportModalOpen } = useModalsContext()
@@ -322,8 +331,8 @@ export default function WithdrawBankPage() {
         }
     }
 
-    // Offer the skippable advisory pre-empt once, then run the offramp. When the
-    // gate isn't `ready` (or nothing is future-dated) this is a no-op and
+    // Enforce the mandatory verification pre-empt, then run the offramp. When the
+    // gate isn't `ready` (or there's no pending requirement) this is a no-op and
     // proceedWithOfframp runs straight away (it handles the not-ready cases).
     const handleCreateAndInitiateOfframp = () => advisoryIntercept(() => void proceedWithOfframp())
 

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -99,7 +99,10 @@ export default function WithdrawBankPage() {
     } = useEeaUpliftFunnel('withdraw')
 
     const sumsubFlow = useMultiPhaseKycFlow({
-        onKycSuccess: () => trackUpliftCompleted(),
+        // Fire completed at Sumsub approval (verification submitted), not at
+        // end-of-flow — so it isn't lost if the user drops during the
+        // post-approval ToS / preparing steps.
+        onKycApproved: () => trackUpliftCompleted(),
         // Abandoned attempt: clear the pending start so a later unrelated KYC
         // success on this page can't mis-fire eea_uplift_completed.
         onManualClose: resetUpliftFunnel,

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -92,9 +92,18 @@ export default function WithdrawBankPage() {
     const gate = useMemo(() => gateFor('withdraw', { channel: 'bank', country: bankCountry }), [gateFor, bankCountry])
     // EEA-uplift funnel events (PostHog): started on launch, completed on KYC
     // success. trackCompleted no-ops unless an uplift was started this session.
-    const { trackStarted: trackUpliftStarted, trackCompleted: trackUpliftCompleted } = useEeaUpliftFunnel('withdraw')
+    const {
+        trackStarted: trackUpliftStarted,
+        trackCompleted: trackUpliftCompleted,
+        reset: resetUpliftFunnel,
+    } = useEeaUpliftFunnel('withdraw')
 
-    const sumsubFlow = useMultiPhaseKycFlow({ onKycSuccess: () => trackUpliftCompleted() })
+    const sumsubFlow = useMultiPhaseKycFlow({
+        onKycSuccess: () => trackUpliftCompleted(),
+        // Abandoned attempt: clear the pending start so a later unrelated KYC
+        // success on this page can't mis-fire eea_uplift_completed.
+        onManualClose: resetUpliftFunnel,
+    })
     // A ready bank rail can still carry a pending Bridge requirement (the gate's
     // `advisory`). Enforce it as a mandatory, non-skippable pre-empt before the
     // withdrawal — the offramp cannot proceed until it's completed.

--- a/src/components/Kyc/AdvisoryPreemptModal.tsx
+++ b/src/components/Kyc/AdvisoryPreemptModal.tsx
@@ -5,11 +5,8 @@ interface AdvisoryPreemptModalProps {
     /** ISO date the requirement becomes blocking; drives the deadline copy. */
     effectiveDate?: string
     isLoading?: boolean
-    /** Launch the verification flow early. */
+    /** Launch the verification flow. */
     onCompleteNow: () => void
-    /** Dismiss and continue with what the user was doing. */
-    onSkip: () => void
-    onClose: () => void
 }
 
 function formatEffectiveDate(iso?: string): string | null {
@@ -23,32 +20,33 @@ function formatEffectiveDate(iso?: string): string | null {
 }
 
 /**
- * Skippable pre-empt for a future-dated verification requirement on a rail that
- * still works today (the gate's `ready` + `advisory`). "Complete now" launches
- * the verification early; "Not now" lets the user carry on and resolve it later.
- * Once the effective date passes the backend reclassifies the requirement to
- * blocking and the non-skippable InitiateKycModal takes over — there is no FE
- * cutover logic here.
+ * Mandatory pre-empt for a pending Bridge verification requirement on the bank
+ * rails. Non-closable and non-skippable: the user must complete the verification
+ * before they can continue with a bank transfer. There is no "Not now" / X /
+ * backdrop dismiss — the only way forward is "Complete now".
  */
 export default function AdvisoryPreemptModal({
     visible,
     effectiveDate,
     isLoading = false,
     onCompleteNow,
-    onSkip,
-    onClose,
 }: AdvisoryPreemptModalProps) {
     const formatted = formatEffectiveDate(effectiveDate)
     return (
         <ActionModal
             visible={visible}
-            onClose={onClose}
+            // Hard gate: no dismiss. onClose is required by ActionModal but
+            // `preventClose` blocks backdrop/escape and `hideModalCloseButton`
+            // removes the X, so it is never reachable.
+            onClose={() => {}}
+            preventClose
+            hideModalCloseButton
             icon="badge"
-            title="One quick step coming up"
+            title="One quick step to continue"
             description={
                 formatted
-                    ? `To keep using bank transfers, you'll need to complete a short verification by ${formatted}. Take care of it now so nothing pauses later.`
-                    : `To keep using bank transfers, you'll need to complete a short verification soon. Take care of it now so nothing pauses later.`
+                    ? `To continue using bank transfers, please complete a short verification (required by ${formatted}). It only takes a couple of minutes.`
+                    : `To continue using bank transfers, please complete a short verification. It only takes a couple of minutes.`
             }
             ctas={[
                 {
@@ -58,7 +56,6 @@ export default function AdvisoryPreemptModal({
                     shadowSize: '4',
                     disabled: isLoading,
                 },
-                { text: 'Not now', onClick: onSkip, variant: 'stroke', disabled: isLoading },
             ]}
         />
     )

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -33,6 +33,14 @@ export const ANALYTICS_EVENTS = {
     KYC_REJECTED: 'kyc_rejected',
     KYC_ABANDONED: 'kyc_abandoned',
 
+    // ── EEA uplift (Bridge endorsement re-verification) ──
+    // Dedicated funnel events for the mandatory EEA-uplift gate so the flow can
+    // be filtered directly in PostHog. `started` = user launched the
+    // verification from the gate; `completed` = the KYC flow succeeded for that
+    // same uplift attempt.
+    EEA_UPLIFT_STARTED: 'eea_uplift_started',
+    EEA_UPLIFT_COMPLETED: 'eea_uplift_completed',
+
     // ── KYC (Manteca) ──
     MANTECA_KYC_INITIATED: 'manteca_kyc_initiated',
     MANTECA_KYC_COMPLETED: 'manteca_kyc_completed',

--- a/src/hooks/useAdvisoryPreempt.test.ts
+++ b/src/hooks/useAdvisoryPreempt.test.ts
@@ -16,7 +16,7 @@ describe('useAdvisoryPreempt', () => {
         expect(result.current.modalProps.visible).toBe(false)
     })
 
-    test('advisory present → intercept opens the modal and defers proceed', () => {
+    test('advisory present → intercept opens the modal and blocks proceed', () => {
         const proceed = jest.fn()
         const onCompleteNow = jest.fn()
         const { result } = renderHook(() => useAdvisoryPreempt({ advisory, onCompleteNow }))
@@ -28,43 +28,21 @@ describe('useAdvisoryPreempt', () => {
         expect(result.current.modalProps.effectiveDate).toBe('2099-06-29')
     })
 
-    test('skip runs the deferred proceed; once dismissed, later intercepts pass straight through', () => {
-        const proceed = jest.fn()
+    test('hard gate: while the advisory is pending, repeated intercepts never pass through', () => {
         const onCompleteNow = jest.fn()
         const { result } = renderHook(() => useAdvisoryPreempt({ advisory, onCompleteNow }))
 
-        act(() => result.current.intercept(proceed))
-        act(() => result.current.modalProps.onSkip())
-
-        expect(proceed).toHaveBeenCalledTimes(1)
-        expect(result.current.modalProps.visible).toBe(false)
-
-        // Dismissed for the session — a second proceed runs immediately, no re-prompt.
+        const proceed1 = jest.fn()
+        act(() => result.current.intercept(proceed1))
         const proceed2 = jest.fn()
         act(() => result.current.intercept(proceed2))
-        expect(proceed2).toHaveBeenCalledTimes(1)
-        expect(result.current.modalProps.visible).toBe(false)
+
+        expect(proceed1).not.toHaveBeenCalled()
+        expect(proceed2).not.toHaveBeenCalled()
+        expect(result.current.modalProps.visible).toBe(true)
     })
 
-    test('onClose dismisses without running the deferred proceed (X must not trigger the money action)', () => {
-        const proceed = jest.fn()
-        const onCompleteNow = jest.fn()
-        const { result } = renderHook(() => useAdvisoryPreempt({ advisory, onCompleteNow }))
-
-        act(() => result.current.intercept(proceed))
-        act(() => result.current.modalProps.onClose())
-
-        expect(proceed).not.toHaveBeenCalled()
-        expect(result.current.modalProps.visible).toBe(false)
-
-        // ...but it dismisses for the session — the next click passes through, no re-prompt.
-        const proceed2 = jest.fn()
-        act(() => result.current.intercept(proceed2))
-        expect(proceed2).toHaveBeenCalledTimes(1)
-        expect(result.current.modalProps.visible).toBe(false)
-    })
-
-    test('completeNow launches the verification and does NOT run the deferred proceed', async () => {
+    test('completeNow launches the verification, hides the modal, and does NOT run the deferred proceed', async () => {
         const proceed = jest.fn()
         const onCompleteNow = jest.fn()
         const { result } = renderHook(() => useAdvisoryPreempt({ advisory, onCompleteNow }))
@@ -77,5 +55,37 @@ describe('useAdvisoryPreempt', () => {
         expect(onCompleteNow).toHaveBeenCalledTimes(1)
         expect(proceed).not.toHaveBeenCalled()
         expect(result.current.modalProps.visible).toBe(false)
+    })
+
+    test('completeNow ignores rapid double-clicks (single submit)', async () => {
+        let resolve: () => void = () => {}
+        const onCompleteNow = jest.fn(() => new Promise<void>((r) => (resolve = r)))
+        const { result } = renderHook(() => useAdvisoryPreempt({ advisory, onCompleteNow }))
+
+        await act(async () => {
+            result.current.modalProps.onCompleteNow()
+            result.current.modalProps.onCompleteNow()
+            resolve()
+        })
+
+        expect(onCompleteNow).toHaveBeenCalledTimes(1)
+    })
+
+    test('once the requirement clears (advisory undefined), intercept passes through again', () => {
+        const onCompleteNow = jest.fn()
+        const { result, rerender } = renderHook(
+            ({ adv }: { adv: GateAdvisory | undefined }) => useAdvisoryPreempt({ advisory: adv, onCompleteNow }),
+            { initialProps: { adv: advisory as GateAdvisory | undefined } }
+        )
+
+        const blocked = jest.fn()
+        act(() => result.current.intercept(blocked))
+        expect(blocked).not.toHaveBeenCalled()
+
+        // Backend cleared the requirement → gate no longer carries an advisory.
+        rerender({ adv: undefined })
+        const proceed = jest.fn()
+        act(() => result.current.intercept(proceed))
+        expect(proceed).toHaveBeenCalledTimes(1)
     })
 })

--- a/src/hooks/useAdvisoryPreempt.test.ts
+++ b/src/hooks/useAdvisoryPreempt.test.ts
@@ -88,4 +88,32 @@ describe('useAdvisoryPreempt', () => {
         act(() => result.current.intercept(proceed))
         expect(proceed).toHaveBeenCalledTimes(1)
     })
+
+    test('auto-closes the modal when the advisory clears while it is open', () => {
+        const onCompleteNow = jest.fn()
+        const { result, rerender } = renderHook(
+            ({ adv }: { adv: GateAdvisory | undefined }) => useAdvisoryPreempt({ advisory: adv, onCompleteNow }),
+            { initialProps: { adv: advisory as GateAdvisory | undefined } }
+        )
+
+        act(() => result.current.intercept(jest.fn()))
+        expect(result.current.modalProps.visible).toBe(true)
+
+        // backend cleared the requirement while the modal was open
+        rerender({ adv: undefined })
+        expect(result.current.modalProps.visible).toBe(false)
+    })
+
+    test('re-shows the modal if the launch (onCompleteNow) fails', async () => {
+        const onCompleteNow = jest.fn().mockRejectedValue(new Error('launch failed'))
+        const { result } = renderHook(() => useAdvisoryPreempt({ advisory, onCompleteNow }))
+
+        act(() => result.current.intercept(jest.fn()))
+        await act(async () => {
+            await expect(result.current.modalProps.onCompleteNow()).rejects.toThrow('launch failed')
+        })
+
+        // hard gate must not silently vanish on a failed launch
+        expect(result.current.modalProps.visible).toBe(true)
+    })
 })

--- a/src/hooks/useAdvisoryPreempt.ts
+++ b/src/hooks/useAdvisoryPreempt.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { GateAdvisory } from '@/utils/capability-gate'
 
 interface UseAdvisoryPreemptArgs {
@@ -27,6 +27,13 @@ export function useAdvisoryPreempt({ advisory, onCompleteNow, isLoading = false 
     // would otherwise launch duplicate requests.
     const completingRef = useRef(false)
 
+    // Keep the modal in sync with the requirement: if the backend clears the
+    // advisory (requirement resolved) while the modal is open, auto-close it so
+    // the gate doesn't linger over an already-unblocked transfer.
+    useEffect(() => {
+        if (!advisory) setVisible(false)
+    }, [advisory])
+
     const intercept = useCallback(
         (proceed: () => void) => {
             // Hard gate: a pending requirement blocks the transfer outright. The
@@ -47,6 +54,11 @@ export function useAdvisoryPreempt({ advisory, onCompleteNow, isLoading = false 
         setVisible(false)
         try {
             await onCompleteNow()
+        } catch (error) {
+            // Launch failed — re-show the gate so the user isn't left with a
+            // silently dismissed mandatory step and a still-pending requirement.
+            setVisible(true)
+            throw error
         } finally {
             completingRef.current = false
         }

--- a/src/hooks/useAdvisoryPreempt.ts
+++ b/src/hooks/useAdvisoryPreempt.ts
@@ -4,71 +4,53 @@ import type { GateAdvisory } from '@/utils/capability-gate'
 interface UseAdvisoryPreemptArgs {
     /** The advisory from a `ready` gate (`gate.kind === 'ready' ? gate.advisory : undefined`). */
     advisory: GateAdvisory | undefined
-    /** Launch the verification flow early — e.g. `sumsubFlow.handleInitiateKyc(region, advisory.levelKey, …)`. */
+    /** Launch the verification flow — e.g. `sumsubFlow.handleSelfHealResubmit('BRIDGE', advisory.requirementKey)`. */
     onCompleteNow: () => void | Promise<void>
     isLoading?: boolean
 }
 
 /**
- * Drives the skippable advisory pre-empt at the add/withdraw entry points. The
- * rail is usable now, so we don't block — we intercept the "proceed" step ONCE
- * per session with a skippable modal. "Complete now" launches the verification
- * early; "Not now" dismisses and runs the original proceed action. Either choice
- * marks it dismissed so the user isn't re-prompted mid-session.
+ * Drives the MANDATORY verification pre-empt at the add/withdraw entry points.
+ * If a pending Bridge requirement (`advisory`) exists, the user CANNOT proceed
+ * with the transfer until they complete it: `intercept` opens a non-closable,
+ * non-skippable modal and never runs the deferred action. "Complete now"
+ * launches the verification; once it clears, the gate drops the advisory and the
+ * next add/withdraw click passes straight through.
  *
  * Returns `intercept(proceed)` to call in the gate's `ready` branch, and
  * `modalProps` to spread onto {@link AdvisoryPreemptModal}.
  */
 export function useAdvisoryPreempt({ advisory, onCompleteNow, isLoading = false }: UseAdvisoryPreemptArgs) {
-    const [dismissed, setDismissed] = useState(false)
     const [visible, setVisible] = useState(false)
-    const pendingProceed = useRef<(() => void) | null>(null)
-    // Guards against double-submit: onCompleteNow now fires a real network call
+    // Guards against double-submit: onCompleteNow fires a real network call
     // (self-heal resubmit), so rapid clicks before isLoading disables the CTA
     // would otherwise launch duplicate requests.
     const completingRef = useRef(false)
 
     const intercept = useCallback(
         (proceed: () => void) => {
-            if (advisory && !dismissed) {
-                pendingProceed.current = proceed
+            // Hard gate: a pending requirement blocks the transfer outright. The
+            // deferred action only runs when there is no advisory — i.e. the user
+            // has completed verification and the backend cleared the requirement.
+            if (advisory) {
                 setVisible(true)
                 return
             }
             proceed()
         },
-        [advisory, dismissed]
+        [advisory]
     )
 
     const completeNow = useCallback(async () => {
         if (completingRef.current) return
         completingRef.current = true
-        setDismissed(true)
         setVisible(false)
-        pendingProceed.current = null
         try {
             await onCompleteNow()
         } finally {
             completingRef.current = false
         }
     }, [onCompleteNow])
-
-    const skip = useCallback(() => {
-        setDismissed(true)
-        setVisible(false)
-        const proceed = pendingProceed.current
-        pendingProceed.current = null
-        proceed?.()
-    }, [])
-
-    // X / backdrop / Escape: dismiss for the session WITHOUT running the deferred
-    // proceed — closing the dialog must not auto-trigger the add/withdraw action.
-    // The user's next add/withdraw click then passes straight through (dismissed).
-    const close = useCallback(() => {
-        setDismissed(true)
-        setVisible(false)
-        pendingProceed.current = null
-    }, [])
 
     return {
         intercept,
@@ -77,8 +59,6 @@ export function useAdvisoryPreempt({ advisory, onCompleteNow, isLoading = false 
             effectiveDate: advisory?.effectiveDate,
             isLoading,
             onCompleteNow: completeNow,
-            onSkip: skip,
-            onClose: close,
         },
     }
 }

--- a/src/hooks/useEeaUpliftFunnel.test.ts
+++ b/src/hooks/useEeaUpliftFunnel.test.ts
@@ -59,4 +59,15 @@ describe('useEeaUpliftFunnel', () => {
         act(() => result.current.trackCompleted())
         expect(capture).toHaveBeenCalledTimes(1)
     })
+
+    test('reset clears a pending start so a later success cannot mis-fire completed', () => {
+        const { result } = renderHook(() => useEeaUpliftFunnel('deposit'))
+        act(() => result.current.trackStarted(advisory))
+        capture.mockClear()
+
+        // user abandoned the flow → reset, then an unrelated KYC success fires
+        act(() => result.current.reset())
+        act(() => result.current.trackCompleted())
+        expect(capture).not.toHaveBeenCalled()
+    })
 })

--- a/src/hooks/useEeaUpliftFunnel.test.ts
+++ b/src/hooks/useEeaUpliftFunnel.test.ts
@@ -1,0 +1,62 @@
+import { act, renderHook } from '@testing-library/react'
+import posthog from 'posthog-js'
+import { useEeaUpliftFunnel } from './useEeaUpliftFunnel'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import type { GateAdvisory } from '@/utils/capability-gate'
+
+jest.mock('posthog-js', () => ({ capture: jest.fn() }))
+const capture = posthog.capture as jest.Mock
+
+const advisory: GateAdvisory = {
+    effectiveDate: '2026-06-29',
+    actionKey: 'sumsub:eea_uplift',
+    requirementKey: 'sof_individual_primary_purpose',
+}
+
+beforeEach(() => capture.mockClear())
+
+describe('useEeaUpliftFunnel', () => {
+    test('trackStarted fires eea_uplift_started with channel + advisory props', () => {
+        const { result } = renderHook(() => useEeaUpliftFunnel('deposit'))
+        act(() => result.current.trackStarted(advisory))
+
+        expect(capture).toHaveBeenCalledTimes(1)
+        expect(capture).toHaveBeenCalledWith(ANALYTICS_EVENTS.EEA_UPLIFT_STARTED, {
+            channel: 'deposit',
+            requirement_key: 'sof_individual_primary_purpose',
+            action_key: 'sumsub:eea_uplift',
+            effective_date: '2026-06-29',
+        })
+    })
+
+    test('trackCompleted fires eea_uplift_completed only after a start', () => {
+        const { result } = renderHook(() => useEeaUpliftFunnel('withdraw'))
+        act(() => result.current.trackStarted(advisory))
+        capture.mockClear()
+
+        act(() => result.current.trackCompleted())
+        expect(capture).toHaveBeenCalledTimes(1)
+        expect(capture).toHaveBeenCalledWith(ANALYTICS_EVENTS.EEA_UPLIFT_COMPLETED, {
+            channel: 'withdraw',
+            requirement_key: 'sof_individual_primary_purpose',
+            action_key: 'sumsub:eea_uplift',
+            effective_date: '2026-06-29',
+        })
+    })
+
+    test('trackCompleted is a no-op when no start was recorded (generic KYC success)', () => {
+        const { result } = renderHook(() => useEeaUpliftFunnel('deposit'))
+        act(() => result.current.trackCompleted())
+        expect(capture).not.toHaveBeenCalled()
+    })
+
+    test('trackCompleted only fires once per start (ref cleared)', () => {
+        const { result } = renderHook(() => useEeaUpliftFunnel('deposit'))
+        act(() => result.current.trackStarted(advisory))
+        capture.mockClear()
+
+        act(() => result.current.trackCompleted())
+        act(() => result.current.trackCompleted())
+        expect(capture).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/hooks/useEeaUpliftFunnel.ts
+++ b/src/hooks/useEeaUpliftFunnel.ts
@@ -24,13 +24,16 @@ export function useEeaUpliftFunnel(channel: UpliftChannel) {
     const startedRef = useRef<GateAdvisory | null>(null)
 
     const trackStarted = useCallback(
-        (advisory: GateAdvisory | undefined) => {
-            startedRef.current = advisory ?? null
+        // `advisory` is required: callers gate on it before launching, and the
+        // funnel contract needs requirement_key / action_key / effective_date
+        // always present on the event.
+        (advisory: GateAdvisory) => {
+            startedRef.current = advisory
             posthog.capture(ANALYTICS_EVENTS.EEA_UPLIFT_STARTED, {
                 channel,
-                requirement_key: advisory?.requirementKey,
-                action_key: advisory?.actionKey,
-                effective_date: advisory?.effectiveDate,
+                requirement_key: advisory.requirementKey,
+                action_key: advisory.actionKey,
+                effective_date: advisory.effectiveDate,
             })
         },
         [channel]

--- a/src/hooks/useEeaUpliftFunnel.ts
+++ b/src/hooks/useEeaUpliftFunnel.ts
@@ -15,6 +15,10 @@ type UpliftChannel = 'deposit' | 'withdraw'
  * `startedRef` guard stops a generic success from mis-firing the completed
  * event. The advisory snapshot is captured at start time because the gate's
  * `advisory` clears once the requirement resolves, so it's gone by completion.
+ *
+ * `reset` clears the pending start on abandonment (KYC modal closed without
+ * success). Without it the latch would survive an abandoned attempt, and a later
+ * unrelated KYC success on the same mounted page could mis-fire `completed`.
  */
 export function useEeaUpliftFunnel(channel: UpliftChannel) {
     const startedRef = useRef<GateAdvisory | null>(null)
@@ -44,5 +48,9 @@ export function useEeaUpliftFunnel(channel: UpliftChannel) {
         })
     }, [channel])
 
-    return { trackStarted, trackCompleted }
+    const reset = useCallback(() => {
+        startedRef.current = null
+    }, [])
+
+    return { trackStarted, trackCompleted, reset }
 }

--- a/src/hooks/useEeaUpliftFunnel.ts
+++ b/src/hooks/useEeaUpliftFunnel.ts
@@ -1,0 +1,48 @@
+import { useCallback, useRef } from 'react'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import type { GateAdvisory } from '@/utils/capability-gate'
+
+type UpliftChannel = 'deposit' | 'withdraw'
+
+/**
+ * Fires the EEA-uplift funnel events for PostHog so the flow can be filtered
+ * directly: `eea_uplift_started` when the user launches the verification, and
+ * `eea_uplift_completed` on KYC success.
+ *
+ * `trackCompleted` only emits if a start was recorded in this session — the KYC
+ * success callback on the bank pages is shared with non-uplift KYC, so the
+ * `startedRef` guard stops a generic success from mis-firing the completed
+ * event. The advisory snapshot is captured at start time because the gate's
+ * `advisory` clears once the requirement resolves, so it's gone by completion.
+ */
+export function useEeaUpliftFunnel(channel: UpliftChannel) {
+    const startedRef = useRef<GateAdvisory | null>(null)
+
+    const trackStarted = useCallback(
+        (advisory: GateAdvisory | undefined) => {
+            startedRef.current = advisory ?? null
+            posthog.capture(ANALYTICS_EVENTS.EEA_UPLIFT_STARTED, {
+                channel,
+                requirement_key: advisory?.requirementKey,
+                action_key: advisory?.actionKey,
+                effective_date: advisory?.effectiveDate,
+            })
+        },
+        [channel]
+    )
+
+    const trackCompleted = useCallback(() => {
+        const advisory = startedRef.current
+        if (!advisory) return
+        startedRef.current = null
+        posthog.capture(ANALYTICS_EVENTS.EEA_UPLIFT_COMPLETED, {
+            channel,
+            requirement_key: advisory.requirementKey,
+            action_key: advisory.actionKey,
+            effective_date: advisory.effectiveDate,
+        })
+    }, [channel])
+
+    return { trackStarted, trackCompleted }
+}

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -75,6 +75,14 @@ export async function confirmBridgeTosAndAwaitRails(fetchUser: () => Promise<IUs
 
 interface UseMultiPhaseKycFlowOptions {
     onKycSuccess?: () => void
+    /**
+     * Fired the moment Sumsub reports approval (the verification was submitted),
+     * BEFORE the post-approval ToS / rail-preparing steps. Use this for
+     * "completed the verification" signals so they aren't lost when the user
+     * drops during those follow-up steps. `onKycSuccess` still fires later, once
+     * the whole flow settles.
+     */
+    onKycApproved?: () => void
     onManualClose?: () => void
     regionIntent?: KYCRegionIntent
 }
@@ -87,7 +95,12 @@ interface UseMultiPhaseKycFlowOptions {
  * use this hook anywhere kyc is initiated. pair with SumsubKycModals
  * for the modal rendering.
  */
-export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: UseMultiPhaseKycFlowOptions) => {
+export const useMultiPhaseKycFlow = ({
+    onKycSuccess,
+    onKycApproved,
+    onManualClose,
+    regionIntent,
+}: UseMultiPhaseKycFlowOptions) => {
     const { fetchUser, user } = useAuth()
     const acquisitionSource = user?.invitedBy ? 'referred' : 'organic'
 
@@ -163,6 +176,11 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
         // the next route mount / window focus. See useSubmissionWindow.
         markSubmitted()
 
+        // Sumsub approved the submission — the verification flow is done from the
+        // user's side. Fire here (not in completeFlow) so a "completed" signal
+        // survives a drop during the post-approval ToS / preparing steps.
+        onKycApproved?.()
+
         // for real-time flow, optimistically show "Identity verified!" while we check rails
         if (isRealtimeFlowRef.current) {
             setModalPhase('preparing')
@@ -192,7 +210,7 @@ export const useMultiPhaseKycFlow = ({ onKycSuccess, onManualClose, regionIntent
 
         // all settled — done
         completeFlow()
-    }, [fetchUser, startTracking, clearPreparingTimer, completeFlow])
+    }, [fetchUser, startTracking, clearPreparingTimer, completeFlow, onKycApproved])
 
     const {
         isLoading,


### PR DESCRIPTION
## Summary
Users were **skipping the EEA-uplift KYC** via the modal's "Not now" / close button and then continuing to transact — so the Bridge endorsement requirement never got completed before a bank transfer. This makes the verification a **hard gate**:

- `AdvisoryPreemptModal` is now **non-closable + non-skippable** (`preventClose` + `hideModalCloseButton`, "Not now" removed). Only **"Complete now"** proceeds.
- `useAdvisoryPreempt` blocks the deferred deposit/withdraw action while a requirement is pending; it passes through only once the gate clears the `advisory`. It also auto-closes if the requirement clears while open, and re-shows if the launch fails.

## Analytics (the second ask)
Two dedicated PostHog events so the funnel can be filtered directly:
- **`eea_uplift_started`** — fired when the user taps "Complete now".
- **`eea_uplift_completed`** — fired at the **Sumsub approval transition** (verification submitted), via a new `onKycApproved` callback on `useMultiPhaseKycFlow` — *not* at end-of-flow, so it isn't lost if the user drops during post-approval ToS/preparing, and isn't mis-fired on a ToS-skip. Ref-guarded + reset on abandon so non-uplift KYC successes don't mis-fire it.
- Both carry `channel` (`deposit`/`withdraw`), `requirement_key`, `action_key`, `effective_date`.

## Risks / scope
- **Front-end enforcement only** — does not change Bridge's underlying requirement.
- **Removes the grace-period skip.** Users with a pending requirement can no longer move money via bank until they complete it (they can still navigate away — not trapped in-app). The uplift flow has non-trivial drop-off, so expect a support-ticket bump; pairing with a "contact support" affordance / drop-off monitoring is advised. Product-approved trade-off.
- Scope is the **advisory hard-gate path** on `add-money/[country]/bank` and `withdraw/[country]/bank`. The post-cliff blocking `InitiateKycModal` path still emits the generic `kyc_*` events; the dedicated events are not wired there.
- `onKycApproved` is additive on the shared `useMultiPhaseKycFlow` (optional, no-op for existing consumers).

## QA
- `useAdvisoryPreempt.test.ts` + `useEeaUpliftFunnel.test.ts` — 13 tests (hard-gate semantics, modal lifecycle, funnel firing/guards/reset).
- Manual (sandbox): with a pending Bridge `eea_uplift` requirement, open add-money/[country]/bank → tap continue → modal appears with no X / no backdrop dismiss / no "Not now"; "Complete now" launches Sumsub; `eea_uplift_started` fires on launch, `eea_uplift_completed` on Sumsub approval. Same on withdraw/[country]/bank.

Local gate: prettier ✅ · typecheck ✅ · unit 13/13 ✅. (eslint is the repo's known-amber baseline — not worsened; new code lints clean.)