### PR TITLE
fix: block crypto withdrawals below Rhino route minimums

### DIFF
--- a/src/app/(mobile-ui)/withdraw/__tests__/withdraw-states.test.tsx
+++ b/src/app/(mobile-ui)/withdraw/__tests__/withdraw-states.test.tsx
@@ -413,44 +413,6 @@ describe('GROUP 3: Amount Validation', () => {
         expect(mockRouterPush).toHaveBeenCalledWith('/withdraw/crypto')
     })
 
-    test('Crypto amount under $0.50 shows the bridge-minimums notice, non-blocking', () => {
-        mockWithdrawFlow.selectedMethod = { type: 'crypto' }
-        mockWithdrawFlow.amountToWithdraw = '0.3'
-
-        renderWithdraw()
-
-        expect(screen.getByText(/Bridging to another network needs at least \$0\.50/)).toBeInTheDocument()
-        expect(screen.getByText('Continue')).not.toBeDisabled()
-    })
-
-    test('Crypto amount under $5 shows the Ethereum minimum notice, non-blocking', () => {
-        mockWithdrawFlow.selectedMethod = { type: 'crypto' }
-        mockWithdrawFlow.amountToWithdraw = '2'
-
-        renderWithdraw()
-
-        expect(screen.getByText(/Ethereum mainnet needs at least \$5/)).toBeInTheDocument()
-        expect(screen.getByText('Continue')).not.toBeDisabled()
-    })
-
-    test('Crypto amount at $5+ shows no Ethereum notice', () => {
-        mockWithdrawFlow.selectedMethod = { type: 'crypto' }
-        mockWithdrawFlow.amountToWithdraw = '5'
-
-        renderWithdraw()
-
-        expect(screen.queryByText(/Ethereum mainnet needs at least \$5/)).not.toBeInTheDocument()
-    })
-
-    test('Bank withdrawal shows no Ethereum notice', () => {
-        mockWithdrawFlow.selectedMethod = { type: 'bridge', countryPath: 'us' }
-        mockWithdrawFlow.amountToWithdraw = '2'
-
-        renderWithdraw()
-
-        expect(screen.queryByText(/Ethereum mainnet needs at least \$5/)).not.toBeInTheDocument()
-    })
-
     test('Bank withdrawal keeps the $1 minimum for sub-$1 amounts', async () => {
         mockWithdrawFlow.selectedMethod = { type: 'bridge', countryPath: 'us' }
         mockWithdrawFlow.amountToWithdraw = '0.5'

--- a/src/app/(mobile-ui)/withdraw/__tests__/withdraw-states.test.tsx
+++ b/src/app/(mobile-ui)/withdraw/__tests__/withdraw-states.test.tsx
@@ -436,7 +436,7 @@ describe('GROUP 3: Amount Validation', () => {
 
         renderWithdraw()
 
-        expect(screen.getByText(/Ethereum mainnet withdrawals need at least \$5/)).toBeInTheDocument()
+        expect(screen.getByText(/Ethereum mainnet needs at least \$5/)).toBeInTheDocument()
         expect(screen.getByText('Continue')).not.toBeDisabled()
     })
 
@@ -446,7 +446,7 @@ describe('GROUP 3: Amount Validation', () => {
 
         renderWithdraw()
 
-        expect(screen.queryByText(/Ethereum mainnet withdrawals need at least \$5/)).not.toBeInTheDocument()
+        expect(screen.queryByText(/Ethereum mainnet needs at least \$5/)).not.toBeInTheDocument()
     })
 
     test('Bank withdrawal shows no Ethereum notice', () => {
@@ -455,7 +455,7 @@ describe('GROUP 3: Amount Validation', () => {
 
         renderWithdraw()
 
-        expect(screen.queryByText(/Ethereum mainnet withdrawals need at least \$5/)).not.toBeInTheDocument()
+        expect(screen.queryByText(/Ethereum mainnet needs at least \$5/)).not.toBeInTheDocument()
     })
 
     test('Bank withdrawal keeps the $1 minimum for sub-$1 amounts', async () => {

--- a/src/app/(mobile-ui)/withdraw/__tests__/withdraw-states.test.tsx
+++ b/src/app/(mobile-ui)/withdraw/__tests__/withdraw-states.test.tsx
@@ -395,10 +395,11 @@ describe('GROUP 3: Amount Validation', () => {
         expect(screen.getByTestId('limits-warning-card')).toBeInTheDocument()
     })
 
-    test('Crypto withdrawal allows sub-$1 amounts (no fiat-rail minimum)', () => {
+    test('Crypto withdrawal allows sub-$1 amounts down to the $0.50 bridge floor', () => {
         // Regression: the shared amount step applied the bank $1 minimum to
         // crypto (getMinimumAmount('') → 1), blocking sub-$1 on-chain sends
-        // that send-via-link already allows.
+        // that send-via-link already allows. Crypto's own floor is Rhino's
+        // $0.50 route minimum — $0.50 exactly must still pass.
         mockWithdrawFlow.selectedMethod = { type: 'crypto' }
         mockWithdrawFlow.amountToWithdraw = '0.5'
 
@@ -409,6 +410,52 @@ describe('GROUP 3: Amount Validation', () => {
 
         fireEvent.click(continueBtn)
         expect(mockRouterPush).toHaveBeenCalledWith('/withdraw/crypto')
+    })
+
+    test('Crypto withdrawal blocks below the $0.50 bridge floor', async () => {
+        // Rhino parks (doesn't refund) bridge deposits under the route minimum,
+        // so amounts under $0.50 never leave the amount step.
+        mockWithdrawFlow.selectedMethod = { type: 'crypto' }
+        mockWithdrawFlow.amountToWithdraw = '0.4'
+
+        renderWithdraw()
+
+        expect(screen.getByText('Continue')).toBeDisabled()
+        // validation is debounced 300ms behind typing
+        await waitFor(() =>
+            expect(mockSetError).toHaveBeenCalledWith({
+                showError: true,
+                errorMessage: 'Minimum withdrawal is $0.50.',
+            })
+        )
+    })
+
+    test('Crypto amount under $5 shows the Ethereum minimum notice, non-blocking', () => {
+        mockWithdrawFlow.selectedMethod = { type: 'crypto' }
+        mockWithdrawFlow.amountToWithdraw = '2'
+
+        renderWithdraw()
+
+        expect(screen.getByText(/Ethereum mainnet withdrawals need at least \$5/)).toBeInTheDocument()
+        expect(screen.getByText('Continue')).not.toBeDisabled()
+    })
+
+    test('Crypto amount at $5+ shows no Ethereum notice', () => {
+        mockWithdrawFlow.selectedMethod = { type: 'crypto' }
+        mockWithdrawFlow.amountToWithdraw = '5'
+
+        renderWithdraw()
+
+        expect(screen.queryByText(/Ethereum mainnet withdrawals need at least \$5/)).not.toBeInTheDocument()
+    })
+
+    test('Bank withdrawal shows no Ethereum notice', () => {
+        mockWithdrawFlow.selectedMethod = { type: 'bridge', countryPath: 'us' }
+        mockWithdrawFlow.amountToWithdraw = '2'
+
+        renderWithdraw()
+
+        expect(screen.queryByText(/Ethereum mainnet withdrawals need at least \$5/)).not.toBeInTheDocument()
     })
 
     test('Bank withdrawal keeps the $1 minimum for sub-$1 amounts', async () => {

--- a/src/app/(mobile-ui)/withdraw/__tests__/withdraw-states.test.tsx
+++ b/src/app/(mobile-ui)/withdraw/__tests__/withdraw-states.test.tsx
@@ -395,13 +395,14 @@ describe('GROUP 3: Amount Validation', () => {
         expect(screen.getByTestId('limits-warning-card')).toBeInTheDocument()
     })
 
-    test('Crypto withdrawal allows sub-$1 amounts down to the $0.50 bridge floor', () => {
+    test('Crypto withdrawal has no amount-step minimum (parity with send-via-link)', () => {
         // Regression: the shared amount step applied the bank $1 minimum to
         // crypto (getMinimumAmount('') → 1), blocking sub-$1 on-chain sends
-        // that send-via-link already allows. Crypto's own floor is Rhino's
-        // $0.50 route minimum — $0.50 exactly must still pass.
+        // that send-via-link already allows. Same-chain Arbitrum withdrawals
+        // have no minimum at all; Rhino's per-network bridge minimums are
+        // enforced at review time, once the destination is known.
         mockWithdrawFlow.selectedMethod = { type: 'crypto' }
-        mockWithdrawFlow.amountToWithdraw = '0.5'
+        mockWithdrawFlow.amountToWithdraw = '0.4'
 
         renderWithdraw()
 
@@ -412,22 +413,14 @@ describe('GROUP 3: Amount Validation', () => {
         expect(mockRouterPush).toHaveBeenCalledWith('/withdraw/crypto')
     })
 
-    test('Crypto withdrawal blocks below the $0.50 bridge floor', async () => {
-        // Rhino parks (doesn't refund) bridge deposits under the route minimum,
-        // so amounts under $0.50 never leave the amount step.
+    test('Crypto amount under $0.50 shows the bridge-minimums notice, non-blocking', () => {
         mockWithdrawFlow.selectedMethod = { type: 'crypto' }
-        mockWithdrawFlow.amountToWithdraw = '0.4'
+        mockWithdrawFlow.amountToWithdraw = '0.3'
 
         renderWithdraw()
 
-        expect(screen.getByText('Continue')).toBeDisabled()
-        // validation is debounced 300ms behind typing
-        await waitFor(() =>
-            expect(mockSetError).toHaveBeenCalledWith({
-                showError: true,
-                errorMessage: 'Minimum withdrawal is $0.50.',
-            })
-        )
+        expect(screen.getByText(/Bridging to another network needs at least \$0\.50/)).toBeInTheDocument()
+        expect(screen.getByText('Continue')).not.toBeDisabled()
     })
 
     test('Crypto amount under $5 shows the Ethereum minimum notice, non-blocking', () => {

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -487,7 +487,8 @@ export default function WithdrawCryptoPage() {
 
     // Rhino accepts SDA deposits below the route minimum on-chain but never
     // bridges them — funds strand at the SDA, uncredited. Block the CTA before
-    // the user signs. Same-chain USDC transfers have no minimum.
+    // the user signs. Same-chain USDC transfers don't ride Rhino; they share
+    // the flat $0.50 floor enforced at the amount step and in handleSetupReview.
     const belowMinimumMessage = useMemo<string | null>(
         () =>
             isCrossChainWithdrawal && isBelowRhinoMinDeposit(payAmount, minDepositLimitUsd)

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -171,17 +171,24 @@ export default function WithdrawCryptoPage() {
                 return
             }
 
-            // Rhino parks (doesn't auto-refund) bridge deposits below the route
-            // minimum, so block sub-minimum withdrawals for the chosen network
-            // before any request/charge is created. amountToWithdraw is USD.
-            const usdToWithdraw = parseFloat(amountToWithdraw)
-            const minUsd = getMinWithdrawUsdForChain(data.chain.chainId)
-            if (!Number.isFinite(usdToWithdraw) || usdToWithdraw < minUsd) {
-                const minDisplay = minUsd % 1 === 0 ? `$${minUsd}` : `$${minUsd.toFixed(2)}`
-                setError(
-                    `Withdrawals to ${data.chain.networkName} need at least ${minDisplay}. Increase the amount or pick a different network.`
-                )
-                return
+            // Same-chain USDC is a direct transfer — no Rhino, no minimum
+            // (parity with send-via-link). Every other destination/token rides
+            // Rhino, which parks (doesn't auto-refund) deposits below the route
+            // minimum — block those before any request/charge is created.
+            // amountToWithdraw is USD.
+            const isSameChainUsdc =
+                data.chain.chainId.toString() === PEANUT_WALLET_CHAIN.id.toString() &&
+                data.token.address.toLowerCase() === PEANUT_WALLET_TOKEN.toLowerCase()
+            if (!isSameChainUsdc) {
+                const usdToWithdraw = parseFloat(amountToWithdraw)
+                const minUsd = getMinWithdrawUsdForChain(data.chain.chainId)
+                if (!Number.isFinite(usdToWithdraw) || usdToWithdraw < minUsd) {
+                    const minDisplay = minUsd % 1 === 0 ? `$${minUsd}` : `$${minUsd.toFixed(2)}`
+                    setError(
+                        `Withdrawals to ${data.chain.networkName} need at least ${minDisplay}. Increase the amount or pick a different network.`
+                    )
+                    return
+                }
             }
 
             clearErrors()
@@ -487,8 +494,7 @@ export default function WithdrawCryptoPage() {
 
     // Rhino accepts SDA deposits below the route minimum on-chain but never
     // bridges them — funds strand at the SDA, uncredited. Block the CTA before
-    // the user signs. Same-chain USDC transfers don't ride Rhino; they share
-    // the flat $0.50 floor enforced at the amount step and in handleSetupReview.
+    // the user signs. Same-chain USDC transfers have no minimum.
     const belowMinimumMessage = useMemo<string | null>(
         () =>
             isCrossChainWithdrawal && isBelowRhinoMinDeposit(payAmount, minDepositLimitUsd)

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -17,7 +17,7 @@ import type {
     TRequestResponse,
 } from '@/services/services.types'
 import { NATIVE_TOKEN_ADDRESS } from '@/utils/token.utils'
-import { isWithdrawFeeDisproportionate } from '@/utils/cross-chain-fee.utils'
+import { isWithdrawFeeDisproportionate, getMinWithdrawUsdForChain } from '@/utils/cross-chain-fee.utils'
 import { isAmountWithinBalance } from '@/utils/balance.utils'
 import { isBelowRhinoMinDeposit } from '@/utils/withdraw.utils'
 import * as peanutInterfaces from '@/interfaces/peanut-sdk-types'
@@ -168,6 +168,19 @@ export default function WithdrawCryptoPage() {
             if (!amountToWithdraw) {
                 console.error('Amount to withdraw is not set or not available from context')
                 setError('Withdrawal amount is missing.')
+                return
+            }
+
+            // Rhino parks (doesn't auto-refund) bridge deposits below the route
+            // minimum, so block sub-minimum withdrawals for the chosen network
+            // before any request/charge is created. amountToWithdraw is USD.
+            const usdToWithdraw = parseFloat(amountToWithdraw)
+            const minUsd = getMinWithdrawUsdForChain(data.chain.chainId)
+            if (!Number.isFinite(usdToWithdraw) || usdToWithdraw < minUsd) {
+                const minDisplay = minUsd % 1 === 0 ? `$${minUsd}` : `$${minUsd.toFixed(2)}`
+                setError(
+                    `Withdrawals to ${data.chain.networkName} need at least ${minDisplay}. Increase the amount or pick a different network.`
+                )
                 return
             }
 

--- a/src/app/(mobile-ui)/withdraw/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/page.tsx
@@ -393,7 +393,10 @@ export default function WithdrawPage() {
         // crypto amounts that clear the $0.50 floor but not Ethereum's $5 get a
         // non-blocking heads-up — the destination chain isn't chosen yet, so we
         // warn here and hard-block at review time if Ethereum is picked.
-        const typedUsd = (selectedTokenData?.price ?? 1) * parseFloat(rawTokenAmount || '0')
+        // AmountInput is pinned to USD on this page (price: 1), so read the raw
+        // value — scaling by the app-wide token price would mis-warn on stale
+        // non-USD context.
+        const typedUsd = parseFloat(rawTokenAmount || '0')
         const showEthereumMinNotice =
             isCryptoWithdraw && typedUsd >= MIN_CRYPTO_WITHDRAW_USD && typedUsd < ETHEREUM_MIN_WITHDRAW_USD
 
@@ -453,7 +456,7 @@ export default function WithdrawPage() {
                             icon="info-filled"
                             iconClassName="text-yellow-9"
                             title="Withdrawing to Ethereum?"
-                            description={`Ethereum mainnet withdrawals need at least $${ETHEREUM_MIN_WITHDRAW_USD}. Your amount works on all other networks.`}
+                            description={`Ethereum mainnet needs at least $${ETHEREUM_MIN_WITHDRAW_USD}. Your amount works on all other networks.`}
                         />
                     )}
 

--- a/src/app/(mobile-ui)/withdraw/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/page.tsx
@@ -129,10 +129,12 @@ export default function WithdrawPage() {
 
     // compute minimum withdrawal in USD using the exchange rate
     const minUsdAmount = useMemo(() => {
-        // crypto rides the Rhino bridge, which parks (doesn't refund) deposits
-        // below the route minimum — $0.50 floors every network; Ethereum's $5
-        // is enforced chain-aware at review time (see withdraw/crypto).
-        if (isCryptoWithdraw) return MIN_CRYPTO_WITHDRAW_USD
+        // no amount-step minimum for crypto: same-chain (Arbitrum) withdrawals
+        // are direct transfers with no floor, matching send-via-link. Rhino's
+        // per-network bridge minimums ($0.50, ETH $5, Tron $10) are enforced
+        // chain-aware at review time (see withdraw/crypto) — the destination
+        // isn't known yet here, so we only warn below.
+        if (isCryptoWithdraw) return 0
         const localMin = getMinimumAmount(countryIso2)
         // for US or unknown, minimum is already in USD
         if (!countryIso2 || countryIso2 === 'US') return localMin
@@ -388,15 +390,17 @@ export default function WithdrawPage() {
         // only show limits card for bank/manteca withdrawals, not crypto
         const showLimitsCard = !isCryptoWithdraw && (limitsValidation.isBlocking || limitsValidation.isWarning)
 
-        // crypto amounts that clear the $0.50 floor but not Ethereum's $5 get a
-        // non-blocking heads-up — the destination chain isn't chosen yet, so we
-        // warn here and hard-block at review time if Ethereum is picked.
-        // AmountInput is pinned to USD on this page (price: 1), so read the raw
-        // value — scaling by the app-wide token price would mis-warn on stale
-        // non-USD context.
+        // crypto amounts under a bridge minimum get a non-blocking heads-up —
+        // the destination chain isn't chosen yet (same-chain Arbitrum has no
+        // minimum at all), so we warn here and hard-block at review time only
+        // for bridged routes. AmountInput is pinned to USD on this page
+        // (price: 1), so read the raw value.
         const typedUsd = parseFloat(rawTokenAmount || '0')
-        const showEthereumMinNotice =
-            isCryptoWithdraw && typedUsd >= MIN_CRYPTO_WITHDRAW_USD && typedUsd < ETHEREUM_MIN_WITHDRAW_USD
+        const showBridgeMinNotice = isCryptoWithdraw && typedUsd > 0 && typedUsd < ETHEREUM_MIN_WITHDRAW_USD
+        const bridgeMinNoticeText =
+            typedUsd < MIN_CRYPTO_WITHDRAW_USD
+                ? `Bridging to another network needs at least $${MIN_CRYPTO_WITHDRAW_USD.toFixed(2)} — $${ETHEREUM_MIN_WITHDRAW_USD} for Ethereum mainnet. Withdrawals within Arbitrum have no minimum.`
+                : `Ethereum mainnet needs at least $${ETHEREUM_MIN_WITHDRAW_USD}. Most other networks work from $${MIN_CRYPTO_WITHDRAW_USD.toFixed(2)}.`
 
         return (
             <div className="flex min-h-[inherit] flex-col justify-start space-y-8">
@@ -447,14 +451,18 @@ export default function WithdrawPage() {
                             return limitsCardProps ? <LimitsWarningCard {...limitsCardProps} /> : null
                         })()}
 
-                    {/* heads-up for crypto amounts below Ethereum's bridge minimum */}
-                    {showEthereumMinNotice && (
+                    {/* heads-up for crypto amounts below a bridge minimum */}
+                    {showBridgeMinNotice && (
                         <InfoCard
                             variant="warning"
                             icon="info-filled"
                             iconClassName="text-yellow-9"
-                            title="Withdrawing to Ethereum?"
-                            description={`Ethereum mainnet needs at least $${ETHEREUM_MIN_WITHDRAW_USD}. Most other networks work from $${MIN_CRYPTO_WITHDRAW_USD.toFixed(2)}.`}
+                            title={
+                                typedUsd < MIN_CRYPTO_WITHDRAW_USD
+                                    ? 'Heads up: network minimums'
+                                    : 'Withdrawing to Ethereum?'
+                            }
+                            description={bridgeMinNoticeText}
                         />
                     )}
 

--- a/src/app/(mobile-ui)/withdraw/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/page.tsx
@@ -8,7 +8,6 @@ import AmountInput from '@/components/Global/AmountInput'
 import { PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
 import { useWithdrawFlow } from '@/context/WithdrawFlowContext'
 import { useWallet } from '@/hooks/wallet/useWallet'
-import { tokenSelectorContext } from '@/context/tokenSelector.context'
 import { INSUFFICIENT_BALANCE_MESSAGE } from '@/utils/balance.utils'
 import { getCountryFromAccount, getCountryFromPath, getMinimumAmount } from '@/utils/bridge.utils'
 import { MIN_CRYPTO_WITHDRAW_USD, ETHEREUM_MIN_WITHDRAW_USD } from '@/utils/cross-chain-fee.utils'
@@ -16,7 +15,7 @@ import InfoCard from '@/components/Global/InfoCard'
 import useGetExchangeRate from '@/hooks/useGetExchangeRate'
 import { AccountType } from '@/interfaces'
 import { useRouter, useSearchParams } from 'next/navigation'
-import React, { useCallback, useEffect, useMemo, useState, useRef, useContext } from 'react'
+import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react'
 import { formatUnits } from 'viem'
 import { useLimitsValidation } from '@/features/limits/hooks/useLimitsValidation'
 import LimitsWarningCard from '@/features/limits/components/LimitsWarningCard'
@@ -30,7 +29,6 @@ type WithdrawStep = 'inputAmount' | 'selectMethod'
 export default function WithdrawPage() {
     const router = useRouter()
     const searchParams = useSearchParams()
-    const { selectedTokenData } = useContext(tokenSelectorContext)
 
     // check if coming from send flow based on method query param
     const methodParam = searchParams.get('method')
@@ -200,9 +198,10 @@ export default function WithdrawPage() {
                 return false
             }
 
-            // convert the entered token amount to USD
-            const price = selectedTokenData?.price ?? 0 // 0 for safety; will fail below
-            const usdEquivalent = price ? amount * price : amount // if no price assume token pegged 1 USD
+            // AmountInput is USD-pinned on this page (price: 1), so the typed
+            // value IS the USD value — scaling by the app-wide token price let
+            // a stale non-USD price loosen or false-trip the minimums.
+            const usdEquivalent = amount
 
             // While the balance is still loading, maxDecimalAmount is 0 — skip the
             // balance check so a pre-filled amount isn't false-blocked; the effect
@@ -228,7 +227,7 @@ export default function WithdrawPage() {
             setError({ showError: true, errorMessage: message })
             return false
         },
-        [balance, maxDecimalAmount, setError, selectedTokenData?.price, isFromSendFlow, minUsdAmount]
+        [balance, maxDecimalAmount, setError, isFromSendFlow, minUsdAmount]
     )
 
     const handleTokenAmountChange = useCallback(
@@ -279,7 +278,7 @@ export default function WithdrawPage() {
     const handleAmountContinue = () => {
         if (validateAmount(rawTokenAmount) && selectedMethod) {
             setAmountToWithdraw(rawTokenAmount)
-            const usdVal = (selectedTokenData?.price ?? 1) * parseFloat(rawTokenAmount)
+            const usdVal = parseFloat(rawTokenAmount)
             setUsdAmount(usdVal.toString())
             posthog.capture(ANALYTICS_EVENTS.WITHDRAW_AMOUNT_ENTERED, {
                 amount_usd: usdVal,
@@ -357,13 +356,12 @@ export default function WithdrawPage() {
         const numericAmount = parseFloat(rawTokenAmount)
         if (!Number.isFinite(numericAmount) || numericAmount <= 0) return true
 
-        const usdEq = (selectedTokenData?.price ?? 1) * numericAmount
-        if (usdEq < minUsdAmount) return true // below country-specific minimum
+        if (numericAmount < minUsdAmount) return true // below the method's USD minimum
 
         // only apply the balance ceiling once it has loaded (maxDecimalAmount is 0
         // while spendableBalance is undefined) — else Continue is disabled during load
         return (balance !== undefined && numericAmount > maxDecimalAmount) || error.showError
-    }, [rawTokenAmount, balance, maxDecimalAmount, error.showError, selectedTokenData?.price, minUsdAmount])
+    }, [rawTokenAmount, balance, maxDecimalAmount, error.showError, minUsdAmount])
 
     // native app: render country-specific views when ?country= is present
     const viewFromQuery = searchParams.get('view')
@@ -456,7 +454,7 @@ export default function WithdrawPage() {
                             icon="info-filled"
                             iconClassName="text-yellow-9"
                             title="Withdrawing to Ethereum?"
-                            description={`Ethereum mainnet needs at least $${ETHEREUM_MIN_WITHDRAW_USD}. Your amount works on all other networks.`}
+                            description={`Ethereum mainnet needs at least $${ETHEREUM_MIN_WITHDRAW_USD}. Most other networks work from $${MIN_CRYPTO_WITHDRAW_USD.toFixed(2)}.`}
                         />
                     )}
 

--- a/src/app/(mobile-ui)/withdraw/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/page.tsx
@@ -10,8 +10,6 @@ import { useWithdrawFlow } from '@/context/WithdrawFlowContext'
 import { useWallet } from '@/hooks/wallet/useWallet'
 import { INSUFFICIENT_BALANCE_MESSAGE } from '@/utils/balance.utils'
 import { getCountryFromAccount, getCountryFromPath, getMinimumAmount } from '@/utils/bridge.utils'
-import { MIN_CRYPTO_WITHDRAW_USD, ETHEREUM_MIN_WITHDRAW_USD } from '@/utils/cross-chain-fee.utils'
-import InfoCard from '@/components/Global/InfoCard'
 import useGetExchangeRate from '@/hooks/useGetExchangeRate'
 import { AccountType } from '@/interfaces'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -132,8 +130,8 @@ export default function WithdrawPage() {
         // no amount-step minimum for crypto: same-chain (Arbitrum) withdrawals
         // are direct transfers with no floor, matching send-via-link. Rhino's
         // per-network bridge minimums ($0.50, ETH $5, Tron $10) are enforced
-        // chain-aware at review time (see withdraw/crypto) — the destination
-        // isn't known yet here, so we only warn below.
+        // chain-aware at review time (see withdraw/crypto), once the
+        // destination is known.
         if (isCryptoWithdraw) return 0
         const localMin = getMinimumAmount(countryIso2)
         // for US or unknown, minimum is already in USD
@@ -390,18 +388,6 @@ export default function WithdrawPage() {
         // only show limits card for bank/manteca withdrawals, not crypto
         const showLimitsCard = !isCryptoWithdraw && (limitsValidation.isBlocking || limitsValidation.isWarning)
 
-        // crypto amounts under a bridge minimum get a non-blocking heads-up —
-        // the destination chain isn't chosen yet (same-chain Arbitrum has no
-        // minimum at all), so we warn here and hard-block at review time only
-        // for bridged routes. AmountInput is pinned to USD on this page
-        // (price: 1), so read the raw value.
-        const typedUsd = parseFloat(rawTokenAmount || '0')
-        const showBridgeMinNotice = isCryptoWithdraw && typedUsd > 0 && typedUsd < ETHEREUM_MIN_WITHDRAW_USD
-        const bridgeMinNoticeText =
-            typedUsd < MIN_CRYPTO_WITHDRAW_USD
-                ? `Bridging to another network needs at least $${MIN_CRYPTO_WITHDRAW_USD.toFixed(2)} — $${ETHEREUM_MIN_WITHDRAW_USD} for Ethereum mainnet. Withdrawals within Arbitrum have no minimum.`
-                : `Ethereum mainnet needs at least $${ETHEREUM_MIN_WITHDRAW_USD}. Most other networks work from $${MIN_CRYPTO_WITHDRAW_USD.toFixed(2)}.`
-
         return (
             <div className="flex min-h-[inherit] flex-col justify-start space-y-8">
                 <NavHeader
@@ -450,21 +436,6 @@ export default function WithdrawPage() {
                             })
                             return limitsCardProps ? <LimitsWarningCard {...limitsCardProps} /> : null
                         })()}
-
-                    {/* heads-up for crypto amounts below a bridge minimum */}
-                    {showBridgeMinNotice && (
-                        <InfoCard
-                            variant="warning"
-                            icon="info-filled"
-                            iconClassName="text-yellow-9"
-                            title={
-                                typedUsd < MIN_CRYPTO_WITHDRAW_USD
-                                    ? 'Heads up: network minimums'
-                                    : 'Withdrawing to Ethereum?'
-                            }
-                            description={bridgeMinNoticeText}
-                        />
-                    )}
 
                     <Button
                         variant="purple"

--- a/src/app/(mobile-ui)/withdraw/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/page.tsx
@@ -11,6 +11,8 @@ import { useWallet } from '@/hooks/wallet/useWallet'
 import { tokenSelectorContext } from '@/context/tokenSelector.context'
 import { INSUFFICIENT_BALANCE_MESSAGE } from '@/utils/balance.utils'
 import { getCountryFromAccount, getCountryFromPath, getMinimumAmount } from '@/utils/bridge.utils'
+import { MIN_CRYPTO_WITHDRAW_USD, ETHEREUM_MIN_WITHDRAW_USD } from '@/utils/cross-chain-fee.utils'
+import InfoCard from '@/components/Global/InfoCard'
 import useGetExchangeRate from '@/hooks/useGetExchangeRate'
 import { AccountType } from '@/interfaces'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -129,7 +131,10 @@ export default function WithdrawPage() {
 
     // compute minimum withdrawal in USD using the exchange rate
     const minUsdAmount = useMemo(() => {
-        if (isCryptoWithdraw) return 0 // any amount > 0 is valid, same as send-via-link
+        // crypto rides the Rhino bridge, which parks (doesn't refund) deposits
+        // below the route minimum — $0.50 floors every network; Ethereum's $5
+        // is enforced chain-aware at review time (see withdraw/crypto).
+        if (isCryptoWithdraw) return MIN_CRYPTO_WITHDRAW_USD
         const localMin = getMinimumAmount(countryIso2)
         // for US or unknown, minimum is already in USD
         if (!countryIso2 || countryIso2 === 'US') return localMin
@@ -385,6 +390,13 @@ export default function WithdrawPage() {
         // only show limits card for bank/manteca withdrawals, not crypto
         const showLimitsCard = !isCryptoWithdraw && (limitsValidation.isBlocking || limitsValidation.isWarning)
 
+        // crypto amounts that clear the $0.50 floor but not Ethereum's $5 get a
+        // non-blocking heads-up — the destination chain isn't chosen yet, so we
+        // warn here and hard-block at review time if Ethereum is picked.
+        const typedUsd = (selectedTokenData?.price ?? 1) * parseFloat(rawTokenAmount || '0')
+        const showEthereumMinNotice =
+            isCryptoWithdraw && typedUsd >= MIN_CRYPTO_WITHDRAW_USD && typedUsd < ETHEREUM_MIN_WITHDRAW_USD
+
         return (
             <div className="flex min-h-[inherit] flex-col justify-start space-y-8">
                 <NavHeader
@@ -433,6 +445,17 @@ export default function WithdrawPage() {
                             })
                             return limitsCardProps ? <LimitsWarningCard {...limitsCardProps} /> : null
                         })()}
+
+                    {/* heads-up for crypto amounts below Ethereum's bridge minimum */}
+                    {showEthereumMinNotice && (
+                        <InfoCard
+                            variant="warning"
+                            icon="info-filled"
+                            iconClassName="text-yellow-9"
+                            title="Withdrawing to Ethereum?"
+                            description={`Ethereum mainnet withdrawals need at least $${ETHEREUM_MIN_WITHDRAW_USD}. Your amount works on all other networks.`}
+                        />
+                    )}
 
                     <Button
                         variant="purple"

--- a/src/components/Withdraw/views/Initial.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Initial.withdraw.view.tsx
@@ -57,6 +57,19 @@ export default function InitialWithdrawView({ amount, onReview, onBack, isProces
         }
     }, [addressFamily, setRecipient, setIsValidRecipient])
 
+    // Changing the destination chain invalidates chain-scoped errors (e.g. the
+    // per-network minimum block from review, which says "pick a different
+    // network") — without this the stale error keeps Review disabled after the
+    // user follows that instruction. Safe for address errors too: Review stays
+    // gated by isValidRecipient regardless of the error banner.
+    const prevChainRef = useRef(selectedChainID)
+    useEffect(() => {
+        if (prevChainRef.current !== selectedChainID) {
+            prevChainRef.current = selectedChainID
+            if (error.showError) setError({ showError: false, errorMessage: '' })
+        }
+    }, [selectedChainID, error.showError, setError])
+
     const handleReview = () => {
         // Context record already includes the synthetic non-EVM withdraw
         // destinations (merged once in tokenSelector.context).

--- a/src/utils/cross-chain-fee.utils.test.ts
+++ b/src/utils/cross-chain-fee.utils.test.ts
@@ -1,4 +1,10 @@
-import { isWithdrawFeeDisproportionate, HIGH_WITHDRAW_FEE_RATIO } from './cross-chain-fee.utils'
+import {
+    isWithdrawFeeDisproportionate,
+    getMinWithdrawUsdForChain,
+    HIGH_WITHDRAW_FEE_RATIO,
+    MIN_CRYPTO_WITHDRAW_USD,
+    ETHEREUM_MIN_WITHDRAW_USD,
+} from './cross-chain-fee.utils'
 
 describe('isWithdrawFeeDisproportionate', () => {
     test('no heads-up for a tiny L2 fee on a normal amount', () => {
@@ -39,5 +45,24 @@ describe('isWithdrawFeeDisproportionate', () => {
 
     test('default threshold is 5%', () => {
         expect(HIGH_WITHDRAW_FEE_RATIO).toBe(0.05)
+    })
+})
+
+describe('getMinWithdrawUsdForChain', () => {
+    test('Ethereum mainnet needs $5, string or numeric chainId', () => {
+        expect(getMinWithdrawUsdForChain('1')).toBe(5)
+        expect(getMinWithdrawUsdForChain(1)).toBe(5)
+        expect(getMinWithdrawUsdForChain('1')).toBe(ETHEREUM_MIN_WITHDRAW_USD)
+    })
+
+    test('Tron needs $10', () => {
+        expect(getMinWithdrawUsdForChain('728126428')).toBe(10)
+    })
+
+    test('every other network floors at $0.50', () => {
+        expect(getMinWithdrawUsdForChain('42161')).toBe(0.5) // Arbitrum (same-chain)
+        expect(getMinWithdrawUsdForChain('8453')).toBe(0.5) // Base
+        expect(getMinWithdrawUsdForChain('10')).toBe(0.5) // Optimism — NOT Ethereum's '1'
+        expect(getMinWithdrawUsdForChain('unknown-chain')).toBe(MIN_CRYPTO_WITHDRAW_USD)
     })
 })

--- a/src/utils/cross-chain-fee.utils.test.ts
+++ b/src/utils/cross-chain-fee.utils.test.ts
@@ -55,7 +55,9 @@ describe('getMinWithdrawUsdForChain', () => {
         expect(getMinWithdrawUsdForChain('1')).toBe(ETHEREUM_MIN_WITHDRAW_USD)
     })
 
-    test('Tron needs $10', () => {
+    test('Tron needs $10 — both the picker slug and the numeric id', () => {
+        // the withdraw picker supplies 'tron' (NON_EVM_WITHDRAW_CHAINS slug)
+        expect(getMinWithdrawUsdForChain('tron')).toBe(10)
         expect(getMinWithdrawUsdForChain('728126428')).toBe(10)
     })
 

--- a/src/utils/cross-chain-fee.utils.test.ts
+++ b/src/utils/cross-chain-fee.utils.test.ts
@@ -5,6 +5,8 @@ import {
     MIN_CRYPTO_WITHDRAW_USD,
     ETHEREUM_MIN_WITHDRAW_USD,
 } from './cross-chain-fee.utils'
+import { NON_EVM_WITHDRAW_CHAINS } from '@/constants/chainRegistry.consts'
+import chainDetails from '@/constants/chain-details.json'
 
 describe('isWithdrawFeeDisproportionate', () => {
     test('no heads-up for a tiny L2 fee on a normal amount', () => {
@@ -66,5 +68,18 @@ describe('getMinWithdrawUsdForChain', () => {
         expect(getMinWithdrawUsdForChain('8453')).toBe(0.5) // Base
         expect(getMinWithdrawUsdForChain('10')).toBe(0.5) // Optimism — NOT Ethereum's '1'
         expect(getMinWithdrawUsdForChain('unknown-chain')).toBe(MIN_CRYPTO_WITHDRAW_USD)
+    })
+
+    test('the REAL chain records the withdraw flow supplies hit the intended minimums', () => {
+        // Anti-drift: the original version of this map keyed Tron by its
+        // numeric chain id, which no picker record ever carries — the $10
+        // floor was dead code and the hand-typed-id test passed vacuously.
+        // Assert against the records the flow actually passes to the guard.
+        const tron = NON_EVM_WITHDRAW_CHAINS['tron']
+        expect(tron).toBeDefined()
+        expect(getMinWithdrawUsdForChain(tron.chainId)).toBe(10)
+
+        expect((chainDetails as Record<string, unknown>)['1']).toBeDefined()
+        expect(getMinWithdrawUsdForChain('1')).toBe(ETHEREUM_MIN_WITHDRAW_USD)
     })
 })

--- a/src/utils/cross-chain-fee.utils.ts
+++ b/src/utils/cross-chain-fee.utils.ts
@@ -44,7 +44,11 @@ export const ETHEREUM_MIN_WITHDRAW_USD = 5
 
 const CHAIN_MIN_WITHDRAW_USD: Record<string, number> = {
     '1': ETHEREUM_MIN_WITHDRAW_USD, // Ethereum mainnet
-    '728126428': 10, // Tron
+    // Tron: the withdraw picker's NON_EVM_WITHDRAW_CHAINS entry uses the
+    // 'tron' slug (chainRegistry.consts.ts), not the numeric chain id — key
+    // both so neither representation slips past the $10 floor.
+    tron: 10,
+    '728126428': 10,
 }
 
 /** Minimum USD amount for a crypto withdrawal to the given destination chain. */

--- a/src/utils/cross-chain-fee.utils.ts
+++ b/src/utils/cross-chain-fee.utils.ts
@@ -37,6 +37,8 @@ export function isWithdrawFeeDisproportionate(
  * So sub-minimum withdrawals must be blocked before funds move. Minimums are
  * USD, uniform across tokens on a chain, and driven by the expensive side of
  * the route: $0.50 everywhere except Ethereum mainnet ($5) and Tron ($10).
+ * They apply to RHINO-ROUTED withdrawals only — same-chain (Arbitrum) USDC is
+ * a direct transfer with no minimum; callers exempt it before consulting this.
  * Verified against Rhino's getSupportedTokens API on 2026-07-21.
  */
 export const MIN_CRYPTO_WITHDRAW_USD = 0.5

--- a/src/utils/cross-chain-fee.utils.ts
+++ b/src/utils/cross-chain-fee.utils.ts
@@ -27,3 +27,27 @@ export function isWithdrawFeeDisproportionate(
     if (!Number.isFinite(amountUsd) || amountUsd <= 0) return false
     return feeUsd / amountUsd > threshold
 }
+
+/**
+ * Rhino per-network withdrawal minimums.
+ *
+ * Rhino REJECTS a bridge deposit below the route minimum (`UNDER_MIN` webhook)
+ * and parks the funds at the deposit address — no auto-refund, recovery is a
+ * manual Rhino support action (2026-07-15 incident: $2.50 → Ethereum stuck).
+ * So sub-minimum withdrawals must be blocked before funds move. Minimums are
+ * USD, uniform across tokens on a chain, and driven by the expensive side of
+ * the route: $0.50 everywhere except Ethereum mainnet ($5) and Tron ($10).
+ * Verified against Rhino's getSupportedTokens API on 2026-07-21.
+ */
+export const MIN_CRYPTO_WITHDRAW_USD = 0.5
+export const ETHEREUM_MIN_WITHDRAW_USD = 5
+
+const CHAIN_MIN_WITHDRAW_USD: Record<string, number> = {
+    '1': ETHEREUM_MIN_WITHDRAW_USD, // Ethereum mainnet
+    '728126428': 10, // Tron
+}
+
+/** Minimum USD amount for a crypto withdrawal to the given destination chain. */
+export function getMinWithdrawUsdForChain(chainId: string | number): number {
+    return CHAIN_MIN_WITHDRAW_USD[String(chainId)] ?? MIN_CRYPTO_WITHDRAW_USD
+}


### PR DESCRIPTION
## Summary

Rhino rejects bridge-SDA deposits below the route minimum (`UNDER_MIN` webhook) and **parks the funds — no auto-refund** (2026-07-15 incident: $2.50 → Ethereum against a $5 min, stranded at the SDA while the intent completed off the source leg; a second case from 05-21 sat unnoticed for two months). Prod's only net is a confirm-time CTA check that fires after the request/charge already exist.

This PR adds the missing early guard (FE), **scoped to where Rhino is actually involved** — same-chain Arbitrum USDC withdrawals are direct transfers with **no minimum** (parity with send-via-link and P2P sends), and the amount step is untouched (no floor, no warning):

- **Chain-aware hard block in `handleSetupReview`** — at the network/coin selection step, before any request/charge is created, for every destination **except same-chain Arbitrum USDC**: Ethereum $5, Tron $10 (keyed by the picker's real `'tron'` slug), $0.50 default. Map in `cross-chain-fee.utils.ts`, verified against Rhino's `getSupportedTokens` API 2026-07-21.
- **Error recovery**: chain-scoped errors clear when the destination chain changes (previously the block's own "pick a different network" advice dead-ended the Review button).
- **USD-pinned input compared directly** (CodeRabbit): the amount page's min/balance gates no longer scale by the app-wide token price — a stale non-USD price could loosen or false-trip the minimums (fixes the same latent bug for bank minimums).

## Design notes / accepted trade-offs
- Static mins + the existing live-quote confirm check back each other up (static = earliest possible + pre-charge, live = per-route truth). Rhino min drift-monitoring extension: follow-up.
- Same-chain **non-USDC** withdrawals (if/when offered) are treated as Rhino-routed and get the $0.50 floor — conservative by mechanism.
- No amount-step warning card (product call) — users learn the minimum at network selection, where it's actionable.
- `minDisplay` formatting appears twice (page + review guard) — left inline, 1 expression × 2 sites.

## Out of scope (follow-ups)
- BE guard in `peanut-api-ts` `/rhino/sda-transfer` (`payAmount` vs `minDepositLimitUsd`).
- `DEPOSIT_ADDRESS_BRIDGE_REJECTED` → intent flag + alert (currently updates an in-memory store only).
- `pay-request` / `claim-xchain` cross-chain flows fund SDAs unguarded (amounts fixed by requester/link, not the payer).

## Risks
- FE-only; no API/contract changes. Hotfix to `main` → **back-merge debt main→dev** (dev's crypto-min line will conflict trivially — keep this branch's version).
- Same-chain sub-$0.50 withdrawals remain allowed (deliberate — direct transfer, no Rhino).

## QA
- Unit: `cross-chain-fee.utils.test.ts` (mins map incl. real-registry anti-drift assertions), `withdraw-states.test.tsx` (no amount-step floor at $0.4, bank minimums untouched).
- Visual (Vercel preview): $2 → Ethereum → Review blocked pre-charge with the per-network message; switch to Base → error clears, proceeds; $0.4 → same-chain Arbitrum USDC goes through.
- Full suite: 145/145 suites, 2001 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
