### PR TITLE
fix(card): render the share asset's hand crisp, not pixelated

### DIFF
--- a/local/scratch/pr-peanut-ui-feat-share-asset-crisp-hand.md
+++ b/local/scratch/pr-peanut-ui-feat-share-asset-crisp-hand.md
@@ -1,0 +1,15 @@
+PR: https://github.com/peanutprotocol/peanut-ui/pull/2516   base: dev   worktree: mono/worktrees/peanut-ui-feat/share-asset-crisp-hand
+phase: 3 (CI)            last-tick: 873c98aff
+checks: prettier ✅ typecheck ✅ unit ✅ (162 suites) build ✅ (needs --max-old-space-size=5120 locally; default heap OOMs on this box)
+coderabbit: not yet pulled
+code-review: not yet run
+smells: TBD
+screenshots: attached via orphan branch pr-assets-2516 (DELETE post-merge)
+reporters: Konrad (this session) — no Crisp/Notion ticket
+notes:
+  - worktree has its OWN node_modules (not symlinked): primary peanut-ui tree is on a stale dev
+    without the @capacitor/* deps, which broke next dev + 3 test suites. pnpm via `corepack pnpm`
+    (global /usr/bin/pnpm is too old for the packages-less pnpm-workspace.yaml).
+  - dev server on this box dies mid-compile under memory pressure; screenshots were taken through
+    a throwaway route (deleted) rather than the real-backend phase-2b pipeline. Documented in the PR body.
+todo: watch CI → CodeRabbit → /code-review → smell pass → readiness report

--- a/src/app/(mobile-ui)/dev/share-builder/page.tsx
+++ b/src/app/(mobile-ui)/dev/share-builder/page.tsx
@@ -47,7 +47,7 @@ export default function ShareBuilderPage() {
     // ─── Capture (Save image) ────────────────────────────────────────────
     // Ref points at the native-size asset node (the pre-scale div) so the
     // capture renders at full 1200×900 fidelity. `assetReady` flips once the
-    // card face's async hand <canvas> mounts (ShareAssetD3.onReady) — Save is
+    // card face's hand <img> loads (ShareAssetD3.onReady) — Save is
     // disabled until then so a capture can never snapshot a blank card.
     const assetRef = useRef<HTMLDivElement>(null)
     const [assetReady, setAssetReady] = useState(false)

--- a/src/components/Card/share-asset/PixelatedCardFace.tsx
+++ b/src/components/Card/share-asset/PixelatedCardFace.tsx
@@ -1,6 +1,6 @@
 /**
- * <PixelatedCardFace /> — the pink peanut card with a pre-pixelated
- * peanut-card-hand overlay.
+ * <PixelatedCardFace /> — the pink peanut card with a peanut-card-hand
+ * overlay: crisp by default, pixelated under `blurAll`.
  *
  * Renders at native 620×391 (CARD_W/CARD_H). Wrap in `transform: scale(...)`
  * if you need a smaller preview — the inner layout uses absolute pixel
@@ -11,7 +11,8 @@
  * logo, card number, and Virtual pill all get rasterised through a
  * canvas → image-rendering:pixelated pipeline, with a shared CELL_PX cell
  * size — so every detail on the card is hidden by consistent chunky pixels
- * instead of a mix of pixelation + CSS blur.
+ * instead of a mix of pixelation + CSS blur. The hand follows the same
+ * switch: pixelated with the rest of the tease, crisp on the share asset.
  *
  * Shared between <ShareAssetD3 />, the eligibility-check screen, and the
  * `/shhhhh` LP hero. Keep this file the single source of truth for the
@@ -25,11 +26,13 @@ import { type FC, type CSSProperties } from 'react'
 import { CARD_W, CARD_H } from './shareAssetLayout'
 import { PEANUTMAN } from '@/assets/mascot'
 import PEANUT_CARD_HAND_PIXEL_ASSET from '@/assets/cards/peanut-card-hand-pixel.png'
+import PEANUT_CARD_HAND_ASSET from '@/assets/cards/peanut-card-hand.svg'
 import VISA_BRAND_MARK_ASSET from '@/assets/cards/visa-brand-mark.png'
 
 const ASSET_PEANUTMAN = PEANUTMAN.src
 const ASSET_VISA_BRAND = VISA_BRAND_MARK_ASSET.src
 const ASSET_CARD_HAND_PIXEL = PEANUT_CARD_HAND_PIXEL_ASSET.src
+const ASSET_CARD_HAND = PEANUT_CARD_HAND_ASSET.src
 
 // Shared pixel-cell target across every element on the card. Each
 // element rasterises to (displayPx / CELL_PX) pixels then stretches back
@@ -55,8 +58,8 @@ export interface PixelatedCardFaceProps {
      *  display the Visa wordmark for compliance reasons (it renders crisp
      *  there since the share asset is the one surface that doesn't `blurAll`). */
     hideVisa?: boolean
