### PR TITLE
fix(native): route push notification taps inside the app

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -59,6 +59,14 @@
                 <data android:pathPrefix="/withdraw/" />
                 <data android:path="/receipt" />
                 <data android:pathPrefix="/receipt/" />
+                <data android:path="/history" />
+                <data android:pathPrefix="/history/" />
+                <data android:path="/rewards" />
+                <data android:pathPrefix="/rewards/" />
+                <data android:path="/badges" />
+                <data android:pathPrefix="/badges/" />
+                <data android:path="/profile" />
+                <data android:pathPrefix="/profile/" />
             </intent-filter>
 
         </activity>
@@ -78,6 +86,15 @@
         <meta-data
             android:name="asset_statements"
             android:resource="@string/capacitor_passkey_asset_statements" />
+
+        <!-- Don't let OneSignal fire its own ACTION_VIEW for a notification's
+             launch URL. The tap opens the app and useNativePlugins routes on the
+             deep link in-app instead — which covers destinations outside the App
+             Links filter above, doesn't depend on link verification, and keeps
+             iOS and Android on the same code path. -->
+        <meta-data
+            android:name="com.onesignal.suppressLaunchURLs"
+            android:value="true" />
     </application>
 
     <!-- Phone-only: require a telephony radio so Play filters out Wi-Fi-only

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -49,6 +49,12 @@
 	<string>Peanut may use your location to help verify your identity and prevent fraud during account setup and support.</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<!-- Stop OneSignal calling openURL for a notification's launch URL. iOS won't
+	     re-enter this app for its own universal link, so without this a tapped push
+	     bounces the user out to Safari. useNativePlugins routes the deep link in-app
+	     from the click listener instead. -->
+	<key>OneSignal_suppress_launch_urls</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/src/app/(mobile-ui)/notifications/page.tsx
+++ b/src/app/(mobile-ui)/notifications/page.tsx
@@ -7,6 +7,7 @@ import NavHeader from '@/components/Global/NavHeader'
 import PeanutLoading from '@/components/Global/PeanutLoading'
 import { notificationsApi, type InAppItem } from '@/services/notifications'
 import { formatGroupHeaderDate, getDateGroup, getDateGroupKey } from '@/utils/dateGrouping.utils'
+import { deepLinkToNativePath } from '@/utils/native-routes'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import Image from 'next/image'
 import { PEANUTMAN } from '@/assets'
