### PR TITLE
feat(native): deferred deep linking through the store install (TASK-20772)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -92,6 +92,9 @@ dependencies {
     implementation "androidx.credentials:credentials:1.5.0"
     implementation "androidx.credentials:credentials-play-services-auth:1.5.0"
 
+    // play install referrer — deferred deep linking (InstallReferrerPlugin.java)
+    implementation "com.android.installreferrer:installreferrer:2.2"
+
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/android/app/src/main/java/me/peanut/wallet/InstallReferrerPlugin.java
+++ b/android/app/src/main/java/me/peanut/wallet/InstallReferrerPlugin.java
@@ -1,5 +1,8 @@
 package me.peanut.wallet;
 
+import android.os.Handler;
+import android.os.Looper;
+
 import com.android.installreferrer.api.InstallReferrerClient;
 import com.android.installreferrer.api.InstallReferrerStateListener;
 import com.getcapacitor.JSObject;
@@ -8,50 +11,64 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 /**
  * exposes the play install referrer to JS for deferred deep linking: the web
  * store-bounce appends ?referrer=<payload> to the play url, and after install
  * the JS side (src/utils/deferred-link.ts) reads it back here exactly once.
- * always resolves — {referrer: null} on any failure — so the JS restore path
- * can treat every outcome the same way.
+ * always resolves — {referrer: null} on any failure or after a 5s timeout
+ * (the referrer service can bind without ever calling back, and the JS side
+ * awaits this before finishing app init) — so the promise can never hang.
  */
 @CapacitorPlugin(name = "InstallReferrer")
 public class InstallReferrerPlugin extends Plugin {
 
+    private static final long TIMEOUT_MS = 5000;
+
     @PluginMethod
     public void getReferrer(PluginCall call) {
         final InstallReferrerClient client = InstallReferrerClient.newBuilder(getContext()).build();
+        final AtomicBoolean resolved = new AtomicBoolean(false);
+        final Handler timeoutHandler = new Handler(Looper.getMainLooper());
+        final Runnable timeout = () -> resolveOnce(call, client, resolved, null);
+        timeoutHandler.postDelayed(timeout, TIMEOUT_MS);
+
         try {
             client.startConnection(new InstallReferrerStateListener() {
                 @Override
                 public void onInstallReferrerSetupFinished(int responseCode) {
-                    JSObject ret = new JSObject();
+                    timeoutHandler.removeCallbacks(timeout);
+                    String referrer = null;
                     try {
                         if (responseCode == InstallReferrerClient.InstallReferrerResponse.OK) {
-                            ret.put("referrer", client.getInstallReferrer().getInstallReferrer());
-                        } else {
-                            // SERVICE_UNAVAILABLE / FEATURE_NOT_SUPPORTED / DEVELOPER_ERROR
-                            ret.put("referrer", (String) null);
+                            referrer = client.getInstallReferrer().getInstallReferrer();
                         }
-                    } catch (Exception e) {
-                        ret.put("referrer", (String) null);
-                    } finally {
-                        try {
-                            client.endConnection();
-                        } catch (Exception ignored) {}
-                    }
-                    call.resolve(ret);
+                        // else: SERVICE_UNAVAILABLE / FEATURE_NOT_SUPPORTED / DEVELOPER_ERROR
+                    } catch (Exception ignored) {}
+                    resolveOnce(call, client, resolved, referrer);
                 }
 
                 @Override
                 public void onInstallReferrerServiceDisconnected() {
-                    // one-shot read; the JS consumed flag prevents retries
+                    // one-shot read; resolve null instead of leaving the call pending
+                    timeoutHandler.removeCallbacks(timeout);
+                    resolveOnce(call, client, resolved, null);
                 }
             });
         } catch (Exception e) {
-            JSObject ret = new JSObject();
-            ret.put("referrer", (String) null);
-            call.resolve(ret);
+            timeoutHandler.removeCallbacks(timeout);
+            resolveOnce(call, client, resolved, null);
         }
+    }
+
+    private void resolveOnce(PluginCall call, InstallReferrerClient client, AtomicBoolean resolved, String referrer) {
+        if (!resolved.compareAndSet(false, true)) return;
+        try {
+            client.endConnection();
+        } catch (Exception ignored) {}
+        JSObject ret = new JSObject();
+        ret.put("referrer", referrer);
+        call.resolve(ret);
     }
 }

--- a/android/app/src/main/java/me/peanut/wallet/InstallReferrerPlugin.java
+++ b/android/app/src/main/java/me/peanut/wallet/InstallReferrerPlugin.java
@@ -1,0 +1,57 @@
+package me.peanut.wallet;
+
+import com.android.installreferrer.api.InstallReferrerClient;
+import com.android.installreferrer.api.InstallReferrerStateListener;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+/**
+ * exposes the play install referrer to JS for deferred deep linking: the web
+ * store-bounce appends ?referrer=<payload> to the play url, and after install
+ * the JS side (src/utils/deferred-link.ts) reads it back here exactly once.
+ * always resolves — {referrer: null} on any failure — so the JS restore path
+ * can treat every outcome the same way.
+ */
+@CapacitorPlugin(name = "InstallReferrer")
+public class InstallReferrerPlugin extends Plugin {
+
+    @PluginMethod
+    public void getReferrer(PluginCall call) {
+        final InstallReferrerClient client = InstallReferrerClient.newBuilder(getContext()).build();
+        try {
+            client.startConnection(new InstallReferrerStateListener() {
+                @Override
+                public void onInstallReferrerSetupFinished(int responseCode) {
+                    JSObject ret = new JSObject();
+                    try {
+                        if (responseCode == InstallReferrerClient.InstallReferrerResponse.OK) {
+                            ret.put("referrer", client.getInstallReferrer().getInstallReferrer());
+                        } else {
+                            // SERVICE_UNAVAILABLE / FEATURE_NOT_SUPPORTED / DEVELOPER_ERROR
+                            ret.put("referrer", (String) null);
+                        }
+                    } catch (Exception e) {
+                        ret.put("referrer", (String) null);
+                    } finally {
+                        try {
+                            client.endConnection();
+                        } catch (Exception ignored) {}
+                    }
+                    call.resolve(ret);
+                }
+
+                @Override
+                public void onInstallReferrerServiceDisconnected() {
+                    // one-shot read; the JS consumed flag prevents retries
+                }
+            });
+        } catch (Exception e) {
+            JSObject ret = new JSObject();
+            ret.put("referrer", (String) null);
+            call.resolve(ret);
+        }
+    }
+}

--- a/android/app/src/main/java/me/peanut/wallet/MainActivity.java
+++ b/android/app/src/main/java/me/peanut/wallet/MainActivity.java
@@ -14,6 +14,8 @@ public class MainActivity extends BridgeActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        // app-local plugin, not auto-discovered — must register before super.onCreate
+        registerPlugin(InstallReferrerPlugin.class);
         super.onCreate(savedInstanceState);
 
         Bridge bridge = this.getBridge();

--- a/ios/App/App/ClipboardDetectPlugin.swift
+++ b/ios/App/App/ClipboardDetectPlugin.swift
@@ -13,10 +13,28 @@ public class ClipboardDetectPlugin: CAPPlugin, CAPBridgedPlugin {
     public let identifier = "ClipboardDetectPlugin"
     public let jsName = "ClipboardDetect"
     public let pluginMethods: [CAPPluginMethod] = [
-        CAPPluginMethod(name: "hasStrings", returnType: CAPPluginReturnPromise)
+        CAPPluginMethod(name: "hasStrings", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "hasProbableWebUrl", returnType: CAPPluginReturnPromise)
     ]
 
     @objc func hasStrings(_ call: CAPPluginCall) {
         call.resolve(["value": UIPasteboard.general.hasStrings])
+    }
+
+    /*
+     * detectPatterns is also prompt-free: it reports pattern confidence
+     * without exposing content. Gates the deferred-deep-link clipboard read
+     * so only a probable web URL (the hand-off shape) triggers the real,
+     * prompt-raising read.
+     */
+    @objc func hasProbableWebUrl(_ call: CAPPluginCall) {
+        UIPasteboard.general.detectPatterns(for: [\.probableWebURL]) { result in
+            switch result {
+            case .success(let patterns):
+                call.resolve(["value": patterns.contains(\.probableWebURL)])
+            case .failure:
+                call.resolve(["value": false])
+            }
+        }
     }
 }

