### PR TITLE
feat(kyc): honest UK-resident block on Bridge bank flows (TASK-20729)

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -11,7 +11,7 @@ import { formatAmount } from '@/utils/general.utils'
 import { countryData } from '@/components/AddMoney/consts'
 import { useAuth } from '@/context/authContext'
 import { useCapabilities } from '@/hooks/useCapabilities'
-import { getKycModalVariant, getGateUserMessage } from '@/utils/capability-gate'
+import { resolveKycModalVariant, getGateUserMessage } from '@/utils/capability-gate'
 import { useModalsContext } from '@/context/ModalsContext'
 import { useCreateOnramp, GENERIC_ONRAMP_ERROR } from '@/hooks/useCreateOnramp'
 import { useParams, useSearchParams } from 'next/navigation'
@@ -502,11 +502,7 @@ export default function OnrampBankPage() {
                     }}
                     isLoading={sumsubFlow.isLoading}
                     error={sumsubFlow.error}
-                    variant={
-                        'reason' in gate && gate.reason?.code === 'uk_resident_blocked'
-                            ? 'region-unavailable'
-                            : getKycModalVariant(gate.kind)
-                    }
+                    variant={resolveKycModalVariant(gate)}
                     providerMessage={getGateUserMessage(gate)}
                     regionName={selectedCountry?.title}
                 />

--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -502,7 +502,11 @@ export default function OnrampBankPage() {
                     }}
                     isLoading={sumsubFlow.isLoading}
                     error={sumsubFlow.error}
-                    variant={getKycModalVariant(gate.kind)}
+                    variant={
+                        'reason' in gate && gate.reason?.code === 'uk_resident_blocked'
+                            ? 'region-unavailable'
+                            : getKycModalVariant(gate.kind)
+                    }
                     providerMessage={getGateUserMessage(gate)}
                     regionName={selectedCountry?.title}
                 />

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -37,7 +37,7 @@ import { useAdvisoryPreempt } from '@/hooks/useAdvisoryPreempt'
 import { useEeaUpliftFunnel } from '@/hooks/useEeaUpliftFunnel'
 import { upliftTriggerFromGate, upliftTriggerFromAdvisory } from '@/utils/eea-uplift.utils'
 import { useCapabilities } from '@/hooks/useCapabilities'
-import { getKycModalVariant, getGateUserMessage } from '@/utils/capability-gate'
+import { resolveKycModalVariant, getGateUserMessage } from '@/utils/capability-gate'
 import { useModalsContext } from '@/context/ModalsContext'
 import ExchangeRate from '@/components/ExchangeRate'
 import countryCurrencyMappings, { isNonEuroSepaCountry } from '@/constants/countryCurrencyMapping'
@@ -594,11 +594,7 @@ export default function WithdrawBankPage() {
                 }}
                 isLoading={sumsubFlow.isLoading}
                 error={sumsubFlow.error}
-                variant={
-                    'reason' in gate && gate.reason?.code === 'uk_resident_blocked'
-                        ? 'region-unavailable'
-                        : getKycModalVariant(gate.kind)
-                }
+                variant={resolveKycModalVariant(gate)}
                 providerMessage={getGateUserMessage(gate)}
                 regionName={getCountryFromPath(country)?.title}
             />

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -594,7 +594,11 @@ export default function WithdrawBankPage() {
                 }}
                 isLoading={sumsubFlow.isLoading}
                 error={sumsubFlow.error}
-                variant={getKycModalVariant(gate.kind)}
+                variant={
+                    'reason' in gate && gate.reason?.code === 'uk_resident_blocked'
+                        ? 'region-unavailable'
+                        : getKycModalVariant(gate.kind)
+                }
                 providerMessage={getGateUserMessage(gate)}
                 regionName={getCountryFromPath(country)?.title}
             />

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -373,7 +373,11 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                 }}
                 isLoading={sumsubFlow.isLoading}
                 error={sumsubFlow.error}
-                variant={getKycModalVariant(gate.kind)}
+                variant={
+                    'reason' in gate && gate.reason?.code === 'uk_resident_blocked'
+                        ? 'region-unavailable'
+                        : getKycModalVariant(gate.kind)
+                }
                 providerMessage={getGateUserMessage(gate)}
                 regionName={currentCountry?.title}
             />

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -29,7 +29,7 @@ import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
 import { useCapabilities } from '@/hooks/useCapabilities'
