### PR TITLE
hotfix: redirect bare card legal slugs to /en pages

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -65,6 +65,11 @@
         "permanent": false
     },
     {
+        "source": "/:slug(card-terms-us|card-terms-international|card-esign|card-privacy|card-prohibited-activities)",
+        "destination": "/en/:slug",
+        "permanent": false
+    },
+    {
         "source": "/docs",
         "destination": "/en/help",
         "permanent": true


### PR DESCRIPTION
One redirect entry: `/card-terms-us`, `/card-terms-international`, `/card-esign`, `/card-privacy`, `/card-prohibited-activities` → `/en/:slug` (they 404'd bare; matcher verified against Next's path-to-regexp). Same pattern `/terms` and `/privacy` already use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added redirect handling for card-related pages, preserving access through localized English URLs.
  * Redirects are temporary, allowing future routing updates without permanent browser caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->