### PR TITLE
feat(footer): Squirrel Labs Ltd legal-entity line on landing footer

### DIFF
--- a/src/components/LandingPage/Footer.tsx
+++ b/src/components/LandingPage/Footer.tsx
@@ -21,6 +21,9 @@ const Footer = ({ showSiteDirectory = true, locale = 'en' }: { showSiteDirectory
                             Squirrel Labs
                         </a>
                     </p>
+                    <p className="text-xs text-white/70">
+                        Peanut is a trading name of Squirrel Labs Ltd, registered in England &amp; Wales (No. 14558823)
+                    </p>
                 </section>
 
                 <section className="absolute left-1/2 top-5 flex -translate-x-1/2 flex-col items-center gap-4 md:static md:translate-x-0">


### PR DESCRIPTION
## Why

Apple rejected the iOS submission under Guideline 5.1.1 (highly regulated services): the app "must be published under a seller and company name that reflects the Peanut name." Our seller is the legal entity Squirrel Labs Ltd, and Apple doesn't accept trade names on developer accounts, so the fix is making the Peanut ↔ Squirrel Labs Ltd association publicly obvious on peanut.me.

[Terms §1](https://peanut.me/terms) already states "Squirrel Labs Ltd, trading as 'Peanut'". This PR adds the same disclosure to the landing footer (standard UK trading-name practice), so reviewers see it without digging:

> Peanut is a trading name of Squirrel Labs Ltd, registered in England & Wales (No. 14558823)

## What

- One muted `text-xs text-white/70` line under the existing "made with love by Squirrel Labs" credit in `LandingPage/Footer.tsx`. No other changes.

## Verify

- Prettier clean, zero typecheck hits on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)