### PR TITLE
fix(deposits): stop support-chat clicks from cancelling deposits + confirm-before-cancel + uniform reference

### DIFF
--- a/src/components/AddMoney/components/AddMoneyBankDetails.tsx
+++ b/src/components/AddMoney/components/AddMoneyBankDetails.tsx
@@ -9,7 +9,7 @@ import { useRouter, useParams } from 'next/navigation'
 import { useCallback, useEffect, useMemo } from 'react'
 import { countryData } from '@/components/AddMoney/consts'
 import { formatCurrencyAmount } from '@/utils/currency'
-import { formatBankAccountDisplay } from '@/utils/format.utils'
+import { formatBankAccountDisplay, shortDepositReference } from '@/utils/format.utils'
 import { applyBridgeCrossCurrencyFee, getCurrencyConfig, getCurrencySymbol } from '@/utils/bridge.utils'
 import { RequestFulfillmentBankFlowStep, useRequestFulfillmentFlow } from '@/context/RequestFulfillmentFlowContext'
 import { formatAmount } from '@/utils/general.utils'
@@ -236,7 +236,7 @@ ${routingLabel}: ${routingValue}`
         }
 
         bankDetails += `
-Deposit Reference: ${onrampData?.depositInstructions?.depositMessage?.slice(0, 10) || 'Loading...'}
+Deposit Reference: ${shortDepositReference(onrampData?.depositInstructions?.depositMessage) || 'Loading...'}
 
 Please use these details to complete your bank transfer.`
 
@@ -274,11 +274,11 @@ Please use these details to complete your bank transfer.`
                     <p className="text-xs font-normal text-gray-1">Deposit reference</p>
                     <div className="flex items-baseline gap-2">
                         <p className="text-xl font-extrabold text-black md:text-4xl">