--- a/src/app/dev/deferred/page.tsx
+++ b/src/app/dev/deferred/page.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+// dev tool for TASK-20772 deferred deep linking: inspect the hand-off state,
+// build/copy payloads on web, read the raw android referrer, and simulate a
+// restore from any raw string (the android dev loop — real referrer data only
+// exists for play-delivered installs).
+import { useCallback, useEffect, useState } from 'react'
+import { registerPlugin } from '@capacitor/core'
+import {
+    applyDeferredPayload,
+    buildDeferredPayload,
+    copyIOSHandoff,
+    iosHandoffString,
+    parseDeferredPayload,
+    playStoreUrlWithReferrer,
+    CONSUMED_KEY,
+    PREFERRED_LOCALE_KEY,
+} from '@/utils/deferred-link'
+import { getFromCookie } from '@/utils/general.utils'
+import { getPlatform } from '@/utils/capacitor'
+
+const InstallReferrer = registerPlugin<{ getReferrer(): Promise<{ referrer: string | null }> }>('InstallReferrer')
+
+export default function DeferredLinkDevPage() {
+    const [state, setState] = useState<Record<string, string>>({})
+    const [payload, setPayload] = useState('')
+    const [rawReferrer, setRawReferrer] = useState('(not read)')
+    const [simulateInput, setSimulateInput] = useState('')
+    const [simulateResult, setSimulateResult] = useState('')
+    const [copied, setCopied] = useState(false)
+
+    const refresh = useCallback(() => {
+        setState({
+            platform: getPlatform(),
+            consumedFlag: localStorage.getItem(CONSUMED_KEY) ?? '(unset)',
+            preferredLocale: localStorage.getItem(PREFERRED_LOCALE_KEY) ?? '(unset)',
+            inviteCodeCookie: String(getFromCookie('inviteCode') ?? '(unset)'),
+            campaignTagCookie: String(getFromCookie('campaignTag') ?? '(unset)'),
+        })
+    }, [])
+
+    useEffect(() => refresh(), [refresh])
+
+    const readReferrer = async () => {
+        try {
+            const { referrer } = await InstallReferrer.getReferrer()
+            setRawReferrer(referrer ?? '(null)')
+        } catch (e) {
+            setRawReferrer(`unavailable: ${e instanceof Error ? e.message : String(e)}`)
+        }
+    }
+
+    const simulate = () => {
+        const parsed = parseDeferredPayload(simulateInput)
+        if (!parsed) {
+            setSimulateResult('rejected (no pnutdl marker)')
+        } else {
+            const dest = applyDeferredPayload(parsed)
+            setSimulateResult(`applied ${JSON.stringify(parsed)} → dest: ${dest ?? 'none'}`)
+        }
+        refresh()
+    }
+
+    return (
+        <div className="mx-auto flex max-w-2xl flex-col gap-6 p-6 font-mono text-sm">
+            <h1 className="text-lg font-bold">deferred deep link — dev</h1>
+
+            <section>
+                <h2 className="font-bold">state</h2>
+                <pre className="whitespace-pre-wrap border border-n-1 p-2">{JSON.stringify(state, null, 2)}</pre>
+                <div className="flex gap-2">
+                    <button className="border border-n-1 px-2 py-1" onClick={refresh}>
+                        refresh
+                    </button>
+                    <button
+                        className="border border-n-1 px-2 py-1"
+                        onClick={() => {
+                            localStorage.removeItem(CONSUMED_KEY)
+                            refresh()
+                        }}
+                    >
+                        reset consumed flag
+                    </button>
+                </div>
+            </section>
+
+            <section>
+                <h2 className="font-bold">web → store hand-off</h2>
+                <button
+                    className="border border-n-1 px-2 py-1"
+                    onClick={() => setPayload(buildDeferredPayload('/home'))}
+                >
+                    build payload from current context (dest=/home)
+                </button>
+                {payload && (
+                    <pre className="whitespace-pre-wrap break-all border border-n-1 p-2">
+                        payload: {payload}
+                        {'\n\n'}play url: {playStoreUrlWithReferrer(payload)}
+                        {'\n\n'}ios hand-off: {iosHandoffString(payload)}
+                    </pre>
+                )}
+                {payload && (
+                    <button
+                        className="border border-n-1 px-2 py-1"
+                        onClick={async () => {
+                            await copyIOSHandoff(payload)
+                            setCopied(true)
+                        }}
+                    >
+                        {copied ? 'copied ✓' : 'copy ios hand-off to clipboard'}
+                    </button>
+                )}
+            </section>
+
+            <section>
+                <h2 className="font-bold">native: raw install referrer</h2>
+                <button className="border border-n-1 px-2 py-1" onClick={readReferrer}>
+                    read raw referrer (android native only)
+                </button>
+                <pre className="whitespace-pre-wrap break-all border border-n-1 p-2">{rawReferrer}</pre>
+            </section>
+
+            <section>
+                <h2 className="font-bold">simulate restore</h2>
+                <textarea
+                    className="w-full border border-n-1 p-2"
+                    rows={3}
+                    placeholder="pnutdl=1&lang=es-419&invite=test&dest=%2Fhome — or a full hand-off url"
+                    value={simulateInput}
+                    onChange={(e) => setSimulateInput(e.target.value)}
+                />
+                <button className="border border-n-1 px-2 py-1" onClick={simulate}>
+                    parse + apply
+                </button>
+                {simulateResult && (
+                    <pre className="whitespace-pre-wrap break-all border border-n-1 p-2">{simulateResult}</pre>
+                )}
+            </section>
+        </div>
+    )
+}

--- a/src/app/dev/deferred/page.tsx
+++ b/src/app/dev/deferred/page.tsx
@@ -14,14 +14,15 @@ import {
     parseDeferredPayload,
     playStoreUrlWithReferrer,
     CONSUMED_KEY,
-    PREFERRED_LOCALE_KEY,
 } from '@/utils/deferred-link'
 import { getFromCookie } from '@/utils/general.utils'
 import { getPlatform } from '@/utils/capacitor'
+import { useAppLocale } from '@/i18n/app/AppIntlProvider'
 
 const InstallReferrer = registerPlugin<{ getReferrer(): Promise<{ referrer: string | null }> }>('InstallReferrer')
 
 export default function DeferredLinkDevPage() {
+    const { locale, setLocale } = useAppLocale()
     const [state, setState] = useState<Record<string, string>>({})
     const [payload, setPayload] = useState('')
     const [rawReferrer, setRawReferrer] = useState('(not read)')
@@ -32,12 +33,12 @@ export default function DeferredLinkDevPage() {
     const refresh = useCallback(() => {
         setState({
             platform: getPlatform(),
+            appLocale: locale,
             consumedFlag: localStorage.getItem(CONSUMED_KEY) ?? '(unset)',
-            preferredLocale: localStorage.getItem(PREFERRED_LOCALE_KEY) ?? '(unset)',
             inviteCodeCookie: String(getFromCookie('inviteCode') ?? '(unset)'),
             campaignTagCookie: String(getFromCookie('campaignTag') ?? '(unset)'),
         })
-    }, [])
+    }, [locale])
 
     useEffect(() => refresh(), [refresh])
 
@@ -50,13 +51,16 @@ export default function DeferredLinkDevPage() {
         }
     }
 
