### PR TITLE
ci(content): publish content to production automatically

### DIFF
--- a/.github/workflows/content-pipeline-watchdog.yml
+++ b/.github/workflows/content-pipeline-watchdog.yml
@@ -1,0 +1,121 @@
+name: Content pipeline watchdog
+
+# Content publishes to production with no human in the loop. The failure mode
+# that creates is silence: a broken internal link fails `validate-links`, the
+# publish PR never merges, and nothing anywhere goes red — the content simply
+# never appears and nobody finds out until someone notices the site is stale.
+#
+# This asserts the end-to-end invariant instead of instrumenting each failure:
+#
+#     is production's content the same as the content on mono `main`?
+#
+# One question, every failure mode — mirror died, dispatch never fired,
+# update-content errored, CI red, PR conflicted, and whatever we haven't
+# thought of yet.
+#
+# It lives here rather than in mono because peanut-ui already holds tokens to
+# read all three repos (MONO_READ_TOKEN, SUBMODULE_TOKEN); mono has no secrets.
+#
+# Loud by construction: a stuck pipeline ALWAYS fails the run (red in Actions),
+# and additionally posts to Discord when the webhook is configured. A missing
+# webhook degrades the alert; it never silences it.
+
+on:
+    schedule:
+        - cron: '*/15 * * * *'
+    workflow_dispatch:
+
+permissions:
+    contents: read
+    pull-requests: read
+
+# How long the pipeline may legitimately be mid-flight. Mirror ~1min + CI ~5min
+# + Vercel ~8min lands around 15-20min in practice; 45 leaves room for a queue
+# without letting a real stall hide for long.
+env:
+    GRACE_MINUTES: 45
+
+jobs:
+    check:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Is production's content current?
+              env:
+                  UI_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  CONTENT_TOKEN: ${{ secrets.SUBMODULE_TOKEN }}
+                  MONO_TOKEN: ${{ secrets.MONO_READ_TOKEN }}
+                  DISCORD_WEBHOOK: ${{ secrets.CONTENT_PIPELINE_DISCORD_WEBHOOK }}
+                  REPO: ${{ github.repository }}
+                  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+              run: |
+                  set -uo pipefail
+
+                  # ---- hop 3: what production is serving -----------------------
+                  LIVE=$(GH_TOKEN=$UI_TOKEN gh api "repos/$REPO/contents/src/content?ref=main" --jq '.sha')
+
+                  # ---- hop 2: what the mirror has published --------------------
+                  TIP=$(GH_TOKEN=$CONTENT_TOKEN gh api repos/peanutprotocol/peanut-content/commits/main --jq '.sha')
+                  TIP_MSG=$(GH_TOKEN=$CONTENT_TOKEN gh api repos/peanutprotocol/peanut-content/commits/main --jq '.commit.message' | head -1)
+                  TIP_AT=$(GH_TOKEN=$CONTENT_TOKEN gh api repos/peanutprotocol/peanut-content/commits/main --jq '.commit.committer.date')
+
+                  # ---- hop 1: what mono says the content should be -------------
+                  # The mirror stamps "mirror: sync from mono@<sha>", so a mismatch
+                  # here means the mirror itself is stuck — invisible from hops 2/3
+                  # alone, which would look perfectly consistent with each other.
+                  MONO_SHA=$(GH_TOKEN=$MONO_TOKEN gh api "repos/peanutprotocol/mono/commits?path=content&per_page=1" --jq '.[0].sha' | cut -c1-7)
+                  MIRRORED_SHA=$(printf '%s' "$TIP_MSG" | sed -nE 's/.*mono@([0-9a-f]+).*/\1/p' | cut -c1-7)
+
+                  echo "mono content@$MONO_SHA | mirrored from @${MIRRORED_SHA:-?} | peanut-content ${TIP:0:7} | live ${LIVE:0:7}"
+
+                  STALE=""
+                  if [ -n "$MIRRORED_SHA" ] && [ "$MONO_SHA" != "$MIRRORED_SHA" ]; then
+                    STALE="the mirror is behind mono (mono content@\`$MONO_SHA\`, mirror published \`$MIRRORED_SHA\`)"
+                  elif [ "$LIVE" != "$TIP" ]; then
+                    STALE="production is behind peanut-content (live \`${LIVE:0:7}\`, latest \`${TIP:0:7}\`)"
+                  fi
+
+                  if [ -z "$STALE" ]; then
+                    echo "production content is current."
+                    exit 0
+                  fi
+
+                  AGE=$(( ( $(date -u +%s) - $(date -u -d "$TIP_AT" +%s) ) / 60 ))
+
+                  # ---- which hop, and is it already doomed? --------------------
+                  NUM=$(GH_TOKEN=$UI_TOKEN gh pr list --repo "$REPO" --state open --base main \
+                          --json number,headRefName \
+                          --jq '[.[] | select((.headRefName | startswith("auto/update-content-")) or (.headRefName | startswith("content/publish-to-main")))] | first | .number // empty')
+
+                  DOOMED=false
+                  if [ -n "$NUM" ]; then
+                    SHA=$(GH_TOKEN=$UI_TOKEN gh api "repos/$REPO/pulls/$NUM" --jq '.head.sha')
+                    CI=$(GH_TOKEN=$UI_TOKEN gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" \
+                           --jq '[.check_runs[] | select(.name=="ci-success")] | if length == 0 then "pending" elif all(.conclusion == "success") then "green" else "RED" end')
+                    WHERE="publish PR #$NUM is open, ci-success=$CI"
+                    [ "$CI" = "RED" ] && DOOMED=true
+                  else
+                    WHERE="no publish PR is open — the mirror, the dispatch, or update-content.yml failed"
+                  fi
+
+                  # Red CI never self-resolves, so don't wait out the grace period.
+                  if [ "$DOOMED" = false ] && [ "$AGE" -lt "$GRACE_MINUTES" ]; then
+                    echo "$STALE — ${AGE}m old, within ${GRACE_MINUTES}m grace ($WHERE). Not alerting yet."
+                    exit 0
+                  fi
+
+                  echo "::error::$STALE — stuck ${AGE}m — $WHERE"
+
+                  if [ -n "${DISCORD_WEBHOOK:-}" ]; then
+                    export ALERT=":rotating_light: **Content is not reaching production.**
+                  $STALE
+                  Stuck for **${AGE}m** — $WHERE
+                  Runbook: \`skills/publish-content/scripts/pipeline-status.sh\`
+                  $RUN_URL"
+                    python3 -c "import json,os,urllib.request; d=json.dumps({'content':os.environ['ALERT']}).encode(); urllib.request.urlopen(urllib.request.Request(os.environ['DISCORD_WEBHOOK'],data=d,headers={'Content-Type':'application/json'}),timeout=15); print('alerted Discord')" \
+                      || echo "::warning::Discord post failed — the failed run below is still the alert."
+                  else
+                    echo "::warning::CONTENT_PIPELINE_DISCORD_WEBHOOK is not set — alerting via this failed run only."
+                  fi
+
+                  # Always loud, webhook or not.
+                  exit 1

--- a/.github/workflows/content-pipeline-watchdog.yml
+++ b/.github/workflows/content-pipeline-watchdog.yml
@@ -111,7 +111,10 @@ jobs:
                   Stuck for **${AGE}m** — $WHERE
                   Runbook: \`skills/publish-content/scripts/pipeline-status.sh\`
                   $RUN_URL"
-                    python3 -c "import json,os,urllib.request; d=json.dumps({'content':os.environ['ALERT']}).encode(); urllib.request.urlopen(urllib.request.Request(os.environ['DISCORD_WEBHOOK'],data=d,headers={'Content-Type':'application/json'}),timeout=15); print('alerted Discord')" \
+                    # The User-Agent is load-bearing, not decoration: Cloudflare 403s
+                    # Discord webhook posts sent with python-urllib's default UA.
+                    # Verified 2026-07-28 — without it this silently never alerts.
+                    python3 -c "import json,os,urllib.request; d=json.dumps({'content':os.environ['ALERT']}).encode(); urllib.request.urlopen(urllib.request.Request(os.environ['DISCORD_WEBHOOK'],data=d,headers={'Content-Type':'application/json','User-Agent':'peanut-content-watchdog/1.0'}),timeout=15); print('alerted Discord')" \
                       || echo "::warning::Discord post failed — the failed run below is still the alert."
                   else
                     echo "::warning::CONTENT_PIPELINE_DISCORD_WEBHOOK is not set — alerting via this failed run only."

--- a/.github/workflows/content-publish-automerge.yml
+++ b/.github/workflows/content-publish-automerge.yml
@@ -12,21 +12,36 @@ name: Content publish auto-merge
 # in force for real code. eslint is already advisory (not in `ci-success`), so
 # "green tests" here means the real test/typecheck/build jobs, not lint.
 #
+# TWO PATHS TO MERGE, because the approver can't always approve:
+#
+#   1. `approve-and-merge` (pull_request_target) — approve, then `--auto --merge`.
+#      GitHub enforces `ci-success` before auto-merge fires. This is the path for
+#      any publish authored by someone other than CONTENT_BOT_TOKEN's user.
+#
+#   2. `merge-on-green` (workflow_run) — for publishes that CONTENT_BOT_TOKEN's
+#      own user authored, where GitHub forbids self-approval so path 1 can never
+#      complete. Since `update-content.yml` now opens its PRs as that user, this
+#      is the common path, not the exception. It merges via the org-admin bypass,
+#      which skips the review requirement (intended — the diff guard replaces it)
+#      AND the required status check (NOT intended). So this job re-establishes
+#      green `ci-success` ITSELF before merging. Never merge on the bypass alone.
+#
 # Security model:
-#   - `pull_request_target` runs THIS logic from the base branch (main), so a PR
-#     cannot tamper with the guard or the approve step. We never check out or run
-#     PR code — only `gh` API calls by PR number — so pull_request_target is safe
-#     here (no untrusted-code execution).
-#   - Same-repo branches only (fork guard on the job).
-#   - The approval is submitted by CONTENT_BOT_TOKEN's user (Hugo0). GitHub
-#     forbids approving your own PR, so this auto-approves anyone's content
-#     publish EXCEPT one that same user authored — those fall back to a manual
-#     merge (org-admin bypass). Konrad-authored publishes (the target case) work.
+#   - `pull_request_target` and `workflow_run` both run THIS logic from the
+#     default branch (main), so a PR cannot tamper with the guard or the merge
+#     step. We never check out or run PR code — only `gh` API calls by PR number
+#     — so both triggers are safe here (no untrusted-code execution).
+#   - Same-repo branches only (fork guards on both jobs).
+#   - Both paths require the diff to be EXACTLY `src/content` and are fail-closed:
+#     any extra file, any `gh` error, any missing check → no merge.
 
 on:
     pull_request_target:
         types: [opened, synchronize, reopened, ready_for_review]
         branches: [main]
+    workflow_run:
+        workflows: ['Tests']
+        types: [completed]
 
 permissions:
     contents: read
@@ -35,7 +50,7 @@ permissions:
 jobs:
     approve-and-merge:
         # Same-repo PRs only — never a fork.
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository
         runs-on: ubuntu-latest
         steps:
             - name: Guard — diff must be exactly the content submodule pointer
@@ -64,13 +79,73 @@ jobs:
                   REPO: ${{ github.repository }}
               run: |
                   set -euo pipefail
-                  # Approve — satisfies the 1-review rule. Fails only when the bot
-                  # user authored the PR (GitHub blocks self-approval); in that
-                  # case leave it for a manual merge.
+                  # Approve — satisfies the 1-review rule. Fails when the bot user
+                  # authored the PR (GitHub blocks self-approval); `merge-on-green`
+                  # picks those up once CI is green.
                   if gh pr review "$PR" --repo "$REPO" --approve; then
                     # main ruleset allows merge commits only (not squash/rebase).
                     gh pr merge "$PR" --repo "$REPO" --auto --merge \
                       || echo "::warning::auto-merge not enabled/permitted — merge manually."
                   else
-                    echo "::warning::Could not approve (bot may be the PR author) — merge manually."
+                    echo "::notice::Could not approve (bot authored this PR) — merge-on-green will handle it once ci-success is green."
                   fi
+
+    merge-on-green:
+        # Self-approval fallback. Fires when `Tests` finishes for any commit; the
+        # job itself works out whether there's a content publish to merge.
+        if: github.event_name == 'workflow_run'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Merge content-only publishes once ci-success is green
+              env:
+                  GH_TOKEN: ${{ secrets.CONTENT_BOT_TOKEN }}
+                  SHA: ${{ github.event.workflow_run.head_sha }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  set -euo pipefail
+
+                  # Key off the `ci-success` check run, NOT `workflow_run.conclusion`.
+                  # `ci-success` is the single check the "Protect Prod" ruleset gates
+                  # on; the run conclusion also folds in advisory jobs. Today eslint is
+                  # `continue-on-error: true` so it happens not to move the conclusion —
+                  # but that's an eslint config detail, not a guarantee. Gate on exactly
+                  # what the ruleset gates on.
+                  #
+                  # `Tests` runs on both `push` and `pull_request`, so a commit usually
+                  # carries TWO ci-success check runs. Require at least one and ALL of
+                  # them green — a single red run must block the merge.
+                  RUNS="repos/$REPO/commits/$SHA/check-runs?per_page=100"
+                  TOTAL=$(gh api "$RUNS" --jq '[.check_runs[] | select(.name=="ci-success")] | length')
+                  GREEN=$(gh api "$RUNS" --jq '[.check_runs[] | select(.name=="ci-success" and .conclusion=="success")] | length')
+                  if [ "$TOTAL" -eq 0 ] || [ "$TOTAL" -ne "$GREEN" ]; then
+                    echo "ci-success not green for $SHA ($GREEN/$TOTAL) — nothing to merge."
+                    exit 0
+                  fi
+
+                  # Open, non-draft, same-repo PRs into main still sitting on this exact
+                  # commit. The head.sha match stops us merging a PR that has since
+                  # moved on to an untested commit.
+                  PRS=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq "
+                    .[]
+                    | select(.state == \"open\")
+                    | select(.draft == false)
+                    | select(.base.ref == \"main\")
+                    | select(.head.repo.full_name == \"$REPO\")
+                    | select(.head.sha == \"$SHA\")
+                    | .number")
+
+                  if [ -z "$PRS" ]; then
+                    echo "No open content-publish candidates on $SHA."
+                    exit 0
+                  fi
+
+                  for PR in $PRS; do
+                    FILES=$(gh pr diff "$PR" --repo "$REPO" --name-only)
+                    if [ "$FILES" != "src/content" ]; then
+                      echo "::notice::#$PR is not content-only — normal review gate stays in place."
+                      continue
+                    fi
+                    echo "Merging #$PR — diff is exactly src/content, ci-success green ($GREEN/$TOTAL) on $SHA."
+                    gh pr merge "$PR" --repo "$REPO" --merge \
+                      || echo "::warning::merge failed for #$PR (already merged, or bypass unavailable) — merge manually."
+                  done

--- a/.github/workflows/update-content.yml
+++ b/.github/workflows/update-content.yml
@@ -13,14 +13,19 @@ jobs:
     update:
         runs-on: ubuntu-latest
         steps:
-            # Base the bump on `dev` (the PR target), NOT the repo default branch.
-            # Branching off a different branch than the base is what let unrelated
-            # code drift leak into the auto-PR (#2226) and made it conflict with dev
-            # once dev's content pointer moved (#2247). Off `dev`, the PR is
-            # content-only by construction and always cleanly mergeable.
+            # Base the bump on `main` — the branch peanut.me actually deploys from.
+            # This used to target `dev`, which was a dead end: `dev` only ever
+            # receives content pointers *downward* via the main->dev back-merge, so
+            # it was never ahead of main and a release could never carry a content
+            # bump up. 29 auto-PRs were opened against `dev` and not one ever
+            # merged. Publishing to production was a manual signed PR every time.
+            #
+            # Branch off the SAME ref we target, so the PR is content-only by
+            # construction — branching off a different base is what let unrelated
+            # code drift leak into the auto-PR (#2226) and conflict (#2247).
             - uses: actions/checkout@v4
               with:
-                  ref: dev
+                  ref: main
 
             - name: Init and update submodule
               env:
@@ -41,19 +46,23 @@ jobs:
                     echo "changed=true" >> "$GITHUB_OUTPUT"
                   fi
 
-            - name: Create PR + auto-merge (content-only)
+            - name: Create PR (content-only)
               if: steps.check.outputs.changed == 'true'
-              # Prefer a PAT (CONTENT_BOT_TOKEN) so the PR triggers CI and auto-merge
-              # can fire on green checks. Falls back to GITHUB_TOKEN — the PR still
-              # opens, but GITHUB_TOKEN-created PRs don't trigger CI, so auto-merge
-              # won't fire until the PAT is configured (no regression vs today).
+              # Prefer a PAT (CONTENT_BOT_TOKEN) so the PR triggers CI. Falls back to
+              # GITHUB_TOKEN — the PR still opens, but GITHUB_TOKEN-created PRs don't
+              # trigger CI, so nothing would ever gate or merge it.
+              #
+              # Approve + merge are deliberately NOT done here: that belongs to
+              # content-publish-automerge.yml, which runs from `main` (tamper-proof)
+              # and re-verifies the content-only diff AND green `ci-success` before
+              # merging. One guard, in one place, on the base branch.
               env:
                   GH_TOKEN: ${{ secrets.CONTENT_BOT_TOKEN || secrets.GITHUB_TOKEN }}
               run: |
                   set -euo pipefail
                   BRANCH="auto/update-content-$(date -u +%Y%m%d-%H%M%S)"
                   SUBMODULE_SHA=$(git -C src/content rev-parse HEAD)
-                  PARENT=$(git rev-parse HEAD)   # dev tip — bump is content-only vs dev
+                  PARENT=$(git rev-parse HEAD)   # main tip — bump is content-only vs main
                   BASE_TREE=$(gh api repos/${{ github.repository }}/git/commits/$PARENT --jq '.tree.sha')
                   # Create tree via API with updated submodule pointer
                   TREE=$(gh api repos/${{ github.repository }}/git/trees \
@@ -64,30 +73,34 @@ jobs:
                     -f "tree[][type]=commit" \
                     -f "tree[][sha]=$SUBMODULE_SHA" \
                     --jq '.sha')
-                  # Create signed commit via API (verified signature)
+                  # Create the bump commit via the Git Data API. NOTE: API-created
+                  # commits are UNSIGNED, and `required_signatures` is active on both
+                  # the "All branches" and "Protect Prod" rulesets. This works only
+                  # because CONTENT_BOT_TOKEN belongs to an OrganizationAdmin, who has
+                  # `bypass_mode: always` on both. If that token is ever moved to a
+                  # non-admin account, this step starts failing at ref-creation and the
+                  # bump must be made as a locally signed commit instead.
                   COMMIT_SHA=$(gh api repos/${{ github.repository }}/git/commits \
                     --method POST \
                     -f message="Update content submodule to latest main" \
                     -f "tree=$TREE" \
                     -f "parents[]=$PARENT" \
                     --jq '.sha')
-                  # Create branch pointing to signed commit
+                  # Create branch pointing at the bump commit
                   gh api repos/${{ github.repository }}/git/refs \
                     --method POST \
                     -f "ref=refs/heads/$BRANCH" \
                     -f "sha=$COMMIT_SHA"
-                  PR_URL=$(gh pr create \
+                  cat > /tmp/pr-body.md <<'BODY'
+                  Auto-generated: bumps `src/content` to latest peanut-content `main`.
+
+                  Based on `main`, so the diff is exactly the submodule pointer.
+                  `content-publish-automerge.yml` approves and merges this once
+                  `ci-success` is green. Anything other than a lone `src/content`
+                  change falls back to the normal 1-review gate.
+                  BODY
+                  gh pr create \
                     --head "$BRANCH" \
-                    --base dev \
-                    --title "Update content submodule" \
-                    --body "Auto-generated: bumps the content submodule to latest peanut-content main. Based on dev, so it's content-only and auto-merges once checks pass.")
-                  # Guard: only auto-merge when the PR touches NOTHING but the submodule
-                  # pointer. If anything else slipped in, leave it for a human.
-                  FILES=$(gh pr diff "$PR_URL" --name-only)
-                  if [ "$FILES" = "src/content" ]; then
-                    gh pr merge "$PR_URL" --auto --squash \
-                      || echo "::warning::auto-merge not enabled/permitted — left for manual merge ($PR_URL)"
-                  else
-                    echo "::warning::PR touches more than src/content — left for manual review:"
-                    echo "$FILES"
-                  fi
+                    --base main \
+                    --title "content: publish latest to production (src/content → peanut-content@${SUBMODULE_SHA:0:7})" \
+                    --body-file /tmp/pr-body.md

--- a/.github/workflows/update-content.yml
+++ b/.github/workflows/update-content.yml
@@ -9,6 +9,15 @@ permissions:
     contents: write
     pull-requests: write
 
+# A burst of content pushes dispatches several runs. Without this they race:
+# each branches off the same `main` and opens its own PR, and once the first
+# merges the rest conflict on the `src/content` gitlink and can NEVER merge.
+# The newest dispatch wins — it checks out peanut-content's tip, so it already
+# contains everything the runs it cancels would have published.
+concurrency:
+    group: update-content
+    cancel-in-progress: true
+
 jobs:
     update:
         runs-on: ubuntu-latest
@@ -99,8 +108,28 @@ jobs:
                   `ci-success` is green. Anything other than a lone `src/content`
                   change falls back to the normal 1-review gate.
                   BODY
-                  gh pr create \
+                  PR_URL=$(gh pr create \
                     --head "$BRANCH" \
                     --base main \
                     --title "content: publish latest to production (src/content → peanut-content@${SUBMODULE_SHA:0:7})" \
-                    --body-file /tmp/pr-body.md
+                    --body-file /tmp/pr-body.md)
+                  echo "Opened $PR_URL"
+
+                  # Retire every older auto-PR. They point at stale content, and once
+                  # this one merges they conflict on the gitlink and can never merge —
+                  # they'd just pile up. (29 of them did, on `dev`.) Closing them keeps
+                  # exactly one live publish PR. Best-effort: a failure here must not
+                  # fail the publish we just opened.
+                  NEW="${PR_URL##*/}"
+                  STALE=$(gh pr list --repo "${{ github.repository }}" --state open --base main \
+                            --json number,headRefName \
+                            --jq '.[] | select(.headRefName | startswith("auto/update-content-")) | .number' \
+                          || true)
+                  for N in $STALE; do
+                    if [ "$N" != "$NEW" ]; then
+                      echo "Closing superseded #$N"
+                      gh pr close "$N" --repo "${{ github.repository }}" --delete-branch \
+                        --comment "Superseded by $PR_URL (newer content pointer)." \
+                        || echo "::warning::could not close #$N"
+                    fi
+                  done

--- a/src/lib/__tests__/mdx-security.test.ts
+++ b/src/lib/__tests__/mdx-security.test.ts
@@ -1,0 +1,133 @@
+import { remarkNoExecutableContent } from '@/lib/mdx-security'
+
+/**
+ * Node type names and estree shapes below mirror what @mdx-js/mdx's parser
+ * actually emits — they were read off the real parser, not guessed.
+ */
+const plugin = remarkNoExecutableContent()
+
+const root = (...children: unknown[]) => ({ type: 'root', children }) as never
+
+/** An expression node carrying a parsed program, the way the real parser emits it. */
+const expression = (type: string, value: string, body: unknown[], line?: number) => ({
+    type,
+    value,
+    data: { estree: { body } },
+    ...(line ? { position: { start: { line } } } : {}),
+})
+
+const statement = (expr: unknown) => ({ type: 'ExpressionStatement', expression: expr })
+const literal = (value: unknown) => ({ type: 'Literal', value })
+
+describe('remarkNoExecutableContent', () => {
+    describe('rejects executable MDX', () => {
+        it('rejects a call expression', () => {
+            const tree = root(
+                expression('mdxFlowExpression', 'require("fs")', [statement({ type: 'CallExpression' })], 3)
+            )
+            expect(() => plugin(tree)).toThrow(/JavaScript expression.*line 3/s)
+        })
+
+        it('rejects a member expression prop', () => {
+            const tree = root({
+                type: 'mdxJsxFlowElement',
+                attributes: [
+                    {
+                        type: 'mdxJsxAttribute',
+                        name: 'bar',
+                        value: expression('mdxJsxAttributeValueExpression', 'process.env', [
+                            statement({ type: 'MemberExpression' }),
+                        ]),
+                    },
+                ],
+            })
+            expect(() => plugin(tree)).toThrow(/expression prop/)
+        })
+
+        it('rejects import/export outright', () => {
+            const tree = root({ type: 'mdxjsEsm', value: "import fs from 'fs'" })
+            expect(() => plugin(tree)).toThrow(/import\/export statement/)
+        })
+
+        it('rejects a JSX spread attribute outright', () => {
+            const tree = root({
+                type: 'mdxJsxFlowElement',
+                attributes: [{ type: 'mdxJsxExpressionAttribute', value: '...process.env' }],
+            })
+            expect(() => plugin(tree)).toThrow(/spread attribute/)
+        })
+
+        it('rejects a multi-statement program', () => {
+            const tree = root(
+                expression('mdxTextExpression', 'a;b', [statement(literal(1)), statement({ type: 'CallExpression' })])
+            )
+            expect(() => plugin(tree)).toThrow(/JavaScript expression/)
+        })
+
+        it('fails closed when the expression has no parsed program', () => {
+            const tree = root({ type: 'mdxTextExpression', value: 'whatever' })
+            expect(() => plugin(tree)).toThrow(/JavaScript expression/)
+        })
+
+        it('finds executable nodes nested deep in the tree', () => {
+            const tree = root({
+                type: 'blockquote',
+                children: [
+                    {
+                        type: 'paragraph',
+                        children: [expression('mdxTextExpression', 'evil()', [statement({ type: 'CallExpression' })])],
+                    },
+                ],
+            })
+            expect(() => plugin(tree)).toThrow(/JavaScript expression/)
+        })
+    })
+
+    describe('allows the inert forms content actually uses', () => {
+        it('allows a comment-only expression — {/* … */} parses to an empty program', () => {
+            const tree = root(expression('mdxFlowExpression', '/* a note to editors */', []))
+            expect(() => plugin(tree)).not.toThrow()
+        })
+
+        it('allows a literal prop — <Step number={1} />', () => {
+            const tree = root({
+                type: 'mdxJsxFlowElement',
+                attributes: [
+                    {
+                        type: 'mdxJsxAttribute',
+                        name: 'number',
+                        value: expression('mdxJsxAttributeValueExpression', '1', [statement(literal(1))]),
+                    },
+                ],
+            })
+            expect(() => plugin(tree)).not.toThrow()
+        })
+
+        it('allows a signed literal — {-1}', () => {
+            const tree = root(
+                expression('mdxTextExpression', '-1', [
+                    statement({ type: 'UnaryExpression', operator: '-', argument: literal(1) }),
+                ])
+            )
+            expect(() => plugin(tree)).not.toThrow()
+        })
+
+        it('allows plain markdown', () => {
+            const tree = root({ type: 'heading', depth: 1, children: [{ type: 'text', value: 'Fees' }] })
+            expect(() => plugin(tree)).not.toThrow()
+        })
+
+        it('allows a JSX component with string props', () => {
+            const tree = root({
+                type: 'mdxJsxFlowElement',
+                attributes: [{ type: 'mdxJsxAttribute', name: 'currency', value: 'ARS' }],
+                children: [{ type: 'text', value: 'hi' }],
+            })
+            expect(() => plugin(tree)).not.toThrow()
+        })
+
+        it('tolerates an empty tree', () => {
+            expect(() => plugin(root())).not.toThrow()
+        })
+    })
+})

--- a/src/lib/mdx-security.ts
+++ b/src/lib/mdx-security.ts
@@ -1,0 +1,106 @@
+/**
+ * MDX is code, not text.
+ *
+ * An expression in a content file compiles straight through to executable
+ * JavaScript — `{require('fs').readFileSync('/etc/passwd')}` survives
+ * compilation verbatim — and then runs wherever the page is rendered: the CI
+ * runner during `next build`, and the production build on Vercel. Both carry
+ * environment secrets.
+ *
+ * That was tolerable while every content publish went through a human. It isn't
+ * now: `.github/workflows/content-publish-automerge.yml` merges content-only
+ * bumps to production with no review, on the premise that "content can't do
+ * anything dangerous". This module enforces that premise instead of assuming it.
+ *
+ * It is deliberately not a blanket ban on `{...}` — content legitimately uses
+ * two inert forms, and breaking them would just push authors around the guard:
+ *
+ *   {/* a comment *\/}          → compiles to nothing at all
+ *   <Step number={1} />         → a literal; there is no code to run
+ *
+ * So the rule is *executable*, not *braced*: an expression is allowed only when
+ * its parsed program is empty (comment-only) or a single literal. Anything that
+ * can call, read, or reference — `{process.env}`, `{fn()}`, `{...spread}`,
+ * `import` — is rejected at compile time.
+ *
+ * Fail-closed: if an expression arrives without a parsed program we cannot prove
+ * it is inert, so it is rejected.
+ */
+
+/** Executable unless proven inert. Node type names verified against @mdx-js/mdx's parser. */
+const GUARDED_EXPRESSIONS: Record<string, string> = {
+    mdxFlowExpression: 'a JavaScript expression',
+    mdxTextExpression: 'a JavaScript expression',
+    mdxJsxAttributeValueExpression: 'a JSX expression prop (prop={x})',
+}
+
+/** Never legitimate in content — no inert form exists. */
+const FORBIDDEN_NODES: Record<string, string> = {
+    mdxjsEsm: 'an import/export statement',
+    mdxJsxExpressionAttribute: 'a JSX spread attribute ({...x})',
+}
+
+type EstreeNode = { type?: string; operator?: string; argument?: EstreeNode; expression?: EstreeNode }
+
+type MdxNode = {
+    type?: string
+    children?: MdxNode[]
+    attributes?: MdxNode[]
+    value?: unknown
+    data?: { estree?: { body?: EstreeNode[] } }
+    position?: { start?: { line?: number } }
+}
+
+/** A literal — or a signed literal like `{-1}`, which is still nothing to execute. */
+function isLiteral(expression?: EstreeNode): boolean {
+    if (expression?.type === 'Literal') return true
+    if (expression?.type === 'UnaryExpression' && (expression.operator === '-' || expression.operator === '+')) {
+        return expression.argument?.type === 'Literal'
+    }
+    return false
+}
+
+function isInert(node: MdxNode): boolean {
+    const body = node.data?.estree?.body
+    if (!Array.isArray(body)) return false // unparsed — cannot prove it is safe
+    if (body.length === 0) return true // comment-only
+    if (body.length > 1) return false
+    const [statement] = body
+    return statement?.type === 'ExpressionStatement' && isLiteral(statement.expression)
+}
+
+function reject(node: MdxNode, what: string): never {
+    const at = node.position?.start?.line ? ` at line ${node.position.start.line}` : ''
+    throw new Error(
+        `Executable MDX rejected: content contains ${what}${at}. ` +
+            `Content is published to production without human review, so it must not be able to run code. ` +
+            `Use markdown, a literal prop, or a registered component.`
+    )
+}
+
+function walk(node: MdxNode): void {
+    if (!node || typeof node !== 'object') return
+
+    const type = node.type as string
+    if (type in FORBIDDEN_NODES) reject(node, FORBIDDEN_NODES[type])
+    if (type in GUARDED_EXPRESSIONS && !isInert(node)) reject(node, GUARDED_EXPRESSIONS[type])
+
+    for (const child of node.children ?? []) walk(child)
+
+    // JSX attributes are not `children`, so they need their own pass: both the
+    // attribute node itself (a spread) and its value (an expression prop) can
+    // carry code.
+    for (const attribute of node.attributes ?? []) {
+        walk(attribute)
+        const value = attribute?.value
+        if (value && typeof value === 'object') walk(value as MdxNode)
+    }
+}
+
+/**
+ * Remark plugin that fails the compile if content contains executable MDX.
+ * It throws, which aborts the build rather than silently rendering.
+ */
+export function remarkNoExecutableContent() {
+    return (tree: MdxNode): void => walk(tree)
+}

--- a/src/lib/mdx-security.ts
+++ b/src/lib/mdx-security.ts
@@ -1,16 +1,28 @@
 /**
- * MDX is code, not text.
+ * Make it a build error for content to contain executable JavaScript.
  *
- * An expression in a content file compiles straight through to executable
- * JavaScript — `{require('fs').readFileSync('/etc/passwd')}` survives
- * compilation verbatim — and then runs wherever the page is rendered: the CI
- * runner during `next build`, and the production build on Vercel. Both carry
- * environment secrets.
+ * Raw MDX compiles expressions straight through to executable JS —
+ * `{require('fs').readFileSync('/etc/passwd')}` survives verbatim — which would
+ * run during `next build`, in CI and on Vercel, both of which carry secrets.
  *
- * That was tolerable while every content publish went through a human. It isn't
- * now: `.github/workflows/content-publish-automerge.yml` merges content-only
- * bumps to production with no review, on the premise that "content can't do
- * anything dangerous". This module enforces that premise instead of assuming it.
+ * We are not exposed to that today, and this module is NOT the thing preventing
+ * it: `next-mdx-remote@6` already strips the same node set by default, via
+ * `removeJavaScriptExpressions` (`blockJS`) and `removeImportsExportsPlugin`
+ * (`useDynamicImport: false`). This exists for two reasons anyway:
+ *
+ * 1. That protection is a dependency's *default*, on a path that now publishes
+ *    to production with no human review. A major upgrade, or someone passing
+ *    `blockJS: false` or `useDynamicImport: true` for an unrelated reason,
+ *    re-opens it silently. This asserts the invariant in our own repo, where it
+ *    is visible and tested.
+ * 2. next-mdx-remote *silently strips*; we run first in `remarkPlugins`, so we
+ *    *throw*. An author who writes `{price}` expecting interpolation currently
+ *    gets a page that quietly renders nothing and auto-publishes. They should
+ *    get a failed build naming the file and line.
+ *
+ * So: the value here is failing loud and pinning the invariant, not closing a
+ * live hole. Do not delete it on the grounds that "the library handles it" —
+ * that is precisely the assumption it exists to keep honest.
  *
  * It is deliberately not a blanket ban on `{...}` — content legitimately uses
  * two inert forms, and breaking them would just push authors around the guard:

--- a/src/lib/mdx.ts
+++ b/src/lib/mdx.ts
@@ -1,6 +1,7 @@
 import { compileMDX } from 'next-mdx-remote/rsc'
 import remarkGfm from 'remark-gfm'
 import { mdxComponents } from '@/components/Marketing/mdx/components'
+import { remarkNoExecutableContent } from '@/lib/mdx-security'
 
 /**
  * Compile markdown/MDX content into a React element with registered components.
@@ -14,6 +15,9 @@ import { mdxComponents } from '@/components/Marketing/mdx/components'
  *
  * Limitation: next-mdx-remote/rsc strips JSX expression props ({...}).
  * Components that need structured data accept JSON strings instead.
+ *
+ * remarkNoExecutableContent — content is published to production without human
+ * review, so it must not be able to execute. See mdx-security.ts.
  */
 export async function renderContent(source: string) {
     return compileMDX<Record<string, unknown>>({
@@ -22,7 +26,7 @@ export async function renderContent(source: string) {
         options: {
             mdxOptions: {
                 format: 'mdx',
-                remarkPlugins: [remarkGfm],
+                remarkPlugins: [remarkNoExecutableContent, remarkGfm],
             },
         },
     })


### PR DESCRIPTION
Makes content publish itself to production, safely, and say so loudly when it doesn't.

## The problem

Content merged to mono never reached peanut.me on its own — every publish needed a manual signed PR to `main`.

`update-content.yml` opened its `src/content` bump PRs against **`dev`**. But content only ever flows `main` → `dev` (via the back-merge), so `dev` was never *ahead* of `main` and a release could never carry a bump up:

- **29 `auto/update-content` PRs opened against `dev`. Zero ever merged** — each closed by hand as superseded.
- The last 5 `dev` → `main` releases (#2506, #2407, #2391, #2340, #2298) all left `src/content` untouched.
- At time of writing `main` = `peanut-content@c268e5d`, `dev` = `@1078c28` — dev's is a strict *ancestor*.

## What changes

**1. Retarget the auto-PR to `main`** and hand the gate to `content-publish-automerge.yml`.

**2. Add a `merge-on-green` fallback.** `update-content.yml` authors as `CONTENT_BOT_TOKEN`'s user — the same user the automerge workflow approves with — and GitHub forbids self-approval, so the existing approve → `--auto --merge` path can never complete. The fallback merges via the org-admin bypass instead.

That bypass skips the **required status check** as well as the review, so the fallback re-establishes green CI *itself*. It merges only when all of: ≥1 `ci-success` check run on the exact head commit and **all** of them green; diff **exactly** `src/content`; PR open, non-draft, base `main`, same-repo head, head SHA still equal to the tested commit. It keys off the `ci-success` check run rather than `workflow_run.conclusion`, because `ci-success` is what "Protect Prod" actually gates on.

**3. Stop publishes racing and piling up.** `concurrency: update-content` — a burst of pushes otherwise branches several PRs off the same `main`, and once the first merges the rest conflict on the gitlink and can *never* merge. Plus close superseded auto-PRs on open, automating a chore done by hand 29 times.

**4. Pin the "content can't execute" invariant.** Raw MDX compiles expressions to executable JS, which would run during `next build` in CI and on Vercel.

**Correction, and it matters:** we are **not** exposed to this today, and this guard is not what prevents it. `next-mdx-remote@6` already strips the same node set by default (`removeJavaScriptExpressions` via `blockJS`, `removeImportsExportsPlugin` via `useDynamicImport: false`). My original proof compiled through raw `@mdx-js/mdx`, which is not what `renderContent` calls. There was no live hole.

It is still worth keeping, for two smaller and truer reasons:
1. That protection is a *dependency default*, on a path that now publishes to production unreviewed. A major upgrade, or someone setting `blockJS: false` for an unrelated reason, silently re-opens it. This asserts the invariant in our repo, visibly and under test.
2. next-mdx-remote *silently strips*; we run first in `remarkPlugins`, so we **throw**. An author writing `{price}` expecting interpolation currently gets a page that quietly renders nothing and auto-publishes. They should get a failed build naming the file and line.

It checks *executable*, not *braced* — content legitimately uses two inert forms that must keep working:

| Still works | Now a build error |
|---|---|
| markdown, GFM tables | `{require('fs')...}` |
| `<ExchangeWidget currency="ARS" />` | `<Foo bar={process.env.X} />` |
| `<Step number={1} />` | `<Foo {...process.env} />` |
| `{/* editor comments */}` | `import fs from 'node:fs'` |

An expression passes only if its parsed program is empty (comment) or a single literal. Fail-closed: an expression that can't be parsed is rejected.

**Reviewer: this is the one item I'd understand you dropping.** It is defence-in-depth, not a fix. Items 1-3 and 5 are the PR.

**5. Fail loud.** `content-pipeline-watchdog.yml`, every 15 min, asserts one end-to-end invariant — *is production serving what's on mono `main`?* One question covering every failure mode: dead mirror, missed dispatch, failed update-content, red CI, conflicted PR, and whatever we haven't thought of. It checks hop 1 too (parsing the `mirror: sync from mono@<sha>` stamp), because comparing only peanut-content against peanut-ui looks perfectly consistent while the mirror is dead and mono races ahead. It lives here rather than in mono because peanut-ui already holds tokens for all three repos; mono has no secrets.

A stall **always** fails the run (red in Actions, re-failing every 15 min so it can't scroll away) **and** posts to Discord. A missing webhook degrades the alert, never silences it. Red `ci-success` skips the 45-min grace period since it will never self-resolve.

## Risks

- **Content now reaches production with no human in the loop.** Approved on the condition that it is *content-bump only* and *tests pass*; both are enforced, fail-closed (any extra file, any `gh` error, any missing/red check → no merge).
- Code cannot ride this path — verified live on this very PR: `approve-and-merge` ran, saw a non-content diff, and logged *"Not content-only — normal review gate stays in place."*
- Worst case is wrong copy on peanut.me, revertible in one pointer bump. Content cannot execute (next-mdx-remote strips JS by default; item 4 pins that).

## Design notes / accepted trade-offs

- **Depends on `CONTENT_BOT_TOKEN` belonging to an OrganizationAdmin.** API-made commits are unsigned and `required_signatures` is on both rulesets; the admin `bypass_mode: always` is the only reason this works. Documented inline — move that token to a non-admin account and the bump must become a locally signed commit. (Considered granting a bot App a ruleset bypass and rejected it: bypass is per-*ruleset*, not per-rule, so it would also hand out branch-deletion and force-push.)
- Both merge jobs run from the base branch (`pull_request_target` / `workflow_run`) — a PR cannot tamper with the guard judging it. Neither checks out or executes PR code.
- Corrected two materially wrong comments: the Git Data API commit was labelled "signed ... (verified signature)" (it is unsigned), and the Discord alert needs an explicit `User-Agent` (Cloudflare 403s python-urllib's default — caught by firing the webhook rather than trusting it, which would otherwise have been a silent failure in the thing built to prevent silent failures).

## QA

- Both workflows: `yaml.safe_load` parses, every `run:` block passes `bash -n`.
- `merge-on-green` jq filters dry-run against the real merged publish #2537 (`029e5566`): `TOTAL ci-success: 2, GREEN: 2` — the two-run (`push` + `pull_request`) case the all-green rule exists for. PR-selection correctly returns empty for an already-merged PR.
- Watchdog logic dry-run against live data: `mono content@0b0740a | mirrored from @0b0740a | peanut-content c268e5d | live c268e5d` → CURRENT, stays quiet.
- Discord webhook fired for real: HTTP 204 delivered.
- MDX guard against the real compiler: 7 attack payloads rejected (fs read, env exfil, spread, import, IIFE, template literal, bare identifier); **all 758 files under `src/content` compile unchanged**. Full inventory of every `{...}` in content: 15 literals, 2 comments, **0 executable**.
- 13 unit tests for the guard. Full suite: 4 pre-existing worktree failures (`@capacitor/clipboard` missing, `public/flags` ungenerated) — environment, not this diff.
- Prettier clean; typecheck clean for these files.

End-to-end can only be verified after merge: push content to mono → expect an auto-PR to `main` that self-merges on green, live in ~15–20 min.

## Docs

Updated on mono `main` (539b81f4, 15457469): `content/_system/ARCHITECTURE.md`, `skills/publish-content/SKILL.md` (+ frontmatter, now the *fallback* skill), `skills/publish-content/references/slack-draft.md`, `skills/update-content/SKILL.md`, `skills/README.md`. Each carries a note that the new behaviour activates when this PR merges — **delete those notes on merge**.

## Follow-up (not blocking)

`skills/publish-content/scripts/pipeline-status.sh` still prints `dev` for hop ③; flagged in the skill, worth a tidy-up pass later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated monitoring for content publishing, including alerts when production content becomes outdated or publishing is blocked.
  - Improved automatic publishing so validated content updates can merge reliably once checks pass.

- **Bug Fixes**
  - Prevented executable or unsafe MDX content from being published, including scripts, imports, exports, and unsafe JSX expressions.
  - Added validation to protect content rendered in production while allowing supported static content formats.

- **Tests**
  - Added coverage for safe and unsafe MDX content scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->