### PR TITLE
feat(add-money): default Manteca deposit input to local currency

### DIFF
--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -72,10 +72,11 @@ const MantecaAddMoney: FC = () => {
     const selectedCountry = useMemo(() => {
         return countryData.find((country) => country.type === 'country' && country.path === selectedCountryPath)
     }, [selectedCountryPath])
-    // Default the input denomination to BRL for Brazil (PIX is in BRL); every other
-    // country keeps the USD default.
+    // Default the input denomination to the local currency (like withdraw) — the user
+    // pays the bank/QR in ARS/BRL, and a USD-first input causes wrong-amount deposits.
+    // USD stays one toggle away and sticks via the URL param.
     const currentDenomination: CurrencyDenomination =
-        urlState.currency ?? (selectedCountry?.currency === 'BRL' ? 'BRL' : 'USD')
+        urlState.currency ?? (selectedCountry?.currency as CurrencyDenomination) ?? 'USD'
     const onBack = useSafeBack(addMoneyCountryUrl(selectedCountryPath))
     // The pool→full upgrade gate asks "did the user clear ID verification?",
     // not "do they have an enabled rail elsewhere?" — read the identity
@@ -149,12 +150,16 @@ const MantecaAddMoney: FC = () => {
         setUsdAmount(value)
     }, [])
 