@@ -157,7 +158,13 @@ export default function NotificationsPage() {
                                         if (group.items.length === 1) position = 'single'
                                         else if (idx === 0) position = 'first'
                                         else if (idx === group.items.length - 1) position = 'last'
+                                        // Rows minted from the OneSignal-dashboard webhook store the
+                                        // operator's `url` verbatim, so an absolute peanut.me link would
+                                        // navigate the webview off-app. Map those back to an in-app path;
+                                        // genuinely external links fall through untouched.
                                         const href = notif.ctaDeeplink
+                                            ? (deepLinkToNativePath(notif.ctaDeeplink) ?? notif.ctaDeeplink)
+                                            : notif.ctaDeeplink
                                         return (
                                             <Card
                                                 key={notif.id}

--- a/src/app/(mobile-ui)/receipt/page.tsx
+++ b/src/app/(mobile-ui)/receipt/page.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useQuery } from '@tanstack/react-query'
+import PageContainer from '@/components/0_Bruddle/PageContainer'
+import NavHeader from '@/components/Global/NavHeader'
+import PeanutLoading from '@/components/Global/PeanutLoading'
+import { TransactionDetailsReceipt } from '@/components/TransactionDetails/TransactionDetailsReceipt'
+import { mapTransactionDataForDrawer } from '@/components/TransactionDetails/transactionTransformer'
+import { resolveReceiptKind } from '@/components/TransactionDetails/strategies/registry'
+import { TRANSACTIONS } from '@/constants/query.consts'
+import { apiFetch } from '@/utils/api-fetch'
+import { completeHistoryEntry, isFinalState, type HistoryEntry } from '@/utils/history.utils'
+
+// Client twin of the web /receipt/[entryId] page. That one is a server component
+// and is stripped from the static export (scripts/native-build.js), so a receipt
+// deep link — the most common push destination — had nothing to render natively.
+// deepLinkToNativePath maps /receipt/<id>?kind=X onto this route's query params.
+export default function NativeReceiptPage() {
+    const router = useRouter()
+    const searchParams = useSearchParams()
+    const entryId = searchParams.get('id')
+    const kind = resolveReceiptKind(searchParams.get('kind') ?? undefined, searchParams.get('t') ?? undefined)
+
+    const {
+        data: entry,
+        isLoading,
+        isError,
+    } = useQuery({
+        queryKey: [TRANSACTIONS, 'entry', entryId, kind],
+        enabled: Boolean(entryId && kind),
+        queryFn: async (): Promise<HistoryEntry> => {
+            const response = await apiFetch(`/history/${encodeURIComponent(entryId!)}?kind=${kind}`)
+            if (!response.ok) throw new Error(`Failed to fetch history entry: ${response.status}`)
+            return completeHistoryEntry(await response.json())
+        },
+        // A pending transaction can still settle while the receipt is open.
+        refetchInterval: (query) => (query.state.data && !isFinalState(query.state.data) ? 15_000 : false),
+    })
+
+    useEffect(() => {
+        if (!entryId || !kind || isError) router.replace('/home')
+    }, [entryId, kind, isError, router])
+
+    if (!entryId || !kind || isError) return null
+
+    return (
+        <PageContainer className="flex min-h-[100dvh] flex-col items-center justify-center p-6">
+            <div className="md:hidden">
+                <NavHeader title="Receipt" />
+            </div>
+            <div className="flex flex-1 flex-col items-center justify-center">
+                {isLoading || !entry ? (
+                    <PeanutLoading />
+                ) : (
+                    <TransactionDetailsReceipt
+                        className="w-full"
+                        transaction={mapTransactionDataForDrawer(entry).transactionDetails}
+                    />
+                )}
+            </div>
+        </PageContainer>
+    )
+}

--- a/src/app/(mobile-ui)/receipt/page.tsx
+++ b/src/app/(mobile-ui)/receipt/page.tsx
@@ -39,11 +39,16 @@ export default function NativeReceiptPage() {
         refetchInterval: (query) => (query.state.data && !isFinalState(query.state.data) ? 15_000 : false),
     })
 
-    useEffect(() => {
-        if (!entryId || !kind || isError) router.replace('/home')
-    }, [entryId, kind, isError, router])
+    // `isError` also trips on a failed background poll, so gate the bail-out on
+    // having no data at all — a flaky refetch must not yank the user off a
+    // receipt they're watching settle.
+    const isUnrecoverable = !entryId || !kind || (isError && !entry)
 
