### PR TITLE
feat(card): re-enable prompt on stale-approval withdraw refusal

### DIFF
--- a/src/app/ClientProviders.tsx
+++ b/src/app/ClientProviders.tsx
@@ -8,6 +8,7 @@
  */
 import { ConsoleGreeting } from '@/components/Global/ConsoleGreeting'
 import RainCooldownIntroModal from '@/components/Global/RainCooldown/IntroModal'
+import StaleCardApprovalReEnableModal from '@/components/Global/StaleCardApproval/ReEnableModal'
 import BadgeEarnToast from '@/components/Badges/BadgeEarnToast'
 import { ScreenOrientationLocker } from '@/components/Global/ScreenOrientationLocker'
 import { TranslationSafeWrapper } from '@/components/Global/TranslationSafeWrapper'
@@ -46,6 +47,11 @@ export function ClientProviders({ children }: { children: React.ReactNode }) {
                                 explainer also covers public pay/send/request pages —
                                 the rain:cooldown event fires on every spend path. */}
                             <RainCooldownIntroModal />
+                            {/* Global recovery prompt: a withdraw refused with 409
+                                STALE_CARD_APPROVAL (stale session-key approval) fires
+                                RAIN_STALE_APPROVAL_EVENT — mount here so the re-enable
+                                CTA covers every spend path, not just the card screen. */}
+                            <StaleCardApprovalReEnableModal />
                             {/* Non-intrusive "badge unlocked" toast on /home (TASK-19791).
                                 Global so it surfaces wherever the user lands after earning. */}
                             <BadgeEarnToast />

--- a/src/components/Global/StaleCardApproval/ReEnableModal.tsx
+++ b/src/components/Global/StaleCardApproval/ReEnableModal.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import ActionModal, { type ActionModalButtonProps } from '@/components/Global/ActionModal'
+import { useGrantSessionKey } from '@/hooks/wallet/useGrantSessionKey'
+import { RAIN_STALE_APPROVAL_EVENT } from '@/services/rain'
+
+/**
+ * Global recovery modal for the stale-card-approval case.
+ *
+ * When a card withdrawal is refused with 409 STALE_CARD_APPROVAL, the user's
+ * stored session-key approval is bound to a deprecated validator that can no
+ * longer be sponsored — so no funds can move until they re-enable the card.
+ * `rainRequest` (services/rain.ts) dispatches `RAIN_STALE_APPROVAL_EVENT` on
+ * that refusal; this modal listens globally (mounted once in ClientProviders)
+ * so the recovery CTA surfaces on ANY spend path — withdraw, QR pay, send —
+ * without threading state through each flow's catch block.
+ *
+ * The CTA reuses the existing session-key grant (`useGrantSessionKey().grant()`
+ * — the same flow EnableAutoBalanceBanner drives) rather than building a new
+ * one; a fresh grant re-binds a sponsorable approval and unblocks withdrawals.
+ * Note: these users have `hasWithdrawApproval === true` (the approval exists,
+ * it's just stale), so EnableAutoBalanceBanner never fires for them — this
+ * modal is their only prompt.
+ *
+ * Unlike EnableAutoBalanceBanner this is NOT a hard block: the user can dismiss
+ * and re-enable later. On a successful grant we show a short confirmation so
+ * they know to retry the withdrawal.
+ */
+export default function StaleCardApprovalReEnableModal() {
+    const { grant, isGranting } = useGrantSessionKey()
+    const [visible, setVisible] = useState(false)
+    const [succeeded, setSucceeded] = useState(false)
+    const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+    useEffect(() => {
+        const handler = () => {
+            setSucceeded(false)
+            setErrorMessage(null)
+            setVisible(true)
+        }
+        window.addEventListener(RAIN_STALE_APPROVAL_EVENT, handler)
+        return () => window.removeEventListener(RAIN_STALE_APPROVAL_EVENT, handler)
+    }, [])
+
+    const close = useCallback(() => setVisible(false), [])
+
+    const onReEnable = useCallback(async () => {
+        setErrorMessage(null)
+        const result = await grant()
+        if (result.ok) {
+            setSucceeded(true)
+        } else {
+            setErrorMessage(
+                result.error.kind === 'user-cancelled'
+                    ? 'Re-enabling was cancelled. Tap Re-enable card to try again.'
+                    : "We couldn't re-enable your card. Please try again."
+            )
+        }
+    }, [grant])
+
+    const ctas: ActionModalButtonProps[] = succeeded
+        ? [{ text: 'Done', variant: 'purple', shadowSize: '4', onClick: close }]
+        : [
+              {
+                  text: isGranting ? 'Working…' : 'Re-enable card',
+                  variant: 'purple',
+                  shadowSize: '4',
+                  disabled: isGranting,
+                  onClick: () => void onReEnable(),
+              },
+              { text: 'Not now', variant: 'stroke', disabled: isGranting, onClick: close },
+          ]
+
+    return (
+        <ActionModal
+            visible={visible}
+            onClose={close}
+            icon="credit-card"
+            iconContainerClassName="bg-yellow-1"
+            title={succeeded ? 'Card re-enabled' : 'Re-enable your card'}
+            description={
+                succeeded
+                    ? 'Your card is ready — please try your withdrawal again.'
+                    : (errorMessage ??
+                      'Your card needs to be re-enabled before you can withdraw. It only takes one passkey tap.')
+            }
+            ctas={ctas}
+        />
+    )
+}

