### PR TITLE
fix: warn about name mismatch on bank deposit details

### DIFF
--- a/src/components/AddMoney/components/AddMoneyBankDetails.tsx
+++ b/src/components/AddMoney/components/AddMoneyBankDetails.tsx
@@ -421,7 +421,10 @@ Please use these details to complete your bank transfer.`
                         // own-name rule holds for ACH/SEPA/wire; MX SPEI supports paying from a
                         // third-party/client account, so this item is omitted there.
                         ...(currentCountryDetails?.id !== 'MX'
-                            ? ['Sender: use a bank account in your own name (a name mismatch bounces the transfer)']
+                            ? [
+                                  'Sender: use a bank account in your own name (a name mismatch bounces the transfer)',
+                                  'Recipient: enter the name exactly as shown above',
+                              ]
                             : []),
                     ]}
                 />

--- a/src/components/AddMoney/components/AddMoneyBankDetails.tsx
+++ b/src/components/AddMoney/components/AddMoneyBankDetails.tsx
@@ -296,14 +296,6 @@ Please use these details to complete your bank transfer.`
                 <Card className="gap-2 rounded-sm">
                     <h1 className="text-xs">Bank Details</h1>
 
-                    {/* name-match is the top cause of returned deposits (Bridge BE01): send from an
-                        account in the user's own name and enter the recipient name exactly as shown */}
-                    <InfoCard
-                        variant="warning"
-                        icon="alert"
-                        description="Send from a bank account in your own name, and enter the recipient name exactly as shown. A name mismatch will bounce the transfer."
-                    />
-
                     {/* resolveBridgeAccountHolderName maps Bridge's stale/absent legal entity name to the current one (Sp. Z.o.o. -> S.A.) */}
                     <PaymentInfoRow
                         label={'Account Holder Name'}
@@ -425,6 +417,12 @@ Please use these details to complete your bank transfer.`
                     items={[
                         `Amount: ${formattedCurrencyAmount} (exact)`,
                         `Reference: ${shortDepositReference(onrampData?.depositInstructions?.depositMessage) || 'Loading...'} (included)`,
+                        // name mismatch is the top cause of returned deposits (Bridge BE01). the
+                        // own-name rule holds for ACH/SEPA/wire; MX SPEI supports paying from a
+                        // third-party/client account, so this item is omitted there.
+                        ...(currentCountryDetails?.id !== 'MX'
+                            ? ['Sender: use a bank account in your own name (a name mismatch bounces the transfer)']
+                            : []),
                     ]}
                 />
 

--- a/src/components/AddMoney/components/AddMoneyBankDetails.tsx
+++ b/src/components/AddMoney/components/AddMoneyBankDetails.tsx
@@ -296,6 +296,14 @@ Please use these details to complete your bank transfer.`
                 <Card className="gap-2 rounded-sm">
                     <h1 className="text-xs">Bank Details</h1>
 
+                    {/* name-match is the top cause of returned deposits (Bridge BE01): send from an
+                        account in the user's own name and enter the recipient name exactly as shown */}
+                    <InfoCard
+                        variant="warning"
+                        icon="alert"
+                        description="Send from a bank account in your own name, and enter the recipient name exactly as shown. A name mismatch will bounce the transfer."
+                    />
+
                     {/* resolveBridgeAccountHolderName maps Bridge's stale/absent legal entity name to the current one (Sp. Z.o.o. -> S.A.) */}
                     <PaymentInfoRow
                         label={'Account Holder Name'}


### PR DESCRIPTION
## Summary

Name mismatch is the **top cause of returned SEPA/ACH deposits** — Bridge confirmed (ticket #174270) that Banking Circle validates the sender name on every inbound transfer and auto-returns on mismatch (`BE01`). The "Transfer details" screen already warns about *amount* and *reference* in a consolidated pre-send checklist, but said nothing about the name. This adds the missing name-match line to that same checklist.

Context: TASK-20574 (non-EUR SEPA deposits). Investigation confirmed non-EUR SEPA deposits *do* work (the user's bank converts to EUR before it reaches Bridge); the real failure mode was always name mismatch, not currency — so this is the one user-facing gap worth closing.

## Change
One conditional item added to the existing `Double check in your bank before sending:` `InfoCard` in `AddMoneyBankDetails.tsx`. +6 lines, no logic change.

## Design notes
- **Consolidated, not a new card.** Folded into the existing pre-send checklist so there's a single source of pre-send do-nots — avoids a fourth alarm card diluting the signal and two places drifting out of sync. (Surfaced by /code-review.)
- **Omitted for MX/SPEI.** The own-name rule is confirmed for ACH/SEPA/wire; Mexico SPEI supports paying from a third-party/client account (per `product/support-answers/bank-deposit-name-mismatch.md`), so the item is gated out there.
- Deliberately did **not** touch the amount-step "EUR accounts only — your local currency account may not work" card; reframing it (now known over-cautious) is a separate product-copy call.

## Risks / breaking changes
None. Pure additive UI copy on an existing screen. No API, no cross-repo impact.

## QA
- Add Money → any non-MX country → bank → enter amount → Continue → **Transfer details**: the pre-send checklist shows a third `Sender: use a bank account in your own name…` line.
- Add Money → **Mexico** → bank: checklist shows only Amount + Reference (no sender-name line).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added a reminder to send funds from a bank account in the user’s own name during applicable bank transfer flows.
  * The reminder is omitted for Mexico-specific flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->