### PR TITLE
fix(kyc): resume Sumsub SDK after PWA reload (TASK-20396)

### DIFF
--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 import { type FC, useCallback, useEffect, useRef, useState } from 'react'
 import { notFound } from 'next/navigation'
-import { useQueryState, parseAsBoolean } from 'nuqs'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
@@ -26,6 +25,7 @@ import { useGrantSessionKey } from '@/hooks/wallet/useGrantSessionKey'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { useModalsContext } from '@/context/ModalsContext'
 import { useSafeBack } from '@/hooks/useSafeBack'
+import { useSumsubReloadResume } from '@/hooks/useSumsubReloadResume'
 
 // localStorage key for the one-time celebration gate (per-device by design:
 // re-doing the funnel re-celebrates, see the eligibility-check effect below).
@@ -76,13 +76,6 @@ const CardPage: FC = () => {
     // Sumsub card-application token — populated when POST /rain/cards reports
     // the user still needs to complete the rain-card-application level.
     const [sumsubToken, setSumsubToken] = useState<string | null>(null)
-    // Mirror "SDK is open" to the URL so it survives a PWA reload. Android
-    // evicts backgrounded standalone PWAs from memory (opening camera/gallery
-    // mid-KYC is the common trigger); on return the page cold-reloads and
-    // sumsubToken — being useState — resets to null, dropping the user out of
-    // Sumsub back to the card screen. With the flag in the URL, a reload can
-    // re-acquire a fresh token for the same applicant and reopen the SDK.
-    const [kycInProgress, setKycInProgress] = useQueryState('kyc', parseAsBoolean.withDefault(false))
     const [applyError, setApplyError] = useState<string | null>(null)
     // When backend returns status:'terms-required', we capture it here so
     // the dispatcher can render the terms screen between Sumsub and submit.
@@ -410,44 +403,20 @@ const CardPage: FC = () => {
         return ''
     }, [invalidateOverview])
 
-    // PWA-reload resume. If the URL says we were mid-Sumsub (see kycInProgress),
+    // PWA-reload resume (see useSumsubReloadResume). On a reload mid-Sumsub,
     // re-apply to mint a fresh token for the same in-progress applicant and
