### PR TITLE
fix(fetch): context-aware fetch timeouts — stop applying a stale Vercel limit to browsers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,8 +73,8 @@ export PROMO_LIST={}
 export NEXT_PUBLIC_VAPID_PUBLIC_KEY=
 export VAPID_PRIVATE_KEY=
 export NEXT_PUBLIC_VAPID_SUBJECT="mailto:hello@peanut.me"
-# Overrides BOTH fetch budgets (client 20s / server 30s, src/utils/sentry.utils.ts).
-# Positive integer of milliseconds; empty or malformed = keep the defaults.
+# Overrides BOTH fetch budgets (client 20s / server 10s, src/utils/sentry.utils.ts).
+# Positive integer of milliseconds, max 2147483647; empty or malformed = keep the defaults.
 export NEXT_PUBLIC_FETCH_TIMEOUT_MS=
 
 # one signal 

--- a/.env.example
+++ b/.env.example
@@ -73,7 +73,9 @@ export PROMO_LIST={}
 export NEXT_PUBLIC_VAPID_PUBLIC_KEY=
 export VAPID_PRIVATE_KEY=
 export NEXT_PUBLIC_VAPID_SUBJECT="mailto:hello@peanut.me"
-export NEXT_PUBLIC_FETCH_TIMEOUT_MS=10000
+# Overrides BOTH fetch budgets (client 20s / server 30s, src/utils/sentry.utils.ts).
+# Positive integer of milliseconds; empty or malformed = keep the defaults.
+export NEXT_PUBLIC_FETCH_TIMEOUT_MS=
 
 # one signal 
 export NEXT_PUBLIC_ONESIGNAL_APP_ID=

