### PR TITLE
fix(receipt): shorten crypto destination address so it can't overflow the card

### DIFF
--- a/src/components/Payment/PaymentInfoRow.tsx
+++ b/src/components/Payment/PaymentInfoRow.tsx
@@ -49,8 +49,13 @@ export const PaymentInfoRow = ({
                 <Loading />
             ) : (
                 <div className="flex items-center justify-between">
-                    <div className={twMerge('flex w-fit justify-end text-sm font-bold')}>
-                        <span>{value}</span>
+                    {/* min-w-0 + break-words: a single unbreakable token (wallet
+                        address, tx hash) must wrap inside the card, not stretch
+                        the row to the token's full width and escape the layout.
+                        break-word only activates when a word can't fit, so
+                        normal values render unchanged. */}
+                    <div className={twMerge('flex w-fit min-w-0 justify-end break-words text-sm font-bold')}>
+                        <span className="min-w-0">{value}</span>
                     </div>
                     {allowCopy && typeof value === 'string' && (
                         <CopyToClipboard textToCopy={copyValue ?? value} fill="black" iconSize="4" />

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -39,7 +39,6 @@ import { TransactionDetailsHeaderCard } from './TransactionDetailsHeaderCard'
 import CopyToClipboard from '../Global/CopyToClipboard'
 import CancelSendLinkModal from '../Global/CancelSendLinkModal'
 import { twMerge } from 'tailwind-merge'
-import { isAddress } from 'viem'
 import { getAccountCopyValue, getBankAccountLabel } from './transaction-details.utils'
 import { useModalsContext } from '@/context/ModalsContext'
 import { useRouter } from 'next/navigation'
@@ -418,11 +417,11 @@ export const TransactionDetailsReceipt = ({
                             label={'To'}
                             value={
                                 <div className="flex items-center gap-2">
-                                    <span>
-                                        {isAddress(transaction.userName)
-                                            ? printableAddress(transaction.userName)
-                                            : transaction.userName}
-                                    </span>
+                                    {/* printableAddress shortens Solana/Tron/EVM and
+                                        passes usernames through — no viem isAddress
+                                        pre-guard, which is EVM-only and let 44-char
+                                        Solana counterparties render full-length. */}
+                                    <span>{printableAddress(transaction.userName)}</span>
                                     <CopyToClipboard textToCopy={transaction.userName} iconSize="4" />
                                 </div>
                             }

--- a/src/components/TransactionDetails/__tests__/transaction-details.utils.test.ts
+++ b/src/components/TransactionDetails/__tests__/transaction-details.utils.test.ts
@@ -55,12 +55,22 @@ describe('getAccountCopyValue — copy path', () => {
 })
 
 describe('maskAccountIdentifier — display path', () => {
-    test("Tron address with a digit 3rd char (wire type 'address') displays VERBATIM, not IBAN-chunked", () => {
-        expect(maskAccountIdentifier(TRON_ADDR_DIGIT, 'address')).toBe(TRON_ADDR_DIGIT)
+    // Shortened (start...end), never IBAN-chunked — the full 34/44-char
+    // address is one unbreakable token that overflows the receipt card on
+    // mobile (Crisp session_779df6b2, TASK-20889). Copy stays verbatim —
+    // see the getAccountCopyValue suite above.
+    test("Tron address with a digit 3rd char (wire type 'address') displays shortened, not IBAN-chunked", () => {
+        expect(maskAccountIdentifier(TRON_ADDR_DIGIT, 'address')).toBe('TN9RRa...zxLQPP')
     })
 
-    test("Solana address (wire type 'address') displays VERBATIM", () => {
-        expect(maskAccountIdentifier(SOLANA_ADDR, 'address')).toBe(SOLANA_ADDR)
+    test("Solana address (wire type 'address') displays shortened", () => {
+        expect(maskAccountIdentifier(SOLANA_ADDR, 'address')).toBe('6PqX5b...U9iM6b')
+    })
+
+    test("EVM address (wire type 'evm-address') displays shortened", () => {
+        expect(maskAccountIdentifier('0xCfB0eA7Ba06EffC1534f232736c31F69aD03F91b', 'evm-address')).toBe(
+            '0xCfB0...03F91b'
+        )
     })
 
     test('IBAN rail still masks to last-4 groups (no regression)', () => {

--- a/src/utils/account-mask.utils.ts
+++ b/src/utils/account-mask.utils.ts
@@ -1,4 +1,4 @@
-import { formatIban } from './general.utils'
+import { formatIban, shortenStringLong } from './general.utils'
 
 /**
  * Per-rail bank account masking for receipt display.
@@ -87,10 +87,19 @@ export function maskAccountIdentifier(
     accountType: string | null | undefined
 ): string {
     if (!identifier) return ''
-    // Crypto wallet addresses are shown verbatim — never routed through the
-    // 'plain' branch's IBAN-shape heuristic, which mangles base58 addresses
-    // whose 2nd char is a letter and 3rd a digit (e.g. Tron `TN9R…`).
-    if (isCryptoAddressType(accountType)) return identifier
+    // Crypto wallet addresses are shortened for display ("BfbXuD...NKNb19") —
+    // a full 44-char Solana address is one unbreakable token that overflows
+    // the receipt card on mobile. Copy still yields the verbatim address via
+    // getAccountCopyValue. Shorten by wire type, NOT via printableAddress's
+    // shape re-validation (viem isAddress rejects wrong-checksum mixed-case
+    // strings and would fall back to the full overflowing address). Never
+    // route these through the 'plain' branch's IBAN-shape heuristic, which
+    // mangles case-sensitive base58 (Tron `TN9R…`). The length guard keeps
+    // degenerate short identifiers intact — shortenStringLong would garble
+    // anything shorter than its 6+6 window; real addresses are 32+ chars.
+    if (isCryptoAddressType(accountType)) {
+        return identifier.length <= 16 ? identifier : shortenStringLong(identifier)
+    }
     const rail = (accountType ?? '').toUpperCase()
     const rule = MASK_RULES[rail] ?? { mode: 'plain' as MaskMode }
 


### PR DESCRIPTION
## Summary
A withdrawal to a Solana address renders the full 44-char base58 address in the receipt drawer's **Address** row. It's one unbreakable token, so the whole card blows out of the viewport on mobile (user report: Crisp session_779df6b2 / Notion TASK-20889). EVM (42-char) and Tron (34-char) destinations overflow the same way.

**Root cause:** the 2026-07-23 Tron fix made `maskAccountIdentifier` return crypto addresses **verbatim** (correctly bypassing the `formatIban` base58 corruption) — but nothing shortens them for display, unlike every other long value in the drawer (header, TX ID, Transfer ID all shorten). Structurally, `PaymentInfoRow` also had no flex containment: `min-width: auto` resolves to the token's full width, so any unbreakable value escapes the card.

**Fix (3 pieces):**
1. `maskAccountIdentifier` crypto branch shortens for display (`BfbXuD...NKNb19` — same shape the drawer header shows). Copy untouched: `getAccountCopyValue` still yields the verbatim address.
2. `PaymentInfoRow` value wrapper gets `min-w-0 break-words` — any future unbreakable token wraps inside the card instead of stretching the row. `break-word` only activates when a word can't fit, so normal values render unchanged.
3. The **To** row drops its viem `isAddress` pre-guard (EVM-only — Solana/Tron counterparties rendered full-length); `printableAddress` already passes usernames through untouched.

**Why not `printableAddress` in (1):** it re-validates shape via viem `isAddress`, which rejects wrong-checksum mixed-case strings and would silently fall back to the full overflowing address. The wire `type` (`address` / `evm-address` / `peanut-wallet`) already tells us it's a crypto address — shorten unconditionally, with a length guard for degenerate short strings.

**Base = `main`:** `account-mask.utils.ts` / `isCryptoAddressType` only exist on `main` (the Tron hotfix hasn't back-merged to `dev`). Merging adds to the existing main→dev back-merge debt.

## Design notes / accepted trade-offs
- Adversarially reviewed by two independent agents (correctness attack + codebase-wide overflow sweep). Findings: fix covers the reported row; deposit-instruction surfaces (where the full address must stay readable) are on a separate render path and untouched.
- Known remaining sibling (out of scope, contained by (2) but not shortened): the `isGuestBankClaim` branch renders identifiers verbatim — a full IBAN now wraps instead of overflowing. Follow-up candidate, not bundled.
- `CRYPTO_ADDRESS_TYPES` is a closed 3-value set; if the BE ever emits a new crypto wire type it falls to the `plain` branch (pre-existing property, unchanged here).

## Risks / breaking changes
- Display-only. Bank rails (IBAN/CLABE/PIX/ACH/alias) untouched — pinned by existing tests. `break-words` affects all 22 `PaymentInfoRow` consumers but only when a single word exceeds the line — no layout change for fitting values.
- No cross-repo impact.

## QA
- `npm test`: 2154 passed (updated the 2 verbatim-display assertions to shortened; added EVM case).
- Full typecheck clean; eslint on touched files: 0 new problems (5 pre-existing in TransactionDetailsReceipt, none on changed lines).

## Screenshots
Captured on the local sandbox (mobile 375×667, seeded user, mocked Solana `CRYPTO_WITHDRAW` via route interception — same entry shape the BE serializes). Before = `origin/main`, After = this branch.

| Before (main) | After (this PR) |
|---|---|
| ![before](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2527/before.png) | ![after](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2527/after.png) |

The before shot reproduces the user's report exactly: the 44-char address escapes the card's right edge and the copy icon is pushed out of view. After: shortened display, copy icon inline, copy still yields the full address. (Assets live on the `pr-assets-2527` branch — delete after merge.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Crypto wallet addresses are now displayed in a shortened, readable format in transaction receipts.
  * Transaction details better support displaying usernames and addresses across supported networks.

* **Bug Fixes**
  * Long wallet addresses and transaction identifiers now wrap within payment information rows instead of breaking the layout.
  * Improved receipt formatting for Tron, Solana, and EVM addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->