### PR TITLE
fix(request): show Completed on a fully funded request pot

### DIFF
--- a/src/components/TransactionDetails/__tests__/transactionTransformer.test.ts
+++ b/src/components/TransactionDetails/__tests__/transactionTransformer.test.ts
@@ -482,6 +482,47 @@ describe('mapTransactionDataForDrawer', () => {
         })
     })
 
+    describe('request pot rollup status', () => {
+        const pot = (overrides: Partial<HistoryEntry>): HistoryEntry =>
+            baseEntry({
+                userRole: EHistoryUserRole.RECIPIENT,
+                status: EHistoryStatus.OPEN,
+                amount: '1750',
+                isRequestLink: true,
+                extraData: { kind: 'P2P_REQUEST_FULFILL', provider: 'PEANUT', isRequestPotRollup: true },
+                ...overrides,
+            })
+
+        it('an open pot that met its goal reads as completed', () => {
+            const result = mapTransactionDataForDrawer(pot({ totalAmountCollected: 1750 })).transactionDetails
+            expect(result.status).toBe('completed')
+        })
+
+        it('an over-funded open pot reads as completed', () => {
+            const result = mapTransactionDataForDrawer(pot({ totalAmountCollected: 2000 })).transactionDetails
+            expect(result.status).toBe('completed')
+        })
+
+        it('a partially funded open pot stays pending', () => {
+            const result = mapTransactionDataForDrawer(pot({ totalAmountCollected: 500 })).transactionDetails
+            expect(result.status).toBe('pending')
+        })
+
+        it('a goal-less pot stays pending no matter what it collected', () => {
+            const result = mapTransactionDataForDrawer(
+                pot({ amount: '0', totalAmountCollected: 500 })
+            ).transactionDetails
+            expect(result.status).toBe('pending')
+        })
+
+        it('a closed pot still reads as closed, not completed', () => {
+            const result = mapTransactionDataForDrawer(
+                pot({ status: EHistoryStatus.CLOSED, totalAmountCollected: 1750 })
+            ).transactionDetails
+            expect(result.status).toBe('closed')
+        })
+    })
+
     describe('refund credit rows (status + sign + flag)', () => {
         const negativeAuth = baseEntry({
             userRole: EHistoryUserRole.SENDER,

--- a/src/components/TransactionDetails/transactionTransformer.ts
+++ b/src/components/TransactionDetails/transactionTransformer.ts
@@ -192,6 +192,14 @@ function mapEntryStatusToUiStatus(entry: HistoryEntry, direction: TransactionDir
         }
     }
 
+    // A request link stays OPEN until the requester closes it, so its raw status
+    // never reports that the goal was met — derive that from the collected sum.
+    // Goal 0 is the "no goal set" pot, which can never be fully funded.
+    if (entry.isRequestLink && status === 'OPEN') {
+        const goal = Number(entry.amount ?? 0)
+        return goal > 0 && (entry.totalAmountCollected ?? 0) >= goal ? 'completed' : 'pending'
+    }
+
     switch (status) {
         case 'NEW':
         case 'PENDING':

--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -52,6 +52,7 @@ export enum EHistoryStatus {
     refunded = 'refunded',
     canceled = 'canceled', // from simplefi, canceled with only one l
     expired = 'expired',
+    OPEN = 'OPEN',
     CLOSED = 'CLOSED',
 }
 


### PR DESCRIPTION
## The issue

A request pot that had been fully paid still showed a **Pending** badge, even with the progress bar at 100% and **$0 remaining** right next to it:

> `Request $1,750.00` — `Pending` — `$1750 contributed` / `$0 remaining`

## Why it happened

The badge wasn't reading the collected amount at all — it was reading the wrong field entirely.

A request link's status is an `OPEN`/`CLOSED` enum on the backend (`RequestLinkStatus`). It only flips to `CLOSED` when the requester *explicitly* closes the request, so it never reports "the goal was met". Meanwhile `mapEntryStatusToUiStatus` in `transactionTransformer.ts` had no `case 'OPEN'` at all, so an open pot fell through to the default branch:

```ts
default: {
    const knownStatuses: StatusType[] = ['completed', 'pending', 'failed', 'cancelled', 'soon', 'processing']
    const lower = entry.status?.toLowerCase()   // 'open' — not a known status
    return lower && knownStatuses.includes(lower as StatusPillType) ? (lower as StatusPillType) : 'pending'
}
```

`'open'` isn't in `knownStatuses`, so every open pot returned `'pending'`. A fully funded pot and an untouched one were indistinguishable to the badge.

Compounding it: `OPEN` wasn't even a member of the frontend's `EHistoryStatus` enum, even though the backend sends it — `history.ts` casts past the type (`link.status as HistoryEntry['status']`), so nothing flagged the gap.

## The fix

For request links with status `OPEN`, derive the badge from the collected sum against the goal — the same data the progress bar already renders:

```ts
if (entry.isRequestLink && status === 'OPEN') {
    const goal = Number(entry.amount ?? 0)
    return goal > 0 && (entry.totalAmountCollected ?? 0) >= goal ? 'completed' : 'pending'
}
```

`goal > 0` guards the "no goal set" pot, which can never be fully funded — without it, such a pot would flip to Completed instantly. Closed pots keep their existing `closed`/`cancelled` behaviour, which is decided further down the switch.

`OPEN` is also added to `EHistoryStatus` so the type reflects what actually arrives on the wire.

## Tests

5 new cases in `transactionTransformer.test.ts` covering exactly-funded, over-funded, partially funded, goal-less, and closed pots. Full `TransactionDetails` suite passes (39 in this file), `tsc` clean.

## Related

The number this badge now keys off is summed on the backend, and the requester's rollup and the payer's request route were computing it two different ways (intent `COMPLETED` + requested amount vs. entry-backed `SUCCESSFUL` + settled amount). That's fixed separately in a `peanut-api-ts` PR. This change is independent and safe to ship on its own — it just inherits whatever the current sum reports until that lands.