-    /** Fires once the pixelated hand <img> has loaded — i.e. the card face is
-     *  fully painted. Capture surfaces gate the Share/Save buttons on this so a
+    /** Fires once the hand <img> has loaded — i.e. the card face is fully
+     *  painted. Capture surfaces gate the Share/Save buttons on this so a
      *  snapshot can never fire before the hand is ready. */
     onReady?: () => void
 }
@@ -85,7 +88,7 @@ export const PixelatedCardFace: FC<PixelatedCardFaceProps> = ({
                 ...style,
             }}
         >
-            <PixelatedHand onReady={onReady} />
+            <CardHand pixelated={blurAll} onReady={onReady} />
 
             {/* Top row: peanut logo (left) + visa logo (right) */}
             <div
@@ -277,18 +280,21 @@ const PixelatedText: FC<PixelatedTextProps> = ({ text, displayW, displayH, font,
 }
 
 // ---------------------------------------------------------------------------
-// The hand — a pre-pixelated PNG rendered as a plain <img>, NOT a runtime
-// <canvas>. html-to-image silently drops a live <canvas> it can't serialise
-// (canvas.toDataURL() returns empty on iOS Safari for an SVG-sourced canvas →
-// blank card, no error: the launch-day "blank share asset" bug), but inlines
-// <img> reliably — same path the badge stickers take, which never blank. The
-// PNG is authored at the 36px raster and upscaled by image-rendering:pixelated,
-// so it reads identically to the old canvas.
+// The hand — always a plain <img>, NEVER a runtime <canvas>. html-to-image
+// silently drops a live <canvas> it can't serialise (canvas.toDataURL() returns
+// empty on iOS Safari for an SVG-sourced canvas → blank card, no error: the
+// launch-day "blank share asset" bug), but inlines <img> reliably — same path
+// the badge stickers and the peanut logo above take, which never blank.
+//
+// `pixelated` picks the source: the tease surfaces get the pre-pixelated PNG
+// (authored at the 36px raster, upscaled by image-rendering:pixelated), the
+// share asset gets the full-resolution vector — nothing on that asset is
+// hidden, so there is nothing for the pixelation to obscure.
 // ---------------------------------------------------------------------------
 
-const PixelatedHand: FC<{ onReady?: () => void }> = ({ onReady }) => (
+const CardHand: FC<{ pixelated: boolean; onReady?: () => void }> = ({ pixelated, onReady }) => (
     <img
-        src={ASSET_CARD_HAND_PIXEL}
+        src={pixelated ? ASSET_CARD_HAND_PIXEL : ASSET_CARD_HAND}
         alt=""
         aria-hidden
         draggable={false}
@@ -307,7 +313,7 @@ const PixelatedHand: FC<{ onReady?: () => void }> = ({ onReady }) => (
             height: 471,
             transform: 'rotate(-15deg)',
             transformOrigin: 'center',
-            imageRendering: 'pixelated',
+            ...(pixelated ? { imageRendering: 'pixelated' as const } : {}),
         }}
     />
 )

--- a/src/components/Card/share-asset/PixelatedCardFace.tsx
+++ b/src/components/Card/share-asset/PixelatedCardFace.tsx
@@ -2,7 +2,8 @@
  * <PixelatedCardFace /> — the pink peanut card with a peanut-card-hand
  * overlay: crisp by default, pixelated under `blurAll`.
  *
- * Renders at native 620×391 (CARD_W/CARD_H). Wrap in `transform: scale(...)`
+ * Renders at native CARD_W×CARD_H (see shareAssetLayout — don't restate the
+ * numbers here, they drift). Wrap in `transform: scale(...)`
  * if you need a smaller preview — the inner layout uses absolute pixel
  * offsets that scale linearly with the wrapper. For width-fit, use
  * <ScaledPixelatedCardFace />.
@@ -313,7 +314,7 @@ const CardHand: FC<{ pixelated: boolean; onReady?: () => void }> = ({ pixelated,
             height: 471,
             transform: 'rotate(-15deg)',
             transformOrigin: 'center',
-            ...(pixelated ? { imageRendering: 'pixelated' as const } : {}),
+            imageRendering: pixelated ? 'pixelated' : undefined,
         }}
     />
 )

