### PR TITLE
fix(support): recover blank Crisp chat panel on multi-account devices

### DIFF
--- a/src/app/crisp-proxy/page.tsx
+++ b/src/app/crisp-proxy/page.tsx
@@ -28,18 +28,35 @@ function CrispProxyContent() {
         const prefilledMessage = searchParams.get('prefilled_message')
         const currentTokenId = searchParams.get('crisp_token_id')
 
-        // Notify the parent (SupportDrawer) exactly once — either ready or failed —
-        // so a spinner never hangs forever and a failure surfaces a fallback UI.
-        let notified = false
-        const notifyParent = (type: 'CRISP_READY' | 'CRISP_FAILED') => {
-            if (notified) return
-            notified = true
+        // Report readiness to the parent (SupportDrawer). A READY may supersede an earlier
+        // FAILED: on a slow connection the 8s watchdog can post FAILED before the chatbox
+        // finishes loading, and the later session:loaded must still be able to dismiss the
+        // fallback. Once READY has been sent, FAILED never fires. Each is sent at most once.
+        let readyNotified = false
+        let failedNotified = false
+        const postToParent = (type: 'CRISP_READY' | 'CRISP_FAILED') => {
             if (window.parent !== window) {
                 window.parent.postMessage({ type }, window.location.origin)
             }
         }
-        const notifyParentReady = () => notifyParent('CRISP_READY')
-        const notifyParentFailed = () => notifyParent('CRISP_FAILED')
+        const notifyParentReady = () => {
+            if (readyNotified) return
+            readyNotified = true
+            // Record the identity as loaded only now that Crisp has confirmed ready —
+            // writing it optimistically would let a failed load skip the reset on Retry.
+            try {
+                localStorage.setItem('crisp_last_token_id', currentTokenId ?? '')
+            } catch {
+                // storage blocked (private mode / partitioned iframe) — the token-change
+                // reset simply re-fires on the next load, which is harmless.
+            }
+            postToParent('CRISP_READY')
+        }
+        const notifyParentFailed = () => {
+            if (failedNotified || readyNotified) return
+            failedNotified = true
+            postToParent('CRISP_FAILED')
+        }
 
         // Crisp upgrades the $crisp array in place once l.js loads, adding methods.
         const crispScriptLoaded = () => typeof window.$crisp?.is === 'function'
@@ -56,14 +73,27 @@ function CrispProxyContent() {
             //     survives restarts. Crisp silently refuses to bind a new token over a
             //     persisted session without a reset first, which is what leaves the
             //     chatbox blank for users who have hosted more than one account.
-            const needsReset = sessionStorage.getItem('crisp_needs_reset') === 'true'
-            const lastTokenId = localStorage.getItem('crisp_last_token_id') ?? ''
+            let needsReset = false
+            let lastTokenId = ''
+            try {
+                needsReset = sessionStorage.getItem('crisp_needs_reset') === 'true'
+                lastTokenId = localStorage.getItem('crisp_last_token_id') ?? ''
+            } catch {
+                // storage blocked (private mode / partitioned iframe) — fall back to no
+                // stored identity; the token-change check below still triggers a reset,
+                // and identity/session setup below proceeds instead of aborting.
+            }
             const tokenChanged = lastTokenId !== (currentTokenId ?? '')
             if (needsReset || tokenChanged) {
                 window.$crisp.push(['do', 'session:reset'])
-                sessionStorage.removeItem('crisp_needs_reset')
+                try {
+                    sessionStorage.removeItem('crisp_needs_reset')
+                } catch {
+                    // storage blocked — the flag couldn't have been read as true anyway.
+                }
             }
-            localStorage.setItem('crisp_last_token_id', currentTokenId ?? '')
+            // NB: crisp_last_token_id is persisted in notifyParentReady, once Crisp confirms
+            // the session actually loaded — not here, so a failed load still resets on Retry.
 
             // Set user identification
             if (email) {

--- a/src/app/crisp-proxy/page.tsx
+++ b/src/app/crisp-proxy/page.tsx
@@ -26,27 +26,44 @@ function CrispProxyContent() {
         const avatar = searchParams.get('user_avatar')
         const sessionDataJson = searchParams.get('session_data')
         const prefilledMessage = searchParams.get('prefilled_message')
+        const currentTokenId = searchParams.get('crisp_token_id')
 
-        const notifyParentReady = () => {
+        // Notify the parent (SupportDrawer) exactly once — either ready or failed —
+        // so a spinner never hangs forever and a failure surfaces a fallback UI.
+        let notified = false
+        const notifyParent = (type: 'CRISP_READY' | 'CRISP_FAILED') => {
+            if (notified) return
+            notified = true
             if (window.parent !== window) {
-                window.parent.postMessage(
-                    {
-                        type: 'CRISP_READY',
-                    },
-                    window.location.origin
-                )
+                window.parent.postMessage({ type }, window.location.origin)
             }
         }
+        const notifyParentReady = () => notifyParent('CRISP_READY')
+        const notifyParentFailed = () => notifyParent('CRISP_FAILED')
+
+        // Crisp upgrades the $crisp array in place once l.js loads, adding methods.
+        const crispScriptLoaded = () => typeof window.$crisp?.is === 'function'
 
         const setAllData = () => {
             if (!window.$crisp) return false
 
-            // Check sessionStorage for reset flag (set during logout)
-            const needsReset = sessionStorage.getItem('crisp_needs_reset')
-            if (needsReset === 'true') {
+            // Reset the Crisp session whenever the identity changes, so Crisp binds
+            // the new token to a clean session. Two independent triggers:
+            //  1. explicit logout flag (sessionStorage) — set at logout, but per-tab
+            //     and wiped on app restart, so it is routinely missed on multi-account
+            //     devices.
+            //  2. token mismatch vs the last identity we loaded (localStorage) —
+            //     survives restarts. Crisp silently refuses to bind a new token over a
+            //     persisted session without a reset first, which is what leaves the
+            //     chatbox blank for users who have hosted more than one account.
+            const needsReset = sessionStorage.getItem('crisp_needs_reset') === 'true'
+            const lastTokenId = localStorage.getItem('crisp_last_token_id') ?? ''
+            const tokenChanged = lastTokenId !== (currentTokenId ?? '')
+            if (needsReset || tokenChanged) {
                 window.$crisp.push(['do', 'session:reset'])
                 sessionStorage.removeItem('crisp_needs_reset')
             }
+            localStorage.setItem('crisp_last_token_id', currentTokenId ?? '')
 
             // Set user identification
             if (email) {
@@ -88,9 +105,6 @@ function CrispProxyContent() {
             // Wait for Crisp to be fully ready (session loaded and UI rendered)
             window.$crisp.push(['on', 'session:loaded', notifyParentReady])
 
-            // Fallback: notify after a delay if session:loaded doesn't fire
-            setTimeout(notifyParentReady, 1500)
-
             return true
         }
 
@@ -108,6 +122,20 @@ function CrispProxyContent() {
             setTimeout(() => clearInterval(checkCrisp), 5000)
         }
 
+        // Readiness watchdog. session:loaded is the real "chatbox is up" signal, but it
+        // doesn't always fire. After 8s, if we haven't already reported ready, decide:
+        //  - the Crisp bundle errored or never upgraded the $crisp stub  → report FAILED
+        //    (parent shows a fallback so the user isn't stuck on a blank panel).
+        //  - the bundle loaded but session:loaded didn't fire            → report READY
+        //    (assume the chatbox rendered — preserves the prior fallback behaviour).
+        const readinessTimer = setTimeout(() => {
+            if (window.__crispLoadFailed || !crispScriptLoaded()) {
+                notifyParentFailed()
+            } else {
+                notifyParentReady()
+            }
+        }, 8000)
+
         // Listen for reset messages from parent window
         const handleMessage = (event: MessageEvent) => {
             if (event.origin !== window.location.origin) return
@@ -119,7 +147,10 @@ function CrispProxyContent() {
         }
 
         window.addEventListener('message', handleMessage)
-        return () => window.removeEventListener('message', handleMessage)
+        return () => {
+            clearTimeout(readinessTimer)
+            window.removeEventListener('message', handleMessage)
+        }
     }, [searchParams])
 
     return (
@@ -138,6 +169,7 @@ function CrispProxyContent() {
                         var s=d.createElement("script");
                         s.src="https://client.crisp.chat/l.js";
                         s.async=1;
+                        s.onerror=function(){window.__crispLoadFailed=true;};
                         d.getElementsByTagName("head")[0].appendChild(s);
                     })();
                     window.$crisp.push(["safe", true]);

--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -14,9 +14,10 @@
  * Anonymous visitors (no userId, no token by design) proceed immediately.
  */
 import React from 'react'
-import { render, screen, act, waitFor } from '@testing-library/react'
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react'
 import SupportDrawer from '../index'
 import { isCapacitor } from '@/utils/capacitor'
+import { SUPPORT_EMAIL } from '@/constants/crisp'
 
 const mockUseCrispUserData = jest.fn()
 const mockUseCrispTokenId = jest.fn()
@@ -56,6 +57,12 @@ jest.mock('@capgo/capacitor-crisp', () => ({ CapacitorCrisp: nativeCrisp }))
 
 const supportIframe = () => screen.queryByTitle('Support Chat')
 
+const postCrispMessage = (type: 'CRISP_READY' | 'CRISP_FAILED') => {
+    act(() => {
+        window.dispatchEvent(new MessageEvent('message', { data: { type }, origin: window.location.origin }))
+    })
+}
+
 describe('SupportDrawer Crisp session gate — web iframe', () => {
     beforeEach(() => {
         mockUseCrispUserData.mockReset()
@@ -93,6 +100,52 @@ describe('SupportDrawer Crisp session gate — web iframe', () => {
         const iframe = supportIframe()
         expect(iframe).toBeInTheDocument()
         expect(iframe).toHaveAttribute('src', '/crisp-proxy')
+    })
+})
+
+describe('SupportDrawer — Crisp load-failure fallback', () => {
+    beforeEach(() => {
+        mockUseCrispUserData.mockReset().mockReturnValue({ userId: undefined, email: undefined })
+        mockUseCrispTokenId.mockReset().mockReturnValue(undefined)
+        mockIsCapacitor.mockReset().mockReturnValue(false)
+    })
+
+    it('shows the mailto fallback + retry when the proxy reports CRISP_FAILED', () => {
+        render(<SupportDrawer />)
+
+        // spinner up, no fallback yet
+        expect(screen.getByTestId('peanut-loading')).toBeInTheDocument()
+        expect(screen.queryByText(/chat couldn’t load/i)).not.toBeInTheDocument()
+
+        postCrispMessage('CRISP_FAILED')
+
+        // spinner replaced by a fallback with a mailto link to the real support inbox
+        expect(screen.queryByTestId('peanut-loading')).not.toBeInTheDocument()
+        expect(screen.getByText(/chat couldn’t load/i)).toBeInTheDocument()
+        const mailto = screen.getByRole('link', { name: SUPPORT_EMAIL })
+        expect(mailto).toHaveAttribute('href', `mailto:${SUPPORT_EMAIL}`)
+        expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument()
+    })
+
+    it('clears the fallback and re-shows the loader when Retry is pressed', () => {
+        render(<SupportDrawer />)
+        postCrispMessage('CRISP_FAILED')
+
+        fireEvent.click(screen.getByRole('button', { name: /try again/i }))
+
+        expect(screen.queryByText(/chat couldn’t load/i)).not.toBeInTheDocument()
+        expect(screen.getByTestId('peanut-loading')).toBeInTheDocument()
+    })
+
+    it('a later CRISP_READY dismisses the fallback', () => {
+        render(<SupportDrawer />)
+        postCrispMessage('CRISP_FAILED')
+        expect(screen.getByText(/chat couldn’t load/i)).toBeInTheDocument()
+
+        postCrispMessage('CRISP_READY')
+
+        expect(screen.queryByText(/chat couldn’t load/i)).not.toBeInTheDocument()
+        expect(screen.queryByTestId('peanut-loading')).not.toBeInTheDocument()
     })
 })
 

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -6,6 +6,8 @@ import { useCrispUserData } from '@/hooks/useCrispUserData'
 import { useCrispTokenId } from '@/hooks/useCrispTokenId'
 import { useCrispProxyUrl } from '@/hooks/useCrispProxyUrl'
 import PeanutLoading from '../PeanutLoading'
+import { Button } from '@/components/0_Bruddle/Button'
+import { SUPPORT_EMAIL } from '@/constants/crisp'
 import { isCapacitor } from '@/utils/capacitor'
 
 const DISMISS_THRESHOLD = 100
@@ -15,8 +17,18 @@ const SupportDrawer = () => {
     const userData = useCrispUserData()
     const crispTokenId = useCrispTokenId()
     const [isCrispReady, setIsCrispReady] = useState(false)
+    // The proxy reports CRISP_FAILED when the Crisp bundle never loads (blank-panel bug).
+    const [isCrispFailed, setIsCrispFailed] = useState(false)
+    // Bumping this key remounts the iframe, giving the user a clean retry.
+    const [iframeKey, setIframeKey] = useState(0)
 
     const crispProxyUrl = useCrispProxyUrl(userData, prefilledMessage, crispTokenId)
+
+    const handleRetry = useCallback(() => {
+        setIsCrispFailed(false)
+        setIsCrispReady(false)
+        setIframeKey((k) => k + 1)
+    }, [])
 
     // A logged-in user's token is computed asynchronously (SHA-256 of their userId).
     // Until it resolves we must NOT load the proxy: a token-less load makes Crisp fall
@@ -96,6 +108,9 @@ const SupportDrawer = () => {
 
             if (event.data.type === 'CRISP_READY') {
                 setIsCrispReady(true)
+                setIsCrispFailed(false)
+            } else if (event.data.type === 'CRISP_FAILED') {
+                setIsCrispFailed(true)
             }
         }
 
@@ -151,13 +166,28 @@ const SupportDrawer = () => {
 
                 <div className="flex w-full justify-center">
                     <div className="relative h-[80vh] w-full overflow-auto md:max-w-xl">
-                        {(!isCrispReady || isAwaitingToken) && (
+                        {(!isCrispReady || isAwaitingToken) && !isCrispFailed && (
                             <div className="absolute inset-0 z-10 flex items-center justify-center bg-background">
                                 <PeanutLoading />
                             </div>
                         )}
+                        {isCrispFailed && (
+                            <div className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-4 bg-background px-8 text-center">
+                                <p className="text-base font-bold text-n-1">Chat couldn’t load</p>
+                                <p className="text-sm text-grey-1">
+                                    Something went wrong loading support chat. Email us and we’ll help you out:
+                                </p>
+                                <a href={`mailto:${SUPPORT_EMAIL}`} className="text-black underline">
+                                    {SUPPORT_EMAIL}
+                                </a>
+                                <Button variant="stroke" className="w-full" onClick={handleRetry}>
+                                    Try again
+                                </Button>
+                            </div>
+                        )}
                         {!isAwaitingToken && (
                             <iframe
+                                key={iframeKey}
                                 src={crispProxyUrl}
                                 className="h-full w-full"
                                 allow="storage-access *"

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -106,10 +106,10 @@ const SupportDrawer = () => {
         const handleMessage = (event: MessageEvent) => {
             if (event.origin !== window.location.origin) return
 
-            if (event.data.type === 'CRISP_READY') {
+            if (event.data?.type === 'CRISP_READY') {
                 setIsCrispReady(true)
                 setIsCrispFailed(false)
-            } else if (event.data.type === 'CRISP_FAILED') {
+            } else if (event.data?.type === 'CRISP_FAILED') {
                 setIsCrispFailed(true)
             }
         }

--- a/src/constants/crisp.ts
+++ b/src/constants/crisp.ts
@@ -4,3 +4,6 @@
 
 /** Crisp website ID for Peanut's support chat */
 export const CRISP_WEBSITE_ID = '916078be-a6af-4696-82cb-bc08d43d9125'
+
+/** Support inbox — the mailto fallback when the Crisp chatbox fails to load. */
+export const SUPPORT_EMAIL = 'help@peanut.me'

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,8 +1,13 @@
 interface Window {
     gtag?: (command: string, ...args: unknown[]) => void
-    $crisp?: Array<unknown[]>
+    // Before client.crisp.chat/l.js loads, $crisp is a plain push-queue array. Once the
+    // script loads it upgrades the object in place, adding methods like `is()` — we use
+    // the presence of `is` as the "Crisp actually loaded" signal.
+    $crisp?: Array<unknown[]> & { is?: (feature: string) => boolean }
     CRISP_TOKEN_ID?: string | null
     CRISP_WEBSITE_ID?: string
+    // Set to true by the l.js <script> onerror handler if the Crisp bundle fails to load.
+    __crispLoadFailed?: boolean
 }
 
 interface Navigator {


### PR DESCRIPTION
## Summary — why

The in-app support chat (`SupportDrawer` → `/crisp-proxy` iframe) renders a **permanent blank white panel** for some users. A real 5-account/one-device user canceled his card **twice** with reason *"No puedo hablar con soporte"* because of it. Two independent root causes, confirmed by code reading:

1. **Token-switch bricks Crisp on multi-account devices.** Crisp refuses to initialize a chatbox when `CRISP_TOKEN_ID` changes over an existing locally-persisted session without a `session:reset` first. Our reset depended on a `crisp_needs_reset` **sessionStorage** flag set at logout — sessionStorage is per-tab and wiped on app restart, so on devices that hosted multiple Peanut accounts the flag was routinely missed → Crisp silently never loaded.
2. **The failure was invisible.** `crisp-proxy` cleared the parent's loading spinner with a blind `setTimeout(notifyParentReady, 1500)` even when Crisp never loaded → permanent blank panel, no error, no retry, no fallback contact.

## What changed (surgical, hotfix scope)

- **`crisp-proxy/page.tsx`** — robust reset on token change: persist the last-used token in `localStorage` (`crisp_last_token_id`); on load, if the current `crisp_token_id` differs from the stored value (including stored→anonymous transitions) push `session:reset` and update the store. The existing `crisp_needs_reset` sessionStorage path still works. Replaced the blind 1.5s fallback with a genuine readiness signal: notify `CRISP_READY` on `session:loaded`, plus an ~8s watchdog that posts **`CRISP_FAILED`** when the Crisp bundle errored (`<script> onerror`) or never upgraded the `$crisp` stub (`typeof $crisp.is !== 'function'`). If the bundle loaded but `session:loaded` never fired, it still falls back to `CRISP_READY` (preserves prior behavior).
- **`SupportDrawer/index.tsx`** — handle `CRISP_FAILED`: hide the spinner and show a small fallback panel — *"Chat couldn't load"* + a `mailto:help@peanut.me` link (the address the app's own legal docs use) + a **Try again** button that remounts the iframe (bumps a key). Design-system compliant (`Button variant="stroke"`, `text-black underline` link).
- **`constants/crisp.ts`** — new `SUPPORT_EMAIL = 'help@peanut.me'`.
- **`types/global.d.ts`** — typed `window.$crisp.is` and `window.__crispLoadFailed` for the readiness check.
- Tests extended (`SupportDrawer.test.tsx`): CRISP_FAILED renders the mailto+retry fallback, Retry clears it back to the loader, and a later CRISP_READY dismisses it. 9/9 green.

Capacitor/native path untouched beyond nothing (no changes).

## Risks / breaking changes

- **This is a hotfix to `main` — it rides straight to prod (peanut.me / Vercel) on merge.** No backend changes, no migrations, no cross-repo coupling.
- **Back-merge debt:** `main → dev` back-merge required after merge or the next release PR conflicts.
- Behavioral note: on success `session:loaded` clears the spinner as before (~1–2s typical); in the rare "loaded-but-no-event" case the spinner now lingers up to 8s (was 1.5s) before assuming ready — the necessary tradeoff to genuinely detect failure rather than mask it.
- First open after deploy triggers one `session:reset` for existing logged-in users (localStorage store is empty) — intended; this is what heals currently-bricked sessions.

## QA

1. Multi-account device repro: log in as user A, open support (Crisp loads), log out, log in as user B, open support → chat loads for B (previously blank). Restart the app between accounts to defeat sessionStorage → still loads.
2. Failure fallback: block `client.crisp.chat` (devtools request-block) and open support → after ~8s the panel shows *"Chat couldn't load"* + `help@peanut.me` mailto + **Try again**; clicking Try again reloads the iframe.
3. `npm test` — SupportDrawer suite 9/9 green.
