### PR TITLE
fix(qr-scanner): stop clipboard paste-prompt racing the camera; platform-gate the copied-address chip

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		4D22ABE92AF431CB00220026 /* CapApp-SPM in Frameworks */ = {isa = PBXBuildFile; productRef = 4D22ABE82AF431CB00220026 /* CapApp-SPM */; };
 		50379B232058CBB4000EE86E /* capacitor.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 50379B222058CBB4000EE86E /* capacitor.config.json */; };
 		504EC3081FED79650016851F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3071FED79650016851F /* AppDelegate.swift */; };
+		7A1C0DE7C11B0A4D2E5F3901 /* AppViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1C0DE7C11B0A4D2E5F3902 /* AppViewController.swift */; };
+		7A1C0DE7C11B0A4D2E5F3903 /* ClipboardDetectPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1C0DE7C11B0A4D2E5F3904 /* ClipboardDetectPlugin.swift */; };
 		504EC30D1FED79650016851F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30B1FED79650016851F /* Main.storyboard */; };
 		504EC30F1FED79650016851F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
@@ -22,6 +24,8 @@
 		50379B222058CBB4000EE86E /* capacitor.config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = capacitor.config.json; sourceTree = "<group>"; };
 		504EC3041FED79650016851F /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		504EC3071FED79650016851F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		7A1C0DE7C11B0A4D2E5F3902 /* AppViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppViewController.swift; sourceTree = "<group>"; };
+		7A1C0DE7C11B0A4D2E5F3904 /* ClipboardDetectPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardDetectPlugin.swift; sourceTree = "<group>"; };
 		504EC30C1FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		504EC30E1FED79650016851F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		504EC3111FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -64,6 +68,8 @@
 			children = (
 				50379B222058CBB4000EE86E /* capacitor.config.json */,
 				504EC3071FED79650016851F /* AppDelegate.swift */,
+				7A1C0DE7C11B0A4D2E5F3902 /* AppViewController.swift */,
+				7A1C0DE7C11B0A4D2E5F3904 /* ClipboardDetectPlugin.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -156,6 +162,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
+				7A1C0DE7C11B0A4D2E5F3901 /* AppViewController.swift in Sources */,
+				7A1C0DE7C11B0A4D2E5F3903 /* ClipboardDetectPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/App/App/AppViewController.swift
+++ b/ios/App/App/AppViewController.swift
@@ -1,0 +1,9 @@
+import Capacitor
+import UIKit
+
+// App-local plugins aren't auto-discovered; register them once the bridge is up.
+class AppViewController: CAPBridgeViewController {
+    override open func capacitorDidLoad() {
+        bridge?.registerPluginInstance(ClipboardDetectPlugin())
+    }
+}

--- a/ios/App/App/Base.lproj/Main.storyboard
+++ b/ios/App/App/Base.lproj/Main.storyboard
@@ -11,7 +11,7 @@
         <!--Bridge View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="CAPBridgeViewController" customModule="Capacitor" sceneMemberID="viewController"/>
+                <viewController id="BYZ-38-t0r" customClass="AppViewController" customModule="App" customModuleProvider="target" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
         </scene>

--- a/ios/App/App/ClipboardDetectPlugin.swift
+++ b/ios/App/App/ClipboardDetectPlugin.swift
@@ -1,0 +1,22 @@
+import Capacitor
+import UIKit
+
+/*
+ * Prompt-free clipboard presence check. UIPasteboard.hasStrings is metadata
+ * only, so it never raises the iOS 16+ "Allow Paste" alert — unlike a real
+ * Clipboard.read(), whose un-gestured use raced (and blocked) the camera
+ * permission dialog in the QR scanner. Content is still read exclusively via
+ * @capacitor/clipboard on a user gesture.
+ */
+@objc(ClipboardDetectPlugin)
+public class ClipboardDetectPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "ClipboardDetectPlugin"
+    public let jsName = "ClipboardDetect"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "hasStrings", returnType: CAPPluginReturnPromise)
+    ]
+
+    @objc func hasStrings(_ call: CAPPluginCall) {
+        call.resolve(["value": UIPasteboard.general.hasStrings])
+    }
+}

