### PR TITLE
fix(add-money): PIX deposit Done exits to home instead of starting a new deposit

### DIFF
--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -4,7 +4,7 @@ import MantecaDepositShareDetails from '@/components/AddMoney/components/Manteca
 import MantecaPixQrDeposit from '@/components/AddMoney/components/MantecaPixQrDeposit'
 import CyclingLoading from '@/components/Global/PeanutLoading/CyclingLoading'
 import InputAmountStep from '@/components/AddMoney/components/InputAmountStep'
-import { useParams, useSearchParams } from 'next/navigation'
+import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import { addMoneyCountryUrl } from '@/utils/native-routes'
 import { useSafeBack } from '@/hooks/useSafeBack'
 import { type CountryData, countryData } from '@/components/AddMoney/consts'
@@ -38,6 +38,7 @@ const MantecaAddMoney: FC = () => {
     const params = useParams()
     const searchParams = useSearchParams()
     const queryClient = useQueryClient()
+    const router = useRouter()
 
     // URL state - persisted in query params
     // Example: /add-money/argentina/manteca?step=inputAmount&amount=100&currency=ARS
@@ -334,6 +335,9 @@ const MantecaAddMoney: FC = () => {
                 depositDetails={depositDetails}
                 currencyAmount={localCurrencyAmount}
                 onBack={() => setUrlState({ step: 'inputAmount' })}
+                // Terminal exit — `replace` so device/browser back can't pop into the
+                // finished deposit (whose step=showQR would redirect to a new one).
+                onDone={() => router.replace('/home')}
                 onComplete={() => queryClient.invalidateQueries({ queryKey: [TRANSACTIONS] })}
             />
         )

--- a/src/components/AddMoney/components/MantecaPixQrDeposit.tsx
+++ b/src/components/AddMoney/components/MantecaPixQrDeposit.tsx
@@ -68,10 +68,14 @@ const MantecaPixQrDeposit: FC<{
     }
 
     // Payment detected, settling — show the branded processing screen (same as PIX payments).
+    // `processing` means stage >= 2, i.e. the fiat HAS left the user's bank, so this exits
+    // like `completed` does: going "back" here would offer the amount input, pre-filled with
+    // the amount they just paid, one tap from paying twice. The credit doesn't depend on this
+    // screen — the webhook/poller post it server-side.
     if (status === 'processing') {
         return (
             <div className="flex min-h-[inherit] flex-col gap-8">
-                <NavHeader title="Add Money" onPrev={onBack} />
+                <NavHeader title="Add Money" onPrev={onDone} />
                 <div className="my-auto flex flex-col justify-center">
                     <CyclingLoading />
                 </div>

--- a/src/components/AddMoney/components/MantecaPixQrDeposit.tsx
+++ b/src/components/AddMoney/components/MantecaPixQrDeposit.tsx
@@ -15,9 +15,13 @@ const MantecaPixQrDeposit: FC<{
     currencyAmount?: string
     // Parent owns step navigation — usually setUrlState({ step: 'inputAmount' }).
     onBack: () => void
+    // Exits the deposit flow entirely (home). Distinct from onBack: once the
+    // deposit has settled there is nothing to go "back" to — reusing onBack here
+    // dropped the user on the amount input, i.e. straight into a NEW deposit.
+    onDone: () => void
     // Fired once when the deposit settles (parent refreshes balance/history).
     onComplete: () => void
-}> = ({ depositDetails, currencyAmount, onBack, onComplete }) => {
+}> = ({ depositDetails, currencyAmount, onBack, onDone, onComplete }) => {
     // The dynamic PIX QR (EMVCo copia-e-cola) rides in the ramp-on synthetic's
     // details.depositAddresses.PIX (confirmed against prod 2026-07-02).
     const qr = depositDetails.details.depositAddresses?.PIX?.code
@@ -48,14 +52,14 @@ const MantecaPixQrDeposit: FC<{
     if (status === 'completed') {
         return (
             <div className="flex min-h-[inherit] flex-col gap-8">
-                <NavHeader title="Add Money" onPrev={onBack} />
+                <NavHeader title="Add Money" onPrev={onDone} />
                 <div className="my-auto flex flex-col items-center gap-4 text-center">
                     <div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-1">
                         <Icon name="check" size={32} />
                     </div>
                     <h2 className="text-2xl font-bold text-n-1">Deposit received!</h2>
                     <p className="text-grey-1">Your balance has been updated.</p>
-                    <Button variant="purple" shadowSize="4" className="w-full" onClick={onBack}>
+                    <Button variant="purple" shadowSize="4" className="w-full" onClick={onDone}>
                         Done
                     </Button>
                 </div>

--- a/src/components/AddMoney/components/__tests__/MantecaAddMoney.test.tsx
+++ b/src/components/AddMoney/components/__tests__/MantecaAddMoney.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * MantecaAddMoney — the BRL/PIX exit contract.
+ *
+ * The child (MantecaPixQrDeposit) has two distinct exits and this is where they get
+ * their meaning: `onBack` returns to the amount step, `onDone` leaves the flow. Only
+ * the destination is under test here — everything else is stubbed to the thinnest
+ * thing that lets the showQR step render.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockRouterReplace = jest.fn()
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ push: jest.fn(), replace: mockRouterReplace, back: jest.fn(), prefetch: jest.fn() }),
+    useParams: () => ({ country: 'brazil' }),
+    useSearchParams: () => ({ get: () => null }),
+}))
+
+// nuqs — a plain object store, so `step` transitions are observable
+const queryState: Record<string, any> = {}
+const setQueryState = jest.fn((updates: Record<string, any>) => Object.assign(queryState, updates))
+jest.mock('nuqs', () => ({
+    useQueryStates: () => [queryState, setQueryState],
+    parseAsString: {},
+    parseAsStringEnum: () => ({}),
+}))
+
+// The child: surface both exits as buttons so the test can fire either one.
+jest.mock('@/components/AddMoney/components/MantecaPixQrDeposit', () => ({
+    __esModule: true,
+    default: ({ onBack, onDone }: { onBack: () => void; onDone: () => void }) => (
+        <div>
+            <button onClick={onDone}>child-done</button>
+            <button onClick={onBack}>child-back</button>
+        </div>
+    ),
+}))
+jest.mock('@/components/AddMoney/components/InputAmountStep', () => ({
+    __esModule: true,
+    default: ({ onSubmit }: { onSubmit: () => void }) => <button onClick={onSubmit}>submit-amount</button>,
+}))
+jest.mock('@/components/AddMoney/components/MantecaDepositShareDetails', () => ({
+    __esModule: true,
+    default: () => null,
+}))
+jest.mock('@/components/Global/PeanutLoading/CyclingLoading', () => ({ __esModule: true, default: () => null }))
+jest.mock('@/components/Kyc/SumsubKycModals', () => ({ SumsubKycModals: () => null }))
+jest.mock('@/components/Kyc/InitiateKycModal', () => ({ InitiateKycModal: () => null }))
+
+const mockDeposit = jest.fn()
+jest.mock('@/services/manteca', () => ({ mantecaApi: { deposit: (...a: unknown[]) => mockDeposit(...a) } }))
+
+jest.mock('@/hooks/useCurrency', () => ({ useCurrency: () => ({ symbol: 'R$', price: 5 }) }))
+jest.mock('@/hooks/useCapabilities', () => ({ useCapabilities: () => ({ rails: [] }) }))
+jest.mock('@/hooks/useIdentityVerification', () => ({ useIdentityVerification: () => ({ isVerified: true }) }))
+jest.mock('@/hooks/useMultiPhaseKycFlow', () => ({ useMultiPhaseKycFlow: () => ({ isLoading: false, error: null }) }))
+jest.mock('@/features/limits/hooks/useLimitsValidation', () => ({
+    useLimitsValidation: () => ({ currency: 'BRL' }),
+}))
+jest.mock('@/utils/regions.utils', () => ({ isVerifiedForCountry: () => true }))
+jest.mock('@/utils/provider-rejection.utils', () => ({ deriveProviderRejection: () => ({ state: 'none' }) }))
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
+
+// imported after the jest.mock calls above, which must be hoisted first
+import MantecaAddMoney from '../MantecaAddMoney'
+
+const renderFlow = () =>
+    render(
+        <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+            <MantecaAddMoney />
+        </QueryClientProvider>
+    )
+
+// Drive the real handleAmountSubmit so `depositDetails` is populated the way it is in
+// production — the showQR step renders `null` without it.
+const reachQrStep = async () => {
+    fireEvent.click(screen.getByText('submit-amount'))
+    await waitFor(() => expect(screen.getByText('child-done')).toBeInTheDocument())
+}
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    Object.keys(queryState).forEach((k) => delete queryState[k])
+    Object.assign(queryState, { amount: '250', currency: 'BRL' })
+    mockDeposit.mockResolvedValue({ data: { id: 'syn-1', details: {}, stages: {} } })
+})
+
+describe('MantecaAddMoney — BRL/PIX exits', () => {
+    // The bug: Done was wired to the same handler as back, so a settled deposit sent
+    // the user to the amount input — i.e. into a new deposit — instead of out of the flow.
+    it('sends the user home when the PIX screen signals it is done', async () => {
+        renderFlow()
+        await reachQrStep()
+
+        fireEvent.click(screen.getByText('child-done'))
+
+        expect(mockRouterReplace).toHaveBeenCalledWith('/home')
+        // and specifically NOT back into the flow
+        expect(setQueryState).not.toHaveBeenCalledWith({ step: 'inputAmount' })
+    })
+
+    it('returns to the amount step on back — the non-terminal exit is unchanged', async () => {
+        renderFlow()
+        await reachQrStep()
+
+        fireEvent.click(screen.getByText('child-back'))
+
+        expect(setQueryState).toHaveBeenCalledWith({ step: 'inputAmount' })
+        expect(mockRouterReplace).not.toHaveBeenCalled()
+    })
+})

