### PR TITLE
feat(security): biometric app lock for the native app

### DIFF
--- a/src/app/ClientProviders.tsx
+++ b/src/app/ClientProviders.tsx
@@ -56,15 +56,14 @@ export function ClientProviders({ children }: { children: React.ReactNode }) {
                             {/* Non-intrusive "badge unlocked" toast on /home (TASK-19791).
                                 Global so it surfaces wherever the user lands after earning. */}
                             <BadgeEarnToast />
-                            {/* Biometric gate for the native app on cold start and
-                                long background. Renders nothing on web. */}
-                            <AppLockGate />
                             {HarnessBootstrap && (
                                 <Suspense fallback={null}>
                                     <HarnessBootstrap />
                                 </Suspense>
                             )}
-                            {children}
+                            {/* Wraps rather than sits beside the page: while the
+                                native app is locked, nothing protected renders. */}
+                            <AppLockGate>{children}</AppLockGate>
                         </TranslationSafeWrapper>
                     </FooterVisibilityProvider>
                 </ContextProvider>

--- a/src/app/ClientProviders.tsx
+++ b/src/app/ClientProviders.tsx
@@ -10,6 +10,7 @@ import { ConsoleGreeting } from '@/components/Global/ConsoleGreeting'
 import RainCooldownIntroModal from '@/components/Global/RainCooldown/IntroModal'
 import StaleCardApprovalReEnableModal from '@/components/Global/StaleCardApproval/ReEnableModal'
 import BadgeEarnToast from '@/components/Badges/BadgeEarnToast'
+import { AppLockGate } from '@/components/Global/AppLock'
 import { ScreenOrientationLocker } from '@/components/Global/ScreenOrientationLocker'
 import { TranslationSafeWrapper } from '@/components/Global/TranslationSafeWrapper'
 import { PeanutProvider } from '@/config/peanut.config'
@@ -55,6 +56,9 @@ export function ClientProviders({ children }: { children: React.ReactNode }) {
                             {/* Non-intrusive "badge unlocked" toast on /home (TASK-19791).
                                 Global so it surfaces wherever the user lands after earning. */}
                             <BadgeEarnToast />
+                            {/* Biometric gate for the native app on cold start and
+                                long background. Renders nothing on web. */}
+                            <AppLockGate />
                             {HarnessBootstrap && (
                                 <Suspense fallback={null}>
                                     <HarnessBootstrap />

--- a/src/components/Global/AppLock/index.tsx
+++ b/src/components/Global/AppLock/index.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+/**
+ * Native app lock. Covers the app with a biometric gate on cold start and
+ * whenever it returns from more than LOCK_AFTER_BACKGROUND_MS in the
+ * background, so a session that outlives the user's attention doesn't hand the
+ * account to whoever picks the phone up next.
+ *
+ * Web is unaffected — there is no OS-backed presence check to lean on there,
+ * and the browser tab has no equivalent of "resumed from background".
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Button } from '@/components/0_Bruddle/Button'
+import { useAuth } from '@/context/authContext'
+import { isCapacitor } from '@/utils/capacitor'
+import { getUserPreferences } from '@/utils/general.utils'
+import { LOCK_AFTER_BACKGROUND_MS, requestLocalUserPresence } from '@/utils/app-lock'
+
+export function AppLockGate() {
+    const { user, logoutUser } = useAuth()
+    const userId = user?.user.userId
+    const [locked, setLocked] = useState(false)
+    const [unlocking, setUnlocking] = useState(false)
+    const [failed, setFailed] = useState(false)
+    const backgroundedAt = useRef<number | null>(null)
+    // Cold-start lock must fire once per launch, not on every login state change.
+    const coldStartHandled = useRef(false)
+
+    const credentialId = userId ? getUserPreferences(userId)?.webAuthnKey?.authenticatorId : undefined
+
+    const attemptUnlock = useCallback(async () => {
+        setUnlocking(true)
+        const outcome = await requestLocalUserPresence(credentialId)
+        setUnlocking(false)
+        // 'unsupported' means we can never raise this lock — never leave the
+        // user staring at a gate with no key.
+        if (outcome === 'unlocked' || outcome === 'unsupported') {
+            setLocked(false)
+            setFailed(false)
+            return
+        }
+        setFailed(true)
+    }, [credentialId])
+
+    useEffect(() => {
+        if (!isCapacitor() || !userId || coldStartHandled.current) return
+        coldStartHandled.current = true
+        if (!credentialId) return
+        setLocked(true)
+    }, [userId, credentialId])
+
+    useEffect(() => {
+        if (!isCapacitor() || !userId || !credentialId) return
+
+        let removeListener: (() => void) | undefined
+        let cancelled = false
+
+        import('@capacitor/app')
+            .then(({ App }) =>
+                App.addListener('appStateChange', ({ isActive }) => {
+                    if (!isActive) {
+                        backgroundedAt.current = Date.now()
+                        return
+                    }
+                    const since = backgroundedAt.current
+                    backgroundedAt.current = null
+                    if (since !== null && Date.now() - since > LOCK_AFTER_BACKGROUND_MS) {
+                        setLocked(true)
+                        setFailed(false)
+                    }
+                })
+            )
+            .then((handle) => {
+                if (cancelled) {
+                    handle.remove()
+                    return
+                }
+                removeListener = () => handle.remove()
+            })
+            .catch(() => {
+                // No @capacitor/app bridge (web bundle, or an old native shell):
+                // resume-locking is simply unavailable. Cold-start lock still works.
+            })
+
+        return () => {
+            cancelled = true
+            removeListener?.()
+        }
+    }, [userId, credentialId])
+
+    // Auto-prompt as soon as the gate goes up, so the common case is one Face ID
+    // prompt and no taps at all.
+    useEffect(() => {
+        if (locked && !unlocking && !failed) void attemptUnlock()
+        // attemptUnlock is stable for a given credential; re-running on every
+        // render would re-prompt in a loop.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [locked])
+
+    if (!locked) return null
+
+    return (
+        <div className="fixed inset-0 z-[9999] flex flex-col items-center justify-center gap-6 bg-white px-6">
+            <div className="text-center">
+                <h1 className="text-2xl font-bold">Peanut is locked</h1>
+                <p className="mt-2 text-sm text-grey-1">
+                    {failed ? 'Could not confirm it is you. Try again to continue.' : 'Confirm it is you to continue.'}
+                </p>
+            </div>
+            <div className="flex w-full max-w-xs flex-col gap-3">
+                <Button variant="purple" shadowSize="4" loading={unlocking} onClick={() => void attemptUnlock()}>
+                    Unlock
+                </Button>
+                <Button variant="stroke" shadowSize="4" onClick={() => void logoutUser()}>
+                    Log out
+                </Button>
+            </div>
+        </div>
+    )
+}

--- a/src/components/Global/AppLock/index.tsx
+++ b/src/components/Global/AppLock/index.tsx
@@ -1,13 +1,20 @@
 'use client'
 
 /**
- * Native app lock. Covers the app with a biometric gate on cold start and
- * whenever it returns from more than LOCK_AFTER_BACKGROUND_MS in the
- * background, so a session that outlives the user's attention doesn't hand the
- * account to whoever picks the phone up next.
+ * Native app lock. Wraps the app on cold start and whenever it returns from
+ * more than LOCK_AFTER_BACKGROUND_MS in the background, so a session that
+ * outlives the user's attention doesn't hand the account to whoever picks the
+ * phone up next.
+ *
+ * It is a gate, not an overlay: while locked, the protected tree is not
+ * rendered at all. Nothing paints behind the lock screen and nothing back
+ * there is focusable or reachable by assistive tech. The cost is that
+ * remounting on unlock loses in-flight component state — acceptable, since the
+ * lock only fires on cold start (no state yet) or after five minutes
+ * backgrounded (where iOS has often discarded the webview anyway).
  *
  * Web is unaffected — there is no OS-backed presence check to lean on there,
- * and the browser tab has no equivalent of "resumed from background".
+ * and a browser tab has no equivalent of "resumed from background".
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -17,38 +24,80 @@ import { isCapacitor } from '@/utils/capacitor'
 import { getUserPreferences } from '@/utils/general.utils'
 import { LOCK_AFTER_BACKGROUND_MS, requestLocalUserPresence } from '@/utils/app-lock'
 
-export function AppLockGate() {
-    const { user, logoutUser } = useAuth()
+/**
+ * `pending` is the state that makes this a boundary rather than a curtain: on
+ * native we enter it on the very first client paint, before the user query can
+ * resolve and render balances. Only once auth settles do we learn whether this
+ * becomes `locked` or, for a signed-out user or one with no usable credential,
+ * `open`.
+ */
+type GateState = 'open' | 'pending' | 'locked'
+
+function LockScreen({
+    failed,
+    unlocking,
+    onUnlock,
+    onLogout,
+}: {
+    failed: boolean
+    unlocking: boolean
+    onUnlock: () => void
+    onLogout: () => void
+}) {
+    return (
+        <div className="fixed inset-0 z-[9999] flex flex-col items-center justify-center gap-6 bg-white px-6">
+            <div className="text-center">
+                <h1 className="text-2xl font-bold">Peanut is locked</h1>
+                <p className="mt-2 text-sm text-grey-1">
+                    {failed ? 'Could not confirm it is you. Try again to continue.' : 'Confirm it is you to continue.'}
+                </p>
+            </div>
+            <div className="flex w-full max-w-xs flex-col gap-3">
+                <Button variant="purple" shadowSize="4" loading={unlocking} onClick={onUnlock}>
+                    Unlock
+                </Button>
+                <Button variant="stroke" shadowSize="4" onClick={onLogout}>
+                    Log out
+                </Button>
+            </div>
+        </div>
+    )
+}
+
+export function AppLockGate({ children }: { children: React.ReactNode }) {
+    const { user, isFetchingUser, logoutUser } = useAuth()
     const userId = user?.user.userId
-    const [locked, setLocked] = useState(false)
+    const [state, setState] = useState<GateState>('open')
     const [unlocking, setUnlocking] = useState(false)
     const [failed, setFailed] = useState(false)
     const backgroundedAt = useRef<number | null>(null)
-    // Cold-start lock must fire once per launch, not on every login state change.
-    const coldStartHandled = useRef(false)
 
     const credentialId = userId ? getUserPreferences(userId)?.webAuthnKey?.authenticatorId : undefined
+
+    // Close the gate on the first client paint, before anything protected can
+    // render. Runs once — later transitions are driven by resume or unlock.
+    useEffect(() => {
+        if (isCapacitor()) setState('pending')
+    }, [])
+
+    useEffect(() => {
+        if (state !== 'pending' || isFetchingUser) return
+        // Nothing to protect, or no credential we could ever prompt against —
+        // a gate we can't open would strand the user in their own app.
+        setState(userId && credentialId ? 'locked' : 'open')
+    }, [state, isFetchingUser, userId, credentialId])
 
     const attemptUnlock = useCallback(async () => {
         setUnlocking(true)
         const outcome = await requestLocalUserPresence(credentialId)
         setUnlocking(false)
-        // 'unsupported' means we can never raise this lock — never leave the
-        // user staring at a gate with no key.
         if (outcome === 'unlocked' || outcome === 'unsupported') {
-            setLocked(false)
             setFailed(false)
+            setState('open')
             return
         }
         setFailed(true)
     }, [credentialId])
-
-    useEffect(() => {
-        if (!isCapacitor() || !userId || coldStartHandled.current) return
-        coldStartHandled.current = true
-        if (!credentialId) return
-        setLocked(true)
-    }, [userId, credentialId])
 
     useEffect(() => {
         if (!isCapacitor() || !userId || !credentialId) return
@@ -66,8 +115,8 @@ export function AppLockGate() {
                     const since = backgroundedAt.current
                     backgroundedAt.current = null
                     if (since !== null && Date.now() - since > LOCK_AFTER_BACKGROUND_MS) {
-                        setLocked(true)
                         setFailed(false)
+                        setState('locked')
                     }
                 })
             )
@@ -80,7 +129,7 @@ export function AppLockGate() {
             })
             .catch(() => {
                 // No @capacitor/app bridge (web bundle, or an old native shell):
-                // resume-locking is simply unavailable. Cold-start lock still works.
+                // resume-locking is unavailable. Cold-start locking still works.
             })
 
         return () => {
@@ -89,33 +138,28 @@ export function AppLockGate() {
         }
     }, [userId, credentialId])
 
-    // Auto-prompt as soon as the gate goes up, so the common case is one Face ID
+    // Prompt as soon as the gate closes, so the common case is one Face ID
     // prompt and no taps at all.
     useEffect(() => {
-        if (locked && !unlocking && !failed) void attemptUnlock()
-        // attemptUnlock is stable for a given credential; re-running on every
-        // render would re-prompt in a loop.
+        if (state === 'locked' && !unlocking && !failed) void attemptUnlock()
+        // Deliberately keyed on `state` alone: including attemptUnlock or the
+        // transient flags would re-fire the prompt in a loop.
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [locked])
+    }, [state])
 
-    if (!locked) return null
+    if (state === 'open') return <>{children}</>
+
+    // 'pending': auth hasn't settled, so we don't yet know whether to prompt.
+    // Show the bare cover rather than the "locked" copy, which would be a lie
+    // for a signed-out user about to be let straight through.
+    if (state === 'pending') return <div className="fixed inset-0 z-[9999] bg-white" />
 
     return (
-        <div className="fixed inset-0 z-[9999] flex flex-col items-center justify-center gap-6 bg-white px-6">
-            <div className="text-center">
-                <h1 className="text-2xl font-bold">Peanut is locked</h1>
-                <p className="mt-2 text-sm text-grey-1">
-                    {failed ? 'Could not confirm it is you. Try again to continue.' : 'Confirm it is you to continue.'}
-                </p>
-            </div>
-            <div className="flex w-full max-w-xs flex-col gap-3">
-                <Button variant="purple" shadowSize="4" loading={unlocking} onClick={() => void attemptUnlock()}>
-                    Unlock
-                </Button>
-                <Button variant="stroke" shadowSize="4" onClick={() => void logoutUser()}>
-                    Log out
-                </Button>
-            </div>
-        </div>
+        <LockScreen
+            failed={failed}
+            unlocking={unlocking}
+            onUnlock={() => void attemptUnlock()}
+            onLogout={() => void logoutUser()}
+        />
     )
 }

--- a/src/utils/__tests__/app-lock.test.ts
+++ b/src/utils/__tests__/app-lock.test.ts
@@ -1,0 +1,65 @@
+/**
+ * The lock's safety property is asymmetric: failing to lock is a security
+ * weakness, but failing to UNLOCK strands the user in their own app with no
+ * way out. These tests pin which failure modes fall which way.
+ */
+import { webcrypto } from 'node:crypto'
+
+import { requestLocalUserPresence } from '../app-lock'
+
+if (!globalThis.crypto?.getRandomValues) {
+    Object.defineProperty(globalThis, 'crypto', { value: webcrypto, configurable: true })
+}
+
+const CREDENTIAL_ID = 'YWJjZGVmZ2g'
+
+function withCredentialsGet(impl: () => Promise<Credential | null>) {
+    Object.defineProperty(globalThis, 'PublicKeyCredential', { value: function () {}, configurable: true })
+    Object.defineProperty(globalThis.navigator, 'credentials', {
+        value: { get: impl },
+        configurable: true,
+    })
+}
+
+describe('requestLocalUserPresence', () => {
+    it('reports unsupported when there is no stored credential to prompt against', async () => {
+        withCredentialsGet(async () => ({}) as Credential)
+        await expect(requestLocalUserPresence(undefined)).resolves.toBe('unsupported')
+    })
+
+    it('reports unsupported when the platform has no WebAuthn', async () => {
+        Object.defineProperty(globalThis, 'PublicKeyCredential', { value: undefined, configurable: true })
+        await expect(requestLocalUserPresence(CREDENTIAL_ID)).resolves.toBe('unsupported')
+    })
+
+    it('unlocks when the authenticator returns an assertion', async () => {
+        withCredentialsGet(async () => ({}) as Credential)
+        await expect(requestLocalUserPresence(CREDENTIAL_ID)).resolves.toBe('unlocked')
+    })
+
+    it('stays locked when the user cancels the prompt', async () => {
+        withCredentialsGet(async () => {
+            throw Object.assign(new Error('cancelled'), { name: 'NotAllowedError' })
+        })
+        await expect(requestLocalUserPresence(CREDENTIAL_ID)).resolves.toBe('dismissed')
+    })
+
+    it('reports unsupported when the authenticator rejects the request outright', async () => {
+        withCredentialsGet(async () => {
+            throw Object.assign(new Error('nope'), { name: 'NotSupportedError' })
+        })
+        await expect(requestLocalUserPresence(CREDENTIAL_ID)).resolves.toBe('unsupported')
+    })
+
+    it('pins the request to the stored credential and demands user verification', async () => {
+        let received: PublicKeyCredentialRequestOptions | undefined
+        withCredentialsGet(async (options?: CredentialRequestOptions) => {
+            received = options?.publicKey
+            return {} as Credential
+        })
+        await requestLocalUserPresence(CREDENTIAL_ID)
+        expect(received?.userVerification).toBe('required')
+        expect(received?.allowCredentials).toHaveLength(1)
+        expect(new Uint8Array(received!.challenge as ArrayBufferView['buffer'])).not.toHaveLength(0)
+    })
+})

--- a/src/utils/__tests__/app-lock.test.ts
+++ b/src/utils/__tests__/app-lock.test.ts
@@ -6,6 +6,7 @@
 import { webcrypto } from 'node:crypto'
 
 import { requestLocalUserPresence } from '../app-lock'
+import { base64URLToBytes } from '../native-webauthn'
 
 if (!globalThis.crypto?.getRandomValues) {
     Object.defineProperty(globalThis, 'crypto', { value: webcrypto, configurable: true })
@@ -60,6 +61,12 @@ describe('requestLocalUserPresence', () => {
         await requestLocalUserPresence(CREDENTIAL_ID)
         expect(received?.userVerification).toBe('required')
         expect(received?.allowCredentials).toHaveLength(1)
-        expect(new Uint8Array(received!.challenge as ArrayBufferView['buffer'])).not.toHaveLength(0)
+        // Assert the actual bytes, not just the count: a descriptor for the
+        // WRONG credential would satisfy a length check while letting some
+        // other passkey on the device open the lock.
+        expect(Array.from(new Uint8Array(received!.allowCredentials![0].id as ArrayBuffer))).toEqual(
+            Array.from(base64URLToBytes(CREDENTIAL_ID))
+        )
+        expect(new Uint8Array(received!.challenge as ArrayBuffer)).not.toHaveLength(0)
     })
 })