--- a/src/components/Global/QRScanner/__tests__/index.test.tsx
+++ b/src/components/Global/QRScanner/__tests__/index.test.tsx
@@ -1,0 +1,133 @@
+/** @jest-environment jsdom */
+/**
+ * QRScanner clipboard shortcut — platform split (PEANUT-UI-PYW regression pin).
+ *
+ * The load-bearing claim: `Clipboard.read()` must NEVER run at scanner open
+ * off Android-native. An un-gestured read raises the iOS "Allow Paste" alert,
+ * which raced (and blocked) the camera permission dialog. iOS native only
+ * probes prompt-free `hasStrings` and reads on the chip TAP; web/PWA does
+ * neither.
+ */
+import React from 'react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { Clipboard } from '@capacitor/clipboard'
+import { clipboardHasStrings } from '@/utils/clipboard-detect'
+import { isAndroidNative } from '@/utils/capacitor'
+
+const mockToastError = jest.fn()
+
+jest.mock('@capacitor/clipboard', () => ({ Clipboard: { read: jest.fn() } }))
+jest.mock('@/utils/clipboard-detect', () => ({ clipboardHasStrings: jest.fn() }))
+jest.mock('@/utils/capacitor', () => ({ isAndroidNative: jest.fn() }))
+// general.utils transitively imports env-requiring constants; passthrough keeps
+// the chip text assertable as the full address.
+jest.mock('@/utils/general.utils', () => ({ printableAddress: (a: string) => a }))
+jest.mock('@/components/0_Bruddle/Toast', () => ({
+    useToast: () => ({ error: mockToastError, info: jest.fn() }),
+}))
+jest.mock('next/image', () => ({
+    __esModule: true,
+    default: (props: { alt?: string }) => <img alt={props.alt ?? ''} />,
+}))
+jest.mock('../CameraPermissionModal', () => ({ __esModule: true, default: () => null }))
+jest.mock('../useQRScanner', () => ({
+    useQRScanner: () => ({
+        error: null,
+        isPermissionDenied: false,
+        isScanning: true,
+        isCameraReady: true,
+        videoRef: { current: null },
+        close: jest.fn(),
+        toggleCamera: jest.fn(),
+        retryCamera: jest.fn(),
+    }),
+}))
+
+import QRScanner from '../index'
+
+const mockRead = Clipboard.read as jest.MockedFunction<typeof Clipboard.read>
+const mockHasStrings = clipboardHasStrings as jest.MockedFunction<typeof clipboardHasStrings>
+const mockIsAndroidNative = isAndroidNative as jest.MockedFunction<typeof isAndroidNative>
+
+// all-lowercase: viem isAddress enforces checksum on mixed-case forms
+const ADDRESS = '0xab5801a7d398351b8be11c439e05c5b3259aec9b'
+const CHIP_LABEL = 'Use copied address'
+
+const renderScanner = (onScan = jest.fn().mockResolvedValue({ success: true })) => {
+    render(<QRScanner onScan={onScan} />)
+    return onScan
+}
+
+beforeEach(() => {
+    jest.clearAllMocks()
+})
+
+it('web/PWA: never reads the clipboard at open and shows no chip', async () => {
+    mockIsAndroidNative.mockReturnValue(false)
+    mockHasStrings.mockResolvedValue(false)
+
+    renderScanner()
+
+    await waitFor(() => expect(mockHasStrings).toHaveBeenCalledTimes(1))
+    expect(mockRead).not.toHaveBeenCalled()
+    expect(screen.queryByText(CHIP_LABEL)).toBeNull()
+})
+
+it('iOS native: probes hasStrings only at open; the read happens on chip tap', async () => {
+    mockIsAndroidNative.mockReturnValue(false)
+    mockHasStrings.mockResolvedValue(true)
+    mockRead.mockResolvedValue({ value: ADDRESS, type: 'text/plain' })
+
+    const onScan = renderScanner()
+
+    const chip = await screen.findByText(CHIP_LABEL)
+    expect(mockRead).not.toHaveBeenCalled() // the PYW pin: no read before the tap
+
+    await act(async () => {
+        fireEvent.click(chip)
+    })
+    expect(mockRead).toHaveBeenCalledTimes(1)
+    expect(onScan).toHaveBeenCalledWith(ADDRESS)
+})
+
+it('Android native: keeps the read-at-open address preview', async () => {
+    mockIsAndroidNative.mockReturnValue(true)
+    mockRead.mockResolvedValue({ value: ADDRESS, type: 'text/plain' })
+
+    renderScanner()
+
+    expect(await screen.findByText(ADDRESS)).toBeTruthy()
+    expect(mockRead).toHaveBeenCalledTimes(1)
+    expect(mockHasStrings).not.toHaveBeenCalled()
+})
+
+it('chip tap: onScan failure is not misreported as a clipboard error', async () => {
+    mockIsAndroidNative.mockReturnValue(false)
+    mockHasStrings.mockResolvedValue(true)
+    mockRead.mockResolvedValue({ value: ADDRESS, type: 'text/plain' })
+
+    const onScan = jest.fn().mockRejectedValue(new Error('routing exploded'))
+    renderScanner(onScan)
+
+    const chip = await screen.findByText(CHIP_LABEL)
+    await act(async () => {
+        fireEvent.click(chip)
+    })
+    expect(mockToastError).toHaveBeenCalledWith('Error processing QR code')
+    expect(mockToastError).not.toHaveBeenCalledWith('Could not access clipboard')
+})
+
+it('chip tap: empty clipboard maps to the same copy as "Click to paste"', async () => {
+    mockIsAndroidNative.mockReturnValue(false)
+    mockHasStrings.mockResolvedValue(true)
+    mockRead.mockRejectedValue(new Error('There is no data on the clipboard'))
+
+    renderScanner()
+
+    const chip = await screen.findByText(CHIP_LABEL)
+    await act(async () => {
+        fireEvent.click(chip)
+    })
+    expect(mockToastError).toHaveBeenCalledWith('Clipboard is empty')
+    await waitFor(() => expect(screen.queryByText(CHIP_LABEL)).toBeNull())
+})

