### PR TITLE
fix: receipt avatar initials, ErrorAlert icon shrink, setup iOS bottom inset

### DIFF
--- a/src/app/(setup)/layout.tsx
+++ b/src/app/(setup)/layout.tsx
@@ -11,7 +11,7 @@ import { Banner } from '@/components/Global/Banner'
 import SupportDrawer from '@/components/Global/SupportDrawer'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { usePullToRefresh } from '@/hooks/usePullToRefresh'
-import { isCapacitor, isIOSNative } from '@/utils/capacitor'
+import { isCapacitor } from '@/utils/capacitor'
 
 function SetupLayoutContent({ children }: { children?: React.ReactNode }) {
     const dispatch = useAppDispatch()
@@ -22,13 +22,16 @@ function SetupLayoutContent({ children }: { children?: React.ReactNode }) {
      * Bottom-inset fill color. Periwinkle is for Android 15 edge-to-edge (matches
      * the status-bar strip). On iOS the content directly above the home-indicator
      * inset is the white panel, so periwinkle reads as a stray bar on Face ID
-     * devices — fill with white there instead. State + effect (not a render-time
-     * platform check) so the static export's prerendered HTML hydrates cleanly.
+     * devices — fill with white there instead. This applies to ALL iOS (native
+     * app, home-screen PWA, and Safari), not just the Capacitor native build, so
+     * key off the device type rather than isIOSNative(). State + effect (not a
+     * render-time platform check) so the static export's prerendered HTML hydrates
+     * cleanly.
      */
     const [bottomInsetFill, setBottomInsetFill] = useState('bg-secondary-3')
     useEffect(() => {
-        if (isIOSNative()) setBottomInsetFill('bg-white')
-    }, [])
+        if (deviceType === DeviceType.IOS) setBottomInsetFill('bg-white')
+    }, [deviceType])
 
     // configure status bar for native. the setup/onboarding flow has a periwinkle
     // top (illustration + feedback ribbon), so tint the status bar to match — on

--- a/src/components/Global/ErrorAlert/index.tsx
+++ b/src/components/Global/ErrorAlert/index.tsx
@@ -11,7 +11,7 @@ interface ErrorAlertProps {
 const ErrorAlert = ({ className, iconSize = 16, description, iconClassName }: ErrorAlertProps) => {
     return (
         <div className={twMerge('flex items-start justify-center gap-3 text-[12px] font-medium text-error', className)}>
-            <Icon name="error" size={iconSize} className={twMerge('mt-0.5 text-error', iconClassName)} />
+            <Icon name="error" size={iconSize} className={twMerge('mt-0.5 shrink-0 text-error', iconClassName)} />
             <div>{description}</div>
         </div>
     )

--- a/src/components/TransactionDetails/__tests__/transactionTransformer.test.ts
+++ b/src/components/TransactionDetails/__tests__/transactionTransformer.test.ts
@@ -28,6 +28,19 @@ const bobUser: Account = {
     showFullName: false,
 }
 
+// A Peanut user who has a display name (showFullName) but no @username — only
+// their wallet address as identifier. The strategy must thread fullName +
+// showFullName so the avatar resolves to their initials, not the address (which
+// would trip isAddress() → wallet icon in TransactionAvatarBadge).
+const displayNameOnlyUser: Account = {
+    identifier: '0xNancyWalletAddressForTesting0000000000',
+    type: 'WALLET_SMART',
+    isUser: true,
+    fullName: 'Nancy Drew',
+    userId: 'user-nancy',
+    showFullName: true,
+}
+
 const externalEoa: Account = {
     identifier: '0xExternalAddress000000000000000000000000',
     type: 'WALLET_EXTERNAL',
@@ -525,6 +538,39 @@ describe('mapTransactionDataForDrawer', () => {
                 })
             )
             expect(pipelineAlert).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('direct P2P avatar for display-name-only users (no @username)', () => {
+        // Regression guard: p2p-send used to drop fullName/showFullName, so a
+        // recipient/sender with only a display name fell back to their wallet
+        // address for the avatar name → isAddress() → wallet icon instead of
+        // initials. The strategy now threads both, matching every sibling.
+        it('outgoing send resolves the recipient display name → initials, not the address', () => {
+            const result = mapTransactionDataForDrawer(
+                baseEntry({
+                    userRole: EHistoryUserRole.SENDER,
+                    recipientAccount: displayNameOnlyUser,
+                    extraData: { kind: 'DIRECT_TRANSFER' },
+                })
+            ).transactionDetails
+            expect(result.fullName).toBe('Nancy Drew')
+            expect(result.showFullName).toBe(true)
+            expect(result.initials).toBe('ND')
+        })
+
+        it('incoming receive resolves the sender display name → initials, not the address', () => {
+            const result = mapTransactionDataForDrawer(
+                baseEntry({
+                    userRole: EHistoryUserRole.RECIPIENT,
+                    senderAccount: displayNameOnlyUser,
+                    recipientAccount: aliceUser,
+                    extraData: { kind: 'DIRECT_TRANSFER' },
+                })
+            ).transactionDetails
+            expect(result.fullName).toBe('Nancy Drew')
+            expect(result.showFullName).toBe(true)
+            expect(result.initials).toBe('ND')
         })
     })
 })

