### PR TITLE
feat: sync Rhino chain support with live catalogs (Avalanche + 8 more withdraw destinations, Tempo deposits)

### DIFF
--- a/src/components/Global/TokenSelector/TokenSelector.consts.ts
+++ b/src/components/Global/TokenSelector/TokenSelector.consts.ts
@@ -1,7 +1,7 @@
 import { SOLANA_ICON, TRON_ICON } from '@/assets'
 import { networks } from '@/config'
 import type { IPeanutChainDetails, IToken } from '@/interfaces/interfaces'
-import { celo, linea, worldchain } from 'viem/chains'
+import { celo, linea, scroll, worldchain } from 'viem/chains'
 
 interface CombinedType extends IPeanutChainDetails {
     tokens: IToken[]
@@ -69,7 +69,9 @@ export const TOKEN_SELECTOR_POPULAR_NETWORK_IDS = [
     },
 ]
 
-const networksToExclude: readonly number[] = [celo.id, linea.id, worldchain.id] as const
+// scroll excluded 2026-07-10: Rhino disabled it entirely, and Scroll isn't an
+// SDA deposit chain either, so every cross-chain route from it dead-ends.
+const networksToExclude: readonly number[] = [celo.id, linea.id, scroll.id, worldchain.id] as const
 
 // supported network ids for the network list, getting this from reown appkit config
 export const TOKEN_SELECTOR_SUPPORTED_NETWORK_IDS = networks
@@ -92,6 +94,11 @@ export const TOKEN_SELECTOR_SUPPORTED_NETWORK_IDS = networks
  *   BNB Chain is supported.
  * - EVM only (the withdraw flow uses 0x addresses); matches the current
  *   selectable chain set rather than every Rhino chain.
+ * - 2026-07-10 expansion: each new chain verified against Rhino prod with a real
+ *   ARBITRUM→X quote AND an outflow SDA create (see PR #2396). Stablecoins only
+ *   for the new chains — that's what was tested. Plasma/Stable are USDT-only on
+ *   Rhino. KAIA/opBNB deliberately absent: quotes pass but SDA create rejects
+ *   (DepositAddressTokenOutNotSupported).
  */
 export const RHINO_WITHDRAW_SUPPORTED_TOKENS_BY_CHAIN: Record<string, readonly string[]> = {
     '42161': ['ETH', 'USDC', 'USDT'], // Arbitrum
@@ -100,4 +107,13 @@ export const RHINO_WITHDRAW_SUPPORTED_TOKENS_BY_CHAIN: Record<string, readonly s
     '137': ['USDC', 'USDT'], // Polygon (native POL not bridged by Rhino)
     '100': ['USDC', 'USDT'], // Gnosis (native xDAI not bridged by Rhino)
     '56': ['BNB', 'USDC', 'USDT'], // BNB Chain
+    '43114': ['USDC', 'USDT'], // Avalanche
+    '999': ['USDC', 'USDT'], // HyperEVM
+    '57073': ['USDC', 'USDT'], // Ink
+    '747474': ['USDC', 'USDT'], // Katana (delivered as vbUSDC/vbUSDT)
+    '59144': ['USDC', 'USDT'], // Linea
+    '5000': ['USDC', 'USDT'], // Mantle (USDT delivered as USDT0)
+    '9745': ['USDT'], // Plasma (USDT0-only chain)
+    '988': ['USDT'], // Stable (USDT0-only chain)
+    '4217': ['USDC', 'USDT'], // Tempo (delivered as USDC.e/USDT0)
 }

--- a/src/components/Global/TokenSelector/TokenSelector.tsx
+++ b/src/components/Global/TokenSelector/TokenSelector.tsx
@@ -311,8 +311,11 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
         }
 
         if (searchValue) {
-            // search active: show searched token across ALL supported networks
-            return buildTokensForChainArray(TOKEN_SELECTOR_SUPPORTED_NETWORK_IDS, searchValue)
+            // search active: show searched token across all networks selectable
+            // in this mode — the Rhino destination set for withdraw (which
+            // includes destination-only chains like Linea/Avalanche), the wagmi
+            // source list otherwise.
+            return buildTokensForChainArray(Array.from(allowedChainIds), searchValue)
         }
         if (selectedChainID) {
             // specific chain selected: show popular (USDC, USDT, Native) for that chain
@@ -329,6 +332,7 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
         isCrossChainDisabled,
         restrictToRhino,
         isRhinoSupported,
+        allowedChainIds,
     ])
 
     // filter popular tokens by search