--- a/src/components/AddMoney/components/__tests__/MantecaPixQrDeposit.test.tsx
+++ b/src/components/AddMoney/components/__tests__/MantecaPixQrDeposit.test.tsx
@@ -125,9 +125,29 @@ describe('MantecaPixQrDeposit', () => {
         )
 
         fireEvent.click(screen.getByText('Done'))
+        expect(onDone).toHaveBeenCalled()
+
+        onDone.mockClear()
+        fireEvent.click(screen.getByTestId('nav-back'))
+        expect(onDone).toHaveBeenCalled()
+
+        expect(onBack).not.toHaveBeenCalled()
+    })
+
+    // Same class, one state earlier: `processing` means stage >= 2 — the fiat already
+    // left the user's bank, so backing out to a pre-filled amount input invites a
+    // duplicate payment. Exit, don't go back.
+    it('exits via onDone from the processing screen — the fiat has already been sent', () => {
+        mockUseMantecaDepositPolling.mockReturnValue({ status: 'processing' })
+        const onBack = jest.fn()
+        const onDone = jest.fn()
+        render(
+            <MantecaPixQrDeposit depositDetails={baseDeposit} onBack={onBack} onDone={onDone} onComplete={jest.fn()} />
+        )
+
         fireEvent.click(screen.getByTestId('nav-back'))
 
-        expect(onDone).toHaveBeenCalledTimes(2)
+        expect(onDone).toHaveBeenCalled()
         expect(onBack).not.toHaveBeenCalled()
     })
 

