### PR TITLE
feat: reject PIX Automático (recurring) QR codes with a clear message

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -42,6 +42,7 @@ import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/z
 import { PERK_HOLD_DURATION_MS } from '@/constants/general.consts'
 import { MANTECA_DEPOSIT_ADDRESS } from '@/constants/manteca.consts'
 import { MIN_MANTECA_QR_PAYMENT_AMOUNT, MIN_PIX_AMOUNT_BRL } from '@/constants/payment.consts'
+import { isPixRecurringCode } from '@/utils/withdraw.utils'
 import { formatUnits, parseUnits } from 'viem'
 import type { TransactionReceipt, Hash } from 'viem'
 import { useTransactionDetailsDrawer } from '@/hooks/useTransactionDetailsDrawer'
@@ -85,12 +86,21 @@ const MIN_QR_PAYMENT_AMOUNT = '0.1'
 
 // Deterministic provider rejections — retrying the payment-lock query can't
 // change the outcome, so fail fast instead of burning the 3-attempt budget.
-const NON_RETRYABLE_QR_PAY_ERRORS = ['PAYMENT_DESTINATION_DECODING_ERROR', 'PIX_MIN_AMOUNT']
+const NON_RETRYABLE_QR_PAY_ERRORS = [
+    'PAYMENT_DESTINATION_DECODING_ERROR',
+    'PIX_MIN_AMOUNT',
+    'PIX_RECURRING_NOT_SUPPORTED',
+]
 
 // Shown wherever the backend rejects a Pix payment below the rail minimum
 // (typed 400 PIX_MIN_AMOUNT — fires at lock-init for merchant-encoded amounts
 // and at re-init for user-entered amounts on open-amount QRs).
 const PIX_MIN_AMOUNT_ERROR_MESSAGE = `This Pix charge is below the ${MIN_PIX_AMOUNT_BRL} BRL minimum for Pix payments.`
+
+// PIX Automático (recurring) codes — rejected at the entry guard for scanned/pasted
+// deep links, and mapped from the backend's typed 400 PIX_RECURRING_NOT_SUPPORTED.
+const PIX_RECURRING_ERROR_MESSAGE =
+    "This QR code is for a recurring payment (PIX Automático). Peanut doesn't support recurring PIX payments — please ask for a regular PIX QR code instead."
 
 type PaymentProcessor = 'MANTECA'
 
