### PR TITLE
feat(security): report-only CSP with a script-src allow-list

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,18 +7,24 @@ const redirectsConfig = require('./redirects.json')
 
 /**
  * Sentry's CSP-report ingest endpoint, derived from the browser DSN
- * (`https://<publicKey>@<host>/<projectId>`). Returns null when the DSN is
- * absent or malformed, in which case the policy still ships — it just has
- * nowhere to report, which is better than emitting a broken `report-uri`.
+ * (`<protocol>://<publicKey>@<host><path>/<projectId>`). Returns null when the
+ * DSN is absent or malformed, in which case the policy still ships — it just
+ * has nowhere to report, which is better than emitting a broken `report-uri`.
+ *
+ * Protocol and any path prefix are preserved: self-hosted Sentry is commonly
+ * mounted under a sub-path, and flattening one would silently post reports to
+ * an endpoint that doesn't exist.
  */
 function sentryCspReportUri() {
     const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN
     if (!dsn) return null
     try {
-        const { host, username, pathname } = new URL(dsn)
-        const projectId = pathname.replace(/^\//, '')
+        const { protocol, host, username, pathname } = new URL(dsn)
+        const segments = pathname.split('/').filter(Boolean)
+        const projectId = segments.pop()
         if (!host || !username || !projectId) return null
-        return `https://${host}/api/${projectId}/security/?sentry_key=${username}`
+        const prefix = segments.length ? `/${segments.join('/')}` : ''
+        return `${protocol}//${host}${prefix}/api/${projectId}/security/?sentry_key=${username}`
     } catch {
         return null
     }

--- a/next.config.js
+++ b/next.config.js
@@ -79,8 +79,21 @@ function contentSecurityPolicyReportOnly() {
         "base-uri 'self'",
         "form-action 'self'",
     ]
-    if (reportUri) directives.push(`report-uri ${reportUri}`)
+    // Both delivery mechanisms on purpose: `report-uri` is deprecated but what
+    // Firefox/Safari actually send today, `report-to` (backed by the
+    // Reporting-Endpoints header below) is what replaces it in Chromium.
+    // Shipping only one would undercount violations and promote the policy on
+    // a partial picture.
+    if (reportUri) directives.push(`report-uri ${reportUri}`, `report-to ${CSP_REPORT_GROUP}`)
     return directives.join('; ')
+}
+
+const CSP_REPORT_GROUP = 'csp-endpoint'
+
+function reportingEndpointsHeader() {
+    const reportUri = sentryCspReportUri()
+    if (!reportUri) return []
+    return [{ key: 'Reporting-Endpoints', value: `${CSP_REPORT_GROUP}="${reportUri}"` }]
 }
 
 // Get git commit hash at build time
@@ -271,6 +284,7 @@ let nextConfig = {
                         value: "frame-ancestors 'self' https://hugo0.com; object-src 'none'; base-uri 'self'",
                     },
                     { key: 'Content-Security-Policy-Report-Only', value: contentSecurityPolicyReportOnly() },
+                    ...reportingEndpointsHeader(),
                     { key: 'X-Content-Type-Options', value: 'nosniff' },
                     { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
                 ],

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,78 @@ const withBundleAnalyzer =
 
 const redirectsConfig = require('./redirects.json')
 
+/**
+ * Sentry's CSP-report ingest endpoint, derived from the browser DSN
+ * (`https://<publicKey>@<host>/<projectId>`). Returns null when the DSN is
+ * absent or malformed, in which case the policy still ships — it just has
+ * nowhere to report, which is better than emitting a broken `report-uri`.
+ */
+function sentryCspReportUri() {
+    const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN
+    if (!dsn) return null
+    try {
+        const { host, username, pathname } = new URL(dsn)
+        const projectId = pathname.replace(/^\//, '')
+        if (!host || !username || !projectId) return null
+        return `https://${host}/api/${projectId}/security/?sentry_key=${username}`
+    } catch {
+        return null
+    }
+}
+
+/**
+ * First-draft CSP, shipped REPORT-ONLY.
+ *
+ * Nothing here is enforced yet: the app currently has no script-src at all, so
+ * an XSS anywhere is unconstrained. Guessing the allow-list and enforcing it
+ * would blank the app; instead this collects violation reports from real
+ * traffic until the list is known to be complete, then it gets promoted to the
+ * enforcing `Content-Security-Policy` header.
+ *
+ * Known-loose parts, to tighten before promotion:
+ * - `'unsafe-inline'` / `'unsafe-eval'` in script-src: Next's inline bootstrap
+ *   and the wallet SDKs need them today. Moving to nonces is its own change.
+ * - connect-src can't enumerate every chain RPC (they come from env and vary by
+ *   network), so the report stream is what completes this list.
+ */
+function contentSecurityPolicyReportOnly() {
+    const reportUri = sentryCspReportUri()
+    const directives = [
+        "default-src 'self'",
+        // PostHog is same-origin via the /relay rewrite, so it needs no entry here.
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://client.crisp.chat https://static.sumsub.com",
+        "style-src 'self' 'unsafe-inline' https://client.crisp.chat",
+        "img-src 'self' data: blob: https:",
+        "font-src 'self' data: https://client.crisp.chat",
+        [
+            "connect-src 'self'",
+            'https://api.peanut.me',
+            'https://*.peanut.me',
+            'https://*.ingest.sentry.io',
+            'https://*.ingest.us.sentry.io',
+            'https://www.google-analytics.com',
+            'https://rpc.zerodev.app',
+            'https://*.g.alchemy.com',
+            'https://rpc.ankr.com',
+            'https://assets.coingecko.com',
+            'https://coin-images.coingecko.com',
+            'https://api.frankfurter.app',
+            'https://dolarapi.com',
+            'https://client.crisp.chat',
+            'wss://client.relay.crisp.chat',
+            'https://*.sumsub.com',
+            'https://widget.manteca.dev',
+        ].join(' '),
+        "frame-src 'self' https://client.crisp.chat https://*.sumsub.com https://widget.manteca.dev https://mpago.la",
+        "worker-src 'self' blob:",
+        "object-src 'none'",
+        "base-uri 'self'",
+        "form-action 'self'",
+    ]
+    if (reportUri) directives.push(`report-uri ${reportUri}`)
+    return directives.join('; ')
+}
+
 // Get git commit hash at build time
 let gitCommitHash = 'unknown'
 try {
@@ -186,7 +258,13 @@ let nextConfig = {
                     },
                     // Security headers - prevents clickjacking and other attacks
                     // Using frame-ancestors instead of X-Frame-Options to allow specific domains
-                    { key: 'Content-Security-Policy', value: "frame-ancestors 'self' https://hugo0.com" },
+                    // object-src/base-uri are safe to enforce today: the app embeds no
+                    // plugins and sets no <base>, so neither can break a working page.
+                    {
+                        key: 'Content-Security-Policy',
+                        value: "frame-ancestors 'self' https://hugo0.com; object-src 'none'; base-uri 'self'",
+                    },
+                    { key: 'Content-Security-Policy-Report-Only', value: contentSecurityPolicyReportOnly() },
                     { key: 'X-Content-Type-Options', value: 'nosniff' },
                     { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
                 ],


### PR DESCRIPTION
## Why

`peanut-ui` has no `script-src` today — the only CSP anywhere is `frame-ancestors`. That means an XSS anywhere in the app runs unconstrained and can exfiltrate to any origin it likes. Combined with a JS-readable session token, one injection is a full account takeover.

This is item **E** of the session-security series. Companion PRs: the native app lock (#2461) and, on the API, session lifetime bounds and step-up auth.

> Heads up for reviewers: [SECURITY-DEFERRED-ISSUES.md](https://github.com/peanutprotocol/peanut-ui) records the audit's UI fixes as already shipped, referencing UI commit `110dea71d`. **That commit does not exist in this repo** and there is no `vercel.json` — the header work never landed. The doc's premise that the policy belongs in `vercel.json` is also wrong: only the *native* build is `output: 'export'`, so `next.config.js` `headers()` works fine for web, which is what this PR uses.

## What

- **Report-only** `Content-Security-Policy-Report-Only` with a full first-draft allow-list — `script-src`, `connect-src`, `style-src`, `img-src`, `font-src`, `frame-src`, `worker-src`, `form-action`.
- Reports go to Sentry via a `report-uri` derived from `NEXT_PUBLIC_SENTRY_DSN`. No DSN → the policy still ships, just without reporting (better than a malformed directive).
- Two directives added to the **enforcing** policy now: `object-src 'none'` and `base-uri 'self'`. The app embeds no plugins and sets no `<base>`, so neither can break a working page.

Nothing in the report-only policy is enforced, so this PR cannot break the app. That's the point — enforcing a guessed allow-list would blank it.

## Rollout

1. Merge; watch Sentry CSP reports across web **and** native for 1–2 weeks.
2. Widen until legitimate traffic stops reporting.
3. Promote to the enforcing header.

## Known-loose, to tighten before promotion

- `'unsafe-inline'` + `'unsafe-eval'` in `script-src` — Next's inline bootstrap and the wallet SDKs need them today. Moving to nonces is its own change, and until it happens `script-src` limits *where* script can come from but not inline injection.
- `connect-src` can't enumerate every chain RPC (env-driven, varies by network). The report stream is what completes that list.

## Testing

Rendered both headers out of the real config and asserted the Sentry `report-uri` derivation, plus the DSN-absent fallback. Not covered by an automated test — `next.config.js` isn't in the jest project.

## Follow-up not in this PR

`Strict-Transport-Security` is still missing and was part of the same lost audit branch. Left out to keep this reviewable; worth a one-line PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened browser security policies by restricting embedded content and tightening document base URL rules.
  * Expanded Content Security Policy coverage to include additional directive protections.
  * Added a non-blocking Content Security Policy “Report-Only” header to surface CSP violation events for monitoring, with optional reporting endpoints derived from existing monitoring configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->