### PR TITLE
fix(deposit): update Bridge SEPA account holder name + deposit details bugs

### DIFF
--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -281,6 +281,7 @@ jest.mock('@/constants/zerodev.consts', () => ({
 jest.mock('@/constants/payment.consts', () => ({
     MIN_MANTECA_DEPOSIT_AMOUNT: 1,
     BRIDGE_DEFAULT_ACCOUNT_HOLDER_NAME: 'Bridge Financial',
+    resolveBridgeAccountHolderName: (name?: string | null) => name || 'Bridge Financial',
 }))
 
 jest.mock('@/constants/manteca.consts', () => ({

--- a/src/components/AddMoney/components/AddMoneyBankDetails.tsx
+++ b/src/components/AddMoney/components/AddMoneyBankDetails.tsx
@@ -15,7 +15,7 @@ import { RequestFulfillmentBankFlowStep, useRequestFulfillmentFlow } from '@/con
 import { formatAmount } from '@/utils/general.utils'
 import InfoCard from '@/components/Global/InfoCard'
 import CopyToClipboard from '@/components/Global/CopyToClipboard'
-import { BRIDGE_DEFAULT_ACCOUNT_HOLDER_NAME } from '@/constants/payment.consts'
+import { resolveBridgeAccountHolderName } from '@/constants/payment.consts'
 import { Button } from '@/components/0_Bruddle/Button'
 import { useOnrampQuote } from '@/hooks/useOnrampQuote'
 import { currencyToAccountType } from '@/utils/bridge.utils'
@@ -296,10 +296,10 @@ Please use these details to complete your bank transfer.`
                 <Card className="gap-2 rounded-sm">
                     <h1 className="text-xs">Bank Details</h1>
 
-                    {/* note: fallback to bridge as account holder name, to cover faster_payments onramp requests as bridge currently doesnt retrun a account holder name in api response */}
+                    {/* resolveBridgeAccountHolderName maps Bridge's stale/absent legal entity name to the current one (Sp. Z.o.o. -> S.A.) */}
                     <PaymentInfoRow
                         label={'Account Holder Name'}
-                        value={onrampData?.depositInstructions?.accountHolderName || BRIDGE_DEFAULT_ACCOUNT_HOLDER_NAME}
+                        value={resolveBridgeAccountHolderName(onrampData?.depositInstructions?.accountHolderName)}
                         allowCopy
                         hideBottomBorder
                     />

--- a/src/components/TransactionDetails/provider-rows/BridgeDepositInstructions.tsx
+++ b/src/components/TransactionDetails/provider-rows/BridgeDepositInstructions.tsx
@@ -6,7 +6,7 @@ import { Icon } from '@/components/Global/Icons/Icon'
 import CopyToClipboard from '@/components/Global/CopyToClipboard'
 import MoreInfo from '@/components/Global/MoreInfo'
 import { type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
-import { BRIDGE_DEFAULT_ACCOUNT_HOLDER_NAME } from '@/constants/payment.consts'
+import { resolveBridgeAccountHolderName } from '@/constants/payment.consts'
 import { formatIban } from '@/utils/general.utils'
 
 /**
@@ -64,11 +64,10 @@ export function BridgeDepositInstructions({ transaction }: { transaction: Transa
             {/* Collapsible bank details */}
             {showBankDetails && (
                 <>
-                    {/* Fallback to bridge as account holder name — covers faster_payments
-                        onramps where bridge doesn't return an account holder name. */}
+                    {/* resolveBridgeAccountHolderName maps Bridge's stale/absent legal entity name to the current one (Sp. Z.o.o. -> S.A.) */}
                     <PaymentInfoRow
                         label="Account Holder Name"
-                        value={instructions.account_holder_name || BRIDGE_DEFAULT_ACCOUNT_HOLDER_NAME}
+                        value={resolveBridgeAccountHolderName(instructions.account_holder_name)}
                         allowCopy
                         hideBottomBorder={false}
                     />

--- a/src/constants/__tests__/payment.consts.test.ts
+++ b/src/constants/__tests__/payment.consts.test.ts
@@ -1,0 +1,20 @@
+import { BRIDGE_DEFAULT_ACCOUNT_HOLDER_NAME, resolveBridgeAccountHolderName } from '../payment.consts'
+
+describe('resolveBridgeAccountHolderName', () => {
+    it('falls back to the current entity when Bridge omits the name (faster_payments/GBP)', () => {
+        expect(resolveBridgeAccountHolderName(undefined)).toBe(BRIDGE_DEFAULT_ACCOUNT_HOLDER_NAME)
+        expect(resolveBridgeAccountHolderName(null)).toBe(BRIDGE_DEFAULT_ACCOUNT_HOLDER_NAME)
+        expect(resolveBridgeAccountHolderName('')).toBe(BRIDGE_DEFAULT_ACCOUNT_HOLDER_NAME)
+    })
+
+    it('maps the stale legacy entity name to the current one, across spacing/case variants', () => {
+        expect(resolveBridgeAccountHolderName('Bridge Building Sp. Z.o.o.')).toBe(BRIDGE_DEFAULT_ACCOUNT_HOLDER_NAME)
+        expect(resolveBridgeAccountHolderName('Bridge Building Sp.z.o.o.')).toBe(BRIDGE_DEFAULT_ACCOUNT_HOLDER_NAME)
+        expect(resolveBridgeAccountHolderName('BRIDGE BUILDING SP. Z.O.O.')).toBe(BRIDGE_DEFAULT_ACCOUNT_HOLDER_NAME)
+    })
+
+    it('passes through any other name Bridge returns (including the already-current one)', () => {
+        expect(resolveBridgeAccountHolderName('Bridge Building S.A.')).toBe('Bridge Building S.A.')
+        expect(resolveBridgeAccountHolderName('Some Other Entity')).toBe('Some Other Entity')
+    })
+})

--- a/src/constants/payment.consts.ts
+++ b/src/constants/payment.consts.ts
@@ -2,6 +2,19 @@
 // bridge currently doesnt return account_holder_name for faster_payments requests
 export const BRIDGE_DEFAULT_ACCOUNT_HOLDER_NAME = 'Bridge Building S.A.'
 
+// Bridge migrated its legal entity (Sp. Z.o.o. -> S.A.) on 2026-06-27. Their
+// SEPA deposit instructions can still return the stale old name, and Faster
+// Payments omits the name entirely. Map both cases to the current entity so the
+// sender's Confirmation-of-Payee check matches (Banking Circle accepts either,
+// so payments still settle — this only removes the name-mismatch warning).
+// ponytail: drop the legacy check once Bridge's API stops returning "Z.o.o."
+export const resolveBridgeAccountHolderName = (name?: string | null): string => {
+    if (!name || name.toLowerCase().replace(/[\s.]/g, '').includes('zoo')) {
+        return BRIDGE_DEFAULT_ACCOUNT_HOLDER_NAME
+    }
+    return name
+}
+
 // minimum amount requirements for different payment methods (in USD)
 export const MIN_BANK_TRANSFER_AMOUNT = 5
 export const MIN_MERCADOPAGO_AMOUNT = 5

--- a/src/constants/payment.consts.ts
+++ b/src/constants/payment.consts.ts
@@ -1,6 +1,6 @@
 // fallback account holder name for bridge onramp deposit instructions
 // bridge currently doesnt return account_holder_name for faster_payments requests
-export const BRIDGE_DEFAULT_ACCOUNT_HOLDER_NAME = 'Bridge Building Sp. Z.o.o.'
+export const BRIDGE_DEFAULT_ACCOUNT_HOLDER_NAME = 'Bridge Building S.A.'
 
 // minimum amount requirements for different payment methods (in USD)
 export const MIN_BANK_TRANSFER_AMOUNT = 5


### PR DESCRIPTION
## What

Batch of deposit-details bug fixes.

### 1. Bridge SEPA account holder name

Bridge completed a legal entity migration on **2026-06-27**. Their EUR/GBP vIBANs now reflect the new entity name **Bridge Building S.A.** (previously *Bridge Building Sp. Z.o.o.*). Sending banks whose records still have the old name surface a name-mismatch warning; Banking Circle accepts payments to either name so transfers still process, but the mismatch confuses users.

Updated the FE fallback account holder name (`BRIDGE_DEFAULT_ACCOUNT_HOLDER_NAME`) to match the current legal entity.

Source: Bridge support (ticket #171111) confirmed the new entity name and that both names route correctly.

## Notes

- Only the fallback constant changed — it's rendered when Bridge omits `account_holder_name` on faster-payments deposit instructions.
- Test fixtures (`render-baseline.json`) still carry the old name as mock *server response* inputs; left unchanged (not the display fallback).

_More deposit-details fixes to follow in this PR._