### PR TITLE
feat(home): pending Bridge verification tasks card

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -22,6 +22,38 @@ global.ResizeObserver = class {
     disconnect() {}
 }
 
+// jsdom has no IntersectionObserver; embla-carousel's SlidesInView needs it on init.
+global.IntersectionObserver = class {
+    root = null
+    rootMargin = ''
+    thresholds = []
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+        return []
+    }
+} as unknown as typeof IntersectionObserver
+
+// jsdom has no matchMedia; embla-carousel calls it for breakpoint options on init.
+// Suites that assert on matchMedia behavior override this with their own stub.
+// Guarded: a few suites run in the node environment, where window doesn't exist.
+if (typeof window !== 'undefined') {
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: (query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: jest.fn(),
+            removeListener: jest.fn(),
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn(),
+        }),
+    })
+}
+
 // Add any global test setup here
 global.console = {
     ...console,

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -334,6 +334,7 @@ jest.mock('@/utils/currency', () => ({
 }))
 
 jest.mock('@/utils/format.utils', () => ({
+    ...jest.requireActual('@/utils/format.utils'),
     formatBankAccountDisplay: jest.fn((val: string) => val),
 }))
 

--- a/src/app/(mobile-ui)/home/page.tsx
+++ b/src/app/(mobile-ui)/home/page.tsx
@@ -218,8 +218,9 @@ export default function Home() {
                     {/* Pending Bridge verification tasks (ToS / hosted re-verification).
                         Sibling of ActivationCTAs on purpose: it must show for users
                         who can already transact (the advisory cohort), whom the
-                        activation card deliberately stands down for. Self-hiding. */}
-                    <PendingVerificationTasks />
+                        activation card deliberately stands down for. Self-hiding;
+                        dismissible here — resurfaces under Profile → Unlocked regions. */}
+                    <PendingVerificationTasks dismissible />
                     {isActivated ? (
                         <HomeCarouselCTA />
                     ) : (

--- a/src/app/(mobile-ui)/home/page.tsx
+++ b/src/app/(mobile-ui)/home/page.tsx
@@ -34,6 +34,7 @@ import { updateUserById } from '@/app/actions/users'
 import { useHaptic } from 'use-haptic'
 import { useActivationStatus } from '@/hooks/useActivationStatus'
 import ActivationCTAs from '@/components/Home/ActivationCTAs'
+import PendingVerificationTasks from '@/components/Home/PendingVerificationTasks'
 import LazyLoadErrorBoundary from '@/components/Global/LazyLoadErrorBoundary'
 import underMaintenanceConfig from '@/config/underMaintenance.config'
 import posthog from 'posthog-js'
@@ -214,6 +215,11 @@ export default function Home() {
                         dismiss/click hides it forever. Rendered above the carousel/activation
                         CTAs so it leads the home stack on launch day. */}
                     <CardLaunchCTA />
+                    {/* Pending Bridge verification tasks (ToS / hosted re-verification).
+                        Sibling of ActivationCTAs on purpose: it must show for users
+                        who can already transact (the advisory cohort), whom the
+                        activation card deliberately stands down for. Self-hiding. */}
+                    <PendingVerificationTasks />
                     {isActivated ? (
                         <HomeCarouselCTA />
                     ) : (

--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -116,6 +116,31 @@ export const initiateSelfHealResubmission = async (
     }
 }
 
+/**
+ * Exchange the `bridge-hosted` capability action for Bridge's hosted
+ * verification URL (same POST /users/kyc/start-action endpoint as
+ * {@link startKycAction}, different response shape: that path mints Sumsub
+ * tokens, this one returns a URL — hence its own guard).
+ */
+export const startBridgeHostedVerification = async (): Promise<{ url?: string; error?: string }> => {
+    try {
+        const response = await serverFetch('/users/kyc/start-action', {
+            method: 'POST',
+            body: JSON.stringify({ key: 'bridge-hosted' }),
+        })
+        const responseJson = await response.json()
+        if (!response.ok) {
+            return { error: responseJson.userMessage || responseJson.error || 'Failed to start verification' }
+        }
+        if (!responseJson.verificationUrl) {
+            return { error: 'Invalid response from server' }
+        }
+        return { url: responseJson.verificationUrl }
+    } catch (e: unknown) {
+        return { error: e instanceof Error ? e.message : 'An unexpected error occurred' }
+    }
+}
+
 export interface StartKycActionResponse {
     token: string
     levelName: string

--- a/src/components/Global/IframeWrapper/__tests__/IframeWrapper.test.tsx
+++ b/src/components/Global/IframeWrapper/__tests__/IframeWrapper.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * IframeWrapper message routing — the wrapper reacts ONLY to postMessages
+ * from ITS OWN iframe (source identity), never to a sibling's. The previous
+ * guard keyed on `visible`, which (a) let two concurrently-visible wrappers
+ * fire each other's handlers (double ToS confirms + phantom flow
+ * transitions) and (b) dropped a real completion that landed in the instant
+ * a modal was hiding — the acceptance existed at Bridge but was never
+ * confirmed in-app.
+ */
+import React from 'react'
+import { render, act } from '@testing-library/react'
+import IframeWrapper from '../index'
+
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn() }) }))
+jest.mock('@/context/ModalsContext', () => ({
+    useModalsContext: () => ({ setIsSupportModalOpen: jest.fn() }),
+}))
+
+function findIframe(src: string): HTMLIFrameElement {
+    // headlessui Dialog portals into document.body — search the document.
+    const iframe = Array.from(document.querySelectorAll('iframe')).find((f) => f.getAttribute('src') === src)
+    if (!iframe) throw new Error(`iframe with src ${src} not mounted`)
+    return iframe
+}
+
+function postFrom(source: Window | null, data: unknown) {
+    act(() => {
+        window.dispatchEvent(new MessageEvent('message', { data, source: source as MessageEventSource | null }))
+    })
+}
+
+describe('IframeWrapper message routing', () => {
+    it("handles its OWN iframe's completion and ToS messages", () => {
+        const onClose = jest.fn()
+        render(<IframeWrapper src="https://one.test/flow" visible onClose={onClose} />)
+        const own = findIframe('https://one.test/flow').contentWindow
+
+        postFrom(own, { name: 'complete', metadata: { status: 'completed' } })
+        expect(onClose).toHaveBeenCalledWith('completed')
+
+        postFrom(own, { signedAgreementId: 'sig-1' })
+        expect(onClose).toHaveBeenCalledWith('tos_accepted')
+    })
+
+    it("ignores a SIBLING iframe's message even when BOTH wrappers are visible", () => {
+        const onCloseA = jest.fn()
+        const onCloseB = jest.fn()
+        render(
+            <>
+                <IframeWrapper src="https://a.test/tos" visible onClose={onCloseA} />
+                <IframeWrapper src="https://b.test/hosted" visible onClose={onCloseB} />
+            </>
+        )
+
+        postFrom(findIframe('https://b.test/hosted').contentWindow, { signedAgreementId: 'sig-b' })
+        expect(onCloseB).toHaveBeenCalledWith('tos_accepted')
+        expect(onCloseA).not.toHaveBeenCalled()
+    })
+
+    it('ignores messages with no source (nothing to attribute them to)', () => {
+        const onClose = jest.fn()
+        render(<IframeWrapper src="https://one.test/flow" visible onClose={onClose} />)
+
+        postFrom(null, { name: 'complete', metadata: { status: 'completed' } })
+        postFrom(null, { signedAgreementId: 'sig-x' })
+        expect(onClose).not.toHaveBeenCalled()
+    })
+})

--- a/src/components/Global/IframeWrapper/index.tsx
+++ b/src/components/Global/IframeWrapper/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import Modal from '../Modal'
 import { Icon, type IconName } from '../Icons/Icon'
 import ActionModal from '../ActionModal'
