### PR TITLE
fix(withdraw): stop success receipt showing 'Sent to undefined'

### DIFF
--- a/src/features/payments/shared/components/PaymentSuccessView.tsx
+++ b/src/features/payments/shared/components/PaymentSuccessView.tsx
@@ -170,7 +170,13 @@ const PaymentSuccessView = ({
                 kind: 'DIRECT_TRANSFER',
                 link: receiptLink,
             },
-            userName: user?.username || parsedPaymentData?.recipient?.identifier,
+            // external-wallet withdrawals have no username/identifier — fall back to
+            // the recipient address so the receipt never renders "Sent to undefined"
+            userName:
+                user?.username ||
+                parsedPaymentData?.recipient?.identifier ||
+                chargeDetails.requestLink?.recipientAddress ||
+                recipientName,
             sourceView: 'status',
             memo: chargeDetails.requestLink?.reference || undefined,
             attachmentUrl: chargeDetails.requestLink?.attachmentUrl || undefined,


### PR DESCRIPTION
## Summary

Reported by Kush while verifying the ENS hotfix: withdrawing to an external crypto wallet shows **"Sent to undefined"** in the success receipt drawer.

Root cause (pre-existing since May 2025, exposed by the crypto-withdraw path): `PaymentSuccessView` builds the drawer's `userName` as `user?.username || parsedPaymentData?.recipient?.identifier` — both undefined for an external-wallet withdrawal — while `recipientName` a few lines up already has a proper address fallback. `getTitle` then renders `Sent to ${undefined}`.

Fix: fall back to `chargeDetails.requestLink?.recipientAddress` (shortened by `printableUserHandle` at render), then `recipientName`.

## Risks / breaking changes
- Minimal: only changes the previously-undefined case; username/identifier paths unchanged.
- Hotfix to `main` → back-merge debt (main→dev).

## QA
- typecheck ✅ · feature tests ✅ · prettier ✅
- Repro: crypto withdraw to external wallet → success receipt now shows "Sent to 0x554a…54ab" instead of "Sent to undefined".

Screenshots: N/A capture (state requires a live withdraw); before-image in the report thread.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction receipt details for external-wallet withdrawals.
  * Receipts now display the recipient’s available name or address instead of showing “Sent to undefined.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->