### PR TITLE
feat: include enabled rails in PostHog identify

### DIFF
--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -93,6 +93,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
             // server-side identify in peanut-api-ts src/log/identifyUser.ts — keep in sync.
             // `name` duplicates username because PostHog's Persons-page search is
             // hardcoded to email/name/distinct_id — username alone is not searchable.
+            const enabledRails = user.rails?.filter((rail) => rail.status === 'ENABLED') ?? []
             posthog.identify(user.user.userId, {
                 username: user.user.username,
                 name: user.user.username,
@@ -101,6 +102,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
                 // Badge codes (human-readable identifier), never the uuid.
                 badges: user.user.badges?.map((badge) => badge.code) ?? [],
                 kycStatus: user.identityVerification?.status ?? 'not_started',
+                // Human-readable PROVIDER:METHOD codes for cohorting, plus the
+                // catalog rail ids for joins against the rails table.
+                enabledRails: enabledRails.map((rail) => `${rail.rail.provider.code}:${rail.rail.method.code}`),
+                enabledRailIds: enabledRails.map((rail) => rail.rail.id),
             })
             // Sentry: every error captured from here on inherits user context
             // as searchable Sentry tags. Closes the historical gap where FE


### PR DESCRIPTION
## What

Adds the user's enabled rails to the PostHog `identify` call in `authContext.tsx`:

- `enabledRails` — human-readable `PROVIDER:METHOD` codes (e.g. `MANTECA:PIX_BR`) for easy cohorting
- `enabledRailIds` — catalog `rail.id` uuids for joins against the rails table

Only rails with `status === 'ENABLED'` are included.

## Why

Person profiles had no rail info, so cohorting by payment capability (who can PIX, who has ACH, etc.) was impossible in PostHog.

## Cross-repo

Mirrors the server-side identify in peanut-api-ts `src/log/identifyUser.ts` — same property names, added on the open PR peanutprotocol/peanut-api-ts#1131 (its contract test now pins the extended property set).

## Testing

- `pnpm typecheck` clean
- `npm test` — only pre-existing worktree-environment failures (missing generated flag assets, add-money limits copy); nothing touching this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
