### PR TITLE
feat(card): show settlement adjustments + next-deposit deduction banner

### DIFF
--- a/src/components/Card/YourCardScreen.tsx
+++ b/src/components/Card/YourCardScreen.tsx
@@ -94,7 +94,7 @@ const YourCardScreen: FC<Props> = ({ overview, card, onPrev }) => {
                 <InfoCard
                     variant="warning"
                     icon="credit-card"
-                    title={`$${(balanceDueCents / 100).toFixed(2)} will come off your next deposit`}
+                    title={`$${(balanceDueCents / 100).toFixed(2)} will be debited based on your next deposit`}
                     description="A recent card payment ended up higher than the amount held at checkout. This happens with tips or updated totals. We'll cover the difference automatically."
                 />
             )}

--- a/src/components/Card/YourCardScreen.tsx
+++ b/src/components/Card/YourCardScreen.tsx
@@ -15,6 +15,7 @@ import LockCardModal from '@/components/Card/LockCardModal'
 import { shouldShowAutoRenewBanner, daysUntilExpiry } from '@/components/Card/cardExpiry.utils'
 import { useCardReveal } from '@/hooks/useCardReveal'
 import { useWalletPlatform } from '@/hooks/useWalletPlatform'
+import { cardBalanceDueCents } from '@/utils/balance.utils'
 import { copyTextToClipboardWithFallback } from '@/utils/general.utils'
 import type { RainCardOverview, RainCardSummary } from '@/services/rain'
 
@@ -26,7 +27,7 @@ interface Props {
     onPrev?: () => void
 }
 
