### PR TITLE
feat: enrich PostHog person profile on identify

### DIFF
--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -86,12 +86,19 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
             if (typeof window !== 'undefined' && window.gtag) {
                 window.gtag('set', { user_id: user.user.userId })
             }
-            // PostHog: identify user (stitches anonymous pre-login events to this user).
+            // PostHog: identify user (stitches anonymous pre-login events to this user)
+            // and enrich the person profile for segmentation. Property names mirror the
+            // server-side identify in peanut-api-ts src/log/identifyUser.ts — keep in sync.
             // `name` duplicates username because PostHog's Persons-page search is
             // hardcoded to email/name/distinct_id — username alone is not searchable.
             posthog.identify(user.user.userId, {
                 username: user.user.username,
                 name: user.user.username,
+                userId: user.user.userId,
+                totalPoints: user.totalPoints,
+                // Badge codes (human-readable identifier), never the uuid.
+                badges: user.user.badges?.map((badge) => badge.code) ?? [],
+                kycStatus: user.identityVerification?.status ?? 'not_started',
             })
             // Sentry: every error captured from here on inherits user context
             // as searchable Sentry tags. Closes the historical gap where FE


### PR DESCRIPTION
## Summary
PostHog person profiles only carried `username`/`name`, so we can't segment by balance, badges, or KYC state. Requested by Konrad.

Expands the existing `posthog.identify` in `src/context/authContext.tsx` with: `userId` (Peanut internal id, joins PostHog persons back to our DB), `totalPoints`, `badges` (badge **codes**, never uuids), `kycStatus` (provider-blind `identityVerification.status`). All read from the already-loaded `IUserProfile` — no new fetches. Refreshes on every profile fetch, so props stay current.

Property names mirror the server-side identify in peanut-api-ts `src/log/identifyUser.ts` (companion PR there covers ad-blocked cohorts at signup/login).

## Risks / breaking changes
- None — additive person properties on an existing identify call; no new renders, fetches, or deps. Any landing order vs the BE PR works.

## QA
- `npm test`: 1674 passed; 1 pre-existing failure on dev (add-money deposit-limit copy, verified failing on pristine origin/dev).
- Typecheck clean.
- Verify: log in on sandbox → PostHog person shows the new properties.