### PR TITLE
fix(add-money): stop page crash when FX rate fails to load (PEANUT-UI-PS7)

### DIFF
--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -1654,6 +1654,33 @@ describe('GROUP 8: InputAmountStep Component', () => {
         expect(screen.getByTestId('peanut-loading')).toBeInTheDocument()
     })
 
+    // Regression for PEANUT-UI-PS7: a failed FX fetch leaves price=null while
+    // isLoading=false. The old `currencyData.price!.buy` derefed null and crashed
+    // the whole render (Next.js page crash). It must now render an error and
+    // disable Continue instead of throwing.
+    test('rate fetch failure renders error and disables Continue (no crash)', () => {
+        renderWithProviders(
+            <InputAmountStep
+                tokenAmount="100"
+                setTokenAmount={jest.fn()}
+                onSubmit={jest.fn()}
+                isLoading={false}
+                error={null}
+                setCurrencyAmount={jest.fn()}
+                currencyData={{ isLoading: false, isError: true, symbol: null, price: null }}
+                limitsValidation={{ isBlocking: false, isWarning: false, currency: 'USD' }}
+                limitsCurrency="USD"
+                onBack={jest.fn()}
+            />
+        )
+
+        expect(screen.getByTestId('error-alert')).toBeInTheDocument()
+        expect(
+            screen.getByText('Exchange rates are temporarily unavailable. Please try again in a moment.')
+        ).toBeInTheDocument()
+        expect(screen.getByText('Continue')).toBeDisabled()
+    })
+
     test('onSubmit called when Continue clicked', async () => {
         const onSubmit = jest.fn()
         renderWithProviders(

--- a/src/components/AddMoney/components/InputAmountStep.tsx
+++ b/src/components/AddMoney/components/InputAmountStep.tsx
@@ -54,6 +54,12 @@ const InputAmountStep = ({
         return <PeanutLoading />
     }
 
+    // FX fetch failed (e.g. provider outage): price is null but not loading.
+    // Without this guard, `currencyData.price!.buy` below derefs null and
+    // crashes the whole render (PEANUT-UI-PS7). Surface an error and block
+    // submission instead — a wrong/absent rate must never reach onramp create.
+    const rateUnavailable = !!currencyData?.isError
+
     const limitsCardProps = limitsValidation
         ? getLimitsWarningCardProps({
               validation: limitsValidation,
@@ -77,10 +83,10 @@ const InputAmountStep = ({
                     setDisplayedAmount={setDisplayedAmount}
                     secondaryDenomination={{ symbol: 'USD', price: 1, decimals: 2 }}
                     primaryDenomination={
-                        currencyData
+                        currencyData?.price && currencyData.symbol
                             ? {
-                                  symbol: currencyData.symbol!,
-                                  price: currencyData.price!.buy,
+                                  symbol: currencyData.symbol,
+                                  price: currencyData.price.buy,
                                   decimals: 2,
                               }
                             : undefined
@@ -100,7 +106,13 @@ const InputAmountStep = ({
                     variant="purple"
                     shadowSize="4"
                     onClick={onSubmit}
-                    disabled={!!error || isLoading || !parseFloat(tokenAmount) || limitsValidation?.isBlocking}
+                    disabled={
+                        !!error ||
+                        isLoading ||
+                        !parseFloat(tokenAmount) ||
+                        limitsValidation?.isBlocking ||
+                        rateUnavailable
+                    }
                     className="w-full"
                     loading={isLoading}
                 >
@@ -108,6 +120,9 @@ const InputAmountStep = ({
                 </Button>
                 {/* only show error if limits blocking card is not displayed (warnings can coexist) */}
                 {error && !limitsValidation?.isBlocking && <ErrorAlert description={error} />}
+                {rateUnavailable && !error && !limitsValidation?.isBlocking && (
+                    <ErrorAlert description="Exchange rates are temporarily unavailable. Please try again in a moment." />
+                )}
             </div>
         </div>
     )

--- a/src/hooks/useCurrency.ts
+++ b/src/hooks/useCurrency.ts
@@ -23,8 +23,13 @@ export const useCurrency = (currencyCode: string | null) => {
     const [symbol, setSymbol] = useState<string | null>(null)
     const [price, setPrice] = useState<{ buy: number; sell: number } | null>(null)
     const [isLoading, setIsLoading] = useState<boolean>(true)
+    // Surfaces a failed FX fetch so consumers can render an error instead of
+    // dereferencing a null price (which crashes the render). See useCurrency
+    // consumers in the add-money / withdraw flows.
+    const [isError, setIsError] = useState<boolean>(false)
 
     useEffect(() => {
+        setIsError(false)
         if (!code) {
             setIsLoading(false)
             return
@@ -52,6 +57,7 @@ export const useCurrency = (currencyCode: string | null) => {
             })
             .catch((err) => {
                 console.error(err)
+                setIsError(true)
                 setIsLoading(false)
             })
     }, [code])
@@ -61,5 +67,6 @@ export const useCurrency = (currencyCode: string | null) => {
         symbol,
         price,
         isLoading,
+        isError,
     }
 }


### PR DESCRIPTION
## What

Fixes a **Next.js page crash** on the Manteca add-money (deposit) flow: `PEANUT-UI-PS7` — `TypeError: Cannot read properties of null (reading 'buy')`, thrown *during React render* (`handled: no`), which crashes the whole page via Next's global error boundary.

## Root cause

Two layers, one root event (Manteca returning no/garbage FX price):

1. `useCurrency` **swallowed the failed price fetch** — the `.catch` only did `console.error` + `setIsLoading(false)`, leaving `price = null`, `symbol = null`, and **no error signal**.
2. `InputAmountStep` only guarded `isLoading`. A *failed* load (`isLoading:false, price:null`) sailed through to `currencyData.price!.buy` — the `!` non-null assertion **lied to the compiler**, so at runtime `null.buy` threw during render → page crash.

Chronic since **2026-04-06** (crashes on *any* price-fetch failure). Today's Manteca outage made every AR/BR deposit attempt hit it, so it spiked and users reported white-screens.

Related upstream symptom (same event, not fixed here — it's the provider outage): `PEANUT-UI-QMR` `Invalid buy rate from provider: NaN` at `currency.ts:16`.

## Fix

- **`useCurrency`** — surface the failure: expose `isError` (set on `.catch`, reset per fetch). This is the root-level fix; the hook no longer hides failures from consumers.
- **`InputAmountStep`** — drop the `!` lies; build `primaryDenomination` only when `price` + `symbol` exist (crash-proof — `AmountInput` already defaults the denomination). When the rate is unavailable, show a friendly `ErrorAlert` and disable **Continue** so a wrong/absent rate can never reach onramp create.
- **Regression test** in `add-money-states.test.tsx` — renders the null-price / `isError` state and asserts it shows the error and disables Continue instead of throwing.

## Blast radius

- The crashing `.price!` is the **only** such site in the codebase, used only by `MantecaAddMoney`.
- The other `useCurrency` consumers (`MantecaReviewStep`, `withdraw/manteca`) read the same nullable `price` but via `?.`, so they render an ugly `undefined` rather than crashing — not touched here.

## Verification

- `tsc --noEmit` — green.
- `add-money-states` suite — 43/43 pass incl. the new regression test.
- Full jest — all suites pass (the `countryCurrencyMapping` flags-existence failures are a gitignored-asset artifact of fresh worktrees, unrelated).

## Note

This is a **P0-P1 live crash**. Targeting `dev` per normal flow — flag if you want it fast-tracked to `main`.
