### PR TITLE
fix(card): bind session-key enable approval to the verified live currentNonce

### DIFF
--- a/src/hooks/wallet/__tests__/useGrantSessionKey.test.tsx
+++ b/src/hooks/wallet/__tests__/useGrantSessionKey.test.tsx
@@ -8,11 +8,14 @@
  * an approval frozen to nonce 1 that the kernel rejects with AA23 InvalidNonce
  * for any account whose live nonce ≠ 1 (migrated / sudo-changed accounts). The
  * card then declines forever. The fix reads `currentNonce` explicitly, binds the
- * enable to it, and throws on a read failure instead of producing a bad approval.
+ * enable to it, and throws on a read failure instead of producing a bad approval —
+ * except for counterfactual (never-deployed) accounts, where the read reverting is
+ * expected and 1 is exact (the kernel initializes currentNonce to 1 at deployment).
  *
  * These tests lock down that contract:
- *  1. the enable approval is bound to the live currentNonce (not a fallback), and
- *  2. a failed currentNonce read aborts the grant — no approval is produced.
+ *  1. the enable approval is bound to the live currentNonce (not a fallback),
+ *  2. a failed currentNonce read on a deployed account aborts the grant, and
+ *  3. counterfactual accounts still grant (nonce 1), so fresh wallets aren't blocked.
  */
 import { renderHook, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -51,7 +54,7 @@ jest.mock('@/hooks/useRainCardOverview', () => ({
     useRainCardOverview: jest.fn(),
     RAIN_CARD_OVERVIEW_QUERY_KEY: 'rain-card-overview',
 }))
-jest.mock('@/app/actions/clients', () => ({ peanutPublicClient: { readContract: jest.fn() } }))
+jest.mock('@/app/actions/clients', () => ({ peanutPublicClient: { readContract: jest.fn(), getCode: jest.fn() } }))
 jest.mock('@/services/rain', () => ({ rainApi: { getSessionKeyAddress: jest.fn() } }))
 jest.mock('@zerodev/permissions', () => ({
     toPermissionValidator: jest.fn(),
@@ -63,32 +66,15 @@ jest.mock('@zerodev/permissions/policies', () => ({
     ParamCondition: { EQUAL: 0 },
 }))
 jest.mock('@zerodev/permissions/signers', () => ({ toECDSASigner: jest.fn() }))
-// jest resolves '@zerodev/sdk' and '@zerodev/sdk/constants' to the same module
-// registry entry (subpath collapses onto the package), so the two mocks clobber
-// each other — last wins. Give BOTH the union of needed exports so every symbol
-// (createKernelAccount, getPluginsEnableTypedData, getEntryPoint, KERNEL_V3_1)
-// is present whichever factory wins.
-jest.mock('@zerodev/sdk', () => ({
-    createKernelAccount: jest.fn(),
-    getPluginsEnableTypedData: jest.fn(),
-    getEntryPoint: () => ({ address: '0x0', version: '0.7' }),
-    KERNEL_V3_1: '0.3.1',
-}))
-jest.mock('@zerodev/sdk/constants', () => ({
-    createKernelAccount: jest.fn(),
-    getPluginsEnableTypedData: jest.fn(),
-    getEntryPoint: () => ({ address: '0x0', version: '0.7' }),
-    KERNEL_V3_1: '0.3.1',
-}))
+// '@zerodev/sdk' and '@zerodev/sdk/constants' both resolve to the shared mock at
+// src/utils/__mocks__/zerodev-sdk.ts via package.json's jest moduleNameMapper
+// ('^@zerodev/sdk(.*)$'), so every export the hook needs lives there.
 
+// These named imports resolve through the mapper to the shared mock file, so
+// they are the exact jest.fn instances the hook calls — configure them per test.
+// (jest.requireMock would auto-mock the mapped file into a second instance.)
+import { accountMetadata, createKernelAccount, getPluginsEnableTypedData } from '@zerodev/sdk'
 import { useGrantSessionKey } from '../useGrantSessionKey'
-
-// `@zerodev/sdk`'s named imports don't bind to the mock cleanly at the test's
-// top level (module-interop quirk); pull the mocked fns from jest's registry.
-const { createKernelAccount, getPluginsEnableTypedData } = jest.requireMock('@zerodev/sdk') as {
-    createKernelAccount: jest.Mock
-    getPluginsEnableTypedData: jest.Mock
-}
 
 const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
@@ -119,7 +105,10 @@ beforeEach(() => {
         kernelPluginManager: { getAction: () => ({ selector: '0xe9ae5c53', address: ACCOUNT }), hook: undefined },
     })
     ;(getPluginsEnableTypedData as jest.Mock).mockResolvedValue({ primaryType: 'Enable', message: {} })
+    ;(accountMetadata as jest.Mock).mockResolvedValue({ name: 'Kernel', version: '0.3.1', chainId: 42161n })
     ;(serializePermissionAccount as jest.Mock).mockResolvedValue('SERIALIZED_APPROVAL')
+    // deployed account by default; individual tests override for counterfactual
+    ;(peanutPublicClient.getCode as jest.Mock).mockResolvedValue('0xdeadbeef')
 })
 
 describe('useGrantSessionKey — enable approval binds to the live currentNonce', () => {
@@ -136,15 +125,18 @@ describe('useGrantSessionKey — enable approval binds to the live currentNonce'
         expect(peanutPublicClient.readContract).toHaveBeenCalledWith(
             expect.objectContaining({ address: ACCOUNT, functionName: 'currentNonce' })
         )
-        // …the enable typed data was built for THAT nonce (2), not a fallback (1)…
-        expect(getPluginsEnableTypedData).toHaveBeenCalledWith(expect.objectContaining({ validatorNonce: 2 }))
+        // …the enable typed data was built for THAT nonce (2), not a fallback (1),
+        // over the account's live EIP-712 domain version…
+        expect(getPluginsEnableTypedData).toHaveBeenCalledWith(
+            expect.objectContaining({ validatorNonce: 2, kernelVersion: '0.3.1' })
+        )
         // …signed by the sudo (passkey) validator, and injected into serialize.
         expect(signTypedData).toHaveBeenCalledWith({ primaryType: 'Enable', message: {} })
         expect(serializePermissionAccount).toHaveBeenCalledWith(expect.anything(), undefined, '0xENABLESIG')
         expect(out!).toEqual({ ok: true, serialized: 'SERIALIZED_APPROVAL' })
     })
 
-    it('aborts the grant when currentNonce cannot be read — no approval is produced', async () => {
+    it('aborts the grant when currentNonce cannot be read on a DEPLOYED account — no approval is produced', async () => {
         ;(peanutPublicClient.readContract as jest.Mock).mockRejectedValue(new Error('RPC read failed'))
 
         const { result } = renderHook(() => useGrantSessionKey(), { wrapper })
@@ -157,5 +149,33 @@ describe('useGrantSessionKey — enable approval binds to the live currentNonce'
         expect(getPluginsEnableTypedData).not.toHaveBeenCalled()
         expect(serializePermissionAccount).not.toHaveBeenCalled()
         expect(out!.ok).toBe(false)
+    })
+
+    it('grants with nonce 1 for a counterfactual (never-deployed) account — the read reverting is expected there', async () => {
+        // No code at the address: the currentNonce read reverts, but 1 is exact
+        // (the kernel initializes currentNonce to 1 at deployment), so the grant
+        // must succeed rather than block card issuance for fresh wallets.
+        ;(peanutPublicClient.getCode as jest.Mock).mockResolvedValue(undefined)
+        ;(peanutPublicClient.readContract as jest.Mock).mockRejectedValue(new Error('returned no data ("0x")'))
+
+        const { result } = renderHook(() => useGrantSessionKey(), { wrapper })
+        let out: Awaited<ReturnType<typeof result.current.serializeGrant>>
+        await act(async () => {
+            out = await result.current.serializeGrant()
+        })
+
+        expect(getPluginsEnableTypedData).toHaveBeenCalledWith(expect.objectContaining({ validatorNonce: 1 }))
+        expect(out!).toEqual({ ok: true, serialized: 'SERIALIZED_APPROVAL' })
+    })
+
+    it('normalizes a deployed-but-uninitialized nonce of 0 to 1, the way the SDK does', async () => {
+        ;(peanutPublicClient.readContract as jest.Mock).mockResolvedValue(0n)
+
+        const { result } = renderHook(() => useGrantSessionKey(), { wrapper })
+        await act(async () => {
+            await result.current.serializeGrant()
+        })
+
+        expect(getPluginsEnableTypedData).toHaveBeenCalledWith(expect.objectContaining({ validatorNonce: 1 }))
     })
 })

--- a/src/hooks/wallet/__tests__/useGrantSessionKey.test.tsx
+++ b/src/hooks/wallet/__tests__/useGrantSessionKey.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Regression guard for the card session-key grant binding its enable approval
+ * to the WRONG kernel nonce.
+ *
+ * The session-key permission installs on-chain via an "enable" approval the
+ * passkey signs at grant time, bound to the account's `currentNonce`. The SDK's
+ * internal `getKernelV3Nonce` silently returns `1` on a read failure — minting
+ * an approval frozen to nonce 1 that the kernel rejects with AA23 InvalidNonce
+ * for any account whose live nonce ≠ 1 (migrated / sudo-changed accounts). The
+ * card then declines forever. The fix reads `currentNonce` explicitly, binds the
+ * enable to it, and throws on a read failure instead of producing a bad approval.
+ *
+ * These tests lock down that contract:
+ *  1. the enable approval is bound to the live currentNonce (not a fallback), and
+ *  2. a failed currentNonce read aborts the grant — no approval is produced.
+ */
+import { renderHook, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { serializePermissionAccount, toPermissionValidator } from '@zerodev/permissions'
+import { toCallPolicy } from '@zerodev/permissions/policies'
+import { toECDSASigner } from '@zerodev/permissions/signers'
+import { peanutPublicClient } from '@/app/actions/clients'
+import { useKernelClient } from '@/context/kernelClient.context'
+import { useRainCardOverview } from '@/hooks/useRainCardOverview'
+import { rainApi } from '@/services/rain'
+
+const COLLATERAL = '0x4e5b89fd498f333ed7f2a59c5f23d5b5dc41b3de'
+const COORDINATOR = '0xc0d5bd6307ec8c8da03e7502a00b8cba24eefc06'
+const ACCOUNT = '0xc97fffbf8768ca90cd62fae2e313b084fe13e553'
+
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
+jest.mock('@/constants/analytics.consts', () => ({
+    ANALYTICS_EVENTS: {
+        CARD_SESSION_KEY_PROMPTED: 'card_session_key_prompted',
+        CARD_SESSION_KEY_GRANTED: 'card_session_key_granted',
+        CARD_SESSION_KEY_FAILED: 'card_session_key_failed',
+    },
+}))
+jest.mock('@/constants/zerodev.consts', () => ({
+    PEANUT_WALLET_CHAIN: { id: 42161 },
+    PEANUT_WALLET_TOKEN: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+}))
+jest.mock('@/constants/rain.consts', () => ({
+    rainCoordinatorAbi: [
+        { type: 'function', name: 'withdrawAsset', inputs: [], outputs: [], stateMutability: 'nonpayable' },
+    ],
+}))
+jest.mock('@/context/kernelClient.context', () => ({ useKernelClient: jest.fn() }))
+jest.mock('@/hooks/useRainCardOverview', () => ({
+    useRainCardOverview: jest.fn(),
+    RAIN_CARD_OVERVIEW_QUERY_KEY: 'rain-card-overview',
+}))
+jest.mock('@/app/actions/clients', () => ({ peanutPublicClient: { readContract: jest.fn() } }))
+jest.mock('@/services/rain', () => ({ rainApi: { getSessionKeyAddress: jest.fn() } }))
+jest.mock('@zerodev/permissions', () => ({
+    toPermissionValidator: jest.fn(),
+    serializePermissionAccount: jest.fn(),
+}))
+jest.mock('@zerodev/permissions/policies', () => ({
+    toCallPolicy: jest.fn(),
+    CallPolicyVersion: { V0_0_4: '0.0.4' },
+    ParamCondition: { EQUAL: 0 },
+}))
+jest.mock('@zerodev/permissions/signers', () => ({ toECDSASigner: jest.fn() }))
+// jest resolves '@zerodev/sdk' and '@zerodev/sdk/constants' to the same module
+// registry entry (subpath collapses onto the package), so the two mocks clobber
+// each other — last wins. Give BOTH the union of needed exports so every symbol
+// (createKernelAccount, getPluginsEnableTypedData, getEntryPoint, KERNEL_V3_1)
+// is present whichever factory wins.
+jest.mock('@zerodev/sdk', () => ({
+    createKernelAccount: jest.fn(),
+    getPluginsEnableTypedData: jest.fn(),
+    getEntryPoint: () => ({ address: '0x0', version: '0.7' }),
+    KERNEL_V3_1: '0.3.1',
+}))
+jest.mock('@zerodev/sdk/constants', () => ({
+    createKernelAccount: jest.fn(),
+    getPluginsEnableTypedData: jest.fn(),
+    getEntryPoint: () => ({ address: '0x0', version: '0.7' }),
+    KERNEL_V3_1: '0.3.1',
+}))
+
+import { useGrantSessionKey } from '../useGrantSessionKey'
+
+// `@zerodev/sdk`'s named imports don't bind to the mock cleanly at the test's
+// top level (module-interop quirk); pull the mocked fns from jest's registry.
+const { createKernelAccount, getPluginsEnableTypedData } = jest.requireMock('@zerodev/sdk') as {
+    createKernelAccount: jest.Mock
+    getPluginsEnableTypedData: jest.Mock
+}
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+)
+
+let signTypedData: jest.Mock
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    signTypedData = jest.fn().mockResolvedValue('0xENABLESIG')
+    ;(useKernelClient as jest.Mock).mockReturnValue({
+        getClientForChain: () => ({
+            account: { address: ACCOUNT, kernelPluginManager: { sudoValidator: { signTypedData } } },
+        }),
+    })
+    ;(useRainCardOverview as jest.Mock).mockReturnValue({
+        overview: { status: { contractAddress: COLLATERAL, coordinatorAddress: COORDINATOR }, cards: [{}] },
+        refetch: jest.fn(),
+    })
+    ;(rainApi.getSessionKeyAddress as jest.Mock).mockResolvedValue({
+        address: '0x4300F803a281e257F3C1de001512e68972f8d022',
+    })
+    ;(toCallPolicy as jest.Mock).mockResolvedValue({ __policy: true })
+    ;(toECDSASigner as jest.Mock).mockResolvedValue({ __signer: true })
+    ;(toPermissionValidator as jest.Mock).mockResolvedValue({ __permission: true })
+    ;(createKernelAccount as jest.Mock).mockResolvedValue({
+        address: ACCOUNT,
+        kernelPluginManager: { getAction: () => ({ selector: '0xe9ae5c53', address: ACCOUNT }), hook: undefined },
+    })
+    ;(getPluginsEnableTypedData as jest.Mock).mockResolvedValue({ primaryType: 'Enable', message: {} })
+    ;(serializePermissionAccount as jest.Mock).mockResolvedValue('SERIALIZED_APPROVAL')
+})
+
+describe('useGrantSessionKey — enable approval binds to the live currentNonce', () => {
+    it('reads currentNonce and binds the enable approval to it, injecting the signature', async () => {
+        ;(peanutPublicClient.readContract as jest.Mock).mockResolvedValue(2n) // migrated account, nonce advanced past 1
+
+        const { result } = renderHook(() => useGrantSessionKey(), { wrapper })
+        let out: Awaited<ReturnType<typeof result.current.serializeGrant>>
+        await act(async () => {
+            out = await result.current.serializeGrant()
+        })
+
+        // currentNonce was read on the account…
+        expect(peanutPublicClient.readContract).toHaveBeenCalledWith(
+            expect.objectContaining({ address: ACCOUNT, functionName: 'currentNonce' })
+        )
+        // …the enable typed data was built for THAT nonce (2), not a fallback (1)…
+        expect(getPluginsEnableTypedData).toHaveBeenCalledWith(expect.objectContaining({ validatorNonce: 2 }))
+        // …signed by the sudo (passkey) validator, and injected into serialize.
+        expect(signTypedData).toHaveBeenCalledWith({ primaryType: 'Enable', message: {} })
+        expect(serializePermissionAccount).toHaveBeenCalledWith(expect.anything(), undefined, '0xENABLESIG')
+        expect(out!).toEqual({ ok: true, serialized: 'SERIALIZED_APPROVAL' })
+    })
+
+    it('aborts the grant when currentNonce cannot be read — no approval is produced', async () => {
+        ;(peanutPublicClient.readContract as jest.Mock).mockRejectedValue(new Error('RPC read failed'))
+
+        const { result } = renderHook(() => useGrantSessionKey(), { wrapper })
+        let out: Awaited<ReturnType<typeof result.current.serializeGrant>>
+        await act(async () => {
+            out = await result.current.serializeGrant()
+        })
+
+        // The old silent fallback would have minted a nonce-1 approval here.
+        expect(getPluginsEnableTypedData).not.toHaveBeenCalled()
+        expect(serializePermissionAccount).not.toHaveBeenCalled()
+        expect(out!.ok).toBe(false)
+    })
+})

--- a/src/hooks/wallet/useGrantSessionKey.ts
+++ b/src/hooks/wallet/useGrantSessionKey.ts
@@ -23,6 +23,22 @@ import { serializePermissionAccount } from '@zerodev/permissions'
 const CURRENT_NONCE_ABI = [
     { type: 'function', name: 'currentNonce', stateMutability: 'view', inputs: [], outputs: [{ type: 'uint32' }] },
 ] as const
+
+/** Minimal structural view of the bits of the kernel account's plugin manager
+ *  this flow touches. The SDK doesn't surface these on its public account type,
+ *  so we model just what we use rather than reaching through `any`. `sudoValidator`
+ *  is typed from `createKernelAccount`'s own `plugins.sudo` so it stays assignable
+ *  back into that call. */
+type SudoValidator = NonNullable<
+    Extract<NonNullable<Parameters<typeof createKernelAccount>[1]['plugins']>, { sudo?: unknown }>['sudo']
+>
+type KernelAccountInternals = {
+    kernelPluginManager: {
+        sudoValidator: SudoValidator
+        getAction: () => unknown
+        hook: unknown
+    }
+}
 import { peanutPublicClient } from '@/app/actions/clients'
 import { rainApi } from '@/services/rain'
 
@@ -166,7 +182,8 @@ export const useGrantSessionKey = (): GrantSessionKeyResult => {
         // natural counterfactual of `createKernelAccount({sudo: newValidator})`
         // is a different, never-funded address. Forcing the address here makes
         // the grant work for both legacy and post-migration users.
-        const sudoValidator = (kernelClient.account as any).kernelPluginManager.sudoValidator
+        const sudoValidator = (kernelClient.account as unknown as KernelAccountInternals).kernelPluginManager
+            .sudoValidator
         const sessionKernelAccount = await createKernelAccount(peanutPublicClient, {
             address: kernelClient.account!.address,
             entryPoint: getEntryPoint('0.7'),
@@ -194,7 +211,7 @@ export const useGrantSessionKey = (): GrantSessionKeyResult => {
                 functionName: 'currentNonce',
             })
         )
-        const pm = (sessionKernelAccount as any).kernelPluginManager
+        const pm = (sessionKernelAccount as unknown as KernelAccountInternals).kernelPluginManager
         const enableTypedData = await getPluginsEnableTypedData({
             accountAddress: sessionKernelAccount.address,
             chainId: PEANUT_WALLET_CHAIN.id,
@@ -203,10 +220,10 @@ export const useGrantSessionKey = (): GrantSessionKeyResult => {
             hook: pm.hook,
             validator: permissionPlugin,
             validatorNonce,
-        } as any)
+        } as Parameters<typeof getPluginsEnableTypedData>[0])
         // Same sudo validator + signing path the SDK uses internally, so for
         // healthy nonce=1 accounts this yields an identical approval.
-        const enableSignature = (await sudoValidator.signTypedData(enableTypedData)) as Hex
+        const enableSignature = await sudoValidator.signTypedData(enableTypedData)
 
         const serialized = await serializePermissionAccount(sessionKernelAccount, undefined, enableSignature)
         return { ok: true, serialized }

--- a/src/hooks/wallet/useGrantSessionKey.ts
+++ b/src/hooks/wallet/useGrantSessionKey.ts
@@ -13,34 +13,29 @@ import { rainCoordinatorAbi } from '@/constants/rain.consts'
 import { toPermissionValidator } from '@zerodev/permissions'
 import { toCallPolicy, CallPolicyVersion, ParamCondition } from '@zerodev/permissions/policies'
 import { toECDSASigner } from '@zerodev/permissions/signers'
-import { createKernelAccount, getPluginsEnableTypedData } from '@zerodev/sdk'
+import { accountMetadata, createKernelAccount, getPluginsEnableTypedData, KernelV3AccountAbi } from '@zerodev/sdk'
 import { getEntryPoint, KERNEL_V3_1 } from '@zerodev/sdk/constants'
 import { serializePermissionAccount } from '@zerodev/permissions'
-
-/** Kernel v3 validator-enable epoch. The permission's enable approval is signed
- *  over this value; the kernel rejects the enable with `InvalidNonce` if the
- *  signed value ≠ the account's live `currentNonce`. */
-const CURRENT_NONCE_ABI = [
-    { type: 'function', name: 'currentNonce', stateMutability: 'view', inputs: [], outputs: [{ type: 'uint32' }] },
-] as const
+import { peanutPublicClient } from '@/app/actions/clients'
+import { rainApi } from '@/services/rain'
 
 /** Minimal structural view of the bits of the kernel account's plugin manager
  *  this flow touches. The SDK doesn't surface these on its public account type,
  *  so we model just what we use rather than reaching through `any`. `sudoValidator`
  *  is typed from `createKernelAccount`'s own `plugins.sudo` so it stays assignable
- *  back into that call. */
+ *  back into that call; `getAction`/`hook` from `getPluginsEnableTypedData`'s own
+ *  parameter so the enable-typed-data call stays fully checked. */
+type EnableTypedDataParams = Parameters<typeof getPluginsEnableTypedData>[0]
 type SudoValidator = NonNullable<
     Extract<NonNullable<Parameters<typeof createKernelAccount>[1]['plugins']>, { sudo?: unknown }>['sudo']
 >
 type KernelAccountInternals = {
     kernelPluginManager: {
         sudoValidator: SudoValidator
-        getAction: () => unknown
-        hook: unknown
+        getAction: () => EnableTypedDataParams['action']
+        hook: EnableTypedDataParams['hook']
     }
 }
-import { peanutPublicClient } from '@/app/actions/clients'
-import { rainApi } from '@/services/rain'
 
 /**
  * One-time session-key grant for Rain card operations.
@@ -184,43 +179,65 @@ export const useGrantSessionKey = (): GrantSessionKeyResult => {
         // the grant work for both legacy and post-migration users.
         const sudoValidator = (kernelClient.account as unknown as KernelAccountInternals).kernelPluginManager
             .sudoValidator
-        const sessionKernelAccount = await createKernelAccount(peanutPublicClient, {
-            address: kernelClient.account!.address,
-            entryPoint: getEntryPoint('0.7'),
-            kernelVersion: KERNEL_V3_1,
-            plugins: {
-                sudo: sudoValidator,
-                regular: permissionPlugin,
-            },
-        })
+        const accountAddress = kernelClient.account!.address
+        // The three on-chain reads only need the (already-known) account address,
+        // so they run alongside the account construction.
+        const [sessionKernelAccount, bytecode, metadata, nonceRead] = await Promise.all([
+            createKernelAccount(peanutPublicClient, {
+                address: accountAddress,
+                entryPoint: getEntryPoint('0.7'),
+                kernelVersion: KERNEL_V3_1,
+                plugins: {
+                    sudo: sudoValidator,
+                    regular: permissionPlugin,
+                },
+            }),
+            peanutPublicClient.getCode({ address: accountAddress }),
+            // Live on-chain EIP-712 domain version, KERNEL_V3_1 fallback when the
+            // account can't report one — the same resolution the SDK's internal
+            // enable path uses (a hardcoded version signs the wrong domain for any
+            // kernel not exactly on that version).
+            accountMetadata(peanutPublicClient, accountAddress, KERNEL_V3_1, PEANUT_WALLET_CHAIN.id),
+            peanutPublicClient
+                .readContract({ address: accountAddress, abi: KernelV3AccountAbi, functionName: 'currentNonce' })
+                .then(
+                    (nonce) => ({ read: true as const, nonce: Number(nonce) }),
+                    (error: unknown) => ({ read: false as const, error })
+                ),
+        ])
 
-        // The session-key permission installs on-chain via an "enable" approval
-        // the passkey signs here, bound to the account's `currentNonce`. We read
-        // that nonce EXPLICITLY and let the read throw on failure: the SDK's
-        // internal `getKernelV3Nonce` silently falls back to `1` on a read error,
-        // which produces an approval frozen to nonce 1. That only mismatches
-        // accounts whose live nonce ≠ 1 (e.g. any account migrated / with a
-        // sudo-validator change), and the grant still "succeeds" — so the card
-        // then declines forever because the enable reverts `AA23 InvalidNonce`
-        // on every auto-balance. Binding the enable to the verified live nonce
-        // (and failing loudly if we can't read it) is the fix.
-        const validatorNonce = Number(
-            await peanutPublicClient.readContract({
-                address: sessionKernelAccount.address,
-                abi: CURRENT_NONCE_ABI,
-                functionName: 'currentNonce',
-            })
-        )
+        // The session-key permission installs on-chain via an "enable" approval the
+        // passkey signs here, bound to the account's `currentNonce` — the kernel
+        // rejects the enable with `AA23 InvalidNonce` if the signed value ≠ its live
+        // value, and the grant still "succeeds", so the card then declines forever.
+        // The SDK's internal `getKernelV3Nonce` silently falls back to `1` on ANY
+        // read failure, which mints exactly that broken approval for accounts whose
+        // live nonce ≠ 1 (e.g. migrated / sudo-changed accounts). Bind to the
+        // verified live nonce instead, and only fall back where 1 is provably
+        // correct: a counterfactual account, whose kernel initializes
+        // `currentNonce` to 1 at deployment (the read itself reverts pre-deploy).
+        let validatorNonce: number
+        if (!bytecode) {
+            validatorNonce = 1
+        } else if (!nonceRead.read) {
+            // Deployed but unreadable: fail LOUDLY rather than sign a guess.
+            throw nonceRead.error
+        } else {
+            // A deployed-but-uninitialized proxy reports 0; enables validate
+            // against ≥1 post-init, so normalize the way the SDK does.
+            validatorNonce = nonceRead.nonce === 0 ? 1 : nonceRead.nonce
+        }
+
         const pm = (sessionKernelAccount as unknown as KernelAccountInternals).kernelPluginManager
         const enableTypedData = await getPluginsEnableTypedData({
             accountAddress: sessionKernelAccount.address,
             chainId: PEANUT_WALLET_CHAIN.id,
-            kernelVersion: KERNEL_V3_1,
+            kernelVersion: metadata.version,
             action: pm.getAction(),
             hook: pm.hook,
             validator: permissionPlugin,
             validatorNonce,
-        } as Parameters<typeof getPluginsEnableTypedData>[0])
+        })
         // Same sudo validator + signing path the SDK uses internally, so for
         // healthy nonce=1 accounts this yields an identical approval.
         const enableSignature = await sudoValidator.signTypedData(enableTypedData)

--- a/src/hooks/wallet/useGrantSessionKey.ts
+++ b/src/hooks/wallet/useGrantSessionKey.ts
@@ -13,9 +13,16 @@ import { rainCoordinatorAbi } from '@/constants/rain.consts'
 import { toPermissionValidator } from '@zerodev/permissions'
 import { toCallPolicy, CallPolicyVersion, ParamCondition } from '@zerodev/permissions/policies'
 import { toECDSASigner } from '@zerodev/permissions/signers'
-import { createKernelAccount } from '@zerodev/sdk'
+import { createKernelAccount, getPluginsEnableTypedData } from '@zerodev/sdk'
 import { getEntryPoint, KERNEL_V3_1 } from '@zerodev/sdk/constants'
 import { serializePermissionAccount } from '@zerodev/permissions'
+
+/** Kernel v3 validator-enable epoch. The permission's enable approval is signed
+ *  over this value; the kernel rejects the enable with `InvalidNonce` if the
+ *  signed value ≠ the account's live `currentNonce`. */
+const CURRENT_NONCE_ABI = [
+    { type: 'function', name: 'currentNonce', stateMutability: 'view', inputs: [], outputs: [{ type: 'uint32' }] },
+] as const
 import { peanutPublicClient } from '@/app/actions/clients'
 import { rainApi } from '@/services/rain'
 
@@ -159,17 +166,49 @@ export const useGrantSessionKey = (): GrantSessionKeyResult => {
         // natural counterfactual of `createKernelAccount({sudo: newValidator})`
         // is a different, never-funded address. Forcing the address here makes
         // the grant work for both legacy and post-migration users.
+        const sudoValidator = (kernelClient.account as any).kernelPluginManager.sudoValidator
         const sessionKernelAccount = await createKernelAccount(peanutPublicClient, {
             address: kernelClient.account!.address,
             entryPoint: getEntryPoint('0.7'),
             kernelVersion: KERNEL_V3_1,
             plugins: {
-                sudo: (kernelClient.account as any).kernelPluginManager.sudoValidator,
+                sudo: sudoValidator,
                 regular: permissionPlugin,
             },
         })
 
-        const serialized = await serializePermissionAccount(sessionKernelAccount)
+        // The session-key permission installs on-chain via an "enable" approval
+        // the passkey signs here, bound to the account's `currentNonce`. We read
+        // that nonce EXPLICITLY and let the read throw on failure: the SDK's
+        // internal `getKernelV3Nonce` silently falls back to `1` on a read error,
+        // which produces an approval frozen to nonce 1. That only mismatches
+        // accounts whose live nonce ≠ 1 (e.g. any account migrated / with a
+        // sudo-validator change), and the grant still "succeeds" — so the card
+        // then declines forever because the enable reverts `AA23 InvalidNonce`
+        // on every auto-balance. Binding the enable to the verified live nonce
+        // (and failing loudly if we can't read it) is the fix.
+        const validatorNonce = Number(
+            await peanutPublicClient.readContract({
+                address: sessionKernelAccount.address,
+                abi: CURRENT_NONCE_ABI,
+                functionName: 'currentNonce',
+            })
+        )
+        const pm = (sessionKernelAccount as any).kernelPluginManager
+        const enableTypedData = await getPluginsEnableTypedData({
+            accountAddress: sessionKernelAccount.address,
+            chainId: PEANUT_WALLET_CHAIN.id,
+            kernelVersion: KERNEL_V3_1,
+            action: pm.getAction(),
+            hook: pm.hook,
+            validator: permissionPlugin,
+            validatorNonce,
+        } as any)
+        // Same sudo validator + signing path the SDK uses internally, so for
+        // healthy nonce=1 accounts this yields an identical approval.
+        const enableSignature = (await sudoValidator.signTypedData(enableTypedData)) as Hex
+
+        const serialized = await serializePermissionAccount(sessionKernelAccount, undefined, enableSignature)
         return { ok: true, serialized }
     }, [overview, getClientForChain])
 

--- a/src/utils/__mocks__/zerodev-sdk.ts
+++ b/src/utils/__mocks__/zerodev-sdk.ts
@@ -60,6 +60,14 @@ export const getEntryPoint = jest.fn((version: string) => ({
     version: version as '0.6' | '0.7',
 }))
 
+export const getPluginsEnableTypedData = jest.fn()
+
+export const accountMetadata = jest.fn(() =>
+    Promise.resolve({ name: 'Kernel', version: '0.3.1', chainId: BigInt(42161) })
+)
+
+export const KernelV3AccountAbi = []
+
 export const constants = {
     KERNEL_V3_1: '0x0DA6a956B9488eD4dd761E59f52FDc6c8068E6B5',
     getEntryPoint,


### PR DESCRIPTION
## Summary
A Rain card can silently fail forever: the card always declines, the auto-balance never funds collateral, yet the user looks set up. Root cause is in the session-key **grant**, not the rebalancer.

The session-key permission installs on-chain via an **enable** approval the passkey signs at grant time, bound to the account's Kernel `currentNonce`. `serializePermissionAccount` reads that nonce via the SDK's `getKernelV3Nonce`, which **silently returns `1` on any read failure**. A flaky read at grant time therefore mints an approval **frozen to nonce 1**. That mismatches only accounts whose live `currentNonce ≠ 1` (migrated / sudo-validator-changed accounts): their permission never installs, and every server-side auto-balance userOp reverts `AA23 InvalidNonce`. The grant still "succeeds", so it's invisible. **Now N=3 in prod and growing** (users `ead23114`, `1e432995`, `71d2d847` — all `currentNonce=2` on-chain, all `AA23 reverted 0x756688fe`, re-failed by the hourly rebalance sweep; two of the three granted after this PR was drafted).

**Fix:** read `currentNonce` explicitly, build the enable typed data bound to that verified nonce, sign with the same sudo validator, and inject it into `serializePermissionAccount`. Fail-loud is scoped to where a wrong guess is possible:

- **Deployed account, read fails → abort the grant loudly.** Never sign a guess — that's the bug.
- **Counterfactual (never-deployed) account → nonce 1 without reading.** The read reverts there and the kernel initializes `currentNonce` to 1 at deployment, so 1 is exact — fresh wallets aren't blocked.
- **Deployed-but-uninitialized `0` → normalize to 1**, mirroring the SDK.
- **EIP-712 domain version** comes from the SDK's own `accountMetadata` (live on-chain `eip712Domain()`, `KERNEL_V3_1` fallback) instead of a hardcoded constant — same resolution the SDK's internal enable path uses. (Spot-checked: affected prod accounts report `0.3.1`, so this is hardening, not a live bug.)

## Risk
Low / cohort-safe. The exported `getPluginsEnableTypedData` honors the explicit `validatorNonce` and uses the same action/hook/validator + sudo-signing path, so `nonce=1` accounts get a **byte-identical** approval. Behavior changes: (1) a failed `currentNonce` read on a deployed account now **aborts the grant loudly** instead of silently producing a broken approval — a transient RPC blip during grant fails the tap and the user retries (intentional trade); (2) the three on-chain reads run in parallel with account construction, slightly faster to the passkey prompt.

## QA
- `useGrantSessionKey.test.tsx` (4 tests): (1) grant binds the enable approval to the live `currentNonce` + live domain version (asserts `validatorNonce`/`kernelVersion` + injected signature), (2) a failed read on a deployed account aborts — no approval produced, (3) counterfactual accounts still grant with nonce 1, (4) nonce `0` normalizes to 1.
- Typecheck + prettier clean; full unit suite green (1630).
- **Pre-merge:** verify in Nutcracker sandbox with a `currentNonce>1` account that the grant→enable→install→auto-balance path now completes.

## Fixes the stuck users
Deploy → each affected user re-grants once → enable binds to their live nonce (2) → permission installs → existing balance auto-balances → card works. (Their stored approvals stay stale until re-grant — ops follow-up: `ops/scripts/rain/repair-stale-card-approval.ts`.)

## Note
Replaces/retires peanut-api-ts #1065 (built on an earlier wrong mechanism — would loop on this InvalidNonce case).
