### PR TITLE
fix(history): clear copy for failed collateral QR-pays (no false charge claim)

### DIFF
--- a/src/components/TransactionDetails/TransactionDetailsHeaderCard.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsHeaderCard.tsx
@@ -120,7 +120,10 @@ const getTitle = (
                 if (status === 'completed') {
                     titleText = `Paid to ${displayName}`
                 } else if (status === 'failed') {
-                    titleText = `Payment to ${displayName}`
+                    // Failed QR-pays carry a self-contained label from the
+                    // transformer ("Failed QR payment attempt") — no "Payment to"
+                    // prefix, which would read "Payment to Failed QR payment attempt".
+                    titleText = displayName
                 } else {
                     titleText = `Paying to ${displayName}`
                 }

--- a/src/components/TransactionDetails/__tests__/transactionTransformer.test.ts
+++ b/src/components/TransactionDetails/__tests__/transactionTransformer.test.ts
@@ -386,7 +386,7 @@ const cases: TestCase[] = [
         expect: { userName: 'alice' },
     },
     {
-        name: 'failed collateral QR_PAY (no reaper reason) renders neutral "didn\'t complete" copy',
+        name: 'failed collateral QR_PAY (no reaper reason) renders "Failed QR payment attempt" copy',
         entry: baseEntry({
             userRole: EHistoryUserRole.SENDER,
             status: EHistoryStatus.FAILED,
@@ -394,7 +394,7 @@ const cases: TestCase[] = [
         }),
         // Overrides the misleading "QR payment to <merchant>" the kind-switch
         // would produce for a FAILED row (peanut-api-ts #1146 surfaces these).
-        expect: { userName: "QR payment didn't complete" },
+        expect: { userName: 'Failed QR payment attempt' },
     },
 ]
 

--- a/src/components/TransactionDetails/__tests__/transactionTransformer.test.ts
+++ b/src/components/TransactionDetails/__tests__/transactionTransformer.test.ts
@@ -385,6 +385,17 @@ const cases: TestCase[] = [
         }),
         expect: { userName: 'alice' },
     },
+    {
+        name: 'failed collateral QR_PAY (no reaper reason) renders neutral "didn\'t complete" copy',
+        entry: baseEntry({
+            userRole: EHistoryUserRole.SENDER,
+            status: EHistoryStatus.FAILED,
+            extraData: { kind: 'QR_PAY', merchantName: 'MERPAGO*CARREFOUR' },
+        }),
+        // Overrides the misleading "QR payment to <merchant>" the kind-switch
+        // would produce for a FAILED row (peanut-api-ts #1146 surfaces these).
+        expect: { userName: "QR payment didn't complete" },
+    },
 ]
 
 describe('mapTransactionDataForDrawer', () => {

--- a/src/components/TransactionDetails/transactionTransformer.ts
+++ b/src/components/TransactionDetails/transactionTransformer.ts
@@ -488,7 +488,7 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
         // happened. Deliberately does NOT assert charge status — a payment that
         // settles then fails is refunded elsewhere — so "didn't complete" is honest
         // whether or not funds moved; the ledger stays the source of truth for that.
-        nameForDetails = REAPER_FAIL_COPY['qr_pay_timeout']
+        nameForDetails = 'Failed QR payment attempt'
         isPeerActuallyUser = false
     }
 

--- a/src/components/TransactionDetails/transactionTransformer.ts
+++ b/src/components/TransactionDetails/transactionTransformer.ts
@@ -480,6 +480,16 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
     if (entry.status === 'FAILED' && reaperFailReason && reaperFailReason.endsWith('_timeout')) {
         nameForDetails = REAPER_FAIL_COPY[reaperFailReason] ?? 'Transaction did not complete'
         isPeerActuallyUser = false
+    } else if (entry.status === 'FAILED' && intentKindOf(entry) === 'QR_PAY') {
+        // A collateral QR-pay that failed at submit (e.g. the stale-approval 403)
+        // has no reaper _timeout reason, but the BE now surfaces it (peanut-api-ts
+        // #1146). Render the same neutral "didn't complete" copy instead of the
+        // kind-switch's "QR payment to <merchant>", which implies the payment
+        // happened. Deliberately does NOT assert charge status — a payment that
+        // settles then fails is refunded elsewhere — so "didn't complete" is honest
+        // whether or not funds moved; the ledger stays the source of truth for that.
+        nameForDetails = REAPER_FAIL_COPY['qr_pay_timeout']
+        isPeerActuallyUser = false
     }
 
     // Strategy uiStatus wins (e.g. SEND_LINK BOTH → 'cancelled'); otherwise


### PR DESCRIPTION
- fixes TASK-20499

## Context

Companion to **[peanut-api-ts #1146](https://github.com/peanutprotocol/peanut-api-ts/pull/1146)**, which surfaces failed collateral QR-pays in transaction history so users see the attempt instead of assuming their funds vanished (CRIT support case, TASK-20499).

## Problem

The BE now returns those failed rows, but the FE reserved its clear failure copy for **reaper-timeout** rows only (gated on `failReason.endsWith('_timeout')`). The rows #1146 surfaces are real submit-failures (`card-spend-fail`, `failReason = null`), so they fell through to the generic kind-switch and rendered **"QR payment to \<merchant\>"** — implying the payment happened.

## Fix

1. **Transformer** (`transactionTransformer.ts`): a `FAILED` `QR_PAY` with no reaper reason now renders the self-contained label **"Failed QR payment attempt"** and drops the peer/merchant framing.
2. **Detail-drawer title** (`TransactionDetailsHeaderCard.tsx`): `getTitle()` prefixed a failed `qr_payment` with `Payment to ${name}`, which produced "Payment to Failed QR payment attempt" in the drawer. A failed QR-pay now uses the label directly — no prefix — matching how reaper-failed rows read.

### Deliberately charge-status-agnostic
The copy does **not** say "you weren't charged." A payment can settle then fail and get refunded, so a blanket not-charged claim would sometimes be wrong. The **ledger stays the source of truth** for charge status.

### Note on merchant name
Real failures of this kind carry **no merchant** (verified: 0/56 in prod) — the pay fails at the paymaster before the Manteca order that records the merchant is created. So "Failed QR payment attempt" (merchant-less) is the honest display. Surfacing the merchant on failures would require threading `paymentRecipientName` into the prepare intent — a separate follow-up.

## Tests

`transactionTransformer.test.ts`: a failed `QR_PAY` (no reaper reason) renders "Failed QR payment attempt". Full suite green (27/27); typecheck + prettier clean. Scoped to `QR_PAY` so the existing "non-reaper FAILED keeps original userName" case (DIRECT_TRANSFER) is unaffected.

Refs TASK-20499.