### PR TITLE
fix(request-pot): count only successful payers as contributors

### DIFF
--- a/src/utils/__tests__/general.utils.test.ts
+++ b/src/utils/__tests__/general.utils.test.ts
@@ -2,6 +2,7 @@ import {
     formatAmount,
     formatExtendedNumber,
     generateInviteCodeLink,
+    getContributorsFromCharge,
     getRequestLink,
     formatTokenAmount,
     isUuid,
@@ -9,6 +10,7 @@ import {
     toInviteCode,
 } from '../general.utils'
 import { AccountType } from '@/interfaces'
+import { type ChargeEntry, type Payment, type TStatus } from '@/services/services.types'
 
 describe('General Utilities', () => {
     describe('Amount Formatting Utilities', () => {
@@ -511,6 +513,60 @@ describe('General Utilities', () => {
 
         it('passes legacy invite codes through with unchanged meaning (BE uppercases before parsing)', () => {
             expect(toInviteCode('ALICEINVITESYOU610')).toBe('aliceinvitesyou610')
+        })
+    })
+
+    describe('getContributorsFromCharge', () => {
+        const makePayment = (status: TStatus, username: string | null): Payment => ({
+            uuid: `pay-${username ?? 'anon'}-${status}`,
+            chargeUuid: 'charge-1',
+            payerTransactionHash: '0xhash',
+            payerChainId: '1',
+            paidTokenAddress: '0xtoken',
+            paidAmountInRequestedToken: '10',
+            payerAddress: '0xpayer',
+            fulfillmentTransactionHash: null,
+            status,
+            reason: null,
+            createdAt: '2026-01-01T00:00:00Z',
+            verifiedAt: null,
+            payerAccount: {
+                userId: username ? 'user-id' : null,
+                identifier: username ?? '0xanon',
+                type: 'PEANUT',
+                user: username ? { username, bridgeKycStatus: 'approved' } : null,
+            },
+        })
+
+        const makeCharge = (uuid: string, payments: Payment[]): ChargeEntry =>
+            ({
+                uuid,
+                tokenAmount: '10',
+                payments,
+                fulfillmentPayment: null,
+            }) as ChargeEntry
+
+        it('drops charges that have no successful payment', () => {
+            const charges = [makeCharge('c1', [makePayment('FAILED', 'bob'), makePayment('PENDING', 'bob')])]
+            expect(getContributorsFromCharge(charges)).toEqual([])
+        })
+
+        it('counts only charges with a successful payment (no inflated count)', () => {
+            const charges = [
+                makeCharge('c1', [makePayment('SUCCESSFUL', 'alice')]),
+                makeCharge('c2', [makePayment('FAILED', 'bob')]),
+            ]
+            const contributors = getContributorsFromCharge(charges)
+            expect(contributors).toHaveLength(1)
+            expect(contributors[0].username).toBe('alice')
+        })
+
+        it('picks the last SUCCESSFUL payment, not the last payment overall', () => {
+            // a failed retry after a successful payment must not surface the failed payer
+            const charges = [makeCharge('c1', [makePayment('SUCCESSFUL', 'alice'), makePayment('FAILED', 'mallory')])]
+            const contributors = getContributorsFromCharge(charges)
+            expect(contributors).toHaveLength(1)
+            expect(contributors[0].username).toBe('alice')
         })
     })
 })

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -930,30 +930,37 @@ export const getValidRedirectUrl = (redirectUrl: string, fallbackRoute: string) 
 }
 
 export const getContributorsFromCharge = (charges: ChargeEntry[]) => {
-    return charges.map((charge) => {
-        const successfulPayment = charge.payments.at(-1)
-        // Prefer the Peanut handle whenever the payer has a linked user,
-        // regardless of account.type. Falls back to the raw on-chain
-        // identifier for anonymous on-chain contributors.
-        const payerAccount = successfulPayment?.payerAccount
-        const username = payerAccount?.user?.username || payerAccount?.identifier
-        const isPeanutUser = !!payerAccount?.user?.username
+    return charges
+        .map((charge) => {
+            // Only a SUCCESSFUL payment makes someone a contributor. Taking the
+            // last payment regardless of status surfaced failed payers and
+            // inflated the "Contributors (N)" count — the BE collected total
+            // counts successful payments only, so this must match.
+            const successfulPayment = charge.payments.filter((p) => p.status === 'SUCCESSFUL').at(-1)
+            if (!successfulPayment) return null
+            // Prefer the Peanut handle whenever the payer has a linked user,
+            // regardless of account.type. Falls back to the raw on-chain
+            // identifier for anonymous on-chain contributors.
+            const payerAccount = successfulPayment.payerAccount
+            const username = payerAccount?.user?.username || payerAccount?.identifier
+            const isPeanutUser = !!payerAccount?.user?.username
 
-        return {
-            uuid: charge.uuid,
-            payments: charge.payments,
-            amount: charge.tokenAmount,
-            username,
-            fulfillmentPayment: charge.fulfillmentPayment,
-            // FOLLOW-UP (tracked, not in this PR pair): the charges/payments BE flow
-            // still returns raw `bridgeKycStatus` on Payment.payerAccount.user. The
-            // user endpoints (/users/:userId, /users/username/:username,
-            // /users/contacts) all migrated to a BE-computed `isVerified` boolean;
-            // bringing the charges flow along requires a focused refactor (project at
-            // intentToCharge + fetchPayerAccounts; change mutation patterns in
-            // charge/service.ts to immutable response building). Scoped separately.
-            isUserVerified: payerAccount?.user?.bridgeKycStatus === 'approved',
-            isPeanutUser,
-        }
-    })
+            return {
+                uuid: charge.uuid,
+                payments: charge.payments,
+                amount: charge.tokenAmount,
+                username,
+                fulfillmentPayment: charge.fulfillmentPayment,
+                // FOLLOW-UP (tracked, not in this PR pair): the charges/payments BE flow
+                // still returns raw `bridgeKycStatus` on Payment.payerAccount.user. The
+                // user endpoints (/users/:userId, /users/username/:username,
+                // /users/contacts) all migrated to a BE-computed `isVerified` boolean;
+                // bringing the charges flow along requires a focused refactor (project at
+                // intentToCharge + fetchPayerAccounts; change mutation patterns in
+                // charge/service.ts to immutable response building). Scoped separately.
+                isUserVerified: payerAccount?.user?.bridgeKycStatus === 'approved',
+                isPeanutUser,
+            }
+        })
+        .filter((c): c is NonNullable<typeof c> => c !== null)
 }


### PR DESCRIPTION
**R3** from the P2P send-link/request follow-ups audit (**TASK-20131**), verified against `origin/main` (identical on `dev`).

### Problem
`getContributorsFromCharge` took `charge.payments.at(-1)` with **no status filter** (despite the `successfulPayment` name). The BE rollup ships *all* `P2P_REQUEST_FULFILL` charges regardless of status, so a failed (or pending) last payment still produced a contributor row — the **"Contributors (N)" count was inflated** and could display a failed payer's name. Collected total was unaffected (the BE sums `SUCCESSFUL` payments only), so the two surfaces disagreed.

### Fix
Pick the last **SUCCESSFUL** payment and drop charges that have none — matching the BE's collected-total semantics. Cosmetic-only, no money path touched.

### Test
- typecheck + prettier clean.