-import { getKycModalVariant, getGateUserMessage } from '@/utils/capability-gate'
+import { resolveKycModalVariant, getGateUserMessage } from '@/utils/capability-gate'
 import { railJurisdictionForBank } from '@/utils/bridge.utils'
 import { getRegionIntent } from '@/utils/regions.utils'
 import { useTosGuard } from '@/hooks/useTosGuard'
@@ -373,11 +373,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                 }}
                 isLoading={sumsubFlow.isLoading}
                 error={sumsubFlow.error}
-                variant={
-                    'reason' in gate && gate.reason?.code === 'uk_resident_blocked'
-                        ? 'region-unavailable'
-                        : getKycModalVariant(gate.kind)
-                }
+                variant={resolveKycModalVariant(gate)}
                 providerMessage={getGateUserMessage(gate)}
                 regionName={currentCountry?.title}
             />

--- a/src/components/Kyc/InitiateKycModal.tsx
+++ b/src/components/Kyc/InitiateKycModal.tsx
@@ -11,7 +11,7 @@ interface InitiateKycModalProps {
     /** error message from a failed verify/resubmit attempt */
     error?: string | null
     /** when set, shows context-specific messaging instead of the generic "unlock" copy */
-    variant?: 'default' | 'provider_rejection' | 'blocked' | 'restart_identity' | 'cross_region'
+    variant?: 'default' | 'provider_rejection' | 'blocked' | 'restart_identity' | 'cross_region' | 'region-unavailable'
     providerMessage?: string
     /** country name shown in cross_region variant (e.g. "Brazil", "Argentina") */
     regionName?: string
@@ -38,9 +38,11 @@ export const InitiateKycModal = ({
     const isBlocked = variant === 'blocked'
     const isRestartIdentity = variant === 'restart_identity'
     const isCrossRegion = variant === 'cross_region'
+    const isRegionUnavailable = variant === 'region-unavailable'
 
     const getTitle = () => {
         if (error) return 'Something went wrong'
+        if (isRegionUnavailable) return 'Not available in the UK'
         if (isBlocked) return 'We couldn’t unlock this'
         if (isRestartIdentity) return 'Verify with a different document'
         if (isProviderRejection) return 'We need extra documents'
@@ -50,6 +52,11 @@ export const InitiateKycModal = ({
 
     const getDescription = () => {
         if (error) return `${error} Please contact support for assistance.`
+        if (isRegionUnavailable)
+            return (
+                providerMessage ||
+                "Bank transfers and the Peanut Card aren't available for UK residents due to regulatory restrictions. You can still use Peanut for crypto."
+            )
         if (isBlocked) return providerMessage || "We couldn't confirm your ID. Please contact support for assistance."
         if (isRestartIdentity)
             return (
@@ -70,6 +77,9 @@ export const InitiateKycModal = ({
                 text: 'Contact support',
                 onClick: onContactSupport ?? onClose,
             }
+        }
+        if (isRegionUnavailable) {
+            return { text: 'Got it', onClick: onClose }
         }
         if (isRestartIdentity) {
             return {
@@ -107,8 +117,8 @@ export const InitiateKycModal = ({
             title={getTitle()}
             description={getDescription()}
             preventClose
-            icon={(error || isBlocked || isRestartIdentity ? 'alert' : 'badge') as IconName}
-            iconContainerClassName={isBlocked || isRestartIdentity ? 'bg-yellow-1' : ''}
+            icon={(error || isBlocked || isRestartIdentity || isRegionUnavailable ? 'alert' : 'badge') as IconName}
+            iconContainerClassName={isBlocked || isRestartIdentity || isRegionUnavailable ? 'bg-yellow-1' : ''}
             modalPanelClassName="max-w-full m-2"
             ctaClassName="grid grid-cols-1 gap-3"
             ctas={[
@@ -123,7 +133,7 @@ export const InitiateKycModal = ({
                 },
             ]}
             footer={
-                isProviderRejection || isBlocked || isRestartIdentity ? undefined : (
+                isProviderRejection || isBlocked || isRestartIdentity || isRegionUnavailable ? undefined : (
                     <PeanutDoesntStoreAnyPersonalInformation className="w-full justify-center" />
                 )
             }

--- a/src/components/Kyc/InitiateKycModal.tsx
+++ b/src/components/Kyc/InitiateKycModal.tsx
@@ -1,3 +1,6 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
 import ActionModal from '@/components/Global/ActionModal'
 import { type IconName } from '@/components/Global/Icons/Icon'
 import { PeanutDoesntStoreAnyPersonalInformation } from '@/components/Kyc/PeanutDoesntStoreAnyPersonalInformation'
@@ -39,10 +42,11 @@ export const InitiateKycModal = ({
     const isRestartIdentity = variant === 'restart_identity'
     const isCrossRegion = variant === 'cross_region'
     const isRegionUnavailable = variant === 'region-unavailable'
+    const router = useRouter()
 
     const getTitle = () => {
         if (error) return 'Something went wrong'
-        if (isRegionUnavailable) return 'Not available in the UK'
+        if (isRegionUnavailable) return 'Not available for UK residents'
         if (isBlocked) return 'We couldn’t unlock this'
         if (isRestartIdentity) return 'Verify with a different document'
         if (isProviderRejection) return 'We need extra documents'
@@ -53,10 +57,7 @@ export const InitiateKycModal = ({
     const getDescription = () => {
         if (error) return `${error} Please contact support for assistance.`
         if (isRegionUnavailable)
-            return (
-                providerMessage ||
-                "Bank transfers and the Peanut Card aren't available for UK residents due to regulatory restrictions. You can still use Peanut for crypto."
-            )
+            return "Due to UK regulations, bank transfers aren't available for UK residents. Your funds are safe — you can withdraw them as crypto anytime."
         if (isBlocked) return providerMessage || "We couldn't confirm your ID. Please contact support for assistance."
         if (isRestartIdentity)
             return (
@@ -79,7 +80,13 @@ export const InitiateKycModal = ({
             }
         }
         if (isRegionUnavailable) {
-            return { text: 'Got it', onClick: onClose }
+            return {
+                text: 'Withdraw funds',
+                onClick: () => {
+                    onClose()
+                    router.push('/withdraw')
+                },
+            }
         }
         if (isRestartIdentity) {
             return {

--- a/src/utils/capability-gate.ts
+++ b/src/utils/capability-gate.ts
@@ -382,6 +382,16 @@ export function getKycModalVariant(
 }
 
 /**
+ * Resolve the InitiateKycModal variant for a gate. Adds the UK-resident
+ * 'region-unavailable' case (TASK-20729) on top of the base kind->variant map,
+ * so the three add/withdraw entry points don't each re-implement the check.
+ */
+export function resolveKycModalVariant(gate: GateState): ReturnType<typeof getKycModalVariant> | 'region-unavailable' {
+    if ('reason' in gate && gate.reason?.code === 'uk_resident_blocked') return 'region-unavailable'
+    return getKycModalVariant(gate.kind)
+}
+
+/**
  * Extract the user-facing message from a gate state (was
  * `getGateProviderMessage` — but the message has never been provider-named, it's
  * `reason.userMessage` from the BE which is already user-friendly + provider-blind).


### PR DESCRIPTION
## Summary
Surface the **UK-resident block honestly** on the Bridge bank deposit/withdraw flows. The backend (peanut-api-ts PR, TASK-20729) now marks every Bridge rail `blocked` for UK residents with `reason.code = 'uk_resident_blocked'`. Without this, the FE would show the generic *"We couldn't unlock this / contact support"* (ID-failure) framing — wrong and misleading for a regulatory block.

- `InitiateKycModal` gains a **`region-unavailable`** variant — title "Not available in the UK", regulatory copy, a single **"Got it"** dismiss (no verify, no contact-support).
- `add-money/[country]/bank` + `withdraw/[country]/bank` pick that variant when `gate.reason?.code === 'uk_resident_blocked'`.
- The **card** block rides on the existing eligibility machinery (BE denylist → `info.ts` returns not-eligible for GB, same path as other prohibited countries).

## Risks / breaking changes
- **Cross-repo:** depends on the peanut-api-ts PR emitting `uk_resident_blocked`. Until BE ships, this variant simply never triggers (no regression). BE-first deploy is safe.
- Presentational only — no capability logic changed on the FE.

## QA
- `add-money-states` + `withdraw-states` suites pass with the change.
- Typecheck clean for touched files (only pre-existing `@capacitor/*` native-module resolution noise in the worktree).
- Manual: as a UK-resident (Bridge `bridge_geo=GB`), add-money → bank and withdraw → bank show "Not available in the UK" instead of a KYC/contact-support modal; non-UK users unaffected.


<img width="370" height="786" alt="image" src="https://github.com/user-attachments/assets/fdebf7e5-3c6d-465e-8663-2a7718021c89" />

<img width="353" height="328" alt="Screenshot 2026-07-21 at 2 54 31 PM" src="https://github.com/user-attachments/assets/dd662f15-aeb4-4528-8d27-c74a4c601db1" />