-    // Handle currency denomination change - sync to URL state
+    // Handle currency denomination change - sync to URL state.
+    // AmountInput reports the DISPLAY symbol ('R$', 'ARS', 'USD'); the URL enum stores
+    // ISO codes, so map anything that isn't USD back to the country's currency code —
+    // otherwise Brazil writes ?currency=R$ which the enum parser silently rejects.
     const handleDenominationChange = useCallback(
         (value: string) => {
-            setUrlState({ currency: value as CurrencyDenomination })
+            const code = value === 'USD' ? 'USD' : (selectedCountry?.currency ?? value)
+            setUrlState({ currency: code as CurrencyDenomination })
         },
-        [setUrlState]
+        [setUrlState, selectedCountry?.currency]
     )
 
     const handleAmountSubmit = useCallback(async () => {

--- a/src/components/AddMoney/components/__tests__/MantecaAddMoney.test.tsx
+++ b/src/components/AddMoney/components/__tests__/MantecaAddMoney.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * MantecaAddMoney — denomination defaulting + URL round-trip.
+ *
+ * The input must open in the country's LOCAL currency (ARS/BRL) — matching the
+ * withdraw flow — unless the URL explicitly pins one (?currency=USD). This was
+ * silently narrowed to Brazil-only once (3ab066885); this suite pins it.
+ * The ?currency= param stores ISO codes while AmountInput reports display
+ * symbols ('R$'), so the write-back must map symbol → code or the enum parser
+ * silently drops it. Nested primitives are stubbed so only this component's
+ * own logic is under test.
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+const mockParams: Record<string, string> = {}
+jest.mock('next/navigation', () => ({
+    useParams: () => mockParams,
+    useSearchParams: () => ({ get: () => null }),
+}))
+
+const mockQueryState: Record<string, any> = {}
+const mockSetQueryState = jest.fn((updates: Record<string, any>) => {
+    Object.entries(updates).forEach(([k, v]) => {
+        mockQueryState[k] = v
+    })
+})
+jest.mock('nuqs', () => ({
+    useQueryStates: () => [mockQueryState, mockSetQueryState],
+    parseAsString: {},
+    parseAsStringEnum: () => ({}),
+}))
+
+jest.mock('@tanstack/react-query', () => ({
+    useQueryClient: () => ({ invalidateQueries: jest.fn() }),
+}))
+
+jest.mock('@/hooks/useSafeBack', () => ({ useSafeBack: () => jest.fn() }))
+
+jest.mock('@/components/AddMoney/consts', () => ({
+    countryData: [
+        { type: 'country', id: 'AR', path: 'argentina', title: 'Argentina', currency: 'ARS' },
+        { type: 'country', id: 'BR', path: 'brazil', title: 'Brazil', currency: 'BRL' },
+    ],
+}))
+
+jest.mock('@/utils/native-routes', () => ({ addMoneyCountryUrl: (path: string) => `/add-money/${path}` }))
+
+jest.mock('@/hooks/useCurrency', () => ({
+    useCurrency: (code: string | null) => ({
+        code,
+        symbol: code === 'BRL' ? 'R$' : code,
+        price: { buy: 1000, sell: 1000 },
+        isLoading: false,
+        isError: false,
+    }),
+}))
+
+jest.mock('@/hooks/useCapabilities', () => ({ useCapabilities: () => ({ rails: [] }) }))
+jest.mock('@/hooks/useIdentityVerification', () => ({ useIdentityVerification: () => ({ isVerified: true }) }))
+jest.mock('@/utils/regions.utils', () => ({ isVerifiedForCountry: () => true }))
+jest.mock('@/utils/provider-rejection.utils', () => ({ deriveProviderRejection: () => ({ state: 'none' }) }))
+jest.mock('@/hooks/useMultiPhaseKycFlow', () => ({
+    useMultiPhaseKycFlow: () => ({ error: null, isLoading: false }),
+}))
+jest.mock('@/features/limits/hooks/useLimitsValidation', () => ({
+    useLimitsValidation: () => ({ isBlocking: false, isWarning: false, currency: 'USD' }),
+}))
+
+jest.mock('@/services/manteca', () => ({ mantecaApi: { deposit: jest.fn() } }))
+jest.mock('posthog-js', () => ({ capture: jest.fn() }))
+
+jest.mock('@/components/Kyc/SumsubKycModals', () => ({ SumsubKycModals: () => null }))
+jest.mock('@/components/Kyc/InitiateKycModal', () => ({ InitiateKycModal: () => null }))
+jest.mock('@/components/AddMoney/components/MantecaDepositShareDetails', () => ({
+    __esModule: true,
+    default: () => <div data-testid="share-details" />,
+}))
+jest.mock('@/components/AddMoney/components/MantecaPixQrDeposit', () => ({
+    __esModule: true,
+    default: () => <div data-testid="pix-qr" />,
+}))
+jest.mock('@/components/Global/PeanutLoading/CyclingLoading', () => ({ __esModule: true, default: () => <div /> }))
+
+// records the props MantecaAddMoney hands to the amount step
+let lastInputStepProps: any = null
+jest.mock('@/components/AddMoney/components/InputAmountStep', () => ({
+    __esModule: true,
+    default: (props: any) => {
+        lastInputStepProps = props
+        return <div data-testid="input-amount-step" data-denomination={props.initialDenomination} />
+    },
+}))
+
+// eslint-disable-next-line import/first -- must come after jest.mock
+import MantecaAddMoney from '../MantecaAddMoney'
+
+const setCountry = (path: string) => {
+    mockParams.country = path
+}
+
+beforeEach(() => {
+    Object.keys(mockQueryState).forEach((k) => delete mockQueryState[k])
+    mockSetQueryState.mockClear()
+    lastInputStepProps = null
+})
+
+describe('denomination default', () => {
+    test('Argentina opens in ARS (local currency), not USD', () => {
+        setCountry('argentina')
+        render(<MantecaAddMoney />)
+
+        expect(screen.getByTestId('input-amount-step')).toHaveAttribute('data-denomination', 'ARS')
+    })
+
+    test('Brazil opens in BRL (local currency)', () => {
+        setCountry('brazil')
+        render(<MantecaAddMoney />)
+
+        expect(screen.getByTestId('input-amount-step')).toHaveAttribute('data-denomination', 'BRL')
+    })
+
+    test('an explicit ?currency=USD deep-link still wins', () => {
+        setCountry('argentina')
+        mockQueryState.currency = 'USD'
+        render(<MantecaAddMoney />)
+
+        expect(screen.getByTestId('input-amount-step')).toHaveAttribute('data-denomination', 'USD')
+    })
+})
+
+describe('denomination change → URL write-back', () => {
+    test("Brazil maps AmountInput's display symbol R$ to the ISO code BRL", () => {
+        setCountry('brazil')
+        render(<MantecaAddMoney />)
+
+        lastInputStepProps.setCurrentDenomination('R$')
+
+        expect(mockSetQueryState).toHaveBeenCalledWith({ currency: 'BRL' })
+    })
+
+    test('toggling to USD writes USD', () => {
+        setCountry('argentina')
+        render(<MantecaAddMoney />)
+
+        lastInputStepProps.setCurrentDenomination('USD')
+
+        expect(mockSetQueryState).toHaveBeenCalledWith({ currency: 'USD' })
+    })
+})

--- a/src/components/AddMoney/components/__tests__/MantecaAddMoney.test.tsx
+++ b/src/components/AddMoney/components/__tests__/MantecaAddMoney.test.tsx
@@ -11,6 +11,8 @@
  */
 import React from 'react'
 import { render, screen } from '@testing-library/react'
+// jest.mock calls are hoisted above this import, so the mocks below apply to it
+import MantecaAddMoney from '../MantecaAddMoney'
 
 const mockParams: Record<string, string> = {}
 jest.mock('next/navigation', () => ({
@@ -18,8 +20,8 @@ jest.mock('next/navigation', () => ({
     useSearchParams: () => ({ get: () => null }),
 }))
 
-const mockQueryState: Record<string, any> = {}
-const mockSetQueryState = jest.fn((updates: Record<string, any>) => {
+const mockQueryState: Record<string, unknown> = {}
+const mockSetQueryState = jest.fn((updates: Record<string, unknown>) => {
     Object.entries(updates).forEach(([k, v]) => {
         mockQueryState[k] = v
     })
@@ -82,17 +84,15 @@ jest.mock('@/components/AddMoney/components/MantecaPixQrDeposit', () => ({
 jest.mock('@/components/Global/PeanutLoading/CyclingLoading', () => ({ __esModule: true, default: () => <div /> }))
 
 // records the props MantecaAddMoney hands to the amount step
-let lastInputStepProps: any = null
+type InputStepProps = { initialDenomination?: string; setCurrentDenomination: (denomination: string) => void }
+let lastInputStepProps: InputStepProps | null = null
 jest.mock('@/components/AddMoney/components/InputAmountStep', () => ({
     __esModule: true,
-    default: (props: any) => {
+    default: (props: InputStepProps) => {
         lastInputStepProps = props
         return <div data-testid="input-amount-step" data-denomination={props.initialDenomination} />
     },
 }))
-
-// eslint-disable-next-line import/first -- must come after jest.mock
-import MantecaAddMoney from '../MantecaAddMoney'
 
 const setCountry = (path: string) => {
     mockParams.country = path
@@ -133,7 +133,7 @@ describe('denomination change → URL write-back', () => {
         setCountry('brazil')
         render(<MantecaAddMoney />)
 
-        lastInputStepProps.setCurrentDenomination('R$')
+        lastInputStepProps!.setCurrentDenomination('R$')
 
         expect(mockSetQueryState).toHaveBeenCalledWith({ currency: 'BRL' })
     })
@@ -142,7 +142,7 @@ describe('denomination change → URL write-back', () => {
         setCountry('argentina')
         render(<MantecaAddMoney />)
 
-        lastInputStepProps.setCurrentDenomination('USD')
+        lastInputStepProps!.setCurrentDenomination('USD')
 
         expect(mockSetQueryState).toHaveBeenCalledWith({ currency: 'USD' })
     })


### PR DESCRIPTION
## Summary
Add-money via Manteca (Argentina / Brazil) opened the amount input **USD-first** (Brazil was special-cased to BRL on 2026-07-01, Argentina reverted to USD in the same commit). Users pay the bank transfer / QR in their local currency, so a USD-first input causes wrong-amount deposits — this matches the withdraw flow, which already defaults to local currency. USD stays one toggle away and an explicit `?currency=` deep-link still wins.

Also fixes a latent URL-state bug: `AmountInput` reports the **display symbol** (`R$`) while the nuqs enum stores **ISO codes**, so Brazil wrote `?currency=R$` — silently rejected on parse, meaning the param never round-tripped. The handler now maps the symbol back to the country's ISO code before persisting.

## Risks / breaking changes
- Behavior change: Argentina's add-money input now opens in ARS instead of USD. `isUsdDenominated` in the deposit payload derives from the same `currentDenomination`, so API semantics are unchanged — just the default flips.
- No cross-repo impact; single component touched.

## Tests
New colocated suite `__tests__/MantecaAddMoney.test.tsx` pins the behavior (this default was silently flipped once before — 3ab066885):
- AR opens ARS / BR opens BRL / explicit `?currency=USD` deep-link wins
- write-back maps `R$` → `BRL` (valid enum value) and `USD` → `USD`

## Screenshots
⚠️ NONE — sandbox on this machine won't boot (primary peanut-api-ts tree is pinned to `main` to match prod; its tsx + @zerodev/permissions resolution breaks the qa harness), so no authenticated add-money screen could be captured. Visual delta is a single default flip on an existing input: it opens showing `ARS`/`BRL` instead of `USD`. The new component tests assert the exact prop driving it.

## QA
- `/add-money/argentina/manteca` → input opens in ARS; toggle to USD → `?currency=USD`; toggle back → `?currency=ARS` (valid enum value, survives refresh).
- `/add-money/brazil/manteca` → opens in BRL; toggling now writes `?currency=BRL` instead of `currency=R$`.
- Deep-link `?currency=USD` still forces USD-first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated URL-backed denomination defaults to use the selected country’s local ISO currency instead of defaulting to USD for non-BRL countries.
  * Clarified precedence so an explicitly set USD denomination in the URL remains authoritative.
  * Improved denomination updates to write standardized currency codes to the URL (avoiding non-code labels).
* **Tests**
  * Added coverage to verify denomination read/write round-tripping for Argentina and Brazil via URL state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->