### PR TITLE
fix(a11y): always give DrawerContent an accessible DialogTitle

### DIFF
--- a/src/components/Badges/BadgeStatusDrawer.tsx
+++ b/src/components/Badges/BadgeStatusDrawer.tsx
@@ -37,7 +37,7 @@ export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerP
     return (
         <>
             <Drawer open={isOpen} onOpenChange={onClose}>
-                <DrawerContent className="py-5" accessibleTitle={`Badge unlocked: ${displayName}`}>
+                <DrawerContent className="py-5">
                     <div className="space-y-5 p-5">
                         <Card
                             className="relative cursor-pointer p-4 md:p-6"

--- a/src/components/Badges/BadgeStatusDrawer.tsx
+++ b/src/components/Badges/BadgeStatusDrawer.tsx
@@ -37,7 +37,7 @@ export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerP
     return (
         <>
             <Drawer open={isOpen} onOpenChange={onClose}>
-                <DrawerContent className="py-5">
+                <DrawerContent className="py-5" accessibleTitle={`Badge unlocked: ${displayName}`}>
                     <div className="space-y-5 p-5">
                         <Card
                             className="relative cursor-pointer p-4 md:p-6"

--- a/src/components/Global/Drawer/__tests__/Drawer.test.tsx
+++ b/src/components/Global/Drawer/__tests__/Drawer.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react'
+import { Drawer, DrawerContent, DrawerTitle } from '..'
+
+beforeAll(() => {
+    window.matchMedia =
+        window.matchMedia ||
+        ((query: string) =>
+            ({
+                matches: false,
+                media: query,
+                addEventListener: () => {},
+                removeEventListener: () => {},
+                addListener: () => {},
+                removeListener: () => {},
+                dispatchEvent: () => false,
+                onchange: null,
+            }) as MediaQueryList)
+})
+
+describe('DrawerContent accessibility', () => {
+    it('renders a visually hidden DialogTitle from accessibleTitle', () => {
+        render(
+            <Drawer open>
+                <DrawerContent accessibleTitle="Badge unlocked">
+                    <div>body</div>
+                </DrawerContent>
+            </Drawer>
+        )
+
+        const dialog = screen.getByRole('dialog')
+        const title = screen.getByText('Badge unlocked')
+        expect(title).toHaveClass('sr-only')
+        expect(dialog).toHaveAttribute('aria-labelledby', title.id)
+    })
+
+    it('labels the dialog with an explicit DrawerTitle child', () => {
+        render(
+            <Drawer open>
+                <DrawerContent>
+                    <DrawerTitle>Choose Network</DrawerTitle>
+                </DrawerContent>
+            </Drawer>
+        )
+
+        const dialog = screen.getByRole('dialog')
+        const title = screen.getByText('Choose Network')
+        expect(dialog).toHaveAttribute('aria-labelledby', title.id)
+    })
+
+    it('does not trigger the Radix missing-DialogTitle warning when accessibleTitle is set', () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+        render(
+            <Drawer open>
+                <DrawerContent accessibleTitle="Transaction Details">
+                    <div>body</div>
+                </DrawerContent>
+            </Drawer>
+        )
+
+        const logged = errorSpy.mock.calls.flat().join(' ')
+        expect(logged).not.toContain('DialogTitle')
+        errorSpy.mockRestore()
+    })
+})

--- a/src/components/Global/Drawer/__tests__/Drawer.test.tsx
+++ b/src/components/Global/Drawer/__tests__/Drawer.test.tsx
@@ -50,16 +50,19 @@ describe('DrawerContent accessibility', () => {
     it('does not trigger the Radix missing-DialogTitle warning when accessibleTitle is set', () => {
         const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
-        render(
-            <Drawer open>
-                <DrawerContent accessibleTitle="Transaction Details">
-                    <div>body</div>
-                </DrawerContent>
-            </Drawer>
-        )
+        try {
+            render(
+                <Drawer open>
+                    <DrawerContent accessibleTitle="Transaction Details">
+                        <div>body</div>
+                    </DrawerContent>
+                </Drawer>
+            )
 
-        const logged = errorSpy.mock.calls.flat().join(' ')
-        expect(logged).not.toContain('DialogTitle')
-        errorSpy.mockRestore()
+            const logged = errorSpy.mock.calls.flat().join(' ')
+            expect(logged).not.toContain('DialogTitle')
+        } finally {
+            errorSpy.mockRestore()
+        }
     })
 })

--- a/src/components/Global/Drawer/index.tsx
+++ b/src/components/Global/Drawer/index.tsx
@@ -23,31 +23,36 @@ const DrawerOverlay = React.forwardRef<
 ))
 DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName
 
