### PR TITLE
fix(csp): close the wss allow-list gap and stop the Sentry report flood

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,23 +16,14 @@ const redirectsConfig = require('./redirects.json')
  */
 const CSP_REPORT_PATH = '/api/csp-report'
 
-/**
- * `report-uri` takes a URI-reference, so the relative path above is valid and
- * stays correct on every origin (prod, staging, preview URLs alike).
- *
- * `Reporting-Endpoints` is not so clearly specified: the Reporting API says an
- * endpoint is a URL resolved against the document, but MDN and Chrome's own
- * docs both describe the value as an absolute one. Getting this wrong fails
- * silently AND expensively — Chromium prefers `report-to` and ignores
- * `report-uri` whenever both are present, so an endpoint it declines to parse
- * would cost us every Chromium report without a single error anywhere. Emit an
- * absolute URL, which is valid under either reading. Mirrors BASE_URL in
- * src/constants/general.consts.ts.
- */
-function cspReportEndpoint() {
-    const base = (process.env.NEXT_PUBLIC_BASE_URL || 'https://peanut.me').replace(/\/$/, '')
-    return `${base}${CSP_REPORT_PATH}`
-}
+// Root-relative on purpose, for `report-uri` and `Reporting-Endpoints` alike.
+// `report-uri` takes a URI-reference; the Reporting API resolves its endpoint
+// "with base URL set to response's url" (W3C Reporting §3.3), so both land on
+// whichever origin actually served the page. An absolute URL would have to be
+// built from an env var and would silently point preview deploys at
+// production's collector — cross-origin, so Chromium would drop those reports
+// entirely, since it prefers `report-to` and ignores `report-uri` when both
+// are present. Don't "fix" this to an absolute URL.
 
 /**
  * Chain RPC endpoints, which have two independent sources that must both be
@@ -157,7 +148,7 @@ function contentSecurityPolicyReportOnly() {
 const CSP_REPORT_GROUP = 'csp-endpoint'
 
 function reportingEndpointsHeader() {
-    return [{ key: 'Reporting-Endpoints', value: `${CSP_REPORT_GROUP}="${cspReportEndpoint()}"` }]
+    return [{ key: 'Reporting-Endpoints', value: `${CSP_REPORT_GROUP}="${CSP_REPORT_PATH}"` }]
 }
 
 // Get git commit hash at build time

--- a/next.config.js
+++ b/next.config.js
@@ -6,29 +6,15 @@ const withBundleAnalyzer =
 const redirectsConfig = require('./redirects.json')
 
 /**
- * Sentry's CSP-report ingest endpoint, derived from the browser DSN
- * (`<protocol>://<publicKey>@<host><path>/<projectId>`). Returns null when the
- * DSN is absent or malformed, in which case the policy still ships — it just
- * has nowhere to report, which is better than emitting a broken `report-uri`.
+ * Same-origin collector for violation reports (src/app/api/csp-report). It
+ * derives Sentry's ingest URL from the DSN and forwards there, dropping the
+ * noise Sentry would otherwise group into issues nobody can act on.
  *
- * Protocol and any path prefix are preserved: self-hosted Sentry is commonly
- * mounted under a sub-path, and flattening one would silently post reports to
- * an endpoint that doesn't exist.
+ * Reporting straight to Sentry — which is what this used to do — is
+ * unfilterable: the browser POSTs violations itself, so they never pass through
+ * the Sentry SDK and `beforeSend` never sees them.
  */
