### PR TITLE
chore(i18n): string sweep, shared intl test helper, toast lint guard

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -141,6 +141,21 @@ module.exports = [
                     message:
                         "Don't pass { history: 'push' } to nuqs useQueryState(s) — a history entry per URL write breaks the back button (useSafeBack steps through same-screen states instead of leaving). Use the default 'replace'; the URL stays shareable. If a flow genuinely needs push-per-step, add a scoped file exemption with a comment (see useNativePlugins).",
                 },
+                {
+                    // Toast copy must come from next-intl. `react/jsx-no-literals` below
+                    // only inspects JSX children, so toasts fired from hooks and contexts
+                    // (authContext, useLogin, useSendMoney, QRScanner) shipped English to
+                    // every locale unnoticed.
+                    //
+                    // Deliberately NOT extended to `throw new Error('…')`: those messages
+                    // are developer/Sentry breadcrumbs that the friendly-error mapper
+                    // collapses to `errors.genericSupport` before any user sees them, so
+                    // translating them would only fragment Sentry issue grouping.
+                    selector:
+                        "CallExpression[callee.object.name='toast'][callee.property.name=/^(error|success|info|warning|loading)$/] > :matches(Literal, TemplateLiteral):first-child",
+                    message:
+                        "Don't pass a string literal to toast.* — copy must come from next-intl. Import the right namespace with useTranslations and pass t('…'). If the value genuinely isn't copy (an id, a URL), assign it to a named const first.",
+                },
             ],
         },
     },

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -16,8 +16,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars, react/display-name */
 import React from 'react'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { NextIntlClientProvider } from 'next-intl'
 import en from '@/i18n/app/messages/en.json'
 
 // ---------- module-level mocks (must be before imports that depend on them) ----------
@@ -897,9 +897,9 @@ function createQueryClient() {
 function renderWithProviders(component: React.ReactElement) {
     const queryClient = createQueryClient()
     return render(
-        <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
+        <IntlWrapper>
             <QueryClientProvider client={queryClient}>{component}</QueryClientProvider>
-        </NextIntlClientProvider>
+        </IntlWrapper>
     )
 }
 

--- a/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
+++ b/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
@@ -10,9 +10,8 @@
 import React from 'react'
 import posthog from 'posthog-js'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
 import { parseUnits } from 'viem'
 import type { RailCapability } from '@/types/capabilities'
 
@@ -536,13 +535,13 @@ function renderQrPay(params: Record<string, string> = {}) {
     }
 
     return render(
-        <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
+        <IntlWrapper>
             <QueryClientProvider client={queryClient}>
                 <LoadingProvider>
                     <QRPayPage />
                 </LoadingProvider>
             </QueryClientProvider>
-        </NextIntlClientProvider>
+        </IntlWrapper>
     )
 }
 