--- a/src/components/Global/QRScanner/__tests__/index.test.tsx
+++ b/src/components/Global/QRScanner/__tests__/index.test.tsx
@@ -117,6 +117,38 @@ it('chip tap: onScan failure is not misreported as a clipboard error', async () 
     expect(mockToastError).not.toHaveBeenCalledWith('Could not access clipboard')
 })
 
+it('"Click to paste": onScan failure is not misreported as a clipboard error', async () => {
+    mockIsAndroidNative.mockReturnValue(false)
+    mockHasStrings.mockResolvedValue(false)
+    mockRead.mockResolvedValue({ value: 'some text', type: 'text/plain' })
+
+    const onScan = jest.fn().mockRejectedValue(new Error('routing exploded'))
+    renderScanner(onScan)
+
+    const paste = await screen.findByText('Click to paste')
+    await act(async () => {
+        fireEvent.click(paste)
+    })
+    expect(onScan).toHaveBeenCalledWith('some text')
+    expect(mockToastError).toHaveBeenCalledWith('Error processing QR code')
+    expect(mockToastError).not.toHaveBeenCalledWith('Could not access clipboard')
+})
+
+it('Android chip: onScan failure surfaces a processing error instead of rejecting unhandled', async () => {
+    mockIsAndroidNative.mockReturnValue(true)
+    mockRead.mockResolvedValue({ value: ADDRESS, type: 'text/plain' })
+
+    const onScan = jest.fn().mockRejectedValue(new Error('routing exploded'))
+    renderScanner(onScan)
+
+    const chip = await screen.findByText(ADDRESS)
+    await act(async () => {
+        fireEvent.click(chip)
+    })
+    expect(onScan).toHaveBeenCalledWith(ADDRESS)
+    expect(mockToastError).toHaveBeenCalledWith('Error processing QR code')
+})
+
 it('chip tap: empty clipboard maps to the same copy as "Click to paste"', async () => {
     mockIsAndroidNative.mockReturnValue(false)
     mockHasStrings.mockResolvedValue(true)

--- a/src/components/Global/QRScanner/index.tsx
+++ b/src/components/Global/QRScanner/index.tsx
@@ -210,18 +210,32 @@ export default function QRScanner({ onScan, onClose, isOpen = true }: QRScannerP
     }, [isScanning])
 
     const handleUsePasteChip = async () => {
+        let address: string | null
         try {
             const { value } = await Clipboard.read()
-            const address = extractPaymentValue((value ?? '').trim(), 'evmAddress')
-            if (address) {
-                await onScan(address)
-            } else {
-                setShowPasteChip(false)
-                toast.error('Copied text is not a wallet address')
-            }
-        } catch {
+            address = extractPaymentValue((value ?? '').trim(), 'evmAddress')
+        } catch (err) {
             setShowPasteChip(false)
-            toast.error('Could not access clipboard')
+            // Android rejects with "There is no data on the clipboard" instead of
+            // resolving with an empty value — same mapping as handlePaste.
+            const message = err instanceof Error ? err.message : String(err)
+            toast.error(
+                message.toLowerCase().includes('no data on the clipboard')
+                    ? 'Clipboard is empty'
+                    : 'Could not access clipboard'
+            )
+            return
+        }
+        if (!address) {
+            setShowPasteChip(false)
+            toast.error('Copied text is not a wallet address')
+            return
+        }
+        try {
+            await onScan(address)
+        } catch (err) {
+            console.error('Error processing QR code:', err)
+            toast.error('Error processing QR code')
         }
     }
 

--- a/src/components/Global/QRScanner/index.tsx
+++ b/src/components/Global/QRScanner/index.tsx
@@ -209,51 +209,17 @@ export default function QRScanner({ onScan, onClose, isOpen = true }: QRScannerP
         }
     }, [isScanning])
 
