### PR TITLE
fix(csp): close report-only allowlist gaps for OneSignal, RPC and analytics

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -31,6 +31,31 @@ function sentryCspReportUri() {
 }
 
 /**
+ * Chain RPC endpoints, which have two independent sources that must both be
+ * allowed: `rpcUrls` in src/constants/general.consts.ts (our own viem clients)
+ * and viem's per-chain defaults, which wagmi's bare `http()` transports fall
+ * back to for external-wallet flows. Neither is importable here — next.config
+ * is CommonJS and general.consts.ts is TS — so this list is a hand-kept mirror.
+ * Re-check it when either source gains a chain.
+ */
+const chainRpcHosts = [
+    'https://*.core.chainstack.com',
+    'https://*.publicnode.com',
+    'https://*.arbitrum.io',
+    'https://*.drpc.org',
+    'https://mainnet.optimism.io',
+    'https://mainnet.base.org',
+    'https://rpc.scroll.io',
+    'https://bsc-dataseed.bnbchain.org',
+    'https://eth.merkle.io',
+    'https://polygon-rpc.com',
+    'https://rpc.gnosischain.com',
+    'https://rpc.linea.build',
+    'https://forno.celo.org',
+    'https://*.rpc.thirdweb.com',
+]
+
+/**
  * First-draft CSP, shipped REPORT-ONLY.
  *
  * Nothing here is enforced yet: the app currently has no script-src at all, so
@@ -42,15 +67,15 @@ function sentryCspReportUri() {
  * Known-loose parts, to tighten before promotion:
  * - `'unsafe-inline'` / `'unsafe-eval'` in script-src: Next's inline bootstrap
  *   and the wallet SDKs need them today. Moving to nonces is its own change.
- * - connect-src can't enumerate every chain RPC (they come from env and vary by
- *   network), so the report stream is what completes this list.
+ * - `chainRpcHosts` is broad (provider-level wildcards), because a single
+ *   provider serves one subdomain per network.
  */
 function contentSecurityPolicyReportOnly() {
     const reportUri = sentryCspReportUri()
     const directives = [
         "default-src 'self'",
         // PostHog is same-origin via the /relay rewrite, so it needs no entry here.
-        "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://client.crisp.chat https://static.sumsub.com",
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://client.crisp.chat https://static.sumsub.com https://cdn.onesignal.com https://api.onesignal.com",
         "style-src 'self' 'unsafe-inline' https://client.crisp.chat",
         "img-src 'self' data: blob: https:",
         "font-src 'self' data: https://client.crisp.chat",
@@ -61,6 +86,12 @@ function contentSecurityPolicyReportOnly() {
             'https://*.ingest.sentry.io',
             'https://*.ingest.us.sentry.io',
             'https://www.google-analytics.com',
+            // GA4 beacons to a region-specific host, and GTM's audience/conversion
+            // pings go to doubleclick and www.google.com.
+            'https://analytics.google.com',
+            'https://*.analytics.google.com',
+            'https://stats.g.doubleclick.net',
+            'https://www.google.com',
             'https://rpc.zerodev.app',
             'https://*.g.alchemy.com',
             'https://rpc.ankr.com',
@@ -68,10 +99,14 @@ function contentSecurityPolicyReportOnly() {
             'https://coin-images.coingecko.com',
             'https://api.frankfurter.app',
             'https://dolarapi.com',
-            'https://client.crisp.chat',
+            'https://ipapi.co',
+            'https://api.justaname.id',
+            'https://*.crisp.chat',
             'wss://client.relay.crisp.chat',
             'https://*.sumsub.com',
             'https://widget.manteca.dev',
+            'https://*.onesignal.com',
+            ...chainRpcHosts,
         ].join(' '),
         "frame-src 'self' https://client.crisp.chat https://*.sumsub.com https://widget.manteca.dev https://mpago.la",
         "worker-src 'self' blob:",


### PR DESCRIPTION
Follow-up to #2462. In the first hours after that merged, the report-only policy produced **~800 violations** (Sentry `logger:csp`). Nothing is broken today — disposition is `report` — but promoting this policy to enforcing as-is would break real functionality.

I audited every reported host against the code that actually originates the request.

## OneSignal was missing entirely

`cdn.onesignal.com` (24 hits, `script-src-elem`) is the web SDK loader, and `api.onesignal.com` was blocked under both `script-src-elem` (12) and `connect-src` (6). Enforcing would have stopped the SDK from loading at all and taken web push with it. Added the two hosts explicitly to `script-src` (kept tight, since that's the XSS-relevant directive) and `https://*.onesignal.com` to `connect-src`.

## Chain RPC endpoints — both sources, not just the reported ones

The reported RPC hosts (~780 of the 800 violations) are only half the story. There are two independent sources and both need allowlisting:

1. `rpcUrls` in `src/constants/general.consts.ts` — the curated per-chain list our own viem clients use.
2. viem's per-chain defaults — wagmi's transports are bare `http()` with no URL, so external-wallet flows fall back to viem's built-in RPC per chain.

Source 2 hadn't shown up in the reports yet (those flows are rarer), so allowlisting only what was reported would have meant a second round of violations. I enumerated both, which is why the list includes hosts like `eth.merkle.io` and `rpc.gnosischain.com` that aren't in the Sentry data.

Provider-level wildcards (`*.core.chainstack.com`, `*.publicnode.com`, `*.arbitrum.io`, `*.drpc.org`) because each provider serves one subdomain per network; single-host providers are listed exactly. Noted in the "known-loose parts" comment as something to revisit before promotion.

The list is a hand-kept mirror — `next.config.js` is CommonJS and `general.consts.ts` is TS, so neither source is importable here. There's a comment on the constant saying to re-check it when either source gains a chain.

## Analytics

`analytics.google.com` (50), `region1.analytics.google.com` (29), `stats.g.doubleclick.net` (16), `www.google.com` (15). These are GA4's region-specific beacon and GTM's audience/conversion pings — the marketing analytics stack depends on them, so they're allowlisted to keep reporting intact once the policy is enforcing.

## Remaining app traffic

`ipapi.co` (`useGeoLocation`), `api.justaname.id` (JustaName ENS provider), and `storage.crisp.chat` — the last via widening `client.crisp.chat` to `*.crisp.chat`, since Crisp serves assets from several subdomains.

## Verification

- Rendered the resulting policy and asserted all 16 reported hosts are covered (accounting for wildcard matching)
- `next.config.js` loads, `eslint` clean, `prettier` reports unchanged
- **Still report-only.** Promotion to enforcing should wait until the violation stream is quiet, and is its own PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Compatibility**
  * Updated content security policies to support additional blockchain RPC providers and external service endpoints.
  * Expanded analytics, location, naming, support chat, and notification service connectivity.
  * Added support for required OneSignal scripts and broader provider domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
