### PR TITLE
feat: share badge from the detail modal (per-badge share copy)

### DIFF
--- a/src/components/Badges/BadgeDetailModal.tsx
+++ b/src/components/Badges/BadgeDetailModal.tsx
@@ -1,33 +1,52 @@
+'use client'
+
 import Image from 'next/image'
 import type { StaticImageData } from 'next/image'
 import ActionModal from '../Global/ActionModal'
+import ShareButton from '../Global/ShareButton'
+import { getBadgeShareText } from './badge.utils'
+import { useUserStore } from '@/redux/hooks'
+import { BASE_URL } from '@/constants/general.consts'
 
 type BadgeDetailModalProps = {
     isOpen: boolean
     onClose: () => void
+    code?: string
     title: string
     description: string
     logo: string | StaticImageData
 }
 
-// the focal badge detail popup — large badge image + name + description.
-// shared by the Your Badges list and the badge-unlock drawer so both
-// surfaces show the exact same modal.
-export const BadgeDetailModal = ({ isOpen, onClose, title, description, logo }: BadgeDetailModalProps) => (
-    <ActionModal
-        icon={<Image height={240} width={240} src={logo} alt={title} className="w-60 object-contain" unoptimized />}
-        iconContainerClassName="bg-transparent min-w-60 h-auto"
-        modalPanelClassName="m-0"
-        visible={isOpen}
-        onClose={onClose}
-        title={title}
-        description={description}
-        ctas={[
-            {
-                text: 'Got it!',
-                onClick: onClose,
-                shadowSize: '4',
-            },
-        ]}
-    />
-)
+// the focal badge detail popup — large badge image + name + description, plus a
+// Share CTA that drops a funny, badge-specific brag into the native share sheet
+// (Web Share API, clipboard fallback). Shared by the Your Badges list and the
+// badge-unlock drawer so both surfaces show the exact same modal. The modal's
+// top-right ✕ is the dismiss affordance now that "Got it" became "Share badge".
+export const BadgeDetailModal = ({ isOpen, onClose, code, title, description, logo }: BadgeDetailModalProps) => {
+    const { user: authUser } = useUserStore()
+    const username = authUser?.user?.username
+    // the sharer's own public profile — showcases their badges + carries the join CTA
+    const profileUrl = username ? `${BASE_URL}/${username}` : BASE_URL
+
+    return (
+        <ActionModal
+            icon={<Image height={240} width={240} src={logo} alt={title} className="w-60 object-contain" unoptimized />}
+            iconContainerClassName="bg-transparent min-w-60 h-auto"
+            modalPanelClassName="m-0"
+            visible={isOpen}
+            onClose={onClose}
+            title={title}
+            description={description}
+            content={
+                <ShareButton
+                    title=""
+                    className="w-full"
+                    onSuccess={onClose}
+                    generateText={() => Promise.resolve(getBadgeShareText(code, title, profileUrl))}
+                >
+                    Share badge
+                </ShareButton>
+            }
+        />
+    )
+}

--- a/src/components/Badges/BadgeDetailModal.tsx
+++ b/src/components/Badges/BadgeDetailModal.tsx
@@ -2,22 +2,31 @@
 
 import Image from 'next/image'
 import type { StaticImageData } from 'next/image'
-import { useTranslations } from 'next-intl'
 import ActionModal from '../Global/ActionModal'
+import ShareButton from '../Global/ShareButton'
+import { getBadgeShareText } from './badge.utils'
+import { useUserStore } from '@/redux/hooks'
+import { BASE_URL } from '@/constants/general.consts'
 
 type BadgeDetailModalProps = {
     isOpen: boolean
     onClose: () => void
+    code?: string
     title: string
     description: string
     logo: string | StaticImageData
 }
 
