### PR TITLE
fix(sentry): match ignore patterns per-field in shouldIgnoreError

### DIFF
--- a/sentry.utils.ts
+++ b/sentry.utils.ts
@@ -7,7 +7,7 @@ import type { ErrorEvent } from '@sentry/nextjs'
  * Patterns to filter out from Sentry reporting.
  * These are generally noise that doesn't require action.
  */
-const IGNORED_ERRORS = {
+const IGNORED_ERRORS: Record<string, Array<string | RegExp>> = {
     // User-initiated cancellations (not bugs)
     userRejected: [
         'User rejected',
@@ -46,6 +46,10 @@ const IGNORED_ERRORS = {
         // which is always true on capacitor://localhost — it then proceeds and the
         // camera works. Pure noise on native (PEANUT-UI-R1M).
         'The camera stream is only accessible if the page is transferred via https',
+        // Capacitor plugin calls (StatusBar, Keyboard, App, …) running inside the
+        // /crisp-proxy iframe, where the native bridge isn't injected — pure noise,
+        // not a broken binary (PEANUT-UI-QV3).
+        /"[a-z]+" plugin is not implemented on/i,
     ],
 }
 
@@ -63,7 +67,9 @@ export function shouldIgnoreError(event: ErrorEvent): boolean {
     // Check all ignore patterns
     for (const patterns of Object.values(IGNORED_ERRORS)) {
         for (const pattern of patterns) {
-            if (searchText.includes(pattern.toLowerCase())) {
+            const matches =
+                typeof pattern === 'string' ? searchText.includes(pattern.toLowerCase()) : pattern.test(searchText)
+            if (matches) {
                 return true
             }
         }

--- a/sentry.utils.ts
+++ b/sentry.utils.ts
@@ -62,13 +62,16 @@ export function shouldIgnoreError(event: ErrorEvent): boolean {
     const exceptionType = event.exception?.values?.[0]?.type || ''
     const culprit = (event as any).culprit || ''
 
-    const searchText = `${message} ${exceptionValue} ${exceptionType} ${culprit}`.toLowerCase()
+    // Match each field independently — concatenating them would let a pattern
+    // match across unrelated fields and suppress a legitimate event.
+    const searchTexts = [message, exceptionValue, exceptionType, culprit]
 
     // Check all ignore patterns
     for (const patterns of Object.values(IGNORED_ERRORS)) {
         for (const pattern of patterns) {
-            const matches =
-                typeof pattern === 'string' ? searchText.includes(pattern.toLowerCase()) : pattern.test(searchText)
+            const matches = searchTexts.some((text) =>
+                typeof pattern === 'string' ? text.toLowerCase().includes(pattern.toLowerCase()) : pattern.test(text)
+            )
             if (matches) {
                 return true
             }

--- a/sentry.utils.ts
+++ b/sentry.utils.ts
@@ -7,7 +7,7 @@ import type { ErrorEvent } from '@sentry/nextjs'
  * Patterns to filter out from Sentry reporting.
  * These are generally noise that doesn't require action.
  */
-const IGNORED_ERRORS: Record<string, Array<string | RegExp>> = {
+const IGNORED_ERRORS = {
     // User-initiated cancellations (not bugs)
     userRejected: [
         'User rejected',
@@ -46,10 +46,6 @@ const IGNORED_ERRORS: Record<string, Array<string | RegExp>> = {
         // which is always true on capacitor://localhost — it then proceeds and the
         // camera works. Pure noise on native (PEANUT-UI-R1M).
         'The camera stream is only accessible if the page is transferred via https',
-        // Capacitor plugin calls (StatusBar, Keyboard, App, …) running inside the
-        // /crisp-proxy iframe, where the native bridge isn't injected — pure noise,
-        // not a broken binary (PEANUT-UI-QV3).
-        /"[a-z]+" plugin is not implemented on/i,
     ],
 }
 
@@ -69,10 +65,7 @@ export function shouldIgnoreError(event: ErrorEvent): boolean {
     // Check all ignore patterns
     for (const patterns of Object.values(IGNORED_ERRORS)) {
         for (const pattern of patterns) {
-            const matches = searchTexts.some((text) =>
-                typeof pattern === 'string' ? text.toLowerCase().includes(pattern.toLowerCase()) : pattern.test(text)
-            )
-            if (matches) {
+            if (searchTexts.some((text) => text.toLowerCase().includes(pattern.toLowerCase()))) {
                 return true
             }
         }

--- a/src/utils/__tests__/sentry-ignore.test.ts
+++ b/src/utils/__tests__/sentry-ignore.test.ts
@@ -10,34 +10,28 @@ function eventWithException(type: string, value: string): ErrorEvent {
     return { type: undefined, exception: { values: [{ type, value }] } } as ErrorEvent
 }
 
-describe('shouldIgnoreError — Capacitor plugin-not-implemented iframe noise (PEANUT-UI-QV3)', () => {
-    it('ignores "StatusBar" plugin not implemented on ios', () => {
-        expect(shouldIgnoreError(eventWithMessage('"StatusBar" plugin is not implemented on ios'))).toBe(true)
+describe('shouldIgnoreError — per-field matching', () => {
+    it('matches a pattern contained in event.message', () => {
+        expect(shouldIgnoreError(eventWithMessage('User rejected the request'))).toBe(true)
     })
 
-    it('ignores other plugin variants from the same iframe (Keyboard, App)', () => {
-        expect(shouldIgnoreError(eventWithMessage('"Keyboard" plugin is not implemented on ios'))).toBe(true)
-        expect(shouldIgnoreError(eventWithMessage('"App" plugin is not implemented on android'))).toBe(true)
-        expect(shouldIgnoreError(eventWithMessage('"StatusBar" plugin is not implemented on web'))).toBe(true)
+    it('matches a pattern contained in an exception value', () => {
+        expect(shouldIgnoreError(eventWithException('Error', 'MetaMask: user rejected signature'))).toBe(true)
     })
 
-    it('matches when the message lives in exception values instead of event.message', () => {
-        expect(shouldIgnoreError(eventWithException('Error', '"StatusBar" plugin is not implemented on ios'))).toBe(
-            true
-        )
+    it('matches case-insensitively', () => {
+        expect(shouldIgnoreError(eventWithMessage('USER REJECTED the request'))).toBe(true)
     })
 
     it('does not match across field boundaries (message + exception value concatenation)', () => {
+        // 'User rejected' split across two fields: the old concatenated-blob
+        // matching would have suppressed this unrelated event.
         const event = {
             type: undefined,
-            message: '"StatusBar"',
-            exception: { values: [{ type: 'Error', value: 'plugin is not implemented on ios' }] },
+            message: 'Signing failed for User',
+            exception: { values: [{ type: 'Error', value: 'rejected promise left unhandled' }] },
         } as unknown as ErrorEvent
         expect(shouldIgnoreError(event)).toBe(false)
-    })
-
-    it('does not match a plugin error that IS implemented-related but differently worded', () => {
-        expect(shouldIgnoreError(eventWithMessage('StatusBar plugin failed to initialize'))).toBe(false)
     })
 
     it('still reports unrelated errors', () => {
@@ -45,9 +39,9 @@ describe('shouldIgnoreError — Capacitor plugin-not-implemented iframe noise (P
     })
 })
 
-describe('shouldIgnoreError — existing string patterns still work', () => {
-    it('ignores user rejections', () => {
-        expect(shouldIgnoreError(eventWithMessage('User rejected the request'))).toBe(true)
+describe('shouldIgnoreError — existing patterns intact', () => {
+    it('ignores network noise', () => {
+        expect(shouldIgnoreError(eventWithException('TypeError', 'Failed to fetch'))).toBe(true)
     })
 
     it('ignores extension noise via stack frames', () => {

--- a/src/utils/__tests__/sentry-ignore.test.ts
+++ b/src/utils/__tests__/sentry-ignore.test.ts
@@ -27,6 +27,15 @@ describe('shouldIgnoreError — Capacitor plugin-not-implemented iframe noise (P
         )
     })
 
+    it('does not match across field boundaries (message + exception value concatenation)', () => {
+        const event = {
+            type: undefined,
+            message: '"StatusBar"',
+            exception: { values: [{ type: 'Error', value: 'plugin is not implemented on ios' }] },
+        } as unknown as ErrorEvent
+        expect(shouldIgnoreError(event)).toBe(false)
+    })
+
     it('does not match a plugin error that IS implemented-related but differently worded', () => {
         expect(shouldIgnoreError(eventWithMessage('StatusBar plugin failed to initialize'))).toBe(false)
     })

--- a/src/utils/__tests__/sentry-ignore.test.ts
+++ b/src/utils/__tests__/sentry-ignore.test.ts
@@ -1,0 +1,59 @@
+import type { ErrorEvent } from '@sentry/nextjs'
+
+import { shouldIgnoreError } from '../../../sentry.utils'
+
+function eventWithMessage(message: string): ErrorEvent {
+    return { type: undefined, message } as ErrorEvent
+}
+
+function eventWithException(type: string, value: string): ErrorEvent {
+    return { type: undefined, exception: { values: [{ type, value }] } } as ErrorEvent
+}
+
+describe('shouldIgnoreError — Capacitor plugin-not-implemented iframe noise (PEANUT-UI-QV3)', () => {
+    it('ignores "StatusBar" plugin not implemented on ios', () => {
+        expect(shouldIgnoreError(eventWithMessage('"StatusBar" plugin is not implemented on ios'))).toBe(true)
+    })
+
+    it('ignores other plugin variants from the same iframe (Keyboard, App)', () => {
+        expect(shouldIgnoreError(eventWithMessage('"Keyboard" plugin is not implemented on ios'))).toBe(true)
+        expect(shouldIgnoreError(eventWithMessage('"App" plugin is not implemented on android'))).toBe(true)
+        expect(shouldIgnoreError(eventWithMessage('"StatusBar" plugin is not implemented on web'))).toBe(true)
+    })
+
+    it('matches when the message lives in exception values instead of event.message', () => {
+        expect(shouldIgnoreError(eventWithException('Error', '"StatusBar" plugin is not implemented on ios'))).toBe(
+            true
+        )
+    })
+
+    it('does not match a plugin error that IS implemented-related but differently worded', () => {
+        expect(shouldIgnoreError(eventWithMessage('StatusBar plugin failed to initialize'))).toBe(false)
+    })
+
+    it('still reports unrelated errors', () => {
+        expect(shouldIgnoreError(eventWithMessage('Cannot read properties of undefined'))).toBe(false)
+    })
+})
+
+describe('shouldIgnoreError — existing string patterns still work', () => {
+    it('ignores user rejections', () => {
+        expect(shouldIgnoreError(eventWithMessage('User rejected the request'))).toBe(true)
+    })
+
+    it('ignores extension noise via stack frames', () => {
+        const event = {
+            type: undefined,
+            exception: {
+                values: [
+                    {
+                        type: 'TypeError',
+                        value: 'boom',
+                        stacktrace: { frames: [{ filename: 'chrome-extension://abc/content.js' }] },
+                    },
+                ],
+            },
+        } as unknown as ErrorEvent
+        expect(shouldIgnoreError(event)).toBe(true)
+    })
+})


### PR DESCRIPTION
## Problem

`shouldIgnoreError` in `sentry.utils.ts` matched ignore patterns against one concatenated blob of independent event fields (`message` + exception value + exception type + culprit). A pattern could therefore match *across a field boundary* — e.g. a message ending in `... User` plus an exception value starting with `rejected ...` would hit the `'User rejected'` pattern and silently suppress an unrelated, legitimate error. The ignore list also had zero test coverage.

## Fix

- Match each field independently: every candidate string is tested on its own (case-insensitive contains), so a pattern must occur entirely within a single field to suppress an event.
- No changes to the pattern list itself.

Note on PEANUT-UI-QV3 (`"StatusBar" plugin is not implemented on ios`), which this PR originally filtered: per the rationale accepted in #2448, the `/crisp-proxy` iframe source was already fixed in 972f35458 and the residual 2,211 events (6 users, last seen 6 days ago) come from stale binaries. A message-regex filter would permanently mask a *top-frame* "plugin not implemented" on a fresh binary — a genuinely broken native build we'd want paged on. So **no new filter is added**; QV3 is resolved in the Sentry dashboard instead, which is reversible (it reopens flagged as regressed if it recurs).

## Impact

- Hardened suppression correctness: cross-field false positives can no longer swallow real errors.
- Existing suppression behavior is otherwise unchanged — every current pattern still matches within its field.
- Zero user-facing change.

## Testing

- New unit suite `src/utils/__tests__/sentry-ignore.test.ts` for the previously untested `shouldIgnoreError`: per-field matching in `message` and exception values, case-insensitivity, the cross-boundary regression case (a pattern split across two fields must NOT match), unrelated errors still reported, and extension-stack-frame filtering intact.
- `pnpm jest src/utils/__tests__/sentry-ignore.test.ts src/utils/__tests__/sentry.utils.test.ts` — 27/27 pass.
- `pnpm typecheck` — clean.
- `pnpm prettier --check` on touched files — clean.
