### PR TITLE
feat(manteca): BRL PIX deposit QR screen (details.depositAddresses.PIX)

### DIFF
--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -7,7 +7,7 @@ import { useParams, useSearchParams } from 'next/navigation'
 import { addMoneyCountryUrl } from '@/utils/native-routes'
 import { useSafeBack } from '@/hooks/useSafeBack'
 import { type CountryData, countryData } from '@/components/AddMoney/consts'
-import { type MantecaDepositResponseData, type MantecaPixDepositData } from '@/types/manteca.types'
+import { type MantecaDepositResponseData } from '@/types/manteca.types'
 import { useCurrency } from '@/hooks/useCurrency'
 import { mantecaApi } from '@/services/manteca'
 import { parseUnits } from 'viem'
@@ -26,8 +26,6 @@ import { useQueryStates, parseAsString, parseAsStringEnum } from 'nuqs'
 import { useLimitsValidation } from '@/features/limits/hooks/useLimitsValidation'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
-import InfoCard from '@/components/Global/InfoCard'
-import underMaintenanceConfig, { PIX_BRAZIL_ONRAMP_MAINTENANCE } from '@/config/underMaintenance.config'
 
 // Step type for URL state
 type MantecaStep = 'inputAmount' | 'depositDetails' | 'showQR'
@@ -68,7 +66,6 @@ const MantecaAddMoney: FC = () => {
     const [isCreatingDeposit, setIsCreatingDeposit] = useState(false)
     const [error, setError] = useState<string | null>(null)
     const [depositDetails, setDepositDetails] = useState<MantecaDepositResponseData>()
-    const [pixDeposit, setPixDeposit] = useState<MantecaPixDepositData>()
 
     // path params (web) or query params (native static export)
     const selectedCountryPath = (params.country as string) || searchParams.get('country') || ''
@@ -76,9 +73,6 @@ const MantecaAddMoney: FC = () => {
         return countryData.find((country) => country.type === 'country' && country.path === selectedCountryPath)
     }, [selectedCountryPath])
     const onBack = useSafeBack(addMoneyCountryUrl(selectedCountryPath))
-    // BRL-via-PIX onramp warn-only maintenance flag (see underMaintenance.config.ts).
-    // Brazil-scoped so the Argentina/ARS Manteca onramp is unaffected.
-    const showPixMaintenance = selectedCountry?.id === 'BR' && underMaintenanceConfig.pixBrazilOnrampMaintenance
     // The pool→full upgrade gate asks "did the user clear ID verification?",
     // not "do they have an enabled rail elsewhere?" — read the identity
     // signal directly (Sumsub-cleared the human) instead of the old
@@ -201,14 +195,13 @@ const MantecaAddMoney: FC = () => {
                 method_type: 'manteca',
                 country: selectedCountryPath,
             })
-            // BRL deposits return a dynamic PIX QR (type: 'QR') → show the QR step.
-            // ARS/others return the static ramp-on shape → show deposit details.
+            // BRL deposits carry the dynamic PIX QR in the ramp-on synthetic's
+            // details → show the QR step. ARS/others show deposit details.
             const data = depositData.data
-            if (data?.type === 'QR') {
-                setPixDeposit(data)
+            setDepositDetails(data)
+            if (selectedCountry?.currency === 'BRL') {
                 setUrlState({ step: 'showQR' })
             } else {
-                setDepositDetails(data)
                 setUrlState({ step: 'depositDetails' })
             }
         } catch (error) {
@@ -238,10 +231,10 @@ const MantecaAddMoney: FC = () => {
         if (step === 'depositDetails' && !depositDetails) {
             setUrlState({ step: 'inputAmount' })
         }
-        if (step === 'showQR' && !pixDeposit) {
+        if (step === 'showQR' && !depositDetails) {
             setUrlState({ step: 'inputAmount' })
         }
-    }, [step, depositDetails, pixDeposit, setUrlState])
+    }, [step, depositDetails, setUrlState])
 
     if (!selectedCountry) return null
 
@@ -299,16 +292,6 @@ const MantecaAddMoney: FC = () => {
                     limitsValidation={limitsValidation}
                     limitsCurrency={limitsValidation.currency}
                     onBack={onBack}
-                    maintenanceBanner={
-                        showPixMaintenance ? (
-                            <InfoCard
-                                variant="warning"
-                                icon="alert"
-                                title={PIX_BRAZIL_ONRAMP_MAINTENANCE.title}
-                                description={PIX_BRAZIL_ONRAMP_MAINTENANCE.description}
-                            />
-                        ) : undefined
-                    }
                 />
             </>
         )
