### PR TITLE
fix(native): don't flag P0_TRANSFORMS pages as uncovered server routes

### DIFF
--- a/scripts/__tests__/native-build-scan.test.js
+++ b/scripts/__tests__/native-build-scan.test.js
@@ -1,0 +1,57 @@
+const fs = require('fs')
+const path = require('path')
+const Module = require('module')
+
+const SCRIPT_PATH = path.join(__dirname, '..', 'native-build.js')
+
+// native-build.js is a script, not a module: it calls main() at import time and
+// exports nothing. Load the real source with that call stripped so the scan
+// helpers can be asserted against the actual app tree.
+function loadScriptInternals() {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf-8')
+    const withoutEntrypoint = source.replace(/\nmain\(\)\s*$/, '\n')
+    expect(withoutEntrypoint).not.toBe(source)
+
+    const exposed =
+        withoutEntrypoint +
+        '\nmodule.exports = { isHandledByTransform, detectUncoveredServerRoutes, P0_TRANSFORMS, APP_DIR }\n'
+
+    const mod = new Module(SCRIPT_PATH, null)
+    mod.filename = SCRIPT_PATH
+    mod.paths = Module._nodeModulePaths(path.dirname(SCRIPT_PATH))
+    mod._compile(exposed, SCRIPT_PATH)
+    return mod.exports
+}
+
+const { isHandledByTransform, detectUncoveredServerRoutes, P0_TRANSFORMS, APP_DIR } = loadScriptInternals()
+
+const toPosix = (p) => p.split(path.sep).join('/')
+
+describe('native build server-route scan', () => {
+    it('treats every P0_TRANSFORMS entry as handled', () => {
+        for (const transform of P0_TRANSFORMS) {
+            expect(isHandledByTransform(transform.path)).toBe(true)
+        }
+    })
+
+    // The scan passes `path.relative(APP_DIR, full)` into the predicate. If the
+    // predicate compared a different path shape it would silently never match.
+    it('matches the relative path shape the scan actually computes', () => {
+        for (const transform of P0_TRANSFORMS) {
+            const absolute = path.join(APP_DIR, transform.path)
+            expect(isHandledByTransform(path.relative(APP_DIR, absolute))).toBe(true)
+        }
+    })
+
+    it('does not suppress routes that are not transformed', () => {
+        expect(isHandledByTransform('some/other/page.tsx')).toBe(false)
+        expect(isHandledByTransform('api/foo/route.ts')).toBe(false)
+        expect(isHandledByTransform('(mobile-ui)/claim/layout.tsx')).toBe(false)
+    })
+
+    it('does not flag transformed pages as uncovered server routes', () => {
+        const transformed = new Set(P0_TRANSFORMS.map((t) => t.path))
+        const offenders = detectUncoveredServerRoutes().filter((o) => transformed.has(toPosix(o.rel)))
+        expect(offenders).toEqual([])
+    })
+})

--- a/scripts/native-build.js
+++ b/scripts/native-build.js
@@ -248,6 +248,14 @@ function isCoveredByDisableList(relPath) {
     })
 }
 
+// P0_TRANSFORMS files are replaced with static-export-safe stubs before `next
+// build`, so their server-only exports (generateMetadata, force-dynamic) never
+// reach the export — the scan must not flag them.
+function isHandledByTransform(relPath) {
+    const normalized = relPath.split(path.sep).join('/')
+    return P0_TRANSFORMS.some((t) => t.path === normalized)
+}
+
 function detectUncoveredServerRoutes(dir = APP_DIR, found = []) {
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
         if (entry.name.includes('.disabled') || entry.name.startsWith('_')) continue
@@ -258,7 +266,7 @@ function detectUncoveredServerRoutes(dir = APP_DIR, found = []) {
             detectUncoveredServerRoutes(full, found)
             continue
         }
-        if (isCoveredByDisableList(rel)) continue
+        if (isCoveredByDisableList(rel) || isHandledByTransform(rel)) continue
         if (entry.name === 'route.ts' || entry.name === 'route.js') {
             found.push({ rel, reason: 'route handler (cannot be statically exported)' })
             continue


### PR DESCRIPTION
## The bug — native builds fail on `main` today

`detectUncoveredServerRoutes()` in `scripts/native-build.js` fails the native build when it finds App Router files with server-only exports. But the script *also* maintains `P0_TRANSFORMS` — files it replaces with static-export-safe client stubs before `next build` runs. Their server-only exports never reach the export, yet the scan flags them anyway, because it only consults `ITEMS_TO_DISABLE`:

```js
if (isCoveredByDisableList(rel)) continue
```

This is not hypothetical. On `main` right now, `src/app/(mobile-ui)/claim/page.tsx` has `export const dynamic = 'force-dynamic'` (line 11) **and** a matching `P0_TRANSFORMS` entry (`native-build.js:86`). Someone did the right thing — added the directive *and* the stub — and the anti-rot guard rejects it anyway. The native build cannot get past this scan.

## The fix

Teach the scan that transformed files are already handled:

```js
if (isCoveredByDisableList(rel) || isHandledByTransform(rel)) continue
```

## Why this isn't a silent no-op

The obvious failure mode is a predicate that never matches — the scan keeps passing, the "fix" looks fine, and the guard still rejects real routes. Both halves were checked:

- **`rel` and `P0_TRANSFORMS[].path` are the same shape.** `rel` is `path.relative(APP_DIR, full)`; the transform loop consumes `item.path` as `path.join(APP_DIR, item.path)`. Both are relative to `src/app`.
- **Negative control against the real scan.** Running the actual (unmodified) scan functions over the real app tree: unpatched → reports `(mobile-ui)/claim/page.tsx (export const dynamic = 'force-dynamic')`; patched → zero offenders.
- **Mutation check.** Breaking the predicate to the plausible-but-wrong form (`'src/app/' + normalized`) fails 3 of the 4 tests, so they aren't vacuous.
- Unrelated routes (`api/foo/route.ts`, `(mobile-ui)/claim/layout.tsx`, `''`) correctly do **not** match, guarding against an always-true predicate.

## Tests

`scripts/__tests__/native-build-scan.test.js` — 4 tests, green under the existing jest config. Plain CJS to match the plain-`.js` script under test. `pnpm-lock.yaml` untouched.

## Not verified

A full `pnpm native:build` was **not** run — it's a 10–30 min native toolchain build and was deliberately skipped. What's proven is the guard logic itself, not that `next build` subsequently completes with the stubs in place. Note that this is already unknown on `main`, where the build stops at this scan; the change can only get it further, not less far.