### PR TITLE
feat(dev): consistent shell for /dev pages + /dev/journey product cockpit

### DIFF
--- a/src/app/(mobile-ui)/dev/_components/DevChip.tsx
+++ b/src/app/(mobile-ui)/dev/_components/DevChip.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { twMerge } from 'tailwind-merge'
+import { DEV_CHIP_TONE_CLASS, type DevChipTone } from './devChipTones'
+
+/** Small colour-coded pill for dev-page taxonomies and badges. */
+export default function DevChip({
+    children,
+    tone = 'neutral',
+    title,
+    className,
+}: {
+    children: React.ReactNode
+    tone?: DevChipTone
+    /** Native tooltip — the taxonomy explanation on hover. */
+    title?: string
+    className?: string
+}) {
+    return (
+        <span
+            title={title}
+            className={twMerge(
+                'inline-block shrink-0 rounded-sm border border-n-1 px-1.5 py-0.5 text-[9px] font-bold uppercase leading-tight',
+                DEV_CHIP_TONE_CLASS[tone],
+                title && 'cursor-help',
+                className
+            )}
+        >
+            {children}
+        </span>
+    )
+}

--- a/src/app/(mobile-ui)/dev/_components/DevField.tsx
+++ b/src/app/(mobile-ui)/dev/_components/DevField.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+/** Labelled form field used inside DevPanel. */
+export default function DevField({ label, children }: { label: string; children: React.ReactNode }) {
+    return (
+        <label className="flex flex-col gap-1.5">
+            <span className="text-xs font-bold text-grey-1">{label}</span>
+            {children}
+        </label>
+    )
+}

--- a/src/app/(mobile-ui)/dev/_components/DevNoteCard.tsx
+++ b/src/app/(mobile-ui)/dev/_components/DevNoteCard.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { Card } from '@/components/0_Bruddle/Card'
+import { Icon } from '@/components/Global/Icons/Icon'
+
+/** Lavender caveat/footnote card that closes several dev pages. */
+export default function DevNoteCard({ title = 'Note', children }: { title?: string; children: React.ReactNode }) {
+    return (
+        <Card className="bg-primary-3/20 p-3">
+            <div className="mb-1 flex items-center gap-2">
+                <Icon name="info" size={14} />
+                <span className="text-xs font-bold">{title}</span>
+            </div>
+            <div className="text-xs text-grey-1">{children}</div>
+        </Card>
+    )
+}

--- a/src/app/(mobile-ui)/dev/_components/DevPageShell.tsx
+++ b/src/app/(mobile-ui)/dev/_components/DevPageShell.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import NavHeader from '@/components/Global/NavHeader'
+import Link from 'next/link'
+import { twMerge } from 'tailwind-merge'
+
+/**
+ * The shell every /dev page sits in.
+ *
+ * Two things it exists to fix, both structural:
+ *  - The (mobile-ui) layout strips all padding for /dev routes (`isDev && 'p-0 pb-0'`)
+ *    and stops constraining the width, so each page had to re-invent its own padding —
+ *    and several forgot, rendering flush against the viewport edge.
+ *  - NavHeader hides both its back button and its title on `md:`, so no dev page had a
+ *    visible heading on desktop, which is where these tools are actually used.
+ *
+ * Dev pages are also flex children of a `justify-start` row: without `w-full` they
+ * shrink to content width (why the leaderboard rendered in a ~800px gutter).
+ */
+export default function DevPageShell({
+    title,
+    description,
+    backHref = '/dev',
+    actions,
+    width = 'wide',
+    className,
+    children,
+}: {
+    title: string
+    description?: React.ReactNode
+    /** Where the back affordance points. Defaults to the dev-tools index. */
+    backHref?: string
+    /** Right-aligned header controls (view toggles, filters). */
+    actions?: React.ReactNode
+    /** `prose` caps the body at a readable column; `wide` fills the viewport. */
+    width?: 'wide' | 'prose'
+    className?: string
+    children: React.ReactNode
+}) {
+    return (
+        <div className={twMerge('flex w-full min-w-0 flex-col gap-6 px-4 py-4 md:px-8 md:py-6', className)}>
+            <header className="flex w-full flex-col gap-2">
+                {/* NavHeader is the mobile back affordance; it renders nothing useful on md+ */}
+                <div className="md:hidden">
+                    <NavHeader href={backHref} hideLabel />
+                </div>
+                <Link
+                    href={backHref}
+                    className="hidden w-max text-xs font-bold uppercase tracking-wide text-grey-1 underline-offset-2 hover:text-n-1 hover:underline md:block"
+                >
+                    ← {backHref === '/dev' ? 'dev tools' : 'back'}
+                </Link>
+                <div className="flex flex-wrap items-start justify-between gap-x-6 gap-y-3">
+                    <div className="flex min-w-0 flex-col gap-1">
+                        <h1 className="text-2xl font-extrabold leading-tight md:text-3xl">{title}</h1>
+                        {description && <p className="max-w-3xl text-sm text-grey-1">{description}</p>}
+                    </div>
+                    {actions}
+                </div>
+            </header>
+
+            <div className={twMerge('flex w-full min-w-0 flex-col gap-8', width === 'prose' && 'max-w-3xl')}>
+                {children}
+            </div>
+        </div>
+    )
+}

--- a/src/app/(mobile-ui)/dev/_components/DevPanel.tsx
+++ b/src/app/(mobile-ui)/dev/_components/DevPanel.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+/** Bordered control panel with a heading — the builders' left-rail sections. */
+export default function DevPanel({ title, children }: { title: string; children: React.ReactNode }) {
+    return (
+        <section className="shadow-4 rounded-sm border-2 border-n-1 bg-white p-4">
+            <h2 className="mb-3 text-xs font-bold uppercase tracking-wide text-grey-1">{title}</h2>
+            <div className="flex flex-col gap-3">{children}</div>
+        </section>
+    )
+}

--- a/src/app/(mobile-ui)/dev/_components/DevPresetButton.tsx
+++ b/src/app/(mobile-ui)/dev/_components/DevPresetButton.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+/** One-tap preset pill inside a DevPanel. */
+export default function DevPresetButton({ onClick, children }: { onClick: () => void; children: React.ReactNode }) {
+    return (
+        <button
+            onClick={onClick}
+            className="rounded-full border border-n-1 bg-white px-2 py-1 text-xs font-bold transition-colors hover:bg-grey-2"
+        >
+            {children}
+        </button>
+    )
+}

--- a/src/app/(mobile-ui)/dev/_components/DevSectionLabel.tsx
+++ b/src/app/(mobile-ui)/dev/_components/DevSectionLabel.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { twMerge } from 'tailwind-merge'
+
+/**
+ * The one section heading for /dev pages. Replaces the four competing idioms
+ * that had drifted across the tree (`text-sm`/`text-xs`, `<p>`/`<h2>`,
+ * `tracking-wide`/`tracking-wider`, `font-bold`/`font-extrabold`).
+ */
+export default function DevSectionLabel({ children, className }: { children: React.ReactNode; className?: string }) {
+    return <h2 className={twMerge('text-xs font-bold uppercase tracking-wide text-grey-1', className)}>{children}</h2>
+}

--- a/src/app/(mobile-ui)/dev/_components/devChipTones.ts
+++ b/src/app/(mobile-ui)/dev/_components/devChipTones.ts
@@ -1,0 +1,14 @@
+/**
+ * Tones for DevChip. Kept in its own module because the surface-kind taxonomy
+ * (journey/surfaceKindMeta.ts) maps onto it and components may not export types.
+ */
+export type DevChipTone = 'neutral' | 'lavender' | 'yellow' | 'pink' | 'green' | 'ink'
+
+export const DEV_CHIP_TONE_CLASS: Record<DevChipTone, string> = {
+    neutral: 'bg-white text-n-1',
+    lavender: 'bg-primary-3 text-n-1',
+    yellow: 'bg-yellow-1 text-n-1',
+    pink: 'bg-primary-1 text-n-1',
+    green: 'bg-green-1 text-n-1',
+    ink: 'bg-n-1 text-white',
+}

--- a/src/app/(mobile-ui)/dev/card-session-approve/page.tsx
+++ b/src/app/(mobile-ui)/dev/card-session-approve/page.tsx
@@ -13,6 +13,7 @@ import { findActiveCard } from '@/components/Card/cardState.utils'
 import { useRainCardOverview } from '@/hooks/useRainCardOverview'
 import { useGrantSessionKey } from '@/hooks/wallet/useGrantSessionKey'
 import { Button } from '@/components/0_Bruddle/Button'
+import DevPageShell from '../_components/DevPageShell'
 
 export default function CardSessionApprovePage() {
     const { overview } = useRainCardOverview()
@@ -32,13 +33,11 @@ export default function CardSessionApprovePage() {
     }
 
     return (
-        <div className="mx-auto flex max-w-xl flex-col gap-4 p-6">
-            <h1 className="text-2xl font-black">Rain card — grant session-key permission</h1>
-            <p className="text-sm text-grey-1">
-                One passkey tap installs both auto-balancer and withdraw policies to your kernel. After this grant, card
-                collateral spends only need a single admin EIP-712 tap per spend.
-            </p>
-
+        <DevPageShell
+            title="Rain card — grant session-key permission"
+            description="One passkey tap installs both auto-balancer and withdraw policies to your kernel. After this grant, card collateral spends only need a single admin EIP-712 tap per spend."
+            width="prose"
+        >
             <div className="rounded-sm border border-n-1 p-3 text-sm">
                 <div>
                     <span className="font-bold">Card status: </span>
@@ -69,6 +68,6 @@ export default function CardSessionApprovePage() {
             </Button>
 
             {status && <pre className="whitespace-pre-wrap rounded-sm border border-n-1 p-3 text-xs">{status}</pre>}
-        </div>
+        </DevPageShell>
     )
 }

--- a/src/app/(mobile-ui)/dev/components/page.tsx
+++ b/src/app/(mobile-ui)/dev/components/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import NavHeader from '@/components/Global/NavHeader'
 import { Icon, type IconName } from '@/components/Global/Icons/Icon'
+import DevPageShell from '../_components/DevPageShell'
 import Divider from '@/components/0_Bruddle/Divider'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Card } from '@/components/0_Bruddle/Card'
