### PR TITLE
fix: honest signup/login CTAs on vanity badge claim screen

### DIFF
--- a/src/components/Invites/InvitesPage.tsx
+++ b/src/components/Invites/InvitesPage.tsx
@@ -197,9 +197,9 @@ function InvitePageContent() {
     const description = isWaitlistSkip
         ? 'Someone at Peanut wants you in. Create your wallet and walk straight past the line — no invite code, no queue.'
         : isVanityClaim
-          ? 'You earned a Peanut badge. Claim it and open your wallet to send and receive money globally.'
+          ? 'You earned a Peanut badge. To claim it, sign up or log in.'
           : 'Members-only access. Use this invite to open your wallet and start sending and receiving money globally.'
-    const ctaLabel = isWaitlistSkip ? 'Claim your Skip Pass' : isVanityClaim ? 'Claim your badge' : 'Claim your spot'
+    const ctaLabel = isWaitlistSkip ? 'Claim your Skip Pass' : isVanityClaim ? 'Sign up' : 'Claim your spot'
 
     return (
         <InvitesPageLayout image={PeanutWavingHello.src}>
@@ -225,7 +225,7 @@ function InvitePageContent() {
                                 onClick={handleLoginClick}
                                 shadowSize="4"
                             >
-                                Already have an account? Log in!
+                                {isVanityClaim ? 'Log in' : 'Already have an account? Log in!'}
                             </Button>
                         )}
                     </div>

--- a/src/components/Invites/InvitesPage.tsx
+++ b/src/components/Invites/InvitesPage.tsx
@@ -200,6 +200,7 @@ function InvitePageContent() {
           ? 'You earned a Peanut badge. To claim it, sign up or log in.'
           : 'Members-only access. Use this invite to open your wallet and start sending and receiving money globally.'
     const ctaLabel = isWaitlistSkip ? 'Claim your Skip Pass' : isVanityClaim ? 'Sign up' : 'Claim your spot'
+    const loginLabel = isVanityClaim ? 'Log in' : 'Already have an account? Log in!'
 
     return (
         <InvitesPageLayout image={PeanutWavingHello.src}>
@@ -225,7 +226,7 @@ function InvitePageContent() {
                                 onClick={handleLoginClick}
                                 shadowSize="4"
                             >
-                                {isVanityClaim ? 'Log in' : 'Already have an account? Log in!'}
+                                {loginLabel}
                             </Button>
                         )}
                     </div>


### PR DESCRIPTION
## Summary

The bare-badge claim screen on `/invite?campaign=...` (TOUCHED_GRASS, IRL_NOMADS, CARD_ALPHA, …) presented a false dichotomy: a primary CTA labeled **"Claim your badge"** that actually routes to signup, next to **"Already have an account? Log in!"** framed as an alternative to claiming. Both paths claim the badge; the real fork is new vs existing user — and an existing user tapping the pink "claim" button got funneled into signup.

Only logged-out visitors ever see this variant (logged-in users are auto-claimed and routed by the effects in `InvitesPage.tsx`), so the fix is unconditional for the `isVanityClaim` branch:

- description → "You earned a Peanut badge. To claim it, sign up or log in."
- primary CTA → **Sign up** (which is what it does)
- login button → **Log in** (peer option, not a fallback)

All per-variant strings (incl. the login label) now live in the copy-variants const block — no copy buried in JSX.

Other variants (waitlist-skip, inviter-code) untouched.

## Risks / breaking changes

None — 3 copy strings in one component, no logic or routing changes. No cross-repo impact.

## QA

Open `/invite?campaign=IRL_NOMADS` logged out → headline "Claim your badge", description "…sign up or log in.", buttons **Sign up** / **Log in**. Sign-up path still sets the `campaignTag` cookie and awards the badge post-registration (unchanged `handleClaim`). Invites unit suite passes (41/41).