--- a/src/components/Card/share-asset/ShareAssetActions.tsx
+++ b/src/components/Card/share-asset/ShareAssetActions.tsx
@@ -69,8 +69,8 @@ interface Props {
     source: string
     /** Optional filename for the downloaded PNG. */
     filename?: string
-    /** Whether the share asset has finished painting its card face (the async
-     *  hand <canvas> has mounted — see PixelatedCardFace.onReady). Until then,
+    /** Whether the share asset has finished painting its card face (the hand
+     *  <img> has loaded — see PixelatedCardFace.onReady). Until then,
      *  capturing would snapshot a blank card, so both buttons stay disabled.
      *  Defaults to true so callers that don't wire the signal aren't blocked. */
     ready?: boolean

--- a/src/components/Card/share-asset/captureShareAsset.ts
+++ b/src/components/Card/share-asset/captureShareAsset.ts
@@ -44,7 +44,7 @@ export class ShareAssetCaptureError extends Error {
  * Wait for the asset's content to be painted before we snapshot.
  *
  * Every visible element of the asset is a plain <img> now — badge stickers, the
- * card logos, AND the card's pixelated hand (see PixelatedCardFace). The hand
+ * card logos, AND the card's hand (see PixelatedCardFace). The hand
  * used to be a runtime <canvas>, which html-to-image silently dropped when it
  * couldn't serialise it (canvas.toDataURL() returns empty on iOS Safari for an
  * SVG-sourced canvas → blank card, no error: the launch-day "blank share asset"

--- a/src/components/Card/share-asset/shareAsset.types.ts
+++ b/src/components/Card/share-asset/shareAsset.types.ts
@@ -107,7 +107,7 @@ export interface ShareAssetD3Props {
     animate?: boolean
 
     /**
-     * Fires once the card face's async hand <canvas> has mounted (forwarded
+     * Fires once the card face's hand <img> has loaded (forwarded
      * straight to <PixelatedCardFace onReady />). Capture surfaces gate the
      * Share/Save buttons on this so a snapshot can never fire before the card
      * face paints — the deterministic fix for the blank-card capture bug.


### PR DESCRIPTION
## Summary

The card share asset rendered its hand through a pre-pixelated PNG, so the one image users actually post looked low-fidelity. Nothing on that asset is hidden — the card number is already `????` and the Visa mark is dropped via `hideVisa` — so the pixelation had nothing left to obscure. It was only costing fidelity.

Pixelation belongs to the closed-beta tease, which is exactly what the existing `blurAll` prop already marks. The hand now follows that switch instead of being unconditional:

- **Share asset** (`ShareAssetD3`, no `blurAll`) → crisp `peanut-card-hand.svg`, `image-rendering: pixelated` dropped.
- **Tease surfaces** (all pass `blurAll`) → pre-pixelated PNG, unchanged: `AddCardEntryScreen`, `CardEligibilityCheckScreen`, `BadgeSkipCelebration`, `/shhhhh` LP hero.

Two files, +23/−17.

## Risks / breaking changes

**None cross-repo.** Frontend-only, no API surface touched.

The one risk worth naming is the capture path. `PixelatedCardFace` carries a comment about the launch-day "blank share asset" bug, so the swap was made to preserve that fix rather than reopen it:

- The hand stays a plain `<img>`. It is **not** returned to a runtime `<canvas>` — that was the actual cause of the blank card (`canvas.toDataURL()` returns empty on iOS Safari for an SVG-sourced canvas), and nothing here reintroduces it.
- The bug was never about an SVG-sourced `<img>`. The peanut logo on this same card face is already `<img src=…svg>` and survives `html-to-image` today.
- Verified directly anyway: the crisp face pushed through `html-to-image` at `pixelRatio: 2` produces a 1560×1000 PNG with the hand fully present (screenshot 3 below).
- ⚠️ **That verification was desktop Chromium only.** The original blank-card bug was iOS Safari–specific, and I have not reproduced the capture there. The precedent above (peanut logo, same face, same inline path, shipping today) is the reason I believe it holds — not a test on the affected browser. Worth one manual Save-image on an iPhone before merge.

`onReady` still fires off the hand's `onLoad` / `complete`, so the Share/Save capture gate is unchanged.

## QA

1. `/dev/share-builder` — the card's hand renders crisp; badges, burst and `@username` pill are untouched.
2. Hit **Save image** — the downloaded PNG shows the crisp hand, not a blank card. This is the regression that matters.
3. `/card` eligibility check, add-card entry, badge-skip celebration, `/shhhhh` — hand still pixelated, whole card still reads as one consistent tease.

Local gate: `prettier --check .` clean · `typecheck` clean · `npm test` 162/162 suites, 2143 tests · `next build` compiles.

## Design notes / accepted trade-offs

Recorded so the next reader doesn't have to re-derive them.

- **Hand placement left as-is (deliberate).** `CardFace.tsx` — the in-app card — renders this same SVG bottom-right at `h-[90%]`, commented as matching the finalised Rain card art. The share asset renders it top-right at 74% of card width, overflowing the top edge, rotated −15°. While pixelated that read as an abstract blur; crisp, it's a recognisable hand in a placement that disagrees with the canonical art. Reviewed and kept — re-anchoring is a design change, not a cleanup, and belongs in its own PR.
- **Component keeps the name `PixelatedCardFace`** even though pixelation is now the non-default. A rename touches 5 consumers plus tests; not worth widening a 2-file diff.
- **Pre-existing smell this PR reveals, NOT fixed here:** `CardFace.tsx` and `PixelatedCardFace.tsx` are two independent implementations of the same card artwork. This change makes them diverge visually rather than converge. Out of blast radius — follow-up.
- **No test pins the `blurAll` → source mapping.** Nothing stops a future refactor from routing the hand back through a `<canvas>` and silently reviving the blank-share-asset bug, which is the expensive failure mode here. This code doesn't move money or mutate shared state, so it isn't a hard gate — but it is the real coverage gap.

## Screenshots

| | |
|---|---|
| **1. Real `ShareAssetD3`, after** — native 1200×900 at 80%, username `edcriptofi`, 6 badges | ![after](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2516/share-after.png) |
| **2. Card face, before vs after** — identical hand box (`top:-40 right:-20 560×471 rotate(-15deg)`); only fidelity changes, the hand does not move | ![before-after](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2516/hand-check-side.png) |
| **3. Through `html-to-image`** — what a user's shared PNG actually is | ![captured](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2516/hand-check-captured.png) |

⚠️ **How these were produced, precisely** — this is not the standard phase-2b real-app-with-backend pipeline, so don't read it as one:

- #1 is the real `<ShareAssetD3 />` component with fixed props, rendered via a throwaway route outside the `(mobile-ui)` auth gate (deleted; not in this diff). The API harness was not running, so the component was driven directly rather than by a seeded user.
- #2 reproduces `PixelatedCardFace`'s exact markup and geometry in a standalone page, in order to show both hand sources side by side — the pixelated variant cannot otherwise be rendered next to the crisp one.
- #3 is the genuine `html-to-image` capture path from `captureShareAsset`, run against #2's crisp face.
- No 375×667 mobile shots: this asset is a fixed 1200×900 share image, not a responsive screen.

Assets branch `pr-assets-2516` is deleted post-merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared card images now show a crisp hand illustration by default, switching to the pixelated version when full blur is enabled.
* **Bug Fixes**
  * Share capture readiness is now correctly aligned with when the card face’s hand image has loaded.
* **Documentation**
  * Updated inline guidance and prop descriptions to reflect the new readiness behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->