### PR TITLE
fix(add-money): bounce Manteca countries off the Bridge bank page (no EUR)

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -14,7 +14,7 @@ import { useCapabilities } from '@/hooks/useCapabilities'
 import { resolveKycModalVariant, getGateUserMessage } from '@/utils/capability-gate'
 import { useModalsContext } from '@/context/ModalsContext'
 import { useCreateOnramp, GENERIC_ONRAMP_ERROR } from '@/hooks/useCreateOnramp'
-import { useParams, useSearchParams } from 'next/navigation'
+import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import countryCurrencyMappings, { isNonEuroSepaCountry, isUKCountry } from '@/constants/countryCurrencyMapping'
 import { formatUnits } from 'viem'
@@ -42,7 +42,8 @@ import { useEeaUpliftFunnel } from '@/hooks/useEeaUpliftFunnel'
 import { upliftTriggerFromGate, upliftTriggerFromAdvisory } from '@/utils/eea-uplift.utils'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
-import { addMoneyCountryUrl } from '@/utils/native-routes'
+import { addMoneyCountryUrl, rewriteMethodPath } from '@/utils/native-routes'
+import { isMantecaCountry } from '@/constants/manteca.consts'
 import { useSafeBack } from '@/hooks/useSafeBack'
 import { getRegionIntent } from '@/utils/regions.utils'
 
@@ -109,6 +110,18 @@ export default function OnrampBankPage() {
         if (!selectedCountryPath) return null
         return countryData.find((country) => country.type === 'country' && country.path === selectedCountryPath)
     }, [selectedCountryPath])
+
+    // Manteca countries (BR/AR) deposit via their own PIX / Mercado Pago flow, not
+    // this Bridge SEPA bank page — getCurrencyConfig has no BR/AR branch, so they'd
+    // render as EUR. A KYC-success redirect or a deep link can still land a Manteca
+    // country here; bounce it to the correct provider route at the single chokepoint.
+    const router = useRouter()
+    const isMantecaRoute = !!selectedCountry && isMantecaCountry(selectedCountry.path)
+    useEffect(() => {
+        if (isMantecaRoute && selectedCountry) {
+            router.replace(rewriteMethodPath(`/add-money/${selectedCountry.path}/manteca`))
+        }
+    }, [isMantecaRoute, selectedCountry, router])
 
     const onBack = useSafeBack(selectedCountryPath ? addMoneyCountryUrl(selectedCountryPath) : '/add-money')
 
@@ -360,6 +373,12 @@ export default function OnrampBankPage() {
             setUrlState({ step: 'inputAmount' })
         }
     }, [urlState.step, onrampData?.transferId, setUrlState])
