### PR TITLE
chore(types): add FE types for GET /notifications/admin/recent

### DIFF
--- a/src/types/api.generated.ts
+++ b/src/types/api.generated.ts
@@ -4,6 +4,81 @@
  */
 
 export interface paths {
+    "/notifications/admin/recent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Recent notification rows for a user (all channels + statuses) */
+        get: {
+            parameters: {
+                query: {
+                    userId: string;
+                    limit: number;
+                };
+                header: {
+                    "x-admin-token": string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                eventType: string;
+                                channel: string;
+                                status: "PENDING" | "SENT" | "FAILED" | "SKIPPED";
+                                skipReason: string | null;
+                                providerId: string | null;
+                                error: unknown;
+                                createdAt: string;
+                                sentAt: string | null;
+                            }[];
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/": {
         parameters: {
             query?: never;

--- a/src/types/api.openapi.json
+++ b/src/types/api.openapi.json
@@ -8,6 +8,171 @@
 		"schemas": {}
 	},
 	"paths": {
+		"/notifications/admin/recent": {
+			"get": {
+				"summary": "Recent notification rows for a user (all channels + statuses)",
+				"tags": ["admin"],
+				"parameters": [
+					{
+						"schema": {
+							"minLength": 1,
+							"type": "string"
+						},
+						"in": "query",
+						"name": "userId",
+						"required": true
+					},
+					{
+						"schema": {
+							"minimum": 1,
+							"maximum": 100,
+							"default": 20,
+							"type": "integer"
+						},
+						"in": "query",
+						"name": "limit",
+						"required": true
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"in": "header",
+						"name": "x-admin-token",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"items": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"id": {
+														"type": "string"
+													},
+													"eventType": {
+														"type": "string"
+													},
+													"channel": {
+														"type": "string"
+													},
+													"status": {
+														"anyOf": [
+															{
+																"type": "string",
+																"enum": ["PENDING"]
+															},
+															{
+																"type": "string",
+																"enum": ["SENT"]
+															},
+															{
+																"type": "string",
+																"enum": ["FAILED"]
+															},
+															{
+																"type": "string",
+																"enum": ["SKIPPED"]
+															}
+														]
+													},
+													"skipReason": {
+														"anyOf": [
+															{
+																"type": "string"
+															},
+															{
+																"type": "null"
+															}
+														]
+													},
+													"providerId": {
+														"anyOf": [
+															{
+																"type": "string"
+															},
+															{
+																"type": "null"
+															}
+														]
+													},
+													"error": {},
+													"createdAt": {
+														"type": "string"
+													},
+													"sentAt": {
+														"anyOf": [
+															{
+																"type": "string"
+															},
+															{
+																"type": "null"
+															}
+														]
+													}
+												},
+												"required": [
+													"id",
+													"eventType",
+													"channel",
+													"status",
+													"skipReason",
+													"providerId",
+													"error",
+													"createdAt",
+													"sentAt"
+												]
+											}
+										}
+									},
+									"required": ["items"]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Default Response",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": ["error"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
 		"/": {
 			"get": {
 				"responses": {


### PR DESCRIPTION
## What

Regenerates the committed OpenAPI snapshot (`src/types/api.openapi.json`) and TypeScript types (`src/types/api.generated.ts`) to include the new backend endpoint `GET /notifications/admin/recent`, added in [peanut-api-ts#1197](https://github.com/peanutprotocol/peanut-api-ts/pull/1197).

## Notes

- **Additive only** — the diff adds exactly one path to the snapshot (165 lines) and its generated types (75 lines); no existing path changes.
- Both files are `.prettierignore`d (snapshot is pulled verbatim from the BE spec), so the block is spliced in the BE's tab format rather than reformatted. `pnpm gen:api` output is idempotent, so `check:api` passes.
- The endpoint is admin-only (`x-admin-token`), so the FE won't call it — this keeps the generated types a faithful mirror of the backend contract, nothing more.

Depends on peanut-api-ts#1197 landing (the endpoint must exist on the BE for the types to be meaningful).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an administrative API endpoint for retrieving recent notifications.
  * Supports filtering by user and result limit, with administrator authentication.
  * Returns notification details, delivery statuses, timestamps, provider identifiers, and error information.
  * Documents validation and authentication error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->