### PR TITLE
fix(notifications): capture notification-click listener init failures

### DIFF
--- a/src/hooks/useNativePlugins.ts
+++ b/src/hooks/useNativePlugins.ts
@@ -15,6 +15,7 @@ import { getOneSignalAdapter } from '@/services/onesignal'
  * exist in native builds (not on vercel/web ci).
  */
 let appListenersFailureCaptured = false
+let clickListenerFailureCaptured = false
 
 export function useNativePlugins() {
     const router = useRouter()
@@ -88,6 +89,15 @@ export function useNativePlugins() {
                 )
             } catch (e) {
                 console.warn('failed to init notification click listener:', e)
+                // launch URLs are suppressed in the SDKs, so without this listener a push tap does nothing
+                if (!clickListenerFailureCaptured) {
+                    clickListenerFailureCaptured = true
+                    captureMessage('failed to init notification click listener', {
+                        level: 'warning',
+                        tags: { feature: 'onesignal', source: 'native_click_listener' },
+                        extra: { error: e instanceof Error ? e.message : String(e) },
+                    })
+                }
             }
 
             try {


### PR DESCRIPTION
Small follow-up to #2473, which made native OneSignal failures visible in Sentry.

#2473 and #2470 were in flight at the same time and merged a minute apart. #2473 covered the two swallowing catches that existed in `useNativePlugins.ts` at the time; #2470 then added a new block to the same file — the notification-click listener — whose catch is `console.warn` only. So one native failure path is silent again.

It matters because launch URLs are suppressed in both the web and native SDKs (`suppressLaunchURLs` / `OneSignal_suppress_launch_urls`), which makes this listener the only thing that routes a push tap. If `getOneSignalAdapter()` or the listener registration throws, every notification tap silently does nothing — and today there'd be no Sentry event to explain why.

Same shape as the capture in the neighbouring app-listener catch: once per session via a module-level flag, `warning` level, tagged `feature:onesignal` and `source:native_click_listener`.

## Verification

- `tsc --noEmit` passes, `eslint` clean, `prettier` reports unchanged
- Native-only path, so it needs an OTA bundle or binary before it can produce events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error tracking when notification click handling fails to initialize.
  * Prevented duplicate reports for the same initialization failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->