### PR TITLE
feat(analytics): fire eea_uplift funnel on modal open, cover all remediation

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -37,7 +37,7 @@ import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
 import AdvisoryPreemptModal from '@/components/Kyc/AdvisoryPreemptModal'
 import { useAdvisoryPreempt } from '@/hooks/useAdvisoryPreempt'
 import { useEeaUpliftFunnel } from '@/hooks/useEeaUpliftFunnel'
-import { eeaUpliftReasonCode, isEeaUpliftAdvisory } from '@/utils/eea-uplift.utils'
+import { upliftTriggerFromGate, upliftTriggerFromAdvisory } from '@/utils/eea-uplift.utils'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { addMoneyCountryUrl } from '@/utils/native-routes'
@@ -142,7 +142,7 @@ export default function OnrampBankPage() {
         // Route through the self-heal resubmit path (reheal-tagged action) so the
         // completed submission round-trips to Bridge. start-action mints a plain
         // token whose webhook completion has no Bridge relay → answers are dropped.
-        // NB: eea_uplift_started is fired at modal-open (handleAmountContinue),
+        // note: eea_uplift_started is fired at modal-open (handleAmountContinue),
         // not here, so abandoners are captured too.
         onCompleteNow: () => {
             if (!advisory) return Promise.resolve()
@@ -264,12 +264,10 @@ export default function OnrampBankPage() {
             if (gate.kind === 'accept-tos') {
                 guardWithTos()
             } else {
-                // urgent (post-cliff) EEA uplift lands here as a fixable-rejection —
+                // urgent (post-cliff) eea uplift lands here as a fixable-rejection —
                 // fire the funnel event as this KYC modal opens.
-                const upliftCode = eeaUpliftReasonCode(gate)
-                if (upliftCode) {
-                    trackUpliftStarted({ requirementKey: upliftCode, source: 'blocking' })
-                }
+                const upliftTrigger = upliftTriggerFromGate(gate)
+                if (upliftTrigger) trackUpliftStarted(upliftTrigger)
                 setShowKycModal(true)
             }
             return
@@ -279,16 +277,10 @@ export default function OnrampBankPage() {
         // (record the amount-entered event, open the confirmation modal) only
         // runs once there's no pending requirement; while one exists the modal
         // blocks and this never fires, so the event can't double-count.
-        // Upcoming (future-dated) EEA uplift opens the advisory modal here — fire
+        // upcoming (future-dated) eea uplift opens the advisory modal here — fire
         // the funnel event as it opens.
-        if (isEeaUpliftAdvisory(advisory)) {
-            trackUpliftStarted({
-                requirementKey: advisory?.requirementKey,
-                actionKey: advisory?.actionKey,
-                effectiveDate: advisory?.effectiveDate,
-                source: 'advisory',
-            })
-        }
+        const advisoryTrigger = upliftTriggerFromAdvisory(advisory)
+        if (advisoryTrigger) trackUpliftStarted(advisoryTrigger)
         advisoryIntercept(() => {
             posthog.capture(ANALYTICS_EVENTS.DEPOSIT_AMOUNT_ENTERED, {
                 amount_usd: usdEquivalent,
@@ -472,7 +464,12 @@ export default function OnrampBankPage() {
 
                 <InitiateKycModal
                     visible={showKycModal}
-                    onClose={() => setShowKycModal(false)}
+                    onClose={() => {
+                        // dismiss = abandon: clear the uplift latch so a later
+                        // unrelated KYC success can't mis-fire eea_uplift_completed.
+                        setShowKycModal(false)
+                        resetUpliftFunnel()
+                    }}
                     onVerify={async () => {
                         if (gate.kind === 'restart-identity') {
                             await sumsubFlow.handleRestartIdentity()
@@ -489,6 +486,7 @@ export default function OnrampBankPage() {
                     }}
                     onContactSupport={() => {
                         setShowKycModal(false)
+                        resetUpliftFunnel()
                         setIsSupportModalOpen(true)
                     }}
                     isLoading={sumsubFlow.isLoading}

--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -37,6 +37,7 @@ import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
 import AdvisoryPreemptModal from '@/components/Kyc/AdvisoryPreemptModal'
 import { useAdvisoryPreempt } from '@/hooks/useAdvisoryPreempt'
 import { useEeaUpliftFunnel } from '@/hooks/useEeaUpliftFunnel'
+import { eeaUpliftReasonCode, isEeaUpliftAdvisory } from '@/utils/eea-uplift.utils'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { addMoneyCountryUrl } from '@/utils/native-routes'
@@ -141,9 +142,10 @@ export default function OnrampBankPage() {
         // Route through the self-heal resubmit path (reheal-tagged action) so the
         // completed submission round-trips to Bridge. start-action mints a plain
         // token whose webhook completion has no Bridge relay → answers are dropped.
+        // NB: eea_uplift_started is fired at modal-open (handleAmountContinue),
+        // not here, so abandoners are captured too.
         onCompleteNow: () => {
             if (!advisory) return Promise.resolve()
-            trackUpliftStarted(advisory)
             return sumsubFlow.handleSelfHealResubmit('BRIDGE', advisory.requirementKey)
         },
     })
@@ -262,6 +264,12 @@ export default function OnrampBankPage() {
             if (gate.kind === 'accept-tos') {
                 guardWithTos()
             } else {
+                // urgent (post-cliff) EEA uplift lands here as a fixable-rejection —
+                // fire the funnel event as this KYC modal opens.
+                const upliftCode = eeaUpliftReasonCode(gate)
+                if (upliftCode) {
+                    trackUpliftStarted({ requirementKey: upliftCode, source: 'blocking' })
+                }
                 setShowKycModal(true)
             }
             return
@@ -271,6 +279,16 @@ export default function OnrampBankPage() {
         // (record the amount-entered event, open the confirmation modal) only
         // runs once there's no pending requirement; while one exists the modal
         // blocks and this never fires, so the event can't double-count.
+        // Upcoming (future-dated) EEA uplift opens the advisory modal here — fire
+        // the funnel event as it opens.
+        if (isEeaUpliftAdvisory(advisory)) {
+            trackUpliftStarted({
+                requirementKey: advisory?.requirementKey,
+                actionKey: advisory?.actionKey,
+                effectiveDate: advisory?.effectiveDate,
+                source: 'advisory',
+            })
+        }
         advisoryIntercept(() => {
             posthog.capture(ANALYTICS_EVENTS.DEPOSIT_AMOUNT_ENTERED, {
                 amount_usd: usdEquivalent,

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -33,7 +33,7 @@ import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
 import AdvisoryPreemptModal from '@/components/Kyc/AdvisoryPreemptModal'
 import { useAdvisoryPreempt } from '@/hooks/useAdvisoryPreempt'
 import { useEeaUpliftFunnel } from '@/hooks/useEeaUpliftFunnel'
-import { eeaUpliftReasonCode, isEeaUpliftAdvisory } from '@/utils/eea-uplift.utils'
+import { upliftTriggerFromGate, upliftTriggerFromAdvisory } from '@/utils/eea-uplift.utils'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { getKycModalVariant, getGateUserMessage } from '@/utils/capability-gate'
 import { useModalsContext } from '@/context/ModalsContext'
@@ -118,8 +118,8 @@ export default function WithdrawBankPage() {
         // Route through the self-heal resubmit path (reheal-tagged action) so the
         // completed submission round-trips to Bridge. start-action mints a plain
         // token whose webhook completion has no Bridge relay → answers are dropped.
-        // NB: eea_uplift_started is fired at modal-open (the handlers below), not
-        // here, so abandoners are captured too.
+        // note: eea_uplift_started is fired at modal-open (the handlers below),
+        // not here, so abandoners are captured too.
         onCompleteNow: () => {
             if (!advisory) return Promise.resolve()
             return sumsubFlow.handleSelfHealResubmit('BRIDGE', advisory.requirementKey)
@@ -219,12 +219,10 @@ export default function WithdrawBankPage() {
             if (gate.kind === 'accept-tos') {
                 guardWithTos()
             } else {
-                // urgent (post-cliff) EEA uplift lands here as a fixable-rejection —
+                // urgent (post-cliff) eea uplift lands here as a fixable-rejection —
                 // fire the funnel event as this KYC modal opens.
-                const upliftCode = eeaUpliftReasonCode(gate)
-                if (upliftCode) {
-                    trackUpliftStarted({ requirementKey: upliftCode, source: 'blocking' })
-                }
+                const upliftTrigger = upliftTriggerFromGate(gate)
+                if (upliftTrigger) trackUpliftStarted(upliftTrigger)
                 setShowKycModal(true)
             }
             return
@@ -354,17 +352,11 @@ export default function WithdrawBankPage() {
     // Enforce the mandatory verification pre-empt, then run the offramp. When the
     // gate isn't `ready` (or there's no pending requirement) this is a no-op and
     // proceedWithOfframp runs straight away (it handles the not-ready cases).
-    // Upcoming (future-dated) EEA uplift opens the advisory modal here — fire the
+    // upcoming (future-dated) eea uplift opens the advisory modal here — fire the
     // funnel event as it opens.
     const handleCreateAndInitiateOfframp = () => {
-        if (isEeaUpliftAdvisory(advisory)) {
-            trackUpliftStarted({
-                requirementKey: advisory?.requirementKey,
-                actionKey: advisory?.actionKey,
-                effectiveDate: advisory?.effectiveDate,
-                source: 'advisory',
-            })
-        }
+        const advisoryTrigger = upliftTriggerFromAdvisory(advisory)
+        if (advisoryTrigger) trackUpliftStarted(advisoryTrigger)
         advisoryIntercept(() => void proceedWithOfframp())
     }
 
@@ -563,7 +555,12 @@ export default function WithdrawBankPage() {
 
             <InitiateKycModal
                 visible={showKycModal}
-                onClose={() => setShowKycModal(false)}
+                onClose={() => {
+                    // dismiss = abandon: clear the uplift latch so a later
+                    // unrelated KYC success can't mis-fire eea_uplift_completed.
+                    setShowKycModal(false)
+                    resetUpliftFunnel()
+                }}
                 onVerify={async () => {
                     if (gate.kind === 'restart-identity') {
                         await sumsubFlow.handleRestartIdentity()
@@ -580,6 +577,7 @@ export default function WithdrawBankPage() {
                 }}
                 onContactSupport={() => {
                     setShowKycModal(false)
+                    resetUpliftFunnel()
                     setIsSupportModalOpen(true)
                 }}
                 isLoading={sumsubFlow.isLoading}

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -33,6 +33,7 @@ import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
 import AdvisoryPreemptModal from '@/components/Kyc/AdvisoryPreemptModal'
 import { useAdvisoryPreempt } from '@/hooks/useAdvisoryPreempt'
 import { useEeaUpliftFunnel } from '@/hooks/useEeaUpliftFunnel'
+import { eeaUpliftReasonCode, isEeaUpliftAdvisory } from '@/utils/eea-uplift.utils'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { getKycModalVariant, getGateUserMessage } from '@/utils/capability-gate'
 import { useModalsContext } from '@/context/ModalsContext'
@@ -117,9 +118,10 @@ export default function WithdrawBankPage() {
         // Route through the self-heal resubmit path (reheal-tagged action) so the
         // completed submission round-trips to Bridge. start-action mints a plain
         // token whose webhook completion has no Bridge relay → answers are dropped.
+        // NB: eea_uplift_started is fired at modal-open (the handlers below), not
+        // here, so abandoners are captured too.
         onCompleteNow: () => {
             if (!advisory) return Promise.resolve()
-            trackUpliftStarted(advisory)
             return sumsubFlow.handleSelfHealResubmit('BRIDGE', advisory.requirementKey)
         },
     })
@@ -217,6 +219,12 @@ export default function WithdrawBankPage() {
             if (gate.kind === 'accept-tos') {
                 guardWithTos()
             } else {
+                // urgent (post-cliff) EEA uplift lands here as a fixable-rejection —
+                // fire the funnel event as this KYC modal opens.
+                const upliftCode = eeaUpliftReasonCode(gate)
+                if (upliftCode) {
+                    trackUpliftStarted({ requirementKey: upliftCode, source: 'blocking' })
+                }
                 setShowKycModal(true)
             }
             return
@@ -346,7 +354,19 @@ export default function WithdrawBankPage() {
     // Enforce the mandatory verification pre-empt, then run the offramp. When the
     // gate isn't `ready` (or there's no pending requirement) this is a no-op and
     // proceedWithOfframp runs straight away (it handles the not-ready cases).
-    const handleCreateAndInitiateOfframp = () => advisoryIntercept(() => void proceedWithOfframp())
+    // Upcoming (future-dated) EEA uplift opens the advisory modal here — fire the
+    // funnel event as it opens.
+    const handleCreateAndInitiateOfframp = () => {
+        if (isEeaUpliftAdvisory(advisory)) {
+            trackUpliftStarted({
+                requirementKey: advisory?.requirementKey,
+                actionKey: advisory?.actionKey,
+                effectiveDate: advisory?.effectiveDate,
+                source: 'advisory',
+            })
+        }
+        advisoryIntercept(() => void proceedWithOfframp())
+    }
 
     const countryCodeForFlag = () => {
         if (!bankAccount?.details?.countryCode) return ''

--- a/src/hooks/useEeaUpliftFunnel.test.ts
+++ b/src/hooks/useEeaUpliftFunnel.test.ts
@@ -1,46 +1,67 @@
 import { act, renderHook } from '@testing-library/react'
 import posthog from 'posthog-js'
-import { useEeaUpliftFunnel } from './useEeaUpliftFunnel'
+import { useEeaUpliftFunnel, type UpliftStartTrigger } from './useEeaUpliftFunnel'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
-import type { GateAdvisory } from '@/utils/capability-gate'
 
 jest.mock('posthog-js', () => ({ capture: jest.fn() }))
 const capture = posthog.capture as jest.Mock
 
-const advisory: GateAdvisory = {
-    effectiveDate: '2026-06-29',
+// future-dated advisory (upcoming) trigger
+const advisoryTrigger: UpliftStartTrigger = {
+    effectiveDate: '2026-12-31',
     actionKey: 'sumsub:eea_uplift',
-    requirementKey: 'sof_individual_primary_purpose',
+    requirementKey: 'has_foreign_tax_registration',
+    source: 'advisory',
+}
+
+// post-cliff blocking trigger — no effective date, reason code as the key
+const blockingTrigger: UpliftStartTrigger = {
+    requirementKey: 'eea_uplift',
+    source: 'blocking',
 }
 
 beforeEach(() => capture.mockClear())
 
 describe('useEeaUpliftFunnel', () => {
-    test('trackStarted fires eea_uplift_started with channel + advisory props', () => {
+    test('trackStarted fires eea_uplift_started with channel + trigger props (advisory = not urgent)', () => {
         const { result } = renderHook(() => useEeaUpliftFunnel('deposit'))
-        act(() => result.current.trackStarted(advisory))
+        act(() => result.current.trackStarted(advisoryTrigger))
 
         expect(capture).toHaveBeenCalledTimes(1)
         expect(capture).toHaveBeenCalledWith(ANALYTICS_EVENTS.EEA_UPLIFT_STARTED, {
             channel: 'deposit',
-            requirement_key: 'sof_individual_primary_purpose',
+            requirement_key: 'has_foreign_tax_registration',
             action_key: 'sumsub:eea_uplift',
-            effective_date: '2026-06-29',
+            effective_date: '2026-12-31',
+            source: 'advisory',
+            urgent: false,
         })
     })
 
-    test('trackCompleted fires eea_uplift_completed only after a start', () => {
+    test('blocking trigger is flagged urgent', () => {
+        const { result } = renderHook(() => useEeaUpliftFunnel('deposit'))
+        act(() => result.current.trackStarted(blockingTrigger))
+
+        expect(capture).toHaveBeenCalledWith(
+            ANALYTICS_EVENTS.EEA_UPLIFT_STARTED,
+            expect.objectContaining({ source: 'blocking', urgent: true, requirement_key: 'eea_uplift' })
+        )
+    })
+
+    test('trackCompleted fires eea_uplift_completed only after a start, echoing the trigger', () => {
         const { result } = renderHook(() => useEeaUpliftFunnel('withdraw'))
-        act(() => result.current.trackStarted(advisory))
+        act(() => result.current.trackStarted(advisoryTrigger))
         capture.mockClear()
 
         act(() => result.current.trackCompleted())
         expect(capture).toHaveBeenCalledTimes(1)
         expect(capture).toHaveBeenCalledWith(ANALYTICS_EVENTS.EEA_UPLIFT_COMPLETED, {
             channel: 'withdraw',
-            requirement_key: 'sof_individual_primary_purpose',
+            requirement_key: 'has_foreign_tax_registration',
             action_key: 'sumsub:eea_uplift',
-            effective_date: '2026-06-29',
+            effective_date: '2026-12-31',
+            source: 'advisory',
+            urgent: false,
         })
     })
 
@@ -52,7 +73,7 @@ describe('useEeaUpliftFunnel', () => {
 
     test('trackCompleted only fires once per start (ref cleared)', () => {
         const { result } = renderHook(() => useEeaUpliftFunnel('deposit'))
-        act(() => result.current.trackStarted(advisory))
+        act(() => result.current.trackStarted(advisoryTrigger))
         capture.mockClear()
 
         act(() => result.current.trackCompleted())
@@ -62,7 +83,7 @@ describe('useEeaUpliftFunnel', () => {
 
     test('reset clears a pending start so a later success cannot mis-fire completed', () => {
         const { result } = renderHook(() => useEeaUpliftFunnel('deposit'))
-        act(() => result.current.trackStarted(advisory))
+        act(() => result.current.trackStarted(advisoryTrigger))
         capture.mockClear()
 
         // user abandoned the flow → reset, then an unrelated KYC success fires

--- a/src/hooks/useEeaUpliftFunnel.test.ts
+++ b/src/hooks/useEeaUpliftFunnel.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react'
 import posthog from 'posthog-js'
-import { useEeaUpliftFunnel, type UpliftStartTrigger } from './useEeaUpliftFunnel'
+import { useEeaUpliftFunnel } from './useEeaUpliftFunnel'
+import type { UpliftStartTrigger } from '@/utils/eea-uplift.utils'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 jest.mock('posthog-js', () => ({ capture: jest.fn() }))
@@ -46,6 +47,25 @@ describe('useEeaUpliftFunnel', () => {
             ANALYTICS_EVENTS.EEA_UPLIFT_STARTED,
             expect.objectContaining({ source: 'blocking', urgent: true, requirement_key: 'eea_uplift' })
         )
+    })
+
+    test('trackStarted is idempotent per armed attempt (repeat clicks do not re-emit)', () => {
+        const { result } = renderHook(() => useEeaUpliftFunnel('deposit'))
+        act(() => result.current.trackStarted(blockingTrigger))
+        act(() => result.current.trackStarted(blockingTrigger))
+        expect(capture).toHaveBeenCalledTimes(1)
+
+        // a genuinely different requirement re-arms and fires again
+        act(() => result.current.trackStarted(advisoryTrigger))
+        expect(capture).toHaveBeenCalledTimes(2)
+    })
+
+    test('after reset, the same trigger fires again (a new attempt)', () => {
+        const { result } = renderHook(() => useEeaUpliftFunnel('deposit'))
+        act(() => result.current.trackStarted(blockingTrigger))
+        act(() => result.current.reset())
+        act(() => result.current.trackStarted(blockingTrigger))
+        expect(capture).toHaveBeenCalledTimes(2)
     })
 
     test('trackCompleted fires eea_uplift_completed only after a start, echoing the trigger', () => {

--- a/src/hooks/useEeaUpliftFunnel.ts
+++ b/src/hooks/useEeaUpliftFunnel.ts
@@ -1,20 +1,24 @@
 import { useCallback, useRef } from 'react'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import type { UpliftStartTrigger } from '@/utils/eea-uplift.utils'
 
 type UpliftChannel = 'deposit' | 'withdraw'
 
-/**
- * Describes the uplift attempt being started. `source` distinguishes the two
- * remediation paths (and, since blocking = the effective date has already
- * passed, doubles as the urgency signal): `blocking` is the urgent post-cliff
- * cohort, `advisory` is the future-dated ("upcoming") one.
- */
-export type UpliftStartTrigger = {
-    requirementKey?: string
-    actionKey?: string
-    effectiveDate?: string
-    source: 'advisory' | 'blocking'
+function upliftEventProps(channel: UpliftChannel, trigger: UpliftStartTrigger) {
+    return {
+        channel,
+        requirement_key: trigger.requirementKey,
+        action_key: trigger.actionKey,
+        effective_date: trigger.effectiveDate,
+        source: trigger.source,
+        // blocking = the cliff date has passed → already gating → urgent.
+        urgent: trigger.source === 'blocking',
+    }
+}
+
+function sameTrigger(a: UpliftStartTrigger | null, b: UpliftStartTrigger): boolean {
+    return !!a && a.requirementKey === b.requirementKey && a.source === b.source
 }
 
 /**
@@ -24,45 +28,39 @@ export type UpliftStartTrigger = {
  *
  * Firing on modal-open (not on the modal's CTA) means abandoners are captured
  * too — the whole point is to watch who attempts the uplift and whether they
- * finish. `trackCompleted` only emits if a start was recorded in this session:
- * the KYC success callback on the bank pages is shared with non-uplift KYC, so
- * the `startedRef` latch stops a generic success from mis-firing `completed`.
- * The trigger snapshot is captured at start because the gate's advisory/reason
- * clears once the requirement resolves, so it's gone by completion.
+ * finish. `trackStarted` is idempotent per armed attempt: re-clicking Continue
+ * while the same requirement is already latched does not re-emit `started`
+ * (until `reset`/`trackCompleted` clears the latch, at which point a genuine new
+ * attempt fires again).
  *
- * `reset` clears the pending start on abandonment (KYC modal closed without
- * success), so a later unrelated KYC success on the same page can't mis-fire.
+ * `trackCompleted` only emits if a start was recorded in this session: the KYC
+ * success callback on the bank pages is shared with non-uplift KYC, so the
+ * latch stops a generic success from mis-firing `completed`. The trigger
+ * snapshot is captured at start because the gate's advisory/reason clears once
+ * the requirement resolves, so it's gone by completion.
+ *
+ * `reset` clears the pending start on abandonment (uplift modal dismissed
+ * without success), so a later unrelated KYC success can't mis-fire.
  */
 export function useEeaUpliftFunnel(channel: UpliftChannel) {
     const startedRef = useRef<UpliftStartTrigger | null>(null)
 
-    const eventProps = useCallback(
-        (trigger: UpliftStartTrigger) => ({
-            channel,
-            requirement_key: trigger.requirementKey,
-            action_key: trigger.actionKey,
-            effective_date: trigger.effectiveDate,
-            source: trigger.source,
-            // blocking = the cliff date has passed → already gating → urgent.
-            urgent: trigger.source === 'blocking',
-        }),
-        [channel]
-    )
-
     const trackStarted = useCallback(
         (trigger: UpliftStartTrigger) => {
+            // idempotent per armed attempt — don't re-emit on repeat clicks.
+            if (sameTrigger(startedRef.current, trigger)) return
             startedRef.current = trigger
-            posthog.capture(ANALYTICS_EVENTS.EEA_UPLIFT_STARTED, eventProps(trigger))
+            posthog.capture(ANALYTICS_EVENTS.EEA_UPLIFT_STARTED, upliftEventProps(channel, trigger))
         },
-        [eventProps]
+        [channel]
     )
 
     const trackCompleted = useCallback(() => {
         const trigger = startedRef.current
         if (!trigger) return
         startedRef.current = null
-        posthog.capture(ANALYTICS_EVENTS.EEA_UPLIFT_COMPLETED, eventProps(trigger))
-    }, [eventProps])
+        posthog.capture(ANALYTICS_EVENTS.EEA_UPLIFT_COMPLETED, upliftEventProps(channel, trigger))
+    }, [channel])
 
     const reset = useCallback(() => {
         startedRef.current = null

--- a/src/hooks/useEeaUpliftFunnel.ts
+++ b/src/hooks/useEeaUpliftFunnel.ts
@@ -1,55 +1,68 @@
 import { useCallback, useRef } from 'react'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
-import type { GateAdvisory } from '@/utils/capability-gate'
 
 type UpliftChannel = 'deposit' | 'withdraw'
 
 /**
+ * Describes the uplift attempt being started. `source` distinguishes the two
+ * remediation paths (and, since blocking = the effective date has already
+ * passed, doubles as the urgency signal): `blocking` is the urgent post-cliff
+ * cohort, `advisory` is the future-dated ("upcoming") one.
+ */
+export type UpliftStartTrigger = {
+    requirementKey?: string
+    actionKey?: string
+    effectiveDate?: string
+    source: 'advisory' | 'blocking'
+}
+
+/**
  * Fires the EEA-uplift funnel events for PostHog so the flow can be filtered
- * directly: `eea_uplift_started` when the user launches the verification, and
- * `eea_uplift_completed` on KYC success.
+ * directly (and session recordings tagged): `eea_uplift_started` when the uplift
+ * modal OPENS, and `eea_uplift_completed` on KYC success.
  *
- * `trackCompleted` only emits if a start was recorded in this session — the KYC
- * success callback on the bank pages is shared with non-uplift KYC, so the
- * `startedRef` guard stops a generic success from mis-firing the completed
- * event. The advisory snapshot is captured at start time because the gate's
- * `advisory` clears once the requirement resolves, so it's gone by completion.
+ * Firing on modal-open (not on the modal's CTA) means abandoners are captured
+ * too — the whole point is to watch who attempts the uplift and whether they
+ * finish. `trackCompleted` only emits if a start was recorded in this session:
+ * the KYC success callback on the bank pages is shared with non-uplift KYC, so
+ * the `startedRef` latch stops a generic success from mis-firing `completed`.
+ * The trigger snapshot is captured at start because the gate's advisory/reason
+ * clears once the requirement resolves, so it's gone by completion.
  *
  * `reset` clears the pending start on abandonment (KYC modal closed without
- * success). Without it the latch would survive an abandoned attempt, and a later
- * unrelated KYC success on the same mounted page could mis-fire `completed`.
+ * success), so a later unrelated KYC success on the same page can't mis-fire.
  */
 export function useEeaUpliftFunnel(channel: UpliftChannel) {
-    const startedRef = useRef<GateAdvisory | null>(null)
+    const startedRef = useRef<UpliftStartTrigger | null>(null)
 
-    const trackStarted = useCallback(
-        // `advisory` is required: callers gate on it before launching, and the
-        // funnel contract needs requirement_key / action_key / effective_date
-        // always present on the event.
-        (advisory: GateAdvisory) => {
-            startedRef.current = advisory
-            posthog.capture(ANALYTICS_EVENTS.EEA_UPLIFT_STARTED, {
-                channel,
-                requirement_key: advisory.requirementKey,
-                action_key: advisory.actionKey,
-                effective_date: advisory.effectiveDate,
-            })
-        },
+    const eventProps = useCallback(
+        (trigger: UpliftStartTrigger) => ({
+            channel,
+            requirement_key: trigger.requirementKey,
+            action_key: trigger.actionKey,
+            effective_date: trigger.effectiveDate,
+            source: trigger.source,
+            // blocking = the cliff date has passed → already gating → urgent.
+            urgent: trigger.source === 'blocking',
+        }),
         [channel]
     )
 
+    const trackStarted = useCallback(
+        (trigger: UpliftStartTrigger) => {
+            startedRef.current = trigger
+            posthog.capture(ANALYTICS_EVENTS.EEA_UPLIFT_STARTED, eventProps(trigger))
+        },
+        [eventProps]
+    )
+
     const trackCompleted = useCallback(() => {
-        const advisory = startedRef.current
-        if (!advisory) return
+        const trigger = startedRef.current
+        if (!trigger) return
         startedRef.current = null
-        posthog.capture(ANALYTICS_EVENTS.EEA_UPLIFT_COMPLETED, {
-            channel,
-            requirement_key: advisory.requirementKey,
-            action_key: advisory.actionKey,
-            effective_date: advisory.effectiveDate,
-        })
-    }, [channel])
+        posthog.capture(ANALYTICS_EVENTS.EEA_UPLIFT_COMPLETED, eventProps(trigger))
+    }, [eventProps])
 
     const reset = useCallback(() => {
         startedRef.current = null

--- a/src/utils/eea-uplift.utils.test.ts
+++ b/src/utils/eea-uplift.utils.test.ts
@@ -1,10 +1,10 @@
-import { eeaUpliftReasonCode, isEeaUpliftAdvisory, EEA_UPLIFT_REQUIREMENT_KEYS } from './eea-uplift.utils'
+import { upliftTriggerFromGate, upliftTriggerFromAdvisory, EEA_UPLIFT_REQUIREMENT_KEYS } from './eea-uplift.utils'
 import type { GateState, GateAdvisory } from '@/utils/capability-gate'
 
-describe('eeaUpliftReasonCode (blocking path)', () => {
-    test('returns the code for an eea_uplift fixable-rejection', () => {
+describe('upliftTriggerFromGate (blocking path)', () => {
+    test('returns a blocking trigger for an eea_uplift fixable-rejection', () => {
         const gate = { kind: 'fixable-rejection', userMessage: 'x', reason: { code: 'eea_uplift', userMessage: 'x' } }
-        expect(eeaUpliftReasonCode(gate as GateState)).toBe('eea_uplift')
+        expect(upliftTriggerFromGate(gate as GateState)).toEqual({ requirementKey: 'eea_uplift', source: 'blocking' })
     })
 
     test('matches the eea_uplift_with_tin variant', () => {
@@ -13,41 +13,46 @@ describe('eeaUpliftReasonCode (blocking path)', () => {
             userMessage: 'x',
             reason: { code: 'eea_uplift_with_tin', userMessage: 'x' },
         }
-        expect(eeaUpliftReasonCode(gate as GateState)).toBe('eea_uplift_with_tin')
+        expect(upliftTriggerFromGate(gate as GateState)?.requirementKey).toBe('eea_uplift_with_tin')
     })
 
-    test('returns undefined for a non-uplift rejection', () => {
+    test('returns null for a non-uplift rejection', () => {
         const gate = {
             kind: 'fixable-rejection',
             userMessage: 'x',
             reason: { code: 'document_rejected', userMessage: 'x' },
         }
-        expect(eeaUpliftReasonCode(gate as GateState)).toBeUndefined()
+        expect(upliftTriggerFromGate(gate as GateState)).toBeNull()
     })
 
-    test('returns undefined for a gate variant without a reason', () => {
-        expect(eeaUpliftReasonCode({ kind: 'ready' } as GateState)).toBeUndefined()
-        expect(eeaUpliftReasonCode({ kind: 'needs-identity' } as GateState)).toBeUndefined()
+    test('returns null for a gate variant without a reason', () => {
+        expect(upliftTriggerFromGate({ kind: 'ready' } as GateState)).toBeNull()
+        expect(upliftTriggerFromGate({ kind: 'needs-identity' } as GateState)).toBeNull()
     })
 })
 
-describe('isEeaUpliftAdvisory (advisory path)', () => {
-    test.each([...EEA_UPLIFT_REQUIREMENT_KEYS])('matches uplift requirement key: %s', (requirementKey) => {
+describe('upliftTriggerFromAdvisory (advisory path)', () => {
+    test.each([...EEA_UPLIFT_REQUIREMENT_KEYS])('builds an advisory trigger for uplift key: %s', (requirementKey) => {
         const advisory: GateAdvisory = { effectiveDate: '2026-12-31', actionKey: 'k', requirementKey }
-        expect(isEeaUpliftAdvisory(advisory)).toBe(true)
+        expect(upliftTriggerFromAdvisory(advisory)).toEqual({
+            requirementKey,
+            actionKey: 'k',
+            effectiveDate: '2026-12-31',
+            source: 'advisory',
+        })
     })
 
-    test('does not match a co-occurring non-uplift key (proof_of_address / gov-id)', () => {
+    test('returns null for a co-occurring non-uplift key (proof_of_address / gov-id)', () => {
         const advisory: GateAdvisory = {
             effectiveDate: '2026-06-29',
             actionKey: 'k',
             requirementKey: 'proof_of_address_document',
         }
-        expect(isEeaUpliftAdvisory(advisory)).toBe(false)
+        expect(upliftTriggerFromAdvisory(advisory)).toBeNull()
     })
 
     test('is safe for undefined / keyless advisory', () => {
-        expect(isEeaUpliftAdvisory(undefined)).toBe(false)
-        expect(isEeaUpliftAdvisory({ effectiveDate: '2026-12-31', actionKey: 'k' })).toBe(false)
+        expect(upliftTriggerFromAdvisory(undefined)).toBeNull()
+        expect(upliftTriggerFromAdvisory({ effectiveDate: '2026-12-31', actionKey: 'k' })).toBeNull()
     })
 })

--- a/src/utils/eea-uplift.utils.test.ts
+++ b/src/utils/eea-uplift.utils.test.ts
@@ -1,0 +1,53 @@
+import { eeaUpliftReasonCode, isEeaUpliftAdvisory, EEA_UPLIFT_REQUIREMENT_KEYS } from './eea-uplift.utils'
+import type { GateState, GateAdvisory } from '@/utils/capability-gate'
+
+describe('eeaUpliftReasonCode (blocking path)', () => {
+    test('returns the code for an eea_uplift fixable-rejection', () => {
+        const gate = { kind: 'fixable-rejection', userMessage: 'x', reason: { code: 'eea_uplift', userMessage: 'x' } }
+        expect(eeaUpliftReasonCode(gate as GateState)).toBe('eea_uplift')
+    })
+
+    test('matches the eea_uplift_with_tin variant', () => {
+        const gate = {
+            kind: 'fixable-rejection',
+            userMessage: 'x',
+            reason: { code: 'eea_uplift_with_tin', userMessage: 'x' },
+        }
+        expect(eeaUpliftReasonCode(gate as GateState)).toBe('eea_uplift_with_tin')
+    })
+
+    test('returns undefined for a non-uplift rejection', () => {
+        const gate = {
+            kind: 'fixable-rejection',
+            userMessage: 'x',
+            reason: { code: 'document_rejected', userMessage: 'x' },
+        }
+        expect(eeaUpliftReasonCode(gate as GateState)).toBeUndefined()
+    })
+
+    test('returns undefined for a gate variant without a reason', () => {
+        expect(eeaUpliftReasonCode({ kind: 'ready' } as GateState)).toBeUndefined()
+        expect(eeaUpliftReasonCode({ kind: 'needs-identity' } as GateState)).toBeUndefined()
+    })
+})
+
+describe('isEeaUpliftAdvisory (advisory path)', () => {
+    test.each([...EEA_UPLIFT_REQUIREMENT_KEYS])('matches uplift requirement key: %s', (requirementKey) => {
+        const advisory: GateAdvisory = { effectiveDate: '2026-12-31', actionKey: 'k', requirementKey }
+        expect(isEeaUpliftAdvisory(advisory)).toBe(true)
+    })
+
+    test('does not match a co-occurring non-uplift key (proof_of_address / gov-id)', () => {
+        const advisory: GateAdvisory = {
+            effectiveDate: '2026-06-29',
+            actionKey: 'k',
+            requirementKey: 'proof_of_address_document',
+        }
+        expect(isEeaUpliftAdvisory(advisory)).toBe(false)
+    })
+
+    test('is safe for undefined / keyless advisory', () => {
+        expect(isEeaUpliftAdvisory(undefined)).toBe(false)
+        expect(isEeaUpliftAdvisory({ effectiveDate: '2026-12-31', actionKey: 'k' })).toBe(false)
+    })
+})

--- a/src/utils/eea-uplift.utils.ts
+++ b/src/utils/eea-uplift.utils.ts
@@ -1,0 +1,39 @@
+import type { GateAdvisory, GateState } from '@/utils/capability-gate'
+
+/**
+ * Bridge remediation identified as an EEA-uplift questionnaire, split by how it
+ * reaches the FE:
+ *
+ * - BLOCKING (post-cliff, effective date passed → gate `fixable-rejection`): the
+ *   BE sets `reason.code` to the questionnaire cluster — `eea_uplift` /
+ *   `eea_uplift_with_tin` (peanut-api-ts resolver). So a code prefix match is
+ *   the clean signal.
+ * - ADVISORY (future-dated → gate `ready` + advisory): the BE injects only
+ *   `effectiveDate` + `requirementKey` onto the NextAction, NOT the cluster, so
+ *   here we match the raw requirement keys whose cluster is `eea_uplift`.
+ *
+ * Key set derived from prod remediation data (2026-07). PoA / gov-id-expired
+ * co-occur on the same cliff but are separate remediation (cluster `null`), so
+ * they're deliberately excluded — keying PoA→eea would over-fire on ordinary
+ * document rejections for non-EEA users.
+ */
+export const EEA_UPLIFT_REQUIREMENT_KEYS = new Set<string>([
+    'sof_individual_primary_purpose',
+    'has_foreign_tax_registration',
+    'place_of_birth_missing',
+    'nationalities',
+])
+
+/**
+ * Blocking path: the gate's reason code IS the `eea_uplift*` cluster. Returns
+ * the code when it's an uplift remediation (truthy → track it), else undefined.
+ */
+export function eeaUpliftReasonCode(gate: GateState): string | undefined {
+    const code = (gate as { reason?: { code?: string } }).reason?.code
+    return code?.startsWith('eea_uplift') ? code : undefined
+}
+
+/** Advisory path: the future-dated requirement key belongs to the uplift set. */
+export function isEeaUpliftAdvisory(advisory: GateAdvisory | undefined): boolean {
+    return !!advisory?.requirementKey && EEA_UPLIFT_REQUIREMENT_KEYS.has(advisory.requirementKey)
+}

--- a/src/utils/eea-uplift.utils.ts
+++ b/src/utils/eea-uplift.utils.ts
@@ -16,6 +16,11 @@ import type { GateAdvisory, GateState } from '@/utils/capability-gate'
  * co-occur on the same cliff but are separate remediation (cluster `null`), so
  * they're deliberately excluded — keying PoA→eea would over-fire on ordinary
  * document rejections for non-EEA users.
+ *
+ * KNOWN LIMITATION: both signals mirror BE-owned strings (the resolver's cluster
+ * codes and requirement keys). If the BE adds/renames an uplift key or reason
+ * code, that segment silently drops out of the funnel until this file follows —
+ * accepted tradeoff for keeping this FE-only.
  */
 export const EEA_UPLIFT_REQUIREMENT_KEYS = new Set<string>([
     'sof_individual_primary_purpose',
@@ -25,15 +30,37 @@ export const EEA_UPLIFT_REQUIREMENT_KEYS = new Set<string>([
 ])
 
 /**
- * Blocking path: the gate's reason code IS the `eea_uplift*` cluster. Returns
- * the code when it's an uplift remediation (truthy → track it), else undefined.
+ * The uplift attempt being started. `source` distinguishes the two remediation
+ * paths and — since blocking = the effective date has already passed — doubles
+ * as the urgency signal: `blocking` = urgent post-cliff, `advisory` = upcoming.
  */
-export function eeaUpliftReasonCode(gate: GateState): string | undefined {
-    const code = (gate as { reason?: { code?: string } }).reason?.code
-    return code?.startsWith('eea_uplift') ? code : undefined
+export type UpliftStartTrigger = {
+    requirementKey?: string
+    actionKey?: string
+    effectiveDate?: string
+    source: 'advisory' | 'blocking'
 }
 
-/** Advisory path: the future-dated requirement key belongs to the uplift set. */
-export function isEeaUpliftAdvisory(advisory: GateAdvisory | undefined): boolean {
-    return !!advisory?.requirementKey && EEA_UPLIFT_REQUIREMENT_KEYS.has(advisory.requirementKey)
+/**
+ * Blocking path: the gate's reason code IS the `eea_uplift*` cluster. Returns a
+ * ready-to-fire trigger when it's an uplift remediation, else null.
+ */
+export function upliftTriggerFromGate(gate: GateState): UpliftStartTrigger | null {
+    const code = (gate as { reason?: { code?: string } }).reason?.code
+    if (!code?.startsWith('eea_uplift')) return null
+    return { requirementKey: code, source: 'blocking' }
+}
+
+/**
+ * Advisory path: the future-dated requirement key belongs to the uplift set.
+ * Returns a ready-to-fire trigger, else null.
+ */
+export function upliftTriggerFromAdvisory(advisory: GateAdvisory | undefined): UpliftStartTrigger | null {
+    if (!advisory?.requirementKey || !EEA_UPLIFT_REQUIREMENT_KEYS.has(advisory.requirementKey)) return null
+    return {
+        requirementKey: advisory.requirementKey,
+        actionKey: advisory.actionKey,
+        effectiveDate: advisory.effectiveDate,
+        source: 'advisory',
+    }
 }


### PR DESCRIPTION
## Summary

Makes the `eea_uplift_started` / `eea_uplift_completed` funnel reliable for watching who **attempts** the EEA uplift and whether they finish — so session recordings can be filtered by the event. Two gaps fixed:

1. **Fired on the modal CTA, not on open** — anyone who opened the uplift modal and abandoned emitted nothing. Now fires at **modal-open**.
2. **Missed the urgent cohort entirely** — post-`2026-06-29`-cliff, the urgent uplift is no longer a future-dated advisory; the BE reclassifies it to **blocking** (`fixable-rejection` → KYC modal), a path that called no tracking. Now covered.

Fires across **both remediation paths** and **both channels** (deposit + withdraw):
- **urgent / blocking** → `gate.reason.code` starts with `eea_uplift` (BE sets reason code to the questionnaire cluster).
- **upcoming / advisory** → `requirementKey` ∈ {`sof_individual_primary_purpose`, `has_foreign_tax_registration`, `place_of_birth_missing`, `nationalities`} — derived from prod remediation data (172 EEA-affected users).

Event now carries `source` (advisory|blocking), `urgent` (blocking = past the cliff = urgent), and `effective_date`, so **urgent vs upcoming (dob-type)** split directly in PostHog.

**Excluded** `proof_of_address_document` / `government_id_expired`: they co-occur on the cliff but are separate remediation (cluster `null`) — keying them to eea would over-fire on ordinary doc rejections for non-EEA users.

## Risks

- Analytics-only; no user-visible behavior change. No BE change.
- Firing moved from CTA to modal-open ⇒ `started` counts rise (now includes abandoners) — that's the intent. `completed` still latches on a recorded start, so completion rate stays meaningful.
- Slight limitation: a blocking uplift whose reason resolves to `document_rejected` (freeform classifier) instead of `eea_uplift` wouldn't be tagged — best signal available FE-side without a BE flag.

## QA

- `npm test` — 107 suites green; new `eea-uplift.utils` (10) + rewritten `useEeaUpliftFunnel` (6) tests, incl. key-set match, reason-code prefix, urgent flag, and the co-occurring-non-uplift exclusion.
- Separate from the deposit silent-failure fix (#2329). Both touch the two bank pages; if #2329 merges first I'll rebase (small, different regions of `handleAmountContinue`).