### PR TITLE
fix(watchdog): don't treat a mid-run mirror as an emergency

### DIFF
--- a/.github/workflows/content-pipeline-watchdog.yml
+++ b/.github/workflows/content-pipeline-watchdog.yml
@@ -116,13 +116,20 @@ jobs:
                   fi
 
                   STALE=""
-                  MIRROR_BROKEN=false
+                  # URGENT = skip the grace period. Reserve it for states that cannot
+                  # resolve on their own. A mirror that is merely mid-run is NOT one of
+                  # them: it finishes in ~30s, and treating it as urgent turned every
+                  # push landing shortly before a tick into a false alarm. That fired
+                  # for real (16:04:13 run, 21s after a push, 12s before the mirror
+                  # completed — "Stuck for 5m", and green again on the next tick).
+                  # A genuinely dead mirror still alerts; it just waits out the grace,
+                  # which is exactly what the grace period is for.
+                  URGENT=false
                   if [ "$DEGRADED" = true ]; then
                     STALE="**the watchdog itself could not evaluate the pipeline** — check its permissions before assuming content is stuck"
-                    MIRROR_BROKEN=true
+                    URGENT=true
                   elif [ "${EXPECTED:0:7}" != "${MIRRORED:0:7}" ]; then
                     STALE="the mirror is behind mono (expected \`${EXPECTED:0:7}\`, published \`${MIRRORED:0:7}\`)"
-                    MIRROR_BROKEN=true
                   elif [ "$LIVE" != "$TIP" ]; then
                     STALE="production is behind peanut-content (live \`${LIVE:0:7}\`, latest \`${TIP:0:7}\`)"
                   fi
@@ -139,8 +146,7 @@ jobs:
                           --json number,headRefName \
                           --jq '[.[] | select((.headRefName | startswith("auto/update-content-")) or (.headRefName | startswith("content/publish-to-main")))] | first | .number // empty' || true)
 
-                  # A failed mirror will not fix itself, so skip the grace period.
-                  DOOMED=$MIRROR_BROKEN
+                  DOOMED=$URGENT
                   if [ -n "$NUM" ]; then
                     PR_SHA=$(GH_TOKEN=$UI_TOKEN gh api "repos/$REPO/pulls/$NUM" --jq '.head.sha' || true)
                     CI=$(GH_TOKEN=$UI_TOKEN gh api "repos/$REPO/commits/$PR_SHA/check-runs?per_page=100" \
@@ -151,7 +157,10 @@ jobs:
                     WHERE="no publish PR is open — the mirror, the dispatch, or update-content.yml failed"
                   fi
 
-                  # Red CI never self-resolves, so don't wait out the grace period.
+                  # Only genuinely unrecoverable states skip the grace period: red CI,
+                  # and a watchdog that cannot evaluate itself. Everything else gets
+                  # the full window, because most staleness at this point is just the
+                  # pipeline mid-flight.
                   if [ "$DOOMED" = false ] && [ "$AGE" -lt "$GRACE_MINUTES" ]; then
                     echo "$STALE — ${AGE}m old, within ${GRACE_MINUTES}m grace ($WHERE). Not alerting yet."
                     exit 0


### PR DESCRIPTION
The watchdog false-alarmed in Discord today. Content was fine — it caught the pipeline **mid-flight**:

```
16:03:52  push f3008839
16:04:13  watchdog: "the mirror is behind mono ... Stuck for 5m"   ← 21s after the push
16:04:25  mirror completes                                          ← 12s after the watchdog looked
16:43:38  green
```

## Cause

Mirror-behind skipped the 45-minute grace period, on my reasoning that *"a failed mirror will not fix itself."* **That reasoning was wrong.** A mirror that is merely mid-run fixes itself in ~30 seconds, and from outside it is indistinguishable from a dead one.

So any content push landing shortly before a `*/15` tick produces a false alarm — roughly **1 in 20 pushes, indefinitely**. That is exactly the alert-fatigue pattern that makes a watchdog worthless.

## Fix

Skipping the grace period is now reserved for states that genuinely cannot recover: **red CI**, and **a watchdog that cannot evaluate itself**. A dead mirror still alerts — it just waits out the window first, which is what the window is for.

## Decision table, verified

| Case | Before | After |
|---|---|---|
| mirror mid-flight, 5m | ALERT ❌ | **SILENT** ✅ |
| mirror genuinely stuck, 60m | ALERT | ALERT ✅ |
| prod behind, 5m | SILENT | SILENT ✅ |
| prod behind, 60m | ALERT | ALERT ✅ |
| prod behind, CI red | ALERT now | ALERT now ✅ |
| watchdog degraded | ALERT now | ALERT now ✅ |
| healthy | silent | silent ✅ |

Also ran the real step under `bash -e` against live APIs — reports `production content is current`, exit 0.

## Note

This is a false-alarm fix, not a pipeline fix. Content publishing itself is working: three consecutive autonomous publishes today (#2561, #2575, #2576), all merged by the automation, production in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pipeline monitoring during degraded conditions.
  * Watchdog evaluation failures are now escalated immediately.
  * Mirror delays receive the full grace period before being marked as failed, reducing premature failure alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->