--- a/src/components/Global/TokenSelector/TokenSelector.tsx
+++ b/src/components/Global/TokenSelector/TokenSelector.tsx
@@ -169,11 +169,16 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
         }
     }
 
+    // Withdraw destinations are gated by what Rhino can DELIVER to
+    // (RHINO_WITHDRAW_SUPPORTED_TOKENS_BY_CHAIN), not by the wagmi source-chain
+    // list — the destination needs no wallet connection or balance reads, and
+    // several deliverable chains (Avalanche, Linea, Ink, …) are intentionally
+    // not source chains. Names/icons come from supportedChainsAndTokens.
     const allowedChainIds = useMemo(
         () =>
             new Set(
                 restrictToRhino
-                    ? TOKEN_SELECTOR_SUPPORTED_NETWORK_IDS.filter((id) => RHINO_WITHDRAW_SUPPORTED_TOKENS_BY_CHAIN[id])
+                    ? Object.keys(RHINO_WITHDRAW_SUPPORTED_TOKENS_BY_CHAIN)
                     : TOKEN_SELECTOR_SUPPORTED_NETWORK_IDS
             ),
         [restrictToRhino]

--- a/src/constants/chain-details.json
+++ b/src/constants/chain-details.json
@@ -106,7 +106,6 @@
         ],
         "mainnet": true
     },
-
     "10": {
         "name": "Optimism",
         "chain": "ETH",
@@ -835,7 +834,6 @@
             "format": "png"
         }
     },
-
     "167009": {
         "name": "Taiko Hekla L2",
         "chain": "ETH",
@@ -1073,5 +1071,173 @@
             "url": "https://raw.githubusercontent.com/spothq/cryptocurrency-icons/master/svg/color/eth.svg",
             "format": "svg"
         }
