### PR TITLE
feat(dev): review the 13 lifecycle email renders inside /dev/journey

### DIFF
--- a/src/app/(mobile-ui)/dev/_components/DevSegmented.tsx
+++ b/src/app/(mobile-ui)/dev/_components/DevSegmented.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { twMerge } from 'tailwind-merge'
+
+/**
+ * The one segmented control for /dev pages — a small row of mutually exclusive
+ * options (view modes, copy variants). Pink-fill = selected, matching DevChip's
+ * `pink` tone so a selected segment and a highlighted chip read as one system.
+ */
+export default function DevSegmented<T extends string>({
+    value,
+    options,
+    onChange,
+    className,
+    size = 'md',
+}: {
+    value: T
+    options: { value: T; label: string; hint?: string }[]
+    onChange: (next: T) => void
+    className?: string
+    /** `sm` for in-panel controls, `md` for page-header controls. */
+    size?: 'sm' | 'md'
+}) {
+    return (
+        <div className={twMerge('flex shrink-0 rounded-sm border border-n-1 bg-white p-0.5', className)}>
+            {options.map((option) => (
+                <button
+                    key={option.value}
+                    type="button"
+                    title={option.hint}
+                    aria-pressed={value === option.value}
+                    onClick={() => onChange(option.value)}
+                    className={twMerge(
+                        'rounded-sm font-bold transition-colors',
+                        size === 'sm' ? 'px-2 py-1 text-[11px]' : 'px-3 py-1.5 text-xs',
+                        value === option.value ? 'bg-primary-1 text-n-1' : 'text-grey-1 hover:bg-primary-3/40'
+                    )}
+                >
+                    {option.label}
+                </button>
+            ))}
+        </div>
+    )
+}

--- a/src/app/(mobile-ui)/dev/journey/EmailCard.tsx
+++ b/src/app/(mobile-ui)/dev/journey/EmailCard.tsx
@@ -1,33 +1,94 @@
 'use client'
 
-import { JOURNEY_API_BASE } from './journeyData'
+import { twMerge } from 'tailwind-merge'
+import DevChip from '../_components/DevChip'
+import { REVIEW_PENDING_CLASS, decisionFlagFor, emailPreviewUrl, examplesForStep, renderId } from './emailReview'
 import StuckBadge from './StuckBadge'
 import type { SpecEmailStep } from './journeyTypes'
 
 /**
- * Compact card for one lifecycle email step. Links to the API's live rendered
- * preview (opens in a new tab against the sandbox API).
+ * Compact card for one lifecycle email step.
+ *
+ * Doubles as the review unit: until every one of the email's renders has a
+ * verdict the card carries the amber dashed `review-pending` treatment and a
+ * "needs verdict" chip, so what still needs a product call is legible from
+ * across the board. Clicking opens the in-place preview panel; the `raw ↗` link
+ * stays as the external fallback.
  */
