### PR TITLE
fix(sentry): stop double-counting fetch failures, add missing DrawerTitle

### DIFF
--- a/sentry.utils.test.ts
+++ b/sentry.utils.test.ts
@@ -1,0 +1,19 @@
+import type { ErrorEvent } from '@sentry/nextjs'
+import { shouldIgnoreError } from './sentry.utils'
+
+function eventWith(partial: { message?: string; type?: string; value?: string }): ErrorEvent {
+    return {
+        message: partial.message,
+        exception: { values: [{ type: partial.type, value: partial.value }] },
+    } as unknown as ErrorEvent
+}
+
+describe('shouldIgnoreError — alreadyReported (fetchWithSentry wrapper)', () => {
+    it('ignores a re-thrown ServiceUnavailableError (already captured at the fetch site)', () => {
+        expect(shouldIgnoreError(eventWith({ type: 'ServiceUnavailableError', value: 'upstream 503' }))).toBe(true)
+    })
+
+    it('does not ignore an unrelated application error', () => {
+        expect(shouldIgnoreError(eventWith({ type: 'TypeError', value: 'x is not a function' }))).toBe(false)
+    })
+})

--- a/sentry.utils.ts
+++ b/sentry.utils.ts
@@ -38,6 +38,12 @@ const IGNORED_ERRORS = {
     // Third-party scripts we don't control
     thirdParty: ['googletagmanager', 'gtag', 'analytics', 'hotjar', 'clarity', 'intercom', 'crisp'],
 
+    // fetchWithSentry wrapper errors: the underlying timeout/network/HTTP
+    // failure is already captured at the fetch site with full context, so the
+    // re-thrown ServiceUnavailableError bubbling to global handlers (or being
+    // console.error'd by a consumer) would only double-count it (PEANUT-UI-QDJ).
+    alreadyReported: ['ServiceUnavailableError'],
+
     // Third-party SDK internal errors (not actionable)
     thirdPartySdkErrors: [
         'IndexedDB:Set:InternalError', // Vercel Analytics storage - fails in private browsing, not actionable

--- a/sentry.utils.ts
+++ b/sentry.utils.ts
@@ -42,6 +42,9 @@ const IGNORED_ERRORS = {
     // failure is already captured at the fetch site with full context, so the
     // re-thrown ServiceUnavailableError bubbling to global handlers (or being
     // console.error'd by a consumer) would only double-count it (PEANUT-UI-QDJ).
+    // Substring-matching this pattern is safe only because ServiceUnavailableError
+    // is our own internal fetchWithSentry wrapper name, not a generic string that
+    // could appear in an unrelated third-party error message.
     alreadyReported: ['ServiceUnavailableError'],
 
     // Third-party SDK internal errors (not actionable)

--- a/src/components/Badges/BadgeStatusDrawer.tsx
+++ b/src/components/Badges/BadgeStatusDrawer.tsx
@@ -1,4 +1,4 @@
-import { Drawer, DrawerContent } from '@/components/Global/Drawer'
+import { Drawer, DrawerContent, DrawerTitle } from '@/components/Global/Drawer'
 import Image from 'next/image'
 import { useState } from 'react'
 import { formatDate } from '@/utils/general.utils'
@@ -64,7 +64,9 @@ export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerP
                                     <h2 className="flex items-center gap-2 text-xs font-medium text-grey-1">
                                         Badge unlocked!
                                     </h2>
-                                    <h1 className={`text-lg font-extrabold md:text-4xl`}>{displayName}</h1>
+                                    <DrawerTitle className="text-lg font-extrabold md:text-4xl">
+                                        {displayName}
+                                    </DrawerTitle>
                                 </div>
                             </div>
                         </Card>

--- a/src/hooks/useTokenPrice.ts
+++ b/src/hooks/useTokenPrice.ts
@@ -95,9 +95,13 @@ export const useTokenPrice = ({
 
                 return null
             } catch (error) {
-                // Preserve Sentry error reporting from original implementation
+                // fetchWithSentry already reported the underlying failure; this
+                // capture only surfaces non-fetch errors (beforeSend drops the
+                // ServiceUnavailableError wrapper). console.info stays out of
+                // captureConsoleIntegration (PEANUT-UI-MH5) — the fallback is
+                // graceful, not an error.
                 Sentry.captureException(error)
-                console.error('error fetching tokenPrice, falling back to tokenDenomination')
+                console.info('error fetching tokenPrice, falling back to tokenDenomination')
                 return null
             }
         },

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -409,7 +409,10 @@ export const fetchWithSentry = async (
         // fetch rejected (timeout / DNS / connection refused) — the request never
         // reached the backend, so flag a connectivity failure.
         reportNetworkError()
-        console.error(error)
+        // console.info, not error: captureConsoleIntegration would turn an
+        // error-level log into a second Sentry event on top of the explicit
+        // captures below.
+        console.info(error)
 
         if (error instanceof Error && error.name === 'AbortError') {
             const timeoutError = new Error(`Request to ${url} timed out after ${timeoutMs}ms`)


### PR DESCRIPTION
## Problem

Three of our top-volume Sentry issues are amplification, not new signal. `captureConsoleIntegration({levels: ['error','warn']})` turns every `console.error`/`console.warn` into a Sentry event, and `fetchWithSentry` both captures the underlying failure at the call site **and** re-throws a `ServiceUnavailableError` wrapper that global handlers capture again. A single API timeout could produce up to three events:

1. the explicit timeout `captureException` (kept — this is the real signal, e.g. [PEANUT-UI-QHG](https://peanut-c34d84c05.sentry.io/issues/PEANUT-UI-QHG))
2. the re-thrown wrapper bubbling up — [PEANUT-UI-QDJ](https://peanut-c34d84c05.sentry.io/issues/PEANUT-UI-QDJ), 1.6k events
3. a consumer's `console.error` about the same failure — [PEANUT-UI-MH5](https://peanut-c34d84c05.sentry.io/issues/PEANUT-UI-MH5), 2.5k events

Separately, [PEANUT-UI-MJS](https://peanut-c34d84c05.sentry.io/issues/PEANUT-UI-MJS) (1.7k events, 854 users) is Radix's `DialogContent requires a DialogTitle` a11y warning: `BadgeStatusDrawer` is the only drawer without a `DrawerTitle`.

## Fix

- **sentry.utils.ts**: add `ServiceUnavailableError` to the ignore list — it is always a wrapper created by `fetchWithSentry` whose cause was already captured with full request context at the fetch site.
- **fetchWithSentry**: log the raw fetch rejection at `console.info` (not `error`) — the explicit `captureException` calls right below carry the full context; the error-level log only produced a duplicate event via captureConsole.
- **useTokenPrice**: the "falling back to tokenDenomination" log becomes `console.info` — the fallback is graceful and the underlying failure is already reported. The `captureException` stays for genuinely new (non-fetch) errors; beforeSend now drops the wrapper case.
- **BadgeStatusDrawer**: the badge name heading becomes the `DrawerTitle` (real a11y fix, not a suppression). Note: `DrawerTitle` adds `leading-none tracking-tight` from the shared component — minor typographic delta on this one-line title.

## Deliberately NOT suppressed

- The timeout captures themselves (`/users/me`, `/rain/cards`, `/tokens/price`) — 10s timeouts hitting 1.7k users is genuine API-latency signal.
- Capacitor "plugin is not implemented" — a top-frame occurrence means a genuinely broken binary; [PEANUT-UI-QV3](https://peanut-c34d84c05.sentry.io/issues/PEANUT-UI-QV3)'s iframe source was already fixed in 972f35458 and residual events are stale binaries (resolve in Sentry, don't filter in code).

## Testing

- `pnpm typecheck` clean, related jest tests green, prettier applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sentry error filtering to ignore re-thrown service-unavailability errors.
  * Reduced duplicate Sentry events from handled network failures.
* **UI Improvements**
  * Updated the badge status drawer header to use a consistent drawer title component.
* **Observability**
  * Adjusted fallback logging to be informational while still capturing exceptions.
* **Tests**
  * Added coverage for the new “already reported” error-filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->