+    },
+    "999": {
+        "name": "HyperEVM",
+        "chain": "HYPE",
+        "icon": {
+            "url": "https://coin-images.coingecko.com/asset_platforms/images/22208/small/hyperliquid.jpg?1740125774",
+            "format": "jpg"
+        },
+        "rpc": ["https://rpc.hyperliquid.xyz/evm"],
+        "features": [],
+        "faucets": [],
+        "nativeCurrency": {
+            "name": "Hype",
+            "symbol": "HYPE",
+            "decimals": 18
+        },
+        "infoURL": "https://hyperliquid.xyz",
+        "shortName": "hyperevm",
+        "chainId": "999",
+        "networkId": 999,
+        "explorers": [
+            {
+                "name": "HyperEVMScan",
+                "url": "https://hyperevmscan.io",
+                "standard": "EIP3091"
+            }
+        ],
+        "mainnet": true
+    },
+    "57073": {
+        "name": "Ink",
+        "chain": "ETH",
+        "icon": {
+            "url": "https://coin-images.coingecko.com/asset_platforms/images/22194/small/ink.jpg?1737600222",
+            "format": "jpg"
+        },
+        "rpc": ["https://rpc-gel.inkonchain.com"],
+        "features": [],
+        "faucets": [],
+        "nativeCurrency": {
+            "name": "Ether",
+            "symbol": "ETH",
+            "decimals": 18
+        },
+        "infoURL": "https://inkonchain.com",
+        "shortName": "ink",
+        "chainId": "57073",
+        "networkId": 57073,
+        "explorers": [
+            {
+                "name": "Ink Explorer",
+                "url": "https://explorer.inkonchain.com",
+                "standard": "EIP3091"
+            }
+        ],
+        "mainnet": true
+    },
+    "747474": {
+        "name": "Katana",
+        "chain": "ETH",
+        "icon": {
+            "url": "https://coin-images.coingecko.com/asset_platforms/images/32239/small/katana.jpg?1751496126",
+            "format": "jpg"
+        },
+        "rpc": ["https://rpc.katana.network"],
+        "features": [],
+        "faucets": [],
+        "nativeCurrency": {
+            "name": "Ether",
+            "symbol": "ETH",
+            "decimals": 18
+        },
+        "infoURL": "https://katana.network",
+        "shortName": "katana",
+        "chainId": "747474",
+        "networkId": 747474,
+        "explorers": [
+            {
+                "name": "Katanascan",
+                "url": "https://katanascan.com",
+                "standard": "EIP3091"
+            }
+        ],
+        "mainnet": true
+    },
+    "9745": {
+        "name": "Plasma",
+        "chain": "Plasma",
+        "icon": {
+            "url": "https://coin-images.coingecko.com/asset_platforms/images/32256/small/plasma.jpg?1758000963",
+            "format": "jpg"
+        },
+        "rpc": ["https://rpc.plasma.to"],
+        "features": [],
+        "faucets": [],
+        "nativeCurrency": {
+            "name": "Plasma",
+            "symbol": "XPL",
+            "decimals": 18
+        },
+        "infoURL": "https://plasma.to",
+        "shortName": "plasma",
+        "chainId": "9745",
+        "networkId": 9745,
+        "explorers": [
+            {
+                "name": "Routescan",
+                "url": "https://plasmascan.to",
+                "standard": "EIP3091"
+            }
+        ],
+        "mainnet": true
+    },
+    "988": {
+        "name": "Stable",
+        "chain": "Stable",
+        "icon": {
+            "url": "https://coin-images.coingecko.com/asset_platforms/images/32271/small/stable.png?1765196531",
+            "format": "png"
+        },
+        "rpc": ["https://rpc.stable.xyz"],
+        "features": [],
+        "faucets": [],
+        "nativeCurrency": {
+            "name": "USDT0",
+            "symbol": "USDT0",
+            "decimals": 18
+        },
+        "infoURL": "https://stable.xyz",
+        "shortName": "stable",
+        "chainId": "988",
+        "networkId": 988,
+        "explorers": [
+            {
+                "name": "Stablescan",
+                "url": "https://stablescan.xyz",
+                "standard": "EIP3091"
+            }
+        ],
+        "mainnet": true
+    },
+    "4217": {
+        "name": "Tempo",
+        "chain": "Tempo",
+        "icon": {
+            "url": "https://icons.llamao.fi/icons/chains/rsz_tempo.jpg",
+            "format": "jpg"
+        },
+        "rpc": ["https://rpc.mainnet.tempo.xyz"],
+        "features": [],
+        "faucets": [],
+        "nativeCurrency": {
+            "name": "USD",
+            "symbol": "USD",
+            "decimals": 18
+        },
+        "infoURL": "https://tempo.xyz",
+        "shortName": "tempo",
+        "chainId": "4217",
+        "networkId": 4217,
+        "explorers": [
+            {
+                "name": "Tempo Explorer",
+                "url": "https://explore.tempo.xyz",
+                "standard": "EIP3091"
+            }
+        ],
+        "mainnet": true
     }
 }

--- a/src/constants/rhino.consts.ts
+++ b/src/constants/rhino.consts.ts
@@ -14,6 +14,7 @@ export const CHAIN_LOGOS = {
     CELO: 'https://assets.coingecko.com/asset_platforms/images/21/standard/celo.jpeg?1711358666',
     TRON: 'https://assets.coingecko.com/asset_platforms/images/1094/standard/TRON_LOGO.png?1706606652',
     SOLANA: 'https://assets.coingecko.com/asset_platforms/images/5/standard/solana.png?1706606708',
+    TEMPO: 'https://icons.llamao.fi/icons/chains/rsz_tempo.jpg',
 } as const
 
 /** Token symbol to logo URL mapping - reusable across the app */
