### PR TITLE
feat(card): proof-of-address upload on stuck Rain applications

### DIFF
--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -233,7 +233,7 @@ const CardPage: FC = () => {
         : undefined
     const onUploadProofOfAddress = poaAction
         ? () => {
-              posthog.capture(ANALYTICS_EVENTS.CARD_SUMSUB_OPENED)
+              posthog.capture(ANALYTICS_EVENTS.CARD_SUMSUB_OPENED, { source: 'poa-self-heal' })
               void selfHealKycFlow.handleSelfHealResubmit('RAIN')
           }
         : undefined

--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -21,6 +21,8 @@ import Loading from '@/components/Global/Loading'
 import { Button } from '@/components/0_Bruddle/Button'
 import PageContainer from '@/components/0_Bruddle/PageContainer'
 import { SumsubKycWrapper } from '@/components/Kyc/SumsubKycWrapper'
+import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
+import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { rainApi, type ApplyForCardResponse } from '@/services/rain'
 import { useGrantSessionKey } from '@/hooks/wallet/useGrantSessionKey'
 import { useCapabilities } from '@/hooks/useCapabilities'
@@ -69,7 +71,7 @@ const CardPage: FC = () => {
 
     const { overview, isLoading: overviewLoading, error: overviewError } = useRainCardOverview()
     const { serializeGrant } = useGrantSessionKey()
-    const { railsForProvider, isLoading: capabilitiesLoading } = useCapabilities()
+    const { railsForProvider, nextActionsForRail, isLoading: capabilitiesLoading } = useCapabilities()
     const { setIsSupportModalOpen } = useModalsContext()
     const onBack = useSafeBack('/home')
 
@@ -211,6 +213,30 @@ const CardPage: FC = () => {
     const invalidateOverview = useCallback(() => {
         void queryClient.invalidateQueries({ queryKey: [RAIN_CARD_OVERVIEW_QUERY_KEY] })
     }, [queryClient])
+
+    // Self-heal Sumsub flow for the requires-info/rejected states (e.g. the
+    // proof-of-address upload). Separate surface from the card-application
+    // SumsubKycWrapper below — that one is driven by applyForCard tokens with
+    // its own refresh/poll semantics; multiplexing them would fight over the
+    // token. On completion the overview refetches so the screen advances.
+    const selfHealKycFlow = useMultiPhaseKycFlow({ onKycSuccess: invalidateOverview })
+
+    // The rain rail's self-serve proof-of-address action, when the backend
+    // classified the application as PoA-fixable (kind 'sumsub' + levelKey
+    // 'proof_of_address' — emitted for WRONG_ADDRESS-class denials). Absent →
+    // the status screens keep their contact-support-only shape.
+    const cardRail = railsForProvider('rain')[0]
+    const poaAction = cardRail
+        ? nextActionsForRail(cardRail.id).find(
+              (action) => action.kind === 'sumsub' && action.levelKey === 'proof_of_address'
+          )
+        : undefined
+    const onUploadProofOfAddress = poaAction
+        ? () => {
+              posthog.capture(ANALYTICS_EVENTS.CARD_SUMSUB_OPENED)
+              void selfHealKycFlow.handleSelfHealResubmit('RAIN')
+          }
+        : undefined
 
     // Routes a non-incomplete apply response to the right next screen. Shared
     // by the user-initiated apply path and the post-Sumsub poll, since both
@@ -605,6 +631,7 @@ const CardPage: FC = () => {
                         variant="requires-info"
                         reasonMessage={cardRailReason}
                         onContactSupport={() => setIsSupportModalOpen(true)}
+                        onUploadProofOfAddress={onUploadProofOfAddress}
                         onPrev={onBack}
                     />
                 )
@@ -641,6 +668,7 @@ const CardPage: FC = () => {
                         variant="rejected"
                         reasonMessage={cardRailReason}
                         onContactSupport={() => setIsSupportModalOpen(true)}
+                        onUploadProofOfAddress={onUploadProofOfAddress}
                         onPrev={onBack}
                     />
                 )
@@ -657,6 +685,7 @@ const CardPage: FC = () => {
     return (
         <PageContainer>
             {renderState()}
+            <SumsubKycModals flow={selfHealKycFlow} />
             <SumsubKycWrapper
                 visible={sumsubToken !== null}
                 accessToken={sumsubToken}

--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -237,19 +237,37 @@ const CardPage: FC = () => {
               (action) => action.kind === 'sumsub' && action.levelKey === 'proof_of_address'
           )
         : undefined
+    // Double-click guard: two concurrent initiations race the backend's
+    // create-action idempotency into minting two Sumsub actions (the id
+    // collision path deliberately mints a suffixed fresh action).
+    const poaStartingRef = useRef(false)
     const startPoaUpload = useCallback(async () => {
+        if (poaStartingRef.current) return
+        poaStartingRef.current = true
         posthog.capture(ANALYTICS_EVENTS.CARD_SUMSUB_OPENED, { source: 'poa-self-heal' })
         setPoaError(null)
-        const response = await initiateSelfHealResubmission('RAIN')
-        if (response.error || !response.data?.token) {
-            // Surfaced inline on the status screen — a silent primary CTA on a
-            // stuck-application screen is worse than no CTA.
-            setPoaError(response.error ?? 'Could not start the upload. Please try again.')
-            return
+        try {
+            const response = await initiateSelfHealResubmission('RAIN')
+            if (response.error || !response.data?.token) {
+                // Surfaced inline on the status screen — a silent primary CTA on
+                // a stuck-application screen is worse than no CTA.
+                setPoaError(response.error ?? 'Could not start the upload. Please try again.')
+                return
+            }
+            setPoaToken(response.data.token)
+        } finally {
+            poaStartingRef.current = false
         }
-        setPoaToken(response.data.token)
     }, [])
     const onUploadProofOfAddress = poaAction && !poaSubmitted ? () => void startPoaUpload() : undefined
+
+    // Once the backend's own state takes over (the rail's sumsub action gives
+    // way to the review-wait state, an approval, or a different ask), drop the
+    // optimistic banner so a later re-offered upload isn't suppressed until
+    // remount.
+    useEffect(() => {
+        if (poaSubmitted && !poaAction) setPoaSubmitted(false)
+    }, [poaSubmitted, poaAction])
 
     // Routes a non-incomplete apply response to the right next screen. Shared
     // by the user-initiated apply path and the post-Sumsub poll, since both

--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -21,8 +21,7 @@ import Loading from '@/components/Global/Loading'
 import { Button } from '@/components/0_Bruddle/Button'
 import PageContainer from '@/components/0_Bruddle/PageContainer'
 import { SumsubKycWrapper } from '@/components/Kyc/SumsubKycWrapper'
-import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
-import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
+import { initiateSelfHealResubmission } from '@/app/actions/sumsub'
 import { rainApi, type ApplyForCardResponse } from '@/services/rain'
 import { useGrantSessionKey } from '@/hooks/wallet/useGrantSessionKey'
 import { useCapabilities } from '@/hooks/useCapabilities'
@@ -214,12 +213,19 @@ const CardPage: FC = () => {
         void queryClient.invalidateQueries({ queryKey: [RAIN_CARD_OVERVIEW_QUERY_KEY] })
     }, [queryClient])
 
-    // Self-heal Sumsub flow for the requires-info/rejected states (e.g. the
-    // proof-of-address upload). Separate surface from the card-application
-    // SumsubKycWrapper below — that one is driven by applyForCard tokens with
-    // its own refresh/poll semantics; multiplexing them would fight over the
-    // token. On completion the overview refetches so the screen advances.
-    const selfHealKycFlow = useMultiPhaseKycFlow({ onKycSuccess: invalidateOverview })
+    // Proof-of-address self-heal — a dedicated, deliberately tiny flow. The
+    // multi-phase KYC machinery (useMultiPhaseKycFlow) is bank-onboarding
+    // shaped: its post-approval phase machine polls a mutating endpoint, can
+    // fan out to Bridge ToS modals, and completes on rail semantics that never
+    // match the Rain PoA lifecycle. Here we only need: mint an action token →
+    // open the SDK → on submit, thank the user and refetch. Separate surface
+    // from the card-application SumsubKycWrapper below — that one is driven by
+    // applyForCard tokens with its own refresh/poll semantics.
+    const [poaToken, setPoaToken] = useState<string | null>(null)
+    const [poaError, setPoaError] = useState<string | null>(null)
+    // Optimistic "we got your document" until the backend webhook flips the
+    // rail reason to its own review-wait state (may lag the SDK by seconds).
+    const [poaSubmitted, setPoaSubmitted] = useState(false)
 
     // The rain rail's self-serve proof-of-address action, when the backend
     // classified the application as PoA-fixable (kind 'sumsub' + levelKey
@@ -231,12 +237,19 @@ const CardPage: FC = () => {
               (action) => action.kind === 'sumsub' && action.levelKey === 'proof_of_address'
           )
         : undefined
-    const onUploadProofOfAddress = poaAction
-        ? () => {
-              posthog.capture(ANALYTICS_EVENTS.CARD_SUMSUB_OPENED, { source: 'poa-self-heal' })
-              void selfHealKycFlow.handleSelfHealResubmit('RAIN')
-          }
-        : undefined
+    const startPoaUpload = useCallback(async () => {
+        posthog.capture(ANALYTICS_EVENTS.CARD_SUMSUB_OPENED, { source: 'poa-self-heal' })
+        setPoaError(null)
+        const response = await initiateSelfHealResubmission('RAIN')
+        if (response.error || !response.data?.token) {
+            // Surfaced inline on the status screen — a silent primary CTA on a
+            // stuck-application screen is worse than no CTA.
+            setPoaError(response.error ?? 'Could not start the upload. Please try again.')
+            return
+        }
+        setPoaToken(response.data.token)
+    }, [])
+    const onUploadProofOfAddress = poaAction && !poaSubmitted ? () => void startPoaUpload() : undefined
 
     // Routes a non-incomplete apply response to the right next screen. Shared
     // by the user-initiated apply path and the post-Sumsub poll, since both
@@ -625,13 +638,16 @@ const CardPage: FC = () => {
                         </div>
                     )
                 }
-                const cardRailReason = railsForProvider('rain')[0]?.reason?.userMessage
+                const cardRailReason = poaSubmitted
+                    ? 'We received your proof of address — it’s being reviewed.'
+                    : railsForProvider('rain')[0]?.reason?.userMessage
                 return (
                     <ApplicationStatusScreen
                         variant="requires-info"
                         reasonMessage={cardRailReason}
                         onContactSupport={() => setIsSupportModalOpen(true)}
                         onUploadProofOfAddress={onUploadProofOfAddress}
+                        uploadError={poaError ?? undefined}
                         onPrev={onBack}
                     />
                 )
@@ -660,15 +676,18 @@ const CardPage: FC = () => {
                 // (meaningless without its reason), the rejected screen is useful
                 // on its own (reassurance + support CTA), so show it now and let
                 // the reason fill in once capabilities resolve.
-                const cardRailReason = capabilitiesLoading
-                    ? undefined
-                    : railsForProvider('rain')[0]?.reason?.userMessage
+                const cardRailReason = poaSubmitted
+                    ? 'We received your proof of address — it’s being reviewed.'
+                    : capabilitiesLoading
+                      ? undefined
+                      : railsForProvider('rain')[0]?.reason?.userMessage
                 return (
                     <ApplicationStatusScreen
                         variant="rejected"
                         reasonMessage={cardRailReason}
                         onContactSupport={() => setIsSupportModalOpen(true)}
                         onUploadProofOfAddress={onUploadProofOfAddress}
+                        uploadError={poaError ?? undefined}
                         onPrev={onBack}
                     />
                 )
@@ -685,7 +704,25 @@ const CardPage: FC = () => {
     return (
         <PageContainer>
             {renderState()}
-            <SumsubKycModals flow={selfHealKycFlow} />
+            <SumsubKycWrapper
+                visible={poaToken !== null}
+                accessToken={poaToken}
+                onClose={() => setPoaToken(null)}
+                onComplete={() => {
+                    // Document submitted to Sumsub. Review + the backend webhook
+                    // stamp happen async — flip the optimistic banner and refetch
+                    // so the screen picks up the backend's wait state when ready.
+                    setPoaToken(null)
+                    setPoaSubmitted(true)
+                    invalidateOverview()
+                    void fetchUser()
+                }}
+                onRefreshToken={async () => {
+                    const response = await initiateSelfHealResubmission('RAIN')
+                    if (!response.data?.token) throw new Error(response.error ?? 'Failed to refresh token')
+                    return response.data.token
+                }}
+            />
             <SumsubKycWrapper
                 visible={sumsubToken !== null}
                 accessToken={sumsubToken}

--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -48,7 +48,7 @@ export interface SelfHealResubmissionResponse {
     applicantId: string
     actionId: string
     externalActionId: string
-    requiredAction: 'REUPLOAD_ID' | 'REUPLOAD_ADDRESS_PROOF' | 'CONTACT_SUPPORT'
+    requiredAction: 'REUPLOAD_ID' | 'REUPLOAD_ADDRESS_PROOF' | 'CONTACT_SUPPORT' | 'RAIN_DOCUMENT'
     userMessage: string
     attempt: number
     maxAttempts: number

--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -86,7 +86,7 @@ export const restartIdentityVerification = async (): Promise<{
 
 // initiate self-heal document resubmission for a provider-rejected user
 export const initiateSelfHealResubmission = async (
-    provider: 'BRIDGE' | 'MANTECA',
+    provider: 'BRIDGE' | 'MANTECA' | 'RAIN',
     // Optional — target a specific (e.g. future-dated advisory) Bridge requirement
     // by key. Omitted for the legacy blocking flow (current nextAction).
     requirementKey?: string

--- a/src/components/Card/ApplicationStatusScreen.tsx
+++ b/src/components/Card/ApplicationStatusScreen.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image'
 import { PeanutCrying } from '@/assets/mascot'
 import NavHeader from '@/components/Global/NavHeader'
 import Loading from '@/components/Global/Loading'
+import { Button } from '@/components/0_Bruddle/Button'
 
 type Variant = 'pending' | 'manual-review' | 'requires-info' | 'requires-support' | 'rejected'
 
@@ -14,6 +15,10 @@ interface Props {
      *  user sees what specifically is missing. Provider-neutral by contract. */
     reasonMessage?: string
     onContactSupport?: () => void
+    /** When the rail carries a self-serve proof-of-address action, this opens
+     *  the Sumsub upload flow — rendered as the primary CTA so users fix it
+     *  themselves instead of messaging support. */
+    onUploadProofOfAddress?: () => void
     onPrev?: () => void
 }
 
@@ -46,7 +51,13 @@ const COPY: Record<Variant, { title: string; body: string }> = {
 /** Variants where support is the only path forward — these render the CTA. */
 const SUPPORT_VARIANTS: ReadonlySet<Variant> = new Set(['requires-info', 'requires-support', 'rejected'])
 
-const ApplicationStatusScreen: FC<Props> = ({ variant, reasonMessage, onContactSupport, onPrev }) => {
+const ApplicationStatusScreen: FC<Props> = ({
+    variant,
+    reasonMessage,
+    onContactSupport,
+    onUploadProofOfAddress,
+    onPrev,
+}) => {
     const copy = COPY[variant]
     return (
         <div className="flex min-h-[inherit] flex-col gap-8">
@@ -69,6 +80,11 @@ const ApplicationStatusScreen: FC<Props> = ({ variant, reasonMessage, onContactS
                     {reasonMessage && <p className="text-grey-1">{reasonMessage}</p>}
                     <p className="text-grey-1">{copy.body}</p>
                 </div>
+                {SUPPORT_VARIANTS.has(variant) && onUploadProofOfAddress && (
+                    <Button variant="purple" shadowSize="4" className="w-full" onClick={onUploadProofOfAddress}>
+                        Upload proof of address
+                    </Button>
+                )}
                 {SUPPORT_VARIANTS.has(variant) && onContactSupport && (
                     <button type="button" onClick={onContactSupport} className="text-black underline">
                         Contact support

--- a/src/components/Card/ApplicationStatusScreen.tsx
+++ b/src/components/Card/ApplicationStatusScreen.tsx
@@ -19,6 +19,9 @@ interface Props {
      *  the Sumsub upload flow — rendered as the primary CTA so users fix it
      *  themselves instead of messaging support. */
     onUploadProofOfAddress?: () => void
+    /** Inline failure from starting the upload (a silent primary CTA on a
+     *  stuck-application screen reads as broken). */
+    uploadError?: string
     onPrev?: () => void
 }
 
@@ -56,6 +59,7 @@ const ApplicationStatusScreen: FC<Props> = ({
     reasonMessage,
     onContactSupport,
     onUploadProofOfAddress,
+    uploadError,
     onPrev,
 }) => {
     const copy = COPY[variant]
@@ -81,9 +85,12 @@ const ApplicationStatusScreen: FC<Props> = ({
                     <p className="text-grey-1">{copy.body}</p>
                 </div>
                 {SUPPORT_VARIANTS.has(variant) && onUploadProofOfAddress && (
-                    <Button variant="purple" shadowSize="4" className="w-full" onClick={onUploadProofOfAddress}>
-                        Upload proof of address
-                    </Button>
+                    <div className="flex w-full flex-col gap-2">
+                        <Button variant="purple" shadowSize="4" className="w-full" onClick={onUploadProofOfAddress}>
+                            Upload proof of address
+                        </Button>
+                        {uploadError && <p className="text-sm text-error">{uploadError}</p>}
+                    </div>
                 )}
                 {SUPPORT_VARIANTS.has(variant) && onContactSupport && (
                     <button type="button" onClick={onContactSupport} className="text-black underline">

--- a/src/components/Card/__tests__/ApplicationStatusScreen.test.tsx
+++ b/src/components/Card/__tests__/ApplicationStatusScreen.test.tsx
@@ -57,3 +57,42 @@ describe('ApplicationStatusScreen — rejected', () => {
         expect(onContactSupport).toHaveBeenCalledTimes(1)
     })
 })
+
+describe('ApplicationStatusScreen — proof-of-address upload CTA', () => {
+    it('renders the upload CTA as primary when the rail carries a PoA action', () => {
+        const onUpload = jest.fn()
+        render(
+            <ApplicationStatusScreen
+                variant="requires-info"
+                reasonMessage="We need a valid proof of address document."
+                onContactSupport={jest.fn()}
+                onUploadProofOfAddress={onUpload}
+            />
+        )
+        fireEvent.click(screen.getByText('Upload proof of address'))
+        expect(onUpload).toHaveBeenCalledTimes(1)
+        // Contact support stays available as the fallback path.
+        expect(screen.getByText('Contact support')).toBeInTheDocument()
+    })
+
+    it('renders the upload CTA on the rejected variant too (denied + fixable PoA)', () => {
+        render(
+            <ApplicationStatusScreen
+                variant="rejected"
+                onContactSupport={jest.fn()}
+                onUploadProofOfAddress={jest.fn()}
+            />
+        )
+        expect(screen.getByText('Upload proof of address')).toBeInTheDocument()
+    })
+
+    it('omits the upload CTA when no PoA action exists', () => {
+        render(<ApplicationStatusScreen variant="requires-info" onContactSupport={jest.fn()} />)
+        expect(screen.queryByText('Upload proof of address')).not.toBeInTheDocument()
+    })
+
+    it('never renders the upload CTA on non-support variants', () => {
+        render(<ApplicationStatusScreen variant="pending" onUploadProofOfAddress={jest.fn()} />)
+        expect(screen.queryByText('Upload proof of address')).not.toBeInTheDocument()
+    })
+})

--- a/src/components/Card/__tests__/ApplicationStatusScreen.test.tsx
+++ b/src/components/Card/__tests__/ApplicationStatusScreen.test.tsx
@@ -96,3 +96,17 @@ describe('ApplicationStatusScreen — proof-of-address upload CTA', () => {
         expect(screen.queryByText('Upload proof of address')).not.toBeInTheDocument()
     })
 })
+
+describe('ApplicationStatusScreen — upload error', () => {
+    it('renders the inline error under the upload CTA', () => {
+        render(
+            <ApplicationStatusScreen
+                variant="requires-info"
+                onContactSupport={jest.fn()}
+                onUploadProofOfAddress={jest.fn()}
+                uploadError="Could not start the upload. Please try again."
+            />
+        )
+        expect(screen.getByText('Could not start the upload. Please try again.')).toBeInTheDocument()
+    })
+})

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -77,7 +77,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     // prevents stale websocket events or mount-time fetches from auto-closing the drawer.
     const userInitiatedRef = useRef(false)
     // tracks self-heal provider for token refresh — null when in regular KYC flow
-    const selfHealProviderRef = useRef<'BRIDGE' | 'MANTECA' | 'RAIN' | null>(null)
+    const selfHealProviderRef = useRef<'BRIDGE' | 'MANTECA' | null>(null)
 
     useEffect(() => {
         regionIntentRef.current = regionIntent
@@ -470,42 +470,39 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     // and opens the sumsub SDK with the action token. `requirementKey` targets a
     // specific (e.g. future-dated advisory) Bridge requirement; omitted for the
     // legacy blocking flow.
-    const handleSelfHealResubmit = useCallback(
-        async (provider: 'BRIDGE' | 'MANTECA' | 'RAIN', requirementKey?: string) => {
-            setIsLoading(true)
-            setError(null)
-            userInitiatedRef.current = true
-            selfHealProviderRef.current = provider
+    const handleSelfHealResubmit = useCallback(async (provider: 'BRIDGE' | 'MANTECA', requirementKey?: string) => {
+        setIsLoading(true)
+        setError(null)
+        userInitiatedRef.current = true
+        selfHealProviderRef.current = provider
 
-            try {
-                const response = await initiateSelfHealResubmission(provider, requirementKey)
+        try {
+            const response = await initiateSelfHealResubmission(provider, requirementKey)
 
-                if (response.error) {
-                    userInitiatedRef.current = false
-                    selfHealProviderRef.current = null
-                    setError(response.error)
-                    return
-                }
-
-                if (response.data?.token) {
-                    setAccessToken(response.data.token)
-                    setShowWrapper(true)
-                } else {
-                    userInitiatedRef.current = false
-                    selfHealProviderRef.current = null
-                    setError('Could not initiate document resubmission. Please try again.')
-                }
-            } catch (e: unknown) {
+            if (response.error) {
                 userInitiatedRef.current = false
                 selfHealProviderRef.current = null
-                const message = e instanceof Error ? e.message : 'An unexpected error occurred'
-                setError(message)
-            } finally {
-                setIsLoading(false)
+                setError(response.error)
+                return
             }
-        },
-        []
-    )
+
+            if (response.data?.token) {
+                setAccessToken(response.data.token)
+                setShowWrapper(true)
+            } else {
+                userInitiatedRef.current = false
+                selfHealProviderRef.current = null
+                setError('Could not initiate document resubmission. Please try again.')
+            }
+        } catch (e: unknown) {
+            userInitiatedRef.current = false
+            selfHealProviderRef.current = null
+            const message = e instanceof Error ? e.message : 'An unexpected error occurred'
+            setError(message)
+        } finally {
+            setIsLoading(false)
+        }
+    }, [])
 
     // Start a capability nextAction by key (POST /users/kyc/start-action) and
     // open the WebSDK with the returned token. Unlike handleInitiateKyc (which

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -77,7 +77,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     // prevents stale websocket events or mount-time fetches from auto-closing the drawer.
     const userInitiatedRef = useRef(false)
     // tracks self-heal provider for token refresh — null when in regular KYC flow
-    const selfHealProviderRef = useRef<'BRIDGE' | 'MANTECA' | null>(null)
+    const selfHealProviderRef = useRef<'BRIDGE' | 'MANTECA' | 'RAIN' | null>(null)
 
     useEffect(() => {
         regionIntentRef.current = regionIntent
@@ -470,39 +470,42 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     // and opens the sumsub SDK with the action token. `requirementKey` targets a
     // specific (e.g. future-dated advisory) Bridge requirement; omitted for the
     // legacy blocking flow.
-    const handleSelfHealResubmit = useCallback(async (provider: 'BRIDGE' | 'MANTECA', requirementKey?: string) => {
-        setIsLoading(true)
-        setError(null)
-        userInitiatedRef.current = true
-        selfHealProviderRef.current = provider
+    const handleSelfHealResubmit = useCallback(
+        async (provider: 'BRIDGE' | 'MANTECA' | 'RAIN', requirementKey?: string) => {
+            setIsLoading(true)
+            setError(null)
+            userInitiatedRef.current = true
+            selfHealProviderRef.current = provider
 
-        try {
-            const response = await initiateSelfHealResubmission(provider, requirementKey)
+            try {
+                const response = await initiateSelfHealResubmission(provider, requirementKey)
 
-            if (response.error) {
+                if (response.error) {
+                    userInitiatedRef.current = false
+                    selfHealProviderRef.current = null
+                    setError(response.error)
+                    return
+                }
+
+                if (response.data?.token) {
+                    setAccessToken(response.data.token)
+                    setShowWrapper(true)
+                } else {
+                    userInitiatedRef.current = false
+                    selfHealProviderRef.current = null
+                    setError('Could not initiate document resubmission. Please try again.')
+                }
+            } catch (e: unknown) {
                 userInitiatedRef.current = false
                 selfHealProviderRef.current = null
-                setError(response.error)
-                return
+                const message = e instanceof Error ? e.message : 'An unexpected error occurred'
+                setError(message)
+            } finally {
+                setIsLoading(false)
             }
-
-            if (response.data?.token) {
-                setAccessToken(response.data.token)
-                setShowWrapper(true)
-            } else {
-                userInitiatedRef.current = false
-                selfHealProviderRef.current = null
-                setError('Could not initiate document resubmission. Please try again.')
-            }
-        } catch (e: unknown) {
-            userInitiatedRef.current = false
-            selfHealProviderRef.current = null
-            const message = e instanceof Error ? e.message : 'An unexpected error occurred'
-            setError(message)
-        } finally {
-            setIsLoading(false)
-        }
-    }, [])
+        },
+        []
+    )
 
     // Start a capability nextAction by key (POST /users/kyc/start-action) and
     // open the WebSDK with the returned token. Unlike handleInitiateKyc (which


### PR DESCRIPTION
## Summary

FE half of the Rain proof-of-address self-heal (backend: peanutprotocol/peanut-api-ts#1194). Users whose card application is stuck on an address/PoA mismatch currently dead-end at "Contact support" on the card status screen; this PR gives them a primary **"Upload proof of address"** CTA that opens the Sumsub RFI upload in-app.

- `ApplicationStatusScreen`: new optional `onUploadProofOfAddress` prop → primary purple CTA above the existing Contact-support link (requires-info / requires-support / rejected variants only).
- `card/page.tsx`: derives the CTA from the capabilities read-model — shown only when the rain rail carries a `sumsub` next-action with `levelKey: 'proof_of_address'` (what the backend emits for `WRONG_ADDRESS`-class denials). Drives a **dedicated, deliberately tiny flow**: `initiateSelfHealResubmission('RAIN')` → second `SumsubKycWrapper` with its own token state → on SDK completion, optimistic "we received your document" banner + overview/capabilities refetch. Initiation failures render **inline under the CTA** (`uploadError`).
- Type widening limited to `initiateSelfHealResubmission`'s provider param (+`RAIN_DOCUMENT` in the response union) — `useSumsubKycFlow` is untouched.

## Design notes / accepted trade-offs

- **Why not `useMultiPhaseKycFlow`:** review confirmed its post-approval phase machine is bank-onboarding-shaped — a mutating status poll that can hang the "verifying" modal indefinitely for already-approved applicants, possible Bridge-ToS modal fan-out on an unrelated rail, and a completeFlow that re-renders the same requires-info screen (users would re-upload and burn attempts). The PoA flow needs none of it: token → SDK → thank-you + refetch.
- **Two Sumsub surfaces on the card page, deliberately.** The existing `SumsubKycWrapper` is driven by card-apply tokens (`applyForCard` → poll semantics); the PoA wrapper has its own token state — multiplexing them would fight over token refresh.
- **Optimistic banner:** Sumsub review + the backend webhook stamp lag the SDK close by seconds-to-minutes; local `poaSubmitted` state hides the CTA and shows "we received your document" until the backend's own wait-state reason takes over on refetch.
- The CTA renders on `rejected` too: Rain `denied` with a fixable PoA reason still carries the next-action (the backend's `resolved` verdict is `fixable`), and those users can be rescued without support.
- No URL state: the upload is a modal flow with no shareable intermediate step.

## Risks / breaking changes

- **Deploy order: peanut-api-ts#1194 must be live first.** Until then the rain rail never carries the PoA next-action, so the CTA simply never renders (fails closed, no breakage) — but if a user somehow POSTs `provider: 'RAIN'` against the old backend they get a 400 "Invalid provider" toast.
- No changes to existing Bridge/Manteca self-heal behavior (pure union widening).

## QA

- `npm test` — new `ApplicationStatusScreen` cases: CTA renders + fires on requires-info and rejected, absent without the action, never on non-support variants. 4 failing suites on this branch (`add-money-states`, `countryCurrencyMapping`, `GeneralRecipientInput`, `request-states`) are unrelated to this diff — verifying against base-branch CI.
- Manual: needs a user whose rain rail is `REQUIRES_INFORMATION` with `rainRemediation.nextAction.documentPurpose === 'proof_of_address'` (any of the 6 currently-stuck prod users' state reproduced in sandbox).
- Note for reviewers: commits are created via GitHub's API (`createCommitOnBranch`, verified web-flow signature) because local GPG signing was unavailable during this run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a self-service option to upload proof of address when card verification requires more information or has been rejected.
  * Added inline error messaging for failed uploads.
  * Added a review-status message after proof of address is submitted.

* **Bug Fixes**
  * Improved the card verification flow by supporting proof-of-address resubmissions and status refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->