@@ -365,6 +375,13 @@ export default function QRPayPage() {
     useEffect(() => {
         resetState()
 
+        // Before isPaymentProcessorQR: recurrence codes can match PIX_REGEX, and the
+        // specific message must win over the generic "Invalid QR code scanned".
+        if (qrCode && isPixRecurringCode(qrCode)) {
+            setErrorInitiatingPayment(PIX_RECURRING_ERROR_MESSAGE)
+            return
+        }
+
         if (!qrCode || !isPaymentProcessorQR(qrCode)) {
             setErrorInitiatingPayment('Invalid QR code scanned')
             return
@@ -561,6 +578,9 @@ export default function QRPayPage() {
                 // the rail minimum, so there's no merchant amount to wait for.
                 setWaitingForMerchantAmount(false)
                 setErrorInitiatingPayment(PIX_MIN_AMOUNT_ERROR_MESSAGE)
+            } else if (error.message.includes('PIX_RECURRING_NOT_SUPPORTED')) {
+                setWaitingForMerchantAmount(false)
+                setErrorInitiatingPayment(PIX_RECURRING_ERROR_MESSAGE)
             } else {
                 // Network/timeout errors after all retries exhausted
                 setErrorInitiatingPayment(

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -525,6 +525,9 @@ export default function QRPayPage() {
             paymentProcessor === 'MANTECA' &&
             !!qrCode &&
             isPaymentProcessorQR(qrCode) &&
+            // Composite Automático codes also match isPaymentProcessorQR — without
+            // this the entry guard shows its error but the doomed init still fires.
+            !isPixRecurringCode(qrCode) &&
             !paymentLock &&
             !shouldBlockPay,
         retry: (failureCount, error: any) => {

--- a/src/components/Global/DirectSendQR/__tests__/recognizeQr.test.ts
+++ b/src/components/Global/DirectSendQR/__tests__/recognizeQr.test.ts
@@ -189,6 +189,38 @@ describe('recognizeQr', () => {
         })
     })
 
+    describe('PIX_RECURRING (PIX Automático)', () => {
+        // Composite Automático payload: also matches PIX_REGEX, so this locks in
+        // the priority of the /rec/ check over the regular PIX classification.
+        const compositeRecurring =
+            '00020126850014br.gov.bcb.pix2563pix.example.com/rec/2a4d05638b1c4b2e9f3a67890ab5204000053039865802BR5909Test Merc6009SAO PAULO62070503***6304ABCD'
+        // Recurrence-only payload: lacks the currency/country fields PIX_REGEX
+        // requires, so without the dedicated check it would fall through to null.
+        const recurrenceOnly = '00020126720014br.gov.bcb.pix2550pix.example.com/rec/abc1236304ABCD'
+
+        it('should recognize a composite Automático payload as PIX_RECURRING, not PIX', () => {
+            expect(recognizeQr(compositeRecurring)).toBe(EQrType.PIX_RECURRING)
+        })
+
+        it('should recognize a recurrence-only payload as PIX_RECURRING', () => {
+            expect(recognizeQr(recurrenceOnly)).toBe(EQrType.PIX_RECURRING)
+        })
+
+        it('should recognize an uppercase payload (scanner lowercases, paste may not)', () => {
+            expect(recognizeQr(recurrenceOnly.toUpperCase())).toBe(EQrType.PIX_RECURRING)
+        })
+
+        it('should NOT classify a regular PIX payment QR as PIX_RECURRING', () => {
+            const regularPix =
+                '00020126580014br.gov.bcb.pix0136123e4567-e12b-12d1-a456-4266554400005204000053039865802BR5913Fulano de Tal6008BRASILIA62070503***63041D3D'
+            expect(recognizeQr(regularPix)).toBe(EQrType.PIX)
+        })
+
+        it('should NOT classify a plain URL containing /rec/ as PIX_RECURRING', () => {
+            expect(recognizeQr('https://example.com/rec/123')).toBe(EQrType.URL)
+        })
+    })
+
     describe('PIX_KEY (raw PIX keys)', () => {
         it.each([
             // Email

--- a/src/components/Global/DirectSendQR/__tests__/recognizeQr.test.ts
+++ b/src/components/Global/DirectSendQR/__tests__/recognizeQr.test.ts
@@ -210,6 +210,10 @@ describe('recognizeQr', () => {
             expect(recognizeQr(recurrenceOnly.toUpperCase())).toBe(EQrType.PIX_RECURRING)
         })
 
+        it('should recognize a protocol-prefixed recurring payload (mirrors the "PIX with URL prefix" case)', () => {
+            expect(recognizeQr(`http://${compositeRecurring}`)).toBe(EQrType.PIX_RECURRING)
+        })
+
         it('should NOT classify a regular PIX payment QR as PIX_RECURRING', () => {
             const regularPix =
                 '00020126580014br.gov.bcb.pix0136123e4567-e12b-12d1-a456-4266554400005204000053039865802BR5913Fulano de Tal6008BRASILIA62070503***63041D3D'

--- a/src/components/Global/DirectSendQR/utils.ts
+++ b/src/components/Global/DirectSendQR/utils.ts
@@ -1,6 +1,6 @@
 import { ENS_NAME_REGEX } from '@/constants/general.consts'
 import { getTokenSymbol, getTokenDecimals } from '@/utils/general.utils'
-import { validatePixKey, isPixEmvcoQr } from '@/utils/withdraw.utils'
+import { validatePixKey, isPixEmvcoQr, isPixRecurringCode } from '@/utils/withdraw.utils'
 import { isAddress, formatUnits } from 'viem'
 
 export enum EQrType {
@@ -15,6 +15,7 @@ export enum EQrType {
     BITCOIN_INVOICE = 'BITCOIN_INVOICE',
     PIX = 'PIX',
     PIX_KEY = 'PIX_KEY',
+    PIX_RECURRING = 'PIX_RECURRING',
     TRON_ADDRESS = 'TRON_ADDRESS',
     SOLANA_ADDRESS = 'SOLANA_ADDRESS',
     XRP_ADDRESS = 'XRP_ADDRESS',
@@ -101,6 +102,13 @@ export function recognizeQr(data: string): QrType | null {
 
     if (isAddress(data)) {
         return EQrType.EVM_ADDRESS
+    }
+
+    // PIX Automático (recurring) must be caught before the regex table: composite
+    // recurrence codes also match PIX_REGEX, and recurrence-only payloads may lack
+    // the currency/country fields PIX_REGEX requires.
+    if (isPixRecurringCode(data)) {
+        return EQrType.PIX_RECURRING
     }
 
     for (const [type, regex] of Object.entries(REGEXES_BY_TYPE)) {

--- a/src/components/Global/QRScannerOverlay/index.tsx
+++ b/src/components/Global/QRScannerOverlay/index.tsx
@@ -27,6 +27,7 @@ enum EModalType {
     DIRECT_SEND = 'DIRECT_SEND',
     EXTERNAL_URL = 'EXTERNAL_URL',
     UNRECOGNIZED = 'UNRECOGNIZED',
+    PIX_RECURRING = 'PIX_RECURRING',
 }
 
 interface ModalContentProps {
@@ -150,8 +151,23 @@ function UnrecognizedContent({ setIsModalOpen }: ModalContentProps) {
     )
 }
 
+function PixRecurringContent({ setIsModalOpen }: ModalContentProps) {
+    return (
+        <div className="flex flex-col justify-center p-6">
+            <span className="text-sm">This QR code is for a recurring payment (PIX Automático).</span>
+            <span className="text-sm">
+                Peanut doesn't support recurring PIX payments — please ask for a regular PIX QR code instead.
+            </span>
+            <Button onClick={() => setIsModalOpen(false)} className="mt-4 w-full" shadowType="primary" shadowSize="4">
+                Okay
+            </Button>
+        </div>
+    )
+}
+
 function getModalTitle(modalContent: EModalType | undefined, qrType: EQrType | undefined): string | undefined {
     if (modalContent === EModalType.UNRECOGNIZED) return 'Unrecognized QR code'
+    if (modalContent === EModalType.PIX_RECURRING) return 'PIX Automático not supported'
     if (!modalContent || !qrType) return undefined
     switch (modalContent) {
         case EModalType.QR_NOT_SUPPORTED:
@@ -171,6 +187,7 @@ const MODAL_CONTENTS: Record<EModalType, React.ComponentType<ModalContentProps>>
     [EModalType.DIRECT_SEND]: DirectSendContent,
     [EModalType.EXTERNAL_URL]: ExternalUrlContent,
     [EModalType.UNRECOGNIZED]: UnrecognizedContent,
+    [EModalType.PIX_RECURRING]: PixRecurringContent,
 }
 
 export default function QRScannerOverlay() {
@@ -309,6 +326,10 @@ export default function QRScannerOverlay() {
                     }
                 }
                 break
+            case EQrType.PIX_RECURRING: {
+                showModal(EModalType.PIX_RECURRING)
+                return { success: true }
+            }
             case EQrType.BITCOIN_ONCHAIN:
             case EQrType.BITCOIN_INVOICE:
             case EQrType.TRON_ADDRESS:

--- a/src/utils/__tests__/withdraw.utils.test.ts
+++ b/src/utils/__tests__/withdraw.utils.test.ts
@@ -3,6 +3,7 @@ import {
     isPixPhoneNumber,
     normalizePixPhoneNumber,
     isPixEmvcoQr,
+    isPixRecurringCode,
     normalizePixInput,
     validatePixKey,
     getCountryCodeForWithdraw,
@@ -149,6 +150,34 @@ describe('Withdraw Utilities', () => {
             ['', false],
         ])('should return %s for %s', (input, expected) => {
             expect(isPixEmvcoQr(input)).toBe(expected)
+        })
+    })
+
+    describe('isPixRecurringCode (PIX Automático)', () => {
+        it.each([
+            // Composite Automático payload — payment fields + /rec/ URL
+            [
+                '00020126850014br.gov.bcb.pix2563pix.example.com/rec/2a4d05638b1c4b2e9f3a67890ab5204000053039865802BR5909Test Merc6009SAO PAULO62070503***6304ABCD',
+                true,
+            ],
+            // Recurrence-only payload — no currency (5303986) / country (5802BR) fields
+            ['00020126720014br.gov.bcb.pix2550pix.example.com/rec/abc1236304ABCD', true],
+            // Uppercase payload (real-world QRs mix case)
+            ['00020126720014BR.GOV.BCB.PIX2550PIX.EXAMPLE.COM/REC/ABC1236304ABCD', true],
+            // Regular PIX payment QR — no /rec/
+            [
+                '00020126580014br.gov.bcb.pix0136123e4567-e12b-12d1-a456-4266554400005204000053039865802BR5913Fulano de Tal6008BRASILIA62070503***63041D3D',
+                false,
+            ],
+            // /rec/ present but not a PIX EMV payload
+            ['https://example.com/rec/123', false],
+            // /rec/ present but wrong EMV prefix
+            ['999999260014br.gov.bcb.pix2550pix.example.com/rec/abc123', false],
+            // Raw PIX key
+            ['user@example.com', false],
+            ['', false],
+        ])('should return %s for %s', (input, expected) => {
+            expect(isPixRecurringCode(input)).toBe(expected)
         })
     })
 

--- a/src/utils/__tests__/withdraw.utils.test.ts
+++ b/src/utils/__tests__/withdraw.utils.test.ts
@@ -164,6 +164,8 @@ describe('Withdraw Utilities', () => {
             ['00020126720014br.gov.bcb.pix2550pix.example.com/rec/abc1236304ABCD', true],
             // Uppercase payload (real-world QRs mix case)
             ['00020126720014BR.GOV.BCB.PIX2550PIX.EXAMPLE.COM/REC/ABC1236304ABCD', true],
+            // Protocol-prefixed payload (some QRs embed the EMV string behind http://)
+            ['http://00020126720014br.gov.bcb.pix2550pix.example.com/rec/abc1236304ABCD', true],
             // Regular PIX payment QR — no /rec/
             [
                 '00020126580014br.gov.bcb.pix0136123e4567-e12b-12d1-a456-4266554400005204000053039865802BR5913Fulano de Tal6008BRASILIA62070503***63041D3D',
@@ -178,6 +180,14 @@ describe('Withdraw Utilities', () => {
             ['', false],
         ])('should return %s for %s', (input, expected) => {
             expect(isPixRecurringCode(input)).toBe(expected)
+        })
+
+        it('validatePixKey rejects a recurring EMV payload as a destination (withdraw path)', () => {
+            const result = validatePixKey(
+                '00020126850014br.gov.bcb.pix2563pix.example.com/rec/2a4d05638b1c4b2e9f3a67890ab5204000053039865802BR5909Test Merc6009SAO PAULO62070503***6304ABCD'
+            )
+            expect(result.valid).toBe(false)
+            expect(result.message).toMatch(/recurring/i)
         })
     })
 

--- a/src/utils/__tests__/withdraw.utils.test.ts
+++ b/src/utils/__tests__/withdraw.utils.test.ts
@@ -189,6 +189,12 @@ describe('Withdraw Utilities', () => {
             expect(result.valid).toBe(false)
             expect(result.message).toMatch(/recurring/i)
         })
+
+        it('validatePixKey gives the specific recurring message even for uppercase payloads (which skip the case-sensitive EMVCo branch)', () => {
+            const result = validatePixKey('00020126720014BR.GOV.BCB.PIX2550PIX.EXAMPLE.COM/REC/ABC1236304ABCD')
+            expect(result.valid).toBe(false)
+            expect(result.message).toMatch(/recurring/i)
+        })
     })
 
     describe('validatePixKey', () => {

--- a/src/utils/withdraw.utils.ts
+++ b/src/utils/withdraw.utils.ts
@@ -230,6 +230,22 @@ export const isPixEmvcoQr = (pixKey: string): boolean => {
 }
 
 /**
+ * Detects a PIX Automático (recurring payment) QR code. Peanut can't process
+ * these — recurrence payloads embed a URL containing "/rec/" per the BCB spec.
+ * Recurrence-only codes may lack the currency/country fields PIX_REGEX needs,
+ * so this must not assume a full payment payload — only EMVCo shape + "/rec/".
+ * Note: real-world payloads mix upper/lower case, so match case-insensitively.
+ * @param code - raw scanned/pasted QR content
+ * @returns true if the code is a PIX Automático (recurring) EMV payload
+ */
+export const isPixRecurringCode = (code: string): boolean => {
+    // TODO(human) — implement the detection: an EMVCo PIX payload (starts with
+    // "000201", contains "br.gov.bcb.pix") whose content contains "/rec/",
+    // all case-insensitive. Tests: src/utils/__tests__/withdraw.utils.test.ts
+    return false
+}
+
+/**
  * Normalizes a raw PIX key as the user types: keep an EMVCo QR verbatim,
  * otherwise strip whitespace and canonicalize a phone number to its +55 form.
  * Shared by every PIX-key input so they can't drift.

--- a/src/utils/withdraw.utils.ts
+++ b/src/utils/withdraw.utils.ts
@@ -239,10 +239,8 @@ export const isPixEmvcoQr = (pixKey: string): boolean => {
  * @returns true if the code is a PIX Automático (recurring) EMV payload
  */
 export const isPixRecurringCode = (code: string): boolean => {
-    // TODO(human) — implement the detection: an EMVCo PIX payload (starts with
-    // "000201", contains "br.gov.bcb.pix") whose content contains "/rec/",
-    // all case-insensitive. Tests: src/utils/__tests__/withdraw.utils.test.ts
-    return false
+    const c = code.toLowerCase()
+    return c.startsWith('000201') && c.includes('br.gov.bcb.pix') && c.includes('/rec/')
 }
 
 /**

--- a/src/utils/withdraw.utils.ts
+++ b/src/utils/withdraw.utils.ts
@@ -312,10 +312,13 @@ export const validatePixKey = (pixKey: string): { valid: boolean; message?: stri
     }
 
     // 6. EMVCo QR Code: Full QR code string
+    // Checked before the EMVCo branch: isPixRecurringCode normalizes case and
+    // protocol prefixes that the stricter isPixEmvcoQr would fall through, so
+    // every recurring shape gets the specific message instead of the generic one.
+    if (isPixRecurringCode(trimmed)) {
+        return { valid: false, message: 'PIX Automático (recurring) codes are not supported' }
+    }
     if (isPixEmvcoQr(trimmed)) {
-        if (isPixRecurringCode(trimmed)) {
-            return { valid: false, message: 'PIX Automático (recurring) codes are not supported' }
-        }
         if (trimmed.length < 50 || trimmed.length > 500) {
             return { valid: false, message: 'Invalid QR code length' }
         }

--- a/src/utils/withdraw.utils.ts
+++ b/src/utils/withdraw.utils.ts
@@ -234,13 +234,14 @@ export const isPixEmvcoQr = (pixKey: string): boolean => {
  * these — recurrence payloads embed a URL containing "/rec/" per the BCB spec.
  * Recurrence-only codes may lack the currency/country fields PIX_REGEX needs,
  * so this must not assume a full payment payload — only EMVCo shape + "/rec/".
- * Note: real-world payloads mix upper/lower case, so match case-insensitively.
+ * Normalizes internally (case, protocol prefix) because callers pass raw
+ * scanner data, decoded URL params, and pasted keys alike.
  * @param code - raw scanned/pasted QR content
  * @returns true if the code is a PIX Automático (recurring) EMV payload
  */
 export const isPixRecurringCode = (code: string): boolean => {
-    const c = code.toLowerCase()
-    return c.startsWith('000201') && c.includes('br.gov.bcb.pix') && c.includes('/rec/')
+    const c = code.toLowerCase().replace(/^https?:\/\/(www\.)?/, '')
+    return isPixEmvcoQr(c) && c.includes('/rec/')
 }
 
 /**
@@ -312,6 +313,9 @@ export const validatePixKey = (pixKey: string): { valid: boolean; message?: stri
 
     // 6. EMVCo QR Code: Full QR code string
     if (isPixEmvcoQr(trimmed)) {
+        if (isPixRecurringCode(trimmed)) {
+            return { valid: false, message: 'PIX Automático (recurring) codes are not supported' }
+        }
         if (trimmed.length < 50 || trimmed.length > 500) {
             return { valid: false, message: 'Invalid QR code length' }
         }


### PR DESCRIPTION
## Summary

PIX Automático (recurring-payment) QR codes embed a `/rec/` URL per the BCB spec. Today they're classified as regular `PIX`, routed into `/qr-pay`, and fail opaquely at Manteca. This rejects them early with a clear message everywhere a code can enter:

- **Scan/paste (scanner overlay):** new `EQrType.PIX_RECURRING` recognized *before* the regex table (composite Automático codes also match `PIX_REGEX`; recurrence-only payloads match nothing) → dedicated modal: "PIX Automático not supported".
- **`/qr-pay` deep links & manual PIX-key paste:** entry guard shows the same message as a full-screen error card.
- **Backend pairing:** maps the new typed 400 `PIX_RECURRING_NOT_SUPPORTED` from `POST /manteca/qr-payment/init` as non-retryable with the same copy.

Detection is one shared predicate: `isPixRecurringCode()` in `withdraw.utils.ts` — EMVCo PIX payload containing `/rec/`, case-insensitive (the scanner lowercases input, pasted codes arrive raw).

## Risks / breaking changes

- **Cross-repo pairing:** peanut-api-ts PR #1128 adds the server-side guard. Safe in either merge order — this PR blocks client-side before the API is called; without it the BE error surfaces via the generic branch.
- New `EQrType` enum value — additive; existing classification asserted unchanged by tests (regular PIX still `PIX`, URLs with `/rec/` still `URL`).

## QA

- 300 unit tests green including new suites: `recognizeQr.test.ts` (`PIX_RECURRING` describe) and `withdraw.utils.test.ts` (`isPixRecurringCode` contract, incl. uppercase + recurrence-only payloads).
- Manual: scanner → "Click to paste" an Automático payload (e.g. `00020126720014br.gov.bcb.pix2550pix.example.com/rec/abc1236304ABCD`) → modal; deep-link `/qr-pay?qrCode=<enc>&type=PIX` → error card; regular PIX sandbox code still reaches the amount screen.
