### PR TITLE
fix(withdraw): amount card says 'You're withdrawing', not 'You're sending'

### DIFF
--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -771,7 +771,7 @@ function MantecaBankWithdrawFlow() {
                             </div>
                             <div>
                                 <p className="flex items-center gap-1 text-center text-sm text-gray-600">
-                                    <Icon name="arrow-up" size={10} /> You're sending
+                                    <Icon name="arrow-up" size={10} /> You're withdrawing
                                 </p>
                                 <p className="text-2xl font-bold">
                                     {currencyCode} {formatNumberForDisplay(currencyAmount, { maxDecimals: 2 })}
@@ -880,7 +880,7 @@ function MantecaBankWithdrawFlow() {
                             </div>
                             <div>
                                 <p className="flex items-center gap-1 text-center text-sm text-gray-600">
-                                    <Icon name="arrow-up" size={10} /> You're sending
+                                    <Icon name="arrow-up" size={10} /> You're withdrawing
                                 </p>
                                 <p className="text-2xl font-bold">
                                     {currencyCode}{' '}

--- a/src/components/Global/PeanutActionDetailsCard/index.tsx
+++ b/src/components/Global/PeanutActionDetailsCard/index.tsx
@@ -106,7 +106,7 @@ export default function PeanutActionDetailsCard({
             else title = `${renderRecipient()} sent you`
         }
         if (transactionType === 'ADD_MONEY' || transactionType === 'ADD_MONEY_BANK_ACCOUNT') title = `You're adding`
-        if (transactionType === 'WITHDRAW' || transactionType === 'WITHDRAW_BANK_ACCOUNT') title = `You're sending`
+        if (transactionType === 'WITHDRAW' || transactionType === 'WITHDRAW_BANK_ACCOUNT') title = `You're withdrawing`
         if (transactionType === 'CLAIM_LINK_BANK_ACCOUNT') {
             if (viewType === 'SUCCESS') {
                 title = 'You will receive'


### PR DESCRIPTION
## Summary

The withdraw amount card sits under a **Withdraw** header but read **"You're sending"**. This is a copy seam: the page frame is named by the user's *intent* (Withdraw — how they got there), while the card was named by the *mechanism* (a crypto withdrawal is, under the hood, a `sendMoney`/charge send of USDC to an external address). Both are "true", but they collide in one viewport and read as a bug.

Two things made it clearly wrong rather than merely debatable:
- It clashes with the sibling `ADD_MONEY` → **"You're adding"**, which *does* match its own header.
- The **bank** withdraw path (`WITHDRAW_BANK_ACCOUNT`) reuses the same string — and you don't "send" to a bank.

Unify both `WITHDRAW` and `WITHDRAW_BANK_ACCOUNT` to **"You're withdrawing"** — matches the header and the `ADD_MONEY` sibling, and reads correctly for crypto *and* bank.

## Changes (copy-only, no architecture change)

- `PeanutActionDetailsCard` — `WITHDRAW` / `WITHDRAW_BANK_ACCOUNT` branch → "You're withdrawing" (covers the crypto withdraw + `[country]/bank` screens, which render the shared card).
- `withdraw/manteca/page.tsx` — two hardcoded literals (the regional/bank withdraw review + status cards) → "You're withdrawing".

The internal `PaymentSuccessView type="SEND"` semantic key is intentionally left as-is — it's a routing key, not user-visible copy.

## Design notes / accepted trade-offs

The shared money-movement components (`PeanutActionDetailsCard`, `PaymentSuccessView`, `sendMoney`/charges) being reused across send/withdraw/add/claim is deliberate, correct factoring — not touched. This is a label fix at that shared seam, not a flow change.

## Risk

Minimal — three string literals, no logic/type/import changes. Blast radius = the withdraw amount card title on crypto + bank withdraw screens.

## QA

- Local gate green: `typecheck` (exit 0), `prettier --check` (clean), jest (withdraw-states + add-money-states pass; full suite green after `copy-flags` prebuild).
- Verify: `/withdraw` → crypto → amount card header reads "You're withdrawing"; same on the Manteca/bank withdraw review + status cards.