### PR TITLE
fix(automerge): pass --admin, and stop swallowing a failed merge

### DIFF
--- a/.github/workflows/content-publish-automerge.yml
+++ b/.github/workflows/content-publish-automerge.yml
@@ -102,7 +102,13 @@ jobs:
                   SHA: ${{ github.event.workflow_run.head_sha }}
                   REPO: ${{ github.repository }}
               run: |
-                  set -euo pipefail
+                  set -uo pipefail
+                  # `set +e` deliberately. GitHub runs this as `bash -e {0}`, so any
+                  # unguarded non-zero — a transient `gh` 5xx, a PR that closed between
+                  # the list and the diff — kills the step mid-loop with no output and
+                  # a bare red run. Every branch below checks its own inputs and says
+                  # what it decided; dying silently is strictly worse than continuing.
+                  set +e
 
                   # Key off the `ci-success` check run, NOT `workflow_run.conclusion`.
                   # `ci-success` is the single check the "Protect Prod" ruleset gates
@@ -115,8 +121,15 @@ jobs:
                   # carries TWO ci-success check runs. Require at least one and ALL of
                   # them green — a single red run must block the merge.
                   RUNS="repos/$REPO/commits/$SHA/check-runs?per_page=100"
-                  TOTAL=$(gh api "$RUNS" --jq '[.check_runs[] | select(.name=="ci-success")] | length')
-                  GREEN=$(gh api "$RUNS" --jq '[.check_runs[] | select(.name=="ci-success" and .conclusion=="success")] | length')
+                  TOTAL=$(gh api "$RUNS" --jq '[.check_runs[] | select(.name=="ci-success")] | length' || echo 0)
+                  GREEN=$(gh api "$RUNS" --jq '[.check_runs[] | select(.name=="ci-success" and .conclusion=="success")] | length' || echo 0)
+                  # On failure `gh` prints its JSON error body to stdout, which lands
+                  # in these vars. Without this, `[ "$TOTAL" -eq 0 ]` errors out and the
+                  # loop below iterates over the error text as if the words were PR
+                  # numbers. Anything non-numeric means "we don't know" -> don't merge.
+                  case "$TOTAL" in '' | *[!0-9]*) TOTAL=0 ;; esac
+                  case "$GREEN" in '' | *[!0-9]*) GREEN=-1 ;; esac
+
                   if [ "$TOTAL" -eq 0 ] || [ "$TOTAL" -ne "$GREEN" ]; then
                     echo "ci-success not green for $SHA ($GREEN/$TOTAL) — nothing to merge."
                     exit 0
@@ -140,12 +153,35 @@ jobs:
                   fi
 
                   for PR in $PRS; do
-                    FILES=$(gh pr diff "$PR" --repo "$REPO" --name-only)
+                    # Same reason: never treat a fragment of an error body as a PR number.
+                    case "$PR" in '' | *[!0-9]*) echo "::warning::ignoring non-numeric PR id '$PR'"; continue ;; esac
+                    FILES=$(gh pr diff "$PR" --repo "$REPO" --name-only || echo UNKNOWN)
                     if [ "$FILES" != "src/content" ]; then
                       echo "::notice::#$PR is not content-only — normal review gate stays in place."
                       continue
                     fi
                     echo "Merging #$PR — diff is exactly src/content, ci-success green ($GREEN/$TOTAL) on $SHA."
-                    gh pr merge "$PR" --repo "$REPO" --merge \
-                      || echo "::warning::merge failed for #$PR (already merged, or bypass unavailable) — merge manually."
+                    # `--admin` is required, not optional. Being an OrganizationAdmin
+                    # does NOT make `gh pr merge` bypass "Protect Prod" — gh enforces
+                    # the branch policy and tells you to pass --admin explicitly.
+                    # Without it every merge here fails with "the base branch policy
+                    # prohibits the merge", which is exactly what happened to #2547.
+                    #
+                    # --admin also skips the required status check, so note what it is
+                    # NOT skipping: this job has already established, itself, that the
+                    # diff is exactly src/content and that every ci-success run on this
+                    # commit is green. The gate is enforced above, in code, before we
+                    # get here — --admin only waives the human review, which is the
+                    # whole point of this workflow.
+                    if ! MERGE_ERR=$(gh pr merge "$PR" --repo "$REPO" --merge --admin 2>&1); then
+                      # A merge we decided to make and then failed to make is the exact
+                      # silent failure this pipeline exists to prevent. Be loud.
+                      echo "::error::MERGE FAILED for #$PR — content will NOT reach production. $MERGE_ERR"
+                      FAILED=1
+                    fi
                   done
+
+                  if [ "${FAILED:-0}" = "1" ]; then
+                    echo "At least one content publish could not be merged (see errors above)."
+                    exit 1
+                  fi


### PR DESCRIPTION
**The content pipeline is currently broken — nothing is reaching production.** The end-to-end test found the real defect, on the last hop.

## What the test showed

Everything worked until the merge itself:

| Hop | Result | Elapsed |
|---|---|---|
| push → mono | `7d255265` | — |
| mirror → peanut-content | ✅ `63abb439` | +20s |
| auto-PR → **`main`** | ✅ #2546 | +48s |
| guard + handoff | ✅ content-only → merge-on-green | +67s |
| supersede on collision | ✅ #2546 auto-closed when #2547 opened | +3.5m |
| **merge** | ❌ | — |

```
Merging #2547 — diff is exactly src/content, ci-success green (2/2)
merge failed for #2547 (already merged, or bypass unavailable)
```

## Cause

**Being an OrganizationAdmin does not make `gh pr merge` bypass "Protect Prod".** gh enforces the branch policy and requires an explicit `--admin`:

```
X Pull request #2544 is not mergeable: the base branch policy prohibits the merge.
  To use administrator privileges to immediately merge the pull request, add the `--admin` flag.
```

I hit that exact error merging #2544 by hand an hour earlier, added the flag, and never carried it back into the workflow.

`--admin` also waives the required status check — note what it is **not** waiving. This job has already established, itself, that the diff is exactly `src/content` and that every `ci-success` run on the commit is green. The gate is enforced in code above; `--admin` only drops the human review, which is the entire purpose of this workflow.

## And the reason nobody noticed for 40 minutes

`|| echo "::warning::merge failed"` — the run went **green** while content sat unpublished. A merge we decided to make and then failed to make now **fails the run loudly**. That silent-warning pattern is precisely what this project exists to eliminate, and it was sitting in the middle of it.

## Two more, found by running the step under `bash -e`

- **`set +e`** with explicit checks. GitHub runs steps as `bash -e`; an unguarded non-zero kills the loop mid-flight with no output. (Same bug class as #2544.)
- **Numeric validation** of `TOTAL`/`GREEN`/`PRS`. `gh` prints its JSON error body to **stdout**, so on an API failure the loop was iterating over the words of an error message as if they were PR numbers.

## QA

Executed the step under `bash -e` against real APIs:
```
bogus SHA (422):        ci-success not green (-1/0) — nothing to merge.   EXIT=0
real commit, no PR:     No open content-publish candidates.               EXIT=0
```

## After merge

#2550 is open with Konrad's real content waiting. Once this lands, the next `Tests` completion on it should merge it automatically — which is the end-to-end proof finishing itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of automatic content updates after successful tests.
  * Prevented transient service or data errors from being overlooked during processing.
  * Added clearer failure reporting when an automatic merge cannot be completed.
  * Blocked merges when validation results are incomplete or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->