### PR TITLE
fix(history): resolve ENS names server-side so mobile shows them too

### DIFF
--- a/src/components/Global/AddressLink/index.tsx
+++ b/src/components/Global/AddressLink/index.tsx
@@ -1,6 +1,6 @@
 import { printableAddress, isCryptoAddress } from '@/utils/general.utils'
 import { normalizeEnsName } from '@/utils/ens.utils'
-import { usePrimaryName } from '@justaname.id/react'
+import { usePrimaryNameServer } from '@/hooks/usePrimaryNameServer'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
@@ -20,11 +20,7 @@ const AddressLink = ({ address, className = '', isLink = true }: AddressLinkProp
     const [urlAddress, setUrlAddress] = useState<string>(address)
 
     // Look up ENS name only for Ethereum addresses (ENS doesn't apply to Solana/Tron)
-    const { primaryName: ensName } = usePrimaryName({
-        address: isAddress(address) ? (address as `0x${string}`) : undefined,
-        chainId: 1, // Mainnet for ENS lookups
-        priority: 'onChain',
-    })
+    const { primaryName: ensName } = usePrimaryNameServer(isAddress(address) ? address : undefined)
 
     useEffect(() => {
         const normalizedEnsName = isAddress(address) ? normalizeEnsName(ensName) : null

--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -23,7 +23,7 @@ import React, { lazy, Suspense } from 'react'
 import { twMerge } from 'tailwind-merge'
 import Image from 'next/image'
 import { isAddress } from 'viem'
-import { usePrimaryName } from '@justaname.id/react'
+import { usePrimaryNameServer } from '@/hooks/usePrimaryNameServer'
 import { normalizeEnsName } from '@/utils/ens.utils'
 import StatusPill, { type StatusPillType } from '../Global/StatusPill'
 import { VerifiedUserLabel } from '../UserHeader'
@@ -105,11 +105,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
     const isTestTransaction = name === 'Enjoy Peanut!'
 
     // ENS reverse-lookup for raw addresses; hook is a no-op when name is a username.
-    const { primaryName } = usePrimaryName({
-        address: isAddress(name) ? (name as `0x${string}`) : undefined,
-        chainId: 1,
-        priority: 'onChain',
-    })
+    const { primaryName } = usePrimaryNameServer(isAddress(name) ? name : undefined)
     let displayName = normalizeEnsName(primaryName) ?? name
     // Shortens crypto addresses AND raw UUIDs (usernameless Peanut users whose
     // `identifier` arrives as a userId) so the feed row never renders a 36-char

--- a/src/components/TransactionDetails/__tests__/TransactionCard.test.tsx
+++ b/src/components/TransactionDetails/__tests__/TransactionCard.test.tsx
@@ -38,8 +38,8 @@ jest.mock('@/hooks/useTransactionDetailsDrawer', () => ({
     }),
 }))
 
-jest.mock('@justaname.id/react', () => ({
-    usePrimaryName: () => ({ primaryName: undefined }),
+jest.mock('@/hooks/usePrimaryNameServer', () => ({
+    usePrimaryNameServer: () => ({ primaryName: undefined }),
 }))
 
 jest.mock('@/context/authContext', () => ({

--- a/src/hooks/__tests__/usePrimaryNameServer.test.tsx
+++ b/src/hooks/__tests__/usePrimaryNameServer.test.tsx
@@ -1,0 +1,53 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { usePrimaryNameServer } from '../usePrimaryNameServer'
+import { serverFetch } from '@/utils/api-fetch'
+
+jest.mock('@/utils/api-fetch', () => ({ serverFetch: jest.fn() }))
+
+const mockServerFetch = serverFetch as jest.MockedFunction<typeof serverFetch>
+
+const wrapper = ({ children }: { children: ReactNode }) => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+const ADDRESS = '0x1bbb000000000000000000000000000000ea0349'
+
+const jsonResponse = (body: unknown, ok = true) => ({ ok, json: async () => body }) as unknown as Response
+
+beforeEach(() => jest.clearAllMocks())
+
+describe('usePrimaryNameServer', () => {
+    it('resolves the address to its primary name via the backend', async () => {
+        mockServerFetch.mockResolvedValue(jsonResponse({ name: 'alice.eth' }))
+        const { result } = renderHook(() => usePrimaryNameServer(ADDRESS), { wrapper })
+        await waitFor(() => expect(result.current.primaryName).toBe('alice.eth'))
+        expect(mockServerFetch).toHaveBeenCalledWith(`/ens/reverse/${ADDRESS}`, { method: 'GET' })
+    })
+
+    it('returns undefined when the backend reports no name', async () => {
+        mockServerFetch.mockResolvedValue(jsonResponse({ name: null }))
+        const { result } = renderHook(() => usePrimaryNameServer(ADDRESS), { wrapper })
+        await waitFor(() => expect(mockServerFetch).toHaveBeenCalled())
+        expect(result.current.primaryName).toBeUndefined()
+    })
+
+    it('fails safe to undefined on a non-OK response (e.g. route not deployed)', async () => {
+        mockServerFetch.mockResolvedValue(jsonResponse({}, false))
+        const { result } = renderHook(() => usePrimaryNameServer(ADDRESS), { wrapper })
+        await waitFor(() => expect(mockServerFetch).toHaveBeenCalled())
+        expect(result.current.primaryName).toBeUndefined()
+    })
+
+    it('does not query for a non-address input', () => {
+        renderHook(() => usePrimaryNameServer('not-an-address'), { wrapper })
+        expect(mockServerFetch).not.toHaveBeenCalled()
+    })
+
+    it('does not query when address is undefined', () => {
+        renderHook(() => usePrimaryNameServer(undefined), { wrapper })
+        expect(mockServerFetch).not.toHaveBeenCalled()
+    })
+})

--- a/src/hooks/usePrimaryNameServer.ts
+++ b/src/hooks/usePrimaryNameServer.ts
@@ -1,0 +1,42 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { isAddress } from 'viem'
+import { serverFetch } from '@/utils/api-fetch'
+
+const PRIMARY_NAME_TTL_MS = 24 * 60 * 60 * 1000 // 1 day
+
+/**
+ * ENS reverse-lookup (address → primary name) resolved SERVER-SIDE via the
+ * backend `/ens/reverse` endpoint, instead of a client call to the mainnet RPC.
+ *
+ * Why: on native the WebView origin (`capacitor://localhost` / `https://localhost`)
+ * is rejected by the RPC's CORS policy, so the client-side `usePrimaryName`
+ * (JustaName, `priority: 'onChain'`) always failed on mobile and the feed fell
+ * back to the raw address. The backend has no such origin restriction and is
+ * already CORS-allowed for native, so this resolves identically on web and
+ * native. Drop-in for `@justaname.id/react`'s `usePrimaryName` — same
+ * `{ primaryName }` shape.
+ *
+ * Fail-safe: any non-OK response (incl. a backend that doesn't yet expose the
+ * route) yields `undefined`, so callers degrade to the address exactly as before.
+ */
+export function usePrimaryNameServer(address?: string): { primaryName: string | undefined } {
+    const enabled = !!address && isAddress(address)
+
+    const { data } = useQuery({
+        queryKey: ['ens-primary-name', address?.toLowerCase()],
+        enabled,
+        staleTime: PRIMARY_NAME_TTL_MS,
+        gcTime: PRIMARY_NAME_TTL_MS,
+        retry: false,
+        queryFn: async (): Promise<string | null> => {
+            const res = await serverFetch(`/ens/reverse/${address}`, { method: 'GET' })
+            if (!res.ok) return null
+            const json = (await res.json()) as { name?: string | null }
+            return json.name ?? null
+        },
+    })
+
+    return { primaryName: data ?? undefined }
+}

--- a/src/hooks/useRecipientDisplay.ts
+++ b/src/hooks/useRecipientDisplay.ts
@@ -1,8 +1,8 @@
 'use client'
 
-import { usePrimaryName } from '@justaname.id/react'
 import { useMemo } from 'react'
 import { isAddress } from 'viem'
+import { usePrimaryNameServer } from '@/hooks/usePrimaryNameServer'
 
 import { resolveRecipientDisplay, type RecipientDisplay, type ResolveRecipientInput } from '@/utils/recipient-display'
 import { normalizeEnsName } from '@/utils/ens.utils'
@@ -20,11 +20,7 @@ import { normalizeEnsName } from '@/utils/ens.utils'
 export function useRecipientDisplay(input: Omit<ResolveRecipientInput, 'ensName'>): RecipientDisplay {
     const skipEnsLookup = !!input.user?.username || !isAddress(input.address)
 
-    const { primaryName } = usePrimaryName({
-        address: skipEnsLookup ? undefined : (input.address as `0x${string}`),
-        chainId: 1,
-        priority: 'onChain',
-    })
+    const { primaryName } = usePrimaryNameServer(skipEnsLookup ? undefined : input.address)
 
     return useMemo(
         () =>


### PR DESCRIPTION
## Problem
On the mobile (native) app, the activity feed shows raw addresses (e.g. `0x1bbb…ea0349`) where the web app shows the resolved ENS name. Root cause: the feed reverse-resolves addresses via a **client-side** mainnet RPC call (`@justaname.id/react` `usePrimaryName`, `priority: 'onChain'`). With `CapacitorHttp` disabled, that third-party RPC call is blocked by CORS on the native WebView origin, so it silently fails and the row falls back to the address. Web (report-only CSP + `peanut.me` origin) resolves fine.

## Fix
Route the reverse-lookup through the backend instead of the client RPC:
- New `usePrimaryNameServer` hook → `GET /ens/reverse/:address` via same-origin `serverFetch` (already CORS-allowed + authed for native).
- Swaps the three `usePrimaryName` call sites: `TransactionCard`, `AddressLink`, `useRecipientDisplay`.
- **Fail-safe:** any non-OK response → `undefined` → row degrades to the address exactly as today. No regression even if the backend route isn't live yet.

## Depends on
peanut-api-ts #1237 (`GET /ens/reverse`) — deploy that first for names to actually appear on native.

## Tests
- New `usePrimaryNameServer` test (resolve / no-name / non-OK fail-safe / skips non-address & undefined).
- Updated `TransactionCard.test.tsx` mock to the new hook; existing suites green; typecheck clean.

## Notes
- Same code path is what's broken on `mobile-release`; once merged, this should be brought into that branch too.
- `JustaNameProvider` / `justaname.config` are now unused by app code and could be removed in a follow-up.