### PR TITLE
chore: back-merge main → dev (offramp migration deposit + invite fixes)

### DIFF
--- a/src/app/(mobile-ui)/add-money/crypto/page.tsx
+++ b/src/app/(mobile-ui)/add-money/crypto/page.tsx
@@ -25,17 +25,27 @@ const AddMoneyCryptoPage = () => {
     const { user } = useAuth()
     const onBack = useSafeBack('/add-money')
     const { address: peanutWalletAddress } = useWallet()
-    const [network] = useQueryState(
+    const [networkParam] = useQueryState(
         'network',
         parseAsStringEnum<RhinoChainType>(['EVM', 'SOL', 'TRON']).withDefault('EVM')
     )
     // offramp migration deep-link: strips the chain/token picker down to arbitrum + usdc
     const [source] = useQueryState('source', parseAsStringEnum(['offramp']))
     const isOfframp = source === 'offramp'
+    // The offramp UI is hardwired to Arbitrum copy, so the underlying address
+    // must be EVM no matter what a shared/edited link says — otherwise a
+    // ?network=SOL&source=offramp URL would show a Solana address labeled
+    // "Arbitrum" and instruct the user to send funds to it.
+    const network: RhinoChainType = isOfframp ? 'EVM' : networkParam
     const [showSuccessView, setShowSuccessView] = useState(false)
     const [depositResult, setDepositResult] = useState<DepositAddressStatusResponse | null>(null)
 
-    const { data: depositAddressData, isLoading } = useQuery({
+    const {
+        data: depositAddressData,
+        isLoading,
+        isError,
+        refetch,
+    } = useQuery({
         queryKey: ['rhino-deposit-address', user?.user.userId, peanutWalletAddress, network],
         queryFn: () =>
             rhinoApi.createDepositAddress(peanutWalletAddress as string, network, user?.user.userId as string),
@@ -61,8 +71,11 @@ const AddMoneyCryptoPage = () => {
     const depositTransactionDetails: TransactionDetails | null = useMemo(() => {
         if (!depositResult) return null
         const usdAmount = depositResult.amount?.toString() ?? '0'
-        const chainName = depositResult.chainIn ?? NETWORK_LABELS[network]
-        const tokenSymbol = depositResult.tokenSymbol ?? 'USDT'
+        // offramp migrants were told "USDC on Arbitrum" — when Rhino's status
+        // response omits token/chain, fall back to that promise instead of the
+        // generic USDT/EVM guess (which renders an Ethereum icon on the receipt).
+        const chainName = depositResult.chainIn ?? (isOfframp ? 'ARBITRUM' : NETWORK_LABELS[network])
+        const tokenSymbol = depositResult.tokenSymbol ?? (isOfframp ? 'USDC' : 'USDT')
         const chainIconUrl = CHAIN_LOGOS[chainName as ChainName] ?? CHAIN_LOGOS.ETHEREUM
         const tokenIconUrl = TOKEN_LOGOS[tokenSymbol as TokenName] ?? TOKEN_LOGOS.USDT
         const explorerUrl =
@@ -100,13 +113,13 @@ const AddMoneyCryptoPage = () => {
             currency: { amount: usdAmount, code: 'USD' },
             totalAmountCollected: 0,
         } satisfies TransactionDetails
-    }, [depositResult, network])
+    }, [depositResult, network, isOfframp])
 
     if (showSuccessView && depositResult) {
         return (
             <PaymentSuccessView
                 type="DEPOSIT"
-                headerTitle="Deposited Crypto"
+                headerTitle={isOfframp ? 'Migration Complete' : 'Deposited Crypto'}
                 usdAmount={depositResult.amount?.toString()}
                 amount={depositResult.tokenAmount}
                 transactionDetails={depositTransactionDetails}
@@ -124,6 +137,8 @@ const AddMoneyCryptoPage = () => {
             network={network}
             depositAddressData={depositAddressData}
             isLoading={isLoading}
+            isError={isError}
+            onRetry={() => refetch()}
             onSuccess={handleSuccess}
             onBack={onBack}
             variant={isOfframp ? 'offramp' : 'default'}

--- a/src/app/(mobile-ui)/add-money/crypto/page.tsx
+++ b/src/app/(mobile-ui)/add-money/crypto/page.tsx
@@ -29,6 +29,9 @@ const AddMoneyCryptoPage = () => {
         'network',
         parseAsStringEnum<RhinoChainType>(['EVM', 'SOL', 'TRON']).withDefault('EVM')
     )
+    // offramp migration deep-link: strips the chain/token picker down to arbitrum + usdc
+    const [source] = useQueryState('source', parseAsStringEnum(['offramp']))
+    const isOfframp = source === 'offramp'
     const [showSuccessView, setShowSuccessView] = useState(false)
     const [depositResult, setDepositResult] = useState<DepositAddressStatusResponse | null>(null)
 
@@ -45,13 +48,13 @@ const AddMoneyCryptoPage = () => {
             posthog.capture(ANALYTICS_EVENTS.DEPOSIT_COMPLETED, {
                 amount,
                 chain_type: network,
-                method_type: 'crypto',
+                method_type: isOfframp ? 'offramp_migration' : 'crypto',
                 acquisition_source: user?.invitedBy ? 'referred' : 'organic',
             })
             setDepositResult(statusData ?? { status: 'completed', amount })
             setShowSuccessView(true)
         },
-        [network, user?.invitedBy]
+        [network, user?.invitedBy, isOfframp]
     )
 
     // build minimal transaction details for the receipt drawer
@@ -123,6 +126,7 @@ const AddMoneyCryptoPage = () => {
             isLoading={isLoading}
             onSuccess={handleSuccess}
             onBack={onBack}
+            variant={isOfframp ? 'offramp' : 'default'}
         />
     )
 }

--- a/src/components/AddMoney/components/HowToDepositModal.tsx
+++ b/src/components/AddMoney/components/HowToDepositModal.tsx
@@ -6,6 +6,10 @@ import InfoCard from '@/components/Global/InfoCard'
 interface HowToDepositModalProps {
     visible: boolean
     onClose: () => void
+    // offramp migration variant: walks the user through offramp.xyz's withdraw
+    // flow instead of the generic wallet/exchange steps (which mention multiple
+    // supported networks — contradicting the Arbitrum-only migration screen).
+    variant?: 'default' | 'offramp'
 }
 
 const STEPS = [
@@ -15,7 +19,16 @@ const STEPS = [
     { step: 'Step 4', text: 'Confirm and send — funds arrive within a few minutes' },
 ]
 
-const HowToDepositModal = ({ visible, onClose }: HowToDepositModalProps) => {
+const OFFRAMP_STEPS = [
+    { step: 'Step 1', text: 'Copy your migration deposit address above' },
+    { step: 'Step 2', text: 'Open your Offramp account and start a withdrawal or send' },
+    { step: 'Step 3', text: 'Choose USDC on the Arbitrum network and paste the address' },
+    { step: 'Step 4', text: 'Confirm and send — your balance arrives within a few minutes' },
+]
+
+const HowToDepositModal = ({ visible, onClose, variant = 'default' }: HowToDepositModalProps) => {
+    const isOfframp = variant === 'offramp'
+    const steps = isOfframp ? OFFRAMP_STEPS : STEPS
     return (
         <Modal
             visible={visible}
@@ -23,12 +36,14 @@ const HowToDepositModal = ({ visible, onClose }: HowToDepositModalProps) => {
             classWrap="sm:m-auto sm:self-center self-center m-4 bg-background rounded-sm"
         >
             <div className="flex flex-col gap-5 p-5">
-                <h3 className={'text-start text-h6 font-bold text-black'}>How to Deposit</h3>
+                <h3 className={'text-start text-h6 font-bold text-black'}>
+                    {isOfframp ? 'How to Migrate' : 'How to Deposit'}
+                </h3>
                 <div className="flex flex-col overflow-hidden rounded-sm border border-black bg-white">
-                    {STEPS.map((item, index) => (
+                    {steps.map((item, index) => (
                         <div
                             key={index}
-                            className={`px-4 py-3 ${index !== STEPS.length - 1 ? 'border-b border-black' : ''}`}
+                            className={`px-4 py-3 ${index !== steps.length - 1 ? 'border-b border-black' : ''}`}
                         >
                             <p className="text-sm font-bold">{item.step}</p>
                             <p className="text-sm text-grey-1">{item.text}</p>
@@ -39,7 +54,11 @@ const HowToDepositModal = ({ visible, onClose }: HowToDepositModalProps) => {
                 <InfoCard
                     variant="warning"
                     icon="alert"
-                    title="Sending to the wrong network or token will result in permanent loss."
+                    title={
+                        isOfframp
+                            ? 'Only send USDC on Arbitrum — other tokens or networks may be lost.'
+                            : 'Sending to the wrong network or token will result in permanent loss.'
+                    }
                 />
             </div>
         </Modal>

--- a/src/components/AddMoney/views/AddMoneyMethodSelection.view.tsx
+++ b/src/components/AddMoney/views/AddMoneyMethodSelection.view.tsx
@@ -8,8 +8,10 @@ import { useAuth } from '@/context/authContext'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
-// placeholder — swap for the real badge code once the offramp badge PR lands.
-const OFFRAMP_BADGE_CODE = 'OFFRAMP'
+// offramp.xyz migrants get this link-granted badge at signup (peanut-api-ts
+// invite/badge routes, code `offramp` / utm `offramp`). Keep in sync with the
+// backend BADGE_CODES.OFFRAMP_USER.
+const OFFRAMP_BADGE_CODE = 'OFFRAMP_USER'
 
 interface AddMoneyMethodSelectionProps {
     onBankTransferClick: () => void

--- a/src/components/AddMoney/views/AddMoneyMethodSelection.view.tsx
+++ b/src/components/AddMoney/views/AddMoneyMethodSelection.view.tsx
@@ -3,15 +3,13 @@
 import { ActionListCard } from '@/components/ActionListCard'
 import AvatarWithBadge from '@/components/Profile/AvatarWithBadge'
 import ChooseNetworkDrawer from '../components/ChooseNetworkDrawer'
+// offramp.xyz migrants get this link-granted badge at signup (peanut-api-ts
+// invite/badge routes, code `offramp` / utm `offramp`).
+import { OFFRAMP_BADGE_CODE } from '@/components/Invites/campaign-maps'
 import type { RhinoChainType } from '@/services/services.types'
 import { useAuth } from '@/context/authContext'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
-
-// offramp.xyz migrants get this link-granted badge at signup (peanut-api-ts
-// invite/badge routes, code `offramp` / utm `offramp`). Keep in sync with the
-// backend BADGE_CODES.OFFRAMP_USER.
-const OFFRAMP_BADGE_CODE = 'OFFRAMP_USER'
 
 interface AddMoneyMethodSelectionProps {
     onBankTransferClick: () => void

--- a/src/components/AddMoney/views/AddMoneyMethodSelection.view.tsx
+++ b/src/components/AddMoney/views/AddMoneyMethodSelection.view.tsx
@@ -4,8 +4,12 @@ import { ActionListCard } from '@/components/ActionListCard'
 import AvatarWithBadge from '@/components/Profile/AvatarWithBadge'
 import ChooseNetworkDrawer from '../components/ChooseNetworkDrawer'
 import type { RhinoChainType } from '@/services/services.types'
+import { useAuth } from '@/context/authContext'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
+
+// placeholder — swap for the real badge code once the offramp badge PR lands.
+const OFFRAMP_BADGE_CODE = 'OFFRAMP'
 
 interface AddMoneyMethodSelectionProps {
     onBankTransferClick: () => void
@@ -13,7 +17,11 @@ interface AddMoneyMethodSelectionProps {
 
 const AddMoneyMethodSelection = ({ onBankTransferClick }: AddMoneyMethodSelectionProps) => {
     const router = useRouter()
+    const { user } = useAuth()
     const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+
+    // offramp migrants get a tailored, de-cluttered arbitrum deposit entry
+    const hasOfframpBadge = user?.user?.badges?.some((b) => b.code === OFFRAMP_BADGE_CODE) ?? false
 
     const handleNetworkSelect = (network: RhinoChainType) => {
         setIsDrawerOpen(false)
@@ -25,10 +33,21 @@ const AddMoneyMethodSelection = ({ onBankTransferClick }: AddMoneyMethodSelectio
             <div className="flex flex-col gap-2">
                 <h2 className="text-base font-bold">How would you like to add money?</h2>
                 <div className="flex flex-col">
+                    {hasOfframpBadge && (
+                        <ActionListCard
+                            title="Migrate from Offramp"
+                            description="Move your Offramp balance to Peanut"
+                            position="first"
+                            leftIcon={
+                                <AvatarWithBadge icon="wallet-outline" size="extra-small" className="bg-yellow-1" />
+                            }
+                            onClick={() => router.push('/add-money/crypto?network=EVM&source=offramp')}
+                        />
+                    )}
                     <ActionListCard
                         title="Crypto"
                         description="Deposit from a wallet or exchange"
-                        position="first"
+                        position={hasOfframpBadge ? 'middle' : 'first'}
                         leftIcon={<AvatarWithBadge icon="wallet-outline" size="extra-small" className="bg-yellow-1" />}
                         onClick={() => setIsDrawerOpen(true)}
                     />

--- a/src/components/AddMoney/views/CryptoDeposit.view.tsx
+++ b/src/components/AddMoney/views/CryptoDeposit.view.tsx
@@ -17,6 +17,7 @@ import {
     SUPPORTED_EVM_CHAINS,
     NETWORK_LABELS,
     NETWORK_LOGOS,
+    TOKEN_LOGOS,
     getSupportedTokens,
 } from '@/constants/rhino.consts'
 import type {
@@ -35,6 +36,9 @@ interface CryptoDepositViewProps {
     isLoading: boolean
     onSuccess: (amount: number, statusData?: DepositAddressStatusResponse) => void
     onBack: () => void
+    // offramp migration: same rhino EVM SDA (funds land on arbitrum) but with the
+    // multi-chain / multi-token picker stripped to a single arbitrum + usdc surface.
+    variant?: 'default' | 'offramp'
 }
 
 const TOOLTIP_TEXT: Record<RhinoChainType, string> = {
@@ -43,23 +47,32 @@ const TOOLTIP_TEXT: Record<RhinoChainType, string> = {
     TRON: 'Your Tron deposit address. Deposits are bridged to Arbitrum (±0.1% variance).',
 }
 
-const CryptoDepositView = ({ network, depositAddressData, isLoading, onSuccess, onBack }: CryptoDepositViewProps) => {
+const CryptoDepositView = ({
+    network,
+    depositAddressData,
+    isLoading,
+    onSuccess,
+    onBack,
+    variant = 'default',
+}: CryptoDepositViewProps) => {
     const [showHowToDeposit, setShowHowToDeposit] = useState(false)
     const [showSupportedNetworks, setShowSupportedNetworks] = useState(false)
     const { status, resetStatus, isResetting } = useCryptoDepositPolling(depositAddressData?.depositAddress, onSuccess)
 
     const networkLabel = NETWORK_LABELS[network]
     const isEvm = network === 'EVM'
+    const isOfframp = variant === 'offramp'
 
     const supportedTokens = getSupportedTokens(network)
 
-    const amountLimitsLabel = isEvm ? 'EVM networks' : networkLabel
+    const amountLimitsLabel = isOfframp ? 'Arbitrum' : isEvm ? 'EVM networks' : networkLabel
+    const headerTitle = isOfframp ? 'Migrate from Offramp' : 'Deposit Crypto'
 
     // failed state
     if (status === 'failed') {
         return (
             <div className="flex min-h-[inherit] w-full flex-col justify-start gap-8 pb-5 md:pb-0">
-                <NavHeader title="Deposit Crypto" onPrev={onBack} />
+                <NavHeader title={headerTitle} onPrev={onBack} />
                 <div className="flex h-full min-h-[60vh] flex-col items-center justify-center gap-4">
                     <Card>
                         <div className="flex w-full flex-col items-center justify-center gap-2">
@@ -85,12 +98,20 @@ const CryptoDepositView = ({ network, depositAddressData, isLoading, onSuccess, 
 
     return (
         <div className="flex min-h-[inherit] w-full flex-col gap-8 pb-5 md:pb-0">
-            <NavHeader title="Deposit Crypto" onPrev={onBack} />
+            <NavHeader title={headerTitle} onPrev={onBack} />
 
             <div className="my-auto flex w-full flex-col gap-4">
                 {/* subtitle */}
                 <p className="text-center text-sm text-grey-1">
-                    Send tokens to this <span className="font-bold text-n-1">{networkLabel}</span> address
+                    {isOfframp ? (
+                        <>
+                            Send <span className="font-bold text-n-1">USDC on Arbitrum</span> to migrate your balance
+                        </>
+                    ) : (
+                        <>
+                            Send tokens to this <span className="font-bold text-n-1">{networkLabel}</span> address
+                        </>
+                    )}
                 </p>
 
                 {/* loading state */}
@@ -106,7 +127,7 @@ const CryptoDepositView = ({ network, depositAddressData, isLoading, onSuccess, 
                         <div className="flex items-center justify-center">
                             <QRCodeWrapper
                                 url={depositAddressData.depositAddress}
-                                centerImage={NETWORK_LOGOS[network]}
+                                centerImage={isOfframp ? CHAIN_LOGOS.ARBITRUM : NETWORK_LOGOS[network]}
                             />
                         </div>
 
@@ -115,14 +136,18 @@ const CryptoDepositView = ({ network, depositAddressData, isLoading, onSuccess, 
                             {/* address section */}
                             <div className="flex flex-col gap-2 p-4">
                                 <div className="flex items-center gap-1">
-                                    <Tooltip content={TOOLTIP_TEXT[network]} position="bottom">
-                                        <span className="flex items-center gap-1">
-                                            <span className="text-sm font-bold">
-                                                {isEvm ? 'Universal Deposit Address' : 'Deposit Address'}
+                                    {isOfframp ? (
+                                        <span className="text-sm font-bold">Your Arbitrum address</span>
+                                    ) : (
+                                        <Tooltip content={TOOLTIP_TEXT[network]} position="bottom">
+                                            <span className="flex items-center gap-1">
+                                                <span className="text-sm font-bold">
+                                                    {isEvm ? 'Universal Deposit Address' : 'Deposit Address'}
+                                                </span>
+                                                <Icon name="info" size={18} className="text-grey-1" />
                                             </span>
-                                            <Icon name="info" size={18} className="text-grey-1" />
-                                        </span>
-                                    </Tooltip>
+                                        </Tooltip>
+                                    )}
                                 </div>
                                 <div className="flex items-start justify-between gap-2">
                                     <p className="break-all text-sm">
@@ -145,16 +170,20 @@ const CryptoDepositView = ({ network, depositAddressData, isLoading, onSuccess, 
                             {/* supported networks section */}
                             <div
                                 onClick={() => {
-                                    if (isEvm) {
+                                    if (isEvm && !isOfframp) {
                                         setShowSupportedNetworks(true)
                                     }
                                 }}
-                                className={`border-t border-black p-4 ${isEvm ? 'cursor-pointer' : ''}`}
+                                className={`border-t border-black p-4 ${isEvm && !isOfframp ? 'cursor-pointer' : ''}`}
                             >
-                                <p className="mb-2 text-sm font-bold">Supported Networks:</p>
+                                <p className="mb-2 text-sm font-bold">
+                                    {isOfframp ? 'Network:' : 'Supported Networks:'}
+                                </p>
                                 <div className="flex items-center gap-2">
                                     <div className="flex flex-wrap gap-2">
-                                        {isEvm ? (
+                                        {isOfframp ? (
+                                            <ChainChip chainName="Arbitrum" chainSymbol={CHAIN_LOGOS.ARBITRUM} />
+                                        ) : isEvm ? (
                                             <>
                                                 {SUPPORTED_EVM_CHAINS.map((chain) => (
                                                     <Image
@@ -174,7 +203,7 @@ const CryptoDepositView = ({ network, depositAddressData, isLoading, onSuccess, 
                                             />
                                         )}
                                     </div>
-                                    {isEvm && (
+                                    {isEvm && !isOfframp && (
                                         <Button
                                             shadowSize="4"
                                             size="small"
@@ -190,15 +219,17 @@ const CryptoDepositView = ({ network, depositAddressData, isLoading, onSuccess, 
 
                             {/* supported tokens section */}
                             <div className="border-t border-black p-4">
-                                <p className="mb-2 text-sm font-bold">Supported Tokens:</p>
+                                <p className="mb-2 text-sm font-bold">{isOfframp ? 'Token:' : 'Supported Tokens:'}</p>
                                 <div className="flex flex-wrap gap-1.5">
-                                    {supportedTokens.map((token) => (
-                                        <ChainChip
-                                            key={token.name}
-                                            chainName={token.name}
-                                            chainSymbol={token.logoUrl}
-                                        />
-                                    ))}
+                                    {(isOfframp ? [{ name: 'USDC', logoUrl: TOKEN_LOGOS.USDC }] : supportedTokens).map(
+                                        (token) => (
+                                            <ChainChip
+                                                key={token.name}
+                                                chainName={token.name}
+                                                chainSymbol={token.logoUrl}
+                                            />
+                                        )
+                                    )}
                                 </div>
                             </div>
                         </div>
@@ -207,8 +238,12 @@ const CryptoDepositView = ({ network, depositAddressData, isLoading, onSuccess, 
                         <InfoCard
                             variant="warning"
                             icon="alert"
-                            title="Send to supported networks only"
-                            description="Wrong token or network may cause permanent loss."
+                            title={isOfframp ? 'Send USDC on Arbitrum only' : 'Send to supported networks only'}
+                            description={
+                                isOfframp
+                                    ? 'Other tokens or networks may cause permanent loss.'
+                                    : 'Wrong token or network may cause permanent loss.'
+                            }
                         />
 
                         {/* min/max limits */}

--- a/src/components/AddMoney/views/CryptoDeposit.view.tsx
+++ b/src/components/AddMoney/views/CryptoDeposit.view.tsx
@@ -34,12 +34,19 @@ interface CryptoDepositViewProps {
     network: RhinoChainType
     depositAddressData: CreateDepositAddressResponse | undefined
     isLoading: boolean
+    // deposit-address creation failed — render a retryable error instead of a
+    // screen that says "send funds" with no address to send them to.
+    isError?: boolean
+    onRetry?: () => void
     onSuccess: (amount: number, statusData?: DepositAddressStatusResponse) => void
     onBack: () => void
     // offramp migration: same rhino EVM SDA (funds land on arbitrum) but with the
     // multi-chain / multi-token picker stripped to a single arbitrum + usdc surface.
     variant?: 'default' | 'offramp'
 }
+
+// The offramp migration surface advertises exactly one safe token.
+const OFFRAMP_DISPLAY_TOKENS = [{ name: 'USDC', logoUrl: TOKEN_LOGOS.USDC }]
 
 const TOOLTIP_TEXT: Record<RhinoChainType, string> = {
     EVM: `${SUPPORTED_EVM_CHAINS.length} EVM networks supported. For exact amounts, deposit USDC on Arbitrum. Other chains/tokens are bridged (±0.1%).`,
@@ -51,6 +58,8 @@ const CryptoDepositView = ({
     network,
     depositAddressData,
     isLoading,
+    isError = false,
+    onRetry,
     onSuccess,
     onBack,
     variant = 'default',
@@ -79,13 +88,29 @@ const CryptoDepositView = ({
                             <div className="flex size-9 items-center justify-center rounded-full bg-secondary-1">
                                 <Icon name="alert" size={20} />
                             </div>
-                            <h1 className="text-base font-bold">Oops! Market moved</h1>
-                            <p className="text-center text-sm text-grey-1">
-                                The exchange rate changed too much to complete your deposit.
-                            </p>
-                            <p className="text-center text-sm font-bold text-grey-1">
-                                Your money is on its way back to your wallet.
-                            </p>
+                            <h1 className="text-base font-bold">
+                                {isOfframp ? 'Transfer sent back' : 'Oops! Market moved'}
+                            </h1>
+                            {isOfframp ? (
+                                <>
+                                    <p className="text-center text-sm text-grey-1">
+                                        We couldn't complete your migration transfer.
+                                    </p>
+                                    <p className="text-center text-sm font-bold text-grey-1">
+                                        Your money was returned to your Offramp account — start the withdrawal again
+                                        from there.
+                                    </p>
+                                </>
+                            ) : (
+                                <>
+                                    <p className="text-center text-sm text-grey-1">
+                                        The exchange rate changed too much to complete your deposit.
+                                    </p>
+                                    <p className="text-center text-sm font-bold text-grey-1">
+                                        Your money is on its way back to your wallet.
+                                    </p>
+                                </>
+                            )}
                         </div>
                     </Card>
                     <Button onClick={resetStatus} shadowSize="4" loading={isResetting} disabled={isResetting}>
@@ -121,6 +146,24 @@ const CryptoDepositView = ({
                     </div>
                 )}
 
+                {/* address-creation error — without this the screen instructs the
+                    user to send funds while showing no address at all */}
+                {isError && !isLoading && status !== 'loading' && (
+                    <div className="flex flex-col items-center gap-4">
+                        <InfoCard
+                            variant="warning"
+                            icon="alert"
+                            title="We couldn't prepare your deposit address"
+                            description="Nothing was sent. Please try again — if this keeps happening, contact support."
+                        />
+                        {onRetry && (
+                            <Button variant="stroke" className="w-full bg-white" shadowSize="4" onClick={onRetry}>
+                                Try Again
+                            </Button>
+                        )}
+                    </div>
+                )}
+
                 {depositAddressData && !isLoading && status !== 'loading' && (
                     <>
                         {/* qr code */}
@@ -137,7 +180,15 @@ const CryptoDepositView = ({
                             <div className="flex flex-col gap-2 p-4">
                                 <div className="flex items-center gap-1">
                                     {isOfframp ? (
-                                        <span className="text-sm font-bold">Your Arbitrum address</span>
+                                        <Tooltip
+                                            content="Use this address for your Offramp migration. It only accepts USDC on Arbitrum — don't save it as a general wallet address."
+                                            position="bottom"
+                                        >
+                                            <span className="flex items-center gap-1">
+                                                <span className="text-sm font-bold">Migration deposit address</span>
+                                                <Icon name="info" size={18} className="text-grey-1" />
+                                            </span>
+                                        </Tooltip>
                                     ) : (
                                         <Tooltip content={TOOLTIP_TEXT[network]} position="bottom">
                                             <span className="flex items-center gap-1">
@@ -221,15 +272,13 @@ const CryptoDepositView = ({
                             <div className="border-t border-black p-4">
                                 <p className="mb-2 text-sm font-bold">{isOfframp ? 'Token:' : 'Supported Tokens:'}</p>
                                 <div className="flex flex-wrap gap-1.5">
-                                    {(isOfframp ? [{ name: 'USDC', logoUrl: TOKEN_LOGOS.USDC }] : supportedTokens).map(
-                                        (token) => (
-                                            <ChainChip
-                                                key={token.name}
-                                                chainName={token.name}
-                                                chainSymbol={token.logoUrl}
-                                            />
-                                        )
-                                    )}
+                                    {(isOfframp ? OFFRAMP_DISPLAY_TOKENS : supportedTokens).map((token) => (
+                                        <ChainChip
+                                            key={token.name}
+                                            chainName={token.name}
+                                            chainSymbol={token.logoUrl}
+                                        />
+                                    ))}
                                 </div>
                             </div>
                         </div>
@@ -249,17 +298,26 @@ const CryptoDepositView = ({
                         {/* min/max limits */}
                         <div className="w-full space-y-1">
                             <div className="flex w-full items-center justify-between">
-                                <p className="text-sm text-grey-1">Min deposit for {amountLimitsLabel}:</p>
+                                <p className="text-sm text-grey-1">
+                                    {isOfframp ? 'Min per transfer:' : `Min deposit for ${amountLimitsLabel}:`}
+                                </p>
                                 <p className="text-sm font-bold">
                                     {depositAddressData.minDepositLimitUsd.toLocaleString()} USD
                                 </p>
                             </div>
                             <div className="flex w-full items-center justify-between">
-                                <p className="text-sm text-grey-1">Max deposit for {amountLimitsLabel}:</p>
+                                <p className="text-sm text-grey-1">
+                                    {isOfframp ? 'Max per transfer:' : `Max deposit for ${amountLimitsLabel}:`}
+                                </p>
                                 <p className="text-sm font-bold">
                                     {depositAddressData.maxDepositLimitUsd.toLocaleString()} USD
                                 </p>
                             </div>
+                            {isOfframp && (
+                                <p className="pt-1 text-sm text-grey-1">
+                                    Moving more than the max? Send it in multiple transfers.
+                                </p>
+                            )}
                         </div>
 
                         {/* how to deposit button */}
@@ -270,14 +328,18 @@ const CryptoDepositView = ({
                             onClick={() => setShowHowToDeposit(true)}
                         >
                             <Icon name="info" size={16} className="mr-1.5" />
-                            How to Deposit
+                            {isOfframp ? 'How to Migrate' : 'How to Deposit'}
                         </Button>
                     </>
                 )}
             </div>
 
             {/* modals */}
-            <HowToDepositModal visible={showHowToDeposit} onClose={() => setShowHowToDeposit(false)} />
+            <HowToDepositModal
+                visible={showHowToDeposit}
+                onClose={() => setShowHowToDeposit(false)}
+                variant={variant}
+            />
             <SupportedNetworksModal visible={showSupportedNetworks} onClose={() => setShowSupportedNetworks(false)} />
         </div>
     )

--- a/src/components/Invites/InvitesPage.tsx
+++ b/src/components/Invites/InvitesPage.tsx
@@ -19,7 +19,7 @@ import UnsupportedBrowserModal from '../Global/UnsupportedBrowserModal'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { profileUrl } from '@/utils/native-routes'
-import { INVITE_CODE_TO_CAMPAIGN_MAP, UTM_CAMPAIGN_TO_BADGE_MAP, classifyBareCampaign } from './campaign-maps'
+import { OFFRAMP_BADGE_CODE, classifyBareCampaign, resolveCampaign } from './campaign-maps'
 
 function InvitePageContent() {
     const searchParams = useSearchParams()
@@ -31,17 +31,8 @@ function InvitePageContent() {
     const utmCampaignParam = searchParams.get('utm_campaign')?.toLowerCase()
     const { user, isFetchingUser, fetchUser } = useAuth()
 
-    // resolution order: explicit campaign / campaignTag query param wins, then
-    // mapped invite code, then mapped utm_campaign. utm_campaign comes last so
-    // an explicit ?campaign= can still override on links that carry both.
-    // A lowercase vanity tag in the explicit param (e.g. ?campaign=offramp) is
-    // resolved through the UTM map to its badge code — otherwise it reaches
-    // /badge/award raw and 400s, since the backend matches the badge code.
-    const campaign =
-        (campaignParam && UTM_CAMPAIGN_TO_BADGE_MAP[campaignParam.toLowerCase()]) ||
-        campaignParam ||
-        (inviteCode ? INVITE_CODE_TO_CAMPAIGN_MAP[inviteCode] : undefined) ||
-        (utmCampaignParam ? UTM_CAMPAIGN_TO_BADGE_MAP[utmCampaignParam] : undefined)
+    // precedence + lowercase-tag mapping live in campaign-maps.ts (unit-tested)
+    const campaign = resolveCampaign(campaignParam, inviteCode, utmCampaignParam)
 
     // Bare campaign link (no invite code) that's claimable without an invite. The
     // effects below treat these specially so a returning logged-in user still gets
@@ -128,7 +119,11 @@ function InvitePageContent() {
                 .finally(async () => {
                     await fetchUser()
                     setIsAwardingBadge(false)
-                    router.push('/home')
+                    // offramp migrants came here to move their balance — land them
+                    // directly on the migration deposit screen, not /home.
+                    router.push(
+                        campaign === OFFRAMP_BADGE_CODE ? '/add-money/crypto?network=EVM&source=offramp' : '/home'
+                    )
                 })
             return
         }

--- a/src/components/Invites/InvitesPage.tsx
+++ b/src/components/Invites/InvitesPage.tsx
@@ -34,7 +34,11 @@ function InvitePageContent() {
     // resolution order: explicit campaign / campaignTag query param wins, then
     // mapped invite code, then mapped utm_campaign. utm_campaign comes last so
     // an explicit ?campaign= can still override on links that carry both.
+    // A lowercase vanity tag in the explicit param (e.g. ?campaign=offramp) is
+    // resolved through the UTM map to its badge code — otherwise it reaches
+    // /badge/award raw and 400s, since the backend matches the badge code.
     const campaign =
+        (campaignParam && UTM_CAMPAIGN_TO_BADGE_MAP[campaignParam.toLowerCase()]) ||
         campaignParam ||
         (inviteCode ? INVITE_CODE_TO_CAMPAIGN_MAP[inviteCode] : undefined) ||
         (utmCampaignParam ? UTM_CAMPAIGN_TO_BADGE_MAP[utmCampaignParam] : undefined)

--- a/src/components/Invites/campaign-maps.test.ts
+++ b/src/components/Invites/campaign-maps.test.ts
@@ -4,7 +4,9 @@ import {
     UTM_CAMPAIGN_TO_BADGE_MAP,
     WAITLIST_SKIP_CAMPAIGNS,
     BARE_VANITY_CAMPAIGNS,
+    OFFRAMP_BADGE_CODE,
     classifyBareCampaign,
+    resolveCampaign,
 } from './campaign-maps'
 
 // Regression guard. The /invite flow resolves an inbound invite code / utm_campaign
@@ -73,5 +75,41 @@ describe('classifyBareCampaign', () => {
     it('an unrelated or missing campaign is not bare-claimable', () => {
         expect(classifyBareCampaign(undefined, undefined).isBareClaimCampaign).toBe(false)
         expect(classifyBareCampaign('FOUNDER_HOUSE', undefined).isBareClaimCampaign).toBe(false)
+    })
+})
+
+describe('resolveCampaign', () => {
+    // The offramp migration regression this guards: ?campaign=offramp used to
+    // reach /badge/award as the raw string 'offramp' and 400 (the backend matches
+    // badge codes). The explicit param must resolve through the UTM map first.
+    it('resolves a lowercase human-facing tag in the explicit param (?campaign=offramp)', () => {
+        expect(resolveCampaign('offramp', undefined, undefined)).toBe(OFFRAMP_BADGE_CODE)
+        expect(resolveCampaign('OFFRAMP', undefined, undefined)).toBe(OFFRAMP_BADGE_CODE)
+    })
+
+    it('passes an unmapped explicit param through raw (?campaign=OFFRAMP_USER)', () => {
+        expect(resolveCampaign('OFFRAMP_USER', undefined, undefined)).toBe('OFFRAMP_USER')
+        expect(resolveCampaign('FOUNDER_HOUSE', undefined, undefined)).toBe('FOUNDER_HOUSE')
+    })
+
+    it('documents that ?campaign=<tag> behaves exactly like ?utm_campaign=<tag>', () => {
+        for (const [utmKey, badgeCode] of Object.entries(UTM_CAMPAIGN_TO_BADGE_MAP)) {
+            expect(resolveCampaign(utmKey, undefined, undefined)).toBe(badgeCode)
+            expect(resolveCampaign(undefined, undefined, utmKey)).toBe(badgeCode)
+        }
+    })
+
+    it('explicit param wins over invite code and utm_campaign', () => {
+        expect(resolveCampaign('offramp', 'alumni', 'touched-grass')).toBe(OFFRAMP_BADGE_CODE)
+    })
+
+    it('invite code wins over utm_campaign when there is no explicit param', () => {
+        expect(resolveCampaign(undefined, 'offramp', 'touched-grass')).toBe(OFFRAMP_BADGE_CODE)
+    })
+
+    it('falls back to utm_campaign, and to undefined when nothing resolves', () => {
+        expect(resolveCampaign(undefined, undefined, 'offramp')).toBe(OFFRAMP_BADGE_CODE)
+        expect(resolveCampaign(undefined, 'not-a-special-code', undefined)).toBeUndefined()
+        expect(resolveCampaign(null, undefined, undefined)).toBeUndefined()
     })
 })

--- a/src/components/Invites/campaign-maps.ts
+++ b/src/components/Invites/campaign-maps.ts
@@ -4,6 +4,11 @@
 // badge silently renders the Peanutman fallback + raw backend name (the
 // parallel-maps→single-record regression). campaign-maps.test.ts guards that.
 
+// offramp.xyz → Peanut migration badge. Single FE source of truth for the code —
+// the add-money entry gate (AddMoneyMethodSelection) and both maps below key on
+// it. Mirrors peanut-api-ts BADGE_CODES.OFFRAMP_USER.
+export const OFFRAMP_BADGE_CODE = 'OFFRAMP_USER'
+
 // mapping of special invite codes to their campaign tags
 // when these invite codes are used, the corresponding campaign tag is automatically applied
 export const INVITE_CODE_TO_CAMPAIGN_MAP: Record<string, string> = {
@@ -12,7 +17,7 @@ export const INVITE_CODE_TO_CAMPAIGN_MAP: Record<string, string> = {
     founderhaus: 'FOUNDER_HOUSE',
     alumni: 'EVENT_ALUMNI',
     touched_grass: 'TOUCHED_GRASS',
-    offramp: 'OFFRAMP_USER',
+    offramp: OFFRAMP_BADGE_CODE,
     irl_nomads: 'IRL_NOMADS',
     survivor: 'SUPPORT_SURVIVOR',
     notsoshhh: 'NOT_SO_SHHHH',
@@ -32,10 +37,35 @@ export const UTM_CAMPAIGN_TO_BADGE_MAP: Record<string, string> = {
     ethfloripa: 'ETHFLORIPA_HUB',
     alumni: 'EVENT_ALUMNI',
     'touched-grass': 'TOUCHED_GRASS',
-    offramp: 'OFFRAMP_USER',
+    offramp: OFFRAMP_BADGE_CODE,
     'festa-junina': 'FESTA_JUNINA_2026',
     'card-alpha': 'CARD_ALPHA',
     'irl-nomads': 'IRL_NOMADS',
+}
+
+// Resolve the effective campaign (a badge code, or a raw passthrough tag) from
+// the three places it can arrive on /invite. Precedence:
+//   1. explicit ?campaign= / ?campaignTag= — mapped through the UTM map first so
+//      a human-facing lowercase token (?campaign=offramp) resolves to its badge
+//      code instead of reaching /badge/award raw and 400ing; unmapped values
+//      pass through unchanged (?campaign=OFFRAMP_USER still works).
+//      NOTE: this deliberately makes ?campaign=<tag> behave exactly like
+//      ?utm_campaign=<tag> — users and partners can't be expected to know the
+//      difference between the two param spellings.
+//   2. a mapped special invite code (?code=offramp).
+//   3. ?utm_campaign= — last so an explicit ?campaign= wins on links carrying both.
+export function resolveCampaign(
+    campaignParam: string | null | undefined,
+    inviteCode: string | null | undefined,
+    utmCampaignParam: string | null | undefined
+): string | undefined {
+    return (
+        (campaignParam && UTM_CAMPAIGN_TO_BADGE_MAP[campaignParam.toLowerCase()]) ||
+        campaignParam ||
+        (inviteCode ? INVITE_CODE_TO_CAMPAIGN_MAP[inviteCode] : undefined) ||
+        (utmCampaignParam ? UTM_CAMPAIGN_TO_BADGE_MAP[utmCampaignParam] : undefined) ||
+        undefined
+    )
 }
 
 // Bare ?campaign= links (no invite code) that are claimable without an invite —


### PR DESCRIPTION
## Summary
Brings the 4 offramp/invite commits that landed on main (add-money offramp migration deposit entry #2333 + review fixes, lowercase vanity-tag resolution, real OFFRAMP_USER badge code) back into dev so the dev→main release #2340 stays a clean superset.

Textually clean merge (zero overlap with the release payload). Typecheck + 1674 jest tests green on the merged tree.

## Risks
None — pure sync of already-merged, already-in-prod main commits. No new code.

## QA
Local gate: typecheck ✅, jest 1674 ✅ (108 suites).