--- a/src/utils/app-lock.ts
+++ b/src/utils/app-lock.ts
@@ -7,6 +7,13 @@
 // user's biometric or device passcode, which is exactly the property we want.
 // Server-side proof of a fresh assertion is a separate concern (step-up auth on
 // sensitive endpoints) and does not belong in a UI lock.
+//
+// It is a privacy screen and a deterrent, NOT account protection: the session
+// token stays where it always was (webview storage / cookie jar), reachable by
+// anything that can read the app's filesystem, and clearing the stored
+// credential id disables the gate entirely. Making it a genuine control means
+// moving the token into biometric-guarded Keychain/Keystore — tracked
+// separately.
 
 import { base64URLToBytes } from './native-webauthn'
 
@@ -19,9 +26,13 @@ export type UnlockOutcome = 'unlocked' | 'dismissed' | 'unsupported'
  * Prompts for the device biometric/passcode via a WebAuthn assertion against
  * the user's existing passkey.
  *
- * Returns 'unsupported' when we cannot prompt at all — no WebAuthn, or no
- * stored credential id. Callers must treat that as "do not lock": a lock we
- * can't lift would strand the user in their own app with no way back.
+ * Returns 'unsupported' when we cannot prompt at all — no WebAuthn, no stored
+ * credential id, or the authenticator rejecting the request outright
+ * (NotSupportedError). Callers must treat that as "do not lock": a lock we
+ * can't lift would strand the user in their own app with no way back. That
+ * makes every 'unsupported' path fail OPEN — this gate is a presence check for
+ * an honest user, not a security boundary against someone who can strip the
+ * stored credential id (see the module comment).
  */
 export async function requestLocalUserPresence(credentialId?: string): Promise<UnlockOutcome> {
     if (typeof window === 'undefined') return 'unsupported'
@@ -46,7 +57,9 @@ export async function requestLocalUserPresence(credentialId?: string): Promise<U
     } catch (error) {
         // A cancelled prompt and a genuinely broken authenticator are
         // indistinguishable here; both leave the app locked with a retry, which
-        // is the safe direction. Only the pre-flight checks above fail open.
+        // is the safe direction. NotSupportedError is the exception: it fails
+        // open (like the pre-flight checks), since it means this device cannot
+        // complete the ceremony at all and retrying would strand the user.
         if (error instanceof Error && error.name === 'NotSupportedError') return 'unsupported'
         return 'dismissed'
     }