@@ -39,6 +40,11 @@ export const SUPPORTED_EVM_CHAINS = [
     'KATANA',
     'GNOSIS',
     'CELO',
+    // TEMPO added 2026-07-10: live SDA catalog lists it with USDC+USDT (the
+    // REQUIRED_TOKENS bar). KAIA/PLASMA stay excluded — USDT-only on Rhino, and
+    // the deposit UI advertises USDC per EVM family, so a USDC deposit there
+    // would be silently lost.
+    'TEMPO',
 ] as const
 
 export const OTHER_SUPPORTED_CHAINS = ['SOLANA', 'TRON'] as const
@@ -111,11 +117,24 @@ export const EVM_CHAIN_ID_TO_RHINO_NAME: Record<string, string | undefined> = {
     '56': 'BINANCE', // Rhino's name for BNB Chain (display: BNB)
     '100': 'GNOSIS',
     '137': 'MATIC_POS', // Rhino's name for Polygon (display: POLYGON)
-    '534352': 'SCROLL',
+    // SCROLL (534352) removed 2026-07-10: Rhino disabled it ("SCROLL is disabled"
+    // InvalidRequest on quote). Re-add only after confirming via getBridgeConfig().
     '42161': 'ARBITRUM',
     '421614': 'ARBITRUM', // Arb Sepolia — same Rhino bucket for sandbox runs
     '8453': 'BASE',
     '42220': 'CELO',
+    // Added 2026-07-10 after verifying each against Rhino's live bridge config
+    // (status=enabled) AND a real ARBITRUM→X quote + outflow-SDA create.
+    // PLASMA/STABLE are USDT-only routes; token gating lives in token-details.json.
+    '43114': 'AVALANCHE',
+    '999': 'HYPEREVM',
+    '57073': 'INK',
+    '747474': 'KATANA',
+    '59144': 'LINEA',
+    '5000': 'MANTLE',
+    '9745': 'PLASMA',
+    '988': 'STABLE',
+    '4217': 'TEMPO',
 }
 
 export function evmChainIdToRhinoName(chainId: string | number): string | undefined {

--- a/src/constants/rhino.consts.ts
+++ b/src/constants/rhino.consts.ts
@@ -15,6 +15,8 @@ export const CHAIN_LOGOS = {
     TRON: 'https://assets.coingecko.com/asset_platforms/images/1094/standard/TRON_LOGO.png?1706606652',
     SOLANA: 'https://assets.coingecko.com/asset_platforms/images/5/standard/solana.png?1706606708',
     TEMPO: 'https://icons.llamao.fi/icons/chains/rsz_tempo.jpg',
+    KAIA: 'https://coin-images.coingecko.com/asset_platforms/images/9672/small/kaia.png?1734946776',
+    PLASMA: 'https://coin-images.coingecko.com/asset_platforms/images/32256/small/plasma.jpg?1758000963',
 } as const
 
 /** Token symbol to logo URL mapping - reusable across the app */
@@ -40,11 +42,14 @@ export const SUPPORTED_EVM_CHAINS = [
     'KATANA',
     'GNOSIS',
     'CELO',
-    // TEMPO added 2026-07-10: live SDA catalog lists it with USDC+USDT (the
-    // REQUIRED_TOKENS bar). KAIA/PLASMA stay excluded — USDT-only on Rhino, and
-    // the deposit UI advertises USDC per EVM family, so a USDC deposit there
-    // would be silently lost.
+    // TEMPO/KAIA/PLASMA added 2026-07-10 from Rhino's live SDA catalog. KAIA and
+    // PLASMA are USDT-only on Rhino while the deposit UI advertises tokens per
+    // EVM family (incl. USDC) — accepted risk (Hugo, 2026-07-10): a USDC deposit
+    // there is recoverable via the Rhino team. Per-chain token gating is the
+    // proper fix (follow-up).
     'TEMPO',
+    'KAIA',
+    'PLASMA',
 ] as const
 
 export const OTHER_SUPPORTED_CHAINS = ['SOLANA', 'TRON'] as const

--- a/src/constants/token-details.json
+++ b/src/constants/token-details.json
@@ -2514,6 +2514,13 @@
                 "symbol": "USDC",
                 "decimals": 6,
                 "logoURI": "https://market-data-images.s3.us-east-1.amazonaws.com/tokenImages/0x10ca7e698fab4eb287d4d33b3886ae17a6d078fbda455cdd673cfec0ca8ef413.png"
+            },
+            {
+                "address": "0x779ded0c9e1022225f8e0630b35a9b54be713736",
+                "name": "Tether USD",
+                "symbol": "USDT",
+                "decimals": 6,
+                "logoURI": "https://assets.coingecko.com/coins/images/325/standard/Tether.png?1696501661"
             }
         ]
     },