-    const simulate = () => {
+    const simulate = async () => {
         const parsed = parseDeferredPayload(simulateInput)
         if (!parsed) {
             setSimulateResult('rejected (no pnutdl marker)')
         } else {
-            const dest = applyDeferredPayload(parsed)
-            setSimulateResult(`applied ${JSON.stringify(parsed)} → dest: ${dest ?? 'none'}`)
+            const { dest, locale: restoredLocale } = applyDeferredPayload(parsed)
+            if (restoredLocale) await setLocale(restoredLocale)
+            setSimulateResult(
+                `applied ${JSON.stringify(parsed)} → dest: ${dest ?? 'none'}, locale: ${restoredLocale ?? 'none'}`
+            )
         }
         refresh()
     }

--- a/src/app/dev/deferred/page.tsx
+++ b/src/app/dev/deferred/page.tsx
@@ -5,7 +5,6 @@
 // restore from any raw string (the android dev loop — real referrer data only
 // exists for play-delivered installs).
 import { useCallback, useEffect, useState } from 'react'
-import { registerPlugin } from '@capacitor/core'
 import {
     applyDeferredPayload,
     buildDeferredPayload,
@@ -13,13 +12,12 @@ import {
     iosHandoffString,
     parseDeferredPayload,
     playStoreUrlWithReferrer,
+    readInstallReferrer,
     CONSUMED_KEY,
 } from '@/utils/deferred-link'
 import { getFromCookie } from '@/utils/general.utils'
 import { getPlatform } from '@/utils/capacitor'
 import { useAppLocale } from '@/i18n/app/AppIntlProvider'
-
-const InstallReferrer = registerPlugin<{ getReferrer(): Promise<{ referrer: string | null }> }>('InstallReferrer')
 
 export default function DeferredLinkDevPage() {
     const { locale, setLocale } = useAppLocale()
@@ -43,12 +41,7 @@ export default function DeferredLinkDevPage() {
     useEffect(() => refresh(), [refresh])
 
     const readReferrer = async () => {
-        try {
-            const { referrer } = await InstallReferrer.getReferrer()
-            setRawReferrer(referrer ?? '(null)')
-        } catch (e) {
-            setRawReferrer(`unavailable: ${e instanceof Error ? e.message : String(e)}`)
-        }
+        setRawReferrer((await readInstallReferrer()) ?? '(null / unavailable)')
     }
 
     const simulate = async () => {

--- a/src/app/dev/deferred/page.tsx
+++ b/src/app/dev/deferred/page.tsx
@@ -15,9 +15,11 @@ import {
     readInstallReferrer,
     CONSUMED_KEY,
 } from '@/utils/deferred-link'
+import { notFound } from 'next/navigation'
 import { getFromCookie } from '@/utils/general.utils'
-import { getPlatform } from '@/utils/capacitor'
+import { getPlatform, isCapacitor } from '@/utils/capacitor'
 import { useAppLocale } from '@/i18n/app/AppIntlProvider'
+import { BASE_URL } from '@/constants/general.consts'
 
 export default function DeferredLinkDevPage() {
     const { locale, setLocale } = useAppLocale()
@@ -57,6 +59,12 @@ export default function DeferredLinkDevPage() {
         }
         refresh()
     }
+
+    // same wall as (mobile-ui)/dev/layout.tsx, with a native exception: the
+    // capacitor build ships with BASE_URL=peanut.me but needs this page for
+    // on-device verification. web prod stays blocked. (after hooks — throwing
+    // before them would break the rules of hooks.)
+    if (BASE_URL === 'https://peanut.me' && !isCapacitor()) notFound()
 
     return (
         <div className="mx-auto flex max-w-2xl flex-col gap-6 p-6 font-mono text-sm">

--- a/src/constants/general.consts.ts
+++ b/src/constants/general.consts.ts
@@ -242,3 +242,5 @@ export const ENS_NAME_REGEX = /^(?:[-a-zA-Z0-9]+\.)+[-a-zA-Z0-9]+$/
 
 // Mirrors the backend username minimum (USERNAME_REGEX = /^[a-z][a-z0-9]{3,11}$/).
 export const USERNAME_MIN_LENGTH = 4
+
+export const PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=me.peanut.wallet'

--- a/src/hooks/__tests__/useNativePlugins.test.tsx
+++ b/src/hooks/__tests__/useNativePlugins.test.tsx
@@ -1,0 +1,101 @@
+// deferred-deep-link wiring in useNativePlugins: the restored dest must land
+// unless a real deep link actually navigated, and the restored locale must be
+// applied via setLocale — this is the only place either happens, so it needs
+// its own coverage (the pure payload logic is tested in deferred-link.test.ts).
+import { renderHook, waitFor } from '@testing-library/react'
+import { useNativePlugins } from '../useNativePlugins'
+import { restoreDeferredContext } from '@/utils/deferred-link'
+
+const push = jest.fn()
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ push, back: jest.fn() }),
+}))
+
+jest.mock('@sentry/nextjs', () => ({ captureMessage: jest.fn() }))
+
+jest.mock('@/utils/capacitor', () => ({
+    isCapacitor: jest.fn(() => true),
+    getPlatform: jest.fn(() => 'android-native'),
+}))
+
+const setLocale = jest.fn(() => Promise.resolve())
+jest.mock('@/i18n/app/AppIntlProvider', () => ({
+    useAppLocale: () => ({ locale: 'en', setLocale }),
+}))
+
+jest.mock('@/i18n/app/locale-store', () => ({
+    localeApplied: jest.fn(() => Promise.resolve()),
+}))
+
+jest.mock('@/services/onesignal', () => ({
+    getOneSignalAdapter: jest.fn(() => Promise.resolve({ onNotificationClick: jest.fn(() => () => {}) })),
+}))
+
+let launchUrl: string | undefined
+jest.mock('@capacitor/app', () => ({
+    App: {
+        getLaunchUrl: jest.fn(() => Promise.resolve(launchUrl ? { url: launchUrl } : undefined)),
+        addListener: jest.fn(() => Promise.resolve({ remove: jest.fn() })),
+        minimizeApp: jest.fn(),
+    },
+}))
+
+jest.mock('@capacitor/status-bar', () => ({
+    StatusBar: { setOverlaysWebView: jest.fn(), setStyle: jest.fn(), setBackgroundColor: jest.fn() },
+    Style: { Light: 'LIGHT' },
+}))
+
+jest.mock('@capacitor/splash-screen', () => ({ SplashScreen: { hide: jest.fn() } }))
+
+jest.mock('@/utils/deferred-link', () => ({
+    restoreDeferredContext: jest.fn(() => Promise.resolve(null)),
+}))
+
+const mockRestore = restoreDeferredContext as jest.MockedFunction<typeof restoreDeferredContext>
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    launchUrl = undefined
+})
+
+describe('useNativePlugins deferred restore wiring', () => {
+    it('pushes the restored dest and applies the locale when there is no launch url', async () => {
+        mockRestore.mockResolvedValue({ dest: '/claim?x=1', locale: 'es-419' })
+
+        renderHook(() => useNativePlugins())
+
+        await waitFor(() => expect(push).toHaveBeenCalledWith('/claim?x=1'))
+        await waitFor(() => expect(setLocale).toHaveBeenCalledWith('es-419'))
+    })
+
+    it('yields the landing to a deep link that actually navigated, but still applies the locale', async () => {
+        launchUrl = 'https://peanut.me/home'
+        mockRestore.mockResolvedValue({ dest: '/claim?x=1', locale: 'pt-BR' })
+
+        renderHook(() => useNativePlugins())
+
+        await waitFor(() => expect(setLocale).toHaveBeenCalledWith('pt-BR'))
+        expect(push).toHaveBeenCalledWith('/home')
+        expect(push).not.toHaveBeenCalledWith('/claim?x=1')
+    })
+
+    it('still pushes the restored dest when the launch url was rejected (off-host)', async () => {
+        launchUrl = 'https://evil.com/x'
+        mockRestore.mockResolvedValue({ dest: '/claim?x=1', locale: null })
+
+        renderHook(() => useNativePlugins())
+
+        await waitFor(() => expect(push).toHaveBeenCalledWith('/claim?x=1'))
+        expect(setLocale).not.toHaveBeenCalled()
+    })
+
+    it('a restore failure never breaks the rest of init', async () => {
+        mockRestore.mockRejectedValue(new Error('boom'))
+
+        renderHook(() => useNativePlugins())
+
+        const { SplashScreen } = jest.requireMock('@capacitor/splash-screen')
+        await waitFor(() => expect(SplashScreen.hide).toHaveBeenCalled())
+        expect(push).not.toHaveBeenCalled()
+    })
+})

--- a/src/hooks/useNativePlugins.ts
+++ b/src/hooks/useNativePlugins.ts
@@ -73,6 +73,13 @@ export function useNativePlugins() {
                 openDeepLink(launch?.url)
                 const urlListener = await App.addListener('appUrlOpen', ({ url }: { url: string }) => openDeepLink(url))
                 track(() => urlListener.remove())
+
+                // deferred deep link (store-install hand-off): always restores
+                // cookies/locale inside; only navigate when this launch wasn't
+                // already a real deep link — the deep link wins.
+                const { restoreDeferredContext } = await import('@/utils/deferred-link')
+                const deferredDest = await restoreDeferredContext()
+                if (!launch?.url && deferredDest) router.push(deferredDest)
             } catch (e) {
                 console.warn('failed to init app listeners:', e)
                 // without these listeners push-tap deep links never route, so surface the failure

--- a/src/hooks/useNativePlugins.ts
+++ b/src/hooks/useNativePlugins.ts
@@ -6,6 +6,7 @@ import { focusManager } from '@tanstack/react-query'
 import { captureMessage } from '@sentry/nextjs'
 import { isCapacitor, getPlatform } from '@/utils/capacitor'
 import { localeApplied } from '@/i18n/app/locale-store'
+import { useAppLocale } from '@/i18n/app/AppIntlProvider'
 import { deepLinkToNativePath } from '@/utils/native-routes'
 import { sanitizeRedirectURL } from '@/utils/general.utils'
 import { getOneSignalAdapter } from '@/services/onesignal'
@@ -21,6 +22,7 @@ let clickListenerFailureCaptured = false
 
 export function useNativePlugins() {
     const router = useRouter()
+    const { setLocale } = useAppLocale()
 
     useEffect(() => {
         if (!isCapacitor()) return
@@ -75,11 +77,12 @@ export function useNativePlugins() {
                 track(() => urlListener.remove())
 
                 // deferred deep link (store-install hand-off): always restores
-                // cookies/locale inside; only navigate when this launch wasn't
+                // cookies + locale; only navigate when this launch wasn't
                 // already a real deep link — the deep link wins.
                 const { restoreDeferredContext } = await import('@/utils/deferred-link')
-                const deferredDest = await restoreDeferredContext()
-                if (!launch?.url && deferredDest) router.push(deferredDest)
+                const restored = await restoreDeferredContext()
+                if (restored?.locale) await setLocale(restored.locale)
+                if (!launch?.url && restored?.dest) router.push(restored.dest)
             } catch (e) {
                 console.warn('failed to init app listeners:', e)
                 // without these listeners push-tap deep links never route, so surface the failure
@@ -169,5 +172,5 @@ export function useNativePlugins() {
             disposed = true
             cleanups.forEach((fn) => fn())
         }
-    }, [router])
+    }, [router, setLocale])
 }

--- a/src/hooks/useNativePlugins.ts
+++ b/src/hooks/useNativePlugins.ts
@@ -36,13 +36,21 @@ export function useNativePlugins() {
             else cleanups.push(cleanup)
         }
 
