### PR TITLE
fix(qr-pay): drop redundant always-400ing /perks/claim call + repair REWARD_CLAIMED analytics

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
+++ b/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
@@ -159,7 +159,6 @@ jest.mock('@/components/TransactionDetails/TransactionDetailsDrawer', () => ({
 const mockMantecaApi = {
     initiateQrPayment: jest.fn(),
     completeQrPaymentWithSignedTx: jest.fn(),
-    claimPerk: jest.fn(),
 }
 jest.mock('@/services/manteca', () => ({
     mantecaApi: mockMantecaApi,
@@ -619,15 +618,6 @@ function applyDefaults() {
             paymentPrice: '1200',
             priceExpireAt: '2026-04-16T23:59:59Z',
             merchant: { name: 'Test Merchant' },
-        },
-    })
-
-    mockMantecaApi.claimPerk.mockResolvedValue({
-        success: true,
-        perk: {
-            amountSponsored: 0.5,
-            discountPercentage: 5,
-            txHash: '0xabc',
         },
     })
 
@@ -1106,6 +1096,57 @@ describe('GROUP 4: Success States', () => {
         await waitFor(() => {
             expect(screen.getByText('Go to Home')).toBeInTheDocument()
         })
+
+        jest.useRealTimers()
+    })
+
+    // Regression: the perk is already claimed server-side during QR-payment
+    // processing, and the QR response carries the sponsored amount. The
+    // hold-to-claim gesture must report that reward directly — it must NOT make
+    // a second /perks/claim round-trip (that endpoint now requires a usageId the
+    // client never has, so the old call always 400'd and surfaced a false
+    // "reward is being processed" error even though the reward had landed).
+    test('Perk claim reports the reward from the QR response, no /perks/claim round-trip, no error', async () => {
+        jest.useFakeTimers()
+        const posthog = require('posthog-js').default
+
+        // BE sends sponsoredUsd; the page maps it to amountSponsored on load.
+        await completeMantecaPayment({
+            perk: {
+                eligible: true,
+                discountPercentage: 5,
+                sponsoredUsd: 0.5,
+            },
+        })
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: /Claim Reward/i })).toBeInTheDocument()
+        })
+
+        const claimButton = screen.getByRole('button', { name: /Claim Reward/i })
+        await act(async () => {
+            fireEvent.pointerDown(claimButton)
+        })
+        // Advance past the hold duration to fire the claim.
+        await act(async () => {
+            jest.advanceTimersByTime(1600)
+        })
+
+        await waitFor(() => {
+            expect(screen.getByText('Go to Home')).toBeInTheDocument()
+        })
+
+        // Reward reported from the QR response (sponsoredUsd → amount_usd).
+        expect(posthog.capture).toHaveBeenCalledWith('reward_claimed', {
+            amount_usd: 0.5,
+            discount_pct: 5,
+        })
+
+        // The old broken round-trip surfaced this false error — it must not appear.
+        expect(screen.queryByText(/reward is being processed/i)).not.toBeInTheDocument()
+
+        // The redundant client claim method is gone entirely.
+        expect('claimPerk' in mockMantecaApi).toBe(false)
 
         jest.useRealTimers()
     })

--- a/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
+++ b/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
@@ -8,6 +8,7 @@
  * per-test via mockReturnValue / mockImplementation.
  */
 import React from 'react'
