### PR TITLE
feat(card): geo-blocked state — stop prohibited-country users before the apply funnel

### DIFF
--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -619,6 +619,10 @@ const CardPage: FC = () => {
                         onPrev={onBack}
                     />
                 )
+            case 'geo-blocked':
+                // Regulatory dead end (country on Rain's prohibited-issuance
+                // list) — no support CTA, support can't override regulation.
+                return <ApplicationStatusScreen variant="geo-blocked" onPrev={onBack} />
             case 'rejected': {
                 // No retry CTA: Rain denials are terminal on our side. The
                 // only path forward is support reviewing the case manually

--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -89,6 +89,11 @@ const CardPage: FC = () => {
     // the new card row". Without it the screen would briefly flip back to Add
     // Card mid-apply before the state machine sees the new state.
     const [isIssuing, setIsIssuing] = useState(false)
+    // Set when POST /rain/cards answers `geo-blocked` (country on Rain's
+    // prohibited-issuance list, detected from the Sumsub address at apply
+    // time). Per-mount — the cardInfo refetch it triggers makes the state
+    // machine's geoProhibited path own the block durably.
+    const [geoBlocked, setGeoBlocked] = useState(false)
 
     // Track whether the user has acknowledged the skip-badge celebration.
     // localStorage on purpose (per-device, replayable via the eligibility
@@ -241,12 +246,26 @@ const CardPage: FC = () => {
                 setPendingTerms({ isUsResident: res.isUsResident })
                 return
             }
+            // Terminal regulatory block from the BE gate. This can fire
+            // mid-funnel for Sumsub-only users whose country is unknown until
+            // their address lands (cardInfo.geoProhibited couldn't catch them
+            // up front). Local flag renders the screen immediately — without
+            // it the user would bounce back to add-card with a generic error
+            // and an apply button that can never succeed. The cardInfo refetch
+            // lets the state machine own the block on subsequent visits.
+            if (res.status === 'geo-blocked') {
+                setPendingTerms(null)
+                setPendingCountryConfirmation(null)
+                setGeoBlocked(true)
+                void refetchCardInfo()
+                return
+            }
             // pending / already-applied → state machine routes based on overview.
             setPendingTerms(null)
             setPendingCountryConfirmation(null)
             invalidateOverview()
         },
-        [invalidateOverview]
+        [invalidateOverview, refetchCardInfo]
     )
 
     // The user picked their residence country on the confirmation screen.
@@ -446,11 +465,14 @@ const CardPage: FC = () => {
             setPendingTerms({ isUsResident: res.isUsResident })
         } else if (res.status === 'country-confirmation-required' && 'candidates' in res) {
             setPendingCountryConfirmation({ candidates: res.candidates })
+        } else if (res.status === 'geo-blocked') {
+            setGeoBlocked(true)
+            void refetchCardInfo()
         } else {
             invalidateOverview()
         }
         return ''
-    }, [invalidateOverview])
+    }, [invalidateOverview, refetchCardInfo])
 
     // Outer-gate fail — the useEffect above fires notFound() to render the
     // 404 boundary; render nothing here so the page doesn't flash for the
