### PR TITLE
fix(withdraw): stop method selection bouncing back to saved accounts

### DIFF
--- a/src/components/AddWithdraw/AddWithdrawRouterView.tsx
+++ b/src/components/AddWithdraw/AddWithdrawRouterView.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/utils/general.utils'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { addMoneyCountryUrl, withdrawCountryUrl, rewriteMethodPath } from '@/utils/native-routes'
-import { type FC, useEffect, useState, useTransition, useCallback } from 'react'
+import { type FC, useEffect, useRef, useState, useTransition, useCallback } from 'react'
 import { useUserStore } from '@/redux/hooks'
 import { AccountType, type Account } from '@/interfaces/interfaces'
 import { useWithdrawFlow } from '@/context/WithdrawFlowContext'
@@ -90,7 +90,11 @@ export const AddWithdrawRouterView: FC<AddWithdrawRouterViewProps> = ({
         shouldShowAllMethods = true
     }
 
-    const baseRoute = flow === 'add' ? '/add-money' : '/withdraw'
+    // apply the default view (saved accounts vs all methods) only once per mount.
+    // the user query re-dispatches a fresh `user` object on every refetch (window
+    // focus, 4s pending-rail poll), and re-running the default unconditionally
+    // yanked an open country list back to the saved-accounts view.
+    const hasAppliedDefaultView = useRef(false)
 
     useEffect(() => {
         setIsLoadingPreferences(true)
@@ -107,7 +111,7 @@ export const AddWithdrawRouterView: FC<AddWithdrawRouterViewProps> = ({
 
             if (bankAccounts.length > 0) {
                 setSavedAccounts(bankAccounts as unknown as Account[])
-                setShouldShowAllMethods(false)
+                if (!hasAppliedDefaultView.current) setShouldShowAllMethods(false)
             } else {
                 setSavedAccounts([])
             }
@@ -117,11 +121,14 @@ export const AddWithdrawRouterView: FC<AddWithdrawRouterViewProps> = ({
             const currentRecentMethods = prefs?.recentAddMethods ?? []
             if (currentRecentMethods.length > 0) {
                 setRecentMethodsState(currentRecentMethods)
-                setShouldShowAllMethods(false)
-            } else {
+                if (!hasAppliedDefaultView.current) setShouldShowAllMethods(false)
+            } else if (!hasAppliedDefaultView.current) {
                 setShouldShowAllMethods(true)
             }
         }
+        // latch only once the user has loaded, so the first real resolution
+        // (not the pre-auth null render) decides the default view
+        if (user) hasAppliedDefaultView.current = true
         setIsLoadingPreferences(false)
     }, [flow, user, setShouldShowAllMethods])
 
@@ -372,17 +379,14 @@ export const AddWithdrawRouterView: FC<AddWithdrawRouterViewProps> = ({
                             method_type: 'crypto',
                             country: 'crypto',
                         })
-                        // preserve method param if coming from send flow (though crypto shouldn't show this screen)
-                        const queryParams = methodParam ? `?method=${methodParam}` : ''
-                        const cryptoPath = `${baseRoute}/crypto${queryParams}`
-                        // Set crypto method and navigate to main page for amount input
+                        // set crypto method in context only — the withdraw page switches to the
+                        // amount step and navigates to /withdraw/crypto after Continue. navigating
+                        // here (pre-amount) trips the crypto page's "no amount" redirect guard,
+                        // whose unmount cleanup resets the whole flow back to saved accounts.
                         setSelectedMethod({
                             type: 'crypto',
                             countryPath: 'crypto',
                             title: 'Crypto',
-                        })
-                        startTransition(() => {
-                            router.push(cryptoPath)
                         })
                     }
                 }}

--- a/src/components/AddWithdraw/AddWithdrawRouterView.tsx
+++ b/src/components/AddWithdraw/AddWithdrawRouterView.tsx
@@ -115,14 +115,15 @@ export const AddWithdrawRouterView: FC<AddWithdrawRouterViewProps> = ({
             } else {
                 setSavedAccounts([])
             }
-        } else {
-            // 'add' flow logic
+        } else if (!hasAppliedDefaultView.current) {
+            // 'add' flow: the default view is a one-shot decision, so skip the
+            // localstorage re-read + state churn on later user refetches
             const prefs = user ? getUserPreferences(user.user.userId) : undefined
             const currentRecentMethods = prefs?.recentAddMethods ?? []
             if (currentRecentMethods.length > 0) {
                 setRecentMethodsState(currentRecentMethods)
-                if (!hasAppliedDefaultView.current) setShouldShowAllMethods(false)
-            } else if (!hasAppliedDefaultView.current) {
+                setShouldShowAllMethods(false)
+            } else {
                 setShouldShowAllMethods(true)
             }
         }
@@ -375,19 +376,12 @@ export const AddWithdrawRouterView: FC<AddWithdrawRouterViewProps> = ({
                         })
                         setIsSupportedTokensModalOpen(true)
                     } else {
-                        posthog.capture(ANALYTICS_EVENTS.WITHDRAW_METHOD_SELECTED, {
-                            method_type: 'crypto',
-                            country: 'crypto',
-                        })
-                        // set crypto method in context only — the withdraw page switches to the
-                        // amount step and navigates to /withdraw/crypto after Continue. navigating
-                        // here (pre-amount) trips the crypto page's "no amount" redirect guard,
-                        // whose unmount cleanup resets the whole flow back to saved accounts.
-                        setSelectedMethod({
-                            type: 'crypto',
-                            countryPath: 'crypto',
-                            title: 'Crypto',
-                        })
+                        // shared withdraw handler: analytics + set method in context, no
+                        // navigation — the withdraw page owns the amount step and navigates
+                        // to /withdraw/crypto after Continue. navigating here (pre-amount)
+                        // trips the crypto page's "no amount" redirect guard, whose unmount
+                        // cleanup resets the whole flow back to saved accounts.
+                        handleMethodSelected({ id: 'crypto', type: 'crypto', title: 'Crypto', path: 'crypto' })
                     }
                 }}
                 flow={flow}

