### PR TITLE
feat(dev): look a user up by username in the journey inspector

### DIFF
--- a/src/app/(mobile-ui)/dev/journey/UserInspector.tsx
+++ b/src/app/(mobile-ui)/dev/journey/UserInspector.tsx
@@ -3,26 +3,35 @@
 import { useState } from 'react'
 import { Button } from '@/components/0_Bruddle/Button'
 import { JOURNEY_API_BASE } from './journeyData'
+import { inspectParam } from './userLookup'
 import type { JourneyInspectResponse } from './journeyTypes'
 
 /**
  * Live user lookup: which lifecycle nudge is due for this user right now, and
- * what have they already received (GET /__dev/journey-inspect?userId=…).
+ * what have they already received (GET /__dev/journey-inspect).
+ *
+ * Takes a username or a raw userId — nobody remembers uuids, and the support
+ * thread you came from only ever names the user by handle.
  */
 export default function UserInspector() {
-    const [userId, setUserId] = useState('')
+    const [term, setTerm] = useState('')
     const [result, setResult] = useState<JourneyInspectResponse | null>(null)
     const [error, setError] = useState<string | null>(null)
     const [loading, setLoading] = useState(false)
 
     const inspect = async () => {
-        const id = userId.trim()
-        if (!id) return
+        const lookup = term.trim()
+        if (!lookup) return
         setLoading(true)
         setError(null)
         setResult(null)
         try {
-            const res = await fetch(`${JOURNEY_API_BASE}/__dev/journey-inspect?userId=${encodeURIComponent(id)}`)
+            const query = `${inspectParam(lookup)}=${encodeURIComponent(lookup)}`
+            const res = await fetch(`${JOURNEY_API_BASE}/__dev/journey-inspect?${query}`)
+            if (res.status === 404) {
+                setError(`No user matches “${lookup}”. Check the spelling, or paste the raw userId.`)
+                return
+            }
             if (!res.ok) throw new Error(`HTTP ${res.status}`)
             setResult((await res.json()) as JourneyInspectResponse)
         } catch {
@@ -44,12 +53,12 @@ export default function UserInspector() {
         <div className="flex max-w-2xl flex-col gap-3">
             <div className="flex gap-2">
                 <input
-                    value={userId}
-                    onChange={(e) => setUserId(e.target.value)}
+                    value={term}
+                    onChange={(e) => setTerm(e.target.value)}
                     onKeyDown={(e) => {
                         if (e.key === 'Enter') void inspect()
                     }}
-                    placeholder="userId (uuid)"
+                    placeholder="username or userId"
                     className="h-10 flex-1 rounded-sm border border-n-1 px-3 font-mono text-sm outline-none"
                 />
                 <Button variant="purple" shadowSize="4" className="w-auto px-6" onClick={() => void inspect()}>
@@ -59,16 +68,16 @@ export default function UserInspector() {
 
             {error && <div className="rounded-sm border border-n-1 bg-yellow-1/40 p-3 text-sm">{error}</div>}
 
-            {result && !result.user && (
-                <div className="rounded-sm border border-n-1 bg-yellow-1/40 p-3 text-sm">User not found.</div>
-            )}
-
-            {result?.user && (
+            {result && (
                 <div className="rounded-sm border border-n-1 bg-white p-3">
                     <div className="text-sm font-bold">
                         {result.user.username ?? '(no username)'}{' '}
                         <span className="font-normal text-grey-1">{result.user.email ?? '(no email)'}</span>
                     </div>
+                    <p className="mt-0.5 font-mono text-[11px] text-grey-1">
+                        resolved {result.user.username ? `@${result.user.username}` : '(no username)'} →{' '}
+                        {result.user.userId}
+                    </p>
                     <p className="mt-0.5 text-xs text-grey-1">
                         signed up {new Date(result.user.createdAt).toLocaleDateString()} · card access{' '}
                         {result.user.cardAccessGrantedAt

--- a/src/app/(mobile-ui)/dev/journey/__tests__/userLookup.test.ts
+++ b/src/app/(mobile-ui)/dev/journey/__tests__/userLookup.test.ts
@@ -1,0 +1,24 @@
+import { inspectParam, isUuid } from '../userLookup'
+
+describe('userLookup', () => {
+    it('recognises a canonical uuid, in either case, with surrounding space', () => {
+        expect(isUuid('3f7b1c2a-9d4e-4a11-8b6c-2e5f0a7d1c93')).toBe(true)
+        expect(isUuid('3F7B1C2A-9D4E-4A11-8B6C-2E5F0A7D1C93')).toBe(true)
+        expect(isUuid('  3f7b1c2a-9d4e-4a11-8b6c-2e5f0a7d1c93  ')).toBe(true)
+    })
+
+    it('rejects usernames and near-miss uuids', () => {
+        expect(isUuid('hugo')).toBe(false)
+        expect(isUuid('uuid-lover')).toBe(false)
+        expect(isUuid('')).toBe(false)
+        // one hex digit short in the last group
+        expect(isUuid('3f7b1c2a-9d4e-4a11-8b6c-2e5f0a7d1c9')).toBe(false)
+        // no hyphens
+        expect(isUuid('3f7b1c2a9d4e4a118b6c2e5f0a7d1c93')).toBe(false)
+    })
+
+    it('routes each term to the right query param', () => {
+        expect(inspectParam('3f7b1c2a-9d4e-4a11-8b6c-2e5f0a7d1c93')).toBe('userId')
+        expect(inspectParam('hugo')).toBe('username')
+    })
+})

--- a/src/app/(mobile-ui)/dev/journey/journeyTypes.ts
+++ b/src/app/(mobile-ui)/dev/journey/journeyTypes.ts
@@ -144,7 +144,7 @@ export interface EmailDecisionFlag {
     note: string
 }
 
-// ---------- live user inspector (GET /__dev/journey-inspect?userId=…) ----------
+// ---------- live user inspector (GET /__dev/journey-inspect?username=…|userId=…) ----------
 
 export interface InspectDue {
     userId: string
@@ -163,12 +163,14 @@ export interface InspectHistoryRow {
 }
 
 export interface JourneyInspectResponse {
+    /** The resolved user — the API 404s instead of returning a null user. */
     user: {
+        userId: string
         username: string | null
         email: string | null
         createdAt: string
         cardAccessGrantedAt: string | null
-    } | null
+    }
     due: InspectDue | null
     history: InspectHistoryRow[]
 }

--- a/src/app/(mobile-ui)/dev/journey/userLookup.ts
+++ b/src/app/(mobile-ui)/dev/journey/userLookup.ts
@@ -1,0 +1,19 @@
+/**
+ * Lookup-term parsing for the /dev/journey user inspector.
+ *
+ * The inspector takes whatever you have to hand — a username you read in a
+ * support thread, or a raw userId you copied out of the DB — and the API takes
+ * exactly one of `userId` or `username`. This decides which.
+ */
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/** True when the term is a canonical uuid — our userIds are uuids, usernames never are. */
+export function isUuid(value: string): boolean {
+    return UUID_PATTERN.test(value.trim())
+}
+
+/** The GET /__dev/journey-inspect query param this term belongs in. */
+export function inspectParam(value: string): 'userId' | 'username' {
+    return isUuid(value) ? 'userId' : 'username'
+}


### PR DESCRIPTION
## Why

The User Inspector on `/dev/journey` only took a userId uuid. Nobody has one to hand — every lookup started with a trip to the DB to translate the handle you already had.

## What

- The box takes **a username or a userId**. The term is trimmed; a uuid goes out as `userId=`, anything else as `username=`.
- The uuid test lives in `userLookup.ts` (`isUuid`, `inspectParam`) with a unit test, so the routing rule is checked, not just eyeballed.
- The result header gains a `resolved @username → <uuid>` line, so you can see which account a handle landed on.
- A miss is now a plain inline sentence — *No user matches "…". Check the spelling, or paste the raw userId.* The API returns 404 for a miss rather than a 200 with a null user, so the old empty-panel branch is gone.

Existing dev styling only — `rounded-sm`, `border border-n-1`, the yellow inline notice already used for the transport error.

## Depends on

peanutprotocol/peanut-api-ts#1256 — adds the `username` param and `user.userId` to the response. Merge that first. Without it the lookup 400s; nothing else on the page is affected.

## Verification

UI on :3057 against a dev-bundle API on :5051 (local dev DB):

- `v5u` → resolved, header shows `resolved @v5u → 1d0aecbc-9da1-40e2-a850-de62834cc066`, history table renders.
- `no_such_user_xyz` → inline "No user matches…" notice.

`npm test` 178/178 suites green (2321 tests). `npm run typecheck` clean, zero errors. Prettier clean.
