### PR TITLE
feat(notifications): per-session push subscription snapshot on native

### DIFF
--- a/src/services/onesignal/native.adapter.test.ts
+++ b/src/services/onesignal/native.adapter.test.ts
@@ -17,9 +17,13 @@ jest.mock(
                 requestPermission: jest.fn(),
             },
             User: {
+                getOnesignalId: jest.fn().mockResolvedValue('os-id'),
+                getExternalId: jest.fn().mockResolvedValue(null),
                 pushSubscription: {
                     addEventListener: jest.fn(),
                     getOptedInAsync: jest.fn().mockResolvedValue(true),
+                    getIdAsync: jest.fn().mockResolvedValue('sub-id'),
+                    getTokenAsync: jest.fn().mockResolvedValue(null),
                 },
             },
         },

--- a/src/services/onesignal/native.adapter.ts
+++ b/src/services/onesignal/native.adapter.ts
@@ -61,7 +61,7 @@ function captureSubscriptionSnapshot(trigger: string) {
                     'onesignal.opted_in': String(optedIn),
                     'onesignal.linked': String(!!externalId),
                 },
-                extra: { subscriptionId, onesignalId, externalId },
+                extra: { subscriptionId, onesignalId },
             })
         } catch (err) {
             captureMessage('onesignal subscription snapshot failed', {

--- a/src/services/onesignal/native.adapter.ts
+++ b/src/services/onesignal/native.adapter.ts
@@ -26,6 +26,53 @@ const clickListeners = new Set<(info: NotificationClickInfo) => void>()
 let pendingClick: NotificationClickInfo | null = null
 let underlyingListenersAttached = false
 
+const snapshotTriggersFired = new Set<string>()
+
+/**
+ * Fleet-visibility snapshot for debugging push without OneSignal dashboard
+ * access: hasToken distinguishes "device never registered with FCM/APNs"
+ * from "registered but nothing delivered" (a dashboard-credentials problem),
+ * and linked shows whether login() attached the external_id pushes target.
+ * Captured once per session per trigger — ~10s after init (token registration
+ * and login are async) and again on the first subscription change (opt-in
+ * often lands after the init snapshot). Deliberately omits the raw token.
+ */
+function captureSubscriptionSnapshot(trigger: string) {
+    if (snapshotTriggersFired.has(trigger)) return
+    snapshotTriggersFired.add(trigger)
+    void (async () => {
+        try {
+            const [subscriptionId, token, optedIn, onesignalId, externalId, permission] = await Promise.all([
+                OneSignal.User.pushSubscription.getIdAsync(),
+                OneSignal.User.pushSubscription.getTokenAsync(),
+                OneSignal.User.pushSubscription.getOptedInAsync(),
+                OneSignal.User.getOnesignalId(),
+                OneSignal.User.getExternalId(),
+                nativePermission(),
+            ])
+            captureMessage('onesignal subscription snapshot', {
+                level: 'info',
+                tags: {
+                    feature: 'onesignal',
+                    onesignal: 'subscription-snapshot',
+                    'onesignal.trigger': trigger,
+                    'onesignal.permission': permission,
+                    'onesignal.has_token': String(!!token),
+                    'onesignal.opted_in': String(optedIn),
+                    'onesignal.linked': String(!!externalId),
+                },
+                extra: { subscriptionId, onesignalId, externalId },
+            })
+        } catch (err) {
+            captureMessage('onesignal subscription snapshot failed', {
+                level: 'warning',
+                tags: { feature: 'onesignal', onesignal: 'subscription-snapshot', 'onesignal.trigger': trigger },
+                extra: { error: String(err) },
+            })
+        }
+    })()
+}
+
 function attachUnderlyingListeners() {
     if (underlyingListenersAttached) return
     underlyingListenersAttached = true
@@ -36,6 +83,7 @@ function attachUnderlyingListeners() {
 
     OneSignal.User.pushSubscription.addEventListener('change', (event: PushSubscriptionChangedState) => {
         const optedIn = !!event.current?.optedIn
+        captureSubscriptionSnapshot('subscription-change')
         subscriptionListeners.forEach((cb) => cb(optedIn))
     })
 
@@ -67,6 +115,7 @@ export const nativeOneSignalAdapter: OneSignalAdapter = {
             }
             await OneSignal.initialize(appId)
             attachUnderlyingListeners()
+            setTimeout(() => captureSubscriptionSnapshot('init'), 10_000)
         })()
         return initPromise
     },


### PR DESCRIPTION
## What

Captures a once-per-session-per-trigger OneSignal subscription snapshot to Sentry on native builds: subscription id, push-token presence (boolean only — never the raw token), opt-in state, notification permission, and whether `login()` linked an `external_id`.

Fires ~10s after `OneSignal.initialize()` (token registration and login are async) and again on the first push-subscription change (opt-in usually lands after the init snapshot).

## Why

Native push doesn't deliver while web push to the same user works, and we have no OneSignal dashboard access. The visibility we shipped in #2473 only surfaces *thrown* errors — a device that silently ends up with no FCM/APNs token, or unlinked from its `external_id`, produces nothing. This snapshot distinguishes, fleet-wide in Sentry (`onesignal:subscription-snapshot`, `environment:native`):

- `has_token:false` → FCM/APNs registration failing on device
- `linked:false` → `external_id` login not attaching (pushes hit 0 recipients)
- all healthy but no delivery → OneSignal-side send credentials (APNs key / FCM service account)

## Testing

- `pnpm jest src/services/onesignal/native.adapter.test.ts` green (mock extended with the new getters)
- `pnpm typecheck` clean
- `prettier` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved monitoring of push notification subscription status during app startup and when subscription settings change.
  * Added more detailed diagnostic information to help identify notification delivery and permission issues.
  * Enhanced reliability of subscription-state tracking across initialization and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->