### PR TITLE
hotfix(maintenance): block Manteca add-money + withdraw during provider outage

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/[regional-method]/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/[regional-method]/page.tsx
@@ -1,7 +1,9 @@
 'use client'
 import MantecaAddMoney from '@/components/AddMoney/components/MantecaAddMoney'
+import { MantecaTransfersMaintenanceView } from '@/components/Global/Banner/MantecaTransfersMaintenanceView'
 import { type CountryData, countryData } from '@/components/AddMoney/consts'
 import { isMantecaSupportedCountryCode } from '@/constants/manteca.consts'
+import underMaintenanceConfig from '@/config/underMaintenance.config'
 import { useParams, useSearchParams } from 'next/navigation'
 
 export default function AddMoneyRegionalMethodPage() {
@@ -14,6 +16,10 @@ export default function AddMoneyRegionalMethodPage() {
     const countryDetails: CountryData | undefined = countryData.find((c) => c.path === country)
 
     if (isMantecaSupportedCountryCode(countryDetails?.id) && method === 'manteca') {
+        // Manteca provider outage kill-switch — block the onramp with a clear message.
+        if (underMaintenanceConfig.disableMantecaTransfers) {
+            return <MantecaTransfersMaintenanceView action="deposits" />
+        }
         return <MantecaAddMoney />
     }
     return null

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -618,6 +618,15 @@ jest.mock('@/components/AddMoney/components/MantecaAddMoney', () => ({
     default: () => <div data-testid="manteca-add-money">Manteca Add Money</div>,
 }))
 
+// MantecaTransfersMaintenanceView — the outage screen shown when the
+// disableMantecaTransfers kill-switch is on. Mocked to a testid so GROUP 7 can
+// assert which branch the regional-method route renders without pulling the
+// real NavHeader/Card tree.
+jest.mock('@/components/Global/Banner/MantecaTransfersMaintenanceView', () => ({
+    __esModule: true,
+    MantecaTransfersMaintenanceView: () => <div data-testid="manteca-transfers-maintenance">Manteca Maintenance</div>,
+}))
+
 // AddMoneyBankDetails (for US bank page and bank details step)
 jest.mock('@/components/AddMoney/components/AddMoneyBankDetails', () => ({
     __esModule: true,
@@ -716,6 +725,7 @@ import OnrampBankPage from '../[country]/bank/page'
 import AddMoneyRegionalMethodPage from '../[country]/[regional-method]/page'
 import AddMoneyCountryPage from '../[country]/page'
 import CryptoDepositView from '@/components/AddMoney/views/CryptoDeposit.view'
+import underMaintenanceConfig from '@/config/underMaintenance.config'
 
 // ---------- helpers ----------
 
@@ -1412,11 +1422,26 @@ describe('GROUP 6: US Bank Page', () => {
 // GROUP 7: Manteca Deposit (AR, BR)
 // ============================================================
 describe('GROUP 7: Manteca Deposit (Regional Method)', () => {
-    test('AR + manteca renders MantecaAddMoney', () => {
+    afterEach(() => {
+        // reset the outage kill-switch so its default value can't leak between tests
+        underMaintenanceConfig.disableMantecaTransfers = false
+    })
+
+    test('AR + manteca renders MantecaAddMoney when transfers are enabled', () => {
+        underMaintenanceConfig.disableMantecaTransfers = false
         setParams({ country: 'argentina', 'regional-method': 'manteca' })
         renderWithProviders(<AddMoneyRegionalMethodPage />)
 
         expect(screen.getByTestId('manteca-add-money')).toBeInTheDocument()
+    })
+
+    test('AR + manteca shows the outage screen when transfers are disabled', () => {
+        underMaintenanceConfig.disableMantecaTransfers = true
+        setParams({ country: 'argentina', 'regional-method': 'manteca' })
+        renderWithProviders(<AddMoneyRegionalMethodPage />)
+
+        expect(screen.getByTestId('manteca-transfers-maintenance')).toBeInTheDocument()
+        expect(screen.queryByTestId('manteca-add-money')).not.toBeInTheDocument()
     })
 
     test('unsupported country + manteca renders nothing', () => {

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -71,6 +71,8 @@ import { SumsubKycWrapper } from '@/components/Kyc/SumsubKycWrapper'
 import { useLimits } from '@/hooks/useLimits'
 import { isVerifiedForCountry } from '@/utils/regions.utils'
 import PixKeySendView from '@/components/Withdraw/views/PixKeySend.view'
+import underMaintenanceConfig from '@/config/underMaintenance.config'
+import { MantecaTransfersMaintenanceView } from '@/components/Global/Banner/MantecaTransfersMaintenanceView'
 
 type MantecaWithdrawStep = 'amountInput' | 'bankDetails' | 'review' | 'success' | 'failure'
 
@@ -85,6 +87,12 @@ export default function MantecaWithdrawFlow() {
     // chokepoint that flips the endpoint without touching the AR / bank paths.
     if (searchParams.get('country') === 'brazil' && searchParams.get('method') === 'pix') {
         return <PixKeySendView destinationParam={searchParams.get('destination')} />
+    }
+    // Manteca provider outage kill-switch — block the offramp with a clear
+    // message. Placed AFTER the Brazil-PIX delegation so PIX-over-QR sends
+    // (which ride the QR-payment endpoint, not Manteca offramp) stay open.
+    if (underMaintenanceConfig.disableMantecaTransfers) {
+        return <MantecaTransfersMaintenanceView action="withdrawals" />
     }
     return <MantecaBankWithdrawFlow />
 }

--- a/src/components/Global/Banner/MantecaTransfersMaintenanceView.tsx
+++ b/src/components/Global/Banner/MantecaTransfersMaintenanceView.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { Button } from '@/components/0_Bruddle/Button'
+import { Card } from '@/components/0_Bruddle/Card'
+import { Icon } from '@/components/Global/Icons/Icon'
+import { useModalsContext } from '@/context/ModalsContext'
+import { useRouter } from 'next/navigation'
+
+/**
+ * Provider-outage screen for the Manteca add-money (onramp) and withdraw
+ * (offramp) flows when `disableMantecaTransfers` is on. Mirrors the QR-pay
+ * provider-outage screen (disabledPaymentProviders) — same layout and copy.
+ * User-facing copy is provider-agnostic on purpose: users never see "Manteca".
+ */
+export function MantecaTransfersMaintenanceView({ action }: { action: 'deposits' | 'withdrawals' }) {
+    const router = useRouter()
+    const { setIsSupportModalOpen } = useModalsContext()
+    return (
+        <div className="my-auto flex h-full w-full flex-col justify-center space-y-4">
+            <Card className="flex w-full flex-col items-center gap-2 p-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-secondary-1 p-3">
+                    <Icon name="alert" size={24} />
+                </div>
+                <span className="text-lg font-bold">Service Temporarily Unavailable</span>
+                <p className="text-center font-normal text-grey-1">
+                    We're experiencing issues with {action} due to an external provider outage. We're working to restore
+                    service as soon as possible.
+                </p>
+            </Card>
+            <Button onClick={() => router.push('/home')} variant="purple" shadowSize="4">
+                Go Back
+            </Button>
+            <button
+                onClick={() => setIsSupportModalOpen(true)}
+                className="flex w-full items-center justify-center gap-2 text-sm font-medium text-grey-1 transition-colors hover:text-black"
+            >
+                <Icon name="peanut-support" size={16} className="text-grey-1" />
+                Having trouble?
+            </button>
+        </div>
+    )
+}

--- a/src/config/underMaintenance.config.ts
+++ b/src/config/underMaintenance.config.ts
@@ -45,6 +45,12 @@
  *    - the /card flow, /shhhhh page, and waitlist pill stay reachable regardless — this only mutes the proactive in-app nudge
  *    - currently false (CTA live, routes to /shhhhh); set true to dial down in-app load without touching the flow
  *
+ * 9. disableMantecaTransfers: kill-switch for the Manteca add-money (onramp) and withdraw (offramp) flows
+ *    - blocks entry to /add-money/<country>/manteca and /withdraw/manteca with a "temporarily unavailable" screen
+ *    - use during a Manteca provider outage so users see a clear message instead of a mid-flow failure
+ *    - does NOT touch QR payments (Manteca QR / Brazil PIX-over-QR stay open) — that is disabledPaymentProviders
+ *    - set to false when Manteca transfers are restored
+ *
  * note: if either mode is enabled, the maintenance banner will show everywhere
  *
  * I HOPE WE NEVER NEED TO USE THIS...
@@ -62,6 +68,7 @@ interface MaintenanceConfig {
     disableCardPioneers: boolean
     disableCardLaunchCTA: boolean
     pixBrazilOnrampMaintenance: boolean
+    disableMantecaTransfers: boolean
 }
 
 const underMaintenanceConfig: MaintenanceConfig = {
@@ -73,6 +80,7 @@ const underMaintenanceConfig: MaintenanceConfig = {
     disableCardPioneers: true, // set to false to enable the Card Pioneers waitlist feature
     disableCardLaunchCTA: false, // kill-switch for the in-app "shhh" card CTA (funnel card step + activated home splash). Set true to mute it (dial down in-app load); /card flow + /shhhhh + waitlist stay reachable regardless.
     pixBrazilOnrampMaintenance: true, // set to false when BRL-via-PIX deposits are stable again
+    disableMantecaTransfers: true, // Manteca provider outage — add-money + withdraw blocked with a maintenance screen; set to false when restored
 }
 
 // shared user-facing copy for cross-chain disabled paths — keep wording aligned with TokenSelector banner


### PR DESCRIPTION
## Why
Manteca onramp (add money) and offramp (withdraw) are **down** (provider outage). There was **no kill-switch** for these flows — `disabledPaymentProviders` only gates QR-pay — so users currently hit an ugly mid-flow failure (they sign a spend UserOp, then the provider call throws).

## What
- Adds `disableMantecaTransfers` flag to `underMaintenance.config.ts` (**default `true`** — turn off to restore).
- Renders the **same provider-outage screen as the QR path** ("Service Temporarily Unavailable / external provider outage") at the two Manteca flow entry points, before any provider call.
  - Onramp: `/add-money/[country]/manteca` route
  - Offramp: `/withdraw/manteca` — guard placed **after** the Brazil-PIX delegation so **PIX-over-QR sends stay open**.
- User-facing copy is **provider-agnostic** (users never see "Manteca"); internal var names keep the Manteca label to match existing `PaymentProvider = 'MANTECA'`.

## Scope / not touched
- QR payments (`disabledPaymentProviders`) — untouched, still open.
- Bridge (EU/US/MX) add-money & withdraw, crypto — untouched.

## To restore
Flip `disableMantecaTransfers: false` and ship.

## Tests
- New: `add-money-states` GROUP 7 — outage screen renders when flag on; `MantecaAddMoney` renders when off.
- ⚠️ Pre-existing unrelated failure in `add-money-states` GROUP 3 ("loaded EVM deposit shows QR code and address" — `10,000 USD` assertion). Confirmed it fails identically on this base **with my flag off**, i.e. not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)