### PR TITLE
fix(watchdog): stop the script dying silently under bash -e

### DIFF
--- a/.github/workflows/content-pipeline-watchdog.yml
+++ b/.github/workflows/content-pipeline-watchdog.yml
@@ -49,11 +49,15 @@ jobs:
                   RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
               run: |
                   set -uo pipefail
-
-                  # Every API call is `|| true`: the step shell is `bash -e`, so an
-                  # unguarded 403 aborts mid-script and surfaces as a bare red run
-                  # indistinguishable from a real content alert. That happened once
-                  # (actions:read 403). Collect what we can, then decide explicitly.
+                  # `set +e` is deliberate, and `-e` here is actively harmful.
+                  # GitHub runs this step as `bash -e {0}`, which combined with
+                  # pipefail means ANY non-zero anywhere kills the script at that
+                  # line with no output at all — a red run and an empty log. It bit
+                  # twice: a 403 from the Actions API, then a `grep` with no match
+                  # inside the mirrored-paths filter (grep exits 1 on no-match, which
+                  # is a normal answer, not an error). This script decides everything
+                  # explicitly below; it must never die silently mid-check.
+                  set +e
 
                   # ---- hop 3: what production is serving -----------------------
                   LIVE=$(GH_TOKEN=$UI_TOKEN gh api "repos/$REPO/contents/src/content?ref=main" --jq '.sha' || true)
@@ -86,6 +90,15 @@ jobs:
                                    printf '%s\n' "$FILES" | grep '^content/_system/generated/'; } | head -1 )
                     if [ -n "$PUBLISHED" ]; then EXPECTED="$SHA"; break; fi
                   done
+
+                  # On failure `gh` prints its error body to stdout, which would land
+                  # in these vars and read as a bogus sha. Keep only real ones, so a
+                  # broken call resolves to empty and trips the DEGRADED branch below
+                  # instead of being compared as if it were data.
+                  only_sha() { printf '%s' "${1:-}" | grep -Eox '[0-9a-f]{40}' || true; }
+                  LIVE=$(only_sha "$LIVE")
+                  TIP=$(only_sha "$TIP")
+                  EXPECTED=$(only_sha "$EXPECTED")
 
                   MIRRORED=$(printf '%s' "$TIP_MSG" | sed -nE 's/.*mono@([0-9a-f]+).*/\1/p')
 


### PR DESCRIPTION
Third fix for this watchdog, and the root cause was the same all three times: **I verified in an environment that wasn't the one it runs in.**

## The bug

The last run produced *no output at all* — nothing between the env block and `exit 1`:

```
  RUN_URL: https://github.com/.../actions/runs/30352752517
  ##[endgroup]
  ##[error]Process completed with exit code 1.
```

GitHub runs the step as `bash -e {0}`. With `set -o pipefail`, any non-zero anywhere kills the script at that line with no message. It died on the **first loop iteration**: `grep` returns 1 when a commit touched no mirrored paths — a normal answer, not an error — and `d9a33de` is exactly that case.

Reproduced in isolation:
```
$ bash -e repro.sh
exit=1          # and the line after never runs
```

## The fix

`set +e`, explicitly and with the reasoning in a comment. Every branch in this script already decides for itself and reports why; `-e` contributes nothing except the ability to die mid-check without saying so.

Also filter `LIVE`/`TIP`/`EXPECTED` through a 40-hex check — on failure `gh` prints its error body to **stdout**, which was landing in those vars and being compared as though it were a sha (`tip={ "m`). Now a broken call resolves to empty and trips the labelled DEGRADED branch.

## Verification — the check I should have run from the start

Extracted the step from the YAML and executed it under `bash -e` against the real APIs, both paths:

```
healthy:       expected mono@0b0740a | mirrored @0b0740a | peanut-content c268e5d | live c268e5d
               production content is current.                        EXIT=0  (silent)

broken token:  ::error::WATCHDOG DEGRADED — could not evaluate the pipeline
               (expected=0b0740a mirrored=none live=c268e5d tip=)     EXIT=1
```

`bash -n` and dry-running the logic in my own shell both passed every time and caught none of this, because neither has `-e` set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content pipeline monitoring reliability when checking commit synchronization.
  * Prevented API errors or malformed commit values from triggering incorrect “stuck” alerts.
  * Ensured watchdog checks continue handling failures visibly instead of terminating unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->