### PR TITLE
feat(offramp): require the migrant's Offramp username/email before revealing the deposit address

### DIFF
--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -584,6 +584,14 @@ jest.mock('@/components/AddMoney/hooks/useCryptoDepositPolling', () => ({
     useCryptoDepositPolling: (...args: any[]) => mockUseCryptoDepositPolling(...args),
 }))
 
+// updateUserById — the offramp handle gate persists the migrant's offramp.xyz
+// username/email through this server action
+const mockUpdateUserById = jest.fn()
+jest.mock('@/app/actions/users', () => ({
+    ...jest.requireActual('@/app/actions/users'),
+    updateUserById: (...args: any[]) => mockUpdateUserById(...args),
+}))
+
 // Country list
 jest.mock('@/components/Common/CountryList', () => ({
     CountryList: (props: any) => (
@@ -1202,6 +1210,86 @@ describe('GROUP 4: Crypto Page (with success)', () => {
 
         // The component renders CryptoDepositView which shows Deposit Crypto
         expect(screen.getByText('Deposit Crypto')).toBeInTheDocument()
+    })
+})
+
+// ============================================================
+// GROUP 4b: Offramp migration — required handle gate
+// ============================================================
+describe('GROUP 4b: Offramp migration handle gate', () => {
+    const authWithHandle = (offrampHandle: string | null) => {
+        mockUseAuth.mockReturnValue({
+            user: { user: { username: 'test-user', userId: 'user-123', offrampHandle } },
+            isFetchingUser: false,
+            fetchUser: jest.fn().mockResolvedValue(null),
+        })
+    }
+
+    beforeEach(() => {
+        resetQueryState({ network: 'EVM', source: 'offramp' })
+        mockUseCryptoDepositPolling.mockReturnValue({
+            status: 'not_started',
+            resetStatus: jest.fn(),
+            isResetting: false,
+        })
+        mockRhinoApi.createDepositAddress.mockResolvedValue({
+            depositAddress: '0xDepositAddress123',
+            minDepositLimitUsd: 5,
+            maxDepositLimitUsd: 10000,
+        })
+    })
+
+    test('migrant without a stored handle must enter it before seeing the deposit address', () => {
+        authWithHandle(null)
+        renderWithProviders(<AddMoneyCryptoPage />)
+
+        expect(screen.getByPlaceholderText('Offramp username or email')).toBeInTheDocument()
+        expect(screen.queryByTestId('qr-code')).not.toBeInTheDocument()
+    })
+
+    test('submitting the handle saves it trimmed and reveals the deposit screen', async () => {
+        authWithHandle(null)
+        mockUpdateUserById.mockResolvedValue({ data: {} })
+        renderWithProviders(<AddMoneyCryptoPage />)
+
+        fireEvent.change(screen.getByPlaceholderText('Offramp username or email'), {
+            target: { value: '  alice@offramp.xyz  ' },
+        })
+        fireEvent.click(screen.getByText('Continue'))
+
+        await waitFor(() => {
+            expect(mockUpdateUserById).toHaveBeenCalledWith({
+                userId: 'user-123',
+                offrampHandle: 'alice@offramp.xyz',
+            })
+        })
+        await waitFor(() => {
+            expect(screen.queryByPlaceholderText('Offramp username or email')).not.toBeInTheDocument()
+        })
+    })
+
+    test('save failure keeps the gate up and shows an error', async () => {
+        authWithHandle(null)
+        mockUpdateUserById.mockResolvedValue({ error: 'boom' })
+        renderWithProviders(<AddMoneyCryptoPage />)
+
+        fireEvent.change(screen.getByPlaceholderText('Offramp username or email'), {
+            target: { value: 'alice@offramp.xyz' },
+        })
+        fireEvent.click(screen.getByText('Continue'))
+
+        await waitFor(() => {
+            expect(screen.getByText(/Could not save your Offramp account/)).toBeInTheDocument()
+        })
+        expect(screen.getByPlaceholderText('Offramp username or email')).toBeInTheDocument()
+    })
+
+    test('migrant with a stored handle goes straight to the deposit screen', () => {
+        authWithHandle('alice@offramp.xyz')
+        renderWithProviders(<AddMoneyCryptoPage />)
+
+        expect(screen.queryByPlaceholderText('Offramp username or email')).not.toBeInTheDocument()
+        expect(screen.getAllByText('Migrate from Offramp').length).toBeGreaterThan(0)
     })
 })
 

--- a/src/app/(mobile-ui)/add-money/crypto/page.tsx
+++ b/src/app/(mobile-ui)/add-money/crypto/page.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import CryptoDepositView from '@/components/AddMoney/views/CryptoDeposit.view'
+import OfframpHandleGateView from '@/components/AddMoney/views/OfframpHandleGate.view'
+import PeanutLoading from '@/components/Global/PeanutLoading'
 import PaymentSuccessView from '@/features/payments/shared/components/PaymentSuccessView'
 import { useAuth } from '@/context/authContext'
 import { useWallet } from '@/hooks/wallet/useWallet'
@@ -22,7 +24,7 @@ import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 const DEPOSIT_EXPLORER_BASE_URL = getExplorerUrl(PEANUT_WALLET_CHAIN.id.toString())
 
 const AddMoneyCryptoPage = () => {
-    const { user } = useAuth()
+    const { user, isFetchingUser } = useAuth()
     const onBack = useSafeBack('/add-money')
     const { address: peanutWalletAddress } = useWallet()
     const [networkParam] = useQueryState(
@@ -39,6 +41,12 @@ const AddMoneyCryptoPage = () => {
     const network: RhinoChainType = isOfframp ? 'EVM' : networkParam
     const [showSuccessView, setShowSuccessView] = useState(false)
     const [depositResult, setDepositResult] = useState<DepositAddressStatusResponse | null>(null)
+    // Offramp migrants must self-report their offramp.xyz username/email once
+    // before the deposit address is revealed — Peanut owes the partner a
+    // per-migrant payout, and this handle is what reconciliation keys on.
+    // Local flag bridges the moment between saving and the user refetch.
+    const [offrampHandleSaved, setOfframpHandleSaved] = useState(false)
+    const needsOfframpHandle = isOfframp && !offrampHandleSaved && !user?.user.offrampHandle
 
     const {
         data: depositAddressData,
@@ -114,6 +122,15 @@ const AddMoneyCryptoPage = () => {
             totalAmountCollected: 0,
         } satisfies TransactionDetails
     }, [depositResult, network, isOfframp])
+
+    if (needsOfframpHandle && !showSuccessView) {
+        // wait for the cached user before deciding — otherwise a migrant who
+        // already provided their handle gets a flash of the gate on every visit
+        if (isFetchingUser && !user) {
+            return <PeanutLoading />
+        }
+        return <OfframpHandleGateView onBack={onBack} onDone={() => setOfframpHandleSaved(true)} />
+    }
 
     if (showSuccessView && depositResult) {
         return (

--- a/src/components/AddMoney/views/OfframpHandleGate.view.tsx
+++ b/src/components/AddMoney/views/OfframpHandleGate.view.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/0_Bruddle/Button'
+import BaseInput from '@/components/0_Bruddle/BaseInput'
+import NavHeader from '@/components/Global/NavHeader'
+import { updateUserById } from '@/app/actions/users'
+import { useAuth } from '@/context/authContext'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+
+interface OfframpHandleGateViewProps {
+    onBack: () => void
+    /** Called once the handle is saved — the caller reveals the deposit address. */
+    onDone: () => void
+}
+
+// Required gate in front of the offramp migration deposit screen: migrants
+// must self-report which offramp.xyz account they're migrating from before the
+// deposit address is revealed. Peanut owes the partner a per-migrant payout,
+// so this is what reconciliation keys on. Deliberately unverified — asking is
+// enough of a deterrent against farming the public campaign link.
+const OfframpHandleGateView = ({ onBack, onDone }: OfframpHandleGateViewProps) => {
+    const { user, fetchUser } = useAuth()
+    const [handle, setHandle] = useState('')
+    const [isSaving, setIsSaving] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+    const trimmedHandle = handle.trim()
+    const canSubmit = trimmedHandle.length >= 3 && !!user?.user.userId && !isSaving
+
+    const handleSubmit = async () => {
+        if (!canSubmit) return
+        setIsSaving(true)
+        setError(null)
+        const { error: apiError } = await updateUserById({
+            userId: user!.user.userId,
+            offrampHandle: trimmedHandle,
+        })
+        if (apiError) {
+            setError('Could not save your Offramp account. Please try again.')
+            setIsSaving(false)
+            return
+        }
+        posthog.capture(ANALYTICS_EVENTS.OFFRAMP_HANDLE_SUBMITTED)
+        // refresh the cached user so the gate stays passed on future visits;
+        // onDone doesn't wait on it — the handle is already persisted.
+        fetchUser().catch(() => {})
+        onDone()
+    }
+
+    return (
+        <div className="flex min-h-[inherit] w-full flex-col gap-8 pb-5 md:pb-0">
+            <NavHeader title="Migrate from Offramp" onPrev={onBack} />
+            <div className="my-auto flex flex-col gap-6">
+                <div className="flex flex-col gap-2">
+                    <h2 className="text-xl font-extrabold">Which Offramp account is this?</h2>
+                    <p className="text-base font-medium text-grey-1">
+                        Enter the username or email of the Offramp account you're migrating from, so we can match your
+                        balance to your new Peanut wallet.
+                    </p>
+                </div>
+                <div className="flex flex-col gap-2">
+                    <BaseInput
+                        type="text"
+                        value={handle}
+                        onChange={(e) => setHandle(e.target.value)}
+                        onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+                        placeholder="Offramp username or email"
+                        maxLength={320}
+                        autoFocus
+                        autoComplete="off"
+                        autoCapitalize="none"
+                        spellCheck={false}
+                    />
+                    {error && <p className="text-sm font-medium text-error">{error}</p>}
+                </div>
+                <Button
+                    variant="purple"
+                    shadowSize="4"
+                    className="w-full"
+                    disabled={!canSubmit}
+                    loading={isSaving}
+                    onClick={handleSubmit}
+                >
+                    Continue
+                </Button>
+            </div>
+        </div>
+    )
+}
+
+export default OfframpHandleGateView

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -67,6 +67,9 @@ export const ANALYTICS_EVENTS = {
     DEPOSIT_CONFIRMED: 'deposit_confirmed',
     DEPOSIT_COMPLETED: 'deposit_completed',
     DEPOSIT_FAILED: 'deposit_failed',
+    // offramp.xyz migrants must self-report their Offramp username/email
+    // before the migration deposit address is revealed (payout reconciliation)
+    OFFRAMP_HANDLE_SUBMITTED: 'offramp_handle_submitted',
 
     // ── Withdraw ──
     WITHDRAW_AMOUNT_ENTERED: 'withdraw_amount_entered',

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -193,6 +193,9 @@ export interface User {
     bridgeCustomerId: string | null
     fullName: string
     telegram: string | null
+    /** Self-reported offramp.xyz username/email — collected once on the
+     *  migration deposit screen (offramp payout reconciliation). */
+    offrampHandle?: string | null
     hasAppAccess: boolean
     isActivated?: boolean
     activatedAt?: string | null


### PR DESCRIPTION
## Summary

Follow-up to #2346 and companion to **peanutprotocol/peanut-api-ts#1127**. The public offramp campaign link awards the $10 OFFRAMP_USER badge to anyone who clicks it — fine for the $10, but Peanut owes the partner **$30+$25 per _actual_ migrant** and today we can't tell which badge holders are real offramp.xyz users (Konrad's ask, 2026-07-03).

This gates the migration deposit screen (`/add-money/crypto?source=offramp`) behind a **required input**: the migrant's offramp.xyz username or email.

- New `OfframpHandleGateView`: NavHeader + copy + input + Continue (disabled until ≥3 chars). Saves via the existing `updateUserById` server action (`POST /update-user { offrampHandle }`), fires `offramp_handle_submitted` PostHog event, then reveals the deposit address.
- Skipped entirely once `user.user.offrampHandle` is set (new field on `/users/me`, BE #1127) — one-time friction per user.
- Value is deliberately **unverified**: per Konrad, asking is deterrent enough; reconciliation with the partner happens later via `SELECT username, offramp_handle FROM app.users WHERE offramp_handle IS NOT NULL`.

## Risks / breaking changes

- **Cross-repo deploy ordering: peanut-api-ts#1127 must deploy first.** Fastify strips unknown body fields, so FE-first would silently drop the handle (gate would re-appear on next visit; no data stored).
- Scope: only the `source=offramp` variant of the crypto deposit page — normal crypto deposits unaffected.
- While the auth user is still loading, offramp visitors see a spinner instead of a gate flash; migrants with a stored handle go straight through.
- Base **main** (hotfix path, matching #2346) — back-merge to `dev` after merge.

## QA

- 4 new tests in `add-money-states.test.tsx` (GROUP 4b): gate blocks address for migrants without a handle; submit trims + saves + reveals; save failure keeps gate up with error copy; stored handle skips gate.
- Local gate: prettier ✅ typecheck ✅ jest 47/47 in the suite (full run has 2 pre-existing env-only failures: locale-dependent `10,000 USD` assertion + gitignored `public/flags` in fresh worktree; both pass with en_US locale / postinstall) ✅ `next build` ✅.

Manual QA path: log in as a user with the OFFRAMP_USER badge → Add money → Migrate from Offramp → gate appears → enter handle → deposit QR revealed; revisit → no gate.