### PR TITLE
feat(card): let password managers save the revealed card

### DIFF
--- a/src/components/Card/CardDetailField.tsx
+++ b/src/components/Card/CardDetailField.tsx
@@ -40,7 +40,11 @@ const CardDetailField: FC<Props> = ({ value, autoComplete, name, ariaLabel, clas
             aria-label={ariaLabel}
             value={value}
             className={twMerge(
-                'ph-no-capture absolute inset-0 w-full whitespace-pre border-0 bg-transparent p-0 text-n-1 outline-none',
+                'ph-no-capture absolute inset-0 w-full whitespace-pre border-0 bg-transparent p-0 text-n-1',
+                // Real, tabbable inputs (so managers/keyboard users can interact),
+                // so keep a keyboard focus cue — but only on keyboard focus, not on
+                // casual taps, so the pink card isn't ringed every time it's touched.
+                'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-n-1',
                 className
             )}
         />

--- a/src/components/Card/CardDetailField.tsx
+++ b/src/components/Card/CardDetailField.tsx
@@ -1,0 +1,50 @@
+'use client'
+import { type FC } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+interface Props {
+    /** The value to display AND expose to the password manager. */
+    value: string
+    /** Autocomplete token the password manager keys off (e.g. `cc-number`). */
+    autoComplete: 'cc-number' | 'cc-name' | 'cc-exp' | 'cc-csc'
+    /** Field name — a second detection hint for managers that sniff names. */
+    name: string
+    /** Accessible label — the sizer span is aria-hidden, so the input owns a11y. */
+    ariaLabel: string
+    /** Typography classes, applied to BOTH sizer and input so widths match. */
+    className?: string
+}
+
+/**
+ * A readOnly card-detail value rendered as a real `<input>` so password managers
+ * recognise it (via `autoComplete`) and offer to save the card — while staying
+ * pixel-identical to plain text.
+ *
+ * `<input>` can't shrink-to-fit its value (no `field-sizing: content` on iOS
+ * Safari), so we size it with an invisible sizer span in the same font: the
+ * span reserves the exact text width, the input overlays it `inset-0`. Result:
+ * a genuinely-visible, manager-detectable field with zero layout shift vs the
+ * `<span>` it replaced. `ph-no-capture` on both keeps the value (PII/PAN) out of
+ * session recordings.
+ */
+const CardDetailField: FC<Props> = ({ value, autoComplete, name, ariaLabel, className }) => (
+    <span className="relative inline-block">
+        <span aria-hidden className={twMerge('ph-no-capture invisible block whitespace-pre', className)}>
+            {value}
+        </span>
+        <input
+            type="text"
+            readOnly
+            name={name}
+            autoComplete={autoComplete}
+            aria-label={ariaLabel}
+            value={value}
+            className={twMerge(
+                'ph-no-capture absolute inset-0 w-full whitespace-pre border-0 bg-transparent p-0 text-n-1 outline-none',
+                className
+            )}
+        />
+    </span>
+)
+
+export default CardDetailField

--- a/src/components/Card/CardFace.tsx
+++ b/src/components/Card/CardFace.tsx
@@ -3,6 +3,7 @@ import { type FC, useState } from 'react'
 import Image from 'next/image'
 import { twMerge } from 'tailwind-merge'
 import { Icon } from '@/components/Global/Icons/Icon'
+import CardDetailField from '@/components/Card/CardDetailField'
 import { PEANUT_CARD_HAND, VISA_BRAND_MARK } from '@/assets/cards'
 import { PEANUTMAN } from '@/assets/mascot'
 
@@ -109,14 +110,21 @@ const CardFace: FC<Props> = ({
                             </div>
                         </>
                     ) : showingDetails ? (
-                        <>
+                        // Fields are real readOnly <input>s (via CardDetailField) inside a
+                        // <form> so password managers recognise the card and offer to save
+                        // it. `contents` keeps the form out of the layout box tree, so the
+                        // flex layout — and every field's rendered position — is unchanged.
+                        <form className="contents" onSubmit={(e) => e.preventDefault()}>
                             <div className="flex items-center gap-2">
-                                {/* ph-no-capture: PAN out of session recordings. Wraps only
-                                 * the digits, not the copy button — we still want to see in
-                                 * replays whether the user tapped copy. */}
-                                <span className="ph-no-capture text-xl font-extrabold tracking-wider">
-                                    {formatPan(revealed.pan)}
-                                </span>
+                                {/* Copy button stays outside the field so replays still show
+                                 * whether the user tapped copy (the field itself is ph-no-capture). */}
+                                <CardDetailField
+                                    value={formatPan(revealed.pan)}
+                                    autoComplete="cc-number"
+                                    name="cardnumber"
+                                    ariaLabel="Card number"
+                                    className="text-xl font-extrabold tracking-wider"
+                                />
                                 {onCopy && (
                                     <button
                                         type="button"
@@ -131,25 +139,38 @@ const CardFace: FC<Props> = ({
                             {/* Registered cardholder name — PII, kept out of session
                              * recordings like the other revealed fields. */}
                             {revealed.cardholderName && (
-                                <span className="ph-no-capture mt-1 text-sm font-bold uppercase tracking-wide">
-                                    {revealed.cardholderName}
-                                </span>
+                                <CardDetailField
+                                    value={revealed.cardholderName}
+                                    autoComplete="cc-name"
+                                    name="ccname"
+                                    ariaLabel="Cardholder name"
+                                    className="mt-1 text-sm font-bold uppercase tracking-wide"
+                                />
                             )}
                             <div className="flex items-end justify-between">
                                 <div className="text-s flex gap-6">
                                     <div>
                                         {/* "Expiry" label dropped — value row stays one line so PAN/name clear the artwork */}
-                                        {/* ph-no-capture: expiry digits out of recordings. */}
-                                        <div className="ph-no-capture font-bold">
-                                            {String(revealed.expiryMonth).padStart(2, '0')}/
-                                            {String(revealed.expiryYear).slice(-2)}
-                                        </div>
+                                        <CardDetailField
+                                            value={`${String(revealed.expiryMonth).padStart(2, '0')}/${String(
+                                                revealed.expiryYear
+                                            ).slice(-2)}`}
+                                            autoComplete="cc-exp"
+                                            name="cc-exp"
+                                            ariaLabel="Expiry date"
+                                            className="font-bold"
+                                        />
                                     </div>
                                     <div className="flex items-end gap-1">
                                         <div>
                                             {/* "CVV" label dropped — value only */}
-                                            {/* ph-no-capture: CVV out of recordings. */}
-                                            <div className="ph-no-capture font-bold">{revealed.cvv}</div>
+                                            <CardDetailField
+                                                value={revealed.cvv}
+                                                autoComplete="cc-csc"
+                                                name="cvc"
+                                                ariaLabel="Security code"
+                                                className="font-bold"
+                                            />
                                         </div>
                                         {onCopy && (
                                             <button
@@ -174,7 +195,7 @@ const CardFace: FC<Props> = ({
                                     </button>
                                 )}
                             </div>
-                        </>
+                        </form>
                     ) : loading ? (
                         <>
                             <div className="h-7 w-56 animate-pulse rounded bg-white/40" />

--- a/src/components/Card/CardFace.tsx
+++ b/src/components/Card/CardFace.tsx
@@ -139,13 +139,15 @@ const CardFace: FC<Props> = ({
                             {/* Registered cardholder name — PII, kept out of session
                              * recordings like the other revealed fields. */}
                             {revealed.cardholderName && (
-                                <CardDetailField
-                                    value={revealed.cardholderName}
-                                    autoComplete="cc-name"
-                                    name="ccname"
-                                    ariaLabel="Cardholder name"
-                                    className="mt-1 text-sm font-bold uppercase tracking-wide"
-                                />
+                                <div className="mt-1">
+                                    <CardDetailField
+                                        value={revealed.cardholderName}
+                                        autoComplete="cc-name"
+                                        name="ccname"
+                                        ariaLabel="Cardholder name"
+                                        className="text-sm font-bold uppercase tracking-wide"
+                                    />
+                                </div>
                             )}
                             <div className="flex items-end justify-between">
                                 <div className="text-s flex gap-6">

--- a/src/components/Card/__tests__/CardFace.test.tsx
+++ b/src/components/Card/__tests__/CardFace.test.tsx
@@ -21,23 +21,33 @@ const revealed: RevealedCardDetails = {
 describe('CardFace cardholder name', () => {
     it('shows the registered name when the card is revealed', () => {
         render(<CardFace last4="1234" revealed={revealed} />)
-        const name = screen.getByText('Jane Doe')
+        // Revealed details are readOnly inputs (so password managers can save the
+        // card), so the value lives on `value`, not text content.
+        const name = screen.getByDisplayValue('Jane Doe')
         expect(name).toBeInTheDocument()
-        // PII guard: the name must stay inside the ph-no-capture wrapper so it's
-        // kept out of session recordings — assert the class, not just the text.
+        // PII guard: the name field must carry ph-no-capture so it's kept out of
+        // session recordings — assert the class, not just the value.
         expect(name).toHaveClass('ph-no-capture')
     })
 
     it('hides the name when the card is masked (not revealed)', () => {
         render(<CardFace last4="1234" revealed={null} />)
-        expect(screen.queryByText('Jane Doe')).not.toBeInTheDocument()
+        expect(screen.queryByDisplayValue('Jane Doe')).not.toBeInTheDocument()
     })
 
     it('still renders the revealed card when the name is absent', () => {
         const { cardholderName: _omitted, ...withoutName } = revealed
         render(<CardFace last4="1234" revealed={withoutName} />)
-        expect(screen.queryByText('Jane Doe')).not.toBeInTheDocument()
+        expect(screen.queryByDisplayValue('Jane Doe')).not.toBeInTheDocument()
         // PAN still renders, proving reveal works without the name.
-        expect(screen.getByText('4111 1111 1111 1234')).toBeInTheDocument()
+        expect(screen.getByDisplayValue('4111 1111 1111 1234')).toBeInTheDocument()
+    })
+
+    it('exposes card fields with the autocomplete tokens password managers detect', () => {
+        render(<CardFace last4="1234" revealed={revealed} />)
+        expect(screen.getByDisplayValue('4111 1111 1111 1234')).toHaveAttribute('autocomplete', 'cc-number')
+        expect(screen.getByDisplayValue('Jane Doe')).toHaveAttribute('autocomplete', 'cc-name')
+        expect(screen.getByDisplayValue('12/30')).toHaveAttribute('autocomplete', 'cc-exp')
+        expect(screen.getByDisplayValue('123')).toHaveAttribute('autocomplete', 'cc-csc')
     })
 })


### PR DESCRIPTION
## Summary

User request (Telegram): *"would be nice to one-click add the card to my password manager."*

The "Your card" reveal renders PAN / cardholder name / expiry / CVV as plain
text `<span>`/`<div>`, which password managers can't detect. This wraps the
revealed fields in a `<form>` and renders each value as a real **readOnly
`<input>` with a `cc-*` autocomplete token** (`cc-number`, `cc-name`, `cc-exp`,
`cc-csc`). That's the standard signal 1Password / iCloud Keychain / Chrome /
Bitwarden key off to recognise a card and offer to save it.

## Zero layout shift (explicitly verified)

`<input>` can't shrink-to-fit its value without `field-sizing: content`, which
**iOS Safari lacks** — a naive span→input swap would reflow. New
`CardDetailField` uses the JS-free auto-sizing pattern: an `invisible` sizer
span (same font/size/weight/tracking) reserves the exact text width, and the
real input is overlaid `absolute inset-0 w-full`. Width is defined by the sizer
in the real font → pixel-identical, and the input is genuinely visible so
managers detect it. The `<form>` is `display:contents` so it adds no layout box.

Measured span vs. auto-sizing input in a browser: **Δwidth = 0, Δheight = 0,
Δtext-left = 0** (identical box + glyph position). Tailwind Preflight guarantees
the input inherits `font-family`, so the parity holds in-app.

## Scope / safety

- **FE-only. No backend, no PCI scope change** — the PAN/CVV are already raw
  values in our React state (fetched from our own `GET /rain/cards/{id}/details`,
  no third-party PCI iframe). Moving them from a `<span>` into a readOnly
  `<input>` exposes nothing new.
- `ph-no-capture` preserved on every field (sizer + input) → PAN/CVV/name stay
  out of PostHog session recordings.
- Blast radius is tight: the `revealed` branch is only ever mounted in
  `YourCardScreen`. The share-asset capture path uses masked/pixelated state and
  never receives `revealed`, so the iOS canvas-capture path is untouched.
- Auto-mask / no-store / blur-mask behaviour in `useCardReveal` is unchanged.

## Best-effort caveat (set expectations)

This is a **convenience**, not a guaranteed feature. Managers reliably prompt to
save during *checkout* flows; on a read-only display the common UX is the
manager's in-field "save" affordance the user taps. Behaviour varies by
manager/OS, and **CVV is generally not stored** (PCI) — so the realistic win is
one-tap save of number + expiry + name.

## QA

- `npm test` — `CardFace.test.tsx` green (4/4), incl. a new test asserting the
  `cc-*` autocomplete tokens are present.
- typecheck + build green.
- Manual: reveal a sandbox card, confirm the card face looks identical and your
  password manager offers to save number/expiry/name. (Couldn't fully stand up
  an authed revealed card locally — a device eyeball on the real reveal is the
  one remaining check.)
