### PR TITLE
fix(card): space in physical-waitlist position copy ("#16on" → "#16 on")

### DIFF
--- a/src/components/Card/PhysicalCardScreen.tsx
+++ b/src/components/Card/PhysicalCardScreen.tsx
@@ -76,8 +76,7 @@ const PhysicalCardScreen: FC<Props> = ({ cardId, last4, onPrev }) => {
                     <Image src={PeanutWalking} unoptimized alt="" aria-hidden className="h-32 w-auto" />
                     <h1 className="text-xl font-extrabold">You are on the list!</h1>
                     <p className="text-sm text-grey-1">
-                        You are #{data.position} on the list. We&apos;ll let you know when cards are ready to be
-                        shipped.
+                        {`You are #${data.position} on the list. We'll let you know when cards are ready to be shipped.`}
                     </p>
                 </div>
             ) : (


### PR DESCRIPTION
## Summary
The physical-card waitlist "joined" state renders **"You are #16on the list"** (missing space) in production. Confirmed live on **both** `peanut.me` and `staging.peanut.me` — the shipped bundle is `["You are #", position, "on the list…"]` with no leading space.

The source *looks* correct (`#{data.position} on the list`, space on the same line), and:
- prettier **enforces** that literal space (it reverts an explicit `{' '}` back to a literal space), and
- a clean `@next/swc` compile of the current source **keeps** the space.

So the live no-space output is a **stale build artifact**, not a source bug. This fix sidesteps the whole class of problem by moving the sentence into a **template literal** — the space becomes a literal character inside one JS string, immune to JSX whitespace handling, and the module change guarantees a fresh compile (no stale-artifact reuse). Matches the existing template-literal pattern in `JoinWaitlistPage.tsx`.

## Risk
Minimal. One-line, copy-only change in `PhysicalCardScreen.tsx`; no logic, props, imports, or types touched. `data.position` is interpolated identically; `&apos;` → literal `'` inside the template string renders the same apostrophe.

## QA
Load `/card/physical` as a user already on the physical-card waitlist → the joined state should read **"You are #16 on the list."** (space present). Verifiable on staging once back-merged to `dev`.

## Back-merge
Staging shows the same bug, so after this lands on `main` it should be **back-merged to `dev`**.