--- a/src/components/Global/StaleCardApproval/__tests__/ReEnableModal.test.tsx
+++ b/src/components/Global/StaleCardApproval/__tests__/ReEnableModal.test.tsx
@@ -1,0 +1,95 @@
+/** @jest-environment jsdom */
+/**
+ * StaleCardApprovalReEnableModal — global recovery prompt for the
+ * 409 STALE_CARD_APPROVAL withdraw refusal.
+ *
+ * Hidden until `RAIN_STALE_APPROVAL_EVENT` fires; then it offers a re-enable
+ * CTA that reuses the session-key grant. A successful grant flips to a "try
+ * again" confirmation; a failed grant surfaces a recoverable message.
+ */
+import React from 'react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { RAIN_STALE_APPROVAL_EVENT } from '@/services/rain'
+
+const mockGrant = jest.fn<Promise<{ ok: boolean; error?: { kind: string } }>, []>()
+jest.mock('@/hooks/wallet/useGrantSessionKey', () => ({
+    useGrantSessionKey: () => ({ grant: mockGrant, isGranting: false }),
+}))
+
+jest.mock('@/components/Global/ActionModal', () => ({
+    __esModule: true,
+    default: (props: {
+        visible: boolean
+        title?: string
+        description?: string
+        ctas?: { text: string; onClick: () => void }[]
+    }) =>
+        props.visible ? (
+            <div data-testid="modal">
+                <h3>{props.title}</h3>
+                <p>{props.description}</p>
+                {props.ctas?.map((c) => (
+                    <button key={c.text} onClick={c.onClick}>
+                        {c.text}
+                    </button>
+                ))}
+            </div>
+        ) : null,
+}))
+
+import StaleCardApprovalReEnableModal from '../ReEnableModal'
+
+const fireStaleEvent = () =>
+    act(() => {
+        window.dispatchEvent(new CustomEvent(RAIN_STALE_APPROVAL_EVENT))
+    })
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    mockGrant.mockResolvedValue({ ok: false, error: { kind: 'unexpected' } })
+})
+
+describe('StaleCardApprovalReEnableModal', () => {
+    it('is hidden until the stale-approval event fires', () => {
+        render(<StaleCardApprovalReEnableModal />)
+        expect(screen.queryByTestId('modal')).not.toBeInTheDocument()
+
+        fireStaleEvent()
+        expect(screen.getByTestId('modal')).toBeInTheDocument()
+        expect(screen.getByText('Re-enable your card')).toBeInTheDocument()
+        expect(screen.getByText('Re-enable card')).toBeInTheDocument()
+    })
+
+    it('a successful grant flips to the "try your withdrawal again" confirmation', async () => {
+        mockGrant.mockResolvedValue({ ok: true })
+        render(<StaleCardApprovalReEnableModal />)
+        fireStaleEvent()
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('Re-enable card'))
+        })
+
+        expect(mockGrant).toHaveBeenCalledTimes(1)
+        expect(screen.getByText('Card re-enabled')).toBeInTheDocument()
+        expect(screen.getByText(/try your withdrawal again/i)).toBeInTheDocument()
+    })
+
+    it('a failed grant surfaces a recoverable message and keeps the retry CTA', async () => {
+        render(<StaleCardApprovalReEnableModal />)
+        fireStaleEvent()
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('Re-enable card'))
+        })
+
+        expect(screen.getByText(/couldn't re-enable your card/i)).toBeInTheDocument()
+        expect(screen.getByText('Re-enable card')).toBeInTheDocument()
+    })
+
+    it('can be dismissed with "Not now"', () => {
+        render(<StaleCardApprovalReEnableModal />)
+        fireStaleEvent()
+        fireEvent.click(screen.getByText('Not now'))
+        expect(screen.queryByTestId('modal')).not.toBeInTheDocument()
+    })
+})

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -156,6 +156,9 @@ export const ANALYTICS_EVENTS = {
     CARD_SESSION_KEY_PROMPTED: 'card_session_key_prompted',
     CARD_SESSION_KEY_GRANTED: 'card_session_key_granted',
     CARD_SESSION_KEY_FAILED: 'card_session_key_failed',
+    // Withdraw refused with 409 STALE_CARD_APPROVAL — stored session-key
+    // approval is bound to a deprecated validator; user must re-enable the card.
+    CARD_STALE_APPROVAL_HIT: 'card_stale_approval_hit',
 
     // ── Card: waitlist + early-access funnel (M2 Card Waitlist Launch) ──
     // /shhhhh closed-beta landing page → /card.

--- a/src/services/__tests__/rain-stale-approval.test.ts
+++ b/src/services/__tests__/rain-stale-approval.test.ts
@@ -1,0 +1,86 @@
+/** @jest-environment jsdom */
+/**
+ * Withdraw-submit error handling for the stale-card-approval case
+ * (companion to peanut-api-ts #1143).
+ *
+ * A 409 whose body carries `code: 'STALE_CARD_APPROVAL'` must throw the typed
+ * `StaleCardApprovalError` AND dispatch `RAIN_STALE_APPROVAL_EVENT` so the
+ * global re-enable modal can surface the recovery CTA. Every other failure
+ * (a plain 409, a 500, a network error) must fall through to the existing
+ * generic `Error` unchanged.
+ */
+import { rainApi, StaleCardApprovalError, RAIN_STALE_APPROVAL_EVENT } from '@/services/rain'
+
+const mockFetchWithSentry = jest.fn()
+jest.mock('@/utils/sentry.utils', () => ({
+    fetchWithSentry: (...args: unknown[]) => mockFetchWithSentry(...args),
+}))
+jest.mock('js-cookie', () => ({ __esModule: true, default: { get: () => 'jwt-abc' } }))
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
+
+const withdrawInput = {
+    preparationId: 'prep-1',
+    amount: '1000000',
+    recipientAddress: '0xrecipient',
+    directTransfer: true,
+    adminSalt: '0xsalt',
+    adminNonce: '1',
+    adminSignature: '0xsig',
+    executorSignature: '0xexec',
+    executorSalt: '0xexecsalt',
+    expiresAt: 1893456000,
+}
+
+const jsonResponse = (status: number, body: unknown) =>
+    ({ ok: status >= 200 && status < 300, status, json: async () => body }) as unknown as Response
+
+beforeEach(() => jest.clearAllMocks())
+
+describe('rainApi.submitWithdrawal — stale card approval', () => {
+    it('throws StaleCardApprovalError and dispatches the re-enable event on 409 STALE_CARD_APPROVAL', async () => {
+        mockFetchWithSentry.mockResolvedValue(
+            jsonResponse(409, { error: 'Your card needs to be re-enabled.', code: 'STALE_CARD_APPROVAL' })
+        )
+        const onEvent = jest.fn()
+        window.addEventListener(RAIN_STALE_APPROVAL_EVENT, onEvent)
+
+        await expect(rainApi.submitWithdrawal(withdrawInput)).rejects.toBeInstanceOf(StaleCardApprovalError)
+        expect(onEvent).toHaveBeenCalledTimes(1)
+
+        window.removeEventListener(RAIN_STALE_APPROVAL_EVENT, onEvent)
+    })
+
+    it('surfaces the backend copy verbatim on the typed error', async () => {
+        mockFetchWithSentry.mockResolvedValue(
+            jsonResponse(409, { error: 'Your card needs to be re-enabled.', code: 'STALE_CARD_APPROVAL' })
+        )
+        await expect(rainApi.submitWithdrawal(withdrawInput)).rejects.toThrow('Your card needs to be re-enabled.')
+    })
+
+    it('a 409 WITHOUT the code falls through to a generic Error and fires no event', async () => {
+        mockFetchWithSentry.mockResolvedValue(jsonResponse(409, { error: 'Charge already paid' }))
+        const onEvent = jest.fn()
+        window.addEventListener(RAIN_STALE_APPROVAL_EVENT, onEvent)
+
+        const err = await rainApi.submitWithdrawal(withdrawInput).catch((e) => e)
+        expect(err).toBeInstanceOf(Error)
+        expect(err).not.toBeInstanceOf(StaleCardApprovalError)
+        expect(err.message).toBe('Charge already paid')
+        expect(onEvent).not.toHaveBeenCalled()
+
+        window.removeEventListener(RAIN_STALE_APPROVAL_EVENT, onEvent)
+    })
+
+    it('a non-409 failure is unchanged (generic Error, no event)', async () => {
+        mockFetchWithSentry.mockResolvedValue(jsonResponse(500, { error: 'boom' }))
+        const onEvent = jest.fn()
+        window.addEventListener(RAIN_STALE_APPROVAL_EVENT, onEvent)
+
+        const err = await rainApi.submitWithdrawal(withdrawInput).catch((e) => e)
+        expect(err).toBeInstanceOf(Error)
+        expect(err).not.toBeInstanceOf(StaleCardApprovalError)
+        expect(onEvent).not.toHaveBeenCalled()
+
+        window.removeEventListener(RAIN_STALE_APPROVAL_EVENT, onEvent)
+    })
+})

--- a/src/services/rain.ts
+++ b/src/services/rain.ts
@@ -224,6 +224,36 @@ export interface RainCooldownEventDetail {
     message: string
 }
 
+/**
+ * Thrown on 409 `{ code: 'STALE_CARD_APPROVAL' }` from
+ * `/rain/cards/withdraw/submit`. The user's stored card session-key approval is
+ * bound to a deprecated ZeroDev validator that can no longer be sponsored, so
+ * the withdrawal can't be broadcast until the user re-enables their card
+ * (re-grants the session key, which mints a fresh, sponsorable approval).
+ *
+ * `rainRequest` also dispatches a `RAIN_STALE_APPROVAL_EVENT` window event when
+ * it constructs this error, so the global re-enable modal can surface the
+ * recovery CTA on ANY spend path without threading state through the call —
+ * same event-driven pattern as the cooldown 425 above.
+ *
+ * TODO(gen:api): the backend (peanut-api-ts #1143) added `code:
+ * 'STALE_CARD_APPROVAL'` to the withdraw error contract. Once that openapi
+ * lands on dev, run `pnpm gen:api` and branch off the generated union type
+ * instead of this hand-written string literal.
+ */
+export class StaleCardApprovalError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = 'StaleCardApprovalError'
+    }
+}
+
+/** The only path that returns a 409 STALE_CARD_APPROVAL — the withdraw submit.
+ *  Gate the branch on it so an unrelated 409 elsewhere stays a generic error. */
+const RAIN_WITHDRAW_SUBMIT_PATH = '/rain/cards/withdraw/submit'
+/** Window event the global re-enable modal listens for. */
+export const RAIN_STALE_APPROVAL_EVENT = 'rain:stale-card-approval'
+
 /** Path that legitimately produces the cooldown 425. Any other 425 from a
  *  Rain endpoint is treated as a generic upstream error — without this gate,
  *  an unrelated 425 (e.g. proxy "Too Early") would pop the cooldown modal on
@@ -348,6 +378,23 @@ async function rainRequest<T>(opts: RequestOpts): Promise<T> {
             }
         }
         throw new RainCooldownError(message, retryAfterSec)
+    }
+
+    if (response.status === 409 && opts.path === RAIN_WITHDRAW_SUBMIT_PATH) {
+        const err = await response.json().catch(() => ({}))
+        // Only the stale-approval discriminant routes to the re-enable flow.
+        // Any other 409 on submit (e.g. "Charge already paid") stays generic.
+        if (err.code === 'STALE_CARD_APPROVAL') {
+            const message =
+                err.error ||
+                'Your card needs to be re-enabled before you can withdraw. Please re-enable your card and try again.'
+            if (typeof window !== 'undefined') {
+                posthog.capture(ANALYTICS_EVENTS.CARD_STALE_APPROVAL_HIT)
+                window.dispatchEvent(new CustomEvent(RAIN_STALE_APPROVAL_EVENT))
+            }
+            throw new StaleCardApprovalError(message)
+        }
+        throw new Error(err.error || err.message || `Request failed: ${response.status}`)
     }
 
     if (!response.ok) {

--- a/src/utils/__tests__/friendly-error.utils.test.tsx
+++ b/src/utils/__tests__/friendly-error.utils.test.tsx
@@ -78,4 +78,13 @@ describe('ErrorHandler', () => {
         expect(rainCollateralErrorMessage(cooldown)).toBe(cooldown.message)
         expect(ErrorHandler(cooldown)).toBe(cooldown.message)
     })
+
+    test('stale-card-approval surfaces its friendly copy inline, not the "contact support" fallback', () => {
+        // Matched by error name so the inline path matches the global re-enable
+        // modal instead of dead-ending on the generic support fallback.
+        const stale = new Error('Your card needs to be re-enabled before you can withdraw.')
+        stale.name = 'StaleCardApprovalError'
+        expect(rainCollateralErrorMessage(stale)).toBe(stale.message)
+        expect(ErrorHandler(stale)).toBe(stale.message)
+    })
 })

--- a/src/utils/friendly-error.utils.tsx
+++ b/src/utils/friendly-error.utils.tsx
@@ -28,7 +28,12 @@ function extractErrorParts(error: unknown): { text: string; message: string | un
  * (signSpend / spend / sendMoney / sendTransactions(requiredUsdcAmount)).
  */
 export const rainCollateralErrorMessage = (error: unknown): string | null => {
-    const { text, message } = extractErrorParts(error)
+    const { text, message, name } = extractErrorParts(error)
+    // Stale card approval (409 STALE_CARD_APPROVAL) — the global re-enable modal
+    // owns the recovery CTA, but the flow that threw still shows an inline error.
+    // Surface the backend's friendly re-enable copy here so the inline path
+    // matches the modal instead of dead-ending on "contact support".
+    if (name === 'StaleCardApprovalError') return message ?? text
     if (
         text.includes('A previous withdrawal is still active for this card') ||
         text.includes('A previous withdrawal signature is still active') ||


### PR DESCRIPTION
## Summary

FE follow-up to **peanut-api-ts #1143** (deploy BE first). That PR makes the Rain card withdraw submit endpoint (`POST /rain/cards/withdraw/submit`, via `verifyRainWithdrawal`) return **409 `{ error, code: 'STALE_CARD_APPROVAL' }`** when a user's stored card session-key approval is bound to the deprecated ZeroDev v0.0.2 validator — which can no longer be sponsored, so withdrawals are impossible until the user re-grants.

Until now the FE had no handling for this code, so these users hit the generic "There was an issue with your request. Please contact support." dead-end. This maps the code to a clear, actionable recovery: **re-enable your card** (re-run the existing session-key grant, which mints a fresh v0.0.3-bound approval and unblocks withdrawals).

## What changed

- **`src/services/rain.ts`** — `rainRequest` now branches on a 409 for the withdraw-submit path: if the body carries `code: 'STALE_CARD_APPROVAL'` it throws a typed `StaleCardApprovalError` and dispatches a `rain:stale-card-approval` window event (mirrors the existing `rain:cooldown` 425 pattern). Any other 409 on that path (e.g. "Charge already paid") falls through to the existing generic `Error` unchanged.
- **`src/components/Global/StaleCardApproval/ReEnableModal.tsx`** (new) — global modal, mounted once in `ClientProviders`, that listens for the event and offers a **"Re-enable card"** primary CTA (`variant="purple" shadowSize="4"`). The CTA **reuses `useGrantSessionKey().grant()`** — the same flow `EnableAutoBalanceBanner` drives — rather than building a new grant. Global mount means the prompt covers every spend path (withdraw, QR pay, send), not just the card screen. A successful grant flips to a "try your withdrawal again" confirmation; a failed one shows a recoverable message. Dismissable ("Not now") — this is a recovery prompt, not a hard block.
- **`src/constants/analytics.consts.ts`** — adds `CARD_STALE_APPROVAL_HIT` telemetry.
- No provider names in any user-facing copy (no "ZeroDev"/"Rain").

## gen:api sync TODO

The backend added `code: 'STALE_CARD_APPROVAL'` to its withdraw error contract in #1143. That openapi hasn't landed on `dev` yet, so this PR **handles the code defensively as a string literal** and leaves a `TODO(gen:api)` in `rain.ts`: once #1143's openapi is on dev, run `pnpm gen:api` and branch off the generated union type instead of the hand-written literal. Not blocking this PR.

## Risks

- Low blast radius — pure error-handling + a recovery CTA; no money-moving logic changed, no migration, no new provider calls. The new 409 branch is gated on the exact submit path + the `code` discriminant, so unrelated 409s are untouched.
- **Cross-repo deploy order:** deploy peanut-api-ts #1143 **first** (it emits the code). Before then this FE code is dormant (no endpoint returns the code). No hard dependency the other way — the FE degrades to the previous generic error if the code is absent.

## QA — simulate a 409 locally

The typed-error + event path is unit-tested (`src/services/__tests__/rain-stale-approval.test.ts` — 409-with-code → `StaleCardApprovalError` + event; plain 409 / 500 → generic Error, no event) and the modal states in `ReEnableModal.test.tsx`. To exercise end-to-end in a browser without the BE:

- In devtools, dispatch the event to see the modal on any page: `window.dispatchEvent(new CustomEvent('rain:stale-card-approval'))`.
- Or stub the submit response: make `POST /rain/cards/withdraw/submit` return `409 {"error":"...","code":"STALE_CARD_APPROVAL"}` (e.g. a devtools network override) and run a card withdraw — the re-enable modal appears; "Re-enable card" runs the passkey grant.

Sandbox values only.
