### PR TITLE
fix(kyc): route every native entry point through the Sumsub Cordova SDK

### DIFF
--- a/src/components/Kyc/SumsubKycFlow.tsx
+++ b/src/components/Kyc/SumsubKycFlow.tsx
@@ -2,7 +2,6 @@ import { Button, type ButtonProps } from '@/components/0_Bruddle/Button'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { type KYCRegionIntent } from '@/app/actions/types/sumsub.types'
-import { isCapacitor } from '@/utils/capacitor'
 
 interface SumsubKycFlowProps extends ButtonProps {
     onKycSuccess?: () => void
@@ -10,8 +9,8 @@ interface SumsubKycFlowProps extends ButtonProps {
     regionIntent?: KYCRegionIntent
 }
 
-// entry point for kyc. delegates to useMultiPhaseKycFlow which handles
-// both web (sumsub web sdk) and native (sumsub cordova plugin) paths.
+// entry point for kyc. delegates to useMultiPhaseKycFlow for the logic;
+// SumsubKycModals -> SumsubKycWrapper picks the web or native SDK by platform.
 export const SumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent, ...buttonProps }: SumsubKycFlowProps) => {
     const flow = useMultiPhaseKycFlow({ onKycSuccess, onManualClose, regionIntent })
 
@@ -23,7 +22,7 @@ export const SumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent, ...bu
 
             {flow.error && <p className="text-red-500 mt-2 text-sm">{flow.error}</p>}
 
-            {!isCapacitor() && <SumsubKycModals flow={flow} />}
+            <SumsubKycModals flow={flow} />
         </>
     )
 }

--- a/src/components/Kyc/SumsubKycWrapper.tsx
+++ b/src/components/Kyc/SumsubKycWrapper.tsx
@@ -5,12 +5,16 @@ import { useTranslations } from 'next-intl'
 import Modal from '@/components/Global/Modal'
 import ActionModal from '@/components/Global/ActionModal'
 import { Icon, type IconName } from '@/components/Global/Icons/Icon'
-import { Button, type ButtonVariant } from '@/components/0_Bruddle/Button'
+import { type ButtonVariant } from '@/components/0_Bruddle/Button'
 import Loading from '@/components/Global/Loading'
 import posthog from 'posthog-js'
 import { useModalsContext } from '@/context/ModalsContext'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { isCapacitor } from '@/utils/capacitor'
 import { evaluateSumsubStatusEvent, type SumsubStatusEventPayload } from './sumsubStatusEvent.utils'
+import { SumsubNativeSdk } from './SumsubNativeSdk'
+import { SumsubSdkErrorView } from './SumsubSdkErrorView'
+import type { SumsubSdkProps } from './sumsubSdk.types'
 
 // todo: move to consts
 const SUMSUB_SDK_URL = 'https://static.sumsub.com/idensic/static/sns-websdk-builder.js'
@@ -25,18 +29,19 @@ const SUMSUB_SDK_URL = 'https://static.sumsub.com/idensic/static/sns-websdk-buil
  */
 const SDK_LAUNCH_TIMEOUT_MS = 20_000
 
