### PR TITLE
fix(re-consent): make the terms prompt escapable, per our own ToS §17

### DIFF
--- a/src/components/Global/ReConsentModal/__tests__/index.test.tsx
+++ b/src/components/Global/ReConsentModal/__tests__/index.test.tsx
@@ -74,6 +74,40 @@ jest.mock('@sentry/nextjs', () => ({
 }))
 
 import ReConsentModal from '../index'
+import { nextPromptAt, LEGAL_NOTICE_PERIOD_DAYS, MIN_SNOOZE_DAYS } from '../utils'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+describe('nextPromptAt', () => {
+    // 2026-07-15 + 30d = 2026-08-14, the date the current terms take effect
+    const posted = '2026-07-15'
+    const dayAfterPosting = Date.parse('2026-07-16')
+
+    it('defers to the effective date — the full §17.2 notice period, not a fixed interval', () => {
+        expect(nextPromptAt([posted], dayAfterPosting)).toBe(Date.parse('2026-08-14'))
+    })
+
+    it('uses the LATEST effective date when several documents are shown at once', () => {
+        expect(nextPromptAt(['2026-07-01', posted], dayAfterPosting)).toBe(Date.parse('2026-08-14'))
+    })
+
+    it('floors to MIN_SNOOZE_DAYS once a document is already past its notice period', () => {
+        // §17.3 already makes continued use acceptance here, so the prompt only
+        // still asks to record explicit consent — it must not nag every open
+        const longAfter = Date.parse('2027-01-01')
+        expect(nextPromptAt([posted], longAfter)).toBe(longAfter + MIN_SNOOZE_DAYS * DAY_MS)
+    })
+
+    it('falls back to the floor rather than throwing on an unparseable version', () => {
+        const now = Date.parse('2026-07-29')
+        expect(nextPromptAt(['not-a-date'], now)).toBe(now + MIN_SNOOZE_DAYS * DAY_MS)
+        expect(nextPromptAt([], now)).toBe(now + MIN_SNOOZE_DAYS * DAY_MS)
+    })
+
+    it('pins the notice period to the 30 days our own ToS §17.2 promises', () => {
+        expect(LEGAL_NOTICE_PERIOD_DAYS).toBe(30)
+    })
+})
 
 const statusDoc = (slug: string) => ({
     slug,

--- a/src/components/Global/ReConsentModal/__tests__/index.test.tsx
+++ b/src/components/Global/ReConsentModal/__tests__/index.test.tsx
@@ -1,12 +1,13 @@
 /** @jest-environment jsdom */
 /**
- * ReConsentModal — the ToS §17 blocking click-through.
+ * ReConsentModal — the ToS §17 click-through.
  *
- * This modal gates the entire app, so the safety properties matter more than
- * the happy path: a failed status check must NEVER lock the app (fail-open),
- * a failed accept must keep the retry path alive, and an account switch must
- * not leak the previous user's consent state (a regression already caught
- * once in review).
+ * The safety properties matter more than the happy path: a failed status check
+ * must NEVER block the app (fail-open), a failed accept must keep the retry
+ * path alive, an account switch must not leak the previous user's consent state
+ * (a regression already caught once in review), and — because §17.2 gives a
+ * 30-day runway and §17.3 requires a decliner to still reach their funds — the
+ * prompt must ALWAYS be escapable and must never ledger a refusal as consent.
  */
 import React from 'react'
 import { render, screen, fireEvent, act } from '@testing-library/react'
@@ -64,7 +65,8 @@ jest.mock('@/components/Global/DocsLink', () => ({
     default: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
 }))
 
-jest.mock('posthog-js', () => ({ capture: jest.fn() }))
+const mockCapture = jest.fn()
+jest.mock('posthog-js', () => ({ capture: (...args: unknown[]) => mockCapture(...args) }))
 
 const mockCaptureException = jest.fn()
 jest.mock('@sentry/nextjs', () => ({
@@ -85,8 +87,13 @@ const flush = () => act(async () => {})
 
 beforeEach(() => {
     jest.clearAllMocks()
+    // the snooze is persisted per-user in localStorage — a leaked entry would
+    // silently suppress the prompt in every later test
+    window.localStorage.clear()
     mockUser = { user: { userId: 'user-1' } }
 })
+
+const capturedEvents = () => mockCapture.mock.calls.map(([event]) => event)
 
 describe('ReConsentModal', () => {
     it('fails open: a failed status check never shows (or locks) the modal', async () => {
@@ -138,6 +145,71 @@ describe('ReConsentModal', () => {
             expect.objectContaining({ slug: 'privacy' }),
         ])
         expect(screen.queryByTestId('modal')).not.toBeInTheDocument()
+        // acceptance must be distinguishable from refusal in analytics —
+        // the accept-vs-postpone ratio is the rollout's headline metric
+        expect(capturedEvents()).toEqual(['modal_shown', 'modal_cta_clicked'])
+    })
+
+    it('"Not now" is always available and never gated on the checkbox', async () => {
+        mockGetStatus.mockResolvedValue({ needsReConsent: true, documents: [statusDoc('terms')] })
+        render(<ReConsentModal />)
+        await flush()
+
+        expect(screen.getByText('Accept & continue')).toBeDisabled()
+        // the escape hatch must not require ticking a consent box first
+        expect(screen.getByText('Not now')).not.toBeDisabled()
+    })
+
+    it('"Not now" dismisses without recording any consent (a refusal is not a ledger row)', async () => {
+        mockGetStatus.mockResolvedValue({ needsReConsent: true, documents: [statusDoc('terms')] })
+        render(<ReConsentModal />)
+        await flush()
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('Not now'))
+        })
+
+        expect(screen.queryByTestId('modal')).not.toBeInTheDocument()
+        expect(mockAccept).not.toHaveBeenCalled()
+        expect(capturedEvents()).toEqual(['modal_shown', 'modal_dismissed'])
+    })
+
+    it('a postponed prompt stays away on the next session, then returns once the snooze lapses', async () => {
+        mockGetStatus.mockResolvedValue({ needsReConsent: true, documents: [statusDoc('terms')] })
+        const first = render(<ReConsentModal />)
+        await flush()
+        await act(async () => {
+            fireEvent.click(screen.getByText('Not now'))
+        })
+        first.unmount()
+
+        // fresh session (remount → fresh refs), still inside the snooze window
+        render(<ReConsentModal />)
+        await flush()
+        expect(screen.queryByTestId('modal')).not.toBeInTheDocument()
+        // and we don't even spend the request while snoozed
+        expect(mockGetStatus).toHaveBeenCalledTimes(1)
+
+        // snooze lapses → the prompt comes back
+        window.localStorage.setItem('peanut.reconsent.snoozedUntil.user-1', String(Date.now() - 1))
+        render(<ReConsentModal />)
+        await flush()
+        expect(screen.getByTestId('modal')).toBeInTheDocument()
+    })
+
+    it('one user postponing does not suppress the prompt for a different account', async () => {
+        mockGetStatus.mockResolvedValue({ needsReConsent: true, documents: [statusDoc('terms')] })
+        const first = render(<ReConsentModal />)
+        await flush()
+        await act(async () => {
+            fireEvent.click(screen.getByText('Not now'))
+        })
+        first.unmount()
+
+        mockUser = { user: { userId: 'user-2' } }
+        render(<ReConsentModal />)
+        await flush()
+        expect(screen.getByTestId('modal')).toBeInTheDocument()
     })
 
     it('a failed accept keeps the modal, shows the error, and leaves retry enabled', async () => {

--- a/src/components/Global/ReConsentModal/index.tsx
+++ b/src/components/Global/ReConsentModal/index.tsx
@@ -8,6 +8,7 @@ import { useAuth } from '@/context/authContext'
 import { acceptedLegalDocument, consentApi, type ConsentStatusDocument } from '@/services/consent'
 import { LEGAL_DOCUMENT_VERSIONS, type LegalDocumentSlug } from '@/constants/legal-versions.generated'
 import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
+import { isReConsentSnoozed, snoozeReConsent } from './utils'
 
 const DOC_LABELS: Record<string, { name: string; href: string }> = {
     terms: { name: 'Terms of Service', href: '/terms' },
@@ -19,12 +20,21 @@ const DOC_LABELS: Record<string, { name: string; href: string }> = {
     'card-prohibited-activities': { name: 'Prohibited Activities Policy', href: '/card-prohibited-activities' },
 }
 
+/** Keep "Not now" stacked BELOW the primary CTA at every width — side-by-side
+ *  would read as two equally-weighted choices. */
+const STACKED_CTAS = 'flex-col sm:flex-col'
+
 /**
  * Re-consent click-through (tos-v1 phase 2, ToS §17): when a legal document's
- * published version moves past what the user last provably accepted, this
- * blocking modal lists the updated documents and appends fresh consent-ledger
- * rows on acceptance. Backed by GET /users/consent/status and
- * POST /users/consent/accept — see peanut-api.
+ * published version moves past what the user last provably accepted, this modal
+ * lists the updated documents and appends fresh consent-ledger rows on
+ * acceptance. Backed by GET /users/consent/status and POST /users/consent/accept.
+ *
+ * It is a PROMPT, not a gate. §17.2 gives material changes 30 days and offers
+ * the click-through as a way to accept sooner; §17.3 requires that a user who
+ * declines can still stop using the Services — which, for a non-custodial
+ * wallet, means they must be able to reach `/withdraw`. So "Not now" always
+ * exists, and dismissing never writes a ledger row (declining is not consent).
  */
 const ReConsentModal = () => {
     const { user } = useAuth()
@@ -45,6 +55,8 @@ const ReConsentModal = () => {
         setOutdatedDocs([])
         setChecked(false)
         setError(null)
+        // a recent "Not now" defers the prompt — don't even spend the request
+        if (isReConsentSnoozed(userId)) return
         consentApi
             .getStatus()
             .then((status) => {
@@ -62,7 +74,7 @@ const ReConsentModal = () => {
                 })
             })
             .catch((e) => {
-                // a failed status check must never lock the app — retry next
+                // a failed status check must never block the app — retry next
                 // session. Sentry (not console): a systematic failure here means
                 // re-consent silently stops rolling out, and prod must say so.
                 Sentry.captureException(e, { tags: { feature: 're-consent', action: 'status' } })
@@ -75,7 +87,9 @@ const ReConsentModal = () => {
         setError(null)
         try {
             await consentApi.accept(outdatedDocs.map((d) => acceptedLegalDocument(d.slug as LegalDocumentSlug)))
-            posthog.capture(ANALYTICS_EVENTS.MODAL_DISMISSED, {
+            // CTA_CLICKED, not DISMISSED — acceptance and refusal must be
+            // distinguishable, since their ratio is the rollout's headline metric
+            posthog.capture(ANALYTICS_EVENTS.MODAL_CTA_CLICKED, {
                 modal_type: MODAL_TYPES.RE_CONSENT,
                 documents: outdatedDocs.map((d) => d.slug),
             })
@@ -84,8 +98,8 @@ const ReConsentModal = () => {
             // must start with an unticked box
             setChecked(false)
         } catch (e) {
-            // Sentry (not console): if /accept fails systematically, every user
-            // sits behind this undismissable modal — that must be visible in prod
+            // Sentry (not console): if /accept fails systematically, nobody can
+            // record consent at all — that must be visible in prod
             Sentry.captureException(e, { tags: { feature: 're-consent', action: 'accept' } })
             setError('Could not save your acceptance — please try again.')
         } finally {
@@ -93,27 +107,40 @@ const ReConsentModal = () => {
         }
     }
 
+    /** "Not now", the close button, backdrop and Escape all land here. */
+    const handlePostpone = () => {
+        if (submitting) return
+        const userId = user?.user.userId
+        if (userId) snoozeReConsent(userId)
+        posthog.capture(ANALYTICS_EVENTS.MODAL_DISMISSED, {
+            modal_type: MODAL_TYPES.RE_CONSENT,
+            documents: outdatedDocs.map((d) => d.slug),
+        })
+        setOutdatedDocs([])
+        setChecked(false)
+        setError(null)
+    }
+
     if (!outdatedDocs.length) return null
 
     return (
         <ActionModal
             visible
-            onClose={() => undefined}
-            preventClose
-            hideModalCloseButton
+            onClose={handlePostpone}
             icon="info"
             title="We've updated our terms"
             content={
-                <>
+                <div className="w-full space-y-3 text-left">
                     <p className="text-sm text-grey-1">
-                        To keep using Peanut, please review and accept the updated documents:
+                        We've refreshed the documents below. Give them a read and accept when you're ready — you can
+                        keep using Peanut in the meantime.
                     </p>
-                    <ul className="list-disc pl-5 text-sm">
+                    <ul className="space-y-1 text-sm">
                         {outdatedDocs.map((doc) => {
                             const label = DOC_LABELS[doc.slug] ?? { name: doc.slug, href: `/${doc.slug}` }
                             return (
                                 <li key={doc.slug}>
-                                    <DocsLink href={label.href} className="underline">
+                                    <DocsLink href={label.href} className="text-black underline dark:text-white">
                                         {label.name}
                                     </DocsLink>
                                 </li>
@@ -121,7 +148,7 @@ const ReConsentModal = () => {
                         })}
                     </ul>
                     {error && <p className="text-sm text-error">{error}</p>}
-                </>
+                </div>
             }
             checkbox={{
                 text: 'I have read and accept the updated documents',
@@ -131,10 +158,19 @@ const ReConsentModal = () => {
             ctas={[
                 {
                     text: submitting ? 'Saving…' : 'Accept & continue',
+                    variant: 'purple',
+                    shadowSize: '4',
                     disabled: !checked || submitting,
                     onClick: handleAccept,
                 },
+                {
+                    text: 'Not now',
+                    variant: 'transparent',
+                    disabled: submitting,
+                    onClick: handlePostpone,
+                },
             ]}
+            ctaClassName={STACKED_CTAS}
         />
     )
 }

--- a/src/components/Global/ReConsentModal/index.tsx
+++ b/src/components/Global/ReConsentModal/index.tsx
@@ -111,7 +111,13 @@ const ReConsentModal = () => {
     const handlePostpone = () => {
         if (submitting) return
         const userId = user?.user.userId
-        if (userId) snoozeReConsent(userId)
+        // defer to the date these documents actually take effect (§17.2), not a
+        // fixed interval — a doc posted today buys the user its full 30 days
+        if (userId)
+            snoozeReConsent(
+                userId,
+                outdatedDocs.map((d) => d.currentVersion)
+            )
         posthog.capture(ANALYTICS_EVENTS.MODAL_DISMISSED, {
             modal_type: MODAL_TYPES.RE_CONSENT,
             documents: outdatedDocs.map((d) => d.slug),

--- a/src/components/Global/ReConsentModal/utils.ts
+++ b/src/components/Global/ReConsentModal/utils.ts
@@ -1,23 +1,33 @@
 /**
  * Local snooze for the re-consent prompt.
  *
- * ToS §17.2 gives material changes a 30-day runway and frames the in-app
- * click-through as a way to accept *sooner* — voluntarily. §17.3 then says a
- * user who does not agree must be able to stop using the Services, which for a
- * non-custodial wallet has to include reaching their funds. So the prompt is a
- * reminder, not a lock: "Not now" defers it instead of gating the app.
+ * ToS §17.2 gives material changes a 30-day notice period and offers the in-app
+ * click-through as a way to accept sooner, by choice. §17.3 then says a user who
+ * does not agree must be able to stop using the Services — which, for a
+ * non-custodial wallet, has to include reaching their own funds. So the prompt
+ * is a reminder, not a lock: "Not now" defers it to the date the documents
+ * actually take effect.
  *
  * Deliberately localStorage and not the consent ledger — declining is not a
  * consent event and must never write a row. Losing the snooze (cleared storage,
- * another device) just re-shows the prompt, which is the safe direction.
+ * another device) only re-shows the prompt, which is the safe direction.
  */
 
-/** Long enough not to nag a wallet people open daily, short enough to still land. */
-export const RE_CONSENT_SNOOZE_DAYS = 3
+/** ToS §17.2 — material changes take effect no earlier than 30 days after posting. */
+export const LEGAL_NOTICE_PERIOD_DAYS = 30
+
+/**
+ * Floor for a document already past its notice period. Past that date §17.3
+ * makes continued use acceptance on its own, so the prompt only still asks in
+ * order to record explicit consent — worth a gentle cadence, not every app open.
+ */
+export const MIN_SNOOZE_DAYS = 7
+
+const DAY_MS = 24 * 60 * 60 * 1000
 
 const snoozeKey = (userId: string) => `peanut.reconsent.snoozedUntil.${userId}`
 
-/** Storage is unavailable during SSR and throws outright in Safari private mode. */
+/** Storage is absent during SSR and throws outright in Safari private mode. */
 function readStorage(key: string): string | null {
     try {
         return typeof window === 'undefined' ? null : window.localStorage.getItem(key)
@@ -30,8 +40,24 @@ function writeStorage(key: string, value: string): void {
     try {
         if (typeof window !== 'undefined') window.localStorage.setItem(key, value)
     } catch {
-        // a full or blocked quota just means the prompt returns next session
+        // a full or blocked quota only means the prompt returns next session
     }
+}
+
+/**
+ * When the prompt may reappear after a "Not now": the latest effective date
+ * across the documents shown, floored to MIN_SNOOZE_DAYS.
+ *
+ * `currentVersion` is the document's frontmatter `last_updated` (an ISO date),
+ * so effective = version + 30 days. An unparseable version contributes nothing
+ * rather than throwing — the floor still applies.
+ */
+export function nextPromptAt(versions: string[], now: number = Date.now()): number {
+    const effectiveDates = versions
+        .map((version) => Date.parse(version))
+        .filter((parsed) => Number.isFinite(parsed))
+        .map((parsed) => parsed + LEGAL_NOTICE_PERIOD_DAYS * DAY_MS)
+    return Math.max(now + MIN_SNOOZE_DAYS * DAY_MS, ...effectiveDates)
 }
 
 export function isReConsentSnoozed(userId: string): boolean {
@@ -42,7 +68,6 @@ export function isReConsentSnoozed(userId: string): boolean {
     return Number.isFinite(until) && until > Date.now()
 }
 
-export function snoozeReConsent(userId: string): void {
-    const until = Date.now() + RE_CONSENT_SNOOZE_DAYS * 24 * 60 * 60 * 1000
-    writeStorage(snoozeKey(userId), String(until))
+export function snoozeReConsent(userId: string, versions: string[]): void {
+    writeStorage(snoozeKey(userId), String(nextPromptAt(versions)))
 }

--- a/src/components/Global/ReConsentModal/utils.ts
+++ b/src/components/Global/ReConsentModal/utils.ts
@@ -1,0 +1,48 @@
+/**
+ * Local snooze for the re-consent prompt.
+ *
+ * ToS §17.2 gives material changes a 30-day runway and frames the in-app
+ * click-through as a way to accept *sooner* — voluntarily. §17.3 then says a
+ * user who does not agree must be able to stop using the Services, which for a
+ * non-custodial wallet has to include reaching their funds. So the prompt is a
+ * reminder, not a lock: "Not now" defers it instead of gating the app.
+ *
+ * Deliberately localStorage and not the consent ledger — declining is not a
+ * consent event and must never write a row. Losing the snooze (cleared storage,
+ * another device) just re-shows the prompt, which is the safe direction.
+ */
+
+/** Long enough not to nag a wallet people open daily, short enough to still land. */
+export const RE_CONSENT_SNOOZE_DAYS = 3
+
+const snoozeKey = (userId: string) => `peanut.reconsent.snoozedUntil.${userId}`
+
+/** Storage is unavailable during SSR and throws outright in Safari private mode. */
+function readStorage(key: string): string | null {
+    try {
+        return typeof window === 'undefined' ? null : window.localStorage.getItem(key)
+    } catch {
+        return null
+    }
+}
+
+function writeStorage(key: string, value: string): void {
+    try {
+        if (typeof window !== 'undefined') window.localStorage.setItem(key, value)
+    } catch {
+        // a full or blocked quota just means the prompt returns next session
+    }
+}
+
+export function isReConsentSnoozed(userId: string): boolean {
+    const raw = readStorage(snoozeKey(userId))
+    if (!raw) return false
+    const until = Number(raw)
+    // a corrupt value must not suppress the prompt forever
+    return Number.isFinite(until) && until > Date.now()
+}
+
+export function snoozeReConsent(userId: string): void {
+    const until = Date.now() + RE_CONSENT_SNOOZE_DAYS * 24 * 60 * 60 * 1000
+    writeStorage(snoozeKey(userId), String(until))
+}

--- a/src/constants/legal-versions.generated.ts
+++ b/src/constants/legal-versions.generated.ts
@@ -21,8 +21,8 @@ export const LEGAL_DOCUMENT_VERSIONS = {
         hash: 'd0ea9e1b239179c9ca4e5c26badb49506d8453399958ed040f68bb6650fd6e6c',
     },
     'card-terms-international': {
-        version: '2026-06-01',
-        hash: 'a6476057cd5bcf553f2c1faffc5261ad3c5e59eecbc8bf068e3b561df22035cf',
+        version: '2026-07-14',
+        hash: '9eb731e649de21ef8a28fca821f4123d63be55f0765a0843fe42bac31bbbe0bd',
     },
     'card-terms-us': {
         version: '2026-06-01',


### PR DESCRIPTION
Targets `release/sp-153-cherry-picks`, so it ships inside SP-153 rather than after it. Pairs with [peanut-api-ts#1255](https://github.com/peanutprotocol/peanut-api-ts/pull/1255).

## Why

`ReConsentModal` shipped as a hard gate: `preventClose`, hidden close button, one Accept CTA. It mounts in the `(mobile-ui)` layout, so it covers the whole app — including `/withdraw`.

That conflicts with the terms it enforces:

> **§17.2** Material changes take effect for existing users no earlier than **30 days** after we post the updated terms, *unless you accept them sooner through a mechanism we provide (such as a click-through acceptance)*.
>
> **§17.3** If you do not agree to the updated terms, **you must stop using the Services** before they take effect.

Two problems. We posted on **2026-07-15**, so the terms take effect around **2026-08-14** — a hard gate enforces them about two weeks early, and §17.2 frames the click-through as voluntary. And §17.3 assumes a user who declines can still stop using the Services, which for a non-custodial wallet has to leave a path to their own funds.

The prompt itself is correct and stays. Terms and privacy were genuinely rewritten (terms went 22 → 188 lines; privacy had not been touched since 2022), and **12,216 of 12,777 users** predate that change. Only the gate strength changes.

## What changed

- **"Not now" always exists** — plus close button, backdrop and Escape. The checkbox does not gate the exit.
- **A dismissal defers to the effective date**: the document's frontmatter version plus the 30 days §17.2 promises, floored to 7 days for a document already past its notice period. Stored per user in `localStorage`. It **never writes a ledger row** — a refusal is not consent.
- **Accept reports `modal_cta_clicked`**, not `modal_dismissed`. Both events already existed; refusal now reports `modal_dismissed`. We need the accept-vs-refuse ratio to measure the rollout.
- **Copy no longer says "To keep using Peanut"** — that claim is no longer true.

Accept stays the primary action: purple, shadowed, first in the stack. "Not now" is a subordinate transparent button below it.

## ⚠️ Cross-repo — needs a fix in peanut-api-ts#1255

`card-terms-international` was updated **2026-07-14** (§8.4 Nigerian Users, Rain-approved). Both constants still say `2026-06-01`:

| Source | Version |
|---|---|
| `src/content` (pinned on this branch) | **2026-07-14** |
| `legal-versions.generated.ts` (was committed) | 2026-06-01 — stale |
| peanut-api `CURRENT_LEGAL_VERSIONS` | 2026-06-01 — **still stale** |

`predev`/`prebuild` regenerate the FE file, so any dev server or Vercel build already produces `2026-07-14`. The regenerated file is committed here. But `sanitizeEchoedDocuments` treats a client version newer than the server's as an attack and **clamps it, dropping the hash**. Net effect: international card applicants get ledgered as accepting `2026-06-01` when they were shown `2026-07-14`, and the clause update never triggers re-consent. Only a warn log says so.

**The BE constant needs the same bump.** One line, in #1255.

## Screenshots

375×667 (iPhone SE), the two states of the prompt. The close button is now visible, and "Not now" sits below the primary CTA.

| Opens (primary gated by the checkbox) | Checkbox ticked (accept live) |
|---|---|
| <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2579/01-prompt.png" width="300"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2579/02-accept-enabled.png" width="300"> |

Captured from a throwaway `/dev` page rendering the same `ActionModal` props this component passes — so the pixels, the `Button`, and the Tailwind are all real. The page was deleted before push; it is not in the diff. The full-app route was not reachable locally in the time available — the app shell needs several endpoints stubbed past `/users/me` before the layout stops rendering its loading state. Assets live on `pr-assets-2579` — **delete that branch after merge**.

> Unrelated, pre-existing, not fixed here: `ActionModal`'s checkbox renders the browser-default **blue** when checked in light mode. It sets `dark:checked:bg-primary-1` but has no light-mode equivalent, so it misses the Peanut pink. Visible in the second shot.

## Worktree note (fixed separately)

`pnpm dev` cannot run in any peanut-ui worktree created by `scripts/setup-worktree`: Next 16 defaults to Turbopack, which rejects a `node_modules` symlink pointing outside the project root. `dev:fallback` does not help — plain `next dev` is Turbopack too. Replacing the symlink with a real `pnpm install --frozen-lockfile --prefer-offline` takes ~7s and fixes it. Being fixed in `scripts/setup-worktree` separately; not part of this PR.

## Design notes / accepted trade-offs

- **The checkbox stays.** One-tap accept would be smoother, but this is a legal consent artifact and removing the affirmation is Legal's call, not a UI cleanup. Drop it in one line if Legal is comfortable.
- **The snooze is client-side.** Consequence: cleared storage or a second device re-shows the prompt. That is the safe direction — the failure mode is asking again, never suppressing.
- **A dismissal records nothing.** After the effective date §17.3 makes continued use acceptance on its own, so the legal position holds — but there is no *evidence* row for anyone who never clicks. Closing that gap needs a BE decision, listed below.

### Revealed, not fixed (pre-existing — flagging per the boy-scout rule)

- **A legal document's slug now lives in three places**: `DOC_LABELS` here, `LEGAL_DOCUMENT_VERSIONS` (generated), and `CONSENT_DOCUMENT_SLUGS` in peanut-api. Adding a document means editing all three, and nothing fails if you miss one.
- **Nothing checks the committed `legal-versions.generated.ts` against its source.** The drift above went unnoticed because the mismatch is only visible once someone runs `predev`. A CI step that regenerates and diffs would have caught it the day the content landed.

## Open — BE decisions, not in this PR

1. **The 561.** 12,216 of 12,777 users predate 2026-07-15 and legitimately need to re-consent. The other **561 signed up after** and already accepted at signup; they are prompted only because the ledger starts empty. A backfill keyed on `users.created_at` and the version live at that time would spare them. Rows would be *inferred*, so they want `surface: 'backfill'`, not `'signup'`.
2. **The evidence tail.** Optionally record an implied-consent row (`surface: 'continued-use'`) once a user keeps using the app past the effective date, per §17.3. Closes the proof gap without nagging.

## Risk

Low, and strictly in the safe direction: the modal becomes escapable. No API contract change, no new endpoint, no migration. Worst case a user postpones and is asked again after the effective date. Deploy order is unchanged — BE #1255 first.

## QA

16 unit tests, up from 7. The added ones pin the properties that matter:

- "Not now" is never gated on the checkbox
- dismissing calls no `accept` and emits `modal_dismissed`
- a postponed prompt stays away next session, returns once the snooze lapses, and does not spend the status request while snoozed
- one user postponing does not suppress the prompt for a different account
- `nextPromptAt` honours the effective date, takes the latest across documents, floors past the notice period, and does not throw on a bad version

Whole repo green locally: **169/169 suites, 2252 tests**, `tsc --noEmit` clean with zero errors.

Worth noting for anyone who has fought worktrees: that full-green run is only possible *because* the `node_modules` symlink was replaced with a real install. The long-standing "phantom" worktree failures — `TS2307` on `@/assets/*`, missing `@capacitor/*`, ungenerated `public/flags` — were all the symlink, and all disappear. They were never real.