@@ -488,6 +510,12 @@ const CardPage: FC = () => {
         // to Add Card for a split second while the API call is in flight.
         if (isIssuing) {
             return <ApplicationStatusScreen variant="pending" />
+        }
+        // Terminal regulatory block detected mid-funnel by the BE apply gate —
+        // takes precedence over the confirmation/terms overlays (those flows
+        // are moot once the country verdict is in).
+        if (geoBlocked) {
+            return <ApplicationStatusScreen variant="geo-blocked" onPrev={onBack} />
         }
         // Residence confirmation comes before terms in the funnel — the
         // backend won't return terms-required until the country is resolved.

--- a/src/components/Card/ApplicationStatusScreen.tsx
+++ b/src/components/Card/ApplicationStatusScreen.tsx
@@ -5,7 +5,7 @@ import { PeanutCrying } from '@/assets/mascot'
 import NavHeader from '@/components/Global/NavHeader'
 import Loading from '@/components/Global/Loading'
 
-type Variant = 'pending' | 'manual-review' | 'requires-info' | 'requires-support' | 'rejected'
+type Variant = 'pending' | 'manual-review' | 'requires-info' | 'requires-support' | 'rejected' | 'geo-blocked'
 
 interface Props {
     variant: Variant
@@ -41,6 +41,12 @@ const COPY: Record<Variant, { title: string; body: string }> = {
         title: "We couldn't issue you a card",
         body: 'You can still use Peanut freely to deposit, withdraw, and pay with crypto.',
     },
+    'geo-blocked': {
+        // Terminal, nothing support can do (regulatory) — no support CTA.
+        // Same reassurance as `rejected`: the rest of the account still works.
+        title: "Cards aren't available in your region yet",
+        body: 'Due to regulatory restrictions, we can’t issue cards in your region. You can still use Peanut freely to deposit, withdraw, and pay with crypto.',
+    },
 }
 
 /** Variants where support is the only path forward — these render the CTA. */
@@ -53,7 +59,7 @@ const ApplicationStatusScreen: FC<Props> = ({ variant, reasonMessage, onContactS
             <NavHeader title="Add card" onPrev={onPrev} />
             <div className="my-auto flex flex-col items-center gap-6 text-center">
                 {variant === 'pending' && <Loading />}
-                {(variant === 'rejected' || variant === 'requires-support') && (
+                {(variant === 'rejected' || variant === 'requires-support' || variant === 'geo-blocked') && (
                     <Image
                         src={PeanutCrying.src}
                         unoptimized

--- a/src/components/Card/ApplicationStatusScreen.tsx
+++ b/src/components/Card/ApplicationStatusScreen.tsx
@@ -45,7 +45,7 @@ const COPY: Record<Variant, { title: string; body: string }> = {
         // Terminal, nothing support can do (regulatory) — no support CTA.
         // Same reassurance as `rejected`: the rest of the account still works.
         title: "Cards aren't available in your region yet",
-        body: 'Due to regulatory restrictions, we can’t issue cards in your region. You can still use Peanut freely to deposit, withdraw, and pay with crypto.',
+        body: "Due to regulatory restrictions, we can't issue cards in your region. You can still use Peanut freely to deposit, withdraw, and pay with crypto.",
     },
 }
 

--- a/src/components/Card/ApplicationStatusScreen.tsx
+++ b/src/components/Card/ApplicationStatusScreen.tsx
@@ -52,6 +52,15 @@ const COPY: Record<Variant, { title: string; body: string }> = {
 /** Variants where support is the only path forward — these render the CTA. */
 const SUPPORT_VARIANTS: ReadonlySet<Variant> = new Set(['requires-info', 'requires-support', 'rejected'])
 
+/**
+ * The legal policy behind the geo block — §1 "Restricted Countries" lists the
+ * issuance denylist. A LEGAL page on purpose: Rain's marketing-compliance
+ * rules ban country names / eligibility framing in card-marketing surfaces
+ * (help articles included), so this policy page is the one compliant place
+ * the full list is published. Mirrors CardTermsScreen's absolute-URL pattern.
+ */
+const PROHIBITED_ACTIVITIES_POLICY_URL = 'https://peanut.me/en/card-prohibited-activities'
+
 const ApplicationStatusScreen: FC<Props> = ({ variant, reasonMessage, onContactSupport, onPrev }) => {
     const copy = COPY[variant]
     return (
@@ -75,6 +84,16 @@ const ApplicationStatusScreen: FC<Props> = ({ variant, reasonMessage, onContactS
                     {reasonMessage && <p className="text-grey-1">{reasonMessage}</p>}
                     <p className="text-grey-1">{copy.body}</p>
                 </div>
+                {variant === 'geo-blocked' && (
+                    <a
+                        href={PROHIBITED_ACTIVITIES_POLICY_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-black underline"
+                    >
+                        See which regions are restricted
+                    </a>
+                )}
                 {SUPPORT_VARIANTS.has(variant) && onContactSupport && (
                     <button type="button" onClick={onContactSupport} className="text-black underline">
                         Contact support

--- a/src/components/Card/__tests__/ApplicationStatusScreen.test.tsx
+++ b/src/components/Card/__tests__/ApplicationStatusScreen.test.tsx
@@ -72,4 +72,16 @@ describe('ApplicationStatusScreen — geo-blocked', () => {
         render(<ApplicationStatusScreen variant="geo-blocked" onContactSupport={jest.fn()} />)
         expect(screen.queryByText('Contact support')).not.toBeInTheDocument()
     })
+
+    it('links the Prohibited Activities Policy — the one compliant place the country list is published', () => {
+        render(<ApplicationStatusScreen variant="geo-blocked" />)
+        const link = screen.getByRole('link', { name: 'See which regions are restricted' })
+        expect(link).toHaveAttribute('href', 'https://peanut.me/en/card-prohibited-activities')
+        expect(link).toHaveAttribute('target', '_blank')
+    })
+
+    it('does not show the policy link on other variants', () => {
+        render(<ApplicationStatusScreen variant="rejected" onContactSupport={jest.fn()} />)
+        expect(screen.queryByText('See which regions are restricted')).not.toBeInTheDocument()
+    })
 })

--- a/src/components/Card/__tests__/ApplicationStatusScreen.test.tsx
+++ b/src/components/Card/__tests__/ApplicationStatusScreen.test.tsx
@@ -57,3 +57,19 @@ describe('ApplicationStatusScreen — rejected', () => {
         expect(onContactSupport).toHaveBeenCalledTimes(1)
     })
 })
+
+describe('ApplicationStatusScreen — geo-blocked', () => {
+    it('renders the regional copy with the reassurance', () => {
+        render(<ApplicationStatusScreen variant="geo-blocked" />)
+        expect(screen.getByText("Cards aren't available in your region yet")).toBeInTheDocument()
+        expect(screen.getByText(/regulatory restrictions.*deposit, withdraw, and pay with crypto/)).toBeInTheDocument()
+    })
+
+    it('never renders a Contact-support CTA — regulation is not a support case', () => {
+        // Even if a caller wires the handler, geo-blocked must not show the
+        // CTA: support cannot override Rain's prohibited-issuance list, so the
+        // button would be a dead end by design. Guards SUPPORT_VARIANTS drift.
+        render(<ApplicationStatusScreen variant="geo-blocked" onContactSupport={jest.fn()} />)
+        expect(screen.queryByText('Contact support')).not.toBeInTheDocument()
+    })
+})

--- a/src/components/Card/__tests__/cardState.utils.test.ts
+++ b/src/components/Card/__tests__/cardState.utils.test.ts
@@ -10,6 +10,7 @@ const cardInfo = (
         waitlistPosition?: number | null
         waitlistReleasedAt?: string | null
         skipBadges?: string[]
+        geoProhibited?: boolean
     } = {}
 ): CardInfoResponse => ({
     hasCardAccess: opts.hasCardAccess ?? false,
@@ -20,6 +21,7 @@ const cardInfo = (
     waitlistPosition: opts.waitlistPosition ?? null,
     waitlistReleasedAt: opts.waitlistReleasedAt ?? null,
     skipBadges: opts.skipBadges ?? [],
+    geoProhibited: opts.geoProhibited,
 })
 
 const emptyOverview: RainCardOverview = {
@@ -272,6 +274,71 @@ describe('computeCardState', () => {
                     skipCelebrationSeen: true,
                 })
             ).toBe('requires-support')
+        })
+    })
+
+    describe('geo-blocked (country on Rain prohibited-issuance list)', () => {
+        it('blocks a fresh user (no application) before the press-and-hold gate', () => {
+            expect(
+                computeCardState({
+                    ...base,
+                    overview: emptyOverview,
+                    cardInfo: cardInfo({ hasCardAccess: true, geoProhibited: true }),
+                    eligibilityCheckDone: false,
+                })
+            ).toBe('geo-blocked')
+        })
+
+        it('blocks a waitlist-bound user too (no card access, no application)', () => {
+            expect(
+                computeCardState({
+                    ...base,
+                    overview: emptyOverview,
+                    cardInfo: cardInfo({ hasCardAccess: false, geoProhibited: true }),
+                })
+            ).toBe('geo-blocked')
+        })
+
+        it('does NOT block an existing card holder', () => {
+            expect(
+                computeCardState({
+                    ...base,
+                    overview: withCard('ACTIVE'),
+                    cardInfo: cardInfo({ hasCardAccess: true, geoProhibited: true }),
+                })
+            ).toBe('active')
+        })
+
+        it('does NOT mask an in-flight application state', () => {
+            expect(
+                computeCardState({
+                    ...base,
+                    overview: withApp('PENDING'),
+                    cardInfo: cardInfo({ hasCardAccess: true, geoProhibited: true }),
+                })
+            ).toBe('pending')
+        })
+
+        it('does NOT block the re-issue path (ENABLED rail, no card — already approved by Rain)', () => {
+            expect(
+                computeCardState({
+                    ...base,
+                    overview: withApp('ENABLED'),
+                    cardInfo: cardInfo({ hasCardAccess: true, geoProhibited: true }),
+                    skipCelebrationSeen: true,
+                })
+            ).toBe('add-card')
+        })
+
+        it('treats a missing geoProhibited field (older BE) as not blocked', () => {
+            expect(
+                computeCardState({
+                    ...base,
+                    overview: emptyOverview,
+                    cardInfo: cardInfo({ hasCardAccess: true, skipBadges: [] }),
+                    skipCelebrationSeen: true,
+                })
+            ).toBe('add-card')
         })
     })
 

--- a/src/components/Card/cardState.utils.ts
+++ b/src/components/Card/cardState.utils.ts
@@ -17,6 +17,7 @@ export function findActiveCard(overview: RainCardOverview | undefined): RainCard
  * Precedence (top wins) in `computeCardState`:
  *   loading → active → no-flow-access → rejected (incl. FAILED) →
  *   requires-support → requires-info → pending/manual-review →
+ *   geo-blocked (no application, country on Rain's prohibited list) →
  *   eligibility-check (first arrival, not yet held) → skip-celebration →
  *   add-card → waitlist
  *
@@ -46,6 +47,11 @@ export type CardTopLevelState =
     /** Our pipeline broke en route to the provider (rail REQUIRES_SUPPORT).
      *  Not self-fixable — support has to step in. */
     | 'requires-support'
+    /** Country known (from KYC) and on Rain's prohibited-issuance list — the
+     *  user can't apply, so block entry into the funnel before the
+     *  press-and-hold moment. Only for users with NO existing application;
+     *  in-flight/approved applicants keep their truthful rail state above. */
+    | 'geo-blocked'
     | 'rejected'
     | 'active'
 
@@ -121,6 +127,16 @@ export function computeCardState({
     // through to add-card would re-create the apply loop ("Application
     // already submitted" → add-card → …), so route unknowns to support.
     if (rail && rail !== 'ENABLED') return 'requires-support'
+
+    // Country known (from KYC) and on Rain's prohibited-issuance list — no
+    // point letting the user into the funnel (the BE apply gate would refuse
+    // anyway). Checked BEFORE the press-and-hold so they aren't teased with
+    // "see if you qualify". Scoped to `!rail` on purpose: an ENABLED rail
+    // without a card is the re-issue path (already approved by Rain), which
+    // stays untouched — mirroring the BE gate placement. Unknown-country
+    // users (`geoProhibited` false/undefined) pass through; the BE re-checks
+    // the Sumsub address at submission time.
+    if (!rail && cardInfo.geoProhibited) return 'geo-blocked'
 
     // First arrival from /shhhhh: gate everything else behind the press-and-hold
     // "see if you qualify" moment. Applies whether the user ultimately lands on

--- a/src/services/card.ts
+++ b/src/services/card.ts
@@ -21,6 +21,12 @@ export interface CardInfoResponse {
      *  Rain card geo list. Not affected by waitlist state. */
     isEligible: boolean
     eligibilityReason?: string
+    /** True iff the user's KYC country is KNOWN and on Rain's prohibited-issuance
+     *  list. Distinct from `!isEligible`, which is also true when the country is
+     *  simply unknown (no KYC yet) — the card state machine blocks on this, never
+     *  on unknown. OPTIONAL: the BE that returns it deploys first; older APIs
+     *  omit it and the FE must treat that as "not blocked". */
+    geoProhibited?: boolean
     // ─── Waitlist fields (Card Waitlist Launch — M2 2026-06-01) ──
     /** Outer gate. True iff user can ENTER the /card flow (via /shhhhh
      *  early access or post-public-launch). */

--- a/src/services/rain.ts
+++ b/src/services/rain.ts
@@ -275,6 +275,12 @@ export type ApplyForCardResponse =
           message: string
       }
     | {
+          // Residence country is on Rain's prohibited-issuance list —
+          // terminal. Render the geo-blocked screen; no retry, no support CTA.
+          status: 'geo-blocked'
+          message: string
+      }
+    | {
           status: string
           rainUserId?: string
           message: string

--- a/src/types/api.generated.ts
+++ b/src/types/api.generated.ts
@@ -6404,6 +6404,10 @@ export interface paths {
                                 idDocumentCountry: string | null;
                             };
                         } | {
+                            /** @enum {string} */
+                            status: "geo-blocked";
+                            message: string;
+                        } | {
                             status: string;
                             rainUserId?: string;
                             message: string;

--- a/src/types/api.generated.ts
+++ b/src/types/api.generated.ts
@@ -6012,6 +6012,7 @@ export interface paths {
                             hasCardAccess: boolean;
                             isEligible: boolean;
                             eligibilityReason?: string;
+                            geoProhibited: boolean;
                             flowEarlyAccess: boolean;
                             waitlistJoinedAt: string | null;
                             waitlistPosition: number | null;

--- a/src/types/api.openapi.json
+++ b/src/types/api.openapi.json
@@ -7915,6 +7915,9 @@
 										"eligibilityReason": {
 											"type": "string"
 										},
+										"geoProhibited": {
+											"type": "boolean"
+										},
 										"flowEarlyAccess": {
 											"type": "boolean"
 										},
@@ -7958,6 +7961,7 @@
 									"required": [
 										"hasCardAccess",
 										"isEligible",
+										"geoProhibited",
 										"flowEarlyAccess",
 										"waitlistJoinedAt",
 										"waitlistPosition",

--- a/src/types/api.openapi.json
+++ b/src/types/api.openapi.json
@@ -8343,6 +8343,19 @@
 											"type": "object",
 											"properties": {
 												"status": {
+													"type": "string",
+													"enum": ["geo-blocked"]
+												},
+												"message": {
+													"type": "string"
+												}
+											},
+											"required": ["status", "message"]
+										},
+										{
+											"type": "object",
+											"properties": {
+												"status": {
 													"type": "string"
 												},
 												"rainUserId": {


### PR DESCRIPTION
## Summary

The `/card` state machine ignored country eligibility: users from Rain's prohibited-issuance countries were teased with the press-and-hold "see if you qualify" gate and could run the whole KYC funnel before Rain rejected them at the end.

- **`computeCardState`**: new `geo-blocked` state, keyed on the BE's new `geoProhibited` field (country KNOWN and prohibited — never blocks on unknown, so pre-KYC users still enter the funnel). Scoped to users with **no existing application**: in-flight/rejected rails keep their truthful state, and the re-issue path (ENABLED rail, already Rain-approved) is untouched — mirroring the BE gate placement. Checked before the press-and-hold so blocked users aren't teased.
- **`ApplicationStatusScreen`**: new `geo-blocked` variant — regulatory dead end, no support CTA (support can't override regulation), same "rest of the account still works" reassurance as `rejected`.
- `CardInfoResponse.geoProhibited?` (optional on purpose — older BE omits it → treated as not blocked).
- `api.openapi.json` / `api.generated.ts` patched surgically with just the new field; the committed copy has pre-existing drift vs BE that belongs in its own sync PR.
- 6 new state-machine tests (suite: 34 passing).
- **Geo-blocked screen links the [Prohibited Activities Policy](https://peanut.me/en/card-prohibited-activities)** — the one Rain-compliant place the restricted-country list is published (marketing surfaces can't name countries per Rain rules, so the legal page is the canonical customer-facing source).

## Risks / breaking changes

- **Cross-repo**: depends on peanutprotocol/peanut-api-ts#1156 (`geoProhibited` on `GET /card` + the BE apply gate). **BE deploys first**; this FE treats a missing field as not-blocked, so rollout order is safe.
- Pure additive state — existing states and precedence unchanged (covered by the untouched 28 pre-existing tests).

## QA

- `npm run typecheck` ✅, card state-machine jest suite 34/34 ✅, prettier ✅.
- Known pre-existing failures on this env unrelated to the diff: `countryCurrencyMapping` flag-svg existence checks and `add-money-states` (untouched files).