-function sentryCspReportUri() {
-    const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN
-    if (!dsn) return null
-    try {
-        const { protocol, host, username, pathname } = new URL(dsn)
-        const segments = pathname.split('/').filter(Boolean)
-        const projectId = segments.pop()
-        if (!host || !username || !projectId) return null
-        const prefix = segments.length ? `/${segments.join('/')}` : ''
-        return `${protocol}//${host}${prefix}/api/${projectId}/security/?sentry_key=${username}`
-    } catch {
-        return null
-    }
-}
+const CSP_REPORT_PATH = '/api/csp-report'
 
 /**
  * Chain RPC endpoints, which have two independent sources that must both be
@@ -71,7 +57,6 @@ const chainRpcHosts = [
  *   provider serves one subdomain per network.
  */
 function contentSecurityPolicyReportOnly() {
-    const reportUri = sentryCspReportUri()
     const directives = [
         "default-src 'self'",
         // PostHog is same-origin via the /relay rewrite, so it needs no entry here.
@@ -83,20 +68,37 @@ function contentSecurityPolicyReportOnly() {
             "connect-src 'self'",
             'https://api.peanut.me',
             'https://*.peanut.me',
+            // CSP treats wss: as a scheme distinct from https:, so the two
+            // entries above do NOT cover the charges websocket
+            // (NEXT_PUBLIC_PEANUT_WS_URL — wss://api.peanut.me in production,
+            // wss://api.staging.peanut.me on staging). This gap is what makes
+            // /card the single loudest violation in Sentry today, and it would
+            // break the socket for every user the moment the policy is enforced.
+            'wss://api.peanut.me',
+            'wss://*.peanut.me',
             'https://*.ingest.sentry.io',
             'https://*.ingest.us.sentry.io',
-            'https://www.google-analytics.com',
+            // Wildcarded because GA4 shards collection by region: EU traffic
+            // beacons to region1.google-analytics.com, not just www. The same
+            // sharding is already visible on analytics.google.com below.
+            'https://*.google-analytics.com',
             // GA4 beacons to a region-specific host, and GTM's audience/conversion
-            // pings go to doubleclick and www.google.com.
+            // pings go to doubleclick and www.google.com. The GTM container
+            // itself is fetched as well as executed, so it needs a connect-src
+            // entry on top of the script-src one.
             'https://analytics.google.com',
             'https://*.analytics.google.com',
             'https://stats.g.doubleclick.net',
             'https://www.google.com',
+            'https://www.googletagmanager.com',
             'https://rpc.zerodev.app',
             'https://*.g.alchemy.com',
             'https://rpc.ankr.com',
             'https://assets.coingecko.com',
             'https://coin-images.coingecko.com',
+            // Token metadata lookup in TransactionDetailsReceipt — a different
+            // CoinGecko host from the two image CDNs above.
+            'https://api.coingecko.com',
             'https://api.frankfurter.app',
             'https://dolarapi.com',
             'https://ipapi.co',
@@ -104,11 +106,22 @@ function contentSecurityPolicyReportOnly() {
             'https://*.crisp.chat',
             'wss://client.relay.crisp.chat',
             'https://*.sumsub.com',
+            // Same scheme trap as api.peanut.me above: the Sumsub WebSDK opens a
+            // websocket for liveness/video-ident signalling, which the https
+            // entry does not authorize. Silent in the reports only because
+            // liveness is a rare path — it would still break under enforcement.
+            'wss://*.sumsub.com',
             'https://widget.manteca.dev',
             'https://*.onesignal.com',
             ...chainRpcHosts,
         ].join(' '),
-        "frame-src 'self' https://client.crisp.chat https://*.sumsub.com https://widget.manteca.dev https://mpago.la",
+        // Bridge is the terms-of-service iframe BridgeTosStep renders through
+        // IframeWrapper — enforcing without it would dead-end KYC. Wildcarded
+        // like *.sumsub.com because the URL is chosen by the provider at
+        // runtime (compliance.bridge.xyz today) rather than by us. Crisp is
+        // wildcarded to match connect-src: the widget pulls attachments from
+        // assets.crisp.chat, not just client.
+        "frame-src 'self' https://*.crisp.chat https://*.sumsub.com https://widget.manteca.dev https://mpago.la https://*.bridge.xyz",
         "worker-src 'self' blob:",
         "object-src 'none'",
         "base-uri 'self'",
@@ -119,16 +132,14 @@ function contentSecurityPolicyReportOnly() {
     // Reporting-Endpoints header below) is what replaces it in Chromium.
     // Shipping only one would undercount violations and promote the policy on
     // a partial picture.
-    if (reportUri) directives.push(`report-uri ${reportUri}`, `report-to ${CSP_REPORT_GROUP}`)
+    directives.push(`report-uri ${CSP_REPORT_PATH}`, `report-to ${CSP_REPORT_GROUP}`)
     return directives.join('; ')
 }
 
 const CSP_REPORT_GROUP = 'csp-endpoint'
 
 function reportingEndpointsHeader() {
-    const reportUri = sentryCspReportUri()
-    if (!reportUri) return []
-    return [{ key: 'Reporting-Endpoints', value: `${CSP_REPORT_GROUP}="${reportUri}"` }]
+    return [{ key: 'Reporting-Endpoints', value: `${CSP_REPORT_GROUP}="${CSP_REPORT_PATH}"` }]
 }
 
 // Get git commit hash at build time

--- a/next.config.js
+++ b/next.config.js
@@ -17,6 +17,24 @@ const redirectsConfig = require('./redirects.json')
 const CSP_REPORT_PATH = '/api/csp-report'
 
 /**
+ * `report-uri` takes a URI-reference, so the relative path above is valid and
+ * stays correct on every origin (prod, staging, preview URLs alike).
+ *
+ * `Reporting-Endpoints` is not so clearly specified: the Reporting API says an
+ * endpoint is a URL resolved against the document, but MDN and Chrome's own
+ * docs both describe the value as an absolute one. Getting this wrong fails
+ * silently AND expensively — Chromium prefers `report-to` and ignores
+ * `report-uri` whenever both are present, so an endpoint it declines to parse
+ * would cost us every Chromium report without a single error anywhere. Emit an
+ * absolute URL, which is valid under either reading. Mirrors BASE_URL in
+ * src/constants/general.consts.ts.
+ */
+function cspReportEndpoint() {
+    const base = (process.env.NEXT_PUBLIC_BASE_URL || 'https://peanut.me').replace(/\/$/, '')
+    return `${base}${CSP_REPORT_PATH}`
+}
+
+/**
  * Chain RPC endpoints, which have two independent sources that must both be
  * allowed: `rpcUrls` in src/constants/general.consts.ts (our own viem clients)
  * and viem's per-chain defaults, which wagmi's bare `http()` transports fall
@@ -139,7 +157,7 @@ function contentSecurityPolicyReportOnly() {
 const CSP_REPORT_GROUP = 'csp-endpoint'
 
 function reportingEndpointsHeader() {
-    return [{ key: 'Reporting-Endpoints', value: `${CSP_REPORT_GROUP}="${CSP_REPORT_PATH}"` }]
+    return [{ key: 'Reporting-Endpoints', value: `${CSP_REPORT_GROUP}="${cspReportEndpoint()}"` }]
 }
 
 // Get git commit hash at build time

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -5,6 +5,7 @@ import {
     normalizeCspReports,
     sentryCspIngestUrl,
     shouldIgnoreCspReport,
+    type CspReport,
 } from '@/utils/csp-report.utils'
 
 export const dynamic = 'force-dynamic'
@@ -58,7 +59,13 @@ const MAX_FORWARDS_PER_REQUEST = 20
 function shouldForward(groupKey: string): boolean {
     if (!seenGroups.has(groupKey)) {
         // Bound the memory: a flood of distinct groups must not grow forever.
-        if (seenGroups.size >= SEEN_GROUPS_MAX) seenGroups.clear()
+        // Evict the oldest rather than clearing — a Set iterates in insertion
+        // order, so this drops one stale group instead of dumping all 500 and
+        // letting every still-active violation re-forward at once.
+        if (seenGroups.size >= SEEN_GROUPS_MAX) {
+            const oldest = seenGroups.values().next().value
+            if (oldest !== undefined) seenGroups.delete(oldest)
+        }
         seenGroups.add(groupKey)
         return true
     }
@@ -79,20 +86,44 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
         const reports = normalizeCspReports(await request.json())
 
-        // Cap BEFORE shouldForward, never after: shouldForward records each
-        // group as seen, so truncating afterwards would mark groups seen that
-        // were never actually sent — their real first sighting would be lost
-        // and every later repeat sampled away as a duplicate.
-        const forwardable = reports
-            .filter((report) => !shouldIgnoreCspReport(report))
-            .slice(0, MAX_FORWARDS_PER_REQUEST)
-            .filter((report) => shouldForward(cspReportGroupKey(report)))
+        const seenInBatch = new Set<string>()
+        const forwardable: CspReport[] = []
+        for (const report of reports) {
+            if (shouldIgnoreCspReport(report)) continue
+
+            const groupKey = cspReportGroupKey(report)
+            // One slot per distinct group: a batch is usually dominated by
+            // repeats of a single violation, and 20 copies of it must not
+            // crowd a genuinely new group out of the per-request cap.
+            if (seenInBatch.has(groupKey)) continue
+            seenInBatch.add(groupKey)
+
+            // Cap BEFORE shouldForward, never after: shouldForward records
+            // each group as seen, so admitting more than we can send would
+            // mark groups seen that were never actually sent — their real
+            // first sighting lost, every later repeat sampled away.
+            if (seenInBatch.size > MAX_FORWARDS_PER_REQUEST) break
+
+            if (shouldForward(groupKey)) forwardable.push(report)
+        }
+
+        // Sentry derives the event's browser and request context from the
+        // headers of whoever POSTs to its security endpoint. That used to be
+        // the browser itself; now it is us, so pass the originals through or
+        // every CSP event is attributed to one Vercel egress IP running
+        // undici — deleting the "which browser / how many users" dimension
+        // these reports are read for.
+        const forwardedHeaders: Record<string, string> = { 'Content-Type': 'application/csp-report' }
+        const userAgent = request.headers.get('user-agent')
+        if (userAgent) forwardedHeaders['User-Agent'] = userAgent
+        const forwardedFor = request.headers.get('x-forwarded-for')
+        if (forwardedFor) forwardedHeaders['X-Forwarded-For'] = forwardedFor
 
         await Promise.allSettled(
             forwardable.map((report) =>
                 fetch(ingestUrl, {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/csp-report' },
+                    headers: forwardedHeaders,
                     body: JSON.stringify({ 'csp-report': report }),
                     signal: AbortSignal.timeout(FORWARD_TIMEOUT_MS),
                 })

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -53,7 +53,7 @@ function shouldForward(groupKey: string): boolean {
     return Math.random() < DUPLICATE_SAMPLE_RATE
 }
 
-export async function POST(request: NextRequest) {
+export async function POST(request: NextRequest): Promise<NextResponse> {
     // Always 204, whatever happens. A non-2xx here makes browsers retry and
     // log console errors, which would be a second, self-inflicted noise source.
     const noContent = new NextResponse(null, { status: 204 })

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -79,10 +79,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
         const reports = normalizeCspReports(await request.json())
 
+        // Cap BEFORE shouldForward, never after: shouldForward records each
+        // group as seen, so truncating afterwards would mark groups seen that
+        // were never actually sent — their real first sighting would be lost
+        // and every later repeat sampled away as a duplicate.
         const forwardable = reports
             .filter((report) => !shouldIgnoreCspReport(report))
-            .filter((report) => shouldForward(cspReportGroupKey(report)))
             .slice(0, MAX_FORWARDS_PER_REQUEST)
+            .filter((report) => shouldForward(cspReportGroupKey(report)))
 
         await Promise.allSettled(
             forwardable.map((report) =>

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -18,10 +18,12 @@ export const dynamic = 'force-dynamic'
  * the Sentry browser SDK entirely, so no `beforeSend` filter could touch them —
  * the only place to filter is an endpoint we own.
  *
- * This forwards to Sentry exactly as before, minus two classes of pure noise:
- * repeats of a violation Sentry has already grouped (the dominant class — one
- * missing allow-list entry produced 14k events on its own) and reports injected
- * by browser extensions.
+ * This forwards to Sentry exactly as before, minus repeats of a violation
+ * Sentry has already grouped — one missing allow-list entry produced 14k
+ * identical events on its own, so de-duplication is the entire lever here. The
+ * extension-scheme filter in csp-report.utils.ts is a cheap extra that saves an
+ * outbound request; Sentry's own default inbound filter already drops that
+ * class server-side, so it is not doing the real work.
  */
 
 /** Both wire formats, plus plain JSON from anything replaying a report. */
@@ -42,6 +44,16 @@ const SEEN_GROUPS_MAX = 500
 const seenGroups = new Set<string>()
 
 const FORWARD_TIMEOUT_MS = 3000
+
+/**
+ * Hard cap on forwards per request. This endpoint is unauthenticated and a
+ * Reporting-API batch is an array, so without a cap one POST could fan out
+ * arbitrarily many events. That matters more than it looks: Sentry bills CSP
+ * reports against the *error* quota under a per-DSN-key rate limit, so an
+ * uncapped fan-out could exhaust the quota that real application exceptions
+ * depend on. A genuine browser batch is a handful of reports.
+ */
+const MAX_FORWARDS_PER_REQUEST = 20
 
 function shouldForward(groupKey: string): boolean {
     if (!seenGroups.has(groupKey)) {
@@ -70,6 +82,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         const forwardable = reports
             .filter((report) => !shouldIgnoreCspReport(report))
             .filter((report) => shouldForward(cspReportGroupKey(report)))
+            .slice(0, MAX_FORWARDS_PER_REQUEST)
 
         await Promise.allSettled(
             forwardable.map((report) =>

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import {
+    cspReportGroupKey,
+    normalizeCspReports,
+    sentryCspIngestUrl,
+    shouldIgnoreCspReport,
+} from '@/utils/csp-report.utils'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * Collector for the report-only CSP's violation reports.
+ *
+ * The policy used to point `report-uri` / `report-to` straight at Sentry's
+ * security endpoint, which put ~65k events across ~1.3k users into the
+ * peanut-ui project in four days and buried real signal. Those reports bypass
+ * the Sentry browser SDK entirely, so no `beforeSend` filter could touch them —
+ * the only place to filter is an endpoint we own.
+ *
+ * This forwards to Sentry exactly as before, minus two classes of pure noise:
+ * repeats of a violation Sentry has already grouped (the dominant class — one
+ * missing allow-list entry produced 14k events on its own) and reports injected
+ * by browser extensions.
+ */
+
+/** Both wire formats, plus plain JSON from anything replaying a report. */
+const ACCEPTED_CONTENT_TYPES = ['application/csp-report', 'application/reports+json', 'application/json']
+
+/**
+ * Sentry groups CSP issues by directive + blocked origin, so every duplicate
+ * past the first adds quota, not information. Forward the first sighting of
+ * each group unconditionally — a genuinely new violation always creates its
+ * issue and fires its alert — then sample the repeats hard.
+ *
+ * The Set is per-serverless-instance and resets on cold start, which just means
+ * an occasional extra first-sighting. Same trade-off the health route's
+ * in-memory Discord cooldown already accepts.
+ */
+const DUPLICATE_SAMPLE_RATE = 0.01
+const SEEN_GROUPS_MAX = 500
+const seenGroups = new Set<string>()
+
+const FORWARD_TIMEOUT_MS = 3000
+
+function shouldForward(groupKey: string): boolean {
+    if (!seenGroups.has(groupKey)) {
+        // Bound the memory: a flood of distinct groups must not grow forever.
+        if (seenGroups.size >= SEEN_GROUPS_MAX) seenGroups.clear()
+        seenGroups.add(groupKey)
+        return true
+    }
+    return Math.random() < DUPLICATE_SAMPLE_RATE
+}
+
+export async function POST(request: NextRequest) {
+    // Always 204, whatever happens. A non-2xx here makes browsers retry and
+    // log console errors, which would be a second, self-inflicted noise source.
+    const noContent = new NextResponse(null, { status: 204 })
+
+    try {
+        const contentType = request.headers.get('content-type')?.split(';')[0].trim().toLowerCase() ?? ''
+        if (!ACCEPTED_CONTENT_TYPES.includes(contentType)) return noContent
+
+        const ingestUrl = sentryCspIngestUrl(process.env.NEXT_PUBLIC_SENTRY_DSN)
+        if (!ingestUrl) return noContent
+
+        const reports = normalizeCspReports(await request.json())
+
+        const forwardable = reports
+            .filter((report) => !shouldIgnoreCspReport(report))
+            .filter((report) => shouldForward(cspReportGroupKey(report)))
+
+        await Promise.allSettled(
+            forwardable.map((report) =>
+                fetch(ingestUrl, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/csp-report' },
+                    body: JSON.stringify({ 'csp-report': report }),
+                    signal: AbortSignal.timeout(FORWARD_TIMEOUT_MS),
+                })
+            )
+        )
+    } catch {
+        // Malformed body, unreachable Sentry, timeout — a dropped violation
+        // report is never worth surfacing an error to the browser.
+    }
+
+    return noContent
+}

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -13,8 +13,8 @@ export const dynamic = 'force-dynamic'
  * Collector for the report-only CSP's violation reports.
  *
  * The policy used to point `report-uri` / `report-to` straight at Sentry's
- * security endpoint, which put ~65k events across ~1.3k users into the
- * peanut-ui project in four days and buried real signal. Those reports bypass
+ * security endpoint, which put ~70k events across ~1.8k users into the
+ * peanut-ui project in a week and buried real signal. Those reports bypass
  * the Sentry browser SDK entirely, so no `beforeSend` filter could touch them —
  * the only place to filter is an endpoint we own.
  *

--- a/src/utils/__tests__/csp-report.utils.test.ts
+++ b/src/utils/__tests__/csp-report.utils.test.ts
@@ -153,6 +153,22 @@ describe('cspReportGroupKey', () => {
         )
     })
 
+    // What browsers actually emit: the specific sub-directive that was checked.
+    // Inline <script> reports as script-src-elem, inline handlers as
+    // script-src-attr; only eval stays plain script-src.
+    it.each(['script-src-elem', 'script-src-attr'])(
+        'applies the keyword grouping to %s, not just the bare script-src',
+        (directive) => {
+            expect(
+                cspReportGroupKey({
+                    'effective-directive': directive,
+                    'violated-directive': `${directive} 'unsafe-inline'`,
+                    'blocked-uri': 'inline',
+                })
+            ).toBe(`${directive}|unsafe-inline`)
+        }
+    )
+
     it('leaves a normal script-src host violation keyed on its origin', () => {
         expect(
             cspReportGroupKey({

--- a/src/utils/__tests__/csp-report.utils.test.ts
+++ b/src/utils/__tests__/csp-report.utils.test.ts
@@ -1,0 +1,145 @@
+import {
+    cspReportGroupKey,
+    normalizeCspReports,
+    sentryCspIngestUrl,
+    shouldIgnoreCspReport,
+    type CspReport,
+} from '../csp-report.utils'
+
+describe('shouldIgnoreCspReport', () => {
+    it.each([
+        'chrome-extension://abcdefghijklmnop/inject.js',
+        'moz-extension://1234-5678/content.js',
+        'safari-web-extension://ABCD/script.js',
+        'resource://gre/modules/Foo.jsm',
+        'about:blank',
+    ])('ignores extension/browser-internal blocked-uri %s', (blockedUri) => {
+        expect(shouldIgnoreCspReport({ 'blocked-uri': blockedUri })).toBe(true)
+    })
+
+    it('ignores a report whose source-file is an extension, even when the blocked-uri looks real', () => {
+        expect(
+            shouldIgnoreCspReport({
+                'blocked-uri': 'https://evil-tracker.example/beacon',
+                'source-file': 'chrome-extension://abcdefghijklmnop/inject.js',
+            })
+        ).toBe(true)
+    })
+
+    it('keeps the wss gap that this hotfix closes', () => {
+        expect(
+            shouldIgnoreCspReport({
+                'blocked-uri': 'wss://api.peanut.me',
+                'effective-directive': 'connect-src',
+            })
+        ).toBe(false)
+    })
+
+    it.each(['inline', 'eval', 'data', 'blob'])(
+        'keeps keyword blocked-uri %s — genuine signal about how loose script-src still is',
+        (blockedUri) => {
+            expect(shouldIgnoreCspReport({ 'blocked-uri': blockedUri })).toBe(false)
+        }
+    )
+
+    it('keeps a real third-party host we simply forgot to allow-list', () => {
+        expect(shouldIgnoreCspReport({ 'blocked-uri': 'https://arb1.arbitrum.io/rpc' })).toBe(false)
+    })
+
+    it('does not treat a missing blocked-uri as noise', () => {
+        expect(shouldIgnoreCspReport({})).toBe(false)
+    })
+})
+
+describe('normalizeCspReports', () => {
+    it('reads the legacy report-uri payload', () => {
+        expect(
+            normalizeCspReports({
+                'csp-report': { 'blocked-uri': 'wss://api.peanut.me', 'effective-directive': 'connect-src' },
+            })
+        ).toEqual([{ 'blocked-uri': 'wss://api.peanut.me', 'effective-directive': 'connect-src' }])
+    })
+
+    it('reads a Reporting-API batch and maps it onto the legacy shape', () => {
+        const [report] = normalizeCspReports([
+            {
+                type: 'csp-violation',
+                body: {
+                    blockedURL: 'wss://api.peanut.me',
+                    documentURL: 'https://peanut.me/card',
+                    effectiveDirective: 'connect-src',
+                    disposition: 'report',
+                },
+            },
+        ])
+
+        expect(report['blocked-uri']).toBe('wss://api.peanut.me')
+        expect(report['document-uri']).toBe('https://peanut.me/card')
+        expect(report['effective-directive']).toBe('connect-src')
+        expect(report['violated-directive']).toBe('connect-src')
+    })
+
+    it('drops non-CSP entries from a Reporting-API batch', () => {
+        expect(
+            normalizeCspReports([
+                { type: 'deprecation', body: { id: 'SomeApi' } },
+                { type: 'csp-violation', body: { blockedURL: 'inline', effectiveDirective: 'script-src' } },
+            ])
+        ).toHaveLength(1)
+    })
+
+    it.each([null, undefined, 'not json', 42, {}, { 'csp-report': 'nonsense' }])(
+        'returns nothing for the malformed payload %p rather than throwing',
+        (payload) => {
+            expect(normalizeCspReports(payload)).toEqual([])
+        }
+    )
+})
+
+describe('cspReportGroupKey', () => {
+    it('collapses different paths on one origin into a single group', () => {
+        const a: CspReport = { 'effective-directive': 'connect-src', 'blocked-uri': 'https://arb1.arbitrum.io/rpc' }
+        const b: CspReport = { 'effective-directive': 'connect-src', 'blocked-uri': 'https://arb1.arbitrum.io/other' }
+
+        expect(cspReportGroupKey(a)).toBe(cspReportGroupKey(b))
+    })
+
+    it('separates different directives on the same origin', () => {
+        expect(
+            cspReportGroupKey({ 'effective-directive': 'connect-src', 'blocked-uri': 'https://a.example' })
+        ).not.toBe(cspReportGroupKey({ 'effective-directive': 'script-src', 'blocked-uri': 'https://a.example' }))
+    })
+
+    it('handles keyword blocked-uris that are not URLs', () => {
+        expect(cspReportGroupKey({ 'effective-directive': 'script-src', 'blocked-uri': 'inline' })).toBe(
+            'script-src|inline'
+        )
+    })
+
+    it('falls back to violated-directive when the effective one is absent', () => {
+        expect(cspReportGroupKey({ 'violated-directive': 'connect-src', 'blocked-uri': 'inline' })).toBe(
+            'connect-src|inline'
+        )
+    })
+})
+
+describe('sentryCspIngestUrl', () => {
+    it('derives the security endpoint from a browser DSN', () => {
+        expect(sentryCspIngestUrl('https://abc123@o1.ingest.us.sentry.io/4505827431415808')).toBe(
+            'https://o1.ingest.us.sentry.io/api/4505827431415808/security/?sentry_key=abc123'
+        )
+    })
+
+    it('preserves a sub-path, as self-hosted Sentry needs', () => {
+        expect(sentryCspIngestUrl('https://abc123@sentry.internal/sentry/42')).toBe(
+            'https://sentry.internal/sentry/api/42/security/?sentry_key=abc123'
+        )
+    })
+
+    it.each([undefined, '', 'not-a-dsn', 'https://o1.ingest.sentry.io/123'])(
+        'returns null for the unusable DSN %p',
+        (dsn) => {
+            expect(sentryCspIngestUrl(dsn)).toBeNull()
+        }
+    )
+})

--- a/src/utils/__tests__/csp-report.utils.test.ts
+++ b/src/utils/__tests__/csp-report.utils.test.ts
@@ -116,6 +116,53 @@ describe('cspReportGroupKey', () => {
         )
     })
 
+    // Sentry's csp:v1 strategy keys these two on the keyword rather than the
+    // blocked URI, so it raises two separate issues. If the group key collapsed
+    // them, the second would be sampled away as a duplicate and its issue might
+    // never be created — in the one category this policy most needs to see.
+    it('separates unsafe-inline from unsafe-eval, matching how Sentry groups them', () => {
+        const inline = cspReportGroupKey({
+            'effective-directive': 'script-src',
+            'violated-directive': "script-src 'unsafe-inline'",
+            'blocked-uri': 'inline',
+        })
+        const evaluated = cspReportGroupKey({
+            'effective-directive': 'script-src',
+            'violated-directive': "script-src 'unsafe-eval'",
+            'blocked-uri': 'eval',
+        })
+
+        expect(inline).toBe('script-src|unsafe-inline')
+        expect(evaluated).toBe('script-src|unsafe-eval')
+        expect(inline).not.toBe(evaluated)
+    })
+
+    it('groups one keyword consistently even when browsers report a different blocked-uri', () => {
+        expect(
+            cspReportGroupKey({
+                'effective-directive': 'script-src',
+                'violated-directive': "script-src 'unsafe-inline'",
+                'blocked-uri': 'inline',
+            })
+        ).toBe(
+            cspReportGroupKey({
+                'effective-directive': 'script-src',
+                'violated-directive': "script-src 'unsafe-inline'",
+                'blocked-uri': 'self',
+            })
+        )
+    })
+
+    it('leaves a normal script-src host violation keyed on its origin', () => {
+        expect(
+            cspReportGroupKey({
+                'effective-directive': 'script-src',
+                'violated-directive': 'script-src',
+                'blocked-uri': 'https://cdn.example/x.js',
+            })
+        ).toBe('script-src|https://cdn.example')
+    })
+
     it('falls back to violated-directive when the effective one is absent', () => {
         expect(cspReportGroupKey({ 'violated-directive': 'connect-src', 'blocked-uri': 'inline' })).toBe(
             'connect-src|inline'

--- a/src/utils/__tests__/csp-report.utils.test.ts
+++ b/src/utils/__tests__/csp-report.utils.test.ts
@@ -124,33 +124,17 @@ describe('cspReportGroupKey', () => {
         const inline = cspReportGroupKey({
             'effective-directive': 'script-src',
             'violated-directive': "script-src 'unsafe-inline'",
-            'blocked-uri': 'inline',
+            'blocked-uri': 'self',
         })
         const evaluated = cspReportGroupKey({
             'effective-directive': 'script-src',
             'violated-directive': "script-src 'unsafe-eval'",
-            'blocked-uri': 'eval',
+            'blocked-uri': 'self',
         })
 
         expect(inline).toBe('script-src|unsafe-inline')
         expect(evaluated).toBe('script-src|unsafe-eval')
         expect(inline).not.toBe(evaluated)
-    })
-
-    it('groups one keyword consistently even when browsers report a different blocked-uri', () => {
-        expect(
-            cspReportGroupKey({
-                'effective-directive': 'script-src',
-                'violated-directive': "script-src 'unsafe-inline'",
-                'blocked-uri': 'inline',
-            })
-        ).toBe(
-            cspReportGroupKey({
-                'effective-directive': 'script-src',
-                'violated-directive': "script-src 'unsafe-inline'",
-                'blocked-uri': 'self',
-            })
-        )
     })
 
     // What browsers actually emit: the specific sub-directive that was checked.
@@ -163,7 +147,7 @@ describe('cspReportGroupKey', () => {
                 cspReportGroupKey({
                     'effective-directive': directive,
                     'violated-directive': `${directive} 'unsafe-inline'`,
-                    'blocked-uri': 'inline',
+                    'blocked-uri': 'self',
                 })
             ).toBe(`${directive}|unsafe-inline`)
         }
@@ -177,6 +161,42 @@ describe('cspReportGroupKey', () => {
                 'blocked-uri': 'https://cdn.example/x.js',
             })
         ).toBe('script-src|https://cdn.example')
+    })
+
+    // The regression that matters most. Our own script-src contains
+    // 'unsafe-inline' and 'unsafe-eval', and Firefox/Safari echo the entire
+    // source list back in violated-directive. Keying on the keyword without
+    // checking that the violation was local collapsed every blocked
+    // third-party script into the ubiquitous inline group, where the 1%
+    // duplicate sampling would bury it — the exact issue-loss the grouping
+    // exists to prevent.
+    it('keys a blocked third-party script on its origin even when the policy text names unsafe-inline', () => {
+        const realPolicy = "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com"
+
+        const blockedCdn = cspReportGroupKey({
+            'effective-directive': 'script-src-elem',
+            'violated-directive': realPolicy,
+            'blocked-uri': 'https://cdn.attacker.example/x.js',
+        })
+        const ourInlineBootstrap = cspReportGroupKey({
+            'effective-directive': 'script-src-elem',
+            'violated-directive': realPolicy,
+            'blocked-uri': 'self',
+        })
+
+        expect(blockedCdn).toBe('script-src-elem|https://cdn.attacker.example')
+        expect(blockedCdn).not.toBe(ourInlineBootstrap)
+    })
+
+    // Firefox omits effective-directive and sends the full source list, so an
+    // un-normalized key would embed the whole policy and reset on every edit.
+    it('normalizes a full Firefox violated-directive down to the bare directive', () => {
+        expect(
+            cspReportGroupKey({
+                'violated-directive': "connect-src 'self' https://api.peanut.me https://*.peanut.me",
+                'blocked-uri': 'wss://api.peanut.me/charges',
+            })
+        ).toBe('connect-src|wss://api.peanut.me')
     })
 
     it('falls back to violated-directive when the effective one is absent', () => {

--- a/src/utils/csp-report.utils.ts
+++ b/src/utils/csp-report.utils.ts
@@ -116,35 +116,57 @@ export function normalizeCspReports(payload: unknown): CspReport[] {
 }
 
 /**
+ * Blocked-URIs that Sentry normalizes to "local" — the violation came from our
+ * own document rather than a third-party origin. Chrome reports the keyword
+ * (`inline` / `eval`) instead and is deliberately NOT in this list, matching
+ * Sentry, which keys those on the keyword URI and raises a separate issue.
+ */
+const LOCAL_BLOCKED_URIS = ['', 'self', "'self'"]
+
+/**
  * Grouping key used to decide whether a report is the first of its kind.
  * Mirrors how Sentry groups CSP issues (directive + blocked origin), so "first
  * of its kind here" means "would create a new Sentry issue".
  */
 export function cspReportGroupKey(report: CspReport): string {
-    const directive = report['effective-directive'] || report['violated-directive'] || 'unknown'
+    // Take the first token, not the raw string. Firefox omits
+    // `effective-directive` entirely and sends `violated-directive` as the FULL
+    // directive text with its source list attached, so without this every
+    // Firefox group key embeds the whole policy and churns on any policy edit.
+    const directive = (report['effective-directive'] || report['violated-directive'] || 'unknown').split(' ')[0]
+    const blocked = report['blocked-uri'] || 'unknown'
 
     // Sentry's csp:v1 strategy drops the blocked URI entirely and keys on the
-    // keyword when script-src is violated by 'unsafe-inline' / 'unsafe-eval',
-    // so it raises TWO issues where a URI-based key sees one. Mirror that:
-    // otherwise whichever of the pair arrives second looks like a duplicate,
-    // gets sampled away, and its issue may never be created — and those two
-    // are the top of this policy's "tighten before enforcing" list, precisely
-    // the signal the de-duplication must never swallow.
+    // keyword when a *local* script-src violation names 'unsafe-inline' /
+    // 'unsafe-eval', so it raises TWO issues where a URI-based key sees one.
+    // Mirror that: otherwise whichever of the pair arrives second looks like a
+    // duplicate, gets sampled away, and its issue may never be created — and
+    // those two are the top of this policy's "tighten before enforcing" list.
     //
-    // Matches the whole script-src family, not just the bare directive:
-    // browsers report the specific sub-directive they checked, so inline
-    // <script> violations arrive as `script-src-elem` and inline handlers as
-    // `script-src-attr` (only eval stays plain `script-src`). Keying more
-    // finely than Sentry is always safe — it can only over-forward — whereas
-    // keying more coarsely is what loses an issue.
-    const violated = String(report['violated-directive'] ?? '')
-    if (directive === 'script-src' || directive.startsWith('script-src-')) {
+    // The LOCAL_BLOCKED_URIS guard is load-bearing, not decoration. Our own
+    // script-src literally contains 'unsafe-inline' and 'unsafe-eval', and
+    // Firefox/Safari echo the entire source list back in violated-directive —
+    // so without the guard EVERY script-src report matches a keyword,
+    // including a genuinely blocked third-party script. That report would then
+    // be grouped with the ubiquitous inline violation and sampled away at 1%,
+    // which is precisely the issue-loss this de-duplication exists to prevent,
+    // in the one directive that matters most for XSS. Match the quoted form
+    // for the same reason Sentry does: an unquoted substring would also hit a
+    // host in the source list.
+    //
+    // Matching the whole script-src family is deliberate: browsers report the
+    // specific sub-directive they checked, so inline <script> violations
+    // arrive as `script-src-elem` and inline handlers as `script-src-attr`
+    // (only eval stays plain `script-src`). Keying more finely than Sentry is
+    // always safe — it can only over-forward — whereas keying more coarsely is
+    // what loses an issue.
+    if ((directive === 'script-src' || directive.startsWith('script-src-')) && LOCAL_BLOCKED_URIS.includes(blocked)) {
+        const violated = String(report['violated-directive'] ?? '')
         for (const keyword of ['unsafe-inline', 'unsafe-eval']) {
-            if (violated.includes(keyword)) return `${directive}|${keyword}`
+            if (violated.includes(`'${keyword}'`)) return `${directive}|${keyword}`
         }
     }
 
-    const blocked = report['blocked-uri'] || 'unknown'
     // Only the origin matters for grouping; paths and query strings vary per
     // request and would otherwise make every single report look distinct.
     let origin = blocked

--- a/src/utils/csp-report.utils.ts
+++ b/src/utils/csp-report.utils.ts
@@ -1,0 +1,156 @@
+/**
+ * CSP violation report handling.
+ *
+ * Violation reports are POSTed by the browser straight to the policy's
+ * `report-uri` / `report-to` endpoint. They never travel through the Sentry
+ * browser SDK, so `beforeSend` / `shouldIgnoreError` in sentry.utils.ts cannot
+ * see or drop them — which is why the noise filter lives here, behind the
+ * /api/csp-report collector, instead of alongside the other Sentry filters.
+ */
+
+/**
+ * Legacy `report-uri` payload (`application/csp-report`). Still what Firefox
+ * and Safari send today. Kept as the canonical internal shape because it is
+ * also the shape Sentry's security endpoint ingests.
+ */
+export interface CspReport {
+    'blocked-uri'?: string
+    'document-uri'?: string
+    'effective-directive'?: string
+    'violated-directive'?: string
+    'source-file'?: string
+    [key: string]: unknown
+}
+
+/** One entry of a Reporting-API (`report-to`) `application/reports+json` batch. */
+interface ReportingApiEntry {
+    type?: string
+    body?: Record<string, unknown>
+}
+
+/**
+ * Schemes that only ever appear because a browser extension (or the browser
+ * itself) injected a script, style or request into our page. They are
+ * inherently unfixable: an extension's origin is per-install, so no allow-list
+ * entry can ever cover them, and nothing we ship causes them.
+ *
+ * Sentry's own security endpoint already drops most of this class server-side
+ * (no `chrome-extension://` report has reached the project), so this is
+ * defense-in-depth rather than the main lever — it keeps the guarantee ours
+ * instead of depending on a Sentry project setting nobody remembers exists.
+ * The bulk of the noise is repeated reports of one violation, which
+ * cspReportGroupKey + the collector's de-duplication handle generically —
+ * including injected hosts like Google Translate's fonts.gstatic.com that
+ * arrive over plain https and no scheme check could catch.
+ */
+const EXTENSION_SCHEMES = [
+    'chrome-extension:',
+    'moz-extension:',
+    'safari-extension:',
+    'safari-web-extension:',
+    'ms-browser-extension:',
+    'webkit-masked-url:',
+    'resource:', // Firefox internal pages/scripts
+    'chrome:', // Chromium internal pages/scripts
+    'about:', // about:blank / about:srcdoc injections
+]
+
+function isUnfixableOrigin(value: unknown): boolean {
+    if (typeof value !== 'string') return false
+    const lower = value.toLowerCase()
+    return EXTENSION_SCHEMES.some((scheme) => lower.startsWith(scheme))
+}
+
+/**
+ * True when a report is noise we can never act on. Deliberately narrow: the
+ * keyword blocked-uris (`inline`, `eval`, `data`, `blob`) are NOT filtered —
+ * those are genuine signal about how loose script-src still is, and they are
+ * exactly what has to be driven to zero before the policy can be enforced.
+ */
+export function shouldIgnoreCspReport(report: CspReport): boolean {
+    return isUnfixableOrigin(report['blocked-uri']) || isUnfixableOrigin(report['source-file'])
+}
+
+/** Reporting-API body (camelCase) → the legacy hyphenated shape. */
+function fromReportingApi(body: Record<string, unknown>): CspReport {
+    return {
+        'blocked-uri': body.blockedURL as string | undefined,
+        'document-uri': body.documentURL as string | undefined,
+        'effective-directive': body.effectiveDirective as string | undefined,
+        // Sentry keys its CSP grouping off violated-directive; the Reporting
+        // API dropped the field, so mirror the effective one.
+        'violated-directive': body.effectiveDirective as string | undefined,
+        'original-policy': body.originalPolicy,
+        'source-file': body.sourceFile as string | undefined,
+        'line-number': body.lineNumber,
+        'column-number': body.columnNumber,
+        'script-sample': body.sample,
+        'status-code': body.statusCode,
+        disposition: body.disposition,
+        referrer: body.referrer,
+    }
+}
+
+/**
+ * Accept either wire format and return the reports in the legacy shape.
+ * Unrecognised payloads yield an empty list rather than throwing — a malformed
+ * report is never worth a 5xx back to the browser.
+ */
+export function normalizeCspReports(payload: unknown): CspReport[] {
+    if (!payload || typeof payload !== 'object') return []
+
+    // `report-to` — a batch of reports, only some of which are CSP violations.
+    if (Array.isArray(payload)) {
+        return (payload as ReportingApiEntry[])
+            .filter((entry) => entry?.type === 'csp-violation' && entry.body && typeof entry.body === 'object')
+            .map((entry) => fromReportingApi(entry.body as Record<string, unknown>))
+    }
+
+    // `report-uri` — a single report under the `csp-report` key.
+    const legacy = (payload as Record<string, unknown>)['csp-report']
+    if (legacy && typeof legacy === 'object' && !Array.isArray(legacy)) return [legacy as CspReport]
+
+    return []
+}
+
+/**
+ * Grouping key used to decide whether a report is the first of its kind.
+ * Mirrors how Sentry groups CSP issues (directive + blocked origin), so "first
+ * of its kind here" means "would create a new Sentry issue".
+ */
+export function cspReportGroupKey(report: CspReport): string {
+    const directive = report['effective-directive'] || report['violated-directive'] || 'unknown'
+    const blocked = report['blocked-uri'] || 'unknown'
+    // Only the origin matters for grouping; paths and query strings vary per
+    // request and would otherwise make every single report look distinct.
+    let origin = blocked
+    try {
+        origin = new URL(blocked).origin
+    } catch {
+        // Keyword blocked-uris (`inline`, `eval`, …) are not URLs — use as-is.
+    }
+    return `${directive}|${origin}`
+}
+
+/**
+ * Sentry's CSP ingest endpoint, derived from the browser DSN
+ * (`<protocol>://<publicKey>@<host><path>/<projectId>`). Returns null when the
+ * DSN is absent or malformed, in which case reports are simply dropped.
+ *
+ * Protocol and any path prefix are preserved: self-hosted Sentry is commonly
+ * mounted under a sub-path, and flattening one would silently post reports to
+ * an endpoint that doesn't exist.
+ */
+export function sentryCspIngestUrl(dsn: string | undefined): string | null {
+    if (!dsn) return null
+    try {
+        const { protocol, host, username, pathname } = new URL(dsn)
+        const segments = pathname.split('/').filter(Boolean)
+        const projectId = segments.pop()
+        if (!host || !username || !projectId) return null
+        const prefix = segments.length ? `/${segments.join('/')}` : ''
+        return `${protocol}//${host}${prefix}/api/${projectId}/security/?sentry_key=${username}`
+    } catch {
+        return null
+    }
+}

--- a/src/utils/csp-report.utils.ts
+++ b/src/utils/csp-report.utils.ts
@@ -130,8 +130,15 @@ export function cspReportGroupKey(report: CspReport): string {
     // gets sampled away, and its issue may never be created — and those two
     // are the top of this policy's "tighten before enforcing" list, precisely
     // the signal the de-duplication must never swallow.
+    //
+    // Matches the whole script-src family, not just the bare directive:
+    // browsers report the specific sub-directive they checked, so inline
+    // <script> violations arrive as `script-src-elem` and inline handlers as
+    // `script-src-attr` (only eval stays plain `script-src`). Keying more
+    // finely than Sentry is always safe — it can only over-forward — whereas
+    // keying more coarsely is what loses an issue.
     const violated = String(report['violated-directive'] ?? '')
-    if (directive === 'script-src') {
+    if (directive === 'script-src' || directive.startsWith('script-src-')) {
         for (const keyword of ['unsafe-inline', 'unsafe-eval']) {
             if (violated.includes(keyword)) return `${directive}|${keyword}`
         }

--- a/src/utils/csp-report.utils.ts
+++ b/src/utils/csp-report.utils.ts
@@ -74,7 +74,9 @@ export function shouldIgnoreCspReport(report: CspReport): boolean {
 /** Reporting-API body (camelCase) → the legacy hyphenated shape. */
 function fromReportingApi(body: Record<string, unknown>): CspReport {
     return {
-        'blocked-uri': body.blockedURL as string | undefined,
+        // blockedURL is the spec field; blockedURI is what some Chromium
+        // versions still emit.
+        'blocked-uri': (body.blockedURL ?? body.blockedURI) as string | undefined,
         'document-uri': body.documentURL as string | undefined,
         'effective-directive': body.effectiveDirective as string | undefined,
         // Sentry keys its CSP grouping off violated-directive; the Reporting
@@ -120,6 +122,21 @@ export function normalizeCspReports(payload: unknown): CspReport[] {
  */
 export function cspReportGroupKey(report: CspReport): string {
     const directive = report['effective-directive'] || report['violated-directive'] || 'unknown'
+
+    // Sentry's csp:v1 strategy drops the blocked URI entirely and keys on the
+    // keyword when script-src is violated by 'unsafe-inline' / 'unsafe-eval',
+    // so it raises TWO issues where a URI-based key sees one. Mirror that:
+    // otherwise whichever of the pair arrives second looks like a duplicate,
+    // gets sampled away, and its issue may never be created — and those two
+    // are the top of this policy's "tighten before enforcing" list, precisely
+    // the signal the de-duplication must never swallow.
+    const violated = String(report['violated-directive'] ?? '')
+    if (directive === 'script-src') {
+        for (const keyword of ['unsafe-inline', 'unsafe-eval']) {
+            if (violated.includes(keyword)) return `${directive}|${keyword}`
+        }
+    }
+
     const blocked = report['blocked-uri'] || 'unknown'
     // Only the origin matters for grouping; paths and query strings vary per
     // request and would otherwise make every single report look distinct.


### PR DESCRIPTION
## Summary

Two problems, one root area: the report-only CSP is flooding Sentry, and it has a genuine allow-list gap that would break production the moment the policy is enforced.

**~70k CSP events across ~1.8k users in 7 days** made the 20 newest `peanut-ui` issues *all* CSP reports. **99.3% of that volume is production** (`peanut.me`), not staging — the "culprit" shown in Sentry's issue list is only the *latest* event's URL, which is why staging looks over-represented at a glance. Staging is 0.49%.

### a) How CSP reports reach Sentry

Not the browser SDK. `next.config.js` emitted `report-uri` / `report-to` pointing **straight at Sentry's `/api/<projectId>/security/` ingest endpoint**, derived from the public DSN. The browser POSTs violations itself, so these events **never pass through `Sentry.init`** — `beforeSend` and the existing `shouldIgnoreError` helper are structurally unable to see them. (Worth stating plainly, since "filter it in `shouldIgnoreError`" is the obvious first instinct and it cannot work.)

The only place to filter is an endpoint we own, so `report-uri` / `Reporting-Endpoints` now point at a same-origin collector, `POST /api/csp-report`, which forwards to the exact same Sentry endpoint minus the noise.

### b) The real gap — `wss://`

`connect-src` had `https://api.peanut.me` and `https://*.peanut.me`. **CSP treats `wss:` as a scheme distinct from `https:`**, so neither authorized the charges websocket (`NEXT_PUBLIC_PEANUT_WS_URL`) that every logged-in session opens. It is **84% of the violations still firing** (2,377 of 2,834 in the last 24h; 6,177 events / 1,780 users over 7d, still escalating) and it would have broken the socket for **every user** on promotion to enforcing.

Everything added below is evidence-backed — either a live Sentry violation or a confirmed call site. Nothing speculative.

| Directive | Added | Why |
|---|---|---|
| `connect-src` | `wss://api.peanut.me`, `wss://*.peanut.me` | The charges websocket. The headline gap. |
| `connect-src` | `wss://*.sumsub.com` | **Identical scheme trap.** Sumsub's WebSDK opens a socket for liveness/video-ident. Silent in the reports only because liveness is a rare path — it would still break KYC under enforcement. |
| `connect-src` | `https://api.coingecko.com` | `TransactionDetailsReceipt.tsx:162` token-metadata fallback. Only the two *image* CDNs were allowed. |
| `connect-src` | `https://www.googletagmanager.com` | Present in `script-src` but not `connect-src`; gtag XHRs back to it. 44 events / 21 users per day. |
| `connect-src` | `https://www.google-analytics.com` → `https://*.google-analytics.com` | GA4 shards collection by region (`region1.…`). Same sharding is already observed on `analytics.google.com`. The wildcard covers `www.`, so this is a simplification, not a widening. |
| `frame-src` | `https://*.bridge.xyz` | **Would dead-end KYC.** `BridgeTosStep` → `IframeWrapper` renders a Bridge-hosted ToS URL (`compliance.bridge.xyz`, 18 events / 11 users). Wildcarded like the existing `*.sumsub.com` because the URL is chosen by the provider at runtime, not by us. |
| `frame-src` | `https://client.crisp.chat` → `https://*.crisp.chat` | `assets.crisp.chat` was blocked; matches what `connect-src` already does. |

**Verified NOT needed** (so the policy isn't widened for nothing): WalletConnect/Reown is not wired in at all — `wagmi.config.tsx` passes no `connectors`, no `@walletconnect`/`@reown` dependency, and `NEXT_PUBLIC_WC_PROJECT_ID` has zero references. PostHog, Sentry and the ZeroDev passkey server are all same-origin via existing rewrites. Every chain RPC (ours and viem's per-chain defaults for all 10 configured chains) is already covered.

### c) Stopping the flood

The noise is overwhelmingly **repetition**, not variety: Sentry groups CSP issues by directive + blocked origin, so one missing entry produced 14,378 identical events. So the collector:

1. **Forwards the first sighting of each `(directive, blocked-origin)` group unconditionally** — a genuinely new violation always creates its issue and fires its alert, so no future signal is hidden — then samples repeats at 1%.
2. **Drops browser-extension / browser-internal schemes.** Note this is defense-in-depth, not the main lever: Sentry already drops that class server-side (zero `chrome-extension://` reports have ever reached the project). Keeping it in code means the guarantee is ours rather than a Sentry project setting nobody remembers exists.

Deliberately **not** filtered, because they are the signal the report-only phase exists to collect: `inline`, `eval`, `data:`, `blob:` — these are what has to reach zero before `script-src` can be enforced.

Extension-injected violations that arrive over plain `https` (Google/Brave Translate's `fonts.gstatic.com`, a coupon extension's `images.simplycodes.com`, `connect.facebook.net`) are **not** allow-listed — they aren't ours. No scheme check can catch them, but the per-group de-duplication reduces each to ~1 event, which is why the generic mechanism beats a hand-maintained host denylist.

Projected effect: from ~2,800 events/day to **roughly one event per distinct violation**.

## d) Base branch — and the companion action

**Targeted `main`, because that is where the flood is** (99.3% of volume) and this is a hotfix. Prod gets both the wss fix and the collector on merge.

**A `main` → `dev` back-merge is required** and closes the staging side at the same time. `dev` is missing PR #2479's entire allow-list (chain RPC hosts, OneSignal, the Google hosts, ipapi, justaname) because that fix also went straight to `main` — so staging currently runs the *old* policy. The standard post-release back-merge carries #2479 **and** this PR to `dev` in one go; no second PR needed. Flagging it explicitly since it is the only thing standing between staging and the same gaps.

## Risks

- **Reporting path changes owner.** Reports now traverse our route instead of going directly to Sentry. Mitigated: the handler always returns `204` whatever happens (a non-2xx would make browsers retry and log console errors — a second, self-inflicted noise source), everything is wrapped in try/catch, and the forward has a 3s timeout. Worst case is losing violation reports, which are already report-only diagnostics.
- **Not a user-facing change.** The enforcing header (`frame-ancestors`/`object-src`/`base-uri`) is untouched; the policy this PR edits is still `Content-Security-Policy-Report-Only`, so **there is zero user impact today** — the value is that enforcement later won't break the websocket, KYC, or the ToS iframe.
- **Cold starts reset the de-dup `Set`** (per-serverless-instance, bounded at 500 groups), so an occasional extra first-sighting gets through. Same trade-off the health route's in-memory Discord cooldown already documents.
- Adds serverless invocations proportional to violation volume — currently ~2.8k/day and falling steeply once the gaps close.

## Design notes / accepted trade-offs

- **De-duplication mirrors Sentry's `csp:v1` grouping, including its one special case.** Sentry drops the blocked URI and keys on the keyword when `script-src` is violated by `'unsafe-inline'` / `'unsafe-eval'`, raising **two** issues where a URI-based key sees one. An earlier revision of the group key collapsed them, so whichever arrived second would have been sampled away and its issue possibly never created — in exactly the category this policy exists to eliminate. Fixed and covered by tests.
- **The forward loop is capped at 20 per request.** The endpoint is unauthenticated and a Reporting-API payload is an array. Sentry bills CSP reports against the **error** quota under a per-DSN-key rate limit, so an uncapped fan-out is a way to starve real exception reporting, not just a noise problem.
- **`report-uri` and `Reporting-Endpoints` are both root-relative.** The Reporting API resolves an endpoint "with base URL set to response's url" (W3C Reporting §3.3), so a relative path lands on whichever origin served the page. An absolute URL would have to come from `NEXT_PUBLIC_BASE_URL`, which is unset on preview deploys — previews would have pointed at production's collector, cross-origin, and Chromium **ignores `report-uri` whenever `report-to` is present**, so those reports would be dropped rather than falling back. There is a comment in `next.config.js` saying not to "fix" this to an absolute URL.
- **Sentry attributes forwarded reports to the server, not the browser.** Relay reads the user agent and IP from the forwarding request, and its own edge sets `X-Sentry-Forwarded-For`, which outranks anything we could send. So **the "users affected" count on CSP issues after this lands is not a real user count** — don't read it as one. The blocked URI, directive and document URL (the fields that actually drive the fix) are unaffected.

- **Why not `shouldIgnoreError`:** structurally impossible, as above. The new filter is a pure function in `src/utils/csp-report.utils.ts` with 32 unit tests; the route is a thin transport over it.
- **`sentryCspReportUri()` moved rather than duplicated** — out of `next.config.js` (CommonJS) into the collector as `sentryCspIngestUrl(dsn)`, so the DSN→ingest-URL derivation still lives in exactly one place. `next.config.js` now just points at a static same-origin path.
- **Alternative considered and rejected:** a dedicated Sentry project for CSP reports. Smaller diff, but it only *moves* the 70k events (still billed, still needing an out-of-repo project + env var in three environments) instead of eliminating them.
- **`www.google.<ccTLD>` long tail (~50 events/day across 45 ccTLDs)** is left alone: CSP host-sources allow subdomain wildcards but **not** TLD wildcards, so it is literally inexpressible. Analytics-only, no functional risk. De-dup reduces it to ~45 one-off events.

## Follow-ups (not in this PR — pre-existing, out of blast radius)

- `/dev/kyc-flows` loads Mermaid from `cdn.jsdelivr.net`, and `/dev/` routes are reachable in prod. Better fixed by dropping the CDN or blocking `/dev/` in prod than by weakening `script-src`.
- Allow-list entries that appear unused: `dolarapi.com` (only reached from `'use server'` code), `rpc.ankr.com` (every Ankr URL is commented out), `www.google.com` (only `window.open` navigation; reCAPTCHA isn't wired).
- `NEXT_PUBLIC_ONESIGNAL_WEBHOOK` is blank in `.env.example` and fetched from the service worker — its deployed origin couldn't be determined from the repo. If it points anywhere other than `api.peanut.me` it needs an entry. No violation has been reported for it.

## QA

- `npx jest src/utils/__tests__/csp-report.utils.test.ts` — 35/35 pass, covering both wire formats (`application/csp-report` and the Reporting-API `reports+json` batch), the group key, malformed payloads, and DSN parsing.
- Rendered the actual header out of `next.config.js` and diffed the directives — `report-uri /api/csp-report`, `report-to csp-endpoint`, `Reporting-Endpoints: csp-endpoint="/api/csp-report"`, and the new `wss:` / `frame-src` entries all present.
- Full suite: 2,130 pass. Two suites fail to *load* locally on missing `@capacitor/*` packages (declared in `package.json`, absent from this machine's shared `node_modules`) — same pre-existing cause as the 10 local typecheck errors, none in changed files. CI installs them.

**Post-deploy check (needed — a green CI cannot prove this).** Sentry's Relay returns **200 before it parses the body** and discards anything it can't read as an `Invalid` outcome, so a broken forward would look identical to a working one from our side. After deploy, confirm a CSP event actually lands in the `peanut-ui` project (and that `wss://api.peanut.me` stops appearing). That is the only real proof the pipeline works end to end.

**Screenshots: N/A** (no UI change — HTTP headers and a report collector).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a same-origin endpoint for collecting Content Security Policy violation reports.
  * Normalized, filtered, de-duplicated, sampled, and safely forwarded CSP events for monitoring.
  * Improved CSP configuration to report to a fixed collector and expanded WebSocket scheme coverage.

* **Bug Fixes**
  * Reduced noise from browser/extension-origin reports while preserving meaningful CSP keyword signals.

* **Tests**
  * Added comprehensive test coverage for CSP report parsing, ignore rules, grouping behavior, and forwarding URL construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->