+
+    // Show loading while the Manteca-country redirect above runs — never flash
+    // the EUR bank UI to a BR/AR user.
+    if (isMantecaRoute) {
+        return <PeanutLoading />
+    }
 
     // Show loading while user is being fetched and no step in URL yet
     if (!urlState.step && user === null) {

--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -43,7 +43,7 @@ import { upliftTriggerFromGate, upliftTriggerFromAdvisory } from '@/utils/eea-up
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { addMoneyCountryUrl, rewriteMethodPath } from '@/utils/native-routes'
-import { isMantecaCountry } from '@/constants/manteca.consts'
+import { isMantecaSupportedCountryCode } from '@/constants/manteca.consts'
 import { useSafeBack } from '@/hooks/useSafeBack'
 import { getRegionIntent } from '@/utils/regions.utils'
 
@@ -115,8 +115,10 @@ export default function OnrampBankPage() {
     // this Bridge SEPA bank page — getCurrencyConfig has no BR/AR branch, so they'd
     // render as EUR. A KYC-success redirect or a deep link can still land a Manteca
     // country here; bounce it to the correct provider route at the single chokepoint.
+    // Use the same predicate the root dispatcher routes with (add-money/page.tsx) so
+    // the two can never disagree on which countries are Manteca.
     const router = useRouter()
-    const isMantecaRoute = !!selectedCountry && isMantecaCountry(selectedCountry.path)
+    const isMantecaRoute = !!selectedCountry && isMantecaSupportedCountryCode(selectedCountry.id)
     useEffect(() => {
         if (isMantecaRoute && selectedCountry) {
             router.replace(rewriteMethodPath(`/add-money/${selectedCountry.path}/manteca`))

--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -50,7 +50,10 @@ import { getRegionIntent } from '@/utils/regions.utils'
 // Step type for URL state
 type BridgeBankStep = 'inputAmount' | 'showDetails'
 
-export default function OnrampBankPage() {
+// The Bridge SEPA bank deposit page. Only mounted for non-Manteca countries — the
+// default export below bounces BR/AR away before this ever renders, so none of its
+// data hooks / URL-state effects run for a Manteca deep link.
+function BridgeBankOnrampPage() {
     const params = useParams()
     const _searchParams = useSearchParams()
 
@@ -110,20 +113,6 @@ export default function OnrampBankPage() {
         if (!selectedCountryPath) return null
         return countryData.find((country) => country.type === 'country' && country.path === selectedCountryPath)
     }, [selectedCountryPath])
-
-    // Manteca countries (BR/AR) deposit via their own PIX / Mercado Pago flow, not
-    // this Bridge SEPA bank page — getCurrencyConfig has no BR/AR branch, so they'd
-    // render as EUR. A KYC-success redirect or a deep link can still land a Manteca
-    // country here; bounce it to the correct provider route at the single chokepoint.
-    // Use the same predicate the root dispatcher routes with (add-money/page.tsx) so
-    // the two can never disagree on which countries are Manteca.
-    const router = useRouter()
-    const isMantecaRoute = !!selectedCountry && isMantecaSupportedCountryCode(selectedCountry.id)
-    useEffect(() => {
-        if (isMantecaRoute && selectedCountry) {
-            router.replace(rewriteMethodPath(`/add-money/${selectedCountry.path}/manteca`))
-        }
-    }, [isMantecaRoute, selectedCountry, router])
 
     const onBack = useSafeBack(selectedCountryPath ? addMoneyCountryUrl(selectedCountryPath) : '/add-money')
 
@@ -376,12 +365,6 @@ export default function OnrampBankPage() {
         }
     }, [urlState.step, onrampData?.transferId, setUrlState])
 
-    // Show loading while the Manteca-country redirect above runs — never flash
-    // the EUR bank UI to a BR/AR user.
-    if (isMantecaRoute) {
-        return <PeanutLoading />
-    }
-
     // Show loading while user is being fetched and no step in URL yet
     if (!urlState.step && user === null) {
         return <PeanutLoading />
@@ -552,4 +535,36 @@ export default function OnrampBankPage() {
     }
 
     return null
+}
+
+// Route entry. Manteca countries (BR/AR) deposit via their own PIX / Mercado Pago
+// flow, not this Bridge SEPA page — getCurrencyConfig has no BR/AR branch, so the
+// Bridge page would render the amount in EUR. A KYC-success redirect or a deep link
+// can still target /add-money/[country]/bank for a Manteca country, so bounce it
+// here — before BridgeBankOnrampPage mounts — and never run its data hooks / URL
+// effects for BR/AR. Uses the same predicate the root dispatcher routes with
+// (add-money/page.tsx) so the two can't disagree on which countries are Manteca.
+export default function OnrampBankPage() {
+    const params = useParams()
+    const searchParams = useSearchParams()
+    const router = useRouter()
+
+    const selectedCountryPath = (params.country as string) || searchParams.get('country') || ''
+    const selectedCountry = useMemo(() => {
+        if (!selectedCountryPath) return null
+        return countryData.find((country) => country.type === 'country' && country.path === selectedCountryPath)
+    }, [selectedCountryPath])
+    const isMantecaRoute = !!selectedCountry && isMantecaSupportedCountryCode(selectedCountry.id)
+
+    useEffect(() => {
+        if (isMantecaRoute && selectedCountry) {
+            router.replace(rewriteMethodPath(`/add-money/${selectedCountry.path}/manteca`))
+        }
+    }, [isMantecaRoute, selectedCountry, router])
+
+    if (isMantecaRoute) {
+        return <PeanutLoading />
+    }
+
+    return <BridgeBankOnrampPage />
 }

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -1385,6 +1385,16 @@ describe('GROUP 5: Bridge Bank Onramp', () => {
         }
     )
 
+    // Control: a non-Manteca bank country (Mexico) must NOT be bounced — it stays on
+    // the Bridge amount UI. Guards against the redirect over-firing.
+    test('non-Manteca country (mexico) stays on the Bridge bank UI, no redirect', () => {
+        setParams({ country: 'mexico' })
+        renderWithProviders(<OnrampBankPage />)
+
+        expect(mockRouterReplace).not.toHaveBeenCalled()
+        expect(screen.getByText('How much do you want to add?')).toBeInTheDocument()
+    })
+
     test('fresh user needs KYC before Bridge deposit confirmation', async () => {
         mockUseKycStatus.mockReturnValue({
             isUserKycApproved: false,

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -1373,14 +1373,17 @@ describe('GROUP 5: Bridge Bank Onramp', () => {
 
     // Manteca countries (BR/AR) must never render this Bridge SEPA page — it has no
     // BR/AR currency and would show EUR (TASK-20225). Bounce them to /manteca instead.
-    test('Manteca country (brazil) redirects to the manteca route, never shows EUR bank UI', () => {
-        setParams({ country: 'brazil' })
-        renderWithProviders(<OnrampBankPage />)
+    test.each(['brazil', 'argentina'])(
+        'Manteca country (%s) redirects to the manteca route, never shows EUR bank UI',
+        (country) => {
+            setParams({ country })
+            renderWithProviders(<OnrampBankPage />)
 
-        expect(mockRouterReplace).toHaveBeenCalledWith('/add-money/brazil/manteca')
-        expect(screen.queryByText('How much do you want to add?')).not.toBeInTheDocument()
-        expect(screen.getByTestId('peanut-loading')).toBeInTheDocument()
-    })
+            expect(mockRouterReplace).toHaveBeenCalledWith(`/add-money/${country}/manteca`)
+            expect(screen.queryByText('How much do you want to add?')).not.toBeInTheDocument()
+            expect(screen.getByTestId('peanut-loading')).toBeInTheDocument()
+        }
+    )
 
     test('fresh user needs KYC before Bridge deposit confirmation', async () => {
         mockUseKycStatus.mockReturnValue({

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -1371,6 +1371,17 @@ describe('GROUP 5: Bridge Bank Onramp', () => {
         expect(screen.getByText('Country not found')).toBeInTheDocument()
     })
 
+    // Manteca countries (BR/AR) must never render this Bridge SEPA page — it has no
+    // BR/AR currency and would show EUR (TASK-20225). Bounce them to /manteca instead.
+    test('Manteca country (brazil) redirects to the manteca route, never shows EUR bank UI', () => {
+        setParams({ country: 'brazil' })
+        renderWithProviders(<OnrampBankPage />)
+
+        expect(mockRouterReplace).toHaveBeenCalledWith('/add-money/brazil/manteca')
+        expect(screen.queryByText('How much do you want to add?')).not.toBeInTheDocument()
+        expect(screen.getByTestId('peanut-loading')).toBeInTheDocument()
+    })
+
     test('fresh user needs KYC before Bridge deposit confirmation', async () => {
         mockUseKycStatus.mockReturnValue({
             isUserKycApproved: false,


### PR DESCRIPTION
## Summary

Brazil & Argentina are Manteca-only deposit markets — they add money through their own PIX / Mercado Pago flow (`/add-money/[country]/manteca`). The **Bridge SEPA bank page** (`/add-money/[country]/bank`) derives its displayed currency from `getCurrencyConfig`, which only branches on US/MX/GB and **falls through to `EUR/SEPA` for everything else** — including BR/AR. So any Manteca country that lands on the bank page renders the amount in **euros** with no way to proceed.

This is exactly what a user hit (TASK-20225 / Crisp): verified with non-Brazilian docs, picked Brazil → PIX, and the amount screen showed EUR and wouldn't advance. The in-app Manteca amount screen was already fixed to default to BRL (Jul 2), but the bank page remained a live EUR entry point — reachable via the `onKycSuccess` redirect (`AddWithdrawCountriesList` pushes `/add-money/${slug}/bank` for `flow === 'add'`) and via deep/shared links.

**Fix:** guard at the route entry. The default export is now a thin wrapper that resolves the country and, if it's a Manteca country, `router.replace`s to the `/manteca` route and renders loading — so the Bridge page component (`BridgeBankOnrampPage`) **never mounts** for BR/AR. One chokepoint covers every entry path (KYC redirect, deep link, direct URL), and none of the Bridge page's data hooks or URL-state effects run during the redirect.

## Risk

Low, FE-only. Blast radius is the one route; non-Manteca countries (US/MX/GB/EU) render `BridgeBankOnrampPage` exactly as before. The Manteca predicate (`isMantecaSupportedCountryCode`) is the same one the root dispatcher (`add-money/page.tsx`) already routes with, so the guard and dispatcher read one source of truth (`MANTECA_SUPPORTED_EXCHANGES`) and can't disagree.

## QA

- `/add-money/brazil/bank` and `/add-money/argentina/bank` → redirect to `/add-money/<country>/manteca`, no EUR shown.
- `/add-money/germany/bank`, `/add-money/usa/bank`, `/add-money/mexico/bank` → unchanged (correct currency, Bridge flow).
- Unit: `add-money-states` suite (53) green — Brazil + Argentina redirect cases, a Mexico non-Manteca control (stays on Bridge UI, no redirect); Capacitor rewrite covered by `native-routes.test.ts`.

## Design notes

- **Route-wrapper altitude (not per-caller):** one guard on the shared route entry rather than patching each thing that can navigate to `/bank`. Also means the Bridge page's effects never fire for a Manteca deep link (raised in review).
- **Predicate unified with the dispatcher** — adding a future Manteca country updates one list and both routing sites follow.
- Not fixed here (follow-up, out of scope): `getCurrencyConfig` still has no BR/AR branch (correct — BR/AR are Manteca rails, not Bridge, so they should never reach it); the `/add-money/<path>/manteca` route string is built in a few places and could fold into a `mantecaMethodUrl()` helper.