--- a/src/components/AddMoney/components/__tests__/MantecaPixQrDeposit.test.tsx
+++ b/src/components/AddMoney/components/__tests__/MantecaPixQrDeposit.test.tsx
@@ -7,14 +7,17 @@
  * primitives are stubbed so only this component's own logic is under test.
  */
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 
 const mockUseMantecaDepositPolling = jest.fn()
 jest.mock('@/components/AddMoney/hooks/useMantecaDepositPolling', () => ({
     useMantecaDepositPolling: (...args: unknown[]) => mockUseMantecaDepositPolling(...args),
 }))
 
-jest.mock('@/components/Global/NavHeader', () => ({ __esModule: true, default: () => <div /> }))
+jest.mock('@/components/Global/NavHeader', () => ({
+    __esModule: true,
+    default: ({ onPrev }: { onPrev?: () => void }) => <div data-testid="nav-back" onClick={onPrev} />,
+}))
 jest.mock('@/components/Global/QRCodeWrapper', () => ({
     __esModule: true,
     default: ({ url, disabled }: { url: string; disabled?: boolean }) => (
@@ -67,6 +70,7 @@ describe('MantecaPixQrDeposit', () => {
                 depositDetails={baseDeposit}
                 currencyAmount="10"
                 onBack={jest.fn()}
+                onDone={jest.fn()}
                 onComplete={jest.fn()}
             />
         )
@@ -81,7 +85,14 @@ describe('MantecaPixQrDeposit', () => {
             ...baseDeposit,
             details: { ...baseDeposit.details, priceExpireAt: new Date(Date.now() - 1000).toISOString() },
         }
-        render(<MantecaPixQrDeposit depositDetails={expired} onBack={jest.fn()} onComplete={jest.fn()} />)
+        render(
+            <MantecaPixQrDeposit
+                depositDetails={expired}
+                onBack={jest.fn()}
+                onDone={jest.fn()}
+                onComplete={jest.fn()}
+            />
+        )
 
         expect(screen.getByText(/expired/i)).toBeInTheDocument()
         expect(screen.getByTestId('qr')).toHaveAttribute('data-disabled', 'true')
@@ -90,9 +101,47 @@ describe('MantecaPixQrDeposit', () => {
 
     it('shows the success state when the deposit completes', () => {
         mockUseMantecaDepositPolling.mockReturnValue({ status: 'completed' })
-        render(<MantecaPixQrDeposit depositDetails={baseDeposit} onBack={jest.fn()} onComplete={jest.fn()} />)
+        render(
+            <MantecaPixQrDeposit
+                depositDetails={baseDeposit}
+                onBack={jest.fn()}
+                onDone={jest.fn()}
+                onComplete={jest.fn()}
+            />
+        )
 
         expect(screen.getByText('Deposit received!')).toBeInTheDocument()
         expect(screen.queryByTestId('qr')).not.toBeInTheDocument()
+    })
+
+    // Regression: both exits on the success screen used to call onBack, which the
+    // parent wires to step=inputAmount — so "Done" started a NEW deposit.
+    it('exits the flow via onDone (never onBack) from the success screen', () => {
+        mockUseMantecaDepositPolling.mockReturnValue({ status: 'completed' })
+        const onBack = jest.fn()
+        const onDone = jest.fn()
+        render(
+            <MantecaPixQrDeposit depositDetails={baseDeposit} onBack={onBack} onDone={onDone} onComplete={jest.fn()} />
+        )
+
+        fireEvent.click(screen.getByText('Done'))
+        fireEvent.click(screen.getByTestId('nav-back'))
+
+        expect(onDone).toHaveBeenCalledTimes(2)
+        expect(onBack).not.toHaveBeenCalled()
+    })
+
+    it('still uses onBack from the expired state — that one is a real go-back', () => {
+        const onBack = jest.fn()
+        const expired = {
+            ...baseDeposit,
+            details: { ...baseDeposit.details, priceExpireAt: new Date(Date.now() - 1000).toISOString() },
+        }
+        render(
+            <MantecaPixQrDeposit depositDetails={expired} onBack={onBack} onDone={jest.fn()} onComplete={jest.fn()} />
+        )
+
+        fireEvent.click(screen.getByText('Go back'))
+        expect(onBack).toHaveBeenCalledTimes(1)
     })
 })


### PR DESCRIPTION
## Summary

After a completed BRL deposit via PIX, tapping **Done** started a *new* deposit instead of returning home — the successful deposit read as unfinished and invited an accidental repeat payment. ([Discord report](https://discord.com/channels/972435984954302464/1484181812715585576/1531632169594650664), TASK-20961)

**Root cause:** the PIX screen wired its *terminal* exits to `onBack`, which the parent defines as `setUrlState({ step: 'inputAmount' })`. Once the fiat has been sent there is nothing to go "back" to, so "back" meant "restart the flow".

**Fix:** `MantecaPixQrDeposit` gets a distinct `onDone` exit; `MantecaAddMoney` wires it to `router.replace('/home')`.

- `replace`, not `push` — device/browser back must not pop into the finished flow, whose `step=showQR` with `depositDetails` gone redirects to `inputAmount`, still carrying `?amount=…&currency=BRL` in the URL, i.e. the same trap one back-press later. Matches the `replaceOnDone` convention in `PaymentSuccessView` (used by the crypto-deposit success path). `useSafeBack` would be wrong here: its in-app-history branch calls `router.back()`, which lands on the country list, not home.
- **Also fixed: the `processing` state**, found by the adversarial review pass. `processing` means the poller saw `stage >= 2` — [documented](../blob/main/src/components/AddMoney/hooks/useMantecaDepositPolling.ts) as "the fiat actually arrived" — and the spinner's only affordance was a back arrow to a **pre-filled** amount input, one tap from paying twice while the first deposit settles. It now exits like the settled state. Leaving is safe: the credit is posted server-side by the webhook/poller, not by this screen's polling.
- The expired-QR **Go back** keeps `onBack` — that one is a genuine go-back (re-quote the deposit).

## Risk

Low, narrowly scoped: two components in the BRL/PIX add-money flow, no API or state-shape change. Blast radius is `step === 'showQR'` in `MantecaAddMoney` only. The ARS/other-currency path (`MantecaDepositShareDetails`) has no completion screen and is untouched; the crypto-deposit path already routes home via `PaymentSuccessView`. No cross-repo impact.

## QA

1. Brazil → Add money → enter a BRL amount → PIX QR screen.
2. Pay the QR (Manteca sandbox) and wait for polling to flip to **Deposit received!**
3. Tap **Done** → lands on `/home`, **no** new deposit flow, balance/history refreshed.
4. Device back from `/home` → does **not** return to the completed deposit.
5. While the spinner is up (payment detected, settling), tap the header back arrow → also lands on `/home`, not a pre-filled amount input.
6. Regression: let a QR expire → **Go back** still returns to the amount input.

Automated — `MantecaPixQrDeposit.test.tsx` + new `MantecaAddMoney.test.tsx`: the settled and processing screens exit via `onDone` (never `onBack`), the expired screen still uses `onBack`, and the parent sends the user to `/home` rather than back into the flow. Each assertion was mutation-checked: reverting the corresponding fix line makes exactly that test fail.

## Design notes / accepted trade-offs

- **Not reused: `PaymentSuccessView`.** It already implements terminal-exit semantics and would delete this screen's bespoke success block. Deliberately deferred — it pulls in Redux, the receipt drawer, confetti and `useTokenChainIcons`, changes the layout (`justify-between` vs this screen's `my-auto`) and the header icon, and duplicates the parent's `TRANSACTIONS` invalidation. That's a UI change, not a bug fix. Worth a follow-up.
- **Not fixed here: `['balance']` is never invalidated** after a deposit — only `[TRANSACTIONS]` is. It self-heals (no observer during the flow, `staleTime` 30s, `refetchOnMount`), and the omission is codebase-wide (`PaymentSuccessView`, `withdraw/manteca`), so fixing it only here would be inconsistent. Follow-up, not a regression from this PR.
- **`onDone={() => router.replace('/home')}` is not covered by the `no-restricted-syntax` back-button guard**, which only matches `onPrev`/`onBack` attributes. The guard's hazard (a `push` growing in-app history so `useSafeBack` cycles) doesn't apply to a `replace` on a terminal screen — but a future `replace` → `push` edit on that line would be lint-silent. The inline comment holds the invariant.

## Screenshots

⚠️ **NONE** — no pixel change. Both screens render identically; only the exit *destination* changes. Reaching them for a capture needs a settled Manteca-sandbox PIX payment, which the local harness can't drive. Behavior is covered by the tests above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved navigation after PIX deposits complete or remain in processing.
  - The deposit flow now correctly returns to the home screen when users finish or exit terminal deposit states.
  - Preserved the option to return to the amount-entry step when backing out before completion.
  - Retained the existing behavior for expired deposits.

- **Tests**
  - Added coverage for deposit completion, processing, back navigation, and expiration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->