### PR TITLE
fix(badges): sort a copy in BadgesRow instead of mutating the prop

### DIFF
--- a/src/components/Badges/BadgesRow.tsx
+++ b/src/components/Badges/BadgesRow.tsx
@@ -38,7 +38,7 @@ const BadgesRow = ({ badges, className, isSelfProfile = true }: BadgesRowProps) 
 
     // sort by earnedAt, newest first
     const sortedBadges = useMemo(() => {
-        return badges.sort((a, b) => {
+        return [...badges].sort((a, b) => {
             const at = a.earnedAt ? new Date(a.earnedAt).getTime() : 0
             const bt = b.earnedAt ? new Date(b.earnedAt).getTime() : 0
             return bt - at

--- a/src/components/Badges/__tests__/BadgesRow.test.tsx
+++ b/src/components/Badges/__tests__/BadgesRow.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react'
+import type { ComponentProps } from 'react'
+import BadgesRow from '@/components/Badges/BadgesRow'
+
+jest.mock('next/image', () => ({
+    __esModule: true,
+    default: ({ unoptimized, fill, ...rest }: ComponentProps<'img'> & { unoptimized?: boolean; fill?: boolean }) => (
+        <img {...rest} />
+    ),
+}))
+
+jest.mock('@/components/Tooltip', () => ({
+    Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+const badge = (code: string, earnedAt: string) => ({
+    code,
+    name: code,
+    description: null,
+    iconUrl: null,
+    earnedAt,
+})
+
+describe('BadgesRow', () => {
+    it('does not mutate the badges array it is given', () => {
+        // Oldest first, so a newest-first sort has to reorder them.
+        const badges = [
+            badge('OLDEST', '2024-01-01T00:00:00.000Z'),
+            badge('MIDDLE', '2024-06-01T00:00:00.000Z'),
+            badge('NEWEST', '2024-12-01T00:00:00.000Z'),
+        ]
+
+        render(<BadgesRow badges={badges} />)
+
+        expect(badges.map((b) => b.code)).toEqual(['OLDEST', 'MIDDLE', 'NEWEST'])
+    })
+})


### PR DESCRIPTION
## What

`BadgesRow`'s `sortedBadges` `useMemo` called `badges.sort(...)`. `Array.prototype.sort` sorts **in place**, so the memo mutated the caller-owned `badges` array during render and returned the same reference. Sort a copy instead.

```diff
-return badges.sort((a, b) => {
+return [...badges].sort((a, b) => {
```

## Severity — deliberately not oversold

**There is most likely no user-visible symptom today.** The only caller is `PublicProfile.tsx`, which passes `profileBadges` — a local `useState` array populated fresh from `usersApi.getByUsername(...)` on mount. The mutation hits a locally-owned array that no other consumer reads, and the resulting order is the desired one anyway.

It's worth fixing as **correctness/robustness**, not as a user-facing bug fix:

1. A `useMemo` callback must be pure. Mutating during render is what React's concurrent rendering rules forbid.
2. It's a live trap: the day someone passes a parent- or context-owned array (e.g. `user.badges` from the auth context), this silently reorders shared state.

## Test

Added `src/components/Badges/__tests__/BadgesRow.test.tsx`, asserting the input array is not mutated. It **fails before the fix** (the caller's array comes back reordered to `NEWEST, MIDDLE, OLDEST`) and passes after — not a regression test that would pass either way.

## Audit of other in-place sorts

Swept `src` for `.sort(` on arrays the caller doesn't own. **`BadgesRow` was the only real offender.** Everything else either already copies via `[...arr]` or sorts a fresh array returned from a `.map`/`.filter` chain:

| Site | Verdict |
|---|---|
| `lib/blog.ts:53`, `lib/content.ts:298`, `badgeCelebration.utils.ts:101`, `dev/leaderboard/page.tsx:53`, `cardUnlock.types.ts:69` | Sorts a fresh array from a `map`/`filter` chain, or a locally-built array — safe |
| `HomeHistory.tsx:260`, `history/page.tsx:202` | `entries.sort(...)` looks in-place, but `entries` is built via `[...spread]` locally (`:158` / `:166`) — safe |
| `useGeoFilteredPaymentOptions`, `CountryList`, `InvitesGraph`, `TokenSelector`, `shareAssetLayout`, `useContributePotFlow` | Already `[...arr].sort(...)` |

Left them as-is rather than churn the diff.

## Verification

- `pnpm typecheck` — clean
- `npx jest src/components/Badges` — 27 passed, 5 suites
- `npx eslint src/components/Badges` — no new errors (the one error, `badge.types.ts:11` `no-explicit-any`, is pre-existing; the new test's `<img>` warning matches the identical existing mock in `BadgeEarnToast.test.tsx`)
- `prettier --write` on both touched files

Found incidentally during localization work on `feat/app-localization`; unrelated to i18n, so branched off `main` and kept separate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the original badge order when displaying badges, preventing unintended changes to badge data.

* **Tests**
  * Added coverage to verify that rendering the badges list does not alter the provided badge collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->