-export default function EmailCard({ step, showDev }: { step: SpecEmailStep; showDev: boolean }) {
+export default function EmailCard({
+    step,
+    showDev,
+    isReviewed,
+    onOpen,
+}: {
+    step: SpecEmailStep
+    showDev: boolean
+    isReviewed: (id: string) => boolean
+    onOpen: (eventType: string, example: number) => void
+}) {
+    const examples = examplesForStep(step)
+    const reviewedCount = examples.filter((example) => isReviewed(renderId(step.type, example.index))).length
+    const pending = reviewedCount < examples.length
+    const decision = decisionFlagFor(step.type)
+
     return (
-        <a
-            href={`${JOURNEY_API_BASE}/__dev/email-preview/${step.type}?example=0`}
-            target="_blank"
-            rel="noreferrer"
-            className="block rounded-sm border border-n-1 bg-white p-2.5 hover:bg-primary-3/30"
+        <div
+            data-review-state={pending ? 'pending' : 'reviewed'}
+            data-email-type={step.type}
+            className={twMerge('rounded-sm border border-n-1 bg-white', pending && REVIEW_PENDING_CLASS)}
         >
-            <div className="flex items-start justify-between gap-2">
-                <div className="text-xs font-bold leading-tight">{step.subject}</div>
-                {typeof step.afterDaysStuck === 'number' && <StuckBadge days={step.afterDaysStuck} />}
+            <button
+                type="button"
+                onClick={() => onOpen(step.type, 0)}
+                className="block w-full p-2.5 text-left hover:bg-primary-3/30"
+            >
+                <div className="flex items-start justify-between gap-2">
+                    <div className="text-xs font-bold leading-tight">{step.subject}</div>
+                    <div className="flex shrink-0 flex-col items-end gap-1">
+                        {typeof step.afterDaysStuck === 'number' && <StuckBadge days={step.afterDaysStuck} />}
+                        {pending ? (
+                            <DevChip tone="yellow" title="No product verdict recorded for this copy yet.">
+                                needs verdict{examples.length > 1 && ` ${reviewedCount}/${examples.length}`}
+                            </DevChip>
+                        ) : (
+                            <DevChip tone="green" title="Marked reviewed in the preview panel.">
+                                reviewed ✓
+                            </DevChip>
+                        )}
+                    </div>
+                </div>
+                <p className="mt-1 text-[11px] leading-snug text-grey-1">{step.preview}</p>
+                <p className="mt-1 text-[11px] leading-snug">
+                    <span className="rounded-sm bg-yellow-1 px-1 font-bold">{step.ctaText}</span>
+                    <span className="text-grey-1"> → {step.ctaPath}</span>
+                </p>
+                {decision && (
+                    <div className="mt-1.5 flex flex-col gap-0.5">
+                        <DevChip tone="pink" className="self-start" title={decision.note}>
+                            {decision.label}
+                        </DevChip>
+                        <p className="text-[10px] leading-snug text-grey-1">{decision.note}</p>
+                    </div>
+                )}
+                {examples.length > 1 && (
+                    <p className="mt-1 text-[10px] leading-snug text-grey-1">
+                        {examples.length} copy variants: {examples.map((example) => example.label).join(' / ')}
+                    </p>
+                )}
+            </button>
+            <div className="flex items-center justify-between gap-2 border-t border-n-1 px-2.5 py-1">
+                <span className="truncate font-mono text-[9px] leading-tight text-grey-1">
+                    {showDev ? step.type : 'click to review'}
+                </span>
+                <a
+                    href={emailPreviewUrl(step.type, 0, false)}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="shrink-0 text-[9px] font-bold text-black underline"
+                >
+                    raw ↗
+                </a>
             </div>
-            <p className="mt-1 text-[11px] leading-snug text-grey-1">{step.preview}</p>
-            <p className="mt-1 text-[11px] leading-snug">
-                <span className="rounded-sm bg-yellow-1 px-1 font-bold">{step.ctaText}</span>
-                <span className="text-grey-1"> → {step.ctaPath}</span>
-            </p>
-            <p className="mt-1.5 font-mono text-[9px] leading-tight text-grey-1">
-                {showDev ? `${step.type} · preview ↗` : 'preview ↗'}
-            </p>
-        </a>
+        </div>
     )
 }

--- a/src/app/(mobile-ui)/dev/journey/EmailPreviewPanel.tsx
+++ b/src/app/(mobile-ui)/dev/journey/EmailPreviewPanel.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import { useEffect } from 'react'
+import Checkbox from '@/components/0_Bruddle/Checkbox'
+import DevChip from '../_components/DevChip'
+import DevSegmented from '../_components/DevSegmented'
+import { decisionFlagFor, emailPreviewUrl } from './emailReview'
+import StuckBadge from './StuckBadge'
+import type { EmailRenderRef } from './journeyTypes'
+
+/**
+ * In-place reader for one email render — the review surface.
+ *
+ * Iframes the API's real React Email output rather than re-describing it, so
+ * the verdict is recorded against exactly what the user receives. The API sends
+ * `frame-ancestors 'self' http://localhost:3050` on /__dev/ responses, which is
+ * what makes the embed possible at all; on any other origin the browser blocks
+ * the frame and the "open raw ↗" link is the way through.
+ *
+ * Prev/next walk every render on the board in order, so a full copy pass is one
+ * keyboard-free sweep instead of 13 separate tab-opens.
+ */
+export default function EmailPreviewPanel({
+    renders,
+    activeIndex,
+    isReviewed,
+    onToggleReviewed,
+    onSelect,
+    onClose,
+}: {
+    renders: EmailRenderRef[]
+    activeIndex: number
+    isReviewed: (id: string) => boolean
+    onToggleReviewed: (id: string) => void
+    onSelect: (index: number) => void
+    onClose: () => void
+}) {
+    const active = renders[activeIndex]
+
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') onClose()
+        }
+        window.addEventListener('keydown', onKeyDown)
+        return () => window.removeEventListener('keydown', onKeyDown)
+    }, [onClose])
+
+    if (!active) return null
+
+    const siblings = renders.filter((render) => render.eventType === active.eventType)
+    const decision = decisionFlagFor(active.eventType)
+    const reviewed = isReviewed(active.id)
+    const position = activeIndex + 1
+
+    return (
+        <div className="fixed inset-0 z-50 flex justify-end">
+            <button
+                type="button"
+                aria-label="Close preview"
+                onClick={onClose}
+                className="absolute inset-0 cursor-default bg-n-1/40"
+            />
+
+            <aside className="relative flex h-full w-full max-w-full flex-col border-l-2 border-n-1 bg-white md:w-[640px]">
+                <header className="flex flex-col gap-2 border-b border-n-1 p-3">
+                    <div className="flex items-start justify-between gap-3">
+                        <div className="flex min-w-0 flex-col gap-1">
+                            <div className="text-sm font-bold leading-tight">{active.step.subject}</div>
+                            <div className="flex flex-wrap items-center gap-1.5">
+                                <span className="font-mono text-[10px] text-grey-1">{active.eventType}</span>
+                                {typeof active.step.afterDaysStuck === 'number' && (
+                                    <StuckBadge days={active.step.afterDaysStuck} />
+                                )}
+                            </div>
+                        </div>
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            aria-label="Close preview"
+                            className="shrink-0 rounded-sm border border-n-1 px-2 py-1 text-xs font-bold hover:bg-primary-3/40"
+                        >
+                            esc ✕
+                        </button>
+                    </div>
+
+                    {decision && (
+                        <div className="flex flex-col gap-1 rounded-sm border border-n-1 bg-yellow-1/40 p-2">
+                            <DevChip tone="pink" className="self-start">
+                                {decision.label}
+                            </DevChip>
+                            <p className="text-[11px] leading-snug">{decision.note}</p>
+                        </div>
+                    )}
+
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                        {siblings.length > 1 ? (
+                            <DevSegmented
+                                size="sm"
+                                value={String(active.example)}
+                                options={siblings.map((sibling) => ({
+                                    value: String(sibling.example),
+                                    label: sibling.exampleLabel,
+                                    hint: `example=${sibling.example}`,
+                                }))}
+                                onChange={(next) =>
+                                    onSelect(renders.findIndex((render) => render.id === `${active.eventType}#${next}`))
+                                }
+                            />
+                        ) : (
+                            <span className="text-[11px] text-grey-1">Single copy variant.</span>
+                        )}
+                        <a
+                            href={emailPreviewUrl(active.eventType, active.example, false)}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-xs font-bold text-black underline"
+                        >
+                            open raw ↗
+                        </a>
+                    </div>
+                    <p className="text-[10px] leading-snug text-grey-1">
+                        Frame blank? The API only allows the embed from localhost:3050 — use open raw ↗ instead.
+                    </p>
+                </header>
+
+                <div className="min-h-0 flex-1 bg-primary-3/20">
+                    <iframe
+                        key={active.id}
+                        title={`Email preview — ${active.eventType} example ${active.example}`}
+                        src={emailPreviewUrl(active.eventType, active.example, true)}
+                        className="h-full w-full border-0"
+                    />
+                </div>
+
+                {/* pl-14 on mobile: the panel is full-screen there and the dev overlay badge sits bottom-left */}
+                <footer className="flex flex-wrap items-center justify-between gap-3 border-t border-n-1 p-3 pl-14 md:pl-3">
+                    <Checkbox
+                        label={reviewed ? 'Reviewed — copy approved' : 'Mark reviewed'}
+                        value={reviewed}
+                        onChange={() => onToggleReviewed(active.id)}
+                    />
+                    <div className="flex items-center gap-2">
+                        <span className="text-[11px] text-grey-1">
+                            {position}/{renders.length}
+                        </span>
+                        <button
+                            type="button"
+                            disabled={activeIndex === 0}
+                            onClick={() => onSelect(activeIndex - 1)}
+                            className="rounded-sm border border-n-1 px-2.5 py-1 text-xs font-bold hover:bg-primary-3/40 disabled:opacity-30"
+                        >
+                            ← prev
+                        </button>
+                        <button
+                            type="button"
+                            disabled={activeIndex >= renders.length - 1}
+                            onClick={() => onSelect(activeIndex + 1)}
+                            className="rounded-sm border border-n-1 px-2.5 py-1 text-xs font-bold hover:bg-primary-3/40 disabled:opacity-30"
+                        >
+                            next →
+                        </button>
+                    </div>
+                </footer>
+            </aside>
+        </div>
+    )
+}