--- a/src/components/AddWithdraw/__tests__/AddWithdrawRouterView.test.tsx
+++ b/src/components/AddWithdraw/__tests__/AddWithdrawRouterView.test.tsx
@@ -1,14 +1,17 @@
 /**
  * AddWithdrawRouterView — regression tests for the withdraw method-selection bounce.
  *
- * Two regressions pinned here:
+ * two regressions pinned here:
  * 1. clicking "Crypto" must set the method in context WITHOUT navigating to
  *    /withdraw/crypto (navigating pre-amount trips that page's "no amount"
  *    redirect guard, whose unmount cleanup resets the whole flow).
  * 2. a user-object refetch (new identity, same data) must NOT force the view
  *    back from the country list to saved accounts.
+ *
+ * uses the real WithdrawFlowContextProvider (pure useState, no heavy deps) so
+ * the tests exercise the actual context wiring instead of a hand-rolled copy.
  */
-import React from 'react'
+import React, { useEffect } from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 
 const mockRouterPush = jest.fn()
@@ -47,19 +50,6 @@ interface MockUser {
 let mockUser: MockUser | null
 jest.mock('@/redux/hooks', () => ({
     useUserStore: () => ({ user: mockUser }),
-}))
-
-// stateful withdraw-flow mock, wired up per-render by the harness below
-interface MockWithdrawFlow {
-    showAllWithdrawMethods: boolean
-    setShowAllWithdrawMethods: (show: boolean) => void
-    setSelectedMethod: jest.Mock
-    setSelectedBankAccount: jest.Mock
-}
-
-let withdrawFlow: MockWithdrawFlow
-jest.mock('@/context/WithdrawFlowContext', () => ({
-    useWithdrawFlow: () => withdrawFlow,
 }))
 
 jest.mock('@/context/OnrampFlowContext', () => ({
@@ -125,25 +115,31 @@ jest.mock('../../Global/TokenAndNetworkConfirmationModal', () => ({
 }))
 
 import { AddWithdrawRouterView } from '../AddWithdrawRouterView'
+import { WithdrawFlowContextProvider, useWithdrawFlow } from '@/context/WithdrawFlowContext'
 
 const makeUser = (): MockUser => ({
     user: { userId: 'user-1' },
     accounts: [{ type: 'iban', identifier: 'BE10905272880104', details: {} }],
 })
 
-const mockSetSelectedMethod = jest.fn()
+// exposes the real context's selectedMethod so tests can assert on it
+const onSelectedMethodChange = jest.fn()
+function SelectedMethodProbe() {
+    const { selectedMethod } = useWithdrawFlow()
+    useEffect(() => {
+        if (selectedMethod) onSelectedMethodChange(selectedMethod)
+    }, [selectedMethod])
+    return null
+}
 
-// harness giving the context mock real state so setShowAllWithdrawMethods re-renders
 function Harness({ user }: { user: MockUser }) {
-    const [showAll, setShowAll] = React.useState(false)
     mockUser = user
-    withdrawFlow = {
-        showAllWithdrawMethods: showAll,
-        setShowAllWithdrawMethods: setShowAll,
-        setSelectedMethod: mockSetSelectedMethod,
-        setSelectedBankAccount: jest.fn(),
-    }
-    return <AddWithdrawRouterView flow="withdraw" pageTitle="Withdraw" mainHeading="How?" />
+    return (
+        <WithdrawFlowContextProvider>
+            <AddWithdrawRouterView flow="withdraw" pageTitle="Withdraw" mainHeading="How?" />
+            <SelectedMethodProbe />
+        </WithdrawFlowContextProvider>
+    )
 }
 
 describe('AddWithdrawRouterView — withdraw method selection', () => {
@@ -161,7 +157,9 @@ describe('AddWithdrawRouterView — withdraw method selection', () => {
         fireEvent.click(screen.getByTestId('select-new-method'))
         fireEvent.click(screen.getByTestId('crypto-option'))
 
-        expect(mockSetSelectedMethod).toHaveBeenCalledWith(expect.objectContaining({ type: 'crypto', title: 'Crypto' }))
+        expect(onSelectedMethodChange).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'crypto', title: 'Crypto' })
+        )
         expect(mockRouterPush).not.toHaveBeenCalled()
     })
 

--- a/src/components/AddWithdraw/__tests__/AddWithdrawRouterView.test.tsx
+++ b/src/components/AddWithdraw/__tests__/AddWithdrawRouterView.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * AddWithdrawRouterView — regression tests for the withdraw method-selection bounce.
+ *
+ * Two regressions pinned here:
+ * 1. clicking "Crypto" must set the method in context WITHOUT navigating to
+ *    /withdraw/crypto (navigating pre-amount trips that page's "no amount"
+ *    redirect guard, whose unmount cleanup resets the whole flow).
+ * 2. a user-object refetch (new identity, same data) must NOT force the view
+ *    back from the country list to saved accounts.
+ */
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+const mockRouterPush = jest.fn()
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ push: mockRouterPush, back: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
+    useSearchParams: () => ({ get: () => null }),
+    usePathname: () => '/withdraw',
+}))
+
+jest.mock('posthog-js', () => ({
+    __esModule: true,
+    default: { capture: jest.fn(), init: jest.fn() },
+}))
+
+jest.mock('@/utils/general.utils', () => ({
+    getUserPreferences: jest.fn(() => undefined),
+    updateUserPreferences: jest.fn(),
+    getFromLocalStorage: jest.fn(() => null),
+}))
+
+jest.mock('@/utils/native-routes', () => ({
+    addMoneyCountryUrl: (p: string) => `/add-money/${p}`,
+    withdrawCountryUrl: (p: string, q?: string) => `/withdraw/${p}${q ?? ''}`,
+    rewriteMethodPath: (p: string) => p,
+}))
+
+jest.mock('@/constants/manteca.consts', () => ({
+    isMantecaCountry: jest.fn(() => false),
+}))
+
+let mockUser: any
+jest.mock('@/redux/hooks', () => ({
+    useUserStore: () => ({ user: mockUser }),
+}))
+
+// stateful withdraw-flow mock, wired up per-render by the harness below
+let withdrawFlow: any
+jest.mock('@/context/WithdrawFlowContext', () => ({
+    useWithdrawFlow: () => withdrawFlow,
+}))
+
+jest.mock('@/context/OnrampFlowContext', () => ({
+    useOnrampFlow: () => ({ setFromBankSelected: jest.fn() }),
+}))
+
+jest.mock('@/components/0_Bruddle/Button', () => ({
+    Button: (props: any) => (
+        <button onClick={props.onClick} disabled={props.disabled}>
+            {props.children}
+        </button>
+    ),
+}))
+
+jest.mock('@/components/AddMoney/components/DepositMethodList', () => ({
+    DepositMethodList: () => <div data-testid="deposit-method-list" />,
+}))
+
+jest.mock('@/components/Global/NavHeader', () => ({
+    __esModule: true,
+    default: (props: any) => <div data-testid="nav-header">{props.title}</div>,
+}))
+
+jest.mock('@/components/Global/Card', () => ({
+    __esModule: true,
+    default: (props: any) => <div>{props.children}</div>,
+}))
+
+jest.mock('@/components/Profile/AvatarWithBadge', () => ({
+    __esModule: true,
+    default: () => <div />,
+}))
+
+jest.mock('../../Common/CountryList', () => ({
+    CountryList: (props: any) => (
+        <div data-testid="country-list">
+            <button data-testid="crypto-option" onClick={props.onCryptoClick}>
+                Crypto
+            </button>
+        </div>
+    ),
+}))
+
+jest.mock('../../Global/PeanutLoading', () => ({
+    __esModule: true,
+    default: () => <div data-testid="loading" />,
+}))
+
+jest.mock('../../Common/SavedAccountsView', () => ({
+    __esModule: true,
+    default: (props: any) => (
+        <div data-testid="saved-accounts-view">
+            <button data-testid="select-new-method" onClick={props.onSelectNewMethodClick}>
+                Select new method
+            </button>
+        </div>
+    ),
+}))
+
+jest.mock('../../Global/TokenAndNetworkConfirmationModal', () => ({
+    __esModule: true,
+    default: () => null,
+}))
+
+import { AddWithdrawRouterView } from '../AddWithdrawRouterView'
+
+const makeUser = () => ({
+    user: { userId: 'user-1' },
+    accounts: [{ type: 'iban', identifier: 'BE10905272880104', details: {} }],
+})
+
+const mockSetSelectedMethod = jest.fn()
+
+// harness giving the context mock real state so setShowAllWithdrawMethods re-renders
+function Harness({ user }: { user: any }) {
+    const [showAll, setShowAll] = React.useState(false)
+    mockUser = user
+    withdrawFlow = {
+        showAllWithdrawMethods: showAll,
+        setShowAllWithdrawMethods: setShowAll,
+        setSelectedMethod: mockSetSelectedMethod,
+        setSelectedBankAccount: jest.fn(),
+    }
+    return <AddWithdrawRouterView flow="withdraw" pageTitle="Withdraw" mainHeading="How?" />
+}
+
+describe('AddWithdrawRouterView — withdraw method selection', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    test('shows saved accounts by default when bank accounts exist', () => {
+        render(<Harness user={makeUser()} />)
+        expect(screen.getByTestId('saved-accounts-view')).toBeInTheDocument()
+    })
+
+    test('clicking Crypto sets the method in context and does NOT navigate', () => {
+        render(<Harness user={makeUser()} />)
+        fireEvent.click(screen.getByTestId('select-new-method'))
+        fireEvent.click(screen.getByTestId('crypto-option'))
+
+        expect(mockSetSelectedMethod).toHaveBeenCalledWith(expect.objectContaining({ type: 'crypto', title: 'Crypto' }))
+        expect(mockRouterPush).not.toHaveBeenCalled()
+    })
+
+    test('a user refetch (new object identity) does not bounce the country list back to saved accounts', () => {
+        const { rerender } = render(<Harness user={makeUser()} />)
+        fireEvent.click(screen.getByTestId('select-new-method'))
+        expect(screen.getByTestId('country-list')).toBeInTheDocument()
+
+        // simulate the 4s pending-rail poll / window-focus refetch dispatching a fresh user object
+        rerender(<Harness user={makeUser()} />)
+
+        expect(screen.getByTestId('country-list')).toBeInTheDocument()
+        expect(screen.queryByTestId('saved-accounts-view')).not.toBeInTheDocument()
+    })
+})