-// the focal badge detail popup — large badge image + name + description.
-// shared by the Your Badges list and the badge-unlock drawer so both
-// surfaces show the exact same modal.
-export const BadgeDetailModal = ({ isOpen, onClose, title, description, logo }: BadgeDetailModalProps) => {
-    const t = useTranslations('common')
+// the focal badge detail popup — large badge image + name + description, plus a
+// Share CTA that drops a funny, badge-specific brag into the native share sheet
+// (Web Share API, clipboard fallback). Shared by the Your Badges list and the
+// badge-unlock drawer so both surfaces show the exact same modal. The modal's
+// top-right ✕ is the dismiss affordance now that "Got it" became "Share badge".
+export const BadgeDetailModal = ({ isOpen, onClose, code, title, description, logo }: BadgeDetailModalProps) => {
+    const { user: authUser } = useUserStore()
+    const username = authUser?.user?.username
+    // the sharer's own public profile — showcases their badges + carries the join CTA
+    const profileUrl = username ? `${BASE_URL}/${username}` : BASE_URL
 
     return (
         <ActionModal
@@ -28,13 +37,16 @@ export const BadgeDetailModal = ({ isOpen, onClose, title, description, logo }: 
             onClose={onClose}
             title={title}
             description={description}
-            ctas={[
-                {
-                    text: t('gotIt'),
-                    onClick: onClose,
-                    shadowSize: '4',
-                },
-            ]}
+            content={
+                <ShareButton
+                    title=""
+                    className="w-full"
+                    onSuccess={onClose}
+                    generateText={() => Promise.resolve(getBadgeShareText(code, title, profileUrl))}
+                >
+                    Share badge
+                </ShareButton>
+            }
         />
     )
 }

--- a/src/components/Badges/BadgeDetailModal.tsx
+++ b/src/components/Badges/BadgeDetailModal.tsx
@@ -2,31 +2,22 @@
 
 import Image from 'next/image'
 import type { StaticImageData } from 'next/image'
+import { useTranslations } from 'next-intl'
 import ActionModal from '../Global/ActionModal'
-import ShareButton from '../Global/ShareButton'
-import { getBadgeShareText } from './badge.utils'
-import { useUserStore } from '@/redux/hooks'
-import { BASE_URL } from '@/constants/general.consts'
 
 type BadgeDetailModalProps = {
     isOpen: boolean
     onClose: () => void
-    code?: string
     title: string
     description: string
     logo: string | StaticImageData
 }
 
-// the focal badge detail popup — large badge image + name + description, plus a
-// Share CTA that drops a funny, badge-specific brag into the native share sheet
-// (Web Share API, clipboard fallback). Shared by the Your Badges list and the
-// badge-unlock drawer so both surfaces show the exact same modal. The modal's
-// top-right ✕ is the dismiss affordance now that "Got it" became "Share badge".
-export const BadgeDetailModal = ({ isOpen, onClose, code, title, description, logo }: BadgeDetailModalProps) => {
-    const { user: authUser } = useUserStore()
-    const username = authUser?.user?.username
-    // the sharer's own public profile — showcases their badges + carries the join CTA
-    const profileUrl = username ? `${BASE_URL}/${username}` : BASE_URL
+// the focal badge detail popup — large badge image + name + description.
+// shared by the Your Badges list and the badge-unlock drawer so both
+// surfaces show the exact same modal.
+export const BadgeDetailModal = ({ isOpen, onClose, title, description, logo }: BadgeDetailModalProps) => {
+    const t = useTranslations('common')
 
     return (
         <ActionModal
@@ -37,16 +28,13 @@ export const BadgeDetailModal = ({ isOpen, onClose, code, title, description, lo
             onClose={onClose}
             title={title}
             description={description}
-            content={
-                <ShareButton
-                    title=""
-                    className="w-full"
-                    onSuccess={onClose}
-                    generateText={() => Promise.resolve(getBadgeShareText(code, title, profileUrl))}
-                >
-                    Share badge
-                </ShareButton>
-            }
+            ctas={[
+                {
+                    text: t('gotIt'),
+                    onClick: onClose,
+                    shadowSize: '4',
+                },
+            ]}
         />
     )
 }

--- a/src/components/Badges/BadgeEarnToast.tsx
+++ b/src/components/Badges/BadgeEarnToast.tsx
@@ -28,7 +28,7 @@ import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 const HOME_PATH = '/home'
 
-type ModalBadge = { title: string; description: string; logo: string }
+type ModalBadge = { code: string; title: string; description: string; logo: string }
 
 export default function BadgeEarnToast() {
     const pathname = usePathname()
@@ -64,6 +64,7 @@ export default function BadgeEarnToast() {
             posthog.capture(ANALYTICS_EVENTS.BADGE_EARN_TOAST_TAPPED, { count })
             if (count === 1) {
                 setModalBadge({
+                    code: newest.code,
                     title: newestName,
                     description: newest.description || getPublicBadgeDescription(newest.code) || '',
                     logo: newestIcon,
@@ -116,6 +117,7 @@ export default function BadgeEarnToast() {
         <BadgeDetailModal
             isOpen
             onClose={() => setModalBadge(null)}
+            code={modalBadge.code}
             title={modalBadge.title}
             description={modalBadge.description}
             logo={modalBadge.logo}

--- a/src/components/Badges/BadgeStatusDrawer.tsx
+++ b/src/components/Badges/BadgeStatusDrawer.tsx
@@ -92,6 +92,7 @@ export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerP
             <BadgeDetailModal
                 isOpen={isDetailOpen}
                 onClose={() => setIsDetailOpen(false)}
+                code={badge.code}
                 title={displayName}
                 description={badge.description || ''}
                 logo={getBadgeIcon(badge.code)}

--- a/src/components/Badges/BadgeStatusDrawer.tsx
+++ b/src/components/Badges/BadgeStatusDrawer.tsx
@@ -6,7 +6,7 @@ import Card from '../Global/Card'
 import { PaymentInfoRow } from '../Payment/PaymentInfoRow'
 import ShareButton from '../Global/ShareButton'
 import { BadgeDetailModal } from './BadgeDetailModal'
-import { getBadgeDisplayName, getBadgeIcon } from './badge.utils'
+import { getBadgeDisplayName, getBadgeIcon, getBadgeShareText } from './badge.utils'
 import { BASE_URL } from '@/constants/general.consts'
 import { useAuth } from '@/context/authContext'
 
@@ -78,9 +78,7 @@ export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerP
                             <ShareButton
                                 title=""
                                 generateText={() =>
-                                    Promise.resolve(
-                                        `I earned ${displayName} badge on Peanut!\n\nJoin Peanut now and start earning points, unlocking achievements and moving money worldwide\n\n${profileLink}`
-                                    )
+                                    Promise.resolve(getBadgeShareText(badge.code, displayName, profileLink))
                                 }
                             >
                                 Share Achievement

--- a/src/components/Badges/BadgeStatusDrawer.tsx
+++ b/src/components/Badges/BadgeStatusDrawer.tsx
@@ -1,12 +1,12 @@
-import { Drawer, DrawerContent, DrawerTitle } from '@/components/Global/Drawer'
+import { Drawer, DrawerContent } from '@/components/Global/Drawer'
 import Image from 'next/image'
 import { useState } from 'react'
-import { useFormatter, useTranslations } from 'next-intl'
+import { formatDate } from '@/utils/general.utils'
 import Card from '../Global/Card'
 import { PaymentInfoRow } from '../Payment/PaymentInfoRow'
 import ShareButton from '../Global/ShareButton'
 import { BadgeDetailModal } from './BadgeDetailModal'
-import { getBadgeDisplayName, getBadgeIcon } from './badge.utils'
+import { getBadgeDisplayName, getBadgeIcon, getBadgeShareText } from './badge.utils'
 import { BASE_URL } from '@/constants/general.consts'
 import { useAuth } from '@/context/authContext'
 
@@ -24,23 +24,11 @@ export type BadgeStatusDrawerProps = {
 
 // shows a drawer for a newly unlocked badge
 export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerProps) => {
-    const t = useTranslations('badges')
-    const format = useFormatter()
     const { user: authUser } = useAuth()
     const [isDetailOpen, setIsDetailOpen] = useState(false)
     const username = authUser?.user.username
     const earnedAt = badge.earnedAt ? new Date(badge.earnedAt) : undefined
-    const dateStr =
-        earnedAt && !isNaN(earnedAt.getTime())
-            ? format.dateTime(earnedAt, {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric',
-                  hour: '2-digit',
-                  minute: '2-digit',
-                  hour12: false,
-              })
-            : undefined
+    const dateStr = earnedAt ? formatDate(earnedAt) : undefined
     const displayName = getBadgeDisplayName(badge.code, badge.name)
 
     // generate profile link for sharing
@@ -65,7 +53,7 @@ export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerP
                                 <div className="flex h-12 w-12 items-center justify-center rounded-full">
                                     <Image
                                         src={getBadgeIcon(badge.code)}
-                                        alt={t('iconAlt', { name: displayName })}
+                                        alt="Icon"
                                         className="size-full object-contain"
                                         width={160}
                                         height={160}
@@ -74,28 +62,26 @@ export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerP
 
                                 <div className="space-y-1">
                                     <h2 className="flex items-center gap-2 text-xs font-medium text-grey-1">
-                                        {t('unlocked')}
+                                        Badge unlocked!
                                     </h2>
-                                    <DrawerTitle className="text-lg font-extrabold md:text-4xl">
-                                        {displayName}
-                                    </DrawerTitle>
+                                    <h1 className={`text-lg font-extrabold md:text-4xl`}>{displayName}</h1>
                                 </div>
                             </div>
                         </Card>
 
                         <Card position="single">
-                            <PaymentInfoRow label={t('unlockedAtLabel')} value={dateStr} />
-                            <PaymentInfoRow label={t('reasonLabel')} value={badge.description} hideBottomBorder />
+                            <PaymentInfoRow label="Unlocked" value={dateStr} />
+                            <PaymentInfoRow label="Reason" value={badge.description} hideBottomBorder />
                         </Card>
 
                         <div className="pb-4">
                             <ShareButton
                                 title=""
                                 generateText={() =>
-                                    Promise.resolve(t('shareText', { badge: displayName, link: profileLink }))
+                                    Promise.resolve(getBadgeShareText(badge.code, displayName, profileLink))
                                 }
                             >
-                                {t('shareAchievement')}
+                                Share Achievement
                             </ShareButton>
                         </div>
                     </div>
@@ -104,6 +90,7 @@ export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerP
             <BadgeDetailModal
                 isOpen={isDetailOpen}
                 onClose={() => setIsDetailOpen(false)}
+                code={badge.code}
                 title={displayName}
                 description={badge.description || ''}
                 logo={getBadgeIcon(badge.code)}

--- a/src/components/Badges/BadgeStatusDrawer.tsx
+++ b/src/components/Badges/BadgeStatusDrawer.tsx
@@ -1,12 +1,12 @@
-import { Drawer, DrawerContent } from '@/components/Global/Drawer'
+import { Drawer, DrawerContent, DrawerTitle } from '@/components/Global/Drawer'
 import Image from 'next/image'
 import { useState } from 'react'
-import { formatDate } from '@/utils/general.utils'
+import { useFormatter, useTranslations } from 'next-intl'
 import Card from '../Global/Card'
 import { PaymentInfoRow } from '../Payment/PaymentInfoRow'
 import ShareButton from '../Global/ShareButton'
 import { BadgeDetailModal } from './BadgeDetailModal'
-import { getBadgeDisplayName, getBadgeIcon, getBadgeShareText } from './badge.utils'
+import { getBadgeDisplayName, getBadgeIcon } from './badge.utils'
 import { BASE_URL } from '@/constants/general.consts'
 import { useAuth } from '@/context/authContext'
 
@@ -24,11 +24,23 @@ export type BadgeStatusDrawerProps = {
 
 // shows a drawer for a newly unlocked badge
 export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerProps) => {
+    const t = useTranslations('badges')
+    const format = useFormatter()
     const { user: authUser } = useAuth()
     const [isDetailOpen, setIsDetailOpen] = useState(false)
     const username = authUser?.user.username
     const earnedAt = badge.earnedAt ? new Date(badge.earnedAt) : undefined
-    const dateStr = earnedAt ? formatDate(earnedAt) : undefined
+    const dateStr =
+        earnedAt && !isNaN(earnedAt.getTime())
+            ? format.dateTime(earnedAt, {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                  hour: '2-digit',
+                  minute: '2-digit',
+                  hour12: false,
+              })
+            : undefined
     const displayName = getBadgeDisplayName(badge.code, badge.name)
 
     // generate profile link for sharing
@@ -53,7 +65,7 @@ export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerP
                                 <div className="flex h-12 w-12 items-center justify-center rounded-full">
                                     <Image
                                         src={getBadgeIcon(badge.code)}
-                                        alt="Icon"
+                                        alt={t('iconAlt', { name: displayName })}
                                         className="size-full object-contain"
                                         width={160}
                                         height={160}
@@ -62,26 +74,28 @@ export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerP
 
                                 <div className="space-y-1">
                                     <h2 className="flex items-center gap-2 text-xs font-medium text-grey-1">
-                                        Badge unlocked!
+                                        {t('unlocked')}
                                     </h2>
-                                    <h1 className={`text-lg font-extrabold md:text-4xl`}>{displayName}</h1>
+                                    <DrawerTitle className="text-lg font-extrabold md:text-4xl">
+                                        {displayName}
+                                    </DrawerTitle>
                                 </div>
                             </div>
                         </Card>
 
                         <Card position="single">
-                            <PaymentInfoRow label="Unlocked" value={dateStr} />
-                            <PaymentInfoRow label="Reason" value={badge.description} hideBottomBorder />
+                            <PaymentInfoRow label={t('unlockedAtLabel')} value={dateStr} />
+                            <PaymentInfoRow label={t('reasonLabel')} value={badge.description} hideBottomBorder />
                         </Card>
 
                         <div className="pb-4">
                             <ShareButton
                                 title=""
                                 generateText={() =>
-                                    Promise.resolve(getBadgeShareText(badge.code, displayName, profileLink))
+                                    Promise.resolve(t('shareText', { badge: displayName, link: profileLink }))
                                 }
                             >
-                                Share Achievement
+                                {t('shareAchievement')}
                             </ShareButton>
                         </div>
                     </div>
@@ -90,7 +104,6 @@ export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerP
             <BadgeDetailModal
                 isOpen={isDetailOpen}
                 onClose={() => setIsDetailOpen(false)}
-                code={badge.code}
                 title={displayName}
                 description={badge.description || ''}
                 logo={getBadgeIcon(badge.code)}

--- a/src/components/Badges/__tests__/badge.utils.test.ts
+++ b/src/components/Badges/__tests__/badge.utils.test.ts
@@ -1,4 +1,4 @@
-import { BADGES, getBadgeIcon } from '../badge.utils'
+import { BADGES, getBadgeIcon, getBadgeShareText } from '../badge.utils'
 
 describe('getBadgeIcon', () => {
     it('returns the badge path for known codes', () => {
@@ -12,5 +12,29 @@ describe('getBadgeIcon', () => {
         expect(typeof getBadgeIcon('NOT_A_REAL_BADGE')).toBe('string')
         expect(getBadgeIcon('NOT_A_REAL_BADGE')).toBeTruthy()
         expect(getBadgeIcon(undefined)).toBe(getBadgeIcon('NOT_A_REAL_BADGE'))
+    })
+})
+
+describe('getBadgeShareText', () => {
+    const url = 'https://peanut.me/satoshi'
+
+    it('uses the badge-specific brag line for a known code and appends the profile url', () => {
+        const text = getBadgeShareText('CARD_FIRST_SWIPE', 'First Swipe', url)
+        expect(text.toLowerCase()).toContain('swipe')
+        expect(text).toContain(url)
+        // first-person voice — the sharer is bragging about themselves
+        expect(text).toMatch(/\b(I|my)\b/i)
+    })
+
+    it('falls back to a generic brag (with display name) for unknown / parked codes', () => {
+        const text = getBadgeShareText('NOT_A_REAL_BADGE', 'Mystery Badge', url)
+        expect(text).toContain('Mystery Badge')
+        expect(text).toContain(url)
+    })
+
+    it('still produces shareable text when the code is undefined', () => {
+        const text = getBadgeShareText(undefined, 'Some Badge', url)
+        expect(text).toContain('Some Badge')
+        expect(text).toContain(url)
     })
 })

--- a/src/components/Badges/__tests__/badge.utils.test.ts
+++ b/src/components/Badges/__tests__/badge.utils.test.ts
@@ -18,12 +18,15 @@ describe('getBadgeIcon', () => {
 describe('getBadgeShareText', () => {
     const url = 'https://peanut.me/satoshi'
 
-    it('uses the badge-specific brag line for a known code and appends the profile url', () => {
-        const text = getBadgeShareText('CARD_FIRST_SWIPE', 'First Swipe', url)
-        expect(text.toLowerCase()).toContain('swipe')
-        expect(text).toContain(url)
+    it('uses the badge-specific brag line for a known code (not the generic fallback) and appends the profile url', () => {
+        // Copy-agnostic on purpose: assert a mapped code yields something OTHER than
+        // the generic fallback, so editing a line never breaks this test.
+        const mapped = getBadgeShareText('CARD_FIRST_SWIPE', 'First Swipe', url)
+        const fallback = getBadgeShareText('___UNMAPPED___', 'First Swipe', url)
+        expect(mapped).not.toBe(fallback)
+        expect(mapped).toContain(url)
         // first-person voice — the sharer is bragging about themselves
-        expect(text).toMatch(/\b(I|my)\b/i)
+        expect(mapped).toMatch(/\b(I|my)\b/i)
     })
 
     it('falls back to a generic brag (with display name) for unknown / parked codes', () => {

--- a/src/components/Badges/badge.utils.ts
+++ b/src/components/Badges/badge.utils.ts
@@ -261,57 +261,56 @@ export function getBadgeDisplayName(code: string | undefined, fallback: string):
 
 // Funny, first-person share copy for each badge. The user is bragging about their
 // OWN achievement, so these read in first person ("I…") — unlike the third-person
-// `description` above (which narrates the badge to others). Thematically they mirror
-// each badge's description so the voice stays consistent across surfaces. Aliased
-// codes (CARD_PIONEER/FOUNDING_PIONEER, SUPPORT_SURVIVOR/BUG_WHISPERER) share a line;
-// unknown/parked codes fall back to a generic-but-proud brag in getBadgeShareText.
+// `description` above (which narrates the badge to others). Aliased codes
+// (CARD_PIONEER/FOUNDING_PIONEER, BUG_WHISPERER/SUPPORT_SURVIVOR) share a line.
+// Rarely-earned badges are intentionally OMITTED (e.g. CERTIFIED_YAPPER,
+// TOKEN_NATION_SP_2026, FESTA_JUNINA_2026) — getBadgeShareText falls back to a
+// generic brag for any code not listed, so a badge almost nobody has isn't worth
+// bespoke copy. Lines + the keep/blank split were chosen against real prod holder
+// counts; order below is roughly most-earned first.
 const BADGE_SHARE_LINES: Record<string, string> = {
     BETA_TESTER: "I've been in the Peanut lab since the early experiments. Officially a beta tester 🧪",
-    DEVCONNECT_BA_2025: 'Came to Devconnect BA, claimed my badge, ate the steak. Priorities 🥩🇦🇷',
-    PRODUCT_HUNT: 'I upvoted Peanut on Product Hunt before it was cool. Hope dealer, certified 🚀',
     OG_2025_10_12: 'I was here before it was cool. Certified Peanut OG 🥜',
-    MOST_RESTAURANTS_DEVCON:
-        'I hit more restaurants at Devconnect than the Michelin guide. Paid for all of them with Peanut 🍽️',
-    BIG_SPENDER_5K: "I didn't come to Devconnect to network. I came to spend. $5K later… 💸",
-    MOST_PAYMENTS_DEVCON: "I move money like it's light work. Most payments at Devconnect — certified money machine ⚡",
-    MOST_INVITES: "I onboarded more people to Peanut than Coinbase's ad budget did 📈",
-    BIGGEST_REQUEST_POT: 'High roller or master beggar? Either way I ran the biggest pot on Peanut 🫗',
-    SEEDLING_DEVCONNECT_BA_2025: "I shill Peanut so they don't have to. Honorary squirrel 🐿️",
-    ARBIVERSE_DEVCONNECT_BA_2025:
-        'Found the Arbiverse booth, walked out with a Peanut badge. Mutual onboarding achieved 🔵',
-    CARD_PIONEER: 'I was building Peanut before it had a launch. Founding Pioneer 🛠️',
-    FOUNDING_PIONEER: 'I was building Peanut before it had a launch. Founding Pioneer 🛠️',
-    FOUNDER_HOUSE: 'On-chain energy, off-chain handshakes. Built it IRL at Founder Haus 🤝',
+    DEVCONNECT_BA_2025: 'Buenos Aires ✅ Peanut badge ✅ A perfect trip',
+    ARBIVERSE_DEVCONNECT_BA_2025: 'I went looking for Arbitrum and Peanut found me 🔵',
+    OFFRAMP_USER: 'Cashed out the easy way. Offramp badge unlocked 💸',
     BUG_WHISPERER: 'I found a real bug in Peanut, reported it, and stuck around. Someone owes me a beer 🐛🍺',
     SUPPORT_SURVIVOR: 'I found a real bug in Peanut, reported it, and stuck around. Someone owes me a beer 🐛🍺',
-    SHHHHH: "I know the secret. That's all I'm allowed to say 🤫",
+    CARD_FIRST_SWIPE: 'Just put my Peanut card to work for the first time. They grow up so fast 💳',
+    WAITLIST_SKIP: "Got the skip pass. It's not what you know, it's who invites you 🔑",
+    EVENT_ALUMNI: 'Old school. I was in the room before most of you 🎟️',
+    IRL_NOMADS: 'Nomad mode on. My office is wherever the wifi is ☕',
+    ETHFLORIPA_HUB: 'Ilha da Magia, baby. Coconuts and consensus 🥥',
+    CARD_ALPHA: 'I tested the Peanut card while it was still held together with tape and hope 🩹💳',
+    SEEDLING_DEVCONNECT_BA_2025: "I shill Peanut so they don't have to. Honorary squirrel 🐿️",
+    CARD_SPENT_1K: "Crossed $1K on the Peanut card. It's earning its keep 💳",
+    FOUNDER_HOUSE: 'On-chain energy, off-chain handshakes. Built it IRL at Founder Haus 🤝',
     NOT_SO_SHHHH: "I couldn't keep the secret… and Peanut paid me for it 🤫💸",
-    CARD_FIRST_SWIPE: 'First swipe on my Peanut card. My money finally got a job 💳',
-    CARD_SPENT_1K: '$1K swiped on my Peanut card. I put my money where my card is 💳',
+    PSYOPS_DIVISION: 'Enlisted in the Peanut Psyops Division. The influence game is real 🧠',
+    TOUCHED_GRASS: 'Touched grass badge. Proof that I do go outside 🌱',
+    ARBITRUM: 'Peanut × Arbitrum. Fast chains, faster money 🔵',
+    BIG_SPENDER_5K: "I didn't come to Devconnect to network. I came to spend. $5K later… 💸",
+    BIGGEST_REQUEST_POT: 'High roller or master beggar? Either way I ran the biggest pot on Peanut 🫗',
+    CARD_CLOSED_BETA: 'I was testing the Peanut card before you knew it existed. IYKYK 🤫💳',
+    DOUBLE_DIGITS: 'Crossed into double digits on Peanut. Real money now 💰',
+    DUNBAR: "150 invites — more people than I can even remember. I hit Dunbar's number 🧠",
+    FIRST_CRUMB: 'Earned my first dollar on Peanut. Proof that it pays 🪙',
     FIRST_INVITE: 'Brought my first friend onto Peanut. One down, the whole group chat to go 👋',
-    SECOND_INVITE: "Two friends on Peanut and counting. Word's getting around 📣",
-    THIRD_INVITE: 'Three friends on Peanut, zero misses. Tip your hat 🎩',
-    MINI_INFLUENCER: 'Built a little Peanut fan club, one invite at a time 🌟',
+    MOST_RESTAURANTS_DEVCON:
+        'I hit more restaurants at Devconnect than the Michelin guide. Paid for all of them with Peanut 🍽️',
+    CARD_PIONEER: 'I was building Peanut before it had a launch. Founding Pioneer 🛠️',
+    FOUNDING_PIONEER: 'I was building Peanut before it had a launch. Founding Pioneer 🛠️',
+    GIGA_YAPPER: "I don't mention Peanut, I broadcast it. Giga Yapper 📢",
     INFLUENCER_25: 'Twenty-five friends on Peanut. The likes keep rolling in 🌟',
     MEGA_INFLUENCER: "A hundred friends on Peanut. I'm kind of a big deal now 😎",
-    DUNBAR: "150 invites — more people than I can even remember. I hit Dunbar's number 🧠",
-    CERTIFIED_YAPPER: "Certified loud. I talk about Peanut so they don't have to 🗣️",
-    GIGA_YAPPER: "I don't mention Peanut, I broadcast it. Giga Yapper 📢",
-    FIRST_CRUMB: 'Earned my first dollar on Peanut. Proof that it pays 🪙',
-    DOUBLE_DIGITS: 'Crossed into double digits on Peanut. Real money now 💰',
+    MINI_INFLUENCER: 'Built a little Peanut fan club, one invite at a time 🌟',
+    MOST_PAYMENTS_DEVCON: "I move money like it's light work. Most payments at Devconnect — certified money machine ⚡",
+    MOST_INVITES: "I onboarded more people to Peanut than Coinbase's ad budget did 📈",
+    PRODUCT_HUNT: 'I upvoted Peanut on Product Hunt before it was cool. Hope dealer, certified 🚀',
+    SECOND_INVITE: "Two friends on Peanut and counting. Word's getting around 📣",
+    SHHHHH: "I know the secret. That's all I'm allowed to say 🤫",
+    THIRD_INVITE: 'Three friends on Peanut, zero misses. Tip your hat 🎩',
     VERIFIED: 'ID checked, identity confirmed. Officially verified on Peanut ✅',
-    CARD_CLOSED_BETA: 'I was testing the Peanut card before you knew it existed. IYKYK 🤫💳',
-    CARD_ALPHA: 'I tested the Peanut card while it was still held together with tape and hope 🩹💳',
-    ARBITRUM: 'Found on Arbitrum, onboarded to Peanut. Mutual W 🔵',
-    TOKEN_NATION_SP_2026: 'São Paulo, baby. Came, claimed, tagged the wall 🇧🇷',
-    FESTA_JUNINA_2026: 'I danced the quadrilha with Peanut. Arraiá unlocked 🎉🌽',
-    TOUCHED_GRASS: 'I logged off and touched real grass — with Peanut. Rare 🌱',
-    OFFRAMP_USER: 'I migrated to Peanut and never looked back 👋',
-    PSYOPS_DIVISION: 'Enlisted in the Peanut Psyops Division. The influence game is real 🧠',
-    EVENT_ALUMNI: 'Old school. I was in the room before most of you 🎟️',
-    ETHFLORIPA_HUB: 'Ilha da Magia, baby. Coconuts and consensus 🥥',
-    IRL_NOMADS: 'No fixed address, just good coffee and better wifi. Certified Nomad 🎒',
-    WAITLIST_SKIP: 'Skipped the waitlist. A friend handed me the key and I walked right in 🔑',
 }
 
 // Builds the text pre-filled into the native share sheet (Web Share API) / copied to

--- a/src/components/Badges/badge.utils.ts
+++ b/src/components/Badges/badge.utils.ts
@@ -258,3 +258,68 @@ export function getPublicBadgeDescription(code?: string): string | null {
 export function getBadgeDisplayName(code: string | undefined, fallback: string): string {
     return (code && BADGES[code]?.displayName) || fallback
 }
+
+// Funny, first-person share copy for each badge. The user is bragging about their
+// OWN achievement, so these read in first person ("I…") — unlike the third-person
+// `description` above (which narrates the badge to others). Thematically they mirror
+// each badge's description so the voice stays consistent across surfaces. Aliased
+// codes (CARD_PIONEER/FOUNDING_PIONEER, SUPPORT_SURVIVOR/BUG_WHISPERER) share a line;
+// unknown/parked codes fall back to a generic-but-proud brag in getBadgeShareText.
+const BADGE_SHARE_LINES: Record<string, string> = {
+    BETA_TESTER: "I've been in the Peanut lab since the early experiments. Officially a beta tester 🧪",
+    DEVCONNECT_BA_2025: 'Came to Devconnect BA, claimed my badge, ate the steak. Priorities 🥩🇦🇷',
+    PRODUCT_HUNT: 'I upvoted Peanut on Product Hunt before it was cool. Hope dealer, certified 🚀',
+    OG_2025_10_12: 'I was here before it was cool. Certified Peanut OG 🥜',
+    MOST_RESTAURANTS_DEVCON:
+        'I hit more restaurants at Devconnect than the Michelin guide. Paid for all of them with Peanut 🍽️',
+    BIG_SPENDER_5K: "I didn't come to Devconnect to network. I came to spend. $5K later… 💸",
+    MOST_PAYMENTS_DEVCON: "I move money like it's light work. Most payments at Devconnect — certified money machine ⚡",
+    MOST_INVITES: "I onboarded more people to Peanut than Coinbase's ad budget did 📈",
+    BIGGEST_REQUEST_POT: 'High roller or master beggar? Either way I ran the biggest pot on Peanut 🫗',
+    SEEDLING_DEVCONNECT_BA_2025: "I shill Peanut so they don't have to. Honorary squirrel 🐿️",
+    ARBIVERSE_DEVCONNECT_BA_2025:
+        'Found the Arbiverse booth, walked out with a Peanut badge. Mutual onboarding achieved 🔵',
+    CARD_PIONEER: 'I was building Peanut before it had a launch. Founding Pioneer 🛠️',
+    FOUNDING_PIONEER: 'I was building Peanut before it had a launch. Founding Pioneer 🛠️',
+    FOUNDER_HOUSE: 'On-chain energy, off-chain handshakes. Built it IRL at Founder Haus 🤝',
+    BUG_WHISPERER: 'I found a real bug in Peanut, reported it, and stuck around. Someone owes me a beer 🐛🍺',
+    SUPPORT_SURVIVOR: 'I found a real bug in Peanut, reported it, and stuck around. Someone owes me a beer 🐛🍺',
+    SHHHHH: "I know the secret. That's all I'm allowed to say 🤫",
+    NOT_SO_SHHHH: "I couldn't keep the secret… and Peanut paid me for it 🤫💸",
+    CARD_FIRST_SWIPE: 'First swipe on my Peanut card. My money finally got a job 💳',
+    CARD_SPENT_1K: '$1K swiped on my Peanut card. I put my money where my card is 💳',
+    FIRST_INVITE: 'Brought my first friend onto Peanut. One down, the whole group chat to go 👋',
+    SECOND_INVITE: "Two friends on Peanut and counting. Word's getting around 📣",
+    THIRD_INVITE: 'Three friends on Peanut, zero misses. Tip your hat 🎩',
+    MINI_INFLUENCER: 'Built a little Peanut fan club, one invite at a time 🌟',
+    INFLUENCER_25: 'Twenty-five friends on Peanut. The likes keep rolling in 🌟',
+    MEGA_INFLUENCER: "A hundred friends on Peanut. I'm kind of a big deal now 😎",
+    DUNBAR: "150 invites — more people than I can even remember. I hit Dunbar's number 🧠",
+    CERTIFIED_YAPPER: "Certified loud. I talk about Peanut so they don't have to 🗣️",
+    GIGA_YAPPER: "I don't mention Peanut, I broadcast it. Giga Yapper 📢",
+    FIRST_CRUMB: 'Earned my first dollar on Peanut. Proof that it pays 🪙',
+    DOUBLE_DIGITS: 'Crossed into double digits on Peanut. Real money now 💰',
+    VERIFIED: 'ID checked, identity confirmed. Officially verified on Peanut ✅',
+    CARD_CLOSED_BETA: 'I was testing the Peanut card before you knew it existed. IYKYK 🤫💳',
+    CARD_ALPHA: 'I tested the Peanut card while it was still held together with tape and hope 🩹💳',
+    ARBITRUM: 'Found on Arbitrum, onboarded to Peanut. Mutual W 🔵',
+    TOKEN_NATION_SP_2026: 'São Paulo, baby. Came, claimed, tagged the wall 🇧🇷',
+    FESTA_JUNINA_2026: 'I danced the quadrilha with Peanut. Arraiá unlocked 🎉🌽',
+    TOUCHED_GRASS: 'I logged off and touched real grass — with Peanut. Rare 🌱',
+    OFFRAMP_USER: 'I migrated to Peanut and never looked back 👋',
+    PSYOPS_DIVISION: 'Enlisted in the Peanut Psyops Division. The influence game is real 🧠',
+    EVENT_ALUMNI: 'Old school. I was in the room before most of you 🎟️',
+    ETHFLORIPA_HUB: 'Ilha da Magia, baby. Coconuts and consensus 🥥',
+    IRL_NOMADS: 'No fixed address, just good coffee and better wifi. Certified Nomad 🎒',
+    WAITLIST_SKIP: 'Skipped the waitlist. A friend handed me the key and I walked right in 🔑',
+}
+
+// Builds the text pre-filled into the native share sheet (Web Share API) / copied to
+// clipboard when a badge is shared from the detail modal. Composition:
+//   <funny first-person brag>\n\nJoin me on Peanut 👉 <profileUrl>
+// profileUrl is the sharer's own public profile — it showcases their badges and
+// carries the join CTA, so the link doubles as the growth loop.
+export function getBadgeShareText(code: string | undefined, displayName: string, profileUrl: string): string {
+    const brag = (code && BADGE_SHARE_LINES[code]) || `I just unlocked the "${displayName}" badge on Peanut 🥜`
+    return `${brag}\n\nJoin me on Peanut 👉 ${profileUrl}`
+}

--- a/src/components/Badges/index.tsx
+++ b/src/components/Badges/index.tsx
@@ -14,7 +14,7 @@ import { useUserStore } from '@/redux/hooks'
 import { ActionListCard } from '../ActionListCard'
 import { useAuth } from '@/context/authContext'
 
-type BadgeView = { title: string; description: string; logo: string | StaticImageData }
+type BadgeView = { code: string; title: string; description: string; logo: string | StaticImageData }
 
 export const Badges = () => {
     const onBack = useSafeBack('/profile')
@@ -33,6 +33,7 @@ export const Badges = () => {
         // get badges from user object and map to card fields
         const raw = authUser?.user?.badges || []
         return raw.map((b) => ({
+            code: b.code,
             title: getBadgeDisplayName(b.code, b.name),
             description: b.description || '',
             logo: getBadgeIcon(b.code),
@@ -101,6 +102,7 @@ export const Badges = () => {
                         setIsBadgeModalOpen(false)
                         setSelectedBadge(null)
                     }}
+                    code={selectedBadge.code}
                     title={selectedBadge.title}
                     description={selectedBadge.description}
                     logo={selectedBadge.logo}


### PR DESCRIPTION
## Summary

The badge detail modal's **"Got it!"** button (a dead dismiss) is now **"Share badge"** — tapping it drops a funny, badge-specific, first-person line into the native share sheet (Web Share API, with clipboard-copy fallback + toast on desktop). The goal is a share that feels natural enough that people actually post it, turning earned badges into a growth loop. The modal's top-right ✕ still dismisses.

- New `BADGE_SHARE_LINES` map + `getBadgeShareText(code, displayName, profileUrl)` in `badge.utils.ts` — kept next to `BADGES` as the FE source of truth. Composes `‹brag›\n\nJoin me on Peanut 👉 ‹the sharer's own profile URL›`.
- Reuses the existing `ShareButton` (same pattern as the unlock drawer's "Share Achievement"), so behavior matches the rest of the app.
- Badge `code` is threaded into `BadgeDetailModal` from both call sites (`Badges` list + `BadgeStatusDrawer`), so the per-badge line works from both entry points.

### Copy selection — driven by real usage
Lines were chosen against **live prod holder counts** (`app.user_acknowledgments`). Bespoke copy only pays off for badges people actually have, so **rarely-earned badges are intentionally omitted** from the map (`CERTIFIED_YAPPER`, `TOKEN_NATION_SP_2026`, `FESTA_JUNINA_2026`) — `getBadgeShareText` returns a generic `I just unlocked the "X" badge on Peanut 🥜` fallback for any unlisted code, so they still share cleanly with zero upkeep.

## Risks / breaking changes
- **None cross-repo.** FE-only; no API/schema change. `code` is an optional prop (falls back to the generic line if absent).
- Blast radius = the badge detail modal + the two components that render it. No money/state mutation.

## QA
1. Profile → **Your Badges** → tap any badge → modal shows **Share badge**.
2. Mobile: opens the native share sheet pre-filled with the badge's line + your profile URL. Desktop: copies to clipboard, toasts "Text copied", modal dismisses on success.
3. Also reachable via the badge-unlock drawer → tap the badge card → same modal.
4. A badge with no mapped line (e.g. an omitted one) shares the generic fallback.

Unit tests: `getBadgeShareText` (mapped code, generic fallback, undefined code) in `badge.utils.test.ts`.