-const YourCardScreen: FC<Props> = ({ card, onPrev }) => {
+const YourCardScreen: FC<Props> = ({ overview, card, onPrev }) => {
     const [autoRenewDismissed, setAutoRenewDismissed] = useState(false)
     const [action, setAction] = useQueryState('action', parseAsStringEnum<CardAction>(['lock', 'unlock', 'cancel']))
     const { revealed, isLoading: isRevealing, error: revealError, toggle } = useCardReveal({ cardId: card.id })
@@ -40,6 +41,7 @@ const YourCardScreen: FC<Props> = ({ card, onPrev }) => {
     const closeAction = () => void setAction(null)
     const showAutoRenew = !autoRenewDismissed && shouldShowAutoRenewBanner(card.expiryMonth, card.expiryYear)
     const daysLeft = daysUntilExpiry(card.expiryMonth, card.expiryYear)
+    const balanceDueCents = cardBalanceDueCents(overview.balance?.spendingPower)
 
     const handleCopy = useCallback(
         (value: string, field: 'pan' | 'cvv') => {
@@ -86,6 +88,15 @@ const YourCardScreen: FC<Props> = ({ card, onPrev }) => {
                         <Icon name="chevron-up" size={16} className="rotate-45" />
                     </button>
                 </div>
+            )}
+
+            {balanceDueCents > 0 && (
+                <InfoCard
+                    variant="warning"
+                    icon="credit-card"
+                    title={`Card balance due: $${(balanceDueCents / 100).toFixed(2)}`}
+                    description="Usually a payment that settled above its authorized amount. Your next deposit covers this automatically."
+                />
             )}
 
             <InfoCard

--- a/src/components/Card/YourCardScreen.tsx
+++ b/src/components/Card/YourCardScreen.tsx
@@ -94,8 +94,8 @@ const YourCardScreen: FC<Props> = ({ overview, card, onPrev }) => {
                 <InfoCard
                     variant="warning"
                     icon="credit-card"
-                    title={`Card balance due: $${(balanceDueCents / 100).toFixed(2)}`}
-                    description="Usually a payment that settled above its authorized amount. Your next deposit covers this automatically."
+                    title={`$${(balanceDueCents / 100).toFixed(2)} will come off your next deposit`}
+                    description="A recent card payment ended up higher than the amount held at checkout. This happens with tips or updated totals. We'll cover the difference automatically."
                 />
             )}
 

--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -174,6 +174,16 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
     const isDeclinedCardSpend =
         status === 'failed' && isCardPaymentEntry(transaction) && !transaction.extraDataForDrawer?.cardPayment?.isRefund
 
+    // Settlement cleared at a different amount than authorized (tip / FX
+    // true-up) — flag the row so the balance impact isn't invisible in the
+    // feed; the receipt carries the authorized/adjustment breakdown. Refunds
+    // excluded like isDeclinedCardSpend above — a refund-auth that clears at
+    // a different amount would otherwise render "Refund · Adjusted".
+    const isAdjustedCardSpend =
+        isCardPaymentEntry(transaction) &&
+        Boolean(transaction.extraDataForDrawer?.cardPayment?.settlementAdjusted) &&
+        !transaction.extraDataForDrawer?.cardPayment?.isRefund
+
     return (
         <>
             {/* the clickable card */}
@@ -244,6 +254,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
                                           : getActionText(type, status)}
                                 </span>
                                 {status && <StatusPill status={status} />}
+                                {isAdjustedCardSpend && <span>· Adjusted</span>}
                             </div>
                         </div>
                     </div>

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -58,6 +58,7 @@ import { buildSplitBillRequestUrl } from './splitBill.utils'
 import { CardPaymentRows } from './provider-rows/CardPaymentRows'
 import { LocalRailNudge } from './provider-rows/LocalRailNudge'
 import { CardUsdAbroadNotice } from './provider-rows/CardUsdAbroadNotice'
+import { CardAdjustmentNotice } from './provider-rows/CardAdjustmentNotice'
 import { MantecaDepositInfo } from './provider-rows/MantecaDepositInfo'
 import { BridgeDepositInstructions } from './provider-rows/BridgeDepositInstructions'
 import { CancelDepositActions } from './provider-actions/CancelDepositActions'
@@ -637,6 +638,12 @@ export const TransactionDetailsReceipt = ({
                     )}
                 </div>
             </Card>
+
+            {/* Over-capture explainer — the words for the Initial hold /
+                Adjustment rows in the details card and the merchant-recourse
+                path. First of the notices: it explains THIS receipt's numbers;
+                the others nudge future behavior. */}
+            {!isPublic && <CardAdjustmentNotice transaction={transaction} />}
 
             {/* Local-rail nudge — card spends in a country with a cheaper
                 first-party rail (AR → QR, BR → Pix). Self-gates: renders

--- a/src/components/TransactionDetails/__tests__/TransactionCard.test.tsx
+++ b/src/components/TransactionDetails/__tests__/TransactionCard.test.tsx
@@ -130,3 +130,35 @@ describe('TransactionCard — clickable counterparty name', () => {
         expect(openTransactionDetails).toHaveBeenCalledTimes(1)
     })
 })
+
+/** A Rain card spend row; `cardPayment` overrides shape the flag cases. */
+function cardSpendTx(cardPayment: Record<string, unknown>): TransactionDetails {
+    const tx = eligibleTx()
+    ;(tx.extraDataForDrawer as Record<string, unknown>).cardPayment = {
+        merchantName: 'Savannah Taphouse',
+        isRefund: false,
+        settlementAdjusted: false,
+        ...cardPayment,
+    }
+    return tx
+}
+
+// The '· Adjusted' feed flag — settlement cleared at a different amount than
+// authorized. Refunds are excluded even when the BE forwards the flag on a
+// negative-auth refund clear (they'd read "Refund · Adjusted" otherwise).
+describe('TransactionCard — settlement-adjusted flag', () => {
+    it('shows · Adjusted for an adjusted card spend', () => {
+        renderCard(cardSpendTx({ settlementAdjusted: true }))
+        expect(screen.getByText('· Adjusted')).toBeInTheDocument()
+    })
+
+    it('hides it for a non-adjusted card spend', () => {
+        renderCard(cardSpendTx({ settlementAdjusted: false }))
+        expect(screen.queryByText('· Adjusted')).not.toBeInTheDocument()
+    })
+
+    it('hides it for an adjusted card REFUND', () => {
+        renderCard(cardSpendTx({ settlementAdjusted: true, isRefund: true }))
+        expect(screen.queryByText('· Adjusted')).not.toBeInTheDocument()
+    })
+})

--- a/src/components/TransactionDetails/provider-rows/CardAdjustmentNotice.tsx
+++ b/src/components/TransactionDetails/provider-rows/CardAdjustmentNotice.tsx
@@ -33,7 +33,7 @@ export function CardAdjustmentNotice({ transaction }: { transaction: Transaction
         <InfoCard
             variant="info"
             icon="info"
-            description={`The final charge was $${(deltaCents / 100).toFixed(2)} higher than the initial hold. This is common with tips and updated totals. Don’t recognize it? Contact the merchant.`}
+            description={`The final amount was $${(deltaCents / 100).toFixed(2)} higher than the initial hold. This is common with tips and updated totals. Don’t recognize it? Contact the merchant.`}
         />
     )
 }

--- a/src/components/TransactionDetails/provider-rows/CardAdjustmentNotice.tsx
+++ b/src/components/TransactionDetails/provider-rows/CardAdjustmentNotice.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import InfoCard from '@/components/Global/InfoCard'
+import { type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
+import { parseCents } from '@/components/TransactionDetails/transaction-details.utils'
+
+/**
+ * Notice on a card-spend receipt whose settlement captured MORE than its auth
+ * hold. Pairs with the Initial hold / Adjustment breakdown rows in
+ * CardPaymentRows: the rows carry the math, this carries the words and the
+ * merchant-recourse path. A visible card, not a row tooltip — the recourse
+ * sentence is the receipt's only action, and info-icon tooltips go mostly
+ * unopened.
+ *
+ * Fires only for over-captures. Under-captures return money — nothing to
+ * warn about; the breakdown rows already show the math. Refunds are excluded
+ * like the feed's "Adjusted" flag — a refund clearing at a different amount
+ * isn't a merchant overcharge. Copy names example causes ("tips and updated
+ * totals") without asserting one — Rain doesn't report why capture ≠ auth.
+ */
+export function CardAdjustmentNotice({ transaction }: { transaction: TransactionDetails }) {
+    const card = transaction.extraDataForDrawer?.cardPayment
+    if (!card?.settlementAdjusted || card.isRefund) return null
+
+    const authCents = parseCents(card.authAmount)
+    const settledCents = parseCents(card.settledAmount)
+    if (authCents == null || settledCents == null) return null
+
+    const deltaCents = settledCents - authCents
+    if (deltaCents <= 0) return null
+
+    return (
+        <InfoCard
+            variant="info"
+            icon="info"
+            description={`The final charge was $${(deltaCents / 100).toFixed(2)} higher than the initial hold. This is common with tips and updated totals. Don’t recognize it? Contact the merchant.`}
+        />
+    )
+}

--- a/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
+++ b/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
@@ -31,8 +31,13 @@ function parseCents(value: string | null | undefined): number | null {
  *  charge moved vs the auth, and what to do if it looks wrong. Falls back to
  *  a delta-less sentence when the settled amount is missing (legacy rows). */
 function adjustmentInfoText(authCents: number, settledCents: number | null): string {
-    if (settledCents == null || settledCents === authCents) {
+    if (settledCents == null) {
         return 'The merchant’s final charge differed from the amount authorized at payment. If you don’t recognize this, contact the merchant.'
+    }
+    // Stuck-true settlementAdjusted with equal amounts (a later re-settle back
+    // to the auth) — don't claim a difference that isn't displayed.
+    if (settledCents === authCents) {
+        return 'The merchant’s final charge matched the amount authorized at payment.'
     }
     const deltaUsd = `$${(Math.abs(settledCents - authCents) / 100).toFixed(2)}`
     const direction = settledCents > authCents ? 'higher' : 'lower'

--- a/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
+++ b/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
@@ -27,6 +27,18 @@ function parseCents(value: string | null | undefined): number | null {
     return Number.isFinite(n) ? n : null
 }
 
+/** Tooltip for the Authorized row's info icon — says by how much the final
+ *  charge moved vs the auth, and what to do if it looks wrong. Falls back to
+ *  a delta-less sentence when the settled amount is missing (legacy rows). */
+function adjustmentInfoText(authCents: number, settledCents: number | null): string {
+    if (settledCents == null || settledCents === authCents) {
+        return 'The merchant’s final charge differed from the amount authorized at payment. If you don’t recognize this, contact the merchant.'
+    }
+    const deltaUsd = `$${(Math.abs(settledCents - authCents) / 100).toFixed(2)}`
+    const direction = settledCents > authCents ? 'higher' : 'lower'
+    return `The merchant’s final charge was ${deltaUsd} ${direction} than the amount authorized at payment. If you don’t recognize this, contact the merchant.`
+}
+
 /**
  * Friendly copy for the dispute status row. The drawer shows ONE row labeled
  * "Dispute" with the status-mapped text. Keep terminal-state copy actionable:
@@ -121,7 +133,7 @@ export function CardPaymentRows({
 
     // Compose the visible sub-rows in order, then mark the final one as
     // border-suppressed if this whole slot is also the receipt's last.
-    const subRows: { label: string; value: ReactNode; key: string }[] = []
+    const subRows: { label: string; value: ReactNode; key: string; moreInfoText?: string }[] = []
 
     // Merchant category was dropped — the MCC label adds noise without
     // signal for non-finance users ("Eating Places, Restaurants" tells them
@@ -150,15 +162,27 @@ export function CardPaymentRows({
     }
 
     // Spec §4.6 — settled amount differs from the original auth (overcapture,
-    // tip, partial capture). Show the original auth amount as a hint.
+    // tip, partial capture). Break out authorized vs adjustment so the delta
+    // is explicit. Cause stays unlabeled — Rain doesn't say whether it was a
+    // tip, FX true-up, or incidentals.
     if (card.settlementAdjusted) {
         const authCents = parseCents(card.authAmount)
+        const settledCents = parseCents(card.settledAmount)
         if (authCents != null) {
             subRows.push({
-                key: 'adjustedFrom',
-                label: 'Original amount',
+                key: 'authorizedAmount',
+                label: 'Authorized',
                 value: `$${(authCents / 100).toFixed(2)}`,
+                moreInfoText: adjustmentInfoText(authCents, settledCents),
             })
+            if (settledCents != null && settledCents !== authCents) {
+                const deltaCents = settledCents - authCents
+                subRows.push({
+                    key: 'settlementAdjustment',
+                    label: 'Adjustment',
+                    value: `${deltaCents > 0 ? '+' : '-'}$${(Math.abs(deltaCents) / 100).toFixed(2)}`,
+                })
+            }
         }
     }
 
@@ -266,6 +290,7 @@ export function CardPaymentRows({
                     key={row.key}
                     label={row.label}
                     value={row.value}
+                    moreInfoText={row.moreInfoText}
                     hideBottomBorder={isLastRow && idx === subRows.length - 1}
                 />
             ))}

--- a/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
+++ b/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
@@ -6,7 +6,7 @@ import { PaymentInfoRow } from '@/components/Payment/PaymentInfoRow'
 import { type DisputeStatus, type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
 import { friendlyDeclineReason } from '@/utils/cardDeclineReason'
 import { getFlagUrl } from '@/constants/countryCurrencyMapping'
-import { extractMerchantIso2 } from '@/components/TransactionDetails/transaction-details.utils'
+import { extractMerchantIso2, parseCents } from '@/components/TransactionDetails/transaction-details.utils'
 
 /** Strings from Rain's sandbox arrive whitespace-padded ("  ", " - ") and
  *  legacy intents in the DB pre-date the backend cleanField pass — treat any
@@ -17,31 +17,6 @@ function nonBlank(value: string | null | undefined): string | null {
     if (trimmed.length === 0) return null
     if (/^[-_]{1,3}$/.test(trimmed)) return null
     return trimmed
-}
-
-/** Parse a cents amount and reject NaN / Infinity / null up-front so the
- *  drawer never renders "Charged in NaN EUR". */
-function parseCents(value: string | null | undefined): number | null {
-    if (value == null) return null
-    const n = Number(value)
-    return Number.isFinite(n) ? n : null
-}
-
-/** Tooltip for the Authorized row's info icon — says by how much the final
- *  charge moved vs the auth, and what to do if it looks wrong. Falls back to
- *  a delta-less sentence when the settled amount is missing (legacy rows). */
-function adjustmentInfoText(authCents: number, settledCents: number | null): string {
-    if (settledCents == null) {
-        return 'The merchant’s final charge differed from the amount authorized at payment. If you don’t recognize this, contact the merchant.'
-    }
-    // Stuck-true settlementAdjusted with equal amounts (a later re-settle back
-    // to the auth) — don't claim a difference that isn't displayed.
-    if (settledCents === authCents) {
-        return 'The merchant’s final charge matched the amount authorized at payment.'
-    }
-    const deltaUsd = `$${(Math.abs(settledCents - authCents) / 100).toFixed(2)}`
-    const direction = settledCents > authCents ? 'higher' : 'lower'
-    return `The merchant’s final charge was ${deltaUsd} ${direction} than the amount authorized at payment. If you don’t recognize this, contact the merchant.`
 }
 
 /**
@@ -138,7 +113,7 @@ export function CardPaymentRows({
 
     // Compose the visible sub-rows in order, then mark the final one as
     // border-suppressed if this whole slot is also the receipt's last.
-    const subRows: { label: string; value: ReactNode; key: string; moreInfoText?: string }[] = []
+    const subRows: { label: string; value: ReactNode; key: string }[] = []
 
     // Merchant category was dropped — the MCC label adds noise without
     // signal for non-finance users ("Eating Places, Restaurants" tells them
@@ -167,18 +142,19 @@ export function CardPaymentRows({
     }
 
     // Spec §4.6 — settled amount differs from the original auth (overcapture,
-    // tip, partial capture). Break out authorized vs adjustment so the delta
-    // is explicit. Cause stays unlabeled — Rain doesn't say whether it was a
-    // tip, FX true-up, or incidentals.
+    // tip, partial capture). Break out the hold vs the delta so the math is
+    // explicit. "Initial hold" over "Authorized": hold is the one card term
+    // users already know (hotels, gas stations). The words — examples and the
+    // merchant-recourse path — live in CardAdjustmentNotice below the details
+    // card, visible instead of behind an info-icon tooltip nobody opens.
     if (card.settlementAdjusted) {
         const authCents = parseCents(card.authAmount)
         const settledCents = parseCents(card.settledAmount)
         if (authCents != null) {
             subRows.push({
-                key: 'authorizedAmount',
-                label: 'Authorized',
+                key: 'initialHold',
+                label: 'Initial hold',
                 value: `$${(authCents / 100).toFixed(2)}`,
-                moreInfoText: adjustmentInfoText(authCents, settledCents),
             })
             if (settledCents != null && settledCents !== authCents) {
                 const deltaCents = settledCents - authCents
@@ -295,7 +271,6 @@ export function CardPaymentRows({
                     key={row.key}
                     label={row.label}
                     value={row.value}
-                    moreInfoText={row.moreInfoText}
                     hideBottomBorder={isLastRow && idx === subRows.length - 1}
                 />
             ))}

--- a/src/components/TransactionDetails/provider-rows/__tests__/CardAdjustmentNotice.test.tsx
+++ b/src/components/TransactionDetails/provider-rows/__tests__/CardAdjustmentNotice.test.tsx
@@ -33,7 +33,7 @@ describe('CardAdjustmentNotice', () => {
     test('over-capture renders delta, example causes, and merchant recourse (incident: 4591 → 5509)', () => {
         render(<CardAdjustmentNotice transaction={makeTransaction(ADJUSTED_SPEND)} />)
         expect(screen.getByTestId('info-card')).toHaveTextContent(
-            'The final charge was $9.18 higher than the initial hold. This is common with tips and updated totals. Don’t recognize it? Contact the merchant.'
+            'The final amount was $9.18 higher than the initial hold. This is common with tips and updated totals. Don’t recognize it? Contact the merchant.'
         )
     })
 

--- a/src/components/TransactionDetails/provider-rows/__tests__/CardAdjustmentNotice.test.tsx
+++ b/src/components/TransactionDetails/provider-rows/__tests__/CardAdjustmentNotice.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * CardAdjustmentNotice — the visible explainer for over-captured card spends.
+ * Replaced the Initial hold row's info-icon tooltip: the merchant-recourse
+ * sentence is the receipt's only action, so it must not hide behind a tap.
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+jest.mock('@/components/Global/InfoCard', () => ({
+    __esModule: true,
+    default: ({ description }: { description?: React.ReactNode }) => <div data-testid="info-card">{description}</div>,
+}))
+
+// import must come after jest.mock
+import { CardAdjustmentNotice } from '../CardAdjustmentNotice'
+import type { TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
+
+const ADJUSTED_SPEND = {
+    settlementAdjusted: true,
+    authAmount: '4591',
+    settledAmount: '5509',
+    isRefund: false,
+}
+
+function makeTransaction(cardPayment: Record<string, unknown>): TransactionDetails {
+    return {
+        status: 'completed',
+        extraDataForDrawer: { cardPayment },
+    } as unknown as TransactionDetails
+}
+
+describe('CardAdjustmentNotice', () => {
+    test('over-capture renders delta, example causes, and merchant recourse (incident: 4591 → 5509)', () => {
+        render(<CardAdjustmentNotice transaction={makeTransaction(ADJUSTED_SPEND)} />)
+        expect(screen.getByTestId('info-card')).toHaveTextContent(
+            'The final charge was $9.18 higher than the initial hold. This is common with tips and updated totals. Don’t recognize it? Contact the merchant.'
+        )
+    })
+
+    test('under-capture (money back) renders nothing', () => {
+        const { container } = render(
+            <CardAdjustmentNotice
+                transaction={makeTransaction({ ...ADJUSTED_SPEND, authAmount: '11323', settledAmount: '7653' })}
+            />
+        )
+        expect(container).toBeEmptyDOMElement()
+    })
+
+    test('equal amounts (stuck-true flag) renders nothing', () => {
+        const { container } = render(
+            <CardAdjustmentNotice transaction={makeTransaction({ ...ADJUSTED_SPEND, settledAmount: '4591' })} />
+        )
+        expect(container).toBeEmptyDOMElement()
+    })
+
+    test('missing settledAmount renders nothing', () => {
+        const { container } = render(
+            <CardAdjustmentNotice transaction={makeTransaction({ ...ADJUSTED_SPEND, settledAmount: null })} />
+        )
+        expect(container).toBeEmptyDOMElement()
+    })
+
+    test('refunds are excluded even with a positive delta', () => {
+        const { container } = render(
+            <CardAdjustmentNotice transaction={makeTransaction({ ...ADJUSTED_SPEND, isRefund: true })} />
+        )
+        expect(container).toBeEmptyDOMElement()
+    })
+
+    test('non-adjusted spend renders nothing', () => {
+        const { container } = render(
+            <CardAdjustmentNotice transaction={makeTransaction({ ...ADJUSTED_SPEND, settlementAdjusted: false })} />
+        )
+        expect(container).toBeEmptyDOMElement()
+    })
+})

--- a/src/components/TransactionDetails/provider-rows/__tests__/CardPaymentRows.settlement-adjustment.test.tsx
+++ b/src/components/TransactionDetails/provider-rows/__tests__/CardPaymentRows.settlement-adjustment.test.tsx
@@ -1,30 +1,21 @@
 /**
- * CardPaymentRows — authorized vs adjustment breakdown for settlement-adjusted
- * card spends (capture ≠ auth: tips, FX true-ups, partial captures).
+ * CardPaymentRows — Initial hold vs Adjustment breakdown for settlement-
+ * adjusted card spends (capture ≠ auth: tips, FX true-ups, partial captures).
  *
  * The 2026-07-21 incident: a restaurant auth of $45.91 settled at $55.09 four
  * days later and the receipt showed only a bare "Original amount" hint — the
  * +$9.18 delta (which silently overdrew the user's collateral) was nowhere.
- * These rows are the receipt half of making that delta explicit. Copy stays
- * cause-neutral (no "tip") — Rain doesn't report why the capture differed.
+ * These rows are the receipt's math half; the words and the merchant-recourse
+ * path live in CardAdjustmentNotice (tested separately).
  */
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 
 jest.mock('@/components/Payment/PaymentInfoRow', () => ({
-    PaymentInfoRow: ({
-        label,
-        value,
-        moreInfoText,
-    }: {
-        label: React.ReactNode
-        value: React.ReactNode
-        moreInfoText?: string
-    }) => (
+    PaymentInfoRow: ({ label, value }: { label: React.ReactNode; value: React.ReactNode }) => (
         <div data-testid="row">
             <span>{label}</span>
             <span>{value}</span>
-            {moreInfoText && <span data-testid="more-info">{moreInfoText}</span>}
         </div>
     ),
 }))
@@ -61,21 +52,17 @@ function makeTransaction(cardPayment: Record<string, unknown>): TransactionDetai
 }
 
 describe('CardPaymentRows — settlement adjustment breakdown', () => {
-    test('over-capture shows Authorized and a positive Adjustment (incident: 4591 → 5509)', () => {
+    test('over-capture shows Initial hold and a positive Adjustment (incident: 4591 → 5509)', () => {
         render(
             <CardPaymentRows
                 transaction={makeTransaction({ settlementAdjusted: true, authAmount: '4591', settledAmount: '5509' })}
                 isLastRow={false}
             />
         )
-        expect(screen.getByText('Authorized')).toBeInTheDocument()
+        expect(screen.getByText('Initial hold')).toBeInTheDocument()
         expect(screen.getByText('$45.91')).toBeInTheDocument()
         expect(screen.getByText('Adjustment')).toBeInTheDocument()
         expect(screen.getByText('+$9.18')).toBeInTheDocument()
-        // the "i" tooltip: names the delta and tells the user who to contact
-        expect(screen.getByTestId('more-info')).toHaveTextContent(
-            'The merchant’s final charge was $9.18 higher than the amount authorized at payment. If you don’t recognize this, contact the merchant.'
-        )
     })
 
     test('partial capture shows a negative Adjustment', () => {
@@ -85,34 +72,31 @@ describe('CardPaymentRows — settlement adjustment breakdown', () => {
                 isLastRow={false}
             />
         )
+        expect(screen.getByText('Initial hold')).toBeInTheDocument()
         expect(screen.getByText('$113.23')).toBeInTheDocument()
         expect(screen.getByText('-$36.70')).toBeInTheDocument()
     })
 
-    test('adjusted but settledAmount missing → Authorized row only, no Adjustment', () => {
+    test('adjusted but settledAmount missing → Initial hold row only, no Adjustment', () => {
         render(
             <CardPaymentRows
                 transaction={makeTransaction({ settlementAdjusted: true, authAmount: '4591', settledAmount: null })}
                 isLastRow={false}
             />
         )
-        expect(screen.getByText('Authorized')).toBeInTheDocument()
+        expect(screen.getByText('Initial hold')).toBeInTheDocument()
         expect(screen.queryByText('Adjustment')).not.toBeInTheDocument()
-        // no delta known → generic tooltip, still actionable
-        expect(screen.getByTestId('more-info')).toHaveTextContent('If you don’t recognize this, contact the merchant.')
     })
 
-    test('stuck-true flag with equal amounts → "matched" copy, no false difference claim', () => {
+    test('stuck-true flag with equal amounts → no Adjustment row, no false difference claim', () => {
         render(
             <CardPaymentRows
                 transaction={makeTransaction({ settlementAdjusted: true, authAmount: '4591', settledAmount: '4591' })}
                 isLastRow={false}
             />
         )
+        expect(screen.getByText('Initial hold')).toBeInTheDocument()
         expect(screen.queryByText('Adjustment')).not.toBeInTheDocument()
-        expect(screen.getByTestId('more-info')).toHaveTextContent(
-            'The merchant’s final charge matched the amount authorized at payment.'
-        )
     })
 
     test('non-adjusted settle renders neither row', () => {
@@ -122,7 +106,7 @@ describe('CardPaymentRows — settlement adjustment breakdown', () => {
                 isLastRow={false}
             />
         )
-        expect(screen.queryByText('Authorized')).not.toBeInTheDocument()
+        expect(screen.queryByText('Initial hold')).not.toBeInTheDocument()
         expect(screen.queryByText('Adjustment')).not.toBeInTheDocument()
     })
 })

--- a/src/components/TransactionDetails/provider-rows/__tests__/CardPaymentRows.settlement-adjustment.test.tsx
+++ b/src/components/TransactionDetails/provider-rows/__tests__/CardPaymentRows.settlement-adjustment.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * CardPaymentRows — authorized vs adjustment breakdown for settlement-adjusted
+ * card spends (capture ≠ auth: tips, FX true-ups, partial captures).
+ *
+ * The 2026-07-21 incident: a restaurant auth of $45.91 settled at $55.09 four
+ * days later and the receipt showed only a bare "Original amount" hint — the
+ * +$9.18 delta (which silently overdrew the user's collateral) was nowhere.
+ * These rows are the receipt half of making that delta explicit. Copy stays
+ * cause-neutral (no "tip") — Rain doesn't report why the capture differed.
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+jest.mock('@/components/Payment/PaymentInfoRow', () => ({
+    PaymentInfoRow: ({
+        label,
+        value,
+        moreInfoText,
+    }: {
+        label: React.ReactNode
+        value: React.ReactNode
+        moreInfoText?: string
+    }) => (
+        <div data-testid="row">
+            <span>{label}</span>
+            <span>{value}</span>
+            {moreInfoText && <span data-testid="more-info">{moreInfoText}</span>}
+        </div>
+    ),
+}))
+jest.mock('next/image', () => ({ __esModule: true, default: () => <span /> }))
+
+// import must come after jest.mock
+import { CardPaymentRows } from '../CardPaymentRows'
+import type { TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
+
+const CARD_PAYMENT_BASE = {
+    merchantName: 'Savannah Taphouse',
+    merchantCategory: null,
+    merchantCity: null,
+    merchantCountry: null,
+    merchantMcc: null,
+    merchantLogo: null,
+    merchantId: null,
+    localAmount: null,
+    localCurrency: null,
+    declineReason: null,
+    declineCategory: null,
+    cancellationReason: null,
+    parentRainTxId: null,
+    rainTransactionId: 'rain-tx-1',
+    isRefund: false,
+    dispute: null,
+}
+
+function makeTransaction(cardPayment: Record<string, unknown>): TransactionDetails {
+    return {
+        status: 'completed',
+        extraDataForDrawer: { cardPayment: { ...CARD_PAYMENT_BASE, ...cardPayment } },
+    } as unknown as TransactionDetails
+}
+
+describe('CardPaymentRows — settlement adjustment breakdown', () => {
+    test('over-capture shows Authorized and a positive Adjustment (incident: 4591 → 5509)', () => {
+        render(
+            <CardPaymentRows
+                transaction={makeTransaction({ settlementAdjusted: true, authAmount: '4591', settledAmount: '5509' })}
+                isLastRow={false}
+            />
+        )
+        expect(screen.getByText('Authorized')).toBeInTheDocument()
+        expect(screen.getByText('$45.91')).toBeInTheDocument()
+        expect(screen.getByText('Adjustment')).toBeInTheDocument()
+        expect(screen.getByText('+$9.18')).toBeInTheDocument()
+        // the "i" tooltip: names the delta and tells the user who to contact
+        expect(screen.getByTestId('more-info')).toHaveTextContent(
+            'The merchant’s final charge was $9.18 higher than the amount authorized at payment. If you don’t recognize this, contact the merchant.'
+        )
+    })
+
+    test('partial capture shows a negative Adjustment', () => {
+        render(
+            <CardPaymentRows
+                transaction={makeTransaction({ settlementAdjusted: true, authAmount: '11323', settledAmount: '7653' })}
+                isLastRow={false}
+            />
+        )
+        expect(screen.getByText('$113.23')).toBeInTheDocument()
+        expect(screen.getByText('-$36.70')).toBeInTheDocument()
+    })
+
+    test('adjusted but settledAmount missing → Authorized row only, no Adjustment', () => {
+        render(
+            <CardPaymentRows
+                transaction={makeTransaction({ settlementAdjusted: true, authAmount: '4591', settledAmount: null })}
+                isLastRow={false}
+            />
+        )
+        expect(screen.getByText('Authorized')).toBeInTheDocument()
+        expect(screen.queryByText('Adjustment')).not.toBeInTheDocument()
+        // no delta known → generic tooltip, still actionable
+        expect(screen.getByTestId('more-info')).toHaveTextContent('If you don’t recognize this, contact the merchant.')
+    })
+
+    test('non-adjusted settle renders neither row', () => {
+        render(
+            <CardPaymentRows
+                transaction={makeTransaction({ settlementAdjusted: false, authAmount: '6831', settledAmount: '6831' })}
+                isLastRow={false}
+            />
+        )
+        expect(screen.queryByText('Authorized')).not.toBeInTheDocument()
+        expect(screen.queryByText('Adjustment')).not.toBeInTheDocument()
+    })
+})

--- a/src/components/TransactionDetails/provider-rows/__tests__/CardPaymentRows.settlement-adjustment.test.tsx
+++ b/src/components/TransactionDetails/provider-rows/__tests__/CardPaymentRows.settlement-adjustment.test.tsx
@@ -102,6 +102,19 @@ describe('CardPaymentRows — settlement adjustment breakdown', () => {
         expect(screen.getByTestId('more-info')).toHaveTextContent('If you don’t recognize this, contact the merchant.')
     })
 
+    test('stuck-true flag with equal amounts → "matched" copy, no false difference claim', () => {
+        render(
+            <CardPaymentRows
+                transaction={makeTransaction({ settlementAdjusted: true, authAmount: '4591', settledAmount: '4591' })}
+                isLastRow={false}
+            />
+        )
+        expect(screen.queryByText('Adjustment')).not.toBeInTheDocument()
+        expect(screen.getByTestId('more-info')).toHaveTextContent(
+            'The merchant’s final charge matched the amount authorized at payment.'
+        )
+    })
+
     test('non-adjusted settle renders neither row', () => {
         render(
             <CardPaymentRows

--- a/src/components/TransactionDetails/transaction-details.utils.ts
+++ b/src/components/TransactionDetails/transaction-details.utils.ts
@@ -105,3 +105,13 @@ export function isNegativeWireAmount(amount: string | number | null | undefined)
     const n = parseWireAmount(amount)
     return Number.isFinite(n) && n < 0
 }
+
+/** Parse a cents amount and reject NaN / Infinity / null up-front so the
+ *  drawer never renders "Charged in NaN EUR". Shared by CardPaymentRows
+ *  (breakdown math) and CardAdjustmentNotice (over-capture gate) so both
+ *  read Rain's auth/settled cents identically. */
+export function parseCents(value: string | null | undefined): number | null {
+    if (value == null) return null
+    const n = Number(value)
+    return Number.isFinite(n) ? n : null
+}

--- a/src/utils/__tests__/balance.utils.test.ts
+++ b/src/utils/__tests__/balance.utils.test.ts
@@ -1,4 +1,5 @@
 import {
+    cardBalanceDueCents,
     computeAvailableSpendable,
     computeDisplaySpendable,
     computeExcessCollateralCents,
@@ -63,6 +64,27 @@ describe('balance utils', () => {
 
         it("floors fractional cents (shouldn't happen but is defensive)", () => {
             expect(rainCentsToUsdcUnits(99.9)).toBe(990_000n) // floors to 99 cents
+        })
+    })
+
+    describe('cardBalanceDueCents', () => {
+        it('surfaces a negative spending power as positive debt cents (incident: -631 = $6.31 due)', () => {
+            expect(cardBalanceDueCents(-631)).toBe(631)
+        })
+
+        it.each([
+            [0, 0],
+            [4218, 0], // healthy positive balance — no debt
+            [null, 0],
+            [undefined, 0],
+            [Number.NaN, 0],
+            [Number.NEGATIVE_INFINITY, 0],
+        ])('returns 0 for non-debt input (%s)', (input, expected) => {
+            expect(cardBalanceDueCents(input)).toBe(expected)
+        })
+
+        it('rounds fractional cents from the wire', () => {
+            expect(cardBalanceDueCents(-630.6)).toBe(631)
         })
     })
 

--- a/src/utils/balance.utils.ts
+++ b/src/utils/balance.utils.ts
@@ -85,6 +85,22 @@ export const rainCentsToUsdcUnits = (spendingPowerCents: number | null | undefin
 }
 
 /**
+ * Debt owed to the card, in whole cents (> 0), or 0 when there is none.
+ *
+ * Rain reports negative `spendingPower` when a settlement captured more than
+ * its auth hold (tip / FX true-up) on an already-drained collateral account.
+ * The clamp in `rainCentsToUsdcUnits` hides that debt from balance sums — the
+ * card screen surfaces it via this helper instead, because the next
+ * auto-balance sweep silently repays it from the user's deposit.
+ */
+export const cardBalanceDueCents = (spendingPowerCents: number | null | undefined): number => {
+    if (spendingPowerCents == null || !Number.isFinite(spendingPowerCents) || spendingPowerCents >= 0) {
+        return 0
+    }
+    return Math.round(-spendingPowerCents)
+}
+
+/**
  * Available-now spendable balance, as a USDC base-unit bigint (6dp) — the
  * smart-account balance plus landed Rain collateral `spendingPower`. This is
  * what `useSpendBundle` can actually route through right now. It is the base of


### PR DESCRIPTION
## Summary

A restaurant tip settled **+\$9.18 above its auth** (auth \$45.91 → capture \$55.09, four days later) and silently overdrew a user's card collateral to **−\$6.31**; her next deposit repaid it invisibly and she reported *"my deposit was not fully credited"* (2026-07-21, user `juanacervio`). The FE clamped negative spending power to \$0 and buried the adjustment inside a week-old receipt — nothing anywhere explained the balance drop.

This is the FE half of the fix (paired BE PR: peanut-api-ts `feat/card-settlement-adjust-visibility`):

- **Receipt**: `Initial hold` + `Adjustment` breakdown rows, plus a visible `CardAdjustmentNotice` info card below the details card (over-captures only) — *"The final amount was \$X higher than the initial hold. This is common with tips and updated totals. Don't recognize it? Contact the merchant."*
- **Feed**: `· Adjusted` flag on settlement-adjusted card rows (refunds excluded).
- **Card screen**: `\$X will be debited based on your next deposit` warning banner derived from negative Rain `spendingPower` (previously silently clamped to \$0).

## Risks / breaking changes

- **None breaking.** Renders purely from fields the prod BE already serializes (`cardAuthAmount` / `cardSettledAmount` / `settlementAdjusted` / unclamped `spendingPower`) — **safe to merge before the BE PR; FE-first is the recommended order** (first adjusted push then deep-links into a receipt that already shows the breakdown).
- Banner can display transiently while an in-transit auto-balance top-up is about to repay the debt (≤10 min, self-resolving).
- Known pre-existing nit (BE side, not addressed here): `settlementAdjusted` stays true if a later re-settle returns to exactly the auth amount — receipt self-heals (delta row and notice both hidden), feed flag would still show.

## Design notes / accepted trade-offs

Revised after design review (2026-07-23) — the first cut used "Card balance due" + an info-icon tooltip; both were rejected:

- **Event framing, not debt framing.** "Card balance due" imported credit-card-bill semantics into a prepaid mental model (deposit → spend), and warned without offering an action. The banner now narrates the observable consequence — "\$X will be debited based on your next deposit" — in checkout vocabulary ("amount held at checkout"), not auth/capture jargon.
- **Explanation is visible, not behind a tooltip.** The merchant-recourse sentence is the receipt's only action; info-icon tooltips go mostly unopened (and don't announce themselves on mobile). It now renders as a standard notice card (same pattern as `LocalRailNudge` / `CardUsdAbroadNotice`), over-captures only — under-captures return money and need no warning.
- **"Initial hold"** over "Authorized" — the one card-hold term consumers already know (hotels, gas stations).
- Copy names **example causes** ("tips and updated totals") without asserting one — Rain doesn't report why capture ≠ auth (tip / FX true-up / incidentals look identical).
- Home total keeps showing spendable (clamped) — netting the debt into the balance would be wrong (it collects from the *next deposit*; today's balance is genuinely spendable), so the card screen banner is where the debt is explained. Every spend/withdraw path already clamps ≤0 → 0.

## Screenshots

| Card screen — deposit-deduction banner | Receipt — breakdown + visible notice | Feed — Adjusted flag |
|---|---|---|
| <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2459/card-screen-banner.png" width="250" /> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2459/receipt-breakdown-notice.png" width="250" /> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2459/feed-adjusted-flag.png" width="250" /> |

Captured on the local sandbox stack (seeded $45.91 → $55.09 settle, user `abtest`; banner from the incident's −$6.31 spending power). Assets live on the `pr-assets-2459` branch — delete after merge.

## QA

- Unit: 97 tests on touched suites — receipt breakdown rows, `CardAdjustmentNotice` gating (over-capture only, refund/equal/missing-settled excluded) incl. exact copy with the incident's \$9.18, feed flag incl. refund exclusion, `cardBalanceDueCents` edges with the incident's −631. Full suite green except `routes.test.ts`, which fails only on machines carrying the local-only `dev/negative-demo` scaffold (git-excluded, not in the PR).
- Visual: local stack with seeded settles on a test account — normal \$68.31 row unchanged; 45.91→55.09 row shows the flag, breakdown, and notice.
- Adversarial review: 3 independent subagent passes on the first cut (verdict SHIP), then a 4-point design review drove this revision (banner reframe, hold vocabulary, tooltip → visible notice).