@@ -2966,6 +2973,126 @@
                 "symbol": "ETH",
                 "decimals": 18,
                 "logoURI": "https://raw.githubusercontent.com/spothq/cryptocurrency-icons/master/svg/color/eth.svg"
+            }
+        ]
+    },
+    {
+        "chainId": "999",
+        "name": "HyperEVM",
+        "tokens": [
+            {
+                "address": "0xb88339cb7199b77e23db6e890353e22632ba630f",
+                "name": "USD Coin",
+                "symbol": "USDC",
+                "decimals": 6,
+                "logoURI": "https://assets.coingecko.com/coins/images/6319/small/USD_Coin_icon.png"
+            },
+            {
+                "address": "0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb",
+                "name": "Tether USD",
+                "symbol": "USDT",
+                "decimals": 6,
+                "logoURI": "https://assets.coingecko.com/coins/images/325/standard/Tether.png?1696501661"
+            }
+        ]
+    },
+    {
+        "chainId": "57073",
+        "name": "Ink",
+        "tokens": [
+            {
+                "address": "0x0000000000000000000000000000000000000000",
+                "name": "Ether",
+                "symbol": "ETH",
+                "decimals": 18,
+                "logoURI": "https://assets.coingecko.com/coins/images/279/standard/ethereum.png?1696501628"
+            },
+            {
+                "address": "0x2d270e6886d130d724215a266106e6832161eaed",
+                "name": "USD Coin",
+                "symbol": "USDC",
+                "decimals": 6,
+                "logoURI": "https://assets.coingecko.com/coins/images/6319/small/USD_Coin_icon.png"
+            },
+            {
+                "address": "0x0200c29006150606b650577bbe7b6248f58470c1",
+                "name": "Tether USD",
+                "symbol": "USDT",
+                "decimals": 6,
+                "logoURI": "https://assets.coingecko.com/coins/images/325/standard/Tether.png?1696501661"
+            }
+        ]
+    },
+    {
+        "chainId": "747474",
+        "name": "Katana",
+        "tokens": [
+            {
+                "address": "0x0000000000000000000000000000000000000000",
+                "name": "Ether",
+                "symbol": "ETH",
+                "decimals": 18,
+                "logoURI": "https://assets.coingecko.com/coins/images/279/standard/ethereum.png?1696501628"
+            },
+            {
+                "address": "0x203a662b0bd271a6ed5a60edfbd04bfce608fd36",
+                "name": "USD Coin",
+                "symbol": "USDC",
+                "decimals": 6,
+                "logoURI": "https://assets.coingecko.com/coins/images/6319/small/USD_Coin_icon.png"
+            },
+            {
+                "address": "0x2dca96907fde857dd3d816880a0df407eeb2d2f2",
+                "name": "Tether USD",
+                "symbol": "USDT",
+                "decimals": 6,
+                "logoURI": "https://assets.coingecko.com/coins/images/325/standard/Tether.png?1696501661"
+            }
+        ]
+    },
+    {
+        "chainId": "9745",
+        "name": "Plasma",
+        "tokens": [
+            {
+                "address": "0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb",
+                "name": "Tether USD",
+                "symbol": "USDT",
+                "decimals": 6,
+                "logoURI": "https://assets.coingecko.com/coins/images/325/standard/Tether.png?1696501661"
+            }
+        ]
+    },
+    {
+        "chainId": "988",
+        "name": "Stable",
+        "tokens": [
+            {
+                "address": "0x779ded0c9e1022225f8e0630b35a9b54be713736",
+                "name": "Tether USD",
+                "symbol": "USDT",
+                "decimals": 6,
+                "logoURI": "https://assets.coingecko.com/coins/images/325/standard/Tether.png?1696501661"
+            }
+        ]
+    },
+    {
+        "chainId": "4217",
+        "name": "Tempo",
+        "tokens": [
+            {
+                "address": "0x20c000000000000000000000b9537d11c60e8b50",
+                "name": "USD Coin",
+                "symbol": "USDC",
+                "decimals": 6,
+                "logoURI": "https://assets.coingecko.com/coins/images/6319/small/USD_Coin_icon.png"
+            },
+            {
+                "address": "0x20c00000000000000000000014f22ca97301eb73",
+                "name": "Tether USD",
+                "symbol": "USDT",
+                "decimals": 6,
+                "logoURI": "https://assets.coingecko.com/coins/images/325/standard/Tether.png?1696501661"
             }
         ]
     }


