### PR TITLE
fix(card): keep share-asset stickers off the username pill

### DIFF
--- a/src/components/Card/share-asset/ShareAssetD3.tsx
+++ b/src/components/Card/share-asset/ShareAssetD3.tsx
@@ -237,9 +237,10 @@ const ShareAssetD3: FC<ShareAssetD3Props> = ({
             ))}
 
             {/* ─── @username pill — the sharer's own handle, the asset's
-                "this is ME" anchor. Sits below the stickers (z-index 4) so a
-                sticker that lands over it reads as slapped on top; the pill's
-                repulsion keep-out keeps it mostly clear regardless.
+                "this is ME" anchor and the whole point of a shareable asset.
+                Renders ABOVE the stickers (z-index 5 > sticker z-index 4) so
+                the handle can never be covered; the layout keep-out still keeps
+                stickers mostly off it, so they rarely even tuck behind it.
 
                 The anti-dox "hide username" toggle hides it via `visibility`
                 (not conditional unmount): the entrance animation plays once on
@@ -252,7 +253,7 @@ const ShareAssetD3: FC<ShareAssetD3Props> = ({
                 style={{
                     bottom: 48,
                     right: 56,
-                    zIndex: 3,
+                    zIndex: 5,
                     visibility: hideUsername ? 'hidden' : 'visible',
                     animation: animate ? `fadeUp 600ms ease-out ${ANIM_ATTRIBUTION_DELAY}ms both` : 'none',
                 }}

--- a/src/components/Card/share-asset/__tests__/shareAssetLayout.test.ts
+++ b/src/components/Card/share-asset/__tests__/shareAssetLayout.test.ts
@@ -14,7 +14,10 @@ import {
     CANVAS_H,
     CARD_LEFT,
     CARD_TOP,
+    PILL_RIGHT,
+    PILL_BOTTOM,
     placeStamps,
+    pillKeepoutBox,
     buildStatColumns,
     usernameFontSize,
 } from '../shareAssetLayout'
@@ -200,6 +203,47 @@ describe('placeStamps', () => {
         const badges = Array.from({ length: 13 }, (_, i) => badge(`B${i}`))
         const placed = placeStamps(badges, new SeededRandom('kkonrad'))
         expect(placed.length).toBe(13)
+    })
+
+    // The @username pill is the whole point of the shareable asset, so the
+    // repulsion must keep stickers off it — including through the final
+    // separation pass, which used to DROP the pill keep-out and let a sticker
+    // get shoved onto the handle on the last cleanup pass (covering ~65% of the
+    // pill in the worst case). No sticker may heavily overlap the pill's
+    // rendered footprint. (The pill also renders above the stickers as a
+    // hard guarantee, but that's a render concern; here we pin the layout.)
+    it('keeps stickers off the username pill (final pass respects the keep-out)', () => {
+        const seeds = ['kkonrad', 'hugo', 'testo', 'me', 'a', 'longusername', 'satoshi', '🥜']
+        // Representative rendered pill footprints (short handle → long handle).
+        const pills = [
+            { w: 300, h: 120 },
+            { w: 460, h: 110 },
+            { w: 620, h: 100 },
+        ]
+        const MAX_PILL_COVER = 0.4 // fraction of the pill rect a sticker may overlap
+        for (const { w, h } of pills) {
+            const box = pillKeepoutBox(w, h)
+            // Rendered pill rect: bottom-right anchored (box top-left → canvas corner inset).
+            const rect = { x0: box.x0, y0: box.y0, x1: CANVAS_W - PILL_RIGHT, y1: CANVAS_H - PILL_BOTTOM }
+            const rectArea = (rect.x1 - rect.x0) * (rect.y1 - rect.y0)
+            for (let n = 1; n <= 8; n++) {
+                const badges = Array.from({ length: n }, (_, i) => badge(`B${i}`))
+                for (const seed of seeds) {
+                    const placed = placeStamps(badges, new SeededRandom(seed), [], box)
+                    for (const s of placed) {
+                        const ix = Math.max(0, Math.min(s.left + s.width, rect.x1) - Math.max(s.left, rect.x0))
+                        const iy = Math.max(0, Math.min(s.top + s.height, rect.y1) - Math.max(s.top, rect.y0))
+                        const cover = (ix * iy) / rectArea
+                        if (cover > MAX_PILL_COVER) {
+                            throw new Error(
+                                `Sticker covers ${(cover * 100).toFixed(0)}% of the username pill ` +
+                                    `at count=${n} seed="${seed}" pill=${w}×${h} (max ${MAX_PILL_COVER * 100}%)`
+                            )
+                        }
+                    }
+                }
+            }
+        }
     })
 })
 

--- a/src/components/Card/share-asset/shareAssetLayout.ts
+++ b/src/components/Card/share-asset/shareAssetLayout.ts
@@ -256,13 +256,17 @@ export function placeStamps(
         }
     }
 
-    // ── Final separation pass. The soft edge/pill pulls above can deadlock two
-    //    stickers against a corner (a Gauss–Seidel local minimum: the edge +
-    //    pill shove keeps cramming them back together faster than the pairwise
-    //    push can spread them). Run a short cleanup of separation + hard keep-
-    //    outs + clamp ONLY — no edge/pill pull — so pairwise spread gets the
-    //    last word. Card marks / hero stay clear; a sticker may drift under the
-    //    pill (which renders on top), but no two stickers pile up.
+    // ── Final separation pass. The main loop's *hard* edge + pill shoves can
+    //    deadlock two stickers against a corner (a Gauss–Seidel local minimum:
+    //    the hard shove crams them back together faster than the pairwise push
+    //    can spread them). Run a short cleanup of separation + hard card keep-
+    //    outs + a *soft* pill pull + clamp: the soft pull nudges stickers off
+    //    the @username pill without re-creating the hard-shove deadlock, so
+    //    pairwise spread still gets the last word. Dropping the pill entirely
+    //    here (the old behaviour) let separation shove a sticker onto the pill
+    //    on the last pass — the username-covered bug. Card marks / hero stay
+    //    clear and no two stickers pile up. The pill also renders ABOVE the
+    //    stickers, so the handle stays legible even if a corner drifts under it.
     for (let step = 0; step < SEPARATION_PASSES; step++) {
         for (let i = 0; i < count; i++) {
             for (let j = i + 1; j < count; j++) {
@@ -300,6 +304,17 @@ export function placeStamps(
                     p.x = ko.cx + (p.x - ko.cx) * s
                     p.y = ko.cy + (p.y - ko.cy) * s
                 }
+            }
+            // soft pull off the @username pill — a gentle nudge, not the main
+            // loop's hard shove (a hard shove here re-creates the corner
+            // deadlock this pass exists to break). The pill renders on top
+            // regardless, so this only has to stop stickers crowding it, not
+            // fully evict them.
+            if (hitsPill(p.x, p.y, half, pill)) {
+                const exitLeft = p.x + half - (pill.x0 - PILL_PAD)
+                const exitUp = p.y + half - (pill.y0 - PILL_PAD)
+                if (exitLeft < exitUp) p.x -= exitLeft * 0.5
+                else p.y -= exitUp * 0.5
             }
             p.x = clamp(p.x, minC, maxCx)
             p.y = clamp(p.y, minC, maxCy)


### PR DESCRIPTION
## Summary

The card share asset ("I'M IN!") could render a badge sticker **on top of the `peanut.me/<handle>` username pill**, hiding the handle — which is the entire point of a shareable asset. Two compounding causes:

- **Layout:** the final `SEPARATION_PASSES` cleanup in `placeStamps` dropped the pill keep-out (it only re-applied the card keep-outs), so pairwise sticker separation could shove a sticker onto the pill on the last pass. Measured up to **~65% of the pill covered** across a username × badge-count sweep.
- **Render:** the pill was drawn at `z-index: 3`, **below** the stickers at `z-index: 4`, so any sticker that landed over it painted on top.

## Fix

- Re-apply the pill keep-out in the final separation pass as a **soft pull** (0.5 factor, like the existing edge-margin nudge). A *hard* shove here re-creates the corner deadlock the final pass exists to break — the soft pull avoids that while keeping stickers off the pill.
- Render the pill at **`z-index: 5`**, above the stickers, so the handle can never be covered even if a corner drifts under it.

Both are needed: the soft pull keeps the collage clean; the z-index is the hard guarantee.

## Risks / blast radius

Small and self-contained — only the share-asset layout engine + its renderer. No API/contract changes, no shared-state or money paths. `placeStamps` stays deterministic (same seed → same layout). Only visible effect elsewhere: a badge sticker may now sit slightly higher/left near the bottom-right, and the pill paints over any residual overlap.

## QA

- 29 layout unit tests pass, incl. a new regression test asserting **no sticker covers >40% of the rendered pill rect** across a seed/count sweep (fails on the old code at ~52–65%, passes now at ≤3%).
- Verified against the **real** `<ShareAssetD3 />` rendered from the running app across 20 representative + 5 extreme configs (1-char / 12-char / emoji handles, 1–12 badges): every handle legible, pill on top.