-                            {onrampData?.depositInstructions?.depositMessage?.slice(0, 10) || 'Loading...'}
+                            {shortDepositReference(onrampData?.depositInstructions?.depositMessage) || 'Loading...'}
                         </p>
                         {onrampData?.depositInstructions?.depositMessage && (
                             <CopyToClipboard
-                                textToCopy={onrampData.depositInstructions.depositMessage?.slice(0, 10)}
+                                textToCopy={shortDepositReference(onrampData.depositInstructions.depositMessage)}
                                 fill="black"
                                 iconSize="4"
                             />
@@ -416,7 +416,7 @@ Please use these details to complete your bank transfer.`
                     title="Double check in your bank before sending:"
                     items={[
                         `Amount: ${formattedCurrencyAmount} (exact)`,
-                        `Reference: ${onrampData?.depositInstructions?.depositMessage?.slice(0, 10) || 'Loading...'} (included)`,
+                        `Reference: ${shortDepositReference(onrampData?.depositInstructions?.depositMessage) || 'Loading...'} (included)`,
                     ]}
                 />
 

--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -149,6 +149,31 @@ describe('SupportDrawer — Crisp load-failure fallback', () => {
     })
 })
 
+describe('SupportDrawer — pointer-events when opened inside a vaul drawer', () => {
+    beforeEach(() => {
+        mockUseCrispUserData.mockReset().mockReturnValue({ userId: undefined, email: undefined })
+        mockUseCrispTokenId.mockReset().mockReturnValue(undefined)
+        mockIsCapacitor.mockReset().mockReturnValue(false)
+    })
+
+    it('backdrop and panel explicitly re-enable pointer events while open', () => {
+        // vaul sets pointer-events:none on <body> while the transaction drawer is
+        // open. Without an explicit pointer-events-auto, the support overlay
+        // inherits none and becomes click-transparent — taps fall through to the
+        // receipt underneath (one landed on "Cancel deposit" and cancelled a
+        // user's funded bank deposit).
+        const { container } = render(<SupportDrawer />)
+
+        const backdrop = container.querySelector('[aria-hidden="true"]')
+        const panel = screen.getByRole('dialog', { name: 'Support' })
+
+        expect(backdrop?.className).toContain('pointer-events-auto')
+        expect(panel.className).toContain('pointer-events-auto')
+        expect(backdrop?.className).not.toContain('pointer-events-none')
+        expect(panel.className).not.toContain('pointer-events-none')
+    })
+})
+
 describe('SupportDrawer Crisp session gate — native (Capacitor)', () => {
     beforeEach(() => {
         mockUseCrispUserData.mockReset()

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -131,9 +131,15 @@ const SupportDrawer = () => {
     return (
         <>
             {/* backdrop */}
+            {/* pointer-events-auto is load-bearing on BOTH divs: when this drawer is
+                opened from inside a vaul drawer (transaction receipt), vaul sets
+                pointer-events:none on <body> and these divs inherit it — the whole
+                support overlay becomes click-transparent, and taps fall through to
+                the receipt underneath (a fall-through tap on "Cancel deposit"
+                cancelled a user's funded bank deposit). */}
             <div
                 className={`fixed inset-0 z-[999998] bg-black/80 transition-opacity duration-300 ${
-                    isSupportModalOpen ? 'opacity-100' : 'pointer-events-none opacity-0'
+                    isSupportModalOpen ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'
                 }`}
                 onClick={() => setIsSupportModalOpen(false)}
                 aria-hidden="true"
@@ -147,7 +153,7 @@ const SupportDrawer = () => {
                 aria-label="Support"
                 aria-modal={isSupportModalOpen}
                 className={`fixed inset-x-0 bottom-0 z-[999999] flex max-h-[85vh] flex-col rounded-t-[10px] border bg-background pt-4 ${
-                    isSupportModalOpen ? 'translate-y-0' : 'pointer-events-none translate-y-full'
+                    isSupportModalOpen ? 'pointer-events-auto translate-y-0' : 'pointer-events-none translate-y-full'
                 }`}
                 style={{
                     transform: isSupportModalOpen ? `translateY(${dragOffset}px)` : 'translateY(100%)',

--- a/src/components/TransactionDetails/provider-actions/CancelDepositActions.tsx
+++ b/src/components/TransactionDetails/provider-actions/CancelDepositActions.tsx
@@ -2,6 +2,7 @@
 
 import { useState, type ReactNode } from 'react'
 import { Button } from '@/components/0_Bruddle/Button'
+import ActionModal from '@/components/Global/ActionModal'
 import ErrorAlert from '@/components/Global/ErrorAlert'
 import { Icon } from '@/components/Global/Icons/Icon'
 import { type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
@@ -40,6 +41,10 @@ export function CancelDepositActions({
 }) {
     const queryClient = useQueryClient()
     const [error, setError] = useState<string | null>(null)
+    // Cancels are irreversible and the button sits next to the support link —
+    // a real user cancelled a funded deposit while trying to report a problem
+    // (no way to match the wire once cancelled). Every cancel confirms first.
+    const [pendingCancel, setPendingCancel] = useState<{ noun: string; run: () => Promise<void> } | null>(null)
     if (!setIsLoading || !onClose) return null
 
     const refetchAndClose = () =>
@@ -63,11 +68,45 @@ export function CancelDepositActions({
         }
     }
 
-    // Render the active cancel button (if any) alongside any failure message.
+    const confirmThenRun = async () => {
+        if (!pendingCancel) return
+        setPendingCancel(null)
+        await wrapAction(pendingCancel.run)
+    }
+
+    // Render the active cancel button (if any) alongside the shared
+    // confirmation modal and any failure message.
     const withError = (button: ReactNode) => (
         <div className="flex w-full flex-col gap-2">
             {button}
             {error && <ErrorAlert description={error} />}
+            <ActionModal
+                visible={pendingCancel !== null}
+                onClose={() => setPendingCancel(null)}
+                icon="ban"
+                iconContainerClassName="bg-purple-1"
+                iconProps={{ className: 'text-black' }}
+                title={`Cancel this ${pendingCancel?.noun ?? 'deposit'}?`}
+                modalClassName="!z-[9999] pointer-events-auto"
+                description={
+                    <>
+                        This can't be undone. If you already sent the bank transfer, <strong>don't cancel</strong> — a
+                        cancelled deposit can no longer be matched to your account, and the money will be returned to
+                        your bank instead.
+                    </>
+                }
+                modalPanelClassName="max-w-sm mx-8 !z-[9999] pointer-events-auto"
+                contentContainerClassName="relative pointer-events-auto"
+                classOverlay="!bg-black/40 !z-[9998]"
+                ctas={[
+                    {
+                        text: `Yes, cancel ${pendingCancel?.noun ?? 'deposit'}`,
+                        shadowSize: '4',
+                        className: 'md:py-2',
+                        onClick: confirmThenRun,
+                    },
+                ]}
+            />
         </div>
     )
 
@@ -84,9 +123,12 @@ export function CancelDepositActions({
             <CancelButton
                 disabled={!!isLoading}
                 onClick={() =>
-                    wrapAction(async () => {
-                        const result = await cancelOnramp(transaction.id)
-                        if (result.error) throw new Error(result.error)
+                    setPendingCancel({
+                        noun: 'deposit',
+                        run: async () => {
+                            const result = await cancelOnramp(transaction.id)
+                            if (result.error) throw new Error(result.error)
+                        },
                     })
                 }
             />
@@ -101,9 +143,12 @@ export function CancelDepositActions({
             <CancelButton
                 disabled={!!isLoading}
                 onClick={() =>
-                    wrapAction(async () => {
-                        const result = await mantecaApi.cancelDeposit(transaction.id)
-                        if (result.error) throw new Error(result.error)
+                    setPendingCancel({
+                        noun: 'deposit',
+                        run: async () => {
+                            const result = await mantecaApi.cancelDeposit(transaction.id)
+                            if (result.error) throw new Error(result.error)
+                        },
                     })
                 }
             />
@@ -123,17 +168,20 @@ export function CancelDepositActions({
                     label="Cancel Request"
                     disabled={!!isLoading}
                     onClick={() =>
-                        wrapAction(async () => {
-                            const bridgeTransferId = transaction.extraDataForDrawer?.bridgeTransferId
-                            if (!bridgeTransferId) {
-                                throw new Error('Cannot cancel REQUEST: missing bridgeTransferId on transaction')
-                            }
-                            // Bridge cancel must succeed before we cancel the
-                            // charge — otherwise the onramp orphans on Bridge's
-                            // side while the user sees the request as cancelled.
-                            const bridgeResult = await cancelOnramp(bridgeTransferId)
-                            if (bridgeResult.error) throw new Error(bridgeResult.error)
-                            await chargesApi.cancel(transaction.id)
+                        setPendingCancel({
+                            noun: 'request',
+                            run: async () => {
+                                const bridgeTransferId = transaction.extraDataForDrawer?.bridgeTransferId
+                                if (!bridgeTransferId) {
+                                    throw new Error('Cannot cancel REQUEST: missing bridgeTransferId on transaction')
+                                }
+                                // Bridge cancel must succeed before we cancel the
+                                // charge — otherwise the onramp orphans on Bridge's
+                                // side while the user sees the request as cancelled.
+                                const bridgeResult = await cancelOnramp(bridgeTransferId)
+                                if (bridgeResult.error) throw new Error(bridgeResult.error)
+                                await chargesApi.cancel(transaction.id)
+                            },
                         })
                     }
                 />

--- a/src/components/TransactionDetails/provider-actions/CancelDepositActions.tsx
+++ b/src/components/TransactionDetails/provider-actions/CancelDepositActions.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, type ReactNode } from 'react'
+import { useRef, useState, type ReactNode } from 'react'
 import { Button } from '@/components/0_Bruddle/Button'
 import ActionModal from '@/components/Global/ActionModal'
 import ErrorAlert from '@/components/Global/ErrorAlert'
@@ -49,6 +49,10 @@ export function CancelDepositActions({
     // during the modal's fade-out (nulling it mid-fade flashed 'deposit'
     // over 'request' titles).
     const [confirmOpen, setConfirmOpen] = useState(false)
+    // Ref, not state: a double-tap on the confirm CTA during the modal's
+    // fade-out lands both clicks before a re-render, so a state guard would
+    // let the cancel fire twice. Refs are synchronous.
+    const isCancelRunning = useRef(false)
     if (!setIsLoading || !onClose) return null
 
     const refetchAndClose = () =>
@@ -78,9 +82,14 @@ export function CancelDepositActions({
     }
 
     const confirmThenRun = async () => {
-        if (!pendingCancel) return
+        if (!pendingCancel || isCancelRunning.current) return
+        isCancelRunning.current = true
         setConfirmOpen(false)
-        await wrapAction(pendingCancel.run)
+        try {
+            await wrapAction(pendingCancel.run)
+        } finally {
+            isCancelRunning.current = false
+        }
     }
 
     // Render the active cancel button (if any) alongside the shared

--- a/src/components/TransactionDetails/provider-actions/CancelDepositActions.tsx
+++ b/src/components/TransactionDetails/provider-actions/CancelDepositActions.tsx
@@ -45,6 +45,10 @@ export function CancelDepositActions({
     // a real user cancelled a funded deposit while trying to report a problem
     // (no way to match the wire once cancelled). Every cancel confirms first.
     const [pendingCancel, setPendingCancel] = useState<{ noun: string; run: () => Promise<void> } | null>(null)
+    // Visibility is separate from pendingCancel so the noun stays rendered
+    // during the modal's fade-out (nulling it mid-fade flashed 'deposit'
+    // over 'request' titles).
+    const [confirmOpen, setConfirmOpen] = useState(false)
     if (!setIsLoading || !onClose) return null
 
     const refetchAndClose = () =>
@@ -68,9 +72,14 @@ export function CancelDepositActions({
         }
     }
 
+    const armCancel = (noun: string, run: () => Promise<void>) => {
+        setPendingCancel({ noun, run })
+        setConfirmOpen(true)
+    }
+
     const confirmThenRun = async () => {
         if (!pendingCancel) return
-        setPendingCancel(null)
+        setConfirmOpen(false)
         await wrapAction(pendingCancel.run)
     }
 
@@ -81,11 +90,9 @@ export function CancelDepositActions({
             {button}
             {error && <ErrorAlert description={error} />}
             <ActionModal
-                visible={pendingCancel !== null}
-                onClose={() => setPendingCancel(null)}
+                visible={confirmOpen}
+                onClose={() => setConfirmOpen(false)}
                 icon="ban"
-                iconContainerClassName="bg-purple-1"
-                iconProps={{ className: 'text-black' }}
                 title={`Cancel this ${pendingCancel?.noun ?? 'deposit'}?`}
                 modalClassName="!z-[9999] pointer-events-auto"
                 description={
@@ -123,12 +130,9 @@ export function CancelDepositActions({
             <CancelButton
                 disabled={!!isLoading}
                 onClick={() =>
-                    setPendingCancel({
-                        noun: 'deposit',
-                        run: async () => {
-                            const result = await cancelOnramp(transaction.id)
-                            if (result.error) throw new Error(result.error)
-                        },
+                    armCancel('deposit', async () => {
+                        const result = await cancelOnramp(transaction.id)
+                        if (result.error) throw new Error(result.error)
                     })
                 }
             />
@@ -143,12 +147,9 @@ export function CancelDepositActions({
             <CancelButton
                 disabled={!!isLoading}
                 onClick={() =>
-                    setPendingCancel({
-                        noun: 'deposit',
-                        run: async () => {
-                            const result = await mantecaApi.cancelDeposit(transaction.id)
-                            if (result.error) throw new Error(result.error)
-                        },
+                    armCancel('deposit', async () => {
+                        const result = await mantecaApi.cancelDeposit(transaction.id)
+                        if (result.error) throw new Error(result.error)
                     })
                 }
             />
@@ -168,20 +169,17 @@ export function CancelDepositActions({
                     label="Cancel Request"
                     disabled={!!isLoading}
                     onClick={() =>
-                        setPendingCancel({
-                            noun: 'request',
-                            run: async () => {
-                                const bridgeTransferId = transaction.extraDataForDrawer?.bridgeTransferId
-                                if (!bridgeTransferId) {
-                                    throw new Error('Cannot cancel REQUEST: missing bridgeTransferId on transaction')
-                                }
-                                // Bridge cancel must succeed before we cancel the
-                                // charge — otherwise the onramp orphans on Bridge's
-                                // side while the user sees the request as cancelled.
-                                const bridgeResult = await cancelOnramp(bridgeTransferId)
-                                if (bridgeResult.error) throw new Error(bridgeResult.error)
-                                await chargesApi.cancel(transaction.id)
-                            },
+                        armCancel('request', async () => {
+                            const bridgeTransferId = transaction.extraDataForDrawer?.bridgeTransferId
+                            if (!bridgeTransferId) {
+                                throw new Error('Cannot cancel REQUEST: missing bridgeTransferId on transaction')
+                            }
+                            // Bridge cancel must succeed before we cancel the
+                            // charge — otherwise the onramp orphans on Bridge's
+                            // side while the user sees the request as cancelled.
+                            const bridgeResult = await cancelOnramp(bridgeTransferId)
+                            if (bridgeResult.error) throw new Error(bridgeResult.error)
+                            await chargesApi.cancel(transaction.id)
                         })
                     }
                 />

--- a/src/components/TransactionDetails/provider-actions/__tests__/CancelDepositActions.test.tsx
+++ b/src/components/TransactionDetails/provider-actions/__tests__/CancelDepositActions.test.tsx
@@ -128,6 +128,21 @@ describe('CancelDepositActions confirmation gate', () => {
         await waitFor(() => expect(mockCancelOnramp).toHaveBeenCalledWith('tx-1'))
     })
 
+    it('double-tapping the confirm button fires the cancel exactly once', async () => {
+        // keep the cancel in-flight so the second tap lands while the first runs
+        let resolveCancel: (v: unknown) => void
+        mockCancelOnramp.mockReturnValue(new Promise((resolve) => (resolveCancel = resolve)))
+        renderCancel()
+
+        fireEvent.click(screen.getByText('Cancel deposit'))
+        const confirmButton = screen.getByText('Yes, cancel deposit')
+        fireEvent.click(confirmButton)
+        fireEvent.click(confirmButton)
+
+        resolveCancel!({})
+        await waitFor(() => expect(mockCancelOnramp).toHaveBeenCalledTimes(1))
+    })
+
     it('dismissing the confirmation leaves the deposit untouched', () => {
         renderCancel()
 

--- a/src/components/TransactionDetails/provider-actions/__tests__/CancelDepositActions.test.tsx
+++ b/src/components/TransactionDetails/provider-actions/__tests__/CancelDepositActions.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * CancelDepositActions — cancel buttons for pending bank-deposit flows.
+ *
+ * Regression tests for the instant-cancel bug: the cancel button fired
+ * cancelOnramp straight from onClick with no confirmation, sitting right next
+ * to the support link — a real user cancelled a funded deposit while trying to
+ * report a problem, making the wire unmatchable. Every cancel must go through
+ * an explicit confirmation first. Nested primitives are stubbed so only this
+ * component's own logic is under test.
+ */
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+const mockCancelOnramp = jest.fn()
+jest.mock('@/app/actions/onramp', () => ({
+    cancelOnramp: (...args: unknown[]) => mockCancelOnramp(...args),
+}))
+const mockMantecaCancel = jest.fn()
+jest.mock('@/services/manteca', () => ({
+    mantecaApi: { cancelDeposit: (...args: unknown[]) => mockMantecaCancel(...args) },
+}))
+jest.mock('@/services/charges', () => ({
+    chargesApi: { cancel: jest.fn() },
+}))
+const mockInvalidateQueries = jest.fn()
+jest.mock('@tanstack/react-query', () => ({
+    useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+}))
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }))
+jest.mock('@/components/TransactionDetails/transaction-predicates', () => ({
+    isMantecaOnrampEntry: () => false,
+    isRequestEntry: () => false,
+}))
+jest.mock('@/hooks/useTransactionHistory', () => ({
+    EHistoryUserRole: { SENDER: 'SENDER' },
+}))
+jest.mock('@/components/0_Bruddle/Button', () => ({
+    Button: ({
+        children,
+        onClick,
+        disabled,
+    }: {
+        children: React.ReactNode
+        onClick?: () => void
+        disabled?: boolean
+    }) => (
+        <button onClick={onClick} disabled={disabled}>
+            {children}
+        </button>
+    ),
+}))
+jest.mock('@/components/Global/ErrorAlert', () => ({
+    __esModule: true,
+    default: ({ description }: { description: string }) => <div data-testid="error">{description}</div>,
+}))
+jest.mock('@/components/Global/Icons/Icon', () => ({ Icon: () => <span /> }))
+jest.mock('@/components/Global/ActionModal', () => ({
+    __esModule: true,
+    default: ({
+        visible,
+        title,
+        ctas,
+        onClose,
+    }: {
+        visible: boolean
+        title: React.ReactNode
+        ctas?: Array<{ text: string; onClick?: () => void }>
+        onClose: () => void
+    }) =>
+        visible ? (
+            <div data-testid="confirm-modal">
+                <p>{title}</p>
+                {ctas?.map((cta) => (
+                    <button key={cta.text} onClick={cta.onClick}>
+                        {cta.text}
+                    </button>
+                ))}
+                <button onClick={onClose}>Dismiss</button>
+            </div>
+        ) : null,
+}))
+
+// import must come after jest.mock
+import { CancelDepositActions } from '../CancelDepositActions'
+
+const pendingBridgeOnramp = {
+    id: 'tx-1',
+    direction: 'bank_deposit',
+    status: 'pending',
+    extraDataForDrawer: { depositInstructions: { deposit_message: 'BRGTESTREF1234567890' } },
+} as unknown as import('@/components/TransactionDetails/transactionTransformer').TransactionDetails
+
+const renderCancel = () =>
+    render(
+        <CancelDepositActions
+            transaction={pendingBridgeOnramp}
+            isPendingBankRequest={false}
+            isLoading={false}
+            setIsLoading={jest.fn()}
+            onClose={jest.fn()}
+        />
+    )
+
+beforeEach(() => {
+    mockCancelOnramp.mockReset().mockResolvedValue({})
+    mockMantecaCancel.mockReset()
+    mockInvalidateQueries.mockReset().mockResolvedValue(undefined)
+})
+
+describe('CancelDepositActions confirmation gate', () => {
+    it('does NOT cancel on the first click — it asks for confirmation instead', () => {
+        renderCancel()
+
+        expect(screen.queryByTestId('confirm-modal')).not.toBeInTheDocument()
+        fireEvent.click(screen.getByText('Cancel deposit'))
+
+        expect(mockCancelOnramp).not.toHaveBeenCalled()
+        expect(screen.getByTestId('confirm-modal')).toBeInTheDocument()
+        expect(screen.getByText('Cancel this deposit?')).toBeInTheDocument()
+    })
+
+    it('cancels only after the user confirms', async () => {
+        renderCancel()
+
+        fireEvent.click(screen.getByText('Cancel deposit'))
+        fireEvent.click(screen.getByText('Yes, cancel deposit'))
+
+        await waitFor(() => expect(mockCancelOnramp).toHaveBeenCalledWith('tx-1'))
+    })
+
+    it('dismissing the confirmation leaves the deposit untouched', () => {
+        renderCancel()
+
+        fireEvent.click(screen.getByText('Cancel deposit'))
+        fireEvent.click(screen.getByText('Dismiss'))
+
+        expect(mockCancelOnramp).not.toHaveBeenCalled()
+        expect(screen.queryByTestId('confirm-modal')).not.toBeInTheDocument()
+    })
+})

--- a/src/components/TransactionDetails/provider-rows/BridgeDepositInstructions.tsx
+++ b/src/components/TransactionDetails/provider-rows/BridgeDepositInstructions.tsx
@@ -7,6 +7,7 @@ import CopyToClipboard from '@/components/Global/CopyToClipboard'
 import MoreInfo from '@/components/Global/MoreInfo'
 import { type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
 import { BRIDGE_DEFAULT_ACCOUNT_HOLDER_NAME } from '@/constants/payment.consts'
+import { shortDepositReference } from '@/utils/format.utils'
 import { formatIban } from '@/utils/general.utils'
 
 /**
@@ -36,13 +37,14 @@ export function BridgeDepositInstructions({ transaction }: { transaction: Transa
                 }
                 value={
                     <div className="flex items-center gap-2">
-                        {/* Shortened to 10 chars to match the Add Money screen — some
-                            banks (e.g. Wise) cap reference fields at 10 chars, and
-                            Bridge matches deposits on the partial reference. Showing
-                            the full form only here made users think they wired with
-                            the "wrong" code (two-different-codes confusion). */}
-                        <span className="break-all">{instructions.deposit_message?.slice(0, 10)}</span>
-                        <CopyToClipboard textToCopy={instructions.deposit_message?.slice(0, 10)} iconSize="4" />
+                        {/* Same shortened form as the Add Money screen — rationale on
+                            shortDepositReference. Showing the full form only here made
+                            users think they wired with the "wrong" code. */}
+                        <span className="break-all">{shortDepositReference(instructions.deposit_message)}</span>
+                        <CopyToClipboard
+                            textToCopy={shortDepositReference(instructions.deposit_message)}
+                            iconSize="4"
+                        />
                     </div>
                 }
                 hideBottomBorder={false}

--- a/src/components/TransactionDetails/provider-rows/BridgeDepositInstructions.tsx
+++ b/src/components/TransactionDetails/provider-rows/BridgeDepositInstructions.tsx
@@ -36,12 +36,13 @@ export function BridgeDepositInstructions({ transaction }: { transaction: Transa
                 }
                 value={
                     <div className="flex items-center gap-2">
-                        {/* Display can wrap / be truncated visually via CSS, but
-                            the copyable text MUST be the full reference — Bridge
-                            won't reconcile a deposit if the user enters the
-                            truncated form. */}
-                        <span className="break-all">{instructions.deposit_message}</span>
-                        <CopyToClipboard textToCopy={instructions.deposit_message} iconSize="4" />
+                        {/* Shortened to 10 chars to match the Add Money screen — some
+                            banks (e.g. Wise) cap reference fields at 10 chars, and
+                            Bridge matches deposits on the partial reference. Showing
+                            the full form only here made users think they wired with
+                            the "wrong" code (two-different-codes confusion). */}
+                        <span className="break-all">{instructions.deposit_message?.slice(0, 10)}</span>
+                        <CopyToClipboard textToCopy={instructions.deposit_message?.slice(0, 10)} iconSize="4" />
                     </div>
                 }
                 hideBottomBorder={false}

--- a/src/components/TransactionDetails/provider-rows/__tests__/BridgeDepositInstructions.test.tsx
+++ b/src/components/TransactionDetails/provider-rows/__tests__/BridgeDepositInstructions.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * BridgeDepositInstructions — the deposit-instructions block in the
+ * transaction drawer.
+ *
+ * The reference here must be the SAME shortened 10-char form the Add Money
+ * screen shows (some banks cap reference fields at 10 chars; Bridge matches
+ * deposits on the partial reference). Showing the full form only here made a
+ * user believe they wired with the wrong code — the two-different-codes
+ * confusion. Nested primitives are stubbed.
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+jest.mock('@/components/Payment/PaymentInfoRow', () => ({
+    PaymentInfoRow: ({ label, value }: { label: React.ReactNode; value: React.ReactNode }) => (
+        <div>
+            {label}
+            {value}
+        </div>
+    ),
+}))
+jest.mock('@/components/Global/CopyToClipboard', () => ({
+    __esModule: true,
+    default: ({ textToCopy }: { textToCopy: string }) => <div data-testid="copy" data-text={textToCopy} />,
+}))
+jest.mock('@/components/Global/MoreInfo', () => ({ __esModule: true, default: () => <span /> }))
+jest.mock('@/components/Global/Icons/Icon', () => ({ Icon: () => <span /> }))
+
+// import must come after jest.mock
+import { BridgeDepositInstructions } from '../BridgeDepositInstructions'
+
+const FULL_REFERENCE = 'BRGTESTREF1234567890'
+const SHORT_REFERENCE = FULL_REFERENCE.slice(0, 10)
+
+const transaction = {
+    extraDataForDrawer: {
+        depositInstructions: {
+            deposit_message: FULL_REFERENCE,
+            bank_name: 'Deutsche Bank',
+            bank_address: 'Frankfurt, Germany',
+            account_holder_name: 'Peanut Protocol',
+            iban: 'DE89370400440532013000',
+            bic: 'COBADEFFXXX',
+        },
+    },
+} as unknown as import('@/components/TransactionDetails/transactionTransformer').TransactionDetails
+
+describe('BridgeDepositInstructions deposit message', () => {
+    it('shows and copies the same shortened 10-char reference as the Add Money screen', () => {
+        render(<BridgeDepositInstructions transaction={transaction} />)
+
+        expect(screen.getByText(SHORT_REFERENCE)).toBeInTheDocument()
+        expect(screen.queryByText(FULL_REFERENCE)).not.toBeInTheDocument()
+
+        const copyTexts = screen.getAllByTestId('copy').map((el) => el.getAttribute('data-text'))
+        expect(copyTexts).toContain(SHORT_REFERENCE)
+        expect(copyTexts).not.toContain(FULL_REFERENCE)
+    })
+})

--- a/src/utils/format.utils.ts
+++ b/src/utils/format.utils.ts
@@ -53,3 +53,14 @@ export const formatBankAccountDisplay = (value: string | undefined, type?: 'iban
 }
 
 export const isValidEmail = (email: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+
+// Some banks (e.g. Wise) cap the transfer-reference field at 10 characters, and
+// Bridge matches incoming deposits on this partial reference. Every surface that
+// shows or copies a Bridge deposit reference must use this same shortened form —
+// different lengths on different screens made a user believe he wired with the
+// wrong code (two-different-codes confusion, peanut-ui#2416).
+export function shortDepositReference(reference: string): string
+export function shortDepositReference(reference: string | undefined): string | undefined
+export function shortDepositReference(reference: string | undefined): string | undefined {
+    return reference?.slice(0, 10)
+}


### PR DESCRIPTION
## Summary

### The bug, explained for a stupid 5-year-old 🖍️

The transaction screen has two buttons near each other:

- 🟢 **"Issues with this transaction?"** — calls support for help. Totally harmless.
- 🔴 **"Cancel deposit"** — shreds your deposit order. Forever.

You press the green button and a big support-chat window slides up in front of everything. Looks great. Except the chat window is a **hologram**: the page underneath had told the browser "ignore fingers" (that's what the transaction drawer does while it's open), and the chat window forgot to say "except me — fingers stop HERE!". So it *looks* solid, but your finger goes **straight through the glass**.

Now you tap the chat to type your message… and the browser delivers that tap to whatever is *behind* the hologram at that exact spot. And what's behind it, right there? The red shred button. *Click.* Deposit cancelled. You never saw it, you never meant it, and the money that arrives at the bank can no longer be matched to anything.

That's why the fix is not "disconnect the green button from cancel" — **there was never a wire between them**. The green button was innocent. The fix is two words, `pointer-events-auto`: *"this glass is solid."* Plus a seatbelt: the shred button now always asks "are you REALLY sure?" — so no stray tap can ever shred money in one touch again.

---

Replaces #2415 (closed — wrong diagnosis). Three fixes, grounded in the Valentin case (Crisp session_27a67f97) and reproduced by @abalinda (intent cbc0fd7d-14e9-4a6c-b5be-c54dbe0c49ee):

1. **ROOT CAUSE — "Issues with this transaction?" cancelled deposits via click fall-through.** vaul sets `pointer-events: none` on `<body>` while the transaction drawer is open; the `SupportDrawer`'s backdrop and panel never re-enabled pointer events, so the entire support overlay inherited `none` and was **click-transparent**. Taps on the visually-open support chat fell through to the receipt underneath — where `Cancel deposit` renders adjacent to the support link — and fired the un-guarded cancel. PostHog element chains prove it: support link clicked 15:05:47.742 → fall-through click autocaptured on `Cancel deposit` 15:05:48.798 (1.06s — not a human aim) → BE `user_cancelled` 15:05:49.444, with `body[style="pointer-events: none"]` captured in both chains. Fixed with explicit `pointer-events-auto` on the backdrop and panel while open, plus a regression test.

2. **Confirmation before any deposit/request cancel** (defense in depth — the cancel is irreversible money-state). All three cancel variants (Bridge onramp, Manteca onramp, bank request) now arm a shared `ActionModal` confirmation warning that a sent transfer can no longer be matched after cancelling. Even a fall-through click can now only open the modal, never cancel.

3. **Uniform 10-char deposit reference.** The Add Money screen intentionally shortens the Bridge reference to 10 chars (some banks, e.g. Wise, cap reference fields; Bridge matches deposits on the partial reference) — but the transaction drawer showed the full 20-char form. Seeing 'two different codes' is what sent the user into the drawer in a panic in the first place. Both screens now route through a single `shortDepositReference()` helper (6 call sites), so the lengths can't drift apart again.


### Before (drawer 20 char; deposit flow transaction screen 10 chars)
<img width="445" height="464" alt="image" src="https://github.com/user-attachments/assets/2589a6db-6a2e-4a4c-9f4d-ef2162a235db" />
<img width="472" height="956" alt="image" src="https://github.com/user-attachments/assets/b9927b4b-c4e9-4818-a10a-6f883dcb02fc" />


### Now - 10 chars everywhere + cancel confirmation popup + "Need help with this transaction" doesn't trigger auto-cancel
<img width="569" height="1199" alt="image" src="https://github.com/user-attachments/assets/cd7c526c-07d6-4b63-8273-061c76e4290f" />
<img width="568" height="1208" alt="image" src="https://github.com/user-attachments/assets/d2294778-88e2-42cb-9f11-2e0d0e023c49" />

this is after clicking on the explicit "Cancel deposit"
<img width="524" height="438" alt="image" src="https://github.com/user-attachments/assets/b40766ee-f3af-478a-9246-a8903b858eaf" />


## Design notes / accepted trade-offs

- Confirmation modal lives inside `CancelDepositActions` reusing the global `ActionModal` (same pattern as `CancelSendLinkModal`) — one modal serves all three cancel branches, parameterized by noun (deposit/request).
- The drawer truncation is display+copy — uniform with Add Money. **The full reference is no longer shown anywhere in the UI** (deliberate, per product decision — Bridge matches on the partial). If support ever needs the full form for manual reconciliation, it stays available in the DB/Bridge dashboard; surfacing it in-app would be a follow-up, not a mismatch.
- The z-[9999]/pointer-events modal-stacking overrides are the third copy of this pattern (`CancelSendLinkModal`, `TokenAndNetworkConfirmationModal`) — extracting a shared confirm-in-drawer wrapper is a follow-up, out of hotfix scope.

## Risks / breaking changes

- None cross-repo; FE-only. Cancel behaviour unchanged after confirmation.
- Hotfix to `main` → back-merge debt main→dev after merge.

## QA

- New suites: `CancelDepositActions.test.tsx` (3 tests: click ≠ cancel, confirm → cancel, dismiss → untouched), `BridgeDepositInstructions.test.tsx` (shortened ref in display + copy), and a `SupportDrawer` regression test asserting backdrop + panel carry `pointer-events-auto` while open (the vaul-inheritance trap).
- Full local gate: prettier ✅ · typecheck ✅ · jest 1832 tests ✅ · changed-files eslint clean.
- Visual QA: local harness, pending bank deposit → drawer → Cancel deposit shows confirmation; reference matches Add Money screen; support chat opens and absorbs clicks.

