### PR TITLE
hotfix(step-up): stop prompting where the flow already proves the passkey

### DIFF
--- a/src/services/rain.ts
+++ b/src/services/rain.ts
@@ -429,12 +429,15 @@ export const rainApi = {
     /**
      * Persist the serialized ZeroDev permission on the user's card so the
      * backend can submit session-key UserOps for collateral withdrawals.
+     *
+     * No step-up: the payload is itself a fresh passkey signature (the grant
+     * ceremony's enable sig) — an extra assertion here just doubles the
+     * fingerprint prompts on the grant flow.
      */
     submitWithdrawSessionApproval: async (input: { serializedApproval: string }): Promise<void> => {
         await rainRequest<{ ok: boolean }>({
             method: 'POST',
             path: '/rain/cards/withdraw/session-approve',
-            stepUp: true,
             body: input,
         })
     },
@@ -443,12 +446,16 @@ export const rainApi = {
      * Stage a Rain V2 withdrawal: backend fetches Rain's executor signature,
      * reads the current adminNonce from the collateral proxy, and persists a
      * short-lived prep record. Caller then signs the admin EIP-712 payload.
+     *
+     * No step-up: a prep is inert until the passkey produces the admin
+     * EIP-712 signature that follows it, so the flow proves user presence on
+     * its own. Step-up here made every collateral-funded send cost three
+     * fingerprint prompts instead of two (the 2026-07 triple-prompt reports).
      */
     prepareWithdrawal: async (input: PrepareRainWithdrawalInput): Promise<PrepareRainWithdrawalResponse> => {
         return rainRequest<PrepareRainWithdrawalResponse>({
             method: 'POST',
             path: '/rain/cards/withdraw/prepare',
-            stepUp: true,
             body: input,
         })
     },


### PR DESCRIPTION
## Summary
FE half of peanutprotocol/peanut-api-ts#1241 — removes `stepUp: true` from `prepareWithdrawal` and `submitWithdrawSessionApproval`. These flows are self-proving (admin EIP-712 / enable signature follow immediately from the same passkey), so the step-up assertion added by #2463 only added a third fingerprint sheet to every collateral-funded send (the triple-prompt reports from Hugo and Jota, confirmed on-chain: the send tx carries exactly 2 WebAuthn signatures).

Card PAN/CVV/PIN and bank-account add keep step-up.

## Risks / breaking changes
- **Deploy order: backend PR first.** If `STEP_UP_ENFORCED` is on and this ships before the BE drops the gate, withdraw prepare would 401.

## QA
- prettier clean, step-up service tests pass (8/8), 0 typecheck errors in changed file. 3 failing suites are the known missing-submodule worktree gotcha (content/countryCurrency/add-money), green in CI.
- After both deploy: a collateral-funded send link = 2 fingerprint prompts (admin sig + userop); card-detail reveal still prompts.

Screenshots: N/A (no UI change — prompt-count behavior only)

---
Hotfix to `main` (production user-visible triple-prompt). Supersedes #2514 (dev-targeted). **Deploy order: peanut-api-ts hotfix first.** Back-merge main→dev after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary passkey or fingerprint prompts during withdrawal preparation and session approval.
  * Withdrawal actions now rely on the provided passkey-derived approval signature for verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->