@@ -127,13 +128,12 @@ export default function ComponentsPage() {
     const { success, error, info, warning } = useToast()
 
     return (
-        <div className="flex w-full flex-col">
-            <div className="px-4 pt-4">
-                <NavHeader title="Components" href="/dev" />
-            </div>
-
+        <DevPageShell
+            title="Components"
+            description="Every Bruddle primitive and Global component, with all variants — the live counterpart to the design-system docs."
+        >
             {/* sticky TOC */}
-            <div className="sticky top-0 z-10 border-b border-n-1 bg-background px-4 py-2">
+            <div className="sticky top-0 z-10 -mx-1 border-b border-n-1 bg-background px-1 py-2">
                 <div className="flex gap-1 overflow-x-auto">
                     {TOC.map((item) => (
                         <a
@@ -148,7 +148,7 @@ export default function ComponentsPage() {
                 </div>
             </div>
 
-            <div className="space-y-8 px-4 py-6">
+            <div className="space-y-8">
                 {/* ━━━━━━━━━━━━━━━━━━ GUIDELINES ━━━━━━━━━━━━━━━━━━ */}
                 <div id="guidelines" className="scroll-mt-16 space-y-4">
                     <h2 className="text-lg font-bold">Guidelines & Legend</h2>
@@ -1389,6 +1389,6 @@ export default function ComponentsPage() {
                     </Section>
                 </div>
             </div>
-        </div>
+        </DevPageShell>
     )
 }

--- a/src/app/(mobile-ui)/dev/debug/page.tsx
+++ b/src/app/(mobile-ui)/dev/debug/page.tsx
@@ -18,13 +18,17 @@
 
 import { useEffect, useState, useCallback, useRef } from 'react'
 import Link from 'next/link'
-import NavHeader from '@/components/Global/NavHeader'
 import { Button } from '@/components/0_Bruddle/Button'
 import { useAuth } from '@/context/authContext'
 import { PEANUT_API_URL } from '@/constants/general.consts'
 import { debugLog } from '@/utils/debug-console'
+import DevPageShell from '../_components/DevPageShell'
+import DevSectionLabel from '../_components/DevSectionLabel'
 
 type ActionResult = { ok: boolean; raw: any; ms: number }
+
+const DEBUG_DESCRIPTION =
+    'Sandbox-only cheats: one-click full setup, fund USDC, fast-forward KYC, complete pending intents. Every action also logs to the console in pink.'
 
 const WAITLIST_SKIP_BADGES = [
     { code: 'OG_2025_10_12', holders: 2196 },
@@ -115,21 +119,23 @@ export default function DebugPage() {
         if (userId) refreshWhoami()
     }, [userId, refreshWhoami])
 
-    if (isFetchingUser) return <div className="p-4 font-mono text-sm">loading user…</div>
+    if (isFetchingUser)
+        return (
+            <DevPageShell title="Debug" description={DEBUG_DESCRIPTION} width="prose">
+                <p className="font-mono text-sm">loading user…</p>
+            </DevPageShell>
+        )
     if (!userId) {
         return (
-            <div className="flex min-h-screen flex-col">
-                <NavHeader title="Debug" />
-                <div className="p-6">
-                    <p className="font-mono text-sm">
-                        Not signed in. Sign up via{' '}
-                        <Link className="underline" href="/setup">
-                            /setup
-                        </Link>{' '}
-                        first, then come back.
-                    </p>
-                </div>
-            </div>
+            <DevPageShell title="Debug" description={DEBUG_DESCRIPTION} width="prose">
+                <p className="font-mono text-sm">
+                    Not signed in. Sign up via{' '}
+                    <Link className="text-black underline" href="/setup">
+                        /setup
+                    </Link>{' '}
+                    first, then come back.
+                </p>
+            </DevPageShell>
         )
     }
 
@@ -449,9 +455,8 @@ export default function DebugPage() {
     ]
 
     return (
-        <div className="flex min-h-screen flex-col">
-            <NavHeader title="Debug" />
-            <div className="space-y-4 p-4 pb-24">
+        <DevPageShell title="Debug" description={DEBUG_DESCRIPTION} width="prose">
+            <div className="space-y-4">
                 <section className="border border-n-1 bg-primary-3 p-3 font-mono text-xs">
                     <div className="mb-2 font-bold">User</div>
                     <div>
@@ -495,7 +500,7 @@ export default function DebugPage() {
 
                 {sections.map((section) => (
                     <section key={section.title}>
-                        <h2 className="mb-2 font-display text-lg">{section.title}</h2>
+                        <DevSectionLabel className="mb-2">{section.title}</DevSectionLabel>
                         <div className="space-y-2">
                             {section.actions.map((a) => {
                                 const r = results[a.key]
@@ -520,7 +525,7 @@ export default function DebugPage() {
                                         {r && (
                                             <pre
                                                 className={`mt-2 max-h-48 overflow-auto border border-n-1 p-2 text-[10px] leading-tight ${
-                                                    r.ok ? 'bg-green-1/30' : 'bg-red-100'
+                                                    r.ok ? 'bg-green-1/30' : 'bg-error-1/20'
                                                 }`}
                                             >
                                                 {`(${r.ms}ms) `}
@@ -535,7 +540,7 @@ export default function DebugPage() {
                 ))}
 
                 <section className="pt-4">
-                    <h2 className="mb-2 font-display text-lg">Shortcuts</h2>
+                    <DevSectionLabel className="mb-2">Shortcuts</DevSectionLabel>
                     <div className="space-y-1 font-mono text-xs">
                         <div>
                             <Link className="underline" href="/home">
@@ -571,6 +576,6 @@ export default function DebugPage() {
                     </div>
                 </section>
             </div>
-        </div>
+        </DevPageShell>
     )
 }

--- a/src/app/(mobile-ui)/dev/home-ctas/page.tsx
+++ b/src/app/(mobile-ui)/dev/home-ctas/page.tsx
@@ -2,14 +2,15 @@
 
 import { type ReactNode } from 'react'
 import type { StaticImageData } from 'next/image'
-import NavHeader from '@/components/Global/NavHeader'
-import { Card } from '@/components/0_Bruddle/Card'
-import { Icon, type IconName } from '@/components/Global/Icons/Icon'
+import { type IconName } from '@/components/Global/Icons/Icon'
 import CardLaunchCTABanner from '@/components/Home/CardLaunchCTA/CardLaunchCTABanner'
 import CarouselCTA from '@/components/Home/HomeCarouselCTA/CarouselCTA'
 import ActivationCTAs from '@/components/Home/ActivationCTAs'
 import { type ActivationStep } from '@/hooks/useActivationStatus'
 import STAR_STRAIGHT_ICON from '@/assets/icons/starStraight.svg'
+import DevNoteCard from '../_components/DevNoteCard'
+import DevPageShell from '../_components/DevPageShell'
+import DevSectionLabel from '../_components/DevSectionLabel'
 
 /**
  * /dev/home-ctas — force-renders every home-screen CTA in isolation so they can
@@ -158,32 +159,23 @@ const ACTIVATION_STEPS: { step: Exclude<ActivationStep, 'completed'>; label: str
     { step: 'outbound', label: "STEPS.outbound — 'Make your first payment'" },
 ]
 
-function SectionLabel({ children }: { children: ReactNode }) {
-    return <p className="text-xs font-bold uppercase tracking-wide text-grey-1">{children}</p>
-}
-
 export default function HomeCTAsPreviewPage() {
     return (
-        <div className="flex min-h-[inherit] flex-col gap-6 pb-8">
-            <div className="px-4 pt-4">
-                <NavHeader title="Home CTAs" />
-            </div>
-
-            <div className="flex flex-col gap-8 px-4">
-                <p className="text-sm text-grey-1">
-                    Every home-screen CTA, force-rendered in isolation — no auth, state, or launch gating. Handlers are
-                    no-op console.logs.
-                </p>
-
+        <DevPageShell
+            title="Home CTAs"
+            description="Every home-screen CTA, force-rendered in isolation — no auth, state, or launch gating. Handlers are no-op console.logs."
+            width="prose"
+        >
+            <div className="flex flex-col gap-8">
                 {/* Card launch banner */}
                 <section className="flex flex-col gap-3">
-                    <SectionLabel>Card launch banner (CardLaunchCTABanner)</SectionLabel>
+                    <DevSectionLabel>Card launch banner (CardLaunchCTABanner)</DevSectionLabel>
                     <CardLaunchCTABanner onTryDoor={noop('onTryDoor')} onDismiss={noop('onDismiss')} />
                 </section>
 
                 {/* Carousel CTAs */}
                 <section className="flex flex-col gap-4">
-                    <SectionLabel>Carousel CTAs (CarouselCTA)</SectionLabel>
+                    <DevSectionLabel>Carousel CTAs (CarouselCTA)</DevSectionLabel>
                     {CAROUSEL_PREVIEWS.map((cta) => (
                         <div key={cta.id} className="flex flex-col gap-1.5">
                             <p className="text-[11px] text-grey-1">{cta.label}</p>
@@ -205,7 +197,7 @@ export default function HomeCTAsPreviewPage() {
 
                 {/* Activation funnel steps */}
                 <section className="flex flex-col gap-4">
-                    <SectionLabel>Activation funnel steps (ActivationCTAs)</SectionLabel>
+                    <DevSectionLabel>Activation funnel steps (ActivationCTAs)</DevSectionLabel>
                     {ACTIVATION_STEPS.map(({ step, label }) => (
                         <div key={step} className="flex flex-col gap-1.5">
                             <p className="text-[11px] text-grey-1">{label}</p>
@@ -217,17 +209,11 @@ export default function HomeCTAsPreviewPage() {
                     ))}
                 </section>
 
-                <Card className="bg-primary-3/20 p-3">
-                    <div className="mb-1 flex items-center gap-2">
-                        <Icon name="info" size={14} />
-                        <span className="text-xs font-bold">Note</span>
-                    </div>
-                    <p className="text-xs text-grey-1">
-                        Activation steps read defensive hooks (useCapabilities / useIdentityVerification) that return
-                        empty defaults when logged out, so every step renders here regardless of real KYC state.
-                    </p>
-                </Card>
+                <DevNoteCard>
+                    Activation steps read defensive hooks (useCapabilities / useIdentityVerification) that return empty
+                    defaults when logged out, so every step renders here regardless of real KYC state.
+                </DevNoteCard>
             </div>
-        </div>
+        </DevPageShell>
     )
 }

--- a/src/app/(mobile-ui)/dev/journey/BoardGroup.tsx
+++ b/src/app/(mobile-ui)/dev/journey/BoardGroup.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { twMerge } from 'tailwind-merge'
+
+/**
+ * One channel band inside a funnel column. Each band carries its own tint so
+ * "what the user sees in the app" and "what we send them" are separable at a
+ * glance instead of being one undifferentiated stack of cards.
+ */
+export default function BoardGroup({
+    icon,
+    label,
+    count,
+    tint,
+    children,
+}: {
+    icon: string
+    label: string
+    count: number
+    tint: string
+    children: React.ReactNode
+}) {
+    return (
+        <section className={twMerge('border-t border-n-1', tint)}>
+            <header className="flex items-center gap-1.5 px-2.5 py-1.5">
+                <span aria-hidden>{icon}</span>
+                <span className="text-[10px] font-bold uppercase tracking-wide text-n-1">{label}</span>
+                <span className="text-[10px] font-bold text-grey-1">{count}</span>
+            </header>
+            <div className="flex flex-col gap-1.5 px-2 pb-2">{children}</div>
+        </section>
+    )
+}

--- a/src/app/(mobile-ui)/dev/journey/EmailCard.tsx
+++ b/src/app/(mobile-ui)/dev/journey/EmailCard.tsx
@@ -1,13 +1,14 @@
 'use client'
 
 import { JOURNEY_API_BASE } from './journeyData'
+import StuckBadge from './StuckBadge'
 import type { SpecEmailStep } from './journeyTypes'
 
 /**
  * Compact card for one lifecycle email step. Links to the API's live rendered
  * preview (opens in a new tab against the sandbox API).
  */
-export default function EmailCard({ step }: { step: SpecEmailStep }) {
+export default function EmailCard({ step, showDev }: { step: SpecEmailStep; showDev: boolean }) {
     return (
         <a
             href={`${JOURNEY_API_BASE}/__dev/email-preview/${step.type}?example=0`}
@@ -17,18 +18,16 @@ export default function EmailCard({ step }: { step: SpecEmailStep }) {
         >
             <div className="flex items-start justify-between gap-2">
                 <div className="text-xs font-bold leading-tight">{step.subject}</div>
-                {typeof step.afterDaysStuck === 'number' && (
-                    <span className="shrink-0 rounded-sm border border-n-1 bg-yellow-1 px-1 py-0.5 text-[9px] font-bold">
-                        day {step.afterDaysStuck} stuck
-                    </span>
-                )}
+                {typeof step.afterDaysStuck === 'number' && <StuckBadge days={step.afterDaysStuck} />}
             </div>
             <p className="mt-1 text-[11px] leading-snug text-grey-1">{step.preview}</p>
             <p className="mt-1 text-[11px] leading-snug">
                 <span className="rounded-sm bg-yellow-1 px-1 font-bold">{step.ctaText}</span>
                 <span className="text-grey-1"> → {step.ctaPath}</span>
             </p>
-            <p className="mt-1.5 font-mono text-[9px] leading-tight text-grey-1">{step.type} · preview ↗</p>
+            <p className="mt-1.5 font-mono text-[9px] leading-tight text-grey-1">
+                {showDev ? `${step.type} · preview ↗` : 'preview ↗'}
+            </p>
         </a>
     )
 }

--- a/src/app/(mobile-ui)/dev/journey/FindingsStrip.tsx
+++ b/src/app/(mobile-ui)/dev/journey/FindingsStrip.tsx
@@ -6,7 +6,7 @@ import { FINDINGS } from './journeyData'
  * The inventory's product-issue findings as collapsible warning cards —
  * real gaps in the activation journey, kept visible next to the board.
  */
-export default function FindingsStrip() {
+export default function FindingsStrip({ showDev }: { showDev: boolean }) {
     return (
         <div className="flex flex-col gap-2">
             {FINDINGS.map((finding) => (
@@ -16,9 +16,11 @@ export default function FindingsStrip() {
                     </summary>
                     <div className="border-t border-n-1 bg-white px-3 py-2">
                         <p className="text-sm">{finding.detail}</p>
-                        <p className="mt-1.5 break-all font-mono text-[10px] leading-relaxed text-grey-1">
-                            {finding.sourceFiles.join(' · ')}
-                        </p>
+                        {showDev && (
+                            <p className="mt-1.5 break-all font-mono text-[10px] leading-relaxed text-grey-1">
+                                {finding.sourceFiles.join(' · ')}
+                            </p>
+                        )}
                     </div>
                 </details>
             ))}

--- a/src/app/(mobile-ui)/dev/journey/JourneyBoard.tsx
+++ b/src/app/(mobile-ui)/dev/journey/JourneyBoard.tsx
@@ -1,114 +1,133 @@
 'use client'
 
-import { FUNNEL_STATES, IN_APP_SURFACES } from './journeyData'
-import type { JourneySpec } from './journeyTypes'
-import SurfaceCard from './SurfaceCard'
+import BoardGroup from './BoardGroup'
 import EmailCard from './EmailCard'
+import PushCard from './PushCard'
+import SurfaceCard from './SurfaceCard'
+import { FUNNEL_STATES, IN_APP_SURFACES } from './journeyData'
+import type { JourneySpec, JourneyViewMode } from './journeyTypes'
 
-function GroupHeader({ emoji, label }: { emoji: string; label: string }) {
-    return (
-        <div className="mt-1 text-[10px] font-bold uppercase tracking-wide text-grey-1">
-            {emoji} {label}
-        </div>
-    )
-}
+const EMPTY_NOTE = 'text-[11px] italic leading-snug text-grey-1'
 
 /**
  * The column-per-funnel-state board: in-app surfaces (static catalog from
  * journeyData) + emails/push (live from the API spec) stacked per state.
  */
-export default function JourneyBoard({ spec, specError }: { spec: JourneySpec | null; specError: string | null }) {
+export default function JourneyBoard({
+    spec,
+    specError,
+    view,
+}: {
+    spec: JourneySpec | null
+    specError: string | null
+    view: JourneyViewMode
+}) {
+    const showDev = view === 'dev'
     const mappedStageNames = new Set(FUNNEL_STATES.flatMap((s) => s.specStages))
     const unmappedStages = spec ? spec.stages.filter((st) => !mappedStageNames.has(st.stage)) : []
 
     return (
-        <div className="overflow-x-auto pb-2">
-            <div className="flex w-max gap-3">
-                {FUNNEL_STATES.map((state, i) => {
-                    const surfaces = IN_APP_SURFACES.filter((s) => s.states.includes(state.id))
-                    const stages = spec ? spec.stages.filter((st) => state.specStages.includes(st.stage)) : []
-                    return (
-                        <div key={state.id} className="w-72 shrink-0 rounded-sm border border-n-1 bg-primary-3/40">
-                            <div className="border-b border-n-1 bg-white p-2.5">
-                                <div className="text-sm font-bold">
-                                    {i + 1}. {state.label}
-                                </div>
-                                <p className="mt-0.5 text-[11px] leading-snug text-grey-1">{state.description}</p>
-                            </div>
-                            <div className="flex flex-col gap-1.5 p-2">
-                                <GroupHeader emoji="🏠" label="in-app" />
-                                {surfaces.map((surface) => (
-                                    <SurfaceCard key={surface.id} surface={surface} />
-                                ))}
-                                {surfaces.length === 0 && (
-                                    <p className="text-[11px] italic text-grey-1">No activation-specific surface.</p>
-                                )}
+        <div className="flex flex-col gap-2">
+            <p className="text-[11px] text-grey-1">
+                {FUNNEL_STATES.length} funnel states, left to right — scroll sideways to reach the last one →
+            </p>
 
-                                <GroupHeader emoji="✉️" label="emails" />
-                                {specError && <p className="text-[11px] italic text-grey-1">{specError}</p>}
-                                {spec && state.includesWelcome && (
-                                    <>
-                                        <p className="text-[10px] italic leading-snug text-grey-1">
-                                            On signup (immediate):
+            <div className="relative">
+                <div className="overflow-x-auto pb-3">
+                    <div className="flex w-max items-start gap-3 pr-12">
+                        {FUNNEL_STATES.map((state, i) => {
+                            const surfaces = IN_APP_SURFACES.filter((s) => s.states.includes(state.id))
+                            const stages = spec ? spec.stages.filter((st) => state.specStages.includes(st.stage)) : []
+                            const emailCount =
+                                stages.reduce((total, stage) => total + stage.steps.length, 0) +
+                                (spec && state.includesWelcome ? 1 : 0)
+                            const pushCount = spec && state.includesPushReminder ? spec.pushReminders.length : 0
+
+                            return (
+                                <div
+                                    key={state.id}
+                                    className="flex w-80 shrink-0 flex-col overflow-hidden rounded-sm border border-n-1 bg-white"
+                                >
+                                    <header className="bg-white p-3">
+                                        <div className="text-sm font-bold">
+                                            {i + 1}. {state.label}
+                                        </div>
+                                        <p className="mt-0.5 text-[11px] leading-snug text-grey-1">
+                                            {state.description}
                                         </p>
-                                        <EmailCard step={spec.welcome} />
-                                    </>
-                                )}
-                                {stages.map((stage) => (
-                                    <div key={stage.stage} className="flex flex-col gap-1.5">
-                                        <p className="text-[10px] italic leading-snug text-grey-1">
-                                            stage <span className="font-mono font-bold">{stage.stage}</span> —{' '}
-                                            {stage.predicate}
-                                        </p>
-                                        {stage.steps.map((step) => (
-                                            <EmailCard key={step.type} step={step} />
+                                    </header>
+
+                                    <BoardGroup icon="🏠" label="in-app" count={surfaces.length} tint="bg-white">
+                                        {surfaces.map((surface) => (
+                                            <SurfaceCard key={surface.id} surface={surface} showDev={showDev} />
                                         ))}
-                                    </div>
-                                ))}
-                                {spec && stages.length === 0 && !state.includesWelcome && (
-                                    <p className="text-[11px] italic text-grey-1">
-                                        {state.noEmailReason ?? 'No lifecycle email in this state.'}
-                                    </p>
-                                )}
+                                        {surfaces.length === 0 && (
+                                            <p className={EMPTY_NOTE}>No activation-specific surface.</p>
+                                        )}
+                                    </BoardGroup>
 
-                                <GroupHeader emoji="📳" label="push" />
-                                {specError && <p className="text-[11px] italic text-grey-1">{specError}</p>}
-                                {spec &&
-                                    (state.includesPushReminder ? (
-                                        spec.pushReminders.map((push) => (
-                                            <div
-                                                key={push.type}
-                                                className="rounded-sm border border-n-1 bg-white p-2.5"
-                                            >
-                                                <div className="flex items-start justify-between gap-2">
-                                                    <div className="text-xs font-bold leading-tight">{push.title}</div>
-                                                    <span className="shrink-0 rounded-sm border border-n-1 bg-yellow-1 px-1 py-0.5 text-[9px] font-bold">
-                                                        after {push.afterMinutes}min
-                                                    </span>
-                                                </div>
-                                                <p className="mt-1 text-[10px] leading-snug text-grey-1">{push.note}</p>
-                                                <p className="mt-1.5 font-mono text-[9px] leading-tight text-grey-1">
-                                                    {push.type} · {push.channels.join(' + ')}
+                                    <BoardGroup icon="✉️" label="emails" count={emailCount} tint="bg-primary-3/50">
+                                        {specError && <p className={EMPTY_NOTE}>{specError}</p>}
+                                        {spec && state.includesWelcome && (
+                                            <>
+                                                <p className="text-[10px] italic leading-snug text-grey-1">
+                                                    On signup (immediate):
                                                 </p>
+                                                <EmailCard step={spec.welcome} showDev={showDev} />
+                                            </>
+                                        )}
+                                        {stages.map((stage) => (
+                                            <div key={stage.stage} className="flex flex-col gap-1.5">
+                                                {showDev && (
+                                                    <p className="text-[10px] italic leading-snug text-grey-1">
+                                                        stage <span className="font-mono font-bold">{stage.stage}</span>{' '}
+                                                        — {stage.predicate}
+                                                    </p>
+                                                )}
+                                                {stage.steps.map((step) => (
+                                                    <EmailCard key={step.type} step={step} showDev={showDev} />
+                                                ))}
                                             </div>
-                                        ))
-                                    ) : (
-                                        <p className="text-[11px] italic text-grey-1">—</p>
-                                    ))}
+                                        ))}
+                                        {spec && stages.length === 0 && !state.includesWelcome && (
+                                            <p className={EMPTY_NOTE}>
+                                                {state.noEmailReason ?? 'No lifecycle email in this state.'}
+                                            </p>
+                                        )}
+                                    </BoardGroup>
+
+                                    <BoardGroup icon="📳" label="push" count={pushCount} tint="bg-yellow-1/20">
+                                        {specError && <p className={EMPTY_NOTE}>{specError}</p>}
+                                        {spec &&
+                                            (state.includesPushReminder ? (
+                                                spec.pushReminders.map((push) => (
+                                                    <PushCard key={push.type} push={push} showDev={showDev} />
+                                                ))
+                                            ) : (
+                                                <p className={EMPTY_NOTE}>No push in this state.</p>
+                                            ))}
+                                    </BoardGroup>
+                                </div>
+                            )
+                        })}
+
+                        {unmappedStages.length > 0 && (
+                            <div className="w-80 shrink-0 rounded-sm border border-n-1 bg-yellow-1/40 p-3">
+                                <div className="text-sm font-bold">Unmapped spec stages</div>
+                                <p className="mt-1 text-[11px] leading-snug text-grey-1">
+                                    The API spec reports stages this board doesn&apos;t map to a column yet
+                                    {showDev ? ' — update FUNNEL_STATES.specStages in journeyData.ts:' : ':'}
+                                </p>
+                                <p className="mt-1 font-mono text-[11px]">
+                                    {unmappedStages.map((s) => s.stage).join(', ')}
+                                </p>
                             </div>
-                        </div>
-                    )
-                })}
-                {unmappedStages.length > 0 && (
-                    <div className="w-72 shrink-0 rounded-sm border border-n-1 bg-yellow-1/40 p-2.5">
-                        <div className="text-sm font-bold">Unmapped spec stages</div>
-                        <p className="mt-1 text-[11px] text-grey-1">
-                            The API spec reports stages this board doesn&apos;t map to a column yet — update
-                            FUNNEL_STATES.specStages in journeyData.ts:
-                        </p>
-                        <p className="mt-1 font-mono text-[11px]">{unmappedStages.map((s) => s.stage).join(', ')}</p>
+                        )}
                     </div>
-                )}
+                </div>
+
+                {/* Scroll affordance: the last column is otherwise silently cut off. */}
+                <div className="pointer-events-none absolute inset-y-0 right-0 w-12 bg-gradient-to-l from-background to-transparent" />
             </div>
         </div>
     )

--- a/src/app/(mobile-ui)/dev/journey/KindLegend.tsx
+++ b/src/app/(mobile-ui)/dev/journey/KindLegend.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import DevChip from '../_components/DevChip'
+import { SURFACE_KIND_META, SURFACE_KIND_ORDER } from './surfaceKindMeta'
+
+/**
+ * Explains the surface-kind chips used across the board. Without it the
+ * taxonomy (HOME STEP / CAROUSEL / MODAL / /CARD) is unexplained shorthand.
+ */
+export default function KindLegend() {
+    return (
+        <div className="grid gap-2 rounded-sm border border-n-1 bg-white p-3 sm:grid-cols-2 xl:grid-cols-4">
+            {SURFACE_KIND_ORDER.map((kind) => {
+                const meta = SURFACE_KIND_META[kind]
+                return (
+                    <div key={kind} className="flex flex-col gap-1">
+                        <DevChip tone={meta.tone} className="self-start">
+                            {meta.label}
+                        </DevChip>
+                        <p className="text-[11px] leading-snug text-grey-1">{meta.description}</p>
+                    </div>
+                )
+            })}
+        </div>
+    )
+}

--- a/src/app/(mobile-ui)/dev/journey/PushCard.tsx
+++ b/src/app/(mobile-ui)/dev/journey/PushCard.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import DevChip from '../_components/DevChip'
+import type { SpecPushReminder } from './journeyTypes'
+
+/** Compact card for one push reminder from the live spec. */
+export default function PushCard({ push, showDev }: { push: SpecPushReminder; showDev: boolean }) {
+    return (
+        <div className="rounded-sm border border-n-1 bg-white p-2.5">
+            <div className="flex items-start justify-between gap-2">
+                <div className="text-xs font-bold leading-tight">{push.title}</div>
+                <DevChip tone="yellow">after {push.afterMinutes}min</DevChip>
+            </div>
+            <p className="mt-1 text-[10px] leading-snug text-grey-1">{push.note}</p>
+            {showDev && (
+                <p className="mt-1.5 font-mono text-[9px] leading-tight text-grey-1">
+                    {push.type} · {push.channels.join(' + ')}
+                </p>
+            )}
+        </div>
+    )
+}

--- a/src/app/(mobile-ui)/dev/journey/RulesLegend.tsx
+++ b/src/app/(mobile-ui)/dev/journey/RulesLegend.tsx
@@ -1,12 +1,13 @@
 'use client'
 
+import StuckBadge from './StuckBadge'
 import type { SpecRules } from './journeyTypes'
 
-function Chip({ label, value }: { label: string; value: string }) {
+function Rule({ label, children }: { label: string; children: React.ReactNode }) {
     return (
         <div className="flex items-center gap-1.5 rounded-sm border border-n-1 bg-white px-2 py-1">
             <span className="text-[10px] font-bold uppercase tracking-wide text-grey-1">{label}</span>
-            <span className="text-xs font-bold">{value}</span>
+            {children}
         </div>
     )
 }
@@ -22,13 +23,30 @@ export default function RulesLegend({ rules, specError }: { rules: SpecRules | n
     }
     return (
         <div className="flex flex-wrap gap-2">
-            <Chip label="nudge 1" value={`day ${rules.step1AfterDays} stuck`} />
-            <Chip label="nudge 2" value={`day ${rules.step2AfterDays} stuck`} />
-            <Chip label="governor" value={`≥${rules.governorDays}d between emails`} />
-            <Chip label="freshness" value={`${rules.freshnessDays}d window`} />
-            <Chip label="holdout" value={`${Math.round(rules.holdoutFraction * 100)}% control`} />
-            <Chip label="send window" value={`${rules.sendWindowUtc.startHour}–${rules.sendWindowUtc.endHour}h UTC`} />
-            <Chip label="cap" value={`${rules.maxSendsPerCycle}/cycle`} />
+            {/* The two nudge rules render the very badge the board stamps on each email. */}
+            <Rule label="nudge 1">
+                <StuckBadge days={rules.step1AfterDays} />
+            </Rule>
+            <Rule label="nudge 2">
+                <StuckBadge days={rules.step2AfterDays} />
+            </Rule>
+            <Rule label="governor">
+                <span className="text-xs font-bold">≥{rules.governorDays}d between emails</span>
+            </Rule>
+            <Rule label="freshness">
+                <span className="text-xs font-bold">{rules.freshnessDays}d window</span>
+            </Rule>
+            <Rule label="holdout">
+                <span className="text-xs font-bold">{Math.round(rules.holdoutFraction * 100)}% control</span>
+            </Rule>
+            <Rule label="send window">
+                <span className="text-xs font-bold">
+                    {rules.sendWindowUtc.startHour}–{rules.sendWindowUtc.endHour}h UTC
+                </span>
+            </Rule>
+            <Rule label="cap">
+                <span className="text-xs font-bold">{rules.maxSendsPerCycle}/cycle</span>
+            </Rule>
         </div>
     )
 }

--- a/src/app/(mobile-ui)/dev/journey/StuckBadge.tsx
+++ b/src/app/(mobile-ui)/dev/journey/StuckBadge.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import DevChip from '../_components/DevChip'
+
+/**
+ * "day N stuck" — the single badge shared by the email-machine rules strip and
+ * every email card on the board, so the two read as the same fact.
+ */
+export default function StuckBadge({ days }: { days: number }) {
+    return (
+        <DevChip
+            tone="yellow"
+            title={`Sent once the user has been stuck in this stage for ${days} days — see the email-machine rules at the top of the page.`}
+        >
+            day {days} stuck
+        </DevChip>
+    )
+}

--- a/src/app/(mobile-ui)/dev/journey/SurfaceCard.tsx
+++ b/src/app/(mobile-ui)/dev/journey/SurfaceCard.tsx
@@ -1,29 +1,22 @@
 'use client'
 
+import DevChip from '../_components/DevChip'
 import type { InAppSurface } from './journeyTypes'
-
-const KIND_LABEL: Record<InAppSurface['kind'], string> = {
-    step: 'home step',
-    carousel: 'carousel',
-    modal: 'modal',
-    'card-screen': '/card',
-}
+import { SURFACE_KIND_META } from './surfaceKindMeta'
 
 /** Compact card for one in-app surface inside a journey-board column. */
-export default function SurfaceCard({ surface }: { surface: InAppSurface }) {
+export default function SurfaceCard({ surface, showDev }: { surface: InAppSurface; showDev: boolean }) {
+    const kind = SURFACE_KIND_META[surface.kind]
+
     return (
         <div className="rounded-sm border border-n-1 bg-white p-2.5">
             <div className="flex items-start justify-between gap-2">
                 <div className="text-xs font-bold leading-tight">{surface.name}</div>
-                <div className="flex shrink-0 gap-1">
-                    {surface.isNewInThisPr && (
-                        <span className="rounded-sm border border-n-1 bg-green-1 px-1 py-0.5 text-[9px] font-bold uppercase">
-                            NEW in this PR
-                        </span>
-                    )}
-                    <span className="rounded-sm border border-n-1 bg-primary-3 px-1 py-0.5 text-[9px] font-bold uppercase">
-                        {KIND_LABEL[surface.kind]}
-                    </span>
+                <div className="flex shrink-0 flex-wrap justify-end gap-1">
+                    {surface.isNewInThisPr && <DevChip tone="ink">NEW in this PR</DevChip>}
+                    <DevChip tone={kind.tone} title={kind.description}>
+                        {kind.label}
+                    </DevChip>
                 </div>
             </div>
             <p className="mt-1 text-[11px] leading-snug text-n-1">{surface.copy}</p>
@@ -33,9 +26,15 @@ export default function SurfaceCard({ surface }: { surface: InAppSurface }) {
                     <span className="text-grey-1"> → {surface.cta.dest}</span>
                 </p>
             )}
-            <p className="mt-1 text-[10px] italic leading-snug text-grey-1">{surface.condition}</p>
             {surface.note && <p className="mt-1 text-[10px] leading-snug text-grey-1">{surface.note}</p>}
-            <p className="mt-1.5 break-all font-mono text-[9px] leading-tight text-grey-1">{surface.sourceFile}</p>
+            {showDev && (
+                <>
+                    <p className="mt-1 text-[10px] italic leading-snug text-grey-1">{surface.condition}</p>
+                    <p className="mt-1.5 break-all font-mono text-[9px] leading-tight text-grey-1">
+                        {surface.sourceFile}
+                    </p>
+                </>
+            )}
         </div>
     )
 }

--- a/src/app/(mobile-ui)/dev/journey/ViewModeToggle.tsx
+++ b/src/app/(mobile-ui)/dev/journey/ViewModeToggle.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { twMerge } from 'tailwind-merge'
+import type { JourneyViewMode } from './journeyTypes'
+
+const OPTIONS: { value: JourneyViewMode; label: string; hint: string }[] = [
+    { value: 'product', label: 'Product view', hint: 'Copy and flow only — no predicates, no file paths.' },
+    { value: 'dev', label: 'Dev view', hint: 'Adds the gating predicates, source files and event types.' },
+]
+
+/** Segmented control switching the board between cockpit and source-of-truth reading. */
+export default function ViewModeToggle({
+    value,
+    onChange,
+}: {
+    value: JourneyViewMode
+    onChange: (next: JourneyViewMode) => void
+}) {
+    return (
+        <div className="flex shrink-0 rounded-sm border border-n-1 bg-white p-0.5">
+            {OPTIONS.map((option) => (
+                <button
+                    key={option.value}
+                    type="button"
+                    title={option.hint}
+                    aria-pressed={value === option.value}
+                    onClick={() => onChange(option.value)}
+                    className={twMerge(
+                        'rounded-sm px-3 py-1.5 text-xs font-bold transition-colors',
+                        value === option.value ? 'bg-primary-1 text-n-1' : 'text-grey-1 hover:bg-primary-3/40'
+                    )}
+                >
+                    {option.label}
+                </button>
+            ))}
+        </div>
+    )
+}

--- a/src/app/(mobile-ui)/dev/journey/__tests__/surfaceKindMeta.test.ts
+++ b/src/app/(mobile-ui)/dev/journey/__tests__/surfaceKindMeta.test.ts
@@ -1,0 +1,21 @@
+import { IN_APP_SURFACES } from '../journeyData'
+import { SURFACE_KIND_META, SURFACE_KIND_ORDER } from '../surfaceKindMeta'
+
+describe('surfaceKindMeta', () => {
+    it('legend covers every kind used by the catalog', () => {
+        for (const surface of IN_APP_SURFACES) {
+            expect(SURFACE_KIND_META[surface.kind]).toBeDefined()
+        }
+    })
+
+    it('legend order lists every kind exactly once', () => {
+        expect([...SURFACE_KIND_ORDER].sort()).toEqual(Object.keys(SURFACE_KIND_META).sort())
+    })
+
+    it('every kind has a non-empty label and explanation', () => {
+        for (const kind of SURFACE_KIND_ORDER) {
+            expect(SURFACE_KIND_META[kind].label.length).toBeGreaterThan(0)
+            expect(SURFACE_KIND_META[kind].description.length).toBeGreaterThan(0)
+        }
+    })
+})

--- a/src/app/(mobile-ui)/dev/journey/journeyTypes.ts
+++ b/src/app/(mobile-ui)/dev/journey/journeyTypes.ts
@@ -19,6 +19,12 @@ export type FunnelStateId =
 
 export type SurfaceKind = 'step' | 'carousel' | 'modal' | 'card-screen'
 
+/**
+ * How much of the machinery the board exposes. `product` reads as a cockpit
+ * (copy + flow only); `dev` adds gating predicates, source files and event types.
+ */
+export type JourneyViewMode = 'product' | 'dev'
+
 export interface InAppSurface {
     id: string
     kind: SurfaceKind

--- a/src/app/(mobile-ui)/dev/journey/page.tsx
+++ b/src/app/(mobile-ui)/dev/journey/page.tsx
@@ -1,11 +1,16 @@
 'use client'
 
-import NavHeader from '@/components/Global/NavHeader'
-import JourneyBoard from './JourneyBoard'
-import RulesLegend from './RulesLegend'
+import { parseAsStringEnum, useQueryState } from 'nuqs'
+import DevPageShell from '../_components/DevPageShell'
+import DevSectionLabel from '../_components/DevSectionLabel'
 import FindingsStrip from './FindingsStrip'
+import JourneyBoard from './JourneyBoard'
+import KindLegend from './KindLegend'
+import RulesLegend from './RulesLegend'
 import UserInspector from './UserInspector'
+import ViewModeToggle from './ViewModeToggle'
 import { useJourneySpec } from './useJourneySpec'
+import type { JourneyViewMode } from './journeyTypes'
 
 /**
  * /dev/journey — Activation Journey Explorer.
@@ -17,32 +22,42 @@ import { useJourneySpec } from './useJourneySpec'
  */
 export default function JourneyExplorerPage() {
     const { spec, error, loading } = useJourneySpec()
+    const [view, setView] = useQueryState(
+        'view',
+        parseAsStringEnum<JourneyViewMode>(['product', 'dev']).withDefault('product')
+    )
+    const showDev = view === 'dev'
 
     return (
-        <div className="flex w-full flex-col gap-6 pb-8">
-            <NavHeader title="Activation Journey" />
-
+        <DevPageShell
+            title="Activation Journey"
+            description="Every surface a user meets on the way to their first payment — what the app shows them, and what the lifecycle machine sends them — one column per funnel state."
+            actions={<ViewModeToggle value={view} onChange={(next) => void setView(next)} />}
+        >
             <section className="flex flex-col gap-2">
-                <h2 className="text-sm font-bold uppercase tracking-wide text-grey-1">Email-machine rules</h2>
+                <DevSectionLabel>Email-machine rules</DevSectionLabel>
                 <RulesLegend rules={spec?.rules ?? null} specError={loading ? null : error} />
             </section>
 
             <section className="flex flex-col gap-2">
-                <h2 className="text-sm font-bold uppercase tracking-wide text-grey-1">Journey board</h2>
-                <JourneyBoard spec={spec} specError={loading ? 'Loading spec…' : error} />
+                <DevSectionLabel>In-app surface kinds</DevSectionLabel>
+                <KindLegend />
             </section>
 
             <section className="flex flex-col gap-2">
-                <h2 className="text-sm font-bold uppercase tracking-wide text-grey-1">
-                    Findings — real product issues
-                </h2>
-                <FindingsStrip />
+                <DevSectionLabel>Journey board</DevSectionLabel>
+                <JourneyBoard spec={spec} specError={loading ? 'Loading spec…' : error} view={view} />
             </section>
 
             <section className="flex flex-col gap-2">
-                <h2 className="text-sm font-bold uppercase tracking-wide text-grey-1">User inspector</h2>
+                <DevSectionLabel>Findings — real product issues</DevSectionLabel>
+                <FindingsStrip showDev={showDev} />
+            </section>
+
+            <section className="flex flex-col gap-2">
+                <DevSectionLabel>User inspector</DevSectionLabel>
                 <UserInspector />
             </section>
-        </div>
+        </DevPageShell>
     )
 }

--- a/src/app/(mobile-ui)/dev/journey/surfaceKindMeta.ts
+++ b/src/app/(mobile-ui)/dev/journey/surfaceKindMeta.ts
@@ -1,0 +1,41 @@
+/**
+ * Presentation metadata for the in-app surface taxonomy: the label, colour and
+ * plain-language explanation behind each `SurfaceKind` chip. Kept apart from
+ * journeyData.ts, which holds the surfaces themselves.
+ */
+
+import type { DevChipTone } from '../_components/devChipTones'
+import type { SurfaceKind } from './journeyTypes'
+
+export interface SurfaceKindMeta {
+    label: string
+    tone: DevChipTone
+    /** What this kind of surface actually is, for the legend and chip tooltips. */
+    description: string
+}
+
+/** Legend order — roughly how early in the funnel each kind first appears. */
+export const SURFACE_KIND_ORDER: SurfaceKind[] = ['step', 'carousel', 'modal', 'card-screen']
+
+export const SURFACE_KIND_META: Record<SurfaceKind, SurfaceKindMeta> = {
+    step: {
+        label: 'home step',
+        tone: 'yellow',
+        description: 'The single activation step card on /home — one step at a time, picked by useActivationStatus.',
+    },
+    carousel: {
+        label: 'carousel',
+        tone: 'lavender',
+        description: 'A card in the /home carousel, shown to already-activated users and dismissable for 7 days.',
+    },
+    modal: {
+        label: 'modal',
+        tone: 'pink',
+        description: 'A modal, sheet or celebration toast layered over whatever screen the user is already on.',
+    },
+    'card-screen': {
+        label: '/card',
+        tone: 'green',
+        description: 'A full-screen state of the /card route, selected by computeCardState precedence.',
+    },
+}

--- a/src/app/(mobile-ui)/dev/leaderboard/page.tsx
+++ b/src/app/(mobile-ui)/dev/leaderboard/page.tsx
@@ -3,10 +3,10 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Card from '@/components/Global/Card'
-import NavHeader from '@/components/Global/NavHeader'
 import { Button } from '@/components/0_Bruddle/Button'
 import { pointsApi } from '@/services/points'
 import { Icon } from '@/components/Global/Icons/Icon'
+import DevPageShell from '../_components/DevPageShell'
 
 type TimeFilter = '1h' | '6h' | '24h' | 'custom'
 
@@ -280,7 +280,7 @@ export default function LeaderboardPage() {
     const getTierBadgeColor = (tier: number) => {
         switch (tier) {
             case 0:
-                return 'bg-gray-100 text-gray-700'
+                return 'bg-gray-100 text-grey-1'
             case 1:
                 return 'bg-blue-100 text-blue-700'
             case 2:
@@ -288,7 +288,7 @@ export default function LeaderboardPage() {
             case 3:
                 return 'bg-yellow-100 text-yellow-700'
             default:
-                return 'bg-gray-100 text-gray-700'
+                return 'bg-gray-100 text-grey-1'
         }
     }
 
@@ -310,16 +310,15 @@ export default function LeaderboardPage() {
     }
 
     return (
-        <div className="flex min-h-screen flex-col">
-            <NavHeader title="🏆 Points Leaderboard" href="/dev" />
-
-            {/* Main Content - Full Width Container */}
-            <div className="mx-auto w-full max-w-7xl flex-1 space-y-6 px-4 py-6 md:px-8">
+        <DevPageShell
+            title="🏆 Points Leaderboard"
+            description="Live event leaderboard — points earned inside a chosen time window, refreshed on a timer."
+        >
+            <div className="mx-auto w-full max-w-7xl space-y-6">
                 {/* Header with Prize */}
                 <div className="text-center">
-                    <h1 className="mb-2 text-4xl font-bold">Event Leaderboard</h1>
                     <div className="mb-4">
-                        <span className="text-sm text-gray-500">Last update: {lastUpdate.toLocaleTimeString()}</span>
+                        <span className="text-sm text-grey-1">Last update: {lastUpdate.toLocaleTimeString()}</span>
                     </div>
                     <div className="mx-auto max-w-2xl rounded-xl bg-gradient-to-r from-yellow-400 via-yellow-500 to-yellow-600 p-6 shadow-lg">
                         <div className="flex items-center justify-center gap-3">
@@ -338,23 +337,23 @@ export default function LeaderboardPage() {
                     <Card className="p-12">
                         <div className="flex items-center justify-center">
                             <Icon name="pending" size={32} className="animate-spin text-primary-1" />
-                            <span className="ml-3 text-lg text-gray-600">Loading leaderboard...</span>
+                            <span className="ml-3 text-lg text-grey-1">Loading leaderboard...</span>
                         </div>
                     </Card>
                 ) : error ? (
-                    <Card className="bg-red-50 p-8">
-                        <p className="text-red-800 text-center text-lg">{error}</p>
+                    <Card className="bg-error-1/20 p-8">
+                        <p className="text-center text-lg text-n-1">{error}</p>
                     </Card>
                 ) : leaderboard.length === 0 ? (
                     <Card className="p-12">
-                        <p className="text-center text-lg text-gray-600">No points earned in this time period yet.</p>
+                        <p className="text-center text-lg text-grey-1">No points earned in this time period yet.</p>
                     </Card>
                 ) : (
-                    <Card className="divide-y divide-gray-100">
+                    <Card className="divide-y divide-gray-3">
                         {leaderboard.map((entry) => (
                             <div
                                 key={entry.userId}
-                                className={`flex items-center justify-between p-6 transition-colors hover:bg-gray-50 ${
+                                className={`flex items-center justify-between p-6 transition-colors hover:bg-primary-3/20 ${
                                     entry.rank <= 3 ? 'bg-yellow-50/40' : ''
                                 }`}
                             >
@@ -371,14 +370,14 @@ export default function LeaderboardPage() {
                                     {/* User Info */}
                                     <div>
                                         <div className="flex items-center gap-3">
-                                            <span className="text-xl font-bold text-gray-900">{entry.username}</span>
+                                            <span className="text-xl font-bold text-n-1">{entry.username}</span>
                                             <span
                                                 className={`rounded-full px-3 py-1 text-sm font-medium ${getTierBadgeColor(entry.currentTier)}`}
                                             >
                                                 Tier {entry.currentTier}
                                             </span>
                                         </div>
-                                        <span className="text-base text-gray-500">
+                                        <span className="text-base text-grey-1">
                                             {entry.pointsEarned.toLocaleString()} points
                                         </span>
                                     </div>
@@ -392,7 +391,7 @@ export default function LeaderboardPage() {
                                         </span>
                                     )}
                                     {entry.rank === 2 && (
-                                        <span className="rounded-full bg-gray-100 px-4 py-2 text-sm font-bold text-gray-700">
+                                        <span className="rounded-full bg-gray-100 px-4 py-2 text-sm font-bold text-grey-1">
                                             🥈 2nd Place
                                         </span>
                                     )}
@@ -409,12 +408,12 @@ export default function LeaderboardPage() {
             </div>
 
             {/* Compact Filter Bar at Bottom */}
-            <div className="sticky bottom-0 border-t border-gray-200 bg-white shadow-lg">
+            <div className="sticky bottom-0 rounded-sm border border-n-1 bg-white">
                 <div className="mx-auto max-w-7xl px-4 py-4 md:px-8">
                     <div className="flex flex-wrap items-center justify-between gap-4">
                         {/* Quick Filters */}
                         <div className="flex items-center gap-2">
-                            <span className="text-sm font-semibold text-gray-700">Time Period:</span>
+                            <span className="text-sm font-semibold text-grey-1">Time Period:</span>
                             <div className="flex gap-2">
                                 <Button
                                     size="small"
@@ -457,7 +456,7 @@ export default function LeaderboardPage() {
                                 type="datetime-local"
                                 value={customTime}
                                 onChange={(e) => handleCustomTimeChange(e.target.value)}
-                                className="w-48 rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-primary-1 focus:outline-none focus:ring-1 focus:ring-primary-1"
+                                className="w-48 rounded-md border border-gray-3 px-2 py-1 text-sm focus:border-primary-1 focus:outline-none focus:ring-1 focus:ring-primary-1"
                             />
                             <Button
                                 size="small"
@@ -472,13 +471,13 @@ export default function LeaderboardPage() {
 
                         {/* Since Info */}
                         {sinceDate && (
-                            <div className="text-xs text-gray-500">
+                            <div className="text-xs text-grey-1">
                                 Since: <span className="font-medium">{formatDate(sinceDate)}</span>
                             </div>
                         )}
                     </div>
                 </div>
             </div>
-        </div>
+        </DevPageShell>
     )
 }

--- a/src/app/(mobile-ui)/dev/page.tsx
+++ b/src/app/(mobile-ui)/dev/page.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import Card from '@/components/Global/Card'
-import NavHeader from '@/components/Global/NavHeader'
 import Link from 'next/link'
 import { Icon, type IconName } from '@/components/Global/Icons/Icon'
+import DevNoteCard from './_components/DevNoteCard'
+import DevPageShell from './_components/DevPageShell'
 
 export default function DevToolsPage() {
     // static: true → plain <a> (file in public/, not an app route — Next Link can't client-navigate to it)
@@ -62,19 +63,61 @@ export default function DevToolsPage() {
             path: '/dev/home-ctas',
             icon: 'credit-card',
         },
+        {
+            name: 'Components',
+            description: 'The component showcase — every Bruddle primitive and Global component with all variants.',
+            path: '/dev/components',
+            icon: 'docs',
+        },
+        {
+            name: 'Rejection screen builder',
+            description:
+                'Iterate the full mobile CardRejectionScreen — bouncer mascot, door tally, waitlist state — inside a phone frame.',
+            path: '/dev/rejection-builder',
+            icon: 'credit-card',
+        },
+        {
+            name: 'Share asset builder',
+            description:
+                'Iterate the card share asset (sticker collage): badge set, username length, hero variant, seed reroll, PNG capture.',
+            path: '/dev/share-builder',
+            icon: 'docs',
+        },
+        {
+            name: 'Profile card row',
+            description: 'The profile "first group" in both card states, rendered with the real ProfileMenuItem.',
+            path: '/dev/profile-card-row',
+            icon: 'credit-card',
+        },
+        {
+            name: 'Perk success test',
+            description: 'Fires the perk-claim success screens without needing a real perk to claim.',
+            path: '/dev/perk-success-test',
+            icon: 'dollar',
+        },
+        {
+            name: 'Shake test',
+            description: 'Tunes the shake-and-hold gesture — intensity, duration, thresholds.',
+            path: '/dev/shake-test',
+            icon: 'info',
+        },
+        {
+            name: 'Card session approve',
+            description:
+                'Grants the combined Rain session-key permission (auto-balancer + withdraw policies) in one passkey tap.',
+            path: '/dev/card-session-approve',
+            icon: 'credit-card',
+        },
     ]
 
     return (
-        <div className="flex w-full flex-col gap-6">
-            <div className="px-4 pt-4">
-                <NavHeader title="Dev Tools" />
-            </div>
-
-            <div className="flex h-full flex-col space-y-4 px-4 pb-8">
-                <p className="text-sm text-grey-1">
-                    Internal testing tools and components. Publicly accessible for multi-device testing.
-                </p>
-
+        <DevPageShell
+            title="Dev Tools"
+            description="Internal testing tools and components. Publicly accessible for multi-device testing."
+            backHref="/home"
+            width="prose"
+        >
+            <div className="flex flex-col gap-4">
                 <div className="space-y-2">
                     {tools.map((tool) => {
                         const LinkComponent = tool.static ? 'a' : Link
@@ -99,18 +142,14 @@ export default function DevToolsPage() {
                     })}
                 </div>
 
-                <div className="rounded-sm border border-n-1 bg-primary-3/20 p-3">
-                    <div className="mb-1 flex items-center gap-2">
-                        <Icon name="info" size={14} />
-                        <span className="text-xs font-bold">Info</span>
-                    </div>
-                    <ul className="space-y-0.5 text-xs text-grey-1">
+                <DevNoteCard title="Info">
+                    <ul className="space-y-0.5">
                         <li>These tools are only available in development mode</li>
                         <li>Perfect for testing on multiple devices</li>
                         <li>Share the URL with team members for testing</li>
                     </ul>
-                </div>
+                </DevNoteCard>
             </div>
-        </div>
+        </DevPageShell>
     )
 }

--- a/src/app/(mobile-ui)/dev/perk-success-test/page.tsx
+++ b/src/app/(mobile-ui)/dev/perk-success-test/page.tsx
@@ -3,13 +3,14 @@
 import { useState } from 'react'
 import { Card } from '@/components/0_Bruddle/Card'
 import { Button } from '@/components/0_Bruddle/Button'
-import NavHeader from '@/components/Global/NavHeader'
 import GlobalCard from '@/components/Global/Card'
 import { Icon } from '@/components/Global/Icons/Icon'
 import { SoundPlayer } from '@/components/Global/SoundPlayer'
 import { useHaptic } from 'use-haptic'
 import { shootDoubleStarConfetti } from '@/utils/confetti'
 import { extractInviteeName } from '@/utils/general.utils'
+import DevNoteCard from '../_components/DevNoteCard'
+import DevPageShell from '../_components/DevPageShell'
 
 type MockPerk = {
     id: string
@@ -88,19 +89,19 @@ export default function PerkSuccessTestPage() {
     const inviteeName = extractInviteeName(currentPerk.reason)
 
     return (
-        <div className="flex min-h-[inherit] flex-col gap-4 pb-8">
-            <NavHeader title="Perk Success Test" />
-
-            <div className="space-y-4 px-4">
-                {/* Instructions */}
-                <Card className="bg-blue-50 p-4">
-                    <p className="text-sm font-bold text-blue-900">Test the perk claim success screen</p>
-                    <ul className="mt-1 space-y-1 text-sm text-blue-800">
-                        <li>1. Click "Trigger Success" to show the success screen</li>
+        <DevPageShell
+            title="Perk Success Test"
+            description="Fires the perk-claim success screen against mock perks — no real perk needed."
+            width="prose"
+        >
+            <div className="space-y-4">
+                <DevNoteCard title="Test the perk claim success screen">
+                    <ul className="space-y-1">
+                        <li>1. Click &ldquo;Trigger Success&rdquo; to show the success screen</li>
                         <li>2. Wait 2 seconds before you can dismiss (debounce)</li>
                         <li>3. Tap to dismiss and load next mock perk</li>
                     </ul>
-                </Card>
+                </DevNoteCard>
 
                 {/* Current Perk Info */}
                 <Card className="p-4">
@@ -185,6 +186,6 @@ export default function PerkSuccessTestPage() {
                     </Button>
                 </div>
             </div>
-        </div>
+        </DevPageShell>
     )
 }

--- a/src/app/(mobile-ui)/dev/profile-card-row/page.tsx
+++ b/src/app/(mobile-ui)/dev/profile-card-row/page.tsx
@@ -1,12 +1,11 @@
 'use client'
 
-import { type ReactNode } from 'react'
 import Image from 'next/image'
-import NavHeader from '@/components/Global/NavHeader'
-import { Card } from '@/components/0_Bruddle/Card'
-import { Icon } from '@/components/Global/Icons/Icon'
 import ProfileMenuItem from '@/components/Profile/components/ProfileMenuItem'
 import STAR_STRAIGHT_ICON from '@/assets/icons/starStraight.svg'
+import DevNoteCard from '../_components/DevNoteCard'
+import DevPageShell from '../_components/DevPageShell'
+import DevSectionLabel from '../_components/DevSectionLabel'
 
 /**
  * /dev/profile-card-row — 1:1 preview of the profile "first group" (card row +
@@ -49,26 +48,22 @@ function ProfileFirstGroup({ hasCardAccess }: { hasCardAccess: boolean }) {
     )
 }
 
-function SectionLabel({ children }: { children: ReactNode }) {
-    return <p className="text-xs font-bold uppercase tracking-wide text-grey-1">{children}</p>
-}
-
 export default function ProfileCardRowPreviewPage() {
     return (
-        <div className="flex min-h-[inherit] flex-col gap-6 pb-8">
-            <div className="px-4 pt-4">
-                <NavHeader title="Profile card row" />
-            </div>
-
-            <div className="flex flex-col gap-8 px-4">
-                <p className="text-sm text-grey-1">
+        <DevPageShell
+            title="Profile card row"
+            description={
+                <>
                     The profile &ldquo;first group&rdquo; in both card states, rendered with the real{' '}
                     <code>ProfileMenuItem</code>. Rows are live links.
-                </p>
-
+                </>
+            }
+            width="prose"
+        >
+            <div className="flex flex-col gap-8">
                 {/* Non-holder — the new default for most users */}
                 <section className="flex flex-col gap-3">
-                    <SectionLabel>Non-holder (no card yet) — also the loading state</SectionLabel>
+                    <DevSectionLabel>Non-holder (no card yet) — also the loading state</DevSectionLabel>
                     <p className="text-[11px] text-grey-1">
                         &ldquo;Peanut Card&rdquo; · <span className="font-semibold">New!</span> badge · → /shhhhh
                     </p>
@@ -77,23 +72,17 @@ export default function ProfileCardRowPreviewPage() {
 
                 {/* Holder — unchanged from today */}
                 <section className="flex flex-col gap-3">
-                    <SectionLabel>Card holder (hasCardAccess) — unchanged</SectionLabel>
+                    <DevSectionLabel>Card holder (hasCardAccess) — unchanged</DevSectionLabel>
                     <p className="text-[11px] text-grey-1">&ldquo;Your Card&rdquo; · no badge · → /card</p>
                     <ProfileFirstGroup hasCardAccess={true} />
                 </section>
 
-                <Card className="bg-primary-3/20 p-3">
-                    <div className="mb-1 flex items-center gap-2">
-                        <Icon name="info" size={14} />
-                        <span className="text-xs font-bold">Note</span>
-                    </div>
-                    <p className="text-xs text-grey-1">
-                        The <span className="font-semibold">New!</span> pill is the shared StatusBadge{' '}
-                        <code>custom</code> style (lavender <code>primary-3</code>) — the same tag ProfileEdit uses for{' '}
-                        <span className="font-semibold">Soon!</span>. No new design surface.
-                    </p>
-                </Card>
+                <DevNoteCard>
+                    The <span className="font-semibold">New!</span> pill is the shared StatusBadge <code>custom</code>{' '}
+                    style (lavender <code>primary-3</code>) — the same tag ProfileEdit uses for{' '}
+                    <span className="font-semibold">Soon!</span>. No new design surface.
+                </DevNoteCard>
             </div>
-        </div>
+        </DevPageShell>
     )
 }

--- a/src/app/(mobile-ui)/dev/rejection-builder/page.tsx
+++ b/src/app/(mobile-ui)/dev/rejection-builder/page.tsx
@@ -11,10 +11,13 @@
  */
 
 import { useState } from 'react'
-import NavHeader from '@/components/Global/NavHeader'
 import CardRejectionScreen from '@/components/Card/CardRejectionScreen'
 import { computeDoorTally } from '@/components/Card/doorTally.utils'
 import type { RejectionMascot } from '@/components/Card/share-asset/shareAsset.types'
+import DevField from '../_components/DevField'
+import DevPageShell from '../_components/DevPageShell'
+import DevPanel from '../_components/DevPanel'
+import DevPresetButton from '../_components/DevPresetButton'
 
 const MASCOTS: ReadonlyArray<[RejectionMascot, string]> = [
     ['none', 'none'],
@@ -35,14 +38,15 @@ export default function RejectionBuilderPage() {
     const tally = computeDoorTally(waitlistTotal, admittedTotal)
 
     return (
-        <div className="flex min-h-screen flex-col">
-            <NavHeader title="Rejection screen builder" />
-
-            <div className="flex flex-1 flex-col gap-8 px-6 py-6 lg:flex-row">
+        <DevPageShell
+            title="Rejection screen builder"
+            description="Dial in the /card waitlist rejection screen — bouncer mascot, door tally, waitlist state — against a live phone-frame preview."
+        >
+            <div className="flex flex-col gap-8 lg:flex-row">
                 {/* ─── LEFT: Controls ──────────────────────────────────── */}
                 <aside className="flex flex-col gap-6 lg:w-[360px] lg:flex-shrink-0">
-                    <Section title="Identity">
-                        <Field label={`Username (${username.length})`}>
+                    <DevPanel title="Identity">
+                        <DevField label={`Username (${username.length})`}>
                             <input
                                 type="text"
                                 value={username}
@@ -51,21 +55,23 @@ export default function RejectionBuilderPage() {
                                 className="custom-input"
                                 placeholder="kkonrad"
                             />
-                        </Field>
+                        </DevField>
                         <div className="flex flex-wrap gap-2">
-                            <PresetButton onClick={() => setUsername('me')}>2-char</PresetButton>
-                            <PresetButton onClick={() => setUsername('kkonrad')}>kkonrad</PresetButton>
-                            <PresetButton onClick={() => setUsername('thisistwentyplus_chars')}>20+ chars</PresetButton>
+                            <DevPresetButton onClick={() => setUsername('me')}>2-char</DevPresetButton>
+                            <DevPresetButton onClick={() => setUsername('kkonrad')}>kkonrad</DevPresetButton>
+                            <DevPresetButton onClick={() => setUsername('thisistwentyplus_chars')}>
+                                20+ chars
+                            </DevPresetButton>
                         </div>
-                    </Section>
+                    </DevPanel>
 
-                    <Section title="Bouncer mascot (asset, left side)">
+                    <DevPanel title="Bouncer mascot (asset, left side)">
                         <div className="flex flex-wrap gap-2">
                             {MASCOTS.map(([key, label]) => (
                                 <button
                                     key={key}
                                     onClick={() => setMascot(key)}
-                                    className={`rounded-full border-2 border-black px-3 py-1 text-xs font-bold transition-colors ${
+                                    className={`rounded-full border-2 border-n-1 px-3 py-1 text-xs font-bold transition-colors ${
                                         mascot === key
                                             ? 'bg-primary-1 text-n-1'
                                             : 'bg-white text-grey-1 hover:bg-grey-2'
@@ -79,10 +85,10 @@ export default function RejectionBuilderPage() {
                             No dedicated “laughing” peanut exists yet — these are the closest mocking/cool poses. Say
                             the word and I’ll generate a true laughing one via the badges pipeline.
                         </p>
-                    </Section>
+                    </DevPanel>
 
-                    <Section title="Door tally — REAL backend counts">
-                        <Field label={`Waitlist size · real cardWaitlistJoinedAt count (${waitlistTotal})`}>
+                    <DevPanel title="Door tally — REAL backend counts">
+                        <DevField label={`Waitlist size · real cardWaitlistJoinedAt count (${waitlistTotal})`}>
                             <input
                                 type="range"
                                 min={0}
@@ -92,8 +98,8 @@ export default function RejectionBuilderPage() {
                                 onChange={(e) => setWaitlistTotal(Number(e.target.value))}
                                 className="w-full"
                             />
-                        </Field>
-                        <Field label={`Admitted · real cardAccessGrantedAt count (${admittedTotal})`}>
+                        </DevField>
+                        <DevField label={`Admitted · real cardAccessGrantedAt count (${admittedTotal})`}>
                             <input
                                 type="range"
                                 min={0}
@@ -103,7 +109,7 @@ export default function RejectionBuilderPage() {
                                 onChange={(e) => setAdmittedTotal(Number(e.target.value))}
                                 className="w-full"
                             />
-                        </Field>
+                        </DevField>
                         <p className="rounded-sm border border-n-1 bg-grey-3 p-2 text-center text-xs font-bold text-n-1">
                             renders as:{' '}
                             <span className="text-primary-1">
@@ -115,37 +121,37 @@ export default function RejectionBuilderPage() {
                             </span>
                         </p>
                         <div className="flex flex-wrap gap-2">
-                            <PresetButton
+                            <DevPresetButton
                                 onClick={() => {
                                     setWaitlistTotal(0)
                                     setAdmittedTotal(0)
                                 }}
                             >
                                 empty (floor)
-                            </PresetButton>
-                            <PresetButton
+                            </DevPresetButton>
+                            <DevPresetButton
                                 onClick={() => {
                                     setWaitlistTotal(120)
                                     setAdmittedTotal(7)
                                 }}
                             >
                                 early beta
-                            </PresetButton>
-                            <PresetButton
+                            </DevPresetButton>
+                            <DevPresetButton
                                 onClick={() => {
                                     setWaitlistTotal(1842)
                                     setAdmittedTotal(140)
                                 }}
                             >
                                 busy door
-                            </PresetButton>
+                            </DevPresetButton>
                         </div>
-                    </Section>
+                    </DevPanel>
 
-                    <Section title="Waitlist state">
+                    <DevPanel title="Waitlist state">
                         <button
                             onClick={() => setAlreadyJoined((v) => !v)}
-                            className={`rounded-full border-2 border-black px-3 py-1 text-xs font-bold transition-colors ${
+                            className={`rounded-full border-2 border-n-1 px-3 py-1 text-xs font-bold transition-colors ${
                                 alreadyJoined ? 'bg-primary-1 text-n-1' : 'bg-white text-grey-1 hover:bg-grey-2'
                             }`}
                         >
@@ -155,7 +161,7 @@ export default function RejectionBuilderPage() {
                             Toggles the post-join state: “Join anyway” becomes an “on the list” confirmation while the
                             asset + “Tweet to appeal” stay.
                         </p>
-                    </Section>
+                    </DevPanel>
                 </aside>
 
                 {/* ─── RIGHT: Phone-frame preview of the whole screen ──── */}
@@ -180,37 +186,6 @@ export default function RejectionBuilderPage() {
                     </div>
                 </main>
             </div>
-        </div>
-    )
-}
-
-// ─── Small UI primitives ────────────────────────────────────────────────
-
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
-    return (
-        <section className="shadow-4 rounded-sm border-2 border-n-1 bg-white p-4">
-            <h2 className="mb-3 text-xs font-extrabold uppercase tracking-wider text-grey-1">{title}</h2>
-            <div className="flex flex-col gap-3">{children}</div>
-        </section>
-    )
-}
-
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
-    return (
-        <label className="flex flex-col gap-1.5">
-            <span className="text-xs font-bold text-grey-1">{label}</span>
-            {children}
-        </label>
-    )
-}
-
-function PresetButton({ onClick, children }: { onClick: () => void; children: React.ReactNode }) {
-    return (
-        <button
-            onClick={onClick}
-            className="rounded-full border border-n-1 bg-white px-2 py-1 text-xs font-bold transition-colors hover:bg-grey-2"
-        >
-            {children}
-        </button>
+        </DevPageShell>
     )
 }

--- a/src/app/(mobile-ui)/dev/shake-test/page.tsx
+++ b/src/app/(mobile-ui)/dev/shake-test/page.tsx
@@ -3,10 +3,10 @@
 import { useState, useCallback } from 'react'
 import { Button } from '@/components/0_Bruddle/Button'
 import Card from '@/components/Global/Card'
-import NavHeader from '@/components/Global/NavHeader'
 import { shootDoubleStarConfetti } from '@/utils/confetti'
 import { getShakeClass, type ShakeIntensity } from '@/utils/perk.utils'
 import { PERK_HOLD_DURATION_MS } from '@/constants/general.consts'
+import DevPageShell from '../_components/DevPageShell'
 
 export default function DevShakeTestPage() {
     const [isShaking, setIsShaking] = useState(false)
@@ -156,10 +156,13 @@ export default function DevShakeTestPage() {
     }, [holdTimer, progressInterval])
 
     return (
-        <div className={`flex min-h-[inherit] flex-col gap-8 ${getShakeClass(isShaking, shakeIntensity)}`}>
-            <NavHeader title="🧪 Dev Shake Test" />
-
-            <div className="my-auto flex h-full flex-col justify-center space-y-6 px-4">
+        <DevPageShell
+            title="🧪 Dev Shake Test"
+            description="Tunes the shake-and-hold gesture — progressive shake intensity, hold progress, haptics and the confetti payoff."
+            width="prose"
+            className={getShakeClass(isShaking, shakeIntensity)}
+        >
+            <div className="flex flex-col space-y-6">
                 <Card className="space-y-4 p-6">
                     <h2 className="text-center text-2xl font-bold">Shake & Hold Test</h2>
                     <p className="text-center text-sm text-gray-600">
@@ -265,6 +268,6 @@ export default function DevShakeTestPage() {
                     </ul>
                 </Card>
             </div>
-        </div>
+        </DevPageShell>
     )
 }

--- a/src/app/(mobile-ui)/dev/share-builder/page.tsx
+++ b/src/app/(mobile-ui)/dev/share-builder/page.tsx
@@ -15,7 +15,6 @@
  */
 
 import { useMemo, useRef, useState } from 'react'
-import NavHeader from '@/components/Global/NavHeader'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Checkbox } from '@/components/0_Bruddle/Checkbox'
 import ShareAssetD3 from '@/components/Card/share-asset/ShareAssetD3'
@@ -23,6 +22,10 @@ import type { HeroVariant, UsernameBg } from '@/components/Card/share-asset/shar
 import { captureShareAsset, downloadBlob } from '@/components/Card/share-asset/captureShareAsset'
 import { BADGE_CODES, getBadgeDisplayName } from '@/components/Badges/badge.utils'
 import { CANVAS_W, CANVAS_H } from '@/components/Card/share-asset/shareAssetLayout'
+import DevField from '../_components/DevField'
+import DevPageShell from '../_components/DevPageShell'
+import DevPanel from '../_components/DevPanel'
+import DevPresetButton from '../_components/DevPresetButton'
 
 const ALL_CODES = BADGE_CODES
 
@@ -111,20 +114,21 @@ export default function ShareBuilderPage() {
     const seedOverride = seedNonce > 0 ? `${username}::${seedNonce}` : undefined
 
     return (
-        <div className="flex min-h-screen flex-col">
-            <NavHeader title="Share asset builder" />
-
-            <div className="flex flex-1 flex-col gap-8 px-6 py-6 lg:flex-row">
+        <DevPageShell
+            title="Share asset builder"
+            description="Iterate the card share asset (sticker collage) — badge set, username length, hero variant, seed reroll — and capture the PNG."
+        >
+            <div className="flex flex-col gap-8 lg:flex-row">
                 {/* ─── LEFT: Controls ──────────────────────────────────── */}
                 <aside className="flex flex-col gap-6 lg:w-[360px] lg:flex-shrink-0">
-                    <Section title="Hero message (I got in)">
-                        <Field label="Sticker type">
+                    <DevPanel title="Hero message (I got in)">
+                        <DevField label="Sticker type">
                             <div className="flex flex-wrap gap-2">
                                 {(['none', 'burst', 'pill', 'banner'] as const).map((v) => (
                                     <button
                                         key={v}
                                         onClick={() => setHeroVariant(v)}
-                                        className={`rounded-full border-2 border-black px-3 py-1 text-xs font-bold transition-colors ${
+                                        className={`rounded-full border-2 border-n-1 px-3 py-1 text-xs font-bold transition-colors ${
                                             heroVariant === v
                                                 ? 'bg-primary-1 text-n-1'
                                                 : 'bg-white text-grey-1 hover:bg-grey-2'
@@ -134,8 +138,8 @@ export default function ShareBuilderPage() {
                                     </button>
                                 ))}
                             </div>
-                        </Field>
-                        <Field label="Copy">
+                        </DevField>
+                        <DevField label="Copy">
                             <input
                                 type="text"
                                 value={heroText}
@@ -144,14 +148,20 @@ export default function ShareBuilderPage() {
                                 className="custom-input"
                                 placeholder="I'M IN"
                             />
-                        </Field>
+                        </DevField>
                         <div className="flex flex-wrap gap-2">
-                            <PresetButton onClick={() => setHeroText("I'M IN")}>I&apos;M IN</PresetButton>
-                            <PresetButton onClick={() => setHeroText("shhhh, i'm in")}>shhhh, i&apos;m in</PresetButton>
-                            <PresetButton onClick={() => setHeroText('ACCESS GRANTED')}>ACCESS GRANTED</PresetButton>
-                            <PresetButton onClick={() => setHeroText('I GOT THE CARD')}>I GOT THE CARD</PresetButton>
+                            <DevPresetButton onClick={() => setHeroText("I'M IN")}>I&apos;M IN</DevPresetButton>
+                            <DevPresetButton onClick={() => setHeroText("shhhh, i'm in")}>
+                                shhhh, i&apos;m in
+                            </DevPresetButton>
+                            <DevPresetButton onClick={() => setHeroText('ACCESS GRANTED')}>
+                                ACCESS GRANTED
+                            </DevPresetButton>
+                            <DevPresetButton onClick={() => setHeroText('I GOT THE CARD')}>
+                                I GOT THE CARD
+                            </DevPresetButton>
                         </div>
-                        <Field label={`Size (${heroScale.toFixed(2)}×)`}>
+                        <DevField label={`Size (${heroScale.toFixed(2)}×)`}>
                             <input
                                 type="range"
                                 min={0.6}
@@ -161,8 +171,8 @@ export default function ShareBuilderPage() {
                                 onChange={(e) => setHeroScale(Number(e.target.value))}
                                 className="w-full"
                             />
-                        </Field>
-                        <Field label={`Tilt (${heroTilt}°)`}>
+                        </DevField>
+                        <DevField label={`Tilt (${heroTilt}°)`}>
                             <input
                                 type="range"
                                 min={-20}
@@ -172,11 +182,11 @@ export default function ShareBuilderPage() {
                                 onChange={(e) => setHeroTilt(Number(e.target.value))}
                                 className="w-full"
                             />
-                        </Field>
-                    </Section>
+                        </DevField>
+                    </DevPanel>
 
-                    <Section title="Identity">
-                        <Field label={`Username (${username.length} / 12)`}>
+                    <DevPanel title="Identity">
+                        <DevField label={`Username (${username.length} / 12)`}>
                             <input
                                 type="text"
                                 value={username}
@@ -185,23 +195,23 @@ export default function ShareBuilderPage() {
                                 className="custom-input"
                                 placeholder="kkonrad"
                             />
-                        </Field>
+                        </DevField>
                         {username.length > 12 && (
                             <p className="text-[10px] font-bold leading-snug text-red">
                                 ⚠️ Username &gt; 12 chars · production caps at 12. The @username pill shrinks
                                 defensively, but check the input gate in your caller.
                             </p>
                         )}
-                    </Section>
+                    </DevPanel>
 
-                    <Section title="Username pill">
-                        <Field label="Background">
+                    <DevPanel title="Username pill">
+                        <DevField label="Background">
                             <div className="flex flex-wrap gap-2">
                                 {(['white', 'pink', 'blue'] as const).map((c) => (
                                     <button
                                         key={c}
                                         onClick={() => setUnameBg(c)}
-                                        className={`rounded-full border-2 border-black px-3 py-1 text-xs font-bold transition-colors ${
+                                        className={`rounded-full border-2 border-n-1 px-3 py-1 text-xs font-bold transition-colors ${
                                             unameBg === c
                                                 ? 'bg-primary-1 text-n-1'
                                                 : 'bg-white text-grey-1 hover:bg-grey-2'
@@ -211,8 +221,8 @@ export default function ShareBuilderPage() {
                                     </button>
                                 ))}
                             </div>
-                        </Field>
-                        <Field label={`"peanut.me/" size (${unamePrefix.toFixed(2)}× of handle)`}>
+                        </DevField>
+                        <DevField label={`"peanut.me/" size (${unamePrefix.toFixed(2)}× of handle)`}>
                             <input
                                 type="range"
                                 min={0.2}
@@ -222,8 +232,8 @@ export default function ShareBuilderPage() {
                                 onChange={(e) => setUnamePrefix(Number(e.target.value))}
                                 className="w-full"
                             />
-                        </Field>
-                        <Field label={`Handle size (${unameScale.toFixed(2)}×)`}>
+                        </DevField>
+                        <DevField label={`Handle size (${unameScale.toFixed(2)}×)`}>
                             <input
                                 type="range"
                                 min={0.6}
@@ -233,8 +243,8 @@ export default function ShareBuilderPage() {
                                 onChange={(e) => setUnameScale(Number(e.target.value))}
                                 className="w-full"
                             />
-                        </Field>
-                        <Field label={`Handle letter-spacing (${unameTracking.toFixed(3)}em)`}>
+                        </DevField>
+                        <DevField label={`Handle letter-spacing (${unameTracking.toFixed(3)}em)`}>
                             <input
                                 type="range"
                                 min={-0.06}
@@ -244,16 +254,16 @@ export default function ShareBuilderPage() {
                                 onChange={(e) => setUnameTracking(Number(e.target.value))}
                                 className="w-full"
                             />
-                        </Field>
-                    </Section>
+                        </DevField>
+                    </DevPanel>
 
-                    <Section title={`Badges (${selectedBadges.size} selected)`}>
+                    <DevPanel title={`Badges (${selectedBadges.size} selected)`}>
                         <div className="flex flex-wrap gap-2">
                             {ALL_CODES.map((code) => (
                                 <button
                                     key={code}
                                     onClick={() => toggleBadge(code)}
-                                    className={`rounded-full border-2 border-black px-3 py-1 text-xs font-bold transition-colors ${
+                                    className={`rounded-full border-2 border-n-1 px-3 py-1 text-xs font-bold transition-colors ${
                                         selectedBadges.has(code)
                                             ? 'bg-primary-1 text-n-1'
                                             : 'bg-white text-grey-1 hover:bg-grey-2'
@@ -265,18 +275,18 @@ export default function ShareBuilderPage() {
                             ))}
                         </div>
                         <div className="mt-3 flex flex-wrap gap-2">
-                            <PresetButton onClick={() => setSelectedBadges(new Set())}>0 badges</PresetButton>
-                            <PresetButton onClick={() => setSelectedBadges(new Set(['OG_2025_10_12']))}>
+                            <DevPresetButton onClick={() => setSelectedBadges(new Set())}>0 badges</DevPresetButton>
+                            <DevPresetButton onClick={() => setSelectedBadges(new Set(['OG_2025_10_12']))}>
                                 1 badge
-                            </PresetButton>
-                            <PresetButton
+                            </DevPresetButton>
+                            <DevPresetButton
                                 onClick={() =>
                                     setSelectedBadges(new Set(['OG_2025_10_12', 'DEVCONNECT_BA_2025', 'CARD_PIONEER']))
                                 }
                             >
                                 3
-                            </PresetButton>
-                            <PresetButton
+                            </DevPresetButton>
+                            <DevPresetButton
                                 onClick={() =>
                                     setSelectedBadges(
                                         new Set([
@@ -297,15 +307,15 @@ export default function ShareBuilderPage() {
                                 }
                             >
                                 12
-                            </PresetButton>
-                            <PresetButton onClick={() => setSelectedBadges(new Set(ALL_CODES))}>
+                            </DevPresetButton>
+                            <DevPresetButton onClick={() => setSelectedBadges(new Set(ALL_CODES))}>
                                 all {ALL_CODES.length}
-                            </PresetButton>
+                            </DevPresetButton>
                         </div>
-                    </Section>
+                    </DevPanel>
 
-                    <Section title="Layout">
-                        <Field label={`Preview scale (${previewScale.toFixed(2)}×)`}>
+                    <DevPanel title="Layout">
+                        <DevField label={`Preview scale (${previewScale.toFixed(2)}×)`}>
                             <input
                                 type="range"
                                 min={0.3}
@@ -315,7 +325,7 @@ export default function ShareBuilderPage() {
                                 onChange={(e) => setPreviewScale(Number(e.target.value))}
                                 className="w-full"
                             />
-                        </Field>
+                        </DevField>
                         <div className="flex gap-2">
                             <Button
                                 variant="purple"
@@ -341,16 +351,20 @@ export default function ShareBuilderPage() {
                                 {animate ? '✓ Animate' : 'Animate off'}
                             </Button>
                         </div>
-                    </Section>
+                    </DevPanel>
 
-                    <Section title="Username length shortcuts">
+                    <DevPanel title="Username length shortcuts">
                         <div className="grid grid-cols-2 gap-2 text-xs">
-                            <PresetButton onClick={() => setUsername('me')}>2-char user</PresetButton>
-                            <PresetButton onClick={() => setUsername('twelvechars1')}>12 chars (max)</PresetButton>
-                            <PresetButton onClick={() => setUsername('thisistwentyplus_chars')}>20+ chars</PresetButton>
-                            <PresetButton onClick={() => setUsername('kkonrad')}>reset</PresetButton>
+                            <DevPresetButton onClick={() => setUsername('me')}>2-char user</DevPresetButton>
+                            <DevPresetButton onClick={() => setUsername('twelvechars1')}>
+                                12 chars (max)
+                            </DevPresetButton>
+                            <DevPresetButton onClick={() => setUsername('thisistwentyplus_chars')}>
+                                20+ chars
+                            </DevPresetButton>
+                            <DevPresetButton onClick={() => setUsername('kkonrad')}>reset</DevPresetButton>
                         </div>
-                    </Section>
+                    </DevPanel>
                 </aside>
 
                 {/* ─── RIGHT: Preview ──────────────────────────────────── */}
@@ -447,37 +461,6 @@ export default function ShareBuilderPage() {
                     </div>
                 </main>
             </div>
-        </div>
-    )
-}
-
-// ─── Small UI primitives ────────────────────────────────────────────────
-
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
-    return (
-        <section className="shadow-4 rounded-sm border-2 border-n-1 bg-white p-4">
-            <h2 className="mb-3 text-xs font-extrabold uppercase tracking-wider text-grey-1">{title}</h2>
-            <div className="flex flex-col gap-3">{children}</div>
-        </section>
-    )
-}
-
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
-    return (
-        <label className="flex flex-col gap-1.5">
-            <span className="text-xs font-bold text-grey-1">{label}</span>
-            {children}
-        </label>
-    )
-}
-
-function PresetButton({ onClick, children }: { onClick: () => void; children: React.ReactNode }) {
-    return (
-        <button
-            onClick={onClick}
-            className="rounded-full border border-n-1 bg-white px-2 py-1 text-xs font-bold transition-colors hover:bg-grey-2"
-        >
-            {children}
-        </button>
+        </DevPageShell>
     )
 }


### PR DESCRIPTION
Holistic design/UX/code-quality pass over the internal `/dev` pages. **Presentation and information architecture only — no data or logic content changed** (`journeyData.ts` facts, the `__dev/journey-spec` fetch, findings copy are all semantically identical).

## Why

`src/app/(mobile-ui)/layout.tsx` deliberately strips padding and width constraints for `/dev` routes (`isDev && 'p-0 pb-0'`, no `md:w-[calc(100%-160px)]`). Each dev page therefore had to invent its own shell, and they diverged — `px-4` / `px-6` / `p-4` / none at all. Two compounding problems:

- **`NavHeader` hides its title *and* its back button on `md:`** — so no dev page had a visible heading on desktop, which is where these tools are actually used.
- **Pages whose root lacked `w-full`** shrank to content width inside the layout's flex row. The leaderboard rendered in an ~800px gutter on a 1440px screen.

`/dev/journey` had zero page padding, an unexplained chip taxonomy, and no way to read it without wading through gating predicates and `src/...` paths.

## Extracted primitives (`dev/_components/`)

| Primitive | Replaces | Used by |
|---|---|---|
| `DevPageShell` | 6 different ad-hoc shells | 12 pages |
| `DevSectionLabel` | 4 competing heading idioms (`text-sm`/`text-xs`, `<p>`/`<h2>`, `tracking-wide`/`tracking-wider`, `font-bold`/`font-extrabold`) | 5 pages |
| `DevPanel` / `DevField` / `DevPresetButton` | byte-identical local copies in `rejection-builder` **and** `share-builder` | 2 pages, ~25 call sites |
| `DevNoteCard` | identical note-card block | 3 pages |
| `DevChip` + `devChipTones` | ad-hoc `text-[9px]` pill markup | journey (5 sites) |

Journey-local: `surfaceKindMeta.ts`, `KindLegend`, `StuckBadge`, `ViewModeToggle`, `BoardGroup`, `PushCard`.

## `/dev/journey` — Hugo's asks

1. **Legend + tooltips + colour coding for the surface-kind chips.** New `IN-APP SURFACE KINDS` strip explains `HOME STEP` / `CAROUSEL` / `MODAL` / `/CARD`; each kind has a fixed tone (yellow / lavender / pink / green) and a hover explanation on every chip. `NEW in this PR` moves to an ink chip so meta badges never read as taxonomy.
2. **Product view / dev view toggle**, default **product**, URL-backed via nuqs (`?view=dev`). Product view hides gating predicates, `src/...` paths, stage predicates, event types and finding source files, so the page reads as a product cockpit.
3. **EMAILS vs IN-APP distinct at a glance** — the three channels are now tinted bands (in-app white, emails lavender, push yellow) with counts, instead of one undifferentiated card stack.
4. **`day 2 stuck` / `day 6 stuck` tied to the rules strip** — both now render the same `StuckBadge` component, so the rule and its consequence are visibly the same fact.
5. **Horizontal-scroll affordance** — "7 funnel states, left to right — scroll sideways to reach the last one →" plus a right-edge fade over the scroller.
6. **Page padding** — via `DevPageShell`.

## Other fixes

- `/dev` index: full tool list — 7 pages (components, both builders, profile-card-row, perk-success-test, shake-test, card-session-approve) were unreachable from the hub.
- `leaderboard`: removed the duplicate `<h1>` (NavHeader title + `text-4xl` hero said the same thing), width bug fixed, neutral `gray-*` text/hairlines onto the repo's `grey-1` / `gray-3` / `error-1` tokens. Tier and rank colour-coding left alone — intentional.
- `debug`: `font-display text-lg` headings unified; two branches that disagreed on `p-4` vs `p-6` now share the shell; the raw `<Link className="underline">` gets `text-black underline` per the design rules.
- `perk-success-test`: the `bg-blue-50 / text-blue-900` instruction card (blue is not a Peanut colour) becomes a `DevNoteCard`.
- Builders: `border-2 border-black` → `border-2 border-n-1`.

## Deliberately left alone

- **`/dev/full-graph` and `/dev/payment-graph`** — the only `/dev` routes reachable on peanut.me. They escape the layout via `fixed inset-0 z-50` and size their canvas off `window.innerHeight - 120`; padding changes are a no-op at best and a desync at worst. **Verified pixel-identical before/after** (ImageMagick `compare -metric AE` = 0). Their `gray-*` / `cyan-*` palette drift is noted but untouched.
- `/dev/ds` — already has a coherent doc shell (`DocPage` / `DocHeader` / `DocSection`). Pixel-identical before/after. Its `showcase-utils.StatusTag` / `PropTable` duplicate `ds/_components/StatusTag` / `PropsTable` — worth merging, but it's a separate change.
- `shake-test`'s orange/green checklist tints and the leaderboard prize gradient — intentional colour-coding, readable as-is.

## Verification

- Local dev server on :3052 against the sandbox API on :5050; screenshots at 1440px desktop and 390px mobile, before and after, for journey (product + dev view + scrolled + mobile), dev index, leaderboard, both builders, debug, components, ds, full-graph, payment-graph, shake-test, perk-success-test, profile-card-row, card-session-approve.
- `prettier --check .` clean · `npm run typecheck` zero errors · `npm test` 175 suites / 2307 passed.
- New unit test `journey/__tests__/surfaceKindMeta.test.ts` pins the legend to the catalog, so a new `SurfaceKind` can't ship without an explanation.
