### PR TITLE
fix(history): render refunds as refund credits, not payments

### DIFF
--- a/src/components/TransactionDetails/TransactionAvatarBadge.tsx
+++ b/src/components/TransactionDetails/TransactionAvatarBadge.tsx
@@ -94,9 +94,11 @@ const TransactionAvatarBadge: React.FC<TransactionAvatarBadgeProps> = ({
             // textColor = context === 'card' ? AVATAR_TEXT_LIGHT : AVATAR_TEXT_DARK
             break
         case 'card_pay':
-            // Rain card spend without a Rain-enriched merchant logo
-            // (TransactionDetailsHeaderCard prefers `avatarUrl` when set,
-            // so a real merchant brand mark wins over this fallback).
+        case 'refund':
+            // Rain card spend / card refund without a Rain-enriched merchant
+            // logo (TransactionDetailsHeaderCard prefers `avatarUrl` when set,
+            // so a real merchant brand mark wins over this fallback). A refund
+            // shares the card-spend treatment — same merchant, same card.
             displayIconName = 'credit-card'
             displayInitials = undefined
             break

--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -309,6 +309,8 @@ const TYPE_PRESENTATION: Record<TransactionType, { icon: IconName | null; iconSi
     // 'Pay' for card spends — the `card_pay` literal is an internal
     // discriminator (see TransactionType comment) that renders as "Pay".
     card_pay: { icon: 'arrow-up-right', text: 'Pay' },
+    // Refund credit row — same inbound arrow as 'receive', labelled "Refund".
+    refund: { icon: 'arrow-down-left', text: 'Refund' },
 }
 
 // helper functions

--- a/src/components/TransactionDetails/__tests__/fixtures/render-baseline.json
+++ b/src/components/TransactionDetails/__tests__/fixtures/render-baseline.json
@@ -3465,9 +3465,10 @@
       }
     },
     "expected": {
-      "direction": "send",
-      "userName": "<EVM_ADDRESS>",
-      "transactionCardType": "send",
+      "direction": "receive",
+      "userName": "Refund",
+      "transactionCardType": "refund",
+      "kind": "REFUND",
       "provider": "MANTECA",
       "cardPaymentDefined": false,
       "bankAccountDetailsDefined": false

--- a/src/components/TransactionDetails/__tests__/transactionTransformer.test.ts
+++ b/src/components/TransactionDetails/__tests__/transactionTransformer.test.ts
@@ -494,6 +494,16 @@ describe('mapTransactionDataForDrawer', () => {
             expect(result.extraDataForDrawer?.cardPayment?.isRefund).toBe(true)
         })
 
+        it('role-derived display strings follow the refund verdict, not the wire role', () => {
+            // Old BE reports userRole=SENDER on a negative auth. The receipt's
+            // "Sent/Received" label and the +/- currency symbol key off
+            // originalUserRole/currencySymbol — they must agree with the
+            // refund header, not assert the user sent the money.
+            const result = mapTransactionDataForDrawer(negativeAuth).transactionDetails
+            expect(result.extraDataForDrawer?.originalUserRole).toBe(EHistoryUserRole.RECIPIENT)
+            expect(result.currencySymbol).toBe('+$')
+        })
+
         it('kind REFUND no longer trips the unknown-transformer-kind pipeline alert', () => {
             jest.mocked(pipelineAlert).mockClear()
             mapTransactionDataForDrawer(

--- a/src/components/TransactionDetails/__tests__/transactionTransformer.test.ts
+++ b/src/components/TransactionDetails/__tests__/transactionTransformer.test.ts
@@ -1,8 +1,10 @@
 import { mapTransactionDataForDrawer } from '../transactionTransformer'
-import { EHistoryUserRole, EHistoryStatus, type HistoryEntry } from '@/utils/history.utils'
+import { EHistoryUserRole, EHistoryStatus, getTransactionSign, type HistoryEntry } from '@/utils/history.utils'
+import { pipelineAlert } from '@/utils/pipelineAlerts'
 
 jest.mock('@/assets', () => ({}))
 jest.mock('@/assets/payment-apps', () => ({ MERCADO_PAGO: '', PIX: '', SIMPLEFI: '' }))
+jest.mock('@/utils/pipelineAlerts', () => ({ pipelineAlert: jest.fn() }))
 
 type Account = NonNullable<HistoryEntry['recipientAccount']>
 
@@ -348,7 +350,48 @@ const cases: TestCase[] = [
         }),
         expect: {
             direction: 'receive',
-            transactionCardType: 'receive',
+            transactionCardType: 'refund',
+            userName: 'Refund from Acme Coffee',
+            cardPaymentDefined: true,
+        },
+    },
+
+    // ───── REFUND (Rain + Manteca) ─────
+    {
+        name: 'REFUND × RAIN → card refund shape (Refund from merchant)',
+        entry: baseEntry({
+            userRole: EHistoryUserRole.RECIPIENT,
+            recipientAccount: aliceUser,
+            extraData: { kind: 'REFUND', provider: 'RAIN', parentRainTxId: 'rain-789', merchantName: 'Acme Coffee' },
+        }),
+        expect: {
+            direction: 'receive',
+            transactionCardType: 'refund',
+            userName: 'Refund from Acme Coffee',
+            cardPaymentDefined: true,
+        },
+    },
+    {
+        name: 'REFUND × MANTECA → generic Refund credit row',
+        entry: baseEntry({
+            userRole: EHistoryUserRole.RECIPIENT,
+            recipientAccount: aliceUser,
+            extraData: { kind: 'REFUND', provider: 'MANTECA' },
+        }),
+        expect: { direction: 'receive', transactionCardType: 'refund', userName: 'Refund' },
+    },
+    {
+        name: 'negative CARD_SPEND_AUTH (Rain refund credit) → refund, not card_pay',
+        entry: baseEntry({
+            userRole: EHistoryUserRole.SENDER,
+            amount: '-14.68',
+            status: EHistoryStatus.PENDING,
+            recipientAccount: aliceUser,
+            extraData: { kind: 'CARD_SPEND_AUTH', provider: 'RAIN', merchantName: 'Acme Coffee' },
+        }),
+        expect: {
+            direction: 'receive',
+            transactionCardType: 'refund',
             userName: 'Refund from Acme Coffee',
             cardPaymentDefined: true,
         },
@@ -425,6 +468,42 @@ describe('mapTransactionDataForDrawer', () => {
             const result = mapTransactionDataForDrawer(entry).transactionDetails
             expect(result.direction).toBeDefined()
             expect(result.extraDataForDrawer?.kind).toBeUndefined()
+        })
+    })
+
+    describe('refund credit rows (status + sign + flag)', () => {
+        const negativeAuth = baseEntry({
+            userRole: EHistoryUserRole.SENDER,
+            amount: '-14.68',
+            status: EHistoryStatus.PENDING,
+            recipientAccount: aliceUser,
+            extraData: { kind: 'CARD_SPEND_AUTH', provider: 'RAIN', merchantName: 'Acme Coffee', usdAmount: '-14.68' },
+        })
+
+        it('a negative auth stays pending (never "refunded") so the + sign shows', () => {
+            const result = mapTransactionDataForDrawer(negativeAuth).transactionDetails
+            expect(result.status).toBe('pending')
+            expect(result.direction).toBe('receive')
+            // 'refunded'/'failed'/'cancelled' would suppress the sign; a pending
+            // receive keeps the '+'. This is what makes the credit read as +$14.68.
+            expect(getTransactionSign(result)).toBe('+')
+        })
+
+        it('flags the drawer cardPayment as a refund', () => {
+            const result = mapTransactionDataForDrawer(negativeAuth).transactionDetails
+            expect(result.extraDataForDrawer?.cardPayment?.isRefund).toBe(true)
+        })
+
+        it('kind REFUND no longer trips the unknown-transformer-kind pipeline alert', () => {
+            jest.mocked(pipelineAlert).mockClear()
+            mapTransactionDataForDrawer(
+                baseEntry({
+                    userRole: EHistoryUserRole.RECIPIENT,
+                    recipientAccount: aliceUser,
+                    extraData: { kind: 'REFUND', provider: 'MANTECA' },
+                })
+            )
+            expect(pipelineAlert).not.toHaveBeenCalled()
         })
     })
 })

