### PR TITLE
fix(kyc): cross-region 'Unlock region' loop + wrong copy + homepage self-heal dead-end

### DIFF
--- a/src/components/Home/ActivationCTAs.tsx
+++ b/src/components/Home/ActivationCTAs.tsx
@@ -15,6 +15,8 @@ import { useIdentityVerification } from '@/hooks/useIdentityVerification'
 import { useAuth } from '@/context/authContext'
 import { buildContactSupportMessage } from '@/utils/contact-support.utils'
 import ProvideEmailStep from '@/components/Kyc/ProvideEmailStep'
+import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
+import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 
 interface ActivationCTAsProps {
     activationStep: ActivationStep
@@ -89,32 +91,47 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
     // qr-only channels — never through card. Top-level status (not per-op
     // refinement): Manteca's pool tier reads `enabled` at the rail level even when
     // deposit/withdraw individually need an upgrade — that's not a rejection.
-    const { hasFixableRejection, hasBlockedRejection, primaryRejectionMessage, blockedRail, isEmailBlocked } =
-        useMemo(() => {
-            const rejectableRails = rails.filter((rail) => {
-                const channel = channelOf(rail)
-                return channel === 'bank' || channel === 'qr-only'
-            })
-            const fixableRail = rejectableRails.find((rail) => rail.status === 'requires-info')
-            // Email-blocked rails carry a self-serve provide-email action (same
-            // contract the capability gate reads) — prefer one over an earlier
-            // blocked rail with a terminal reason, since one email fixes them all.
-            const emailBlocked = rejectableRails.find(
-                (rail) =>
-                    rail.status === 'blocked' && nextActionsForRail(rail.id).some((a) => a.kind === 'provide-email')
-            )
-            const blocked = emailBlocked ?? rejectableRails.find((rail) => rail.status === 'blocked')
-            return {
-                hasFixableRejection: !!fixableRail,
-                hasBlockedRejection: !!blocked,
-                // Same precedence the copy/onClick use: email-blocked → fixable → terminal.
-                primaryRejectionMessage: (emailBlocked ?? fixableRail ?? blocked)?.reason?.userMessage ?? null,
-                blockedRail: blocked,
-                isEmailBlocked: !!emailBlocked,
-            }
-        }, [rails, channelOf, nextActionsForRail])
+    const {
+        hasFixableRejection,
+        fixableProvider,
+        hasBlockedRejection,
+        primaryRejectionMessage,
+        blockedRail,
+        isEmailBlocked,
+    } = useMemo(() => {
+        const rejectableRails = rails.filter((rail) => {
+            const channel = channelOf(rail)
+            return channel === 'bank' || channel === 'qr-only'
+        })
+        const fixableRail = rejectableRails.find((rail) => rail.status === 'requires-info')
+        // Email-blocked rails carry a self-serve provide-email action (same
+        // contract the capability gate reads) — prefer one over an earlier
+        // blocked rail with a terminal reason, since one email fixes them all.
+        const emailBlocked = rejectableRails.find(
+            (rail) => rail.status === 'blocked' && nextActionsForRail(rail.id).some((a) => a.kind === 'provide-email')
+        )
+        const blocked = emailBlocked ?? rejectableRails.find((rail) => rail.status === 'blocked')
+        return {
+            hasFixableRejection: !!fixableRail,
+            fixableProvider:
+                fixableRail && (fixableRail.provider === 'bridge' || fixableRail.provider === 'manteca')
+                    ? (fixableRail.provider.toUpperCase() as 'BRIDGE' | 'MANTECA')
+                    : null,
+            hasBlockedRejection: !!blocked,
+            // Same precedence the copy/onClick use: email-blocked → fixable → terminal.
+            primaryRejectionMessage: (emailBlocked ?? fixableRail ?? blocked)?.reason?.userMessage ?? null,
+            blockedRail: blocked,
+            isEmailBlocked: !!emailBlocked,
+        }
+    }, [rails, channelOf, nextActionsForRail])
 
     const [showProvideEmail, setShowProvideEmail] = useState(false)
+
+    // Inline self-heal so the home "Upload document" CTA opens the Sumsub document
+    // re-upload directly, instead of routing to /profile/identity-verification (which
+    // only showed the regions list, forcing the user to hunt for the Upload-document
+    // CTA again). Mirrors the add-money bank flow + UnlockedRegions view.
+    const kycFlow = useMultiPhaseKycFlow({})
 
     const lastTrackedStep = useRef<ActivationStep | null>(null)
     useEffect(() => {
@@ -253,6 +270,8 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
                                     userId: user?.user?.userId,
                                 })
                             )