-    if (!entryId || !kind || isError) return null
+    useEffect(() => {
+        if (isUnrecoverable) router.replace('/home')
+    }, [isUnrecoverable, router])
+
+    if (isUnrecoverable) return null
 
     return (
         <PageContainer className="flex min-h-[100dvh] flex-col items-center justify-center p-6">

--- a/src/hooks/useNativePlugins.ts
+++ b/src/hooks/useNativePlugins.ts
@@ -61,7 +61,17 @@ export function useNativePlugins() {
                 cleanups.push(
                     adapter.onNotificationClick(({ deepLink, additionalData }) => {
                         const target = additionalData.deepLink
-                        openDeepLink(typeof target === 'string' ? target : deepLink)
+                        const link = typeof target === 'string' ? target : deepLink
+                        // Off-domain https links (operator sends) can't route in-app;
+                        // with launch URLs suppressed, hand them to the system browser
+                        // rather than silently swallowing the tap.
+                        if (link && !deepLinkToNativePath(link) && /^https:\/\//i.test(link)) {
+                            import('@capacitor/browser')
+                                .then(({ Browser }) => Browser.open({ url: link }))
+                                .catch((e) => console.warn('failed to open external push link:', e))
+                            return
+                        }
+                        openDeepLink(link)
                     })
                 )
             } catch (e) {

--- a/src/hooks/useNativePlugins.ts
+++ b/src/hooks/useNativePlugins.ts
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { isCapacitor, getPlatform } from '@/utils/capacitor'
 import { deepLinkToNativePath } from '@/utils/native-routes'
 import { sanitizeRedirectURL } from '@/utils/general.utils'
+import { getOneSignalAdapter } from '@/services/onesignal'
 
 /**
  * initializes capacitor native plugins (back button, status bar, splash screen).
@@ -48,6 +49,23 @@ export function useNativePlugins() {
                 cleanups.push(() => urlListener.remove())
             } catch (e) {
                 console.warn('failed to init app listeners:', e)
+            }
+
+            try {
+                // Push taps: the OneSignal SDKs are configured not to open the
+                // launch URL themselves (suppressLaunchURLs / OneSignal_suppress_launch_urls),
+                // so routing is ours. `additionalData.deepLink` is the canonical
+                // relative path the API sends; the launch URL is the fallback for
+                // notifications sent before that field existed.
+                const adapter = await getOneSignalAdapter()
+                cleanups.push(
+                    adapter.onNotificationClick(({ deepLink, additionalData }) => {
+                        const target = additionalData.deepLink
+                        openDeepLink(typeof target === 'string' ? target : deepLink)
+                    })
+                )
+            } catch (e) {
+                console.warn('failed to init notification click listener:', e)
             }
 
             try {

--- a/src/services/onesignal/native.adapter.test.ts
+++ b/src/services/onesignal/native.adapter.test.ts
@@ -1,0 +1,80 @@
+import type { NotificationClickInfo } from './types'
+
+// virtual: the plugin ships ESM-only exports jest's resolver can't load;
+// the adapter only ever runs in native builds where webpack resolves it.
+jest.mock(
+    '@onesignal/capacitor-plugin',
+    () => ({
+        __esModule: true,
+        default: {
+            initialize: jest.fn().mockResolvedValue(undefined),
+            login: jest.fn(),
+            logout: jest.fn(),
+            Notifications: {
+                addEventListener: jest.fn(),
+                hasPermission: jest.fn().mockResolvedValue(true),
+                canRequestPermission: jest.fn().mockResolvedValue(true),
+                requestPermission: jest.fn(),
+            },
+            User: {
+                pushSubscription: {
+                    addEventListener: jest.fn(),
+                    getOptedInAsync: jest.fn().mockResolvedValue(true),
+                },
+            },
+        },
+    }),
+    { virtual: true }
+)
+
+import OneSignal from '@onesignal/capacitor-plugin'
+import { nativeOneSignalAdapter } from './native.adapter'
+
+function getClickCallback(): (event: unknown) => void {
+    const call = (OneSignal.Notifications.addEventListener as jest.Mock).mock.calls.find(([name]) => name === 'click')
+    expect(call).toBeDefined()
+    return call![1]
+}
+
+describe('nativeOneSignalAdapter cold-start click buffering', () => {
+    beforeAll(async () => {
+        process.env.NEXT_PUBLIC_ONESIGNAL_APP_ID = 'test-app-id'
+        await nativeOneSignalAdapter.init()
+    })
+
+    // The Capacitor bridge retains a cold-start click only until the first JS
+    // listener attaches — which init() does. If the event arrives before
+    // useNativePlugins has registered its routing callback, the adapter must
+    // hold it and replay it, or the tap is silently dropped.
+    it('replays a click that fired before any listener registered', () => {
+        const fireClick = getClickCallback()
+        fireClick({
+            notification: {
+                launchURL: 'https://peanut.me/receipt/intent-1?kind=ONRAMP',
+                additionalData: { deepLink: '/receipt/intent-1?kind=ONRAMP' },
+            },
+        })
+
+        const seen: NotificationClickInfo[] = []
+        const off = nativeOneSignalAdapter.onNotificationClick((info) => seen.push(info))
+        expect(seen).toEqual([
+            {
+                deepLink: 'https://peanut.me/receipt/intent-1?kind=ONRAMP',
+                additionalData: { deepLink: '/receipt/intent-1?kind=ONRAMP' },
+            },
+        ])
+
+        // one-shot: a second listener must not receive the same tap again
+        const seenLater: NotificationClickInfo[] = []
+        const offLater = nativeOneSignalAdapter.onNotificationClick((info) => seenLater.push(info))
+        expect(seenLater).toEqual([])
+
+        // once listeners exist, clicks are delivered live, not buffered
+        fireClick({ result: { url: 'https://peanut.me/rewards' }, notification: { additionalData: {} } })
+        expect(seen).toHaveLength(2)
+        expect(seenLater).toHaveLength(1)
+
+        off()
+        offLater()
+    })
+})

--- a/src/services/onesignal/native.adapter.ts
+++ b/src/services/onesignal/native.adapter.ts
@@ -14,6 +14,15 @@ let initPromise: Promise<void> | null = null
 const permissionListeners = new Set<(state: NotificationPermissionState) => void>()
 const subscriptionListeners = new Set<(optedIn: boolean) => void>()
 const clickListeners = new Set<(info: NotificationClickInfo) => void>()
+/**
+ * Cold-start tap buffer. Capacitor retains the click event only until the first
+ * JS listener attaches — which happens inside init() (attachUnderlyingListeners),
+ * driven by useNotifications. useNativePlugins registers its routing callback on
+ * a separate async path, so if init() wins that race the retained event would be
+ * consumed with an empty listener set and the tap silently dropped. Hold the
+ * last unconsumed click here and replay it to the next listener that registers.
+ */
+let pendingClick: NotificationClickInfo | null = null
 let underlyingListenersAttached = false
 
 function attachUnderlyingListeners() {
@@ -33,6 +42,10 @@ function attachUnderlyingListeners() {
         const info: NotificationClickInfo = {
             deepLink: event?.result?.url ?? event?.notification?.launchURL,
             additionalData: (event?.notification?.additionalData ?? {}) as Record<string, unknown>,
+        }
+        if (clickListeners.size === 0) {
+            pendingClick = info
+            return
         }
         clickListeners.forEach((cb) => cb(info))
     })
@@ -90,6 +103,11 @@ export const nativeOneSignalAdapter: OneSignalAdapter = {
 
     onNotificationClick(listener) {
         clickListeners.add(listener)
+        if (pendingClick) {
+            const buffered = pendingClick
+            pendingClick = null
+            listener(buffered)
+        }
         return () => clickListeners.delete(listener)
     },
 }

--- a/src/utils/__tests__/native-routes.test.ts
+++ b/src/utils/__tests__/native-routes.test.ts
@@ -20,6 +20,7 @@ import {
     withdrawCountryUrl,
     withdrawBankUrl,
     rewriteMethodPath,
+    deepLinkToNativePath,
 } from '../native-routes'
 
 describe('native-routes', () => {
@@ -287,6 +288,64 @@ describe('native-routes', () => {
         describe('requestPotUrl', () => {
             it('should return /pay-request with id query param', () => {
                 expect(requestPotUrl('pot-789')).toBe('/pay-request?id=pot-789')
+            })
+        })
+    })
+
+    describe('deepLinkToNativePath', () => {
+        describe('capacitor mode', () => {
+            beforeEach(() => {
+                mockIsCapacitor.mockReturnValue(true)
+            })
+
+            it('accepts a bare path — push payloads carry the deep link without a host', () => {
+                expect(deepLinkToNativePath('/receipt/intent-1?kind=ONRAMP')).toBe('/receipt?id=intent-1&kind=ONRAMP')
+            })
+
+            it('accepts a full App-Links url', () => {
+                expect(deepLinkToNativePath('https://peanut.me/receipt/intent-1?kind=ONRAMP')).toBe(
+                    '/receipt?id=intent-1&kind=ONRAMP'
+                )
+            })
+
+            it('maps a charge deep link onto the pay-request stand-in for the disabled catch-all route', () => {
+                expect(deepLinkToNativePath('/alice?chargeId=charge-123')).toBe('/pay-request?chargeId=charge-123')
+            })
+
+            it('leaves a static in-app route untouched', () => {
+                expect(deepLinkToNativePath('https://peanut.me/history')).toBe('/history')
+            })
+
+            it('still rewrites dynamic routes to their query-param form', () => {
+                expect(deepLinkToNativePath('https://peanut.me/send/bob')).toBe('/send?recipient=bob')
+                expect(deepLinkToNativePath('https://peanut.me/qr/abc123')).toBe('/qr?code=abc123')
+                expect(deepLinkToNativePath('https://peanut.me/withdraw/be/bank')).toBe(
+                    '/withdraw?country=be&view=bank'
+                )
+            })
+
+            it('rejects an off-domain url rather than rewriting it into an in-app path', () => {
+                expect(deepLinkToNativePath('https://evil.com/receipt/intent-1')).toBeNull()
+            })
+
+            it('returns null for an unparseable link', () => {
+                expect(deepLinkToNativePath('http://')).toBeNull()
+            })
+        })
+
+        describe('web mode', () => {
+            beforeEach(() => {
+                mockIsCapacitor.mockReturnValue(false)
+            })
+
+            it('keeps the path-based receipt url', () => {
+                expect(deepLinkToNativePath('https://peanut.me/receipt/intent-1?kind=ONRAMP')).toBe(
+                    '/receipt/intent-1?kind=ONRAMP'
+                )
+            })
+
+            it('keeps a profile charge link on the profile route', () => {
+                expect(deepLinkToNativePath('/alice?chargeId=charge-123')).toBe('/alice?chargeId=charge-123')
             })
         })
     })

--- a/src/utils/__tests__/native-routes.test.ts
+++ b/src/utils/__tests__/native-routes.test.ts
@@ -331,6 +331,31 @@ describe('native-routes', () => {
             it('returns null for an unparseable link', () => {
                 expect(deepLinkToNativePath('http://')).toBeNull()
             })
+
+            // This runs during render in the notifications list, so a throw here
+            // would blank the whole page rather than drop one bad row.
+            it.each([
+                ['receipt id', '/receipt/%E0%A4%A'],
+                ['send recipient', '/send/%E0%A4%A'],
+                ['qr code', '/qr/%'],
+                ['bare username', '/%'],
+            ])('never throws on malformed percent-encoding in the %s', (_label, link) => {
+                expect(() => deepLinkToNativePath(link)).not.toThrow()
+            })
+
+            it.each(['/receipt/%E0%A4%A', '/send/%E0%A4%A', '/qr/%'])(
+                'degrades %s to null when the decode fails mid-mapping',
+                (link) => {
+                    expect(deepLinkToNativePath(link)).toBeNull()
+                }
+            )
+
+            it.each(['/rewards', '/history', '/badges', '/profile'])(
+                'leaves the reserved route %s alone even with a chargeId param',
+                (route) => {
+                    expect(deepLinkToNativePath(`${route}?chargeId=charge-123`)).toBe(`${route}?chargeId=charge-123`)
+                }
+            )
         })
 
         describe('web mode', () => {

--- a/src/utils/native-routes.ts
+++ b/src/utils/native-routes.ts
@@ -4,6 +4,12 @@
 
 import { isCapacitor } from './capacitor'
 
+// Deep links are peanut.me links by definition — that's the host the Android
+// App Links filter and the AASA are bound to. Deliberately not derived from
+// NEXT_PUBLIC_BASE_URL: a build pointed at a preview origin must still route a
+// real peanut.me notification link.
+const APP_HOSTS = /^(.+\.)?peanut\.me$/
+
 export function profileUrl(username: string): string {
     return isCapacitor() ? `/send?recipient=${encodeURIComponent(username)}` : `/${username}`
 }
@@ -64,21 +70,29 @@ export function withdrawBankUrl(countryPath: string, queryParams?: string): stri
 }
 
 /**
- * Maps an incoming App-Links URL (https://peanut.me/<path>) to the path the
- * native static export can actually render. Dynamic web routes are funnelled
- * through the same query-param helpers used to build outbound links, so
- * `/send/<user>` → `/send?recipient=<user>`, `/qr/<code>` → `/qr?code=<code>`,
- * `/add-money/<country>/bank` → `/add-money?country=<country>&view=bank`, etc.
- * Static routes (e.g. `/card`, `/pay-request`) pass through unchanged.
- * Returns null for an unparseable URL.
+ * Maps an incoming deep link — an App-Links URL (https://peanut.me/<path>) or a
+ * bare path from a push payload — to the path the native static export can
+ * actually render. Dynamic web routes are funnelled through the same query-param
+ * helpers used to build outbound links, so `/send/<user>` → `/send?recipient=<user>`,
+ * `/qr/<code>` → `/qr?code=<code>`, `/add-money/<country>/bank` →
+ * `/add-money?country=<country>&view=bank`, etc. Static routes (e.g. `/card`,
+ * `/pay-request`) pass through unchanged.
+ *
+ * Returns null for an unparseable link or one pointing at another host — an
+ * off-domain URL must stay off-domain rather than be rewritten into a bogus
+ * in-app path.
  */
 export function deepLinkToNativePath(url: string): string | null {
     let parsed: URL
     try {
-        parsed = new URL(url)
+        // Relative base: push payloads carry the canonical path (`/receipt/<id>`),
+        // App Links carry the full URL. Both must resolve.
+        parsed = new URL(url, 'https://peanut.me')
     } catch {
         return null
     }
+    if (!APP_HOSTS.test(parsed.hostname)) return null
+
     const path = parsed.pathname
     const extraParams = parsed.search.replace(/^\?/, '')
     const segments = path.split('/').filter(Boolean)
@@ -95,6 +109,19 @@ export function deepLinkToNativePath(url: string): string | null {
     }
     if (segments[0] === 'add-money' || segments[0] === 'withdraw') {
         return rewriteMethodPath(path, extraParams || undefined)
+    }
+    // `/receipt/<id>?kind=X` — the web receipt page is a server component and is
+    // stripped from the static export (scripts/native-build.js), so native routes
+    // to the client variant. `kind` rides along in extraParams.
+    if (segments[0] === 'receipt' && segments[1]) {
+        const id = decodeURIComponent(segments[1])
+        return appendParams(isCapacitor() ? `/receipt?id=${encodeURIComponent(id)}` : path, extraParams)
+    }
+    // `/<username>?chargeId=<uuid>` — the catch-all profile route is disabled in
+    // native builds; /pay-request is its stand-in (see (mobile-ui)/pay-request).
+    if (isCapacitor() && segments.length === 1) {
+        const chargeId = parsed.searchParams.get('chargeId')
+        if (chargeId) return chargePayUrl(chargeId)
     }
 
     return appendParams(path, extraParams)

--- a/src/utils/native-routes.ts
+++ b/src/utils/native-routes.ts
@@ -2,6 +2,7 @@
 // in capacitor (static export), dynamic routes don't work — use query params instead.
 // on web, use the normal path-based urls.
 
+import { couldBeRecipient, isReservedRoute } from '@/constants/routes'
 import { isCapacitor } from './capacitor'
 
 // Deep links are peanut.me links by definition — that's the host the Android
@@ -83,14 +84,20 @@ export function withdrawBankUrl(countryPath: string, queryParams?: string): stri
  * in-app path.
  */
 export function deepLinkToNativePath(url: string): string | null {
-    let parsed: URL
     try {
-        // Relative base: push payloads carry the canonical path (`/receipt/<id>`),
-        // App Links carry the full URL. Both must resolve.
-        parsed = new URL(url, 'https://peanut.me')
+        return mapDeepLink(url)
     } catch {
+        // The whole body is guarded, not just the URL parse: decodeURIComponent
+        // throws URIError on a stray `%`, and this runs during render in the
+        // notifications list — one malformed ctaDeeplink would blank the page.
         return null
     }
+}
+
+function mapDeepLink(url: string): string | null {
+    // Relative base: push payloads carry the canonical path (`/receipt/<id>`),
+    // App Links carry the full URL. Both must resolve.
+    const parsed = new URL(url, 'https://peanut.me')
     if (!APP_HOSTS.test(parsed.hostname)) return null
 
     const path = parsed.pathname
@@ -119,7 +126,9 @@ export function deepLinkToNativePath(url: string): string | null {
     }
     // `/<username>?chargeId=<uuid>` — the catch-all profile route is disabled in
     // native builds; /pay-request is its stand-in (see (mobile-ui)/pay-request).
-    if (isCapacitor() && segments.length === 1) {
+    // Gated by the same reserved-route/recipient rules the web catch-all uses, so
+    // `/rewards?chargeId=x` stays on /rewards instead of landing on /pay-request.
+    if (isCapacitor() && segments.length === 1 && !isReservedRoute(path) && couldBeRecipient(segments[0])) {
         const chargeId = parsed.searchParams.get('chargeId')
         if (chargeId) return chargePayUrl(chargeId)
     }


### PR DESCRIPTION
## Problem

Companion to peanutprotocol/peanut-api-ts#1220, which fixes the malformed launch URL (`http:///receipt/<id>` → Chrome on nothing). That alone still leaves the tap outside the app:

- **OneSignal fires its own `ACTION_VIEW`/`openURL`** for the launch URL, so Android only re-enters the app for paths in the App Links filter — `/history`, `/rewards`, `/badges`, `/profile/*` all bounce to the browser
- **iOS always leaves the app.** iOS does not re-enter an app for its own universal link, so `openURL` hands the tap to Safari
- **`/receipt/<id>` 404s *inside* the app.** `scripts/native-build.js` strips the `receipt` directory from the static export (it's a server component), yet `/receipt` is in the intent filter and is the most common push destination
- **`/<username>?chargeId=…`** (charge-paid pushes) targets the catch-all route, which is also disabled in native builds

## Change

**Suppress launch URLs on both platforms** — `com.onesignal.suppressLaunchURLs` (AndroidManifest) and `OneSignal_suppress_launch_urls` (Info.plist) — and route the tap ourselves from the click listener in `useNativePlugins`, reusing the existing App Links path (`deepLinkToNativePath` → `sanitizeRedirectURL` → `router.push`). That covers destinations outside the intent filter and drops the dependency on link verification. It prefers `additionalData.deepLink` (the canonical relative path the API now sends) and falls back to the launch URL for notifications sent before that field existed.

**`deepLinkToNativePath`** now accepts a bare path (push payloads carry one), rejects off-domain links instead of rewriting them into a bogus in-app path, and maps the two missing destinations: `/receipt/<id>?kind=X` and `/<username>?chargeId=` → `/pay-request?chargeId=` (which `(mobile-ui)/pay-request/page.tsx` already describes as the native stand-in for the disabled catch-all). The host allowlist is a hardcoded `peanut.me` matcher, deliberately **not** `NEXT_PUBLIC_BASE_URL` — a build pointed at a preview origin must still route a real notification link.

**New client receipt screen** at `(mobile-ui)/receipt` reading `?id=&kind=`, fetching `GET /history/:id?kind=` through `apiFetch` + `completeHistoryEntry` — the same endpoint the web server component uses — and rendering the existing `TransactionDetailsReceipt`. Pending transactions poll until they reach a final state.

**Also:** widen App Links to `/history`, `/rewards`, `/badges`, `/profile` (email CTA targets that open the browser today — `/help` deliberately left out as a marketing page), and map absolute `peanut.me` hrefs in the in-app inbox back to in-app paths, since dashboard-webhook rows store the operator's `url` verbatim.

## Test

- `pnpm jest src/utils/__tests__/native-routes.test.ts` — 58 pass, incl. 9 new `deepLinkToNativePath` cases across capacitor/web
- `pnpm build` (web) passes, with `/receipt` (static) and `/receipt/[entryId]` (dynamic) coexisting — no route collision
- `node scripts/native-build.js` produces `out/receipt/index.html`, so receipt deep links now render natively

⚠️ **Not yet verified on a device** — needs the tap-through matrix (receipt / `/history` / `/rewards` / charge-paid, app cold + backgrounded + foregrounded, both platforms). Cold start specifically depends on the OneSignal SDK holding the click event until a JS listener attaches. Reinstall is required for App Links to re-verify; check with `adb shell pm get-app-links me.peanut.wallet`.

⚠️ `OneSignal_suppress_launch_urls` comes from [OneSignal's deep-linking docs](https://documentation.onesignal.com/docs/en/deep-linking); the Android counterpart is confirmed present in `notifications-5.9.3.aar` (`OSNotificationOpenAppSettings.getSuppressLaunchURL`). Worth confirming on-device during the iOS pass.

Note: `pnpm native:build` currently fails on `main` before it reaches any of this — the anti-rot guard only consults `ITEMS_TO_DISABLE` and so rejects `(mobile-ui)/claim/page.tsx`, which `P0_TRANSFORMS` already fixes up. Pre-existing and tracked separately; patched locally to run the export check above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a native receipt view to open transaction details from supported deep links.
  - Notification actions now route to the correct in-app destination when possible.
- **Bug Fixes**
  - Improved deep-link mapping and validation for native routing, including receipt/payment request paths.
  - External/unconvertible links now fall back to opening in the system browser.
  - Notification click handling now buffers early taps to prevent missed navigation.
- **Tests**
  - Added/expanded deep-link routing and OneSignal adapter coverage for web and native flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->