### PR TITLE
feat(notifications): capture push-click attribution in PostHog

### DIFF
--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -109,6 +109,7 @@ export const ANALYTICS_EVENTS = {
     NOTIFICATION_PERMISSION_GRANTED: 'notification_permission_granted',
     NOTIFICATION_PERMISSION_DENIED: 'notification_permission_denied',
     NOTIFICATION_SUBSCRIBED: 'notification_subscribed',
+    NOTIFICATION_CLICKED: 'notification_clicked',
 
     // ── Modal Fatigue ──
     MODAL_SHOWN: 'modal_shown',

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -7,6 +7,7 @@ import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils
 import { useUserStore } from '@/redux/hooks'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
+import { UTM_SOURCES, UTM_MEDIUMS } from '@/utils/utm.utils'
 
 export function useNotifications() {
     const { user } = useUserStore()
@@ -226,8 +227,8 @@ export function useNotifications() {
                             deep_link: event?.result?.url ?? event?.notification?.launchURL,
                         }
                         if (campaign) {
-                            props.utm_source = 'onesignal'
-                            props.utm_medium = 'push'
+                            props.utm_source = UTM_SOURCES.ONESIGNAL
+                            props.utm_medium = UTM_MEDIUMS.PUSH
                             props.utm_campaign = campaign
                             if (typeof data.utmContent === 'string') props.utm_content = data.utmContent
                         }

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -213,6 +213,27 @@ export function useNotifications() {
                         }
                     })
 
+                    // Notification tap → PostHog. OneSignal delivers push clicks to its own
+                    // SDK worker (bypassing our sw.ts handler), so this is the only client-side
+                    // hook that sees the tap. Firing an explicit event (with the campaign carried
+                    // in additionalData) makes blast clicks attributable even when the tap merely
+                    // focuses an already-open PWA tab and no `$pageview` — hence no utm capture —
+                    // fires. Marketing sends set `data.campaign`; transactional taps have none.
+                    OneSignal.Notifications.addEventListener('click', (event) => {
+                        const data = (event?.notification?.additionalData ?? {}) as Record<string, unknown>
+                        const campaign = typeof data.campaign === 'string' ? data.campaign : undefined
+                        const props: Record<string, unknown> = {
+                            deep_link: event?.result?.url ?? event?.notification?.launchURL,
+                        }
+                        if (campaign) {
+                            props.utm_source = 'onesignal'
+                            props.utm_medium = 'push'
+                            props.utm_campaign = campaign
+                            if (typeof data.utmContent === 'string') props.utm_content = data.utmContent
+                        }
+                        posthog.capture(ANALYTICS_EVENTS.NOTIFICATION_CLICKED, props)
+                    })
+
                     type PushSubscriptionChangeEvent = { current?: { optedIn?: boolean } | null }
                     OneSignal.User.PushSubscription.addEventListener(
                         'change',

--- a/src/utils/utm.utils.ts
+++ b/src/utils/utm.utils.ts
@@ -23,6 +23,8 @@ export const UTM_MEDIUMS = {
     REFERRAL: 'referral',
     /** Any email — newsletter, drip, transactional. */
     EMAIL: 'email',
+    /** Push / in-app notification blasts (delivered via OneSignal). */
+    PUSH: 'push',
     /** Organic social posts. */
     SOCIAL: 'social',
     /** Paid acquisition where we pay per click (Google ads, Meta ads). */
@@ -47,6 +49,8 @@ export const UTM_SOURCES = {
     CONTENT_HUB: 'c',
     /** Beehiiv-driven email. */
     BEEHIIV: 'beehiiv',
+    /** OneSignal-delivered messages (push + email blasts). Split by medium. */
+    ONESIGNAL: 'onesignal',
     TWITTER: 'twitter',
     INSTAGRAM: 'instagram',
     TIKTOK: 'tiktok',


### PR DESCRIPTION
## Summary

Companion to the peanut-api-ts push-UTM PR. Two gaps left OneSignal push blasts untracked in PostHog:

1. **No client-side event fired on a notification tap.** OneSignal's own SDK worker handles the click (bypassing our `sw.ts`), and on an installed PWA a tap often just *focuses the open tab* — so no `$pageview` fires and UTM capture alone misses the click.
2. **No `push` medium / `onesignal` source in the UTM taxonomy.**

This PR:
- Adds a `notification.clicked` listener in `useNotifications.ts` that fires a `notification_clicked` PostHog event, carrying the campaign from `additionalData` (`utm_source=onesignal`, `utm_medium=push`, `utm_campaign`, optional `utm_content`). Marketing sends set `data.campaign`; transactional taps have none and just log `deep_link`.
- Registers `utm_medium=push` + `utm_source=onesignal` in the typed `withUtm` builder (`utm.utils.ts`).
- Adds the `NOTIFICATION_CLICKED` analytics event constant.

## Risks / breaking changes

- **Low / additive.** One new event constant, one enum value in each of `UTM_MEDIUMS` / `UTM_SOURCES`, one listener registered alongside the existing permission/subscription listeners. No change to existing flows.
- **Cross-repo:** independent of the backend PR — either can merge first.

## QA

- `npm run typecheck` clean; `pnpm prettier --check .` clean.
- Manual: send a marketing push with `data.campaign` set, tap it, confirm a `notification_clicked` event lands in PostHog with `utm_campaign` + `utm_medium=push`. Confirm the tab-focus case (installed PWA, app already open) still emits the event even though no `$pageview` fires.
