### PR TITLE
feat(security): add security.txt and a footer link to the disclosure page

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,8 @@
+# Peanut — security contact
+# https://peanut.me/en/help/security-disclosure
+
+Contact: https://peanut.me/en/help/security-disclosure
+Policy: https://peanut.me/en/help/security-disclosure
+Expires: 2027-07-27T00:00:00.000Z
+Preferred-Languages: en, es, pt
+Canonical: https://peanut.me/.well-known/security.txt

--- a/src/components/LandingPage/Footer.tsx
+++ b/src/components/LandingPage/Footer.tsx
@@ -78,6 +78,9 @@ const Footer = ({ showSiteDirectory = true, locale = 'en' }: { showSiteDirectory
                         <Link className="text-xl font-bold text-white" href={`/${locale}/privacy`}>
                             Privacy
                         </Link>
+                        <Link className="text-xl font-bold text-white" href={`/${locale}/help/security-disclosure`}>
+                            Security
+                        </Link>
                         <a
                             className="text-xl font-bold text-white"
                             href="https://peanutprotocol.notion.site/Career-b351de56d92e405e962f0027b3a60f52"


### PR DESCRIPTION
Makes Peanut's security disclosure channel discoverable. Targets `main` (production) so the surfaces go live with the article rather than waiting on a release.

### Why

Peanut communicated a bug bounty in exactly two public places, and both were broken:

| Surface | Claimed | Reality |
|---|---|---|
| `peanutprotocol/.github` org profile | "open bug bounty, paid out more than $25k to date" | Linked a Notion page that is no longer published |
| `peanut-contracts` README | "bug bounty program and a history of payouts" | Linked `docs.peanut.to`, which refuses connections |

Both advertised a retired tiered program paying up to $10k per finding. Meanwhile there was no `security.txt`, no `SECURITY.md`, and no footer entry, so a researcher who ignored those pages still had nowhere to go. One did exactly that on 2026-07-07: reported an exposed OpenAPI spec and an unauthenticated endpoint through the support chat and asked where the bounty process was.

### What

- **`public/.well-known/security.txt`** — the file scanners and researchers check first. Points `Contact` and `Policy` at the new help article.
- **Footer "Security" link** — sits next to Terms and Privacy, where people look for it.

Both resolve to `/{locale}/help/security-disclosure`, the new help article (en / es-419 / pt-br) shipped in mono `fb32c83b` and published in #2523. That page owns the scope, out-of-scope list, what to include, and the intake channel, and describes rewards as discretionary — replacing the fixed tiers we no longer honour.

The two README fixes are separate PRs: peanutprotocol/.github#6 and peanutprotocol/peanut-contracts#33.

### Note for the reviewer

`Expires` is set to **2027-07-27**. An expired `security.txt` is treated as invalid by tooling, so this needs renewing before then.

### Verification

- `prettier --check .` clean
- `npm test` — 2098 passed, 0 failed
- `npm run typecheck` — zero errors on the changed file

Two test suites cannot load in a worktree because `@capacitor/clipboard` is declared in `main`'s `package.json` but absent from the `dev`-installed shared `node_modules`; CI installs from `main`'s lockfile, so it resolves there. Unrelated to this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Security link to the website footer for easier access to security disclosure information.
  * Published a security contact and vulnerability disclosure policy through the standard security metadata page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->