@@ -329,12 +312,12 @@ const MantecaAddMoney: FC = () => {
     }
 
     if (step === 'showQR') {
-        if (!pixDeposit) {
+        if (!depositDetails) {
             return null
         }
         return (
             <MantecaPixQrDeposit
-                pixDeposit={pixDeposit}
+                depositDetails={depositDetails}
                 currencyAmount={localCurrencyAmount}
                 onBack={() => setUrlState({ step: 'inputAmount' })}
                 onComplete={() => queryClient.invalidateQueries({ queryKey: [TRANSACTIONS] })}

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -72,9 +72,10 @@ const MantecaAddMoney: FC = () => {
     const selectedCountry = useMemo(() => {
         return countryData.find((country) => country.type === 'country' && country.path === selectedCountryPath)
     }, [selectedCountryPath])
-    // Default the input denomination to the country's local currency (Brazil→BRL,
-    // Argentina→ARS) instead of USD — you deposit in your local currency.
-    const currentDenomination = urlState.currency ?? (selectedCountry?.currency as CurrencyDenomination) ?? 'USD'
+    // Default the input denomination to BRL for Brazil (PIX is in BRL); every other
+    // country keeps the USD default.
+    const currentDenomination: CurrencyDenomination =
+        urlState.currency ?? (selectedCountry?.currency === 'BRL' ? 'BRL' : 'USD')
     const onBack = useSafeBack(addMoneyCountryUrl(selectedCountryPath))
     // The pool→full upgrade gate asks "did the user clear ID verification?",
     // not "do they have an enabled rail elsewhere?" — read the identity

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -2,6 +2,7 @@
 import { type FC, useEffect, useMemo, useState, useCallback } from 'react'
 import MantecaDepositShareDetails from '@/components/AddMoney/components/MantecaDepositShareDetails'
 import MantecaPixQrDeposit from '@/components/AddMoney/components/MantecaPixQrDeposit'
+import CyclingLoading from '@/components/Global/PeanutLoading/CyclingLoading'
 import InputAmountStep from '@/components/AddMoney/components/InputAmountStep'
 import { useParams, useSearchParams } from 'next/navigation'
 import { addMoneyCountryUrl } from '@/utils/native-routes'
@@ -56,7 +57,6 @@ const MantecaAddMoney: FC = () => {
     const step: MantecaStep = urlState.step ?? 'inputAmount'
     // Amount from URL - this is in the denomination specified by `currency`
     const displayedAmount = urlState.amount ?? ''
-    const currentDenomination = urlState.currency ?? 'USD'
 
     // Local UI state for tracking both amounts (needed for API call and validation)
     const [usdAmount, setUsdAmount] = useState<string>('')
@@ -72,6 +72,9 @@ const MantecaAddMoney: FC = () => {
     const selectedCountry = useMemo(() => {
         return countryData.find((country) => country.type === 'country' && country.path === selectedCountryPath)
     }, [selectedCountryPath])
+    // Default the input denomination to the country's local currency (Brazil→BRL,
+    // Argentina→ARS) instead of USD — you deposit in your local currency.
+    const currentDenomination = urlState.currency ?? (selectedCountry?.currency as CurrencyDenomination) ?? 'USD'
     const onBack = useSafeBack(addMoneyCountryUrl(selectedCountryPath))
     // The pool→full upgrade gate asks "did the user clear ID verification?",
     // not "do they have an enabled rail elsewhere?" — read the identity
@@ -237,6 +240,16 @@ const MantecaAddMoney: FC = () => {
     }, [step, depositDetails, setUrlState])
 
     if (!selectedCountry) return null
+
+    // While the BRL PIX deposit request is in flight (the QR is being generated),
+    // show the branded processing screen — same as when a PIX payment is processing.
+    if (isCreatingDeposit && selectedCountry.currency === 'BRL') {
+        return (
+            <div className="my-auto flex min-h-[inherit] flex-col justify-center">
+                <CyclingLoading />
+            </div>
+        )
+    }
 
     if (step === 'inputAmount') {
         return (

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -1,12 +1,13 @@
 'use client'
 import { type FC, useEffect, useMemo, useState, useCallback } from 'react'
 import MantecaDepositShareDetails from '@/components/AddMoney/components/MantecaDepositShareDetails'
+import MantecaPixQrDeposit from '@/components/AddMoney/components/MantecaPixQrDeposit'
 import InputAmountStep from '@/components/AddMoney/components/InputAmountStep'
 import { useParams, useSearchParams } from 'next/navigation'
 import { addMoneyCountryUrl } from '@/utils/native-routes'
 import { useSafeBack } from '@/hooks/useSafeBack'
 import { type CountryData, countryData } from '@/components/AddMoney/consts'
-import { type MantecaDepositResponseData } from '@/types/manteca.types'
+import { type MantecaDepositResponseData, type MantecaPixDepositData } from '@/types/manteca.types'
 import { useCurrency } from '@/hooks/useCurrency'
 import { mantecaApi } from '@/services/manteca'
 import { parseUnits } from 'viem'
@@ -29,7 +30,7 @@ import InfoCard from '@/components/Global/InfoCard'
 import underMaintenanceConfig, { PIX_BRAZIL_ONRAMP_MAINTENANCE } from '@/config/underMaintenance.config'
 
 // Step type for URL state
-type MantecaStep = 'inputAmount' | 'depositDetails'
+type MantecaStep = 'inputAmount' | 'depositDetails' | 'showQR'
 
 // Currency denomination type for URL state
 type CurrencyDenomination = 'USD' | 'ARS' | 'BRL' | 'MXN' | 'EUR'
@@ -48,7 +49,7 @@ const MantecaAddMoney: FC = () => {
     // amounts of this same screen instead of leaving it. The URL stays shareable either
     // way. Enforced by the no-restricted-syntax guard in eslint.config.js.
     const [urlState, setUrlState] = useQueryStates({
-        step: parseAsStringEnum<MantecaStep>(['inputAmount', 'depositDetails']),
+        step: parseAsStringEnum<MantecaStep>(['inputAmount', 'depositDetails', 'showQR']),
         amount: parseAsString,
         currency: parseAsStringEnum<CurrencyDenomination>(['USD', 'ARS', 'BRL', 'MXN', 'EUR']),
     })
@@ -67,6 +68,7 @@ const MantecaAddMoney: FC = () => {
     const [isCreatingDeposit, setIsCreatingDeposit] = useState(false)
     const [error, setError] = useState<string | null>(null)
     const [depositDetails, setDepositDetails] = useState<MantecaDepositResponseData>()
+    const [pixDeposit, setPixDeposit] = useState<MantecaPixDepositData>()
 
     // path params (web) or query params (native static export)
     const selectedCountryPath = (params.country as string) || searchParams.get('country') || ''
@@ -194,14 +196,21 @@ const MantecaAddMoney: FC = () => {
                 setError(depositData.error)
                 return
             }
-            setDepositDetails(depositData.data)
             posthog.capture(ANALYTICS_EVENTS.DEPOSIT_CONFIRMED, {
                 amount_usd: usdAmount,
                 method_type: 'manteca',
                 country: selectedCountryPath,
             })
-            // Update URL state to show deposit details step
-            setUrlState({ step: 'depositDetails' })
+            // BRL deposits return a dynamic PIX QR (type: 'QR') → show the QR step.
+            // ARS/others return the static ramp-on shape → show deposit details.
+            const data = depositData.data
+            if (data?.type === 'QR') {
+                setPixDeposit(data)
+                setUrlState({ step: 'showQR' })
+            } else {
+                setDepositDetails(data)
+                setUrlState({ step: 'depositDetails' })
+            }
         } catch (error) {
             console.log(error)
             const errorMessage = error instanceof Error ? error.message : String(error)
@@ -229,7 +238,10 @@ const MantecaAddMoney: FC = () => {
         if (step === 'depositDetails' && !depositDetails) {
             setUrlState({ step: 'inputAmount' })
         }
-    }, [step, depositDetails, setUrlState])
+        if (step === 'showQR' && !pixDeposit) {
+            setUrlState({ step: 'inputAmount' })
+        }
+    }, [step, depositDetails, pixDeposit, setUrlState])
 
     if (!selectedCountry) return null
 
@@ -312,6 +324,20 @@ const MantecaAddMoney: FC = () => {
                 depositDetails={depositDetails}
                 currencyAmount={localCurrencyAmount}
                 onBack={() => setUrlState({ step: 'inputAmount' })}
+            />
+        )
+    }
+
+    if (step === 'showQR') {
+        if (!pixDeposit) {
+            return null
+        }
+        return (
+            <MantecaPixQrDeposit
+                pixDeposit={pixDeposit}
+                currencyAmount={localCurrencyAmount}
+                onBack={() => setUrlState({ step: 'inputAmount' })}
+                onComplete={() => queryClient.invalidateQueries({ queryKey: [TRANSACTIONS] })}
             />
         )
     }

--- a/src/components/AddMoney/components/MantecaDepositShareDetails.tsx
+++ b/src/components/AddMoney/components/MantecaDepositShareDetails.tsx
@@ -53,7 +53,9 @@ const MantecaDepositShareDetails = ({
         return MANTECA_COUNTRIES_CONFIG[currentCountryDetails.id]?.depositAddressLabel ?? 'Deposit Address'
     }, [currentCountryDetails])
 
-    const depositAddress = depositDetails.details.depositAddress
+    // BRL synthetics no longer carry these (QR-only) — but BRL routes to the QR
+    // screen, never here; the fallback just keeps the ARS/static path total.
+    const depositAddress = depositDetails.details.depositAddress ?? ''
     const shortenedAddress = depositAddress.length > 30 ? shortenStringLong(depositAddress, 10) : depositAddress
     const depositAlias = depositDetails.details.depositAlias
     const depositAmount = currencyAmount ?? depositDetails.stages['1'].thresholdAmount

--- a/src/components/AddMoney/components/MantecaPixQrDeposit.tsx
+++ b/src/components/AddMoney/components/MantecaPixQrDeposit.tsx
@@ -18,8 +18,9 @@ const MantecaPixQrDeposit: FC<{
     // Fired once when the deposit settles (parent refreshes balance/history).
     onComplete: () => void
 }> = ({ depositDetails, currencyAmount, onBack, onComplete }) => {
-    // The dynamic PIX QR (EMVCo copia-e-cola) rides in the ramp-on synthetic's details.
-    const qr = depositDetails.details.qr
+    // The dynamic PIX QR (EMVCo copia-e-cola) rides in the ramp-on synthetic's
+    // details.depositAddresses.PIX (confirmed against prod 2026-07-02).
+    const qr = depositDetails.details.depositAddresses?.PIX?.code
     // Poll by the real synthetic id (unchanged polling contract).
     const { status } = useMantecaDepositPolling(depositDetails.id, onComplete)
 

--- a/src/components/AddMoney/components/MantecaPixQrDeposit.tsx
+++ b/src/components/AddMoney/components/MantecaPixQrDeposit.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { type FC, useEffect, useMemo, useState } from 'react'
+import NavHeader from '@/components/Global/NavHeader'
+import QRCodeWrapper from '@/components/Global/QRCodeWrapper'
+import CopyToClipboard from '@/components/Global/CopyToClipboard'
+import { Icon } from '@/components/Global/Icons/Icon'
+import { Button } from '@/components/0_Bruddle/Button'
+import { type MantecaPixDepositData } from '@/types/manteca.types'
+import { useMantecaDepositPolling } from '@/components/AddMoney/hooks/useMantecaDepositPolling'
+
+const MantecaPixQrDeposit: FC<{
+    pixDeposit: MantecaPixDepositData
+    currencyAmount?: string
+    // Parent owns step navigation — usually setUrlState({ step: 'inputAmount' }).
+    onBack: () => void
+    // Fired once when the deposit settles (parent refreshes balance/history).
+    onComplete: () => void
+}> = ({ pixDeposit, currencyAmount, onBack, onComplete }) => {
+    const { status } = useMantecaDepositPolling(pixDeposit.bankId, onComplete)
+
+    // QR expiry countdown. `expiresAt` carries a tz offset, so Date parses it
+    // directly. We tick once a second and stop once the QR is paid or has lapsed
+    // (the effect re-runs when isExpired flips and clears the interval).
+    const expiresAtMs = useMemo(() => new Date(pixDeposit.expiresAt).getTime(), [pixDeposit.expiresAt])
+    const [nowMs, setNowMs] = useState(() => Date.now())
+
+    const remainingMs = expiresAtMs - nowMs
+    const isExpired = remainingMs <= 0
+    const minutes = Math.floor(remainingMs / 60000)
+    const seconds = Math.floor((remainingMs % 60000) / 1000)
+    const countdownLabel = isExpired ? null : `${minutes}:${String(seconds).padStart(2, '0')}`
+
+    useEffect(() => {
+        if (status === 'completed' || isExpired) return
+        const interval = setInterval(() => setNowMs(Date.now()), 1000)
+        return () => clearInterval(interval)
+    }, [status, isExpired])
+
+    if (status === 'completed') {
+        return (
+            <div className="flex min-h-[inherit] flex-col gap-8">
+                <NavHeader title="Add Money" onPrev={onBack} />
+                <div className="my-auto flex flex-col items-center gap-4 text-center">
+                    <div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-1">
+                        <Icon name="check" size={32} />
+                    </div>
+                    <h2 className="text-2xl font-bold text-n-1">Deposit received!</h2>
+                    <p className="text-grey-1">Your balance has been updated.</p>
+                    <Button variant="purple" shadowSize="4" className="w-full" onClick={onBack}>
+                        Done
+                    </Button>
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <div className="flex min-h-[inherit] flex-col gap-8">
+            <NavHeader title="Add Money" onPrev={onBack} />
+            <div className="my-auto flex flex-col gap-6">
+                <div className="text-center">
+                    <p className="text-sm text-grey-1">Pay with PIX</p>
+                    {currencyAmount && <p className="text-2xl font-bold text-n-1">R$ {currencyAmount}</p>}
+                </div>
+
+                <QRCodeWrapper
+                    url={pixDeposit.code}
+                    isBlurred={isExpired}
+                    disabled={isExpired}
+                    className="max-w-[280px]"
+                />
+
+                {countdownLabel && <p className="text-center text-sm text-grey-1">Expires in {countdownLabel}</p>}
+
+                {isExpired ? (
+                    <div className="flex flex-col gap-3 text-center">
+                        <p className="text-sm text-grey-1">This QR code has expired.</p>
+                        <Button variant="stroke" className="w-full" onClick={onBack}>
+                            Go back
+                        </Button>
+                    </div>
+                ) : (
+                    <div className="flex flex-col gap-3">
+                        <p className="text-center text-sm text-grey-1">
+                            Scan with your bank app, or copy the PIX code.
+                        </p>
+                        <CopyToClipboard textToCopy={pixDeposit.code} type="button" className="w-full" />
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}
+
+export default MantecaPixQrDeposit

--- a/src/components/AddMoney/components/MantecaPixQrDeposit.tsx
+++ b/src/components/AddMoney/components/MantecaPixQrDeposit.tsx
@@ -39,7 +39,7 @@ const MantecaPixQrDeposit: FC<{
     const countdownLabel = isExpired ? null : `${minutes}:${String(seconds).padStart(2, '0')}`
 
     useEffect(() => {
-        if (status === 'completed' || isExpired) return
+        if (status === 'completed' || status === 'processing' || isExpired) return
         const interval = setInterval(() => setNowMs(Date.now()), 1000)
         return () => clearInterval(interval)
     }, [status, isExpired])
@@ -57,6 +57,18 @@ const MantecaPixQrDeposit: FC<{
                     <Button variant="purple" shadowSize="4" className="w-full" onClick={onBack}>
                         Done
                     </Button>
+                </div>
+            </div>
+        )
+    }
+
+    // Payment detected, settling — show the branded processing screen (same as PIX payments).
+    if (status === 'processing') {
+        return (
+            <div className="flex min-h-[inherit] flex-col gap-8">
+                <NavHeader title="Add Money" onPrev={onBack} />
+                <div className="my-auto flex flex-col justify-center">
+                    <CyclingLoading />
                 </div>
             </div>
         )

--- a/src/components/AddMoney/components/MantecaPixQrDeposit.tsx
+++ b/src/components/AddMoney/components/MantecaPixQrDeposit.tsx
@@ -6,23 +6,29 @@ import QRCodeWrapper from '@/components/Global/QRCodeWrapper'
 import CopyToClipboard from '@/components/Global/CopyToClipboard'
 import { Icon } from '@/components/Global/Icons/Icon'
 import { Button } from '@/components/0_Bruddle/Button'
-import { type MantecaPixDepositData } from '@/types/manteca.types'
+import { type MantecaDepositResponseData } from '@/types/manteca.types'
 import { useMantecaDepositPolling } from '@/components/AddMoney/hooks/useMantecaDepositPolling'
 
 const MantecaPixQrDeposit: FC<{
-    pixDeposit: MantecaPixDepositData
+    depositDetails: MantecaDepositResponseData
     currencyAmount?: string
     // Parent owns step navigation — usually setUrlState({ step: 'inputAmount' }).
     onBack: () => void
     // Fired once when the deposit settles (parent refreshes balance/history).
     onComplete: () => void
-}> = ({ pixDeposit, currencyAmount, onBack, onComplete }) => {
-    const { status } = useMantecaDepositPolling(pixDeposit.bankId, onComplete)
+}> = ({ depositDetails, currencyAmount, onBack, onComplete }) => {
+    // The dynamic PIX QR (EMVCo copia-e-cola) rides in the ramp-on synthetic's details.
+    const qr = depositDetails.details.qr
+    // Poll by the real synthetic id (unchanged polling contract).
+    const { status } = useMantecaDepositPolling(depositDetails.id, onComplete)
 
-    // QR expiry countdown. `expiresAt` carries a tz offset, so Date parses it
+    // QR expiry countdown. `priceExpireAt` carries a tz offset, so Date parses it
     // directly. We tick once a second and stop once the QR is paid or has lapsed
     // (the effect re-runs when isExpired flips and clears the interval).
-    const expiresAtMs = useMemo(() => new Date(pixDeposit.expiresAt).getTime(), [pixDeposit.expiresAt])
+    const expiresAtMs = useMemo(
+        () => new Date(depositDetails.details.priceExpireAt).getTime(),
+        [depositDetails.details.priceExpireAt]
+    )
     const [nowMs, setNowMs] = useState(() => Date.now())
 
     const remainingMs = expiresAtMs - nowMs
@@ -64,29 +70,32 @@ const MantecaPixQrDeposit: FC<{
                     {currencyAmount && <p className="text-2xl font-bold text-n-1">R$ {currencyAmount}</p>}
                 </div>
 
-                <QRCodeWrapper
-                    url={pixDeposit.code}
-                    isBlurred={isExpired}
-                    disabled={isExpired}
-                    className="max-w-[280px]"
-                />
-
-                {countdownLabel && <p className="text-center text-sm text-grey-1">Expires in {countdownLabel}</p>}
-
-                {isExpired ? (
-                    <div className="flex flex-col gap-3 text-center">
-                        <p className="text-sm text-grey-1">This QR code has expired.</p>
-                        <Button variant="stroke" className="w-full" onClick={onBack}>
-                            Go back
-                        </Button>
-                    </div>
+                {!qr ? (
+                    <p className="text-center text-sm text-grey-1">Preparing your PIX QR…</p>
                 ) : (
-                    <div className="flex flex-col gap-3">
-                        <p className="text-center text-sm text-grey-1">
-                            Scan with your bank app, or copy the PIX code.
-                        </p>
-                        <CopyToClipboard textToCopy={pixDeposit.code} type="button" className="w-full" />
-                    </div>
+                    <>
+                        <QRCodeWrapper url={qr} isBlurred={isExpired} disabled={isExpired} className="max-w-[280px]" />
+
+                        {countdownLabel && (
+                            <p className="text-center text-sm text-grey-1">Expires in {countdownLabel}</p>
+                        )}
+
+                        {isExpired ? (
+                            <div className="flex flex-col gap-3 text-center">
+                                <p className="text-sm text-grey-1">This QR code has expired.</p>
+                                <Button variant="stroke" className="w-full" onClick={onBack}>
+                                    Go back
+                                </Button>
+                            </div>
+                        ) : (
+                            <div className="flex flex-col gap-3">
+                                <p className="text-center text-sm text-grey-1">
+                                    Scan with your bank app, or copy the PIX code.
+                                </p>
+                                <CopyToClipboard textToCopy={qr} type="button" className="w-full" />
+                            </div>
+                        )}
+                    </>
                 )}
             </div>
         </div>

--- a/src/components/AddMoney/components/MantecaPixQrDeposit.tsx
+++ b/src/components/AddMoney/components/MantecaPixQrDeposit.tsx
@@ -8,6 +8,7 @@ import { Icon } from '@/components/Global/Icons/Icon'
 import { Button } from '@/components/0_Bruddle/Button'
 import { type MantecaDepositResponseData } from '@/types/manteca.types'
 import { useMantecaDepositPolling } from '@/components/AddMoney/hooks/useMantecaDepositPolling'
+import CyclingLoading from '@/components/Global/PeanutLoading/CyclingLoading'
 
 const MantecaPixQrDeposit: FC<{
     depositDetails: MantecaDepositResponseData
@@ -71,7 +72,7 @@ const MantecaPixQrDeposit: FC<{
                 </div>
 
                 {!qr ? (
-                    <p className="text-center text-sm text-grey-1">Preparing your PIX QR…</p>
+                    <CyclingLoading />
                 ) : (
                     <>
                         <QRCodeWrapper url={qr} isBlurred={isExpired} disabled={isExpired} className="max-w-[280px]" />

--- a/src/components/AddMoney/components/__tests__/MantecaPixQrDeposit.test.tsx
+++ b/src/components/AddMoney/components/__tests__/MantecaPixQrDeposit.test.tsx
@@ -1,10 +1,10 @@
 /**
  * MantecaPixQrDeposit — the BRL dynamic-PIX-QR screen.
  *
- * One `details.qr` string drives both the QR and the copy button; a live
- * countdown is derived from `details.priceExpireAt`; polling flips the screen to
- * a success state. Nested primitives are stubbed so only this component's own
- * logic is under test.
+ * One `details.depositAddresses.PIX.code` string (EMVCo copia-e-cola) drives
+ * both the QR and the copy button; a live countdown is derived from
+ * `details.priceExpireAt`; polling flips the screen to a success state. Nested
+ * primitives are stubbed so only this component's own logic is under test.
  */
 import React from 'react'
 import { render, screen } from '@testing-library/react'
@@ -35,14 +35,22 @@ jest.mock('@/components/0_Bruddle/Button', () => ({
 // eslint-disable-next-line import/first -- must come after jest.mock
 import MantecaPixQrDeposit from '../MantecaPixQrDeposit'
 
+const PIX_CODE = '00020126-COPIA-E-COLA'
 const baseDeposit = {
     id: 'syn-1',
     type: 'RAMP_OPERATION' as const,
     details: {
-        qr: '00020126-COPIA-E-COLA',
+        // prod shape confirmed 2026-07-02 — the QR rides in depositAddresses.PIX
+        depositAddresses: {
+            PIX: {
+                type: 'QR',
+                code: PIX_CODE,
+                url: `https://widget.manteca.dev/qr?code=${PIX_CODE}`,
+                expiresAt: new Date(Date.now() + 3 * 24 * 60 * 60_000).toISOString(), // ~3 days out
+                bankId: 'bank-1',
+            },
+        },
         priceExpireAt: new Date(Date.now() + 5 * 60_000).toISOString(), // 5 min out
-        depositAddress: '',
-        depositAlias: '',
     },
     stages: {},
 } as unknown as import('@/types/manteca.types').MantecaDepositResponseData
@@ -53,7 +61,7 @@ beforeEach(() => {
 })
 
 describe('MantecaPixQrDeposit', () => {
-    it('renders the QR + copy from the same `details.qr`, the amount, and a live countdown', () => {
+    it('renders the QR + copy from the same PIX copia-e-cola code, the amount, and a live countdown', () => {
         render(
             <MantecaPixQrDeposit
                 depositDetails={baseDeposit}
@@ -62,8 +70,8 @@ describe('MantecaPixQrDeposit', () => {
                 onComplete={jest.fn()}
             />
         )
-        expect(screen.getByTestId('qr')).toHaveAttribute('data-url', baseDeposit.details.qr)
-        expect(screen.getByTestId('copy')).toHaveAttribute('data-text', baseDeposit.details.qr)
+        expect(screen.getByTestId('qr')).toHaveAttribute('data-url', PIX_CODE)
+        expect(screen.getByTestId('copy')).toHaveAttribute('data-text', PIX_CODE)
         expect(screen.getByText('R$ 10')).toBeInTheDocument()
         expect(screen.getByText(/Expires in/)).toBeInTheDocument()
     })

--- a/src/components/AddMoney/components/__tests__/MantecaPixQrDeposit.test.tsx
+++ b/src/components/AddMoney/components/__tests__/MantecaPixQrDeposit.test.tsx
@@ -1,9 +1,10 @@
 /**
  * MantecaPixQrDeposit — the BRL dynamic-PIX-QR screen.
  *
- * One `code` string drives both the QR and the copy button; a live countdown is
- * derived from `expiresAt`; polling flips the screen to a success state. Nested
- * primitives are stubbed so only this component's own logic is under test.
+ * One `details.qr` string drives both the QR and the copy button; a live
+ * countdown is derived from `details.priceExpireAt`; polling flips the screen to
+ * a success state. Nested primitives are stubbed so only this component's own
+ * logic is under test.
  */
 import React from 'react'
 import { render, screen } from '@testing-library/react'
@@ -34,13 +35,17 @@ jest.mock('@/components/0_Bruddle/Button', () => ({
 // eslint-disable-next-line import/first -- must come after jest.mock
 import MantecaPixQrDeposit from '../MantecaPixQrDeposit'
 
-const basePix = {
-    type: 'QR' as const,
-    code: '00020126-COPIA-E-COLA',
-    url: 'https://widget-qa.manteca.dev/qr?code=x',
-    bankId: 'bank-1',
-    expiresAt: new Date(Date.now() + 5 * 60_000).toISOString(), // 5 min out
-}
+const baseDeposit = {
+    id: 'syn-1',
+    type: 'RAMP_OPERATION' as const,
+    details: {
+        qr: '00020126-COPIA-E-COLA',
+        priceExpireAt: new Date(Date.now() + 5 * 60_000).toISOString(), // 5 min out
+        depositAddress: '',
+        depositAlias: '',
+    },
+    stages: {},
+} as unknown as import('@/types/manteca.types').MantecaDepositResponseData
 
 beforeEach(() => {
     mockUseMantecaDepositPolling.mockReset()
@@ -48,19 +53,27 @@ beforeEach(() => {
 })
 
 describe('MantecaPixQrDeposit', () => {
-    it('renders the QR + copy from the same `code`, the amount, and a live countdown', () => {
+    it('renders the QR + copy from the same `details.qr`, the amount, and a live countdown', () => {
         render(
-            <MantecaPixQrDeposit pixDeposit={basePix} currencyAmount="10" onBack={jest.fn()} onComplete={jest.fn()} />
+            <MantecaPixQrDeposit
+                depositDetails={baseDeposit}
+                currencyAmount="10"
+                onBack={jest.fn()}
+                onComplete={jest.fn()}
+            />
         )
-        expect(screen.getByTestId('qr')).toHaveAttribute('data-url', basePix.code)
-        expect(screen.getByTestId('copy')).toHaveAttribute('data-text', basePix.code)
+        expect(screen.getByTestId('qr')).toHaveAttribute('data-url', baseDeposit.details.qr)
+        expect(screen.getByTestId('copy')).toHaveAttribute('data-text', baseDeposit.details.qr)
         expect(screen.getByText('R$ 10')).toBeInTheDocument()
         expect(screen.getByText(/Expires in/)).toBeInTheDocument()
     })
 
-    it('shows the expired state (QR disabled, no countdown) once expiresAt has passed', () => {
-        const expired = { ...basePix, expiresAt: new Date(Date.now() - 1000).toISOString() }
-        render(<MantecaPixQrDeposit pixDeposit={expired} onBack={jest.fn()} onComplete={jest.fn()} />)
+    it('shows the expired state (QR disabled, no countdown) once priceExpireAt has passed', () => {
+        const expired = {
+            ...baseDeposit,
+            details: { ...baseDeposit.details, priceExpireAt: new Date(Date.now() - 1000).toISOString() },
+        }
+        render(<MantecaPixQrDeposit depositDetails={expired} onBack={jest.fn()} onComplete={jest.fn()} />)
 
         expect(screen.getByText(/expired/i)).toBeInTheDocument()
         expect(screen.getByTestId('qr')).toHaveAttribute('data-disabled', 'true')
@@ -69,7 +82,7 @@ describe('MantecaPixQrDeposit', () => {
 
     it('shows the success state when the deposit completes', () => {
         mockUseMantecaDepositPolling.mockReturnValue({ status: 'completed' })
-        render(<MantecaPixQrDeposit pixDeposit={basePix} onBack={jest.fn()} onComplete={jest.fn()} />)
+        render(<MantecaPixQrDeposit depositDetails={baseDeposit} onBack={jest.fn()} onComplete={jest.fn()} />)
 
         expect(screen.getByText('Deposit received!')).toBeInTheDocument()
         expect(screen.queryByTestId('qr')).not.toBeInTheDocument()

--- a/src/components/AddMoney/components/__tests__/MantecaPixQrDeposit.test.tsx
+++ b/src/components/AddMoney/components/__tests__/MantecaPixQrDeposit.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * MantecaPixQrDeposit — the BRL dynamic-PIX-QR screen.
+ *
+ * One `code` string drives both the QR and the copy button; a live countdown is
+ * derived from `expiresAt`; polling flips the screen to a success state. Nested
+ * primitives are stubbed so only this component's own logic is under test.
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+const mockUseMantecaDepositPolling = jest.fn()
+jest.mock('@/components/AddMoney/hooks/useMantecaDepositPolling', () => ({
+    useMantecaDepositPolling: (...args: unknown[]) => mockUseMantecaDepositPolling(...args),
+}))
+
+jest.mock('@/components/Global/NavHeader', () => ({ __esModule: true, default: () => <div /> }))
+jest.mock('@/components/Global/QRCodeWrapper', () => ({
+    __esModule: true,
+    default: ({ url, disabled }: { url: string; disabled?: boolean }) => (
+        <div data-testid="qr" data-url={url} data-disabled={disabled ? 'true' : 'false'} />
+    ),
+}))
+jest.mock('@/components/Global/CopyToClipboard', () => ({
+    __esModule: true,
+    default: ({ textToCopy }: { textToCopy: string }) => <div data-testid="copy" data-text={textToCopy} />,
+}))
+jest.mock('@/components/Global/Icons/Icon', () => ({ Icon: () => <div /> }))
+jest.mock('@/components/0_Bruddle/Button', () => ({
+    Button: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+        <button onClick={onClick}>{children}</button>
+    ),
+}))
+
+// eslint-disable-next-line import/first -- must come after jest.mock
+import MantecaPixQrDeposit from '../MantecaPixQrDeposit'
+
+const basePix = {
+    type: 'QR' as const,
+    code: '00020126-COPIA-E-COLA',
+    url: 'https://widget-qa.manteca.dev/qr?code=x',
+    bankId: 'bank-1',
+    expiresAt: new Date(Date.now() + 5 * 60_000).toISOString(), // 5 min out
+}
+
+beforeEach(() => {
+    mockUseMantecaDepositPolling.mockReset()
+    mockUseMantecaDepositPolling.mockReturnValue({ status: 'pending' })
+})
+
+describe('MantecaPixQrDeposit', () => {
+    it('renders the QR + copy from the same `code`, the amount, and a live countdown', () => {
+        render(
+            <MantecaPixQrDeposit pixDeposit={basePix} currencyAmount="10" onBack={jest.fn()} onComplete={jest.fn()} />
+        )
+        expect(screen.getByTestId('qr')).toHaveAttribute('data-url', basePix.code)
+        expect(screen.getByTestId('copy')).toHaveAttribute('data-text', basePix.code)
+        expect(screen.getByText('R$ 10')).toBeInTheDocument()
+        expect(screen.getByText(/Expires in/)).toBeInTheDocument()
+    })
+
+    it('shows the expired state (QR disabled, no countdown) once expiresAt has passed', () => {
+        const expired = { ...basePix, expiresAt: new Date(Date.now() - 1000).toISOString() }
+        render(<MantecaPixQrDeposit pixDeposit={expired} onBack={jest.fn()} onComplete={jest.fn()} />)
+
+        expect(screen.getByText(/expired/i)).toBeInTheDocument()
+        expect(screen.getByTestId('qr')).toHaveAttribute('data-disabled', 'true')
+        expect(screen.queryByText(/Expires in/)).not.toBeInTheDocument()
+    })
+
+    it('shows the success state when the deposit completes', () => {
+        mockUseMantecaDepositPolling.mockReturnValue({ status: 'completed' })
+        render(<MantecaPixQrDeposit pixDeposit={basePix} onBack={jest.fn()} onComplete={jest.fn()} />)
+
+        expect(screen.getByText('Deposit received!')).toBeInTheDocument()
+        expect(screen.queryByTestId('qr')).not.toBeInTheDocument()
+    })
+})

--- a/src/components/AddMoney/hooks/__tests__/useMantecaDepositPolling.test.tsx
+++ b/src/components/AddMoney/hooks/__tests__/useMantecaDepositPolling.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * useMantecaDepositPolling — maps the BE intent status to a poll status and
+ * fires onComplete exactly once on COMPLETED. Read-only: it never moves money,
+ * it mirrors GET /manteca/deposit/:id/status so the QR screen can advance.
+ */
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+
+const mockGetDepositStatus = jest.fn()
+jest.mock('@/services/manteca', () => ({
+    mantecaApi: { getDepositStatus: mockGetDepositStatus },
+}))
+
+// eslint-disable-next-line import/first -- must come after jest.mock
+import { useMantecaDepositPolling } from '../useMantecaDepositPolling'
+
+describe('useMantecaDepositPolling', () => {
+    let queryClient: QueryClient
+
+    beforeEach(() => {
+        queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+        mockGetDepositStatus.mockReset()
+    })
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    it('reports "pending" for a non-terminal status', async () => {
+        mockGetDepositStatus.mockResolvedValue({ data: { id: 'dep-1', status: 'PENDING' } })
+        const { result } = renderHook(() => useMantecaDepositPolling('dep-1', jest.fn()), { wrapper })
+
+        await waitFor(() => expect(mockGetDepositStatus).toHaveBeenCalledWith('dep-1'))
+        expect(result.current.status).toBe('pending')
+    })
+
+    it('reports "completed" and fires onComplete exactly once on COMPLETED', async () => {
+        mockGetDepositStatus.mockResolvedValue({ data: { id: 'dep-2', status: 'COMPLETED' } })
+        const onComplete = jest.fn()
+        const { result, rerender } = renderHook(() => useMantecaDepositPolling('dep-2', onComplete), { wrapper })
+
+        await waitFor(() => expect(result.current.status).toBe('completed'))
+        rerender()
+        rerender()
+        expect(onComplete).toHaveBeenCalledTimes(1)
+    })
+
+    it('reports "failed" for a terminal failure status', async () => {
+        mockGetDepositStatus.mockResolvedValue({ data: { id: 'dep-3', status: 'CANCELLED' } })
+        const { result } = renderHook(() => useMantecaDepositPolling('dep-3', jest.fn()), { wrapper })
+
+        await waitFor(() => expect(result.current.status).toBe('failed'))
+    })
+
+    it('does not query when depositId is undefined', () => {
+        const { result } = renderHook(() => useMantecaDepositPolling(undefined, jest.fn()), { wrapper })
+
+        expect(result.current.status).toBe('pending')
+        expect(mockGetDepositStatus).not.toHaveBeenCalled()
+    })
+})

--- a/src/components/AddMoney/hooks/__tests__/useMantecaDepositPolling.test.tsx
+++ b/src/components/AddMoney/hooks/__tests__/useMantecaDepositPolling.test.tsx
@@ -53,6 +53,13 @@ describe('useMantecaDepositPolling', () => {
         await waitFor(() => expect(result.current.status).toBe('failed'))
     })
 
+    it('reports "processing" for an intermediate settling status', async () => {
+        mockGetDepositStatus.mockResolvedValue({ data: { id: 'dep-4', status: 'PROCESSING' } })
+        const { result } = renderHook(() => useMantecaDepositPolling('dep-4', jest.fn()), { wrapper })
+
+        await waitFor(() => expect(result.current.status).toBe('processing'))
+    })
+
     it('does not query when depositId is undefined', () => {
         const { result } = renderHook(() => useMantecaDepositPolling(undefined, jest.fn()), { wrapper })
 

--- a/src/components/AddMoney/hooks/useMantecaDepositPolling.ts
+++ b/src/components/AddMoney/hooks/useMantecaDepositPolling.ts
@@ -8,8 +8,10 @@ const POLLING_INTERVAL = 5000
 
 // Terminal TransactionIntentStatus values returned by GET /manteca/deposit/:id/status.
 const TERMINAL_STATUSES = ['COMPLETED', 'FAILED', 'CANCELLED', 'REFUNDED']
+// Non-terminal states that mean "payment detected, settling" — show a processing screen.
+const PROCESSING_STATUSES = ['PROCESSING', 'AWAITING_SETTLEMENT']
 
-type MantecaDepositPollStatus = 'pending' | 'completed' | 'failed'
+type MantecaDepositPollStatus = 'pending' | 'processing' | 'completed' | 'failed'
 
 /**
  * Poll a BRL PIX deposit intent until it settles. Read-only: the webhook/poller
@@ -34,6 +36,7 @@ export function useMantecaDepositPolling(depositId: string | undefined, onComple
         const s = data?.data?.status
         if (s === 'COMPLETED') return 'completed'
         if (s && TERMINAL_STATUSES.includes(s)) return 'failed'
+        if (s && PROCESSING_STATUSES.includes(s)) return 'processing'
         return 'pending'
     }, [data])
 

--- a/src/components/AddMoney/hooks/useMantecaDepositPolling.ts
+++ b/src/components/AddMoney/hooks/useMantecaDepositPolling.ts
@@ -1,0 +1,48 @@
+'use client'
+
+import { mantecaApi } from '@/services/manteca'
+import { useQuery } from '@tanstack/react-query'
+import { useEffect, useMemo, useRef } from 'react'
+
+const POLLING_INTERVAL = 5000
+
+// Terminal TransactionIntentStatus values returned by GET /manteca/deposit/:id/status.
+const TERMINAL_STATUSES = ['COMPLETED', 'FAILED', 'CANCELLED', 'REFUNDED']
+
+type MantecaDepositPollStatus = 'pending' | 'completed' | 'failed'
+
+/**
+ * Poll a BRL PIX deposit intent until it settles. Read-only: the webhook/poller
+ * post the actual credit — this just mirrors `intent.status` so the QR screen can
+ * advance to a success state. Fires `onComplete` exactly once on COMPLETED.
+ */
+export function useMantecaDepositPolling(depositId: string | undefined, onComplete: () => void) {
+    const hasCompleted = useRef(false)
+
+    const { data } = useQuery({
+        queryKey: ['manteca-deposit-status', depositId],
+        queryFn: () => mantecaApi.getDepositStatus(depositId!),
+        enabled: !!depositId,
+        gcTime: 0, // don't carry a settled status across navigations
+        refetchInterval: (query) => {
+            const status = (query.state.data as { data?: { status?: string } } | undefined)?.data?.status
+            return status && TERMINAL_STATUSES.includes(status) ? false : POLLING_INTERVAL
+        },
+    })
+
+    const status: MantecaDepositPollStatus = useMemo(() => {
+        const s = data?.data?.status
+        if (s === 'COMPLETED') return 'completed'
+        if (s && TERMINAL_STATUSES.includes(s)) return 'failed'
+        return 'pending'
+    }, [data])
+
+    useEffect(() => {
+        if (status === 'completed' && !hasCompleted.current) {
+            hasCompleted.current = true
+            onComplete()
+        }
+    }, [status, onComplete])
+
+    return { status }
+}

--- a/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
+++ b/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
@@ -238,18 +238,24 @@ describe('AddWithdrawCountriesList — bank gate', () => {
 })
 
 /**
- * BRL-via-PIX onramp is unstable, so the Pix option is flagged "under maintenance"
- * (config: pixBrazilOnrampMaintenance) — warn-only: it stays visible and clickable.
+ * When the BRL-via-PIX onramp degrades, the Pix option gets flagged "under
+ * maintenance" (config: pixBrazilOnrampMaintenance) — warn-only: it stays
+ * visible and clickable.
  */
 describe('AddWithdrawCountriesList — PIX onramp maintenance tag', () => {
+    // snapshot/restore the shipped flag so each test can flip it without leaking
+    // state — and without coupling the restore to the committed default
+    let originalPixMaintenance: boolean
+
     beforeEach(() => {
         mockPush.mockClear()
         // a ready gate so a click can navigate — proving the option is not blocked
         setCapabilities('ready', [{ status: 'enabled', channel: 'bank', country: 'US' }])
+        originalPixMaintenance = underMaintenanceConfig.pixBrazilOnrampMaintenance
     })
 
     afterEach(() => {
-        underMaintenanceConfig.pixBrazilOnrampMaintenance = true
+        underMaintenanceConfig.pixBrazilOnrampMaintenance = originalPixMaintenance
     })
 
     it('tags the Pix option "Maintenance" but keeps it clickable (warn-only)', () => {

--- a/src/components/Global/QRCodeWrapper/index.tsx
+++ b/src/components/Global/QRCodeWrapper/index.tsx
@@ -11,6 +11,8 @@ interface QRCodeWrapperProps {
     disabled?: boolean
     isBlurred?: boolean
     centerImage?: string
+    /** Merged onto the root — pass a `max-w-*` to override the default 160px width. */
+    className?: string
 }
 
 const QRCodeWrapper = ({
@@ -19,6 +21,7 @@ const QRCodeWrapper = ({
     disabled = false,
     isBlurred = false,
     centerImage,
+    className,
 }: QRCodeWrapperProps) => {
     const [qrRendered, setQrRendered] = useState(false)
 
@@ -39,7 +42,7 @@ const QRCodeWrapper = ({
     const showLoading = isLoading || !qrRendered || !url
 
     return (
-        <div className="relative mx-auto h-auto w-full max-w-[160px]">
+        <div className={twMerge('relative mx-auto h-auto w-full max-w-[160px]', className)}>
             {/* Container with black border and rounded corners */}
             <div
                 className={twMerge(

--- a/src/config/underMaintenance.config.ts
+++ b/src/config/underMaintenance.config.ts
@@ -36,9 +36,8 @@
  *
  * 7. pixBrazilOnrampMaintenance: warn-only flag for the BRL-via-PIX onramp (Manteca Brazil deposit)
  *    - shows a "Maintenance" tag on the Pix option in /add-money/brazil
- *    - shows a warning banner inside the deposit flow (/add-money/brazil/manteca)
  *    - does NOT block deposits — the option stays usable (warn-only)
- *    - set to false when PIX deposits are stable again
+ *    - set to true if the PIX onramp degrades again
  *
  * 8. disableCardLaunchCTA: kill-switch for the in-app "shhh" card CTA (the home nudge)
  *    - true hides BOTH the activation-funnel card step and the activated-base home splash
@@ -84,7 +83,7 @@ const underMaintenanceConfig: MaintenanceConfig = {
     disableXchainSend: true, // set to true to disable cross-chain sends (claim, request payments - only allows USDC on Arbitrum)
     disableCardPioneers: true, // set to false to enable the Card Pioneers waitlist feature
     disableCardLaunchCTA: false, // kill-switch for the in-app "shhh" card CTA (funnel card step + activated home splash). Set true to mute it (dial down in-app load); /card flow + /shhhhh + waitlist stay reachable regardless.
-    pixBrazilOnrampMaintenance: true, // set to false when BRL-via-PIX deposits are stable again
+    pixBrazilOnrampMaintenance: false, // BRL deposits restored via dynamic PIX QR (2026-07-02). Set true if the onramp degrades again.
     disabledMantecaCurrencies: [], // Manteca restored (ARS + BRL live). Add a currency here to block it during a future outage.
 }
 
@@ -92,13 +91,10 @@ const underMaintenanceConfig: MaintenanceConfig = {
 export const CROSS_CHAIN_DISABLED_MESSAGE =
     'Cross-chain claims are temporarily unavailable. Try claiming to an external wallet on the same chain as the link, or try again later.'
 
-// shared user-facing copy for the BRL-via-PIX onramp maintenance warning — keep the list tag and
-// the in-flow banner aligned
+// user-facing copy for the BRL-via-PIX onramp maintenance tag (the in-flow banner was
+// retired when the dynamic-QR deposit flow shipped — the tag is the remaining surface)
 export const PIX_BRAZIL_ONRAMP_MAINTENANCE = {
     badge: 'Maintenance',
-    title: 'PIX deposits are under maintenance',
-    description:
-        'PIX deposits are currently unstable and may be delayed or fail. You can still continue, but service may be unreliable until this is resolved.',
 }
 
 export default underMaintenanceConfig

--- a/src/services/manteca.ts
+++ b/src/services/manteca.ts
@@ -1,6 +1,5 @@
 import {
     type MantecaDepositResponseData,
-    type MantecaPixDepositData,
     type MantecaWithdrawData,
     type MantecaWithdrawResponse,
     type CreateMantecaOnrampParams,
@@ -258,7 +257,7 @@ export const mantecaApi = {
 
     deposit: async (
         params: CreateMantecaOnrampParams
-    ): Promise<{ data?: MantecaDepositResponseData | MantecaPixDepositData; error?: string }> => {
+    ): Promise<{ data?: MantecaDepositResponseData; error?: string }> => {
         try {
             const response = await serverFetch('/manteca/deposit', {
                 method: 'POST',

--- a/src/services/manteca.ts
+++ b/src/services/manteca.ts
@@ -1,5 +1,6 @@
 import {
     type MantecaDepositResponseData,
+    type MantecaPixDepositData,
     type MantecaWithdrawData,
     type MantecaWithdrawResponse,
     type CreateMantecaOnrampParams,
@@ -257,7 +258,7 @@ export const mantecaApi = {
 
     deposit: async (
         params: CreateMantecaOnrampParams
-    ): Promise<{ data?: MantecaDepositResponseData; error?: string }> => {
+    ): Promise<{ data?: MantecaDepositResponseData | MantecaPixDepositData; error?: string }> => {
         try {
             const response = await serverFetch('/manteca/deposit', {
                 method: 'POST',
@@ -284,6 +285,19 @@ export const mantecaApi = {
                 return { error: error.message }
             }
             return { error: 'An unexpected error occurred.' }
+        }
+    },
+
+    getDepositStatus: async (depositId: string): Promise<{ data?: { id: string; status: string }; error?: string }> => {
+        try {
+            const response = await serverFetch(`/manteca/deposit/${depositId}/status`)
+            const data = await response.json()
+            if (!response.ok) {
+                return { error: data.error || 'Failed to fetch deposit status.' }
+            }
+            return { data }
+        } catch (error) {
+            return { error: error instanceof Error ? error.message : 'An unexpected error occurred.' }
         }
     },
 

--- a/src/types/manteca.types.ts
+++ b/src/types/manteca.types.ts
@@ -11,16 +11,27 @@ export interface MantecaDepositResponseData {
     type: 'RAMP_OPERATION'
     details: {
         depositAddresses: {
-            BANK_TRANSFER: string
+            BANK_TRANSFER?: string
+            // dynamic BRL PIX QR — confirmed against prod 2026-07-02
+            // (mono ops/scripts/manteca/probe-brl-rampon-qr.ts)
+            PIX?: {
+                type: 'QR'
+                // EMVCo "copia e cola" string — QR-encode it and offer copy
+                code: string
+                // Manteca-hosted QR page (unused by us, kept for parity)
+                url: string
+                // QR string validity (~3 days) — NOT the price lock expiry
+                expiresAt: string
+                bankId: string
+            }
         }
-        depositAddress: string
-        depositAlias: string
+        // absent for BRL — PIX deposits are QR-only since Manteca's med-2.0 switch
+        depositAddress?: string
+        depositAlias?: string
         withdrawCostInAgainst: string
         withdrawCostInAsset: string
         price: string
         priceExpireAt: string
-        // STUB: dynamic PIX QR (EMVCo copia-e-cola) Manteca will add to BRL ramp-on details — exact field name TBC when they ship it (Slack 2026-06-30).
-        qr?: string
     }
     currentStage: number
     stages: {

--- a/src/types/manteca.types.ts
+++ b/src/types/manteca.types.ts
@@ -19,6 +19,8 @@ export interface MantecaDepositResponseData {
         withdrawCostInAsset: string
         price: string
         priceExpireAt: string
+        // STUB: dynamic PIX QR (EMVCo copia-e-cola) Manteca will add to BRL ramp-on details — exact field name TBC when they ship it (Slack 2026-06-30).
+        qr?: string
     }
     currentStage: number
     stages: {
@@ -53,19 +55,6 @@ export interface MantecaDepositResponseData {
     }
     creationTime: string
     updatedAt: string
-}
-
-/**
- * BRL dynamic PIX QR deposit response (from POST /manteca/deposit when currency=BRL).
- * Discriminated from the ramp-on shape by `type: 'QR'`. The amount + currency are
- * embedded in `code` (the EMVCo "copia e cola" BR Code).
- */
-export interface MantecaPixDepositData {
-    type: 'QR'
-    code: string
-    url: string
-    bankId: string
-    expiresAt: string
 }
 
 export enum MercadoPagoStep {

--- a/src/types/manteca.types.ts
+++ b/src/types/manteca.types.ts
@@ -55,6 +55,19 @@ export interface MantecaDepositResponseData {
     updatedAt: string
 }
 
+/**
+ * BRL dynamic PIX QR deposit response (from POST /manteca/deposit when currency=BRL).
+ * Discriminated from the ramp-on shape by `type: 'QR'`. The amount + currency are
+ * embedded in `code` (the EMVCo "copia e cola" BR Code).
+ */
+export interface MantecaPixDepositData {
+    type: 'QR'
+    code: string
+    url: string
+    bankId: string
+    expiresAt: string
+}
+
 export enum MercadoPagoStep {
     DETAILS = 'details',
     REVIEW = 'review',


### PR DESCRIPTION
## BRL PIX deposit — frontend · ✅ unblocked, wired to the prod-confirmed contract

Supersedes #2315 (same commits rebased onto `main` + the un-stub commit — repo rules block force-push, hence the new branch; targeting `main` since this fixes the currently-broken BRL deposit UX: Manteca stopped returning the static PIX key, so the old share-details screen shows nothing to pay).

Adds a `showQR` step to the Manteca Add-Money flow for BRL: renders the dynamic PIX QR from the ramp-on synthetic's **`details.depositAddresses.PIX`** (prod-confirmed 2026-07-02 via `mono/ops/scripts/manteca/probe-brl-rampon-qr.ts`), with a live `m:ss` countdown off `priceExpireAt` (the locked-rate guarantee — the QR string itself lives ~3 days) and a "copia e cola" copy button. Status polling advances **QR → processing → "Deposit received!"** via `GET /manteca/deposit/:id/status`. ARS keeps its existing bank-details screen, untouched.

**Flow:** `POST /manteca/deposit (BRL)` → ramp-on synthetic with `details.depositAddresses.PIX.code` → `showQR` (routed by currency) → poll status → `processing` (settling) → success on `COMPLETED`.

**Also in this PR:**
- Add money → **Brazil** defaults the input denomination to **BRL** (PIX is in BRL); other countries keep USD.
- **Retires the warn-only PIX maintenance surface** — the QR flow replaces it. `pixBrazilOnrampMaintenance` flips `false` (machinery stays for future outages), the in-flow banner wiring is removed, unused banner copy trimmed to the badge. Makes #2269 obsolete.
- The maintenance test now snapshots/restores the shipped flag value instead of hardcoding `true` (adopted from #2269) — flipping the committed default can't poison the config singleton.
- `details.depositAddress`/`depositAlias` are now optional in the type (absent for BRL); the ARS share-details screen keeps a `''` fallback and BRL never routes there.
- `QRCodeWrapper` gains an optional `className` width-override (zero blast radius on other callers).

**Cross-repo:** depends on peanutprotocol/peanut-api-ts#1110 (status endpoint) — land BE first.

**Local gate:** prettier ✓ · `tsc` ✓ (0 errors) · jest 1650/1654 passed, 3 skipped, 1 failure pre-existing on main (`add-money-states › loaded EVM deposit shows QR code and address` — crypto-deposit limits copy, unrelated; reproduced on pristine main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
