### PR TITLE
hotfix(manteca): fix NaN price (new effectivePrice shape) + re-enable BRL

### DIFF
--- a/src/app/actions/__tests__/currency.test.ts
+++ b/src/app/actions/__tests__/currency.test.ts
@@ -61,6 +61,28 @@ describe('getCurrencyPrice (uncached, commit-path)', () => {
         await expect(getCurrencyPrice('ARS')).resolves.toEqual({ buy: 1200, sell: 1180 })
     })
 
+    it('reads the current Manteca shape where the effective rate is nested under effectivePrice', async () => {
+        // Manteca moved effectiveBuy/effectiveSell under effectivePrice on 2026-07-01;
+        // reading the old top-level fields yielded NaN → "Invalid buy rate from provider".
+        mantecaGetPrices.mockResolvedValue({
+            buy: '1596.90',
+            sell: '1541.96',
+            effectivePrice: { buy: '1596.900', sell: '1541.960' },
+        })
+        const { getCurrencyPrice } = loadModule()
+        await expect(getCurrencyPrice('ARS')).resolves.toEqual({ buy: 1596.9, sell: 1541.96 })
+    })
+
+    it('prefers effectivePrice over the legacy top-level fields when both are present', async () => {
+        mantecaGetPrices.mockResolvedValue({
+            effectiveBuy: '1',
+            effectiveSell: '1',
+            effectivePrice: { buy: '1200', sell: '1180' },
+        })
+        const { getCurrencyPrice } = loadModule()
+        await expect(getCurrencyPrice('ARS')).resolves.toEqual({ buy: 1200, sell: 1180 })
+    })
+
     it('throws on unknown currency code', async () => {
         const { getCurrencyPrice } = loadModule()
         await expect(getCurrencyPrice('XYZ')).rejects.toThrow('Invalid currency code')

--- a/src/app/actions/currency.ts
+++ b/src/app/actions/currency.ts
@@ -33,9 +33,14 @@ const fetchCurrencyPrice = async (currencyCode: string): Promise<{ buy: number; 
 
     if (MANTECA_CURRENCIES.includes(currencyCode)) {
         const response = await mantecaApi.getPrices({ asset: 'USDC', against: currencyCode })
+        // Manteca moved the effective rate under `effectivePrice.{buy,sell}` on 2026-07-01
+        // (previously top-level `effectiveBuy`/`effectiveSell`). Read the new shape first and
+        // fall back to the legacy fields so a provider rollback can't re-break pricing.
+        const effectiveBuy = response.effectivePrice?.buy ?? response.effectiveBuy
+        const effectiveSell = response.effectivePrice?.sell ?? response.effectiveSell
         return {
-            buy: assertPositiveRate('buy', Number(response.effectiveBuy)),
-            sell: assertPositiveRate('sell', Number(response.effectiveSell)),
+            buy: assertPositiveRate('buy', Number(effectiveBuy)),
+            sell: assertPositiveRate('sell', Number(effectiveSell)),
         }
     }
 

--- a/src/config/underMaintenance.config.ts
+++ b/src/config/underMaintenance.config.ts
@@ -85,7 +85,7 @@ const underMaintenanceConfig: MaintenanceConfig = {
     disableCardPioneers: true, // set to false to enable the Card Pioneers waitlist feature
     disableCardLaunchCTA: false, // kill-switch for the in-app "shhh" card CTA (funnel card step + activated home splash). Set true to mute it (dial down in-app load); /card flow + /shhhhh + waitlist stay reachable regardless.
     pixBrazilOnrampMaintenance: true, // set to false when BRL-via-PIX deposits are stable again
-    disabledMantecaCurrencies: ['BRL'], // Manteca partial outage — ARS recovered (live); BRL still down. Empty the array when all restored.
+    disabledMantecaCurrencies: [], // Manteca restored (ARS + BRL live). Add a currency here to block it during a future outage.
 }
 
 // shared user-facing copy for cross-chain disabled paths — keep wording aligned with TokenSelector banner

--- a/src/services/manteca.ts
+++ b/src/services/manteca.ts
@@ -96,8 +96,12 @@ export type MantecaPrice = {
             daily: string
         }
     }
-    effectiveBuy: string
-    effectiveSell: string
+    // Manteca nests the effective (company) rate here as of 2026-07-01.
+    effectivePrice?: { buy: string; sell: string }
+    // Legacy top-level effective rate (pre-2026-07-01). Optional — kept only so a
+    // provider rollback stays parseable; new reads should prefer `effectivePrice`.
+    effectiveBuy?: string
+    effectiveSell?: string
 }
 
 // withdraw init response - contains locked price for withdraw flow


### PR DESCRIPTION
## Root cause
Manteca changed the `/prices/direct/USDC_<CCY>` response shape on **2026-07-01**. The effective rate moved from top-level `effectiveBuy` / `effectiveSell` to nested **`effectivePrice: { buy, sell }`**:

```json
{ "ticker": "USDC_ARS", "buy": "1596.90", "sell": "1541.96",
  "effectivePrice": { "buy": "1596.900", "sell": "1541.960" } }
```

Our `currency.ts` still read `response.effectiveBuy` → `Number(undefined)` = `NaN` → `assertPositiveRate` threw **`Invalid buy rate from provider: NaN`**, which broke the price-display step for **every** Manteca currency — including the already-recovered **ARS**. (This was the real blocker, not a BRL-for-ARS mismatch — the per-currency wiring was correct.)

## Fix
- `currency.ts` reads `effectivePrice.{buy,sell}` first, **falls back** to the legacy top-level fields so a provider rollback can't re-break pricing.
- `MantecaPrice` type updated: new nested `effectivePrice`, legacy fields now optional.
- Manteca is **fully restored**, so `disabledMantecaCurrencies` is emptied → **re-enables BRL** (and keeps ARS live).

## Tests
- `currency.test.ts`: added a test for the current nested shape + a "prefers effectivePrice over legacy" test. Existing legacy-shape tests still pass (they now exercise the fallback). ✅ 19/19.
- ⚠️ Pre-existing/unrelated failures when running `jest currency`: the `countryCurrencyMapping` "flag asset coverage" suite (missing `public/flags/*.svg` in this worktree) and the `add-money-states` GROUP 3 crypto `10,000 USD` assertion — both fail on this base independent of these changes.

## Cross-repo follow-up (non-blocking)
`peanut-api-ts` `MantecaPrice` type has the same stale fields, but that path is **passthrough-only** (BE returns Manteca's JSON verbatim; nothing reads `effectiveBuy` at runtime), so it's a cosmetic type follow-up, not a runtime bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)