### PR TITLE
fix(withdraw): show non-EVM (Tron/Solana) token selection in the selector button

### DIFF
--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -503,11 +503,18 @@ export default function WithdrawCryptoPage() {
         [isCrossChainWithdrawal, payAmount, minDepositLimitUsd]
     )
 
-    if (!amountToWithdraw && currentView !== 'STATUS') {
-        // Redirect to main withdraw page for amount input
-        // Guard against STATUS view: resetWithdrawFlow() clears amountToWithdraw,
-        // which would override the router.push('/home') in handleDone
-        router.push('/withdraw')
+    // Redirect to main withdraw page for amount input. The push must run in an
+    // effect — navigating during render is a React violation ("Cannot update
+    // Router while rendering WithdrawCryptoPage") that hard-errors the Next 16
+    // dev overlay on direct entry/refresh of this route.
+    // Guard against STATUS view: resetWithdrawFlow() clears amountToWithdraw,
+    // which would override the router.push('/home') in handleDone
+    const needsAmountRedirect = !amountToWithdraw && currentView !== 'STATUS'
+    useEffect(() => {
+        if (needsAmountRedirect) router.push('/withdraw')
+    }, [needsAmountRedirect, router])
+
+    if (needsAmountRedirect) {
         return <PeanutLoading />
     }
 

--- a/src/components/Global/TokenSelector/TokenSelector.tsx
+++ b/src/components/Global/TokenSelector/TokenSelector.tsx
@@ -177,14 +177,16 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
 
     if (selectedTokenAddress && selectedChainID) {
         const chainInfo = supportedChainsAndTokens[selectedChainID]
-        // areEvmAddressesEqual handles native-proxy aliasing for EVM tokens but is
-        // always false for non-EVM (base58 Tron/Solana) selections — without the
-        // literal fallback the button kept showing "Select a token" after picking
-        // USDT-Tron / USDT/USDC-Solana in the withdraw flow.
+        // areEvmAddressesEqual handles EVM case variance (checksum casing) and
+        // native-proxy aliasing but is always false for non-EVM (base58
+        // Tron/Solana) selections — without a fallback the button kept showing
+        // "Select a token" after picking USDT-Tron / USDT/USDC-Solana. The
+        // fallback is EXACT equality on purpose: base58 is case-significant and
+        // both operands come from the same registry, so a case-insensitive
+        // compare could only ever mask an upstream case-corruption bug, never
+        // fix a legitimate mismatch.
         const tokenDetails = chainInfo?.tokens.find(
-            (t) =>
-                areEvmAddressesEqual(t.address, selectedTokenAddress) ||
-                t.address.toLowerCase() === selectedTokenAddress.toLowerCase()
+            (t) => areEvmAddressesEqual(t.address, selectedTokenAddress) || t.address === selectedTokenAddress
         )
         if (tokenDetails && chainInfo) {
             buttonSymbol = tokenDetails.symbol

--- a/src/components/Global/TokenSelector/TokenSelector.tsx
+++ b/src/components/Global/TokenSelector/TokenSelector.tsx
@@ -177,7 +177,15 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
 
     if (selectedTokenAddress && selectedChainID) {
         const chainInfo = supportedChainsAndTokens[selectedChainID]
-        const tokenDetails = chainInfo?.tokens.find((t) => areEvmAddressesEqual(t.address, selectedTokenAddress))
+        // areEvmAddressesEqual handles native-proxy aliasing for EVM tokens but is
+        // always false for non-EVM (base58 Tron/Solana) selections — without the
+        // literal fallback the button kept showing "Select a token" after picking
+        // USDT-Tron / USDT/USDC-Solana in the withdraw flow.
+        const tokenDetails = chainInfo?.tokens.find(
+            (t) =>
+                areEvmAddressesEqual(t.address, selectedTokenAddress) ||
+                t.address.toLowerCase() === selectedTokenAddress.toLowerCase()
+        )
         if (tokenDetails && chainInfo) {
             buttonSymbol = tokenDetails.symbol
             buttonLogoURI = tokenDetails.logoURI


### PR DESCRIPTION
## Summary

Picking **USDT-Tron / USDT+USDC-Solana** in the withdraw token drawer looked like it did nothing: the tap *did* select the token (context updates unconditionally, the drawer highlight even shows it), but the collapsed selector button resolves its label via `areEvmAddressesEqual` — always `false` for base58 addresses — so it kept reading **"Select a token"**. Users read that as "the coin can't be selected".

One-line fallback to a case-insensitive literal match. `areEvmAddressesEqual` stays first for its native-proxy aliasing on EVM tokens (`0xeee…` ↔ `0x000…`).

Pairs with peanutprotocol/peanut-api-ts#1230, which unblocks the actual request/charge creation for these destinations (EVM-only schema pattern + base58 case-corruption on storage). Without the BE fix, proceeding past the (now visible) selection still 400s at setup review.

Also fixes a pre-existing React violation hit while QA-ing this flow: the page called `router.push('/withdraw')` **during render** when no amount was set, which hard-errors Next 16's dev overlay on any direct entry/refresh of `/withdraw/crypto`. The redirect now runs in an effect — same behavior, one frame later.

## Risks

Display-only. The literal fallback cannot resolve a *different* token than before: distinct registry tokens never differ only by address case, and native aliasing is still handled by the EVM comparator first.

## QA

- typecheck + jest green vs dev-tip baseline (pre-existing `countryCurrencyMapping` suite failure is unrelated).
- Manual: withdraw → search or network-first → Tron/USDT → button shows the selection; same for Solana USDC/USDT. (Note: non-EVM tokens intentionally don't appear in the default popular list — search or network-first only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Design notes / adversarial review

- Adversarially verified the full click chain (tap → context write → drawer close → `selectedTokenData` derivation → CTA → `onReview`): selection state always worked (handler unconditional; Sentry payloads prove base58 reached the BE); the collapsed-button label was the only broken link. No auto-reset effect exists that could clear the selection.
- The exact fallback can never resolve a different token than before: EVM case variance is fully handled by `areEvmAddressesEqual`; for base58 the registry is the single source, so exact equality is both sufficient and a canary for any future case corruption in the selection path.

> **Hotfix to `main`** (re-targeted from dev per Aleks — supersedes #2488; repo rules block force-push, hence the fresh branch). Creates **main→dev back-merge debt** after merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved token selection display for non-EVM networks (e.g., Tron and Solana) by correctly matching the selected token address so the selector stays on the valid choice.
  - Prevented the token selector from falling back to “Select a token” after a successful selection.
  - Improved withdrawal-page behavior when the withdrawal amount is missing, using a safer post-render redirect while showing the loading state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->