### PR TITLE
feat(add-money): offramp migration deposit entry

### DIFF
--- a/src/app/(mobile-ui)/add-money/crypto/page.tsx
+++ b/src/app/(mobile-ui)/add-money/crypto/page.tsx
@@ -29,6 +29,9 @@ const AddMoneyCryptoPage = () => {
         'network',
         parseAsStringEnum<RhinoChainType>(['EVM', 'SOL', 'TRON']).withDefault('EVM')
     )
+    // offramp migration deep-link: strips the chain/token picker down to arbitrum + usdc
+    const [source] = useQueryState('source', parseAsStringEnum(['offramp']))
+    const isOfframp = source === 'offramp'
     const [showSuccessView, setShowSuccessView] = useState(false)
     const [depositResult, setDepositResult] = useState<DepositAddressStatusResponse | null>(null)
 
@@ -45,13 +48,13 @@ const AddMoneyCryptoPage = () => {
             posthog.capture(ANALYTICS_EVENTS.DEPOSIT_COMPLETED, {
                 amount,
                 chain_type: network,
-                method_type: 'crypto',
+                method_type: isOfframp ? 'offramp_migration' : 'crypto',
                 acquisition_source: user?.invitedBy ? 'referred' : 'organic',
             })
             setDepositResult(statusData ?? { status: 'completed', amount })
             setShowSuccessView(true)
         },
-        [network, user?.invitedBy]
+        [network, user?.invitedBy, isOfframp]
     )
 
     // build minimal transaction details for the receipt drawer
@@ -123,6 +126,7 @@ const AddMoneyCryptoPage = () => {
             isLoading={isLoading}
             onSuccess={handleSuccess}
             onBack={onBack}
+            variant={isOfframp ? 'offramp' : 'default'}
         />
     )
 }