--- a/src/app/(mobile-ui)/dev/journey/JourneyBoard.tsx
+++ b/src/app/(mobile-ui)/dev/journey/JourneyBoard.tsx
@@ -17,10 +17,14 @@ export default function JourneyBoard({
     spec,
     specError,
     view,
+    isReviewed,
+    onOpenEmail,
 }: {
     spec: JourneySpec | null
     specError: string | null
     view: JourneyViewMode
+    isReviewed: (id: string) => boolean
+    onOpenEmail: (eventType: string, example: number) => void
 }) {
     const showDev = view === 'dev'
     const mappedStageNames = new Set(FUNNEL_STATES.flatMap((s) => s.specStages))
@@ -73,7 +77,12 @@ export default function JourneyBoard({
                                                 <p className="text-[10px] italic leading-snug text-grey-1">
                                                     On signup (immediate):
                                                 </p>
-                                                <EmailCard step={spec.welcome} showDev={showDev} />
+                                                <EmailCard
+                                                    step={spec.welcome}
+                                                    showDev={showDev}
+                                                    isReviewed={isReviewed}
+                                                    onOpen={onOpenEmail}
+                                                />
                                             </>
                                         )}
                                         {stages.map((stage) => (
@@ -85,7 +94,13 @@ export default function JourneyBoard({
                                                     </p>
                                                 )}
                                                 {stage.steps.map((step) => (
-                                                    <EmailCard key={step.type} step={step} showDev={showDev} />
+                                                    <EmailCard
+                                                        key={step.type}
+                                                        step={step}
+                                                        showDev={showDev}
+                                                        isReviewed={isReviewed}
+                                                        onOpen={onOpenEmail}
+                                                    />
                                                 ))}
                                             </div>
                                         ))}

--- a/src/app/(mobile-ui)/dev/journey/ReviewProgressStrip.tsx
+++ b/src/app/(mobile-ui)/dev/journey/ReviewProgressStrip.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import DevChip from '../_components/DevChip'
+
+/**
+ * Sticky "how much of the copy review is left" bar.
+ *
+ * The board scrolls sideways and the email cards are spread across seven
+ * columns, so without a running count there is no way to tell a half-finished
+ * review from a finished one.
+ */
+export default function ReviewProgressStrip({
+    checked,
+    total,
+    onReset,
+}: {
+    checked: number
+    total: number
+    onReset: () => void
+}) {
+    const done = total > 0 && checked === total
+    const percent = total > 0 ? Math.round((checked / total) * 100) : 0
+
+    return (
+        <div className="sticky top-0 z-30 flex flex-wrap items-center gap-x-4 gap-y-2 rounded-sm border border-n-1 bg-white px-3 py-2">
+            <span className="text-sm font-bold">
+                Copy review: {checked}/{total || '…'} checked
+            </span>
+            <div className="h-2 min-w-24 flex-1 overflow-hidden rounded-sm border border-n-1 bg-white">
+                <div
+                    className={done ? 'h-full bg-green-1' : 'h-full bg-yellow-1'}
+                    style={{ width: `${percent}%` }}
+                    aria-hidden
+                />
+            </div>
+            {done ? (
+                <DevChip tone="green">all reviewed</DevChip>
+            ) : (
+                <DevChip tone="yellow">{total - checked} awaiting verdict</DevChip>
+            )}
+            <button type="button" onClick={onReset} className="text-[10px] text-grey-1 underline hover:text-n-1">
+                reset
+            </button>
+        </div>
+    )
+}

--- a/src/app/(mobile-ui)/dev/journey/ViewModeToggle.tsx
+++ b/src/app/(mobile-ui)/dev/journey/ViewModeToggle.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { twMerge } from 'tailwind-merge'
+import DevSegmented from '../_components/DevSegmented'
 import type { JourneyViewMode } from './journeyTypes'
 
 const OPTIONS: { value: JourneyViewMode; label: string; hint: string }[] = [
@@ -16,23 +16,5 @@ export default function ViewModeToggle({
     value: JourneyViewMode
     onChange: (next: JourneyViewMode) => void
 }) {
-    return (
-        <div className="flex shrink-0 rounded-sm border border-n-1 bg-white p-0.5">
-            {OPTIONS.map((option) => (
-                <button
-                    key={option.value}
-                    type="button"
-                    title={option.hint}
-                    aria-pressed={value === option.value}
-                    onClick={() => onChange(option.value)}
-                    className={twMerge(
-                        'rounded-sm px-3 py-1.5 text-xs font-bold transition-colors',
-                        value === option.value ? 'bg-primary-1 text-n-1' : 'text-grey-1 hover:bg-primary-3/40'
-                    )}
-                >
-                    {option.label}
-                </button>
-            ))}
-        </div>
-    )
+    return <DevSegmented value={value} options={OPTIONS} onChange={onChange} />
 }

--- a/src/app/(mobile-ui)/dev/journey/__tests__/copyReviewStorage.test.ts
+++ b/src/app/(mobile-ui)/dev/journey/__tests__/copyReviewStorage.test.ts
@@ -1,0 +1,41 @@
+import { countReviewed, parseCopyReviewState, serializeCopyReviewState, toggleCopyReview } from '../copyReviewStorage'
+
+describe('copyReviewStorage', () => {
+    it('treats missing or unreadable storage as "nothing reviewed"', () => {
+        expect(parseCopyReviewState(null)).toEqual({})
+        expect(parseCopyReviewState('')).toEqual({})
+        expect(parseCopyReviewState('not json')).toEqual({})
+        expect(parseCopyReviewState('["lifecycle.fund_1#0"]')).toEqual({})
+        expect(parseCopyReviewState('null')).toEqual({})
+    })
+
+    it('keeps only entries explicitly marked reviewed', () => {
+        expect(parseCopyReviewState('{"a#0":true,"b#0":false,"c#0":"yes","d#0":1}')).toEqual({ 'a#0': true })
+    })
+
+    it('round-trips through serialize', () => {
+        const state = toggleCopyReview({}, 'lifecycle.welcome#0')
+        expect(parseCopyReviewState(serializeCopyReviewState(state))).toEqual(state)
+    })
+
+    it('toggles a verdict on and back off without mutating the input', () => {
+        const empty = {}
+        const on = toggleCopyReview(empty, 'lifecycle.verify_1#0')
+        expect(on).toEqual({ 'lifecycle.verify_1#0': true })
+        expect(empty).toEqual({})
+
+        const off = toggleCopyReview(on, 'lifecycle.verify_1#0')
+        expect(off).toEqual({})
+        expect(on).toEqual({ 'lifecycle.verify_1#0': true })
+    })
+
+    it('counts the two first_spend examples independently', () => {
+        const state = toggleCopyReview({}, 'lifecycle.first_spend_1#1')
+        expect(countReviewed(state, ['lifecycle.first_spend_1#0', 'lifecycle.first_spend_1#1'])).toBe(1)
+    })
+
+    it('ignores verdicts for renders that no longer exist on the board', () => {
+        const state = { 'lifecycle.removed_email#0': true as const, 'lifecycle.welcome#0': true as const }
+        expect(countReviewed(state, ['lifecycle.welcome#0'])).toBe(1)
+    })
+})

--- a/src/app/(mobile-ui)/dev/journey/__tests__/emailReview.test.ts
+++ b/src/app/(mobile-ui)/dev/journey/__tests__/emailReview.test.ts
@@ -1,0 +1,85 @@
+import { buildEmailRenderList, decisionFlagFor, examplesForStep, renderId } from '../emailReview'
+import type { JourneySpec, SpecEmailStep } from '../journeyTypes'
+
+const step = (type: string, extra: Partial<SpecEmailStep> = {}): SpecEmailStep => ({
+    type,
+    subject: `subject ${type}`,
+    preview: 'preview',
+    title: 'title',
+    paragraphs: ['p'],
+    ctaText: 'Go',
+    ctaPath: '/home',
+    ...extra,
+})
+
+const spec = (): JourneySpec => ({
+    generatedFrom: 'test',
+    rules: {
+        step1AfterDays: 2,
+        step2AfterDays: 6,
+        governorDays: 3,
+        freshnessDays: 30,
+        holdoutFraction: 0.1,
+        sendWindowUtc: { startHour: 13, endHour: 21 },
+        maxSendsPerCycle: 500,
+    },
+    welcome: step('lifecycle.welcome'),
+    stages: [
+        { stage: 'verify', order: 1, predicate: 'p', steps: [step('lifecycle.verify_1'), step('lifecycle.verify_2')] },
+        {
+            stage: 'first_spend',
+            order: 5,
+            predicate: 'p',
+            steps: [
+                step('lifecycle.first_spend_1', { paragraphsWithRewards: ['rewards copy'] }),
+                step('lifecycle.first_spend_2', { paragraphsWithRewards: ['rewards copy'] }),
+            ],
+        },
+    ],
+    pushReminders: [],
+    emailPreviewBase: '/__dev/email-preview',
+})
+
+describe('emailReview', () => {
+    it('has no renders until the spec loads', () => {
+        expect(buildEmailRenderList(null)).toEqual([])
+    })
+
+    it('splits a rewards-branch email into two labelled examples', () => {
+        expect(examplesForStep(step('x'))).toEqual([{ index: 0, label: 'default' }])
+        expect(examplesForStep(step('x', { paragraphsWithRewards: ['a'] }))).toEqual([
+            { index: 0, label: 'plain' },
+            { index: 1, label: 'rewards' },
+        ])
+    })
+
+    it('lists welcome first and every email exactly once, in board order', () => {
+        const renders = buildEmailRenderList(spec())
+        expect(renders.map((render) => render.id)).toEqual([
+            renderId('lifecycle.welcome', 0),
+            renderId('lifecycle.verify_1', 0),
+            renderId('lifecycle.verify_2', 0),
+            renderId('lifecycle.first_spend_1', 0),
+            renderId('lifecycle.first_spend_1', 1),
+            renderId('lifecycle.first_spend_2', 0),
+            renderId('lifecycle.first_spend_2', 1),
+        ])
+    })
+
+    it('still lists emails from a stage the board has not mapped to a column', () => {
+        const withUnmapped = spec()
+        withUnmapped.stages.push({
+            stage: 'brand_new_stage',
+            order: 9,
+            predicate: 'p',
+            steps: [step('lifecycle.brand_new_1')],
+        })
+        expect(buildEmailRenderList(withUnmapped).map((render) => render.eventType)).toContain('lifecycle.brand_new_1')
+    })
+
+    it('flags exactly the two open product decisions', () => {
+        expect(decisionFlagFor('lifecycle.first_spend_1')?.label).toMatch(/rewards branch/)
+        expect(decisionFlagFor('lifecycle.finish_setup_2')?.label).toMatch(/kill or keep/)
+        expect(decisionFlagFor('lifecycle.welcome')).toBeNull()
+    })
+})

--- a/src/app/(mobile-ui)/dev/journey/copyReviewStorage.ts
+++ b/src/app/(mobile-ui)/dev/journey/copyReviewStorage.ts
@@ -1,0 +1,51 @@
+/**
+ * Persistence for the copy-review verdicts on /dev/journey.
+ *
+ * Pure functions only — the hook (useCopyReview) owns localStorage access, this
+ * module owns the shape, so the "did Hugo already check this render?" logic is
+ * unit-testable without a DOM.
+ *
+ * A render is identified by `${eventType}#${exampleIndex}` (see emailReview.ts),
+ * so the two first_spend copy variants are reviewed independently.
+ */
+
+/** Only reviewed ids are stored; absence means "still needs a verdict". */
+export type CopyReviewState = Record<string, true>
+
+/** Namespaced and versioned: bumping the suffix retires stale verdicts wholesale. */
+export const COPY_REVIEW_STORAGE_KEY = 'journey-copy-review-v1'
+
+/** Tolerates every shape a hand-edited or pre-versioned localStorage value can take. */
+export function parseCopyReviewState(raw: string | null): CopyReviewState {
+    if (!raw) return {}
+    try {
+        const parsed: unknown = JSON.parse(raw)
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+        const state: CopyReviewState = {}
+        for (const [id, value] of Object.entries(parsed as Record<string, unknown>)) {
+            if (value === true) state[id] = true
+        }
+        return state
+    } catch {
+        return {}
+    }
+}
+
+export function serializeCopyReviewState(state: CopyReviewState): string {
+    return JSON.stringify(state)
+}
+
+export function toggleCopyReview(state: CopyReviewState, id: string): CopyReviewState {
+    const next = { ...state }
+    if (next[id]) delete next[id]
+    else next[id] = true
+    return next
+}
+
+/**
+ * Counted against the ids that currently exist on the board, so verdicts left
+ * over from a renamed/removed email never inflate the "N/13 checked" progress.
+ */
+export function countReviewed(state: CopyReviewState, ids: string[]): number {
+    return ids.reduce((total, id) => (state[id] ? total + 1 : total), 0)
+}

--- a/src/app/(mobile-ui)/dev/journey/emailReview.ts
+++ b/src/app/(mobile-ui)/dev/journey/emailReview.ts
@@ -1,0 +1,103 @@
+/**
+ * The copy-review layer over the live email spec.
+ *
+ * Turns the spec into a flat, board-ordered list of *renders* — one entry per
+ * (email, `?example=N`) pair — which is what a product review actually walks:
+ * 11 lifecycle emails, but 13 renders, because both first_spend steps render a
+ * second example for the rewards branch.
+ *
+ * Nothing here restates a journeyData fact; the ordering is derived from
+ * FUNNEL_STATES so the review list and the board can never disagree.
+ */
+
+import { FUNNEL_STATES, JOURNEY_API_BASE } from './journeyData'
+import type { EmailDecisionFlag, EmailExample, EmailRenderRef, JourneySpec, SpecEmailStep } from './journeyTypes'
+
+/** Tailwind treatment for anything still awaiting a product verdict. */
+export const REVIEW_PENDING_CLASS = 'review-pending border-2 border-dashed border-yellow-1'
+
+export function renderId(eventType: string, example: number): string {
+    return `${eventType}#${example}`
+}
+
+export function emailPreviewUrl(eventType: string, example: number, raw: boolean): string {
+    return `${JOURNEY_API_BASE}/__dev/email-preview/${eventType}?example=${example}${raw ? '&raw=1' : ''}`
+}
+
+/**
+ * Which `?example=N` renders exist for a step. The spec only tells us a rewards
+ * branch exists (`paragraphsWithRewards`), not what to call it — the labels are
+ * ours, and deliberately name the branch rather than the index.
+ */
+export function examplesForStep(step: SpecEmailStep): EmailExample[] {
+    if (step.paragraphsWithRewards?.length) {
+        return [
+            { index: 0, label: 'plain' },
+            { index: 1, label: 'rewards' },
+        ]
+    }
+    return [{ index: 0, label: 'default' }]
+}
+
+/**
+ * Every email render, in the order the board lays them out (welcome first, then
+ * each funnel column's stages left to right). Steps from stages the board hasn't
+ * mapped to a column yet are appended rather than dropped — an unreviewed email
+ * must never be invisible just because the column mapping lags the API.
+ */
+export function buildEmailRenderList(spec: JourneySpec | null): EmailRenderRef[] {
+    if (!spec) return []
+
+    const steps: SpecEmailStep[] = []
+    const seen = new Set<string>()
+    const add = (step: SpecEmailStep) => {
+        if (seen.has(step.type)) return
+        seen.add(step.type)
+        steps.push(step)
+    }
+
+    for (const state of FUNNEL_STATES) {
+        if (state.includesWelcome) add(spec.welcome)
+        for (const stageName of state.specStages) {
+            spec.stages.find((stage) => stage.stage === stageName)?.steps.forEach(add)
+        }
+    }
+    for (const stage of spec.stages) stage.steps.forEach(add)
+
+    return steps.flatMap((step) =>
+        examplesForStep(step).map((example) => ({
+            id: renderId(step.type, example.index),
+            eventType: step.type,
+            example: example.index,
+            exampleLabel: example.label,
+            step,
+        }))
+    )
+}
+
+/**
+ * The two calls this review exists to settle. Everything else on the board is a
+ * yes/no on the copy; these two are structural product decisions.
+ */
+export const EMAIL_DECISION_FLAGS: Record<string, EmailDecisionFlag> = {
+    'lifecycle.first_spend_1': {
+        label: 'decide: rewards branch keep/kill',
+        note: 'Renders a second copy variant when the user has unclaimed rewards. Keep the branch or cut it to one message?',
+    },
+    'lifecycle.first_spend_2': {
+        label: 'decide: rewards branch keep/kill',
+        note: 'Renders a second copy variant when the user has unclaimed rewards. Keep the branch or cut it to one message?',
+    },
+    'lifecycle.finish_setup_1': {
+        label: 'decide: kill or keep (0 prod audience)',
+        note: 'The finish_setup stage matches no users in prod today. Keep the pair for future card states, or drop the stage?',
+    },
+    'lifecycle.finish_setup_2': {
+        label: 'decide: kill or keep (0 prod audience)',
+        note: 'The finish_setup stage matches no users in prod today. Keep the pair for future card states, or drop the stage?',
+    },
+}
+
+export function decisionFlagFor(eventType: string): EmailDecisionFlag | null {
+    return EMAIL_DECISION_FLAGS[eventType] ?? null
+}

--- a/src/app/(mobile-ui)/dev/journey/journeyTypes.ts
+++ b/src/app/(mobile-ui)/dev/journey/journeyTypes.ts
@@ -114,6 +114,36 @@ export interface JourneySpec {
     emailPreviewBase: string
 }
 
+// ---------- copy review (email renders awaiting a product verdict) ----------
+
+/**
+ * One `?example=N` of an email. Most lifecycle emails render a single example;
+ * the two first_spend steps render a second one for the rewards branch.
+ */
+export interface EmailExample {
+    index: number
+    /** Human label for the variant toggle ("plain" / "rewards"). */
+    label: string
+}
+
+/** One reviewable email render — an (email, example) pair, in board order. */
+export interface EmailRenderRef {
+    /** `${eventType}#${example}` — the localStorage verdict key. */
+    id: string
+    eventType: string
+    example: number
+    exampleLabel: string
+    step: SpecEmailStep
+}
+
+/** An open product decision attached to an email, surfaced as a chip on its card. */
+export interface EmailDecisionFlag {
+    /** Chip text — imperative, so the board reads as a to-do list. */
+    label: string
+    /** One line explaining what is actually being decided. */
+    note: string
+}
+
 // ---------- live user inspector (GET /__dev/journey-inspect?userId=…) ----------
 
 export interface InspectDue {

--- a/src/app/(mobile-ui)/dev/journey/page.tsx
+++ b/src/app/(mobile-ui)/dev/journey/page.tsx
@@ -1,14 +1,20 @@
 'use client'
 
-import { parseAsStringEnum, useQueryState } from 'nuqs'
+import { parseAsInteger, parseAsString, parseAsStringEnum, useQueryState, useQueryStates } from 'nuqs'
+import { useCallback, useMemo } from 'react'
 import DevPageShell from '../_components/DevPageShell'
 import DevSectionLabel from '../_components/DevSectionLabel'
+import EmailPreviewPanel from './EmailPreviewPanel'
 import FindingsStrip from './FindingsStrip'
 import JourneyBoard from './JourneyBoard'
 import KindLegend from './KindLegend'
+import ReviewProgressStrip from './ReviewProgressStrip'
 import RulesLegend from './RulesLegend'
 import UserInspector from './UserInspector'
 import ViewModeToggle from './ViewModeToggle'
+import { buildEmailRenderList, renderId } from './emailReview'
+import { countReviewed } from './copyReviewStorage'
+import { useCopyReview } from './useCopyReview'
 import { useJourneySpec } from './useJourneySpec'
 import type { JourneyViewMode } from './journeyTypes'
 
@@ -19,6 +25,11 @@ import type { JourneyViewMode } from './journeyTypes'
  * from the journey UI inventory with source-file annotations) AND every
  * email/push the lifecycle machine sends (fetched LIVE from the sandbox API's
  * __dev/journey-spec endpoint, api PR #1234). Internal tool; desktop-ok.
+ *
+ * Also the copy-review surface: every email render is read in place (iframed
+ * from the API) and carries a verdict, counted in the progress strip above the
+ * board. The selected render lives in the URL (`?email=…&example=…`) so one
+ * email is shareable mid-review.
  */
 export default function JourneyExplorerPage() {
     const { spec, error, loading } = useJourneySpec()
@@ -26,7 +37,34 @@ export default function JourneyExplorerPage() {
         'view',
         parseAsStringEnum<JourneyViewMode>(['product', 'dev']).withDefault('product')
     )
+    const [preview, setPreview] = useQueryStates({
+        email: parseAsString,
+        example: parseAsInteger.withDefault(0),
+    })
+    const { isReviewed, toggle, reset, state } = useCopyReview()
     const showDev = view === 'dev'
+
+    const renders = useMemo(() => buildEmailRenderList(spec), [spec])
+    const checkedCount = countReviewed(
+        state,
+        renders.map((render) => render.id)
+    )
+    const activeIndex = preview.email
+        ? renders.findIndex((render) => render.id === renderId(preview.email as string, preview.example))
+        : -1
+
+    const openEmail = useCallback(
+        (eventType: string, example: number) => void setPreview({ email: eventType, example }),
+        [setPreview]
+    )
+    const selectIndex = useCallback(
+        (index: number) => {
+            const next = renders[index]
+            if (next) void setPreview({ email: next.eventType, example: next.example })
+        },
+        [renders, setPreview]
+    )
+    const closePreview = useCallback(() => void setPreview({ email: null, example: null }), [setPreview])
 
     return (
         <DevPageShell
@@ -46,7 +84,20 @@ export default function JourneyExplorerPage() {
 
             <section className="flex flex-col gap-2">
                 <DevSectionLabel>Journey board</DevSectionLabel>
-                <JourneyBoard spec={spec} specError={loading ? 'Loading spec…' : error} view={view} />
+                <ReviewProgressStrip checked={checkedCount} total={renders.length} onReset={reset} />
+                <p className="text-[11px] leading-snug text-grey-1">
+                    Every email card with an amber dashed border still needs a product verdict. Click one to read the
+                    real render, then tick <span className="font-bold">Mark reviewed</span>. Two of them also carry a{' '}
+                    <span className="font-bold">decide:</span> chip — those need a keep-or-kill call, not only a copy
+                    read.
+                </p>
+                <JourneyBoard
+                    spec={spec}
+                    specError={loading ? 'Loading spec…' : error}
+                    view={view}
+                    isReviewed={isReviewed}
+                    onOpenEmail={openEmail}
+                />
             </section>
 
             <section className="flex flex-col gap-2">
@@ -58,6 +109,17 @@ export default function JourneyExplorerPage() {
                 <DevSectionLabel>User inspector</DevSectionLabel>
                 <UserInspector />
             </section>
+
+            {activeIndex >= 0 && (
+                <EmailPreviewPanel
+                    renders={renders}
+                    activeIndex={activeIndex}
+                    isReviewed={isReviewed}
+                    onToggleReviewed={toggle}
+                    onSelect={selectIndex}
+                    onClose={closePreview}
+                />
+            )}
         </DevPageShell>
     )
 }

--- a/src/app/(mobile-ui)/dev/journey/useCopyReview.ts
+++ b/src/app/(mobile-ui)/dev/journey/useCopyReview.ts
@@ -1,0 +1,40 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import {
+    COPY_REVIEW_STORAGE_KEY,
+    parseCopyReviewState,
+    serializeCopyReviewState,
+    toggleCopyReview,
+    type CopyReviewState,
+} from './copyReviewStorage'
+
+/**
+ * Copy-review verdicts, persisted in localStorage so a review survives a reload
+ * (and a closed laptop) without needing a backend. Deliberately local-only: this
+ * is one reviewer's checklist, not shared state.
+ *
+ * Reads on mount rather than during render — the board is SSR'd, and a first
+ * paint that already showed verdicts would hydrate-mismatch. Until `hydrated`
+ * flips, every render reads as pending, which is the safe default.
+ */
+export function useCopyReview() {
+    const [state, setState] = useState<CopyReviewState>({})
+    const [hydrated, setHydrated] = useState(false)
+
+    useEffect(() => {
+        setState(parseCopyReviewState(window.localStorage.getItem(COPY_REVIEW_STORAGE_KEY)))
+        setHydrated(true)
+    }, [])
+
+    const persist = useCallback((next: CopyReviewState) => {
+        setState(next)
+        window.localStorage.setItem(COPY_REVIEW_STORAGE_KEY, serializeCopyReviewState(next))
+    }, [])
+
+    const toggle = useCallback((id: string) => persist(toggleCopyReview(state, id)), [persist, state])
+    const reset = useCallback(() => persist({}), [persist])
+    const isReviewed = useCallback((id: string) => hydrated && state[id] === true, [hydrated, state])
+
+    return { state, hydrated, isReviewed, toggle, reset }
+}


### PR DESCRIPTION
Consolidates the lifecycle-email copy review into `/dev/journey`, so Hugo can read all 13 renders and record a verdict on each without leaving the board.

## Why

The board already listed every lifecycle email, but reviewing the copy meant opening 13 separate tabs against the API, and nothing recorded which ones had been read. A review that cannot show its own progress does not get finished.

## What is on the page now

**1. In-place preview panel.** Clicking an email card opens a drawer (right side on desktop ~640px, full-screen on mobile) that iframes the API's real React Email output — not a re-description of it.

- Subject + event type + "day N stuck" badge in the header.
- Variant toggle when the email renders more than one example. The two `first_spend` steps expose `plain` / `rewards`; everything else says "Single copy variant."
- `← prev` / `next →` walk all 13 renders in board order, with an `N/13` position readout.
- `open raw ↗`, Esc, and backdrop click all work. The old per-card external link stays, renamed `raw ↗`.
- Selection lives in the URL — `?email=lifecycle.fund_1&example=0` — so one email is shareable mid-review.

**2. Needs-verdict visual language.**

- Every render without a verdict gets one treatment: `review-pending` — 2px amber dashed border + a `needs verdict` chip. Reviewed cards return to the normal `border border-n-1` and show a green `reviewed ✓` chip.
- Emails with two renders show partial progress on the chip (`needs verdict 1/2`) and stay pending until both are approved.
- The two open product calls carry their own pink chip plus a one-line note, on the card and again at the top of the panel:
  - `lifecycle.first_spend_1` / `_2` → **decide: rewards branch keep/kill**
  - `lifecycle.finish_setup_1` / `_2` → **decide: kill or keep (0 prod audience)**

**3. Review progress.** A sticky `Copy review: N/13 checked` strip above the board, with a fill bar, an `N awaiting verdict` chip and an unobtrusive `reset`. Per-render `Mark reviewed` checkbox in the panel footer; verdicts persist in `localStorage` under `journey-copy-review-v1`.

## Before / after

| | |
|---|---|
| **Before** | Every email card identical, plain black border, single `preview ↗` link out to a new tab. No progress anywhere on the page. |
| **After** | 11 email cards carry the amber dashed pending border and a `needs verdict` chip; 4 of them also carry a `decide:` chip with its note. A sticky `Copy review: 0/13 checked` bar sits above the board. |
| **Panel open** | Drawer over a dimmed board showing the actual rendered email — peanut hero, headline, body copy, pink CTA — with `Mark reviewed`, `8/13`, and prev/next in the footer. |
| **Variant toggle** | On `first_spend_1`, `plain` / `rewards` segments swap the iframe between the two real renders (verified: different body copy). The `decide: rewards branch keep/kill` note sits above the toggle. |
| **Marked reviewed** | The card drops the dashed border, swaps `needs verdict 0/2` for a green `reviewed ✓`, and the strip moves to `2/13 checked`. Survives a page reload. |

## Verified in a browser

Ran against the live sandbox API on a separate dev server (`:3053`, Chrome via Playwright):

- 11 email cards render pending, strip reads `0/13`.
- The iframe displays the real render (read back the email body text for `fund_1` and both `first_spend_1` variants).
- Marking one variant → `1/13`, card stays pending at `1/2`; marking both → card flips to `reviewed`, strip `2/13`.
- `2/13` still shown after a reload — persistence works.
- Esc closes; mobile 375×667 renders the panel full-screen.

Note the CSP allows the embed from `http://localhost:3050` only, so on Hugo's actual server it works as-is. The harness ran on `:3053`, where the browser blocks the frame, so the header was rewritten in the Playwright route for the screenshots. The panel shows a one-line hint pointing at `open raw ↗` for exactly that case.

## Scope

Presentation only, all inside `src/app/(mobile-ui)/dev/**`. No `journeyData` fact, spec-fetch logic or file outside `dev/` changes. `ViewModeToggle` now delegates to a new shared `DevSegmented` primitive rather than the panel growing a second, parallel segmented control — output is visually identical.

## Gates

- `prettier --check .` clean
- `npm run typecheck` — zero errors
- `npm test` — 177 suites, 2318 passed
- 13 new unit tests covering the verdict persistence (`copyReviewStorage`) and the render-list derivation (`emailReview`), including the 11-emails-to-13-renders split and tolerance for corrupt localStorage.
