### PR TITLE
feat: make transaction counterparty name open their profile

### DIFF
--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -5,7 +5,11 @@ import TransactionAvatarBadge from '@/components/TransactionDetails/TransactionA
 import { getBankAccountCountryCode } from '@/constants/countryCurrencyMapping'
 import { type TransactionDirection, type TransactionType } from '@/components/TransactionDetails/transaction-types'
 import { type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
-import { isCardPaymentEntry, isPerkReward } from '@/components/TransactionDetails/transaction-predicates'
+import {
+    canNavigateToUserProfile,
+    isCardPaymentEntry,
+    isPerkReward,
+} from '@/components/TransactionDetails/transaction-predicates'
 import { useTransactionDetailsDrawer } from '@/hooks/useTransactionDetailsDrawer'
 import {
     formatNumberForDisplay,
@@ -28,6 +32,8 @@ import { useHaptic } from 'use-haptic'
 import LazyLoadErrorBoundary from '@/components/Global/LazyLoadErrorBoundary'
 import { PEANUTMAN } from '@/assets/mascot'
 import InvitesIcon from '../Home/InvitesIcon'
+import { useRouter } from 'next/navigation'
+import { profileUrl } from '@/utils/native-routes'
 
 // Lazy load transaction details drawer (~40KB) to reduce initial bundle size
 // Only loaded when user taps a transaction to view details
@@ -72,10 +78,22 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
     const { isDrawerOpen, selectedTransaction, openTransactionDetails, closeTransactionDetails } =
         useTransactionDetailsDrawer()
     const { triggerHaptic } = useHaptic()
+    const router = useRouter()
 
     const handleClick = () => {
         triggerHaptic()
         openTransactionDetails(transaction)
+    }
+
+    const canNavigateToProfile = canNavigateToUserProfile(transaction)
+
+    // Tap the name → the counterparty's profile (to repeat the send/request);
+    // the rest of the card still opens the details drawer. stopPropagation keeps
+    // the name tap from also firing the card's drawer handler.
+    const handleNameClick = (e: React.MouseEvent) => {
+        e.stopPropagation()
+        triggerHaptic()
+        router.push(profileUrl(transaction.userName))
     }
 
     const isLinkTx = transaction.extraDataForDrawer?.isLinkTransaction ?? false
@@ -206,7 +224,13 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
                             {/* display formatted name (address or username) */}
                             <div className="flex flex-row items-center gap-2">
                                 {isPending && <div className="h-2 w-2 animate-pulsate rounded-full bg-primary-1" />}
-                                <div className="min-w-0 flex-1 truncate font-roboto text-[16px] font-medium">
+                                <div
+                                    className={twMerge(
+                                        'min-w-0 flex-1 truncate font-roboto text-[16px] font-medium',
+                                        canNavigateToProfile && 'cursor-pointer'
+                                    )}
+                                    onClick={canNavigateToProfile ? handleNameClick : undefined}
+                                >
                                     <VerifiedUserLabel
                                         username={transaction.userName}
                                         name={displayName}

--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -6,7 +6,7 @@ import { getBankAccountCountryCode } from '@/constants/countryCurrencyMapping'
 import { type TransactionDirection, type TransactionType } from '@/components/TransactionDetails/transaction-types'
 import { type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
 import {
-    canNavigateToUserProfile,
+    hasUserProfile,
     isCardPaymentEntry,
     isPerkReward,
 } from '@/components/TransactionDetails/transaction-predicates'
@@ -85,13 +85,12 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
         openTransactionDetails(transaction)
     }
 
-    const canNavigateToProfile = canNavigateToUserProfile(transaction)
+    const canNavigateToProfile = hasUserProfile(transaction)
 
     // Tap the name → the counterparty's profile (to repeat the send/request);
-    // the rest of the card still opens the details drawer. stopPropagation keeps
-    // the name tap from also firing the card's drawer handler.
-    const handleNameClick = (e: React.MouseEvent) => {
-        e.stopPropagation()
+    // the rest of the card still opens the details drawer (VerifiedUserLabel
+    // stops the name tap from bubbling to the card's drawer handler).
+    const handleNameClick = () => {
         triggerHaptic()
         router.push(profileUrl(transaction.userName))
     }
@@ -224,18 +223,13 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
                             {/* display formatted name (address or username) */}
                             <div className="flex flex-row items-center gap-2">
                                 {isPending && <div className="h-2 w-2 animate-pulsate rounded-full bg-primary-1" />}
-                                <div
-                                    className={twMerge(
-                                        'min-w-0 flex-1 truncate font-roboto text-[16px] font-medium',
-                                        canNavigateToProfile && 'cursor-pointer'
-                                    )}
-                                    onClick={canNavigateToProfile ? handleNameClick : undefined}
-                                >
+                                <div className="min-w-0 flex-1 truncate font-roboto text-[16px] font-medium">
                                     <VerifiedUserLabel
                                         username={transaction.userName}
                                         name={displayName}
                                         isVerified={transaction.isVerified}
                                         haveSentMoneyToUser={haveSentMoneyToUser}
+                                        onNameClick={canNavigateToProfile ? handleNameClick : undefined}
                                     />
                                 </div>
                             </div>

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -46,7 +46,7 @@ import { useRouter } from 'next/navigation'
 import { getBankAccountCountryCode } from '@/constants/countryCurrencyMapping'
 import { useToast } from '@/components/0_Bruddle/Toast'
 import {
-    canNavigateToUserProfile,
+    hasUserProfile,
     isPerkReward as isPerkRewardTransaction,
     isRequestEntry,
     isSendLinkEntry,
@@ -253,8 +253,8 @@ export const TransactionDetailsReceipt = ({
 
     // Show profile button only if it's a send/request/receive to a real Peanut
     // user (not a link or a raw address). Shared with the history row — see
-    // canNavigateToUserProfile.
-    const isAvatarClickable = canNavigateToUserProfile(transaction)
+    // hasUserProfile.
+    const isAvatarClickable = hasUserProfile(transaction)
 
     const closeRequestLink = async () => {
         if (isPendingRequester && setIsLoading && onClose) {

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -46,6 +46,7 @@ import { useRouter } from 'next/navigation'
 import { getBankAccountCountryCode } from '@/constants/countryCurrencyMapping'
 import { useToast } from '@/components/0_Bruddle/Toast'
 import {
+    canNavigateToUserProfile,
     isPerkReward as isPerkRewardTransaction,
     isRequestEntry,
     isSendLinkEntry,
@@ -250,15 +251,10 @@ export const TransactionDetailsReceipt = ({
         amountDisplay = `$${formattedTotalAmountCollected} collected`
     }
 
-    // Show profile button only if txn is completed, not to/by a guest user and its a send/request/receive txn
-    const isAvatarClickable =
-        !!transaction &&
-        !transaction.extraDataForDrawer?.isLinkTransaction &&
-        !!transaction.userName &&
-        !isAddress(transaction.userName) &&
-        (transaction.extraDataForDrawer?.transactionCardType === 'send' ||
-            transaction.extraDataForDrawer?.transactionCardType === 'request' ||
-            transaction.extraDataForDrawer?.transactionCardType === 'receive')
+    // Show profile button only if it's a send/request/receive to a real Peanut
+    // user (not a link or a raw address). Shared with the history row — see
+    // canNavigateToUserProfile.
+    const isAvatarClickable = canNavigateToUserProfile(transaction)
 
     const closeRequestLink = async () => {
         if (isPendingRequester && setIsLoading && onClose) {

--- a/src/components/TransactionDetails/__tests__/TransactionCard.test.tsx
+++ b/src/components/TransactionDetails/__tests__/TransactionCard.test.tsx
@@ -67,6 +67,7 @@ function eligibleTx(): TransactionDetails {
         direction: 'send',
         status: 'completed',
         userName: 'natalia',
+        isPeerActuallyUser: true,
         showFullName: false,
         isVerified: false,
         amount: 10,

--- a/src/components/TransactionDetails/__tests__/TransactionCard.test.tsx
+++ b/src/components/TransactionDetails/__tests__/TransactionCard.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * TransactionCard — clickable counterparty name.
+ *
+ * The counterparty name in a history row is a deep-link to that user's
+ * profile (to repeat the send/request). The tap must:
+ *   1. navigate to `/<username>` (via `profileUrl`) and NOT open the details
+ *      drawer — `stopPropagation` keeps the name tap off the card's handler.
+ *   2. leave the rest of the card opening the drawer as before.
+ *   3. do nothing (no navigation) for an INELIGIBLE row — a link transaction
+ *      or a raw 0x-address counterparty has no Peanut profile to link to.
+ *
+ * The real component is rendered; only leaf hooks/modules that don't matter to
+ * the click wiring are mocked (router, haptic, drawer state, ENS lookup, auth).
+ */
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import TransactionCard from '../TransactionCard'
+import { type TransactionDetails } from '../transactionTransformer'
+
+const push = jest.fn()
+const triggerHaptic = jest.fn()
+const openTransactionDetails = jest.fn()
+
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ push }),
+}))
+
+jest.mock('use-haptic', () => ({
+    useHaptic: () => ({ triggerHaptic }),
+}))
+
+jest.mock('@/hooks/useTransactionDetailsDrawer', () => ({
+    useTransactionDetailsDrawer: () => ({
+        isDrawerOpen: false,
+        selectedTransaction: null,
+        openTransactionDetails,
+        closeTransactionDetails: jest.fn(),
+    }),
+}))
+
+jest.mock('@justaname.id/react', () => ({
+    usePrimaryName: () => ({ primaryName: undefined }),
+}))
+
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => ({ invitedUsernamesSet: new Set(), user: null }),
+}))
+
+// The details drawer is lazy-loaded and never opened in these tests; stub it so
+// the async Suspense resolution doesn't emit an act() warning.
+jest.mock('../TransactionDetailsDrawer', () => ({
+    TransactionDetailsDrawer: () => null,
+}))
+
+jest.mock('next/image', () => ({
+    __esModule: true,
+    default: (props: Record<string, unknown>) => {
+        // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+        return React.createElement('img', props as Record<string, string>)
+    },
+}))
+
+/** A completed P2P send to username `natalia` — the eligible (clickable) case. */
+function eligibleTx(): TransactionDetails {
+    return {
+        id: 'tx-1',
+        direction: 'send',
+        status: 'completed',
+        userName: 'natalia',
+        showFullName: false,
+        isVerified: false,
+        amount: 10,
+        tokenSymbol: 'USDC',
+        totalAmountCollected: 0,
+        isRequestPotLink: false,
+        extraDataForDrawer: {
+            transactionCardType: 'send',
+            isLinkTransaction: false,
+        },
+    } as unknown as TransactionDetails
+}
+
+function renderCard(transaction: TransactionDetails) {
+    return render(
+        <TransactionCard type="send" name="natalia" amount={10} status="completed" transaction={transaction} />
+    )
+}
+
+describe('TransactionCard — clickable counterparty name', () => {
+    beforeEach(() => {
+        push.mockClear()
+        triggerHaptic.mockClear()
+        openTransactionDetails.mockClear()
+    })
+
+    it('AC1: clicking the name navigates to /<username> and does NOT open the drawer', () => {
+        renderCard(eligibleTx())
+
+        fireEvent.click(screen.getByText('natalia'))
+
+        expect(push).toHaveBeenCalledWith('/natalia')
+        expect(openTransactionDetails).not.toHaveBeenCalled()
+    })
+
+    it('AC2: clicking elsewhere on the card (the amount) opens the drawer', () => {
+        renderCard(eligibleTx())
+
+        // displayAmount for a completed send of $10 renders as "-$10"
+        fireEvent.click(screen.getByText('-$10'))
+
+        expect(openTransactionDetails).toHaveBeenCalledTimes(1)
+        expect(push).not.toHaveBeenCalled()
+    })
+
+    it('AC3 (link tx): the name is NOT a nav target — clicking it does not navigate', () => {
+        const tx = eligibleTx()
+        ;(tx.extraDataForDrawer as { isLinkTransaction: boolean }).isLinkTransaction = true
+
+        renderCard(tx)
+
+        fireEvent.click(screen.getByText('natalia'))
+
+        expect(push).not.toHaveBeenCalled()
+        // the click still bubbles to the card, which opens the drawer
+        expect(openTransactionDetails).toHaveBeenCalledTimes(1)
+    })
+
+    it('AC3 (raw address): a 0x-address counterparty name does not navigate', () => {
+        const address = '0x' + 'a'.repeat(40)
+        const tx = eligibleTx()
+        ;(tx as { userName: string }).userName = address
+
+        render(<TransactionCard type="send" name={address} amount={10} status="completed" transaction={tx} />)
+
+        // address is rendered shortened via AddressLink; click the card body instead
+        fireEvent.click(screen.getByTestId('transaction-card'))
+
+        expect(push).not.toHaveBeenCalled()
+    })
+})

--- a/src/components/TransactionDetails/__tests__/TransactionCard.test.tsx
+++ b/src/components/TransactionDetails/__tests__/TransactionCard.test.tsx
@@ -112,7 +112,11 @@ describe('TransactionCard — clickable counterparty name', () => {
         expect(push).not.toHaveBeenCalled()
     })
 
-    it('AC3 (link tx): the name is NOT a nav target — clicking it does not navigate', () => {
+    // Ineligible rows: the name must not be a nav target. Eligibility itself
+    // (link tx / raw address / card type / empty username) is exhaustively
+    // locked by transaction-predicates.test.ts; here we only confirm the
+    // component honors it — one representative ineligible case (a link tx).
+    it('AC3 (ineligible — link tx): the name is not a nav target — clicking it does not navigate', () => {
         const tx = eligibleTx()
         ;(tx.extraDataForDrawer as { isLinkTransaction: boolean }).isLinkTransaction = true
 
@@ -123,18 +127,5 @@ describe('TransactionCard — clickable counterparty name', () => {
         expect(push).not.toHaveBeenCalled()
         // the click still bubbles to the card, which opens the drawer
         expect(openTransactionDetails).toHaveBeenCalledTimes(1)
-    })
-
-    it('AC3 (raw address): a 0x-address counterparty name does not navigate', () => {
-        const address = '0x' + 'a'.repeat(40)
-        const tx = eligibleTx()
-        ;(tx as { userName: string }).userName = address
-
-        render(<TransactionCard type="send" name={address} amount={10} status="completed" transaction={tx} />)
-
-        // address is rendered shortened via AddressLink; click the card body instead
-        fireEvent.click(screen.getByTestId('transaction-card'))
-
-        expect(push).not.toHaveBeenCalled()
     })
 })

--- a/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
+++ b/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
@@ -4,6 +4,7 @@
 // `extraData.kind` pinned to a canonical TransactionIntentKind value.
 
 import {
+    canNavigateToUserProfile,
     isCardSpend,
     isDirectSendEntry,
     isFxBearingFlow,
@@ -150,5 +151,49 @@ describe('isSplittable', () => {
     test('non-QR / non-card kinds are never splittable', () => {
         expect(isSplittable(txWithStatus('DIRECT_TRANSFER', 'completed'))).toBe(false)
         expect(isSplittable(txWithStatus('SEND_LINK', 'completed'))).toBe(false)
+    })
+})
+
+// Gates the clickable counterparty name/avatar in BOTH the history row
+// (TransactionCard) and the receipt header (TransactionDetailsHeaderCard): only
+// a non-link send/request/receive to a real username (not a raw address) deep-
+// links to a Peanut profile.
+describe('canNavigateToUserProfile', () => {
+    const profileTx = (
+        transactionCardType: string | undefined,
+        opts?: { userName?: string; isLinkTransaction?: boolean }
+    ): TransactionDetails =>
+        ({
+            userName: opts?.userName ?? 'natalia',
+            extraDataForDrawer: {
+                originalType: 'TRANSACTION_INTENT',
+                transactionCardType,
+                isLinkTransaction: opts?.isLinkTransaction ?? false,
+            },
+        }) as unknown as TransactionDetails
+
+    test.each(['send', 'request', 'receive'])('a %s to a real username is navigable', (type) => {
+        expect(canNavigateToUserProfile(profileTx(type))).toBe(true)
+    })
+
+    test.each(['withdraw', 'add', 'card_pay', 'bank_withdraw', 'claim_external'])(
+        'a %s has no peer profile → not navigable',
+        (type) => {
+            expect(canNavigateToUserProfile(profileTx(type))).toBe(false)
+        }
+    )
+
+    test('a link send is NOT navigable — there is no user profile behind a link', () => {
+        expect(canNavigateToUserProfile(profileTx('send', { isLinkTransaction: true }))).toBe(false)
+    })
+
+    test('a raw 0x address recipient is NOT navigable — no Peanut profile exists', () => {
+        expect(
+            canNavigateToUserProfile(profileTx('send', { userName: '0x1bf9c9f2b0e8a0b9f2b0e8a0b9f2b0e8a0b9f2b0' }))
+        ).toBe(false)
+    })
+
+    test('a missing username is NOT navigable', () => {
+        expect(canNavigateToUserProfile(profileTx('send', { userName: '' }))).toBe(false)
     })
 })

--- a/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
+++ b/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
@@ -4,7 +4,7 @@
 // `extraData.kind` pinned to a canonical TransactionIntentKind value.
 
 import {
-    canNavigateToUserProfile,
+    hasUserProfile,
     isCardSpend,
     isDirectSendEntry,
     isFxBearingFlow,
@@ -158,7 +158,7 @@ describe('isSplittable', () => {
 // (TransactionCard) and the receipt header (TransactionDetailsHeaderCard): only
 // a non-link send/request/receive to a real username (not a raw address) deep-
 // links to a Peanut profile.
-describe('canNavigateToUserProfile', () => {
+describe('hasUserProfile', () => {
     const profileTx = (
         transactionCardType: string | undefined,
         opts?: { userName?: string; isLinkTransaction?: boolean }
@@ -172,28 +172,32 @@ describe('canNavigateToUserProfile', () => {
             },
         }) as unknown as TransactionDetails
 
-    test.each(['send', 'request', 'receive'])('a %s to a real username is navigable', (type) => {
-        expect(canNavigateToUserProfile(profileTx(type))).toBe(true)
+    test.each(['send', 'request', 'receive'])('a %s to a real username has a profile', (type) => {
+        expect(hasUserProfile(profileTx(type))).toBe(true)
     })
 
     test.each(['withdraw', 'add', 'card_pay', 'bank_withdraw', 'claim_external'])(
-        'a %s has no peer profile → not navigable',
+        'a %s has no peer profile',
         (type) => {
-            expect(canNavigateToUserProfile(profileTx(type))).toBe(false)
+            expect(hasUserProfile(profileTx(type))).toBe(false)
         }
     )
 
-    test('a link send is NOT navigable — there is no user profile behind a link', () => {
-        expect(canNavigateToUserProfile(profileTx('send', { isLinkTransaction: true }))).toBe(false)
+    test('a link send has no user profile behind it', () => {
+        expect(hasUserProfile(profileTx('send', { isLinkTransaction: true }))).toBe(false)
     })
 
-    test('a raw 0x address recipient is NOT navigable — no Peanut profile exists', () => {
-        expect(
-            canNavigateToUserProfile(profileTx('send', { userName: '0x1bf9c9f2b0e8a0b9f2b0e8a0b9f2b0e8a0b9f2b0' }))
-        ).toBe(false)
+    // Same address rule VerifiedUserLabel renders by (isCryptoAddress): EVM,
+    // Solana and Tron shapes all mean "no Peanut profile".
+    test.each([
+        ['EVM', '0x1bf9c9f2b0e8a0b9f2b0e8a0b9f2b0e8a0b9f2b0'],
+        ['Solana', 'DRpbCBMxVnDK7maPM5tGv6MvB3v1sRMC86PZ8okm21hy'],
+        ['Tron', 'TJRabPrwbZy45sbavfcjinPJC18kjpRTv8'],
+    ])('a raw %s address recipient has no profile', (_chain, address) => {
+        expect(hasUserProfile(profileTx('send', { userName: address }))).toBe(false)
     })
 
-    test('a missing username is NOT navigable', () => {
-        expect(canNavigateToUserProfile(profileTx('send', { userName: '' }))).toBe(false)
+    test('a missing username has no profile', () => {
+        expect(hasUserProfile(profileTx('send', { userName: '' }))).toBe(false)
     })
 })

--- a/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
+++ b/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
@@ -161,10 +161,11 @@ describe('isSplittable', () => {
 describe('hasUserProfile', () => {
     const profileTx = (
         transactionCardType: string | undefined,
-        opts?: { userName?: string; isLinkTransaction?: boolean }
+        opts?: { userName?: string; isLinkTransaction?: boolean; isPeerActuallyUser?: boolean }
     ): TransactionDetails =>
         ({
             userName: opts?.userName ?? 'natalia',
+            isPeerActuallyUser: opts?.isPeerActuallyUser ?? true,
             extraDataForDrawer: {
                 originalType: 'TRANSACTION_INTENT',
                 transactionCardType,
@@ -199,5 +200,17 @@ describe('hasUserProfile', () => {
 
     test('a missing username has no profile', () => {
         expect(hasUserProfile(profileTx('send', { userName: '' }))).toBe(false)
+    })
+
+    // A non-user peer (raw address, bank account, or a system copy string like
+    // 'Request'/reaper-fail text) is authoritatively flagged by the transformer.
+    test('a non-user peer has no profile even for a send/request/receive', () => {
+        expect(hasUserProfile(profileTx('send', { isPeerActuallyUser: false }))).toBe(false)
+    })
+
+    // A usernameless Peanut user surfaces their userId (UUID) in `userName`;
+    // there is no /<uuid> profile page, so it must not be a nav target.
+    test('a usernameless user (UUID userId fallback) has no profile', () => {
+        expect(hasUserProfile(profileTx('send', { userName: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d' }))).toBe(false)
     })
 })

--- a/src/components/TransactionDetails/transaction-predicates.ts
+++ b/src/components/TransactionDetails/transaction-predicates.ts
@@ -8,6 +8,7 @@
  * transformer runs (e.g. `extraDataForDrawer.cardPayment`).
  */
 
+import { isAddress } from 'viem'
 import { type TransactionDetails } from './transactionTransformer'
 import type { IntentKind } from './strategies/registry'
 
@@ -120,4 +121,20 @@ export function isOnrampEntry(transaction: TransactionDetails): boolean {
 // positive-identity discriminator.
 export function isMantecaOnrampEntry(transaction: TransactionDetails): boolean {
     return isKind(transaction, 'ONRAMP') && transaction.extraDataForDrawer?.provider === 'MANTECA'
+}
+
+// The counterparty is a real Peanut user whose profile we can deep-link to:
+// a non-link send / request / receive whose identifier is a username (not a
+// raw 0x address, which has no Peanut profile). The single source of truth for
+// the clickable name + avatar in both the history row (TransactionCard) and the
+// receipt header (TransactionDetailsHeaderCard) — keep the eligibility rule here
+// so the two surfaces can't drift.
+export function canNavigateToUserProfile(transaction: TransactionDetails): boolean {
+    const type = transaction.extraDataForDrawer?.transactionCardType
+    return (
+        !transaction.extraDataForDrawer?.isLinkTransaction &&
+        !!transaction.userName &&
+        !isAddress(transaction.userName) &&
+        (type === 'send' || type === 'request' || type === 'receive')
+    )
 }

--- a/src/components/TransactionDetails/transaction-predicates.ts
+++ b/src/components/TransactionDetails/transaction-predicates.ts
@@ -8,7 +8,7 @@
  * transformer runs (e.g. `extraDataForDrawer.cardPayment`).
  */
 
-import { isAddress } from 'viem'
+import { isCryptoAddress } from '@/utils/general.utils'
 import { type TransactionDetails } from './transactionTransformer'
 import type { IntentKind } from './strategies/registry'
 
@@ -123,18 +123,19 @@ export function isMantecaOnrampEntry(transaction: TransactionDetails): boolean {
     return isKind(transaction, 'ONRAMP') && transaction.extraDataForDrawer?.provider === 'MANTECA'
 }
 
-// The counterparty is a real Peanut user whose profile we can deep-link to:
-// a non-link send / request / receive whose identifier is a username (not a
-// raw 0x address, which has no Peanut profile). The single source of truth for
-// the clickable name + avatar in both the history row (TransactionCard) and the
-// receipt header (TransactionDetailsHeaderCard) — keep the eligibility rule here
-// so the two surfaces can't drift.
-export function canNavigateToUserProfile(transaction: TransactionDetails): boolean {
+// The counterparty is a real Peanut user with a profile: a non-link
+// send / request / receive identified by a username — not a raw crypto address
+// (EVM/Solana/Tron, same rule VerifiedUserLabel renders by), which has no
+// profile. What a consumer does with the fact (clickable name, avatar,
+// send-again button) is the call site's business. Shared by the history row
+// (TransactionCard) and the receipt header (TransactionDetailsHeaderCard) —
+// keep the rule here so the two surfaces can't drift.
+export function hasUserProfile(transaction: TransactionDetails): boolean {
     const type = transaction.extraDataForDrawer?.transactionCardType
     return (
         !transaction.extraDataForDrawer?.isLinkTransaction &&
         !!transaction.userName &&
-        !isAddress(transaction.userName) &&
+        !isCryptoAddress(transaction.userName) &&
         (type === 'send' || type === 'request' || type === 'receive')
     )
 }

--- a/src/components/TransactionDetails/transaction-predicates.ts
+++ b/src/components/TransactionDetails/transaction-predicates.ts
@@ -8,7 +8,7 @@
  * transformer runs (e.g. `extraDataForDrawer.cardPayment`).
  */
 
-import { isCryptoAddress } from '@/utils/general.utils'
+import { isCryptoAddress, isUuid } from '@/utils/general.utils'
 import { type TransactionDetails } from './transactionTransformer'
 import type { IntentKind } from './strategies/registry'
 
@@ -123,19 +123,26 @@ export function isMantecaOnrampEntry(transaction: TransactionDetails): boolean {
     return isKind(transaction, 'ONRAMP') && transaction.extraDataForDrawer?.provider === 'MANTECA'
 }
 
-// The counterparty is a real Peanut user with a profile: a non-link
-// send / request / receive identified by a username — not a raw crypto address
-// (EVM/Solana/Tron, same rule VerifiedUserLabel renders by), which has no
-// profile. What a consumer does with the fact (clickable name, avatar,
-// send-again button) is the call site's business. Shared by the history row
+// The counterparty is a real Peanut user with a public profile: a non-link
+// send / request / receive whose peer is an actual user (isPeerActuallyUser)
+// identified by a real username — not a raw crypto address (EVM/Solana/Tron,
+// the same rule VerifiedUserLabel renders by) and not a userId fallback
+// (usernameless users surface their UUID in `userName`, which has no profile
+// page). System copy strings ('Request', 'Recipient', reaper-fail text) are
+// already excluded because the transformer sets isPeerActuallyUser=false for
+// them. What a consumer does with the fact (clickable name, avatar, send-again
+// button) is the call site's business. Shared by the history row
 // (TransactionCard) and the receipt header (TransactionDetailsHeaderCard) —
 // keep the rule here so the two surfaces can't drift.
 export function hasUserProfile(transaction: TransactionDetails): boolean {
     const type = transaction.extraDataForDrawer?.transactionCardType
+    const userName = transaction.userName
     return (
+        !!transaction.isPeerActuallyUser &&
         !transaction.extraDataForDrawer?.isLinkTransaction &&
-        !!transaction.userName &&
-        !isCryptoAddress(transaction.userName) &&
+        !!userName &&
+        !isCryptoAddress(userName) &&
+        !isUuid(userName) &&
         (type === 'send' || type === 'request' || type === 'receive')
     )
 }

--- a/src/components/TransactionDetails/transactionTransformer.ts
+++ b/src/components/TransactionDetails/transactionTransformer.ts
@@ -290,6 +290,12 @@ export interface TransactionDetails {
     id: string
     direction: TransactionDirection
     userName: string
+    /** The counterparty is an actual Peanut user (not a raw address, bank
+     *  account, or a system copy string like 'Request'/'Recipient'/reaper text).
+     *  Authoritative gate for whether the name/avatar can deep-link to a
+     *  profile — see hasUserProfile. Optional so hand-built fixtures fail safe
+     *  to non-clickable; the transformer always sets it. */
+    isPeerActuallyUser?: boolean
     fullName: string
     showFullName?: boolean
     amount: number | bigint
@@ -541,6 +547,7 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
         initials: getInitialsFromName(nameForInitials),
         status: uiStatus,
         isVerified: entry.isVerified && isPeerActuallyUser,
+        isPeerActuallyUser,
         // only show verification badge if the other person is a peanut user
         date: new Date(entry.timestamp),
         // Peanut product convention: fees are baked into the displayed exchange

--- a/src/components/UserHeader/index.tsx
+++ b/src/components/UserHeader/index.tsx
@@ -103,7 +103,14 @@ export const VerifiedUserLabel = ({
                         className,
                         onNameClick && 'cursor-pointer'
                     )}
-                    onClick={onNameClick}
+                    onClick={
+                        onNameClick &&
+                        ((e) => {
+                            // a name with its own action must not also fire the container's onClick
+                            e.stopPropagation()
+                            onNameClick()
+                        })
+                    }
                 >
                     {name}
                 </div>


### PR DESCRIPTION
## Summary

Tapping a peer's **name in the Activity row** now deep-links to that person's profile, so you can immediately send or request again — the exact "get back to this person" flow. Before, the row's name was inert: only tapping the whole card opened the details drawer.

This reuses the two things the codebase already had for exactly this:
- `profileUrl()` — the app-wide way to reach a profile (Invites / Rewards / Contributors / the drawer header).
- `VerifiedUserLabel`'s existing `onNameClick` prop — the clickable-name affordance the receipt header already uses. The row passes a handler; no new click surface is built.

The eligibility rule the receipt header had inline (`isAvatarClickable`) is extracted into a shared `hasUserProfile()` predicate — a *fact* about the counterparty ("a real Peanut user with a profile: non-link send/request/receive to a username, not a raw crypto address"), so the row and the drawer header can't drift. What each surface does with the fact (clickable name, clickable avatar) stays a call-site decision under its own local name.

- Name tap navigates to the profile; `VerifiedUserLabel` stops propagation internally whenever `onNameClick` is set, so a name with its own action can never also fire its container (here: the drawer). The rest of the row still opens the drawer, including blank space next to a short name — the tap target is the name text itself.
- Only eligible for a non-link **send / request / receive** to a **username**. Address detection uses `isCryptoAddress` (EVM **+ Solana + Tron**) — the same rule `VerifiedUserLabel` renders by — not EVM-only `isAddress`, so a Solana/Tron counterparty can't slip through to a garbage `/<address>` URL. This also hardens the receipt header's avatar, which shared the narrower check.

## Repro (the bug this fixes)

On a completed send to a Peanut user, opening the transaction details shows the recipient's name (e.g. **"natalia"**) — but the name was **not clickable**, so there was no one-tap way back to that person to send/request again.

<!-- SCREENSHOT: drag the original "natalia" details screenshot into this section in the GitHub editor -->
_Screenshot of the repro to be attached._

## Files (production: +50 / −11)
- `transaction-predicates.ts` — new `hasUserProfile()` (single source of truth for the eligibility fact).
- `UserHeader/index.tsx` — `VerifiedUserLabel` stops propagation when `onNameClick` is set (the header, its only prior consumer, has no parent handler — behaviour there unchanged).
- `TransactionCard.tsx` — passes `onNameClick` to the existing `VerifiedUserLabel`; no wrapper click-div.
- `TransactionDetailsReceipt.tsx` — `isAvatarClickable` now calls the predicate (net −4; EVM behaviour identical, Solana/Tron now correctly ineligible).
- `__tests__/transaction-predicates.test.ts` (+49, eligibility gate incl. EVM/Solana/Tron address rows) & `__tests__/TransactionCard.test.tsx` (real-component RTL: name→profile with no drawer, non-name→drawer, ineligible-inert).

## Design note — why the existing prop, not a new abstraction
First version hand-rolled a click-div around `VerifiedUserLabel`; review caught that the label already exposes `onNameClick` (used by the receipt header, gated on the same predicate). Reusing it deleted the wrapper, tightened the tap target to the name text, and made address-shaped names inert by construction (the label renders `AddressLink` for those and ignores `onNameClick`). The remaining overlap between row and header is a single `router.push(profileUrl(username))` line — below the abstraction threshold; no shared hook.

_Intentional divergence:_ a name tap in the **row** fires haptic (consistent with the row's other taps); the **header** name/avatar tap stays haptic-free (it never buzzed). Not an oversight — do not "fix" it by reaching into the header handler.

## Risk
Low, FE-only, no API/contract change, no new deps. Blast radius = the counterparty name in the Activity feed (`TransactionCard`, shared by Home + `/history` + pending), the receipt header (avatar now also ineligible for Solana/Tron counterparties), and `VerifiedUserLabel`'s name-click propagation (only prior consumer verified unaffected).

## QA
- `npx jest src/components/TransactionDetails` — 160 green (predicate 13 address/eligibility cases + `TransactionCard` RTL 3/3 mounting the real component: name→`/natalia` with no drawer, non-name→drawer, ineligible→inert).
- Full suite: 110 suites / 1698 tests green. `npm run typecheck` — clean (exit 0).
- Manual (sandbox): open the Activity feed, tap a peer's name on a completed send → lands on their profile with Send/Request. Tap elsewhere on the row → details drawer still opens. A link/withdraw/address row's name stays inert.

> Note: local `next build` OOMs on this box (known infra heap limit, not this change — typecheck already validates imports/types); CI build is the confirmation.