-    // reopen the SDK where the user left off — same idempotent call the
-    // token-refresh path uses. Runs once on mount.
-    const didAttemptKycResumeRef = useRef(false)
-    useEffect(() => {
-        if (didAttemptKycResumeRef.current) return
-        didAttemptKycResumeRef.current = true
-        if (!kycInProgress || sumsubToken !== null) return
-        void (async () => {
-            try {
-                const res = await rainApi.applyForCard({ termsAccepted: false })
-                if ((res.status === 'incomplete' || res.status === 'main-kyc-required') && 'sumsubAccessToken' in res) {
-                    setSumsubToken(res.sumsubAccessToken)
-                    posthog.capture(ANALYTICS_EVENTS.CARD_SUMSUB_OPENED)
-                } else {
-                    // user advanced past Sumsub while backgrounded — route normally
-                    void setKycInProgress(false)
-                    advanceFromApplyResponse(res)
-                }
-            } catch {
-                void setKycInProgress(false)
-            }
-        })()
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
-
-    // Keep the URL flag in sync with the SDK's open state. Skip the first run
-    // so the mount-time resume above can read the persisted flag before we
-    // touch it. Clearing to the `false` default removes the param from the URL.
-    const kycSyncSkipRef = useRef(true)
-    useEffect(() => {
-        if (kycSyncSkipRef.current) {
-            kycSyncSkipRef.current = false
-            return
+    // reopen the SDK — same idempotent call the token-refresh path uses.
+    useSumsubReloadResume(sumsubToken !== null, async () => {
+        const res = await rainApi.applyForCard({ termsAccepted: false })
+        if ((res.status === 'incomplete' || res.status === 'main-kyc-required') && 'sumsubAccessToken' in res) {
+            setSumsubToken(res.sumsubAccessToken)
+            posthog.capture(ANALYTICS_EVENTS.CARD_SUMSUB_OPENED)
+            return true
         }
-        void setKycInProgress(sumsubToken !== null)
-    }, [sumsubToken, setKycInProgress])
+        // user advanced past Sumsub while backgrounded — route normally
+        advanceFromApplyResponse(res)
+        return false
+    })
 
     // Outer-gate fail — the useEffect above fires notFound() to render the
     // 404 boundary; render nothing here so the page doesn't flash for the

--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { type FC, useCallback, useEffect, useRef, useState } from 'react'
 import { notFound } from 'next/navigation'
+import { useQueryState, parseAsBoolean } from 'nuqs'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
@@ -75,6 +76,13 @@ const CardPage: FC = () => {
     // Sumsub card-application token — populated when POST /rain/cards reports
     // the user still needs to complete the rain-card-application level.
     const [sumsubToken, setSumsubToken] = useState<string | null>(null)
+    // Mirror "SDK is open" to the URL so it survives a PWA reload. Android
+    // evicts backgrounded standalone PWAs from memory (opening camera/gallery
+    // mid-KYC is the common trigger); on return the page cold-reloads and
+    // sumsubToken — being useState — resets to null, dropping the user out of
+    // Sumsub back to the card screen. With the flag in the URL, a reload can
+    // re-acquire a fresh token for the same applicant and reopen the SDK.
+    const [kycInProgress, setKycInProgress] = useQueryState('kyc', parseAsBoolean.withDefault(false))
     const [applyError, setApplyError] = useState<string | null>(null)
     // When backend returns status:'terms-required', we capture it here so
     // the dispatcher can render the terms screen between Sumsub and submit.
@@ -401,6 +409,45 @@ const CardPage: FC = () => {
         }
         return ''
     }, [invalidateOverview])
+
+    // PWA-reload resume. If the URL says we were mid-Sumsub (see kycInProgress),
+    // re-apply to mint a fresh token for the same in-progress applicant and
+    // reopen the SDK where the user left off — same idempotent call the
+    // token-refresh path uses. Runs once on mount.
+    const didAttemptKycResumeRef = useRef(false)
+    useEffect(() => {
+        if (didAttemptKycResumeRef.current) return
+        didAttemptKycResumeRef.current = true
+        if (!kycInProgress || sumsubToken !== null) return
+        void (async () => {
+            try {
+                const res = await rainApi.applyForCard({ termsAccepted: false })
+                if ((res.status === 'incomplete' || res.status === 'main-kyc-required') && 'sumsubAccessToken' in res) {
+                    setSumsubToken(res.sumsubAccessToken)
+                    posthog.capture(ANALYTICS_EVENTS.CARD_SUMSUB_OPENED)
+                } else {
+                    // user advanced past Sumsub while backgrounded — route normally
+                    void setKycInProgress(false)
+                    advanceFromApplyResponse(res)
+                }
+            } catch {
+                void setKycInProgress(false)
+            }
+        })()
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    // Keep the URL flag in sync with the SDK's open state. Skip the first run
+    // so the mount-time resume above can read the persisted flag before we
+    // touch it. Clearing to the `false` default removes the param from the URL.
+    const kycSyncSkipRef = useRef(true)
+    useEffect(() => {
+        if (kycSyncSkipRef.current) {
+            kycSyncSkipRef.current = false
+            return
+        }
+        void setKycInProgress(sumsubToken !== null)
+    }, [sumsubToken, setKycInProgress])
 
     // Outer-gate fail — the useEffect above fires notFound() to render the
     // 404 boundary; render nothing here so the page doesn't flash for the

--- a/src/components/Kyc/SumsubKycModals.tsx
+++ b/src/components/Kyc/SumsubKycModals.tsx
@@ -24,7 +24,7 @@ export const SumsubKycModals = ({ flow, autoStartSdk }: SumsubKycModalsProps) =>
                 onClose={flow.handleSdkClose}
                 onComplete={flow.handleSdkComplete}
                 onRefreshToken={flow.refreshToken}
-                autoStart={autoStartSdk}
+                autoStart={autoStartSdk || flow.sdkAutoStart}
                 isMultiLevel={flow.isMultiLevel}
             />
 

--- a/src/components/Kyc/SumsubKycModals.tsx
+++ b/src/components/Kyc/SumsubKycModals.tsx
@@ -24,7 +24,7 @@ export const SumsubKycModals = ({ flow, autoStartSdk }: SumsubKycModalsProps) =>
                 onClose={flow.handleSdkClose}
                 onComplete={flow.handleSdkComplete}
                 onRefreshToken={flow.refreshToken}
-                autoStart={autoStartSdk || flow.sdkAutoStart}
+                autoStart={autoStartSdk ?? flow.sdkAutoStart}
                 isMultiLevel={flow.isMultiLevel}
             />
 

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -285,7 +285,8 @@ export const useMultiPhaseKycFlow = ({
 
     // PWA-reload resume (see useSumsubReloadResume). When true, SumsubKycWrapper
     // skips StartVerificationView and launches straight into the SDK — the user
-    // already consented before the reload.
+    // already consented before the reload. Armed ONLY for the resume-triggered
+    // open, never for a fresh/retry/self-heal open in the same session.
     const [sdkAutoStart, setSdkAutoStart] = useState(false)
     useSumsubReloadResume(showWrapper, async () => {
         // re-initiate: mints a fresh token for the existing applicant and
@@ -294,8 +295,22 @@ export const useMultiPhaseKycFlow = ({
         // remediation flow a bare initiate can't reconstruct) clears the flag
         // instead of falling back to the standard level.
         setSdkAutoStart(true)
-        return handleInitiateKyc()
+        const opened = await handleInitiateKyc()
+        // failed resume never opened the SDK — disarm so it can't skip the
+        // start view on a later genuine reopen this session.
+        if (!opened) setSdkAutoStart(false)
+        return opened
     })
+
+    // Disarm autoStart once the resumed SDK session ends (falling edge of
+    // showWrapper). Without this, a later genuine reopen — retry after
+    // rejection, self-heal resubmit, start-action, restart-identity — would
+    // also skip StartVerificationView. Only the reload-resume should skip it.
+    const prevShowWrapperRef = useRef(showWrapper)
+    useEffect(() => {
+        if (prevShowWrapperRef.current && !showWrapper) setSdkAutoStart(false)
+        prevShowWrapperRef.current = showWrapper
+    }, [showWrapper])
 
     // 30s timeout for preparing phase + elapsed time counter for progressive copy
     useEffect(() => {

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
+import { useQueryState, parseAsBoolean } from 'nuqs'
 import { useAuth } from '@/context/authContext'
 import { useSumsubKycFlow } from '@/hooks/useSumsubKycFlow'
 import { useCapabilities } from '@/hooks/useCapabilities'
@@ -282,6 +283,45 @@ export const useMultiPhaseKycFlow = ({
         [originalHandleInitiateKyc, clearPreparingTimer, regionIntent, acquisitionSource]
     )
 
+    // --- PWA-reload resume ---
+    // Android evicts backgrounded standalone PWAs from memory — opening the
+    // camera/gallery mid-KYC (the exact thing the flow pushes users toward) is
+    // the common trigger. On return the page cold-reloads, `showWrapper`
+    // (useState) resets to false, and the SDK vanishes, dropping the user back
+    // to the underlying page. Mirror "SDK is open" to the URL so a reload can
+    // re-initiate and reopen the SDK for the same in-progress applicant.
+    const [kycInProgress, setKycInProgress] = useQueryState('kyc', parseAsBoolean.withDefault(false))
+    // when true, SumsubKycWrapper skips StartVerificationView and launches
+    // straight into the SDK — the user already consented before the reload.
+    const [sdkAutoStart, setSdkAutoStart] = useState(false)
+
+    const didAttemptResumeRef = useRef(false)
+    useEffect(() => {
+        if (didAttemptResumeRef.current) return
+        didAttemptResumeRef.current = true
+        if (!kycInProgress || showWrapper) return
+        // re-initiate: mints a fresh token for the existing applicant and
+        // reopens the SDK. If the user finished while backgrounded, the BE
+        // returns APPROVED with no token and handleInitiateKyc resolves the
+        // flow instead — showWrapper stays false and the sync effect clears
+        // the URL flag.
+        setSdkAutoStart(true)
+        void handleInitiateKyc()
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    // keep the URL flag in sync with the SDK's open state. skip the first run
+    // so the mount-time resume reads the persisted flag before we touch it.
+    // clearing to the `false` default removes the param from the URL.
+    const kycSyncSkipRef = useRef(true)
+    useEffect(() => {
+        if (kycSyncSkipRef.current) {
+            kycSyncSkipRef.current = false
+            return
+        }
+        void setKycInProgress(showWrapper)
+    }, [showWrapper, setKycInProgress])
+
     // 30s timeout for preparing phase + elapsed time counter for progressive copy
     useEffect(() => {
         if (modalPhase === 'preparing' && !preparingTimedOut) {
@@ -422,6 +462,7 @@ export const useMultiPhaseKycFlow = ({
 
         // SDK wrapper
         showWrapper,
+        sdkAutoStart,
         accessToken,
         handleSdkClose: handleClose,
         handleSdkComplete,

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -260,13 +260,18 @@ export const useMultiPhaseKycFlow = ({
         }
     }, [originalHandleSdkComplete, handleSumsubApproved, isActionFlow, regionIntent])
 
+    // true only while a PWA-reload resume drives handleInitiateKyc, so the
+    // analytics event can distinguish a resume from a genuine new initiation
+    // (a resume otherwise looks identical and inflates "initiated" counts).
+    const resumingRef = useRef(false)
+
     // wrap handleInitiateKyc to reset state for new attempts
     const handleInitiateKyc = useCallback(
         async (overrideIntent?: KYCRegionIntent, levelName?: string, crossRegion?: boolean, targetCountry?: string) => {
             const intent = overrideIntent ?? regionIntent
             posthog.capture(
                 intent === 'LATAM' ? ANALYTICS_EVENTS.MANTECA_KYC_INITIATED : ANALYTICS_EVENTS.KYC_INITIATED,
-                { region_intent: intent, acquisition_source: acquisitionSource }
+                { region_intent: intent, acquisition_source: acquisitionSource, resumed: resumingRef.current }
             )
 
             setModalPhase('verifying')
@@ -295,7 +300,9 @@ export const useMultiPhaseKycFlow = ({
         // remediation flow a bare initiate can't reconstruct) clears the flag
         // instead of falling back to the standard level.
         setSdkAutoStart(true)
+        resumingRef.current = true
         const opened = await handleInitiateKyc()
+        resumingRef.current = false
         // failed resume never opened the SDK — disarm so it can't skip the
         // start view on a later genuine reopen this session.
         if (!opened) setSdkAutoStart(false)

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
-import { useQueryState, parseAsBoolean } from 'nuqs'
 import { useAuth } from '@/context/authContext'
 import { useSumsubKycFlow } from '@/hooks/useSumsubKycFlow'
+import { useSumsubReloadResume } from '@/hooks/useSumsubReloadResume'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { markSubmitted } from '@/hooks/useSubmissionWindow'
 import { deriveGate } from '@/utils/capability-gate'
@@ -278,49 +278,24 @@ export const useMultiPhaseKycFlow = ({
             isRealtimeFlowRef.current = false
             clearPreparingTimer()
 
-            await originalHandleInitiateKyc(overrideIntent, levelName, crossRegion, targetCountry)
+            return originalHandleInitiateKyc(overrideIntent, levelName, crossRegion, targetCountry)
         },
         [originalHandleInitiateKyc, clearPreparingTimer, regionIntent, acquisitionSource]
     )
 
-    // --- PWA-reload resume ---
-    // Android evicts backgrounded standalone PWAs from memory — opening the
-    // camera/gallery mid-KYC (the exact thing the flow pushes users toward) is
-    // the common trigger. On return the page cold-reloads, `showWrapper`
-    // (useState) resets to false, and the SDK vanishes, dropping the user back
-    // to the underlying page. Mirror "SDK is open" to the URL so a reload can
-    // re-initiate and reopen the SDK for the same in-progress applicant.
-    const [kycInProgress, setKycInProgress] = useQueryState('kyc', parseAsBoolean.withDefault(false))
-    // when true, SumsubKycWrapper skips StartVerificationView and launches
-    // straight into the SDK — the user already consented before the reload.
+    // PWA-reload resume (see useSumsubReloadResume). When true, SumsubKycWrapper
+    // skips StartVerificationView and launches straight into the SDK — the user
+    // already consented before the reload.
     const [sdkAutoStart, setSdkAutoStart] = useState(false)
-
-    const didAttemptResumeRef = useRef(false)
-    useEffect(() => {
-        if (didAttemptResumeRef.current) return
-        didAttemptResumeRef.current = true
-        if (!kycInProgress || showWrapper) return
+    useSumsubReloadResume(showWrapper, async () => {
         // re-initiate: mints a fresh token for the existing applicant and
-        // reopens the SDK. If the user finished while backgrounded, the BE
-        // returns APPROVED with no token and handleInitiateKyc resolves the
-        // flow instead — showWrapper stays false and the sync effect clears
-        // the URL flag.
+        // reopens the SDK. Returns whether the SDK actually opened — a resume
+        // that resolves without opening (already-approved user, or a
+        // remediation flow a bare initiate can't reconstruct) clears the flag
+        // instead of falling back to the standard level.
         setSdkAutoStart(true)
-        void handleInitiateKyc()
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
-
-    // keep the URL flag in sync with the SDK's open state. skip the first run
-    // so the mount-time resume reads the persisted flag before we touch it.
-    // clearing to the `false` default removes the param from the URL.
-    const kycSyncSkipRef = useRef(true)
-    useEffect(() => {
-        if (kycSyncSkipRef.current) {
-            kycSyncSkipRef.current = false
-            return
-        }
-        void setKycInProgress(showWrapper)
-    }, [showWrapper, setKycInProgress])
+        return handleInitiateKyc()
+    })
 
     // 30s timeout for preparing phase + elapsed time counter for progressive copy
     useEffect(() => {

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -191,7 +191,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                     userInitiatedRef.current = false
                     if (crossRegion) prevStatusRef.current = savedPrevStatus
                     setError(response.error)
-                    return
+                    return false
                 }
 
                 // cross-region into a region no first-party bank provider serves (ROW).
@@ -209,7 +209,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                     setError(
                         "Bank deposits aren't available in your region yet. We'll let you know as soon as they go live."
                     )
-                    return
+                    return false
                 }
 
                 // sync status from api response, but skip when a token is returned
@@ -234,7 +234,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                     setIsActionFlow(false)
                     setIsVerificationProgressModalOpen(true)
                     onKycSuccess?.()
-                    return
+                    return false
                 }
 
                 // if already approved (or reverifying) and no token returned, kyc is done.
@@ -244,7 +244,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 if ((status === 'APPROVED' || status === 'REVERIFYING') && !response.data?.token) {
                     prevStatusRef.current = status
                     onKycSuccess?.()
-                    return
+                    return false
                 }
 
                 if (response.data?.token) {
@@ -255,7 +255,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                             if (!SNSMobileSDK) {
                                 userInitiatedRef.current = false
                                 setError('KYC SDK not available. Please update the app.')
-                                return
+                                return false
                             }
                             const effectiveRegionIntent = overrideIntent ?? regionIntent
                             const sdk = SNSMobileSDK.init(response.data.token, async () => {
@@ -290,22 +290,28 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                             console.error('[useSumsubKycFlow] native SDK error:', nativeErr)
                             userInitiatedRef.current = false
                             setError('Verification failed. Please try again.')
+                            return false
                         }
-                        return
+                        // native SDK ran to completion (approved / closed) — nothing
+                        // left for the web resume path to reopen.
+                        return false
                     }
 
                     setAccessToken(response.data.token)
                     setIsActionFlow(!!response.data.actionType)
                     setShowWrapper(true)
+                    return true
                 } else {
                     userInitiatedRef.current = false
                     setError('Could not initiate verification. Please try again.')
+                    return false
                 }
             } catch (e: unknown) {
                 userInitiatedRef.current = false
                 if (crossRegion) prevStatusRef.current = savedPrevStatus
                 const message = e instanceof Error ? e.message : 'An unexpected error occurred'
                 setError(message)
+                return false
             } finally {
                 setIsLoading(false)
                 initiatingRef.current = false

--- a/src/hooks/useSumsubReloadResume.ts
+++ b/src/hooks/useSumsubReloadResume.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from 'react'
+import { useQueryState, parseAsBoolean } from 'nuqs'
+
+/**
+ * Persist "the Sumsub SDK is open" to the URL (?kyc=true) so it survives a PWA
+ * reload. Android evicts backgrounded standalone PWAs from memory — opening the
+ * camera/gallery mid-KYC (the exact thing the flow pushes users toward) is the
+ * common trigger. On return the page cold-reloads and the SDK's open-state
+ * (useState) resets to closed, dropping the user out of Sumsub. With the flag
+ * in the URL, a reload can re-acquire a token for the same applicant and reopen
+ * the SDK.
+ *
+ * @param isOpen   whether the SDK is currently open.
+ * @param onResume called once on mount when the flag was set but the SDK is
+ *   closed (i.e. a reload interrupted the flow). MUST resolve to whether the
+ *   SDK actually reopened — a falsy/failed result clears the flag so a resume
+ *   that can't reopen (init error, or a flow the bare resume can't reconstruct)
+ *   doesn't get retried on every future reload.
+ */
+export function useSumsubReloadResume(isOpen: boolean, onResume: () => Promise<boolean>) {
+    const [inProgress, setInProgress] = useQueryState('kyc', parseAsBoolean.withDefault(false))
+
+    // resume once on mount
+    const didResumeRef = useRef(false)
+    useEffect(() => {
+        if (didResumeRef.current) return
+        didResumeRef.current = true
+        if (!inProgress || isOpen) return
+        void (async () => {
+            const reopened = await onResume().catch(() => false)
+            if (!reopened) void setInProgress(false)
+        })()
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    // keep the URL flag in sync with the SDK's open state. skip the first run so
+    // the mount-time resume above reads the persisted flag before we touch it.
+    // clearing to the `false` default removes the param from the URL.
+    const syncSkipRef = useRef(true)
+    useEffect(() => {
+        if (syncSkipRef.current) {
+            syncSkipRef.current = false
+            return
+        }
+        void setInProgress(isOpen)
+    }, [isOpen, setInProgress])
+}


### PR DESCRIPTION
## Problem — TASK-20396

Users report that mid-KYC, if they tab out of the PWA (to camera, gallery, or another app) and come back, they're dropped out of Sumsub and lose their progress. Reproduced on Android.

## Root cause

The app ships as a **standalone PWA** (`display: standalone`). Android aggressively evicts backgrounded standalone PWAs from memory — and opening the native camera/gallery (which the KYC flow pushes users toward) is a strong trigger. On return the page **cold-reloads**; there's no bfcache to restore.

The "SDK is open" state is `useState` in both KYC integrations, so a cold reload resets it and the SDK vanishes:
- `/card` (Rain card): gated by `sumsubToken !== null`.
- shared flow (add-money / withdraw / qr-pay / KYC drawer): gated by `showWrapper` in `useSumsubKycFlow`.

## Fix (approach A — URL-persisted resume)

Mirror the SDK-open state to the URL (`?kyc=true`) via nuqs. An app-switcher relaunch restores the last route + query, so the flag survives. On mount, if set, re-acquire a fresh token for the **same in-progress applicant** and reopen the SDK.

- **`/card`** — re-`applyForCard({ termsAccepted: false })` (the same idempotent call the token-refresh path uses).
- **shared flow** — re-`handleInitiateKyc()` in `useMultiPhaseKycFlow`, with `autoStart` so it lands straight in the SDK (user already consented) instead of the intro screen.

A sync effect keeps the URL flag in step with the SDK's open state (skipping the first run so the mount-time resume reads the persisted flag first).

## ⚠️ This is a PARTIAL fix — read before closing the ticket

**What this fixes:** the SDK reopening. After the reload, the user is taken straight back into Sumsub on the **same applicant**, with all previously-**submitted** steps preserved — instead of being dumped on the underlying page and having to navigate back and restart the flow.

**What this does NOT fix:** the data the user was **actively typing on the current step** (e.g. the personal-info / tax-ID form) is still lost. If they had filled fields but not yet advanced to the next step, those fields come back blank.

**Why we can't fix that part:**

- Sumsub's own docs confirm the SDK autosaves in-progress applicant-data / questionnaire input to the browser's **`sessionStorage`**, scoped to the verification session ([verification-steps docs](https://docs.sumsub.com/docs/verification-steps)): *"Sumsub automatically saves the information an applicant enters ... in the browser session storage ... If the session expires before the applicant finishes entering their information, they will need to re-enter their data when they return."*
- `sessionStorage` survives an in-tab reload but is **destroyed when the browsing context is torn down** — which is exactly what Android does when it kills the backgrounded PWA. That's why submitted steps survive (they're on Sumsub's server) but the mid-typed step does not.
- There is **no Sumsub config flag / init option / dashboard setting** to switch this to `localStorage` or make the draft durable (confirmed across WebSDK settings + get-started + about docs).
- We **cannot recover it ourselves** either: the Sumsub form runs in a cross-origin iframe (`static.sumsub.com`), so we can't read its `sessionStorage`, and the WebSDK only emits step-level events (`onStepCompleted`, `onApplicantSubmitted`) — there's no field-level/keystroke event to capture and re-push.
- We also can't reliably stop Android from killing a backgrounded standalone PWA, so preventing the reload isn't an option.

**The only way to fully preserve typed data** would be an architectural change: collect the personal-info / tax-ID fields in our **own** PWA form (persisted in our storage, which survives the kill), push them to Sumsub via the `fixedInfo` + `/questionnaires` API before the SDK opens, and enable prefill on the Sumsub level (`applicantDataSettings.prefill`). That's a separate, larger project touching FE + BE + Sumsub level config — tracked separately, not in this PR.

## Known limitation (summary)

Recovers the bounce-out + manual re-entry, **not** the fields on the step the user was actively typing. See the section above for why.

## Testing

- `npm run typecheck` clean, `npm run build` passes, prettier clean.
- `jest card` 137/137; `useSumsubKycFlow` / add-money-states / qr-pay-states suites pass (76).
- Manual (preview): start identity verification on Android PWA → tab to camera/gallery → return → SDK should reopen into the resumed applicant instead of the underlying page.

## Files

- `src/app/(mobile-ui)/card/page.tsx`
- `src/hooks/useMultiPhaseKycFlow.ts`
- `src/components/Kyc/SumsubKycModals.tsx`