+                        } else if (hasProviderRejection && hasFixableRejection && fixableProvider) {
+                            void kycFlow.handleSelfHealResubmit(fixableProvider)
                         } else if (activationStep === 'outbound' && !hasProviderRejection) {
                             setIsQRScannerOpen(true)
                         } else {
@@ -273,6 +292,7 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
                 onComplete={() => setShowProvideEmail(false)}
                 onSkip={() => setShowProvideEmail(false)}
             />
+            <SumsubKycModals flow={kycFlow} />
         </Card>
     )
 }

--- a/src/components/Home/__tests__/ActivationCTAs.test.tsx
+++ b/src/components/Home/__tests__/ActivationCTAs.test.tsx
@@ -12,10 +12,18 @@
  * genuinely-fixable bank RFI still surfaces in the /add-money bank flow.
  */
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 
-let mockRails: Array<{ id: string; channel: string; status: string; reason?: { userMessage: string } }> = []
+let mockRails: Array<{
+    id: string
+    provider?: string
+    channel: string
+    status: string
+    reason?: { userMessage: string }
+}> = []
 let mockUser: { user?: { isActivated?: boolean; userId?: string } } | null = null
+const mockHeal = jest.fn()
+const mockPush = jest.fn()
 
 jest.mock('@/hooks/useCapabilities', () => ({
     useCapabilities: () => ({
@@ -34,18 +42,27 @@ jest.mock('@/context/ModalsContext', () => ({
     useModalsContext: () => ({ setIsQRScannerOpen: jest.fn(), openSupportWithMessage: jest.fn() }),
 }))
 jest.mock('next/navigation', () => ({
-    useRouter: () => ({ push: jest.fn() }),
+    useRouter: () => ({ push: mockPush }),
 }))
 jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
 jest.mock('@/components/Home/CardLaunchCTA/CardLaunchCTABanner', () => ({
     __esModule: true,
+
     default: () => null,
+}))
+
+jest.mock('@/hooks/useMultiPhaseKycFlow', () => ({
+    useMultiPhaseKycFlow: () => ({ handleSelfHealResubmit: mockHeal }),
+}))
+jest.mock('@/components/Kyc/SumsubKycModals', () => ({
+    SumsubKycModals: () => null,
 }))
 
 import ActivationCTAs from '../ActivationCTAs'
 
 const bankRejected = {
     id: 'bridge.sepa_eu',
+    provider: 'bridge',
     channel: 'bank',
     status: 'requires-info',
     reason: { userMessage: 'We need a valid proof of address document.' },
@@ -79,5 +96,13 @@ describe('ActivationCTAs — rejection override respects existing transacting ab
         render(<ActivationCTAs activationStep="deposit" />)
         expect(screen.getByText('Complete your setup')).toBeInTheDocument()
         expect(screen.getByText('We need a valid proof of address document.')).toBeInTheDocument()
+    })
+
+    it('fixable rejection: Upload document heals inline (handleSelfHealResubmit), does not navigate away', () => {
+        mockRails = [bankRejected]
+        render(<ActivationCTAs activationStep="deposit" />)
+        fireEvent.click(screen.getByText('Upload document'))
+        expect(mockHeal).toHaveBeenCalledWith('BRIDGE')
+        expect(mockPush).not.toHaveBeenCalled()
     })
 })

--- a/src/components/Kyc/InitiateKycModal.tsx
+++ b/src/components/Kyc/InitiateKycModal.tsx
@@ -87,9 +87,8 @@ export const InitiateKycModal = ({
         }
         if (isCrossRegion) {
             return {
-                text: isLoading ? 'Loading...' : 'Submit document',
+                text: isLoading ? 'Loading...' : 'Continue',
                 onClick: onVerify,
-                icon: 'upload' as IconName,
             }
         }
         return {

--- a/src/components/Kyc/InitiateKycModal.tsx
+++ b/src/components/Kyc/InitiateKycModal.tsx
@@ -58,8 +58,8 @@ export const InitiateKycModal = ({
             )
         if (isProviderRejection) return providerMessage || 'Please upload a clearer photo of your ID to continue.'
         if (isCrossRegion) {
-            const region = regionName ? ` from ${regionName}` : ''
-            return `Your ID is already on file. To unlock payments here, we need a valid ID${region}.`
+            const region = regionName ? ` in ${regionName}` : ' here'
+            return `Your identity is already verified. To turn on payments${region}, we just need to confirm a few more details — about a minute.`
         }
         return 'Confirm your ID to unlock payments. Takes about a minute.'
     }

--- a/src/utils/capability-gate.test.ts
+++ b/src/utils/capability-gate.test.ts
@@ -192,6 +192,21 @@ describe('deriveGate — waiting-on-provider (kind: wait)', () => {
         expect(gate.kind).toBe('fixable-rejection')
     })
 
+    test('requires-info rail with no surfaced action -> fixable-rejection, NOT cross-region needs-enrollment (government-id self-heal loop)', () => {
+        // Reported loop: a Bridge rail that needs a government-id re-upload
+        // (DOCUMENT_SELF_HEAL) carries no blockingAction because the backend resolver
+        // punts it to the FE resubmit endpoint. It must route to the self-heal /
+        // document flow, NOT the misleading "Unlock {region}" cross-region modal
+        // (needs-enrollment) that looped users on a fake "You're unlocked".
+        const rail = bankRail({
+            id: 'bridge.ach_us',
+            status: 'requires-info',
+            blockingActions: [],
+        })
+        const gate = deriveGate(state([rail], []), 'deposit', { channel: 'bank' })
+        expect(gate.kind).toBe('fixable-rejection')
+    })
+
     test('rail with NO actions stays out of waiting-on-provider (would falsely match `every of empty = true`)', () => {
         // Edge case: a requires-info rail with no blockingActions should NOT be
         // misclassified as waiting-on-provider (Array.every returns true on []).

--- a/src/utils/capability-gate.test.ts
+++ b/src/utils/capability-gate.test.ts
@@ -207,6 +207,29 @@ describe('deriveGate — waiting-on-provider (kind: wait)', () => {
         expect(gate.kind).toBe('fixable-rejection')
     })
 
+    test('mixed scope: 7b surfaces the self-heal rail reason, not a wait-only rail message', () => {
+        // A wait-only rail ("finalizing with Bridge") + an action-less self-heal rail
+        // in the same scope. allWaiting is false, so 7b fires — it must pick the
+        // self-heal rail's reason for the Upload-document modal, not the wait message.
+        const waitAction: NextAction = { key: 'wait:bridge', kind: 'wait', purpose: 'bridge-review' }
+        const rails = [
+            bankRail({
+                id: 'bridge.sepa_eu',
+                status: 'requires-info',
+                blockingActions: ['wait:bridge'],
+                reason: { code: 'bridge_processing', userMessage: "We're finalizing your verification with Bridge." },
+            }),
+            bankRail({
+                id: 'bridge.ach_us',
+                status: 'requires-info',
+                blockingActions: [],
+                reason: { code: 'document_rejected', userMessage: 'Please re-upload your ID document.' },
+            }),
+        ]
+        const gate = deriveGate(state(rails, [waitAction]), 'deposit', { channel: 'bank' })
+        expect(gate).toMatchObject({ kind: 'fixable-rejection', userMessage: 'Please re-upload your ID document.' })
+    })
+
     test('rail with NO actions stays out of waiting-on-provider (would falsely match `every of empty = true`)', () => {
         // Edge case: a requires-info rail with no blockingActions should NOT be
         // misclassified as waiting-on-provider (Array.every returns true on []).

--- a/src/utils/capability-gate.ts
+++ b/src/utils/capability-gate.ts
@@ -294,6 +294,24 @@ export function deriveGate(state: CapabilityState, op: RailOperation, scope: Gat
         }
     }
 
+    // 7b. Requires-info rails EXIST in scope but none surfaced an actionable step
+    // (no accept-tos / sumsub / wait). The rail exists so the user is NOT missing a
+    // region; it needs a document the backend resolver punts to the FE resubmit
+    // endpoint (e.g. a Bridge government-id DOCUMENT_SELF_HEAL, requirementKey
+    // government_id_document). Route to the self-heal / document flow
+    // (fixable-rejection -> handleSelfHealResubmit) instead of the misleading
+    // Unlock {region} cross-region modal, which sent these users into a fake
+    // You're unlocked loop (tap Submit document, see success, bounce back with
+    // nothing changed).
+    if (requiresInfoRails.length > 0) {
+        const rail = requiresInfoRails[0]
+        return {
+            kind: 'fixable-rejection',
+            userMessage: rail.reason?.userMessage ?? null,
+            reason: rail.reason,
+        }
+    }
+
     // 8/9. no functional rail in scope. Distinguish identity-not-cleared vs
     // identity-cleared-but-no-rail-for-this-scope (needs enrollment / cross-region).
     if (!state.identityVerified) return { kind: 'needs-identity' }

--- a/src/utils/capability-gate.ts
+++ b/src/utils/capability-gate.ts
@@ -304,7 +304,14 @@ export function deriveGate(state: CapabilityState, op: RailOperation, scope: Gat
     // You're unlocked loop (tap Submit document, see success, bounce back with
     // nothing changed).
     if (requiresInfoRails.length > 0) {
-        const rail = requiresInfoRails[0]
+        // Prefer an action-less / self-heal rail over a wait-only one, so a mixed
+        // scope doesn't surface a "we're finalizing with Bridge" wait message on
+        // the document-upload modal.
+        const rail =
+            requiresInfoRails.find((r) => {
+                const acts = railActions(r, actionByKey)
+                return acts.length === 0 || acts.some((a) => a.kind !== 'wait')
+            }) ?? requiresInfoRails[0]
         return {
             kind: 'fixable-rejection',
             userMessage: rail.reason?.userMessage ?? null,


### PR DESCRIPTION
- fixes TASK-20564

Fixes the KYC deposit issues from Hugo's Discord report + a related homepage dead-end. Targets **main** (hotfix — live, customer-facing). FE-only.

## The bug (verified on prod: username `hugo` / `c511d99c`)
Hugo picks a bank deposit → gets **"Unlock United States — Your ID is already on file. To unlock payments here, we need a valid ID from United States"** → taps **Submit document** → sees **"You're unlocked"** → bounces back → same modal → loop.

His actual state: SUMSUB **APPROVED**, and he **already has** Bridge rails (US ACH, UK, SEPA, SPEI) — all in `REQUIRES_EXTRA_INFORMATION`, each with `bridgeRemediation.nextAction = DOCUMENT_SELF_HEAL / requirementKey: government_id_document` (Bridge wants his ID re-uploaded; it's expired/invalid).

**Root cause:** the backend resolver emits **no capability action** for a generic government-id self-heal (it expects the FE to call the resubmit endpoint directly). So in `deriveGate`, that in-scope `requires-info` rail matches none of the branches and **falls through to `needs-enrollment` → the `cross_region` "Unlock {region}" modal**. Tapping Submit runs a *cross-region enrollment* (wrong flow) that flashes "You're unlocked" and changes nothing → loop.

## The fixes (3)
1. **`capability-gate.ts`** — if an in-scope rail is `requires-info` (the rail **exists**, the user isn't missing a region), route to **`fixable-rejection`** instead of falling through to `needs-enrollment`. `fixable-rejection`'s `onVerify` already calls `handleSelfHealResubmit('BRIDGE')` → the document re-upload flow. `needs-enrollment` (cross_region) is preserved for the genuine "no rail in this scope" case.
2. **`InitiateKycModal.tsx`** — the `cross_region` copy claimed "we need a valid ID **from {region}**", implying a country-specific ID. False — a European doesn't need a US ID for US bank transfer. Replaced with honest, region-agnostic copy: *"Your identity is already verified. To turn on payments in {region}, we just need to confirm a few more details."*
3. **`ActivationCTAs.tsx` (homepage)** — the home "Complete your setup / Upload document" card, for a fixable rejection, `router.push`'d to `/profile/identity-verification` (the UnlockedRegions list) — a dead-end where the user had to hunt for the Upload-document CTA again. Now it calls **`handleSelfHealResubmit(provider)` inline** (opens the Sumsub document re-upload right there), matching the add-money bank flow + UnlockedRegions view. Provider derived from the fixable rail.

## Verified locally (prod-shaped seeds against local DB)
- ✅ requires-info rail → **"We need extra documents"** (not "Unlock US" loop)
- ✅ genuine cross-region → corrected copy (no "valid ID from {country}")
- ✅ homepage "Upload document" heals **inline** (no navigation to /profile)

## Risks
- `deriveGate` is the shared deposit/withdraw gate. The new branch only fires when an in-scope `requires-info` rail exists **and** no accept-tos/sumsub/wait action was surfaced. Genuine cross-region enrollment (no rail in scope) is unchanged; existing tests pin it.
- Copy-only change to the cross_region modal.
- Homepage card now mounts `useMultiPhaseKycFlow` + `SumsubKycModals` (same pattern the other two surfaces already use).

## QA
- `capability-gate.test.ts` — new: `requires-info rail with no surfaced action → fixable-rejection` (31/31).
- `ActivationCTAs.test.tsx` — new: fixable-rejection CTA calls `handleSelfHealResubmit`, does not navigate (4/4).
- typecheck clean. (One unrelated suite, `countryCurrencyMapping.test.ts`, fails locally on a missing flag SVG in the bare worktree — asset artifact, not this diff; green on CI.)

## Follow-up (not this PR)
- **Premature "You're unlocked"** on the *genuine* cross-region `bridge-direct` path (`useSumsubKycFlow.ts`) fires `onKycSuccess` off the response before the rail is `ENABLED`. Hugo no longer hits it (he routes to the doc-upload flow); for real new-region enrollments it should show a "we're verifying" state and confirm rail enablement before success.
- Backend: consider having the resolver surface an explicit self-heal action for the government-id `DOCUMENT_SELF_HEAL` so the gate classifies it via a real action rather than the requires-info fallback.
