### PR TITLE
fix(notifications): surface native OneSignal failures in Sentry

### DIFF
--- a/src/hooks/useNativePlugins.ts
+++ b/src/hooks/useNativePlugins.ts
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
+import { captureMessage } from '@sentry/nextjs'
 import { isCapacitor, getPlatform } from '@/utils/capacitor'
 import { deepLinkToNativePath } from '@/utils/native-routes'
 import { sanitizeRedirectURL } from '@/utils/general.utils'
@@ -12,6 +13,8 @@ import { sanitizeRedirectURL } from '@/utils/general.utils'
  * plugins are loaded via dynamic import with webpackIgnore since they only
  * exist in native builds (not on vercel/web ci).
  */
+let appListenersFailureCaptured = false
+
 export function useNativePlugins() {
     const router = useRouter()
 
@@ -48,6 +51,15 @@ export function useNativePlugins() {
                 cleanups.push(() => urlListener.remove())
             } catch (e) {
                 console.warn('failed to init app listeners:', e)
+                // without these listeners push-tap deep links never route, so surface the failure
+                if (!appListenersFailureCaptured) {
+                    appListenersFailureCaptured = true
+                    captureMessage('failed to init native app listeners', {
+                        level: 'warning',
+                        tags: { feature: 'onesignal', source: 'native_app_listeners' },
+                        extra: { error: e instanceof Error ? e.message : String(e) },
+                    })
+                }
             }
 
             try {

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useSyncExternalStore } from 'react'
-import { captureException } from '@sentry/nextjs'
+import { captureException, captureMessage } from '@sentry/nextjs'
 import { getOneSignalAdapter, type NotificationPermissionState } from '@/services/onesignal'
 import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils'
 import { isDemoMode } from '@/utils/demo'
@@ -62,8 +62,15 @@ function handleLoginError(err: unknown) {
     const msg = err instanceof Error ? err.message : String(err ?? '')
     // disable login on identity verification errors
     if (msg.toLowerCase().includes('identity') || msg.toLowerCase().includes('verify')) {
+        if (disableExternalIdLogin) return
         disableExternalIdLogin = true
         console.warn('OneSignal external_id login disabled due to identity verification error')
+        // silently disabling login unlinks the device from the user, so pushes target no one
+        captureMessage('OneSignal external_id login disabled after identity verification error', {
+            level: 'warning',
+            tags: { feature: 'onesignal', onesignal: 'login-disabled' },
+            extra: { error: msg },
+        })
     }
 }
 
@@ -211,7 +218,7 @@ async function ensureInitialized() {
     } catch (e) {
         // Surface Brave/Shields SDK-block failures; previously silent.
         console.warn('OneSignal init failed', e)
-        captureException(e, { tags: { source: 'onesignal_init' } })
+        captureException(e, { level: 'warning', tags: { feature: 'onesignal', source: 'onesignal_init' } })
     }
 }
 

--- a/src/services/onesignal/native.adapter.ts
+++ b/src/services/onesignal/native.adapter.ts
@@ -1,4 +1,5 @@
 import OneSignal from '@onesignal/capacitor-plugin'
+import { captureMessage } from '@sentry/nextjs'
 import type { NotificationClickEvent, PushSubscriptionChangedState } from '@onesignal/capacitor-plugin'
 import type { NotificationClickInfo, NotificationPermissionState, OneSignalAdapter } from './types'
 
@@ -44,6 +45,11 @@ export const nativeOneSignalAdapter: OneSignalAdapter = {
         initPromise = (async () => {
             const appId = process.env.NEXT_PUBLIC_ONESIGNAL_APP_ID
             if (!appId) {
+                // captured here too so a swallowed init() rejection can't hide a broken build config
+                captureMessage('OneSignal init failed: NEXT_PUBLIC_ONESIGNAL_APP_ID is missing', {
+                    level: 'warning',
+                    tags: { feature: 'onesignal', onesignal: 'missing-app-id' },
+                })
                 throw new Error('OneSignal configuration missing: NEXT_PUBLIC_ONESIGNAL_APP_ID is required')
             }
             await OneSignal.initialize(appId)


### PR DESCRIPTION
## Problem

Native OneSignal failures never reach Sentry — there are zero OneSignal issues tagged `environment:native`, while the same failures on web are plentiful (captured via `captureConsole`). The native failure paths all swallow errors with `console.warn`, so a device that silently unlinks from its user (all pushes target 0 recipients) or an app built without an OneSignal app id is invisible.

## Changes

All captures fire once per session per failure class, at `warning` level, tagged `feature:onesignal` so they're queryable with one search:

- **`useNotifications.ts` — `handleLoginError()`**: when an identity/verify error permanently disables `external_id` login (silently unlinking the device from the user), emit `captureMessage` tagged `onesignal:login-disabled` with the error message. Guarded by the existing `disableExternalIdLogin` flag so it fires once.
- **`useNotifications.ts` — `ensureInitialized()`**: the existing `captureException` now carries `feature:onesignal` and `level: warning` (init runs once per page, so already once-per-session).
- **`useNativePlugins.ts`**: the "failed to init app listeners" catch (back button + push-tap deep-link routing) now captures, gated by a module-level flag. (The "notification click listener" catch mentioned in the report no longer exists on `main` — click listening moved into the OneSignal adapter, whose failures surface via the `ensureInitialized` capture.)
- **`native.adapter.ts` — `init()`**: missing `NEXT_PUBLIC_ONESIGNAL_APP_ID` emits `captureMessage` tagged `onesignal:missing-app-id` before throwing, so a broken build config is visible even if a caller swallows the rejection. Captured once because the rejected `initPromise` is cached.

## Verification

- `tsc --noEmit` passes
- `prettier` run on all touched files