### PR TITLE
test(sentry): pin /invites/validate 400 suppression in fetchWithSentry

### DIFF
--- a/src/utils/__tests__/sentry.utils.test.ts
+++ b/src/utils/__tests__/sentry.utils.test.ts
@@ -1,4 +1,77 @@
-import { sanitizeRequestBody, sanitizeResponseBody, scrubObject } from '../sentry.utils'
+import * as Sentry from '@sentry/nextjs'
+import { fetchWithSentry, sanitizeRequestBody, sanitizeResponseBody, scrubObject } from '../sentry.utils'
+
+jest.mock('@sentry/nextjs', () => ({
+    withScope: jest.fn((cb: (scope: unknown) => void) => cb({ setFingerprint: jest.fn(), setTag: jest.fn() })),
+    captureMessage: jest.fn(),
+    captureException: jest.fn(),
+}))
+
+jest.mock('../connectivity', () => ({
+    reportNetworkError: jest.fn(),
+    reportNetworkOk: jest.fn(),
+}))
+
+describe('fetchWithSentry — expected-response suppression', () => {
+    const mockResponse = (status: number, body: unknown): Response =>
+        ({
+            ok: status >= 200 && status < 300,
+            status,
+            clone: () => ({
+                json: () => Promise.resolve(body),
+                text: () => Promise.resolve(JSON.stringify(body)),
+            }),
+        }) as unknown as Response
+
+    let warnSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+        warnSpy.mockRestore()
+    })
+
+    // Pins the fix for PEANUT-UI-QDR: a 400 from /invites/validate means the
+    // user typed an invalid invite code during onboarding — expected input
+    // validation surfaced inline, not a bug. Must never reach Sentry.
+    it('does NOT report /invites/validate 400 (invalid invite code is expected user input)', async () => {
+        global.fetch = jest.fn().mockResolvedValue(mockResponse(400, { error: 'Invalid Invite' }))
+
+        const res = await fetchWithSentry('https://api.peanut.me/invites/validate', {
+            method: 'POST',
+            body: JSON.stringify({ inviteCode: 'nosuchuser' }),
+        })
+
+        expect(res.status).toBe(400)
+        expect(Sentry.captureMessage).not.toHaveBeenCalled()
+        expect(warnSpy).not.toHaveBeenCalled()
+    })
+
+    it('still reports /invites/validate 500 (real server failure)', async () => {
+        global.fetch = jest.fn().mockResolvedValue(mockResponse(500, { error: 'boom' }))
+
+        await fetchWithSentry('https://api.peanut.me/invites/validate', { method: 'POST', body: '{}' })
+
+        expect(Sentry.captureMessage).toHaveBeenCalledWith(
+            'POST to https://api.peanut.me/invites/validate failed with status 500',
+            expect.objectContaining({ level: 'error' })
+        )
+    })
+
+    it('still reports 400s from endpoints without a skip rule', async () => {
+        global.fetch = jest.fn().mockResolvedValue(mockResponse(400, { error: 'bad request' }))
+
+        await fetchWithSentry('https://api.peanut.me/some/endpoint', { method: 'POST', body: '{}' })
+
+        expect(Sentry.captureMessage).toHaveBeenCalledWith(
+            'POST to https://api.peanut.me/some/endpoint failed with status 400',
+            expect.objectContaining({ level: 'warning' })
+        )
+    })
+})
 
 describe('sanitizeRequestBody', () => {
     it('redacts the PIN-set endpoint body wholesale (sensitive URL)', () => {


### PR DESCRIPTION
## Problem

Sentry issue **PEANUT-UI-QDR** — `POST to https://api.peanut.me/invites/validate failed with status 400` — accumulated **2,850 events from 701 users in 14 days**, culprit page `/setup`.

## Root cause

The 400 is an **expected user-input outcome**, not a bug:

- On `/setup`, `JoinWaitlist` debounce-validates the invite-code input (750ms, min-length gated) against `POST /invites/validate`.
- The backend (`peanut-api-ts/src/routes/invite.ts`) returns `400 Invalid Invite` whenever the typed code doesn't resolve to an existing inviter with app access — i.e. any typo'd or unknown username. The UI already handles this gracefully with an inline "inviter not found" error.
- `fetchWithSentry` reported every non-OK response to Sentry, so each invalid attempt became an event (~4 events/user matches debounced retyping).
- The volume spike from ~July 5 coincides with the iOS launch wave (July 4–7 native/setup commits) funneling many new users through `/setup`.

The suppression fix already landed: f3d8090b1 (July 8) added `/invites/validate` 400 to `SKIP_REPORTING` on `main`, and it reached `feat/mobile-release` on July 9 — which is why the issue is tapering. The residual trickle is stale clients (old native bundles pre-OTA / cached web sessions) and will die off on its own.

**Gap found:** nothing pinned that fix. `sentry.utils.test.ts` never exercised the `shouldSkipReporting` path of `fetchWithSentry` at all, so a refactor of the skip rules could silently resurrect the noise.

## Fix

Regression tests for the suppression contract in `fetchWithSentry`:

- `/invites/validate` 400 → no `Sentry.captureMessage`, no `console.warn` (which would otherwise become a breadcrumb via forward-logs)
- `/invites/validate` 500 → still reported at `error` level (real server failures stay visible)
- unlisted endpoint 400 → still reported at `warning` level

No production code change needed — the suppression is correct and shipped.

## Impact

- Locks in the removal of ~2,850 events/14d of Sentry noise so the skip rule can't regress unnoticed.
- No user-facing change: onboarding already surfaces invalid codes inline, and PostHog still tracks `invite_code_validated` for funnel analytics.

## Testing

`pnpm jest src/utils/__tests__/sentry.utils.test.ts` — 23 passed (3 new + 20 existing). File formatted with prettier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage ensuring expected invalid invite-code responses do not trigger error reporting or console warnings.
  * Verified that genuine server failures and unexpected client errors continue to be reported appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->