### PR DESCRIPTION
## Summary

Syncs our Rhino chain support with Rhino's **live** catalogs — every addition verified today (2026-07-10) against Rhino prod with `getBridgeConfig()`/`getSupportedConfigs()`, a real `ARBITRUM→X` quote, and a real outflow-SDA create per chain.

**Withdrawals** — `EVM_CHAIN_ID_TO_RHINO_NAME` gains 9 proven destinations:

| Chain | chainId | Tokens | Proof |
|---|---|---|---|
| Avalanche | 43114 | USDC, USDT | quote ✅ SDA create ✅ |
| HyperEVM | 999 | USDC, USDT | quote ✅ SDA create ✅ |
| Ink | 57073 | ETH, USDC, USDT | quote ✅ SDA create ✅ |
| Katana | 747474 | ETH, USDC, USDT | quote ✅ SDA create ✅ |
| Linea | 59144 | ETH, USDC, USDT | quote ✅ SDA create ✅ |
| Mantle | 5000 | USDC, USDT | quote ✅ SDA create ✅ |
| Plasma | 9745 | USDT only | quote ✅ SDA create ✅ |
| Stable | 988 | USDT only | quote ✅ SDA create ✅ |
| Tempo | 4217 | USDC, USDT | quote ✅ SDA create ✅ |

- **Avalanche was a live user-facing bug**: it's in `chain-details.json` (pickable in the withdraw/claim selector) but had no Rhino mapping, so selecting it threw `Unsupported Rhino chain mapping`.
- **SCROLL removed** from the mapping: Rhino disabled it (`"SCROLL is disabled"` InvalidRequest on quote), so the stale entry produced a guaranteed quote failure.
- **KAIA / OPBNB deliberately excluded**: their quotes pass but SDA create rejects (`DepositAddressTokenOutNotSupported`).
- USDT-only routes (Plasma, Stable) expose **only USDT** in `token-details.json`, so the token selector can't offer an unbridgeable pair.

**Selector wiring** — the withdraw destination list is gated by `RHINO_WITHDRAW_SUPPORTED_TOKENS_BY_CHAIN` ∩ the wagmi source-network list, so the mapping alone never surfaced new chains. This PR extends that gate with the 9 verified destinations and derives the withdraw list from the gate's own keys (destinations need no wallet connection/balance reads; several deliverable chains are intentionally not source chains). Scroll is also excluded from the source selector — Rhino disabled it and it isn't an SDA deposit chain, so every cross-chain route from it dead-ends.

