### PR TITLE
chore(dev): /dev/migration UI showcase for app-migration surfaces

### DIFF
--- a/src/app/(mobile-ui)/dev/migration/page.tsx
+++ b/src/app/(mobile-ui)/dev/migration/page.tsx
@@ -28,49 +28,42 @@ import starImage from '@/assets/icons/star.png'
 type Platform = 'ios' | 'android' | 'desktop'
 const STORE = { ios: 'App Store', android: 'Google Play' } as const
 
-// device-aware download CTAs. mobile -> the user's store is primary (purple), the
-// other is secondary. desktop -> store links are useless on a laptop, so we show a
-// "Show QR" button that opens a scan-to-download modal (mirrors InstallPWA's
-// DesktopInstructions). brand logos (Apple / Play) aren't in the icon set yet — TODO.
-function storeCtas(platform: Platform, onQr: () => void) {
-    if (platform === 'desktop')
-        return [
-            {
-                text: 'Show QR to download',
-                variant: 'purple' as const,
-                shadowSize: '4' as const,
-                icon: 'qr-code' as const,
-                onClick: onQr,
-            },
-        ]
-    const other: Platform = platform === 'ios' ? 'android' : 'ios'
-    return [
-        {
-            text: STORE[platform],
-            variant: 'purple' as const,
-            shadowSize: '4' as const,
-            icon: 'mobile-install' as const,
-        },
-        { text: STORE[other], variant: 'stroke' as const, shadowSize: '4' as const },
-    ]
-}
-function StoreButtons({ platform, onQr }: { platform: Platform; onQr: () => void }) {
-    if (platform === 'desktop')
-        return (
-            <Button variant="purple" shadowSize="4" icon="qr-code" className="w-full" onClick={onQr}>
-                Show QR to download
-            </Button>
-        )
-    const other: Platform = platform === 'ios' ? 'android' : 'ios'
+const STORE_URL = {
+    ios: 'https://apps.apple.com/app/peanut',
+    android: 'https://play.google.com/store/apps/details?id=me.peanut.wallet',
+} as const
+
+// scan-to-download with a store toggle. on the web we can't know the visitor's phone OS,
+// so we show both store QRs behind a toggle instead of guessing which to display.
+// (A single smart link — peanut.me/app redirecting by device — would remove the toggle.)
+function DownloadQR() {
+    const [store, setStore] = useState<'ios' | 'android'>('ios')
     return (
-        <div className="flex w-full flex-col gap-2">
-            <Button variant="purple" shadowSize="4" icon="mobile-install" className="w-full">
-                {STORE[platform]}
-            </Button>
-            <Button variant="stroke" shadowSize="4" className="w-full">
-                {STORE[other]}
-            </Button>
+        <div className="flex flex-col items-center gap-3 py-2">
+            <div className="flex overflow-hidden rounded-sm border border-n-1">
+                {(['ios', 'android'] as const).map((s) => (
+                    <button
+                        key={s}
+                        onClick={() => setStore(s)}
+                        className={`px-4 py-1.5 text-sm font-semibold ${store === s ? 'bg-primary-1 text-n-1' : 'bg-white text-grey-1'}`}
+                    >
+                        {STORE[s]}
+                    </button>
+                ))}
+            </div>
+            <QRCodeWrapper url={STORE_URL[store]} />
+            <span className="text-xs text-grey-1">Scan with your phone camera</span>
         </div>
+    )
+}
+
+// one primary CTA per device: the visitor's store on mobile, the scan-to-download QR on desktop.
+function StoreButtons({ platform }: { platform: Platform }) {
+    if (platform === 'desktop') return <DownloadQR />
+    return (
+        <Button variant="purple" shadowSize="4" icon="mobile-install" className="w-full">
+            {STORE[platform]}
+        </Button>
     )
 }
 
@@ -138,7 +131,7 @@ function Section({
 const INDEX = [
     [
         '01 Download prompt',
-        'A modal asking logged-in web users to get the app. Countdown variant warns the site is closing.',
+        'A modal telling logged-in web users Peanut is becoming app-only, with the deadline in the copy. QR shown inline on desktop.',
         'Web app, after login, during the migration window.',
     ],
     [
@@ -173,7 +166,7 @@ const INDEX = [
     ],
     [
         '08 Scan-to-download (QR)',
-        'On desktop, store links do nothing — this modal shows a QR to scan with your phone. Replaces the store buttons wherever a download CTA appears on web.',
+        "On desktop we can't tell iOS from Android, so the QR carries a store toggle — one QR at a time. Shown inline (01) or as a modal (03, 05) wherever a download CTA appears on web.",
         'Every download CTA when the visitor is on a desktop browser.',
     ],
 ]
@@ -181,7 +174,6 @@ const INDEX = [
 export default function MigrationMockupsPage() {
     const [platform, setPlatform] = useState<Platform>('ios')
     const [downloadModal, setDownloadModal] = useState(false)
-    const [countdown, setCountdown] = useState(false)
     const [reviewModal, setReviewModal] = useState(false)
     const [pushModal, setPushModal] = useState(false)
     const [qrModal, setQrModal] = useState(false)
@@ -242,59 +234,43 @@ export default function MigrationMockupsPage() {
             <Section
                 n="01"
                 title="Download prompt (logged-in web users)"
-                subtitle="Shown after login on the website. Dismissible. The countdown variant makes the deadline loud."
+                subtitle="Shown after login on the website. One variant, deadline baked into the copy. On mobile: your store's button. On desktop: the QR is shown inline (no extra click)."
             >
-                <div className="flex flex-wrap gap-3">
-                    <Button
-                        variant="stroke"
-                        onClick={() => {
-                            setCountdown(false)
-                            setDownloadModal(true)
-                        }}
-                    >
-                        Open (reminder)
-                    </Button>
-                    <Button
-                        variant="stroke"
-                        onClick={() => {
-                            setCountdown(true)
-                            setDownloadModal(true)
-                        }}
-                    >
-                        Open (with countdown)
-                    </Button>
-                </div>
+                <Button variant="stroke" onClick={() => setDownloadModal(true)}>
+                    Open download prompt
+                </Button>
                 <ActionModal
                     visible={downloadModal}
                     onClose={() => setDownloadModal(false)}
                     icon="mobile-install"
-                    title="Peanut is moving to your phone"
+                    title="Peanut is becoming an app"
                     description={
-                        <div className="spacey-y-4">
-                            <p>
-                                Get the Peanut app to keep using your account — it's faster and you'll get alerts when
-                                money lands.
-                            </p>
-                            {countdown && (
-                                <div className="flex flex-col items-center gap-1">
-                                    <span className="text-3xl font-extrabold leading-none text-n-1">14 days</span>
-                                    <span className="text-xs font-semibold uppercase tracking-wide text-n-1">
-                                        until the website closes
-                                    </span>
-                                </div>
-                            )}
-                        </div>
+                        <p className="py-1">
+                            Peanut is moving to the App Store and Google Play. In{' '}
+                            <b className="text-black">14 days</b> it will only work in the app — download it now to keep
+                            using your account.
+                        </p>
                     }
-                    ctas={storeCtas(platform, openQr)}
+                    content={platform === 'desktop' ? <DownloadQR /> : undefined}
+                    ctas={
+                        platform === 'desktop'
+                            ? []
+                            : [
+                                  {
+                                      text: STORE[platform],
+                                      variant: 'purple' as const,
+                                      shadowSize: '4' as const,
+                                      icon: 'mobile-install' as const,
+                                  },
+                              ]
+                    }
                     footer={
-                        !countdown && (
-                            <button
-                                className="mt-3 w-full text-center text-xs text-grey-1 underline"
-                                onClick={() => setDownloadModal(false)}
-                            >
-                                Remind me later
-                            </button>
-                        )
+                        <button
+                            className="mt-3 w-full text-center text-xs text-grey-1 underline"
+                            onClick={() => setDownloadModal(false)}
+                        >
+                            Remind me later
+                        </button>
                     }
                 />
             </Section>
@@ -310,7 +286,7 @@ export default function MigrationMockupsPage() {
                     sub="The website has closed. Download the app to get back into your account — your money is safe."
                     footer={
                         <>
-                            <StoreButtons platform={platform} onQr={openQr} />
+                            <StoreButtons platform={platform} />
                             <a className="text-center text-sm text-black underline" href="#">
                                 Can&apos;t download the app? Contact support
                             </a>
@@ -360,21 +336,25 @@ export default function MigrationMockupsPage() {
             <Section
                 n="05"
                 title="Landing page hero (new visitors)"
-                subtitle="The real landing hero (same component as peanut.me). Only change from live: the single CTA is device-based — App Store on iOS, Google Play on Android, 'Download the app' on desktop."
+                subtitle="The real landing hero (same component as peanut.me). CTA says 'Download now' for everyone; on mobile it deep-links to the visitor's store, on desktop it opens the scan-to-download QR."
             >
-                <div className="overflow-hidden rounded-sm border border-n-1">
+                <div
+                    className="overflow-hidden rounded-sm border border-n-1"
+                    onClickCapture={
+                        platform === 'desktop'
+                            ? (e) => {
+                                  e.preventDefault()
+                                  setQrModal(true)
+                              }
+                            : undefined
+                    }
+                >
                     <Hero
                         buttonVisible
-                        primaryCta={
-                            platform === 'ios'
-                                ? { label: 'Download on the App Store', href: 'https://apps.apple.com/app/peanut' }
-                                : platform === 'android'
-                                  ? {
-                                        label: 'Get it on Google Play',
-                                        href: 'https://play.google.com/store/apps/details?id=me.peanut.wallet',
-                                    }
-                                  : { label: 'Download the app', href: '#' }
-                        }
+                        primaryCta={{
+                            label: 'Download now',
+                            href: platform === 'ios' ? STORE_URL.ios : platform === 'android' ? STORE_URL.android : '#',
+                        }}
                     />
                 </div>
             </Section>
@@ -438,14 +418,10 @@ export default function MigrationMockupsPage() {
             <ActionModal
                 visible={qrModal}
                 onClose={() => setQrModal(false)}
-                icon="mobile-install"
+                icon="qr-code"
                 title="Scan to download Peanut"
-                description="Point your phone's camera at the code to get the app from your store."
-                content={
-                    <div className="mx-auto py-2">
-                        <QRCodeWrapper url="https://peanut.me/app" />
-                    </div>
-                }
+                description="Pick your phone's store, then scan the code with your camera."
+                content={<DownloadQR />}
                 ctas={[{ text: 'Done', variant: 'purple', shadowSize: '4', onClick: () => setQrModal(false) }]}
             />
         </div>

--- a/src/app/(mobile-ui)/dev/migration/page.tsx
+++ b/src/app/(mobile-ui)/dev/migration/page.tsx
@@ -67,12 +67,14 @@ function StoreButtons({ platform }: { platform: Platform }) {
     )
 }
 
-// mascot-holding-phone hero over white content. used for the access-ending screen + landing.
-const STARS = ['left-[8%] top-[16%] size-8', 'right-[12%] top-[12%] size-9', 'right-[16%] bottom-[18%] size-7'] as const
+// mascot hero over white content. used for the access-ending screen.
+// height is content-driven (no fixed h) so the desktop QR never overflows, and the
+// mascot is size-capped with margin inside the hero so its feet never clip.
+const STARS = ['left-[8%] top-[18%] size-8', 'right-[12%] top-[14%] size-9', 'right-[14%] bottom-[16%] size-7'] as const
 function InstallScreen({ heading, sub, footer }: { heading: string; sub: string; footer?: React.ReactNode }) {
     return (
-        <div className="relative mx-auto flex h-[660px] w-full max-w-[380px] flex-col overflow-hidden rounded-sm border border-n-1 bg-white">
-            <section className="relative flex h-2/5 w-full items-center justify-center overflow-hidden bg-secondary-3">
+        <div className="mx-auto flex w-full max-w-[380px] flex-col overflow-hidden rounded-sm border border-n-1 bg-white">
+            <section className="relative flex h-64 w-full items-center justify-center overflow-hidden bg-secondary-3 px-6">
                 {STARS.map((pos, i) => (
                     <Image
                         key={i}
@@ -83,12 +85,18 @@ function InstallScreen({ heading, sub, footer }: { heading: string; sub: string;
                         className={`absolute z-10 ${pos}`}
                     />
                 ))}
-                <Image src={PEANUTMAN_MOBILE} alt="Peanut" width={150} height={150} className="z-0 object-contain" />
+                <Image
+                    src={PEANUTMAN_MOBILE}
+                    alt="Peanut"
+                    width={200}
+                    height={200}
+                    className="z-0 h-40 w-auto object-contain"
+                />
             </section>
-            <section className="flex flex-1 flex-col gap-3 bg-white p-6">
+            <section className="flex flex-col gap-3 bg-white p-6">
                 <h1 className="text-3xl font-bold text-n-1">{heading}</h1>
                 <p className="text-base text-grey-1">{sub}</p>
-                <div className="mt-auto flex flex-col gap-4">{footer}</div>
+                <div className="mt-4 flex flex-col gap-4">{footer}</div>
             </section>
         </div>
     )

--- a/src/app/(mobile-ui)/dev/migration/page.tsx
+++ b/src/app/(mobile-ui)/dev/migration/page.tsx
@@ -1,54 +1,59 @@
 'use client'
 
-// dev-only showcase of every UI surface in the PWA -> native app migration.
+// dev-only showcase of every UI surface in the "Peanut moves to the app stores" migration.
 // route: /dev/migration (public in local dev, notFound on prod).
-// composed from the app's REAL components — ActionModal, AvatarWithBadge, Button,
-// QRCodeWrapper — and mirrors the ForceIOSPWAInstall two-section install screen,
-// so these read like the live app, not bespoke markup.
+// composed from the app's REAL components — ActionModal, CarouselCTA (home carousel),
+// AvatarWithBadge, Button, the "Continue with Peanut" pattern and the landing hero —
+// so these read like the live app. copy avoids the word "native app" (users don't know it).
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import ActionModal from '@/components/Global/ActionModal'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Icon } from '@/components/Global/Icons/Icon'
 import AvatarWithBadge from '@/components/Profile/AvatarWithBadge'
 import QRCodeWrapper from '@/components/Global/QRCodeWrapper'
-import { PEANUTMAN_PFP } from '@/assets'
+import CarouselCTA from '@/components/Home/HomeCarouselCTA/CarouselCTA'
+import { PEANUTMAN, PEANUTMAN_MOBILE, PeanutWhistling } from '@/assets/mascot'
+import { PEANUT_LOGO_BLACK } from '@/assets/logos'
 import starImage from '@/assets/icons/star.png'
 
-// platform-aware in prod (App Store on iOS, Play on Android). shown stacked here.
-function StoreButtons() {
+type Platform = 'ios' | 'android'
+const STORE = { ios: 'App Store', android: 'Google Play' } as const
+
+// device-aware store CTAs: the user's platform is the primary (purple), the other
+// is secondary (stroke). brand logos (Apple / Play) aren't in the icon set yet — TODO.
+function storeCtas(platform: Platform) {
+    const other: Platform = platform === 'ios' ? 'android' : 'ios'
+    return [
+        { text: STORE[platform], variant: 'purple' as const, shadowSize: '4' as const, icon: 'mobile-install' as const },
+        { text: STORE[other], variant: 'stroke' as const, shadowSize: '4' as const },
+    ]
+}
+function StoreButtons({ platform }: { platform: Platform }) {
+    const other: Platform = platform === 'ios' ? 'android' : 'ios'
     return (
         <div className="flex w-full flex-col gap-2">
             <Button variant="purple" shadowSize="4" icon="mobile-install" className="w-full">
-                Download on the App Store
+                {STORE[platform]}
             </Button>
             <Button variant="stroke" shadowSize="4" className="w-full">
-                Get it on Google Play
+                {STORE[other]}
             </Button>
         </div>
     )
 }
 
-// mirrors ForceIOSPWAInstall: secondary-3 hero (peanut + stars) over a white
-// content half. used for the full-screen block and the app-store-only landing.
-const STARS = ['left-[8%] top-[14%] size-8', 'right-[12%] top-[10%] size-9', 'right-[14%] bottom-[16%] size-8'] as const
-function InstallScreen({
-    heading,
-    sub,
-    footer,
-}: {
-    heading: string
-    sub: string
-    footer?: React.ReactNode
-}) {
+// mascot-holding-phone hero over white content. used for the access-ending screen + landing.
+const STARS = ['left-[8%] top-[16%] size-8', 'right-[12%] top-[12%] size-9', 'right-[16%] bottom-[18%] size-7'] as const
+function InstallScreen({ heading, sub, footer }: { heading: string; sub: string; footer?: React.ReactNode }) {
     return (
         <div className="relative mx-auto flex h-[660px] w-full max-w-[380px] flex-col overflow-hidden rounded-sm border border-n-1 bg-white">
             <section className="relative flex h-2/5 w-full items-center justify-center overflow-hidden bg-secondary-3">
                 {STARS.map((pos, i) => (
-                    <Image key={i} src={starImage.src} alt="" width={40} height={40} className={`absolute z-10 ${pos}`} />
+                    <Image key={i} src={starImage.src} alt="" width={38} height={38} className={`absolute z-10 ${pos}`} />
                 ))}
-                <Image src={PEANUTMAN_PFP} alt="Peanut" width={132} height={132} className="z-0 object-contain" />
+                <Image src={PEANUTMAN_MOBILE} alt="Peanut" width={150} height={150} className="z-0 object-contain" />
             </section>
             <section className="flex flex-1 flex-col gap-3 bg-white p-6">
                 <h1 className="text-3xl font-bold text-n-1">{heading}</h1>
@@ -59,67 +64,104 @@ function InstallScreen({
     )
 }
 
-function Section({
-    n,
-    title,
-    subtitle,
-    children,
-}: {
-    n: string
-    title: string
-    subtitle: string
-    children: React.ReactNode
-}) {
+// the live "Continue with Peanut" button (mascot + wordmark) from SendLinkActionList.
+function ContinueWithPeanut() {
+    return (
+        <Button shadowSize="4" className="flex w-full items-center justify-center gap-1">
+            <span>Continue with</span>
+            <Image src={PEANUTMAN} alt="" className="size-5" />
+            <Image src={PEANUT_LOGO_BLACK} alt="Peanut" className="h-4 w-auto" />
+        </Button>
+    )
+}
+
+function Section({ n, title, subtitle, children }: { n: string; title: string; subtitle: string; children: React.ReactNode }) {
     return (
         <section className="flex flex-col gap-4 border-b border-n-1/15 py-10">
             <div>
                 <div className="font-mono text-xs uppercase tracking-widest text-grey-1">{n}</div>
                 <h2 className="text-h4 font-bold text-n-1">{title}</h2>
-                <p className="max-w-xl text-sm text-grey-1">{subtitle}</p>
+                <p className="max-w-2xl text-sm text-grey-1">{subtitle}</p>
             </div>
             {children}
         </section>
     )
 }
 
+const INDEX = [
+    ['01 Download prompt', 'A modal asking logged-in web users to get the app. Countdown variant warns the site is closing.', 'Web app, after login, during the migration window.'],
+    ['02 Access-ending screen', 'Full screen shown once the website is switched off — download is the only way forward.', 'Web app, after the cutover date, on every route.'],
+    ['03 Guest link pages', 'The claim / request / invite pages a non-user lands on. Primary action is "Continue with Peanut" (opens the app / store).', 'Public links: /claim, /request, /invite, /pay, /profile.'],
+    ['04 Get-the-app banner', 'A home-carousel card nudging users to install, without blocking anything.', 'Home screen carousel (web).'],
+    ['05 Landing page', 'The marketing homepage hero — CTA is "Download", not "Sign up".', 'peanut.me for new / anonymous visitors.'],
+    ['06 Review prompt', 'Asks happy users to rate the app; unhappy ones go to support instead.', 'In the app, after a good moment (money received, payment done).'],
+    ['07 Notifications prompt', 'Custom ask before the OS permission popup, so we can ask again later.', 'In the app, at launch for users who never enabled push.'],
+]
+
 export default function MigrationMockupsPage() {
+    const [platform, setPlatform] = useState<Platform>('ios')
     const [downloadModal, setDownloadModal] = useState(false)
-    const [downloadCountdown, setDownloadCountdown] = useState(false)
+    const [countdown, setCountdown] = useState(false)
     const [reviewModal, setReviewModal] = useState(false)
     const [pushModal, setPushModal] = useState(false)
     const [bannerOpen, setBannerOpen] = useState(true)
 
+    // device-aware: default the primary store CTA to the visitor's platform.
+    useEffect(() => {
+        if (typeof navigator !== 'undefined' && /android/i.test(navigator.userAgent)) setPlatform('android')
+    }, [])
+
     return (
         <div className="mx-auto w-full max-w-3xl px-6 py-10">
-            <h1 className="text-h2 font-bold text-n-1">Native App Migration — UI</h1>
-            <p className="mt-1 text-sm text-grey-1">
-                Every component in the PWA to native migration, built from the app&apos;s real components. Dev-only
-                preview.
-            </p>
+            <div className="flex flex-wrap items-end justify-between gap-4">
+                <div>
+                    <h1 className="text-h2 font-bold text-n-1">App migration — UI</h1>
+                    <p className="mt-1 text-sm text-grey-1">
+                        Every screen for moving Peanut to the App Store &amp; Google Play. Built from the real app
+                        components.
+                    </p>
+                </div>
+                {/* platform toggle — drives which store CTA is primary */}
+                <div className="flex overflow-hidden rounded-sm border border-n-1">
+                    {(['ios', 'android'] as Platform[]).map((p) => (
+                        <button
+                            key={p}
+                            onClick={() => setPlatform(p)}
+                            className={`px-4 py-2 text-sm font-semibold ${platform === p ? 'bg-primary-1 text-n-1' : 'bg-white text-grey-1'}`}
+                        >
+                            {p === 'ios' ? 'iOS' : 'Android'}
+                        </button>
+                    ))}
+                </div>
+            </div>
 
-            {/* 1. Existing-user download modal — ActionModal */}
+            {/* Component index */}
+            <div className="mt-8 overflow-hidden rounded-sm border border-n-1">
+                <div className="grid grid-cols-[minmax(0,1fr)] divide-y divide-n-1/15">
+                    {INDEX.map(([name, what, where]) => (
+                        <div key={name} className="grid gap-1 p-4 sm:grid-cols-[180px_1fr_1fr] sm:gap-4">
+                            <div className="text-sm font-bold text-n-1">{name}</div>
+                            <div className="text-sm text-grey-1">{what}</div>
+                            <div className="text-sm text-grey-1">
+                                <span className="font-mono text-xs uppercase text-n-1">where · </span>
+                                {where}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            {/* 01 Download prompt */}
             <Section
                 n="01"
-                title="Download modal (existing user, web)"
-                subtitle="Fired post-login on web. Dismissible. Countdown variant adds the sunset deadline."
+                title="Download prompt (logged-in web users)"
+                subtitle="Shown after login on the website. Dismissible. The countdown variant makes the deadline loud."
             >
                 <div className="flex flex-wrap gap-3">
-                    <Button
-                        variant="stroke"
-                        onClick={() => {
-                            setDownloadCountdown(false)
-                            setDownloadModal(true)
-                        }}
-                    >
-                        Open (notice)
+                    <Button variant="stroke" onClick={() => { setCountdown(false); setDownloadModal(true) }}>
+                        Open (reminder)
                     </Button>
-                    <Button
-                        variant="stroke"
-                        onClick={() => {
-                            setDownloadCountdown(true)
-                            setDownloadModal(true)
-                        }}
-                    >
+                    <Button variant="stroke" onClick={() => { setCountdown(true); setDownloadModal(true) }}>
                         Open (with countdown)
                     </Button>
                 </div>
@@ -127,22 +169,19 @@ export default function MigrationMockupsPage() {
                     visible={downloadModal}
                     onClose={() => setDownloadModal(false)}
                     icon="mobile-install"
-                    title="Peanut is now a native app"
-                    description="We've moved to a native app for a faster, smoother experience. Download it to keep using Peanut."
-                    ctas={[
-                        { text: 'Download on the App Store', variant: 'purple', shadowSize: '4', icon: 'mobile-install' },
-                        { text: 'Get it on Google Play', variant: 'stroke', shadowSize: '4' },
-                    ]}
+                    title="Peanut is moving to your phone"
+                    description="Get the Peanut app from the App Store or Google Play to keep using your account — it's faster and you'll get alerts when money lands."
+                    ctas={storeCtas(platform)}
                     footer={
-                        downloadCountdown ? (
-                            <p className="mt-3 text-center text-sm font-semibold text-n-1">
-                                14 days until web access ends
-                            </p>
+                        countdown ? (
+                            <div className="mt-4 flex flex-col items-center gap-1 rounded-sm border border-n-1 bg-primary-1 px-4 py-3">
+                                <span className="text-3xl font-extrabold leading-none text-n-1">14 days</span>
+                                <span className="text-xs font-semibold uppercase tracking-wide text-n-1">
+                                    until the website closes
+                                </span>
+                            </div>
                         ) : (
-                            <button
-                                className="mt-3 w-full text-center text-xs text-grey-1 underline"
-                                onClick={() => setDownloadModal(false)}
-                            >
+                            <button className="mt-3 w-full text-center text-xs text-grey-1 underline" onClick={() => setDownloadModal(false)}>
                                 Remind me later
                             </button>
                         )
@@ -150,157 +189,116 @@ export default function MigrationMockupsPage() {
                 />
             </Section>
 
-            {/* 2. 30-day hard block — install screen */}
+            {/* 02 Access-ending screen */}
             <Section
                 n="02"
-                title="30-day hard block (post-deadline, web)"
-                subtitle="Full-screen, non-dismissible. Store CTA + support escape hatch for users who can't install."
+                title="Access-ending screen (after cutover)"
+                subtitle="Full-screen once the website is switched off. Download is the way forward; support link covers people who can't install."
             >
                 <InstallScreen
-                    heading="Web access has ended"
-                    sub="Peanut is now a native app. Download it to continue."
+                    heading="Peanut lives on your phone now"
+                    sub="The website has closed. Download the app to get back into your account — your money is safe."
                     footer={
                         <>
-                            <StoreButtons />
+                            <StoreButtons platform={platform} />
                             <a className="text-center text-sm text-black underline" href="#">
-                                Can&apos;t install? Contact support
+                                Can&apos;t download the app? Contact support
                             </a>
                         </>
                     }
                 />
             </Section>
 
-            {/* 3. Guest download CTA — AvatarWithBadge + real amount hero */}
+            {/* 03 Guest link pages */}
             <Section
                 n="03"
-                title="Guest download CTA (public routes)"
-                subtitle="Non-user opens a claim / pay / invite link in a browser. Mirrors the live pay/claim hero (avatar + amount), then gates the action behind download."
+                title="Guest link pages (claim / request / invite)"
+                subtitle="Whole page a non-user lands on. Same hero as today, primary action is 'Continue with Peanut' (opens the app, or the store if not installed). Mock data."
             >
-                <div className="grid gap-4 sm:grid-cols-3">
-                    <GuestCta name="alice" label="is sending you" amount="$25.00" verb="Claim" icon="gift" />
-                    <GuestCta name="bob" label="requested" amount="$40.00" verb="Pay" icon="arrow-up-right" />
-                    <GuestCta name="carol" label="invited you to Peanut" amount="" verb="Join" icon="invite-heart" />
+                <div className="grid gap-6 lg:grid-cols-3">
+                    <GuestPage kind="claim" name="alice" amount="$25.00" />
+                    <GuestPage kind="request" name="bob" amount="$40.00" />
+                    <GuestPage kind="invite" name="carol" amount="" />
                 </div>
             </Section>
 
-            {/* 4. Open-in-app banner */}
+            {/* 04 Get-the-app banner */}
             <Section
                 n="04"
-                title="Open-in-app banner (installed users, web)"
-                subtitle="Slim, dismissible. Bounces returning users into the native app. iOS Smart App Banner style."
+                title="Get-the-app banner (home carousel)"
+                subtitle="A home-screen carousel card — same component as the other home CTAs. Nudges without blocking."
             >
                 {bannerOpen ? (
-                    <div className="flex items-center gap-3 rounded-sm border border-n-1 bg-white px-3 py-2">
-                        <button className="px-1 text-grey-1" onClick={() => setBannerOpen(false)} aria-label="dismiss">
-                            <Icon name="cancel" size={14} />
-                        </button>
-                        <AvatarWithBadge logo={PEANUTMAN_PFP} size="small" />
-                        <div className="flex-1">
-                            <div className="text-sm font-semibold text-n-1">Peanut</div>
-                            <div className="text-xs text-grey-1">Faster in the app</div>
-                        </div>
-                        <Button variant="purple" shadowSize="4" size="large">
-                            Open
-                        </Button>
+                    <div className="max-w-md">
+                        <CarouselCTA
+                            icon="mobile-install"
+                            logo={PEANUTMAN_MOBILE}
+                            title="Get the Peanut app"
+                            description="Faster payments and alerts when money lands"
+                            onClose={() => setBannerOpen(false)}
+                            onClick={() => {}}
+                        />
                     </div>
                 ) : (
-                    <Button variant="stroke" onClick={() => setBannerOpen(true)}>
-                        Reset banner
-                    </Button>
+                    <Button variant="stroke" onClick={() => setBannerOpen(true)}>Reset banner</Button>
                 )}
             </Section>
 
-            {/* 5. Landing app-store-only — install screen + QR */}
+            {/* 05 Landing page */}
             <Section
                 n="05"
-                title="Landing hero — app-store-only (new users)"
-                subtitle="No web signup. Store badges on mobile, QR for desktop."
+                title="Landing page hero (new visitors)"
+                subtitle="Marketing homepage. Hero mascot + bold headline, CTA is 'Download' not 'Sign up', with a rating for trust (app-landing convention)."
             >
-                <InstallScreen
-                    heading="Money, simplified"
-                    sub="Download the Peanut app to get started."
-                    footer={
-                        <>
-                            <StoreButtons />
-                            <div className="flex flex-col items-center gap-2">
-                                <span className="font-mono text-xs uppercase tracking-widest text-grey-1">
-                                    or scan on desktop
-                                </span>
-                                <QRCodeWrapper url="https://peanut.me/app" className="max-w-[104px]" />
-                            </div>
-                        </>
-                    }
-                />
-            </Section>
-
-            {/* 6. Setup prefill state */}
-            <Section
-                n="06"
-                title="Setup prefill (post-install, deferred deep link)"
-                subtitle="After the deferred deep link resolves, setup confirms the recovered context so it doesn't look like a blank form."
-            >
-                <div className="mx-auto flex w-full max-w-[380px] flex-col items-center gap-5 rounded-sm border border-n-1 bg-white p-6">
-                    <AvatarWithBadge name="carol" size="large" />
-                    <div className="text-center">
-                        <div className="text-2xl font-bold text-n-1">carol invited you</div>
-                        <p className="text-sm text-grey-1">Create your wallet and you&apos;ll land right on the invite.</p>
+                <div className="relative mx-auto flex w-full max-w-[380px] flex-col items-center gap-5 overflow-hidden rounded-sm border border-n-1 bg-secondary-3 px-6 pb-8 pt-10 text-center">
+                    <Image src={PeanutWhistling.src} alt="Peanut" width={150} height={150} className="object-contain" />
+                    <h1 className="text-4xl font-extrabold leading-tight text-n-1">Send money like a text</h1>
+                    <p className="text-base text-n-1/80">No bank, no borders. Download the app and send in seconds.</p>
+                    <div className="flex w-full flex-col gap-2 rounded-sm bg-white/60 p-3">
+                        <StoreButtons platform={platform} />
                     </div>
-                    <Button variant="purple" shadowSize="4" className="w-full">
-                        Create your Peanut wallet
-                    </Button>
+                    <div className="flex items-center gap-1 text-sm font-semibold text-n-1">
+                        <Icon name="star" size={16} /> 4.8 · loved by thousands
+                    </div>
                 </div>
             </Section>
 
-            {/* 7. Review nudge — ActionModal */}
+            {/* 06 Review prompt */}
             <Section
-                n="07"
-                title="App Store review nudge (native)"
-                subtitle="Custom pre-prompt before the OS review sheet, to protect quota and route unhappy users to feedback."
+                n="06"
+                title="Review prompt (in-app, after a good moment)"
+                subtitle="Custom pre-prompt. 'Love it' opens the store rating sheet; 'Could be better' opens support instead — so bad reviews never reach the store."
             >
-                <Button variant="stroke" onClick={() => setReviewModal(true)}>
-                    Open review pre-prompt
-                </Button>
+                <Button variant="stroke" onClick={() => setReviewModal(true)}>Open review prompt</Button>
                 <ActionModal
                     visible={reviewModal}
                     onClose={() => setReviewModal(false)}
                     icon="star"
-                    title="Enjoying Peanut?"
-                    description="Your feedback helps us improve. How's it going so far?"
+                    title="Loving Peanut so far?"
+                    description="A quick rating helps other people find us."
                     ctas={[
                         { text: 'Love it', variant: 'purple', shadowSize: '4', onClick: () => setReviewModal(false) },
-                        { text: 'Not really', variant: 'stroke', onClick: () => setReviewModal(false) },
+                        { text: 'Could be better', variant: 'stroke', shadowSize: '4', onClick: () => setReviewModal(false) },
                     ]}
-                    footer={
-                        <p className="mt-2 text-center text-xs text-grey-1">
-                            &quot;Love it&quot; opens the OS rating sheet · &quot;Not really&quot; routes to support
-                        </p>
-                    }
                 />
             </Section>
 
-            {/* 8. Push opt-in — ActionModal */}
+            {/* 07 Notifications prompt */}
             <Section
-                n="08"
-                title="Push opt-in modal (native launch)"
-                subtitle="Custom modal fires first — the native OS prompt only fires after this confirm, so re-prompt ability is never lost."
+                n="07"
+                title="Notifications prompt (in-app launch)"
+                subtitle="Our own ask before the OS popup — if they say not now, we can ask again later (the OS popup only fires on 'Allow')."
             >
-                <Button variant="stroke" onClick={() => setPushModal(true)}>
-                    Open push opt-in
-                </Button>
+                <Button variant="stroke" onClick={() => setPushModal(true)}>Open notifications prompt</Button>
                 <ActionModal
                     visible={pushModal}
                     onClose={() => setPushModal(false)}
                     icon="bell"
-                    title="Turn on notifications"
-                    description="Get notified when you receive money or a payment request comes in."
+                    title="Get money alerts"
+                    description="We'll ping you the moment money lands or someone asks you to pay."
                     ctas={[
-                        {
-                            text: 'Enable notifications',
-                            variant: 'purple',
-                            shadowSize: '4',
-                            onClick: () => setPushModal(false),
-                        },
-                        { text: 'Not now', variant: 'stroke', onClick: () => setPushModal(false) },
+                        { text: 'Allow', variant: 'purple', shadowSize: '4', onClick: () => setPushModal(false) },
+                        { text: 'Not now', variant: 'stroke', shadowSize: '4', onClick: () => setPushModal(false) },
                     ]}
                 />
             </Section>
@@ -308,32 +306,53 @@ export default function MigrationMockupsPage() {
     )
 }
 
-function GuestCta({
-    name,
-    label,
-    amount,
-    verb,
-    icon,
-}: {
-    name: string
-    label: string
-    amount: string
-    verb: string
-    icon: 'gift' | 'arrow-up-right' | 'invite-heart'
-}) {
+function GuestPage({ kind, name, amount }: { kind: 'claim' | 'request' | 'invite'; name: string; amount: string }) {
+    const hero =
+        kind === 'claim'
+            ? { label: `${name} sent you`, big: amount }
+            : kind === 'request'
+              ? { label: `${name} is requesting`, big: amount }
+              : { label: `${name} invited you to`, big: '' }
     return (
-        <div className="flex flex-col items-center gap-3 rounded-sm border border-n-1 bg-white p-5 text-center">
-            <AvatarWithBadge name={name} icon={icon} />
-            <div>
-                <div className="text-sm text-grey-1">
-                    <span className="font-semibold text-n-1">{name}</span> {label}
-                </div>
-                {amount && <div className="text-h3 font-bold text-n-1">{amount}</div>}
+        <div className="mx-auto flex h-[560px] w-full max-w-[340px] flex-col overflow-hidden rounded-sm border border-n-1 bg-white">
+            {/* header */}
+            <div className="flex items-center justify-center border-b border-n-1/10 py-3">
+                <Image src={PEANUT_LOGO_BLACK} alt="Peanut" className="h-4 w-auto" />
             </div>
-            <Button variant="purple" shadowSize="4" className="w-full">
-                {verb} in the app
-            </Button>
-            <p className="text-xs text-grey-1">Saved — you&apos;ll land here after install.</p>
+            {/* hero */}
+            <div className="flex flex-col items-center gap-3 px-6 pb-4 pt-8">
+                <AvatarWithBadge name={name} size="large" />
+                <div className="text-center">
+                    <div className="text-sm text-grey-1">{hero.label}</div>
+                    {hero.big ? (
+                        <div className="text-4xl font-extrabold text-n-1">{hero.big}</div>
+                    ) : (
+                        <div className="mt-1 flex items-center justify-center gap-1 text-2xl font-extrabold text-n-1">
+                            <Image src={PEANUT_LOGO_BLACK} alt="Peanut" className="h-5 w-auto" />
+                        </div>
+                    )}
+                </div>
+            </div>
+            {/* actions */}
+            <div className="mt-auto flex flex-col gap-3 p-5">
+                <ContinueWithPeanut />
+                {kind !== 'invite' && (
+                    <>
+                        <div className="flex items-center gap-3 text-xs text-grey-1">
+                            <span className="h-px flex-1 bg-n-1/15" /> or <span className="h-px flex-1 bg-n-1/15" />
+                        </div>
+                        <div className="flex flex-col gap-2">
+                            {['Claim to bank account', 'Claim to Pix'].map((m) => (
+                                <div key={m} className="flex items-center gap-3 rounded-sm border border-n-1 px-4 py-3">
+                                    <Icon name="bank" size={18} />
+                                    <span className="text-sm font-medium text-n-1">{m}</span>
+                                </div>
+                            ))}
+                        </div>
+                    </>
+                )}
+                <p className="text-center text-xs text-grey-1">Opens the Peanut app — or the store if you don&apos;t have it yet.</p>
+            </div>
         </div>
     )
 }

--- a/src/app/(mobile-ui)/dev/migration/page.tsx
+++ b/src/app/(mobile-ui)/dev/migration/page.tsx
@@ -1,0 +1,319 @@
+'use client'
+
+// dev-only showcase of every UI surface in the PWA -> native app migration.
+// route: /dev/migration (public in local dev, notFound on prod).
+// components are composed from real Bruddle primitives (Modal, Button, QRCodeWrapper)
+// so this doubles as the integration reference — lift these into real components when wiring.
+
+import { useState } from 'react'
+import Modal from '@/components/Global/Modal'
+import { Button } from '@/components/0_Bruddle/Button'
+import QRCodeWrapper from '@/components/Global/QRCodeWrapper'
+
+// shared store CTA — platform-aware in prod (App Store on iOS, Play on Android).
+// here we show both stacked so every variant is visible at once.
+function StoreButtons() {
+    return (
+        <div className="flex w-full flex-col gap-2">
+            <Button variant="purple" shadowSize="4" icon="download" className="w-full">
+                Download on the App Store
+            </Button>
+            <Button variant="stroke" shadowSize="4" className="w-full">
+                Get it on Google Play
+            </Button>
+        </div>
+    )
+}
+
+// simulates a mobile viewport so full-screen / inline surfaces preview at phone size.
+function PhoneFrame({ children, className = '' }: { children: React.ReactNode; className?: string }) {
+    return (
+        <div
+            className={`relative mx-auto flex h-[640px] w-full max-w-[380px] flex-col overflow-hidden rounded-sm border border-n-1 bg-white ${className}`}
+        >
+            {children}
+        </div>
+    )
+}
+
+function Section({
+    n,
+    title,
+    subtitle,
+    children,
+}: {
+    n: string
+    title: string
+    subtitle: string
+    children: React.ReactNode
+}) {
+    return (
+        <section className="flex flex-col gap-4 border-b border-n-1/20 py-10">
+            <div>
+                <div className="font-mono text-xs uppercase tracking-widest text-grey-1">{n}</div>
+                <h2 className="text-h4 font-bold text-n-1">{title}</h2>
+                <p className="max-w-xl text-sm text-grey-1">{subtitle}</p>
+            </div>
+            {children}
+        </section>
+    )
+}
+
+export default function MigrationMockupsPage() {
+    const [downloadModal, setDownloadModal] = useState(false)
+    const [downloadCountdown, setDownloadCountdown] = useState(false)
+    const [reviewModal, setReviewModal] = useState(false)
+    const [pushModal, setPushModal] = useState(false)
+    const [bannerOpen, setBannerOpen] = useState(true)
+
+    return (
+        <div className="mx-auto w-full max-w-3xl px-6 py-10">
+            <h1 className="text-h2 font-bold text-n-1">Native App Migration — UI</h1>
+            <p className="mt-1 text-sm text-grey-1">
+                Every component in the PWA to native migration, built from real Bruddle primitives. Dev-only preview.
+            </p>
+
+            {/* 1. Existing-user download modal */}
+            <Section
+                n="01"
+                title="Download modal (existing user, web)"
+                subtitle="Fired post-login on web. Dismissible. Second state adds the 30-day countdown."
+            >
+                <div className="flex flex-wrap gap-3">
+                    <Button
+                        variant="stroke"
+                        onClick={() => {
+                            setDownloadCountdown(false)
+                            setDownloadModal(true)
+                        }}
+                    >
+                        Open (notice)
+                    </Button>
+                    <Button
+                        variant="stroke"
+                        onClick={() => {
+                            setDownloadCountdown(true)
+                            setDownloadModal(true)
+                        }}
+                    >
+                        Open (with countdown)
+                    </Button>
+                </div>
+                <Modal
+                    visible={downloadModal}
+                    onClose={() => setDownloadModal(false)}
+                    title="Peanut is now a native app"
+                >
+                    <div className="flex flex-col items-center gap-4 p-6">
+                        <p className="text-center text-sm text-grey-1">
+                            We&apos;ve moved to a native app for a faster, smoother experience. Download it to keep using
+                            Peanut.
+                        </p>
+                        {downloadCountdown && (
+                            <div className="w-full rounded-sm border border-n-1 bg-primary-3 px-4 py-2 text-center text-sm font-semibold text-n-1">
+                                14 days until web access ends
+                            </div>
+                        )}
+                        <StoreButtons />
+                        <button className="text-xs text-grey-1 underline" onClick={() => setDownloadModal(false)}>
+                            Remind me later
+                        </button>
+                    </div>
+                </Modal>
+            </Section>
+
+            {/* 2. 30-day hard block */}
+            <Section
+                n="02"
+                title="30-day hard block (post-deadline, web)"
+                subtitle="Full-screen, non-dismissible. Store CTA + support escape hatch for users who can't install."
+            >
+                <PhoneFrame className="items-center justify-center p-8">
+                    <div className="flex flex-col items-center gap-5 text-center">
+                        <div className="flex h-16 w-16 items-center justify-center rounded-sm border border-n-1 bg-primary-1 text-2xl">
+                            🥜
+                        </div>
+                        <div>
+                            <h3 className="text-h4 font-bold text-n-1">Peanut is now a native app</h3>
+                            <p className="mt-1 text-sm text-grey-1">
+                                Web access has ended. Download the app to continue using Peanut.
+                            </p>
+                        </div>
+                        <StoreButtons />
+                        <a className="text-sm text-black underline" href="#">
+                            Can&apos;t install? Contact support
+                        </a>
+                    </div>
+                </PhoneFrame>
+            </Section>
+
+            {/* 3. Guest download CTA — per flow */}
+            <Section
+                n="03"
+                title="Guest download CTA (public routes)"
+                subtitle="Non-user opens a claim / pay / invite link in a browser. Preview the pending action + gated download. One reusable card, context slot changes per flow."
+            >
+                <div className="grid gap-4 sm:grid-cols-3">
+                    <GuestCta
+                        badge="Claim"
+                        title="You&apos;re claiming"
+                        amount="$25.00"
+                        sub="from alice.peanut"
+                    />
+                    <GuestCta badge="Pay request" title="Pay bob&apos;s request" amount="$40.00" sub="for dinner" />
+                    <GuestCta badge="Invite" title="carol invited you" amount="" sub="to join Peanut" />
+                </div>
+            </Section>
+
+            {/* 4. Open-in-app banner */}
+            <Section
+                n="04"
+                title="Open-in-app banner (installed users, web)"
+                subtitle="Slim, dismissible. Bounces returning users into the native app. iOS Smart App Banner style."
+            >
+                {bannerOpen ? (
+                    <div className="flex items-center gap-3 rounded-sm border border-n-1 bg-white px-4 py-3">
+                        <button className="text-grey-1" onClick={() => setBannerOpen(false)} aria-label="dismiss">
+                            ✕
+                        </button>
+                        <div className="flex h-9 w-9 items-center justify-center rounded-sm border border-n-1 bg-primary-1">
+                            🥜
+                        </div>
+                        <div className="flex-1">
+                            <div className="text-sm font-semibold text-n-1">Peanut</div>
+                            <div className="text-xs text-grey-1">Faster in the app</div>
+                        </div>
+                        <Button variant="purple" shadowSize="4" size="large">
+                            Open
+                        </Button>
+                    </div>
+                ) : (
+                    <Button variant="stroke" onClick={() => setBannerOpen(true)}>
+                        Reset banner
+                    </Button>
+                )}
+            </Section>
+
+            {/* 5. Landing page app-store-only */}
+            <Section
+                n="05"
+                title="Landing hero — app-store-only (new users)"
+                subtitle="No web signup. Store badges on mobile, QR for desktop."
+            >
+                <PhoneFrame className="items-center justify-center p-8">
+                    <div className="flex flex-col items-center gap-5 text-center">
+                        <div className="flex h-20 w-20 items-center justify-center rounded-sm border border-n-1 bg-primary-1 text-3xl">
+                            🥜
+                        </div>
+                        <div>
+                            <h3 className="text-h3 font-bold text-n-1">Money, simplified</h3>
+                            <p className="mt-1 text-sm text-grey-1">Download the Peanut app to get started.</p>
+                        </div>
+                        <StoreButtons />
+                        <div className="flex flex-col items-center gap-2 pt-2">
+                            <span className="font-mono text-xs uppercase tracking-widest text-grey-1">
+                                or scan on desktop
+                            </span>
+                            <QRCodeWrapper url="https://peanut.me/app" className="max-w-[120px]" />
+                        </div>
+                    </div>
+                </PhoneFrame>
+            </Section>
+
+            {/* 6. Setup prefill state */}
+            <Section
+                n="06"
+                title="Setup prefill (post-install, deferred deep link)"
+                subtitle="After the deferred deep link resolves, setup confirms the recovered context so it doesn't look like a blank form."
+            >
+                <div className="mx-auto flex w-full max-w-[380px] flex-col gap-4 rounded-sm border border-n-1 bg-white p-6">
+                    <div className="flex items-center gap-3 rounded-sm border border-n-1 bg-primary-3 px-4 py-3">
+                        <div className="flex h-10 w-10 items-center justify-center rounded-sm border border-n-1 bg-primary-1">
+                            🥜
+                        </div>
+                        <div className="text-sm">
+                            <div className="font-semibold text-n-1">Invited by carol</div>
+                            <div className="text-grey-1">You&apos;ll land on your invite after sign up</div>
+                        </div>
+                    </div>
+                    <Button variant="purple" shadowSize="4" className="w-full">
+                        Create your Peanut wallet
+                    </Button>
+                </div>
+            </Section>
+
+            {/* 7. Review nudge */}
+            <Section
+                n="07"
+                title="App Store review nudge (native)"
+                subtitle="Custom pre-prompt before the OS review sheet, to protect quota and route unhappy users to feedback."
+            >
+                <Button variant="stroke" onClick={() => setReviewModal(true)}>
+                    Open review pre-prompt
+                </Button>
+                <Modal visible={reviewModal} onClose={() => setReviewModal(false)} title="Enjoying Peanut?">
+                    <div className="flex flex-col gap-3 p-6">
+                        <p className="text-center text-sm text-grey-1">
+                            Your feedback helps us improve. How&apos;s it going?
+                        </p>
+                        <Button variant="purple" shadowSize="4" className="w-full" onClick={() => setReviewModal(false)}>
+                            Love it
+                        </Button>
+                        <Button variant="stroke" className="w-full" onClick={() => setReviewModal(false)}>
+                            Not really
+                        </Button>
+                        <p className="text-center text-xs text-grey-1">
+                            &quot;Love it&quot; opens the OS rating sheet. &quot;Not really&quot; routes to support.
+                        </p>
+                    </div>
+                </Modal>
+            </Section>
+
+            {/* 8. Push opt-in modal */}
+            <Section
+                n="08"
+                title="Push opt-in modal (native launch)"
+                subtitle="Custom modal fires first — the native OS prompt only fires after this confirm, so re-prompt ability is never lost."
+            >
+                <Button variant="stroke" onClick={() => setPushModal(true)}>
+                    Open push opt-in
+                </Button>
+                <Modal visible={pushModal} onClose={() => setPushModal(false)} title="Turn on notifications">
+                    <div className="flex flex-col gap-3 p-6">
+                        <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-sm border border-n-1 bg-primary-1 text-2xl">
+                            🔔
+                        </div>
+                        <p className="text-center text-sm text-grey-1">
+                            Get notified when you receive money or a payment request comes in.
+                        </p>
+                        <Button variant="purple" shadowSize="4" className="w-full" onClick={() => setPushModal(false)}>
+                            Enable notifications
+                        </Button>
+                        <button className="text-center text-xs text-grey-1 underline" onClick={() => setPushModal(false)}>
+                            Not now
+                        </button>
+                    </div>
+                </Modal>
+            </Section>
+        </div>
+    )
+}
+
+function GuestCta({ badge, title, amount, sub }: { badge: string; title: string; amount: string; sub: string }) {
+    return (
+        <div className="flex flex-col gap-3 rounded-sm border border-n-1 bg-white p-4">
+            <span className="w-fit rounded-sm border border-n-1 bg-primary-3 px-2 py-0.5 font-mono text-xs uppercase text-n-1">
+                {badge}
+            </span>
+            <div>
+                <div className="text-sm text-grey-1" dangerouslySetInnerHTML={{ __html: title }} />
+                {amount && <div className="text-h3 font-bold text-n-1">{amount}</div>}
+                <div className="text-sm text-grey-1">{sub}</div>
+            </div>
+            <Button variant="purple" shadowSize="4" size="large" className="w-full">
+                Download Peanut
+            </Button>
+            <p className="text-xs text-grey-1">Saved — you&apos;ll land here after install.</p>
+        </div>
+    )
+}

--- a/src/app/(mobile-ui)/dev/migration/page.tsx
+++ b/src/app/(mobile-ui)/dev/migration/page.tsx
@@ -2,20 +2,25 @@
 
 // dev-only showcase of every UI surface in the PWA -> native app migration.
 // route: /dev/migration (public in local dev, notFound on prod).
-// components are composed from real Bruddle primitives (Modal, Button, QRCodeWrapper)
-// so this doubles as the integration reference — lift these into real components when wiring.
+// composed from the app's REAL components — ActionModal, AvatarWithBadge, Button,
+// QRCodeWrapper — and mirrors the ForceIOSPWAInstall two-section install screen,
+// so these read like the live app, not bespoke markup.
 
 import { useState } from 'react'
-import Modal from '@/components/Global/Modal'
+import Image from 'next/image'
+import ActionModal from '@/components/Global/ActionModal'
 import { Button } from '@/components/0_Bruddle/Button'
+import { Icon } from '@/components/Global/Icons/Icon'
+import AvatarWithBadge from '@/components/Profile/AvatarWithBadge'
 import QRCodeWrapper from '@/components/Global/QRCodeWrapper'
+import { PEANUTMAN_PFP } from '@/assets'
+import starImage from '@/assets/icons/star.png'
 
-// shared store CTA — platform-aware in prod (App Store on iOS, Play on Android).
-// here we show both stacked so every variant is visible at once.
+// platform-aware in prod (App Store on iOS, Play on Android). shown stacked here.
 function StoreButtons() {
     return (
         <div className="flex w-full flex-col gap-2">
-            <Button variant="purple" shadowSize="4" icon="download" className="w-full">
+            <Button variant="purple" shadowSize="4" icon="mobile-install" className="w-full">
                 Download on the App Store
             </Button>
             <Button variant="stroke" shadowSize="4" className="w-full">
@@ -25,13 +30,31 @@ function StoreButtons() {
     )
 }
 
-// simulates a mobile viewport so full-screen / inline surfaces preview at phone size.
-function PhoneFrame({ children, className = '' }: { children: React.ReactNode; className?: string }) {
+// mirrors ForceIOSPWAInstall: secondary-3 hero (peanut + stars) over a white
+// content half. used for the full-screen block and the app-store-only landing.
+const STARS = ['left-[8%] top-[14%] size-8', 'right-[12%] top-[10%] size-9', 'right-[14%] bottom-[16%] size-8'] as const
+function InstallScreen({
+    heading,
+    sub,
+    footer,
+}: {
+    heading: string
+    sub: string
+    footer?: React.ReactNode
+}) {
     return (
-        <div
-            className={`relative mx-auto flex h-[640px] w-full max-w-[380px] flex-col overflow-hidden rounded-sm border border-n-1 bg-white ${className}`}
-        >
-            {children}
+        <div className="relative mx-auto flex h-[660px] w-full max-w-[380px] flex-col overflow-hidden rounded-sm border border-n-1 bg-white">
+            <section className="relative flex h-2/5 w-full items-center justify-center overflow-hidden bg-secondary-3">
+                {STARS.map((pos, i) => (
+                    <Image key={i} src={starImage.src} alt="" width={40} height={40} className={`absolute z-10 ${pos}`} />
+                ))}
+                <Image src={PEANUTMAN_PFP} alt="Peanut" width={132} height={132} className="z-0 object-contain" />
+            </section>
+            <section className="flex flex-1 flex-col gap-3 bg-white p-6">
+                <h1 className="text-3xl font-bold text-n-1">{heading}</h1>
+                <p className="text-base text-grey-1">{sub}</p>
+                <div className="mt-auto flex flex-col gap-4">{footer}</div>
+            </section>
         </div>
     )
 }
@@ -48,7 +71,7 @@ function Section({
     children: React.ReactNode
 }) {
     return (
-        <section className="flex flex-col gap-4 border-b border-n-1/20 py-10">
+        <section className="flex flex-col gap-4 border-b border-n-1/15 py-10">
             <div>
                 <div className="font-mono text-xs uppercase tracking-widest text-grey-1">{n}</div>
                 <h2 className="text-h4 font-bold text-n-1">{title}</h2>
@@ -70,14 +93,15 @@ export default function MigrationMockupsPage() {
         <div className="mx-auto w-full max-w-3xl px-6 py-10">
             <h1 className="text-h2 font-bold text-n-1">Native App Migration — UI</h1>
             <p className="mt-1 text-sm text-grey-1">
-                Every component in the PWA to native migration, built from real Bruddle primitives. Dev-only preview.
+                Every component in the PWA to native migration, built from the app&apos;s real components. Dev-only
+                preview.
             </p>
 
-            {/* 1. Existing-user download modal */}
+            {/* 1. Existing-user download modal — ActionModal */}
             <Section
                 n="01"
                 title="Download modal (existing user, web)"
-                subtitle="Fired post-login on web. Dismissible. Second state adds the 30-day countdown."
+                subtitle="Fired post-login on web. Dismissible. Countdown variant adds the sunset deadline."
             >
                 <div className="flex flex-wrap gap-3">
                     <Button
@@ -99,69 +123,63 @@ export default function MigrationMockupsPage() {
                         Open (with countdown)
                     </Button>
                 </div>
-                <Modal
+                <ActionModal
                     visible={downloadModal}
                     onClose={() => setDownloadModal(false)}
+                    icon="mobile-install"
                     title="Peanut is now a native app"
-                >
-                    <div className="flex flex-col items-center gap-4 p-6">
-                        <p className="text-center text-sm text-grey-1">
-                            We&apos;ve moved to a native app for a faster, smoother experience. Download it to keep using
-                            Peanut.
-                        </p>
-                        {downloadCountdown && (
-                            <div className="w-full rounded-sm border border-n-1 bg-primary-3 px-4 py-2 text-center text-sm font-semibold text-n-1">
+                    description="We've moved to a native app for a faster, smoother experience. Download it to keep using Peanut."
+                    ctas={[
+                        { text: 'Download on the App Store', variant: 'purple', shadowSize: '4', icon: 'mobile-install' },
+                        { text: 'Get it on Google Play', variant: 'stroke', shadowSize: '4' },
+                    ]}
+                    footer={
+                        downloadCountdown ? (
+                            <p className="mt-3 text-center text-sm font-semibold text-n-1">
                                 14 days until web access ends
-                            </div>
-                        )}
-                        <StoreButtons />
-                        <button className="text-xs text-grey-1 underline" onClick={() => setDownloadModal(false)}>
-                            Remind me later
-                        </button>
-                    </div>
-                </Modal>
+                            </p>
+                        ) : (
+                            <button
+                                className="mt-3 w-full text-center text-xs text-grey-1 underline"
+                                onClick={() => setDownloadModal(false)}
+                            >
+                                Remind me later
+                            </button>
+                        )
+                    }
+                />
             </Section>
 
-            {/* 2. 30-day hard block */}
+            {/* 2. 30-day hard block — install screen */}
             <Section
                 n="02"
                 title="30-day hard block (post-deadline, web)"
                 subtitle="Full-screen, non-dismissible. Store CTA + support escape hatch for users who can't install."
             >
-                <PhoneFrame className="items-center justify-center p-8">
-                    <div className="flex flex-col items-center gap-5 text-center">
-                        <div className="flex h-16 w-16 items-center justify-center rounded-sm border border-n-1 bg-primary-1 text-2xl">
-                            🥜
-                        </div>
-                        <div>
-                            <h3 className="text-h4 font-bold text-n-1">Peanut is now a native app</h3>
-                            <p className="mt-1 text-sm text-grey-1">
-                                Web access has ended. Download the app to continue using Peanut.
-                            </p>
-                        </div>
-                        <StoreButtons />
-                        <a className="text-sm text-black underline" href="#">
-                            Can&apos;t install? Contact support
-                        </a>
-                    </div>
-                </PhoneFrame>
+                <InstallScreen
+                    heading="Web access has ended"
+                    sub="Peanut is now a native app. Download it to continue."
+                    footer={
+                        <>
+                            <StoreButtons />
+                            <a className="text-center text-sm text-black underline" href="#">
+                                Can&apos;t install? Contact support
+                            </a>
+                        </>
+                    }
+                />
             </Section>
 
-            {/* 3. Guest download CTA — per flow */}
+            {/* 3. Guest download CTA — AvatarWithBadge + real amount hero */}
             <Section
                 n="03"
                 title="Guest download CTA (public routes)"
-                subtitle="Non-user opens a claim / pay / invite link in a browser. Preview the pending action + gated download. One reusable card, context slot changes per flow."
+                subtitle="Non-user opens a claim / pay / invite link in a browser. Mirrors the live pay/claim hero (avatar + amount), then gates the action behind download."
             >
                 <div className="grid gap-4 sm:grid-cols-3">
-                    <GuestCta
-                        badge="Claim"
-                        title="You&apos;re claiming"
-                        amount="$25.00"
-                        sub="from alice.peanut"
-                    />
-                    <GuestCta badge="Pay request" title="Pay bob&apos;s request" amount="$40.00" sub="for dinner" />
-                    <GuestCta badge="Invite" title="carol invited you" amount="" sub="to join Peanut" />
+                    <GuestCta name="alice" label="is sending you" amount="$25.00" verb="Claim" icon="gift" />
+                    <GuestCta name="bob" label="requested" amount="$40.00" verb="Pay" icon="arrow-up-right" />
+                    <GuestCta name="carol" label="invited you to Peanut" amount="" verb="Join" icon="invite-heart" />
                 </div>
             </Section>
 
@@ -172,13 +190,11 @@ export default function MigrationMockupsPage() {
                 subtitle="Slim, dismissible. Bounces returning users into the native app. iOS Smart App Banner style."
             >
                 {bannerOpen ? (
-                    <div className="flex items-center gap-3 rounded-sm border border-n-1 bg-white px-4 py-3">
-                        <button className="text-grey-1" onClick={() => setBannerOpen(false)} aria-label="dismiss">
-                            ✕
+                    <div className="flex items-center gap-3 rounded-sm border border-n-1 bg-white px-3 py-2">
+                        <button className="px-1 text-grey-1" onClick={() => setBannerOpen(false)} aria-label="dismiss">
+                            <Icon name="cancel" size={14} />
                         </button>
-                        <div className="flex h-9 w-9 items-center justify-center rounded-sm border border-n-1 bg-primary-1">
-                            🥜
-                        </div>
+                        <AvatarWithBadge logo={PEANUTMAN_PFP} size="small" />
                         <div className="flex-1">
                             <div className="text-sm font-semibold text-n-1">Peanut</div>
                             <div className="text-xs text-grey-1">Faster in the app</div>
@@ -194,30 +210,27 @@ export default function MigrationMockupsPage() {
                 )}
             </Section>
 
-            {/* 5. Landing page app-store-only */}
+            {/* 5. Landing app-store-only — install screen + QR */}
             <Section
                 n="05"
                 title="Landing hero — app-store-only (new users)"
                 subtitle="No web signup. Store badges on mobile, QR for desktop."
             >
-                <PhoneFrame className="items-center justify-center p-8">
-                    <div className="flex flex-col items-center gap-5 text-center">
-                        <div className="flex h-20 w-20 items-center justify-center rounded-sm border border-n-1 bg-primary-1 text-3xl">
-                            🥜
-                        </div>
-                        <div>
-                            <h3 className="text-h3 font-bold text-n-1">Money, simplified</h3>
-                            <p className="mt-1 text-sm text-grey-1">Download the Peanut app to get started.</p>
-                        </div>
-                        <StoreButtons />
-                        <div className="flex flex-col items-center gap-2 pt-2">
-                            <span className="font-mono text-xs uppercase tracking-widest text-grey-1">
-                                or scan on desktop
-                            </span>
-                            <QRCodeWrapper url="https://peanut.me/app" className="max-w-[120px]" />
-                        </div>
-                    </div>
-                </PhoneFrame>
+                <InstallScreen
+                    heading="Money, simplified"
+                    sub="Download the Peanut app to get started."
+                    footer={
+                        <>
+                            <StoreButtons />
+                            <div className="flex flex-col items-center gap-2">
+                                <span className="font-mono text-xs uppercase tracking-widest text-grey-1">
+                                    or scan on desktop
+                                </span>
+                                <QRCodeWrapper url="https://peanut.me/app" className="max-w-[104px]" />
+                            </div>
+                        </>
+                    }
+                />
             </Section>
 
             {/* 6. Setup prefill state */}
@@ -226,15 +239,11 @@ export default function MigrationMockupsPage() {
                 title="Setup prefill (post-install, deferred deep link)"
                 subtitle="After the deferred deep link resolves, setup confirms the recovered context so it doesn't look like a blank form."
             >
-                <div className="mx-auto flex w-full max-w-[380px] flex-col gap-4 rounded-sm border border-n-1 bg-white p-6">
-                    <div className="flex items-center gap-3 rounded-sm border border-n-1 bg-primary-3 px-4 py-3">
-                        <div className="flex h-10 w-10 items-center justify-center rounded-sm border border-n-1 bg-primary-1">
-                            🥜
-                        </div>
-                        <div className="text-sm">
-                            <div className="font-semibold text-n-1">Invited by carol</div>
-                            <div className="text-grey-1">You&apos;ll land on your invite after sign up</div>
-                        </div>
+                <div className="mx-auto flex w-full max-w-[380px] flex-col items-center gap-5 rounded-sm border border-n-1 bg-white p-6">
+                    <AvatarWithBadge name="carol" size="large" />
+                    <div className="text-center">
+                        <div className="text-2xl font-bold text-n-1">carol invited you</div>
+                        <p className="text-sm text-grey-1">Create your wallet and you&apos;ll land right on the invite.</p>
                     </div>
                     <Button variant="purple" shadowSize="4" className="w-full">
                         Create your Peanut wallet
@@ -242,7 +251,7 @@ export default function MigrationMockupsPage() {
                 </div>
             </Section>
 
-            {/* 7. Review nudge */}
+            {/* 7. Review nudge — ActionModal */}
             <Section
                 n="07"
                 title="App Store review nudge (native)"
@@ -251,25 +260,25 @@ export default function MigrationMockupsPage() {
                 <Button variant="stroke" onClick={() => setReviewModal(true)}>
                     Open review pre-prompt
                 </Button>
-                <Modal visible={reviewModal} onClose={() => setReviewModal(false)} title="Enjoying Peanut?">
-                    <div className="flex flex-col gap-3 p-6">
-                        <p className="text-center text-sm text-grey-1">
-                            Your feedback helps us improve. How&apos;s it going?
+                <ActionModal
+                    visible={reviewModal}
+                    onClose={() => setReviewModal(false)}
+                    icon="star"
+                    title="Enjoying Peanut?"
+                    description="Your feedback helps us improve. How's it going so far?"
+                    ctas={[
+                        { text: 'Love it', variant: 'purple', shadowSize: '4', onClick: () => setReviewModal(false) },
+                        { text: 'Not really', variant: 'stroke', onClick: () => setReviewModal(false) },
+                    ]}
+                    footer={
+                        <p className="mt-2 text-center text-xs text-grey-1">
+                            &quot;Love it&quot; opens the OS rating sheet · &quot;Not really&quot; routes to support
                         </p>
-                        <Button variant="purple" shadowSize="4" className="w-full" onClick={() => setReviewModal(false)}>
-                            Love it
-                        </Button>
-                        <Button variant="stroke" className="w-full" onClick={() => setReviewModal(false)}>
-                            Not really
-                        </Button>
-                        <p className="text-center text-xs text-grey-1">
-                            &quot;Love it&quot; opens the OS rating sheet. &quot;Not really&quot; routes to support.
-                        </p>
-                    </div>
-                </Modal>
+                    }
+                />
             </Section>
 
-            {/* 8. Push opt-in modal */}
+            {/* 8. Push opt-in — ActionModal */}
             <Section
                 n="08"
                 title="Push opt-in modal (native launch)"
@@ -278,40 +287,51 @@ export default function MigrationMockupsPage() {
                 <Button variant="stroke" onClick={() => setPushModal(true)}>
                     Open push opt-in
                 </Button>
-                <Modal visible={pushModal} onClose={() => setPushModal(false)} title="Turn on notifications">
-                    <div className="flex flex-col gap-3 p-6">
-                        <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-sm border border-n-1 bg-primary-1 text-2xl">
-                            🔔
-                        </div>
-                        <p className="text-center text-sm text-grey-1">
-                            Get notified when you receive money or a payment request comes in.
-                        </p>
-                        <Button variant="purple" shadowSize="4" className="w-full" onClick={() => setPushModal(false)}>
-                            Enable notifications
-                        </Button>
-                        <button className="text-center text-xs text-grey-1 underline" onClick={() => setPushModal(false)}>
-                            Not now
-                        </button>
-                    </div>
-                </Modal>
+                <ActionModal
+                    visible={pushModal}
+                    onClose={() => setPushModal(false)}
+                    icon="bell"
+                    title="Turn on notifications"
+                    description="Get notified when you receive money or a payment request comes in."
+                    ctas={[
+                        {
+                            text: 'Enable notifications',
+                            variant: 'purple',
+                            shadowSize: '4',
+                            onClick: () => setPushModal(false),
+                        },
+                        { text: 'Not now', variant: 'stroke', onClick: () => setPushModal(false) },
+                    ]}
+                />
             </Section>
         </div>
     )
 }
 
-function GuestCta({ badge, title, amount, sub }: { badge: string; title: string; amount: string; sub: string }) {
+function GuestCta({
+    name,
+    label,
+    amount,
+    verb,
+    icon,
+}: {
+    name: string
+    label: string
+    amount: string
+    verb: string
+    icon: 'gift' | 'arrow-up-right' | 'invite-heart'
+}) {
     return (
-        <div className="flex flex-col gap-3 rounded-sm border border-n-1 bg-white p-4">
-            <span className="w-fit rounded-sm border border-n-1 bg-primary-3 px-2 py-0.5 font-mono text-xs uppercase text-n-1">
-                {badge}
-            </span>
+        <div className="flex flex-col items-center gap-3 rounded-sm border border-n-1 bg-white p-5 text-center">
+            <AvatarWithBadge name={name} icon={icon} />
             <div>
-                <div className="text-sm text-grey-1" dangerouslySetInnerHTML={{ __html: title }} />
+                <div className="text-sm text-grey-1">
+                    <span className="font-semibold text-n-1">{name}</span> {label}
+                </div>
                 {amount && <div className="text-h3 font-bold text-n-1">{amount}</div>}
-                <div className="text-sm text-grey-1">{sub}</div>
             </div>
-            <Button variant="purple" shadowSize="4" size="large" className="w-full">
-                Download Peanut
+            <Button variant="purple" shadowSize="4" className="w-full">
+                {verb} in the app
             </Button>
             <p className="text-xs text-grey-1">Saved — you&apos;ll land here after install.</p>
         </div>

--- a/src/app/(mobile-ui)/dev/migration/page.tsx
+++ b/src/app/(mobile-ui)/dev/migration/page.tsx
@@ -14,6 +14,7 @@ import { Icon } from '@/components/Global/Icons/Icon'
 import AvatarWithBadge from '@/components/Profile/AvatarWithBadge'
 import QRCodeWrapper from '@/components/Global/QRCodeWrapper'
 import CarouselCTA from '@/components/Home/HomeCarouselCTA/CarouselCTA'
+import { CloudsCss } from '@/components/LandingPage/CloudsCss'
 import { PEANUTMAN, PEANUTMAN_MOBILE, PeanutWhistling } from '@/assets/mascot'
 import { PEANUT_LOGO_BLACK } from '@/assets/logos'
 import starImage from '@/assets/icons/star.png'
@@ -244,21 +245,39 @@ export default function MigrationMockupsPage() {
                 )}
             </Section>
 
-            {/* 05 Landing page */}
+            {/* 05 Landing page — responsive full-width hero (mirrors the real landing) */}
             <Section
                 n="05"
                 title="Landing page hero (new visitors)"
-                subtitle="Marketing homepage. Hero mascot + bold headline, CTA is 'Download' not 'Sign up', with a rating for trust (app-landing convention)."
+                subtitle="The real landing hero, reworked: brand-pink + drifting clouds + mascot, responsive (full-width on web, stacked on phone). CTA is 'Download' with store buttons + a rating — no 'Sign up'."
             >
-                <div className="relative mx-auto flex w-full max-w-[380px] flex-col items-center gap-5 overflow-hidden rounded-sm border border-n-1 bg-secondary-3 px-6 pb-8 pt-10 text-center">
-                    <Image src={PeanutWhistling.src} alt="Peanut" width={150} height={150} className="object-contain" />
-                    <h1 className="text-4xl font-extrabold leading-tight text-n-1">Send money like a text</h1>
-                    <p className="text-base text-n-1/80">No bank, no borders. Download the app and send in seconds.</p>
-                    <div className="flex w-full flex-col gap-2 rounded-sm bg-white/60 p-3">
-                        <StoreButtons platform={platform} />
-                    </div>
-                    <div className="flex items-center gap-1 text-sm font-semibold text-n-1">
-                        <Icon name="star" size={16} /> 4.8 · loved by thousands
+                <div className="relative w-full overflow-hidden rounded-sm border border-n-1 bg-primary-1 px-4 py-14 md:py-20">
+                    <CloudsCss />
+                    <div className="relative z-10 mx-auto flex max-w-3xl flex-col items-center gap-4 text-center">
+                        <Image
+                            src={PeanutWhistling.src}
+                            alt="Peanut"
+                            width={220}
+                            height={220}
+                            className="w-28 object-contain md:w-44"
+                        />
+                        <h1 className="font-roboto-flex-extrabold text-[2rem] font-extraBlack leading-none text-n-1 md:text-6xl">
+                            TAP. SCAN. ANYWHERE.
+                        </h1>
+                        <p className="max-w-md text-base text-n-1/80 md:text-xl">
+                            Send money like a text — no bank, no borders. Download the app and send in seconds.
+                        </p>
+                        <div className="mt-2 flex w-full max-w-sm flex-col gap-3 sm:max-w-none sm:flex-row sm:justify-center">
+                            <Button variant="dark" shadowSize="4" icon="mobile-install" className="sm:w-52">
+                                {STORE[platform]}
+                            </Button>
+                            <Button variant="stroke" shadowSize="4" className="bg-white sm:w-52">
+                                {STORE[platform === 'ios' ? 'android' : 'ios']}
+                            </Button>
+                        </div>
+                        <div className="mt-1 flex items-center gap-1 text-sm font-semibold text-n-1">
+                            <Icon name="star" size={16} /> 4.8 · loved by thousands
+                        </div>
                     </div>
                 </div>
             </Section>

--- a/src/app/(mobile-ui)/dev/migration/page.tsx
+++ b/src/app/(mobile-ui)/dev/migration/page.tsx
@@ -15,6 +15,10 @@ import AvatarWithBadge from '@/components/Profile/AvatarWithBadge'
 import QRCodeWrapper from '@/components/Global/QRCodeWrapper'
 import CarouselCTA from '@/components/Home/HomeCarouselCTA/CarouselCTA'
 import { CloudsCss } from '@/components/LandingPage/CloudsCss'
+import PeanutActionDetailsCard, { type PeanutActionDetailsCardTransactionType } from '@/components/Global/PeanutActionDetailsCard'
+import { ActionListCard } from '@/components/ActionListCard'
+import Divider from '@/components/0_Bruddle/Divider'
+import { PEANUT_WALLET_TOKEN_SYMBOL } from '@/constants/zerodev.consts'
 import { PEANUTMAN, PEANUTMAN_MOBILE, PeanutWhistling } from '@/assets/mascot'
 import { PEANUT_LOGO_BLACK } from '@/assets/logos'
 import starImage from '@/assets/icons/star.png'
@@ -235,9 +239,9 @@ export default function MigrationMockupsPage() {
                 subtitle="Whole page a non-user lands on. Same hero as today, primary action is 'Continue with Peanut' (opens the app, or the store if not installed). Mock data."
             >
                 <div className="grid gap-6 lg:grid-cols-3">
-                    <GuestPage kind="claim" name="alice" amount="$25.00" />
-                    <GuestPage kind="request" name="bob" amount="$40.00" />
-                    <GuestPage kind="invite" name="carol" amount="" />
+                    <GuestPage kind="claim" />
+                    <GuestPage kind="request" />
+                    <GuestPage kind="invite" />
                 </div>
             </Section>
 
@@ -321,7 +325,7 @@ export default function MigrationMockupsPage() {
                     description="A quick rating helps other people find us."
                     ctas={[
                         { text: 'Love it', variant: 'purple', shadowSize: '4', onClick: () => setReviewModal(false) },
-                        { text: 'Could be better', variant: 'stroke', shadowSize: '4', onClick: () => setReviewModal(false) },
+                        { text: 'Meh', variant: 'stroke', shadowSize: '4', onClick: () => setReviewModal(false) },
                     ]}
                 />
             </Section>
@@ -369,59 +373,66 @@ export default function MigrationMockupsPage() {
                         <QRCodeWrapper url="https://peanut.me/app" />
                     </div>
                 }
-                ctas={[{ text: 'Done', variant: 'stroke', shadowSize: '4', onClick: () => setQrModal(false) }]}
+                ctas={[{ text: 'Done', variant: 'purple', shadowSize: '4', onClick: () => setQrModal(false) }]}
             />
         </div>
     )
 }
 
-function GuestPage({ kind, name, amount }: { kind: 'claim' | 'request' | 'invite'; name: string; amount: string }) {
-    const hero =
-        kind === 'claim'
-            ? { label: `${name} sent you`, big: amount }
-            : kind === 'request'
-              ? { label: `${name} is requesting`, big: amount }
-              : { label: `${name} invited you to`, big: '' }
+// mirrors the real claim/request page: centered header -> PeanutActionDetailsCard hero
+// (avatar + "alice sent you" + big amount) -> Continue with Peanut -> Divider -> ActionListCard rows.
+const GUEST = {
+    claim: { header: 'Receive', tx: 'CLAIM_LINK', name: 'alice', amount: '25', message: '' },
+    request: { header: 'Pay', tx: 'REQUEST_PAYMENT', name: 'bob', amount: '40', message: 'for dinner' },
+    invite: { header: 'Receive', tx: 'CLAIM_LINK', name: 'carol', amount: '25', message: '' },
+} satisfies Record<string, { header: string; tx: PeanutActionDetailsCardTransactionType; name: string; amount: string; message: string }>
+
+function GuestPage({ kind }: { kind: 'claim' | 'request' | 'invite' }) {
+    const c = GUEST[kind]
     return (
-        <div className="mx-auto flex h-[560px] w-full max-w-[340px] flex-col overflow-hidden rounded-sm border border-n-1 bg-white">
-            {/* header */}
-            <div className="flex items-center justify-center border-b border-n-1/10 py-3">
-                <Image src={PEANUT_LOGO_BLACK} alt="Peanut" className="h-4 w-auto" />
-            </div>
-            {/* hero */}
-            <div className="flex flex-col items-center gap-3 px-6 pb-4 pt-8">
-                <AvatarWithBadge name={name} size="large" />
-                <div className="text-center">
-                    <div className="text-sm text-grey-1">{hero.label}</div>
-                    {hero.big ? (
-                        <div className="text-4xl font-extrabold text-n-1">{hero.big}</div>
-                    ) : (
-                        <div className="mt-1 flex items-center justify-center gap-1 text-2xl font-extrabold text-n-1">
-                            <Image src={PEANUT_LOGO_BLACK} alt="Peanut" className="h-5 w-auto" />
-                        </div>
-                    )}
+        <div className="mx-auto flex h-[600px] w-full max-w-[360px] flex-col justify-between gap-6 overflow-hidden rounded-sm border border-n-1 bg-white p-5">
+            <div className="pb-1 text-center text-2xl font-extrabold text-n-1">{c.header}</div>
+            <div className="my-auto flex flex-col gap-4">
+                <PeanutActionDetailsCard
+                    avatarSize="small"
+                    transactionType={c.tx}
+                    recipientType="USERNAME"
+                    recipientName={c.name}
+                    amount={c.amount}
+                    tokenSymbol={PEANUT_WALLET_TOKEN_SYMBOL}
+                    message={c.message}
+                />
+                {kind === 'invite' && (
+                    <div className="flex items-center justify-center gap-1">
+                        <Image src={starImage.src} alt="" width={18} height={18} />
+                        <p className="text-center text-sm">Invited by {c.name}, you have early access!</p>
+                        <Image src={starImage.src} alt="" width={18} height={18} />
+                    </div>
+                )}
+                <div className="space-y-2">
+                    <ContinueWithPeanut />
+                    <Divider text="or" />
+                    <div>
+                        <ActionListCard
+                            position="first"
+                            leftIcon={<Icon name="bank" size={20} />}
+                            title="Bank transfer"
+                            description="1-2 business days"
+                            onClick={() => {}}
+                        />
+                        <ActionListCard
+                            position="last"
+                            leftIcon={<Icon name="bank" size={20} />}
+                            title="Pix"
+                            description="Instant, Brazil"
+                            onClick={() => {}}
+                        />
+                    </div>
                 </div>
             </div>
-            {/* actions */}
-            <div className="mt-auto flex flex-col gap-3 p-5">
-                <ContinueWithPeanut />
-                {kind !== 'invite' && (
-                    <>
-                        <div className="flex items-center gap-3 text-xs text-grey-1">
-                            <span className="h-px flex-1 bg-n-1/15" /> or <span className="h-px flex-1 bg-n-1/15" />
-                        </div>
-                        <div className="flex flex-col gap-2">
-                            {['Claim to bank account', 'Claim to Pix'].map((m) => (
-                                <div key={m} className="flex items-center gap-3 rounded-sm border border-n-1 px-4 py-3">
-                                    <Icon name="bank" size={18} />
-                                    <span className="text-sm font-medium text-n-1">{m}</span>
-                                </div>
-                            ))}
-                        </div>
-                    </>
-                )}
-                <p className="text-center text-xs text-grey-1">Opens the Peanut app — or the store if you don&apos;t have it yet.</p>
-            </div>
+            <p className="text-center text-xs text-grey-1">
+                Continue with Peanut opens the app — or the store if you don&apos;t have it.
+            </p>
         </div>
     )
 }

--- a/src/app/(mobile-ui)/dev/migration/page.tsx
+++ b/src/app/(mobile-ui)/dev/migration/page.tsx
@@ -14,12 +14,14 @@ import { Icon } from '@/components/Global/Icons/Icon'
 import AvatarWithBadge from '@/components/Profile/AvatarWithBadge'
 import QRCodeWrapper from '@/components/Global/QRCodeWrapper'
 import CarouselCTA from '@/components/Home/HomeCarouselCTA/CarouselCTA'
-import { CloudsCss } from '@/components/LandingPage/CloudsCss'
-import PeanutActionDetailsCard, { type PeanutActionDetailsCardTransactionType } from '@/components/Global/PeanutActionDetailsCard'
+import { Hero } from '@/components/LandingPage/hero'
+import PeanutActionDetailsCard, {
+    type PeanutActionDetailsCardTransactionType,
+} from '@/components/Global/PeanutActionDetailsCard'
 import { ActionListCard } from '@/components/ActionListCard'
 import Divider from '@/components/0_Bruddle/Divider'
 import { PEANUT_WALLET_TOKEN_SYMBOL } from '@/constants/zerodev.consts'
-import { PEANUTMAN, PEANUTMAN_MOBILE, PeanutWhistling } from '@/assets/mascot'
+import { PEANUTMAN, PEANUTMAN_MOBILE } from '@/assets/mascot'
 import { PEANUT_LOGO_BLACK } from '@/assets/logos'
 import starImage from '@/assets/icons/star.png'
 
@@ -32,10 +34,23 @@ const STORE = { ios: 'App Store', android: 'Google Play' } as const
 // DesktopInstructions). brand logos (Apple / Play) aren't in the icon set yet — TODO.
 function storeCtas(platform: Platform, onQr: () => void) {
     if (platform === 'desktop')
-        return [{ text: 'Show QR to download', variant: 'purple' as const, shadowSize: '4' as const, icon: 'qr-code' as const, onClick: onQr }]
+        return [
+            {
+                text: 'Show QR to download',
+                variant: 'purple' as const,
+                shadowSize: '4' as const,
+                icon: 'qr-code' as const,
+                onClick: onQr,
+            },
+        ]
     const other: Platform = platform === 'ios' ? 'android' : 'ios'
     return [
-        { text: STORE[platform], variant: 'purple' as const, shadowSize: '4' as const, icon: 'mobile-install' as const },
+        {
+            text: STORE[platform],
+            variant: 'purple' as const,
+            shadowSize: '4' as const,
+            icon: 'mobile-install' as const,
+        },
         { text: STORE[other], variant: 'stroke' as const, shadowSize: '4' as const },
     ]
 }
@@ -66,7 +81,14 @@ function InstallScreen({ heading, sub, footer }: { heading: string; sub: string;
         <div className="relative mx-auto flex h-[660px] w-full max-w-[380px] flex-col overflow-hidden rounded-sm border border-n-1 bg-white">
             <section className="relative flex h-2/5 w-full items-center justify-center overflow-hidden bg-secondary-3">
                 {STARS.map((pos, i) => (
-                    <Image key={i} src={starImage.src} alt="" width={38} height={38} className={`absolute z-10 ${pos}`} />
+                    <Image
+                        key={i}
+                        src={starImage.src}
+                        alt=""
+                        width={38}
+                        height={38}
+                        className={`absolute z-10 ${pos}`}
+                    />
                 ))}
                 <Image src={PEANUTMAN_MOBILE} alt="Peanut" width={150} height={150} className="z-0 object-contain" />
             </section>
@@ -80,9 +102,9 @@ function InstallScreen({ heading, sub, footer }: { heading: string; sub: string;
 }
 
 // the live "Continue with Peanut" button (mascot + wordmark) from SendLinkActionList.
-function ContinueWithPeanut() {
+function ContinueWithPeanut({ onClick }: { onClick?: () => void }) {
     return (
-        <Button shadowSize="4" className="flex w-full items-center justify-center gap-1">
+        <Button shadowSize="4" onClick={onClick} className="flex w-full items-center justify-center gap-1">
             <span>Continue with</span>
             <Image src={PEANUTMAN} alt="" className="size-5" />
             <Image src={PEANUT_LOGO_BLACK} alt="Peanut" className="h-4 w-auto" />
@@ -90,7 +112,17 @@ function ContinueWithPeanut() {
     )
 }
 
-function Section({ n, title, subtitle, children }: { n: string; title: string; subtitle: string; children: React.ReactNode }) {
+function Section({
+    n,
+    title,
+    subtitle,
+    children,
+}: {
+    n: string
+    title: string
+    subtitle: string
+    children: React.ReactNode
+}) {
     return (
         <section className="flex flex-col gap-4 border-b border-n-1/15 py-10">
             <div>
@@ -104,14 +136,46 @@ function Section({ n, title, subtitle, children }: { n: string; title: string; s
 }
 
 const INDEX = [
-    ['01 Download prompt', 'A modal asking logged-in web users to get the app. Countdown variant warns the site is closing.', 'Web app, after login, during the migration window.'],
-    ['02 Access-ending screen', 'Full screen shown once the website is switched off — download is the only way forward.', 'Web app, after the cutover date, on every route.'],
-    ['03 Guest link pages', 'The claim / request / invite pages a non-user lands on. Primary action is "Continue with Peanut" (opens the app / store).', 'Public links: /claim, /request, /invite, /pay, /profile.'],
-    ['04 Get-the-app banner', 'A home-carousel card nudging users to install, without blocking anything.', 'Home screen carousel (web).'],
-    ['05 Landing page', 'The marketing homepage hero — CTA is "Download", not "Sign up".', 'peanut.me for new / anonymous visitors.'],
-    ['06 Review prompt', 'Asks happy users to rate the app; unhappy ones go to support instead.', 'In the app, after a good moment (money received, payment done).'],
-    ['07 Notifications prompt', 'Custom ask before the OS permission popup, so we can ask again later.', 'In the app, at launch for users who never enabled push.'],
-    ['08 Scan-to-download (QR)', 'On desktop, store links do nothing — this modal shows a QR to scan with your phone. Replaces the store buttons wherever a download CTA appears on web.', 'Every download CTA when the visitor is on a desktop browser.'],
+    [
+        '01 Download prompt',
+        'A modal asking logged-in web users to get the app. Countdown variant warns the site is closing.',
+        'Web app, after login, during the migration window.',
+    ],
+    [
+        '02 Access-ending screen',
+        'Full screen shown once the website is switched off — download is the only way forward.',
+        'Web app, after the cutover date, on every route.',
+    ],
+    [
+        '03 Guest link pages',
+        'The claim / request / invite pages a non-user lands on. Primary action is "Continue with Peanut" (opens the app / store).',
+        'Public links: /claim, /request, /invite, /pay, /profile.',
+    ],
+    [
+        '04 Get-the-app banner',
+        'A home-carousel card nudging users to install, without blocking anything.',
+        'Home screen carousel (web).',
+    ],
+    [
+        '05 Landing page',
+        'The marketing homepage hero — CTA is "Download", not "Sign up".',
+        'peanut.me for new / anonymous visitors.',
+    ],
+    [
+        '06 Review prompt',
+        'Asks happy users to rate the app; unhappy ones go to support instead.',
+        'In the app, after a good moment (money received, payment done).',
+    ],
+    [
+        '07 Notifications prompt',
+        'Custom ask before the OS permission popup, so we can ask again later.',
+        'In the app, at launch for users who never enabled push.',
+    ],
+    [
+        '08 Scan-to-download (QR)',
+        'On desktop, store links do nothing — this modal shows a QR to scan with your phone. Replaces the store buttons wherever a download CTA appears on web.',
+        'Every download CTA when the visitor is on a desktop browser.',
+    ],
 ]
 
 export default function MigrationMockupsPage() {
@@ -181,10 +245,22 @@ export default function MigrationMockupsPage() {
                 subtitle="Shown after login on the website. Dismissible. The countdown variant makes the deadline loud."
             >
                 <div className="flex flex-wrap gap-3">
-                    <Button variant="stroke" onClick={() => { setCountdown(false); setDownloadModal(true) }}>
+                    <Button
+                        variant="stroke"
+                        onClick={() => {
+                            setCountdown(false)
+                            setDownloadModal(true)
+                        }}
+                    >
                         Open (reminder)
                     </Button>
-                    <Button variant="stroke" onClick={() => { setCountdown(true); setDownloadModal(true) }}>
+                    <Button
+                        variant="stroke"
+                        onClick={() => {
+                            setCountdown(true)
+                            setDownloadModal(true)
+                        }}
+                    >
                         Open (with countdown)
                     </Button>
                 </div>
@@ -193,18 +269,29 @@ export default function MigrationMockupsPage() {
                     onClose={() => setDownloadModal(false)}
                     icon="mobile-install"
                     title="Peanut is moving to your phone"
-                    description="Get the Peanut app to keep using your account — it's faster and you'll get alerts when money lands."
+                    description={
+                        <div className="spacey-y-4">
+                            <p>
+                                Get the Peanut app to keep using your account — it's faster and you'll get alerts when
+                                money lands.
+                            </p>
+                            {countdown && (
+                                <div className="flex flex-col items-center gap-1">
+                                    <span className="text-3xl font-extrabold leading-none text-n-1">14 days</span>
+                                    <span className="text-xs font-semibold uppercase tracking-wide text-n-1">
+                                        until the website closes
+                                    </span>
+                                </div>
+                            )}
+                        </div>
+                    }
                     ctas={storeCtas(platform, openQr)}
                     footer={
-                        countdown ? (
-                            <div className="mt-4 flex flex-col items-center gap-1 rounded-sm border border-n-1 bg-primary-1 px-4 py-3">
-                                <span className="text-3xl font-extrabold leading-none text-n-1">14 days</span>
-                                <span className="text-xs font-semibold uppercase tracking-wide text-n-1">
-                                    until the website closes
-                                </span>
-                            </div>
-                        ) : (
-                            <button className="mt-3 w-full text-center text-xs text-grey-1 underline" onClick={() => setDownloadModal(false)}>
+                        !countdown && (
+                            <button
+                                className="mt-3 w-full text-center text-xs text-grey-1 underline"
+                                onClick={() => setDownloadModal(false)}
+                            >
                                 Remind me later
                             </button>
                         )
@@ -239,9 +326,9 @@ export default function MigrationMockupsPage() {
                 subtitle="Whole page a non-user lands on. Same hero as today, primary action is 'Continue with Peanut' (opens the app, or the store if not installed). Mock data."
             >
                 <div className="grid gap-6 lg:grid-cols-3">
-                    <GuestPage kind="claim" />
-                    <GuestPage kind="request" />
-                    <GuestPage kind="invite" />
+                    <GuestPage kind="claim" onCta={platform === 'desktop' ? openQr : () => {}} />
+                    <GuestPage kind="request" onCta={platform === 'desktop' ? openQr : () => {}} />
+                    <GuestPage kind="invite" onCta={platform === 'desktop' ? openQr : () => {}} />
                 </div>
             </Section>
 
@@ -263,50 +350,32 @@ export default function MigrationMockupsPage() {
                         />
                     </div>
                 ) : (
-                    <Button variant="stroke" onClick={() => setBannerOpen(true)}>Reset banner</Button>
+                    <Button variant="stroke" onClick={() => setBannerOpen(true)}>
+                        Reset banner
+                    </Button>
                 )}
             </Section>
 
-            {/* 05 Landing page — responsive full-width hero (mirrors the real landing) */}
+            {/* 05 Landing page — the real <Hero> component, only the CTA is device-based */}
             <Section
                 n="05"
                 title="Landing page hero (new visitors)"
-                subtitle="The real landing hero, reworked: brand-pink + drifting clouds + mascot, responsive (full-width on web, stacked on phone). CTA is 'Download' with store buttons + a rating — no 'Sign up'."
+                subtitle="The real landing hero (same component as peanut.me). Only change from live: the single CTA is device-based — App Store on iOS, Google Play on Android, 'Download the app' on desktop."
             >
-                <div className="relative w-full overflow-hidden rounded-sm border border-n-1 bg-primary-1 px-4 py-14 md:py-20">
-                    <CloudsCss />
-                    <div className="relative z-10 mx-auto flex max-w-3xl flex-col items-center gap-4 text-center">
-                        <Image
-                            src={PeanutWhistling.src}
-                            alt="Peanut"
-                            width={220}
-                            height={220}
-                            className="w-28 object-contain md:w-44"
-                        />
-                        <h1 className="font-roboto-flex-extrabold text-[2rem] font-extraBlack leading-none text-n-1 md:text-6xl">
-                            TAP. SCAN. ANYWHERE.
-                        </h1>
-                        <p className="max-w-md text-base text-n-1/80 md:text-xl">
-                            Send money like a text — no bank, no borders. Download the app and send in seconds.
-                        </p>
-                        {platform === 'desktop' ? (
-                            <Button variant="dark" shadowSize="4" icon="qr-code" className="mt-2 w-full max-w-sm" onClick={openQr}>
-                                Show QR to download
-                            </Button>
-                        ) : (
-                            <div className="mt-2 flex w-full max-w-sm flex-col gap-3 sm:max-w-none sm:flex-row sm:justify-center">
-                                <Button variant="dark" shadowSize="4" icon="mobile-install" className="sm:w-52">
-                                    {STORE[platform]}
-                                </Button>
-                                <Button variant="stroke" shadowSize="4" className="bg-white sm:w-52">
-                                    {STORE[platform === 'ios' ? 'android' : 'ios']}
-                                </Button>
-                            </div>
-                        )}
-                        <div className="mt-1 flex items-center gap-1 text-sm font-semibold text-n-1">
-                            <Icon name="star" size={16} /> 4.8 · loved by thousands
-                        </div>
-                    </div>
+                <div className="overflow-hidden rounded-sm border border-n-1">
+                    <Hero
+                        buttonVisible
+                        primaryCta={
+                            platform === 'ios'
+                                ? { label: 'Download on the App Store', href: 'https://apps.apple.com/app/peanut' }
+                                : platform === 'android'
+                                  ? {
+                                        label: 'Get it on Google Play',
+                                        href: 'https://play.google.com/store/apps/details?id=me.peanut.wallet',
+                                    }
+                                  : { label: 'Download the app', href: '#' }
+                        }
+                    />
                 </div>
             </Section>
 
@@ -316,7 +385,9 @@ export default function MigrationMockupsPage() {
                 title="Review prompt (in-app, after a good moment)"
                 subtitle="Custom pre-prompt. 'Love it' opens the store rating sheet; 'Could be better' opens support instead — so bad reviews never reach the store."
             >
-                <Button variant="stroke" onClick={() => setReviewModal(true)}>Open review prompt</Button>
+                <Button variant="stroke" onClick={() => setReviewModal(true)}>
+                    Open review prompt
+                </Button>
                 <ActionModal
                     visible={reviewModal}
                     onClose={() => setReviewModal(false)}
@@ -336,7 +407,9 @@ export default function MigrationMockupsPage() {
                 title="Notifications prompt (in-app launch)"
                 subtitle="Our own ask before the OS popup — if they say not now, we can ask again later (the OS popup only fires on 'Allow')."
             >
-                <Button variant="stroke" onClick={() => setPushModal(true)}>Open notifications prompt</Button>
+                <Button variant="stroke" onClick={() => setPushModal(true)}>
+                    Open notifications prompt
+                </Button>
                 <ActionModal
                     visible={pushModal}
                     onClose={() => setPushModal(false)}
@@ -365,7 +438,7 @@ export default function MigrationMockupsPage() {
             <ActionModal
                 visible={qrModal}
                 onClose={() => setQrModal(false)}
-                icon="qr-code"
+                icon="mobile-install"
                 title="Scan to download Peanut"
                 description="Point your phone's camera at the code to get the app from your store."
                 content={
@@ -385,9 +458,12 @@ const GUEST = {
     claim: { header: 'Receive', tx: 'CLAIM_LINK', name: 'alice', amount: '25', message: '' },
     request: { header: 'Pay', tx: 'REQUEST_PAYMENT', name: 'bob', amount: '40', message: 'for dinner' },
     invite: { header: 'Receive', tx: 'CLAIM_LINK', name: 'carol', amount: '25', message: '' },
-} satisfies Record<string, { header: string; tx: PeanutActionDetailsCardTransactionType; name: string; amount: string; message: string }>
+} satisfies Record<
+    string,
+    { header: string; tx: PeanutActionDetailsCardTransactionType; name: string; amount: string; message: string }
+>
 
-function GuestPage({ kind }: { kind: 'claim' | 'request' | 'invite' }) {
+function GuestPage({ kind, onCta }: { kind: 'claim' | 'request' | 'invite'; onCta: () => void }) {
     const c = GUEST[kind]
     return (
         <div className="mx-auto flex h-[600px] w-full max-w-[360px] flex-col justify-between gap-6 overflow-hidden rounded-sm border border-n-1 bg-white p-5">
@@ -410,7 +486,7 @@ function GuestPage({ kind }: { kind: 'claim' | 'request' | 'invite' }) {
                     </div>
                 )}
                 <div className="space-y-2">
-                    <ContinueWithPeanut />
+                    <ContinueWithPeanut onClick={onCta} />
                     <Divider text="or" />
                     <div>
                         <ActionListCard
@@ -418,14 +494,14 @@ function GuestPage({ kind }: { kind: 'claim' | 'request' | 'invite' }) {
                             leftIcon={<Icon name="bank" size={20} />}
                             title="Bank transfer"
                             description="1-2 business days"
-                            onClick={() => {}}
+                            onClick={onCta}
                         />
                         <ActionListCard
                             position="last"
                             leftIcon={<Icon name="bank" size={20} />}
                             title="Pix"
                             description="Instant, Brazil"
-                            onClick={() => {}}
+                            onClick={onCta}
                         />
                     </div>
                 </div>

--- a/src/app/(mobile-ui)/dev/migration/page.tsx
+++ b/src/app/(mobile-ui)/dev/migration/page.tsx
@@ -246,9 +246,8 @@ export default function MigrationMockupsPage() {
                     title="Peanut is becoming an app"
                     description={
                         <p className="py-1">
-                            Peanut is moving to the App Store and Google Play. In{' '}
-                            <b className="text-black">14 days</b> it will only work in the app — download it now to keep
-                            using your account.
+                            Peanut is moving to the App Store and Google Play. In <b className="text-black">14 days</b>{' '}
+                            it will only work in the app — download it now to keep using your account.
                         </p>
                     }
                     content={platform === 'desktop' ? <DownloadQR /> : undefined}

--- a/src/app/(mobile-ui)/dev/migration/page.tsx
+++ b/src/app/(mobile-ui)/dev/migration/page.tsx
@@ -19,19 +19,29 @@ import { PEANUTMAN, PEANUTMAN_MOBILE, PeanutWhistling } from '@/assets/mascot'
 import { PEANUT_LOGO_BLACK } from '@/assets/logos'
 import starImage from '@/assets/icons/star.png'
 
-type Platform = 'ios' | 'android'
+type Platform = 'ios' | 'android' | 'desktop'
 const STORE = { ios: 'App Store', android: 'Google Play' } as const
 
-// device-aware store CTAs: the user's platform is the primary (purple), the other
-// is secondary (stroke). brand logos (Apple / Play) aren't in the icon set yet — TODO.
-function storeCtas(platform: Platform) {
+// device-aware download CTAs. mobile -> the user's store is primary (purple), the
+// other is secondary. desktop -> store links are useless on a laptop, so we show a
+// "Show QR" button that opens a scan-to-download modal (mirrors InstallPWA's
+// DesktopInstructions). brand logos (Apple / Play) aren't in the icon set yet — TODO.
+function storeCtas(platform: Platform, onQr: () => void) {
+    if (platform === 'desktop')
+        return [{ text: 'Show QR to download', variant: 'purple' as const, shadowSize: '4' as const, icon: 'qr-code' as const, onClick: onQr }]
     const other: Platform = platform === 'ios' ? 'android' : 'ios'
     return [
         { text: STORE[platform], variant: 'purple' as const, shadowSize: '4' as const, icon: 'mobile-install' as const },
         { text: STORE[other], variant: 'stroke' as const, shadowSize: '4' as const },
     ]
 }
-function StoreButtons({ platform }: { platform: Platform }) {
+function StoreButtons({ platform, onQr }: { platform: Platform; onQr: () => void }) {
+    if (platform === 'desktop')
+        return (
+            <Button variant="purple" shadowSize="4" icon="qr-code" className="w-full" onClick={onQr}>
+                Show QR to download
+            </Button>
+        )
     const other: Platform = platform === 'ios' ? 'android' : 'ios'
     return (
         <div className="flex w-full flex-col gap-2">
@@ -97,6 +107,7 @@ const INDEX = [
     ['05 Landing page', 'The marketing homepage hero — CTA is "Download", not "Sign up".', 'peanut.me for new / anonymous visitors.'],
     ['06 Review prompt', 'Asks happy users to rate the app; unhappy ones go to support instead.', 'In the app, after a good moment (money received, payment done).'],
     ['07 Notifications prompt', 'Custom ask before the OS permission popup, so we can ask again later.', 'In the app, at launch for users who never enabled push.'],
+    ['08 Scan-to-download (QR)', 'On desktop, store links do nothing — this modal shows a QR to scan with your phone. Replaces the store buttons wherever a download CTA appears on web.', 'Every download CTA when the visitor is on a desktop browser.'],
 ]
 
 export default function MigrationMockupsPage() {
@@ -105,7 +116,14 @@ export default function MigrationMockupsPage() {
     const [countdown, setCountdown] = useState(false)
     const [reviewModal, setReviewModal] = useState(false)
     const [pushModal, setPushModal] = useState(false)
+    const [qrModal, setQrModal] = useState(false)
     const [bannerOpen, setBannerOpen] = useState(true)
+
+    // desktop download CTAs open the QR modal instead of dead store links.
+    const openQr = () => {
+        setDownloadModal(false)
+        setQrModal(true)
+    }
 
     // device-aware: default the primary store CTA to the visitor's platform.
     useEffect(() => {
@@ -122,15 +140,15 @@ export default function MigrationMockupsPage() {
                         components.
                     </p>
                 </div>
-                {/* platform toggle — drives which store CTA is primary */}
+                {/* platform toggle — drives the download CTA (store buttons vs desktop QR) */}
                 <div className="flex overflow-hidden rounded-sm border border-n-1">
-                    {(['ios', 'android'] as Platform[]).map((p) => (
+                    {(['ios', 'android', 'desktop'] as Platform[]).map((p) => (
                         <button
                             key={p}
                             onClick={() => setPlatform(p)}
                             className={`px-4 py-2 text-sm font-semibold ${platform === p ? 'bg-primary-1 text-n-1' : 'bg-white text-grey-1'}`}
                         >
-                            {p === 'ios' ? 'iOS' : 'Android'}
+                            {p === 'ios' ? 'iOS' : p === 'android' ? 'Android' : 'Desktop'}
                         </button>
                     ))}
                 </div>
@@ -171,8 +189,8 @@ export default function MigrationMockupsPage() {
                     onClose={() => setDownloadModal(false)}
                     icon="mobile-install"
                     title="Peanut is moving to your phone"
-                    description="Get the Peanut app from the App Store or Google Play to keep using your account — it's faster and you'll get alerts when money lands."
-                    ctas={storeCtas(platform)}
+                    description="Get the Peanut app to keep using your account — it's faster and you'll get alerts when money lands."
+                    ctas={storeCtas(platform, openQr)}
                     footer={
                         countdown ? (
                             <div className="mt-4 flex flex-col items-center gap-1 rounded-sm border border-n-1 bg-primary-1 px-4 py-3">
@@ -201,7 +219,7 @@ export default function MigrationMockupsPage() {
                     sub="The website has closed. Download the app to get back into your account — your money is safe."
                     footer={
                         <>
-                            <StoreButtons platform={platform} />
+                            <StoreButtons platform={platform} onQr={openQr} />
                             <a className="text-center text-sm text-black underline" href="#">
                                 Can&apos;t download the app? Contact support
                             </a>
@@ -267,14 +285,20 @@ export default function MigrationMockupsPage() {
                         <p className="max-w-md text-base text-n-1/80 md:text-xl">
                             Send money like a text — no bank, no borders. Download the app and send in seconds.
                         </p>
-                        <div className="mt-2 flex w-full max-w-sm flex-col gap-3 sm:max-w-none sm:flex-row sm:justify-center">
-                            <Button variant="dark" shadowSize="4" icon="mobile-install" className="sm:w-52">
-                                {STORE[platform]}
+                        {platform === 'desktop' ? (
+                            <Button variant="dark" shadowSize="4" icon="qr-code" className="mt-2 w-full max-w-sm" onClick={openQr}>
+                                Show QR to download
                             </Button>
-                            <Button variant="stroke" shadowSize="4" className="bg-white sm:w-52">
-                                {STORE[platform === 'ios' ? 'android' : 'ios']}
-                            </Button>
-                        </div>
+                        ) : (
+                            <div className="mt-2 flex w-full max-w-sm flex-col gap-3 sm:max-w-none sm:flex-row sm:justify-center">
+                                <Button variant="dark" shadowSize="4" icon="mobile-install" className="sm:w-52">
+                                    {STORE[platform]}
+                                </Button>
+                                <Button variant="stroke" shadowSize="4" className="bg-white sm:w-52">
+                                    {STORE[platform === 'ios' ? 'android' : 'ios']}
+                                </Button>
+                            </div>
+                        )}
                         <div className="mt-1 flex items-center gap-1 text-sm font-semibold text-n-1">
                             <Icon name="star" size={16} /> 4.8 · loved by thousands
                         </div>
@@ -321,6 +345,32 @@ export default function MigrationMockupsPage() {
                     ]}
                 />
             </Section>
+
+            {/* 08 Scan-to-download (QR) — the desktop download surface */}
+            <Section
+                n="08"
+                title="Scan-to-download modal (desktop)"
+                subtitle="Web users can't install from a laptop, so a download CTA on desktop opens this QR to scan with their phone (mirrors InstallPWA's DesktopInstructions). Toggle 'Desktop' above to see it wired into 01 / 02 / 05."
+            >
+                <Button variant="stroke" onClick={() => setQrModal(true)}>
+                    Open scan-to-download
+                </Button>
+            </Section>
+
+            {/* shared QR modal — opened by any desktop download CTA */}
+            <ActionModal
+                visible={qrModal}
+                onClose={() => setQrModal(false)}
+                icon="qr-code"
+                title="Scan to download Peanut"
+                description="Point your phone's camera at the code to get the app from your store."
+                content={
+                    <div className="mx-auto py-2">
+                        <QRCodeWrapper url="https://peanut.me/app" />
+                    </div>
+                }
+                ctas={[{ text: 'Done', variant: 'stroke', shadowSize: '4', onClick: () => setQrModal(false) }]}
+            />
         </div>
     )
 }


### PR DESCRIPTION
## Summary

Adds a **dev-only preview page** at `/dev/migration` that showcases every UI surface for the PWA → app-store migration, composed from the **real app components** (not lookalikes) so the states read like production.

Surfaces covered:
- **01 Download prompt** — single variant, deadline in copy; mobile shows the visitor's store CTA, desktop shows the QR inline.
- **02 Access-ending screen** — full-screen after cutover (mirrors `ForceIOSPWAInstall`).
- **03 Guest link pages** — claim / request / invite, built from `PeanutActionDetailsCard` + `ActionListCard` + the real "Continue with Peanut" button.
- **04 Get-the-app banner** — the real home `CarouselCTA`.
- **05 Landing hero** — the real `<Hero>` component, CTA swapped to "Download now".
- **06 Review prompt** / **07 Notifications prompt** — `ActionModal` pre-prompts.
- **08 Scan-to-download** — a QR with an App Store / Google Play toggle (a browser can't tell iOS from Android).

Device-aware throughout: **one primary CTA per device** (mobile → store button; desktop → QR).

## Risk

**None to production.** Dev-only route — `/dev` is `notFound()` on prod (`dev/layout.tsx`), the whole page is behind that gate. No production code touched; only a new file under `src/app/(mobile-ui)/dev/`.

## QA

```
./scripts/dev   # or: PORT=3055 pnpm dev in this worktree
open http://localhost:3055/dev/migration
```
Toggle **iOS / Android / Desktop** (top-right) to see the device-aware CTAs; open each modal; on Desktop the download CTAs show the dual-store QR.

## Screenshots

Dev-only preview route — best viewed live at `/dev/migration` (steps above). Every surface is rendered from the real components; toggling the platform pill drives the CTA variants.

## Design notes

- No "native app" wording anywhere — users don't know the term; copy is "Peanut is becoming an app" / "download from the App Store or Google Play".
- The dual-store QR toggle is deliberate; a single smart link (`peanut.me/app` redirecting by device) would remove the toggle — noted in a code comment as the lighter alternative, pending a product call.
- Components are composed inline in the dev page for review — **not yet extracted** into production components; that happens when the migration decisions lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
