### PR TITLE
feat(card): specific reason on the rejected-card screen + crypto reassurance

### DIFF
--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -562,17 +562,14 @@ const CardPage: FC = () => {
                 //
                 // Surface the specific, vetted rejection reason from the
                 // capabilities read-model (`rail.reason.userMessage` — e.g.
-                // "Peanut cards aren't available in your state yet."), falling
-                // back to the screen's generic body when capabilities haven't
-                // resolved. Wait for capabilities so the reason never flashes in.
-                if (capabilitiesLoading) {
-                    return (
-                        <div className="flex min-h-[inherit] w-full items-center justify-center">
-                            <Loading />
-                        </div>
-                    )
-                }
-                const cardRailReason = railsForProvider('rain')[0]?.reason?.userMessage
+                // "Peanut cards aren't available in your state yet."). Render
+                // immediately rather than spinner-gating: unlike requires-info
+                // (meaningless without its reason), the rejected screen is useful
+                // on its own (reassurance + support CTA), so show it now and let
+                // the reason fill in once capabilities resolve.
+                const cardRailReason = capabilitiesLoading
+                    ? undefined
+                    : railsForProvider('rain')[0]?.reason?.userMessage
                 return (
                     <ApplicationStatusScreen
                         variant="rejected"

--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -553,19 +553,35 @@ const CardPage: FC = () => {
                         onPrev={onBack}
                     />
                 )
-            case 'rejected':
+            case 'rejected': {
                 // No retry CTA: Rain denials are terminal on our side. The
                 // only path forward is support reviewing the case manually
                 // (PEP / sanctions / fraud-pattern flags need a human in the
                 // loop on Rain's end). Open Crisp directly — sending the user
                 // to /support's FAQ first adds a step for no upside.
+                //
+                // Surface the specific, vetted rejection reason from the
+                // capabilities read-model (`rail.reason.userMessage` — e.g.
+                // "Peanut cards aren't available in your state yet."), falling
+                // back to the screen's generic body when capabilities haven't
+                // resolved. Wait for capabilities so the reason never flashes in.
+                if (capabilitiesLoading) {
+                    return (
+                        <div className="flex min-h-[inherit] w-full items-center justify-center">
+                            <Loading />
+                        </div>
+                    )
+                }
+                const cardRailReason = railsForProvider('rain')[0]?.reason?.userMessage
                 return (
                     <ApplicationStatusScreen
                         variant="rejected"
+                        reasonMessage={cardRailReason}
                         onContactSupport={() => setIsSupportModalOpen(true)}
                         onPrev={onBack}
                     />
                 )
+            }
             case 'active': {
                 const card = findActiveCard(overview)!
                 return <YourCardScreen overview={overview!} card={card} onPrev={onBack} />

--- a/src/components/Card/ApplicationStatusScreen.tsx
+++ b/src/components/Card/ApplicationStatusScreen.tsx
@@ -35,8 +35,11 @@ const COPY: Record<Variant, { title: string; body: string }> = {
         body: "We hit a snag while processing your card application. Our team needs to take a look — message support and we'll get you sorted.",
     },
     rejected: {
+        // The specific reason (when known) renders above via `reasonMessage`;
+        // this body stays reassuring — a declined card doesn't touch the rest
+        // of the account, so point the user back to what still works.
         title: "We couldn't issue you a card",
-        body: "Your card application wasn't approved. This might be because of duplicate attempt, incomplete documents, information mismatch, or regional restrictions.",
+        body: 'You can still use Peanut freely to deposit, withdraw, and pay with crypto.',
     },
 }
 

--- a/src/components/Card/__tests__/ApplicationStatusScreen.test.tsx
+++ b/src/components/Card/__tests__/ApplicationStatusScreen.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * ApplicationStatusScreen — rejected-card copy contract.
+ *
+ * The rejected variant must (1) surface the specific, vetted reason from the
+ * capability read-model when present (e.g. "…available in your state yet."),
+ * (2) always reassure the user that the rest of Peanut still works, and
+ * (3) keep the Contact-support path. The reason line is optional — older
+ * rejections without a persisted reason fall back to the body alone.
+ */
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import ApplicationStatusScreen from '@/components/Card/ApplicationStatusScreen'
+
+// NavHeader reads useAuth; stub it so the presentational screen renders alone.
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => ({ user: { accounts: [] }, fetchUser: jest.fn() }),
+}))
+// next/image → plain img so jsdom doesn't choke on the optimizer.
+jest.mock('next/image', () => ({
+    __esModule: true,
+    default: (props: Record<string, unknown>) => <img alt={String(props.alt ?? '')} />,
+}))
+
+const REASSURANCE = 'You can still use Peanut freely to deposit, withdraw, and pay with crypto.'
+
+describe('ApplicationStatusScreen — rejected', () => {
+    it('renders the specific reason above the reassurance body', () => {
+        render(
+            <ApplicationStatusScreen
+                variant="rejected"
+                reasonMessage="Peanut cards aren't available in your state yet."
+                onContactSupport={jest.fn()}
+            />
+        )
+        expect(screen.getByText("We couldn't issue you a card")).toBeInTheDocument()
+        expect(screen.getByText("Peanut cards aren't available in your state yet.")).toBeInTheDocument()
+        expect(screen.getByText(REASSURANCE)).toBeInTheDocument()
+    })
+
+    it('falls back to the reassurance body alone when no reason is provided', () => {
+        render(<ApplicationStatusScreen variant="rejected" onContactSupport={jest.fn()} />)
+        expect(screen.getByText(REASSURANCE)).toBeInTheDocument()
+        // No phantom reason paragraph — only the generic body shows.
+        expect(screen.queryByText(/available in your/i)).not.toBeInTheDocument()
+    })
+
+    it('keeps the Contact support action', () => {
+        const onContactSupport = jest.fn()
+        render(<ApplicationStatusScreen variant="rejected" onContactSupport={onContactSupport} />)
+        fireEvent.click(screen.getByText('Contact support'))
+        expect(onContactSupport).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/components/Card/__tests__/ApplicationStatusScreen.test.tsx
+++ b/src/components/Card/__tests__/ApplicationStatusScreen.test.tsx
@@ -34,15 +34,20 @@ describe('ApplicationStatusScreen — rejected', () => {
             />
         )
         expect(screen.getByText("We couldn't issue you a card")).toBeInTheDocument()
-        expect(screen.getByText("Peanut cards aren't available in your state yet.")).toBeInTheDocument()
-        expect(screen.getByText(REASSURANCE)).toBeInTheDocument()
+        const reason = screen.getByText("Peanut cards aren't available in your state yet.")
+        const body = screen.getByText(REASSURANCE)
+        // Contract: the specific reason renders ABOVE the reassurance body.
+        expect(reason.compareDocumentPosition(body) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+        // Both paragraphs live in the same copy block (reason + body).
+        expect(body.parentElement?.querySelectorAll('p')).toHaveLength(2)
     })
 
     it('falls back to the reassurance body alone when no reason is provided', () => {
         render(<ApplicationStatusScreen variant="rejected" onContactSupport={jest.fn()} />)
-        expect(screen.getByText(REASSURANCE)).toBeInTheDocument()
-        // No phantom reason paragraph — only the generic body shows.
-        expect(screen.queryByText(/available in your/i)).not.toBeInTheDocument()
+        const body = screen.getByText(REASSURANCE)
+        expect(body).toBeInTheDocument()
+        // No phantom reason paragraph — the copy block holds only the body <p>.
+        expect(body.parentElement?.querySelectorAll('p')).toHaveLength(1)
     })
 
     it('keeps the Contact support action', () => {

--- a/src/components/Card/__tests__/ApplicationStatusScreen.test.tsx
+++ b/src/components/Card/__tests__/ApplicationStatusScreen.test.tsx
@@ -18,6 +18,7 @@ jest.mock('@/context/authContext', () => ({
 // next/image → plain img so jsdom doesn't choke on the optimizer.
 jest.mock('next/image', () => ({
     __esModule: true,
+    // eslint-disable-next-line @next/next/no-img-element -- test stub, not real markup
     default: (props: Record<string, unknown>) => <img alt={String(props.alt ?? '')} />,
 }))
 


### PR DESCRIPTION
## Why
The "We couldn't issue you a card" screen showed only a generic catch-all body ("…duplicate attempt, incomplete documents, information mismatch, or regional restrictions"). Users couldn't tell what actually happened, and the dead-end framing implied the whole account was blocked.

## What
- **card/page.tsx** (`rejected` case): wait for capabilities, then pass the vetted reason from the capability read-model (`railsForProvider('rain')[0].reason.userMessage`) into the screen — mirrors the existing `requires-info` case. Falls back to the generic body when capabilities haven't resolved.
- **ApplicationStatusScreen**: rejected `body` → reassurance: *"You can still use Peanut freely to deposit, withdraw, and pay with crypto."* A declined card doesn't gate the rest of the account. The specific reason (e.g. *"Peanut cards aren't available in your state yet."*) renders above it via the existing `reasonMessage` slot.

## Tests
New `ApplicationStatusScreen.test.tsx` (3): reason-above-body, reassurance-only fallback, Contact-support still wired. Card + capabilities suites green (114).

## Cross-repo
**Requires** peanut-api-ts **ops/card-rejection-reason** (PR #1086) to populate `reason.userMessage` for Rain rejections. Without it the screen falls back to the generic body — safe to merge in either order, best UX once both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)