-interface SumsubKycWrapperProps {
-    visible: boolean
-    accessToken: string | null
-    onClose: () => void
-    onComplete: () => void
-    onError?: (error: unknown) => void
-    onRefreshToken: () => Promise<string>
-    /** multi-level workflow (e.g. LATAM) — don't close SDK on Level 1 submission */
-    isMultiLevel?: boolean
+/**
+ * Every KYC entry point funnels through here, so this is the one place that
+ * knows which Sumsub SDK to drive. Native gets the Cordova SDK: the WebSDK does
+ * run inside the Capacitor WebView, but a Sumsub-side init failure there paints
+ * their "Initialization error" screen inside a cross-origin iframe, silent to
+ * every handler and every reporter we have.
+ */
+export const SumsubKycWrapper = (props: SumsubSdkProps) => {
+    if (isCapacitor()) return <SumsubNativeSdk {...props} />
+    return <SumsubWebSdkModal {...props} />
 }
 
-export const SumsubKycWrapper = ({
+const SumsubWebSdkModal = ({
     visible,
     accessToken,
     onClose,
@@ -44,7 +49,7 @@ export const SumsubKycWrapper = ({
     onError,
     onRefreshToken,
     isMultiLevel,
-}: SumsubKycWrapperProps) => {
+}: SumsubSdkProps) => {
     const [sdkLoaded, setSdkLoaded] = useState(false)
     const [sdkLoadError, setSdkLoadError] = useState(false)
     const [isHelpModalOpen, setIsHelpModalOpen] = useState(false)
@@ -374,13 +379,7 @@ export const SumsubKycWrapper = ({
                 hideOverlay={false}
             >
                 {sdkLoadError ? (
-                    <div className="flex h-full flex-col items-center justify-center gap-4 p-8">
-                        <Icon name="alert" size={24} className="text-red-500" />
-                        <p className="text-center text-lg font-medium">{t('wrapper.loadError')}</p>
-                        <Button variant="purple" shadowSize="4" onClick={onClose}>
-                            {tCommon('close')}
-                        </Button>
-                    </div>
+                    <SumsubSdkErrorView onClose={onClose} message={t('wrapper.loadError')} />
                 ) : (
                     <div className="flex h-full flex-col">
                         <div className="flex items-center justify-between px-4 py-2">

--- a/src/components/Kyc/SumsubNativeSdk.tsx
+++ b/src/components/Kyc/SumsubNativeSdk.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useTranslations } from 'next-intl'
+import * as Sentry from '@sentry/nextjs'
+import posthog from 'posthog-js'
+import Modal from '@/components/Global/Modal'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { SumsubSdkErrorView } from './SumsubSdkErrorView'
+import type { SumsubSdkProps } from './sumsubSdk.types'
+
+/**
+ * `SNSSDKState`s that mean the applicant reached Sumsub — the native analogue
+ * of the web SDK's onApplicantSubmitted/onApplicantActionSubmitted events,
+ * which the Cordova plugin does not forward. Everything before Pending
+ * (Ready/Initial/Incomplete) means the user backed out mid-flow.
+ */
+const SUBMITTED_STATES = new Set(['Pending', 'TemporarilyDeclined', 'FinallyRejected', 'Approved', 'ActionCompleted'])
+
+/**
+ * Drives the Sumsub Cordova SDK inside the Capacitor shell.
+ *
+ * The native SDK owns the whole screen, so this renders nothing while it is up
+ * — only the failure state gets UI. That failure state is the entire point of
+ * the component: run the WebSDK in the WebView instead and a Sumsub-side init
+ * failure paints *their* "Initialization error" screen inside the iframe, which
+ * throws nothing we can catch and reports nothing. Here every exit path is
+ * either a resolved launch or a captured exception.
+ */
+export const SumsubNativeSdk = ({
+    visible,
+    accessToken,
+    onClose,
+    onComplete,
+    onError,
+    onRefreshToken,
+}: SumsubSdkProps) => {
+    const t = useTranslations('kyc')
+    const [failure, setFailure] = useState<'sdk-missing' | 'launch' | null>(null)
+
+    const onCloseRef = useRef(onClose)
+    const onCompleteRef = useRef(onComplete)
+    const onErrorRef = useRef(onError)
+    const onRefreshTokenRef = useRef(onRefreshToken)
+    const accessTokenRef = useRef(accessToken)
+
+    useEffect(() => {
+        onCloseRef.current = onClose
+        onCompleteRef.current = onComplete
+        onErrorRef.current = onError
+        onRefreshTokenRef.current = onRefreshToken
+        accessTokenRef.current = accessToken
+    }, [onClose, onComplete, onError, onRefreshToken, accessToken])
+
+    // Gate on token PRESENCE, not identity: refreshToken() writes a new token
+    // into the same state, and re-running this effect on that would dismiss and
+    // relaunch the native screen out from under a user mid-verification.
+    const hasAccessToken = !!accessToken
+
+    useEffect(() => {
+        if (!visible || !hasAccessToken) return
+
+        const reportFailure = (reason: string, detail: unknown, kind: 'sdk-missing' | 'launch' = 'launch') => {
+            console.error('[sumsub] native sdk failure', reason, detail)
+            posthog.capture(ANALYTICS_EVENTS.KYC_SDK_INIT_FAILED, {
+                platform: 'native',
+                reason,
+                message: detail instanceof Error ? detail.message : String(detail),
+            })
+            Sentry.captureException(detail instanceof Error ? detail : new Error(`[sumsub] native ${reason}`), {
+                tags: { sumsub_sdk: 'native', sumsub_failure: reason },
+                extra: { detail },
+            })
+            setFailure(kind)
+            onErrorRef.current?.(detail)
+        }
+
+        const sumsub = window.SNSMobileSDK
+        if (!sumsub) {
+            reportFailure('sdk-unavailable', new Error('window.SNSMobileSDK is undefined'), 'sdk-missing')
+            return
+        }
+
+        let instance: SNSMobileSDKInstance | null = null
+        let cancelled = false
+        let hasSubmitted = false
+
+        try {
+            instance = sumsub
+                .init(accessTokenRef.current!, () => onRefreshTokenRef.current())
+                .withHandlers({
+                    onStatusChanged: (event) => {
+                        if (event?.newStatus && SUBMITTED_STATES.has(event.newStatus)) hasSubmitted = true
+                    },
+                })
+                .withLocale('en')
+                .withDebug(process.env.NODE_ENV === 'development')
+                .build()
+
+            posthog.capture(ANALYTICS_EVENTS.KYC_SDK_LAUNCHED, { platform: 'native' })
+
+            instance.launch().then(
+                (result) => {
+                    if (cancelled) return
+                    if (result?.success === false) {
+                        reportFailure(result.errorType || 'sdk-failed', new Error(result.errorMsg || result.status))
+                        return
+                    }
+                    // The promise resolves on close, whatever the user did — so
+                    // the status decides between "submitted, go show progress"
+                    // and "backed out, just close".
+                    if (hasSubmitted || SUBMITTED_STATES.has(result?.status ?? '')) {
+                        onCompleteRef.current()
+                    } else {
+                        onCloseRef.current()
+                    }
+                },
+                (error) => {
+                    if (cancelled) return
+                    reportFailure('launch-rejected', error)
+                }
+            )
+        } catch (error) {
+            reportFailure('init-threw', error)
+        }
+
+        return () => {
+            cancelled = true
+            // Releases the plugin's module-level single-instance lock. Skip it
+            // and the next launch rejects with "Aborted since another instance
+            // is in use!" for the rest of the app's lifetime.
+            try {
+                instance?.dismiss()
+            } catch {
+                // already gone
+            }
+        }
+    }, [visible, hasAccessToken])
+
+    useEffect(() => {
+        if (!visible) setFailure(null)
+    }, [visible])
+
+    if (!visible || !failure) return null
+
+    return (
+        <Modal
+            visible
+            onClose={onClose}
+            classWrap="h-full w-full !max-w-none sm:!max-w-[600px] border-none sm:m-auto m-0"
+            classOverlay="bg-black bg-opacity-50"
+            video={false}
+            className="z-[100] !p-0 md:!p-6"
+            classButtonClose="hidden"
+            preventClose={true}
+            hideOverlay={false}
+        >
+            <SumsubSdkErrorView
+                onClose={onClose}
+                message={failure === 'sdk-missing' ? t('errorSdkUnavailable') : t('wrapper.loadError')}
+            />
+        </Modal>
+    )
+}

--- a/src/components/Kyc/SumsubSdkErrorView.tsx
+++ b/src/components/Kyc/SumsubSdkErrorView.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useTranslations } from 'next-intl'
+import { Button } from '@/components/0_Bruddle/Button'
+import { Icon } from '@/components/Global/Icons/Icon'
+
+interface SumsubSdkErrorViewProps {
+    onClose: () => void
+    /** already-translated copy — next-intl message keys are typed, so callers resolve them */
+    message: string
+}
+
+export const SumsubSdkErrorView = ({ onClose, message }: SumsubSdkErrorViewProps) => {
+    const tCommon = useTranslations('common')
+
+    return (
+        <div className="flex h-full flex-col items-center justify-center gap-4 p-8">
+            <Icon name="alert" size={24} className="text-red-500" />
+            <p className="text-center text-lg font-medium">{message}</p>
+            <Button variant="purple" shadowSize="4" onClick={onClose}>
+                {tCommon('close')}
+            </Button>
+        </div>
+    )
+}

--- a/src/components/Kyc/__tests__/SumsubKycWrapper.test.tsx
+++ b/src/components/Kyc/__tests__/SumsubKycWrapper.test.tsx
@@ -37,6 +37,10 @@ jest.mock('@/components/Global/Modal', () => ({
     },
 }))
 
+let onCapacitor = false
+jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => onCapacitor }))
+jest.mock('../SumsubNativeSdk', () => ({ SumsubNativeSdk: () => <div data-testid="native-sdk" /> }))
+
 jest.mock('@/components/Global/ActionModal', () => ({ __esModule: true, default: () => null }))
 jest.mock('@/components/Global/Loading', () => ({ __esModule: true, default: () => <div>loading</div> }))
 jest.mock('@/context/ModalsContext', () => ({ useModalsContext: () => ({ setIsSupportModalOpen: jest.fn() }) }))
@@ -56,6 +60,7 @@ describe('SumsubKycWrapper', () => {
     beforeEach(() => {
         launch.mockClear()
         capture.mockClear()
+        onCapacitor = false
         installSdk()
     })
 
@@ -63,6 +68,26 @@ describe('SumsubKycWrapper', () => {
         // don't leak the global — a later test may need the script-loading path
         // (snsWebSdk absent -> script injected -> onload) to be reachable.
         delete (window as unknown as { snsWebSdk?: unknown }).snsWebSdk
+    })
+
+    // The wrapper is the single choke point every KYC entry point funnels
+    // through — card application, POA, self-heal, start-action, restart-identity
+    // included. Selecting the driver here is what keeps the WebSDK (and its
+    // unreportable in-iframe "Initialization error") out of the WebView.
+    it('drives the native SDK on Capacitor and never loads the websdk', async () => {
+        onCapacitor = true
+        render(
+            <SumsubKycWrapper
+                visible
+                accessToken="tok_abc"
+                onClose={jest.fn()}
+                onComplete={jest.fn()}
+                onRefreshToken={jest.fn().mockResolvedValue('tok_abc')}
+            />
+        )
+
+        expect(await screen.findByTestId('native-sdk')).toBeInTheDocument()
+        expect(launch).not.toHaveBeenCalled()
     })
 
     it('launches the SDK when an already-mounted wrapper is opened (portal mounts container late)', async () => {

--- a/src/components/Kyc/__tests__/SumsubNativeSdk.test.tsx
+++ b/src/components/Kyc/__tests__/SumsubNativeSdk.test.tsx
@@ -1,0 +1,198 @@
+import { act, render as rtlRender, screen, waitFor, type RenderOptions } from '@testing-library/react'
+import { type ReactElement, type ReactNode } from 'react'
+import { NextIntlClientProvider } from 'next-intl'
+import en from '@/i18n/app/messages/en.json'
+import { SumsubNativeSdk } from '../SumsubNativeSdk'
+
+const IntlWrapper = ({ children }: { children: ReactNode }) => (
+    <NextIntlClientProvider locale="en" messages={en}>
+        {children}
+    </NextIntlClientProvider>
+)
+const render = (ui: ReactElement, options?: RenderOptions) => rtlRender(ui, { wrapper: IntlWrapper, ...options })
+
+const capture = jest.fn()
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: (...a: unknown[]) => capture(...a) } }))
+
+const captureException = jest.fn()
+jest.mock('@sentry/nextjs', () => ({ captureException: (...a: unknown[]) => captureException(...a) }))
+
+jest.mock('@/components/Global/Modal', () => ({
+    __esModule: true,
+    default: function MockModal({ visible, children }: { visible: boolean; children: ReactNode }) {
+        if (!visible) return null
+        return <div data-testid="modal">{children}</div>
+    },
+}))
+
+const launch = jest.fn()
+const dismiss = jest.fn()
+let statusHandler: ((event: { newStatus?: string }) => void) | undefined
+
+function installSdk() {
+    const builder: Record<string, unknown> = {}
+    builder.withHandlers = (handlers: { onStatusChanged?: (e: { newStatus?: string }) => void }) => {
+        statusHandler = handlers.onStatusChanged
+        return builder
+    }
+    builder.withLocale = () => builder
+    builder.withDebug = () => builder
+    builder.build = () => ({ launch, dismiss })
+    ;(window as unknown as { SNSMobileSDK: unknown }).SNSMobileSDK = { init: () => builder }
+}
+
+const baseProps = () => ({
+    accessToken: 'tok_abc',
+    onClose: jest.fn(),
+    onComplete: jest.fn(),
+    onRefreshToken: jest.fn().mockResolvedValue('tok_abc'),
+})
+
+describe('SumsubNativeSdk', () => {
+    beforeEach(() => {
+        launch.mockReset()
+        dismiss.mockReset()
+        capture.mockClear()
+        captureException.mockClear()
+        statusHandler = undefined
+        launch.mockReturnValue(new Promise(() => {}))
+        installSdk()
+    })
+
+    afterEach(() => {
+        delete (window as unknown as { SNSMobileSDK?: unknown }).SNSMobileSDK
+    })
+
+    it('launches the native SDK when opened, and not before', async () => {
+        const props = baseProps()
+        const { rerender } = render(<SumsubNativeSdk visible={false} {...props} />)
+        expect(launch).not.toHaveBeenCalled()
+
+        await act(async () => {
+            rerender(<SumsubNativeSdk visible {...props} />)
+        })
+
+        expect(launch).toHaveBeenCalledTimes(1)
+        expect(capture).toHaveBeenCalledWith('kyc_sdk_launched', { platform: 'native' })
+    })
+
+    it('does not launch without an access token', async () => {
+        await act(async () => {
+            render(<SumsubNativeSdk visible {...baseProps()} accessToken={null} />)
+        })
+        expect(launch).not.toHaveBeenCalled()
+    })
+
+    // refreshToken() writes a new token into the same state while the native
+    // screen is up. Relaunching on that would dismiss the SDK out from under a
+    // user mid-verification, so the effect keys on token PRESENCE, not identity.
+    it('does not relaunch when the access token is refreshed mid-flow', async () => {
+        const props = baseProps()
+        const { rerender } = render(<SumsubNativeSdk visible={false} {...props} />)
+        await act(async () => {
+            rerender(<SumsubNativeSdk visible {...props} />)
+        })
+        expect(launch).toHaveBeenCalledTimes(1)
+
+        await act(async () => {
+            rerender(<SumsubNativeSdk visible {...props} accessToken="tok_refreshed" />)
+        })
+
+        expect(launch).toHaveBeenCalledTimes(1)
+        expect(dismiss).not.toHaveBeenCalled()
+    })
+
+    it('completes when the SDK closes in a submitted state', async () => {
+        launch.mockResolvedValue({ success: true, status: 'Pending' })
+        const props = baseProps()
+        const { rerender } = render(<SumsubNativeSdk visible={false} {...props} />)
+
+        await act(async () => {
+            rerender(<SumsubNativeSdk visible {...props} />)
+        })
+
+        await waitFor(() => expect(props.onComplete).toHaveBeenCalled())
+        expect(props.onClose).not.toHaveBeenCalled()
+    })
+
+    // The plugin reports the state at close, which for a user who backed out of
+    // an already-approved level reads Initial — but onStatusChanged saw the
+    // submission. Trusting the closing status alone would strand them.
+    it('completes when a status event reported a submission even if the closing status did not', async () => {
+        let resolveLaunch: (value: unknown) => void = () => {}
+        launch.mockReturnValue(new Promise((resolve) => (resolveLaunch = resolve)))
+        const props = baseProps()
+        const { rerender } = render(<SumsubNativeSdk visible={false} {...props} />)
+        await act(async () => {
+            rerender(<SumsubNativeSdk visible {...props} />)
+        })
+
+        await act(async () => {
+            statusHandler?.({ newStatus: 'Pending' })
+            resolveLaunch({ success: true, status: 'Initial' })
+        })
+
+        await waitFor(() => expect(props.onComplete).toHaveBeenCalled())
+    })
+
+    it('closes without completing when the user backs out', async () => {
+        launch.mockResolvedValue({ success: true, status: 'Initial' })
+        const props = baseProps()
+        const { rerender } = render(<SumsubNativeSdk visible={false} {...props} />)
+
+        await act(async () => {
+            rerender(<SumsubNativeSdk visible {...props} />)
+        })
+
+        await waitFor(() => expect(props.onClose).toHaveBeenCalled())
+        expect(props.onComplete).not.toHaveBeenCalled()
+    })
+
+    // The whole point of moving off the WebSDK: a Sumsub-side failure used to
+    // paint their "Initialization error" screen inside a cross-origin iframe and
+    // report nothing. It must now reach the user AND both reporters.
+    it('surfaces and reports a failed launch', async () => {
+        launch.mockResolvedValue({ success: false, status: 'Failed', errorType: 'Unknown', errorMsg: 'boom' })
+        const props = baseProps()
+        const { rerender } = render(<SumsubNativeSdk visible={false} {...props} />)
+
+        await act(async () => {
+            rerender(<SumsubNativeSdk visible {...props} />)
+        })
+
+        expect(await screen.findByText(/failed to load verification/i)).toBeInTheDocument()
+        expect(capture).toHaveBeenCalledWith('kyc_sdk_init_failed', expect.objectContaining({ platform: 'native' }))
+        expect(captureException).toHaveBeenCalled()
+    })
+
+    it('surfaces and reports a missing plugin instead of opening nothing', async () => {
+        delete (window as unknown as { SNSMobileSDK?: unknown }).SNSMobileSDK
+        const props = baseProps()
+
+        await act(async () => {
+            render(<SumsubNativeSdk visible {...props} />)
+        })
+
+        expect(screen.getByText(/not available/i)).toBeInTheDocument()
+        expect(capture).toHaveBeenCalledWith(
+            'kyc_sdk_init_failed',
+            expect.objectContaining({ reason: 'sdk-unavailable' })
+        )
+    })
+
+    // Without this the plugin's module-level lock is never released and every
+    // later launch rejects with "Aborted since another instance is in use!".
+    it('dismisses the native SDK when the flow closes', async () => {
+        const props = baseProps()
+        const { rerender } = render(<SumsubNativeSdk visible={false} {...props} />)
+        await act(async () => {
+            rerender(<SumsubNativeSdk visible {...props} />)
+        })
+
+        await act(async () => {
+            rerender(<SumsubNativeSdk visible={false} {...props} />)
+        })
+
+        expect(dismiss).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/components/Kyc/sumsubSdk.types.ts
+++ b/src/components/Kyc/sumsubSdk.types.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared contract for the two Sumsub SDK drivers. `SumsubKycWrapper` picks
+ * between them by platform, so the web modal and the native launcher must stay
+ * interchangeable from a call site's point of view.
+ */
+export interface SumsubSdkProps {
+    visible: boolean
+    accessToken: string | null
+    onClose: () => void
+    onComplete: () => void
+    onError?: (error: unknown) => void
+    onRefreshToken: () => Promise<string>
+    /** multi-level workflow (e.g. LATAM) — don't close SDK on Level 1 submission */
+    isMultiLevel?: boolean
+}

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -11,24 +11,12 @@ import {
 } from '@/app/actions/sumsub'
 import { type KYCRegionIntent, type SumsubKycStatus } from '@/app/actions/types/sumsub.types'
 import { isMantecaSupportedCountryCode } from '@/constants/manteca.consts'
-import { isCapacitor } from '@/utils/capacitor'
 import { isDemoMode } from '@/utils/demo'
 
 interface UseSumsubKycFlowOptions {
     onKycSuccess?: () => void
     onManualClose?: () => void
     regionIntent?: KYCRegionIntent
-}
-
-// minimal shape of the native Sumsub SDK the capacitor shell injects on window
-interface SumsubNativeSdkBuilder {
-    withHandlers(handlers: { onStatusChanged: (event: { newStatus?: string }) => void }): SumsubNativeSdkBuilder
-    withLocale(locale: string): SumsubNativeSdkBuilder
-    withDebug(debug: boolean): SumsubNativeSdkBuilder
-    build(): { launch(): Promise<{ status?: string } | undefined> }
-}
-interface SumsubNativeSdk {
-    init(token: string, tokenRefresh: () => Promise<string>): SumsubNativeSdkBuilder
 }
 
 // Time-escalating schedule for the verification-progress-modal status poll.
@@ -319,52 +307,9 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 }
 
                 if (response.data?.token) {
-                    // in capacitor, launch native sumsub sdk instead of web wrapper
-                    if (isCapacitor()) {
-                        try {
-                            const SNSMobileSDK = (window as Window & { SNSMobileSDK?: SumsubNativeSdk }).SNSMobileSDK
-                            if (!SNSMobileSDK) {
-                                userInitiatedRef.current = false
-                                setError(t('errorSdkUnavailable'))
-                                return
-                            }
-                            const effectiveRegionIntent = overrideIntent ?? regionIntent
-                            const sdk = SNSMobileSDK.init(response.data.token, async () => {
-                                // keep parity with the web refreshToken below — dropping
-                                // targetCountry here would mint a token for a different
-                                // (suffix-less) applicant action than the one the user is in.
-                                const r = await initiateSumsubKyc({
-                                    regionIntent: effectiveRegionIntent,
-                                    levelName: levelNameRef.current,
-                                    targetCountry: targetCountryRef.current,
-                                })
-                                return r.data?.token || ''
-                            })
-                                .withHandlers({
-                                    onStatusChanged: (event) => {
-                                        console.log('[useSumsubKycFlow] native onStatusChanged:', JSON.stringify(event))
-                                        if (event?.newStatus === 'Approved') {
-                                            onKycSuccess?.()
-                                        }
-                                    },
-                                })
-                                .withLocale('en')
-                                .withDebug(process.env.NODE_ENV === 'development')
-                                .build()
-
-                            const result = await sdk.launch()
-                            console.log('[useSumsubKycFlow] native SDK result:', JSON.stringify(result))
-                            if (result?.status === 'Approved') {
-                                onKycSuccess?.()
-                            }
-                        } catch (nativeErr) {
-                            console.error('[useSumsubKycFlow] native SDK error:', nativeErr)
-                            userInitiatedRef.current = false
-                            setError(t('errorVerificationFailed'))
-                        }
-                        return
-                    }
-
+                    // Native included: SumsubKycWrapper picks the Cordova SDK over
+                    // the WebSDK by platform, so every flow that mints a token —
+                    // not just this one — reaches the right SDK.
                     setAccessToken(response.data.token)
                     setIsActionFlow(!!response.data.actionType)
                     setShowWrapper(true)

--- a/src/types/sumsub-cordova.d.ts
+++ b/src/types/sumsub-cordova.d.ts
@@ -1,22 +1,55 @@
-declare module '@sumsub/cordova-idensic-mobile-sdk-plugin' {
+// Type declarations for the Sumsub Cordova plugin. The plugin ships no types
+// and clobbers `window.SNSMobileSDK` (see its plugin.xml js-module), so it is
+// only reachable inside the Capacitor shell — `window.SNSMobileSDK` is
+// undefined on web.
+
+declare global {
+    /**
+     * `SNSSDKState` class name reported by the plugin, on both the launch result
+     * and every `onStatusChanged` event. One of: Ready, Initial, Incomplete,
+     * Pending, TemporarilyDeclined, FinallyRejected, Approved, ActionCompleted,
+     * Failed. Typed as a string because the native side sends it verbatim.
+     */
+    interface SNSMobileSDKResult {
+        success: boolean
+        status: string
+        errorType?: string | null
+        errorMsg?: string | null
+    }
+
+    /**
+     * Only these two keys are forwarded to native — the plugin's builder
+     * silently drops any other handler name, so there is no native equivalent
+     * of the web SDK's onApplicantSubmitted/onApplicantActionSubmitted events.
+     */
+    interface SNSMobileSDKHandlers {
+        onStatusChanged?: (event: { newStatus?: string; prevStatus?: string }) => void
+        onEvent?: (event: { eventType?: string; payload?: Record<string, unknown> }) => void
+    }
+
     interface SNSMobileSDKBuilder {
-        withHandlers(handlers: Record<string, (event: unknown) => void>): SNSMobileSDKBuilder
+        withHandlers(handlers: SNSMobileSDKHandlers): SNSMobileSDKBuilder
         withLocale(locale: string): SNSMobileSDKBuilder
         withDebug(debug: boolean): SNSMobileSDKBuilder
         withAnalyticsEnabled(enabled: boolean): SNSMobileSDKBuilder
+        withAutoCloseOnApprove(seconds: number): SNSMobileSDKBuilder
+        withBaseUrl(url: string): SNSMobileSDKBuilder
         withSettings(settings: Record<string, unknown>): SNSMobileSDKBuilder
         withTheme(theme: Record<string, unknown>): SNSMobileSDKBuilder
-        withBaseUrl(url: string): SNSMobileSDKBuilder
-        withAutoCloseOnApprove(seconds: number): SNSMobileSDKBuilder
         build(): SNSMobileSDKInstance
     }
 
     interface SNSMobileSDKInstance {
-        launch(): Promise<{ status: string; [key: string]: unknown }>
+        /** Resolves only once the native screen closes. */
+        launch(): Promise<SNSMobileSDKResult>
         dismiss(): void
     }
 
-    export const SNSMobileSDK: {
-        init(accessToken: string, tokenExpirationHandler: () => Promise<string>): SNSMobileSDKBuilder
+    interface Window {
+        SNSMobileSDK?: {
+            init(accessToken: string, tokenExpirationHandler: () => Promise<string>): SNSMobileSDKBuilder
+        }
     }
 }
+
+export {}


### PR DESCRIPTION
## Problem

Only `handleInitiateKyc` branched to the native Sumsub SDK. `SumsubKycFlow` was the single call site that hid the KYC modals on Capacitor — the other ~12 (card application, POA re-upload, self-heal resubmit, start-action, restart-identity, the Manteca and Claim flows) rendered `SumsubKycWrapper` unconditionally, so on native those ran the **browser WebSDK inside the WebView**.

When Sumsub's own init fails there, it paints their "Initialization error" screen inside a cross-origin iframe: no exception, no `onError`, nothing in Sentry or PostHog. Native KYC could fail completely silently, and did — there are no native-origin Sumsub errors in Sentry at all, which is the symptom, not the reassurance.

## Approach

Move the platform decision into `SumsubKycWrapper` — the choke point every entry point already funnels through — so all of them are fixed at once and there is **one** native path instead of two.

## Changes

| File | |
|---|---|
| `SumsubNativeSdk.tsx` | new — drives the Cordova plugin, reports every exit path |
| `SumsubSdkErrorView.tsx` | new — failure UI shared by both drivers |
| `sumsubSdk.types.ts` | new — shared props contract |
| `SumsubKycWrapper.tsx` | platform switch; web impl renamed `SumsubWebSdkModal`, otherwise untouched |
| `useSumsubKycFlow.ts` | −49 lines: the ad-hoc native branch is gone |
| `SumsubKycFlow.tsx` | dropped the `!isCapacitor()` guard |
| `types/sumsub-cordova.d.ts` | real plugin API, typed off its `dist` bundle + Java source |

Three bugs fixed beyond the routing:

- **Submissions were dropped.** The old handler only fired on `newStatus === 'Approved'`. The plugin forwards no `onApplicantSubmitted` equivalent, so a native user who submitted documents for async review (`Pending`) got neither the in-progress modal nor `onKycSuccess`. Submission is now inferred from the `SNSSDKState` set.
- **A token refresh would have killed the native screen.** `refreshToken()` writes a new token into the same state; the launch effect keys on token *presence*, not identity, so it can't relaunch mid-verification. Covered by a regression test.
- **`dismiss()` on close.** The plugin holds a module-level single-instance lock — without releasing it, every later launch rejects with `"Aborted since another instance is in use!"` for the rest of the app's lifetime.

Every native failure path — missing plugin, throwing init, rejected launch, `success: false` result — now reaches Sentry + `kyc_sdk_init_failed` and surfaces an actionable screen instead of a dead end.

## Testing

- `tsc --noEmit` clean; `eslint` and `prettier` clean on all touched files.
- Full unit suite: **175 suites / 2313 tests passing**, including 9 new tests for the native driver and one asserting the wrapper picks it under Capacitor and never loads the WebSDK.
- **Web behaviour is unchanged** — the existing `SumsubKycWrapper` suite passes untouched.

## Release note

This cannot ship as an OTA — the fix is about which SDK gets driven, so it needs a new binary. Please QA the card application and a LATAM multi-level flow on both platforms before release.
