### PR TITLE
fix(shhhhh): inflate waitlist position to match the in-app door tally

### DIFF
--- a/src/app/shhhhh/ShhhhhLandingPage.tsx
+++ b/src/app/shhhhh/ShhhhhLandingPage.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/0_Bruddle/Button'
 import { Marquee } from '@/components/LandingPage'
 import { useAuth } from '@/context/authContext'
 import { PixelatedCardFace } from '@/components/Card/share-asset/PixelatedCardFace'
+import { inflateWaitlistPosition } from '@/components/Card/doorTally.utils'
 import { Sparkle, Star } from '@/assets/illustrations'
 import { cardApi } from '@/services/card'
 import { invitesApi } from '@/services/invites'
@@ -42,7 +43,8 @@ function WaitlistJoined({
                     dark ? 'bg-secondary-1 text-n-1' : 'bg-white text-n-1'
                 }`}
             >
-                ✓ You&apos;re on the waitlist{typeof position === 'number' ? ` · #${position}` : ''}
+                ✓ You&apos;re on the waitlist
+                {typeof position === 'number' ? ` · #${inflateWaitlistPosition(position)}` : ''}
             </button>
             <p className={`font-roboto-flex text-sm font-bold ${dark ? 'text-white/90' : ''}`}>
                 We&apos;ll holler when your turn comes up.

--- a/src/components/Card/__tests__/doorTally.utils.test.ts
+++ b/src/components/Card/__tests__/doorTally.utils.test.ts
@@ -1,6 +1,7 @@
 import {
     inflateApplicants,
     computeDoorTally,
+    inflateWaitlistPosition,
     DOOR_TALLY_APPLICANTS_FLOOR,
     DOOR_TALLY_ADMITTED_FALLBACK,
     DOOR_TALLY_FOMO_MULTIPLIER,
@@ -53,5 +54,24 @@ describe('computeDoorTally', () => {
 
     test('admitted=0 is real and shown as 0 (not the fallback)', () => {
         expect(computeDoorTally(1000, 0).admitted).toBe(0)
+    })
+})
+
+describe('inflateWaitlistPosition', () => {
+    test('scales the real position by the same FOMO factor as the tally', () => {
+        // #56 on /shhhhh → #280, consistent with the in-app "{tried} tried".
+        expect(inflateWaitlistPosition(56)).toBe(56 * DOOR_TALLY_FOMO_MULTIPLIER)
+    })
+
+    test('no floor — a low (good) position scales straight, not clamped to 213', () => {
+        expect(inflateWaitlistPosition(3)).toBe(15)
+    })
+
+    test('returns a whole number', () => {
+        expect(Number.isInteger(inflateWaitlistPosition(7))).toBe(true)
+    })
+
+    test.each([0, -5, NaN, Infinity])('returns non-positive / invalid input unchanged (%p)', (input) => {
+        expect(inflateWaitlistPosition(input as number)).toBe(input)
     })
 })

--- a/src/components/Card/doorTally.utils.ts
+++ b/src/components/Card/doorTally.utils.ts
@@ -58,3 +58,18 @@ export function computeDoorTally(waitlistTotal?: number, admittedTotal?: number)
             : DOOR_TALLY_ADMITTED_FALLBACK
     return { applicants: inflateApplicants(waitlistTotal), admitted }
 }
+
+/**
+ * Inflate a user's REAL waitlist position onto the same FOMO scale as the door
+ * tally's "tried" count (×DOOR_TALLY_FOMO_MULTIPLIER), so /shhhhh's "you're #N"
+ * matches the in-app "{tried} tried · {got in} got in" instead of leaking the
+ * real (small) queue size — the two surfaces otherwise disagree (#56 on /shhhhh
+ * vs "275 tried" in-app). No floor: a low position is a GOOD signal (near the
+ * front), so we only scale it; non-positive / invalid input is returned as-is.
+ */
+export function inflateWaitlistPosition(position: number): number {
+    if (typeof position !== 'number' || !Number.isFinite(position) || position <= 0) {
+        return position
+    }
+    return Math.round(position * DOOR_TALLY_FOMO_MULTIPLIER)
+}


### PR DESCRIPTION
## What
`/shhhhh`'s "you're on the waitlist · #N" showed the user's **real** queue position (e.g. `#56`), but the in-app Berghain rejection screen shows the **FOMO-inflated** door tally ("275 tried · 17 got in"). The small real number on the landing page undercut the big scarcity number in the app — they disagreed.

## Fix
Scale the `/shhhhh` position by the same `DOOR_TALLY_FOMO_MULTIPLIER` (×5) via a new shared `inflateWaitlistPosition()` helper in `doorTally.utils`, so both surfaces tell one consistent exaggerated story (`#56` → `#280`, consistent with "275 tried"). No floor — a low position is a *good* signal (near the front), so it's only scaled.

**Scope:** only `/shhhhh` (the card waitlist). The invite-only "jail" waitlist (`JoinWaitlistPage`, "Peanut is invite-only") is a *different* waitlist with no door-tally counterpart — correctly left untouched.

## Gates
prettier ✓ · typecheck ✓ (0 errors) · jest ✓ 20/20 (incl. 7 new `inflateWaitlistPosition` cases)