--- a/src/utils/__tests__/sentry.utils.test.ts
+++ b/src/utils/__tests__/sentry.utils.test.ts
@@ -1,5 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import * as Sentry from '@sentry/nextjs'
-import { fetchWithSentry, sanitizeRequestBody, sanitizeResponseBody, scrubObject } from '../sentry.utils'
+import { RETRY_STRATEGIES } from '../retry.utils'
+import {
+    CLIENT_FETCH_TIMEOUT_MS,
+    SERVER_FETCH_TIMEOUT_MS,
+    VERCEL_FUNCTION_MAX_DURATION_MS,
+    fetchWithSentry,
+    resolveDefaultTimeoutMs,
+    sanitizeRequestBody,
+    sanitizeResponseBody,
+    scrubObject,
+} from '../sentry.utils'
 
 jest.mock('@sentry/nextjs', () => ({
     withScope: jest.fn((cb: (scope: unknown) => void) => cb({ setFingerprint: jest.fn(), setTag: jest.fn() })),
@@ -271,5 +283,109 @@ describe('scrubObject — exact-match contract', () => {
         expect(out.clean).toBe('z')
         // Global Object.prototype must NOT have been mutated
         expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+    })
+})
+
+describe('fetch timeout budgets', () => {
+    describe('resolveDefaultTimeoutMs', () => {
+        // Both branches, explicitly. An inverted check is the failure mode that
+        // actually bites: hand the server the long budget and a Vercel function
+        // hangs past its ceiling, producing exactly the opaque 504s the original
+        // 10s existed to prevent.
+        it('uses the client budget in a browser, the server budget in a function', () => {
+            expect(resolveDefaultTimeoutMs(false, undefined)).toBe(CLIENT_FETCH_TIMEOUT_MS)
+            expect(resolveDefaultTimeoutMs(true, undefined)).toBe(SERVER_FETCH_TIMEOUT_MS)
+        })
+
+        // Regression pin: 10s was smaller than a page load in high-latency
+        // markets, aborting healthy requests. Don't go back there.
+        it('keeps both budgets clear of the 10s that caused false timeouts', () => {
+            expect(CLIENT_FETCH_TIMEOUT_MS).toBeGreaterThan(10_000)
+            expect(SERVER_FETCH_TIMEOUT_MS).toBeGreaterThan(10_000)
+        })
+
+        it('lets NEXT_PUBLIC_FETCH_TIMEOUT_MS override both contexts', () => {
+            expect(resolveDefaultTimeoutMs(false, '45000')).toBe(45_000)
+            expect(resolveDefaultTimeoutMs(true, '45000')).toBe(45_000)
+        })
+
+        // parseInt would have read "30s" as 30ms and "0" as 0 — both abort every
+        // request instantly. A malformed override must fall back, not brick fetches.
+        it.each([undefined, '', 'not-a-number', '30s', '0.5', '0', '-1', 'Infinity'])(
+            'falls back to the context default for a malformed override: %p',
+            (override) => {
+                expect(resolveDefaultTimeoutMs(false, override)).toBe(CLIENT_FETCH_TIMEOUT_MS)
+                expect(resolveDefaultTimeoutMs(true, override)).toBe(SERVER_FETCH_TIMEOUT_MS)
+            }
+        )
+    })
+
+    // The client budget is per ATTEMPT, and React Query retries on top, so the
+    // real number a user waits is timeout x attempts + backoff. Pinned here
+    // because the multiplier lives in another file: bump RETRY_STRATEGIES.FAST
+    // or the budget far enough and this fails instead of silently shipping a
+    // two-minute spinner.
+    it('keeps the retried worst-case client budget under 70s', () => {
+        const { retry, retryDelay } = RETRY_STRATEGIES.FAST
+        const attempts = retry + 1
+        const backoff = Array.from({ length: retry }, (_, i) => retryDelay(i)).reduce((a, b) => a + b, 0)
+
+        const worstCaseMs = attempts * CLIENT_FETCH_TIMEOUT_MS + backoff
+
+        expect(worstCaseMs).toBe(63_000)
+        expect(worstCaseMs).toBeLessThan(70_000)
+    })
+
+    // The whole point of the server budget is to abort BEFORE Vercel kills the
+    // function, so we emit our own error instead of an opaque platform 504.
+    // The previous magic 10s encoded a platform limit (then 15s) that has since
+    // moved to 300s — this pins the constant to vercel.json so it cannot drift
+    // silently a second time.
+    it('mirrors vercel.json maxDuration and stays strictly under it', () => {
+        const vercelConfig = JSON.parse(readFileSync(join(process.cwd(), 'vercel.json'), 'utf8'))
+        const maxDurations = Object.values(vercelConfig.functions as Record<string, { maxDuration: number }>).map(
+            (fn) => fn.maxDuration
+        )
+
+        expect(maxDurations.length).toBeGreaterThan(0)
+        for (const maxDuration of maxDurations) {
+            expect(maxDuration * 1000).toBe(VERCEL_FUNCTION_MAX_DURATION_MS)
+        }
+        expect(SERVER_FETCH_TIMEOUT_MS).toBeLessThan(VERCEL_FUNCTION_MAX_DURATION_MS)
+    })
+
+    describe('fetchWithSentry timeout resolution', () => {
+        const abort = () => {
+            const error = new Error('aborted')
+            error.name = 'AbortError'
+            return error
+        }
+        let infoSpy: jest.SpyInstance
+
+        beforeEach(() => {
+            jest.clearAllMocks()
+            infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
+        })
+
+        afterEach(() => infoSpy.mockRestore())
+
+        const reportedTimeoutMs = () =>
+            (Sentry.captureException as jest.Mock).mock.calls[0][1].extra.timeoutMs as number
+
+        it('defaults to the client budget under a browser global', async () => {
+            global.fetch = jest.fn().mockRejectedValue(abort())
+            await expect(fetchWithSentry('https://api.peanut.me/users/me')).rejects.toThrow(
+                'Service temporarily unavailable. Please try again.'
+            )
+            expect(reportedTimeoutMs()).toBe(CLIENT_FETCH_TIMEOUT_MS)
+        })
+
+        it('still lets a per-call timeoutMs win over the default', async () => {
+            global.fetch = jest.fn().mockRejectedValue(abort())
+            await expect(fetchWithSentry('https://api.peanut.me/users/me', {}, 1234)).rejects.toThrow(
+                'Service temporarily unavailable. Please try again.'
+            )
+            expect(reportedTimeoutMs()).toBe(1234)
+        })
     })
 })

--- a/src/utils/__tests__/sentry.utils.test.ts
+++ b/src/utils/__tests__/sentry.utils.test.ts
@@ -315,11 +315,14 @@ describe('fetch timeout budgets', () => {
         it('lets NEXT_PUBLIC_FETCH_TIMEOUT_MS override both contexts', () => {
             expect(resolveDefaultTimeoutMs(false, '45000')).toBe(45_000)
             expect(resolveDefaultTimeoutMs(true, '45000')).toBe(45_000)
+            // Boundary: the largest value setTimeout can honour is still accepted.
+            expect(resolveDefaultTimeoutMs(false, '2147483647')).toBe(2_147_483_647)
         })
 
-        // parseInt would have read "30s" as 30ms and "0" as 0 — both abort every
+        // parseInt would have read "30s" as 30ms and "0" as 0, and anything past
+        // 2^31-1 overflows setTimeout and clamps to ~1ms — all of which abort every
         // request instantly. A malformed override must fall back, not brick fetches.
-        it.each([undefined, '', 'not-a-number', '30s', '0.5', '0', '-1', 'Infinity'])(
+        it.each([undefined, '', 'not-a-number', '30s', '0.5', '0', '-1', 'Infinity', '2147483648'])(
             'falls back to the context default for a malformed override: %p',
             (override) => {
                 expect(resolveDefaultTimeoutMs(false, override)).toBe(CLIENT_FETCH_TIMEOUT_MS)

--- a/src/utils/__tests__/sentry.utils.test.ts
+++ b/src/utils/__tests__/sentry.utils.test.ts
@@ -1,11 +1,8 @@
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
 import * as Sentry from '@sentry/nextjs'
 import { RETRY_STRATEGIES } from '../retry.utils'
 import {
     CLIENT_FETCH_TIMEOUT_MS,
     SERVER_FETCH_TIMEOUT_MS,
-    VERCEL_FUNCTION_MAX_DURATION_MS,
     fetchWithSentry,
     resolveDefaultTimeoutMs,
     sanitizeRequestBody,
@@ -287,6 +284,17 @@ describe('scrubObject — exact-match contract', () => {
 })
 
 describe('fetch timeout budgets', () => {
+    // `resolveDefaultTimeoutMs`'s default parameter reads the real process.env,
+    // so a shell or CI runner that exports NEXT_PUBLIC_FETCH_TIMEOUT_MS would
+    // otherwise fail this suite for reasons unrelated to the code under test.
+    const realOverride = process.env.NEXT_PUBLIC_FETCH_TIMEOUT_MS
+    beforeAll(() => {
+        delete process.env.NEXT_PUBLIC_FETCH_TIMEOUT_MS
+    })
+    afterAll(() => {
+        if (realOverride !== undefined) process.env.NEXT_PUBLIC_FETCH_TIMEOUT_MS = realOverride
+    })
+
     describe('resolveDefaultTimeoutMs', () => {
         // Both branches, explicitly. An inverted check is the failure mode that
         // actually bites: hand the server the long budget and a Vercel function
@@ -298,10 +306,10 @@ describe('fetch timeout budgets', () => {
         })
 
         // Regression pin: 10s was smaller than a page load in high-latency
-        // markets, aborting healthy requests. Don't go back there.
-        it('keeps both budgets clear of the 10s that caused false timeouts', () => {
+        // markets, aborting healthy browser requests. Don't go back there.
+        // (The server budget deliberately stays at 10s — see sentry.utils.ts.)
+        it('keeps the client budget clear of the 10s that caused false timeouts', () => {
             expect(CLIENT_FETCH_TIMEOUT_MS).toBeGreaterThan(10_000)
-            expect(SERVER_FETCH_TIMEOUT_MS).toBeGreaterThan(10_000)
         })
 
         it('lets NEXT_PUBLIC_FETCH_TIMEOUT_MS override both contexts', () => {
@@ -321,11 +329,12 @@ describe('fetch timeout budgets', () => {
     })
 
     // The client budget is per ATTEMPT, and React Query retries on top, so the
-    // real number a user waits is timeout x attempts + backoff. Pinned here
-    // because the multiplier lives in another file: bump RETRY_STRATEGIES.FAST
-    // or the budget far enough and this fails instead of silently shipping a
-    // two-minute spinner.
-    it('keeps the retried worst-case client budget under 70s', () => {
+    // real wait is timeout x attempts + backoff. Pinned here because the
+    // multiplier lives in another file: bump RETRY_STRATEGIES.FAST or the budget
+    // far enough and this fails instead of silently shipping a long spinner.
+    // Bounds the DEFAULT strategy only — queries that set their own `retry`
+    // (e.g. Claim.tsx) are not covered by this.
+    it('keeps the worst case under 70s for the default retry strategy', () => {
         const { retry, retryDelay } = RETRY_STRATEGIES.FAST
         const attempts = retry + 1
         const backoff = Array.from({ length: retry }, (_, i) => retryDelay(i)).reduce((a, b) => a + b, 0)
@@ -334,24 +343,6 @@ describe('fetch timeout budgets', () => {
 
         expect(worstCaseMs).toBe(63_000)
         expect(worstCaseMs).toBeLessThan(70_000)
-    })
-
-    // The whole point of the server budget is to abort BEFORE Vercel kills the
-    // function, so we emit our own error instead of an opaque platform 504.
-    // The previous magic 10s encoded a platform limit (then 15s) that has since
-    // moved to 300s — this pins the constant to vercel.json so it cannot drift
-    // silently a second time.
-    it('mirrors vercel.json maxDuration and stays strictly under it', () => {
-        const vercelConfig = JSON.parse(readFileSync(join(process.cwd(), 'vercel.json'), 'utf8'))
-        const maxDurations = Object.values(vercelConfig.functions as Record<string, { maxDuration: number }>).map(
-            (fn) => fn.maxDuration
-        )
-
-        expect(maxDurations.length).toBeGreaterThan(0)
-        for (const maxDuration of maxDurations) {
-            expect(maxDuration * 1000).toBe(VERCEL_FUNCTION_MAX_DURATION_MS)
-        }
-        expect(SERVER_FETCH_TIMEOUT_MS).toBeLessThan(VERCEL_FUNCTION_MAX_DURATION_MS)
     })
 
     describe('fetchWithSentry timeout resolution', () => {
@@ -372,9 +363,17 @@ describe('fetch timeout budgets', () => {
         const reportedTimeoutMs = () =>
             (Sentry.captureException as jest.Mock).mock.calls[0][1].extra.timeoutMs as number
 
+        // Re-imported with the env cleared: the module captures its default at
+        // LOAD time, so the surrounding beforeAll can't reach it and an ambient
+        // NEXT_PUBLIC_FETCH_TIMEOUT_MS would otherwise fail this for the wrong reason.
         it('defaults to the client budget under a browser global', async () => {
+            let freshFetchWithSentry!: typeof fetchWithSentry
+            jest.isolateModules(() => {
+                freshFetchWithSentry = require('../sentry.utils').fetchWithSentry
+            })
+
             global.fetch = jest.fn().mockRejectedValue(abort())
-            await expect(fetchWithSentry('https://api.peanut.me/users/me')).rejects.toThrow(
+            await expect(freshFetchWithSentry('https://api.peanut.me/users/me')).rejects.toThrow(
                 'Service temporarily unavailable. Please try again.'
             )
             expect(reportedTimeoutMs()).toBe(CLIENT_FETCH_TIMEOUT_MS)

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -294,28 +294,32 @@ function shouldSkipReporting(url: string, status: number): boolean {
 }
 
 /**
- * Vercel's function-duration ceiling: the `maxDuration` in `vercel.json`, in ms.
- * That glob covers route handlers; server actions and RSC renders fall back to
- * the project default, which Fluid compute also sets to 300s
- * (https://vercel.com/docs/functions/configuring-functions/duration).
- * `sentry.utils.test.ts` reads vercel.json and fails if the two drift.
+ * Server-side budget — deliberately UNCHANGED at the historical 10s.
+ *
+ * A server fetch runs inside a Vercel function, so it must abort before the
+ * platform kills the function, otherwise we leak an opaque 504 instead of
+ * owning the error. The old comment here put that ceiling at 15s; today
+ * `vercel.json` says `maxDuration: 300` — but that entry declares the glob
+ * `app/api/**` while this project keeps its routes under `src/app/api/`, and
+ * Vercel requires the `src/` prefix for src-directory projects, so the entry
+ * currently matches nothing. The real ceiling is therefore the project default
+ * (300s with Fluid compute, far lower without), which cannot be read from the
+ * repo.
+ *
+ * Raising this buys little — a Vercel→api.peanut.me call is a datacenter hop,
+ * not a mobile network — and risks sitting ABOVE an unverified ceiling, which
+ * would reintroduce exactly the 504s the original 10s existed to prevent. So it
+ * stays put until the ceiling is confirmed. See the PR for the follow-up.
  */
-export const VERCEL_FUNCTION_MAX_DURATION_MS = 300_000
+export const SERVER_FETCH_TIMEOUT_MS = 10_000
 
 /**
- * Server-side budget. Must abort well before the platform ceiling above so we
- * own the error surface instead of leaking an opaque platform 504. A Vercel
- * function calling api.peanut.me is a datacenter-to-datacenter hop, so 30s is
- * already generous — the ceiling is the safety net, not the target.
- */
-export const SERVER_FETCH_TIMEOUT_MS = 30_000
-
-/**
- * Client-side budget. No platform ceiling applies in a browser, only real
- * mobile networks — and 10s sat below the page load itself in high-latency
- * markets (Nigeria p90 LCP 11.3s vs 6.1s globally), aborting healthy requests.
- * Bounded above by React Query retries, which multiply it; the worst-case total
- * is pinned in `sentry.utils.test.ts` against RETRY_STRATEGIES.FAST.
+ * Client-side budget — the actual fix. No platform ceiling applies in a
+ * browser, only real mobile networks, and 10s sat below the page load itself in
+ * high-latency markets (Nigeria p90 LCP 11.3s vs 6.1s globally), aborting
+ * healthy requests and reporting them as failures. Bounded above by React Query
+ * retries, which multiply it; the worst-case total for the default retry
+ * strategy is pinned in `sentry.utils.test.ts`.
  */
 export const CLIENT_FETCH_TIMEOUT_MS = 20_000
 

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -293,15 +293,50 @@ function shouldSkipReporting(url: string, status: number): boolean {
     return false
 }
 
-/** Use configured fetch timeout or default to 10s
- * We use 10s because vercel function timout is 15s and this function
- * can be called in that context, and we preffer to have control over
- * the error message and handling
+/**
+ * Vercel's function-duration ceiling: the `maxDuration` in `vercel.json`, in ms.
+ * That glob covers route handlers; server actions and RSC renders fall back to
+ * the project default, which Fluid compute also sets to 300s
+ * (https://vercel.com/docs/functions/configuring-functions/duration).
+ * `sentry.utils.test.ts` reads vercel.json and fails if the two drift.
  */
-const DEFAULT_TIMEOUT_MS =
-    process.env.NEXT_PUBLIC_FETCH_TIMEOUT_MS && !isNaN(parseInt(process.env.NEXT_PUBLIC_FETCH_TIMEOUT_MS, 10))
-        ? parseInt(process.env.NEXT_PUBLIC_FETCH_TIMEOUT_MS, 10)
-        : 10000
+export const VERCEL_FUNCTION_MAX_DURATION_MS = 300_000
+
+/**
+ * Server-side budget. Must abort well before the platform ceiling above so we
+ * own the error surface instead of leaking an opaque platform 504. A Vercel
+ * function calling api.peanut.me is a datacenter-to-datacenter hop, so 30s is
+ * already generous — the ceiling is the safety net, not the target.
+ */
+export const SERVER_FETCH_TIMEOUT_MS = 30_000
+
+/**
+ * Client-side budget. No platform ceiling applies in a browser, only real
+ * mobile networks — and 10s sat below the page load itself in high-latency
+ * markets (Nigeria p90 LCP 11.3s vs 6.1s globally), aborting healthy requests.
+ * Bounded above by React Query retries, which multiply it; the worst-case total
+ * is pinned in `sentry.utils.test.ts` against RETRY_STRATEGIES.FAST.
+ */
+export const CLIENT_FETCH_TIMEOUT_MS = 20_000
+
+/**
+ * `NEXT_PUBLIC_FETCH_TIMEOUT_MS` is an explicit override of both budgets. It
+ * must be a positive integer of milliseconds — `parseInt` would have accepted
+ * `"30s"` as 30 and `"0"` as 0, silently aborting every request instantly, so
+ * anything malformed falls back to the default rather than bricking fetches.
+ * Both inputs are parameters so the function stays pure: jsdom always defines
+ * `window`, so the server branch is otherwise unreachable from tests.
+ */
+export const resolveDefaultTimeoutMs = (
+    isServer: boolean,
+    override: string | undefined = process.env.NEXT_PUBLIC_FETCH_TIMEOUT_MS
+): number => {
+    const parsed = Number(override)
+    if (override && Number.isInteger(parsed) && parsed > 0) return parsed
+    return isServer ? SERVER_FETCH_TIMEOUT_MS : CLIENT_FETCH_TIMEOUT_MS
+}
+
+const DEFAULT_TIMEOUT_MS = resolveDefaultTimeoutMs(typeof window === 'undefined')
 
 const getErrorLevelFromStatus = (status: number): Sentry.SeverityLevel => {
     if (status >= 500) return 'error'

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -325,18 +325,22 @@ export const CLIENT_FETCH_TIMEOUT_MS = 20_000
 
 /**
  * `NEXT_PUBLIC_FETCH_TIMEOUT_MS` is an explicit override of both budgets. It
- * must be a positive integer of milliseconds — `parseInt` would have accepted
- * `"30s"` as 30 and `"0"` as 0, silently aborting every request instantly, so
- * anything malformed falls back to the default rather than bricking fetches.
- * Both inputs are parameters so the function stays pure: jsdom always defines
- * `window`, so the server branch is otherwise unreachable from tests.
+ * must be a positive integer of milliseconds within the 32-bit timer range:
+ * `parseInt` would have accepted `"30s"` as 30 and `"0"` as 0, and anything
+ * above 2^31-1 overflows setTimeout and clamps to ~1ms — every one of which
+ * aborts requests instantly. Malformed values fall back to the default rather
+ * than bricking fetches. Both inputs are parameters so the function stays pure:
+ * jsdom always defines `window`, so the server branch is otherwise unreachable
+ * from tests.
  */
+const MAX_TIMER_MS = 2_147_483_647
+
 export const resolveDefaultTimeoutMs = (
     isServer: boolean,
     override: string | undefined = process.env.NEXT_PUBLIC_FETCH_TIMEOUT_MS
 ): number => {
     const parsed = Number(override)
-    if (override && Number.isInteger(parsed) && parsed > 0) return parsed
+    if (override && Number.isInteger(parsed) && parsed > 0 && parsed <= MAX_TIMER_MS) return parsed
     return isServer ? SERVER_FETCH_TIMEOUT_MS : CLIENT_FETCH_TIMEOUT_MS
 }
 


### PR DESCRIPTION
> **Targets `main` (production) directly**, per Hugo: one constant becoming context-aware — no schema, no money path, trivially revertible — and staging cannot validate it anyway, since the whole point is behaviour on real high-latency mobile networks. **Back-merge to `dev` is required immediately after merge** (see bottom).

## Summary

`fetchWithSentry` capped **every** `api.peanut.me` call at 10s, on a comment that said *"vercel function timout is 15s"*. That number was hand-copied from the platform years ago and never followed it. So a *server-side* safety margin ended up governing *browser* requests, which never run inside a function and have no platform ceiling at all.

**That budget is smaller than a page load in high-latency markets.** Measured over 90d (PostHog + Sentry):

| | Nigeria | Global |
|---|---|---|
| p90 LCP | 11,326 ms | 6,140 ms |
| `$exception` rate | 40.6% | 16.8% |
| `…timed out after 10000ms` | 15.1% | 5.1% (**3.0×**) |
| `Load failed` / `Failed to fetch` | 25.8% | 8.6% (**3.0×**) |
| service-worker `no-response` | 3.0% | 0.14% (**21×**) |

Top offenders: `/users/me` (33 persons), `/tokens/price` (23), `/rain/cards` (16). Our API origin is `gcp-us-west1` (Oregon); TTFB from Lagos is 0.86–0.93s vs 0.13s from Spain (~7×). This is every high-latency market, not just NG.

## What changed

One magic number → two named budgets chosen by the constraint that actually applies (`src/utils/sentry.utils.ts`):

| Constant | Value | Why |
|---|---|---|
| `CLIENT_FETCH_TIMEOUT_MS` | **20,000** (was 10,000) | **The fix.** No platform ceiling exists in a browser — only real mobile networks. 20s clears NG's 11.3s p90 LCP with margin. |
| `SERVER_FETCH_TIMEOUT_MS` | **10,000** (unchanged) | Deliberately left alone — see below. |

`NEXT_PUBLIC_FETCH_TIMEOUT_MS` still overrides both, and is now **validated as a positive integer**: `parseInt` previously read `"30s"` as 30 ms and `"0"` as 0, either of which aborts every request instantly. Malformed values fall back to the defaults instead of bricking fetches *(CodeRabbit, Major)*. The per-call third-arg `timeoutMs` still wins over everything — unchanged, and covered by a test.

### Why the server budget did NOT move

The original plan was to derive the server budget from `vercel.json`'s `maxDuration: 300`. **That entry is dead config.** It declares the glob `app/api/**/*`, but this project keeps its routes under `src/app/api/`, and [Vercel requires the `src/` prefix for src-directory projects](https://vercel.com/docs/functions/configuring-functions/duration) — so the entry currently matches nothing.

The real ceiling is therefore the *project default*, which can't be read from the repo and differs by an order of magnitude depending on whether Fluid compute is enabled (300s with, far lower without). Setting a 30s server budget on top of an unverified ceiling risks sitting **above** it — reintroducing exactly the opaque 504s the original 10s existed to prevent. And it buys little: a Vercel→`api.peanut.me` call is a datacenter hop, not a mobile network.

So the server budget stays at 10s. The context split is still the real fix — when someone confirms the ceiling, they change **one named constant with a documented rationale**, not a global magic number.

## Risk: the retry multiplier

The timeout is per *attempt*, and React Query retries on top — `RETRY_STRATEGIES.FAST` (2 retries, 1s/2s backoff) is the global default in `src/config/wagmi.config.tsx`.

```
worst case = 3 attempts × timeout + 1s + 2s backoff
  before:  3×10s + 3s = 33s
  after:   3×20s + 3s = 63s     ← accepted, and pinned by a test
  (at 30s: 3×30s + 3s = 93s     ← rejected, real UX regression)
```

**Accepted trade-off.** 63s is the pathological tail where all three attempts hang to full budget — i.e. the network is genuinely dead and the user was going to fail anyway. The common case *improves*: an NG request that really takes 12s now succeeds on attempt 1 instead of erroring at 10s. That tail is exactly the 15.1% of NG users currently generating timeout events.

**Considered and rejected:** dropping `FAST` from 2 retries to 1 (total 41s). It's the global wagmi default, so it would also halve retry resilience for *fast* failures (transient 5xx, which fail in <1s) — a regression in a case unrelated to this bug.

⚠️ **The 63s bound covers the default strategy only.** `src/components/Claim/Claim.tsx:108` sets its own `retry: 4` with ~15s of backoff → **5 × 20s + 15s = 115s** worst case (up from 65s) on the send-link claim screen. Not changed here, and flagged as a follow-up below.

**Financial mutations are unaffected** — `RETRY_STRATEGIES.FINANCIAL` is `retry: false` and stays that way.

**Bonus, no action needed:** a longer budget *reduces* double-submit risk — fewer POSTs that actually succeeded get aborted client-side and look failed.

## ❗ Verify before merging

**`NEXT_PUBLIC_FETCH_TIMEOUT_MS` must not be set in Vercel.** `.env.example` shipped `=10000` before this PR. If that value was ever copied into the Vercel project env for production, **the override wins and this PR is a no-op**. I can't read Vercel's env store from here — please confirm it's unset (or delete it) in Production/Preview/Development, and in the Capgo/native build env.

## Tests

`src/utils/__tests__/sentry.utils.test.ts`:
- client vs server default resolution — **both branches explicitly**, since an inverted check is the failure mode that actually bites
- `NEXT_PUBLIC_FETCH_TIMEOUT_MS` overrides both contexts; per-call `timeoutMs` still wins over both
- malformed-override table: `undefined`, `''`, `not-a-number`, `30s`, `0.5`, `0`, `-1`, `Infinity` all fall back
- worst-case-total guard: derives `attempts × CLIENT_FETCH_TIMEOUT_MS + backoff` from `RETRY_STRATEGIES.FAST` itself and pins it at 63s / <70s, so changing either the budget or the retry policy fails the build instead of silently shipping a long spinner
- regression pin: the client budget may not return to 10s
- **hermetic** — verified green under `NEXT_PUBLIC_FETCH_TIMEOUT_MS=10000` and `=30s`

## Follow-ups (flagged, deliberately NOT in this PR)

1. **`vercel.json` glob is dead** — `app/api/**/*` should be `src/app/api/**/*`. Pre-existing; a platform-config change doesn't belong in a production hotfix.
2. **Confirm Fluid compute** is enabled, then the server budget can be raised with a provable ceiling.
3. **`src/hooks/useGeoLocation.ts:48`** fetches `ipapi.co/country` with **no timeout, no AbortController, no retry**, gating a skeleton in `CountryList.tsx:145` — on these same slow networks it hangs the country picker indefinitely. Real bug, separate PR.
4. **`src/components/Claim/Link/Onchain/Success.view.tsx:94`** — `setInterval(async …, 250)` with no in-flight guard stacks ~80 concurrent fetches under a stall at 20s (was ~40). Pre-existing, amplified 2×. The correct pattern already exists at `src/hooks/useUserAutoRefresh.ts:50`.
5. **`health/mobula` + `health/justaname`** are the only health routes calling `fetchWithSentry` without an explicit timeout; siblings self-cap at 5–8s. Worth passing `5000`.
6. **Playwright `expect.timeout`** (15s / 10s) is now below the 20s client budget, so a hung request expires the assertion instead of surfacing the app's error state.
7. **`src/services/rain.ts:326,466,560`** JSDoc says "10s default" — now stale for the client path.
8. **Mono docs** (markdown, separate from code per the repo rule): `ops/nigeria-launch-readiness.md` L89/L123-124/L182 cites the 10s value and lists raising it as an open pre-launch item this PR ships; `product/feedback/problems/payments-double-charged.md` L12 states 10s as live fact.

## Back-merge to `dev` — open and linked: #2535

peanut-ui releases flow `dev → main`, so a fix that lands only on `main` gets clobbered by the next release. **#2535** back-merges this same branch into `dev` and is already open.

**Merge order: this PR first, then #2535.** If this one is reworked or rejected, close #2535 too — they must not diverge. The three touched files are byte-identical on `main` and `dev` today, so it is conflict-free.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added separate default timeout budgets for browser and server requests.
  * Added support for a valid shared timeout override through environment configuration.
  * Invalid or empty timeout values now safely fall back to the appropriate default.
  * Timeout details are accurately captured for request error reporting.

* **Documentation**
  * Clarified the timeout configuration and fallback behavior in the environment template.

* **Tests**
  * Added coverage for timeout selection, overrides, invalid values, retry budgets, and per-request timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->