### PR TITLE
fix(fetch): context-aware fetch timeouts — stop applying a stale Vercel limit to browsers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,7 +73,9 @@ export PROMO_LIST={}
 export NEXT_PUBLIC_VAPID_PUBLIC_KEY=
 export VAPID_PRIVATE_KEY=
 export NEXT_PUBLIC_VAPID_SUBJECT="mailto:hello@peanut.me"
-export NEXT_PUBLIC_FETCH_TIMEOUT_MS=10000
+# Optional override of BOTH fetch budgets (client 20s / server 30s — see
+# src/utils/sentry.utils.ts). Leave empty to keep the context-aware defaults.
+export NEXT_PUBLIC_FETCH_TIMEOUT_MS=
 
 # one signal 
 export NEXT_PUBLIC_ONESIGNAL_APP_ID=

--- a/src/utils/__tests__/sentry.utils.test.ts
+++ b/src/utils/__tests__/sentry.utils.test.ts
@@ -1,5 +1,16 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import * as Sentry from '@sentry/nextjs'
-import { fetchWithSentry, sanitizeRequestBody, sanitizeResponseBody, scrubObject } from '../sentry.utils'
+import {
+    CLIENT_FETCH_TIMEOUT_MS,
+    SERVER_FETCH_TIMEOUT_MS,
+    VERCEL_FUNCTION_MAX_DURATION_MS,
+    fetchWithSentry,
+    resolveDefaultTimeoutMs,
+    sanitizeRequestBody,
+    sanitizeResponseBody,
+    scrubObject,
+} from '../sentry.utils'
 
 jest.mock('@sentry/nextjs', () => ({
     withScope: jest.fn((cb: (scope: unknown) => void) => cb({ setFingerprint: jest.fn(), setTag: jest.fn() })),
@@ -271,5 +282,89 @@ describe('scrubObject — exact-match contract', () => {
         expect(out.clean).toBe('z')
         // Global Object.prototype must NOT have been mutated
         expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+    })
+})
+
+describe('fetch timeout budgets', () => {
+    describe('resolveDefaultTimeoutMs', () => {
+        it('uses the client budget in a browser, the server budget in a function', () => {
+            expect(resolveDefaultTimeoutMs(false, undefined)).toBe(CLIENT_FETCH_TIMEOUT_MS)
+            expect(resolveDefaultTimeoutMs(true, undefined)).toBe(SERVER_FETCH_TIMEOUT_MS)
+            // The two contexts must actually differ, otherwise this is the old
+            // single global timeout wearing two names.
+            expect(CLIENT_FETCH_TIMEOUT_MS).not.toBe(SERVER_FETCH_TIMEOUT_MS)
+        })
+
+        // Regression pin: the 10s global budget was smaller than a page load in
+        // high-latency markets, aborting healthy requests and reporting them as
+        // failures. Whatever these budgets become, they must not go back there.
+        it('keeps both budgets clear of the 10s that caused false timeouts', () => {
+            expect(CLIENT_FETCH_TIMEOUT_MS).toBeGreaterThan(10_000)
+            expect(SERVER_FETCH_TIMEOUT_MS).toBeGreaterThan(10_000)
+        })
+
+        it('lets NEXT_PUBLIC_FETCH_TIMEOUT_MS override both contexts', () => {
+            expect(resolveDefaultTimeoutMs(false, '45000')).toBe(45_000)
+            expect(resolveDefaultTimeoutMs(true, '45000')).toBe(45_000)
+        })
+
+        it('falls back to the context default when the override is unset or unparseable', () => {
+            expect(resolveDefaultTimeoutMs(false, '')).toBe(CLIENT_FETCH_TIMEOUT_MS)
+            expect(resolveDefaultTimeoutMs(false, 'not-a-number')).toBe(CLIENT_FETCH_TIMEOUT_MS)
+            expect(resolveDefaultTimeoutMs(true, 'not-a-number')).toBe(SERVER_FETCH_TIMEOUT_MS)
+        })
+    })
+
+    // The whole point of the server budget is to abort BEFORE Vercel kills the
+    // function, so we emit our own error instead of an opaque platform 504.
+    // The previous magic 10s encoded a platform limit (then 15s) that has since
+    // moved to 300s — this pins the constant to vercel.json so it cannot drift
+    // silently a second time.
+    it('mirrors vercel.json maxDuration and stays strictly under it', () => {
+        const vercelConfig = JSON.parse(readFileSync(join(process.cwd(), 'vercel.json'), 'utf8'))
+        const maxDurations = Object.values(vercelConfig.functions as Record<string, { maxDuration: number }>).map(
+            (fn) => fn.maxDuration
+        )
+
+        expect(maxDurations.length).toBeGreaterThan(0)
+        for (const maxDuration of maxDurations) {
+            expect(maxDuration * 1000).toBe(VERCEL_FUNCTION_MAX_DURATION_MS)
+        }
+        expect(SERVER_FETCH_TIMEOUT_MS).toBeLessThan(VERCEL_FUNCTION_MAX_DURATION_MS)
+    })
+
+    describe('fetchWithSentry timeout resolution', () => {
+        const abort = () => {
+            const error = new Error('aborted')
+            error.name = 'AbortError'
+            return error
+        }
+        let infoSpy: jest.SpyInstance
+
+        beforeEach(() => {
+            jest.clearAllMocks()
+            infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
+        })
+
+        afterEach(() => infoSpy.mockRestore())
+
+        const reportedTimeoutMs = () =>
+            (Sentry.captureException as jest.Mock).mock.calls[0][1].extra.timeoutMs as number
+
+        it('defaults to the client budget under a browser global', async () => {
+            global.fetch = jest.fn().mockRejectedValue(abort())
+            await expect(fetchWithSentry('https://api.peanut.me/users/me')).rejects.toThrow(
+                'Service temporarily unavailable. Please try again.'
+            )
+            expect(reportedTimeoutMs()).toBe(CLIENT_FETCH_TIMEOUT_MS)
+        })
+
+        it('still lets a per-call timeoutMs win over the default', async () => {
+            global.fetch = jest.fn().mockRejectedValue(abort())
+            await expect(fetchWithSentry('https://api.peanut.me/users/me', {}, 1234)).rejects.toThrow(
+                'Service temporarily unavailable. Please try again.'
+            )
+            expect(reportedTimeoutMs()).toBe(1234)
+        })
     })
 })

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -293,15 +293,50 @@ function shouldSkipReporting(url: string, status: number): boolean {
     return false
 }
 
-/** Use configured fetch timeout or default to 10s
- * We use 10s because vercel function timout is 15s and this function
- * can be called in that context, and we preffer to have control over
- * the error message and handling
+/**
+ * Vercel's function-duration ceiling, mirrored from the `functions` entry in
+ * `vercel.json` (300 seconds, expressed here in ms). Fluid compute's
+ * project-wide default is 300s too, so this equally bounds the server actions
+ * and RSC renders `serverFetch` runs inside. `sentry.utils.test.ts` reads
+ * vercel.json and fails if the two ever drift apart.
  */
-const DEFAULT_TIMEOUT_MS =
-    process.env.NEXT_PUBLIC_FETCH_TIMEOUT_MS && !isNaN(parseInt(process.env.NEXT_PUBLIC_FETCH_TIMEOUT_MS, 10))
-        ? parseInt(process.env.NEXT_PUBLIC_FETCH_TIMEOUT_MS, 10)
-        : 10000
+export const VERCEL_FUNCTION_MAX_DURATION_MS = 300_000
+
+/**
+ * Server-side budget. Must abort well before the platform ceiling above so we
+ * own the error surface instead of leaking an opaque platform 504. A Vercel
+ * function calling api.peanut.me is a datacenter-to-datacenter hop, so 30s is
+ * already generous — the ceiling is the safety net, not the target.
+ */
+export const SERVER_FETCH_TIMEOUT_MS = 30_000
+
+/**
+ * Client-side budget. No platform ceiling applies in a browser, only real
+ * mobile networks do. The previous shared 10s came from hand-copying a
+ * (long-since-stale) Vercel limit onto browsers that never run inside a
+ * function, and it was smaller than a page load in high-latency markets —
+ * Nigeria p90 LCP is 11.3s vs 6.1s globally — so healthy-but-slow requests were
+ * aborted and reported as failures. 20s clears that with margin while keeping
+ * the retried worst case bounded: RETRY_STRATEGIES.FAST adds 2 retries at
+ * 1s/2s backoff, so a fully-hung request errors after 3×20s + 3s = 63s.
+ */
+export const CLIENT_FETCH_TIMEOUT_MS = 20_000
+
+/**
+ * `NEXT_PUBLIC_FETCH_TIMEOUT_MS` is an explicit override of both budgets.
+ * `isServer` is a parameter rather than an inlined `typeof window` check so
+ * both branches stay reachable from the jsdom test environment.
+ */
+export const resolveDefaultTimeoutMs = (
+    isServer: boolean,
+    override: string | undefined = process.env.NEXT_PUBLIC_FETCH_TIMEOUT_MS
+): number => {
+    const parsed = override ? parseInt(override, 10) : NaN
+    if (!isNaN(parsed)) return parsed
+    return isServer ? SERVER_FETCH_TIMEOUT_MS : CLIENT_FETCH_TIMEOUT_MS
+}
+
+const DEFAULT_TIMEOUT_MS = resolveDefaultTimeoutMs(typeof window === 'undefined')
 
 const getErrorLevelFromStatus = (status: number): Sentry.SeverityLevel => {
     if (status >= 500) return 'error'


### PR DESCRIPTION
## Summary

`fetchWithSentry` capped **every** `api.peanut.me` call at 10s, on a comment that said *"vercel function timout is 15s"*. That number was hand-copied from the platform years ago and never followed it:

- our own `vercel.json` declares `maxDuration: 300` for the `app/api` glob;
- Vercel's Fluid compute (default-on) [defaults to 300s](https://vercel.com/docs/functions/configuring-functions/duration) on every plan, max 800s, and [up to 1800s](https://vercel.com/changelog/vercel-functions-can-now-run-up-to-30-minutes) for Pro/Enterprise since 2026-06-15.

So a *server-side* safety margin ended up governing *browser* requests, which never run inside a function and have no platform ceiling at all.

**That budget is smaller than a page load in high-latency markets.** Measured over 90d (PostHog + Sentry):

| | Nigeria | Global |
|---|---|---|
| p90 LCP | 11,326 ms | 6,140 ms |
| `$exception` rate | 40.6% | 16.8% |
| `…timed out after 10000ms` | 15.1% | 5.1% (**3.0×**) |
| `Load failed` / `Failed to fetch` | 25.8% | 8.6% (**3.0×**) |
| service-worker `no-response` | 3.0% | 0.14% (**21×**) |

Top offenders: `/users/me` (33 persons), `/tokens/price` (23), `/rain/cards` (16). Our API origin is `gcp-us-west1` (Oregon); TTFB from Lagos is 0.86–0.93s vs 0.13s from Spain (~7×). This is every high-latency market, not just NG.

## What changed

One magic number → two named budgets picked by the constraint that actually applies, in one place (`src/utils/sentry.utils.ts`):

| Constant | Value | Why |
|---|---|---|
| `VERCEL_FUNCTION_MAX_DURATION_MS` | 300,000 | Mirrors `vercel.json`. A test parses `vercel.json` and fails if they drift — the whole bug was a platform constant copied by hand and then abandoned. |
| `SERVER_FETCH_TIMEOUT_MS` | 30,000 | Must abort **before** the platform kills the function so we emit our own error instead of an opaque 504. Vercel→`api.peanut.me` is a datacenter hop, so 30s is already generous; the 300s ceiling is the safety net, not the target. |
| `CLIENT_FETCH_TIMEOUT_MS` | 20,000 | No platform ceiling in a browser — only real mobile networks. 20s clears NG's 11.3s p90 LCP with margin while bounding the retried worst case (below). |

`NEXT_PUBLIC_FETCH_TIMEOUT_MS` still overrides **both** (`.env.example` updated: it was pinned to `10000`, now empty so the context-aware defaults apply). The per-call third-arg `timeoutMs` on `fetchWithSentry` still wins over everything — unchanged, and now covered by a test.

## Risk: the retry multiplier

**This is the main thing to review.** The timeout is per *attempt*, and React Query retries on top — `RETRY_STRATEGIES.FAST` (2 retries, 1s/2s backoff) is the global default in `src/config/wagmi.config.tsx`.

```
worst case = 3 attempts × timeout + 1s + 2s backoff
  before:  3×10s + 3s = 33s
  after:   3×20s + 3s = 63s     ← accepted
  (at 30s: 3×30s + 3s = 93s     ← rejected, real UX regression)
```

**Accepted trade-off.** 63s is the pathological tail where all three attempts hang to full budget — i.e. the network is genuinely dead, and the user was going to fail anyway. The common case *improves*: an NG request that really takes 12s now succeeds on attempt 1 instead of erroring at 10s. That tail is exactly the 15.1% of NG users currently generating timeout events.

**Considered and rejected:** dropping `FAST` from 2 retries to 1 (total 41s). It's the global wagmi default, so it would also halve retry resilience for *fast* failures (transient 5xx, which fail in <1s and cost ~3s for all 3 attempts today) — a resilience regression in a case unrelated to this bug. Not worth bundling. Happy to revisit if you'd rather cap the total.

**Financial mutations are unaffected** — `RETRY_STRATEGIES.FINANCIAL` is `retry: false` and stays that way.

**Bonus, no action needed:** a longer budget *reduces* double-submit risk — fewer POSTs that actually succeeded get aborted client-side and look failed.

## Tests

`src/utils/__tests__/sentry.utils.test.ts`:
- client vs server default resolution (and that the two contexts genuinely differ)
- `NEXT_PUBLIC_FETCH_TIMEOUT_MS` overrides both contexts; unset/unparseable falls back
- **drift guard**: parses `vercel.json` and asserts `maxDuration × 1000 === VERCEL_FUNCTION_MAX_DURATION_MS`, and that the server budget stays strictly under it
- regression pin: neither budget may return to 10s
- `fetchWithSentry` defaults to the client budget, and a per-call `timeoutMs` still wins

## Out of scope (flagged, not touched)

- `src/app/(mobile-ui)/card/page.tsx` polling (`pollUntilReady` 30000, `pollUntilApplyAdvances` 5000) — separate mechanism, unaffected.
- 🐛 **`src/hooks/useGeoLocation.ts:48` fetches `ipapi.co/country` with no timeout, no AbortController and no retry**, and it gates a skeleton in `CountryList.tsx:145`. On the same slow networks this hangs the country picker indefinitely — a real bug, but a genuinely separate PR.

## QA

Unit tests cover the resolution logic. Behavioural verification is inherently network-dependent; the drift guard is the durable protection against this recurring.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added context-aware fetch timeout defaults for client and server environments.
  - Added an optional configuration override for fetch timeouts, with automatic defaults when left unset.
  - Improved timeout reporting for failed requests.

- **Tests**
  - Added coverage for default, override, fallback, and environment-specific timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->