--- a/src/utils/app-lock.ts
+++ b/src/utils/app-lock.ts
@@ -1,0 +1,53 @@
+// Native app lock: a local user-presence gate shown when the app is opened
+// cold or resumed after a spell in the background.
+//
+// This is deliberately a LOCAL check — the assertion is never sent to the API
+// for verification. The threat it addresses is physical: someone holding an
+// already-unlocked phone. The OS will not produce an assertion without the
+// user's biometric or device passcode, which is exactly the property we want.
+// Server-side proof of a fresh assertion is a separate concern (step-up auth on
+// sensitive endpoints) and does not belong in a UI lock.
+
+import { base64URLToBytes } from './native-webauthn'
+
+/** How long the app may sit in the background before it relocks. */
+export const LOCK_AFTER_BACKGROUND_MS = 5 * 60 * 1000
+
+export type UnlockOutcome = 'unlocked' | 'dismissed' | 'unsupported'
+
+/**
+ * Prompts for the device biometric/passcode via a WebAuthn assertion against
+ * the user's existing passkey.
+ *
+ * Returns 'unsupported' when we cannot prompt at all — no WebAuthn, or no
+ * stored credential id. Callers must treat that as "do not lock": a lock we
+ * can't lift would strand the user in their own app with no way back.
+ */
+export async function requestLocalUserPresence(credentialId?: string): Promise<UnlockOutcome> {
+    if (typeof window === 'undefined') return 'unsupported'
+    if (!credentialId) return 'unsupported'
+    if (!window.PublicKeyCredential || !navigator.credentials?.get) return 'unsupported'
+
+    const challenge = new Uint8Array(32)
+    crypto.getRandomValues(challenge)
+
+    try {
+        const assertion = await navigator.credentials.get({
+            publicKey: {
+                challenge,
+                // Copy into a fresh buffer: BufferSource wants Uint8Array<ArrayBuffer>,
+                // and base64URLToBytes is typed over the wider ArrayBufferLike.
+                allowCredentials: [{ id: new Uint8Array(base64URLToBytes(credentialId)), type: 'public-key' }],
+                userVerification: 'required',
+                timeout: 60_000,
+            },
+        })
+        return assertion ? 'unlocked' : 'dismissed'
+    } catch (error) {
+        // A cancelled prompt and a genuinely broken authenticator are
+        // indistinguishable here; both leave the app locked with a retry, which
+        // is the safe direction. Only the pre-flight checks above fail open.
+        if (error instanceof Error && error.name === 'NotSupportedError') return 'unsupported'
+        return 'dismissed'
+    }
+}


