### PR TITLE
chore(routes): make all /dev pages public in dev mode

### DIFF
--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -108,11 +108,13 @@ export const RESERVED_ROUTES: readonly string[] = [...DEDICATED_ROUTES, ...STATI
 export const PUBLIC_ROUTES_REGEX = /^\/(request\/pay|claim|pay\/.+|support|invite|qr|dev\/payment-graph)/
 
 /**
- * Regex for dev-only public routes (dev index, gift-test, shake-test)
- * Only matched when IS_DEV is true
+ * Regex for dev-only public routes: ALL /dev pages (index + every tool/preview).
+ * Only matched when IS_DEV is true (build-time NODE_ENV==='development'), so this
+ * never applies on prod/preview builds. /dev is also independently notFound()'d on
+ * peanut.me by dev/layout.tsx (except full-graph/payment-graph), so dev tooling is
+ * doubly walled off from prod — this just removes the login-redirect friction locally.
  */
-export const DEV_ONLY_PUBLIC_ROUTES_REGEX =
-    /^\/(dev$|dev\/gift-test|dev\/shake-test|dev\/ds|dev\/components|dev\/share-builder|dev\/rejection-builder)/
+export const DEV_ONLY_PUBLIC_ROUTES_REGEX = /^\/dev(\/|$)/
 
 /**
  * Matches locale tags with a required subtag to avoid false-positives on short


### PR DESCRIPTION
## Summary

The dev-only public-route allowlist (`DEV_ONLY_PUBLIC_ROUTES_REGEX`) is hand-maintained: every new `/dev` tool/preview page has to be manually appended, and any page not on the list gets bounced to `/setup` on localhost. That's pure developer friction with no security upside — dev pages are tooling, not user surfaces.

This generalizes the allowlist to **all** `/dev` routes:
```ts
export const DEV_ONLY_PUBLIC_ROUTES_REGEX = /^\/dev(\/|$)/
```

## Why it's safe (three independent guards)

1. `isPublicRoute(path, IS_DEV)` only consults this regex when `IS_DEV` is true — `IS_DEV = process.env.NODE_ENV === 'development'`, a **build-time** value that is false in every prod/preview build. The carve-out simply doesn't exist off localhost.
2. `isPublicRoute` has **exactly one call site** (`(mobile-ui)/layout.tsx`), which passes `IS_DEV` — nothing else can widen it.
3. Defense-in-depth: `dev/layout.tsx` independently `notFound()`s all `/dev/*` on `peanut.me` except `full-graph`/`payment-graph`. Even a bug here can't expose dev pages in prod.

"Public" only means *not force-redirecting to login* — it grants zero privilege (pages needing a wallet still render empty/loading).

## Risk / blast radius

FE-only, one constant. No behavior change on prod (guard #1). Only effect: on localhost you can open any `/dev` page without logging in first.

## QA

- `npm run typecheck` clean; `src/constants/__tests__/routes.test.ts` 15/15.
- Locally (`NODE_ENV=development`): `/dev/home-ctas`, `/dev/profile-card-row`, etc. load without redirecting to `/setup`.
- Prod guard unchanged: `peanut.me/dev/<anything except full-graph/payment-graph>` still `notFound()`s.
