### PR TITLE
fix(app-lock): friendlier lock-screen copy

### DIFF
--- a/src/components/Global/AppLock/index.tsx
+++ b/src/components/Global/AppLock/index.tsx
@@ -47,14 +47,14 @@ function LockScreen({
     return (
         <div className="fixed inset-0 z-[9999] flex flex-col items-center justify-center gap-6 bg-white px-6">
             <div className="text-center">
-                <h1 className="text-2xl font-bold">Peanut is locked</h1>
+                <h1 className="text-2xl font-bold">Welcome back!</h1>
                 <p className="mt-2 text-sm text-grey-1">
-                    {failed ? 'Could not confirm it is you. Try again to continue.' : 'Confirm it is you to continue.'}
+                    {failed ? 'Please log in again to access the app.' : 'Please log in to access the app.'}
                 </p>
             </div>
             <div className="flex w-full max-w-xs flex-col gap-3">
                 <Button variant="purple" shadowSize="4" loading={unlocking} onClick={onUnlock}>
-                    Unlock
+                    Log in
                 </Button>
                 <Button variant="stroke" shadowSize="4" onClick={onLogout}>
                     Log out


### PR DESCRIPTION
## What

Reword the native app-lock screen. The shipped copy — **"Peanut is locked"** / **"Could not confirm it is you. Try again to continue."** — reads as scary and technical, especially for users hitting the gate for the first time after today's build.

New copy:

- Title: **Welcome back!**
- Prompt: *Please log in to access the app.*
- After a failed/cancelled attempt: *Please log in again to access the app.*
- Primary button: **Log in** (was "Unlock"); "Log out" unchanged.

Copy-only — no behavior change.

## Notes

#2489 rewrites this component with localized strings (`appLock.*` in `src/i18n/app/messages`); a matching commit on that branch updates all three locales, so whichever merges first, the friendly copy wins.