--- a/src/components/AddWithdraw/__tests__/AddWithdrawRouterView.test.tsx
+++ b/src/components/AddWithdraw/__tests__/AddWithdrawRouterView.test.tsx
@@ -39,13 +39,25 @@ jest.mock('@/constants/manteca.consts', () => ({
     isMantecaCountry: jest.fn(() => false),
 }))
 
-let mockUser: any
+interface MockUser {
+    user: { userId: string }
+    accounts: Array<{ type: string; identifier: string; details: Record<string, unknown> }>
+}
+
+let mockUser: MockUser | null
 jest.mock('@/redux/hooks', () => ({
     useUserStore: () => ({ user: mockUser }),
 }))
 
 // stateful withdraw-flow mock, wired up per-render by the harness below
-let withdrawFlow: any
+interface MockWithdrawFlow {
+    showAllWithdrawMethods: boolean
+    setShowAllWithdrawMethods: (show: boolean) => void
+    setSelectedMethod: jest.Mock
+    setSelectedBankAccount: jest.Mock
+}
+
+let withdrawFlow: MockWithdrawFlow
 jest.mock('@/context/WithdrawFlowContext', () => ({
     useWithdrawFlow: () => withdrawFlow,
 }))
@@ -55,7 +67,7 @@ jest.mock('@/context/OnrampFlowContext', () => ({
 }))
 
 jest.mock('@/components/0_Bruddle/Button', () => ({
-    Button: (props: any) => (
+    Button: (props: { onClick?: () => void; disabled?: boolean; children?: React.ReactNode }) => (
         <button onClick={props.onClick} disabled={props.disabled}>
             {props.children}
         </button>
@@ -68,12 +80,12 @@ jest.mock('@/components/AddMoney/components/DepositMethodList', () => ({
 
 jest.mock('@/components/Global/NavHeader', () => ({
     __esModule: true,
-    default: (props: any) => <div data-testid="nav-header">{props.title}</div>,
+    default: (props: { title?: string }) => <div data-testid="nav-header">{props.title}</div>,
 }))
 
 jest.mock('@/components/Global/Card', () => ({
     __esModule: true,
-    default: (props: any) => <div>{props.children}</div>,
+    default: (props: { children?: React.ReactNode }) => <div>{props.children}</div>,
 }))
 
 jest.mock('@/components/Profile/AvatarWithBadge', () => ({
@@ -82,7 +94,7 @@ jest.mock('@/components/Profile/AvatarWithBadge', () => ({
 }))
 
 jest.mock('../../Common/CountryList', () => ({
-    CountryList: (props: any) => (
+    CountryList: (props: { onCryptoClick?: () => void }) => (
         <div data-testid="country-list">
             <button data-testid="crypto-option" onClick={props.onCryptoClick}>
                 Crypto
@@ -98,7 +110,7 @@ jest.mock('../../Global/PeanutLoading', () => ({
 
 jest.mock('../../Common/SavedAccountsView', () => ({
     __esModule: true,
-    default: (props: any) => (
+    default: (props: { onSelectNewMethodClick?: () => void }) => (
         <div data-testid="saved-accounts-view">
             <button data-testid="select-new-method" onClick={props.onSelectNewMethodClick}>
                 Select new method
@@ -114,7 +126,7 @@ jest.mock('../../Global/TokenAndNetworkConfirmationModal', () => ({
 
 import { AddWithdrawRouterView } from '../AddWithdrawRouterView'
 
-const makeUser = () => ({
+const makeUser = (): MockUser => ({
     user: { userId: 'user-1' },
     accounts: [{ type: 'iban', identifier: 'BE10905272880104', details: {} }],
 })
@@ -122,7 +134,7 @@ const makeUser = () => ({
 const mockSetSelectedMethod = jest.fn()
 
 // harness giving the context mock real state so setShowAllWithdrawMethods re-renders
-function Harness({ user }: { user: any }) {
+function Harness({ user }: { user: MockUser }) {
     const [showAll, setShowAll] = React.useState(false)
     mockUser = user
     withdrawFlow = {


### PR DESCRIPTION
## Problem

On /withdraw with saved bank accounts: tapping "Select new method" → "Crypto" landed the user back on the saved-accounts list instead of the amount input. Separately, an open country list would snap back to saved accounts on its own after a few seconds (sometimes immediately).

## Fix

- `AddWithdrawRouterView.onCryptoClick` (withdraw flow) now only sets the crypto method in `WithdrawFlowContext` — same contract as bank-country selection — instead of also pushing `/withdraw/crypto` pre-amount. The withdraw page flips to the amount step and navigates to `/withdraw/crypto` after Continue.
- The default-view effect in `AddWithdrawRouterView` now latches once per mount (ref guard). User refetches still sync the saved-accounts list but no longer force the view back to saved accounts.
- New regression tests in `src/components/AddWithdraw/__tests__/AddWithdrawRouterView.test.tsx` — both fail on the unfixed code, pass with the fix.

## Risks / breaking changes

- FE-only, scoped to the withdraw method-selection screen. The `add` flow shares the component; its crypto path (confirmation modal) and country navigation are untouched.
- No cross-repo impact.

## QA

1. On staging/preview with a user that has saved bank accounts, go to /withdraw.
2. Tap "Select new method" → country list stays put (previously reverted within ~4s when a rail poll / focus refetch fired).
3. Tap "Crypto" → amount input appears; enter an amount ≥ $1 → Continue → lands on /withdraw/crypto initial view.
4. Complete a crypto withdrawal → "Back to home" still goes home (the race `da943d68d` originally fixed remains fixed — reset still happens on unmount, which now only ever fires post-amount or on genuine exit).

## Postmortem

**Regression window:** landed on `dev` 2026-07-14 via PR #2393 (mobile-release merge). Breaking commit: `da943d68d` "fix(withdraw): 'Back to home' no longer bounces to the withdraw screen" (authored 2026-07-02 on the mobile-release branch).

**What broke (symptom 1 — Crypto click):**
`da943d68d` moved `resetWithdrawFlow()` from the success view's `onComplete` to the crypto page's unmount cleanup, to fix a real race where completing a withdrawal bounced "Back to home" to /withdraw. But `/withdraw/crypto` has a render guard: no `amountToWithdraw` → `router.push('/withdraw')`. The method-selection screen had always navigated to `/withdraw/crypto` on the Crypto click *before* an amount exists, relying on that guard bouncing back with `selectedMethod` still intact in context (→ amount input step). After `da943d68d`, the bounce also unmounts the crypto page, whose new cleanup wipes the entire flow context (`selectedMethod`, `showAllWithdrawMethods`) — so the user lands on the saved-accounts list.

Chain: Crypto click → set method + push `/withdraw/crypto` → no-amount guard pushes back → unmount cleanup resets flow → no method selected + showAll=false → saved accounts.

**What broke (symptom 2 — country list reverting on its own):**
Long-latent defect, not from `da943d68d`. The default-view effect in `AddWithdrawRouterView` has `user` in its deps and unconditionally called `setShowAllWithdrawMethods(false)` whenever saved accounts exist. Every `/users/me` fetch dispatches a *fresh* user object into redux (`userActions.setUser(payload)` — no identity preservation), and `useUserQuery` refetches on window focus, on mount, and on a 4s interval while any rail is pending (`useUserAutoRefresh`). Each refetch re-fired the effect and yanked the open country list back to saved accounts — "after a few seconds" = the poll tick; "sometimes immediately" = an in-flight refetch resolving right after the click.

**Why it wasn't caught:** the pre-amount `/withdraw/crypto` entry path (method selection, as opposed to send-flow `?method=crypto` which skips the screen) had no test; `withdraw-states.test.tsx` mocks out `AddWithdrawRouterView` entirely. `da943d68d` was verified against the success-flow race it fixed, not against the pre-amount entry that shares the same guard + cleanup.

**Prevention:** the new tests pin both behaviors: crypto selection must not navigate pre-amount, and user-object identity churn must not override an explicit view choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the add/withdraw screen from unexpectedly switching views when account information refreshes.
  * Improved the withdrawal crypto selection flow so users continue to the next step without unnecessary navigation.

* **Tests**
  * Added coverage for crypto method selection and view stability during account refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->