--- a/src/components/AddMoney/views/AddMoneyMethodSelection.view.tsx
+++ b/src/components/AddMoney/views/AddMoneyMethodSelection.view.tsx
@@ -8,8 +8,10 @@ import { useAuth } from '@/context/authContext'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
-// placeholder — swap for the real badge code once the offramp badge PR lands.
-const OFFRAMP_BADGE_CODE = 'OFFRAMP'
+// offramp.xyz migrants get this link-granted badge at signup (peanut-api-ts
+// invite/badge routes, code `offramp` / utm `offramp`). Keep in sync with the
+// backend BADGE_CODES.OFFRAMP_USER.
+const OFFRAMP_BADGE_CODE = 'OFFRAMP_USER'
 
 interface AddMoneyMethodSelectionProps {
     onBankTransferClick: () => void

--- a/src/components/AddMoney/views/AddMoneyMethodSelection.view.tsx
+++ b/src/components/AddMoney/views/AddMoneyMethodSelection.view.tsx
@@ -4,8 +4,12 @@ import { ActionListCard } from '@/components/ActionListCard'
 import AvatarWithBadge from '@/components/Profile/AvatarWithBadge'
 import ChooseNetworkDrawer from '../components/ChooseNetworkDrawer'
 import type { RhinoChainType } from '@/services/services.types'
+import { useAuth } from '@/context/authContext'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
+
+// placeholder — swap for the real badge code once the offramp badge PR lands.
+const OFFRAMP_BADGE_CODE = 'OFFRAMP'
 
 interface AddMoneyMethodSelectionProps {
     onBankTransferClick: () => void
@@ -13,7 +17,11 @@ interface AddMoneyMethodSelectionProps {
 
 const AddMoneyMethodSelection = ({ onBankTransferClick }: AddMoneyMethodSelectionProps) => {
     const router = useRouter()
+    const { user } = useAuth()
     const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+
+    // offramp migrants get a tailored, de-cluttered arbitrum deposit entry
+    const hasOfframpBadge = user?.user?.badges?.some((b) => b.code === OFFRAMP_BADGE_CODE) ?? false
 
     const handleNetworkSelect = (network: RhinoChainType) => {
         setIsDrawerOpen(false)
@@ -25,10 +33,21 @@ const AddMoneyMethodSelection = ({ onBankTransferClick }: AddMoneyMethodSelectio
             <div className="flex flex-col gap-2">
                 <h2 className="text-base font-bold">How would you like to add money?</h2>
                 <div className="flex flex-col">
+                    {hasOfframpBadge && (
+                        <ActionListCard
+                            title="Migrate from Offramp"
+                            description="Move your Offramp balance to Peanut"
+                            position="first"
+                            leftIcon={
+                                <AvatarWithBadge icon="wallet-outline" size="extra-small" className="bg-yellow-1" />
+                            }
+                            onClick={() => router.push('/add-money/crypto?network=EVM&source=offramp')}
+                        />
+                    )}
                     <ActionListCard
                         title="Crypto"
                         description="Deposit from a wallet or exchange"
-                        position="first"
+                        position={hasOfframpBadge ? 'middle' : 'first'}
                         leftIcon={<AvatarWithBadge icon="wallet-outline" size="extra-small" className="bg-yellow-1" />}
                         onClick={() => setIsDrawerOpen(true)}
                     />

--- a/src/components/AddMoney/views/CryptoDeposit.view.tsx
+++ b/src/components/AddMoney/views/CryptoDeposit.view.tsx
@@ -17,6 +17,7 @@ import {
     SUPPORTED_EVM_CHAINS,
     NETWORK_LABELS,
     NETWORK_LOGOS,
+    TOKEN_LOGOS,
     getSupportedTokens,
 } from '@/constants/rhino.consts'
 import type {
@@ -35,6 +36,9 @@ interface CryptoDepositViewProps {
     isLoading: boolean
     onSuccess: (amount: number, statusData?: DepositAddressStatusResponse) => void
     onBack: () => void
+    // offramp migration: same rhino EVM SDA (funds land on arbitrum) but with the
+    // multi-chain / multi-token picker stripped to a single arbitrum + usdc surface.
+    variant?: 'default' | 'offramp'
 }
 
 const TOOLTIP_TEXT: Record<RhinoChainType, string> = {
@@ -43,23 +47,32 @@ const TOOLTIP_TEXT: Record<RhinoChainType, string> = {
     TRON: 'Your Tron deposit address. Deposits are bridged to Arbitrum (±0.1% variance).',
 }
 
-const CryptoDepositView = ({ network, depositAddressData, isLoading, onSuccess, onBack }: CryptoDepositViewProps) => {
+const CryptoDepositView = ({
+    network,
+    depositAddressData,
+    isLoading,
+    onSuccess,
+    onBack,
+    variant = 'default',
+}: CryptoDepositViewProps) => {
     const [showHowToDeposit, setShowHowToDeposit] = useState(false)
     const [showSupportedNetworks, setShowSupportedNetworks] = useState(false)
     const { status, resetStatus, isResetting } = useCryptoDepositPolling(depositAddressData?.depositAddress, onSuccess)
 
     const networkLabel = NETWORK_LABELS[network]
     const isEvm = network === 'EVM'
+    const isOfframp = variant === 'offramp'
 
     const supportedTokens = getSupportedTokens(network)
 
-    const amountLimitsLabel = isEvm ? 'EVM networks' : networkLabel
+    const amountLimitsLabel = isOfframp ? 'Arbitrum' : isEvm ? 'EVM networks' : networkLabel
+    const headerTitle = isOfframp ? 'Migrate from Offramp' : 'Deposit Crypto'
 
     // failed state
     if (status === 'failed') {
         return (
             <div className="flex min-h-[inherit] w-full flex-col justify-start gap-8 pb-5 md:pb-0">
-                <NavHeader title="Deposit Crypto" onPrev={onBack} />
+                <NavHeader title={headerTitle} onPrev={onBack} />
                 <div className="flex h-full min-h-[60vh] flex-col items-center justify-center gap-4">
                     <Card>
                         <div className="flex w-full flex-col items-center justify-center gap-2">
@@ -85,12 +98,20 @@ const CryptoDepositView = ({ network, depositAddressData, isLoading, onSuccess, 
 
     return (
         <div className="flex min-h-[inherit] w-full flex-col gap-8 pb-5 md:pb-0">
-            <NavHeader title="Deposit Crypto" onPrev={onBack} />
+            <NavHeader title={headerTitle} onPrev={onBack} />
 
             <div className="my-auto flex w-full flex-col gap-4">
                 {/* subtitle */}
                 <p className="text-center text-sm text-grey-1">
-                    Send tokens to this <span className="font-bold text-n-1">{networkLabel}</span> address
+                    {isOfframp ? (
+                        <>
+                            Send <span className="font-bold text-n-1">USDC on Arbitrum</span> to migrate your balance
+                        </>
+                    ) : (
+                        <>
+                            Send tokens to this <span className="font-bold text-n-1">{networkLabel}</span> address
+                        </>
+                    )}
                 </p>
 
                 {/* loading state */}
@@ -106,7 +127,7 @@ const CryptoDepositView = ({ network, depositAddressData, isLoading, onSuccess, 
                         <div className="flex items-center justify-center">
                             <QRCodeWrapper
                                 url={depositAddressData.depositAddress}
-                                centerImage={NETWORK_LOGOS[network]}
+                                centerImage={isOfframp ? CHAIN_LOGOS.ARBITRUM : NETWORK_LOGOS[network]}
                             />
                         </div>
 
@@ -115,14 +136,18 @@ const CryptoDepositView = ({ network, depositAddressData, isLoading, onSuccess, 
                             {/* address section */}
                             <div className="flex flex-col gap-2 p-4">
                                 <div className="flex items-center gap-1">
-                                    <Tooltip content={TOOLTIP_TEXT[network]} position="bottom">
-                                        <span className="flex items-center gap-1">
-                                            <span className="text-sm font-bold">
-                                                {isEvm ? 'Universal Deposit Address' : 'Deposit Address'}
+                                    {isOfframp ? (
+                                        <span className="text-sm font-bold">Your Arbitrum address</span>
+                                    ) : (
+                                        <Tooltip content={TOOLTIP_TEXT[network]} position="bottom">
+                                            <span className="flex items-center gap-1">
+                                                <span className="text-sm font-bold">
+                                                    {isEvm ? 'Universal Deposit Address' : 'Deposit Address'}
+                                                </span>
+                                                <Icon name="info" size={18} className="text-grey-1" />
                                             </span>
-                                            <Icon name="info" size={18} className="text-grey-1" />
-                                        </span>
-                                    </Tooltip>
+                                        </Tooltip>
+                                    )}
                                 </div>
                                 <div className="flex items-start justify-between gap-2">
                                     <p className="break-all text-sm">
@@ -145,16 +170,20 @@ const CryptoDepositView = ({ network, depositAddressData, isLoading, onSuccess, 
                             {/* supported networks section */}
                             <div
                                 onClick={() => {
-                                    if (isEvm) {
+                                    if (isEvm && !isOfframp) {
                                         setShowSupportedNetworks(true)
                                     }
                                 }}
-                                className={`border-t border-black p-4 ${isEvm ? 'cursor-pointer' : ''}`}
+                                className={`border-t border-black p-4 ${isEvm && !isOfframp ? 'cursor-pointer' : ''}`}
                             >
-                                <p className="mb-2 text-sm font-bold">Supported Networks:</p>
+                                <p className="mb-2 text-sm font-bold">
+                                    {isOfframp ? 'Network:' : 'Supported Networks:'}
+                                </p>
                                 <div className="flex items-center gap-2">
                                     <div className="flex flex-wrap gap-2">
-                                        {isEvm ? (
+                                        {isOfframp ? (
+                                            <ChainChip chainName="Arbitrum" chainSymbol={CHAIN_LOGOS.ARBITRUM} />
+                                        ) : isEvm ? (
                                             <>
                                                 {SUPPORTED_EVM_CHAINS.map((chain) => (
                                                     <Image
@@ -174,7 +203,7 @@ const CryptoDepositView = ({ network, depositAddressData, isLoading, onSuccess, 
                                             />
                                         )}
                                     </div>
-                                    {isEvm && (
+                                    {isEvm && !isOfframp && (
                                         <Button
                                             shadowSize="4"
                                             size="small"
@@ -190,15 +219,17 @@ const CryptoDepositView = ({ network, depositAddressData, isLoading, onSuccess, 
 
                             {/* supported tokens section */}
                             <div className="border-t border-black p-4">
-                                <p className="mb-2 text-sm font-bold">Supported Tokens:</p>
+                                <p className="mb-2 text-sm font-bold">{isOfframp ? 'Token:' : 'Supported Tokens:'}</p>
                                 <div className="flex flex-wrap gap-1.5">
-                                    {supportedTokens.map((token) => (
-                                        <ChainChip
-                                            key={token.name}
-                                            chainName={token.name}
-                                            chainSymbol={token.logoUrl}
-                                        />
-                                    ))}
+                                    {(isOfframp ? [{ name: 'USDC', logoUrl: TOKEN_LOGOS.USDC }] : supportedTokens).map(
+                                        (token) => (
+                                            <ChainChip
+                                                key={token.name}
+                                                chainName={token.name}
+                                                chainSymbol={token.logoUrl}
+                                            />
+                                        )
+                                    )}
                                 </div>
                             </div>
                         </div>
@@ -207,8 +238,12 @@ const CryptoDepositView = ({ network, depositAddressData, isLoading, onSuccess, 
                         <InfoCard
                             variant="warning"
                             icon="alert"
-                            title="Send to supported networks only"
-                            description="Wrong token or network may cause permanent loss."
+                            title={isOfframp ? 'Send USDC on Arbitrum only' : 'Send to supported networks only'}
+                            description={
+                                isOfframp
+                                    ? 'Other tokens or networks may cause permanent loss.'
+                                    : 'Wrong token or network may cause permanent loss.'
+                            }
                         />
 
                         {/* min/max limits */}

--- a/src/components/Invites/InvitesPage.tsx
+++ b/src/components/Invites/InvitesPage.tsx
@@ -34,7 +34,11 @@ function InvitePageContent() {
     // resolution order: explicit campaign / campaignTag query param wins, then
     // mapped invite code, then mapped utm_campaign. utm_campaign comes last so
     // an explicit ?campaign= can still override on links that carry both.
+    // A lowercase vanity tag in the explicit param (e.g. ?campaign=offramp) is
+    // resolved through the UTM map to its badge code — otherwise it reaches
+    // /badge/award raw and 400s, since the backend matches the badge code.
     const campaign =
+        (campaignParam && UTM_CAMPAIGN_TO_BADGE_MAP[campaignParam.toLowerCase()]) ||
         campaignParam ||
         (inviteCode ? INVITE_CODE_TO_CAMPAIGN_MAP[inviteCode] : undefined) ||
         (utmCampaignParam ? UTM_CAMPAIGN_TO_BADGE_MAP[utmCampaignParam] : undefined)


### PR DESCRIPTION
## Why

[offramp.xyz is shutting down](https://www.offramp.xyz/blog/were-shutting-down-offramp/) and migrating its users to Peanut (~50k accounts, ~5k active). To improve conversion of migrants, Konrad asked for a dedicated, de-cluttered deposit entry that hands offramp users an Arbitrum address without the full multi-chain crypto picker.

Offramp users hold funds in ZeroDev smart accounts on Arbitrum, so the existing crypto deposit already does the job functionally (Rhino EVM SDA → funds land on the Peanut Arbitrum wallet). This PR is a thin, branded, tracked wrapper over that same infra — **no backend changes**.

## What

- **Gated entry** — a "Migrate from Offramp" card in the add-money method list, shown only to users with the offramp badge. Routes to `/add-money/crypto?network=EVM&source=offramp`.
- **`offramp` variant** of `CryptoDeposit.view` — same Rhino SDA, QR, address, copy, polling and success screen, but strips the chain fluff: single **Arbitrum** network chip + single **USDC** token chip, offramp copy, no network drawer / no supported-networks modal / no multi-chain tooltip.
- **Analytics** — completions tag `method_type: 'offramp_migration'` for the growth dashboard.

## Draft — pending badge wiring ⚠️

The offramp badge doesn't exist yet (Konrad's badges PR is WIP). This PR uses a **placeholder** badge code:

```ts
// AddMoneyMethodSelection.view.tsx
const OFFRAMP_BADGE_CODE = 'OFFRAMP'
```

Before merge:
1. Swap `OFFRAMP_BADGE_CODE` for the real code from the badges PR.
2. Confirm the badge is **`link`-granted at signup** (via the offramp signup invite code/campaign), **not `auto`** on an action — otherwise it's circular (need a deposit to earn the badge that unlocks the deposit entry).

## Reuse / scope

Reuses `useCryptoDepositPolling`, the SDA creation query, and `PaymentSuccessView` unchanged. Default (non-offramp) crypto deposit is untouched. FE-only.

## Test plan
- [ ] Load `/add-money/crypto?network=EVM&source=offramp` → see stripped Arbitrum + USDC surface
- [ ] Add-money method list shows "Migrate from Offramp" only when the user has the (placeholder) offramp badge
- [ ] Deposit USDC on Arbitrum → success screen + receipt work as before
- [ ] Non-offramp crypto deposit unchanged