+import posthog from 'posthog-js'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { parseUnits } from 'viem'
@@ -1108,7 +1109,6 @@ describe('GROUP 4: Success States', () => {
     // "reward is being processed" error even though the reward had landed).
     test('Perk claim reports the reward from the QR response, no /perks/claim round-trip, no error', async () => {
         jest.useFakeTimers()
-        const posthog = require('posthog-js').default
 
         // BE sends sponsoredUsd; the page maps it to amountSponsored on load.
         await completeMantecaPayment({

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -261,7 +261,6 @@ export default function QRPayPage() {
     const queryClient = useQueryClient()
     const [isShaking, setIsShaking] = useState(false)
     const [shakeIntensity, setShakeIntensity] = useState<ShakeIntensity>('none')
-    const [isClaimingPerk, setIsClaimingPerk] = useState(false)
     const [perkClaimed, setPerkClaimed] = useState(false)
     const [holdProgress, setHoldProgress] = useState(0)
     const holdTimerRef = useRef<NodeJS.Timeout | null>(null)
@@ -299,7 +298,6 @@ export default function QRPayPage() {
         setWaitingForMerchantAmount(false)
         retryCount.current = 0
         // reset perk states
-        setIsClaimingPerk(false)
         setPerkClaimed(false)
         // reset analytics tracking refs so a new QR flow gets fresh tracking
         hasTrackedPerkShown.current = false
@@ -784,7 +782,7 @@ export default function QRPayPage() {
     // DEV NOTE: This is an OPTIMISTIC claim flow for better UX
     // We immediately show success UI and trigger confetti, then claim in background
     // If claim fails, we show error post-factum but keep the user in success state
-    const claimPerk = useCallback(async () => {
+    const claimPerk = useCallback(() => {
         if (!qrPayment?.externalId) return
 
         // 1. IMMEDIATELY show success UI (optimistic)
@@ -805,34 +803,21 @@ export default function QRPayPage() {
             shootDoubleStarConfetti({ origin: { x: 0.5, y: 0.5 } })
         }, 100)
 
-        // 5. NOW do the actual API claim in the background
-        setIsClaimingPerk(true)
-        try {
-            const result = await mantecaApi.claimPerk(qrPayment.externalId)
-            if (result.success) {
-                posthog.capture(ANALYTICS_EVENTS.REWARD_CLAIMED, {
-                    amount_usd: result.perk.amountSponsored,
-                    discount_pct: result.perk.discountPercentage,
-                })
-                // Update qrPayment with actual claimed perk info from backend
-                setQrPayment({
-                    ...qrPayment,
-                    perk: {
-                        eligible: true,
-                        discountPercentage: result.perk.discountPercentage,
-                        claimed: true,
-                        amountSponsored: result.perk.amountSponsored,
-                        txHash: result.perk.txHash,
-                    },
-                })
-            }
-        } catch (error) {
-            // If claim fails, show error but keep user in success state
-            // (they already saw confetti, better UX than reverting)
-            captureException(error)
-            setErrorMessage('Reward is being processed. If you do not see it in your history, contact support.')
-        } finally {
-            setIsClaimingPerk(false)
+        // 5. Surface the reward. The perk was already issued AND claimed
+        //    server-side during QR-payment processing, and qrPayment.perk
+        //    already carries the sponsored amount from that response — so mark
+        //    it claimed and report it directly. (The old /perks/claim round-trip
+        //    took a mantecaTransferId the endpoint no longer accepts — it now
+        //    requires a usageId the client never has — so it always 400'd and
+        //    showed a false "reward is being processed" error even though the
+        //    reward had already landed.)
+        const claimedPerk = qrPayment.perk
+        if (claimedPerk) {
+            posthog.capture(ANALYTICS_EVENTS.REWARD_CLAIMED, {
+                amount_usd: claimedPerk.amountSponsored,
+                discount_pct: claimedPerk.discountPercentage,
+            })
+            setQrPayment({ ...qrPayment, perk: { ...claimedPerk, claimed: true } })
         }
     }, [qrPayment])
 
@@ -1366,13 +1351,13 @@ export default function QRPayPage() {
                                 onPointerUp={cancelHold}
                                 onPointerLeave={cancelHold}
                                 onKeyDown={(e) => {
-                                    if ((e.key === 'Enter' || e.key === ' ') && !isClaimingPerk) {
+                                    if (e.key === 'Enter' || e.key === ' ') {
                                         e.preventDefault()
                                         startHold()
                                     }
                                 }}
                                 onKeyUp={(e) => {
-                                    if ((e.key === 'Enter' || e.key === ' ') && !isClaimingPerk) {
+                                    if (e.key === 'Enter' || e.key === ' ') {
                                         e.preventDefault()
                                         cancelHold()
                                     }
@@ -1382,8 +1367,6 @@ export default function QRPayPage() {
                                     e.preventDefault()
                                 }}
                                 shadowSize="4"
-                                disabled={isClaimingPerk}
-                                loading={isClaimingPerk}
                                 className="relative touch-manipulation select-none overflow-hidden"
                                 style={{
                                     WebkitTouchCallout: 'none',

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -808,9 +808,10 @@ export default function QRPayPage() {
         //    already carries the sponsored amount from that response — so mark
         //    it claimed and report it directly. (The old /perks/claim round-trip
         //    took a mantecaTransferId the endpoint no longer accepts — it now
-        //    requires a usageId the client never has — so it always 400'd and
-        //    showed a false "reward is being processed" error even though the
-        //    reward had already landed.)
+        //    requires a usageId the client never has — so it always 400'd: pure
+        //    Sentry noise, and REWARD_CLAIMED never fired because it lived in the
+        //    never-reached success branch. The error it set was invisible here —
+        //    the success screen doesn't render errorMessage.)
         const claimedPerk = qrPayment.perk
         if (claimedPerk) {
             posthog.capture(ANALYTICS_EVENTS.REWARD_CLAIMED, {

--- a/src/services/manteca.ts
+++ b/src/services/manteca.ts
@@ -207,24 +207,6 @@ export const mantecaApi = {
 
         return response.json()
     },
-    claimPerk: async (
-        mantecaTransferId: string
-    ): Promise<{
-        success: boolean
-        perk: { sponsored: boolean; amountSponsored: number; discountPercentage: number; txHash?: string }
-    }> => {
-        const response = await serverFetch('/perks/claim', {
-            method: 'POST',
-            body: jsonStringify({ mantecaTransferId }),
-        })
-
-        if (!response.ok) {
-            const errorData = await response.json().catch(() => ({}))
-            throw new Error(errorData.message || `Perk claim failed: ${response.statusText}`)
-        }
-
-        return response.json()
-    },
     getPrices: async ({ asset, against }: { asset: string; against: string }): Promise<MantecaPrice> => {
         const response = await serverFetch(`/manteca/prices?asset=${asset}&against=${against}`, {
             method: 'GET',


### PR DESCRIPTION
## Summary — the *why*

On every QR payment that earns a cashback perk, the client fired a **second** `POST /perks/claim` with a `{ mantecaTransferId }` body. That endpoint no longer accepts that shape — it now **requires a `usageId` the client never has** — so the call **400'd on every claim** (~23 in the last 16h).

The perk is **already issued AND claimed server-side** during QR-payment processing (`peanut-api-ts` `manteca/qr-payment.ts` → `claimPerk(issuance.usageId, userId)`), and the QR response already carries the sponsored amount on `qrPayment.perk`. So the client round-trip was **pure redundancy** — the reward was never lost.

### Impact (not user-visible)
The failing call is **invisible to the user**: the `setErrorMessage('Reward is being processed…')` in the old catch writes to state, but the `<ErrorAlert>` that renders it lives in the payment-**form** branch, while the claim happens on the **success** screen (which never renders `errorMessage`). Users see the correct claimed state and their reward is in history. The real damage is:

1. **Sentry noise** — a `captureException` on every QR-perk claim (~23 / 16h).
2. **Broken analytics** — `REWARD_CLAIMED` sat inside the never-reached `if (result.success)` branch, so it has **never fired**. This PR moves it onto the (successful) hold-to-claim gesture, sourcing the amount from `qrPayment.perk` — repairing a metric that was silently reporting ~zero for QR perks.
3. A guaranteed-failing HTTP round-trip on every perk claim.

**Fix:** surface the reward straight from the QR response (fire `REWARD_CLAIMED` with the sponsored amount, mark the perk claimed) and delete the dead `mantecaApi.claimPerk` method + the now-unused `isClaimingPerk` loading state.

## Changes
- `src/app/(mobile-ui)/qr-pay/page.tsx` — `claimPerk` handler no longer calls the API; reads `qrPayment.perk` directly. Removed `isClaimingPerk` state + its button/keyboard usages.
- `src/services/manteca.ts` — deleted the dead `claimPerk` method.
- `qr-pay-states.test.tsx` — dropped the dead mock; added a regression test (reward reported from the QR response, no round-trip, no error state).

## Risk
Low. QR-pay success/perk flow only; **no money movement** (the perk claim already happens server-side — this only removes a broken redundant call). `REWARD_CLAIMED` now begins firing for the first time (intended — the growth metric was broken).

## QA
`npm test` — `qr-pay-states` green incl. the new regression test; full suite green; typecheck clean.

## Notes
- **Base: `main` (hotfix)** — back-merge main→dev after merge.
- **No BE change** — the `/perks/claim` contract is untouched; this only stops the client calling it wrongly.
- **Follow-up (cross-repo, out of scope):** the BE QR response sets `perk.claimed:false` even though it already claimed server-side — the mismatch that invited this bug. Cleaner long-term fix is the BE returning `claimed:true`.