--- a/src/components/TransactionDetails/strategies/__tests__/refund.test.ts
+++ b/src/components/TransactionDetails/strategies/__tests__/refund.test.ts
@@ -50,6 +50,13 @@ describe('cardSpend refund detection (negative-amount auths)', () => {
         expect(out.transactionCardType).toBe('refund')
     })
 
+    test('formatted negative amount ("-1,468.00") still routes to refund', () => {
+        // Number('-1,468.00') is NaN — detection must sanitize before parsing
+        // so locale/currency formatting can never silently drop the route.
+        const out = cardSpend(entry({ amount: '-1,468.00', extraData: { merchantName: 'Acme Coffee' } }))
+        expect(out.transactionCardType).toBe('refund')
+    })
+
     test('positive spend, no refund signal → unchanged card_pay (regression)', () => {
         const out = cardSpend(entry({ amount: '14.68', extraData: { merchantName: 'Acme Coffee' } }))
         expect(out.transactionCardType).toBe('card_pay')

--- a/src/components/TransactionDetails/strategies/__tests__/refund.test.ts
+++ b/src/components/TransactionDetails/strategies/__tests__/refund.test.ts
@@ -1,0 +1,58 @@
+// Locks the refund classification at the strategy layer: the `refund`
+// strategy (kind=REFUND, any provider) and the `cardSpend` guard that
+// re-routes negative-amount spend auths (Rain card refunds arrive as credit
+// authorizations under the CARD_SPEND_* kinds). Strategies are pure functions
+// of the wire row, so we call them directly.
+
+import { refund } from '../intent/refund'
+import { cardSpend } from '../intent/card'
+import { type HistoryEntry } from '@/utils/history.utils'
+
+// The strategies read only `entry.amount` + a few `extraData` fields; build
+// minimal rows and cast rather than constructing a full HistoryEntry.
+const entry = (over: { amount?: string; extraData?: Record<string, unknown> }): HistoryEntry =>
+    ({ amount: over.amount ?? '0', extraData: over.extraData ?? {} }) as unknown as HistoryEntry
+
+describe('refund strategy (kind=REFUND)', () => {
+    test('RAIN provider → card refund shape ("Refund from {merchant}")', () => {
+        const out = refund(entry({ extraData: { provider: 'RAIN', merchantName: 'Acme Coffee' } }))
+        expect(out.direction).toBe('receive')
+        expect(out.transactionCardType).toBe('refund')
+        expect(out.nameForDetails).toBe('Refund from Acme Coffee')
+    })
+
+    test('parentRainTxId present but no provider → still the Rain card-refund lane', () => {
+        const out = refund(entry({ extraData: { parentRainTxId: 'rain-456', merchantName: 'Acme Coffee' } }))
+        expect(out.transactionCardType).toBe('refund')
+        expect(out.nameForDetails).toBe('Refund from Acme Coffee')
+    })
+
+    test('MANTECA (no Rain signal) → generic "Refund" credit row', () => {
+        const out = refund(entry({ extraData: { provider: 'MANTECA' } }))
+        expect(out.direction).toBe('receive')
+        expect(out.transactionCardType).toBe('refund')
+        expect(out.nameForDetails).toBe('Refund')
+    })
+})
+
+describe('cardSpend refund detection (negative-amount auths)', () => {
+    test('negative wire amount → routes to the card-refund shape', () => {
+        const out = cardSpend(entry({ amount: '-14.68', extraData: { merchantName: 'Acme Coffee' } }))
+        expect(out.direction).toBe('receive')
+        expect(out.transactionCardType).toBe('refund')
+        expect(out.nameForDetails).toBe('Refund from Acme Coffee')
+    })
+
+    test('extraData.isRefund true with a positive amount → card refund (post-PR-2 tolerance)', () => {
+        // After PR 2 the BE abs()es the amount, so the sign is gone — the
+        // isRefund flag must still route the row to the refund lane.
+        const out = cardSpend(entry({ amount: '14.68', extraData: { isRefund: true, merchantName: 'Acme Coffee' } }))
+        expect(out.transactionCardType).toBe('refund')
+    })
+
+    test('positive spend, no refund signal → unchanged card_pay (regression)', () => {
+        const out = cardSpend(entry({ amount: '14.68', extraData: { merchantName: 'Acme Coffee' } }))
+        expect(out.transactionCardType).toBe('card_pay')
+        expect(out.nameForDetails).toBe('Acme Coffee')
+    })
+})

--- a/src/components/TransactionDetails/strategies/fallback.ts
+++ b/src/components/TransactionDetails/strategies/fallback.ts
@@ -6,12 +6,10 @@ import { pipelineAlert } from '@/utils/pipelineAlerts'
 export const intentFallback: TransactionStrategy = (entry: HistoryEntry): TransactionStrategyOutput => {
     const kind = (entry.extraData?.kind as string | undefined) ?? 'OTHER'
 
-    // Rain card refunds arrive with parentRainTxId set (provider === RAIN).
-    // CARD_AUTH_REVERSAL is the canonical reversal kind (wired in the
-    // registry); OTHER / REFUND catch any historical rows whose kind hasn't
-    // been backfilled. Both lanes route to cardRefund — anything else is
-    // logged as an unknown kind.
-    if ((kind === 'OTHER' || kind === 'REFUND') && entry.extraData?.parentRainTxId) {
+    // Kindless/OTHER historical Rain refund rows carry parentRainTxId —
+    // route them to cardRefund. (kind === 'REFUND' never reaches here:
+    // the registry dispatches it to the refund strategy.)
+    if (kind === 'OTHER' && entry.extraData?.parentRainTxId) {
         return cardRefund(entry)
     }
 

--- a/src/components/TransactionDetails/strategies/intent/card.ts
+++ b/src/components/TransactionDetails/strategies/intent/card.ts
@@ -14,6 +14,14 @@ export const qrPay: TransactionStrategy = (entry: HistoryEntry): TransactionStra
 }
 
 export const cardSpend: TransactionStrategy = (entry: HistoryEntry): TransactionStrategyOutput => {
+    // Rain card refunds arrive as negative-amount spend auths (a credit
+    // authorization booked under the same CARD_SPEND_* kinds, all of which
+    // route here). BE flags them via extraData.isRefund; until that ships we
+    // also detect the negative wire amount directly, so PR 1 works against
+    // today's payload. Either way, render them as a refund credit.
+    if (entry.extraData?.isRefund === true || Number(entry.amount) < 0) {
+        return cardRefund(entry)
+    }
     const merchantName = (entry.extraData?.merchantName as string | null | undefined) ?? null
     return {
         direction: 'qr_payment',
@@ -32,7 +40,7 @@ export const cardRefund: TransactionStrategy = (entry: HistoryEntry): Transactio
     const cleaned = merchantName ? normalizeMerchantName(merchantName) : null
     return {
         direction: 'receive',
-        transactionCardType: 'receive',
+        transactionCardType: 'refund',
         nameForDetails: cleaned ? `Refund from ${cleaned}` : 'Card refund',
         isPeerActuallyUser: false,
         isLinkTx: false,

--- a/src/components/TransactionDetails/strategies/intent/card.ts
+++ b/src/components/TransactionDetails/strategies/intent/card.ts
@@ -1,6 +1,6 @@
 import { type HistoryEntry } from '@/hooks/useTransactionHistory'
 import { type TransactionStrategy, type TransactionStrategyOutput } from '../types'
-import { normalizeMerchantName } from '@/components/TransactionDetails/transaction-details.utils'
+import { isNegativeWireAmount, normalizeMerchantName } from '@/components/TransactionDetails/transaction-details.utils'
 
 export const qrPay: TransactionStrategy = (entry: HistoryEntry): TransactionStrategyOutput => {
     const raw = entry.recipientAccount?.identifier
@@ -19,7 +19,7 @@ export const cardSpend: TransactionStrategy = (entry: HistoryEntry): Transaction
     // route here). BE flags them via extraData.isRefund; until that ships we
     // also detect the negative wire amount directly, so PR 1 works against
     // today's payload. Either way, render them as a refund credit.
-    if (entry.extraData?.isRefund === true || Number(entry.amount) < 0) {
+    if (entry.extraData?.isRefund === true || isNegativeWireAmount(entry.amount)) {
         return cardRefund(entry)
     }
     const merchantName = (entry.extraData?.merchantName as string | null | undefined) ?? null

--- a/src/components/TransactionDetails/strategies/intent/refund.ts
+++ b/src/components/TransactionDetails/strategies/intent/refund.ts
@@ -16,8 +16,8 @@ import { cardRefund } from './card'
 export const refund: TransactionStrategy = (entry: HistoryEntry): TransactionStrategyOutput => {
     // Rain when EITHER signal is present — provider tells us directly, and
     // parentRainTxId catches older/kindless rows that predate the provider
-    // field (mirrors fallback.ts, keeping the two Rain lanes consistent). A
-    // Manteca refund has neither, so it falls through to the generic shape.
+    // field. A Manteca refund has neither, so it falls through to the
+    // generic shape.
     const isRainRefund = entry.extraData?.provider === 'RAIN' || !!entry.extraData?.parentRainTxId
     if (isRainRefund) {
         return cardRefund(entry)

--- a/src/components/TransactionDetails/strategies/intent/refund.ts
+++ b/src/components/TransactionDetails/strategies/intent/refund.ts
@@ -1,0 +1,33 @@
+import { type HistoryEntry } from '@/hooks/useTransactionHistory'
+import { type TransactionStrategy, type TransactionStrategyOutput } from '../types'
+import { cardRefund } from './card'
+
+// Strategy for kind=REFUND intents (any provider). Two shapes converge here:
+//
+//   - Rain card refunds — provider RAIN, or carrying `parentRainTxId`. These
+//     mirror the card-spend refund exactly: "Refund from {merchant}", the
+//     credit-card avatar, direction 'receive'. Delegate to `cardRefund` so the
+//     two lanes stay identical.
+//   - Manteca QR-pay refunds — no Rain signal. A generic "Refund" credit row.
+//
+// Both keep direction 'receive' (drives the '+' sign) and transactionCardType
+// 'refund' (drives the arrow-down-left icon + "Refund" label). The refund row
+// is the *credit*; the original spend row keeps its own REFUNDED strikethrough.
+export const refund: TransactionStrategy = (entry: HistoryEntry): TransactionStrategyOutput => {
+    // Rain when EITHER signal is present — provider tells us directly, and
+    // parentRainTxId catches older/kindless rows that predate the provider
+    // field (mirrors fallback.ts, keeping the two Rain lanes consistent). A
+    // Manteca refund has neither, so it falls through to the generic shape.
+    const isRainRefund = entry.extraData?.provider === 'RAIN' || !!entry.extraData?.parentRainTxId
+    if (isRainRefund) {
+        return cardRefund(entry)
+    }
+
+    return {
+        direction: 'receive',
+        transactionCardType: 'refund',
+        nameForDetails: 'Refund',
+        isPeerActuallyUser: false,
+        isLinkTx: false,
+    }
+}

--- a/src/components/TransactionDetails/strategies/registry.ts
+++ b/src/components/TransactionDetails/strategies/registry.ts
@@ -14,6 +14,7 @@ import { fiatOfframp } from './intent/fiat-offramp'
 import { fiatOnramp } from './intent/fiat-onramp'
 import { perkReward } from './intent/perk-reward'
 import { qrPay, cardSpend } from './intent/card'
+import { refund } from './intent/refund'
 import { intentFallback } from './fallback'
 
 // IntentKind enumerates every raw TransactionIntentKind value the FE
@@ -34,6 +35,7 @@ export type IntentKind =
     | 'CARD_SPEND_AUTH'
     | 'CARD_SPEND_CLEAR'
     | 'CARD_AUTH_REVERSAL'
+    | 'REFUND'
     | 'PERK_REWARD'
 
 const STRATEGIES: Record<IntentKind, TransactionStrategy> = {
@@ -49,6 +51,7 @@ const STRATEGIES: Record<IntentKind, TransactionStrategy> = {
     CARD_SPEND_AUTH: cardSpend,
     CARD_SPEND_CLEAR: cardSpend,
     CARD_AUTH_REVERSAL: cardSpend,
+    REFUND: refund,
     PERK_REWARD: perkReward,
 }
 

--- a/src/components/TransactionDetails/transaction-details.utils.ts
+++ b/src/components/TransactionDetails/transaction-details.utils.ts
@@ -88,3 +88,14 @@ export function normalizeMerchantName(raw: string): string {
     if (raw.length <= ACRONYM_LENGTH_THRESHOLD) return raw
     return raw.toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase())
 }
+
+/** Refund detection off the wire amount. BE amounts are plain decimal
+ *  strings ("14.68"), but parse defensively (strip currency formatting,
+ *  same as the drawer's usdAmount parsing) — `Number('-1,468')` is NaN and
+ *  `NaN < 0` would silently drop the refund route. Shared by the cardSpend
+ *  strategy and the drawer's cardPayment.isRefund flag. */
+export function isNegativeWireAmount(amount: string | number | null | undefined): boolean {
+    if (amount === null || amount === undefined) return false
+    const n = parseFloat(String(amount).replace(/[^\d.-]/g, ''))
+    return Number.isFinite(n) && n < 0
+}

--- a/src/components/TransactionDetails/transaction-details.utils.ts
+++ b/src/components/TransactionDetails/transaction-details.utils.ts
@@ -89,13 +89,19 @@ export function normalizeMerchantName(raw: string): string {
     return raw.toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
-/** Refund detection off the wire amount. BE amounts are plain decimal
- *  strings ("14.68"), but parse defensively (strip currency formatting,
- *  same as the drawer's usdAmount parsing) — `Number('-1,468')` is NaN and
- *  `NaN < 0` would silently drop the refund route. Shared by the cardSpend
- *  strategy and the drawer's cardPayment.isRefund flag. */
+/** Parse a wire amount defensively. BE amounts are plain decimal strings
+ *  ("14.68"), but strip currency formatting before parsing — `Number('-1,468')`
+ *  is NaN. Single source of the parse rule for the TransactionDetails module
+ *  (list-row refund detection AND the transformer's usdAmount), so the two
+ *  can never read the same wire amount differently. */
+export function parseWireAmount(amount: string | number | null | undefined): number {
+    if (amount === null || amount === undefined) return NaN
+    return parseFloat(String(amount).replace(/[^\d.-]/g, ''))
+}
+
+/** Refund detection off the wire amount — NaN never routes to refund. Used
+ *  by the cardSpend strategy's negative-auth detection. */
 export function isNegativeWireAmount(amount: string | number | null | undefined): boolean {
-    if (amount === null || amount === undefined) return false
-    const n = parseFloat(String(amount).replace(/[^\d.-]/g, ''))
+    const n = parseWireAmount(amount)
     return Number.isFinite(n) && n < 0
 }

--- a/src/components/TransactionDetails/transaction-types.ts
+++ b/src/components/TransactionDetails/transaction-types.ts
@@ -44,3 +44,9 @@ export type TransactionType =
     // so the avatar logic can render a credit-card icon instead of the
     // Mercado Pago / PIX brand mark or the generic wallet fallback.
     | 'card_pay'
+    // Refund credit rows — Rain card refunds (negative-amount spend auths or
+    // kind=REFUND) and Manteca QR-pay refunds. Direction stays 'receive' (so
+    // the balance-change sign is '+'); this presentation type drives the
+    // arrow-down-left icon + "Refund" label and keeps the row visually
+    // distinct from a plain 'receive'.
+    | 'refund'

--- a/src/components/TransactionDetails/transactionTransformer.ts
+++ b/src/components/TransactionDetails/transactionTransformer.ts
@@ -17,6 +17,7 @@ import type { Address } from 'viem'
 import { PEANUT_WALLET_CHAIN } from '@/constants/zerodev.consts'
 import { type HistoryEntryPerkReward, type ChargeEntry } from '@/services/services.types'
 import { dispatchStrategy, isIntentKind, type IntentKind } from './strategies/registry'
+import { parseWireAmount } from './transaction-details.utils'
 
 /** Rain dispute lifecycle status values. Source: Rain dispute.* webhooks. */
 export type DisputeStatus = 'pending' | 'inReview' | 'accepted' | 'rejected' | 'canceled' | 'resolvedByMerchant'
@@ -455,6 +456,12 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
     const out = dispatchStrategy(entry)(entry)
     const direction: TransactionDirection = out.direction
     const transactionCardType: TransactionCardType = out.transactionCardType
+    // Role for display strings (the +/- sign, the receipt's "Sent/Received"
+    // label). A pre-#1144 BE reports SENDER on negative-amount card auths,
+    // but the strategy has already classified the row as a refund credit —
+    // trust the strategy verdict so the receipt can't contradict the header.
+    const displayUserRole =
+        transactionCardType === 'refund' ? EHistoryUserRole.RECIPIENT : (entry.userRole as EHistoryUserRole)
     let nameForDetails = out.nameForDetails
     let isPeerActuallyUser = out.isPeerActuallyUser
     const isLinkTx = out.isLinkTx
@@ -500,9 +507,7 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
     }
 
     // parse the amount from the usdamount string in extradata
-    const baseAmount = entry.extraData?.usdAmount
-        ? parseFloat(String(entry.extraData.usdAmount).replace(/[^\d.-]/g, ''))
-        : 0
+    const baseAmount = entry.extraData?.usdAmount ? parseWireAmount(entry.extraData.usdAmount) : 0
     // Bake the cross-chain network fee into the displayed amount (product
     // convention: fees are part of the amount, never a separate line — see the
     // `fee: undefined` note below). The BE only sets `networkFeeUsd` for a
@@ -536,7 +541,7 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
         fullName,
         showFullName,
         currency: rewardData ? undefined : entry.currency,
-        currencySymbol: `${entry.userRole === EHistoryUserRole.SENDER ? '-' : '+'}$`,
+        currencySymbol: `${displayUserRole === EHistoryUserRole.SENDER ? '-' : '+'}$`,
         tokenSymbol: rewardData?.getSymbol(amount) ?? entry.tokenSymbol,
         initials: getInitialsFromName(nameForInitials),
         status: uiStatus,
@@ -573,7 +578,7 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
         extraDataForDrawer: {
             addressExplorerUrl,
             originalType: 'TRANSACTION_INTENT',
-            originalUserRole: entry.userRole as EHistoryUserRole,
+            originalUserRole: displayUserRole,
             kind: intentKindOf(entry),
             provider: entry.extraData?.provider as Provider | undefined,
             bridgeFlow: entry.extraData?.bridgeFlow,

--- a/src/components/TransactionDetails/transactionTransformer.ts
+++ b/src/components/TransactionDetails/transactionTransformer.ts
@@ -17,6 +17,7 @@ import type { Address } from 'viem'
 import { PEANUT_WALLET_CHAIN } from '@/constants/zerodev.consts'
 import { type HistoryEntryPerkReward, type ChargeEntry } from '@/services/services.types'
 import { dispatchStrategy, isIntentKind, type IntentKind } from './strategies/registry'
+import { isNegativeWireAmount } from './transaction-details.utils'
 
 /** Rain dispute lifecycle status values. Source: Rain dispute.* webhooks. */
 export type DisputeStatus = 'pending' | 'inReview' | 'accepted' | 'rejected' | 'canceled' | 'resolvedByMerchant'
@@ -625,7 +626,7 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
                           isRefund:
                               !!entry.extraData?.parentRainTxId ||
                               entry.extraData?.isRefund === true ||
-                              Number(entry.amount) < 0,
+                              isNegativeWireAmount(entry.amount),
                           // Dispute lifecycle — null when Rain hasn't fired
                           // any dispute.* webhook for this spend.
                           dispute: (() => {

--- a/src/components/TransactionDetails/transactionTransformer.ts
+++ b/src/components/TransactionDetails/transactionTransformer.ts
@@ -17,7 +17,6 @@ import type { Address } from 'viem'
 import { PEANUT_WALLET_CHAIN } from '@/constants/zerodev.consts'
 import { type HistoryEntryPerkReward, type ChargeEntry } from '@/services/services.types'
 import { dispatchStrategy, isIntentKind, type IntentKind } from './strategies/registry'
-import { isNegativeWireAmount } from './transaction-details.utils'
 
 /** Rain dispute lifecycle status values. Source: Rain dispute.* webhooks. */
 export type DisputeStatus = 'pending' | 'inReview' | 'accepted' | 'rejected' | 'canceled' | 'resolvedByMerchant'
@@ -623,10 +622,11 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
                           cancellationReason: entry.extraData?.cancellationReason as string | null,
                           parentRainTxId: entry.extraData?.parentRainTxId as string | null,
                           rainTransactionId: entry.extraData?.rainTransactionId as string | null,
-                          isRefund:
-                              !!entry.extraData?.parentRainTxId ||
-                              entry.extraData?.isRefund === true ||
-                              isNegativeWireAmount(entry.amount),
+                          // Reuse the strategy verdict instead of re-deriving the
+                          // parentRainTxId/isRefund/negative-amount heuristic here —
+                          // a local copy would silently diverge from the strategy
+                          // layer as its rules evolve (CodeRabbit #2373).
+                          isRefund: transactionCardType === 'refund',
                           // Dispute lifecycle — null when Rain hasn't fired
                           // any dispute.* webhook for this spend.
                           dispute: (() => {

--- a/src/components/TransactionDetails/transactionTransformer.ts
+++ b/src/components/TransactionDetails/transactionTransformer.ts
@@ -622,7 +622,10 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
                           cancellationReason: entry.extraData?.cancellationReason as string | null,
                           parentRainTxId: entry.extraData?.parentRainTxId as string | null,
                           rainTransactionId: entry.extraData?.rainTransactionId as string | null,
-                          isRefund: !!entry.extraData?.parentRainTxId,
+                          isRefund:
+                              !!entry.extraData?.parentRainTxId ||
+                              entry.extraData?.isRefund === true ||
+                              Number(entry.amount) < 0,
                           // Dispute lifecycle — null when Rain hasn't fired
                           // any dispute.* webhook for this spend.
                           dispute: (() => {

--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -124,6 +124,11 @@ export interface HistoryEntryExtraData {
     // Card-spend cluster. Populated for Rain CARD_SPEND / card-refund
     // intents only.
     parentRainTxId?: string | null
+    /** BE-classified refund flag (serializer-time). True for kind=REFUND (any
+     *  provider) and negative-amount card-spend auths. Mirrors the BE
+     *  `mapGenericIntent` projector; the FE also derives defensively from the
+     *  wire amount so this works before the BE change ships. */
+    isRefund?: boolean
     rainTransactionId?: string | null
     cardAuthAmount?: string | null
     cardSettledAmount?: string | null


### PR DESCRIPTION
## Why

Refund transactions render as regular payments in the transaction feed — no "Refund" tag, wrong direction, and for Manteca a bare "$0.00 send". The FE only shows a refund tag on the **original spend** row (when `uiStatus === 'refunded'`), never on the refund **credit** itself. Three wire shapes all miss the tag: Rain negative-amount spend auths, Rain `kind=REFUND` events, and Manteca `kind=REFUND` intents.

This is **PR 1 of 2** (FE-first). Paired backend PR: `peanut-api-ts#fix/refund-classification`, which classifies refunds at serializer time via an additive `extraData.isRefund`. PR 1 ships first and is independently useful.

## What

Classify refunds at the strategy layer:

- **New `'refund'` presentation type** (`transaction-types.ts`) — `arrow-down-left` icon + "Refund" label (`TYPE_PRESENTATION`), credit-card avatar treatment (shares the `card_pay` branch in `TransactionAvatarBadge`).
- **`cardRefund`** now emits `transactionCardType: 'refund'` (was `'receive'`); **`cardSpend`** re-routes negative-amount auths (Rain refunds arrive as credit authorizations under the `CARD_SPEND_*` kinds).
- **New `REFUND` strategy** (`strategies/intent/refund.ts`, wired in `registry.ts`) — Rain refunds (`provider === 'RAIN'` or `parentRainTxId`) take the card-refund lane ("Refund from {merchant}"); Manteca refunds get a generic "Refund" credit row.
- **Drawer `isRefund` flag** broadened; `HistoryEntryExtraData` gains `isRefund?: boolean` (mirrors the BE projector).

Direction stays `receive`, so the already-abs'd magnitude renders as **+$X** with a normal (non-`refunded`) status pill — no strikethrough. The original-spend `REFUNDED` row is untouched.

**Deploy-order tolerant by design:** detection is defensive (`extraData.isRefund === true || kind REFUND || negative amount`), so this works against today's wire and keeps working after PR 2 abs()es amounts. `fallback.ts`'s `parentRainTxId` REFUND arm becomes dead-defensive (kindless historical rows) — left in place intentionally.

## Tests

- New `strategies/__tests__/refund.test.ts` — RAIN/Manteca routing, negative-auth detection, `isRefund` tolerance, positive-spend regression.
- Extended `transactionTransformer.test.ts` — REFUND shapes, negative auth stays `pending` (keeps the `+` sign), drawer `isRefund` flag, and `pipelineAlert('unknown_transformer_kind')` no longer fires for `REFUND`.
- Re-baked `render-baseline.json` — one case (`refund-manteca-cancelled-recipient`) flips `send → refund/receive`.

**Gate:** typecheck 0 errors · prettier clean · 110 Jest suites green · `next build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
