### PR TITLE
fix(native): QR-pay 400 for legacy cookie sessions + demo unlock-modal repeat

### DIFF
--- a/src/utils/__tests__/api-fetch.test.ts
+++ b/src/utils/__tests__/api-fetch.test.ts
@@ -5,7 +5,8 @@
 
 import { apiFetch, serverFetch } from '../api-fetch'
 import { fetchWithSentry } from '@/utils/sentry.utils'
-import { getAuthHeaders } from '@/utils/auth-token'
+import { getAuthHeaders, getAuthToken } from '@/utils/auth-token'
+import { isCapacitor } from '@/utils/capacitor'
 
 jest.mock('@/utils/sentry.utils', () => ({
     fetchWithSentry: jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) })),
@@ -13,10 +14,15 @@ jest.mock('@/utils/sentry.utils', () => ({
 
 jest.mock('@/utils/auth-token', () => ({
     authReady: jest.fn(() => Promise.resolve()),
+    getAuthToken: jest.fn(() => 'test-token'),
     getAuthHeaders: jest.fn((extra?: Record<string, string>) => ({
         Authorization: 'Bearer test-token',
         ...extra,
     })),
+}))
+
+jest.mock('@/utils/capacitor', () => ({
+    isCapacitor: jest.fn(() => false),
 }))
 
 jest.mock('@/constants/general.consts', () => ({
@@ -75,6 +81,41 @@ describe('apiFetch', () => {
 
             const callArgs = mockFetchWithSentry.mock.calls[0][1]
             expect((callArgs?.headers as Record<string, string>)['Content-Type']).toBeUndefined()
+        })
+    })
+
+    describe('native transport preference', () => {
+        const mockIsCapacitor = isCapacitor as jest.MockedFunction<typeof isCapacitor>
+        const mockGetAuthToken = getAuthToken as jest.MockedFunction<typeof getAuthToken>
+
+        it('prefers the OS transport on native when no token is readable', async () => {
+            mockIsCapacitor.mockReturnValue(true)
+            mockGetAuthToken.mockReturnValue(null)
+
+            await apiFetch('/manteca/qr-payment/init', { method: 'POST', body: '{}' })
+
+            const callArgs = mockFetchWithSentry.mock.calls[0][1] as Record<string, unknown>
+            expect(callArgs.preferNativeTransport).toBe(true)
+        })
+
+        it('does not set the flag on native when a token is present', async () => {
+            mockIsCapacitor.mockReturnValue(true)
+            mockGetAuthToken.mockReturnValue('test-token')
+
+            await apiFetch('/users/me')
+
+            const callArgs = mockFetchWithSentry.mock.calls[0][1] as Record<string, unknown>
+            expect(callArgs).not.toHaveProperty('preferNativeTransport')
+        })
+
+        it('does not set the flag on web even without a token', async () => {
+            mockIsCapacitor.mockReturnValue(false)
+            mockGetAuthToken.mockReturnValue(null)
+
+            await apiFetch('/users/me')
+
+            const callArgs = mockFetchWithSentry.mock.calls[0][1] as Record<string, unknown>
+            expect(callArgs).not.toHaveProperty('preferNativeTransport')
         })
     })
 

--- a/src/utils/__tests__/demo-api.test.ts
+++ b/src/utils/__tests__/demo-api.test.ts
@@ -81,6 +81,36 @@ describe('demoRespond — routing', () => {
         const after = await body('/users/me')
         expect(after.data.user.activationCelebratedAt).toBeTruthy()
     })
+
+    it('persists the celebration stamp across cold starts via localStorage', async () => {
+        // in-memory-only state re-showed the modal on every demo launch; a fresh
+        // module registry per isolateModules block simulates the cold start
+        const store: Record<string, string> = {}
+        ;(globalThis as { window?: unknown }).window = {
+            localStorage: {
+                getItem: (k: string) => store[k] ?? null,
+                setItem: (k: string, v: string) => {
+                    store[k] = v
+                },
+            },
+        }
+        try {
+            await jest.isolateModulesAsync(async () => {
+                const { demoRespond: freshRespond } = await import('@/utils/demo-api')
+                await freshRespond('/update-user', {
+                    method: 'POST',
+                    body: JSON.stringify({ username: 'demo', dismissActivationCelebration: true }),
+                })
+            })
+            await jest.isolateModulesAsync(async () => {
+                const { demoRespond: freshRespond } = await import('@/utils/demo-api')
+                const data = await (await freshRespond('/users/me')).json()
+                expect(data.user.activationCelebratedAt).toBeTruthy()
+            })
+        } finally {
+            delete (globalThis as { window?: unknown }).window
+        }
+    })
 })
 
 describe('demoRespond — rain card overview', () => {

--- a/src/utils/__tests__/sentry-prefer-native.test.ts
+++ b/src/utils/__tests__/sentry-prefer-native.test.ts
@@ -1,0 +1,125 @@
+// fetchWithSentry's preferNativeTransport path: tokenless native sessions go
+// over the OS HTTP client FIRST (the legacy cookie-jar JWT only rides there),
+// falling through to the WebView path when the OS client fails.
+import { fetchWithSentry } from '../sentry.utils'
+import { reportNetworkError, reportNetworkOk } from '../connectivity'
+import { canUseNativeHttp, nativeHttpRequest } from '../native-http'
+import * as Sentry from '@sentry/nextjs'
+
+jest.mock('@sentry/nextjs', () => ({
+    captureMessage: jest.fn(),
+    captureException: jest.fn(),
+    withScope: jest.fn((cb: (scope: unknown) => void) => cb({ setFingerprint: jest.fn(), setTag: jest.fn() })),
+}))
+
+jest.mock('../connectivity', () => ({
+    reportNetworkError: jest.fn(),
+    reportNetworkOk: jest.fn(),
+}))
+
+jest.mock('../native-http', () => ({
+    canUseNativeHttp: jest.fn(() => false),
+    nativeHttpRequest: jest.fn(),
+}))
+
+const mockCanUse = canUseNativeHttp as jest.MockedFunction<typeof canUseNativeHttp>
+const mockNativeRequest = nativeHttpRequest as jest.MockedFunction<typeof nativeHttpRequest>
+
+const fakeResponse = (status: number) =>
+    ({
+        ok: status >= 200 && status < 300,
+        status,
+        clone: () => ({ json: async () => ({ error: 'x' }), text: async () => 'x' }),
+    }) as unknown as Response
+
+const engagedNotices = () =>
+    (Sentry.captureMessage as jest.Mock).mock.calls.filter((c) => c[0] === 'legacy-cookie native transport engaged')
+
+describe('fetchWithSentry preferNativeTransport', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        global.fetch = jest.fn(() => Promise.resolve(fakeResponse(200)))
+    })
+
+    it('sends over the OS client first, without touching the WebView fetch', async () => {
+        mockCanUse.mockReturnValue(true)
+        mockNativeRequest.mockResolvedValue(fakeResponse(200))
+
+        const res = await fetchWithSentry('https://api.test.com/manteca/qr-payment/init', {
+            method: 'POST',
+            body: '{}',
+            preferNativeTransport: true,
+        })
+
+        expect(res.status).toBe(200)
+        expect(global.fetch).not.toHaveBeenCalled()
+        expect(mockNativeRequest).toHaveBeenCalledWith(
+            'https://api.test.com/manteca/qr-payment/init',
+            { method: 'POST', body: '{}' },
+            expect.any(Number)
+        )
+        expect(reportNetworkOk).toHaveBeenCalled()
+        expect(reportNetworkError).not.toHaveBeenCalled()
+
+        // engaged notice fires once per session, not per request
+        expect(engagedNotices()).toHaveLength(1)
+        await fetchWithSentry('https://api.test.com/users/me', { method: 'GET', preferNativeTransport: true })
+        expect(engagedNotices()).toHaveLength(1)
+    })
+
+    it('still reports non-ok statuses from the preferred transport', async () => {
+        mockCanUse.mockReturnValue(true)
+        mockNativeRequest.mockResolvedValue(fakeResponse(503))
+
+        const res = await fetchWithSentry('https://api.test.com/users/me', {
+            method: 'GET',
+            preferNativeTransport: true,
+        })
+
+        expect(res.status).toBe(503)
+        const statusReports = (Sentry.captureMessage as jest.Mock).mock.calls.filter((c) =>
+            String(c[0]).includes('failed with status 503')
+        )
+        expect(statusReports).toHaveLength(1)
+    })
+
+    it('falls through to the WebView path when the OS client rejects', async () => {
+        mockCanUse.mockReturnValue(true)
+        mockNativeRequest.mockRejectedValue(new Error('bridge unavailable'))
+
+        const res = await fetchWithSentry('https://api.test.com/users/me', {
+            method: 'GET',
+            preferNativeTransport: true,
+        })
+
+        expect(res.status).toBe(200)
+        expect(global.fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('skips the OS client for native-ineligible requests (canUseNativeHttp false)', async () => {
+        mockCanUse.mockReturnValue(false)
+
+        await fetchWithSentry('https://api.test.com/upload', { method: 'POST', preferNativeTransport: true })
+
+        expect(mockNativeRequest).not.toHaveBeenCalled()
+        expect(global.fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('never engages without the flag', async () => {
+        mockCanUse.mockReturnValue(true)
+
+        await fetchWithSentry('https://api.test.com/users/me', { method: 'GET' })
+
+        expect(mockNativeRequest).not.toHaveBeenCalled()
+        expect(global.fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('strips preferNativeTransport before the WebView fetch', async () => {
+        mockCanUse.mockReturnValue(false)
+
+        await fetchWithSentry('https://api.test.com/users/me', { method: 'GET', preferNativeTransport: true })
+
+        const init = (global.fetch as jest.Mock).mock.calls[0][1]
+        expect(init).not.toHaveProperty('preferNativeTransport')
+    })
+})

--- a/src/utils/api-fetch.ts
+++ b/src/utils/api-fetch.ts
@@ -2,9 +2,10 @@
 // was retired once peanut-api-ts dropped its api-key requirement (eb616b8c)
 // and CORS already allowed *.peanut.me + capacitor:// + vercel previews.
 
-import { getAuthHeaders, authReady } from './auth-token'
+import { getAuthHeaders, getAuthToken, authReady } from './auth-token'
 import { fetchWithSentry } from './sentry.utils'
 import { PEANUT_API_URL } from '@/constants/general.consts'
+import { isCapacitor } from './capacitor'
 import { isDemoMode } from './demo'
 
 type FetchOptions = RequestInit & { timeoutMs?: number }
@@ -30,7 +31,21 @@ async function callApi(path: string, options?: FetchOptions): Promise<Response> 
     }
     Object.assign(headers, getAuthHeaders(callerHeaders))
 
-    const args: Parameters<typeof fetchWithSentry> = [`${PEANUT_API_URL}${path}`, { ...fetchOptions, headers }]
+    /*
+     * No JS-readable token on native means either logged out or a legacy
+     * cookie-jar session whose JWT lives only in the OS-level cookie store —
+     * unreadable from JS on Android (CapacitorCookies.getCookies ignores its
+     * url param there), so the two are indistinguishable here. Prefer the OS
+     * HTTP client for both: it attaches that cookie where the WebView sends
+     * nothing, and the /users/me sliding refresh then migrates the session to
+     * Preferences + header auth.
+     */
+    const preferNativeTransport = isCapacitor() && !getAuthToken()
+
+    const args: Parameters<typeof fetchWithSentry> = [
+        `${PEANUT_API_URL}${path}`,
+        { ...fetchOptions, headers, ...(preferNativeTransport && { preferNativeTransport }) },
+    ]
     if (timeoutMs !== undefined) args[2] = timeoutMs
     return fetchWithSentry(...args)
 }

--- a/src/utils/auth-token.ts
+++ b/src/utils/auth-token.ts
@@ -42,6 +42,11 @@ async function hydrateFromPreferences(): Promise<void> {
     // POSTs like /manteca/qr-payment/init 400 with "authorization required",
     // while GETs still work via the native-http cookie fallback — a confusing
     // split that surfaced as "cannot pay through QR" (PEANUT-UI-R44 cohort).
+    // iOS-only in practice: Android's CapacitorCookies.getCookies evals
+    // document.cookie and ignores its url param, so the api-domain cookie is
+    // unreadable there — those sessions ride the OS HTTP client instead
+    // (preferNativeTransport in api-fetch) until the sliding refresh migrates
+    // them to Preferences.
     try {
         const { CapacitorCookies } = await import('@capacitor/core')
         const cookies = await CapacitorCookies.getCookies({ url: PEANUT_API_URL })

--- a/src/utils/demo-api.ts
+++ b/src/utils/demo-api.ts
@@ -307,10 +307,28 @@ const demoMantecaWithdraw = () => ({
     updatedAt: CREATED_AT,
 })
 
-// Session-only, mirrors the server stamping activationCelebratedAt on dismiss:
-// keeps the "You're unlocked" celebration showing once per demo session instead
-// of on every home visit. In-memory (like demoCharges) — resets on full reload.
+// Mirrors the server stamping activationCelebratedAt on dismiss. Persisted to
+// localStorage so the "You're unlocked" celebration shows once per install —
+// the previous in-memory flag reset on every cold start, re-showing the modal
+// on every demo launch. The in-memory cache keeps dismissal working within the
+// session even when storage throws.
+const DEMO_CELEBRATED_AT_KEY = 'peanut_demo_activation_celebrated_at'
 let demoActivationCelebratedAt: string | null = null
+
+const getDemoActivationCelebratedAt = (): string | null => {
+    if (demoActivationCelebratedAt) return demoActivationCelebratedAt
+    try {
+        demoActivationCelebratedAt = window.localStorage.getItem(DEMO_CELEBRATED_AT_KEY)
+    } catch {}
+    return demoActivationCelebratedAt
+}
+
+const stampDemoActivationCelebrated = (): void => {
+    demoActivationCelebratedAt = new Date().toISOString()
+    try {
+        window.localStorage.setItem(DEMO_CELEBRATED_AT_KEY, demoActivationCelebratedAt)
+    } catch {}
+}
 
 // ---- routes (ordered: literal paths before :param paths) ----
 
@@ -319,10 +337,12 @@ const ROUTES: Array<{ method: string; pattern: string; handler: Handler }> = [
     {
         method: 'GET',
         pattern: '/users/me',
-        handler: () =>
-            demoActivationCelebratedAt
-                ? { ...DEMO_USER, user: { ...DEMO_USER.user, activationCelebratedAt: demoActivationCelebratedAt } }
-                : DEMO_USER,
+        handler: () => {
+            const celebratedAt = getDemoActivationCelebratedAt()
+            return celebratedAt
+                ? { ...DEMO_USER, user: { ...DEMO_USER.user, activationCelebratedAt: celebratedAt } }
+                : DEMO_USER
+        },
     },
     {
         method: 'GET',
@@ -344,7 +364,7 @@ const ROUTES: Array<{ method: string; pattern: string; handler: Handler }> = [
         pattern: '/update-user',
         handler: ({ options }) => {
             const body = parseBody(options)
-            if (body.dismissActivationCelebration) demoActivationCelebratedAt = new Date().toISOString()
+            if (body.dismissActivationCelebration) stampDemoActivationCelebrated()
             return demoApiUser(body.username ?? 'demo')
         },
     },

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -406,11 +406,50 @@ const noteNativeFallback = (url: string, cause: unknown): void => {
     })
 }
 
+// One Sentry note per session when a tokenless session runs on the OS HTTP
+// client — measures how many users still sit on legacy cookie-jar auth.
+let legacyCookieTransportReported = false
+const noteLegacyCookieTransport = (url: string): void => {
+    if (legacyCookieTransportReported) return
+    legacyCookieTransportReported = true
+    Sentry.captureMessage('legacy-cookie native transport engaged', {
+        level: 'info',
+        tags: { transport: 'cap-native-http', authMode: 'legacy-cookie' },
+        extra: { url: sanitizeUrl(url) },
+    })
+}
+
+export type FetchWithSentryOptions = RequestInit & { preferNativeTransport?: boolean }
+
 export const fetchWithSentry = async (
     url: string,
-    options: RequestInit = {},
+    optionsWithTransport: FetchWithSentryOptions = {},
     timeoutMs: number = DEFAULT_TIMEOUT_MS
 ): Promise<Response> => {
+    const { preferNativeTransport, ...options } = optionsWithTransport
+
+    /*
+     * Tokenless native sessions go over the OS HTTP client FIRST, not as a
+     * rescue: legacy cookie-jar sessions hold the JWT only in the OS-level
+     * cookie store, which rides on CapacitorHttp requests but is invisible to
+     * JS (Android's CapacitorCookies.getCookies evals document.cookie and
+     * ignores its url param). A WebView POST reaches the backend with neither
+     * header nor cookie and 400s — and because it gets an HTTP response, the
+     * rejection fallback below never engages. On OS-client failure, fall
+     * through to the WebView path so logged-out flows behave as before.
+     */
+    if (preferNativeTransport && canUseNativeHttp(url, options)) {
+        try {
+            const response = await nativeHttpRequest(url, options, timeoutMs)
+            reportNetworkOk()
+            noteLegacyCookieTransport(url)
+            await reportNonOkResponse(url, options, response)
+            return response
+        } catch {
+            // OS client failed — the WebView path below is the report of record
+        }
+    }
+
     // Idempotent requests get one silent retry on timeout: stalled-transport
     // failures (Android webview, flaky mobile networks) usually clear on a
     // fresh attempt (PEANUT-UI-R44).


### PR DESCRIPTION
## Why

QR payments still 400 (`headers must have required property 'authorization'`) on Android **1.0.40** — i.e. WITH the 8b242b09f cookie-jar fallback on board. Field data (canary v3, the affected user, seconds before the failing POST): `authMode:none`, so hydration found no token in Preferences **and** the jar fallback came up empty.

Root cause, confirmed in Capacitor source: Android's native `CapacitorCookies.getCookies` evals `document.cookie` in the WebView and **ignores its `url` param** — the api.peanut.me jwt-token cookie is unreadable from JS on Android, period. (iOS honors the url; unaffected.) The session JWT of a legacy cookie-jar user lives only in the OS-level cookie store, which rides on `CapacitorHttp.request` — that's why GETs work (rejection fallback → OS client → cookie attached) while WebView POSTs reach the backend with neither header nor cookie, get an HTTP 400 response, and therefore never trigger the rejection-only fallback.

## What

- **`api-fetch`**: tokenless native requests set `preferNativeTransport`.
- **`fetchWithSentry`**: with that flag (and `canUseNativeHttp`), the request goes over the OS HTTP client **first** — the OS attaches the cookie the WebView can't see — falling through to the WebView path if the OS client fails, so logged-out flows behave exactly as before. Once-per-session Sentry note (`authMode:legacy-cookie`) to size the cohort.
- The `/users/me` sliding refresh then migrates these sessions to Preferences + header auth over time.
- **Demo mode**: the "You're unlocked" celebration re-appeared on every demo launch — dismissal was stamped in module memory only. Now persisted to localStorage (once per install). Real users' dismissals are server-stamped; their only repeat path was this same tokenless-POST bug.

## Verification

- 84 tests green across the 5 touched suites (new: `sentry-prefer-native.test.ts`, prefer/fallback/strip-flag/once-notice; api-fetch flag matrix; demo persistence across isolated module registries simulating cold starts).
- `tsc --noEmit` and eslint clean on touched files; prettier run.
- Backend needs no changes: `ensureAuthHeaderFromCookie` (merged in main) normalizes the cookie the OS client sends.