### PR TITLE
ci: auto-merge content-only publish PRs to main

### DIFF
--- a/.github/workflows/content-publish-automerge.yml
+++ b/.github/workflows/content-publish-automerge.yml
@@ -1,0 +1,76 @@
+name: Content publish auto-merge
+
+# Auto-approve + auto-merge content-only submodule bumps to `main` (production
+# content publishes, e.g. #2400). Everything else keeps the normal gate:
+# 1 human review + green `ci-success` (the "Protect Prod" org ruleset).
+#
+# Why this exists: "Protect Prod" requires 1 approving review on EVERY PR to
+# main — GitHub rulesets can't make that conditional on the changed paths. A
+# content publish PR is a single `src/content` gitlink bump: safe by inspection
+# and shouldn't need a second human. This workflow supplies the approval ONLY
+# when the diff is exactly that pointer, so the review requirement stays fully
+# in force for real code. eslint is already advisory (not in `ci-success`), so
+# "green tests" here means the real test/typecheck/build jobs, not lint.
+#
+# Security model:
+#   - `pull_request_target` runs THIS logic from the base branch (main), so a PR
+#     cannot tamper with the guard or the approve step. We never check out or run
+#     PR code — only `gh` API calls by PR number — so pull_request_target is safe
+#     here (no untrusted-code execution).
+#   - Same-repo branches only (fork guard on the job).
+#   - The approval is submitted by CONTENT_BOT_TOKEN's user (Hugo0). GitHub
+#     forbids approving your own PR, so this auto-approves anyone's content
+#     publish EXCEPT one that same user authored — those fall back to a manual
+#     merge (org-admin bypass). Konrad-authored publishes (the target case) work.
+
+on:
+    pull_request_target:
+        types: [opened, synchronize, reopened, ready_for_review]
+        branches: [main]
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    approve-and-merge:
+        # Same-repo PRs only — never a fork.
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        runs-on: ubuntu-latest
+        steps:
+            - name: Guard — diff must be exactly the content submodule pointer
+              id: guard
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PR: ${{ github.event.pull_request.number }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  set -euo pipefail
+                  FILES=$(gh pr diff "$PR" --repo "$REPO" --name-only)
+                  echo "Changed files:"
+                  echo "$FILES"
+                  if [ "$FILES" = "src/content" ]; then
+                    echo "content_only=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "content_only=false" >> "$GITHUB_OUTPUT"
+                    echo "::notice::Not content-only — normal review gate stays in place."
+                  fi
+
+            - name: Approve + enable auto-merge
+              if: steps.guard.outputs.content_only == 'true'
+              env:
+                  GH_TOKEN: ${{ secrets.CONTENT_BOT_TOKEN }}
+                  PR: ${{ github.event.pull_request.number }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  set -euo pipefail
+                  # Approve — satisfies the 1-review rule. Fails only when the bot
+                  # user authored the PR (GitHub blocks self-approval); in that
+                  # case leave it for a manual merge.
+                  if gh pr review "$PR" --repo "$REPO" --approve; then
+                    # main ruleset allows merge commits only (not squash/rebase).
+                    gh pr merge "$PR" --repo "$REPO" --auto --merge \
+                      || echo "::warning::auto-merge not enabled/permitted — merge manually."
+                  else
+                    echo "::warning::Could not approve (bot may be the PR author) — merge manually."
+                  fi


### PR DESCRIPTION
## Summary

Content publishes to production are a single `src/content` submodule-pointer bump (e.g. #2400). The **Protect Prod** org ruleset requires **1 approving review on every PR to `main`**, and GitHub rulesets can't scope that requirement to the changed paths — so a trivially-safe content bump needs a second human just like real code does.

This adds `content-publish-automerge.yml`: on a PR to `main` whose diff is **exactly** `src/content`, the workflow approves it (as `CONTENT_BOT_TOKEN`'s user) and enables auto-merge. The PR then merges once `ci-success` is green. Anything that touches even one other file gets **no** approval and keeps the normal 1-review gate.

Net effect: Konrad (or anyone) can open a content publish PR and it merges on green tests — no second reviewer — while all real code review requirements stay exactly as they are.

## Why it's safe

- **`pull_request_target`** → the guard + approve logic always runs from `main`, so a PR can't tamper with it. We never check out or execute PR code — only `gh` API calls by PR number — so there's no untrusted-code path.
- **Strict path guard** is the security boundary: `gh pr diff --name-only` must equal exactly `src/content`. Any extra file → no approval.
- **Same-repo branches only** (fork guard).
- **eslint stays advisory** — `ci-success` (the required check) is `needs: [format, typecheck, unit, e2e, report]`, eslint is `continue-on-error`. "Green tests" ≠ green lint, by design.

## Design notes / accepted trade-offs

- The approver identity is `CONTENT_BOT_TOKEN`'s user (**Hugo0**). GitHub forbids approving your own PR, so this auto-approves anyone's content publish **except** one Hugo0 authors himself — those fall back to a manual merge (org-admin bypass). The target flow (Konrad authors the publish, like #2400) works.
- Rulesets are **unchanged** — no weakening of review/branch protection. The approval is supplied, not the requirement removed.
- Uses `--merge` (main ruleset allows merge commits only), unlike the dev auto-content flow which squashes.

## Risk

Low, additive CI-only. Worst case if the guard ever mis-fired: it would approve a PR that isn't content-only — but the guard requires an exact single-path match, and `ci-success` + signatures still gate the merge regardless. No runtime/app code touched.

## QA

- Merge → open a content-only PR to `main` (bump `src/content`) authored by a non-Hugo0 user → expect: auto-approval by Hugo0 + auto-merge on green `ci-success`.
- Open a PR to `main` touching any other file → expect: no approval, normal review gate.
