### PR TITLE
fix(kyc): launch Sumsub SDK when the modal portal mounts the container late

### DIFF
--- a/src/components/Kyc/SumsubKycWrapper.tsx
+++ b/src/components/Kyc/SumsubKycWrapper.tsx
@@ -36,7 +36,11 @@ export const SumsubKycWrapper = ({
     const [sdkLoadError, setSdkLoadError] = useState(false)
     const [isHelpModalOpen, setIsHelpModalOpen] = useState(false)
     const [modalVariant, setModalVariant] = useState<'stop-verification' | 'trouble'>('trouble')
-    const sdkContainerRef = useRef<HTMLDivElement>(null)
+    // Callback ref, NOT useRef: the modal renders through a headlessui Portal, so
+    // the container mounts a commit AFTER `visible` flips true. A plain ref is not
+    // reactive — the init effect below would read null on its only run and never
+    // launch the SDK. State re-runs the effect the moment the node attaches.
+    const [sdkContainer, setSdkContainer] = useState<HTMLDivElement | null>(null)
     const sdkInstanceRef = useRef<SnsWebSdkInstance | null>(null)
     const { setIsSupportModalOpen } = useModalsContext()
 
@@ -103,7 +107,7 @@ export const SumsubKycWrapper = ({
 
     // initialize sdk as soon as the modal is visible and all deps are ready
     useEffect(() => {
-        if (!visible || !accessToken || !sdkLoaded || !sdkContainerRef.current) return
+        if (!visible || !accessToken || !sdkLoaded || !sdkContainer) return
 
         // clean up previous instance
         if (sdkInstanceRef.current) {
@@ -188,7 +192,7 @@ export const SumsubKycWrapper = ({
                 })
                 .build()
 
-            sdk.launch(sdkContainerRef.current)
+            sdk.launch(sdkContainer)
             sdkInstanceRef.current = sdk
 
             // ensure the sdk-created iframe gets camera/microphone permissions.
@@ -203,10 +207,10 @@ export const SumsubKycWrapper = ({
                     }
                 }
             })
-            iframeObserver.observe(sdkContainerRef.current, { childList: true })
+            iframeObserver.observe(sdkContainer, { childList: true })
 
             // also patch any iframe that was added before the observer
-            const existingIframe = sdkContainerRef.current.querySelector('iframe')
+            const existingIframe = sdkContainer.querySelector('iframe')
             if (existingIframe && !existingIframe.allow?.includes('camera')) {
                 existingIframe.allow = 'camera; microphone; fullscreen'
             }
@@ -228,7 +232,7 @@ export const SumsubKycWrapper = ({
                 sdkInstanceRef.current = null
             }
         }
-    }, [visible, accessToken, sdkLoaded, stableOnComplete, stableOnError, stableOnRefreshToken])
+    }, [visible, accessToken, sdkLoaded, sdkContainer, stableOnComplete, stableOnError, stableOnRefreshToken])
 
     // reset state when modal closes (the init effect's cleanup already
     // destroys the SDK instance — visible is one of its deps)
@@ -345,7 +349,7 @@ export const SumsubKycWrapper = ({
                                 <Loading className="h-8 w-8" />
                             </div>
                             <div
-                                ref={sdkContainerRef}
+                                ref={setSdkContainer}
                                 className="relative h-full w-full overflow-auto [&>iframe]:!min-h-full"
                             />
                         </div>

--- a/src/components/Kyc/SumsubKycWrapper.tsx
+++ b/src/components/Kyc/SumsubKycWrapper.tsx
@@ -36,11 +36,7 @@ export const SumsubKycWrapper = ({
     const [sdkLoadError, setSdkLoadError] = useState(false)
     const [isHelpModalOpen, setIsHelpModalOpen] = useState(false)
     const [modalVariant, setModalVariant] = useState<'stop-verification' | 'trouble'>('trouble')
-    // Callback ref, NOT useRef: the modal renders through a headlessui Portal, so
-    // the container mounts a commit AFTER `visible` flips true. A plain ref is not
-    // reactive — the init effect below would read null on its only run and never
-    // launch the SDK. State re-runs the effect the moment the node attaches.
-    const [sdkContainer, setSdkContainer] = useState<HTMLDivElement | null>(null)
+    const sdkContainerRef = useRef<HTMLDivElement>(null)
     const sdkInstanceRef = useRef<SnsWebSdkInstance | null>(null)
     const { setIsSupportModalOpen } = useModalsContext()
 
@@ -107,7 +103,7 @@ export const SumsubKycWrapper = ({
 
     // initialize sdk as soon as the modal is visible and all deps are ready
     useEffect(() => {
-        if (!visible || !accessToken || !sdkLoaded || !sdkContainer) return
+        if (!visible || !accessToken || !sdkLoaded || !sdkContainerRef.current) return
 
         // clean up previous instance
         if (sdkInstanceRef.current) {
@@ -192,7 +188,7 @@ export const SumsubKycWrapper = ({
                 })
                 .build()
 
-            sdk.launch(sdkContainer)
+            sdk.launch(sdkContainerRef.current)
             sdkInstanceRef.current = sdk
 
             // ensure the sdk-created iframe gets camera/microphone permissions.
@@ -207,10 +203,10 @@ export const SumsubKycWrapper = ({
                     }
                 }
             })
-            iframeObserver.observe(sdkContainer, { childList: true })
+            iframeObserver.observe(sdkContainerRef.current, { childList: true })
 
             // also patch any iframe that was added before the observer
-            const existingIframe = sdkContainer.querySelector('iframe')
+            const existingIframe = sdkContainerRef.current.querySelector('iframe')
             if (existingIframe && !existingIframe.allow?.includes('camera')) {
                 existingIframe.allow = 'camera; microphone; fullscreen'
             }
@@ -232,7 +228,7 @@ export const SumsubKycWrapper = ({
                 sdkInstanceRef.current = null
             }
         }
-    }, [visible, accessToken, sdkLoaded, sdkContainer, stableOnComplete, stableOnError, stableOnRefreshToken])
+    }, [visible, accessToken, sdkLoaded, stableOnComplete, stableOnError, stableOnRefreshToken])
 
     // reset state when modal closes (the init effect's cleanup already
     // destroys the SDK instance — visible is one of its deps)
@@ -349,7 +345,7 @@ export const SumsubKycWrapper = ({
                                 <Loading className="h-8 w-8" />
                             </div>
                             <div
-                                ref={setSdkContainer}
+                                ref={sdkContainerRef}
                                 className="relative h-full w-full overflow-auto [&>iframe]:!min-h-full"
                             />
                         </div>

--- a/src/components/Kyc/__tests__/SumsubKycWrapper.test.tsx
+++ b/src/components/Kyc/__tests__/SumsubKycWrapper.test.tsx
@@ -10,10 +10,13 @@ import { SumsubKycWrapper } from '../SumsubKycWrapper'
 // reactive, so the effect never re-runs and the SDK is never launched.
 jest.mock('@/components/Global/Modal', () => ({
     __esModule: true,
-    default: ({ visible, children }: { visible: boolean; children: React.ReactNode }) => {
+    // Named + capitalised so eslint's rules-of-hooks recognises it as a component.
+    default: function MockPortalModal({ visible, children }: { visible: boolean; children: React.ReactNode }) {
+        // `mounted` resets on close so a close/re-open cycle replays the late
+        // mount, exactly like the real portal tearing down and rebuilding.
         const [mounted, setMounted] = useState(false)
         useEffect(() => {
-            if (visible) setMounted(true)
+            setMounted(visible)
         }, [visible])
         if (!visible || !mounted) return null
         return <div data-testid="modal">{children}</div>
@@ -41,6 +44,12 @@ describe('SumsubKycWrapper', () => {
         installSdk()
     })
 
+    afterEach(() => {
+        // don't leak the global — a later test may need the script-loading path
+        // (snsWebSdk absent -> script injected -> onload) to be reachable.
+        delete (window as unknown as { snsWebSdk?: unknown }).snsWebSdk
+    })
+
     it('launches the SDK when an already-mounted wrapper is opened (portal mounts container late)', async () => {
         // Faithful to prod: SumsubKycModals keeps this wrapper mounted, so the
         // websdk script resolves and `sdkLoaded` settles true while hidden. Only
@@ -54,8 +63,13 @@ describe('SumsubKycWrapper', () => {
             onComplete: jest.fn(),
             onRefreshToken: jest.fn().mockResolvedValue('tok_abc'),
         }
+        // window.snsWebSdk is pre-installed, so the script effect resolves
+        // sdkLoaded->true on mount and render() flushes it inside act(). That is
+        // what makes `visible` the LAST dep to flip — if sdkLoaded flipped after
+        // it instead, that flip would re-run the init effect with the container
+        // already mounted and mask the bug entirely.
         const { rerender } = render(<SumsubKycWrapper visible={false} {...props} />)
-        await waitFor(() => expect(launch).not.toHaveBeenCalled())
+        expect(launch).not.toHaveBeenCalled()
 
         rerender(<SumsubKycWrapper visible {...props} />)
 

--- a/src/components/Kyc/__tests__/SumsubKycWrapper.test.tsx
+++ b/src/components/Kyc/__tests__/SumsubKycWrapper.test.tsx
@@ -1,0 +1,95 @@
+import { render, waitFor } from '@testing-library/react'
+import { useEffect, useState } from 'react'
+import { SumsubKycWrapper } from '../SumsubKycWrapper'
+
+// The real Modal is a headlessui <Transition>/<Dialog>, which renders through a
+// Portal: the portal target is created in the portal's OWN effect, so children
+// mount a commit AFTER `visible` flips true. That one-commit delay is the whole
+// bug this suite guards — a plain useRef read in the init effect is null on the
+// pass where visible/accessToken/sdkLoaded are all ready, and a ref is not
+// reactive, so the effect never re-runs and the SDK is never launched.
+jest.mock('@/components/Global/Modal', () => ({
+    __esModule: true,
+    default: ({ visible, children }: { visible: boolean; children: React.ReactNode }) => {
+        const [mounted, setMounted] = useState(false)
+        useEffect(() => {
+            if (visible) setMounted(true)
+        }, [visible])
+        if (!visible || !mounted) return null
+        return <div data-testid="modal">{children}</div>
+    },
+}))
+
+jest.mock('@/components/Global/ActionModal', () => ({ __esModule: true, default: () => null }))
+jest.mock('@/components/Global/Loading', () => ({ __esModule: true, default: () => <div>loading</div> }))
+jest.mock('@/context/ModalsContext', () => ({ useModalsContext: () => ({ setIsSupportModalOpen: jest.fn() }) }))
+
+const launch = jest.fn()
+
+function installSdk() {
+    const builder: Record<string, unknown> = {}
+    builder.withConf = () => builder
+    builder.withOptions = () => builder
+    builder.on = () => builder
+    builder.build = () => ({ launch, destroy: jest.fn() })
+    ;(window as unknown as { snsWebSdk: unknown }).snsWebSdk = { init: () => builder }
+}
+
+describe('SumsubKycWrapper', () => {
+    beforeEach(() => {
+        launch.mockClear()
+        installSdk()
+    })
+
+    it('launches the SDK when an already-mounted wrapper is opened (portal mounts container late)', async () => {
+        // Faithful to prod: SumsubKycModals keeps this wrapper mounted, so the
+        // websdk script resolves and `sdkLoaded` settles true while hidden. Only
+        // `visible` flips later — and if the init effect bails on a null ref at
+        // that moment, NOTHING else ever changes to re-run it. Mounting straight
+        // to visible instead lets the sdkLoaded flip re-run the effect and hides
+        // the bug entirely.
+        const props = {
+            accessToken: 'tok_abc',
+            onClose: jest.fn(),
+            onComplete: jest.fn(),
+            onRefreshToken: jest.fn().mockResolvedValue('tok_abc'),
+        }
+        const { rerender } = render(<SumsubKycWrapper visible={false} {...props} />)
+        await waitFor(() => expect(launch).not.toHaveBeenCalled())
+
+        rerender(<SumsubKycWrapper visible {...props} />)
+
+        // Regression: before the callback-ref fix this never fired, leaving the
+        // user on an infinite spinner (card_sumsub_opened with 0 completions).
+        await waitFor(() => expect(launch).toHaveBeenCalledTimes(1))
+        expect(launch.mock.calls[0][0]).toBeInstanceOf(HTMLElement)
+    })
+
+    it('does not launch while hidden', async () => {
+        render(
+            <SumsubKycWrapper
+                visible={false}
+                accessToken="tok_abc"
+                onClose={jest.fn()}
+                onComplete={jest.fn()}
+                onRefreshToken={jest.fn().mockResolvedValue('tok_abc')}
+            />
+        )
+        await new Promise((r) => setTimeout(r, 0))
+        expect(launch).not.toHaveBeenCalled()
+    })
+
+    it('does not launch without an access token', async () => {
+        render(
+            <SumsubKycWrapper
+                visible
+                accessToken={null}
+                onClose={jest.fn()}
+                onComplete={jest.fn()}
+                onRefreshToken={jest.fn().mockResolvedValue('tok_abc')}
+            />
+        )
+        await new Promise((r) => setTimeout(r, 0))
+        expect(launch).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
## Summary

**P0 — card creation has been at zero for 15h+.** The Sumsub WebSDK opens but nobody can complete verification, so no one gets a card.

The numbers (PostHog, prod):

| event | 07-14 | 07-15 | 07-16 | **07-17** |
|---|---|---|---|---|
| `card_sumsub_opened` | 198 | 129 | 188 | **137** ← normal |
| `card_sumsub_completed` | 85 | 59 | 49 | **0** |
| `kyc_submitted` | 76 | 40 | 27 | **0** |
| `kyc_approved` | 42 | 17 | 16 | **0** |
| `card_sumsub_closed` | 58 | 29 | 46 | **51** ← users giving up |

Users sit on a spinner and walk away. Downstream this is a full card outage: no new verified users, and the **334** already-approved-but-cardless users get routed back through the same SDK for Rain's extra docs. `card_apply` `terms-required` collapsed from **27–42%** of outcomes to **1.4%**, and **0 cards** were created in 15h+ (baseline 24–43/day). Last card: `2026-07-16 21:16`.

Corroborated by a user report: *"When I try to set up the new card, it just spins, nothing appears on the display."*

## Root cause

#2407 replaced the `StartVerificationView` click gate with auto-init on `visible`. The init effect bails on `!sdkContainerRef.current` — but `Modal` is a headlessui `<Transition>`/`<Dialog>` that renders through a **Portal**, and the portal target is created in the portal's *own* effect. So the container mounts a commit **after** `visible` flips true.

A ref is **not reactive** and was not in the dep array, so the effect read `null` on its only run and **never re-ran — the SDK was never launched.** The old click gate hid this by guaranteeing the container was mounted long before init.

It only reproduces when the wrapper is **already mounted** (the real `SumsubKycModals` case) so `sdkLoaded` has settled before `visible` flips. Mounting straight to `visible` lets the `sdkLoaded` flip re-run the effect and masks the bug — which is why it escaped review.

## Fix

Hold the container in state via a **callback ref**, so attachment re-runs the init effect. Keeps #2407's intended no-interstitial UX rather than reverting it.

> I built a surgical revert first and threw it away once the mechanism was proven — the forward fix keeps the UX win and is provable.

## Risks / breaking changes

- **Blast radius: the Sumsub modal only.** 1 source file, +1 test. No API/contract change, no cross-repo deploy order.
- Every `SumsubKycModals` surface benefits (card apply, Manteca add-money, claim/bank flows, profile regions) — all were equally broken.
- Targets **`main`** (prod hotfix) → **back-merge debt main→dev**.

## QA

- New suite `SumsubKycWrapper.test.tsx` reproduces the portal's late mount. **Fails on current prod code** (`launch` called 0 times), **passes with the fix**. Also asserts it does *not* launch while hidden or without a token.
- Full local gate: typecheck clean, prettier clean, 3/3 new tests. Full suite: 4 pre-existing failures identical on clean `origin/main` (content-submodule/worktree env), none from this change.

## Design notes / accepted trade-offs

- Chose the forward fix over reverting 6 files to the pre-#2407 wrapper: the revert would restore the extra "Start verification" click the team deliberately removed.
- **Reveals a pre-existing smell (not fixed here):** this component had **no test coverage at all**, which is how a 100%-reproducible init bug shipped. This PR adds the first suite. A broader "every SDK/portal-mounted wrapper needs a mount test" sweep is a follow-up, not this PR's scope.
