### PR TITLE
fix(ens): warm-cache resolved names to stop the address→name flash on mount

### DIFF
--- a/src/components/Global/AddressLink/index.tsx
+++ b/src/components/Global/AddressLink/index.tsx
@@ -29,6 +29,9 @@ const AddressLink = ({ address, className = '', isLink = true }: AddressLinkProp
             setUrlAddress(normalizedEnsName)
         } else {
             setDisplayAddress(isCryptoAddress(address) ? printableAddress(address) : address)
+            // keep the link target in sync — a cached/evicted ens name must not
+            // leave the href pointing at a name this address may no longer own
+            setUrlAddress(address)
         }
     }, [address, ensName])
 

--- a/src/hooks/__tests__/usePrimaryNameServer.test.tsx
+++ b/src/hooks/__tests__/usePrimaryNameServer.test.tsx
@@ -22,6 +22,7 @@ const jsonResponse = (body: unknown, ok = true) => ({ ok, json: async () => body
 
 beforeEach(() => {
     jest.clearAllMocks()
+    window.localStorage.clear()
     mockUsePrimaryName.mockReturnValue({ primaryName: undefined, isLoading: false, error: null })
 })
 
@@ -61,6 +62,31 @@ describe('usePrimaryNameServer', () => {
             expect(mockUsePrimaryName).toHaveBeenLastCalledWith(expect.objectContaining({ address: ADDRESS }))
         )
         expect(result.current.primaryName).toBeUndefined()
+    })
+
+    it('paints the cached name immediately on mount while the lookup is pending', async () => {
+        // seed the warm cache via a first mount that resolves
+        mockServerFetch.mockResolvedValue(jsonResponse({ name: 'alice.eth' }))
+        const first = renderHook(() => usePrimaryNameServer(ADDRESS), { wrapper })
+        await waitFor(() => expect(first.result.current.primaryName).toBe('alice.eth'))
+        first.unmount()
+
+        // fresh mount with a never-resolving lookup — cached name shows at once
+        mockServerFetch.mockImplementation(() => new Promise(() => {}))
+        const { result } = renderHook(() => usePrimaryNameServer(ADDRESS), { wrapper })
+        expect(result.current.primaryName).toBe('alice.eth')
+    })
+
+    it('does not show a stale cached name once the server settles with no name', async () => {
+        window.localStorage.setItem(
+            'ens-primary-name-cache',
+            JSON.stringify({ [ADDRESS.toLowerCase()]: { name: 'stale.eth', ts: Date.now() } })
+        )
+        mockServerFetch.mockResolvedValue(jsonResponse({ name: null }))
+        const { result } = renderHook(() => usePrimaryNameServer(ADDRESS), { wrapper })
+        await waitFor(() => expect(result.current.primaryName).toBeUndefined())
+        // authoritative "no name" also evicts the cache entry
+        await waitFor(() => expect(window.localStorage.getItem('ens-primary-name-cache')).not.toContain('stale.eth'))
     })
 
     it('does not query for a non-address input', () => {

--- a/src/hooks/__tests__/usePrimaryNameServer.test.tsx
+++ b/src/hooks/__tests__/usePrimaryNameServer.test.tsx
@@ -89,6 +89,19 @@ describe('usePrimaryNameServer', () => {
         await waitFor(() => expect(window.localStorage.getItem('ens-primary-name-cache')).not.toContain('stale.eth'))
     })
 
+    it('evicts the cached name when the client fallback settles with no name', async () => {
+        window.localStorage.setItem(
+            'ens-primary-name-cache',
+            JSON.stringify({ [ADDRESS.toLowerCase()]: { name: 'stale.eth', ts: Date.now() } })
+        )
+        mockServerFetch.mockResolvedValue(jsonResponse({}, false))
+        // justaname settles "not found" as '' (undefined would mean still loading)
+        mockUsePrimaryName.mockReturnValue({ primaryName: '', isLoading: false, error: null })
+        const { result } = renderHook(() => usePrimaryNameServer(ADDRESS), { wrapper })
+        await waitFor(() => expect(window.localStorage.getItem('ens-primary-name-cache')).not.toContain('stale.eth'))
+        expect(result.current.primaryName).toBeUndefined()
+    })
+
     it('does not query for a non-address input', () => {
         renderHook(() => usePrimaryNameServer('not-an-address'), { wrapper })
         expect(mockServerFetch).not.toHaveBeenCalled()

--- a/src/hooks/usePrimaryNameServer.ts
+++ b/src/hooks/usePrimaryNameServer.ts
@@ -36,7 +36,9 @@ type NameCache = Record<string, { name: string; ts: number }>
 function readNameCache(): NameCache {
     if (typeof window === 'undefined') return {}
     try {
-        return JSON.parse(window.localStorage.getItem(CACHE_KEY) ?? '{}') as NameCache
+        // guard the root shape — JSON.parse("null") etc. passes but would blow up on lookup
+        const cache: unknown = JSON.parse(window.localStorage.getItem(CACHE_KEY) ?? '{}')
+        return cache && typeof cache === 'object' && !Array.isArray(cache) ? (cache as NameCache) : {}
     } catch {
         return {}
     }

--- a/src/hooks/usePrimaryNameServer.ts
+++ b/src/hooks/usePrimaryNameServer.ts
@@ -2,6 +2,7 @@
 
 import { usePrimaryName } from '@justaname.id/react'
 import { useQuery } from '@tanstack/react-query'
+import { useEffect, useMemo } from 'react'
 import { isAddress } from 'viem'
 import { serverFetch } from '@/utils/api-fetch'
 
@@ -25,6 +26,44 @@ const PRIMARY_NAME_TTL_MS = 24 * 60 * 60 * 1000 // 1 day
  * `{ primaryName }` shape. If both paths fail, callers degrade to the raw
  * address exactly as before.
  */
+const CACHE_KEY = 'ens-primary-name-cache'
+
+type NameCache = Record<string, { name: string; ts: number }>
+
+// localstorage warm cache so a fresh page load (mobile reopening the pwa)
+// paints the last-known name immediately instead of flashing the raw
+// address while the async lookup runs. lookups still revalidate on mount.
+function readNameCache(): NameCache {
+    if (typeof window === 'undefined') return {}
+    try {
+        return JSON.parse(window.localStorage.getItem(CACHE_KEY) ?? '{}') as NameCache
+    } catch {
+        return {}
+    }
+}
+
+function getCachedName(address?: string): string | undefined {
+    if (!address) return undefined
+    const entry = readNameCache()[address.toLowerCase()]
+    return entry && Date.now() - entry.ts < PRIMARY_NAME_TTL_MS ? entry.name : undefined
+}
+
+function writeCachedName(address: string, name: string | undefined) {
+    if (typeof window === 'undefined') return
+    try {
+        const cache = readNameCache()
+        const key = address.toLowerCase()
+        if (name) {
+            cache[key] = { name, ts: Date.now() }
+        } else {
+            delete cache[key]
+        }
+        window.localStorage.setItem(CACHE_KEY, JSON.stringify(cache))
+    } catch {
+        // storage full/blocked — warm cache is best-effort
+    }
+}
+
 export function usePrimaryNameServer(address?: string): { primaryName: string | undefined } {
     const enabled = !!address && isAddress(address)
 
@@ -52,5 +91,24 @@ export function usePrimaryNameServer(address?: string): { primaryName: string | 
         priority: 'onChain',
     })
 
-    return { primaryName: data ?? (isError ? clientName : undefined) }
+    // resolved: authoritative answer from either path. `data === null` means the
+    // server positively said "no name" — don't mask it with a stale cached name.
+    const settledNoName = data === null
+    const resolved = data ?? (isError ? normalizeToUndefined(clientName) : undefined)
+
+    useEffect(() => {
+        if (!enabled || !address) return
+        if (resolved) writeCachedName(address, resolved)
+        else if (settledNoName) writeCachedName(address, undefined)
+    }, [enabled, address, resolved, settledNoName])
+
+    // read once per address, not on every render — history feeds mount many rows
+    const cachedName = useMemo(() => (enabled ? getCachedName(address) : undefined), [enabled, address])
+
+    return { primaryName: resolved ?? (settledNoName ? undefined : cachedName) }
+}
+
+// justaname resolves "not found" as '' — treat it as undefined
+function normalizeToUndefined(name: string | undefined): string | undefined {
+    return name || undefined
 }

--- a/src/hooks/usePrimaryNameServer.ts
+++ b/src/hooks/usePrimaryNameServer.ts
@@ -93,10 +93,12 @@ export function usePrimaryNameServer(address?: string): { primaryName: string | 
         priority: 'onChain',
     })
 
-    // resolved: authoritative answer from either path. `data === null` means the
-    // server positively said "no name" — don't mask it with a stale cached name.
-    const settledNoName = data === null
-    const resolved = data ?? (isError ? normalizeToUndefined(clientName) : undefined)
+    // authoritative "no name" from either path: server settles null/'' or, when
+    // the server call failed, the client lookup settles '' (justaname's not-found
+    // value — undefined means still loading). don't mask any of these with a
+    // stale cached name, and evict below so it can't repaint next mount.
+    const settledNoName = data === null || data === '' || (isError && clientName === '')
+    const resolved = (data || undefined) ?? (isError ? clientName || undefined : undefined)
 
     useEffect(() => {
         if (!enabled || !address) return
@@ -108,9 +110,4 @@ export function usePrimaryNameServer(address?: string): { primaryName: string | 
     const cachedName = useMemo(() => (enabled ? getCachedName(address) : undefined), [enabled, address])
 
     return { primaryName: resolved ?? (settledNoName ? undefined : cachedName) }
-}
-
-// justaname resolves "not found" as '' — treat it as undefined
-function normalizeToUndefined(name: string | undefined): string | undefined {
-    return name || undefined
 }


### PR DESCRIPTION
## Summary

Follow-up to #2565 (reported by Kush): backgrounding the app and returning reloads the page on mobile, so history briefly shows raw addresses before ENS names pop in. The in-memory react-query cache dies with the page, and every cold mount pays the `/ens/reverse` 404 round-trip before the client fallback resolves.

Fix: persist resolved names in `localStorage` (`ens-primary-name-cache`, 24h TTL). On mount the cached name paints immediately while the fresh lookup revalidates in the background.

**Staleness safety** (from the multi-agent review pass):
- Authoritative "no name" from **either** path masks and evicts the cache entry: server `null`/`''`, or — critical while the backend route is undeployed — the client lookup settling `''` (JustaName's not-found). A released/transferred ENS name cannot keep painting from cache once a lookup settles.
- `AddressLink` now resets its href on the name→address downgrade (pre-existing one-way effect, previously unreachable; the warm cache made it a live path). Prevents navigating to a name's new owner from a row showing the raw address.
- Malformed cache roots (`"null"`, arrays) are treated as empty (CodeRabbit).

## Design notes / accepted trade-offs
- During the pending window a cached name is shown (and linkable) before revalidation settles — that's the point of the warm cache; worst case is bounded by the 24h TTL and by eviction-on-settle.
- No cross-tab `storage` listener: another tab's eviction isn't observed until next mount. Accepted — display-only label, listener plumbing isn't earning its complexity.
- Cache blob is unbounded (grows with distinct counterparties, entries expire logically at 24h). Practically dozens of entries; add pruning if it ever matters.
- Best-effort writes: quota/blocked storage errors are swallowed.

## Risks / breaking changes
- Low: display-only warm cache; lookups still revalidate every mount.
- Hotfix chain on `main` → back-merge debt (main→dev) now covers #2565 + #2572 + this.

## QA
- `npm run typecheck` ✅ · `npm test` ✅ (2235 passed; hook suite 9 tests: warm-paint, server-null eviction, client-'' eviction, both-fail, fallbacks) · prettier ✅
- Manual: open history → background the app → return: name shows instantly (after one prior successful resolution).

Screenshots: N/A (timing behavior, not layout)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added faster display of previously resolved address names while lookups are in progress.
  * Cached address names now expire after one day and update automatically when fresh results arrive.

* **Bug Fixes**
  * Removed outdated cached names when an address has no confirmed name.
  * Ensured address links fall back to the correct raw address when name resolution fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->