### PR TITLE
fix(profile): let verified users save email without a name

### DIFF
--- a/src/components/Profile/views/ProfileEdit.view.tsx
+++ b/src/components/Profile/views/ProfileEdit.view.tsx
@@ -85,7 +85,7 @@ export const ProfileEditView = () => {
             }
 
             // prepare request payload
-            const payload: Record<string, any> = {
+            const payload: { userId?: string; fullName?: string; email?: string } = {
                 userId: user?.user.userId,
             }
 

--- a/src/components/Profile/views/ProfileEdit.view.tsx
+++ b/src/components/Profile/views/ProfileEdit.view.tsx
@@ -74,19 +74,24 @@ export const ProfileEditView = () => {
             setIsLoading(true)
             setErrorMessage('')
 
-            // validate form data
-            if (!formData.name?.trim()) {
+            // only validate/send the name when the field is editable. once the
+            // user is identity-verified the name is provider-owned and the field
+            // is disabled — requiring it would trap verified users whose fullName
+            // is empty at load (can't type, can't save) when they only want to
+            // set their email.
+            if (!isKycApproved && !formData.name?.trim()) {
                 setErrorMessage('Please provide your name.')
                 return
             }
 
-            // combine name and surname for fullName
-            const fullName = `${formData.name} ${formData.surname}`.trim()
-
             // prepare request payload
             const payload: Record<string, any> = {
                 userId: user?.user.userId,
-                fullName: fullName,
+            }
+
+            // only include name when the field is editable (not provider-locked)
+            if (!isKycApproved) {
+                payload.fullName = `${formData.name} ${formData.surname}`.trim()
             }
 
             // only include email if it's not already set and has a value
@@ -112,7 +117,7 @@ export const ProfileEditView = () => {
         } finally {
             setIsLoading(false)
         }
-    }, [formData, user, fetchUser, router, isEmailSet])
+    }, [formData, user, fetchUser, router, isEmailSet, isKycApproved])
 
     const fullName = user?.user.fullName || user?.user?.username || ''
     const username = user?.user.username || ''

--- a/src/components/Profile/views/ProfileEdit.view.tsx
+++ b/src/components/Profile/views/ProfileEdit.view.tsx
@@ -103,8 +103,14 @@ export const ProfileEditView = () => {
                 throw new Error('User ID is undefined.')
             }
 
-            // update user profile
-            await updateUserById(payload)
+            // updateUserById resolves with { error } on a non-2xx response
+            // instead of throwing (e.g. 400 invalid email, 409 email already in
+            // use). Surface it instead of navigating away as a false success.
+            const result = await updateUserById(payload)
+            if (result?.error) {
+                setErrorMessage(result.error)
+                return
+            }
 
             // refresh user data
             await fetchUser()

--- a/src/components/Profile/views/ProfileEdit.view.tsx
+++ b/src/components/Profile/views/ProfileEdit.view.tsx
@@ -47,6 +47,10 @@ export const ProfileEditView = () => {
     // check if email is already set
     const isEmailSet = !!user?.user.email
 
+    // once identity-verified the name is provider-owned, so the name/surname
+    // fields are locked and never sent. one source of truth for that invariant.
+    const canEditName = !isKycApproved
+
     // populate name and surname from fullName
     useEffect(() => {
         if (user?.user.fullName) {
@@ -74,12 +78,11 @@ export const ProfileEditView = () => {
             setIsLoading(true)
             setErrorMessage('')
 
-            // only validate/send the name when the field is editable. once the
-            // user is identity-verified the name is provider-owned and the field
-            // is disabled — requiring it would trap verified users whose fullName
-            // is empty at load (can't type, can't save) when they only want to
-            // set their email.
-            if (!isKycApproved && !formData.name?.trim()) {
+            // only require the name when the field is editable — requiring it
+            // while it's locked (verified user, provider owns the name) would
+            // trap users whose fullName is empty at load (can't type, can't
+            // save) when all they want is to set their email.
+            if (canEditName && !formData.name?.trim()) {
                 setErrorMessage('Please provide your name.')
                 return
             }
@@ -90,7 +93,7 @@ export const ProfileEditView = () => {
             }
 
             // only include name when the field is editable (not provider-locked)
-            if (!isKycApproved) {
+            if (canEditName) {
                 payload.fullName = `${formData.name} ${formData.surname}`.trim()
             }
 
@@ -101,6 +104,13 @@ export const ProfileEditView = () => {
 
             if (!user?.user.userId) {
                 throw new Error('User ID is undefined.')
+            }
+
+            // nothing substantive to update (e.g. a verified user with email
+            // already set clicking Save unchanged) — skip the no-op round-trip.
+            if (payload.fullName === undefined && payload.email === undefined) {
+                router.replace('/profile')
+                return
             }
 
             // updateUserById resolves with { error } on a non-2xx response
@@ -123,7 +133,7 @@ export const ProfileEditView = () => {
         } finally {
             setIsLoading(false)
         }
-    }, [formData, user, fetchUser, router, isEmailSet, isKycApproved])
+    }, [formData, user, fetchUser, router, isEmailSet, canEditName])
 
     const fullName = user?.user.fullName || user?.user?.username || ''
     const username = user?.user.username || ''
@@ -140,7 +150,7 @@ export const ProfileEditView = () => {
                     value={formData.name}
                     onChange={(value) => handleChange('name', value)}
                     placeholder="Add your name"
-                    disabled={isKycApproved}
+                    disabled={!canEditName}
                 />
 
                 <ProfileEditField
@@ -148,7 +158,7 @@ export const ProfileEditView = () => {
                     value={formData.surname}
                     onChange={(value) => handleChange('surname', value)}
                     placeholder="Add your surname"
-                    disabled={isKycApproved}
+                    disabled={!canEditName}
                 />
 
                 <ProfileEditField


### PR DESCRIPTION
## Summary

Verified users could get permanently stuck on **Edit Profile** when trying to set their email.

The Name/Surname fields are `disabled` once the user is identity-verified (the provider owns the legal name), but `handleSave` **hard-required** a non-empty name — sourced *only* from `user.fullName`. When a verified user's `fullName` was empty at form-load, the two rules collided: the field is locked (can't type) yet Save throws *"Please provide your name."* (can't save). Since the email field's whole purpose is an email-only update (`payload.email` is only added when `!isEmailSet`), the user could never complete it.

**Fix:** gate the name validation *and* the `fullName` payload on editability (`!isKycApproved`). Verified users now save email-only; the provider-owned name is left untouched. Non-verified users are unchanged (name still required, still sent).

## Root cause (from a real ticket)

Crisp ticket — user verified, wanted to set email, name form greyed + "Please provide your name" on Save. DB trace showed rails ENABLED before the Sumsub name backfill (`kyc/provider-submission/index.ts`) landed, and the FE was on a **stale cached user** (rails enabled, `fullName`/`email` still empty) → Name locked+empty, Email enabled → dead-end. Also reachable with fresh data whenever Sumsub can't extract a name (backfill skipped) → those users are permanently locked out.

## Risks / breaking changes

- FE-only, single component. No API/contract change.
- Behavior change is strictly a **relaxation**: verified users can now complete an email-only save; the required-name path for editable (non-verified) users is unchanged.

## QA

1. Verified user (`isKycApproved` true) with empty `fullName`, no email set → Edit Profile → type email → Save → succeeds, email persists, name untouched.
2. Non-verified user with empty name → Save → still shows "Please provide your name."
3. Non-verified user → sets name + email → Save → both persist.