### PR TITLE
fix(dev): make dev:fallback actually fall back to webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "scripts": {
         "dev": "NODE_OPTIONS=\"--max-old-space-size=8192\" next dev --turbo",
         "dev:clean": "rm -rf .next && NODE_OPTIONS=\"--max-old-space-size=8192\" next dev --turbo",
-        "dev:fallback": "next dev",
+        "dev:fallback": "next dev --webpack",
         "postinstall": "node scripts/copy-flags.mjs",
         "copy-flags": "node scripts/copy-flags.mjs",
         "prebuild": "node scripts/copy-flags.mjs",


### PR DESCRIPTION
## What

One word: `dev:fallback` now runs `next dev --webpack`.

## Why

Next 16 runs Turbopack by default, so `next dev` **is** Turbopack. `dev:fallback` was byte-identical in behaviour to `dev` — it fell back to nothing. Anyone hitting a Turbopack bug and reaching for the documented escape hatch got the same engine again.

## How it turned up

While fixing worktree setup in mono. A symlinked `node_modules` (which `scripts/setup-worktree` used to create) makes Turbopack panic outright:

```
FATAL: Symlink [project]/node_modules is invalid, it points out of the filesystem root
```

So `pnpm dev` died in every peanut-ui worktree, and the one documented workaround could not work either. Mono now installs deps for real ([`32a0412a`](https://github.com/peanutprotocol/mono/commit/32a0412a)), so the panic should be rare — but the fallback should still do what it says.

## Verification

```
$ npx next dev --webpack -p 3098
▲ Next.js 16.2.3 (webpack)      # was: (Turbopack)
✓ Ready in 526ms
```

`prettier --check package.json` clean. `dev` and `dev:clean` are untouched — Turbopack is genuinely faster (~3.7s vs ~37s first compile) and correct as the default.

## Risk

None. A script nobody could have been relying on for its stated purpose, since it did not serve it.
