### PR TITLE
feat(card): residence-confirmation screen for country-mismatch applications

### DIFF
--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -259,6 +259,17 @@ const CardPage: FC = () => {
             posthog.capture(ANALYTICS_EVENTS.CARD_COUNTRY_CONFIRMED, { country: countryCode })
             try {
                 const res = await rainApi.applyForCard({ confirmedResidenceCountry: countryCode })
+                // Caller-specific `incomplete` branch (advanceFromApplyResponse
+                // deliberately doesn't handle it): the applicant regressed
+                // between the mismatch response and the confirm call — open the
+                // WebSDK instead of silently dumping the user on the entry
+                // screen via the default overview-invalidate arm.
+                if (res.status === 'incomplete' && 'sumsubAccessToken' in res) {
+                    setPendingCountryConfirmation(null)
+                    setSumsubToken(res.sumsubAccessToken)
+                    posthog.capture(ANALYTICS_EVENTS.CARD_SUMSUB_OPENED)
+                    return
+                }
                 advanceFromApplyResponse(res)
             } catch (e) {
                 const message = e instanceof Error ? e.message : 'Failed to confirm country'
@@ -486,7 +497,12 @@ const CardPage: FC = () => {
                     candidates={pendingCountryConfirmation.candidates}
                     onConfirm={handleConfirmCountry}
                     onContactSupport={() => setIsSupportModalOpen(true)}
-                    onPrev={() => setPendingCountryConfirmation(null)}
+                    onPrev={() => {
+                        // Clear the shared error too — a confirm failure must not
+                        // leak onto the entry/terms screens after backing out.
+                        setPendingCountryConfirmation(null)
+                        setApplyError(null)
+                    }}
                     submitError={applyError}
                 />
             )

--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -12,6 +12,7 @@ import { pollUntilApplyAdvances, pollUntilReady } from '@/components/Card/cardAp
 import AddCardEntryScreen from '@/components/Card/AddCardEntryScreen'
 import ApplicationStatusScreen from '@/components/Card/ApplicationStatusScreen'
 import CardTermsScreen from '@/components/Card/CardTermsScreen'
+import CardCountryConfirmScreen from '@/components/Card/CardCountryConfirmScreen'
 import CardRejectionScreen from '@/components/Card/CardRejectionScreen'
 import BadgeSkipCelebration from '@/components/Card/BadgeSkipCelebration'
 import CardEligibilityCheckScreen from '@/components/Card/CardEligibilityCheckScreen'
@@ -79,6 +80,11 @@ const CardPage: FC = () => {
     // When backend returns status:'terms-required', we capture it here so
     // the dispatcher can render the terms screen between Sumsub and submit.
     const [pendingTerms, setPendingTerms] = useState<{ isUsResident: boolean } | null>(null)
+    // When backend returns status:'country-confirmation-required' (Sumsub
+    // address country contradicts the ID-document country), we capture the
+    // candidate list here so the dispatcher can render the residence
+    // confirmation screen before terms.
+    const [pendingCountryConfirmation, setPendingCountryConfirmation] = useState<{ candidates: string[] } | null>(null)
     // Covers the moment between "terms accepted" and "overview refetched with
     // the new card row". Without it the screen would briefly flip back to Add
     // Card mid-apply before the state machine sees the new state.
@@ -222,15 +228,46 @@ const CardPage: FC = () => {
                 posthog.capture(ANALYTICS_EVENTS.CARD_SUMSUB_OPENED)
                 return
             }
+            // Conflicting residence evidence — collect the user's pick before
+            // anything reaches Rain. Cleared once a later response advances
+            // past it (the answer is persisted server-side).
+            if (res.status === 'country-confirmation-required' && 'candidates' in res) {
+                setPendingTerms(null)
+                setPendingCountryConfirmation({ candidates: res.candidates })
+                return
+            }
             if (res.status === 'terms-required' && 'isUsResident' in res) {
+                setPendingCountryConfirmation(null)
                 setPendingTerms({ isUsResident: res.isUsResident })
                 return
             }
             // pending / already-applied → state machine routes based on overview.
             setPendingTerms(null)
+            setPendingCountryConfirmation(null)
             invalidateOverview()
         },
         [invalidateOverview]
+    )
+
+    // The user picked their residence country on the confirmation screen.
+    // Re-apply with the pick — the backend validates it against its own
+    // candidate recompute, repairs the Sumsub data, and usually answers
+    // `terms-required` next.
+    const handleConfirmCountry = useCallback(
+        async (countryCode: string) => {
+            setApplyError(null)
+            posthog.capture(ANALYTICS_EVENTS.CARD_COUNTRY_CONFIRMED, { country: countryCode })
+            try {
+                const res = await rainApi.applyForCard({ confirmedResidenceCountry: countryCode })
+                advanceFromApplyResponse(res)
+            } catch (e) {
+                const message = e instanceof Error ? e.message : 'Failed to confirm country'
+                console.error('[card apply] country confirm error:', e)
+                setApplyError(message)
+                posthog.capture(ANALYTICS_EVENTS.CARD_APPLY_FAILED, { error_message: message })
+            }
+        },
+        [advanceFromApplyResponse]
     )
 
     const handleApply = useCallback(
@@ -396,6 +433,8 @@ const CardPage: FC = () => {
         setSumsubToken(null)
         if (res.status === 'terms-required' && 'isUsResident' in res) {
             setPendingTerms({ isUsResident: res.isUsResident })
+        } else if (res.status === 'country-confirmation-required' && 'candidates' in res) {
+            setPendingCountryConfirmation({ candidates: res.candidates })
         } else {
             invalidateOverview()
         }
@@ -438,6 +477,19 @@ const CardPage: FC = () => {
         // to Add Card for a split second while the API call is in flight.
         if (isIssuing) {
             return <ApplicationStatusScreen variant="pending" />
+        }
+        // Residence confirmation comes before terms in the funnel — the
+        // backend won't return terms-required until the country is resolved.
+        if (pendingCountryConfirmation) {
+            return (
+                <CardCountryConfirmScreen
+                    candidates={pendingCountryConfirmation.candidates}
+                    onConfirm={handleConfirmCountry}
+                    onContactSupport={() => setIsSupportModalOpen(true)}
+                    onPrev={() => setPendingCountryConfirmation(null)}
+                    submitError={applyError}
+                />
+            )
         }
         // Terms screen takes precedence over the state-machine target — the
         // user already clicked "Get your card" or completed Sumsub; we need

--- a/src/components/Card/CardCountryConfirmScreen.tsx
+++ b/src/components/Card/CardCountryConfirmScreen.tsx
@@ -1,0 +1,118 @@
+'use client'
+import { type FC, useEffect, useState } from 'react'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import NavHeader from '@/components/Global/NavHeader'
+import { Button } from '@/components/0_Bruddle/Button'
+
+interface Props {
+    /** ISO-2 codes the backend derived from the applicant's own evidence. */
+    candidates: string[]
+    onConfirm: (countryCode: string) => void | Promise<void>
+    /** Rendered when `candidates` is empty — neither signal was usable. */
+    onContactSupport: () => void
+    onPrev?: () => void
+    submitError?: string | null
+}
+
+const regionNames = new Intl.DisplayNames(['en'], { type: 'region' })
+
+/** "BR" → "Brazil", falling back to the raw code for anything unmappable. */
+const countryName = (iso2: string): string => {
+    try {
+        return regionNames.of(iso2) ?? iso2
+    } catch {
+        return iso2
+    }
+}
+
+/**
+ * Shown when the backend detects conflicting residence evidence on the card
+ * application (Sumsub address country vs ID-document country — see
+ * `country-confirmation-required` in services/rain.ts). The user picks where
+ * they live; the pick is persisted server-side so this is asked at most once.
+ */
+const CardCountryConfirmScreen: FC<Props> = ({ candidates, onConfirm, onContactSupport, onPrev, submitError }) => {
+    const [selected, setSelected] = useState<string | null>(null)
+    const [submitting, setSubmitting] = useState(false)
+
+    useEffect(() => {
+        posthog.capture(ANALYTICS_EVENTS.CARD_COUNTRY_CONFIRM_VIEWED, {
+            candidates,
+        })
+    }, [candidates])
+
+    const handleContinue = async () => {
+        if (!selected) return
+        setSubmitting(true)
+        try {
+            await onConfirm(selected)
+        } finally {
+            setSubmitting(false)
+        }
+    }
+
+    if (candidates.length === 0) {
+        return (
+            <div className="flex min-h-[inherit] flex-col gap-6">
+                <NavHeader title="Add card" onPrev={onPrev} />
+                <div className="my-auto flex flex-col items-center gap-3 text-center">
+                    <h1 className="text-2xl font-extrabold text-n-1">We need to check your details</h1>
+                    <p className="text-grey-1">
+                        We couldn't confirm your country of residence from your verification. Our team will sort it out
+                        — message support to continue.
+                    </p>
+                    <button type="button" onClick={onContactSupport} className="text-black underline">
+                        Contact support
+                    </button>
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <div className="flex min-h-[inherit] flex-col gap-6">
+            <NavHeader title="Add card" onPrev={onPrev} />
+
+            <div className="flex flex-col gap-2">
+                <h1 className="text-2xl font-extrabold text-n-1">Confirm your country of residence</h1>
+                <p className="text-grey-1">
+                    Your verification shows two different countries. Pick the one where you currently live — your card
+                    application is processed under its rules.
+                </p>
+            </div>
+
+            <ul className="flex flex-col gap-3">
+                {candidates.map((iso2) => (
+                    <li key={iso2}>
+                        <button
+                            type="button"
+                            onClick={() => setSelected(iso2)}
+                            aria-pressed={selected === iso2}
+                            className={`w-full rounded-sm border border-n-1 p-4 text-left text-sm font-semibold ${
+                                selected === iso2 ? 'bg-primary-3' : 'bg-white'
+                            }`}
+                        >
+                            {countryName(iso2)}
+                        </button>
+                    </li>
+                ))}
+            </ul>
+
+            {submitError && <p className="text-sm text-red">{submitError}</p>}
+
+            <Button
+                variant="purple"
+                shadowSize="4"
+                className="mt-auto w-full"
+                onClick={handleContinue}
+                disabled={!selected || submitting}
+                loading={submitting}
+            >
+                Continue
+            </Button>
+        </div>
+    )
+}
+
+export default CardCountryConfirmScreen

--- a/src/components/Card/__tests__/CardCountryConfirmScreen.test.tsx
+++ b/src/components/Card/__tests__/CardCountryConfirmScreen.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * CardCountryConfirmScreen — residence-confirmation contract.
+ *
+ * Shown when the backend detects conflicting residence evidence (Sumsub
+ * address country vs ID-document country). Must (1) render human-readable
+ * country names for the ISO-2 candidates, (2) keep Continue disabled until a
+ * pick is made, (3) pass the picked ISO-2 (not the display name) to
+ * onConfirm, and (4) fall back to a contact-support path when the backend
+ * couldn't derive any candidates.
+ */
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import CardCountryConfirmScreen from '@/components/Card/CardCountryConfirmScreen'
+
+// NavHeader reads useAuth; stub it so the presentational screen renders alone.
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => ({ user: { accounts: [] }, fetchUser: jest.fn() }),
+}))
+jest.mock('posthog-js', () => ({
+    __esModule: true,
+    default: { capture: jest.fn() },
+}))
+
+describe('CardCountryConfirmScreen', () => {
+    it('renders candidate country names and disables Continue until a pick', () => {
+        render(
+            <CardCountryConfirmScreen candidates={['BR', 'AR']} onConfirm={jest.fn()} onContactSupport={jest.fn()} />
+        )
+        expect(screen.getByText('Brazil')).toBeInTheDocument()
+        expect(screen.getByText('Argentina')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
+    })
+
+    it('passes the picked ISO-2 code to onConfirm', async () => {
+        const onConfirm = jest.fn()
+        render(
+            <CardCountryConfirmScreen candidates={['BR', 'AR']} onConfirm={onConfirm} onContactSupport={jest.fn()} />
+        )
+        fireEvent.click(screen.getByText('Brazil'))
+        const continueBtn = screen.getByRole('button', { name: 'Continue' })
+        expect(continueBtn).toBeEnabled()
+        fireEvent.click(continueBtn)
+        await waitFor(() => expect(onConfirm).toHaveBeenCalledWith('BR'))
+    })
+
+    it('routes to support when no candidates could be derived', () => {
+        const onContactSupport = jest.fn()
+        render(<CardCountryConfirmScreen candidates={[]} onConfirm={jest.fn()} onContactSupport={onContactSupport} />)
+        fireEvent.click(screen.getByText('Contact support'))
+        expect(onContactSupport).toHaveBeenCalledTimes(1)
+        expect(screen.queryByRole('button', { name: 'Continue' })).not.toBeInTheDocument()
+    })
+})

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -148,6 +148,10 @@ export const ANALYTICS_EVENTS = {
     // the Continue button is HTML-disabled until all are checked.
     CARD_TERMS_VIEWED: 'card_terms_viewed',
     CARD_TERMS_ACCEPTED: 'card_terms_accepted',
+    // Residence-country confirmation screen (address vs ID-document mismatch).
+    // VIEWED→CONFIRMED drop-off = users confused or scared by the question.
+    CARD_COUNTRY_CONFIRM_VIEWED: 'card_country_confirm_viewed',
+    CARD_COUNTRY_CONFIRMED: 'card_country_confirmed',
     // Session-key permission grant (passkey tap). `kind` mirrors GrantSessionKeyError.kind.
     CARD_SESSION_KEY_PROMPTED: 'card_session_key_prompted',
     CARD_SESSION_KEY_GRANTED: 'card_session_key_granted',

--- a/src/services/rain.ts
+++ b/src/services/rain.ts
@@ -258,6 +258,18 @@ export type ApplyForCardResponse =
           termsVersion: string
       }
     | {
+          // Sumsub address country contradicts the ID-document country (or is
+          // junk). Show the residence-confirmation screen; re-call with
+          // `confirmedResidenceCountry` set to one of `candidates`. Empty
+          // `candidates` = neither signal usable → route to support.
+          status: 'country-confirmation-required'
+          candidates: string[]
+          evidence: {
+              addressCountry: string | null
+              idDocumentCountry: string | null
+          }
+      }
+    | {
           status: 'pending'
           rainUserId: string
           message: string
@@ -468,12 +480,15 @@ export const rainApi = {
      *    Applicant Action. The token to open it is included.
      *  - `terms-required` → backend is ready to submit but needs explicit
      *    consent; re-call with `termsAccepted: true` to proceed.
+     *  - `country-confirmation-required` → conflicting residence evidence;
+     *    show the confirmation screen and re-call with
+     *    `confirmedResidenceCountry` set to the user's pick.
      *  - `pending` / `ENABLED` / other → application submitted or already
      *    in-flight. Frontend should refetch overview and let the state
      *    machine route.
      */
     applyForCard: async (
-        opts: { termsAccepted?: boolean; serializedApproval?: string } = {}
+        opts: { termsAccepted?: boolean; serializedApproval?: string; confirmedResidenceCountry?: string } = {}
     ): Promise<ApplyForCardResponse> => {
         // `serializedApproval` is consumed only by the re-issue branch on the
         // backend (where a RainCard row is created synchronously). First-time
@@ -481,6 +496,7 @@ export const rainApi = {
         // the field entirely in that case.
         const body: Record<string, unknown> = { termsAccepted: opts.termsAccepted === true }
         if (opts.serializedApproval) body.serializedApproval = opts.serializedApproval
+        if (opts.confirmedResidenceCountry) body.confirmedResidenceCountry = opts.confirmedResidenceCountry
         return rainRequest<ApplyForCardResponse>({
             method: 'POST',
             path: '/rain/cards',

--- a/src/types/api.generated.ts
+++ b/src/types/api.generated.ts
@@ -6362,6 +6362,7 @@ export interface paths {
                     "application/json": {
                         termsAccepted?: boolean;
                         serializedApproval?: string;
+                        confirmedResidenceCountry?: string;
                     };
                 };
             };
@@ -6393,6 +6394,14 @@ export interface paths {
                             status: "terms-required";
                             isUsResident: boolean;
                             termsVersion: string;
+                        } | {
+                            /** @enum {string} */
+                            status: "country-confirmation-required";
+                            candidates: string[];
+                            evidence: {
+                                addressCountry: string | null;
+                                idDocumentCountry: string | null;
+                            };
                         } | {
                             status: string;
                             rainUserId?: string;

--- a/src/types/api.openapi.json
+++ b/src/types/api.openapi.json
@@ -8197,6 +8197,11 @@
 									"serializedApproval": {
 										"minLength": 1,
 										"type": "string"
+									},
+									"confirmedResidenceCountry": {
+										"minLength": 2,
+										"maxLength": 2,
+										"type": "string"
 									}
 								}
 							}
@@ -8287,6 +8292,48 @@
 												}
 											},
 											"required": ["status", "isUsResident", "termsVersion"]
+										},
+										{
+											"type": "object",
+											"properties": {
+												"status": {
+													"type": "string",
+													"enum": ["country-confirmation-required"]
+												},
+												"candidates": {
+													"type": "array",
+													"items": {
+														"type": "string"
+													}
+												},
+												"evidence": {
+													"type": "object",
+													"properties": {
+														"addressCountry": {
+															"anyOf": [
+																{
+																	"type": "string"
+																},
+																{
+																	"type": "null"
+																}
+															]
+														},
+														"idDocumentCountry": {
+															"anyOf": [
+																{
+																	"type": "string"
+																},
+																{
+																	"type": "null"
+																}
+															]
+														}
+													},
+													"required": ["addressCountry", "idDocumentCountry"]
+												}
+											},
+											"required": ["status", "candidates", "evidence"]
 										},
 										{
 											"type": "object",


### PR DESCRIPTION
## Summary

Companion to peanutprotocol/peanut-api-ts#1130 (full incident context there: Rain user `bca9672b-8057-469a-9981-36b2f9b94a7e` denied `INCORRECT_SOCIAL_NUMBER` on 2026-06-30 because a contaminated `AR` country rode an all-Brazil applicant to Rain).

The backend returns `country-confirmation-required` from POST /rain/cards when the Sumsub address country contradicts the ID-document country. This PR renders it:

- **`CardCountryConfirmScreen`** (modeled on `CardTermsScreen`) — one-tap picker of the evidence-backed candidates (`Intl.DisplayNames` labels); Continue disabled until a pick; empty candidates falls back to contact-support.
- **`card/page.tsx` wiring** — `pendingCountryConfirmation` state rendered above the terms screen; handled in `advanceFromApplyResponse` and `handleSumsubRefreshToken`; `handleConfirmCountry` re-applies with the pick, handles an `incomplete` regression inline (opens WebSDK instead of silently bouncing), and backing out clears the shared `applyError`.
- **API snapshot + generated types synced** for the new contract (surgical splice of `/rain/cards` only — the snapshot has pre-existing drift vs main on ~15 unrelated paths, flagged as a separate regen follow-up).
- Analytics: `card_country_confirm_viewed` / `card_country_confirmed`.

The screen appears **only** for mismatched applicants (~13 in the current cohort + future dual-geo/expat cases), at most once — the backend persists the answer.

## Risks / breaking changes
- **Deploy THIS PR first, then the BE PR** — new FE + old BE is a no-op (the status never arrives); old FE + new BE silently bounces mismatched users until their bundle refreshes.
- No changes to existing flow states; the new screen is an additional interstitial branch.

## QA
- `CardCountryConfirmScreen.test.tsx`: candidate names, disabled-until-pick, ISO-2 payload, empty-candidates support fallback.
- `pnpm check:api` green; typecheck green; no new jest failures (2 pre-existing failing suites on clean origin/main: `countryCurrencyMapping`, `add-money-states`).