-    const handleUsePasteChip = async () => {
-        let address: string | null
+    // Capacitor Clipboard reads through the native bridge on device (the
+    // WebView's navigator.clipboard.readText is unreliable/blocked in the
+    // Android WebView); its web shim falls back to navigator.clipboard.
+    // Returns trimmed text, or null after toasting the read failure. Android
+    // rejects with "There is no data on the clipboard" instead of resolving
+    // with an empty value.
+    const readClipboardText = async (): Promise<string | null> => {
         try {
             const { value } = await Clipboard.read()
-            address = extractPaymentValue((value ?? '').trim(), 'evmAddress')
+            return (value ?? '').trim()
         } catch (err) {
-            setShowPasteChip(false)
-            // Android rejects with "There is no data on the clipboard" instead of
-            // resolving with an empty value — same mapping as handlePaste.
-            const message = err instanceof Error ? err.message : String(err)
-            toast.error(
-                message.toLowerCase().includes('no data on the clipboard')
-                    ? 'Clipboard is empty'
-                    : 'Could not access clipboard'
-            )
-            return
-        }
-        if (!address) {
-            setShowPasteChip(false)
-            toast.error('Copied text is not a wallet address')
-            return
-        }
-        try {
-            await onScan(address)
-        } catch (err) {
-            console.error('Error processing QR code:', err)
-            toast.error('Error processing QR code')
-        }
-    }
-
-    const handlePaste = async () => {
-        try {
-            // Capacitor Clipboard reads through the native bridge on device (the
-            // WebView's navigator.clipboard.readText is unreliable/blocked in the
-            // Android WebView); its web shim falls back to navigator.clipboard.
-            const { value } = await Clipboard.read()
-            const text = (value ?? '').trim()
-            if (text) {
-                await onScan(text)
-            } else {
-                toast.error('Clipboard is empty')
-            }
-        } catch (err) {
-            // Android rejects with "There is no data on the clipboard" instead of
-            // resolving with an empty value
             const message = err instanceof Error ? err.message : String(err)
             if (message.toLowerCase().includes('no data on the clipboard')) {
                 toast.error('Clipboard is empty')
@@ -261,7 +227,45 @@ export default function QRScanner({ onScan, onClose, isOpen = true }: QRScannerP
                 console.error('Failed to read clipboard:', err)
                 toast.error('Could not access clipboard')
             }
+            return null
         }
+    }
+
+    // Every tap path funnels onScan through this so a payment/routing failure
+    // is reported as a processing error, never as a clipboard problem.
+    const scanValue = async (data: string) => {
+        try {
+            await onScan(data)
+        } catch (err) {
+            console.error('Error processing QR code:', err)
+            toast.error('Error processing QR code')
+        }
+    }
+
+    const handleUsePasteChip = async () => {
+        const text = await readClipboardText()
+        if (!text) {
+            setShowPasteChip(false)
+            if (text === '') toast.error('Clipboard is empty')
+            return
+        }
+        const address = extractPaymentValue(text, 'evmAddress')
+        if (!address) {
+            setShowPasteChip(false)
+            toast.error('Copied text is not a wallet address')
+            return
+        }
+        await scanValue(address)
+    }
+
+    const handlePaste = async () => {
+        const text = await readClipboardText()
+        if (text === null) return
+        if (!text) {
+            toast.error('Clipboard is empty')
+            return
+        }
+        await scanValue(text)
     }
 
     if (!isScanning) return null
@@ -293,7 +297,7 @@ export default function QRScanner({ onScan, onClose, isOpen = true }: QRScannerP
                     <ScanRegionOverlay
                         onPaste={handlePaste}
                         detectedAddress={detectedAddress}
-                        onUseDetected={() => onScan(detectedAddress!)}
+                        onUseDetected={() => scanValue(detectedAddress!)}
                         showPasteChip={showPasteChip}
                         onUsePasteChip={handleUsePasteChip}
                     />

--- a/src/components/Global/QRScanner/index.tsx
+++ b/src/components/Global/QRScanner/index.tsx
@@ -1,5 +1,4 @@
 import { createPortal } from 'react-dom'
-import { useEffect, useState } from 'react'
 import { Button } from '@/components/0_Bruddle/Button'
 import { MERCADO_PAGO, PIX } from '@/assets/payment-apps'
 import { PEANUTMAN } from '@/assets/mascot'
@@ -10,8 +9,6 @@ import { useQRScanner, type QRScanHandler } from './useQRScanner'
 import { useToast } from '@/components/0_Bruddle/Toast'
 import CameraPermissionModal from './CameraPermissionModal'
 import { Clipboard } from '@capacitor/clipboard'
-import { extractPaymentValue } from '@/utils/clipboard-extract.utils'
-import { printableAddress } from '@/utils/general.utils'
 
 // ============================================================================
 // Configuration
@@ -92,15 +89,7 @@ function ScannerControls({ onClose, onToggleCamera }: { onClose: () => void; onT
     )
 }
 
-function ScanRegionOverlay({
-    onPaste,
-    detectedAddress,
-    onUseDetected,
-}: {
-    onPaste: () => void
-    detectedAddress: string | null
-    onUseDetected: () => void
-}) {
+function ScanRegionOverlay({ onPaste }: { onPaste: () => void }) {
     return (
         <div className="fixed left-1/2 flex h-64 w-64 -translate-x-1/2 translate-y-1/2 justify-center">
             {/* Darkened background with transparent scan region */}
@@ -125,15 +114,6 @@ function ScanRegionOverlay({
                     <Icon name="paste" fill="white" height={16} width={16} />
                     <span className="text-sm">Click to paste</span>
                 </button>
-                {detectedAddress && (
-                    <button
-                        onClick={onUseDetected}
-                        className="mx-auto mt-3 flex items-center gap-1.5 rounded-full border border-white/40 px-3 py-1.5 text-white"
-                    >
-                        <Icon name="wallet" fill="white" height={16} width={16} />
-                        <span className="text-sm font-semibold">{printableAddress(detectedAddress)}</span>
-                    </button>
-                )}
             </div>
         </div>
     )
@@ -158,28 +138,6 @@ export default function QRScanner({ onScan, onClose, isOpen = true }: QRScannerP
     const { error, isPermissionDenied, isScanning, isCameraReady, videoRef, close, toggleCamera, retryCamera } =
         useQRScanner(onScan, onClose, isOpen)
     const toast = useToast()
-    const [detectedAddress, setDetectedAddress] = useState<string | null>(null)
-
-    // When the scanner opens, surface an EVM address already on the clipboard so the
-    // user can pay it in one tap without scanning. (Reading here trips Android's
-    // "pasted from clipboard" toast — the tradeoff for the shortcut.)
-    useEffect(() => {
-        if (!isScanning) {
-            setDetectedAddress(null)
-            return
-        }
-        let cancelled = false
-        Clipboard.read()
-            .then(({ value }) => {
-                if (!cancelled) setDetectedAddress(extractPaymentValue((value ?? '').trim(), 'evmAddress'))
-            })
-            .catch(() => {
-                if (!cancelled) setDetectedAddress(null)
-            })
-        return () => {
-            cancelled = true
-        }
-    }, [isScanning])
 
     const handlePaste = async () => {
         try {
@@ -232,11 +190,7 @@ export default function QRScanner({ onScan, onClose, isOpen = true }: QRScannerP
                         </div>
                     )}
                     <ScannerControls onClose={close} onToggleCamera={toggleCamera} />
-                    <ScanRegionOverlay
-                        onPaste={handlePaste}
-                        detectedAddress={detectedAddress}
-                        onUseDetected={() => onScan(detectedAddress!)}
-                    />
+                    <ScanRegionOverlay onPaste={handlePaste} />
                 </>
             )}
         </div>,

--- a/src/components/Global/QRScanner/index.tsx
+++ b/src/components/Global/QRScanner/index.tsx
@@ -1,4 +1,5 @@
 import { createPortal } from 'react-dom'
+import { useEffect, useState } from 'react'
 import { Button } from '@/components/0_Bruddle/Button'
 import { MERCADO_PAGO, PIX } from '@/assets/payment-apps'
 import { PEANUTMAN } from '@/assets/mascot'
@@ -9,6 +10,10 @@ import { useQRScanner, type QRScanHandler } from './useQRScanner'
 import { useToast } from '@/components/0_Bruddle/Toast'
 import CameraPermissionModal from './CameraPermissionModal'
 import { Clipboard } from '@capacitor/clipboard'
+import { clipboardHasStrings } from '@/utils/clipboard-detect'
+import { extractPaymentValue } from '@/utils/clipboard-extract.utils'
+import { isAndroidNative } from '@/utils/capacitor'
+import { printableAddress } from '@/utils/general.utils'
 
 // ============================================================================
 // Configuration
@@ -89,7 +94,19 @@ function ScannerControls({ onClose, onToggleCamera }: { onClose: () => void; onT
     )
 }
 
-function ScanRegionOverlay({ onPaste }: { onPaste: () => void }) {
+function ScanRegionOverlay({
+    onPaste,
+    detectedAddress,
+    onUseDetected,
+    showPasteChip,
+    onUsePasteChip,
+}: {
+    onPaste: () => void
+    detectedAddress: string | null
+    onUseDetected: () => void
+    showPasteChip: boolean
+    onUsePasteChip: () => void
+}) {
     return (
         <div className="fixed left-1/2 flex h-64 w-64 -translate-x-1/2 translate-y-1/2 justify-center">
             {/* Darkened background with transparent scan region */}
@@ -114,6 +131,23 @@ function ScanRegionOverlay({ onPaste }: { onPaste: () => void }) {
                     <Icon name="paste" fill="white" height={16} width={16} />
                     <span className="text-sm">Click to paste</span>
                 </button>
+                {detectedAddress ? (
+                    <button
+                        onClick={onUseDetected}
+                        className="mx-auto mt-3 flex items-center gap-1.5 rounded-full border border-white/40 px-3 py-1.5 text-white"
+                    >
+                        <Icon name="wallet" fill="white" height={16} width={16} />
+                        <span className="text-sm font-semibold">{printableAddress(detectedAddress)}</span>
+                    </button>
+                ) : showPasteChip ? (
+                    <button
+                        onClick={onUsePasteChip}
+                        className="mx-auto mt-3 flex items-center gap-1.5 rounded-full border border-white/40 px-3 py-1.5 text-white"
+                    >
+                        <Icon name="wallet" fill="white" height={16} width={16} />
+                        <span className="text-sm font-semibold">Use copied address</span>
+                    </button>
+                ) : null}
             </div>
         </div>
     )
@@ -138,6 +172,58 @@ export default function QRScanner({ onScan, onClose, isOpen = true }: QRScannerP
     const { error, isPermissionDenied, isScanning, isCameraReady, videoRef, close, toggleCamera, retryCamera } =
         useQRScanner(onScan, onClose, isOpen)
     const toast = useToast()
+    const [detectedAddress, setDetectedAddress] = useState<string | null>(null)
+    const [showPasteChip, setShowPasteChip] = useState(false)
+
+    /*
+     * Platform-split clipboard shortcut. Android native: read at open and
+     * preview the copied EVM address — the read only trips the system paste
+     * toast, nothing blocking. iOS native: an un-gestured Clipboard.read()
+     * raises the "Allow Paste" alert, which raced the camera permission dialog
+     * and blocked it (PEANUT-UI-PYW) — so only a prompt-free hasStrings check
+     * runs here, and the actual read happens on the chip tap (a real gesture).
+     * Web/PWA: no pre-read at all; "Click to paste" remains.
+     */
+    useEffect(() => {
+        if (!isScanning) {
+            setDetectedAddress(null)
+            setShowPasteChip(false)
+            return
+        }
+        let cancelled = false
+        if (isAndroidNative()) {
+            Clipboard.read()
+                .then(({ value }) => {
+                    if (!cancelled) setDetectedAddress(extractPaymentValue((value ?? '').trim(), 'evmAddress'))
+                })
+                .catch(() => {
+                    if (!cancelled) setDetectedAddress(null)
+                })
+        } else {
+            clipboardHasStrings().then((hasStrings) => {
+                if (!cancelled) setShowPasteChip(hasStrings)
+            })
+        }
+        return () => {
+            cancelled = true
+        }
+    }, [isScanning])
+
+    const handleUsePasteChip = async () => {
+        try {
+            const { value } = await Clipboard.read()
+            const address = extractPaymentValue((value ?? '').trim(), 'evmAddress')
+            if (address) {
+                await onScan(address)
+            } else {
+                setShowPasteChip(false)
+                toast.error('Copied text is not a wallet address')
+            }
+        } catch {
+            setShowPasteChip(false)
+            toast.error('Could not access clipboard')
+        }
+    }
 
     const handlePaste = async () => {
         try {
@@ -190,7 +276,13 @@ export default function QRScanner({ onScan, onClose, isOpen = true }: QRScannerP
                         </div>
                     )}
                     <ScannerControls onClose={close} onToggleCamera={toggleCamera} />
-                    <ScanRegionOverlay onPaste={handlePaste} />
+                    <ScanRegionOverlay
+                        onPaste={handlePaste}
+                        detectedAddress={detectedAddress}
+                        onUseDetected={() => onScan(detectedAddress!)}
+                        showPasteChip={showPasteChip}
+                        onUsePasteChip={handleUsePasteChip}
+                    />
                 </>
             )}
         </div>,

--- a/src/utils/__tests__/clipboard-detect.test.ts
+++ b/src/utils/__tests__/clipboard-detect.test.ts
@@ -1,0 +1,44 @@
+// clipboardHasStrings gates the iOS QR-scanner paste chip: prompt-free on iOS
+// native, and silently false everywhere the plugin can't answer (web, Android,
+// older binaries running OTA'd JS).
+import { clipboardHasStrings } from '../clipboard-detect'
+import { isIOSNative } from '../capacitor'
+
+const hasStrings = jest.fn()
+
+jest.mock('@capacitor/core', () => ({
+    registerPlugin: jest.fn(() => ({ hasStrings: () => hasStrings() })),
+}))
+
+jest.mock('../capacitor', () => ({
+    isIOSNative: jest.fn(() => false),
+}))
+
+const mockIsIOSNative = isIOSNative as jest.MockedFunction<typeof isIOSNative>
+
+describe('clipboardHasStrings', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('returns false off iOS without touching the plugin', async () => {
+        mockIsIOSNative.mockReturnValue(false)
+        await expect(clipboardHasStrings()).resolves.toBe(false)
+        expect(hasStrings).not.toHaveBeenCalled()
+    })
+
+    it('returns the native answer on iOS', async () => {
+        mockIsIOSNative.mockReturnValue(true)
+        hasStrings.mockResolvedValue({ value: true })
+        await expect(clipboardHasStrings()).resolves.toBe(true)
+
+        hasStrings.mockResolvedValue({ value: false })
+        await expect(clipboardHasStrings()).resolves.toBe(false)
+    })
+
+    it('returns false when the plugin is unavailable (older binary)', async () => {
+        mockIsIOSNative.mockReturnValue(true)
+        hasStrings.mockRejectedValue(new Error('"ClipboardDetect" plugin is not implemented on ios'))
+        await expect(clipboardHasStrings()).resolves.toBe(false)
+    })
+})

--- a/src/utils/clipboard-detect.ts
+++ b/src/utils/clipboard-detect.ts
@@ -1,0 +1,27 @@
+import { registerPlugin } from '@capacitor/core'
+import { isIOSNative } from './capacitor'
+
+interface ClipboardDetectPlugin {
+    hasStrings(): Promise<{ value: boolean }>
+}
+
+// App-local iOS plugin (ios/App/App/ClipboardDetectPlugin.swift); no web/Android
+// implementation exists — callers must treat "unavailable" as false.
+const ClipboardDetect = registerPlugin<ClipboardDetectPlugin>('ClipboardDetect')
+
+/**
+ * iOS-native only: prompt-free "is there text on the clipboard?" check via
+ * UIPasteboard.hasStrings — metadata only, so it never raises the iOS 16+
+ * "Allow Paste" alert the way an un-gestured Clipboard.read() does. Returns
+ * false on every other platform and on older binaries without the plugin
+ * (OTA'd JS), so the caller simply doesn't offer the paste shortcut there.
+ */
+export async function clipboardHasStrings(): Promise<boolean> {
+    if (!isIOSNative()) return false
+    try {
+        const { value } = await ClipboardDetect.hasStrings()
+        return value
+    } catch {
+        return false
+    }
+}


### PR DESCRIPTION
## Summary

**The bug (TASK-20906):** since 32454bb83 (2026-07-02) the QR scanner read the clipboard the moment it opened — no user gesture — to offer a copied EVM address as a one-tap target. On iOS that raises the system "Allow Paste" prompt at open: it lands before `getUserMedia` (camera start deliberately sleeps 200ms on iOS), so users got a paste prompt instead of a camera, and the camera only appeared on the second attempt. On the iOS web/PWA path the blocked permission dialog also let the 5s watchdog fire a false `NotAllowedError` ("Camera start timed out").

**This PR (three commits):**

1. `cfd9797cb` — byte-exact revert of the pre-read (@abalinda). Kills the prompt-at-open on every surface; the explicit "Click to paste" button (gesture-driven) is untouched.
2. `9c78dc2bd` — platform-gated reintroduction of the shortcut (@innolope-dev, folded in from #2521): **Android native** keeps the read-at-open + address-preview chip exactly as before (only side effect is the system paste toast). **iOS native** probes `UIPasteboard.hasStrings` via a new app-local `ClipboardDetect` plugin — metadata-only, provably prompt-free — and shows a generic "Use copied address" chip whose real `Clipboard.read()` runs on tap (user gesture, camera already live). **Web/PWA** has no pre-read at all. Older iOS binaries running OTA'd JS resolve `hasStrings` → false: no chip, no error.
3. `3af6b6dc3` — review fixes: `onScan` failures on the chip path no longer misreport as "Could not access clipboard"; empty-clipboard copy unified with "Click to paste"; new component test pinning the platform split (read never fires at open off Android-native).

**Fail-safe property:** if the native plugin is missing, broken, or unregistered, `hasStrings` rejects → `false` → no chip, no error, camera unaffected. The Swift code gates only whether the *feature appears*, never whether the *bugfix works*.

## Impact

- Fixes the reported symptom directly (2 users confirmed via support; Crisp link in TASK-20906). The pre-read shipped in native binaries since 07-02 and prod web since 07-16 (#2407).
- **Sentry attribution, corrected during adversarial review:** the PEANUT-UI-PYW spike (~4.3→17/day from late June) is **not** this bug — release ancestry shows the spike ran on prod web builds that did not yet contain the pre-read. It tracks the QR-perk campaign wave: first-time users answering the real camera permission prompt slower than the pre-existing 5s watchdog. This PR removes the clipboard-caused share of current volume (post-07-16 residual) and the iOS prompt-at-open; the watchdog baseline needs its own fix (below).

## Follow-ups (separate PRs, not bundled)

1. **Web camera-start watchdog false-positive** — `useQRScanner.ts:270-278` races `scanner.start()` against 5s while the user may still be answering the real permission prompt; already fixed on the native path only (`useQRScanner.ts:260-265`). Dominant cause of PEANUT-UI-PYW.
2. **`useClipboardSuggestion` gesture-gating** — same gesture-less `Clipboard.read()` pattern (1s after mount) on claim/withdraw/request screens; still fires iOS paste prompts there.

## Risks / release notes

- **iOS chip activates only with the next iOS binary release** (new native plugin). Until then iOS behaves as pure-revert: camera immediately, no chip — which is the bugfix.
- ⚠️ **CI cannot compile Swift.** Before the next iOS binary release, one Xcode/device pass must confirm: project compiles with the hand-edited pbxproj, storyboard boots `AppViewController` (a bad customClass would crash at launch), chip appears with no Allow Paste alert at open, tap-allow pays / tap-deny leaves the camera live, and `npx cap sync ios` is run before archiving (the committed `CapApp-SPM/Package.swift` is stale — release CI syncs automatically, a raw local Xcode build does not).
- Android behavior is byte-equivalent to the pre-revert feature; web loses nothing (never had the chip working — only the prompt bug).
- No cross-repo impact, no API change.

## QA

- `pnpm typecheck` 0 errors · 2151 tests green (5 new: platform-split pin + error-attribution + copy) · `npm run build` green (Node 22) · pbxproj passes plist lint.
- 4-agent adversarial pass: revert verified byte-exact and regression-free; rework verified across the 5-surface matrix (no system UI can fire at open anywhere; OTA fallback confirmed against @capacitor/core 8.2.0 internals; plugin registration timing correct — registered in `capacitorDidLoad` before any JS, including Capgo-swapped bundles, loads).
- Post-deploy expectation: paste-prompt-at-open reports stop; PEANUT-UI-PYW drops partially, not to baseline (watchdog follow-up owns the rest).

Screenshots: ⚠️ NONE — the fix is OS permission-prompt behavior (not capturable headless); visual delta is the removed/regated chip, fully visible in the diff. Device screenshots belong to the pre-binary-release checklist above.