**Deposits** — `SUPPORTED_EVM_CHAINS` gains **TEMPO, KAIA, PLASMA** (all in Rhino's live SDA catalog; the backend already provisions inflow SDAs accepting them). Kaia/Plasma are USDT-only on Rhino while the deposit UI advertises tokens per EVM family (incl. USDC) — **accepted risk (Hugo, 2026-07-10)**: a USDC deposit there is recoverable via Rhino support; per-chain token gating is the proper fix (follow-up).

**Data provenance**: token addresses come from Rhino's `getBridgeConfig()` (authoritative — it's what Rhino delivers); chain metadata (RPC, explorer, native currency) from the chainid.network registry; existing AVALANCHE/LINEA token-details addresses cross-checked against Rhino (all match).

## Risks / breaking changes

- Additive only; no existing flow changes shape. The one removal (SCROLL) converts a guaranteed Rhino 400 into the standard unsupported-chain error.
- New `chain-details.json` entries also appear in the shared token selector (claim x-chain / request flows) — those flows use the same `useCrossChainTransfer` mapping, so they gain the same verified chains. Consumers otherwise limited to explorer-URL lookup.
- No backend change required for withdrawals (source chain is always ARBITRUM). Known follow-up (non-blocking): peanut-api-ts `CHAINS_CONFIG` lacks TEMPO, so a TEMPO **deposit** webhook enriches intent metadata with the Arbitrum fallback + error log. Small BE follow-up PR will add it.

## QA

- POC scripts (run against Rhino prod, read-only + burn-address SDA creates): `peanut-api-ts/scripts/poc/check-avalanche-rhino-support.ts`, `check-all-missing-rhino-chains.ts`.
- Local gate (re-run after selector wiring): typecheck ✅ · 1814 jest tests ✅ · prettier ✅ · `next build` ✅
- Manual: withdraw flow → pick Avalanche/Linea/etc. as destination → preview quote should render fee + receive amount (was: hard error).

## Design notes / verification

**Token addresses verified on-chain** (eth_call `symbol()`/`decimals()` against each chain's public RPC, 2026-07-10). Two USDT address pairs are shared across chains — that's **not** a copy-paste error, it's LayerZero's USDT0 deterministic OFT deployment:

| Chain | Token | Address | On-chain symbol | Decimals |
|---|---|---|---|---|
| Mantle | USDT | `0x779d…3736` | `USDT0` | 6 |
| Stable | USDT | `0x779d…3736` (same, deterministic) | `USDT0` | 6 |
| HyperEVM | USDT | `0xb8ce…5ebb` | `USD₮0` | 6 |
| Plasma | USDT | `0xb8ce…5ebb` (same, deterministic) | `USDT0` | 6 |
| HyperEVM | USDC | `0xb883…630f` | `USDC` | 6 |
| Ink | USDC / USDT | `0x2d27…eaed` / `0x0200…70c1` | `USDC` / `USD₮0` | 6 |
| Katana | USDC / USDT | `0x203a…fd36` / `0x2dca…d2f2` | `vbUSDC` / `vbUSDT` (Katana's canonical vault-bridged stables) | 6 |
| Tempo | USDC / USDT | `0x20c0…8b50` / `0x20c0…eb73` | `USDC.e` / `USDT0` | 6 |

Note Mantle's legacy bridged USDT (`0x201E…56aE`) is deliberately NOT used — Rhino delivers USDT0.

**Accepted trade-offs / follow-ups (not blocking):**
- The chainId→Rhino-name map and deposit chain list remain hand-maintained mirrors of Rhino's live config (the SCROLL rot pattern). Follow-up: a CI/drift check against `getBridgeConfig()`/`getSupportedConfigs()`.
- Deposit UI advertises tokens per EVM *family* (USDT/USDC/ETH), not per chain — pre-existing model (Celo/Gnosis already lack ETH). Tempo inherits it. Follow-up: per-chain token gating on deposit surfaces.
- peanut-api-ts `CHAINS_CONFIG` lacks TEMPO — a Tempo deposit webhook enriches intent metadata with the Arbitrum fallback (error-logged, non-fatal). Small BE follow-up PR.
