### PR TITLE
hotfix(maintenance): per-currency Manteca outage block — re-enable ARS

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/[regional-method]/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/[regional-method]/page.tsx
@@ -16,8 +16,9 @@ export default function AddMoneyRegionalMethodPage() {
     const countryDetails: CountryData | undefined = countryData.find((c) => c.path === country)
 
     if (isMantecaSupportedCountryCode(countryDetails?.id) && method === 'manteca') {
-        // Manteca provider outage kill-switch — block the onramp with a clear message.
-        if (underMaintenanceConfig.disableMantecaTransfers) {
+        // Manteca provider outage — block the onramp only for currencies still down.
+        const currency = countryDetails?.currency?.toUpperCase() ?? ''
+        if ((underMaintenanceConfig.disabledMantecaCurrencies as string[]).includes(currency)) {
             return <MantecaTransfersMaintenanceView action="deposits" />
         }
         return <MantecaAddMoney />

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -618,10 +618,9 @@ jest.mock('@/components/AddMoney/components/MantecaAddMoney', () => ({
     default: () => <div data-testid="manteca-add-money">Manteca Add Money</div>,
 }))
 
-// MantecaTransfersMaintenanceView — the outage screen shown when the
-// disableMantecaTransfers kill-switch is on. Mocked to a testid so GROUP 7 can
-// assert which branch the regional-method route renders without pulling the
-// real NavHeader/Card tree.
+// MantecaTransfersMaintenanceView — the outage screen shown when a currency is
+// in disabledMantecaCurrencies. Mocked to a testid so GROUP 7 can assert which
+// branch the regional-method route renders without pulling the real Card tree.
 jest.mock('@/components/Global/Banner/MantecaTransfersMaintenanceView', () => ({
     __esModule: true,
     MantecaTransfersMaintenanceView: () => <div data-testid="manteca-transfers-maintenance">Manteca Maintenance</div>,
@@ -1423,20 +1422,20 @@ describe('GROUP 6: US Bank Page', () => {
 // ============================================================
 describe('GROUP 7: Manteca Deposit (Regional Method)', () => {
     afterEach(() => {
-        // reset the outage kill-switch so its default value can't leak between tests
-        underMaintenanceConfig.disableMantecaTransfers = false
+        // reset the per-currency outage list so its default value can't leak between tests
+        underMaintenanceConfig.disabledMantecaCurrencies = []
     })
 
-    test('AR + manteca renders MantecaAddMoney when transfers are enabled', () => {
-        underMaintenanceConfig.disableMantecaTransfers = false
+    test('AR + manteca renders MantecaAddMoney when its currency (ARS) is live', () => {
+        underMaintenanceConfig.disabledMantecaCurrencies = ['BRL'] // BRL down, ARS live
         setParams({ country: 'argentina', 'regional-method': 'manteca' })
         renderWithProviders(<AddMoneyRegionalMethodPage />)
 
         expect(screen.getByTestId('manteca-add-money')).toBeInTheDocument()
     })
 
-    test('AR + manteca shows the outage screen when transfers are disabled', () => {
-        underMaintenanceConfig.disableMantecaTransfers = true
+    test('AR + manteca shows the outage screen when ARS is in the disabled list', () => {
+        underMaintenanceConfig.disabledMantecaCurrencies = ['ARS']
         setParams({ country: 'argentina', 'regional-method': 'manteca' })
         renderWithProviders(<AddMoneyRegionalMethodPage />)
 

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -88,10 +88,11 @@ export default function MantecaWithdrawFlow() {
     if (searchParams.get('country') === 'brazil' && searchParams.get('method') === 'pix') {
         return <PixKeySendView destinationParam={searchParams.get('destination')} />
     }
-    // Manteca provider outage kill-switch — block the offramp with a clear
-    // message. Placed AFTER the Brazil-PIX delegation so PIX-over-QR sends
-    // (which ride the QR-payment endpoint, not Manteca offramp) stay open.
-    if (underMaintenanceConfig.disableMantecaTransfers) {
+    // Manteca provider outage — block the offramp only for currencies still
+    // down. Placed AFTER the Brazil-PIX delegation so PIX-over-QR sends (which
+    // ride the QR-payment endpoint, not Manteca offramp) stay open.
+    const withdrawCurrency = countryData.find((c) => c.path === searchParams.get('country'))?.currency?.toUpperCase()
+    if (withdrawCurrency && (underMaintenanceConfig.disabledMantecaCurrencies as string[]).includes(withdrawCurrency)) {
         return <MantecaTransfersMaintenanceView action="withdrawals" />
     }
     return <MantecaBankWithdrawFlow />

--- a/src/config/underMaintenance.config.ts
+++ b/src/config/underMaintenance.config.ts
@@ -45,11 +45,12 @@
  *    - the /card flow, /shhhhh page, and waitlist pill stay reachable regardless — this only mutes the proactive in-app nudge
  *    - currently false (CTA live, routes to /shhhhh); set true to dial down in-app load without touching the flow
  *
- * 9. disableMantecaTransfers: kill-switch for the Manteca add-money (onramp) and withdraw (offramp) flows
- *    - blocks entry to /add-money/<country>/manteca and /withdraw/manteca with a "temporarily unavailable" screen
- *    - use during a Manteca provider outage so users see a clear message instead of a mid-flow failure
+ * 9. disabledMantecaCurrencies: per-currency kill-switch for the Manteca add-money (onramp) and withdraw (offramp) flows
+ *    - list the fiat currencies still down (e.g. ['BRL']) — those countries' /add-money/<country>/manteca and
+ *      /withdraw/manteca show a "temporarily unavailable" screen; currencies NOT listed stay live
+ *    - Manteca currencies are ARS (Argentina) and BRL (Brazil); empty array = all Manteca transfers enabled
+ *    - use during a partial Manteca outage so recovered currencies (e.g. ARS) come back while others stay blocked
  *    - does NOT touch QR payments (Manteca QR / Brazil PIX-over-QR stay open) — that is disabledPaymentProviders
- *    - set to false when Manteca transfers are restored
  *
  * note: if either mode is enabled, the maintenance banner will show everywhere
  *
@@ -68,8 +69,12 @@ interface MaintenanceConfig {
     disableCardPioneers: boolean
     disableCardLaunchCTA: boolean
     pixBrazilOnrampMaintenance: boolean
-    disableMantecaTransfers: boolean
+    /** Manteca fiat currencies still down (e.g. ['BRL']); currencies not listed stay live. Empty = all enabled. */
+    disabledMantecaCurrencies: MantecaCurrency[]
 }
+
+// Manteca first-party bank/kyc rails currently exist only in Argentina (ARS) and Brazil (BRL).
+export type MantecaCurrency = 'ARS' | 'BRL'
 
 const underMaintenanceConfig: MaintenanceConfig = {
     enableFullMaintenance: false, // set to true to redirect all pages to /maintenance
@@ -80,7 +85,7 @@ const underMaintenanceConfig: MaintenanceConfig = {
     disableCardPioneers: true, // set to false to enable the Card Pioneers waitlist feature
     disableCardLaunchCTA: false, // kill-switch for the in-app "shhh" card CTA (funnel card step + activated home splash). Set true to mute it (dial down in-app load); /card flow + /shhhhh + waitlist stay reachable regardless.
     pixBrazilOnrampMaintenance: true, // set to false when BRL-via-PIX deposits are stable again
-    disableMantecaTransfers: true, // Manteca provider outage — add-money + withdraw blocked with a maintenance screen; set to false when restored
+    disabledMantecaCurrencies: ['BRL'], // Manteca partial outage — ARS recovered (live); BRL still down. Empty the array when all restored.
 }
 
 // shared user-facing copy for cross-chain disabled paths — keep wording aligned with TokenSelector banner


### PR DESCRIPTION
## Why
Manteca is recovering **per-currency**: **ARS is back**, **BRL still down**. The prior hotfix (#2321) was all-or-nothing (`disableMantecaTransfers`), so we couldn't bring ARS back without also un-blocking BRL.

## What
- Replaces the boolean `disableMantecaTransfers` with `disabledMantecaCurrencies: MantecaCurrency[]` — a **blocklist**, mirroring the existing `disabledPaymentProviders` convention. Only currencies in the list show the outage screen; unlisted ones stay live.
- Set to **`['BRL']`** → **ARS add-money + withdraw go live again; BRL stays blocked.**
- Both guard points now derive the currency from `countryData` (AR→ARS, BR→BRL). Withdraw guard still sits **after** the Brazil-PIX delegation, so PIX-over-QR sends stay open regardless.
- User-facing copy unchanged (provider-agnostic); `MantecaCurrency = 'ARS' | 'BRL'` (only AR/BR have first-party Manteca rails).

## To operate
- ARS regresses → add `'ARS'` to the list.
- Manteca fully restored → set `disabledMantecaCurrencies: []`.

## Tests
- Updated `add-money-states` GROUP 7: ARS renders the flow when only BRL is disabled; ARS renders the outage screen when ARS is listed.
- ⚠️ Same **pre-existing, unrelated** `add-money-states` GROUP 3 failure ("loaded EVM deposit… 10,000 USD") as #2321 — not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)