--- a/src/app/(mobile-ui)/receipt/page.tsx
+++ b/src/app/(mobile-ui)/receipt/page.tsx
@@ -53,7 +53,7 @@ export default function NativeReceiptPage() {
     return (
         <PageContainer className="flex min-h-[100dvh] flex-col items-center justify-center p-6">
             <div className="md:hidden">
-                <NavHeader title="Receipt" />
+                <NavHeader titleKey="receipt" />
             </div>
             <div className="flex flex-1 flex-col items-center justify-center">
                 {isLoading || !entry ? (

--- a/src/app/(mobile-ui)/withdraw/__tests__/withdraw-states.test.tsx
+++ b/src/app/(mobile-ui)/withdraw/__tests__/withdraw-states.test.tsx
@@ -9,9 +9,8 @@
  */
 import React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
 import { parseUnits } from 'viem'
 
 // ---------- module-level mocks (must be before imports that depend on them) ----------
@@ -226,11 +225,11 @@ function renderWithdraw(params: Record<string, string> = {}) {
     setSearchParams(params)
     const queryClient = createQueryClient()
     return render(
-        <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
+        <IntlWrapper>
             <QueryClientProvider client={queryClient}>
                 <WithdrawPage />
             </QueryClientProvider>
-        </NextIntlClientProvider>
+        </IntlWrapper>
     )
 }
 

--- a/src/app/(mobile-ui)/withdraw/crypto/__tests__/crypto-withdraw-confirm.test.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/__tests__/crypto-withdraw-confirm.test.tsx
@@ -14,8 +14,7 @@
  */
 import React from 'react'
 import { render as rtlRender, screen, fireEvent, waitFor } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import enMessages from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 
 // ---------- module-level mocks ----------
 
@@ -251,12 +250,6 @@ jest.mock('@/features/payments/shared/hooks/usePaymentRecorder', () => ({
 }))
 
 import WithdrawCryptoPage from '../page'
-
-const IntlWrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 
 const render = (ui: React.ReactElement, options?: Omit<Parameters<typeof rtlRender>[1], 'wrapper'>) =>
     rtlRender(ui, { wrapper: IntlWrapper, ...options })

--- a/src/app/receipt/[entryId]/page.tsx
+++ b/src/app/receipt/[entryId]/page.tsx
@@ -192,7 +192,7 @@ export default async function ReceiptPage({
     return (
         <PageContainer className="flex min-h-[100dvh] flex-col items-center justify-center p-6">
             <div className="md:hidden">
-                <NavHeader title="Receipt" />
+                <NavHeader titleKey="receipt" />
             </div>
             <div className="flex flex-1 flex-col items-center justify-center">
                 <TransactionDetailsReceipt className="w-full" transaction={transactionDetails!} isPublic />

--- a/src/components/AddMoney/components/__tests__/MantecaAddMoney.test.tsx
+++ b/src/components/AddMoney/components/__tests__/MantecaAddMoney.test.tsx
@@ -11,16 +11,9 @@
  */
 import React from 'react'
 import { render as rtlRender, screen } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import enMessages from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 // jest.mock calls are hoisted above this import, so the mocks below apply to it
 import MantecaAddMoney from '../MantecaAddMoney'
-
-const IntlWrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 
 const render = (ui: React.ReactElement, options?: Omit<Parameters<typeof rtlRender>[1], 'wrapper'>) =>
     rtlRender(ui, { wrapper: IntlWrapper, ...options })

--- a/src/components/AddMoney/components/__tests__/MantecaPixQrDeposit.test.tsx
+++ b/src/components/AddMoney/components/__tests__/MantecaPixQrDeposit.test.tsx
@@ -8,15 +8,9 @@
  */
 import React from 'react'
 import { render as rtlRender, screen } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 
-const render = (ui: React.ReactElement) =>
-    rtlRender(
-        <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
-            {ui}
-        </NextIntlClientProvider>
-    )
+const render = (ui: React.ReactElement) => rtlRender(<IntlWrapper>{ui}</IntlWrapper>)
 
 const mockUseMantecaDepositPolling = jest.fn()
 jest.mock('@/components/AddMoney/hooks/useMantecaDepositPolling', () => ({

--- a/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
+++ b/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
@@ -16,17 +16,11 @@
  */
 import React from 'react'
 import { render as rtlRender, screen, fireEvent, within } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 import AddWithdrawCountriesList from '../AddWithdrawCountriesList'
 import underMaintenanceConfig from '@/config/underMaintenance.config'
 
-const render = (ui: React.ReactElement) =>
-    rtlRender(
-        <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
-            {ui}
-        </NextIntlClientProvider>
-    )
+const render = (ui: React.ReactElement) => rtlRender(<IntlWrapper>{ui}</IntlWrapper>)
 
 // ---- routing ----
 const mockPush = jest.fn()

--- a/src/components/AddWithdraw/__tests__/AddWithdrawRouterView.test.tsx
+++ b/src/components/AddWithdraw/__tests__/AddWithdrawRouterView.test.tsx
@@ -13,8 +13,7 @@
  */
 import React, { useEffect } from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 
 const mockRouterPush = jest.fn()
 jest.mock('next/navigation', () => ({
@@ -137,12 +136,12 @@ function SelectedMethodProbe() {
 function Harness({ user }: { user: MockUser }) {
     mockUser = user
     return (
-        <NextIntlClientProvider locale="en" messages={en}>
+        <IntlWrapper>
             <WithdrawFlowContextProvider>
                 <AddWithdrawRouterView flow="withdraw" pageTitle="Withdraw" mainHeading="How?" />
                 <SelectedMethodProbe />
             </WithdrawFlowContextProvider>
-        </NextIntlClientProvider>
+        </IntlWrapper>
     )
 }
 

--- a/src/components/Badges/__tests__/BadgeEarnToast.test.tsx
+++ b/src/components/Badges/__tests__/BadgeEarnToast.test.tsx
@@ -1,14 +1,8 @@
 import { render as rtlRender, screen, act } from '@testing-library/react'
-import type { ComponentProps, ReactNode } from 'react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
+import type { ComponentProps } from 'react'
 import BadgeEarnToast from '@/components/Badges/BadgeEarnToast'
 
-const IntlWrapper = ({ children }: { children: ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 const render = (ui: Parameters<typeof rtlRender>[0]) => rtlRender(ui, { wrapper: IntlWrapper })
 
 // next/navigation — mutable pathname so we can exercise the /home gate; stable

--- a/src/components/Badges/__tests__/BadgesRow.test.tsx
+++ b/src/components/Badges/__tests__/BadgesRow.test.tsx
@@ -1,15 +1,8 @@
 import { render as rtlRender } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
 import React from 'react'
-import { NextIntlClientProvider } from 'next-intl'
-import enMessages from '@/i18n/app/messages/en.json'
 import type { ComponentProps } from 'react'
 import BadgesRow from '@/components/Badges/BadgesRow'
-
-const IntlWrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 
 const render = (ui: React.ReactElement, options?: Omit<Parameters<typeof rtlRender>[1], 'wrapper'>) =>
     rtlRender(ui, { wrapper: IntlWrapper, ...options })

--- a/src/components/Card/__tests__/ApplicationStatusScreen.test.tsx
+++ b/src/components/Card/__tests__/ApplicationStatusScreen.test.tsx
@@ -9,15 +9,10 @@
  */
 import React from 'react'
 import { render as rtlRender, screen, fireEvent } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
+import { IntlWrapper } from '@/test-utils/intl'
 import en from '@/i18n/app/messages/en.json'
 import ApplicationStatusScreen from '@/components/Card/ApplicationStatusScreen'
 
-const IntlWrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: IntlWrapper })
 
 // NavHeader reads useAuth; stub it so the presentational screen renders alone.

--- a/src/components/Card/__tests__/CardCountryConfirmScreen.test.tsx
+++ b/src/components/Card/__tests__/CardCountryConfirmScreen.test.tsx
@@ -10,15 +10,9 @@
  */
 import React from 'react'
 import { render as rtlRender, screen, fireEvent, waitFor } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 import CardCountryConfirmScreen from '@/components/Card/CardCountryConfirmScreen'
 
-const IntlWrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: IntlWrapper })
 
 // NavHeader reads useAuth; stub it so the presentational screen renders alone.

--- a/src/components/Card/__tests__/CardFace.test.tsx
+++ b/src/components/Card/__tests__/CardFace.test.tsx
@@ -8,15 +8,9 @@
  */
 import React from 'react'
 import { render as rtlRender, screen } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 import CardFace, { type RevealedCardDetails } from '@/components/Card/CardFace'
 
-const IntlWrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: IntlWrapper })
 
 const revealed: RevealedCardDetails = {

--- a/src/components/Card/__tests__/PhysicalCardScreen.test.tsx
+++ b/src/components/Card/__tests__/PhysicalCardScreen.test.tsx
@@ -7,17 +7,10 @@
  */
 import React from 'react'
 import { render as rtlRender, screen } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import enMessages from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import PhysicalCardScreen from '@/components/Card/PhysicalCardScreen'
 import { rainApi } from '@/services/rain'
-
-const IntlWrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 
 const render = (ui: React.ReactElement, options?: Omit<Parameters<typeof rtlRender>[1], 'wrapper'>) =>
     rtlRender(ui, { wrapper: IntlWrapper, ...options })

--- a/src/components/Claim/Link/__tests__/SendLinkActionList.test.tsx
+++ b/src/components/Claim/Link/__tests__/SendLinkActionList.test.tsx
@@ -8,8 +8,7 @@
  */
 import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 
 // ---------- module-level mocks (before importing the component) ----------
 
@@ -129,9 +128,9 @@ const claimLinkData = {
 
 function renderList() {
     return render(
-        <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
+        <IntlWrapper>
             <SendLinkActionList claimLinkData={claimLinkData} isLoggedIn isInviteLink={false} />
-        </NextIntlClientProvider>
+        </IntlWrapper>
     )
 }
 

--- a/src/components/Claim/__tests__/claim-states.test.tsx
+++ b/src/components/Claim/__tests__/claim-states.test.tsx
@@ -10,9 +10,8 @@
  */
 import React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
 
 // ---------- module-level mocks (must be before imports that depend on them) ----------
 
@@ -241,11 +240,11 @@ function createQueryClient() {
 function renderClaim() {
     const queryClient = createQueryClient()
     return render(
-        <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
+        <IntlWrapper>
             <QueryClientProvider client={queryClient}>
                 <Claim />
             </QueryClientProvider>
-        </NextIntlClientProvider>
+        </IntlWrapper>
     )
 }
 

--- a/src/components/Global/BackendErrorScreen/index.tsx
+++ b/src/components/Global/BackendErrorScreen/index.tsx
@@ -8,14 +8,8 @@ import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 // inline peanut icon svg to ensure it works without needing to fetch external assets
-const PeanutIcon = ({ className }: { className?: string }) => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 291 389"
-        fill="none"
-        aria-label="Peanut Logo"
-        className={className}
-    >
+const PeanutIcon = ({ className, label }: { className?: string; label: string }) => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 291 389" fill="none" aria-label={label} className={className}>
         {/* peanut shape */}
         <path
             d="M60.3258 45.632C64.7897 43.0841 70.8696 42.4485 77.6753 42.1648L77.6751 42.1639C86.6738 41.7919 95.9563 42.9122 105.073 44.8494C131.211 50.4032 159.276 64.4612 173.241 88.947L173.241 88.948C182.385 105.004 187.299 122.974 187.679 140.59L187.68 140.615L187.681 140.639C188.214 158.799 197.656 175.377 213.007 185.103L213.027 185.115L213.048 185.129C227.987 194.435 240.944 207.825 250.088 223.88L250.089 223.881C264.205 248.652 262.114 279.714 253.648 304.817C253.251 305.963 252.866 307.057 252.469 308.126L252.46 308.151L252.45 308.178C252.436 308.216 252.422 308.255 252.408 308.294C252.395 308.33 252.381 308.367 252.367 308.403C246.631 323.792 238.741 335.81 232.382 341.201C232.326 341.246 232.276 341.285 232.239 341.315C232.158 341.378 232.121 341.409 232.087 341.434L232.052 341.462L232.017 341.489C231.506 341.893 231.256 342.093 231.002 342.275C230.703 342.487 230.41 342.68 230.129 342.856L229.759 343.068C226.058 345.176 218.929 346.766 209.112 346.794C199.522 346.822 188.125 345.356 176.457 342.08C153.35 335.592 130.193 322.32 117.448 300.794L116.849 299.762C107.705 283.706 102.79 265.736 102.41 248.12L102.409 248.096L102.409 248.072C101.876 229.912 92.433 213.335 77.0818 203.609L77.0617 203.595L77.0418 203.583L75.6472 202.699C61.7596 193.736 49.6638 181.222 40.8698 166.328L40.0013 164.831L39.4191 163.79C27.402 141.848 27.7929 115.163 33.9934 91.9808C37.1244 80.275 41.6741 69.7248 46.5873 61.491C51.6171 53.0618 56.6207 47.7423 60.3214 45.6342L60.3258 45.632Z"
@@ -71,6 +65,7 @@ const PeanutIcon = ({ className }: { className?: string }) => (
  */
 export default function BackendErrorScreen() {
     const t = useTranslations('global')
+    const tNav = useTranslations('navigation')
     const { logoutUser, isLoggingOut } = useAuth()
 
     useEffect(() => {
@@ -91,7 +86,7 @@ export default function BackendErrorScreen() {
     return (
         <div className="flex h-[100dvh] w-full flex-col items-center justify-center gap-6 bg-background p-6">
             <div className="h-32 w-32 opacity-50 grayscale">
-                <PeanutIcon className="h-full w-full" />
+                <PeanutIcon className="h-full w-full" label={tNav('peanutLogoAlt')} />
             </div>
             <div className="flex flex-col items-center gap-2 text-center">
                 <h1 className="text-2xl font-bold text-gray-800">{t('backendErrorScreen.title')}</h1>

--- a/src/components/Global/Banner/index.tsx
+++ b/src/components/Global/Banner/index.tsx
@@ -81,7 +81,7 @@ function FeedbackBanner() {
             <MarqueeWrapper backgroundColor="bg-primary-1" direction="left">
                 <span className="z-10 mx-4 flex items-center gap-2 text-sm font-semibold">
                     {t('betaBanner')}
-                    <Image src={HandThumbsUp} alt="Thumbs up" className="h-4 w-4" />
+                    <Image src={HandThumbsUp} alt={t('betaBannerThumbsUpAlt')} className="h-4 w-4" />
                     {!IS_PRODUCTION && <span className="ml-2 text-sm font-semibold">version: {GIT_COMMIT_HASH}</span>}
                     {mode && (
                         // High-contrast yellow-on-black pill. Visually impossible

--- a/src/components/Global/EasterEggModal/index.tsx
+++ b/src/components/Global/EasterEggModal/index.tsx
@@ -55,7 +55,7 @@ const EasterEggModal = ({ visible, onClose, countryCode }: EasterEggModalProps) 
             icon={
                 <Image
                     src={config.image}
-                    alt="Easter egg"
+                    alt={t('easterEggImageAlt')}
                     width={400}
                     height={400}
                     className="h-auto w-full"

--- a/src/components/Global/GeneralRecipientInput/__tests__/GeneralRecipientInput.test.tsx
+++ b/src/components/Global/GeneralRecipientInput/__tests__/GeneralRecipientInput.test.tsx
@@ -1,7 +1,5 @@
 import { render as rtlRender, act } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import type { ReactNode } from 'react'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 import GeneralRecipientInput from '../index'
 import * as bridgeUtils from '@/utils/bridge-accounts.utils'
 import * as sentryUtils from '@/utils/sentry.utils'
@@ -9,11 +7,6 @@ import * as ens from '@/app/actions/ens'
 import type { RecipientType } from '@/interfaces/interfaces'
 import { validateEnsName } from '@/utils/general.utils'
 
-const IntlWrapper = ({ children }: { children: ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 const render = (ui: Parameters<typeof rtlRender>[0]) => rtlRender(ui, { wrapper: IntlWrapper })
 
 // Test case type definition for better maintainability

--- a/src/components/Global/NavHeader/index.tsx
+++ b/src/components/Global/NavHeader/index.tsx
@@ -1,4 +1,7 @@
 'use client'
+import { useTranslations } from 'next-intl'
+// type-only: erased at build, so the catalog is not bundled here
+import type enMessages from '@/i18n/app/messages/en.json'
 import { Button } from '@/components/0_Bruddle/Button'
 import Link from 'next/link'
 import { twMerge } from 'tailwind-merge'
@@ -9,6 +12,11 @@ interface NavHeaderProps {
     onPrev?: () => void
     disableBackBtn?: boolean
     title?: string
+    /** Localized title for callers that cannot call useTranslations — i.e. server
+     *  components, since this app has no server-side next-intl setup (locale is
+     *  resolved entirely client-side by AppIntlProvider). Resolved against the
+     *  `navigation` namespace. Prefer plain `title` from client components. */
+    titleKey?: keyof typeof enMessages.navigation
     href?: string
     hideLabel?: boolean
     icon?: IconName
@@ -18,6 +26,7 @@ interface NavHeaderProps {
 
 const NavHeader = ({
     title,
+    titleKey,
     icon = 'chevron-up',
     href,
     hideLabel = false,
@@ -27,6 +36,8 @@ const NavHeader = ({
     titleClassName,
 }: NavHeaderProps) => {
     const { logoutUser, isLoggingOut } = useAuth()
+    const tNav = useTranslations('navigation')
+    const label = title ?? (titleKey ? tNav(titleKey) : undefined)
 
     return (
         <div className="relative flex w-full flex-row items-center justify-between md:block">
@@ -62,7 +73,7 @@ const NavHeader = ({
                         titleClassName
                     )}
                 >
-                    {title}
+                    {label}
                 </div>
             )}
 

--- a/src/components/Global/OfflineScreen/index.tsx
+++ b/src/components/Global/OfflineScreen/index.tsx
@@ -6,14 +6,8 @@ import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 
 // inline peanut icon svg to ensure it works offline without needing to fetch external assets
-const PeanutIcon = ({ className }: { className?: string }) => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 291 389"
-        fill="none"
-        aria-label="Peanut Logo"
-        className={className}
-    >
+const PeanutIcon = ({ className, label }: { className?: string; label: string }) => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 291 389" fill="none" aria-label={label} className={className}>
         {/* <!-- Peanut shape --> */}
         <path
             d="M60.3258 45.632C64.7897 43.0841 70.8696 42.4485 77.6753 42.1648L77.6751 42.1639C86.6738 41.7919 95.9563 42.9122 105.073 44.8494C131.211 50.4032 159.276 64.4612 173.241 88.947L173.241 88.948C182.385 105.004 187.299 122.974 187.679 140.59L187.68 140.615L187.681 140.639C188.214 158.799 197.656 175.377 213.007 185.103L213.027 185.115L213.048 185.129C227.987 194.435 240.944 207.825 250.088 223.88L250.089 223.881C264.205 248.652 262.114 279.714 253.648 304.817C253.251 305.963 252.866 307.057 252.469 308.126L252.46 308.151L252.45 308.178C252.436 308.216 252.422 308.255 252.408 308.294C252.395 308.33 252.381 308.367 252.367 308.403C246.631 323.792 238.741 335.81 232.382 341.201C232.326 341.246 232.276 341.285 232.239 341.315C232.158 341.378 232.121 341.409 232.087 341.434L232.052 341.462L232.017 341.489C231.506 341.893 231.256 342.093 231.002 342.275C230.703 342.487 230.41 342.68 230.129 342.856L229.759 343.068C226.058 345.176 218.929 346.766 209.112 346.794C199.522 346.822 188.125 345.356 176.457 342.08C153.35 335.592 130.193 322.32 117.448 300.794L116.849 299.762C107.705 283.706 102.79 265.736 102.41 248.12L102.409 248.096L102.409 248.072C101.876 229.912 92.433 213.335 77.0818 203.609L77.0617 203.595L77.0418 203.583L75.6472 202.699C61.7596 193.736 49.6638 181.222 40.8698 166.328L40.0013 164.831L39.4191 163.79C27.402 141.848 27.7929 115.163 33.9934 91.9808C37.1244 80.275 41.6741 69.7248 46.5873 61.491C51.6171 53.0618 56.6207 47.7423 60.3214 45.6342L60.3258 45.632Z"
@@ -129,6 +123,7 @@ const PeanutIcon = ({ className }: { className?: string }) => (
  */
 export default function OfflineScreen() {
     const t = useTranslations('global')
+    const tNav = useTranslations('navigation')
     const [isChecking, setIsChecking] = useState(false)
 
     // verify with a real fetch instead of trusting navigator.onLine
@@ -145,7 +140,7 @@ export default function OfflineScreen() {
     return (
         <div className="flex h-[100dvh] w-full flex-col items-center justify-center gap-6 bg-background p-6">
             <div className="h-32 w-32 opacity-50 grayscale">
-                <PeanutIcon className="h-full w-full" />
+                <PeanutIcon className="h-full w-full" label={tNav('peanutLogoAlt')} />
             </div>
             <div className="flex flex-col items-center gap-2 text-center">
                 <h1 className="text-2xl font-bold text-gray-800">{t('offlineScreen.title')}</h1>

--- a/src/components/Global/QRScanner/__tests__/index.test.tsx
+++ b/src/components/Global/QRScanner/__tests__/index.test.tsx
@@ -10,8 +10,7 @@
  */
 import React from 'react'
 import { render as rtlRender, screen, fireEvent, waitFor, act } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import enMessages from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 import { Clipboard } from '@capacitor/clipboard'
 import { clipboardHasStrings } from '@/utils/clipboard-detect'
 import { isAndroidNative } from '@/utils/capacitor'
@@ -46,12 +45,6 @@ jest.mock('../useQRScanner', () => ({
 }))
 
 import QRScanner from '../index'
-
-const IntlWrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 
 const render = (ui: React.ReactElement, options?: Omit<Parameters<typeof rtlRender>[1], 'wrapper'>) =>
     rtlRender(ui, { wrapper: IntlWrapper, ...options })

--- a/src/components/Global/QRScanner/index.tsx
+++ b/src/components/Global/QRScanner/index.tsx
@@ -12,7 +12,7 @@ import { useToast } from '@/components/0_Bruddle/Toast'
 import CameraPermissionModal from './CameraPermissionModal'
 import { Clipboard } from '@capacitor/clipboard'
 import { clipboardHasStrings } from '@/utils/clipboard-detect'
-import { extractPaymentValue } from '@/utils/clipboard-extract.utils'
+import { extractPaymentValue, readClipboard } from '@/utils/clipboard-extract.utils'
 import { isAndroidNative } from '@/utils/capacitor'
 import { printableAddress } from '@/utils/general.utils'
 
@@ -20,11 +20,14 @@ import { printableAddress } from '@/utils/general.utils'
 // Configuration
 // ============================================================================
 
+// Brand names stay verbatim — they are proper nouns in every locale. The EVM
+// row is the odd one out: its label and alt text are descriptive prose, so it
+// carries a key instead and is resolved at render.
 const PAYMENT_METHODS = [
     { src: PEANUTMAN, alt: 'Peanut', name: 'Peanut' },
     { src: MERCADO_PAGO, alt: 'Mercado Pago', name: 'Mercado Pago' },
     { src: PIX, alt: 'PIX', name: 'PIX' },
-    { src: ETHEREUM_ICON, alt: 'Ethereum and EVMs', name: 'ETH & EVMs' },
+    { src: ETHEREUM_ICON, alt: null, name: null },
 ] as const
 
 const CORNER_POSITIONS = [
@@ -124,7 +127,12 @@ function ScanRegionOverlay({
             <div className="flex-column z-50 translate-y-[100%] transform items-center text-center">
                 <div className="mt-10 flex flex-wrap justify-center gap-2">
                     {PAYMENT_METHODS.map((method) => (
-                        <PaymentMethodBadge key={method.name} {...method} />
+                        <PaymentMethodBadge
+                            key={method.name ?? 'evm'}
+                            src={method.src}
+                            alt={method.alt ?? t('qrScanner.paymentMethods.evmAlt')}
+                            name={method.name ?? t('qrScanner.paymentMethods.evmName')}
+                        />
                     ))}
                 </div>
                 <button
@@ -217,23 +225,13 @@ export default function QRScanner({ onScan, onClose, isOpen = true }: QRScannerP
     // Capacitor Clipboard reads through the native bridge on device (the
     // WebView's navigator.clipboard.readText is unreliable/blocked in the
     // Android WebView); its web shim falls back to navigator.clipboard.
-    // Returns trimmed text, or null after toasting the read failure. Android
-    // rejects with "There is no data on the clipboard" instead of resolving
-    // with an empty value.
+    // Returns trimmed text, or null after toasting the read failure.
     const readClipboardText = async (): Promise<string | null> => {
-        try {
-            const { value } = await Clipboard.read()
-            return (value ?? '').trim()
-        } catch (err) {
-            const message = err instanceof Error ? err.message : String(err)
-            if (message.toLowerCase().includes('no data on the clipboard')) {
-                toast.error(t('qrScanner.clipboardEmpty'))
-            } else {
-                console.error('Failed to read clipboard:', err)
-                toast.error(t('qrScanner.clipboardUnavailable'))
-            }
-            return null
-        }
+        const result = await readClipboard()
+        if (result.ok) return result.text
+        if (result.reason === 'unavailable') console.error('Failed to read clipboard:', result.cause)
+        toast.error(t(result.reason === 'empty' ? 'qrScanner.clipboardEmpty' : 'qrScanner.clipboardUnavailable'))
+        return null
     }
 
     // Every tap path funnels onScan through this so a payment/routing failure
@@ -243,7 +241,7 @@ export default function QRScanner({ onScan, onClose, isOpen = true }: QRScannerP
             await onScan(data)
         } catch (err) {
             console.error('Error processing QR code:', err)
-            toast.error('Error processing QR code')
+            toast.error(t('qrScanner.qrProcessingError'))
         }
     }
 
@@ -251,13 +249,13 @@ export default function QRScanner({ onScan, onClose, isOpen = true }: QRScannerP
         const text = await readClipboardText()
         if (!text) {
             setShowPasteChip(false)
-            if (text === '') toast.error('Clipboard is empty')
+            if (text === '') toast.error(t('qrScanner.clipboardEmpty'))
             return
         }
         const address = extractPaymentValue(text, 'evmAddress')
         if (!address) {
             setShowPasteChip(false)
-            toast.error('Copied text is not a wallet address')
+            toast.error(t('qrScanner.pastedTextNotAnAddress'))
             return
         }
         await scanValue(address)
@@ -267,7 +265,7 @@ export default function QRScanner({ onScan, onClose, isOpen = true }: QRScannerP
         const text = await readClipboardText()
         if (text === null) return
         if (!text) {
-            toast.error('Clipboard is empty')
+            toast.error(t('qrScanner.clipboardEmpty'))
             return
         }
         await scanValue(text)

--- a/src/components/Global/StaleCardApproval/__tests__/ReEnableModal.test.tsx
+++ b/src/components/Global/StaleCardApproval/__tests__/ReEnableModal.test.tsx
@@ -9,15 +9,9 @@
  */
 import React from 'react'
 import { render as rtlRender, screen, fireEvent, act } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 import { RAIN_STALE_APPROVAL_EVENT } from '@/services/rain'
 
-const IntlWrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 const render = (ui: Parameters<typeof rtlRender>[0]) => rtlRender(ui, { wrapper: IntlWrapper })
 
 const mockGrant = jest.fn<Promise<{ ok: boolean; error?: { kind: string } }>, []>()

--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -15,17 +15,11 @@
  */
 import React from 'react'
 import { render as rtlRender, screen, act, waitFor, fireEvent } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 import SupportDrawer from '../index'
 import { isCapacitor } from '@/utils/capacitor'
 import { SUPPORT_EMAIL } from '@/constants/crisp'
 
-const IntlWrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 const render = (ui: Parameters<typeof rtlRender>[0]) => rtlRender(ui, { wrapper: IntlWrapper })
 
 const mockUseCrispUserData = jest.fn()

--- a/src/components/Home/__tests__/ActivationCTAs.test.tsx
+++ b/src/components/Home/__tests__/ActivationCTAs.test.tsx
@@ -13,14 +13,8 @@
  */
 import React from 'react'
 import { render as rtlRender, screen, fireEvent } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 
-const IntlWrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: IntlWrapper })
 
 let mockRails: Array<{

--- a/src/components/Home/__tests__/EnableAutoBalanceBanner.test.tsx
+++ b/src/components/Home/__tests__/EnableAutoBalanceBanner.test.tsx
@@ -16,14 +16,8 @@
  */
 import React from 'react'
 import { render as rtlRender, screen, fireEvent, act } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 
-const IntlWrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: IntlWrapper })
 import type { GrantSessionKeyError } from '@/hooks/wallet/useGrantSessionKey'
 

--- a/src/components/Invites/JoinWaitlistPage.tsx
+++ b/src/components/Invites/JoinWaitlistPage.tsx
@@ -281,7 +281,7 @@ const JoinWaitlistPage = () => {
                                 type="email"
                                 variant="sm"
                                 aria-label={t('emailLabel')}
-                                placeholder="you@example.com"
+                                placeholder={t('emailPlaceholder')}
                                 value={emailValue}
                                 onChange={(e) => {
                                     setEmailValue(e.target.value)

--- a/src/components/Kyc/__tests__/SumsubKycWrapper.test.tsx
+++ b/src/components/Kyc/__tests__/SumsubKycWrapper.test.tsx
@@ -1,14 +1,8 @@
 import { act, render as rtlRender, screen, waitFor, type RenderOptions } from '@testing-library/react'
-import { useEffect, useState, type ReactElement, type ReactNode } from 'react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
+import { useEffect, useState, type ReactElement } from 'react'
 import { SumsubKycWrapper } from '../SumsubKycWrapper'
 
-const IntlWrapper = ({ children }: { children: ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en}>
-        {children}
-    </NextIntlClientProvider>
-)
 const render = (ui: ReactElement, options?: RenderOptions) => rtlRender(ui, { wrapper: IntlWrapper, ...options })
 
 const capture = jest.fn()

--- a/src/components/Kyc/states/__tests__/KycActionRequired.rejectCopy.test.tsx
+++ b/src/components/Kyc/states/__tests__/KycActionRequired.rejectCopy.test.tsx
@@ -1,7 +1,5 @@
 import { render as rtlRender, screen } from '@testing-library/react'
-import { type ReactNode } from 'react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 import { KycActionRequired } from '../KycActionRequired'
 
 // Integration-level companion to KycStates.test.tsx: that suite mocks
@@ -10,11 +8,6 @@ import { KycActionRequired } from '../KycActionRequired'
 // DUPLICATE_EMAIL → "Email already in use" mapping (the whole point of the
 // precedence fix) actually fails a test instead of shipping silently.
 
-const IntlWrapper = ({ children }: { children: ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 const render = (ui: Parameters<typeof rtlRender>[0]) => rtlRender(ui, { wrapper: IntlWrapper })
 
 jest.mock('use-haptic', () => ({

--- a/src/components/Kyc/states/__tests__/KycStates.test.tsx
+++ b/src/components/Kyc/states/__tests__/KycStates.test.tsx
@@ -1,15 +1,9 @@
 import { fireEvent, render as rtlRender, screen } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 import { type ReactNode } from 'react'
 import { KycActionRequired } from '../KycActionRequired'
 import { KycFailed } from '../KycFailed'
 
-const IntlWrapper = ({ children }: { children: ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 const render = (ui: Parameters<typeof rtlRender>[0]) => rtlRender(ui, { wrapper: IntlWrapper })
 
 jest.mock('use-haptic', () => ({

--- a/src/components/Kyc/states/__tests__/kycCallbackHygiene.test.tsx
+++ b/src/components/Kyc/states/__tests__/kycCallbackHygiene.test.tsx
@@ -1,6 +1,5 @@
 import { fireEvent, render as rtlRender, screen } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 import { type ReactNode } from 'react'
 import { KycActionRequired } from '../KycActionRequired'
 import { KycFailed } from '../KycFailed'
@@ -11,11 +10,6 @@ import { KycFailed } from '../KycFailed'
 // KycRequiresDocuments with KycActionRequired, so this now covers the two
 // surviving rejection/resubmit states.
 
-const IntlWrapper = ({ children }: { children: ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 const render = (ui: Parameters<typeof rtlRender>[0]) => rtlRender(ui, { wrapper: IntlWrapper })
 
 jest.mock('../../KYCStatusDrawerItem', () => ({

--- a/src/components/Request/__tests__/request-states.test.tsx
+++ b/src/components/Request/__tests__/request-states.test.tsx
@@ -9,9 +9,8 @@
  */
 import React from 'react'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
 
 // ---------- module-level mocks (must be before imports that depend on them) ----------
 
@@ -331,12 +330,6 @@ function createQueryClient() {
         },
     })
 }
-
-const IntlWrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 
 function renderCreateRequest(params: Record<string, string> = {}) {
     setSearchParams(params)

--- a/src/components/Send/__tests__/send-states.test.tsx
+++ b/src/components/Send/__tests__/send-states.test.tsx
@@ -9,9 +9,8 @@
  */
 import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
 
 // ---------- module-level mocks (must be before imports that depend on them) ----------
 
@@ -193,11 +192,11 @@ function renderSend(params: Record<string, string> = {}) {
     setSearchParams(params)
     const queryClient = createQueryClient()
     return render(
-        <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
+        <IntlWrapper>
             <QueryClientProvider client={queryClient}>
                 <SendRouterView />
             </QueryClientProvider>
-        </NextIntlClientProvider>
+        </IntlWrapper>
     )
 }
 

--- a/src/components/Send/link/views/__tests__/Initial.link.send.view.test.tsx
+++ b/src/components/Send/link/views/__tests__/Initial.link.send.view.test.tsx
@@ -11,9 +11,9 @@
  */
 import React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { LinkSendFlowProvider, useLinkSendFlow } from '@/context/LinkSendFlowContext'
-import { NextIntlClientProvider } from 'next-intl'
 import en from '@/i18n/app/messages/en.json'
 
 const COOLDOWN_MESSAGE = 'A previous withdrawal signature is still active. Try again in about 2 min.'
@@ -121,14 +121,14 @@ const SetAmount = ({ amount }: { amount: string }) => {
 const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
 const viewTree = (amount: string) => (
-    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
+    <IntlWrapper>
         <QueryClientProvider client={queryClient}>
             <LinkSendFlowProvider>
                 <SetAmount amount={amount} />
                 <LinkSendInitialView />
             </LinkSendFlowProvider>
         </QueryClientProvider>
-    </NextIntlClientProvider>
+    </IntlWrapper>
 )
 
 const renderView = (amount: string) => {

--- a/src/components/Settings/__tests__/DeleteAccountButton.test.tsx
+++ b/src/components/Settings/__tests__/DeleteAccountButton.test.tsx
@@ -6,16 +6,10 @@
  */
 import React from 'react'
 import { render as rtlRender, screen, fireEvent, waitFor } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 import DeleteAccountButton from '@/components/Settings/DeleteAccountButton'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
-const IntlWrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: IntlWrapper })
 
 const mockLogout = jest.fn()

--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -19,7 +19,7 @@ import {
     isStableCoin,
     shortenStringLong,
 } from '@/utils/general.utils'
-import { getAvatarUrl, getTransactionSign } from '@/utils/history.utils'
+import { getAvatarUrl, getTransactionSign, isTestTransaction } from '@/utils/history.utils'
 import React, { lazy, Suspense } from 'react'
 import { twMerge } from 'tailwind-merge'
 import Image from 'next/image'
@@ -104,7 +104,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
         transaction.showFullName && transaction.fullName ? transaction.fullName : transaction.userName
     const avatarUrl = getAvatarUrl(transaction)
     // check if this is a test transaction (setup confirmation)
-    const isTestTransaction = name === 'Enjoy Peanut!'
+    const isTest = isTestTransaction(name)
 
     // ENS reverse-lookup for raw addresses; hook is a no-op when name is a username.
     const { primaryName } = usePrimaryNameServer(isAddress(name) ? name : undefined)
@@ -189,7 +189,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
                 <div className="flex items-center justify-between">
                     <div className="flex items-center gap-3">
                         {/* txn avatar component handles icon/initials/colors */}
-                        {isTestTransaction ? (
+                        {isTest ? (
                             <div className={'relative flex size-7 items-center justify-center rounded-full p-0.5'}>
                                 <Image
                                     src={PEANUTMAN}
@@ -243,9 +243,9 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
                             </div>
                             {/* display the action icon and type text */}
                             <div className="flex items-center gap-1 text-xs font-medium text-gray-1">
-                                {!isTestTransaction && getActionIcon(type, transaction.direction, status)}
+                                {!isTest && getActionIcon(type, transaction.direction, status)}
                                 <span>
-                                    {isTestTransaction
+                                    {isTest
                                         ? t('type.setup')
                                         : isPerkRewardEntry
                                           ? t('type.reward')
@@ -258,7 +258,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
                     </div>
 
                     {/* amount and status on the right side */}
-                    {isTestTransaction ? (
+                    {isTest ? (
                         <InvitesIcon animate={false} className="size-4" />
                     ) : (
                         <div className="flex items-center gap-2">

--- a/src/components/TransactionDetails/TransactionDetailsHeaderCard.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsHeaderCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import StatusBadge, { type StatusType } from '@/components/Global/Badges/StatusBadge'
+import { isTestTransaction } from '@/utils/history.utils'
 import TransactionAvatarBadge from '@/components/TransactionDetails/TransactionAvatarBadge'
 import { type TransactionDirection, type TransactionType } from '@/components/TransactionDetails/transaction-types'
 import { printableUserHandle } from '@/utils/general.utils'
@@ -69,7 +70,7 @@ const getTitle = (
 
         // check if this is a test transaction (setup confirmation)
         // note: bad check, but its a quick fix for now - kush (18 nov 2025), to be handled in the backend post devconnect.
-        const isTestTransaction = displayName === 'Enjoy Peanut!'
+        const isTest = isTestTransaction(displayName)
 
         switch (direction) {
             case 'send':
@@ -111,8 +112,8 @@ const getTitle = (
                 break
             case 'add':
             case 'bank_deposit':
-                if (isTestTransaction) {
-                    titleText = 'Enjoy Peanut!'
+                if (isTest) {
+                    titleText = t('enjoyPeanut')
                 } else {
                     titleText = t(status === 'completed' ? 'title.addedFrom' : 'title.addingFrom', {
                         name: displayName,
@@ -210,8 +211,8 @@ export const TransactionDetailsHeaderCard: React.FC<TransactionDetailsHeaderCard
     const nameForAvatar = showFullName && fullName ? fullName : userName
 
     // check if this is a test transaction (setup confirmation)
-    const isTestTransaction = userName === 'Enjoy Peanut!'
-    const icon = getIcon(direction, isLinkTransaction, isTestTransaction)
+    const isTest = isTestTransaction(userName)
+    const icon = getIcon(direction, isLinkTransaction, isTest)
 
     const handleUserPfpClick = () => {
         if (isAvatarClickable) {
@@ -223,7 +224,7 @@ export const TransactionDetailsHeaderCard: React.FC<TransactionDetailsHeaderCard
 
     return (
         <Card className="relative p-4 md:p-6" position="single">
-            {isTestTransaction ? (
+            {isTest ? (
                 <div className="flex items-center gap-3">
                     <div>
                         <Image src={PEANUTMAN} alt="Peanut Logo" width={64} height={64} className="size-8" />

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -19,7 +19,7 @@ import { chargesApi } from '@/services/charges'
 import useClaimLink from '@/components/Claim/useClaimLink'
 import { formatAmount, isStableCoin, formatCurrency } from '@/utils/general.utils'
 import { formatPoints } from '@/utils/format.utils'
-import { getAvatarUrl } from '@/utils/history.utils'
+import { getAvatarUrl, isTestTransaction } from '@/utils/history.utils'
 import { printableAddress, shortenAddress, shortenStringLong, slugify } from '@/utils/general.utils'
 import { maskAccountIdentifier } from '@/utils/account-mask.utils'
 import { captureException } from '@sentry/nextjs'
@@ -848,7 +848,7 @@ export const TransactionDetailsReceipt = ({
                 )}
 
             {/* support link section or passkey docs for test transactions */}
-            {transaction.userName === 'Enjoy Peanut!' ? (
+            {isTestTransaction(transaction.userName) ? (
                 <PasskeyDocsLink className="border-t-0 pt-0" />
             ) : (
                 <button

--- a/src/components/TransactionDetails/__tests__/CardUsdAbroadNotice.test.tsx
+++ b/src/components/TransactionDetails/__tests__/CardUsdAbroadNotice.test.tsx
@@ -10,16 +10,10 @@
  */
 import React from 'react'
 import { render as rtlRender, screen } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 import { CardUsdAbroadNotice } from '../provider-rows/CardUsdAbroadNotice'
 import { type TransactionDetails } from '../transactionTransformer'
 
-const IntlWrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: IntlWrapper })
 
 /** Minimal TransactionDetails shaped for the notice's inputs only. */

--- a/src/components/TransactionDetails/__tests__/LocalRailNudge.test.tsx
+++ b/src/components/TransactionDetails/__tests__/LocalRailNudge.test.tsx
@@ -13,16 +13,10 @@
  */
 import React from 'react'
 import { render as rtlRender, screen } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 import { LocalRailNudge } from '../provider-rows/LocalRailNudge'
 import { type TransactionDetails } from '../transactionTransformer'
 
-const IntlWrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: IntlWrapper })
 
 jest.mock('@/hooks/useCardMarkupRate', () => ({

--- a/src/components/TransactionDetails/__tests__/TransactionCard.test.tsx
+++ b/src/components/TransactionDetails/__tests__/TransactionCard.test.tsx
@@ -14,16 +14,10 @@
  */
 import React from 'react'
 import { render as rtlRender, screen, fireEvent } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 import TransactionCard from '../TransactionCard'
 import { type TransactionDetails } from '../transactionTransformer'
 
-const IntlWrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: IntlWrapper })
 
 const push = jest.fn()

--- a/src/components/TransactionDetails/provider-actions/__tests__/CancelDepositActions.test.tsx
+++ b/src/components/TransactionDetails/provider-actions/__tests__/CancelDepositActions.test.tsx
@@ -10,14 +10,8 @@
  */
 import React from 'react'
 import { render as rtlRender, screen, fireEvent, waitFor, type RenderOptions } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 
-const IntlWrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en}>
-        {children}
-    </NextIntlClientProvider>
-)
 const render = (ui: React.ReactElement, options?: RenderOptions) => rtlRender(ui, { wrapper: IntlWrapper, ...options })
 
 const mockCancelOnramp = jest.fn()

--- a/src/components/TransactionDetails/provider-rows/__tests__/BridgeDepositInstructions.test.tsx
+++ b/src/components/TransactionDetails/provider-rows/__tests__/BridgeDepositInstructions.test.tsx
@@ -10,14 +10,8 @@
  */
 import React from 'react'
 import { render as rtlRender, screen, type RenderOptions } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 
-const IntlWrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en}>
-        {children}
-    </NextIntlClientProvider>
-)
 const render = (ui: React.ReactElement, options?: RenderOptions) => rtlRender(ui, { wrapper: IntlWrapper, ...options })
 
 jest.mock('@/components/Payment/PaymentInfoRow', () => ({

--- a/src/components/TransactionDetails/provider-rows/__tests__/CardPaymentRows.settlement-adjustment.test.tsx
+++ b/src/components/TransactionDetails/provider-rows/__tests__/CardPaymentRows.settlement-adjustment.test.tsx
@@ -10,8 +10,7 @@
  */
 import React from 'react'
 import { render as rtlRender, screen } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import enMessages from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 
 jest.mock('@/components/Payment/PaymentInfoRow', () => ({
     PaymentInfoRow: ({ label, value }: { label: React.ReactNode; value: React.ReactNode }) => (
@@ -26,12 +25,6 @@ jest.mock('next/image', () => ({ __esModule: true, default: () => <span /> }))
 // import must come after jest.mock
 import { CardPaymentRows } from '../CardPaymentRows'
 import type { TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
-
-const IntlWrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 
 const render = (ui: React.ReactElement, options?: Omit<Parameters<typeof rtlRender>[1], 'wrapper'>) =>
     rtlRender(ui, { wrapper: IntlWrapper, ...options })

--- a/src/context/__tests__/RainCooldownContext.test.tsx
+++ b/src/context/__tests__/RainCooldownContext.test.tsx
@@ -1,7 +1,6 @@
 import { act, renderHook } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
+import { IntlWrapper } from '@/test-utils/intl'
 import { ToastProvider } from '@/components/0_Bruddle/Toast'
-import en from '@/i18n/app/messages/en.json'
 import { RainCooldownProvider, useRainCooldown } from '../RainCooldownContext'
 
 // Dispatch the same window event that `rainRequest` fires on a 425 from
@@ -14,11 +13,11 @@ function fireCooldown(retryAfterSec: number, message = 'cooling down') {
 
 // The countdown pill renders localized copy, so the provider is required.
 const wrapper = ({ children }: { children: React.ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
+    <IntlWrapper>
         <ToastProvider>
             <RainCooldownProvider>{children}</RainCooldownProvider>
         </ToastProvider>
-    </NextIntlClientProvider>
+    </IntlWrapper>
 )
 
 describe('RainCooldownContext', () => {

--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { useTranslations } from 'next-intl'
 import { useToast } from '@/components/0_Bruddle/Toast'
 import { useUserQuery } from '@/hooks/query/user'
 import { useUserAutoRefresh } from '@/hooks/useUserAutoRefresh'
@@ -65,6 +66,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const _router = useRouter()
     const dispatch = useAppDispatch()
     const toast = useToast()
+    const tErrors = useTranslations('errors')
     const queryClient = useQueryClient()
     const WEB_AUTHN_COOKIE_KEY = 'web-authn-key'
 
@@ -286,12 +288,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
                 captureException(error)
                 console.error('Error logging out user', error)
                 // TODO: remove debug info after native testing
-                toast.error('Error logging out')
+                toast.error(tErrors('logoutFailed'))
             } finally {
                 setIsLoggingOut(false)
             }
         },
-        [clearLocalAuthState, fetchUser, isLoggingOut, toast]
+        [clearLocalAuthState, fetchUser, isLoggingOut, toast, tErrors]
     )
 
     return (

--- a/src/features/payments/shared/components/__tests__/PaymentMethodActionList.test.tsx
+++ b/src/features/payments/shared/components/__tests__/PaymentMethodActionList.test.tsx
@@ -6,16 +6,10 @@
  * a silent no-op (dead button). The card must only render when the caller can
  * honor it (i.e. provides the handler — the semantic-request flow does).
  */
-import React, { type ReactNode } from 'react'
+import React from 'react'
 import { render as rtlRender, screen, fireEvent } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { IntlWrapper } from '@/test-utils/intl'
 
-const IntlWrapper = ({ children }: { children: ReactNode }) => (
-    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
-        {children}
-    </NextIntlClientProvider>
-)
 const render = (ui: Parameters<typeof rtlRender>[0]) => rtlRender(ui, { wrapper: IntlWrapper })
 
 const mockRouterPush = jest.fn()

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -1,7 +1,5 @@
-import React from 'react'
-import { act, renderHook as rtlRenderHook, waitFor } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
-import en from '@/i18n/app/messages/en.json'
+import { act, waitFor } from '@testing-library/react'
+import { renderHookWithIntl as renderHook } from '@/test-utils/intl'
 import { useSumsubKycFlow } from '@/hooks/useSumsubKycFlow'
 import { initiateSumsubKyc } from '@/app/actions/sumsub'
 
@@ -10,13 +8,6 @@ import { initiateSumsubKyc } from '@/app/actions/sumsub'
 // asserts hook behaviour (does onKycSuccess fire? is an error surfaced?) and nothing else.
 // The websocket mock captures the status-update handler so a test can simulate a
 // late/stale APPROVED event arriving after the flow has resolved.
-// the hook calls useTranslations, so it needs an intl context to render at all
-const IntlWrapper = ({ children }: { children: React.ReactNode }) =>
-    // NextIntlClientProvider types `children` as a required prop, so createElement's third-arg
-    // form doesn't typecheck; this is a .ts file, so JSX isn't an option either.
-    // eslint-disable-next-line react/no-children-prop
-    React.createElement(NextIntlClientProvider, { locale: 'en', messages: en, timeZone: 'UTC', children })
-const renderHook = <T>(cb: () => T) => rtlRenderHook(cb, { wrapper: IntlWrapper })
 
 const mockWs: { handler?: (status: string, labels?: string[]) => void } = {}
 jest.mock('@/app/actions/sumsub', () => ({

--- a/src/hooks/useLogin.tsx
+++ b/src/hooks/useLogin.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import { useToast } from '@/components/0_Bruddle/Toast'
 import { useAuth } from '@/context/authContext'
 import { useZeroDev } from './useZeroDev'
@@ -33,6 +34,7 @@ export const useLogin = () => {
     const searchParams = useSearchParams()
     const router = useRouter()
     const toast = useToast()
+    const tErrors = useTranslations('errors')
     const [isloginClicked, setIsloginClicked] = useState(false)
     const [loginResolved, setLoginResolved] = useState(false)
 
@@ -65,7 +67,7 @@ export const useLogin = () => {
         const timer = setTimeout(() => {
             setIsloginClicked(false)
             setLoginResolved(false)
-            toast.error('Login didn’t complete. Please try again.')
+            toast.error(tErrors('loginIncomplete'))
             captureMessage('login ceremony succeeded but user never loaded', {
                 level: 'warning',
                 tags: { error_type: 'login_stalled' },

--- a/src/hooks/wallet/useSendMoney.ts
+++ b/src/hooks/wallet/useSendMoney.ts
@@ -137,9 +137,9 @@ export const useSendMoney = ({ address }: UseSendMoneyOptions) => {
                 // User cancelled or the grant failed — no transaction happened.
                 // Let the caller show its own UI for this; default to a toast.
                 if (error.cause.kind === 'user-cancelled') {
-                    toast.error('Approval cancelled — you can retry anytime.')
+                    toast.error(tErrors('cardApprovalCancelled'))
                 } else {
-                    toast.error('Card approval failed — please try again.')
+                    toast.error(tErrors('cardApprovalFailed'))
                 }
                 return
             }

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -42,7 +42,8 @@
         "pay": "Pay",
         "cashout": "Cashout",
         "claim": "Claim",
-        "peanutLogoAlt": "Peanut Logo"
+        "peanutLogoAlt": "Peanut Logo",
+        "receipt": "Receipt"
     },
     "home": {
         "rewards": "Rewards",
@@ -1803,7 +1804,8 @@
         "skipTheLine": "Skip the line — drop the username of the member who invited you.",
         "acceptFailed": "Something went wrong. Please try again or contact support.",
         "pleaseWait": "Please wait...",
-        "logInDifferentAccount": "Log in with a different account"
+        "logInDifferentAccount": "Log in with a different account",
+        "emailPlaceholder": "you@example.com"
     },
     "badges": {
         "title": "Badges",
@@ -2311,7 +2313,12 @@
                 "iosSafari2": "Step 2: tap “Website Settings”",
                 "iosSafari3": "Step 3: set Camera to “Allow”"
             },
-            "useCopiedAddress": "Use copied address"
+            "useCopiedAddress": "Use copied address",
+            "paymentMethods": {
+                "evmName": "ETH & EVMs",
+                "evmAlt": "Ethereum and EVMs"
+            },
+            "pastedTextNotAnAddress": "Copied text is not a wallet address"
         },
         "qrScannerOverlay": {
             "notSupportedWorking": "We're working on an integration.",
@@ -2643,7 +2650,9 @@
         },
         "betaBanner": "Peanut is in beta! Thank you for being an early user, share your feedback here",
         "demoBanner": "Demo mode — you're previewing Peanut with a simulated wallet. Balances and transactions aren't real.",
-        "rainCooldownPill": "Card cool-down"
+        "rainCooldownPill": "Card cool-down",
+        "betaBannerThumbsUpAlt": "Thumbs up",
+        "easterEggImageAlt": "Easter egg illustration"
     },
     "errors": {
         "balanceSettling": "Your balance isn't fully available yet. Please try again in a few seconds.",
@@ -2684,7 +2693,11 @@
         "rainInsufficientCollateral": "Your card doesn’t have enough collateral for this withdrawal.",
         "staleCardApproval": "Your card needs to be re-enabled before you can withdraw. It only takes one passkey tap.",
         "cardRateLimited": "Too many card requests. Please wait a moment and try again.",
-        "linkTransactionHashFetch": "We couldn’t load this link’s transaction. Please refresh and try again."
+        "linkTransactionHashFetch": "We couldn’t load this link’s transaction. Please refresh and try again.",
+        "cardApprovalCancelled": "Approval cancelled — you can retry anytime.",
+        "cardApprovalFailed": "Card approval failed — please try again.",
+        "logoutFailed": "Couldn’t log out. Please try again.",
+        "loginIncomplete": "Login didn’t complete. Please try again."
     },
     "appLock": {
         "title": "Peanut is locked",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -42,7 +42,8 @@
         "pay": "Pagar",
         "cashout": "Retiro",
         "claim": "Reclamar",
-        "peanutLogoAlt": "Logo de Peanut"
+        "peanutLogoAlt": "Logo de Peanut",
+        "receipt": "Recibo"
     },
     "home": {
         "rewards": "Recompensas",
@@ -1803,7 +1804,8 @@
         "skipTheLine": "Sáltate la fila: escribe el usuario del miembro que te invitó.",
         "acceptFailed": "Algo salió mal. Inténtalo de nuevo o comunícate con soporte.",
         "pleaseWait": "Espera un momento...",
-        "logInDifferentAccount": "Iniciar sesión con otra cuenta"
+        "logInDifferentAccount": "Iniciar sesión con otra cuenta",
+        "emailPlaceholder": "tu@ejemplo.com"
     },
     "badges": {
         "title": "Insignias",
@@ -2311,7 +2313,12 @@
                 "iosSafari2": "Paso 2: toca “Ajustes del sitio web”",
                 "iosSafari3": "Paso 3: configura la cámara en “Permitir”"
             },
-            "useCopiedAddress": "Usar dirección copiada"
+            "useCopiedAddress": "Usar dirección copiada",
+            "paymentMethods": {
+                "evmName": "ETH y EVMs",
+                "evmAlt": "Ethereum y EVMs"
+            },
+            "pastedTextNotAnAddress": "El texto copiado no es una dirección de billetera"
         },
         "qrScannerOverlay": {
             "notSupportedWorking": "Estamos trabajando en una integración.",
@@ -2643,7 +2650,9 @@
         },
         "betaBanner": "¡Peanut está en beta! Gracias por ser un usuario temprano, comparte tu opinión aquí",
         "demoBanner": "Modo demo: estás viendo Peanut con una billetera simulada. Los saldos y las transacciones no son reales.",
-        "rainCooldownPill": "Enfriamiento de tarjeta"
+        "rainCooldownPill": "Enfriamiento de tarjeta",
+        "betaBannerThumbsUpAlt": "Pulgar arriba",
+        "easterEggImageAlt": "Ilustración de huevo de pascua"
     },
     "errors": {
         "balanceSettling": "Tu saldo aún no está totalmente disponible. Inténtalo de nuevo en unos segundos.",
@@ -2684,7 +2693,11 @@
         "rainInsufficientCollateral": "Tu tarjeta no tiene suficiente colateral para este retiro.",
         "staleCardApproval": "Necesitas volver a habilitar tu tarjeta antes de retirar. Solo toma un toque con tu passkey.",
         "cardRateLimited": "Demasiadas solicitudes con la tarjeta. Espera un momento e inténtalo de nuevo.",
-        "linkTransactionHashFetch": "No pudimos cargar la transacción de este enlace. Actualiza la página e inténtalo de nuevo."
+        "linkTransactionHashFetch": "No pudimos cargar la transacción de este enlace. Actualiza la página e inténtalo de nuevo.",
+        "cardApprovalCancelled": "Aprobación cancelada: puedes volver a intentarlo cuando quieras.",
+        "cardApprovalFailed": "No se pudo aprobar la tarjeta. Inténtalo de nuevo.",
+        "logoutFailed": "No pudimos cerrar tu sesión. Inténtalo de nuevo.",
+        "loginIncomplete": "No se completó el inicio de sesión. Inténtalo de nuevo."
     },
     "appLock": {
         "title": "Peanut está bloqueado",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -42,7 +42,8 @@
         "pay": "Pagar",
         "cashout": "Saque",
         "claim": "Resgatar",
-        "peanutLogoAlt": "Logo da Peanut"
+        "peanutLogoAlt": "Logo da Peanut",
+        "receipt": "Recibo"
     },
     "home": {
         "rewards": "Recompensas",
@@ -1803,7 +1804,8 @@
         "skipTheLine": "Fure a fila: informe o usuário do membro que convidou você.",
         "acceptFailed": "Algo deu errado. Tente de novo ou fale com o suporte.",
         "pleaseWait": "Aguarde...",
-        "logInDifferentAccount": "Entrar com outra conta"
+        "logInDifferentAccount": "Entrar com outra conta",
+        "emailPlaceholder": "voce@exemplo.com"
     },
     "badges": {
         "title": "Selos",
@@ -2311,7 +2313,12 @@
                 "iosSafari2": "Passo 2: toque em “Ajustes do site”",
                 "iosSafari3": "Passo 3: defina a câmera como “Permitir”"
             },
-            "useCopiedAddress": "Usar endereço copiado"
+            "useCopiedAddress": "Usar endereço copiado",
+            "paymentMethods": {
+                "evmName": "ETH e EVMs",
+                "evmAlt": "Ethereum e EVMs"
+            },
+            "pastedTextNotAnAddress": "O texto copiado não é um endereço de carteira"
         },
         "qrScannerOverlay": {
             "notSupportedWorking": "Estamos trabalhando em uma integração.",
@@ -2643,7 +2650,9 @@
         },
         "betaBanner": "O Peanut está em beta! Obrigado por ser um usuário inicial, compartilhe sua opinião aqui",
         "demoBanner": "Modo demo — você está testando o Peanut com uma carteira simulada. Saldos e transações não são reais.",
-        "rainCooldownPill": "Resfriamento do cartão"
+        "rainCooldownPill": "Resfriamento do cartão",
+        "betaBannerThumbsUpAlt": "Joinha",
+        "easterEggImageAlt": "Ilustração de easter egg"
     },
     "errors": {
         "balanceSettling": "Seu saldo ainda não está totalmente disponível. Tente novamente em alguns segundos.",
@@ -2684,7 +2693,11 @@
         "rainInsufficientCollateral": "Seu cartão não tem colateral suficiente para este saque.",
         "staleCardApproval": "Você precisa reativar seu cartão antes de sacar. Basta um toque com sua passkey.",
         "cardRateLimited": "Muitas solicitações com o cartão. Aguarde um momento e tente novamente.",
-        "linkTransactionHashFetch": "Não conseguimos carregar a transação deste link. Atualize a página e tente novamente."
+        "linkTransactionHashFetch": "Não conseguimos carregar a transação deste link. Atualize a página e tente novamente.",
+        "cardApprovalCancelled": "Aprovação cancelada — você pode tentar novamente quando quiser.",
+        "cardApprovalFailed": "Não foi possível aprovar o cartão. Tente novamente.",
+        "logoutFailed": "Não foi possível sair da sua conta. Tente novamente.",
+        "loginIncomplete": "O login não foi concluído. Tente novamente."
     },
     "appLock": {
         "title": "A Peanut está bloqueada",

--- a/src/test-utils/intl.tsx
+++ b/src/test-utils/intl.tsx
@@ -1,0 +1,36 @@
+import { render as rtlRender, renderHook as rtlRenderHook } from '@testing-library/react'
+import type { RenderHookOptions, RenderOptions } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import type { ReactElement, ReactNode } from 'react'
+import en from '@/i18n/app/messages/en.json'
+
+/**
+ * The single intl wrapper for tests, replacing ~33 hand-rolled copies.
+ *
+ * `timeZone` is pinned to UTC because next-intl otherwise falls back to the
+ * runner's system zone, which made date formatting machine-dependent in the two
+ * suites that had omitted it.
+ *
+ * Locale is always `en` — locale-specific rendering is covered by
+ * src/i18n/app/__tests__, not by component suites.
+ */
+export const IntlWrapper = ({ children }: { children: ReactNode }) => (
+    <NextIntlClientProvider locale="en" messages={en} timeZone="UTC">
+        {children}
+    </NextIntlClientProvider>
+)
+
+/** Drop-in for RTL's `render`. Compose extra providers inside `ui`. */
+export function renderWithIntl(ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) {
+    return rtlRender(ui, { wrapper: IntlWrapper, ...options })
+}
+
+/** Drop-in for RTL's `renderHook`. Callable from `.ts` files — no JSX at the
+ *  call site, which is why the Sumsub hook suite previously needed a
+ *  React.createElement dance plus an eslint-disable. */
+export function renderHookWithIntl<Result, Props>(
+    callback: (props: Props) => Result,
+    options?: Omit<RenderHookOptions<Props>, 'wrapper'>
+) {
+    return rtlRenderHook(callback, { wrapper: IntlWrapper, ...options })
+}

--- a/src/utils/clipboard-extract.utils.ts
+++ b/src/utils/clipboard-extract.utils.ts
@@ -1,3 +1,4 @@
+import { Clipboard } from '@capacitor/clipboard'
 import { isAddress } from 'viem'
 import { isIBAN } from 'validator'
 import { isValidRoutingNumber, isValidSortCode, isValidUKAccountNumber } from '@/utils/bridge-accounts.utils'
@@ -145,5 +146,42 @@ export function createSmartPasteHandler(
             e.preventDefault()
             applyValue(extracted)
         }
+    }
+}
+
+/**
+ * Result of a native clipboard read. `empty` and `unavailable` are separated so
+ * callers can say "nothing to paste" rather than "something broke".
+ */
+export type ClipboardReadResult =
+    | { ok: true; text: string }
+    | { ok: false; reason: 'empty' | 'unavailable'; cause?: unknown }
+
+/**
+ * Reads the clipboard, classifying a rejection instead of matching its message.
+ *
+ * Capacitor's Android plugin REJECTS on an empty clipboard rather than
+ * resolving with an empty value, and the message it rejects with ("There is no
+ * data on the clipboard") is a hardcoded English literal inside the plugin's
+ * Java — not an OS string. Matching on it therefore isn't a locale bug, but it
+ * does couple us to a dependency's copy: a plugin patch bump silently flips the
+ * branch and an empty clipboard starts reporting as a failure.
+ *
+ * Default an unrecognised rejection to `empty`: Android has no runtime
+ * clipboard-read permission (the focused app can always read), so `unavailable`
+ * is effectively unreachable there and `empty` is the better guess. The web path
+ * can genuinely be blocked, so a NotAllowedError there stays `unavailable`.
+ */
+export async function readClipboard(): Promise<ClipboardReadResult> {
+    try {
+        const { value } = await Clipboard.read()
+        const text = (value ?? '').trim()
+        return text ? { ok: true, text } : { ok: false, reason: 'empty' }
+    } catch (cause) {
+        const name = cause instanceof Error ? cause.name : ''
+        if (name === 'NotAllowedError' || name === 'SecurityError') {
+            return { ok: false, reason: 'unavailable', cause }
+        }
+        return { ok: false, reason: 'empty', cause }
     }
 }

--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -462,3 +462,11 @@ export async function completeHistoryEntry(entry: HistoryEntry): Promise<History
         },
     }
 }
+
+/** Marker `userName` the backend sends for the onboarding test transaction.
+ *  Compared against BACKEND data, never against localized copy, so this is
+ *  locale-safe — but it is still a magic string the backend owns. Follow-up:
+ *  have the API send an explicit `isTestTransaction` flag and delete this. */
+const TEST_TRANSACTION_USER_NAME = 'Enjoy Peanut!'
+
+export const isTestTransaction = (name: string | null | undefined): boolean => name === TEST_TRANSACTION_USER_NAME


### PR DESCRIPTION
> **Stacked on #2554** — review that first; this PR's diff is against it, and the base retargets to `dev` once #2554 merges.

## Why

Follow-up to #2447. `react/jsx-no-literals` only inspects JSX **children**, so hardcoded copy kept reaching users through toasts, placeholders, aria-labels and alt text.

## The ticket was right about QRScanner

It named QRScanner as a known offender with "3–4 toasts". It had **four**, on `dev`, and three of them had keys that already existed and simply weren't being used. (An earlier pass of mine looked at a divergent branch where they'd been extracted and wrongly concluded the ticket was stale.)

## The lint rule

A `no-restricted-syntax` selector banning string literals as the first argument to `toast.error|success|info|warning|loading`.

**Appended to the existing array, not a new config block** — ESLint flat config *replaces* rule options when a later block names the same rule, so a second `no-restricted-syntax` entry would have silently disabled the four `router.back` selectors. That array already sits under `files: ['src/**/*.{ts,tsx}']`, which is exactly the coverage needed, since every offender lives in `src/hooks` or `src/context` — outside the `jsx-no-literals` globs.

Verified it fires by planting a synthetic violation, not just by observing a green run.

**Scoped to `toast.*`, not `throw new Error('…')`.** Every throw site flagged in the ticket was traced to its catch handler: they all funnel through `toFriendlyError` to `errors.genericSupport`, or into an already-localized toast. Those strings are Sentry breadcrumbs and issue-grouping keys — translating them would fragment triage for zero user-facing gain.

Note the rule can't actually block a merge: the `eslint` job is still `continue-on-error` and absent from `ci-success.needs`. Left as-is deliberately; promoting it is a separate team decision.

## Shared test helper

`src/test-utils/intl.tsx` replaces **39** hand-rolled `NextIntlClientProvider` wrappers (the ticket estimated ~15). Exports the three shapes call sites actually need: `IntlWrapper` (composable, for suites nesting `QueryClientProvider`), `renderWithIntl`, and `renderHookWithIntl`.

Two suites had omitted `timeZone`, so next-intl fell back to the runner's system zone and their date formatting was machine-dependent — the shared wrapper pins UTC. `renderHookWithIntl` exists so `useSumsubKycFlow.test.ts` (a `.ts` file, no JSX) can drop its `React.createElement` workaround and the `eslint-disable react/no-children-prop` that came with it.

`ClientProviders.test.tsx` deliberately keeps its own reference — it asserts on provider *ordering*, so the provider is the subject under test.

## Extractions

Four QRScanner toasts, both logout/login toasts, two card-approval toasts, the waitlist email placeholder, two `"Peanut Logo"` aria-labels (reusing the existing `navigation.peanutLogoAlt`), two descriptive alt strings. The QRScanner payment-method row keeps its brand names verbatim — proper nouns — and only the EVM row, whose label is prose, moves to a key.

`NavHeader` gains an optional `titleKey`: `/receipt/[entryId]` is an async **server** component and this app has no server-side next-intl setup (locale is resolved entirely client-side by `AppIntlProvider`), so `useTranslations` is unavailable there.

## Two structural fixes

**Clipboard.** The match on `"There is no data on the clipboard"` was **not** a locale bug — that string is a hardcoded English literal inside `@capacitor/clipboard`'s Java (`ClipboardPlugin.java:53`), not an OS message. It *was* a dependency coupling: a plugin patch bump silently flips the branch and an empty clipboard starts reporting as a failure. `readClipboard()` now classifies the rejection and returns a reason.

**`'Enjoy Peanut!'`** is consolidated behind one `isTestTransaction()` predicate. It compares backend data, so it's locale-safe, but it was repeated in four places and one of them rendered the raw literal instead of the `transaction.enjoyPeanut` key that already existed *and was already translated*. The backend should own this flag — worth a ticket.

## Verification

`pnpm typecheck` clean · 174 suites / 2311 tests pass · `eslint` 0 errors · `prettier --check .` clean

Note: peanut-ui's `pull_request` CI trigger only fires for `main`/`dev`/`develop` bases, so this PR's checks come from the `push` trigger.