### PR TITLE
fix: surface bridge deposit errors instead of failing silently

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -13,7 +13,7 @@ import { useAuth } from '@/context/authContext'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { getKycModalVariant, getGateUserMessage } from '@/utils/capability-gate'
 import { useModalsContext } from '@/context/ModalsContext'
-import { useCreateOnramp } from '@/hooks/useCreateOnramp'
+import { useCreateOnramp, GENERIC_ONRAMP_ERROR } from '@/hooks/useCreateOnramp'
 import { useParams, useSearchParams } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import countryCurrencyMappings, { isNonEuroSepaCountry, isUKCountry } from '@/constants/countryCurrencyMapping'
@@ -261,9 +261,12 @@ export default function OnrampBankPage() {
             // reviewing eea-uplift docs) — tell them to wait instead of a dead
             // button or a doomed transfer attempt with no feedback.
             if (gate.kind === 'waiting-on-provider') {
+                // prefer the backend's specific review copy (via the gate reason)
+                // and fall back to generic wait text.
                 setError({
                     showError: true,
                     errorMessage:
+                        gate.userMessage ??
                         'Your verification details are being reviewed. This usually takes a few minutes — please try again soon.',
                 })
                 return
@@ -323,17 +326,15 @@ export default function OnrampBankPage() {
             }
         } catch (error) {
             setShowWarningModal(false)
-            const errorMessage =
-                error instanceof Error
-                    ? error.message
-                    : 'Failed to create bank transfer. Please try again or contact support.'
+            const isError = error instanceof Error
+            const errorMessage = isError ? error.message : GENERIC_ONRAMP_ERROR
             posthog.capture(ANALYTICS_EVENTS.DEPOSIT_FAILED, {
                 method_type: 'bank',
-                error_message: errorMessage,
+                // keep the distinct label for truly-unexpected non-Error throws
+                error_message: isError ? errorMessage : 'Unknown error',
             })
-            // show the caught message directly — the hook's error state hasn't
-            // flushed yet in this synchronous catch, so reading it here always
-            // sees the previous render's value (null on first attempt).
+            // show the caught message directly — createOnramp carries the specific
+            // reason on the thrown Error, so we don't read any hook state here.
             setError({
                 showError: true,
                 errorMessage,

--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -73,7 +73,7 @@ export default function OnrampBankPage() {
 
     const { balance } = useWallet()
     const { user, fetchUser } = useAuth()
-    const { createOnramp, isLoading: isCreatingOnramp, error: onrampError } = useCreateOnramp()
+    const { createOnramp, isLoading: isCreatingOnramp } = useCreateOnramp()
 
     // inline sumsub kyc flow for bridge bank onramp
     // regionIntent is NOT passed here to avoid creating a backend record on mount.
@@ -254,11 +254,20 @@ export default function OnrampBankPage() {
         if (!validateAmount(rawTokenAmount)) return
 
         if (gate.kind !== 'ready') {
-            // capabilities still loading OR provider doing internal review —
-            // silently no-op instead of flashing a misleading needs_kyc modal.
-            // `waiting-on-provider` means the user has nothing to do; opening
-            // a KYC modal would imply otherwise.
-            if (gate.kind === 'loading' || gate.kind === 'waiting-on-provider') return
+            // capabilities still loading — silently no-op instead of flashing
+            // a misleading needs_kyc modal.
+            if (gate.kind === 'loading') return
+            // `waiting-on-provider` means the user has nothing to do (e.g. bridge
+            // reviewing eea-uplift docs) — tell them to wait instead of a dead
+            // button or a doomed transfer attempt with no feedback.
+            if (gate.kind === 'waiting-on-provider') {
+                setError({
+                    showError: true,
+                    errorMessage:
+                        'Your verification details are being reviewed. This usually takes a few minutes — please try again soon.',
+                })
+                return
+            }
             if (gate.kind === 'accept-tos') {
                 guardWithTos()
             } else {
@@ -314,17 +323,21 @@ export default function OnrampBankPage() {
             }
         } catch (error) {
             setShowWarningModal(false)
-            const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+            const errorMessage =
+                error instanceof Error
+                    ? error.message
+                    : 'Failed to create bank transfer. Please try again or contact support.'
             posthog.capture(ANALYTICS_EVENTS.DEPOSIT_FAILED, {
                 method_type: 'bank',
                 error_message: errorMessage,
             })
-            if (onrampError) {
-                setError({
-                    showError: true,
-                    errorMessage: onrampError,
-                })
-            }
+            // show the caught message directly — the hook's error state hasn't
+            // flushed yet in this synchronous catch, so reading it here always
+            // sees the previous render's value (null on first attempt).
+            setError({
+                showError: true,
+                errorMessage,
+            })
         }
     }
 

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -921,7 +921,6 @@ function applyDefaults() {
     mockUseCreateOnramp.mockReturnValue({
         createOnramp: jest.fn(),
         isLoading: false,
-        error: null,
     })
 
     mockUseLimitsValidation.mockReturnValue({
@@ -1309,7 +1308,6 @@ describe('GROUP 5: Bridge Bank Onramp', () => {
         mockUseCreateOnramp.mockReturnValue({
             createOnramp: mockCreateOnramp,
             isLoading: false,
-            error: null,
         })
         resetQueryState({ step: 'inputAmount', amount: '100' })
 
@@ -1331,13 +1329,11 @@ describe('GROUP 5: Bridge Bank Onramp', () => {
 
     test('onramp error displays ErrorAlert', async () => {
         const mockCreateOnramp = jest.fn().mockRejectedValue(new Error('Service unavailable'))
-        // error: null reproduces the first-attempt reality — the hook's error
-        // state hasn't flushed when the page's catch runs, so the page must
-        // surface the caught message itself, not read the hook state.
+        // the page must surface the caught error's message directly — the hook
+        // exposes no error state to read (that channel was the stale-closure trap).
         mockUseCreateOnramp.mockReturnValue({
             createOnramp: mockCreateOnramp,
             isLoading: false,
-            error: null,
         })
         resetQueryState({ step: 'inputAmount', amount: '100' })
 
@@ -1366,7 +1362,6 @@ describe('GROUP 5: Bridge Bank Onramp', () => {
         mockUseCreateOnramp.mockReturnValue({
             createOnramp: mockCreateOnramp,
             isLoading: false,
-            error: null,
         })
         resetQueryState({ step: 'inputAmount', amount: '100' })
 

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -746,7 +746,14 @@ function setParams(params: Record<string, string>) {
 // then push it onto the useCapabilities mock. The page reads `gateFor(...)`,
 // so the mock returns a stub gateFor closing over the desired state; it also
 // exposes `bankRails()` for the few sites that read it directly.
-type Gate = 'ready' | 'accept-tos' | 'fixable-rejection' | 'blocked-rejection' | 'needs-identity' | 'needs-enrollment'
+type Gate =
+    | 'ready'
+    | 'accept-tos'
+    | 'fixable-rejection'
+    | 'blocked-rejection'
+    | 'needs-identity'
+    | 'needs-enrollment'
+    | 'waiting-on-provider'
 
 function setGate(kind: Gate) {
     let rails: any[] = []
@@ -832,6 +839,22 @@ function setGate(kind: Gate) {
         case 'needs-identity':
             rails = []
             gateState = { kind: 'needs-identity' }
+            break
+        case 'waiting-on-provider':
+            // provider reviewing submitted info (e.g. eea-uplift docs) — user
+            // has nothing to do but wait
+            rails = [
+                {
+                    id: 'bridge.ach_us',
+                    provider: 'bridge',
+                    method: 'ACH_US',
+                    country: 'US',
+                    currency: 'USD',
+                    status: 'requires-info',
+                    blockingActions: ['wait:bridge'],
+                },
+            ]
+            gateState = { kind: 'waiting-on-provider', reason: { code: 'bridge_processing' } }
             break
     }
 
@@ -1308,10 +1331,13 @@ describe('GROUP 5: Bridge Bank Onramp', () => {
 
     test('onramp error displays ErrorAlert', async () => {
         const mockCreateOnramp = jest.fn().mockRejectedValue(new Error('Service unavailable'))
+        // error: null reproduces the first-attempt reality — the hook's error
+        // state hasn't flushed when the page's catch runs, so the page must
+        // surface the caught message itself, not read the hook state.
         mockUseCreateOnramp.mockReturnValue({
             createOnramp: mockCreateOnramp,
             isLoading: false,
-            error: 'Service unavailable',
+            error: null,
         })
         resetQueryState({ step: 'inputAmount', amount: '100' })
 
@@ -1327,8 +1353,35 @@ describe('GROUP 5: Bridge Bank Onramp', () => {
             fireEvent.click(screen.getByTestId('confirm-onramp'))
         })
 
-        // After error, the setError should have been called
-        expect(mockOnrampFlow.setError).toHaveBeenCalled()
+        // the caught message must be shown to the user
+        expect(mockOnrampFlow.setError).toHaveBeenCalledWith({
+            showError: true,
+            errorMessage: 'Service unavailable',
+        })
+    })
+
+    test('waiting-on-provider gate shows under-review message instead of silent no-op', async () => {
+        setGate('waiting-on-provider')
+        const mockCreateOnramp = jest.fn()
+        mockUseCreateOnramp.mockReturnValue({
+            createOnramp: mockCreateOnramp,
+            isLoading: false,
+            error: null,
+        })
+        resetQueryState({ step: 'inputAmount', amount: '100' })
+
+        renderWithProviders(<OnrampBankPage />)
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('Continue'))
+        })
+
+        // no transfer attempt, but the user is told why
+        expect(mockCreateOnramp).not.toHaveBeenCalled()
+        expect(mockOnrampFlow.setError).toHaveBeenCalledWith({
+            showError: true,
+            errorMessage: expect.stringContaining('being reviewed'),
+        })
     })
 
     test('limits blocking disables Continue and shows LimitsWarningCard', () => {

--- a/src/hooks/__tests__/useCreateOnramp.test.ts
+++ b/src/hooks/__tests__/useCreateOnramp.test.ts
@@ -1,0 +1,78 @@
+import { renderHook, act } from '@testing-library/react'
+import { useCreateOnramp } from '@/hooks/useCreateOnramp'
+import { type CountryData } from '@/components/AddMoney/consts'
+
+// regression test for the eea-uplift silent-failure incident: the backend
+// returns { error: '...' } on 400 (e.g. "Could not create transfer: customer
+// under review") but the hook used to throw a hardcoded generic message
+// without reading the body — users retried blind with no reason shown.
+const apiFetchMock = jest.fn()
+jest.mock('@/utils/api-fetch', () => ({
+    apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+jest.mock('@/utils/bridge.utils', () => ({
+    getCurrencyConfig: () => ({ currency: 'eur', paymentRail: 'sepa' }),
+}))
+
+jest.mock('@/app/actions/currency', () => ({
+    getCurrencyPrice: jest.fn(),
+}))
+
+const country = { id: 'DE', type: 'country', path: 'germany' } as unknown as CountryData
+
+describe('useCreateOnramp', () => {
+    beforeEach(() => {
+        apiFetchMock.mockReset()
+        jest.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
+    it('surfaces the backend error body on a non-ok response', async () => {
+        apiFetchMock.mockResolvedValue({
+            ok: false,
+            json: async () => ({ error: 'Could not create transfer: customer is under review' }),
+        })
+        const { result } = renderHook(() => useCreateOnramp())
+
+        await act(async () => {
+            await expect(result.current.createOnramp({ amount: '100', country })).rejects.toThrow(
+                'Could not create transfer: customer is under review'
+            )
+        })
+        expect(result.current.error).toBe('Could not create transfer: customer is under review')
+    })
+
+    it('falls back to the generic message when the error body is unparseable', async () => {
+        apiFetchMock.mockResolvedValue({
+            ok: false,
+            json: async () => {
+                throw new Error('not json')
+            },
+        })
+        const { result } = renderHook(() => useCreateOnramp())
+
+        await act(async () => {
+            await expect(result.current.createOnramp({ amount: '100', country })).rejects.toThrow(
+                'Failed to create bank transfer. Please try again or contact support.'
+            )
+        })
+        expect(result.current.error).toBe('Failed to create bank transfer. Please try again or contact support.')
+    })
+
+    it('returns the onramp data on success', async () => {
+        const data = { transferId: 't-1', depositInstructions: { amount: '100', currency: 'eur' } }
+        apiFetchMock.mockResolvedValue({ ok: true, json: async () => data })
+        const { result } = renderHook(() => useCreateOnramp())
+
+        let response: unknown
+        await act(async () => {
+            response = await result.current.createOnramp({ amount: '100', country })
+        })
+        expect(response).toEqual(data)
+        expect(result.current.error).toBeNull()
+    })
+})

--- a/src/hooks/__tests__/useCreateOnramp.test.ts
+++ b/src/hooks/__tests__/useCreateOnramp.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from '@testing-library/react'
-import { useCreateOnramp } from '@/hooks/useCreateOnramp'
+import { useCreateOnramp, GENERIC_ONRAMP_ERROR } from '@/hooks/useCreateOnramp'
 import { type CountryData } from '@/components/AddMoney/consts'
 
 // regression test for the eea-uplift silent-failure incident: the backend
@@ -31,9 +31,10 @@ describe('useCreateOnramp', () => {
         jest.restoreAllMocks()
     })
 
-    it('surfaces the backend error body on a non-ok response', async () => {
+    it('throws the backend error body on a 4xx response', async () => {
         apiFetchMock.mockResolvedValue({
             ok: false,
+            status: 400,
             json: async () => ({ error: 'Could not create transfer: customer is under review' }),
         })
         const { result } = renderHook(() => useCreateOnramp())
@@ -43,12 +44,26 @@ describe('useCreateOnramp', () => {
                 'Could not create transfer: customer is under review'
             )
         })
-        expect(result.current.error).toBe('Could not create transfer: customer is under review')
     })
 
-    it('falls back to the generic message when the error body is unparseable', async () => {
+    // the leak guard: a 500's body carries raw internal text (the BE global
+    // handler only sanitizes Prisma), so it must NOT be surfaced — the user
+    // gets the generic string and the body is never even read.
+    it('does not surface a 5xx error body, uses the generic message', async () => {
+        const jsonSpy = jest.fn(async () => ({ error: 'Request failed with status code 401 at /internal/bridge' }))
+        apiFetchMock.mockResolvedValue({ ok: false, status: 500, json: jsonSpy })
+        const { result } = renderHook(() => useCreateOnramp())
+
+        await act(async () => {
+            await expect(result.current.createOnramp({ amount: '100', country })).rejects.toThrow(GENERIC_ONRAMP_ERROR)
+        })
+        expect(jsonSpy).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the generic message when a 4xx body is unparseable', async () => {
         apiFetchMock.mockResolvedValue({
             ok: false,
+            status: 400,
             json: async () => {
                 throw new Error('not json')
             },
@@ -56,16 +71,13 @@ describe('useCreateOnramp', () => {
         const { result } = renderHook(() => useCreateOnramp())
 
         await act(async () => {
-            await expect(result.current.createOnramp({ amount: '100', country })).rejects.toThrow(
-                'Failed to create bank transfer. Please try again or contact support.'
-            )
+            await expect(result.current.createOnramp({ amount: '100', country })).rejects.toThrow(GENERIC_ONRAMP_ERROR)
         })
-        expect(result.current.error).toBe('Failed to create bank transfer. Please try again or contact support.')
     })
 
     it('returns the onramp data on success', async () => {
         const data = { transferId: 't-1', depositInstructions: { amount: '100', currency: 'eur' } }
-        apiFetchMock.mockResolvedValue({ ok: true, json: async () => data })
+        apiFetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => data })
         const { result } = renderHook(() => useCreateOnramp())
 
         let response: unknown
@@ -73,6 +85,5 @@ describe('useCreateOnramp', () => {
             response = await result.current.createOnramp({ amount: '100', country })
         })
         expect(response).toEqual(data)
-        expect(result.current.error).toBeNull()
     })
 })

--- a/src/hooks/useCreateOnramp.ts
+++ b/src/hooks/useCreateOnramp.ts
@@ -20,23 +20,28 @@ export type CreateOnrampParams = {
       }
 )
 
+// shared so the hook, the page catch, and their tests can't drift apart.
+export const GENERIC_ONRAMP_ERROR = 'Failed to create bank transfer. Please try again or contact support.'
+
 export interface UseCreateOnrampReturn {
     createOnramp: (params: CreateOnrampParams) => Promise<any>
     isLoading: boolean
-    error: string | null
 }
 
 /**
- * Custom hook for creating onramp transactions
+ * Custom hook for creating onramp transactions.
+ *
+ * The specific failure reason travels via the thrown Error's message — the
+ * caller shows `error.message` directly. We deliberately do NOT expose a React
+ * `error` state: reading it in a synchronous catch sees the pre-flush (stale)
+ * value, which is the silent-failure bug this hook was fixed for.
  */
 export const useCreateOnramp = (): UseCreateOnrampReturn => {
     const [isLoading, setIsLoading] = useState(false)
-    const [error, setError] = useState<string | null>(null)
 
     const createOnramp = useCallback(
         async ({ amount, country, chargeId, recipientAddress, usdAmount }: CreateOnrampParams) => {
             setIsLoading(true)
-            setError(null)
 
             try {
                 const { currency, paymentRail } = getCurrencyConfig(country.id, 'onramp')
@@ -59,23 +64,22 @@ export const useCreateOnramp = (): UseCreateOnrampReturn => {
                 })
 
                 if (!response.ok) {
-                    // parse error body from backend to get specific message
-                    const body = await response.json().catch(() => null)
-                    const errorMessage =
-                        body?.error ||
-                        body?.message ||
-                        'Failed to create bank transfer. Please try again or contact support.'
-                    setError(errorMessage)
-                    throw new Error(errorMessage)
+                    // Only trust the backend's error copy for client errors (4xx) —
+                    // those are deliberate, user-actionable messages from the route
+                    // (ToS-not-accepted, KYC/endorsement needed, Bridge decline).
+                    // 5xx bodies carry raw internal messages (the global handler only
+                    // sanitizes Prisma), so surfacing them would leak internals — fall
+                    // back to the generic string instead.
+                    const isClientError = response.status >= 400 && response.status < 500
+                    const body = isClientError ? await response.json().catch(() => null) : null
+                    throw new Error(body?.error || body?.message || GENERIC_ONRAMP_ERROR)
                 }
 
                 const onrampData = await response.json()
                 return onrampData
             } catch (err) {
                 console.error('Error creating onramp:', err)
-                // only set generic fallback if no specific error was already set by the !response.ok block
-                setError((prev) => prev ?? 'Failed to create bank transfer. Please try again or contact support.')
-                throw err
+                throw err instanceof Error ? err : new Error(GENERIC_ONRAMP_ERROR)
             } finally {
                 setIsLoading(false)
             }
@@ -86,6 +90,5 @@ export const useCreateOnramp = (): UseCreateOnrampReturn => {
     return {
         createOnramp,
         isLoading,
-        error,
     }
 }

--- a/src/hooks/useCreateOnramp.ts
+++ b/src/hooks/useCreateOnramp.ts
@@ -60,7 +60,11 @@ export const useCreateOnramp = (): UseCreateOnrampReturn => {
 
                 if (!response.ok) {
                     // parse error body from backend to get specific message
-                    let errorMessage = 'Failed to create bank transfer. Please try again or contact support.'
+                    const body = await response.json().catch(() => null)
+                    const errorMessage =
+                        body?.error ||
+                        body?.message ||
+                        'Failed to create bank transfer. Please try again or contact support.'
                     setError(errorMessage)
                     throw new Error(errorMessage)
                 }


### PR DESCRIPTION
## Summary

EEA-uplift users whose Bridge KYC docs are under review were creating deposits that failed with **zero feedback** — they retried blind (user recording confirmed; ~369 prod users currently sit in the waiting-on-provider state). Three silent-failure holes on the bank deposit path:

1. `useCreateOnramp` threw a hardcoded generic message without parsing the backend's `{ error }` body (the comment claimed it parsed; it didn't). Backend reasons like *"Could not create transfer: customer is under review"* were discarded.
2. The page's catch gated the visible error on the hook's `error` state, which hasn't flushed when the synchronous catch runs — always `null` on first attempt, so nothing displayed.
3. `gate.kind === 'waiting-on-provider'` silently no-op'd the Continue button — no "under review" UX existed anywhere.

Fix: parse the error body (`error`/`message` keys, generic fallback), show the caught message directly in the catch, and show a friendly "your verification details are being reviewed" message on the waiting-on-provider gate.

## Risks / breaking changes

- FE-only; no backend or contract changes.
- Backend error strings are now shown verbatim to users — they're already user-appropriate on this route ("Bridge Terms of Service must be accepted…", "Additional KYC may be required"), and any string beats the silent failure.
- Blast radius: bank deposit page + one hook (single consumer).

## QA

- `npm test` — 107 suites green, incl. new `useCreateOnramp` hook tests + 2 page tests (error surfacing with unflushed hook state; waiting-on-provider message instead of dead button).
- The strengthened page test reproduces the incident: old code fails it (hook `error: null` → no `setError` call), new code passes.
- Manual repro path: sandbox user with Bridge rail in `REQUIRES_EXTRA_INFORMATION` + `kyc_approval` wait signal → deposit → Continue now shows the under-review message.