--- a/src/components/TransactionDetails/__tests__/transactionTransformer.test.ts
+++ b/src/components/TransactionDetails/__tests__/transactionTransformer.test.ts
@@ -33,7 +33,9 @@ const bobUser: Account = {
 // showFullName so the avatar resolves to their initials, not the address (which
 // would trip isAddress() → wallet icon in TransactionAvatarBadge).
 const displayNameOnlyUser: Account = {
-    identifier: '0xNancyWalletAddressForTesting0000000000',
+    // real hex address so isAddress() would be true on the old code path —
+    // faithfully reproduces the "avatar name is an address → wallet icon" symptom.
+    identifier: '0x1234567890abcdef1234567890abcdef12345678',
     type: 'WALLET_SMART',
     isUser: true,
     fullName: 'Nancy Drew',

--- a/src/components/TransactionDetails/strategies/intent/p2p-send.ts
+++ b/src/components/TransactionDetails/strategies/intent/p2p-send.ts
@@ -33,6 +33,8 @@ export const p2pSendOrRequestFulfill: TransactionStrategy = (entry: HistoryEntry
                 direction: 'receive',
                 transactionCardType: 'receive',
                 nameForDetails: entry.senderAccount?.username || entry.senderAccount?.identifier || 'Sender',
+                fullName: entry.senderAccount?.fullName ?? '',
+                showFullName: entry.senderAccount?.showFullName,
                 isPeerActuallyUser: !!entry.senderAccount?.isUser,
                 isLinkTx: false,
             }
@@ -51,6 +53,8 @@ export const p2pSendOrRequestFulfill: TransactionStrategy = (entry: HistoryEntry
         direction: 'send',
         transactionCardType: 'send',
         nameForDetails: entry.recipientAccount?.username || entry.recipientAccount?.identifier || 'Recipient',
+        fullName: entry.recipientAccount?.fullName ?? '',
+        showFullName: entry.recipientAccount?.showFullName,
         isPeerActuallyUser: !!entry.recipientAccount?.isUser,
         isLinkTx: false,
     }


### PR DESCRIPTION
## Summary
Three small, independent UI bug fixes (one commit each):

1. **Receipt avatar (`p2p-send` strategy).** Direct P2P sends to a Peanut user who has a display name but **no @username** rendered the generic wallet icon instead of the recipient's initials. `p2p-send` was the only strategy not threading `fullName`/`showFullName`, so `nameForAvatar` fell back to the wallet address → `isAddress()` true → wallet icon. Now threads both fields (both send and receive directions), matching every sibling strategy (`send-link`, `bank_request_fulfillment`, `crypto`).
2. **`ErrorAlert` icon shrink.** The 16px leading icon got squished by flexbox when the message wrapped at full width. Added `shrink-0`.
3. **Setup bottom safe-area.** The white bottom-inset fill only applied on Capacitor native iOS (`isIOSNative()`), so iOS home-screen PWA / Safari showed a stray periwinkle strip below the white panel. Now keys off `DeviceType.IOS`, covering all iOS surfaces. Android edge-to-edge keeps periwinkle (unchanged).

## Risks / breaking changes
Low, FE-only, no cross-repo impact.
- (1) Pure additive data threading; users with a `@username` already resolved correctly and are unaffected. Recipients with neither a name nor a username still fall to the wallet icon (correct).
- (3) Android and web behaviour unchanged; only broadens the existing iOS white-fill. Removed the now-unused `isIOSNative` import (`isCapacitor` still used).

## QA
- `p2p-send`: unit test added in `transactionTransformer.test.ts` — a display-name-only user (fullName, `showFullName`, no username, identified by a real wallet address) resolves to initials (`ND`) for both send and receive; fails on old code (would derive initials from the address).
- `ErrorAlert`: force a full-width passkey error on `/withdraw/<country>/bank` confirm → icon stays 16px on multi-line wrap.
- Setup: open `/setup` as an iOS home-screen PWA / Safari → bottom inset is white, no blue strip; Android still periwinkle.

## Design notes / accepted trade-offs
- **No new smells.** Fix (1) removes a latent inconsistency (p2p-send was the odd strategy out).
- **Follow-up (not this PR):** the `nameForDetails` + `fullName ?? ''` + `showFullName` trio is now repeated across ~10 peer-facing branches in 4 strategy files. A small `peerFields(account)` helper would DRY this up — out of scope here, worth a follow-up.
- **Known cosmetic (pre-existing, not a regression):** on the iOS static-export prerender the bottom inset paints periwinkle for one frame before the client effect flips it white — same behaviour as the `isIOSNative()`-in-effect pattern this replaces; the state+effect is required to avoid a hydration mismatch against the WEB-prerendered HTML.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bottom safe-area styling on iOS devices.
  * Prevented error alert icons from shrinking when displayed alongside text.
  * Fixed transaction details so users with display names but no usernames show the correct avatar initials.
  * Improved P2P transaction details by displaying available sender and recipient names consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->