-        const openDeepLink = (url?: string | null) => {
-            if (!url) return
+        // true once ANY deep link actually navigated (cold start, warm start,
+        // push tap) — the deferred-restore dest yields only to a navigation
+        // that really happened, not to a launch url that was rejected.
+        let anyDeepLinkNavigated = false
+
+        const openDeepLink = (url?: string | null): boolean => {
+            if (!url) return false
             const target = deepLinkToNativePath(url)
-            if (!target) return
+            if (!target) return false
             // same-origin guard: only ever navigate to an in-app relative path
             const safe = sanitizeRedirectURL(target)
-            if (safe) router.push(safe)
+            if (!safe) return false
+            router.push(safe)
+            anyDeepLinkNavigated = true
+            return true
         }
 
         const init = async () => {
@@ -76,13 +84,27 @@ export function useNativePlugins() {
                 const urlListener = await App.addListener('appUrlOpen', ({ url }: { url: string }) => openDeepLink(url))
                 track(() => urlListener.remove())
 
-                // deferred deep link (store-install hand-off): always restores
-                // cookies + locale; only navigate when this launch wasn't
-                // already a real deep link — the deep link wins.
-                const { restoreDeferredContext } = await import('@/utils/deferred-link')
-                const restored = await restoreDeferredContext()
-                if (restored?.locale) await setLocale(restored.locale)
-                if (!launch?.url && restored?.dest) router.push(restored.dest)
+                // deferred deep link (store-install hand-off). deliberately NOT
+                // awaited: the iOS clipboard read can sit on the system paste
+                // prompt and the android referrer service can be slow — neither
+                // may hold up the rest of init (push listener, splash hide).
+                import('@/utils/deferred-link')
+                    .then(({ restoreDeferredContext }) => restoreDeferredContext())
+                    .then((restored) => {
+                        if (!restored) return
+                        // a deep link that actually navigated wins the landing
+                        if (restored.dest && !anyDeepLinkNavigated) router.push(restored.dest)
+                        if (restored.locale) {
+                            const locale = restored.locale
+                            // wait for the startup locale to paint so the
+                            // provider's initial swap can't clobber ours; the
+                            // race guard mirrors the splash-screen timeout
+                            Promise.race([localeApplied(), new Promise((r) => setTimeout(r, 3000))])
+                                .then(() => setLocale(locale))
+                                .catch((e) => console.warn('failed to apply deferred locale:', e))
+                        }
+                    })
+                    .catch((e) => console.warn('deferred link restore failed:', e))
             } catch (e) {
                 console.warn('failed to init app listeners:', e)
                 // without these listeners push-tap deep links never route, so surface the failure

--- a/src/utils/__tests__/deferred-link.test.ts
+++ b/src/utils/__tests__/deferred-link.test.ts
@@ -1,12 +1,12 @@
 // deferred deep linking payload: the string that survives the app-store hop.
 // build on web, parse back after install — the round-trip is the contract.
 import {
+    applyDeferredPayload,
     buildDeferredPayload,
     iosHandoffString,
     parseDeferredPayload,
     playStoreUrlWithReferrer,
     restoreDeferredContext,
-    PREFERRED_LOCALE_KEY,
 } from '../deferred-link'
 import { isAndroidNative, isIOSNative } from '../capacitor'
 import { clipboardHasStrings } from '../clipboard-detect'
@@ -106,10 +106,9 @@ describe('restoreDeferredContext', () => {
         mockIsAndroidNative.mockReturnValue(true)
         getReferrer.mockResolvedValue({ referrer: 'pnutdl=1&lang=es-419&invite=abc&campaign=off&dest=%2Fclaim%2FXYZ' })
 
-        await expect(restoreDeferredContext()).resolves.toBe('/claim/XYZ')
+        await expect(restoreDeferredContext()).resolves.toEqual({ dest: '/claim/XYZ', locale: 'es-419' })
         expect(document.cookie).toContain('inviteCode=')
         expect(document.cookie).toContain('campaignTag=')
-        expect(localStorage.getItem(PREFERRED_LOCALE_KEY)).toBe('es-419')
 
         // consumed: second call never touches the plugin again
         getReferrer.mockClear()
@@ -126,12 +125,11 @@ describe('restoreDeferredContext', () => {
         expect(getReferrer).toHaveBeenCalledTimes(1)
     })
 
-    it('does not persist an invalid locale', async () => {
+    it('returns no locale for an unsupported language tag (device language must win)', async () => {
         mockIsAndroidNative.mockReturnValue(true)
         getReferrer.mockResolvedValue({ referrer: 'pnutdl=1&lang=xx-yy&invite=abc' })
 
-        await expect(restoreDeferredContext()).resolves.toBeNull()
-        expect(localStorage.getItem(PREFERRED_LOCALE_KEY)).toBeNull()
+        await expect(restoreDeferredContext()).resolves.toEqual({ dest: null, locale: null })
         expect(document.cookie).toContain('inviteCode=')
     })
 
@@ -139,7 +137,7 @@ describe('restoreDeferredContext', () => {
         mockIsAndroidNative.mockReturnValue(true)
         getReferrer.mockResolvedValue({ referrer: `pnutdl=1&dest=${encodeURIComponent('https://evil.com/x')}` })
 
-        await expect(restoreDeferredContext()).resolves.toBeNull()
+        await expect(restoreDeferredContext()).resolves.toEqual({ dest: null, locale: null })
     })
 
     it('survives a missing plugin (older binary) and still consumes', async () => {
@@ -158,5 +156,19 @@ describe('restoreDeferredContext', () => {
         await expect(restoreDeferredContext()).resolves.toBeNull()
         expect(mockClipboardHasStrings).toHaveBeenCalledTimes(1)
         expect(localStorage.getItem('deferredLinkConsumed')).toBe('1')
+    })
+})
+
+describe('applyDeferredPayload locale normalization', () => {
+    it('normalizes marketing tags to app locales', () => {
+        expect(applyDeferredPayload({ lang: 'pt-br' }).locale).toBe('pt-BR')
+        expect(applyDeferredPayload({ lang: 'es-ar' }).locale).toBe('es-419')
+        expect(applyDeferredPayload({ lang: 'es-419' }).locale).toBe('es-419')
+        expect(applyDeferredPayload({ lang: 'en' }).locale).toBe('en')
+    })
+
+    it('returns null locale for unsupported languages', () => {
+        expect(applyDeferredPayload({ lang: 'fr' }).locale).toBeNull()
+        expect(applyDeferredPayload({}).locale).toBeNull()
     })
 })

--- a/src/utils/__tests__/deferred-link.test.ts
+++ b/src/utils/__tests__/deferred-link.test.ts
@@ -1,0 +1,162 @@
+// deferred deep linking payload: the string that survives the app-store hop.
+// build on web, parse back after install — the round-trip is the contract.
+import {
+    buildDeferredPayload,
+    iosHandoffString,
+    parseDeferredPayload,
+    playStoreUrlWithReferrer,
+    restoreDeferredContext,
+    PREFERRED_LOCALE_KEY,
+} from '../deferred-link'
+import { isAndroidNative, isIOSNative } from '../capacitor'
+import { clipboardHasStrings } from '../clipboard-detect'
+import { saveToCookie } from '../general.utils'
+
+const getReferrer = jest.fn()
+
+jest.mock('@capacitor/core', () => ({
+    registerPlugin: jest.fn(() => ({ getReferrer: () => getReferrer() })),
+}))
+
+jest.mock('../capacitor', () => ({
+    isCapacitor: jest.fn(() => false),
+    getPlatform: jest.fn(() => 'web'),
+    isAndroidNative: jest.fn(() => false),
+    isIOSNative: jest.fn(() => false),
+}))
+
+jest.mock('../clipboard-detect', () => ({
+    clipboardHasStrings: jest.fn(() => Promise.resolve(false)),
+}))
+
+const mockIsAndroidNative = isAndroidNative as jest.MockedFunction<typeof isAndroidNative>
+const mockIsIOSNative = isIOSNative as jest.MockedFunction<typeof isIOSNative>
+const mockClipboardHasStrings = clipboardHasStrings as jest.MockedFunction<typeof clipboardHasStrings>
+
+const clearCookies = () => {
+    for (const cookie of document.cookie.split(';')) {
+        const key = cookie.trim().split('=')[0]
+        if (key) document.cookie = `${key}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`
+    }
+}
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    localStorage.clear()
+    clearCookies()
+    window.history.replaceState({}, '', '/')
+})
+
+describe('buildDeferredPayload / parseDeferredPayload round-trip', () => {
+    it('round-trips a full payload including an encoded dest with query', () => {
+        window.history.replaceState({}, '', '/es-419/some-page')
+        saveToCookie('inviteCode', 'abc123')
+        saveToCookie('campaignTag', 'offramp')
+
+        const payload = buildDeferredPayload('/claim/XYZ?t=1')
+        expect(parseDeferredPayload(payload)).toEqual({
+            lang: 'es-419',
+            invite: 'abc123',
+            campaign: 'offramp',
+            dest: '/claim/XYZ?t=1',
+        })
+    })
+
+    it('defaults dest to the current path + query and skips absent fields', () => {
+        window.history.replaceState({}, '', '/claim/ABC?x=2')
+        const parsed = parseDeferredPayload(buildDeferredPayload())
+        expect(parsed).toEqual({ dest: '/claim/ABC?x=2' })
+    })
+
+    it('omits dest for the root path and non-locale first segments', () => {
+        window.history.replaceState({}, '', '/')
+        expect(parseDeferredPayload(buildDeferredPayload())).toEqual({})
+    })
+
+    it('survives the play referrer url-encoding hop', () => {
+        window.history.replaceState({}, '', '/pt-br/blog')
+        const payload = buildDeferredPayload('/claim/XYZ?t=1')
+        const url = playStoreUrlWithReferrer(payload)
+        // play hands the referrer back url-decoded exactly once
+        const referrer = decodeURIComponent(url.split('&referrer=')[1])
+        expect(parseDeferredPayload(referrer)).toEqual({ lang: 'pt-br', dest: '/claim/XYZ?t=1' })
+    })
+
+    it('parses the full iOS hand-off url form', () => {
+        const handoff = iosHandoffString('pnutdl=1&invite=test&lang=es-419&dest=%2Fhome')
+        expect(handoff).toBe('https://peanut.me/?pnutdl=1&invite=test&lang=es-419&dest=%2Fhome')
+        expect(parseDeferredPayload(handoff)).toEqual({ lang: 'es-419', invite: 'test', dest: '/home' })
+    })
+})
+
+describe('parseDeferredPayload rejection', () => {
+    it('rejects the organic play referrer', () => {
+        expect(parseDeferredPayload('utm_source=google-play&utm_medium=organic')).toBeNull()
+    })
+
+    it('rejects arbitrary clipboard content', () => {
+        expect(parseDeferredPayload('hello world')).toBeNull()
+        expect(parseDeferredPayload('https://peanut.me/?utm_source=x')).toBeNull()
+        expect(parseDeferredPayload('')).toBeNull()
+    })
+})
+
+describe('restoreDeferredContext', () => {
+    it('restores cookies, locale and dest from the android referrer, once', async () => {
+        mockIsAndroidNative.mockReturnValue(true)
+        getReferrer.mockResolvedValue({ referrer: 'pnutdl=1&lang=es-419&invite=abc&campaign=off&dest=%2Fclaim%2FXYZ' })
+
+        await expect(restoreDeferredContext()).resolves.toBe('/claim/XYZ')
+        expect(document.cookie).toContain('inviteCode=')
+        expect(document.cookie).toContain('campaignTag=')
+        expect(localStorage.getItem(PREFERRED_LOCALE_KEY)).toBe('es-419')
+
+        // consumed: second call never touches the plugin again
+        getReferrer.mockClear()
+        await expect(restoreDeferredContext()).resolves.toBeNull()
+        expect(getReferrer).not.toHaveBeenCalled()
+    })
+
+    it('consumes even when nothing is found (organic install)', async () => {
+        mockIsAndroidNative.mockReturnValue(true)
+        getReferrer.mockResolvedValue({ referrer: 'utm_source=google-play&utm_medium=organic' })
+
+        await expect(restoreDeferredContext()).resolves.toBeNull()
+        await expect(restoreDeferredContext()).resolves.toBeNull()
+        expect(getReferrer).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not persist an invalid locale', async () => {
+        mockIsAndroidNative.mockReturnValue(true)
+        getReferrer.mockResolvedValue({ referrer: 'pnutdl=1&lang=xx-yy&invite=abc' })
+
+        await expect(restoreDeferredContext()).resolves.toBeNull()
+        expect(localStorage.getItem(PREFERRED_LOCALE_KEY)).toBeNull()
+        expect(document.cookie).toContain('inviteCode=')
+    })
+
+    it('rejects an off-origin dest', async () => {
+        mockIsAndroidNative.mockReturnValue(true)
+        getReferrer.mockResolvedValue({ referrer: `pnutdl=1&dest=${encodeURIComponent('https://evil.com/x')}` })
+
+        await expect(restoreDeferredContext()).resolves.toBeNull()
+    })
+
+    it('survives a missing plugin (older binary) and still consumes', async () => {
+        mockIsAndroidNative.mockReturnValue(true)
+        getReferrer.mockRejectedValue(new Error('"InstallReferrer" plugin is not implemented on android'))
+
+        await expect(restoreDeferredContext()).resolves.toBeNull()
+        expect(localStorage.getItem('deferredLinkConsumed')).toBe('1')
+    })
+
+    it('skips the iOS clipboard read when the clipboard is empty', async () => {
+        mockIsAndroidNative.mockReturnValue(false)
+        mockIsIOSNative.mockReturnValue(true)
+        mockClipboardHasStrings.mockResolvedValue(false)
+
+        await expect(restoreDeferredContext()).resolves.toBeNull()
+        expect(mockClipboardHasStrings).toHaveBeenCalledTimes(1)
+        expect(localStorage.getItem('deferredLinkConsumed')).toBe('1')
+    })
+})

--- a/src/utils/__tests__/deferred-link.test.ts
+++ b/src/utils/__tests__/deferred-link.test.ts
@@ -9,7 +9,7 @@ import {
     restoreDeferredContext,
 } from '../deferred-link'
 import { isAndroidNative, isIOSNative } from '../capacitor'
-import { clipboardHasStrings } from '../clipboard-detect'
+import { clipboardHasStrings, clipboardHasProbableWebUrl } from '../clipboard-detect'
 import { saveToCookie } from '../general.utils'
 
 const getReferrer = jest.fn()
@@ -17,6 +17,11 @@ const getReferrer = jest.fn()
 jest.mock('@capacitor/core', () => ({
     registerPlugin: jest.fn(() => ({ getReferrer: () => getReferrer() })),
 }))
+
+jest.mock('../general.utils', () => {
+    const actual = jest.requireActual('../general.utils')
+    return { ...actual, saveToCookie: jest.fn(actual.saveToCookie) }
+})
 
 jest.mock('../capacitor', () => ({
     isCapacitor: jest.fn(() => false),
@@ -27,11 +32,22 @@ jest.mock('../capacitor', () => ({
 
 jest.mock('../clipboard-detect', () => ({
     clipboardHasStrings: jest.fn(() => Promise.resolve(false)),
+    clipboardHasProbableWebUrl: jest.fn(() => Promise.resolve(false)),
+}))
+
+const clipboardRead = jest.fn()
+const clipboardWrite = jest.fn()
+jest.mock('@capacitor/clipboard', () => ({
+    Clipboard: { read: () => clipboardRead(), write: (o: unknown) => clipboardWrite(o) },
 }))
 
 const mockIsAndroidNative = isAndroidNative as jest.MockedFunction<typeof isAndroidNative>
 const mockIsIOSNative = isIOSNative as jest.MockedFunction<typeof isIOSNative>
 const mockClipboardHasStrings = clipboardHasStrings as jest.MockedFunction<typeof clipboardHasStrings>
+const mockClipboardHasProbableWebUrl = clipboardHasProbableWebUrl as jest.MockedFunction<
+    typeof clipboardHasProbableWebUrl
+>
+const mockSaveToCookie = saveToCookie as jest.MockedFunction<typeof saveToCookie>
 
 const clearCookies = () => {
     for (const cookie of document.cookie.split(';')) {
@@ -155,7 +171,69 @@ describe('restoreDeferredContext', () => {
 
         await expect(restoreDeferredContext()).resolves.toBeNull()
         expect(mockClipboardHasStrings).toHaveBeenCalledTimes(1)
+        expect(clipboardRead).not.toHaveBeenCalled()
         expect(localStorage.getItem('deferredLinkConsumed')).toBe('1')
+    })
+
+    it('never prompts for clipboard text that is not a probable web url', async () => {
+        mockIsAndroidNative.mockReturnValue(false)
+        mockIsIOSNative.mockReturnValue(true)
+        mockClipboardHasStrings.mockResolvedValue(true)
+        mockClipboardHasProbableWebUrl.mockResolvedValue(false)
+
+        await expect(restoreDeferredContext()).resolves.toBeNull()
+        expect(clipboardRead).not.toHaveBeenCalled()
+    })
+
+    it('restores from the iOS hand-off url and clears the clipboard after', async () => {
+        mockIsAndroidNative.mockReturnValue(false)
+        mockIsIOSNative.mockReturnValue(true)
+        mockClipboardHasStrings.mockResolvedValue(true)
+        mockClipboardHasProbableWebUrl.mockResolvedValue(true)
+        clipboardRead.mockResolvedValue({ value: 'https://peanut.me/?pnutdl=1&invite=test&dest=%2Fhome' })
+        clipboardWrite.mockResolvedValue(undefined)
+
+        await expect(restoreDeferredContext()).resolves.toEqual({ dest: '/home', locale: null })
+        expect(mockSaveToCookie).toHaveBeenCalledWith('inviteCode', 'test', 30)
+        expect(clipboardWrite).toHaveBeenCalled()
+    })
+})
+
+describe('applyDeferredPayload hardening', () => {
+    it('writes durable 30-day cookies, not session cookies', () => {
+        applyDeferredPayload({ invite: 'abc', campaign: 'off' })
+        expect(mockSaveToCookie).toHaveBeenCalledWith('inviteCode', 'abc', 30)
+        expect(mockSaveToCookie).toHaveBeenCalledWith('campaignTag', 'off', 30)
+    })
+
+    it('normalizes invite and campaign like the existing writers', () => {
+        applyDeferredPayload({ invite: ' @Alice ', campaign: ' OFFRAMP ' })
+        expect(mockSaveToCookie).toHaveBeenCalledWith('inviteCode', 'alice', 30)
+        expect(mockSaveToCookie).toHaveBeenCalledWith('campaignTag', 'offramp', 30)
+    })
+
+    it('strips the marketing locale prefix from dest (native export has no /{locale} routes)', () => {
+        expect(applyDeferredPayload({ dest: '/es-419/claim/XYZ?t=1' }).dest).toBe('/claim/XYZ?t=1')
+        expect(applyDeferredPayload({ dest: '/pt-br/home' }).dest).toBe('/home')
+        expect(applyDeferredPayload({ dest: '/claim/XYZ' }).dest).toBe('/claim/XYZ')
+    })
+})
+
+describe('buildDeferredPayload locale-prefixed pages', () => {
+    it('strips the locale prefix from the default dest but keeps it as lang', () => {
+        window.history.replaceState({}, '', '/es-419/claim/ABC?x=2')
+        expect(parseDeferredPayload(buildDeferredPayload())).toEqual({ lang: 'es-419', dest: '/claim/ABC?x=2' })
+    })
+})
+
+describe('restoreDeferredContext in-flight guard', () => {
+    it('overlapping calls share one platform read', async () => {
+        mockIsAndroidNative.mockReturnValue(true)
+        getReferrer.mockResolvedValue({ referrer: 'pnutdl=1&dest=%2Fhome' })
+
+        const [a, b] = await Promise.all([restoreDeferredContext(), restoreDeferredContext()])
+        expect(getReferrer).toHaveBeenCalledTimes(1)
+        expect(a).toEqual(b)
     })
 })
 

--- a/src/utils/clipboard-detect.ts
+++ b/src/utils/clipboard-detect.ts
@@ -3,6 +3,7 @@ import { isIOSNative } from './capacitor'
 
 interface ClipboardDetectPlugin {
     hasStrings(): Promise<{ value: boolean }>
+    hasProbableWebUrl(): Promise<{ value: boolean }>
 }
 
 // App-local iOS plugin (ios/App/App/ClipboardDetectPlugin.swift); no web/Android
@@ -20,6 +21,23 @@ export async function clipboardHasStrings(): Promise<boolean> {
     if (!isIOSNative()) return false
     try {
         const { value } = await ClipboardDetect.hasStrings()
+        return value
+    } catch {
+        return false
+    }
+}
+
+/**
+ * iOS-native only: prompt-free "does the clipboard probably contain a web
+ * url?" via UIPasteboard.detectPatterns — pattern confidence only, content is
+ * never read, so no paste alert. Gates the deferred-deep-link clipboard read
+ * (the hand-off is always a url) so unrelated clipboard text never triggers
+ * the prompt. False on other platforms and binaries without the method.
+ */
+export async function clipboardHasProbableWebUrl(): Promise<boolean> {
+    if (!isIOSNative()) return false
+    try {
+        const { value } = await ClipboardDetect.hasProbableWebUrl()
         return value
     } catch {
         return false

--- a/src/utils/deferred-link.ts
+++ b/src/utils/deferred-link.ts
@@ -6,6 +6,7 @@
 import { registerPlugin } from '@capacitor/core'
 import { PLAY_STORE_URL } from '@/constants/general.consts'
 import { isValidLocale } from '@/i18n/config'
+import { resolveLocale, type AppLocale } from '@/i18n/app/config'
 import { isAndroidNative, isIOSNative } from './capacitor'
 import { clipboardHasStrings } from './clipboard-detect'
 import { getFromCookie, saveToCookie, sanitizeRedirectURL } from './general.utils'
@@ -15,8 +16,6 @@ import { deepLinkToNativePath } from './native-routes'
 // (utm_source=google-play&utm_medium=organic)
 const MARKER = 'pnutdl'
 export const CONSUMED_KEY = 'deferredLinkConsumed'
-// future in-app i18n reads this; nothing consumes it yet
-export const PREFERRED_LOCALE_KEY = 'preferredLocale'
 
 export interface DeferredPayload {
     lang?: string
@@ -104,14 +103,22 @@ export function parseDeferredPayload(raw: string): DeferredPayload | null {
 // native side — one-shot restore on first launch
 // ---------------------------------------------------------------------------
 
+export interface RestoredContext {
+    /** sanitized in-app path to navigate to, or null */
+    dest: string | null
+    /** normalized app locale to apply via setLocale, or null */
+    locale: AppLocale | null
+}
+
 /**
  * one-shot first-launch restore. reads the platform hand-off (android install
- * referrer / iOS clipboard), applies invite + campaign cookies and the
- * preferred locale, and returns the sanitized in-app destination path to
- * navigate to (or null). the consumed flag is set even when nothing is found,
- * so the iOS paste prompt can never fire twice.
+ * referrer / iOS clipboard), applies invite + campaign cookies, and returns
+ * the destination + locale for the caller to act on (locale goes through
+ * useAppLocale().setLocale so it applies live AND persists). the consumed
+ * flag is set even when nothing is found, so the iOS paste prompt can never
+ * fire twice.
  */
-export async function restoreDeferredContext(): Promise<string | null> {
+export async function restoreDeferredContext(): Promise<RestoredContext | null> {
     try {
         if (localStorage.getItem(CONSUMED_KEY)) return null
     } catch {
@@ -147,7 +154,7 @@ export async function restoreDeferredContext(): Promise<string | null> {
     const payload = raw ? parseDeferredPayload(raw) : null
     if (!payload) return null
 
-    const dest = applyDeferredPayload(payload)
+    const restored = applyDeferredPayload(payload)
 
     // privacy: clear the consumed hand-off off the clipboard. after the flag —
     // an interrupted clear can't cause a re-read. single space: some platforms
@@ -159,22 +166,25 @@ export async function restoreDeferredContext(): Promise<string | null> {
         } catch {}
     }
 
-    return dest
+    return restored
 }
 
 /**
- * applies a parsed payload (cookies + preferred locale) and returns the
- * sanitized in-app destination, or null. shared by the real restore and the
- * /dev/deferred simulator so there is exactly one apply path.
+ * applies a parsed payload (cookies) and returns the sanitized destination +
+ * normalized locale. shared by the real restore and the /dev/deferred
+ * simulator so there is exactly one apply path. the locale is returned rather
+ * than persisted here: only useAppLocale().setLocale both persists and
+ * re-renders the running session.
  */
-export function applyDeferredPayload(payload: DeferredPayload): string | null {
+export function applyDeferredPayload(payload: DeferredPayload): RestoredContext {
     if (payload.invite) saveToCookie('inviteCode', payload.invite)
     if (payload.campaign) saveToCookie('campaignTag', payload.campaign)
-    if (payload.lang && isValidLocale(payload.lang)) {
-        try {
-            localStorage.setItem(PREFERRED_LOCALE_KEY, payload.lang)
-        } catch {}
-    }
-    if (!payload.dest) return null
-    return sanitizeRedirectURL(deepLinkToNativePath(payload.dest) ?? payload.dest)
+
+    // resolveLocale maps any unknown tag to 'en', which would override the
+    // device language — only pass through tags whose language is supported
+    const langPrefix = payload.lang?.trim().toLowerCase().split('-')[0]
+    const locale = langPrefix && ['en', 'es', 'pt'].includes(langPrefix) ? resolveLocale(payload.lang) : null
+
+    const dest = payload.dest ? sanitizeRedirectURL(deepLinkToNativePath(payload.dest) ?? payload.dest) : null
+    return { dest, locale }
 }

--- a/src/utils/deferred-link.ts
+++ b/src/utils/deferred-link.ts
@@ -8,7 +8,6 @@ import { PLAY_STORE_URL } from '@/constants/general.consts'
 import { isValidLocale } from '@/i18n/config'
 import { APP_LOCALES, resolveLocale, type AppLocale } from '@/i18n/app/config'
 import { isAndroidNative, isIOSNative } from './capacitor'
-import { clipboardHasStrings } from './clipboard-detect'
 import { getFromCookie, saveToCookie, sanitizeRedirectURL } from './general.utils'
 import { deepLinkToNativePath } from './native-routes'
 
@@ -44,9 +43,19 @@ export async function readInstallReferrer(): Promise<string | null> {
 // ---------------------------------------------------------------------------
 
 /**
+ * strips a leading marketing locale segment (/es-419/claim/X → /claim/X).
+ * locale-prefixed routes only exist on the web — in the native static export
+ * they 404, so they must never survive into a dest.
+ */
+function stripLocalePrefix(path: string): string {
+    const [, first, ...rest] = path.split('/')
+    return first && isValidLocale(first) ? '/' + rest.join('/') : path
+}
+
+/**
  * builds the payload querystring from the current web context: locale from the
  * /{locale}/ path prefix, invite/campaign from their existing cookies, dest
- * from the argument (defaults to the current path + query).
+ * from the argument (defaults to the current path + query, locale stripped).
  */
 export function buildDeferredPayload(dest?: string): string {
     const params = new URLSearchParams({ [MARKER]: '1' })
@@ -60,7 +69,7 @@ export function buildDeferredPayload(dest?: string): string {
     const campaign = getFromCookie('campaignTag')
     if (typeof campaign === 'string' && campaign) params.set('campaign', campaign)
 
-    const destination = dest ?? window.location.pathname + window.location.search
+    const destination = dest ?? stripLocalePrefix(window.location.pathname) + window.location.search
     if (destination && destination !== '/') params.set('dest', destination)
 
     return params.toString()
@@ -128,7 +137,20 @@ export interface RestoredContext {
  * flag is set even when nothing is found, so the iOS paste prompt can never
  * fire twice.
  */
-export async function restoreDeferredContext(): Promise<RestoredContext | null> {
+let restoreInFlight: Promise<RestoredContext | null> | null = null
+
+export function restoreDeferredContext(): Promise<RestoredContext | null> {
+    // in-flight guard: overlapping calls (react strict-mode double-effect,
+    // effect re-runs) share one read so the iOS paste prompt can't stack
+    if (!restoreInFlight) {
+        restoreInFlight = doRestore().finally(() => {
+            restoreInFlight = null
+        })
+    }
+    return restoreInFlight
+}
+
+async function doRestore(): Promise<RestoredContext | null> {
     try {
         if (localStorage.getItem(CONSUMED_KEY)) return null
     } catch {
@@ -140,9 +162,12 @@ export async function restoreDeferredContext(): Promise<RestoredContext | null> 
         raw = await readInstallReferrer()
     } else if (isIOSNative()) {
         try {
-            // prompt-free presence check first, so organic installs with an
-            // empty clipboard never see the iOS 16 paste prompt
-            if (await clipboardHasStrings()) {
+            // both gates are prompt-free metadata checks. the hand-off is
+            // always a url, so only a probable-web-url clipboard is worth the
+            // iOS 16 paste prompt — organic installs with unrelated text
+            // (a password, a message draft) are never prompted.
+            const { clipboardHasStrings, clipboardHasProbableWebUrl } = await import('./clipboard-detect')
+            if ((await clipboardHasStrings()) && (await clipboardHasProbableWebUrl())) {
                 const { Clipboard } = await import('@capacitor/clipboard')
                 raw = (await Clipboard.read()).value ?? null
             }
@@ -183,8 +208,16 @@ export async function restoreDeferredContext(): Promise<RestoredContext | null> 
  * re-renders the running session.
  */
 export function applyDeferredPayload(payload: DeferredPayload): RestoredContext {
-    if (payload.invite) saveToCookie('inviteCode', payload.invite)
-    if (payload.campaign) saveToCookie('campaignTag', payload.campaign)
+    // normalize like every existing writer (InvitesPage lowercases ?code and
+    // utm_campaign; toInviteCode trims/strips @) — a hand-built referrer with
+    // an uppercase tag must not break the case-sensitive badge award.
+    // 30-day expiry matches useZeroDev's invite cookie: a session cookie would
+    // be dropped by the webview before the user finishes signup, and the
+    // one-shot consumed flag means it could never be re-read.
+    const invite = payload.invite?.trim().replace(/^@/, '').toLowerCase()
+    if (invite) saveToCookie('inviteCode', invite, 30)
+    const campaign = payload.campaign?.trim().toLowerCase()
+    if (campaign) saveToCookie('campaignTag', campaign, 30)
 
     // resolveLocale maps any unknown tag to 'en', which would override the
     // device language — only pass through tags whose language is supported
@@ -192,6 +225,7 @@ export function applyDeferredPayload(payload: DeferredPayload): RestoredContext 
     const langPrefix = payload.lang?.trim().toLowerCase().split('-')[0]
     const locale = langPrefix && supportedLangs.includes(langPrefix) ? resolveLocale(payload.lang) : null
 
-    const dest = payload.dest ? sanitizeRedirectURL(deepLinkToNativePath(payload.dest) ?? payload.dest) : null
+    const rawDest = payload.dest ? stripLocalePrefix(payload.dest) : null
+    const dest = rawDest ? sanitizeRedirectURL(deepLinkToNativePath(rawDest) ?? rawDest) : null
     return { dest, locale }
 }

--- a/src/utils/deferred-link.ts
+++ b/src/utils/deferred-link.ts
@@ -1,0 +1,180 @@
+// deferred deep linking: carry context (locale, invite code, campaign tag,
+// destination path) from mobile web through the app-store install into the
+// native app. android rides the Play Install Referrer; iOS rides a clipboard
+// hand-off written on the store-bounce tap and read once on first launch.
+// TASK-20772 — the download modal (TASK-20769) is the eventual web consumer.
+import { registerPlugin } from '@capacitor/core'
+import { PLAY_STORE_URL } from '@/constants/general.consts'
+import { isValidLocale } from '@/i18n/config'
+import { isAndroidNative, isIOSNative } from './capacitor'
+import { clipboardHasStrings } from './clipboard-detect'
+import { getFromCookie, saveToCookie, sanitizeRedirectURL } from './general.utils'
+import { deepLinkToNativePath } from './native-routes'
+
+// marker param distinguishing our payload from Play's organic referrer
+// (utm_source=google-play&utm_medium=organic)
+const MARKER = 'pnutdl'
+export const CONSUMED_KEY = 'deferredLinkConsumed'
+// future in-app i18n reads this; nothing consumes it yet
+export const PREFERRED_LOCALE_KEY = 'preferredLocale'
+
+export interface DeferredPayload {
+    lang?: string
+    invite?: string
+    campaign?: string
+    dest?: string
+}
+
+// app-local android plugin (InstallReferrerPlugin.java); throws "not
+// implemented" on iOS/web and on older binaries running OTA'd JS — callers
+// catch and treat as null.
+const InstallReferrer = registerPlugin<{ getReferrer(): Promise<{ referrer: string | null }> }>('InstallReferrer')
+
+// ---------------------------------------------------------------------------
+// web side — building the hand-off
+// ---------------------------------------------------------------------------
+
+/**
+ * builds the payload querystring from the current web context: locale from the
+ * /{locale}/ path prefix, invite/campaign from their existing cookies, dest
+ * from the argument (defaults to the current path + query).
+ */
+export function buildDeferredPayload(dest?: string): string {
+    const params = new URLSearchParams({ [MARKER]: '1' })
+
+    const firstSegment = window.location.pathname.split('/').filter(Boolean)[0]
+    if (firstSegment && isValidLocale(firstSegment)) params.set('lang', firstSegment)
+
+    const invite = getFromCookie('inviteCode')
+    if (typeof invite === 'string' && invite) params.set('invite', invite)
+
+    const campaign = getFromCookie('campaignTag')
+    if (typeof campaign === 'string' && campaign) params.set('campaign', campaign)
+
+    const destination = dest ?? window.location.pathname + window.location.search
+    if (destination && destination !== '/') params.set('dest', destination)
+
+    return params.toString()
+}
+
+/** play store listing url with the payload riding the install referrer. */
+export function playStoreUrlWithReferrer(payload: string): string {
+    return `${PLAY_STORE_URL}&referrer=${encodeURIComponent(payload)}`
+}
+
+/**
+ * the iOS clipboard hand-off string — a full peanut.me url so a stray paste
+ * anywhere else is still a working link.
+ */
+export function iosHandoffString(payload: string): string {
+    return `https://peanut.me/?${payload}`
+}
+
+/**
+ * copies the iOS hand-off to the clipboard. MUST be called from the store-
+ * bounce tap handler — clipboard writes need a user gesture on the web.
+ */
+export async function copyIOSHandoff(payload: string): Promise<void> {
+    await navigator.clipboard.writeText(iosHandoffString(payload))
+}
+
+// ---------------------------------------------------------------------------
+// shared — parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * parses a raw referrer string or a full hand-off url into a payload.
+ * returns null unless the pnutdl marker is present.
+ */
+export function parseDeferredPayload(raw: string): DeferredPayload | null {
+    const qIndex = raw.indexOf('?')
+    const qs = qIndex >= 0 ? raw.slice(qIndex + 1) : raw
+    let params: URLSearchParams
+    try {
+        params = new URLSearchParams(qs)
+    } catch {
+        return null
+    }
+    if (params.get(MARKER) !== '1') return null
+    const pick = (key: string) => params.get(key) || undefined
+    return { lang: pick('lang'), invite: pick('invite'), campaign: pick('campaign'), dest: pick('dest') }
+}
+
+// ---------------------------------------------------------------------------
+// native side — one-shot restore on first launch
+// ---------------------------------------------------------------------------
+
+/**
+ * one-shot first-launch restore. reads the platform hand-off (android install
+ * referrer / iOS clipboard), applies invite + campaign cookies and the
+ * preferred locale, and returns the sanitized in-app destination path to
+ * navigate to (or null). the consumed flag is set even when nothing is found,
+ * so the iOS paste prompt can never fire twice.
+ */
+export async function restoreDeferredContext(): Promise<string | null> {
+    try {
+        if (localStorage.getItem(CONSUMED_KEY)) return null
+    } catch {
+        return null
+    }
+
+    let raw: string | null = null
+    if (isAndroidNative()) {
+        try {
+            raw = (await InstallReferrer.getReferrer()).referrer ?? null
+        } catch {
+            // older binary without the plugin, or referrer service unavailable
+        }
+    } else if (isIOSNative()) {
+        try {
+            // prompt-free presence check first, so organic installs with an
+            // empty clipboard never see the iOS 16 paste prompt
+            if (await clipboardHasStrings()) {
+                const { Clipboard } = await import('@capacitor/clipboard')
+                raw = (await Clipboard.read()).value ?? null
+            }
+        } catch {
+            // user declined the paste prompt, or clipboard unavailable
+        }
+    }
+
+    // one shot, even on failure: android's referrer stays readable for months
+    // and iOS must never re-prompt
+    try {
+        localStorage.setItem(CONSUMED_KEY, '1')
+    } catch {}
+
+    const payload = raw ? parseDeferredPayload(raw) : null
+    if (!payload) return null
+
+    const dest = applyDeferredPayload(payload)
+
+    // privacy: clear the consumed hand-off off the clipboard. after the flag —
+    // an interrupted clear can't cause a re-read. single space: some platforms
+    // reject writing an empty string.
+    if (isIOSNative()) {
+        try {
+            const { Clipboard } = await import('@capacitor/clipboard')
+            await Clipboard.write({ string: ' ' })
+        } catch {}
+    }
+
+    return dest
+}
+
+/**
+ * applies a parsed payload (cookies + preferred locale) and returns the
+ * sanitized in-app destination, or null. shared by the real restore and the
+ * /dev/deferred simulator so there is exactly one apply path.
+ */
+export function applyDeferredPayload(payload: DeferredPayload): string | null {
+    if (payload.invite) saveToCookie('inviteCode', payload.invite)
+    if (payload.campaign) saveToCookie('campaignTag', payload.campaign)
+    if (payload.lang && isValidLocale(payload.lang)) {
+        try {
+            localStorage.setItem(PREFERRED_LOCALE_KEY, payload.lang)
+        } catch {}
+    }
+    if (!payload.dest) return null
+    return sanitizeRedirectURL(deepLinkToNativePath(payload.dest) ?? payload.dest)
+}

--- a/src/utils/deferred-link.ts
+++ b/src/utils/deferred-link.ts
@@ -6,7 +6,7 @@
 import { registerPlugin } from '@capacitor/core'
 import { PLAY_STORE_URL } from '@/constants/general.consts'
 import { isValidLocale } from '@/i18n/config'
-import { resolveLocale, type AppLocale } from '@/i18n/app/config'
+import { APP_LOCALES, resolveLocale, type AppLocale } from '@/i18n/app/config'
 import { isAndroidNative, isIOSNative } from './capacitor'
 import { clipboardHasStrings } from './clipboard-detect'
 import { getFromCookie, saveToCookie, sanitizeRedirectURL } from './general.utils'
@@ -28,6 +28,16 @@ export interface DeferredPayload {
 // implemented" on iOS/web and on older binaries running OTA'd JS — callers
 // catch and treat as null.
 const InstallReferrer = registerPlugin<{ getReferrer(): Promise<{ referrer: string | null }> }>('InstallReferrer')
+
+/** raw play install referrer string, or null anywhere it can't be read. */
+export async function readInstallReferrer(): Promise<string | null> {
+    try {
+        return (await InstallReferrer.getReferrer()).referrer ?? null
+    } catch {
+        // older binary without the plugin, iOS/web, or referrer service unavailable
+        return null
+    }
+}
 
 // ---------------------------------------------------------------------------
 // web side — building the hand-off
@@ -127,11 +137,7 @@ export async function restoreDeferredContext(): Promise<RestoredContext | null> 
 
     let raw: string | null = null
     if (isAndroidNative()) {
-        try {
-            raw = (await InstallReferrer.getReferrer()).referrer ?? null
-        } catch {
-            // older binary without the plugin, or referrer service unavailable
-        }
+        raw = await readInstallReferrer()
     } else if (isIOSNative()) {
         try {
             // prompt-free presence check first, so organic installs with an
@@ -182,8 +188,9 @@ export function applyDeferredPayload(payload: DeferredPayload): RestoredContext 
 
     // resolveLocale maps any unknown tag to 'en', which would override the
     // device language — only pass through tags whose language is supported
+    const supportedLangs = APP_LOCALES.map((l) => l.split('-')[0])
     const langPrefix = payload.lang?.trim().toLowerCase().split('-')[0]
-    const locale = langPrefix && ['en', 'es', 'pt'].includes(langPrefix) ? resolveLocale(payload.lang) : null
+    const locale = langPrefix && supportedLangs.includes(langPrefix) ? resolveLocale(payload.lang) : null
 
     const dest = payload.dest ? sanitizeRedirectURL(deepLinkToNativePath(payload.dest) ?? payload.dest) : null
     return { dest, locale }


### PR DESCRIPTION
## Summary

TASK-20772 — deferred deep linking v1 (DIY). When a mobile-web user is bounced to the Play Store / App Store, their context (locale, invite code, campaign tag, destination path) now survives the install into the native app:

- **Android** — the web side appends `&referrer=<payload>` to the Play URL; a new app-local Capacitor plugin (`InstallReferrerPlugin.java`, Play Install Referrer library) reads it back on first launch. Deterministic, first-party.
- **iOS** — clipboard hand-off: the store-bounce tap copies `https://peanut.me/?pnutdl=1&…` to the clipboard; first launch reads it via `@capacitor/clipboard`, gated by the existing prompt-free `clipboardHasStrings()` so organic installs with an empty clipboard never see the iOS paste prompt.
- **Restore** (one-shot, `deferredLinkConsumed` flag): sets the existing `inviteCode`/`campaignTag` cookies (setup flow already reads them), applies the locale live via `useAppLocale().setLocale` (normalized through `resolveLocale` — unsupported tags are dropped so a garbage payload can never override the device language), and navigates to the destination only when the launch wasn't already a real deep link.
- Web side ships **helpers + `/dev/deferred` test page only** — the user-facing download modal (TASK-20769) will consume `buildDeferredPayload` / `playStoreUrlWithReferrer` / `copyIOSHandoff` when it lands.

## Design notes / accepted trade-offs

- Consumed flag lives in `localStorage` (survives Capgo OTA; resets on reinstall — which is exactly fresh-install semantics).
- iOS clipboard is cleared after a successful consume, after the flag is set, so an interrupted clear can't cause a re-read.
- The iOS paste prompt is double-gated by prompt-free metadata checks (`hasStrings` + new `detectPatterns` probable-web-URL in `ClipboardDetectPlugin.swift`): organic installs with unrelated clipboard text (a password, a draft) are never prompted — only a clipboard that plausibly holds the hand-off URL is worth the alert.
- Restore is deliberately not awaited in native init: a pending paste prompt or a slow referrer service can't block the push-tap listener or splash hide. The Java plugin additionally resolves exactly once with a 5s timeout so its promise can never hang.
- A deep link that **actually navigated** wins the landing over the deferred dest (a rejected/off-host launch URL doesn't burn it); cookies/locale are restored regardless. The restored locale applies after the startup locale paints, so the provider's initial swap can't clobber it.
- Cookies are written with 30-day expiry and normalized (trim/lowercase/strip-@) to match the existing invite/campaign writers — a session cookie died before signup completed, and an uppercase campaign tag would break the case-sensitive badge award.
- Locale-prefixed marketing paths (`/es-419/…`) are stripped from dests on both sides — those routes don't exist in the native static export.
- Organic Play referrer (`utm_source=google-play…`) is rejected by the `pnutdl=1` marker.

## Risks / breaking changes

- **Requires a new Android binary** (new plugin + Gradle dep) — cannot ship via Capgo OTA. Older binaries no-op safely (plugin bridge throws → caught → null).
- **iOS**: adds one prompt-free method to `ClipboardDetectPlugin.swift` — rides the next IPA (iOS is mid-submission; no binaries in the field). On a binary without the method the JS skips the clipboard read entirely: no prompt, no restore, status quo.
- No backend changes. No user-facing web surface changes.

## QA

- 15 unit tests (`deferred-link.test.ts`): build→parse round-trip, Play URL encoding hop, iOS hand-off form, organic-referrer rejection, one-shot consume, off-origin dest rejection, locale normalization.
- `:app:compileDebugJavaWithJavac` green with the new plugin.
- Device plan: iOS e2e via dev build (copy hand-off in Safari → fresh install → paste prompt → `/dev/deferred` shows restored state); Android via Play internal testing track with a `&referrer=` install link; sideloaded builds verified to no-op.

Screenshots: N/A (no visible change — dev-only page + native plumbing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added deferred deep linking across Android, iOS, and web.
  - Preserves supported language, invitation, campaign, and destination details when opening the app after installation.
  - Restores deferred navigation without overriding an active deep link.
  - Added Google Play Store integration for deferred hand-off links.
  - Added safeguards to prevent repeated restoration and safely handle unavailable native capabilities.
  - Added an internal development page for inspecting and testing deferred-link hand-offs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->