### PR TITLE
fix(home): activation-rejection CTA respects users who can already transact

### DIFF
--- a/src/components/Home/ActivationCTAs.tsx
+++ b/src/components/Home/ActivationCTAs.tsx
@@ -126,10 +126,27 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
         }
     }, [activationStep])
 
+    // A user who can already transact — they hold an active card (its rail reads
+    // `enabled`), have any other enabled rail, or the BE has marked them
+    // activated — is NOT mid-activation. A rejected *bank* rail is then an
+    // optional extra capability, not a setup blocker, so the home activation CTA
+    // must stand down. A genuinely-fixable bank RFI still surfaces in context in
+    // the /add-money bank flow (which runs its own gate). Without this, a
+    // card-holder with a dead/rejected bank rail gets nagged with "Complete your
+    // setup" on a rail they can't — and needn't — fix.
+    const canAlreadyTransact = useMemo(
+        () => rails.some((rail) => rail.status === 'enabled') || (user?.user?.isActivated ?? false),
+        [rails, user?.user?.isActivated]
+    )
+
     // provider rejection overrides the step copy when user is past the verify step
-    // (sumsub approved but provider rejected — deposit/outbound CTAs are useless)
+    // (sumsub approved but provider rejected — deposit/outbound CTAs are useless),
+    // UNLESS they can already transact via card / another rail (see above).
     const hasProviderRejection =
-        activationStep !== 'verify' && activationStep !== 'card' && (hasFixableRejection || hasBlockedRejection)
+        activationStep !== 'verify' &&
+        activationStep !== 'card' &&
+        !canAlreadyTransact &&
+        (hasFixableRejection || hasBlockedRejection)
 
     const step: StepConfig | null = useMemo(() => {
         if (activationStep === 'completed' && !hasProviderRejection) return null

--- a/src/components/Home/__tests__/ActivationCTAs.test.tsx
+++ b/src/components/Home/__tests__/ActivationCTAs.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * ActivationCTAs — the provider-rejection override must respect that a user can
+ * already transact.
+ *
+ * A Sumsub-approved user whose *bank* rail is rejected used to always get the
+ * "Complete your setup → Upload document" (fixable) / "Verification issue"
+ * (blocked) home card, even when they hold an active card or another enabled
+ * rail. For a card-holder that's a nag on a capability they don't need — and,
+ * for a terminally-rejected bank rail, one they can't fix. The gate below
+ * suppresses the override whenever the user can already transact (any enabled
+ * rail — the card's rail reads `enabled` — or BE-marked `isActivated`). A
+ * genuinely-fixable bank RFI still surfaces in the /add-money bank flow.
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+let mockRails: Array<{ id: string; channel: string; status: string; reason?: { userMessage: string } }> = []
+let mockUser: { user?: { isActivated?: boolean; userId?: string } } | null = null
+
+jest.mock('@/hooks/useCapabilities', () => ({
+    useCapabilities: () => ({
+        rails: mockRails,
+        channelOf: (rail: { channel: string }) => rail.channel,
+        nextActionsForRail: () => [],
+    }),
+}))
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => ({ user: mockUser }),
+}))
+jest.mock('@/hooks/useIdentityVerification', () => ({
+    useIdentityVerification: () => ({ isProcessing: false, needsAction: false }),
+}))
+jest.mock('@/context/ModalsContext', () => ({
+    useModalsContext: () => ({ setIsQRScannerOpen: jest.fn(), openSupportWithMessage: jest.fn() }),
+}))
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ push: jest.fn() }),
+}))
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
+jest.mock('@/components/Home/CardLaunchCTA/CardLaunchCTABanner', () => ({
+    __esModule: true,
+    default: () => null,
+}))
+
+import ActivationCTAs from '../ActivationCTAs'
+
+const bankRejected = {
+    id: 'bridge.sepa_eu',
+    channel: 'bank',
+    status: 'requires-info',
+    reason: { userMessage: 'We need a valid proof of address document.' },
+}
+const enabledCardRail = { id: 'rain.card_rain', channel: 'card', status: 'enabled' }
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    mockRails = []
+    mockUser = { user: { isActivated: false, userId: 'u1' } }
+})
+
+describe('ActivationCTAs — rejection override respects existing transacting ability', () => {
+    it('a card-holder (enabled card rail) with a rejected bank rail does NOT see "Complete your setup"', () => {
+        mockRails = [enabledCardRail, bankRejected]
+        render(<ActivationCTAs activationStep="deposit" />)
+        expect(screen.queryByText('Complete your setup')).not.toBeInTheDocument()
+        // Falls through to the normal funnel step instead of the rejection card.
+        expect(screen.getByText('Deposit')).toBeInTheDocument()
+    })
+
+    it('a BE-activated user with a rejected bank rail does NOT see the nag', () => {
+        mockRails = [bankRejected]
+        mockUser = { user: { isActivated: true, userId: 'u1' } }
+        render(<ActivationCTAs activationStep="deposit" />)
+        expect(screen.queryByText('Complete your setup')).not.toBeInTheDocument()
+    })
+
+    it('a user with NO working rail still sees the fixable-rejection nag (unchanged behavior)', () => {
+        mockRails = [bankRejected]
+        render(<ActivationCTAs activationStep="deposit" />)
+        expect(screen.getByText('Complete your setup')).toBeInTheDocument()
+        expect(screen.getByText('We need a valid proof of address document.')).toBeInTheDocument()
+    })
+})


### PR DESCRIPTION
## Summary
The home activation-rejection override (`ActivationCTAs`) showed "Complete your setup → Upload document" (fixable) or "Verification issue" (blocked) to **any** Sumsub-approved user with a rejected bank/qr rail — even users who already hold an active card or another enabled rail, or whom the BE has marked `isActivated`. For a card-holder that's a nag on an optional capability they don't need (and, for a terminally-rejected bank rail, can't fix).

Gate the override on `!canAlreadyTransact`, where `canAlreadyTransact = rails.some(status === 'enabled') || user.isActivated`. The card's own rail reads `enabled`, so a card-holder is covered. A genuinely-fixable bank RFI is unaffected on the home screen only — it still surfaces in context in the `/add-money/[country]/bank` flow, which runs its own capability gate.

## Risk
Low. One added boolean guard on an existing memo; the fixable/blocked branches themselves are untouched. Covered by new tests.

## Cross-repo
Pairs with the peanut-api-ts hotfix *terminal Bridge → blocked* (peanutprotocol/peanut-api-ts #1132). Independent — either can ship first. The API fix flips a terminal user from the "fixable/upload" card to the "blocked/contact-support" card; this FE fix suppresses **both** for users who can already transact.

## QA
`npm test` — new `src/components/Home/__tests__/ActivationCTAs.test.tsx`:
- card-holder (enabled card rail) + rejected bank rail → no "Complete your setup"; falls through to the normal funnel step
- BE-activated user + rejected bank rail → no nag
- user with no working rail + fixable rejection → still nagged (behavior unchanged)
