### PR TITLE
hotfix(footer): Squirrel Labs Ltd legal-entity line on landing footer

### DIFF
--- a/src/components/LandingPage/Footer.tsx
+++ b/src/components/LandingPage/Footer.tsx
@@ -21,6 +21,9 @@ const Footer = ({ showSiteDirectory = true, locale = 'en' }: { showSiteDirectory
                             Squirrel Labs
                         </a>
                     </p>
+                    <p className="text-xs text-white/70">
+                        Peanut is a trading name of Squirrel Labs Ltd, registered in England &amp; Wales (No. 14558823)
+                    </p>
                 </section>
 
                 <section className="absolute left-1/2 top-5 flex -translate-x-1/2 flex-col items-center gap-4 md:static md:translate-x-0">


### PR DESCRIPTION
## Why

Apple rejected the iOS submission under Guideline 5.1.1 (highly regulated services): the app "must be published under a seller and company name that reflects the Peanut name." The fix is making the Peanut ↔ Squirrel Labs Ltd association publicly obvious on peanut.me before we appeal/resubmit — hence hotfix straight to `main` so it's live today, not waiting on the next release.

[Terms §1](https://peanut.me/terms) already states "Squirrel Labs Ltd, trading as 'Peanut'". This adds the same disclosure to the landing footer (standard UK trading-name practice):

> Peanut is a trading name of Squirrel Labs Ltd, registered in England & Wales (No. 14558823)

## What

- One muted `text-xs text-white/70` line under the existing "made with love by Squirrel Labs" credit in `LandingPage/Footer.tsx`. No other changes.
- Cherry-pick of the commit from https://github.com/peanutprotocol/peanut-ui/pull/2498 (closed in favour of this one — dev doesn't deploy, and Apple timeline needs it live now). Flows back to `dev` with the next back-merge.

## Verify

- Prettier clean, zero typecheck hits on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added company registration details to the footer beneath the existing attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->