### PR TITLE
fix(native): refetch stale queries on app resume

### DIFF
--- a/src/config/wagmi.config.tsx
+++ b/src/config/wagmi.config.tsx
@@ -14,7 +14,6 @@ const queryClient = new QueryClient({
             refetchOnWindowFocus: true, // Refetch stale data when user returns
             refetchOnReconnect: true, // Refetch when connectivity restored
             // Allow queries when offline to read from TanStack Query in-memory cache
-            // Service Worker provides additional HTTP API response caching (user data, history, prices)
             networkMode: 'always', // Run queries even when offline (reads from cache)
         },
         mutations: {

--- a/src/hooks/useNativePlugins.ts
+++ b/src/hooks/useNativePlugins.ts
@@ -24,6 +24,13 @@ export function useNativePlugins() {
         if (!isCapacitor()) return
 
         const cleanups: Array<() => void> = []
+        let disposed = false
+        // Registrations resolve async; if the effect tore down first, run the
+        // cleanup now instead of leaking the handle.
+        const track = (cleanup: () => void) => {
+            if (disposed) cleanup()
+            else cleanups.push(cleanup)
+        }
 
         const openDeepLink = (url?: string | null) => {
             if (!url) return
@@ -45,7 +52,7 @@ export function useNativePlugins() {
                 const stateListener = await App.addListener('appStateChange', ({ isActive }: { isActive: boolean }) =>
                     focusManager.setFocused(isActive)
                 )
-                cleanups.push(() => {
+                track(() => {
                     stateListener.remove()
                     focusManager.setFocused(undefined)
                 })
@@ -57,13 +64,13 @@ export function useNativePlugins() {
                         App.minimizeApp()
                     }
                 })
-                cleanups.push(() => backListener.remove())
+                track(() => backListener.remove())
 
                 // App Links: cold start (getLaunchUrl) + warm start (appUrlOpen).
                 const launch = await App.getLaunchUrl()
                 openDeepLink(launch?.url)
                 const urlListener = await App.addListener('appUrlOpen', ({ url }: { url: string }) => openDeepLink(url))
-                cleanups.push(() => urlListener.remove())
+                track(() => urlListener.remove())
             } catch (e) {
                 console.warn('failed to init app listeners:', e)
                 // without these listeners push-tap deep links never route, so surface the failure
@@ -84,7 +91,7 @@ export function useNativePlugins() {
                 // relative path the API sends; the launch URL is the fallback for
                 // notifications sent before that field existed.
                 const adapter = await getOneSignalAdapter()
-                cleanups.push(
+                track(
                     adapter.onNotificationClick(({ deepLink, additionalData }) => {
                         const target = additionalData.deepLink
                         const link = typeof target === 'string' ? target : deepLink
@@ -137,6 +144,7 @@ export function useNativePlugins() {
         init()
 
         return () => {
+            disposed = true
             cleanups.forEach((fn) => fn())
         }
     }, [router])

--- a/src/hooks/useNativePlugins.ts
+++ b/src/hooks/useNativePlugins.ts
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
+import { focusManager } from '@tanstack/react-query'
 import { captureMessage } from '@sentry/nextjs'
 import { isCapacitor, getPlatform } from '@/utils/capacitor'
 import { deepLinkToNativePath } from '@/utils/native-routes'
@@ -36,6 +37,19 @@ export function useNativePlugins() {
         const init = async () => {
             try {
                 const { App } = await import('@capacitor/app')
+
+                // TanStack Query's refetchOnWindowFocus keys off visibilitychange,
+                // which Android WebViews don't reliably fire on app resume — a
+                // resumed app kept rendering its pre-background query data (stale
+                // home Activity). Drive the focusManager from the native lifecycle.
+                const stateListener = await App.addListener('appStateChange', ({ isActive }: { isActive: boolean }) =>
+                    focusManager.setFocused(isActive)
+                )
+                cleanups.push(() => {
+                    stateListener.remove()
+                    focusManager.setFocused(undefined)
+                })
+
                 const backListener = await App.addListener('backButton', ({ canGoBack }: { canGoBack: boolean }) => {
                     if (canGoBack) {
                         router.back()

--- a/src/hooks/useTransactionHistory.ts
+++ b/src/hooks/useTransactionHistory.ts
@@ -72,8 +72,11 @@ export function useTransactionHistory({
         // append targetUsername to the query params if filterMutualTxs is true and username is provided
         if (filterMutualTxs && username) queryParams.append('targetUsername', username)
 
+        // no-store: home Activity must never render a cached copy of history
+        // (server also sends Cache-Control: no-store; this covers the WebView path)
         const response = await serverFetch(`/users/history?${queryParams.toString()}`, {
             method: 'GET',
+            cache: 'no-store',
         })
 
         if (!response.ok) {
@@ -94,7 +97,7 @@ export function useTransactionHistory({
     // that bites if a caller ever flips `mode` mid-life.
 
     // Latest transactions (home page).
-    // Two-tier caching: TQ in-memory (30s) → SW disk cache (1 week) → Network.
+    // Cached only in TQ memory (30s stale); the HTTP response is no-store end to end.
     const latestQuery = useQuery({
         queryKey: [TRANSACTIONS, 'latest', { limit, targetUsername: filterMutualTxs ? username : undefined }],
         queryFn: () => fetchHistory({ limit }),


### PR DESCRIPTION
## Problem

The Android app's home-screen **Activity** widget can show weeks-old transactions while web shows the fresh list for the same account.

TanStack Query's `refetchOnWindowFocus` relies on `visibilitychange`, which Android WebViews don't reliably fire when the app resumes from background. An app process kept alive/frozen by the OS resumes with its pre-background in-memory query data and never refetches — there is currently no native lifecycle → query-refetch wiring anywhere in the app.

## Fix

- `useNativePlugins`: listen to Capacitor `appStateChange` and drive TanStack's `focusManager`, so stale queries refetch on every app resume (the canonical TanStack pattern for non-browser hosts). Registered first among the App listeners so a deep-link init failure can't skip it.
- `useTransactionHistory`: send the history request with `cache: 'no-store'` — defense in depth alongside the API-side `Cache-Control: no-store` (companion peanut-api-ts PR).
- Drop stale "SW disk cache (1 week)" comments: the service worker no longer intercepts API responses (verified against the built `public/sw.js`).

## Verification

- `tsc --noEmit` clean; prettier run on touched files.
- On-device check after release: background the app, make a transaction from web, resume the app → Activity should refresh within the 30s staleTime window.

## Notes

Ships in the next binary/OTA release; no API contract changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data freshness for transaction history by preventing stale HTTP responses from being reused.
  * Improved query updates when the app moves between active and inactive states.
  * Preserved offline access to previously loaded data through in-memory caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->