@@ -18,6 +18,7 @@ const IframeWrapper = ({ src, visible, onClose, closeConfirmMessage }: IFrameWra
     const [isHelpModalOpen, setIsHelpModalOpen] = useState(false)
     const [modalVariant, setModalVariant] = useState<'stop-verification' | 'trouble'>('trouble')
     const [copied, setCopied] = useState(false)
+    const iframeRef = useRef<HTMLIFrameElement | null>(null)
     const router = useRouter()
     const { setIsSupportModalOpen } = useModalsContext()
 
@@ -96,12 +97,16 @@ const IframeWrapper = ({ src, visible, onClose, closeConfirmMessage }: IFrameWra
     // track completed event from iframe and close the modal
     useEffect(() => {
         const handleMessage = (event: MessageEvent) => {
-            // A hidden-but-mounted wrapper must not react: several surfaces keep
-            // a wrapper mounted after a manual close (e.g. the multi-phase KYC
+            // React only to messages from OUR iframe. Several surfaces keep a
+            // wrapper mounted after a manual close (e.g. the multi-phase KYC
             // flow's ToS iframe), and a sibling iframe's completion event would
             // otherwise fire BOTH handlers — double ToS confirms + phantom flow
-            // transitions.
-            if (!visible) return
+            // transitions. Matching on the message SOURCE (not `visible`) keeps
+            // that protection — even against a sibling that is visible at the
+            // same time — without dropping a completion that lands in the
+            // instant the modal is hiding: the acceptance already happened at
+            // Bridge, and never confirming it strands a stale task.
+            if (!event.source || event.source !== iframeRef.current?.contentWindow) return
             const data = event.data
             if (data?.name === 'complete' && data?.metadata?.status === 'completed') {
                 onClose('completed')
@@ -115,7 +120,7 @@ const IframeWrapper = ({ src, visible, onClose, closeConfirmMessage }: IFrameWra
 
         window.addEventListener('message', handleMessage)
         return () => window.removeEventListener('message', handleMessage)
-    }, [onClose, visible])
+    }, [onClose])
 
     return (
         <Modal
@@ -142,6 +147,7 @@ const IframeWrapper = ({ src, visible, onClose, closeConfirmMessage }: IFrameWra
                 <div className="h-full w-full flex-grow overflow-scroll">
                     <iframe
                         key={src}
+                        ref={iframeRef}
                         src={src}
                         allow="camera *; microphone *; fullscreen *"
                         style={{ width: '100%', height: '85%', border: 'none' }}

--- a/src/components/Global/IframeWrapper/index.tsx
+++ b/src/components/Global/IframeWrapper/index.tsx
@@ -96,6 +96,12 @@ const IframeWrapper = ({ src, visible, onClose, closeConfirmMessage }: IFrameWra
     // track completed event from iframe and close the modal
     useEffect(() => {
         const handleMessage = (event: MessageEvent) => {
+            // A hidden-but-mounted wrapper must not react: several surfaces keep
+            // a wrapper mounted after a manual close (e.g. the multi-phase KYC
+            // flow's ToS iframe), and a sibling iframe's completion event would
+            // otherwise fire BOTH handlers — double ToS confirms + phantom flow
+            // transitions.
+            if (!visible) return
             const data = event.data
             if (data?.name === 'complete' && data?.metadata?.status === 'completed') {
                 onClose('completed')
@@ -109,7 +115,7 @@ const IframeWrapper = ({ src, visible, onClose, closeConfirmMessage }: IFrameWra
 
         window.addEventListener('message', handleMessage)
         return () => window.removeEventListener('message', handleMessage)
-    }, [onClose])
+    }, [onClose, visible])
 
     return (
         <Modal

--- a/src/components/Home/PendingVerificationTasks.tsx
+++ b/src/components/Home/PendingVerificationTasks.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { startBridgeHostedVerification } from '@/app/actions/sumsub'
+import { Button } from '@/components/0_Bruddle/Button'
+import IframeWrapper from '@/components/Global/IframeWrapper'
+import { Icon } from '@/components/Global/Icons/Icon'
+import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
+import { useAuth } from '@/context/authContext'
+import { useCapabilities } from '@/hooks/useCapabilities'
+import type { NextAction } from '@/types/capabilities'
+import { selectBridgeTasks } from '@/utils/bridge-tasks.utils'
+import Card from '../Global/Card'
+
+const TASK_COPY = {
+    tosBase: {
+        title: 'Accept Terms of Service',
+        description: "Accept our payment partner's terms to keep bank transfers available.",
+    },
+    tosSepa: {
+        title: 'Accept SEPA Terms of Service',
+        description: "Accept our payment partner's updated terms to keep EUR and GBP bank transfers available.",
+    },
+    hosted: {
+        title: 'Additional verification needed',
+        description: 'Complete a quick verification with our payment partner to keep bank transfers available.',
+    },
+} as const
+
+function taskCopy(task: NextAction): { title: string; description: string } {
+    if (task.kind === 'accept-tos') {
+        return task.key === 'accept-tos:sepa' ? TASK_COPY.tosSepa : TASK_COPY.tosBase
+    }
+    return TASK_COPY.hosted
+}
+
+/** "2099-03-01" → "Mar 1, 2099" — UTC so the date never shifts across timezones. */
+function formatDeadline(isoDate: string): string {
+    return new Date(`${isoDate}T00:00:00Z`).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        timeZone: 'UTC',
+    })
+}
+
+/**
+ * Home card listing the user's pending Bridge verification tasks — the in-app
+ * mirror of Bridge's "additional verification needed" dashboard state. Reads
+ * top-level capability `nextActions` (NOT rail gates), so it also catches the
+ * advisory orphans (future-dated tasks on fully-enabled users) and sidesteps
+ * ActivationCTAs' can-already-transact stand-down. Renders nothing when no
+ * task is pending.
+ */
+export default function PendingVerificationTasks() {
+    const { nextActions } = useCapabilities()
+    const { fetchUser } = useAuth()
+    const [tosOpen, setTosOpen] = useState(false)
+    const [hostedUrl, setHostedUrl] = useState<string | null>(null)
+    const [isStartingHosted, setIsStartingHosted] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+
+    const tasks = selectBridgeTasks(nextActions)
+    const tosTask = tasks.find((task) => task.kind === 'accept-tos')
+
+    const handleOpenTask = useCallback(async (task: NextAction) => {
+        setError(null)
+        if (task.kind === 'accept-tos') {
+            setTosOpen(true)
+            return
+        }
+        setIsStartingHosted(true)
+        const { url, error: startError } = await startBridgeHostedVerification()
+        setIsStartingHosted(false)
+        if (!url) {
+            setError(startError ?? 'Something went wrong. Please try again.')
+            return
+        }
+        setHostedUrl(url)
+    }, [])
+
+    const handleHostedClose = useCallback(
+        (source?: 'manual' | 'completed' | 'tos_accepted') => {
+            setHostedUrl(null)
+            if (source === 'completed') {
+                // Bridge re-checks the customer asynchronously — refresh so the
+                // task clears as soon as the capability model catches up.
+                void fetchUser()
+            }
+        },
+        [fetchUser]
+    )
+
+    if (tasks.length === 0) return null
+
+    return (
+        <>
+            <Card position="single" className="p-0">
+                <div className="flex flex-col gap-5 px-4 py-5">
+                    {tasks.map((task) => {
+                        const copy = taskCopy(task)
+                        const isHosted = task.kind === 'bridge-hosted'
+                        return (
+                            <div key={task.key} className="flex flex-col items-center gap-2 text-center">
+                                <div className="flex size-10 items-center justify-center rounded-full bg-secondary-1">
+                                    <Icon name={isHosted ? 'user-id' : 'badge'} size={20} />
+                                </div>
+                                <div className="w-full">
+                                    <div className="text-base font-bold">{copy.title}</div>
+                                    <div className="text-sm text-grey-1">{copy.description}</div>
+                                    {task.effectiveDate && (
+                                        <div className="mt-1 text-xs font-medium">
+                                            Complete before {formatDeadline(task.effectiveDate)}
+                                        </div>
+                                    )}
+                                </div>
+                                <Button
+                                    variant="purple"
+                                    shadowSize="4"
+                                    className="mt-1 w-full"
+                                    disabled={isHosted && isStartingHosted}
+                                    onClick={() => handleOpenTask(task)}
+                                >
+                                    {isHosted
+                                        ? isStartingHosted
+                                            ? 'Loading...'
+                                            : 'Complete verification'
+                                        : 'Review terms'}
+                                </Button>
+                            </div>
+                        )
+                    })}
+                    {error && <p className="text-center text-sm text-error">{error}</p>}
+                </div>
+            </Card>
+
+            {tosTask && (
+                <BridgeTosStep
+                    visible={tosOpen}
+                    onComplete={() => setTosOpen(false)}
+                    onSkip={() => setTosOpen(false)}
+                    reasonCode={tosTask.key === 'accept-tos:sepa' ? 'bridge_tos_v2_required' : 'bridge_tos_required'}
+                />
+            )}
+
+            {hostedUrl && <IframeWrapper src={hostedUrl} visible onClose={handleHostedClose} />}
+        </>
+    )
+}

--- a/src/components/Home/PendingVerificationTasks.tsx
+++ b/src/components/Home/PendingVerificationTasks.tsx
@@ -84,11 +84,13 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
     const [hostedUrl, setHostedUrl] = useState<string | null>(null)
     const [isStartingHosted, setIsStartingHosted] = useState(false)
     const [error, setError] = useState<string | null>(null)
-    // null = stored dismissals not yet hydrated (localStorage is unreadable
-    // during SSR, hence the post-render effect). The dismissible mount must
-    // not paint until then — rendering with an empty list would flash tasks
-    // the user already dismissed.
-    const [dismissedKeys, setDismissedKeys] = useState<string[] | null>(null)
+    // Stored dismissals, tagged with the user they were loaded for
+    // (localStorage is unreadable during SSR, hence the post-render effect).
+    // The dismissible mount must not paint until the CURRENT user's entry is
+    // hydrated: an empty list would flash already-dismissed tasks, and an
+    // untagged list would leak the previous user's dismissals for one render
+    // after a logout/login.
+    const [storedDismissals, setStoredDismissals] = useState<{ forUserId: string; keys: string[] } | null>(null)
 
     const userId = user?.user?.userId
     const tasks = selectBridgeTasks(nextActions)
@@ -104,15 +106,23 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
 
     useEffect(() => {
         if (!dismissible || !userId) return
-        setDismissedKeys(getUserPreferences(userId)?.pendingVerificationTasksDismissed ?? [])
+        setStoredDismissals({
+            forUserId: userId,
+            keys: getUserPreferences(userId)?.pendingVerificationTasksDismissed ?? [],
+        })
     }, [dismissible, userId])
+
+    // Hydrated only when the stored entry belongs to the current user.
+    const dismissedKeys = storedDismissals && storedDismissals.forUserId === userId ? storedDismissals.keys : null
 
     const handleDismissTask = useCallback(
         (task: NextAction) => {
-            setDismissedKeys((prev) => {
-                const next = [...(prev ?? []), bridgeTaskDismissalKey(task)]
+            if (!userId) return
+            setStoredDismissals((prev) => {
+                const keys = prev && prev.forUserId === userId ? prev.keys : []
+                const next = [...keys, bridgeTaskDismissalKey(task)]
                 updateUserPreferences(userId, { pendingVerificationTasksDismissed: next })
-                return next
+                return { forUserId: userId, keys: next }
             })
         },
         [userId]

--- a/src/components/Home/PendingVerificationTasks.tsx
+++ b/src/components/Home/PendingVerificationTasks.tsx
@@ -10,6 +10,7 @@ import { useAuth } from '@/context/authContext'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import type { NextAction } from '@/types/capabilities'
 import { selectBridgeTasks } from '@/utils/bridge-tasks.utils'
+import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils'
 import Card from '../Global/Card'
 
 function taskCopy(task: NextAction): { title: string; description: string } {
@@ -65,22 +66,44 @@ function formatDeadline(isoDate: string): string | null {
  * user refetch (~4s auto-refresh while rails are pending), and an open
  * modal/iframe must survive its task disappearing mid-flow — the card hides,
  * the flow keeps running.
+ *
+ * `dismissible` (the /home mount): an X persists the dismissal per task-key
+ * set (carousel-CTA pattern) — a DIFFERENT set of pending tasks re-shows the
+ * card. The Profile → Unlocked regions mount is non-dismissible, so dismissed
+ * tasks stay reachable there.
  */
-export default function PendingVerificationTasks() {
+export default function PendingVerificationTasks({ dismissible = false }: { dismissible?: boolean }) {
     const { nextActions } = useCapabilities()
-    const { fetchUser } = useAuth()
+    const { user, fetchUser } = useAuth()
     const [activeTosTask, setActiveTosTask] = useState<NextAction | null>(null)
     const [hostedUrl, setHostedUrl] = useState<string | null>(null)
     const [isStartingHosted, setIsStartingHosted] = useState(false)
     const [error, setError] = useState<string | null>(null)
+    const [dismissedKeys, setDismissedKeys] = useState<string | null>(null)
 
+    const userId = user?.user?.userId
     const tasks = selectBridgeTasks(nextActions)
-    const taskKeys = tasks.map((task) => task.key).join(',')
+    const taskKeys = tasks
+        .map((task) => task.key)
+        .sort()
+        .join(',')
 
     // A new task set means the previous failure context is gone.
     useEffect(() => {
         setError(null)
     }, [taskKeys])
+
+    useEffect(() => {
+        if (!dismissible || !userId) return
+        setDismissedKeys(getUserPreferences(userId)?.pendingVerificationTasksDismissed ?? null)
+    }, [dismissible, userId])
+
+    const handleDismiss = useCallback(() => {
+        updateUserPreferences(userId, { pendingVerificationTasksDismissed: taskKeys })
+        setDismissedKeys(taskKeys)
+    }, [userId, taskKeys])
+
+    const isDismissed = dismissible && dismissedKeys !== null && dismissedKeys === taskKeys
 
     const handleOpenTask = useCallback(
         async (task: NextAction) => {
@@ -118,13 +141,23 @@ export default function PendingVerificationTasks() {
 
     const closeTos = useCallback(() => setActiveTosTask(null), [])
 
-    if (tasks.length === 0 && !activeTosTask && !hostedUrl) return null
+    if ((tasks.length === 0 || isDismissed) && !activeTosTask && !hostedUrl) return null
 
     return (
         <>
-            {tasks.length > 0 && (
+            {tasks.length > 0 && !isDismissed && (
                 <Card position="single" className="p-0">
-                    <div className="flex flex-col gap-5 px-4 py-5">
+                    <div className="relative flex flex-col gap-5 px-4 py-5">
+                        {dismissible && (
+                            <button
+                                type="button"
+                                aria-label="Dismiss pending verification tasks"
+                                onClick={handleDismiss}
+                                className="absolute right-3 top-3 z-10 cursor-pointer p-0 text-black outline-none"
+                            >
+                                <Icon name="cancel" size={16} />
+                            </button>
+                        )}
                         {tasks.map((task) => {
                             const copy = taskCopy(task)
                             const isHosted = task.kind === 'bridge-hosted'

--- a/src/components/Home/PendingVerificationTasks.tsx
+++ b/src/components/Home/PendingVerificationTasks.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { startBridgeHostedVerification } from '@/app/actions/sumsub'
 import { Button } from '@/components/0_Bruddle/Button'
 import IframeWrapper from '@/components/Global/IframeWrapper'
@@ -12,31 +12,40 @@ import type { NextAction } from '@/types/capabilities'
 import { selectBridgeTasks } from '@/utils/bridge-tasks.utils'
 import Card from '../Global/Card'
 
-const TASK_COPY = {
-    tosBase: {
-        title: 'Accept Terms of Service',
-        description: "Accept our payment partner's terms to keep bank transfers available.",
-    },
-    tosSepa: {
-        title: 'Accept SEPA Terms of Service',
-        description: "Accept our payment partner's updated terms to keep EUR and GBP bank transfers available.",
-    },
-    hosted: {
-        title: 'Additional verification needed',
-        description: 'Complete a quick verification with our payment partner to keep bank transfers available.',
-    },
-} as const
-
 function taskCopy(task: NextAction): { title: string; description: string } {
+    // Advisory tasks (future-dated, rails still usable) are about KEEPING
+    // access; blocking tasks are about ENABLING it — don't tell a blocked
+    // user their transfers are "available".
+    const advisory = !!task.effectiveDate
     if (task.kind === 'accept-tos') {
-        return task.key === 'accept-tos:sepa' ? TASK_COPY.tosSepa : TASK_COPY.tosBase
+        if (task.key === 'accept-tos:sepa') {
+            return {
+                title: 'Accept SEPA Terms of Service',
+                description: advisory
+                    ? "Accept our payment partner's updated terms to keep EUR and GBP bank transfers available."
+                    : "Accept our payment partner's updated terms to enable EUR and GBP bank transfers.",
+            }
+        }
+        return {
+            title: 'Accept Terms of Service',
+            description: advisory
+                ? "Accept our payment partner's terms to keep bank transfers available."
+                : "Accept our payment partner's terms to enable bank transfers.",
+        }
     }
-    return TASK_COPY.hosted
+    return {
+        title: 'Additional verification needed',
+        description: advisory
+            ? 'Complete a quick verification with our payment partner to keep bank transfers available.'
+            : 'Complete a quick verification with our payment partner to enable bank transfers.',
+    }
 }
 
 /** "2099-03-01" → "Mar 1, 2099" — UTC so the date never shifts across timezones. */
-function formatDeadline(isoDate: string): string {
-    return new Date(`${isoDate}T00:00:00Z`).toLocaleDateString('en-US', {
+function formatDeadline(isoDate: string): string | null {
+    const parsed = new Date(`${isoDate.slice(0, 10)}T00:00:00Z`)
+    if (Number.isNaN(parsed.getTime())) return null
+    return parsed.toLocaleDateString('en-US', {
         month: 'short',
         day: 'numeric',
         year: 'numeric',
@@ -48,36 +57,52 @@ function formatDeadline(isoDate: string): string {
  * Home card listing the user's pending Bridge verification tasks — the in-app
  * mirror of Bridge's "additional verification needed" dashboard state. Reads
  * top-level capability `nextActions` (NOT rail gates), so it also catches the
- * advisory orphans (future-dated tasks on fully-enabled users) and sidesteps
- * ActivationCTAs' can-already-transact stand-down. Renders nothing when no
- * task is pending.
+ * orphan actions no rail references (both blocking hosted tasks and advisory
+ * future-dated ones) and sidesteps ActivationCTAs' can-already-transact
+ * stand-down. Renders nothing when no task is pending.
+ *
+ * Open flows are SNAPSHOTTED at tap time: the task list re-derives from every
+ * user refetch (~4s auto-refresh while rails are pending), and an open
+ * modal/iframe must survive its task disappearing mid-flow — the card hides,
+ * the flow keeps running.
  */
 export default function PendingVerificationTasks() {
     const { nextActions } = useCapabilities()
     const { fetchUser } = useAuth()
-    const [tosOpen, setTosOpen] = useState(false)
+    const [activeTosTask, setActiveTosTask] = useState<NextAction | null>(null)
     const [hostedUrl, setHostedUrl] = useState<string | null>(null)
     const [isStartingHosted, setIsStartingHosted] = useState(false)
     const [error, setError] = useState<string | null>(null)
 
     const tasks = selectBridgeTasks(nextActions)
-    const tosTask = tasks.find((task) => task.kind === 'accept-tos')
+    const taskKeys = tasks.map((task) => task.key).join(',')
 
-    const handleOpenTask = useCallback(async (task: NextAction) => {
+    // A new task set means the previous failure context is gone.
+    useEffect(() => {
         setError(null)
-        if (task.kind === 'accept-tos') {
-            setTosOpen(true)
-            return
-        }
-        setIsStartingHosted(true)
-        const { url, error: startError } = await startBridgeHostedVerification()
-        setIsStartingHosted(false)
-        if (!url) {
-            setError(startError ?? 'Something went wrong. Please try again.')
-            return
-        }
-        setHostedUrl(url)
-    }, [])
+    }, [taskKeys])
+
+    const handleOpenTask = useCallback(
+        async (task: NextAction) => {
+            setError(null)
+            if (task.kind === 'accept-tos') {
+                setActiveTosTask(task)
+                return
+            }
+            setIsStartingHosted(true)
+            const { url } = await startBridgeHostedVerification()
+            setIsStartingHosted(false)
+            if (!url) {
+                // Friendly copy regardless of the server detail (a 403 here just
+                // means the action aged out); refetch so a stale card self-corrects.
+                setError("We couldn't start the verification. Please try again in a moment.")
+                void fetchUser()
+                return
+            }
+            setHostedUrl(url)
+        },
+        [fetchUser]
+    )
 
     const handleHostedClose = useCallback(
         (source?: 'manual' | 'completed' | 'tos_accepted') => {
@@ -91,55 +116,60 @@ export default function PendingVerificationTasks() {
         [fetchUser]
     )
 
-    if (tasks.length === 0) return null
+    const closeTos = useCallback(() => setActiveTosTask(null), [])
+
+    if (tasks.length === 0 && !activeTosTask && !hostedUrl) return null
 
     return (
         <>
-            <Card position="single" className="p-0">
-                <div className="flex flex-col gap-5 px-4 py-5">
-                    {tasks.map((task) => {
-                        const copy = taskCopy(task)
-                        const isHosted = task.kind === 'bridge-hosted'
-                        return (
-                            <div key={task.key} className="flex flex-col items-center gap-2 text-center">
-                                <div className="flex size-10 items-center justify-center rounded-full bg-secondary-1">
-                                    <Icon name={isHosted ? 'user-id' : 'badge'} size={20} />
+            {tasks.length > 0 && (
+                <Card position="single" className="p-0">
+                    <div className="flex flex-col gap-5 px-4 py-5">
+                        {tasks.map((task) => {
+                            const copy = taskCopy(task)
+                            const isHosted = task.kind === 'bridge-hosted'
+                            const deadline = task.effectiveDate ? formatDeadline(task.effectiveDate) : null
+                            return (
+                                <div key={task.key} className="flex flex-col items-center gap-2 text-center">
+                                    <div className="flex size-10 items-center justify-center rounded-full bg-secondary-1">
+                                        <Icon name={isHosted ? 'user-id' : 'badge'} size={20} />
+                                    </div>
+                                    <div className="w-full">
+                                        <div className="text-base font-bold">{copy.title}</div>
+                                        <div className="text-sm text-grey-1">{copy.description}</div>
+                                        {deadline && (
+                                            <div className="mt-1 text-xs font-medium">Complete before {deadline}</div>
+                                        )}
+                                    </div>
+                                    <Button
+                                        variant="purple"
+                                        shadowSize="4"
+                                        className="mt-1 w-full"
+                                        disabled={isStartingHosted}
+                                        onClick={() => handleOpenTask(task)}
+                                    >
+                                        {isHosted
+                                            ? isStartingHosted
+                                                ? 'Loading...'
+                                                : 'Complete verification'
+                                            : 'Review terms'}
+                                    </Button>
                                 </div>
-                                <div className="w-full">
-                                    <div className="text-base font-bold">{copy.title}</div>
-                                    <div className="text-sm text-grey-1">{copy.description}</div>
-                                    {task.effectiveDate && (
-                                        <div className="mt-1 text-xs font-medium">
-                                            Complete before {formatDeadline(task.effectiveDate)}
-                                        </div>
-                                    )}
-                                </div>
-                                <Button
-                                    variant="purple"
-                                    shadowSize="4"
-                                    className="mt-1 w-full"
-                                    disabled={isHosted && isStartingHosted}
-                                    onClick={() => handleOpenTask(task)}
-                                >
-                                    {isHosted
-                                        ? isStartingHosted
-                                            ? 'Loading...'
-                                            : 'Complete verification'
-                                        : 'Review terms'}
-                                </Button>
-                            </div>
-                        )
-                    })}
-                    {error && <p className="text-center text-sm text-error">{error}</p>}
-                </div>
-            </Card>
+                            )
+                        })}
+                        {error && <p className="text-center text-sm text-error">{error}</p>}
+                    </div>
+                </Card>
+            )}
 
-            {tosTask && (
+            {activeTosTask && (
                 <BridgeTosStep
-                    visible={tosOpen}
-                    onComplete={() => setTosOpen(false)}
-                    onSkip={() => setTosOpen(false)}
-                    reasonCode={tosTask.key === 'accept-tos:sepa' ? 'bridge_tos_v2_required' : 'bridge_tos_required'}
+                    visible
+                    onComplete={closeTos}
+                    onSkip={closeTos}
+                    reasonCode={
+                        activeTosTask.key === 'accept-tos:sepa' ? 'bridge_tos_v2_required' : 'bridge_tos_required'
+                    }
                 />
             )}
 

--- a/src/components/Home/PendingVerificationTasks.tsx
+++ b/src/components/Home/PendingVerificationTasks.tsx
@@ -84,7 +84,11 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
     const [hostedUrl, setHostedUrl] = useState<string | null>(null)
     const [isStartingHosted, setIsStartingHosted] = useState(false)
     const [error, setError] = useState<string | null>(null)
-    const [dismissedKeys, setDismissedKeys] = useState<string[]>([])
+    // null = stored dismissals not yet hydrated (localStorage is unreadable
+    // during SSR, hence the post-render effect). The dismissible mount must
+    // not paint until then — rendering with an empty list would flash tasks
+    // the user already dismissed.
+    const [dismissedKeys, setDismissedKeys] = useState<string[] | null>(null)
 
     const userId = user?.user?.userId
     const tasks = selectBridgeTasks(nextActions)
@@ -106,7 +110,7 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
     const handleDismissTask = useCallback(
         (task: NextAction) => {
             setDismissedKeys((prev) => {
-                const next = [...prev, bridgeTaskDismissalKey(task)]
+                const next = [...(prev ?? []), bridgeTaskDismissalKey(task)]
                 updateUserPreferences(userId, { pendingVerificationTasksDismissed: next })
                 return next
             })
@@ -114,9 +118,11 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
         [userId]
     )
 
-    const visibleTasks = dismissible
-        ? tasks.filter((task) => !dismissedKeys.includes(bridgeTaskDismissalKey(task)))
-        : tasks
+    const visibleTasks = !dismissible
+        ? tasks
+        : dismissedKeys === null
+          ? [] // hold the first paint until stored dismissals hydrate
+          : tasks.filter((task) => !dismissedKeys.includes(bridgeTaskDismissalKey(task)))
 
     const handleOpenTask = useCallback(
         async (task: NextAction) => {

--- a/src/components/Home/PendingVerificationTasks.tsx
+++ b/src/components/Home/PendingVerificationTasks.tsx
@@ -70,10 +70,11 @@ function formatDeadline(isoDate: string): string | null {
  * modal/iframe must survive its task disappearing mid-flow — the card hides,
  * the flow keeps running.
  *
- * `dismissible` (the /home mount): an X persists the dismissal per task-key
- * set (carousel-CTA pattern) — a DIFFERENT set of pending tasks re-shows the
- * card. The Profile → Unlocked regions mount is non-dismissible, so dismissed
- * tasks stay reachable there.
+ * `dismissible` (the /home mount): each slide carries its own X that
+ * dismisses ONLY that task (persisted per task key) — the other slides stay.
+ * A dismissed key stays hidden on /home until the task resolves; the
+ * Profile → Unlocked regions mount is non-dismissible, so dismissed tasks
+ * stay reachable there.
  */
 export default function PendingVerificationTasks({ dismissible = false }: { dismissible?: boolean }) {
     const { nextActions } = useCapabilities()
@@ -82,7 +83,7 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
     const [hostedUrl, setHostedUrl] = useState<string | null>(null)
     const [isStartingHosted, setIsStartingHosted] = useState(false)
     const [error, setError] = useState<string | null>(null)
-    const [dismissedKeys, setDismissedKeys] = useState<string | null>(null)
+    const [dismissedKeys, setDismissedKeys] = useState<string[]>([])
 
     const userId = user?.user?.userId
     const tasks = selectBridgeTasks(nextActions)
@@ -98,15 +99,21 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
 
     useEffect(() => {
         if (!dismissible || !userId) return
-        setDismissedKeys(getUserPreferences(userId)?.pendingVerificationTasksDismissed ?? null)
+        setDismissedKeys(getUserPreferences(userId)?.pendingVerificationTasksDismissed ?? [])
     }, [dismissible, userId])
 
-    const handleDismiss = useCallback(() => {
-        updateUserPreferences(userId, { pendingVerificationTasksDismissed: taskKeys })
-        setDismissedKeys(taskKeys)
-    }, [userId, taskKeys])
+    const handleDismissTask = useCallback(
+        (taskKey: string) => {
+            setDismissedKeys((prev) => {
+                const next = [...prev, taskKey]
+                updateUserPreferences(userId, { pendingVerificationTasksDismissed: next })
+                return next
+            })
+        },
+        [userId]
+    )
 
-    const isDismissed = dismissible && dismissedKeys !== null && dismissedKeys === taskKeys
+    const visibleTasks = dismissible ? tasks.filter((task) => !dismissedKeys.includes(task.key)) : tasks
 
     const handleOpenTask = useCallback(
         async (task: NextAction) => {
@@ -144,30 +151,30 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
 
     const closeTos = useCallback(() => setActiveTosTask(null), [])
 
-    if ((tasks.length === 0 || isDismissed) && !activeTosTask && !hostedUrl) return null
+    if (visibleTasks.length === 0 && !activeTosTask && !hostedUrl) return null
 
     return (
         <>
-            {tasks.length > 0 && !isDismissed && (
-                <div className="relative">
-                    {dismissible && (
-                        <button
-                            type="button"
-                            aria-label="Dismiss pending verification tasks"
-                            onClick={handleDismiss}
-                            className="absolute right-3 top-3 z-10 cursor-pointer p-0 text-black outline-none"
-                        >
-                            <Icon name="cancel" size={16} />
-                        </button>
-                    )}
+            {visibleTasks.length > 0 && (
+                <div>
                     <Carousel>
-                        {tasks.map((task) => {
+                        {visibleTasks.map((task) => {
                             const copy = taskCopy(task)
                             const isHosted = task.kind === 'bridge-hosted'
                             const deadline = task.effectiveDate ? formatDeadline(task.effectiveDate) : null
                             return (
-                                <Card key={task.key} position="single" className="embla__slide p-0">
+                                <Card key={task.key} position="single" className="embla__slide relative p-0">
                                     <div className="flex flex-col items-center gap-2 px-4 py-5 text-center">
+                                        {dismissible && (
+                                            <button
+                                                type="button"
+                                                aria-label={`Dismiss ${copy.title}`}
+                                                onClick={() => handleDismissTask(task.key)}
+                                                className="absolute right-3 top-3 z-10 cursor-pointer p-0 text-black outline-none"
+                                            >
+                                                <Icon name="cancel" size={16} />
+                                            </button>
+                                        )}
                                         <div className="flex size-10 items-center justify-center rounded-full bg-secondary-1">
                                             <Icon name={isHosted ? 'user-id' : 'badge'} size={20} />
                                         </div>

--- a/src/components/Home/PendingVerificationTasks.tsx
+++ b/src/components/Home/PendingVerificationTasks.tsx
@@ -8,9 +8,11 @@ import IframeWrapper from '@/components/Global/IframeWrapper'
 import { Icon } from '@/components/Global/Icons/Icon'
 import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
 import { useAuth } from '@/context/authContext'
+import { confirmBridgeTosAndAwaitRails } from '@/hooks/useMultiPhaseKycFlow'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import type { NextAction } from '@/types/capabilities'
 import { bridgeTaskDismissalKey, selectBridgeTasks } from '@/utils/bridge-tasks.utils'
+import { formatEffectiveDate } from '@/utils/format.utils'
 import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils'
 import Card from '../Global/Card'
 
@@ -43,18 +45,6 @@ function taskCopy(task: NextAction): { title: string; description: string } {
     }
 }
 
-/** "2099-03-01" → "Mar 1, 2099" — UTC so the date never shifts across timezones. */
-function formatDeadline(isoDate: string): string | null {
-    const parsed = new Date(`${isoDate.slice(0, 10)}T00:00:00Z`)
-    if (Number.isNaN(parsed.getTime())) return null
-    return parsed.toLocaleDateString('en-US', {
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric',
-        timeZone: 'UTC',
-    })
-}
-
 /**
  * Home card listing the user's pending Bridge verification tasks — the in-app
  * mirror of Bridge's "additional verification needed" dashboard state. Reads
@@ -70,12 +60,14 @@ function formatDeadline(isoDate: string): string | null {
  * modal/iframe must survive its task disappearing mid-flow — the card hides,
  * the flow keeps running.
  *
- * `dismissible` (the /home mount): each slide carries its own X that
- * dismisses ONLY that task — the other slides stay. Dismissals persist per
- * task FINGERPRINT (key + requirement + due state, see
- * bridgeTaskDismissalKey), so a task that turns blocking or changes substance
- * re-surfaces despite an old dismissal; the Profile → Unlocked regions mount
- * is non-dismissible, so dismissed tasks stay reachable there.
+ * `dismissible` (the /home mount): each ADVISORY (future-dated) slide carries
+ * its own X that dismisses ONLY that task — the other slides stay. Dismissals
+ * persist per task FINGERPRINT (key + requirement + due state, see
+ * bridgeTaskDismissalKey), so a task that changes substance re-surfaces
+ * despite an old dismissal. BLOCKING (due-now) tasks are never dismissible
+ * and ignore stored fingerprints — their fingerprint is constant over time,
+ * and their rails are gated NOW; the Profile → Unlocked regions mount is
+ * non-dismissible for everything.
  */
 export default function PendingVerificationTasks({ dismissible = false }: { dismissible?: boolean }) {
     const { nextActions } = useCapabilities()
@@ -128,11 +120,21 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
         [userId]
     )
 
+    // Only ADVISORY (future-dated) tasks honor dismissals. A blocking task's
+    // fingerprint is constant over time (`accept-tos||due-now`), so an old
+    // stored dismissal would silently hide a NEW same-variant requirement
+    // months later while the user's rails are gated — and for the orphan
+    // bridge-hosted task this card is the only actionable surface outside
+    // Profile (/code-review 08-04). Blocking tasks therefore always render;
+    // advisory ones hold the first paint until stored dismissals hydrate
+    // (an empty list would flash already-dismissed slides).
     const visibleTasks = !dismissible
         ? tasks
-        : dismissedKeys === null
-          ? [] // hold the first paint until stored dismissals hydrate
-          : tasks.filter((task) => !dismissedKeys.includes(bridgeTaskDismissalKey(task)))
+        : tasks.filter(
+              (task) =>
+                  !task.effectiveDate ||
+                  (dismissedKeys !== null && !dismissedKeys.includes(bridgeTaskDismissalKey(task)))
+          )
 
     const handleOpenTask = useCallback(
         async (task: NextAction) => {
@@ -162,10 +164,15 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
             // before the identity steps — exactly for this cohort, which owes
             // both. The wrapper maps that step's signedAgreementId postMessage
             // to 'tos_accepted'; treating it as a close would kill the
-            // verification mid-flow. Keep the iframe open and sync the
-            // acceptance; only 'completed' / 'manual' actually close.
+            // verification mid-flow. Keep the iframe open and CONFIRM the
+            // acceptance to the backend — fetchUser alone re-reads stored
+            // state (the resolver is pure, no Bridge calls), so without the
+            // confirm POST the accept-tos task stays visible until a Bridge
+            // webhook lands and tapping it 409s "already accepted". Same
+            // canonical path as BridgeTosStep / useMultiPhaseKycFlow; it
+            // refetches the user itself. Only 'completed' / 'manual' close.
             if (source === 'tos_accepted') {
-                void fetchUser()
+                void confirmBridgeTosAndAwaitRails(fetchUser).catch(() => void fetchUser())
                 return
             }
             setHostedUrl(null)
@@ -190,11 +197,11 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
                         {visibleTasks.map((task) => {
                             const copy = taskCopy(task)
                             const isHosted = task.kind === 'bridge-hosted'
-                            const deadline = task.effectiveDate ? formatDeadline(task.effectiveDate) : null
+                            const deadline = formatEffectiveDate(task.effectiveDate)
                             return (
                                 <Card key={task.key} position="single" className="embla__slide relative p-0">
                                     <div className="flex flex-col items-center gap-2 px-4 py-5 text-center">
-                                        {dismissible && (
+                                        {dismissible && !!task.effectiveDate && (
                                             <button
                                                 type="button"
                                                 aria-label={`Dismiss ${copy.title}`}

--- a/src/components/Home/PendingVerificationTasks.tsx
+++ b/src/components/Home/PendingVerificationTasks.tsx
@@ -10,7 +10,7 @@ import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
 import { useAuth } from '@/context/authContext'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import type { NextAction } from '@/types/capabilities'
-import { selectBridgeTasks } from '@/utils/bridge-tasks.utils'
+import { bridgeTaskDismissalKey, selectBridgeTasks } from '@/utils/bridge-tasks.utils'
 import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils'
 import Card from '../Global/Card'
 
@@ -71,10 +71,11 @@ function formatDeadline(isoDate: string): string | null {
  * the flow keeps running.
  *
  * `dismissible` (the /home mount): each slide carries its own X that
- * dismisses ONLY that task (persisted per task key) — the other slides stay.
- * A dismissed key stays hidden on /home until the task resolves; the
- * Profile → Unlocked regions mount is non-dismissible, so dismissed tasks
- * stay reachable there.
+ * dismisses ONLY that task — the other slides stay. Dismissals persist per
+ * task FINGERPRINT (key + requirement + due state, see
+ * bridgeTaskDismissalKey), so a task that turns blocking or changes substance
+ * re-surfaces despite an old dismissal; the Profile → Unlocked regions mount
+ * is non-dismissible, so dismissed tasks stay reachable there.
  */
 export default function PendingVerificationTasks({ dismissible = false }: { dismissible?: boolean }) {
     const { nextActions } = useCapabilities()
@@ -103,9 +104,9 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
     }, [dismissible, userId])
 
     const handleDismissTask = useCallback(
-        (taskKey: string) => {
+        (task: NextAction) => {
             setDismissedKeys((prev) => {
-                const next = [...prev, taskKey]
+                const next = [...prev, bridgeTaskDismissalKey(task)]
                 updateUserPreferences(userId, { pendingVerificationTasksDismissed: next })
                 return next
             })
@@ -113,7 +114,9 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
         [userId]
     )
 
-    const visibleTasks = dismissible ? tasks.filter((task) => !dismissedKeys.includes(task.key)) : tasks
+    const visibleTasks = dismissible
+        ? tasks.filter((task) => !dismissedKeys.includes(bridgeTaskDismissalKey(task)))
+        : tasks
 
     const handleOpenTask = useCallback(
         async (task: NextAction) => {
@@ -139,6 +142,16 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
 
     const handleHostedClose = useCallback(
         (source?: 'manual' | 'completed' | 'tos_accepted') => {
+            // Bridge's hosted kyc_link flow can EMBED a ToS-acceptance step
+            // before the identity steps — exactly for this cohort, which owes
+            // both. The wrapper maps that step's signedAgreementId postMessage
+            // to 'tos_accepted'; treating it as a close would kill the
+            // verification mid-flow. Keep the iframe open and sync the
+            // acceptance; only 'completed' / 'manual' actually close.
+            if (source === 'tos_accepted') {
+                void fetchUser()
+                return
+            }
             setHostedUrl(null)
             if (source === 'completed') {
                 // Bridge re-checks the customer asynchronously — refresh so the
@@ -169,7 +182,7 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
                                             <button
                                                 type="button"
                                                 aria-label={`Dismiss ${copy.title}`}
-                                                onClick={() => handleDismissTask(task.key)}
+                                                onClick={() => handleDismissTask(task)}
                                                 className="absolute right-3 top-3 z-10 cursor-pointer p-0 text-black outline-none"
                                             >
                                                 <Icon name="cancel" size={16} />

--- a/src/components/Home/PendingVerificationTasks.tsx
+++ b/src/components/Home/PendingVerificationTasks.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { startBridgeHostedVerification } from '@/app/actions/sumsub'
 import { Button } from '@/components/0_Bruddle/Button'
+import Carousel from '@/components/Global/Carousel'
 import IframeWrapper from '@/components/Global/IframeWrapper'
 import { Icon } from '@/components/Global/Icons/Icon'
 import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
@@ -60,7 +61,9 @@ function formatDeadline(isoDate: string): string | null {
  * top-level capability `nextActions` (NOT rail gates), so it also catches the
  * orphan actions no rail references (both blocking hosted tasks and advisory
  * future-dated ones) and sidesteps ActivationCTAs' can-already-transact
- * stand-down. Renders nothing when no task is pending.
+ * stand-down. Renders nothing when no task is pending. Multiple tasks render
+ * as full-width horizontal carousel slides (same embla setup as
+ * HomeCarouselCTA); a single task looks identical to a static card.
  *
  * Open flows are SNAPSHOTTED at tap time: the task list re-derives from every
  * user refetch (~4s auto-refresh while rails are pending), and an open
@@ -146,53 +149,57 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
     return (
         <>
             {tasks.length > 0 && !isDismissed && (
-                <Card position="single" className="p-0">
-                    <div className="relative flex flex-col gap-5 px-4 py-5">
-                        {dismissible && (
-                            <button
-                                type="button"
-                                aria-label="Dismiss pending verification tasks"
-                                onClick={handleDismiss}
-                                className="absolute right-3 top-3 z-10 cursor-pointer p-0 text-black outline-none"
-                            >
-                                <Icon name="cancel" size={16} />
-                            </button>
-                        )}
+                <div className="relative">
+                    {dismissible && (
+                        <button
+                            type="button"
+                            aria-label="Dismiss pending verification tasks"
+                            onClick={handleDismiss}
+                            className="absolute right-3 top-3 z-10 cursor-pointer p-0 text-black outline-none"
+                        >
+                            <Icon name="cancel" size={16} />
+                        </button>
+                    )}
+                    <Carousel>
                         {tasks.map((task) => {
                             const copy = taskCopy(task)
                             const isHosted = task.kind === 'bridge-hosted'
                             const deadline = task.effectiveDate ? formatDeadline(task.effectiveDate) : null
                             return (
-                                <div key={task.key} className="flex flex-col items-center gap-2 text-center">
-                                    <div className="flex size-10 items-center justify-center rounded-full bg-secondary-1">
-                                        <Icon name={isHosted ? 'user-id' : 'badge'} size={20} />
+                                <Card key={task.key} position="single" className="embla__slide p-0">
+                                    <div className="flex flex-col items-center gap-2 px-4 py-5 text-center">
+                                        <div className="flex size-10 items-center justify-center rounded-full bg-secondary-1">
+                                            <Icon name={isHosted ? 'user-id' : 'badge'} size={20} />
+                                        </div>
+                                        <div className="w-full">
+                                            <div className="text-base font-bold">{copy.title}</div>
+                                            <div className="text-sm text-grey-1">{copy.description}</div>
+                                            {deadline && (
+                                                <div className="mt-1 text-xs font-medium">
+                                                    Complete before {deadline}
+                                                </div>
+                                            )}
+                                        </div>
+                                        <Button
+                                            variant="purple"
+                                            shadowSize="4"
+                                            className="mt-1 w-full"
+                                            disabled={isStartingHosted}
+                                            onClick={() => handleOpenTask(task)}
+                                        >
+                                            {isHosted
+                                                ? isStartingHosted
+                                                    ? 'Loading...'
+                                                    : 'Complete verification'
+                                                : 'Review terms'}
+                                        </Button>
                                     </div>
-                                    <div className="w-full">
-                                        <div className="text-base font-bold">{copy.title}</div>
-                                        <div className="text-sm text-grey-1">{copy.description}</div>
-                                        {deadline && (
-                                            <div className="mt-1 text-xs font-medium">Complete before {deadline}</div>
-                                        )}
-                                    </div>
-                                    <Button
-                                        variant="purple"
-                                        shadowSize="4"
-                                        className="mt-1 w-full"
-                                        disabled={isStartingHosted}
-                                        onClick={() => handleOpenTask(task)}
-                                    >
-                                        {isHosted
-                                            ? isStartingHosted
-                                                ? 'Loading...'
-                                                : 'Complete verification'
-                                            : 'Review terms'}
-                                    </Button>
-                                </div>
+                                </Card>
                             )
                         })}
-                        {error && <p className="text-center text-sm text-error">{error}</p>}
-                    </div>
-                </Card>
+                    </Carousel>
+                    {error && <p className="mt-2 text-center text-sm text-error">{error}</p>}
+                </div>
             )}
 
             {activeTosTask && (

--- a/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
+++ b/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
@@ -23,8 +23,9 @@ const mockUpdatePreferences = jest.fn()
 jest.mock('@/hooks/useCapabilities', () => ({
     useCapabilities: () => ({ nextActions: mockNextActions }),
 }))
+let mockUserId = 'user-1'
 jest.mock('@/context/authContext', () => ({
-    useAuth: () => ({ user: { user: { userId: 'user-1' } }, fetchUser: mockFetchUser }),
+    useAuth: () => ({ user: { user: { userId: mockUserId } }, fetchUser: mockFetchUser }),
 }))
 jest.mock('@/utils/general.utils', () => ({
     getUserPreferences: () => ({ pendingVerificationTasksDismissed: mockStoredDismissal }),
@@ -69,6 +70,7 @@ describe('PendingVerificationTasks', () => {
         mockStartHosted.mockReset()
         mockStoredDismissal = undefined
         mockUpdatePreferences.mockReset()
+        mockUserId = 'user-1'
     })
 
     it('renders nothing when no bridge task is pending', () => {
@@ -260,6 +262,21 @@ describe('PendingVerificationTasks', () => {
             mockNextActions = [tosAction, hostedAction]
             const { container } = render(<PendingVerificationTasks dismissible />)
             expect(container).toBeEmptyDOMElement()
+        })
+
+        it("a user switch does not inherit the previous user's dismissals", () => {
+            mockStoredDismissal = [tosFingerprint, hostedFingerprint]
+            mockNextActions = [tosAction, hostedAction]
+            const { container, rerender } = render(<PendingVerificationTasks dismissible />)
+            expect(container).toBeEmptyDOMElement()
+
+            // user-2 logs in on the same mount with no stored dismissals —
+            // user-1's in-memory keys must not hide user-2's tasks.
+            mockUserId = 'user-2'
+            mockStoredDismissal = undefined
+            rerender(<PendingVerificationTasks dismissible />)
+            expect(screen.getByText('Accept Terms of Service')).toBeInTheDocument()
+            expect(screen.getByText('Additional verification needed')).toBeInTheDocument()
         })
 
         it('the non-dismissible (profile) mount ignores stored dismissals and has no X', () => {

--- a/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
+++ b/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * PendingVerificationTasks — the Home card mirroring Bridge's "additional
+ * verification needed" dashboard state.
+ *
+ * Reads top-level capability nextActions (not rail gates) so it catches both
+ * blocking tasks and advisory orphans (future-dated tasks on fully-enabled
+ * users, which no rail references). accept-tos routes into the existing
+ * BridgeTosStep; bridge-hosted exchanges the key for a hosted URL and opens
+ * it in the IframeWrapper.
+ */
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import type { NextAction } from '@/types/capabilities'
+import PendingVerificationTasks from '../PendingVerificationTasks'
+
+let mockNextActions: NextAction[] = []
+const mockFetchUser = jest.fn()
+const mockStartHosted = jest.fn<Promise<{ url?: string; error?: string }>, []>()
+
+jest.mock('@/hooks/useCapabilities', () => ({
+    useCapabilities: () => ({ nextActions: mockNextActions }),
+}))
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => ({ fetchUser: mockFetchUser }),
+}))
+jest.mock('@/app/actions/sumsub', () => ({
+    startBridgeHostedVerification: () => mockStartHosted(),
+}))
+jest.mock('@/components/Kyc/BridgeTosStep', () => ({
+    BridgeTosStep: (props: { visible: boolean; reasonCode?: string }) =>
+        props.visible ? <div data-testid="tos-step">{props.reasonCode}</div> : null,
+}))
+jest.mock('@/components/Global/IframeWrapper', () => ({
+    __esModule: true,
+    default: (props: { src: string; visible: boolean; onClose: (source?: string) => void }) =>
+        props.visible ? (
+            <div data-testid="hosted-iframe" data-src={props.src}>
+                <button onClick={() => props.onClose('completed')}>finish</button>
+                <button onClick={() => props.onClose('manual')}>close</button>
+            </div>
+        ) : null,
+}))
+
+const tosAction: NextAction = { key: 'accept-tos', kind: 'accept-tos', purpose: 'accept-bridge-tos' }
+const hostedAction: NextAction = {
+    key: 'bridge-hosted',
+    kind: 'bridge-hosted',
+    purpose: 'bridge-additional-verification',
+    requirementKey: 'kyc_approval',
+}
+
+describe('PendingVerificationTasks', () => {
+    beforeEach(() => {
+        mockNextActions = []
+        mockFetchUser.mockReset()
+        mockStartHosted.mockReset()
+    })
+
+    it('renders nothing when no bridge task is pending', () => {
+        mockNextActions = [{ key: 'sumsub:proof_of_address', kind: 'sumsub', purpose: 'unlock-bridge' }]
+        const { container } = render(<PendingVerificationTasks />)
+        expect(container).toBeEmptyDOMElement()
+    })
+
+    it('accept-tos task opens BridgeTosStep with the variant-matched reason code', () => {
+        mockNextActions = [{ ...tosAction, key: 'accept-tos:sepa', purpose: 'accept-bridge-tos-sepa' }]
+        render(<PendingVerificationTasks />)
+
+        expect(screen.getByText('Accept SEPA Terms of Service')).toBeInTheDocument()
+        fireEvent.click(screen.getByRole('button', { name: /review terms/i }))
+        expect(screen.getByTestId('tos-step')).toHaveTextContent('bridge_tos_v2_required')
+    })
+
+    it('bridge-hosted task fetches the hosted URL, opens the iframe, and refreshes the user on completion', async () => {
+        mockNextActions = [hostedAction]
+        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
+        render(<PendingVerificationTasks />)
+
+        expect(screen.getByText('Additional verification needed')).toBeInTheDocument()
+        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
+
+        const iframe = await screen.findByTestId('hosted-iframe')
+        expect(iframe).toHaveAttribute('data-src', 'https://bridge.withpersona.com/verify?x=1')
+
+        fireEvent.click(screen.getByText('finish'))
+        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
+        expect(screen.queryByTestId('hosted-iframe')).not.toBeInTheDocument()
+    })
+
+    it('manual iframe close does not refetch the user', async () => {
+        mockNextActions = [hostedAction]
+        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
+        render(<PendingVerificationTasks />)
+
+        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
+        await screen.findByTestId('hosted-iframe')
+        fireEvent.click(screen.getByText('close'))
+
+        expect(screen.queryByTestId('hosted-iframe')).not.toBeInTheDocument()
+        expect(mockFetchUser).not.toHaveBeenCalled()
+    })
+
+    it('start-action failure surfaces an inline error instead of an iframe', async () => {
+        mockNextActions = [hostedAction]
+        mockStartHosted.mockResolvedValue({ error: 'Action not allowed for this user' })
+        render(<PendingVerificationTasks />)
+
+        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
+        expect(await screen.findByText('Action not allowed for this user')).toBeInTheDocument()
+        expect(screen.queryByTestId('hosted-iframe')).not.toBeInTheDocument()
+    })
+
+    it('advisory task renders its deadline', () => {
+        mockNextActions = [{ ...hostedAction, effectiveDate: '2099-09-01' }]
+        render(<PendingVerificationTasks />)
+        expect(screen.getByText(/complete before sep 1, 2099/i)).toBeInTheDocument()
+    })
+
+    it('renders both tasks when ToS and hosted verification are pending together', () => {
+        mockNextActions = [tosAction, hostedAction]
+        render(<PendingVerificationTasks />)
+        expect(screen.getByText('Accept Terms of Service')).toBeInTheDocument()
+        expect(screen.getByText('Additional verification needed')).toBeInTheDocument()
+    })
+})

--- a/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
+++ b/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
@@ -17,7 +17,7 @@ import PendingVerificationTasks from '../PendingVerificationTasks'
 let mockNextActions: NextAction[] = []
 const mockFetchUser = jest.fn()
 const mockStartHosted = jest.fn<Promise<{ url?: string; error?: string }>, []>()
-let mockStoredDismissal: string | undefined
+let mockStoredDismissal: string[] | undefined
 const mockUpdatePreferences = jest.fn()
 
 jest.mock('@/hooks/useCapabilities', () => ({
@@ -184,37 +184,51 @@ describe('PendingVerificationTasks', () => {
     })
 
     describe('dismissal (home mount)', () => {
-        it('dismissible mount shows an X that hides the card and persists the task-key set', () => {
+        it("a slide's X dismisses ONLY that task — the other slide stays and the key persists", () => {
             mockNextActions = [tosAction, hostedAction]
             render(<PendingVerificationTasks dismissible />)
 
-            fireEvent.click(screen.getByRole('button', { name: /dismiss pending verification tasks/i }))
+            fireEvent.click(screen.getByRole('button', { name: /dismiss accept terms of service/i }))
             expect(screen.queryByText('Accept Terms of Service')).not.toBeInTheDocument()
+            expect(screen.getByText('Additional verification needed')).toBeInTheDocument()
             expect(mockUpdatePreferences).toHaveBeenCalledWith('user-1', {
-                pendingVerificationTasksDismissed: 'accept-tos,bridge-hosted',
+                pendingVerificationTasksDismissed: ['accept-tos'],
             })
         })
 
-        it('a stored dismissal for the SAME task set keeps the card hidden', () => {
-            mockStoredDismissal = 'accept-tos,bridge-hosted'
+        it('dismissing the last remaining task hides the card entirely', () => {
+            mockStoredDismissal = ['accept-tos']
+            mockNextActions = [tosAction, hostedAction]
+            const { container } = render(<PendingVerificationTasks dismissible />)
+
+            fireEvent.click(screen.getByRole('button', { name: /dismiss additional verification needed/i }))
+            expect(container).toBeEmptyDOMElement()
+            expect(mockUpdatePreferences).toHaveBeenCalledWith('user-1', {
+                pendingVerificationTasksDismissed: ['accept-tos', 'bridge-hosted'],
+            })
+        })
+
+        it('stored dismissed keys hide only their tasks; undismissed tasks still show', () => {
+            mockStoredDismissal = ['accept-tos']
+            mockNextActions = [tosAction, hostedAction]
+            render(<PendingVerificationTasks dismissible />)
+            expect(screen.queryByText('Accept Terms of Service')).not.toBeInTheDocument()
+            expect(screen.getByText('Additional verification needed')).toBeInTheDocument()
+        })
+
+        it('all pending tasks stored as dismissed → card hidden', () => {
+            mockStoredDismissal = ['accept-tos', 'bridge-hosted']
             mockNextActions = [tosAction, hostedAction]
             const { container } = render(<PendingVerificationTasks dismissible />)
             expect(container).toBeEmptyDOMElement()
         })
 
-        it('a DIFFERENT pending task set re-shows the card despite a stored dismissal', () => {
-            mockStoredDismissal = 'accept-tos'
-            mockNextActions = [tosAction, hostedAction]
-            render(<PendingVerificationTasks dismissible />)
-            expect(screen.getByText('Additional verification needed')).toBeInTheDocument()
-        })
-
         it('the non-dismissible (profile) mount ignores stored dismissals and has no X', () => {
-            mockStoredDismissal = 'accept-tos,bridge-hosted'
+            mockStoredDismissal = ['accept-tos', 'bridge-hosted']
             mockNextActions = [tosAction, hostedAction]
             render(<PendingVerificationTasks />)
             expect(screen.getByText('Accept Terms of Service')).toBeInTheDocument()
-            expect(screen.queryByRole('button', { name: /dismiss pending/i })).not.toBeInTheDocument()
+            expect(screen.queryByRole('button', { name: /dismiss/i })).not.toBeInTheDocument()
         })
     })
 })

--- a/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
+++ b/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
@@ -34,6 +34,10 @@ jest.mock('@/utils/general.utils', () => ({
 jest.mock('@/app/actions/sumsub', () => ({
     startBridgeHostedVerification: () => mockStartHosted(),
 }))
+const mockConfirmTos = jest.fn<Promise<void>, [unknown]>()
+jest.mock('@/hooks/useMultiPhaseKycFlow', () => ({
+    confirmBridgeTosAndAwaitRails: (fetchUser: () => Promise<unknown>) => mockConfirmTos(fetchUser),
+}))
 jest.mock('@/components/Kyc/BridgeTosStep', () => ({
     BridgeTosStep: (props: { visible: boolean; reasonCode?: string }) =>
         props.visible ? <div data-testid="tos-step">{props.reasonCode}</div> : null,
@@ -68,6 +72,8 @@ describe('PendingVerificationTasks', () => {
         mockNextActions = []
         mockFetchUser.mockReset()
         mockStartHosted.mockReset()
+        mockConfirmTos.mockReset()
+        mockConfirmTos.mockResolvedValue(undefined)
         mockStoredDismissal = undefined
         mockUpdatePreferences.mockReset()
         mockUserId = 'user-1'
@@ -160,7 +166,7 @@ describe('PendingVerificationTasks', () => {
         expect(mockFetchUser).toHaveBeenCalledTimes(1)
     })
 
-    it('an EMBEDDED ToS step inside the hosted flow does NOT close the iframe (mid-flow progress)', async () => {
+    it('an EMBEDDED ToS step inside the hosted flow CONFIRMS to the backend and does NOT close the iframe', async () => {
         mockNextActions = [hostedAction]
         mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
         render(<PendingVerificationTasks />)
@@ -170,19 +176,39 @@ describe('PendingVerificationTasks', () => {
 
         // Bridge's hosted kyc_link flow can open with a ToS-acceptance page;
         // its signedAgreementId postMessage maps to onClose('tos_accepted').
+        // A bare fetchUser would NOT record the acceptance (the resolver is
+        // pure) — the canonical confirm path must run, and it refetches.
         fireEvent.click(screen.getByText('accept-embedded-tos'))
         expect(screen.getByTestId('hosted-iframe')).toBeInTheDocument()
-        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
+        await waitFor(() => expect(mockConfirmTos).toHaveBeenCalledTimes(1))
+        expect(mockConfirmTos).toHaveBeenCalledWith(mockFetchUser)
 
         // The user then finishes the identity steps — completion still closes.
         fireEvent.click(screen.getByText('finish'))
         expect(screen.queryByTestId('hosted-iframe')).not.toBeInTheDocument()
+        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
+    })
+
+    it('a failed embedded-ToS confirm still resyncs the user and keeps the flow alive', async () => {
+        mockNextActions = [hostedAction]
+        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
+        mockConfirmTos.mockRejectedValue(new Error('confirm blew up'))
+        render(<PendingVerificationTasks />)
+
+        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
+        await screen.findByTestId('hosted-iframe')
+
+        fireEvent.click(screen.getByText('accept-embedded-tos'))
+        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
+        expect(screen.getByTestId('hosted-iframe')).toBeInTheDocument()
     })
 
     it('advisory task renders its deadline and keep-access copy; blocking renders enable copy', () => {
         mockNextActions = [{ ...hostedAction, effectiveDate: '2099-09-01' }]
         const { rerender } = render(<PendingVerificationTasks />)
-        expect(screen.getByText(/complete before sep 1, 2099/i)).toBeInTheDocument()
+        // Long month — the SAME formatter AdvisoryPreemptModal uses
+        // (formatEffectiveDate), so one deadline never renders two ways.
+        expect(screen.getByText(/complete before september 1, 2099/i)).toBeInTheDocument()
         expect(screen.getByText(/keep bank transfers available/i)).toBeInTheDocument()
 
         mockNextActions = [hostedAction]
@@ -206,44 +232,71 @@ describe('PendingVerificationTasks', () => {
     })
 
     describe('dismissal (home mount)', () => {
-        const tosFingerprint = 'accept-tos||due-now'
-        const hostedFingerprint = 'bridge-hosted|kyc_approval|due-now'
+        // Only ADVISORY (future-dated) tasks are dismissible — a blocking
+        // fingerprint is constant over time, so honoring one would hide a NEW
+        // same-variant requirement while the user's rails are gated.
+        const advisoryTos: NextAction = {
+            ...sepaTosAction,
+            requirementKey: 'tos_v2_acceptance',
+            effectiveDate: '2099-09-01',
+        }
+        const advisoryHosted: NextAction = { ...hostedAction, effectiveDate: '2099-12-01' }
+        const advisoryTosFingerprint = 'accept-tos:sepa|tos_v2_acceptance|2099-09-01'
+        const advisoryHostedFingerprint = 'bridge-hosted|kyc_approval|2099-12-01'
+        // Pre-fix localStorage can still carry blocking fingerprints.
+        const legacyBlockingFingerprints = ['accept-tos||due-now', 'bridge-hosted|kyc_approval|due-now']
 
-        it("a slide's X dismisses ONLY that task — the other slide stays and the fingerprint persists", () => {
-            mockNextActions = [tosAction, hostedAction]
+        it("an advisory slide's X dismisses ONLY that task — the other slide stays and the fingerprint persists", () => {
+            mockNextActions = [advisoryTos, advisoryHosted]
             render(<PendingVerificationTasks dismissible />)
 
-            fireEvent.click(screen.getByRole('button', { name: /dismiss accept terms of service/i }))
-            expect(screen.queryByText('Accept Terms of Service')).not.toBeInTheDocument()
+            fireEvent.click(screen.getByRole('button', { name: /dismiss accept sepa terms of service/i }))
+            expect(screen.queryByText('Accept SEPA Terms of Service')).not.toBeInTheDocument()
             expect(screen.getByText('Additional verification needed')).toBeInTheDocument()
             expect(mockUpdatePreferences).toHaveBeenCalledWith('user-1', {
-                pendingVerificationTasksDismissed: [tosFingerprint],
+                pendingVerificationTasksDismissed: [advisoryTosFingerprint],
             })
         })
 
-        it('dismissing the last remaining task hides the card entirely', () => {
-            mockStoredDismissal = [tosFingerprint]
+        it('BLOCKING slides carry no X; advisory siblings on the same mount do', () => {
+            mockNextActions = [tosAction, advisoryHosted]
+            render(<PendingVerificationTasks dismissible />)
+
+            expect(screen.queryByRole('button', { name: /dismiss accept terms of service/i })).not.toBeInTheDocument()
+            expect(screen.getByRole('button', { name: /dismiss additional verification needed/i })).toBeInTheDocument()
+        })
+
+        it('a stored (pre-fix) blocking fingerprint never hides a blocking task', () => {
+            mockStoredDismissal = legacyBlockingFingerprints
             mockNextActions = [tosAction, hostedAction]
+            render(<PendingVerificationTasks dismissible />)
+            expect(screen.getByText('Accept Terms of Service')).toBeInTheDocument()
+            expect(screen.getByText('Additional verification needed')).toBeInTheDocument()
+        })
+
+        it('dismissing the last remaining advisory hides the card entirely', () => {
+            mockStoredDismissal = [advisoryTosFingerprint]
+            mockNextActions = [advisoryTos, advisoryHosted]
             const { container } = render(<PendingVerificationTasks dismissible />)
 
             fireEvent.click(screen.getByRole('button', { name: /dismiss additional verification needed/i }))
             expect(container).toBeEmptyDOMElement()
             expect(mockUpdatePreferences).toHaveBeenCalledWith('user-1', {
-                pendingVerificationTasksDismissed: [tosFingerprint, hostedFingerprint],
+                pendingVerificationTasksDismissed: [advisoryTosFingerprint, advisoryHostedFingerprint],
             })
         })
 
-        it('stored dismissed fingerprints hide only their tasks; undismissed tasks still show', () => {
-            mockStoredDismissal = [tosFingerprint]
-            mockNextActions = [tosAction, hostedAction]
+        it('stored dismissed fingerprints hide only their advisories; undismissed tasks still show', () => {
+            mockStoredDismissal = [advisoryTosFingerprint]
+            mockNextActions = [advisoryTos, advisoryHosted]
             render(<PendingVerificationTasks dismissible />)
-            expect(screen.queryByText('Accept Terms of Service')).not.toBeInTheDocument()
+            expect(screen.queryByText('Accept SEPA Terms of Service')).not.toBeInTheDocument()
             expect(screen.getByText('Additional verification needed')).toBeInTheDocument()
         })
 
         it('a dismissed ADVISORY task re-surfaces when it turns blocking (same key, date gone)', () => {
             // User dismissed the "complete before Sep 1" reminder in July…
-            mockStoredDismissal = ['accept-tos:sepa|tos_v2_acceptance|2099-09-01']
+            mockStoredDismissal = [advisoryTosFingerprint]
             // …and on Sep 1 Bridge reclassifies the same requirement as due now.
             mockNextActions = [{ ...sepaTosAction, requirementKey: 'tos_v2_acceptance' }]
             render(<PendingVerificationTasks dismissible />)
@@ -251,22 +304,22 @@ describe('PendingVerificationTasks', () => {
         })
 
         it('a NEW requirement under the shared bridge-hosted key re-surfaces despite a dismissal', () => {
-            mockStoredDismissal = [hostedFingerprint]
-            mockNextActions = [{ ...hostedAction, requirementKey: 'kyc_with_proof_of_address' }]
+            mockStoredDismissal = [advisoryHostedFingerprint]
+            mockNextActions = [{ ...advisoryHosted, requirementKey: 'kyc_with_proof_of_address' }]
             render(<PendingVerificationTasks dismissible />)
             expect(screen.getByText('Additional verification needed')).toBeInTheDocument()
         })
 
-        it('all pending tasks stored as dismissed → card hidden', () => {
-            mockStoredDismissal = [tosFingerprint, hostedFingerprint]
-            mockNextActions = [tosAction, hostedAction]
+        it('all pending advisories stored as dismissed → card hidden', () => {
+            mockStoredDismissal = [advisoryTosFingerprint, advisoryHostedFingerprint]
+            mockNextActions = [advisoryTos, advisoryHosted]
             const { container } = render(<PendingVerificationTasks dismissible />)
             expect(container).toBeEmptyDOMElement()
         })
 
         it("a user switch does not inherit the previous user's dismissals", () => {
-            mockStoredDismissal = [tosFingerprint, hostedFingerprint]
-            mockNextActions = [tosAction, hostedAction]
+            mockStoredDismissal = [advisoryTosFingerprint, advisoryHostedFingerprint]
+            mockNextActions = [advisoryTos, advisoryHosted]
             const { container, rerender } = render(<PendingVerificationTasks dismissible />)
             expect(container).toBeEmptyDOMElement()
 
@@ -275,15 +328,15 @@ describe('PendingVerificationTasks', () => {
             mockUserId = 'user-2'
             mockStoredDismissal = undefined
             rerender(<PendingVerificationTasks dismissible />)
-            expect(screen.getByText('Accept Terms of Service')).toBeInTheDocument()
+            expect(screen.getByText('Accept SEPA Terms of Service')).toBeInTheDocument()
             expect(screen.getByText('Additional verification needed')).toBeInTheDocument()
         })
 
         it('the non-dismissible (profile) mount ignores stored dismissals and has no X', () => {
-            mockStoredDismissal = [tosFingerprint, hostedFingerprint]
-            mockNextActions = [tosAction, hostedAction]
+            mockStoredDismissal = [advisoryTosFingerprint, advisoryHostedFingerprint]
+            mockNextActions = [advisoryTos, advisoryHosted]
             render(<PendingVerificationTasks />)
-            expect(screen.getByText('Accept Terms of Service')).toBeInTheDocument()
+            expect(screen.getByText('Accept SEPA Terms of Service')).toBeInTheDocument()
             expect(screen.queryByRole('button', { name: /dismiss/i })).not.toBeInTheDocument()
         })
     })

--- a/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
+++ b/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
@@ -44,6 +44,7 @@ jest.mock('@/components/Global/IframeWrapper', () => ({
             <div data-testid="hosted-iframe" data-src={props.src}>
                 <button onClick={() => props.onClose('completed')}>finish</button>
                 <button onClick={() => props.onClose('manual')}>close</button>
+                <button onClick={() => props.onClose('tos_accepted')}>accept-embedded-tos</button>
             </div>
         ) : null,
 }))
@@ -157,6 +158,25 @@ describe('PendingVerificationTasks', () => {
         expect(mockFetchUser).toHaveBeenCalledTimes(1)
     })
 
+    it('an EMBEDDED ToS step inside the hosted flow does NOT close the iframe (mid-flow progress)', async () => {
+        mockNextActions = [hostedAction]
+        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
+        render(<PendingVerificationTasks />)
+
+        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
+        await screen.findByTestId('hosted-iframe')
+
+        // Bridge's hosted kyc_link flow can open with a ToS-acceptance page;
+        // its signedAgreementId postMessage maps to onClose('tos_accepted').
+        fireEvent.click(screen.getByText('accept-embedded-tos'))
+        expect(screen.getByTestId('hosted-iframe')).toBeInTheDocument()
+        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
+
+        // The user then finishes the identity steps — completion still closes.
+        fireEvent.click(screen.getByText('finish'))
+        expect(screen.queryByTestId('hosted-iframe')).not.toBeInTheDocument()
+    })
+
     it('advisory task renders its deadline and keep-access copy; blocking renders enable copy', () => {
         mockNextActions = [{ ...hostedAction, effectiveDate: '2099-09-01' }]
         const { rerender } = render(<PendingVerificationTasks />)
@@ -184,7 +204,10 @@ describe('PendingVerificationTasks', () => {
     })
 
     describe('dismissal (home mount)', () => {
-        it("a slide's X dismisses ONLY that task — the other slide stays and the key persists", () => {
+        const tosFingerprint = 'accept-tos||due-now'
+        const hostedFingerprint = 'bridge-hosted|kyc_approval|due-now'
+
+        it("a slide's X dismisses ONLY that task — the other slide stays and the fingerprint persists", () => {
             mockNextActions = [tosAction, hostedAction]
             render(<PendingVerificationTasks dismissible />)
 
@@ -192,39 +215,55 @@ describe('PendingVerificationTasks', () => {
             expect(screen.queryByText('Accept Terms of Service')).not.toBeInTheDocument()
             expect(screen.getByText('Additional verification needed')).toBeInTheDocument()
             expect(mockUpdatePreferences).toHaveBeenCalledWith('user-1', {
-                pendingVerificationTasksDismissed: ['accept-tos'],
+                pendingVerificationTasksDismissed: [tosFingerprint],
             })
         })
 
         it('dismissing the last remaining task hides the card entirely', () => {
-            mockStoredDismissal = ['accept-tos']
+            mockStoredDismissal = [tosFingerprint]
             mockNextActions = [tosAction, hostedAction]
             const { container } = render(<PendingVerificationTasks dismissible />)
 
             fireEvent.click(screen.getByRole('button', { name: /dismiss additional verification needed/i }))
             expect(container).toBeEmptyDOMElement()
             expect(mockUpdatePreferences).toHaveBeenCalledWith('user-1', {
-                pendingVerificationTasksDismissed: ['accept-tos', 'bridge-hosted'],
+                pendingVerificationTasksDismissed: [tosFingerprint, hostedFingerprint],
             })
         })
 
-        it('stored dismissed keys hide only their tasks; undismissed tasks still show', () => {
-            mockStoredDismissal = ['accept-tos']
+        it('stored dismissed fingerprints hide only their tasks; undismissed tasks still show', () => {
+            mockStoredDismissal = [tosFingerprint]
             mockNextActions = [tosAction, hostedAction]
             render(<PendingVerificationTasks dismissible />)
             expect(screen.queryByText('Accept Terms of Service')).not.toBeInTheDocument()
             expect(screen.getByText('Additional verification needed')).toBeInTheDocument()
         })
 
+        it('a dismissed ADVISORY task re-surfaces when it turns blocking (same key, date gone)', () => {
+            // User dismissed the "complete before Sep 1" reminder in July…
+            mockStoredDismissal = ['accept-tos:sepa|tos_v2_acceptance|2099-09-01']
+            // …and on Sep 1 Bridge reclassifies the same requirement as due now.
+            mockNextActions = [{ ...sepaTosAction, requirementKey: 'tos_v2_acceptance' }]
+            render(<PendingVerificationTasks dismissible />)
+            expect(screen.getByText('Accept SEPA Terms of Service')).toBeInTheDocument()
+        })
+
+        it('a NEW requirement under the shared bridge-hosted key re-surfaces despite a dismissal', () => {
+            mockStoredDismissal = [hostedFingerprint]
+            mockNextActions = [{ ...hostedAction, requirementKey: 'kyc_with_proof_of_address' }]
+            render(<PendingVerificationTasks dismissible />)
+            expect(screen.getByText('Additional verification needed')).toBeInTheDocument()
+        })
+
         it('all pending tasks stored as dismissed → card hidden', () => {
-            mockStoredDismissal = ['accept-tos', 'bridge-hosted']
+            mockStoredDismissal = [tosFingerprint, hostedFingerprint]
             mockNextActions = [tosAction, hostedAction]
             const { container } = render(<PendingVerificationTasks dismissible />)
             expect(container).toBeEmptyDOMElement()
         })
 
         it('the non-dismissible (profile) mount ignores stored dismissals and has no X', () => {
-            mockStoredDismissal = ['accept-tos', 'bridge-hosted']
+            mockStoredDismissal = [tosFingerprint, hostedFingerprint]
             mockNextActions = [tosAction, hostedAction]
             render(<PendingVerificationTasks />)
             expect(screen.getByText('Accept Terms of Service')).toBeInTheDocument()

--- a/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
+++ b/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
@@ -17,12 +17,18 @@ import PendingVerificationTasks from '../PendingVerificationTasks'
 let mockNextActions: NextAction[] = []
 const mockFetchUser = jest.fn()
 const mockStartHosted = jest.fn<Promise<{ url?: string; error?: string }>, []>()
+let mockStoredDismissal: string | undefined
+const mockUpdatePreferences = jest.fn()
 
 jest.mock('@/hooks/useCapabilities', () => ({
     useCapabilities: () => ({ nextActions: mockNextActions }),
 }))
 jest.mock('@/context/authContext', () => ({
-    useAuth: () => ({ fetchUser: mockFetchUser }),
+    useAuth: () => ({ user: { user: { userId: 'user-1' } }, fetchUser: mockFetchUser }),
+}))
+jest.mock('@/utils/general.utils', () => ({
+    getUserPreferences: () => ({ pendingVerificationTasksDismissed: mockStoredDismissal }),
+    updateUserPreferences: (userId: string, prefs: Record<string, unknown>) => mockUpdatePreferences(userId, prefs),
 }))
 jest.mock('@/app/actions/sumsub', () => ({
     startBridgeHostedVerification: () => mockStartHosted(),
@@ -60,6 +66,8 @@ describe('PendingVerificationTasks', () => {
         mockNextActions = []
         mockFetchUser.mockReset()
         mockStartHosted.mockReset()
+        mockStoredDismissal = undefined
+        mockUpdatePreferences.mockReset()
     })
 
     it('renders nothing when no bridge task is pending', () => {
@@ -173,5 +181,40 @@ describe('PendingVerificationTasks', () => {
         render(<PendingVerificationTasks />)
         expect(screen.getByText('Accept Terms of Service')).toBeInTheDocument()
         expect(screen.getByText('Additional verification needed')).toBeInTheDocument()
+    })
+
+    describe('dismissal (home mount)', () => {
+        it('dismissible mount shows an X that hides the card and persists the task-key set', () => {
+            mockNextActions = [tosAction, hostedAction]
+            render(<PendingVerificationTasks dismissible />)
+
+            fireEvent.click(screen.getByRole('button', { name: /dismiss pending verification tasks/i }))
+            expect(screen.queryByText('Accept Terms of Service')).not.toBeInTheDocument()
+            expect(mockUpdatePreferences).toHaveBeenCalledWith('user-1', {
+                pendingVerificationTasksDismissed: 'accept-tos,bridge-hosted',
+            })
+        })
+
+        it('a stored dismissal for the SAME task set keeps the card hidden', () => {
+            mockStoredDismissal = 'accept-tos,bridge-hosted'
+            mockNextActions = [tosAction, hostedAction]
+            const { container } = render(<PendingVerificationTasks dismissible />)
+            expect(container).toBeEmptyDOMElement()
+        })
+
+        it('a DIFFERENT pending task set re-shows the card despite a stored dismissal', () => {
+            mockStoredDismissal = 'accept-tos'
+            mockNextActions = [tosAction, hostedAction]
+            render(<PendingVerificationTasks dismissible />)
+            expect(screen.getByText('Additional verification needed')).toBeInTheDocument()
+        })
+
+        it('the non-dismissible (profile) mount ignores stored dismissals and has no X', () => {
+            mockStoredDismissal = 'accept-tos,bridge-hosted'
+            mockNextActions = [tosAction, hostedAction]
+            render(<PendingVerificationTasks />)
+            expect(screen.getByText('Accept Terms of Service')).toBeInTheDocument()
+            expect(screen.queryByRole('button', { name: /dismiss pending/i })).not.toBeInTheDocument()
+        })
     })
 })

--- a/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
+++ b/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
@@ -6,7 +6,8 @@
  * blocking tasks and advisory orphans (future-dated tasks on fully-enabled
  * users, which no rail references). accept-tos routes into the existing
  * BridgeTosStep; bridge-hosted exchanges the key for a hosted URL and opens
- * it in the IframeWrapper.
+ * it in the IframeWrapper. Open flows are snapshotted at tap time so they
+ * survive the task list flapping under the ~4s user auto-refresh.
  */
 import React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
@@ -42,6 +43,11 @@ jest.mock('@/components/Global/IframeWrapper', () => ({
 }))
 
 const tosAction: NextAction = { key: 'accept-tos', kind: 'accept-tos', purpose: 'accept-bridge-tos' }
+const sepaTosAction: NextAction = {
+    key: 'accept-tos:sepa',
+    kind: 'accept-tos',
+    purpose: 'accept-bridge-tos-sepa',
+}
 const hostedAction: NextAction = {
     key: 'bridge-hosted',
     kind: 'bridge-hosted',
@@ -63,11 +69,23 @@ describe('PendingVerificationTasks', () => {
     })
 
     it('accept-tos task opens BridgeTosStep with the variant-matched reason code', () => {
-        mockNextActions = [{ ...tosAction, key: 'accept-tos:sepa', purpose: 'accept-bridge-tos-sepa' }]
+        mockNextActions = [sepaTosAction]
         render(<PendingVerificationTasks />)
 
         expect(screen.getByText('Accept SEPA Terms of Service')).toBeInTheDocument()
         fireEvent.click(screen.getByRole('button', { name: /review terms/i }))
+        expect(screen.getByTestId('tos-step')).toHaveTextContent('bridge_tos_v2_required')
+    })
+
+    it('with BOTH ToS variants pending, each row opens the modal for ITS variant', () => {
+        mockNextActions = [tosAction, sepaTosAction]
+        render(<PendingVerificationTasks />)
+
+        expect(screen.getByText('Accept Terms of Service')).toBeInTheDocument()
+        expect(screen.getByText('Accept SEPA Terms of Service')).toBeInTheDocument()
+
+        const buttons = screen.getAllByRole('button', { name: /review terms/i })
+        fireEvent.click(buttons[1]) // sepa row (render order follows nextActions)
         expect(screen.getByTestId('tos-step')).toHaveTextContent('bridge_tos_v2_required')
     })
 
@@ -87,6 +105,25 @@ describe('PendingVerificationTasks', () => {
         expect(screen.queryByTestId('hosted-iframe')).not.toBeInTheDocument()
     })
 
+    it('an open hosted iframe SURVIVES its task disappearing from nextActions (auto-refresh flap)', async () => {
+        mockNextActions = [hostedAction]
+        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
+        const { rerender } = render(<PendingVerificationTasks />)
+
+        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
+        await screen.findByTestId('hosted-iframe')
+
+        // Bridge reclassifies mid-flow → the task vanishes on the next refetch.
+        mockNextActions = []
+        rerender(<PendingVerificationTasks />)
+
+        expect(screen.queryByText('Additional verification needed')).not.toBeInTheDocument()
+        expect(screen.getByTestId('hosted-iframe')).toBeInTheDocument()
+
+        fireEvent.click(screen.getByText('close'))
+        expect(screen.queryByTestId('hosted-iframe')).not.toBeInTheDocument()
+    })
+
     it('manual iframe close does not refetch the user', async () => {
         mockNextActions = [hostedAction]
         mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
@@ -100,20 +137,35 @@ describe('PendingVerificationTasks', () => {
         expect(mockFetchUser).not.toHaveBeenCalled()
     })
 
-    it('start-action failure surfaces an inline error instead of an iframe', async () => {
+    it('start-action failure surfaces FRIENDLY copy (never the raw server error) and resyncs the user', async () => {
         mockNextActions = [hostedAction]
         mockStartHosted.mockResolvedValue({ error: 'Action not allowed for this user' })
         render(<PendingVerificationTasks />)
 
         fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
-        expect(await screen.findByText('Action not allowed for this user')).toBeInTheDocument()
+        expect(await screen.findByText(/couldn't start the verification/i)).toBeInTheDocument()
+        expect(screen.queryByText('Action not allowed for this user')).not.toBeInTheDocument()
         expect(screen.queryByTestId('hosted-iframe')).not.toBeInTheDocument()
+        expect(mockFetchUser).toHaveBeenCalledTimes(1)
     })
 
-    it('advisory task renders its deadline', () => {
+    it('advisory task renders its deadline and keep-access copy; blocking renders enable copy', () => {
         mockNextActions = [{ ...hostedAction, effectiveDate: '2099-09-01' }]
-        render(<PendingVerificationTasks />)
+        const { rerender } = render(<PendingVerificationTasks />)
         expect(screen.getByText(/complete before sep 1, 2099/i)).toBeInTheDocument()
+        expect(screen.getByText(/keep bank transfers available/i)).toBeInTheDocument()
+
+        mockNextActions = [hostedAction]
+        rerender(<PendingVerificationTasks />)
+        expect(screen.getByText(/enable bank transfers/i)).toBeInTheDocument()
+        expect(screen.queryByText(/complete before/i)).not.toBeInTheDocument()
+    })
+
+    it('malformed effectiveDate renders no deadline line instead of "Invalid Date"', () => {
+        mockNextActions = [{ ...hostedAction, effectiveDate: 'not-a-date' }]
+        render(<PendingVerificationTasks />)
+        expect(screen.queryByText(/complete before/i)).not.toBeInTheDocument()
+        expect(screen.queryByText(/invalid date/i)).not.toBeInTheDocument()
     })
 
     it('renders both tasks when ToS and hosted verification are pending together', () => {

--- a/src/components/Kyc/AdvisoryPreemptModal.tsx
+++ b/src/components/Kyc/AdvisoryPreemptModal.tsx
@@ -1,4 +1,5 @@
 import ActionModal from '@/components/Global/ActionModal'
+import { formatEffectiveDate } from '@/utils/format.utils'
 
 interface AdvisoryPreemptModalProps {
     visible: boolean
@@ -7,16 +8,6 @@ interface AdvisoryPreemptModalProps {
     isLoading?: boolean
     /** Launch the verification flow. */
     onCompleteNow: () => void
-}
-
-function formatEffectiveDate(iso?: string): string | null {
-    if (!iso) return null
-    const date = new Date(iso)
-    // `iso` is a date-only YYYY-MM-DD, so `new Date()` parses it at UTC midnight.
-    // Format in UTC too, or Americas timezones render the day before the deadline.
-    return Number.isNaN(date.getTime())
-        ? null
-        : date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })
 }
 
 /**

--- a/src/components/Profile/views/UnlockedRegions.view.tsx
+++ b/src/components/Profile/views/UnlockedRegions.view.tsx
@@ -7,6 +7,7 @@ import { Icon } from '@/components/Global/Icons/Icon'
 import NavHeader from '@/components/Global/NavHeader'
 import UnlockRegionModal from '@/components/IdentityVerification/UnlockRegionModal'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
+import PendingVerificationTasks from '@/components/Home/PendingVerificationTasks'
 import { KycProcessingModal } from '@/components/Kyc/modals/KycProcessingModal'
 import { KycActionRequiredModal } from '@/components/Kyc/modals/KycActionRequiredModal'
 import { KycFailedModal } from '@/components/Kyc/modals/KycFailedModal'
@@ -204,6 +205,13 @@ const UnlockedRegions = () => {
                 <p className="mt-2 text-sm">
                     Transfer to and receive from any bank account and use supported payments methods.
                 </p>
+
+                {/* Pending Bridge verification tasks (ToS / hosted re-verification).
+                    Non-dismissible here — this is where the /home card's X sends
+                    people to find their tasks again. Self-hiding when none. */}
+                <div className="mt-4">
+                    <PendingVerificationTasks />
+                </div>
 
                 {unlockedRegions.length === 0 && (
                     <EmptyState

--- a/src/types/capabilities.ts
+++ b/src/types/capabilities.ts
@@ -134,8 +134,19 @@ export interface ResolvedRail {
  *                           WebSDK so the user can verify with a different
  *                           document (used for the country-not-supported CTA
  *                           on Manteca-only rails; user has a self-fix path).
+ *   - `bridge-hosted`     — open Bridge's hosted verification flow (the
+ *                           catch-all for requirements with no native Sumsub
+ *                           mapping); exchange the key for a URL via
+ *                           startBridgeHostedVerification().
  */
-export type NextActionKind = 'sumsub' | 'accept-tos' | 'wait' | 'contact-support' | 'restart-identity' | 'provide-email'
+export type NextActionKind =
+    | 'sumsub'
+    | 'accept-tos'
+    | 'wait'
+    | 'contact-support'
+    | 'restart-identity'
+    | 'provide-email'
+    | 'bridge-hosted'
 
 export interface NextAction {
     key: string // stable id, referenced by RailCapability.blockingActions

--- a/src/utils/__tests__/bridge-tasks.utils.test.ts
+++ b/src/utils/__tests__/bridge-tasks.utils.test.ts
@@ -1,4 +1,4 @@
-import { selectBridgeTasks } from '../bridge-tasks.utils'
+import { bridgeTaskDismissalKey, selectBridgeTasks } from '../bridge-tasks.utils'
 import type { NextAction } from '@/types/capabilities'
 
 const action = (overrides: Partial<NextAction>): NextAction => ({
@@ -30,5 +30,32 @@ describe('selectBridgeTasks', () => {
             action({ key: 'bridge-hosted', kind: 'bridge-hosted', effectiveDate: '2099-09-01' }),
         ])
         expect(task.effectiveDate).toBe('2099-09-01')
+    })
+})
+
+describe('bridgeTaskDismissalKey', () => {
+    it('advisory → blocking (effectiveDate disappears) changes the fingerprint', () => {
+        const advisory = action({ key: 'accept-tos:sepa', effectiveDate: '2099-09-01' })
+        const blocking = action({ key: 'accept-tos:sepa' })
+        expect(bridgeTaskDismissalKey(advisory)).not.toBe(bridgeTaskDismissalKey(blocking))
+    })
+
+    it('a new requirement under the shared bridge-hosted key changes the fingerprint', () => {
+        const first = action({ key: 'bridge-hosted', kind: 'bridge-hosted', requirementKey: 'kyc_approval' })
+        const second = action({
+            key: 'bridge-hosted',
+            kind: 'bridge-hosted',
+            requirementKey: 'kyc_with_proof_of_address',
+        })
+        expect(bridgeTaskDismissalKey(first)).not.toBe(bridgeTaskDismissalKey(second))
+    })
+
+    it('an unchanged task keeps a stable fingerprint', () => {
+        const task = action({
+            key: 'accept-tos:sepa',
+            effectiveDate: '2099-09-01',
+            requirementKey: 'tos_v2_acceptance',
+        })
+        expect(bridgeTaskDismissalKey(task)).toBe(bridgeTaskDismissalKey({ ...task }))
     })
 })

--- a/src/utils/__tests__/bridge-tasks.utils.test.ts
+++ b/src/utils/__tests__/bridge-tasks.utils.test.ts
@@ -1,0 +1,34 @@
+import { selectBridgeTasks } from '../bridge-tasks.utils'
+import type { NextAction } from '@/types/capabilities'
+
+const action = (overrides: Partial<NextAction>): NextAction => ({
+    key: 'accept-tos',
+    kind: 'accept-tos',
+    purpose: 'accept-bridge-tos',
+    ...overrides,
+})
+
+describe('selectBridgeTasks', () => {
+    it('keeps accept-tos and bridge-hosted, drops everything else', () => {
+        const tasks = selectBridgeTasks([
+            action({ key: 'accept-tos', kind: 'accept-tos' }),
+            action({ key: 'bridge-hosted', kind: 'bridge-hosted', purpose: 'bridge-additional-verification' }),
+            action({ key: 'sumsub:proof_of_address', kind: 'sumsub' }),
+            action({ key: 'wait:bridge', kind: 'wait' }),
+            action({ key: 'contact-support', kind: 'contact-support' }),
+        ])
+        expect(tasks.map((t) => t.key)).toEqual(['accept-tos', 'bridge-hosted'])
+    })
+
+    it('returns [] when nothing is pending', () => {
+        expect(selectBridgeTasks([])).toEqual([])
+        expect(selectBridgeTasks([action({ key: 'sumsub:eea_uplift', kind: 'sumsub' })])).toEqual([])
+    })
+
+    it('passes advisory metadata (effectiveDate) through untouched', () => {
+        const [task] = selectBridgeTasks([
+            action({ key: 'bridge-hosted', kind: 'bridge-hosted', effectiveDate: '2099-09-01' }),
+        ])
+        expect(task.effectiveDate).toBe('2099-09-01')
+    })
+})

--- a/src/utils/bridge-tasks.utils.ts
+++ b/src/utils/bridge-tasks.utils.ts
@@ -13,13 +13,18 @@ export function selectBridgeTasks(nextActions: NextAction[]): NextAction[] {
 }
 
 /**
- * Fingerprint a task for dismissal persistence. The task `key` alone is NOT
- * enough: keys stay identical when an advisory task turns blocking (its
- * `effectiveDate` passes and disappears) and when a NEW Bridge requirement
- * arrives under the shared `bridge-hosted` key (only `requirementKey`
- * changes). A dismissal must not survive either — the user dismissed a
- * "due later" reminder, not the failure of their live bank transfers — so
- * both fields join the fingerprint and any change re-surfaces the slide.
+ * Fingerprint a task for dismissal persistence. Only ADVISORY (future-dated)
+ * tasks are dismissible — a blocking task's fingerprint is constant over time
+ * (`accept-tos||due-now`), so honoring a stored one would hide a NEW
+ * same-variant requirement months later while the user's rails are gated; the
+ * card exempts blocking tasks from dismissal filtering entirely. For
+ * advisories the task `key` alone is NOT enough: keys stay identical when a
+ * NEW requirement arrives under the shared `bridge-hosted` key (only
+ * `requirementKey` changes) or when a new round of the same requirement gets
+ * a new deadline — so both fields join the fingerprint and any change
+ * re-surfaces the slide. The advisory→blocking escalation is covered twice:
+ * the date leaving changes the fingerprint AND the now-blocking task stops
+ * consulting dismissals at all.
  */
 export function bridgeTaskDismissalKey(task: NextAction): string {
     return [task.key, task.requirementKey ?? '', task.effectiveDate ?? 'due-now'].join('|')

--- a/src/utils/bridge-tasks.utils.ts
+++ b/src/utils/bridge-tasks.utils.ts
@@ -1,0 +1,13 @@
+import type { NextAction } from '@/types/capabilities'
+
+/**
+ * The nextActions renderable as pending Bridge verification tasks:
+ * `accept-tos` (blocking, rail-attached — or advisory orphan) and
+ * `bridge-hosted` (the hosted-flow catch-all). One filter catches both the
+ * blocking and the advisory (future-dated, `effectiveDate`-carrying)
+ * populations — advisory actions arrive as orphans no rail references, so
+ * reading top-level `nextActions` is the only way to see them.
+ */
+export function selectBridgeTasks(nextActions: NextAction[]): NextAction[] {
+    return nextActions.filter((action) => action.kind === 'accept-tos' || action.kind === 'bridge-hosted')
+}

--- a/src/utils/bridge-tasks.utils.ts
+++ b/src/utils/bridge-tasks.utils.ts
@@ -11,3 +11,16 @@ import type { NextAction } from '@/types/capabilities'
 export function selectBridgeTasks(nextActions: NextAction[]): NextAction[] {
     return nextActions.filter((action) => action.kind === 'accept-tos' || action.kind === 'bridge-hosted')
 }
+
+/**
+ * Fingerprint a task for dismissal persistence. The task `key` alone is NOT
+ * enough: keys stay identical when an advisory task turns blocking (its
+ * `effectiveDate` passes and disappears) and when a NEW Bridge requirement
+ * arrives under the shared `bridge-hosted` key (only `requirementKey`
+ * changes). A dismissal must not survive either — the user dismissed a
+ * "due later" reminder, not the failure of their live bank transfers — so
+ * both fields join the fingerprint and any change re-surfaces the slide.
+ */
+export function bridgeTaskDismissalKey(task: NextAction): string {
+    return [task.key, task.requirementKey ?? '', task.effectiveDate ?? 'due-now'].join('|')
+}

--- a/src/utils/format.utils.ts
+++ b/src/utils/format.utils.ts
@@ -64,3 +64,19 @@ export function shortDepositReference(reference: string | undefined): string | u
 export function shortDepositReference(reference: string | undefined): string | undefined {
     return reference?.slice(0, 10)
 }
+
+/**
+ * "2099-03-01" → "March 1, 2099". Capability advisory deadlines
+ * (`NextAction.effectiveDate`) are date-only YYYY-MM-DD strings, which
+ * `new Date()` parses at UTC midnight — format in UTC too, or Americas
+ * timezones render the day before the deadline. One formatter for every
+ * surface that shows the same deadline (AdvisoryPreemptModal, the pending
+ * verification tasks card), so the same date never renders two ways.
+ */
+export function formatEffectiveDate(iso?: string): string | null {
+    if (!iso) return null
+    const date = new Date(iso)
+    return Number.isNaN(date.getTime())
+        ? null
+        : date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })
+}

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -498,9 +498,11 @@ export type UserPreferences = {
      *  Read by useHomeCarouselCTAs to apply a per-CTA cooldown before re-showing.
      *  Legacy shape was `string[]` (permanent dismissal); both are accepted on read. */
     dismissedCarouselCTAs?: string[] | Record<string, string>
-    /** Task keys of the pending Bridge verification tasks the user
-     *  individually dismissed on /home. A dismissed key stays hidden until its
-     *  task resolves; the tasks stay reachable under Profile → Unlocked regions. */
+    /** Dismissal fingerprints (`bridgeTaskDismissalKey`: key|requirement|due)
+     *  of the pending Bridge verification tasks the user individually
+     *  dismissed on /home. A task that turns blocking or changes substance
+     *  gets a new fingerprint and re-surfaces; the tasks always stay
+     *  reachable under Profile → Unlocked regions. */
     pendingVerificationTasksDismissed?: string[]
 }
 

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -498,9 +498,9 @@ export type UserPreferences = {
      *  Read by useHomeCarouselCTAs to apply a per-CTA cooldown before re-showing.
      *  Legacy shape was `string[]` (permanent dismissal); both are accepted on read. */
     dismissedCarouselCTAs?: string[] | Record<string, string>
-    /** The sorted, comma-joined task keys of the pending Bridge verification
-     *  tasks card the user dismissed on /home. A DIFFERENT task set re-shows
-     *  the card; the tasks stay reachable under Profile → Unlocked regions. */
+    /** Task keys of the pending Bridge verification tasks the user
+     *  individually dismissed on /home. A dismissed key stays hidden until its
+     *  task resolves; the tasks stay reachable under Profile → Unlocked regions. */
     pendingVerificationTasksDismissed?: string[]
 }
 

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -498,6 +498,10 @@ export type UserPreferences = {
      *  Read by useHomeCarouselCTAs to apply a per-CTA cooldown before re-showing.
      *  Legacy shape was `string[]` (permanent dismissal); both are accepted on read. */
     dismissedCarouselCTAs?: string[] | Record<string, string>
+    /** The sorted, comma-joined task keys of the pending Bridge verification
+     *  tasks card the user dismissed on /home. A DIFFERENT task set re-shows
+     *  the card; the tasks stay reachable under Profile → Unlocked regions. */
+    pendingVerificationTasksDismissed?: string
 }
 
 export const updateUserPreferences = (

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -501,7 +501,7 @@ export type UserPreferences = {
     /** The sorted, comma-joined task keys of the pending Bridge verification
      *  tasks card the user dismissed on /home. A DIFFERENT task set re-shows
      *  the card; the tasks stay reachable under Profile → Unlocked regions. */
-    pendingVerificationTasksDismissed?: string
+    pendingVerificationTasksDismissed?: string[]
 }
 
 export const updateUserPreferences = (


### PR DESCRIPTION
## Summary

Users whose Bridge customer owes "additional verification" tasks (hosted Persona re-verification and/or ToS (re-)acceptance) could only see them in Bridge's dashboard. In-app: the activation card deliberately stands down for anyone who can already transact, and these tasks arrive as **orphan** `nextActions` no rail references — so affected users saw nothing.

New self-hiding **PendingVerificationTasks** card on `/home`, sibling of ActivationCTAs (outside its stand-down on purpose). Reads top-level capability `nextActions` — the only surface that sees orphan actions (both blocking hosted tasks and advisory future-dated ones) — and renders one slide per task with a "Complete before {date}" line for advisories:

- `accept-tos` → mounts the existing `BridgeTosStep` (link fetch → iframe → `signedAgreementId` confirm → rail await); each row opens the modal for **its** variant (base vs SEPA v2)
- `bridge-hosted` (new kind, peanutprotocol/peanut-api-ts#1248) → exchanges the key for Bridge's hosted verification URL via start-action and opens it in the existing `IframeWrapper` (Persona `complete` postMessage already handled; user refetch on completion)

Open flows are **snapshotted at tap time** and mounted above the self-hiding early return — the task list re-derives from the ~4s user auto-refresh, and an open modal/iframe must survive its task flapping away mid-verification. `IframeWrapper` additionally gained a `visible` guard on its window-message listener: surfaces keep a wrapper mounted after manual close, and a sibling iframe's completion event previously fired **both** handlers (double ToS confirm + phantom flow transitions) — this PR adds the second ToS surface on /home that made that latent hazard reachable, so it carries the fix.

Multiple tasks render as a **horizontal carousel** (same embla setup as HomeCarouselCTA — full-width slides, swipe + dots); a single task looks identical to a static card. On the /home mount each slide has its own X that dismisses **only that task** (persisted per task key — dismissed keys stay hidden until the task resolves); the same component mounts non-dismissibly under **Profile → Unlocked regions**, where dismissed users find their tasks again.

No raw links are shown — both flows open in the in-app full-screen iframe, same UX as the production ToS step. Everything Sumsub-able (questionnaires, doc uploads) keeps flowing through the Sumsub WebSDK untouched.

## Screenshots




Captured on the local sandbox (worktree API #1248 + this branch, seeded state mirroring prod user `7c928f39`'s exact classification), iPhone 14 viewport. Assets branch `pr-assets-2549` — delete after merge.

Video recoridng (only thing you need)

https://github.com/user-attachments/assets/a35caf5e-6190-4bd9-ae2d-15fd156e391e

## Adversarial review

3 independent adversarial agents attacked both PRs before this went up; their confirmed findings are fixed in the second commit (snapshot-at-open, per-variant ToS routing, IframeWrapper visible-guard, population-aware copy, friendly errors + resync, deadline guard). Full detail in the commit message.

## Risks / breaking changes

- **Deploy order: any.** Old BE + this FE → the card renders only what's emitted (older BEs emit `accept-tos` for blocking users, for whom the ToS route already works); new BE + old FE → the new actions are orphans, provably inert to the deployed gate ladder. No `NEXT_PUBLIC_API_VERSION` bump (additive).
- **Base is `main`** (per request) → back-merge debt main→dev after merge.
- `IframeWrapper` visible-guard touches a shared component — behavior change only for hidden-but-mounted wrappers (they previously reacted to sibling iframes' messages; that was the bug).

## QA

- 18 Jest cases (incl. 4 dismissal cases: persist + same-set hidden + new-set re-show + profile-ignores-dismissal) (component + selector): variant routing per row, snapshot-survives-flap, hosted URL → iframe → refetch-on-complete, manual-close no-refetch, friendly-error + resync, deadline + malformed-date guard, population copy, self-hiding.
- Full suite 169/169 green; typecheck clean; sandbox visual QA above (the seeded state also live-verified the BE emission end-to-end).




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a “Pending verification tasks” component to Home and Profile (Unlocked regions) for Bridge/hosted verification actions.
  - Added support for initiating the Bridge Hosted verification flow, including a new action kind.

- **Bug Fixes**
  - Prevented hidden/off-screen verification iframes from triggering unintended close behavior.
  - Improved dismissal-state loading and persistence so tasks can re-surface when their fingerprint changes.
  - Ensured embedded ToS acceptance doesn’t interrupt the hosted verification flow.

- **Tests**
  - Expanded Jest coverage for Bridge task selection, dismissal fingerprints, and embedded ToS + closing behavior.

- **Chores**
  - Enhanced Jest setup for IntersectionObserver and matchMedia.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