-const DrawerContent = React.forwardRef<
-    React.ElementRef<typeof DrawerPrimitive.Content>,
-    React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-    <DrawerPortal>
-        <DrawerOverlay />
-        <DrawerPrimitive.Content
-            ref={ref}
-            className={twMerge(
-                'fixed inset-x-0 bottom-0 z-50 mt-24 flex flex-col rounded-t-[10px] border bg-background',
-                className
-            )}
-            aria-describedby={undefined}
-            {...props}
-            onTouchMove={(e) => e.stopPropagation()}
-        >
-            <div className="mx-auto my-4 h-1.5 w-10 rounded-full bg-black" />
-            <div className="flex w-full justify-center">
-                <div className="max-h-[80vh] w-full overflow-auto pb-[env(safe-area-inset-bottom)] md:max-w-xl">
-                    {children}
+type DrawerContentProps = React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content> & {
+    /** Screen-reader-only DialogTitle for drawers without a visible DrawerTitle (Radix a11y requirement). */
+    accessibleTitle?: string
+}
+
+const DrawerContent = React.forwardRef<React.ElementRef<typeof DrawerPrimitive.Content>, DrawerContentProps>(
+    ({ className, children, accessibleTitle, ...props }, ref) => (
+        <DrawerPortal>
+            <DrawerOverlay />
+            <DrawerPrimitive.Content
+                ref={ref}
+                className={twMerge(
+                    'fixed inset-x-0 bottom-0 z-50 mt-24 flex flex-col rounded-t-[10px] border bg-background',
+                    className
+                )}
+                aria-describedby={undefined}
+                {...props}
+                onTouchMove={(e) => e.stopPropagation()}
+            >
+                {accessibleTitle && <DrawerTitle className="sr-only">{accessibleTitle}</DrawerTitle>}
+                <div className="mx-auto my-4 h-1.5 w-10 rounded-full bg-black" />
+                <div className="flex w-full justify-center">
+                    <div className="max-h-[80vh] w-full overflow-auto pb-[env(safe-area-inset-bottom)] md:max-w-xl">
+                        {children}
+                    </div>
                 </div>
-            </div>
-        </DrawerPrimitive.Content>
-    </DrawerPortal>
-))
+            </DrawerPrimitive.Content>
+        </DrawerPortal>
+    )
+)
 DrawerContent.displayName = 'DrawerContent'
 
 const DrawerHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (


### PR DESCRIPTION
## Problem

Sentry issue [PEANUT-UI-MJS](https://peanut-c34d84c05.sentry.io/issues/?query=PEANUT-UI-MJS): `DialogContent requires a DialogTitle for the component to be accessible for screen reader users.` — 1,703 events in 14 days across 854 users, culprit page `/home`.

This is Radix Dialog's dev-mode accessibility warning (our `Drawer` wrapper is built on vaul, which is built on Radix Dialog). Any `DrawerContent` rendered without a `DrawerTitle` logs it to the console on every open, and the `captureConsole` Sentry integration amplifies it into an event per occurrence. It is also a real accessibility defect: screen readers announce the dialog with no name.

The one instance currently missing a title (`BadgeStatusDrawer`, opened from the badge strip on `/home`) is fixed in **#2448** with a *visible* `DrawerTitle` (the badge name), which is the better a11y outcome there. This PR ships the reusable mechanism and the guardrail so the class of bug can't quietly come back; it no longer touches `BadgeStatusDrawer` and shares no files with #2448 — the two PRs can merge in any order.

## Fix

- `DrawerContent` (`src/components/Global/Drawer`) now accepts an `accessibleTitle` prop that renders a visually hidden (`sr-only`) `DrawerTitle`, for drawers whose design has no visible heading — same idiom already used manually in `KycStatusDrawer`, `TransactionDetailsDrawer`, and `TokenSelector`, now available as a one-prop path.
- Regression tests pin the labelling contract: `accessibleTitle` produces a DialogTitle wired to the dialog's `aria-labelledby`, an explicit `DrawerTitle` child still labels the dialog, and the Radix missing-DialogTitle warning does not fire when the prop is used.
- No warning suppression anywhere.

Audited all `DrawerContent` usages (ContributorsDrawer, CardUnlockDrawer, KycStatusDrawer, TransactionDetailsDrawer, ChooseNetworkDrawer, TokenSelector, QRBottomDrawer, dev DS pages): with #2448, all render a `DrawerTitle`. The headlessui-based `Modal` is unaffected (different library, no Radix warning).

## Impact

- Prevents recurrence of the PEANUT-UI-MJS class of bug: future drawers without a visible heading have a one-prop path to a proper accessible name, and the new tests guard the DialogTitle contract on the shared wrapper. (The instance fix that removes the current ~1.7k events / 14 days ships in #2448.)
- Screen-reader labelling behaviour of the shared drawer is now under test.

## Testing

- New `src/components/Global/Drawer/__tests__/Drawer.test.tsx`: asserts `accessibleTitle` renders an `sr-only` title wired to the dialog's `aria-labelledby`, that an explicit `DrawerTitle` child still labels the dialog, and that the Radix missing-DialogTitle console warning does not fire — 3/3 pass (re-verified after scoping out the BadgeStatusDrawer change; the suite is Drawer-generic).
- `pnpm tsc --noEmit` clean (0 errors); prettier clean on touched files.
