### PR TITLE
fix(kyc): actually apply the callback-ref fix (#2440 shipped the test only)

### DIFF
--- a/src/components/Kyc/SumsubKycWrapper.tsx
+++ b/src/components/Kyc/SumsubKycWrapper.tsx
@@ -36,7 +36,11 @@ export const SumsubKycWrapper = ({
     const [sdkLoadError, setSdkLoadError] = useState(false)
     const [isHelpModalOpen, setIsHelpModalOpen] = useState(false)
     const [modalVariant, setModalVariant] = useState<'stop-verification' | 'trouble'>('trouble')
-    const sdkContainerRef = useRef<HTMLDivElement>(null)
+    // Callback ref, NOT useRef: the modal renders through a headlessui Portal, so
+    // the container mounts a commit AFTER `visible` flips true. A plain ref is not
+    // reactive — the init effect below would read null on its only run and never
+    // launch the SDK. State re-runs the effect the moment the node attaches.
+    const [sdkContainer, setSdkContainer] = useState<HTMLDivElement | null>(null)
     const sdkInstanceRef = useRef<SnsWebSdkInstance | null>(null)
     const { setIsSupportModalOpen } = useModalsContext()
 
@@ -103,7 +107,7 @@ export const SumsubKycWrapper = ({
 
     // initialize sdk as soon as the modal is visible and all deps are ready
     useEffect(() => {
-        if (!visible || !accessToken || !sdkLoaded || !sdkContainerRef.current) return
+        if (!visible || !accessToken || !sdkLoaded || !sdkContainer) return
 
         // clean up previous instance
         if (sdkInstanceRef.current) {
@@ -188,7 +192,7 @@ export const SumsubKycWrapper = ({
                 })
                 .build()
 
-            sdk.launch(sdkContainerRef.current)
+            sdk.launch(sdkContainer)
             sdkInstanceRef.current = sdk
 
             // ensure the sdk-created iframe gets camera/microphone permissions.
@@ -203,10 +207,10 @@ export const SumsubKycWrapper = ({
                     }
                 }
             })
-            iframeObserver.observe(sdkContainerRef.current, { childList: true })
+            iframeObserver.observe(sdkContainer, { childList: true })
 
             // also patch any iframe that was added before the observer
-            const existingIframe = sdkContainerRef.current.querySelector('iframe')
+            const existingIframe = sdkContainer.querySelector('iframe')
             if (existingIframe && !existingIframe.allow?.includes('camera')) {
                 existingIframe.allow = 'camera; microphone; fullscreen'
             }
@@ -228,7 +232,7 @@ export const SumsubKycWrapper = ({
                 sdkInstanceRef.current = null
             }
         }
-    }, [visible, accessToken, sdkLoaded, stableOnComplete, stableOnError, stableOnRefreshToken])
+    }, [visible, accessToken, sdkLoaded, sdkContainer, stableOnComplete, stableOnError, stableOnRefreshToken])
 
     // reset state when modal closes (the init effect's cleanup already
     // destroys the SDK instance — visible is one of its deps)
@@ -345,7 +349,7 @@ export const SumsubKycWrapper = ({
                                 <Loading className="h-8 w-8" />
                             </div>
                             <div
-                                ref={sdkContainerRef}
+                                ref={setSdkContainer}
                                 className="relative h-full w-full overflow-auto [&>iframe]:!min-h-full"
                             />
                         </div>


### PR DESCRIPTION
## ⚠️ #2440 shipped the test but NOT the fix — this lands the actual fix

**The card outage is still live.** #2440 was supposed to fix it, but it merged the regression test **without the code change**.

**How:** while proving the test failed against prod code, I ran `git checkout origin/main -- SumsubKycWrapper.tsx`. That **staged** the reverted file. I restored the working tree with `cp` but never re-staged, so the follow-up commit swept the staged revert in. `main` ended up with a test asserting behaviour `main` doesn't have → **its unit job is red**, and every user still gets the spinner.

## The fix (unchanged from what #2440 intended)

Hold the SDK container in **state via a callback ref** so the init effect re-runs when the headlessui **portal** attaches the node — which happens a commit *after* `visible` flips true.

Without it: the effect reads a `null` ref on its only run and **never re-runs** (a ref isn't reactive and isn't in the dep array) → **`sdk.launch()` is never called** → infinite spinner for 100% of users.

Deterministic, not a race — every `useSumsubKycFlow` call site does:
```js
setAccessToken(response.data.token)
setShowWrapper(true)          // React 18 auto-batches → one commit
```
so `accessToken` + `visible` land together while `sdkLoaded` is already true (the wrapper is persistently mounted). All deps ready, container null, effect bails, done.

Matches prod exactly: `card_sumsub_opened` normal (137/day) vs `card_sumsub_completed` **0** (was 49–85/day), `kyc_approved` **0**, cards **0** for 16h+.

## Not Sumsub

Ruled out by direct API probe — the `rain-requirements` level is **healthy**:
```
docSets: [IDENTITY, SELFIE, APPLICANT_DATA, PHONE_VERIFICATION, EMAIL_VERIFICATION, QUESTIONNAIRE]
69c5b040…  questionnaire: [rain-card-extraInformation]  reviewStatus: completed/GREEN
```
Nothing renamed or deleted. Applicants with empty questionnaires are at `reviewStatus: init` — they never submitted, because the SDK never launched. That's the **symptom**, not the cause. **Do not edit the Sumsub dashboard.**

## Verification

- The test **already on main** fails against main's wrapper (`launch` called **0** times) and **passes** with this commit. That asymmetry is the proof the code change is really here.
- eslint clean on the file, typecheck clean, prettier clean.
- This also turns main's currently-red unit job green.

## Risk

One file, 18 lines, Sumsub modal only. No API/contract change, no migration. Targets `main` → **back-merge debt (main→dev)**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identity verification startup reliability when the verification window becomes visible.
  * Ensured the verification experience initializes only after its display area is ready, reducing loading issues and improving iframe rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->