### PR DESCRIPTION
## Why

Peanut sessions persist for weeks, so an unlocked phone shows a funded account to whoever is holding it. Every peer consumer-fintech app gates the native shell behind a device biometric; we had nothing.

This is item **C** of the session-security series. Companion PRs cover step-up auth on sensitive endpoints (the actual server-side control), session lifetime bounds, and a report-only CSP.

## What this is — and is not

This is a **privacy screen and a deterrent**: it stops a person holding the phone from *seeing or navigating* the app without the owner's biometric. It is **not account protection**, and it must not be described to users as such:

- The session token stays where it always was (webview storage / native cookie jar), untouched by this PR. Anything that can read the app's filesystem — a webview inspector on an unlocked device, a backup — gets full API access without ever seeing the lock.
- Background API polling continues while the gate is up; the gate blocks rendering, not the session.
- Deleting the stored `credentialId` preference disables the gate entirely.

Real account protection on a lost device is server-side (step-up auth, #2463/#1217) plus, as a follow-up, moving the token into biometric-guarded Keychain/Keystore so it only materializes after a successful assertion.

## What

- `AppLockGate` covers the app on **cold start** and whenever it returns from more than **5 minutes** in the background.
- Unlock is a local WebAuthn assertion against the user's existing passkey — Face ID / Touch ID / device passcode.
- While pending or locked, the protected tree is **not rendered at all** — nothing behind the lock screen to focus, screenshot, or expose to assistive tech.
- Mounted once in `ClientProviders`. Renders children directly on web.

No new native dependency: `@capacitor/app` and `@capgo/capacitor-passkey` are already in the binary, so this ships over Capgo rather than needing a store release.

## The local-check decision

The assertion is **not** sent to the API for verification. The threat model here is physical — someone holding an already-unlocked phone — and the OS will not mint an assertion without user verification, which is the property we want. Proving assertion freshness to the server is a different control (step-up auth on card/withdrawal endpoints) and is deliberately not conflated with a UI lock.

## Failing open, on purpose

A lock that cannot be lifted is worse than no lock — it strands users in their own app. The full fail-open surface, explicitly: no stored credential, no WebAuthn on the platform, **and** the authenticator rejecting the ceremony with `NotSupportedError` all resolve to `unsupported`, which the gate treats as "do not lock". A *cancelled* prompt (`NotAllowedError` or any other error) keeps the gate up with a retry and a log-out escape. This asymmetry is acceptable precisely because the gate is a deterrent, not a security boundary — see "What this is — and is not".

## Testing

`src/utils/__tests__/app-lock.test.ts` pins which failure modes fall open vs. closed, credential pinning **including the exact credential-id bytes**, and `userVerification: 'required'`. Typecheck clean.

- [ ] Native smoke test before merge (not yet run on a device): cold start, background 6 min, resume, cancel the prompt, log-out escape — iOS and Android.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a native app security gate that unlocks only after a local WebAuthn user-presence check.
  * While locked, protected screens don’t render and a full-screen lock UI provides “Unlock” and “Log out”.
  * Automatically relocks when the app returns from the background after a set timeout.
* **Tests**
  * Added Jest coverage for unlock outcomes (unlocked, dismissed/canceled, unsupported) and validation of the generated WebAuthn request parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->