### PR TITLE
hotfix: fund Manteca QR payments to per-rail wallets (AR vs non-AR)

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -36,7 +36,7 @@ import { useCardMarkupRate } from '@/hooks/useCardMarkupRate'
 import ErrorAlert from '@/components/Global/ErrorAlert'
 import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
 import { PERK_HOLD_DURATION_MS } from '@/constants/general.consts'
-import { MANTECA_DEPOSIT_ADDRESS } from '@/constants/manteca.consts'
+import { MANTECA_QR_DEPOSIT_ADDRESS_AR, MANTECA_QR_DEPOSIT_ADDRESS_NON_AR } from '@/constants/manteca.consts'
 import { MIN_MANTECA_QR_PAYMENT_AMOUNT, MIN_PIX_AMOUNT_BRL } from '@/constants/payment.consts'
 import { isPixRecurringCode } from '@/utils/withdraw.utils'
 import { formatUnits, parseUnits } from 'viem'
@@ -665,7 +665,9 @@ export default function QRPayPage() {
             const requiredUsdcAmount = parseUnits(finalPaymentLock.paymentAgainstAmount, PEANUT_WALLET_TOKEN_DECIMALS)
             signedArtifact = await signSpend({
                 requiredUsdcAmount,
-                recipient: MANTECA_DEPOSIT_ADDRESS,
+                // Per-rail Manteca QR funding wallet: Pix → non-AR, everything else → AR
+                // (same binary heuristic as the backend's getQrReceiveAddress).
+                recipient: qrType === EQrType.PIX ? MANTECA_QR_DEPOSIT_ADDRESS_NON_AR : MANTECA_QR_DEPOSIT_ADDRESS_AR,
                 rainSpendingPower: rainCentsToUsdcUnits(rainCardOverview?.balance?.spendingPower),
                 kind: 'QR_PAY',
             })

--- a/src/constants/manteca.consts.ts
+++ b/src/constants/manteca.consts.ts
@@ -1,5 +1,12 @@
 export const MANTECA_DEPOSIT_ADDRESS = '0x959e088a09f61aB01cb83b0eBCc74b2CF6d62053'
 
+// QR-payment funding wallets, split by rail country (Manteca request, 2026-07-21):
+// Argentine QRs (MercadoPago / QR3) fund the AR wallet; Pix — and eventually any
+// non-Argentina QR — funds the non-AR wallet. Bank withdrawals and claims still
+// fund MANTECA_DEPOSIT_ADDRESS. Mirrors peanut-api-ts/src/manteca/consts.ts.
+export const MANTECA_QR_DEPOSIT_ADDRESS_AR = '0x6E945f8EC93061f5f11Edc5e6Fb4A70BeB514e97'
+export const MANTECA_QR_DEPOSIT_ADDRESS_NON_AR = '0x49200bF84dC26349C86ce040019063FeCE88CB1c'
+
 export const MANTECA_ARG_DEPOSIT_NAME = 'Sixalime Sas'
 export const MANTECA_ARG_DEPOSIT_CUIT = '30-71678845-3'
 


### PR DESCRIPTION
## Summary

FE counterpart of peanutprotocol/peanut-api-ts#1214. Manteca (Facundo, 2026-07-21) asked that QR-payment funding split by rail instead of all going to the shared wallet `0x959e…2053`:

- **Argentina QRs** (MercadoPago / QR3, and anything non-Pix) → `0x6E945f8EC93061f5f11Edc5e6Fb4A70BeB514e97`
- **Pix (and eventually any non-Argentina QR)** → `0x49200bF84dC26349C86ce040019063FeCE88CB1c`

`qr-pay` now signs the spend to the per-rail wallet (`qrType === PIX ? non-AR : AR` — same binary heuristic as the backend's `getQrReceiveAddress`). Withdrawals (`withdraw/manteca`) and claims (`MantecaReviewStep`) intentionally keep funding `MANTECA_DEPOSIT_ADDRESS` — only QR funding was requested to move.

## Risks / breaking changes

- **Cross-repo deploy order: peanut-api-ts#1214 must be deployed FIRST.** The old API validates QR recipients against the legacy wallet only and would reject every payment signed to the new wallets. The new API accepts both, so stale PWA clients keep working during rollout.
- Money-routing change: recipients are hardcoded consts mirrored from the API; a mismatch would 400 at the API's recipient validation (no funds move — validation happens before Manteca order creation and broadcast).

## QA

- `npm run typecheck` clean; `npm test` — only pre-existing failure on clean `origin/main` (`add-money-states.test.tsx` "10,000 USD", reproduced on the base commit; unrelated).
- Full flow verification: Nutcracker `e2e-qr-pay-ar` in sandbox after API PR lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * QR payments now route funding to the correct deposit wallet based on the selected payment rail.
  * Pix payments use the non-Argentina deposit wallet, while other Manteca QR payment types use the Argentina wallet.
  * Existing bank withdrawal and claim funding behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->