### PR TITLE
feat(invites): root-domain campaign links + stackable multi-campaign awarding

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -145,7 +145,20 @@ let nextConfig = {
         }
     },
     async redirects() {
-        return process.env.NODE_ENV === 'development' ? [] : redirectsConfig
+        // Campaign/invite links on the root domain (peanut.me/?campaign=skip,
+        // peanut.me/?code=alice) hand off to /invite, which owns the claim flow.
+        // Query params carry over automatically. Deliberately NOT keyed on
+        // utm_campaign — that would hijack ordinary marketing links to the
+        // landing page; utm_campaign only resolves to a badge once on /invite.
+        // Active in development too (unlike the locale redirects) so the flow is
+        // locally testable.
+        const campaignRedirects = ['campaign', 'campaignTag', 'code'].map((key) => ({
+            source: '/',
+            has: [{ type: 'query', key }],
+            destination: '/invite',
+            permanent: false,
+        }))
+        return process.env.NODE_ENV === 'development' ? campaignRedirects : [...campaignRedirects, ...redirectsConfig]
     },
     async headers() {
         return [

--- a/src/app/(setup)/setup/page.tsx
+++ b/src/app/(setup)/setup/page.tsx
@@ -91,8 +91,9 @@ function SetupPageContent() {
             //    cookie post-signup to award the badge; the step decision no longer
             //    trusts that cookie.
             //
-            // Why not the campaignTag cookie: it's a session cookie cleared only on a
-            // successful signup, so a returning user who claimed a campaign earlier in
+            // Why not the campaignTag cookie: it's a session cookie cleared on signup
+            // (only once every stacked award succeeds — a failed /badge/award keeps
+            // it for retry), so a returning user who claimed a campaign earlier in
             // the same session was routed past Landing (the only screen with Log In)
             // onto Signup, unable to log back in (regression from PR #2346).
             const inviteCodeFromCookie = getFromCookie('inviteCode')

--- a/src/components/Invites/InvitesPage.tsx
+++ b/src/components/Invites/InvitesPage.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { Suspense, useEffect, useRef, useState } from 'react'
+import { Suspense, useEffect, useMemo, useRef, useState } from 'react'
 import PeanutLoading from '../Global/PeanutLoading'
 import ValidationErrorView from '../Payment/Views/Error.validation.view'
 import InvitesPageLayout from './InvitesPageLayout'
@@ -19,28 +19,37 @@ import UnsupportedBrowserModal from '../Global/UnsupportedBrowserModal'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { profileUrl } from '@/utils/native-routes'
-import { OFFRAMP_BADGE_CODE, classifyBareCampaign, resolveCampaign } from './campaign-maps'
+import { OFFRAMP_BADGE_CODE, classifyBareCampaigns, resolveCampaigns } from './campaign-maps'
 
 function InvitePageContent() {
     const searchParams = useSearchParams()
     // trim trailing '?' from invite code to handle qr codes with ? at the end
     const inviteCode = searchParams.get('code')?.toLowerCase().replace(/\?+$/, '')
     const redirectUri = searchParams.get('redirect_uri')
-    // support 'campaign', 'campaignTag', and 'utm_campaign' query parameters
-    const campaignParam = searchParams.get('campaign') || searchParams.get('campaignTag')
-    const utmCampaignParam = searchParams.get('utm_campaign')?.toLowerCase()
     const { user, isFetchingUser, fetchUser } = useAuth()
 
-    // precedence + lowercase-tag mapping live in campaign-maps.ts (unit-tested)
-    const campaign = resolveCampaign(campaignParam, inviteCode, utmCampaignParam)
+    // support 'campaign', 'campaignTag', and 'utm_campaign' query parameters —
+    // repeated params and comma-separated values stack (all get awarded).
+    // union + lowercase-tag mapping live in campaign-maps.ts (unit-tested).
+    // memoized: the array is an effect dependency below, and a fresh identity
+    // every render would refire the effect.
+    const campaigns = useMemo(
+        () =>
+            resolveCampaigns(
+                [...searchParams.getAll('campaign'), ...searchParams.getAll('campaignTag')],
+                inviteCode,
+                searchParams.get('utm_campaign')?.toLowerCase()
+            ),
+        [searchParams, inviteCode]
+    )
 
     // Bare campaign link (no invite code) that's claimable without an invite. The
     // effects below treat these specially so a returning logged-in user still gets
     // the badge (useZeroDev's award only fires on new-account registration). The
     // copy distinguishes the two flavours: `isWaitlistSkip` (skip + event_alumni)
     // promises a card-waitlist skip; vanity badges (touched_grass) are claimable
-    // but show generic copy. See classifyBareCampaign in campaign-maps.ts.
-    const { isBareClaimCampaign, isWaitlistSkip } = classifyBareCampaign(campaign, inviteCode)
+    // but show generic copy. See classifyBareCampaigns in campaign-maps.ts.
+    const { isBareClaimCampaign, isWaitlistSkip } = classifyBareCampaigns(campaigns, inviteCode)
 
     const dispatch = useAppDispatch()
     const router = useRouter()
@@ -111,20 +120,26 @@ function InvitePageContent() {
 
         hasStartedAwardingRef.current = true
 
-        if (campaign) {
+        if (campaigns.length > 0) {
             setIsAwardingBadge(true)
-            invitesApi
-                .awardBadge(campaign)
-                .catch((e) => console.error('Error awarding campaign badge', e))
-                .finally(async () => {
-                    await fetchUser()
-                    setIsAwardingBadge(false)
-                    // offramp migrants came here to move their balance — land them
-                    // directly on the migration deposit screen, not /home.
-                    router.push(
-                        campaign === OFFRAMP_BADGE_CODE ? '/add-money/crypto?network=EVM&source=offramp' : '/home'
-                    )
-                })
+            // sequential on purpose: each award is an idempotent POST and the
+            // backend flips access flags as side effects — parallel fire-and-forget
+            // would race fetchUser below.
+            ;(async () => {
+                for (const tag of campaigns) {
+                    await invitesApi
+                        .awardBadge(tag)
+                        .catch((e) => console.error('Error awarding campaign badge', tag, e))
+                }
+            })().finally(async () => {
+                await fetchUser()
+                setIsAwardingBadge(false)
+                // offramp migrants came here to move their balance — land them
+                // directly on the migration deposit screen, not /home.
+                router.push(
+                    campaigns.includes(OFFRAMP_BADGE_CODE) ? '/add-money/crypto?network=EVM&source=offramp' : '/home'
+                )
+            })
             return
         }
 
@@ -138,7 +153,7 @@ function InvitePageContent() {
         isLoading,
         isFetchingUser,
         router,
-        campaign,
+        campaigns,
         redirectUri,
         fetchUser,
         isBareClaimCampaign,
@@ -146,7 +161,7 @@ function InvitePageContent() {
     ])
 
     const handleClaim = () => {
-        const eventTag = inviteCode || (isBareClaimCampaign ? campaign : undefined)
+        const eventTag = inviteCode || (isBareClaimCampaign ? campaigns.join(',') : undefined)
         posthog.capture(ANALYTICS_EVENTS.INVITE_CLAIM_CLICKED, { invite_code: eventTag })
 
         if (inviteCode) {
@@ -155,9 +170,10 @@ function InvitePageContent() {
             // Save to cookie so PWA-install + later signup still see the invite.
             saveToCookie('inviteCode', inviteCode)
         }
-        if (campaign) {
-            // useZeroDev reads `campaignTag` post-signup and calls /badge/award.
-            saveToCookie('campaignTag', campaign)
+        if (campaigns.length > 0) {
+            // useZeroDev reads `campaignTag` post-signup (comma-separated for
+            // stacked campaigns) and calls /badge/award for each.
+            saveToCookie('campaignTag', campaigns.join(','))
         }
 
         const signupUrl = redirectUri

--- a/src/components/Invites/InvitesPage.tsx
+++ b/src/components/Invites/InvitesPage.tsx
@@ -124,21 +124,22 @@ function InvitePageContent() {
             setIsAwardingBadge(true)
             // sequential on purpose: each award is an idempotent POST and the
             // backend flips access flags as side effects — parallel fire-and-forget
-            // would race fetchUser below.
+            // would race fetchUser below. awardBadge never throws (the service
+            // catches internally) — check the result instead.
             ;(async () => {
                 for (const tag of campaigns) {
-                    await invitesApi
-                        .awardBadge(tag)
-                        .catch((e) => console.error('Error awarding campaign badge', tag, e))
+                    const { success } = await invitesApi.awardBadge(tag)
+                    if (!success) console.error('Error awarding campaign badge', tag)
                 }
             })().finally(async () => {
                 await fetchUser()
                 setIsAwardingBadge(false)
                 // offramp migrants came here to move their balance — land them
                 // directly on the migration deposit screen, not /home.
-                router.push(
-                    campaigns.includes(OFFRAMP_BADGE_CODE) ? '/add-money/crypto?network=EVM&source=offramp' : '/home'
-                )
+                // case-insensitive: dedup keeps the first-seen casing, so the
+                // stack may carry 'offramp_user' rather than the canonical code.
+                const hasOfframp = campaigns.some((tag) => tag.toLowerCase() === OFFRAMP_BADGE_CODE.toLowerCase())
+                router.push(hasOfframp ? '/add-money/crypto?network=EVM&source=offramp' : '/home')
             })
             return
         }
@@ -160,9 +161,24 @@ function InvitePageContent() {
         inviteCode,
     ])
 
+    // A bare link that resolves to nothing claimable — unknown ?campaign= value,
+    // a stray tracking param swept up by the root-domain redirect, an empty
+    // ?code= — gets the landing page, not the invalid-invite error. That screen
+    // is reserved for links that actually carried an invite code. Safe from a
+    // redirect loop: the root redirect only fires when the params are present,
+    // and we replace with a bare '/'.
+    const isDeadBareLink = !inviteCode && !isBareClaimCampaign
+    useEffect(() => {
+        if (isDeadBareLink) router.replace('/')
+    }, [isDeadBareLink, router])
+
     const handleClaim = () => {
-        const eventTag = inviteCode || (isBareClaimCampaign ? campaigns.join(',') : undefined)
-        posthog.capture(ANALYTICS_EVENTS.INVITE_CLAIM_CLICKED, { invite_code: eventTag })
+        // invite_code keeps its single-value shape for existing PostHog filters;
+        // stacked campaigns ride in their own property.
+        posthog.capture(ANALYTICS_EVENTS.INVITE_CLAIM_CLICKED, {
+            invite_code: inviteCode || (isBareClaimCampaign ? campaigns[0] : undefined),
+            campaign_tags: campaigns.join(',') || undefined,
+        })
 
         if (inviteCode) {
             dispatch(setupActions.setInviteCode(inviteCode))
@@ -182,13 +198,14 @@ function InvitePageContent() {
         router.push(signupUrl)
     }
 
-    if (isAwardingBadge || !shouldShowContent) {
+    if (isAwardingBadge || !shouldShowContent || isDeadBareLink) {
         return <PeanutLoading coverFullScreen />
     }
 
     // Invalid invite code (only reachable when an invite code was supplied).
     // Bare-claim campaigns (skip / event_alumni / touched_grass) carry no invite
-    // code, so they bypass this gate and never show the invalid-invite screen.
+    // code, so they bypass this gate and never show the invalid-invite screen;
+    // bare links with nothing claimable were bounced to '/' above.
     if (!isBareClaimCampaign && (isError || !inviteCodeData?.success)) {
         return (
             <div className="my-auto flex h-[100dvh] w-screen flex-col items-center justify-center space-y-4 px-6">

--- a/src/components/Invites/campaign-maps.test.ts
+++ b/src/components/Invites/campaign-maps.test.ts
@@ -5,8 +5,8 @@ import {
     WAITLIST_SKIP_CAMPAIGNS,
     BARE_VANITY_CAMPAIGNS,
     OFFRAMP_BADGE_CODE,
-    classifyBareCampaign,
-    resolveCampaign,
+    classifyBareCampaigns,
+    resolveCampaigns,
 } from './campaign-maps'
 
 // Regression guard. The /invite flow resolves an inbound invite code / utm_campaign
@@ -35,25 +35,25 @@ describe('campaign maps reference real BADGES codes', () => {
     )
 })
 
-describe('classifyBareCampaign', () => {
+describe('classifyBareCampaigns', () => {
     // A bare campaign (no invite code) must be claimable, or /invite dead-ends at
     // the "Invalid Invite Code" screen. This is the bug that left touched_grass
     // unclaimable — it was never registered as a bare campaign.
     it.each([...WAITLIST_SKIP_CAMPAIGNS, ...BARE_VANITY_CAMPAIGNS])(
         'campaign "%s" is bare-claimable with no invite code',
         (campaign) => {
-            expect(classifyBareCampaign(campaign, undefined).isBareClaimCampaign).toBe(true)
+            expect(classifyBareCampaigns([campaign], undefined).isBareClaimCampaign).toBe(true)
         }
     )
 
     it('classifies waitlist-skip vs vanity, case-insensitively', () => {
         // event_alumni skips the card waitlist → skip copy
-        expect(classifyBareCampaign('EVENT_ALUMNI', undefined)).toEqual({
+        expect(classifyBareCampaigns(['EVENT_ALUMNI'], undefined)).toEqual({
             isBareClaimCampaign: true,
             isWaitlistSkip: true,
         })
         // touched_grass is a vanity badge → claimable but NOT a waitlist skip
-        expect(classifyBareCampaign('TOUCHED_GRASS', undefined)).toEqual({
+        expect(classifyBareCampaigns(['TOUCHED_GRASS'], undefined)).toEqual({
             isBareClaimCampaign: true,
             isWaitlistSkip: false,
         })
@@ -61,55 +61,85 @@ describe('classifyBareCampaign', () => {
 
     it('only waitlist-skip campaigns promise a card-waitlist skip', () => {
         for (const c of BARE_VANITY_CAMPAIGNS) {
-            expect(classifyBareCampaign(c, undefined).isWaitlistSkip).toBe(false)
+            expect(classifyBareCampaigns([c], undefined).isWaitlistSkip).toBe(false)
         }
     })
 
+    it('a stacked link is claimable and shows skip copy when ANY campaign qualifies', () => {
+        expect(classifyBareCampaigns(['TOUCHED_GRASS', 'skip'], undefined)).toEqual({
+            isBareClaimCampaign: true,
+            isWaitlistSkip: true,
+        })
+        // vanity + unknown → claimable, but no skip promise
+        expect(classifyBareCampaigns(['TOUCHED_GRASS', 'SOMETHING_ELSE'], undefined)).toEqual({
+            isBareClaimCampaign: true,
+            isWaitlistSkip: false,
+        })
+    })
+
     it('an invite code defers to the invite flow (not bare-claimable)', () => {
-        expect(classifyBareCampaign('TOUCHED_GRASS', 'somecode')).toEqual({
+        expect(classifyBareCampaigns(['TOUCHED_GRASS'], 'somecode')).toEqual({
+            isBareClaimCampaign: false,
+            isWaitlistSkip: false,
+        })
+        expect(classifyBareCampaigns(['TOUCHED_GRASS', 'skip'], 'somecode')).toEqual({
             isBareClaimCampaign: false,
             isWaitlistSkip: false,
         })
     })
 
     it('an unrelated or missing campaign is not bare-claimable', () => {
-        expect(classifyBareCampaign(undefined, undefined).isBareClaimCampaign).toBe(false)
-        expect(classifyBareCampaign('FOUNDER_HOUSE', undefined).isBareClaimCampaign).toBe(false)
+        expect(classifyBareCampaigns([], undefined).isBareClaimCampaign).toBe(false)
+        expect(classifyBareCampaigns(['FOUNDER_HOUSE'], undefined).isBareClaimCampaign).toBe(false)
     })
 })
 
-describe('resolveCampaign', () => {
+describe('resolveCampaigns', () => {
     // The offramp migration regression this guards: ?campaign=offramp used to
     // reach /badge/award as the raw string 'offramp' and 400 (the backend matches
     // badge codes). The explicit param must resolve through the UTM map first.
     it('resolves a lowercase human-facing tag in the explicit param (?campaign=offramp)', () => {
-        expect(resolveCampaign('offramp', undefined, undefined)).toBe(OFFRAMP_BADGE_CODE)
-        expect(resolveCampaign('OFFRAMP', undefined, undefined)).toBe(OFFRAMP_BADGE_CODE)
+        expect(resolveCampaigns(['offramp'], undefined, undefined)).toEqual([OFFRAMP_BADGE_CODE])
+        expect(resolveCampaigns(['OFFRAMP'], undefined, undefined)).toEqual([OFFRAMP_BADGE_CODE])
     })
 
     it('passes an unmapped explicit param through raw (?campaign=OFFRAMP_USER)', () => {
-        expect(resolveCampaign('OFFRAMP_USER', undefined, undefined)).toBe('OFFRAMP_USER')
-        expect(resolveCampaign('FOUNDER_HOUSE', undefined, undefined)).toBe('FOUNDER_HOUSE')
+        expect(resolveCampaigns(['OFFRAMP_USER'], undefined, undefined)).toEqual(['OFFRAMP_USER'])
+        expect(resolveCampaigns(['FOUNDER_HOUSE'], undefined, undefined)).toEqual(['FOUNDER_HOUSE'])
     })
 
     it('documents that ?campaign=<tag> behaves exactly like ?utm_campaign=<tag>', () => {
         for (const [utmKey, badgeCode] of Object.entries(UTM_CAMPAIGN_TO_BADGE_MAP)) {
-            expect(resolveCampaign(utmKey, undefined, undefined)).toBe(badgeCode)
-            expect(resolveCampaign(undefined, undefined, utmKey)).toBe(badgeCode)
+            expect(resolveCampaigns([utmKey], undefined, undefined)).toEqual([badgeCode])
+            expect(resolveCampaigns([], undefined, utmKey)).toEqual([badgeCode])
         }
     })
 
-    it('explicit param wins over invite code and utm_campaign', () => {
-        expect(resolveCampaign('offramp', 'alumni', 'touched-grass')).toBe(OFFRAMP_BADGE_CODE)
+    // Stacking: every source contributes — repeated params, comma-separated
+    // values, a mapped invite code, and a mapped utm_campaign all UNION.
+    it('stacks repeated params', () => {
+        expect(resolveCampaigns(['skip', 'touched-grass'], undefined, undefined)).toEqual(['skip', 'TOUCHED_GRASS'])
     })
 
-    it('invite code wins over utm_campaign when there is no explicit param', () => {
-        expect(resolveCampaign(undefined, 'offramp', 'touched-grass')).toBe(OFFRAMP_BADGE_CODE)
+    it('stacks comma-separated values in one param', () => {
+        expect(resolveCampaigns(['skip,touched-grass'], undefined, undefined)).toEqual(['skip', 'TOUCHED_GRASS'])
+        // whitespace + empty segments are tolerated
+        expect(resolveCampaigns([' skip , ,offramp '], undefined, undefined)).toEqual(['skip', OFFRAMP_BADGE_CODE])
     })
 
-    it('falls back to utm_campaign, and to undefined when nothing resolves', () => {
-        expect(resolveCampaign(undefined, undefined, 'offramp')).toBe(OFFRAMP_BADGE_CODE)
-        expect(resolveCampaign(undefined, 'not-a-special-code', undefined)).toBeUndefined()
-        expect(resolveCampaign(null, undefined, undefined)).toBeUndefined()
+    it('unions explicit params with a mapped invite code and a mapped utm_campaign', () => {
+        expect(resolveCampaigns(['skip'], 'alumni', 'touched-grass')).toEqual(['skip', 'EVENT_ALUMNI', 'TOUCHED_GRASS'])
+    })
+
+    it('dedupes case-insensitively across sources (first occurrence wins)', () => {
+        // ?campaign=offramp and ?code=offramp resolve to the same badge → once
+        expect(resolveCampaigns(['offramp'], 'offramp', 'offramp')).toEqual([OFFRAMP_BADGE_CODE])
+        expect(resolveCampaigns(['skip', 'SKIP'], undefined, undefined)).toEqual(['skip'])
+    })
+
+    it('an unmapped invite code or utm_campaign contributes nothing', () => {
+        expect(resolveCampaigns([], 'not-a-special-code', undefined)).toEqual([])
+        expect(resolveCampaigns([], undefined, 'ordinary-marketing-utm')).toEqual([])
+        expect(resolveCampaigns([], undefined, undefined)).toEqual([])
     })
 })

--- a/src/components/Invites/campaign-maps.ts
+++ b/src/components/Invites/campaign-maps.ts
@@ -45,9 +45,12 @@ export const UTM_CAMPAIGN_TO_BADGE_MAP: Record<string, string> = {
     manicero: 'MANICERO',
 }
 
-// Resolve the effective campaign (a badge code, or a raw passthrough tag) from
-// the three places it can arrive on /invite. Precedence:
-//   1. explicit ?campaign= / ?campaignTag= — mapped through the UTM map first so
+// Resolve the effective campaigns (badge codes, or raw passthrough tags) from
+// the three places they can arrive on /invite. Campaigns STACK — a link carrying
+// several (repeated ?campaign= params, comma-separated values, an invite code
+// that maps to a badge, plus a mapped utm_campaign) resolves to the union, and
+// the claim flow awards every one. Sources, in output order:
+//   1. explicit ?campaign= / ?campaignTag= — each mapped through the UTM map so
 //      a human-facing lowercase token (?campaign=offramp) resolves to its badge
 //      code instead of reaching /badge/award raw and 400ing; unmapped values
 //      pass through unchanged (?campaign=OFFRAMP_USER still works).
@@ -55,19 +58,33 @@ export const UTM_CAMPAIGN_TO_BADGE_MAP: Record<string, string> = {
 //      ?utm_campaign=<tag> — users and partners can't be expected to know the
 //      difference between the two param spellings.
 //   2. a mapped special invite code (?code=offramp).
-//   3. ?utm_campaign= — last so an explicit ?campaign= wins on links carrying both.
-export function resolveCampaign(
-    campaignParam: string | null | undefined,
+//   3. ?utm_campaign= — only badge-mapped values contribute; ordinary marketing
+//      UTMs resolve to nothing.
+// Deduped case-insensitively on the resolved value, first occurrence wins.
+export function resolveCampaigns(
+    campaignParams: readonly string[],
     inviteCode: string | null | undefined,
     utmCampaignParam: string | null | undefined
-): string | undefined {
-    return (
-        (campaignParam && UTM_CAMPAIGN_TO_BADGE_MAP[campaignParam.toLowerCase()]) ||
-        campaignParam ||
-        (inviteCode ? INVITE_CODE_TO_CAMPAIGN_MAP[inviteCode] : undefined) ||
-        (utmCampaignParam ? UTM_CAMPAIGN_TO_BADGE_MAP[utmCampaignParam] : undefined) ||
-        undefined
-    )
+): string[] {
+    const resolved: string[] = []
+    const seen = new Set<string>()
+    const add = (tag: string | undefined) => {
+        if (!tag) return
+        const key = tag.toLowerCase()
+        if (seen.has(key)) return
+        seen.add(key)
+        resolved.push(tag)
+    }
+    for (const param of campaignParams) {
+        for (const raw of param.split(',')) {
+            const tag = raw.trim()
+            if (!tag) continue
+            add(UTM_CAMPAIGN_TO_BADGE_MAP[tag.toLowerCase()] ?? tag)
+        }
+    }
+    if (inviteCode) add(INVITE_CODE_TO_CAMPAIGN_MAP[inviteCode])
+    if (utmCampaignParam) add(UTM_CAMPAIGN_TO_BADGE_MAP[utmCampaignParam])
+    return resolved
 }
 
 // Bare ?campaign= links (no invite code) that are claimable without an invite —
@@ -98,17 +115,19 @@ export type CampaignClassification = {
     isWaitlistSkip: boolean
 }
 
-// Classify a resolved campaign for a visitor carrying the given invite code (if
-// any). A campaign is only "bare-claimable" when there is no invite code — with
-// an invite code the normal invite-validation path owns the flow. Matching is
-// case-insensitive (campaign codes arrive in any case from ?campaign= URLs).
-export function classifyBareCampaign(
-    campaign: string | undefined,
+// Classify resolved campaigns for a visitor carrying the given invite code (if
+// any). Campaigns are only "bare-claimable" when there is no invite code — with
+// an invite code the normal invite-validation path owns the flow. With stacked
+// campaigns, ANY claimable one makes the link claimable (the claim flow awards
+// all of them; unknown tags 400 harmlessly on the backend whitelist), and ANY
+// skip campaign in the stack earns the skip copy. Matching is case-insensitive
+// (campaign codes arrive in any case from ?campaign= URLs).
+export function classifyBareCampaigns(
+    campaigns: readonly string[],
     inviteCode: string | undefined
 ): CampaignClassification {
-    const key = campaign?.toLowerCase()
-    const isBare = !inviteCode && !!key
-    const isWaitlistSkip = isBare && WAITLIST_SKIP_CAMPAIGNS.has(key!)
-    const isVanity = isBare && BARE_VANITY_CAMPAIGNS.has(key!)
+    const keys = inviteCode ? [] : campaigns.map((c) => c.toLowerCase())
+    const isWaitlistSkip = keys.some((key) => WAITLIST_SKIP_CAMPAIGNS.has(key))
+    const isVanity = keys.some((key) => BARE_VANITY_CAMPAIGNS.has(key))
     return { isBareClaimCampaign: isWaitlistSkip || isVanity, isWaitlistSkip }
 }

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -140,21 +140,24 @@ export const useZeroDev = () => {
             // (?code=alice&campaign=skip) was silently dropped here before this
             // ran unconditionally. /badge/award is idempotent and whitelisted
             // server-side — a tag acceptInvite already awarded no-ops, and
-            // anything unknown 400s harmlessly.
+            // anything unknown 400s harmlessly. awardBadge never throws (the
+            // service catches internally), so check each result: on any failure
+            // keep the cookie — a later signup retry (or a fixed backend) can
+            // still claim, and a Skip Pass must not be silently lost.
             if (campaignTags.length > 0) {
-                try {
-                    for (const tag of campaignTags) {
-                        await invitesApi.awardBadge(tag)
-                    }
-                    if (!userInviteCode?.trim()) {
-                        // the invite-code branch already fired INVITE_ACCEPTED
-                        posthog.capture(ANALYTICS_EVENTS.INVITE_ACCEPTED, {
-                            campaign_tag: campaignTags.join(','),
-                        })
-                    }
-                } catch (e) {
-                    console.error('Error awarding campaign badge', e)
-                } finally {
+                const awarded: string[] = []
+                for (const tag of campaignTags) {
+                    const { success } = await invitesApi.awardBadge(tag)
+                    if (success) awarded.push(tag)
+                    else console.error('Error awarding campaign badge', tag)
+                }
+                if (awarded.length > 0 && !userInviteCode?.trim()) {
+                    // the invite-code branch already fired INVITE_ACCEPTED
+                    posthog.capture(ANALYTICS_EVENTS.INVITE_ACCEPTED, {
+                        campaign_tag: awarded.join(','),
+                    })
+                }
+                if (awarded.length === campaignTags.length) {
                     removeFromCookie('campaignTag')
                 }
             }

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -103,7 +103,10 @@ export const useZeroDev = () => {
                         posthog.capture(ANALYTICS_EVENTS.INVITE_ACCEPTED, {
                             invite_code: userInviteCode,
                             invite_type: inviteType,
-                            campaign_tag: campaignTags.join(','),
+                            // campaign_tag stays single-valued (what acceptInvite
+                            // consumed); the full stack rides the plural CSV.
+                            campaign_tag: campaignTags[0],
+                            campaign_tags: campaignTags.join(',') || undefined,
                         })
                         if (inviteCodeFromCookie) {
                             removeFromCookie('inviteCode')
@@ -154,7 +157,9 @@ export const useZeroDev = () => {
                 if (awarded.length > 0 && !userInviteCode?.trim()) {
                     // the invite-code branch already fired INVITE_ACCEPTED
                     posthog.capture(ANALYTICS_EVENTS.INVITE_ACCEPTED, {
-                        campaign_tag: awarded.join(','),
+                        // single-valued for existing filters; full stack in the CSV
+                        campaign_tag: awarded[0],
+                        campaign_tags: awarded.join(','),
                     })
                 }
                 if (awarded.length === campaignTags.length) {

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -81,7 +81,11 @@ export const useZeroDev = () => {
 
             // invite code can also be store in cookies, so we need to check both
             const userInviteCode = inviteCode || inviteCodeFromCookie
-            const campaignTag = getFromCookie('campaignTag')
+            // comma-separated for stacked campaigns (InvitesPage writes the CSV)
+            const campaignTags = String(getFromCookie('campaignTag') || '')
+                .split(',')
+                .map((tag) => tag.trim())
+                .filter(Boolean)
 
             if (userInviteCode?.trim().length > 0) {
                 /*
@@ -94,18 +98,15 @@ export const useZeroDev = () => {
                  */
                 const keepInviteCodeForRetry = () => saveToCookie('inviteCode', userInviteCode, 30)
                 try {
-                    const result = await invitesApi.acceptInvite(userInviteCode, inviteType, campaignTag)
+                    const result = await invitesApi.acceptInvite(userInviteCode, inviteType, campaignTags[0])
                     if (result.success) {
                         posthog.capture(ANALYTICS_EVENTS.INVITE_ACCEPTED, {
                             invite_code: userInviteCode,
                             invite_type: inviteType,
-                            campaign_tag: campaignTag,
+                            campaign_tag: campaignTags.join(','),
                         })
                         if (inviteCodeFromCookie) {
                             removeFromCookie('inviteCode')
-                        }
-                        if (campaignTag) {
-                            removeFromCookie('campaignTag')
                         }
                     } else {
                         posthog.capture(ANALYTICS_EVENTS.INVITE_ACCEPT_FAILED, {
@@ -131,14 +132,26 @@ export const useZeroDev = () => {
                     keepInviteCodeForRetry()
                     console.error('Error accepting invite', e)
                 }
-            } else if (campaignTag) {
-                // No invite code but a campaign tag — only InvitesPage's skip-path
-                // CTA reaches here today (it sets the cookie without an inviteCode).
-                // The BE whitelists which campaigns are claimable, so passing other
-                // values through is safe — anything not on the whitelist 400s.
+            }
+
+            // Award every campaign badge, with or without an invite code.
+            // /invites/accept only awards its own whitelisted badges, so a
+            // campaign like `skip` riding on an invite link
+            // (?code=alice&campaign=skip) was silently dropped here before this
+            // ran unconditionally. /badge/award is idempotent and whitelisted
+            // server-side — a tag acceptInvite already awarded no-ops, and
+            // anything unknown 400s harmlessly.
+            if (campaignTags.length > 0) {
                 try {
-                    await invitesApi.awardBadge(campaignTag)
-                    posthog.capture(ANALYTICS_EVENTS.INVITE_ACCEPTED, { campaign_tag: campaignTag })
+                    for (const tag of campaignTags) {
+                        await invitesApi.awardBadge(tag)
+                    }
+                    if (!userInviteCode?.trim()) {
+                        // the invite-code branch already fired INVITE_ACCEPTED
+                        posthog.capture(ANALYTICS_EVENTS.INVITE_ACCEPTED, {
+                            campaign_tag: campaignTags.join(','),
+                        })
+                    }
                 } catch (e) {
                     console.error('Error awarding campaign badge', e)
                 } finally {


### PR DESCRIPTION
## Summary

Campaign/badge links now work on the root domain and stack. `peanut.me/?campaign=skip` used to render the landing page and do nothing — only `/invite` (and `/shhhhh`) implement the claim contract — and every layer of that contract was single-valued, so a link carrying two campaigns silently dropped all but one.

- **Root domain**: `/?campaign=`, `/?campaignTag=`, `/?code=` 307-redirect to `/invite` with the full query preserved (next.config `has` redirects, active in dev too). Deliberately **not** keyed on `utm_campaign`, which would hijack ordinary marketing links to the landing page.
- **Stacking**: `resolveCampaigns` unions every source — repeated `?campaign=` params, comma-separated values (`?campaign=skip,touched-grass`), a badge-mapped invite code, and a badge-mapped `utm_campaign` — deduped case-insensitively. The claim flow (logged-in auto-claim and post-signup) awards each via `/badge/award`, which is idempotent and whitelisted server-side.
- **Interop bugfix**: a campaign riding on an invite link (`?code=alice&campaign=skip`) was silently dropped for **new signups** — `useZeroDev` only called `/invites/accept` (whose badge whitelist doesn't include `skip`) and deleted the cookie without ever calling `/badge/award`. The badge-award pass now runs unconditionally after invite acceptance.

No backend changes: `/badge/award` already accepts one tag per call, no-ops on repeats, and 400s unknown tags.

## Risks / breaking changes

- `resolveCampaigns` unions where `resolveCampaign` picked one by precedence: a link with `?code=arbiverseinvitesyou&campaign=skip` now grants **both** badges (previously only skip). This is the intended product change.
- UX: stacked awards fire sequentially before routing to `/home`; badge-earn toasts queue per existing toast behavior. No modal changes in this PR.
- Root redirect consumes `/?code=…` — nothing else on the landing page uses a `code` query param today.
- Analytics: `INVITE_ACCEPTED` / claim events now carry a comma-joined `campaign_tag` when stacked.

## QA

- `campaign-maps.test.ts` covers union/dedup/CSV/classification (44 tests in suite; full jest 2039 green).
- Verified against a local `next start` build:
  - `/?campaign=skip` → 307 `/invite?campaign=skip`
  - `/?code=x&campaign=skip,touched-grass` → 307 preserving both params
  - `/` and `/?utm_campaign=offramp` → 200 (no redirect, no marketing hijack)
- Typecheck 0 errors, `next build` green.

Screenshots: N/A (no visual change — `/invite` renders the same claim screens; behavior verified via curl + unit tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Campaign and invite links can now combine multiple campaign tags.
  - Eligible campaign links can award multiple badges in sequence.
  - Campaign and invite tracking now supports all associated campaign tags.

- **Bug Fixes**
  - Improved handling of campaign links across environments.
  - Invalid bare campaign links now redirect safely to the home page instead of showing an invalid-invite screen.
  - Campaign matching is now case-insensitive and avoids duplicate campaigns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->