### PR TITLE
fix(native): stop the deep-link mapper from dropping the URL fragment

### DIFF
--- a/src/utils/__tests__/native-routes.test.ts
+++ b/src/utils/__tests__/native-routes.test.ts
@@ -324,6 +324,35 @@ describe('native-routes', () => {
                 )
             })
 
+            // The claim-link password lives in the fragment and is never sent to
+            // the server (see peanut-link.utils.ts), so dropping it here yields a
+            // link that resolves to a claim page with no way to claim.
+            it('preserves the claim-link password fragment', () => {
+                expect(deepLinkToNativePath('https://peanut.me/claim?c=42161&v=v4.2&i=99#p=s3cr3t')).toBe(
+                    '/claim?c=42161&v=v4.2&i=99#p=s3cr3t'
+                )
+            })
+
+            it('preserves a fragment on a bare path from a push payload', () => {
+                expect(deepLinkToNativePath('/claim?i=99#p=s3cr3t')).toBe('/claim?i=99#p=s3cr3t')
+            })
+
+            it('carries the fragment through a dynamic-route rewrite', () => {
+                expect(deepLinkToNativePath('https://peanut.me/send/bob#p=s3cr3t')).toBe('/send?recipient=bob#p=s3cr3t')
+                expect(deepLinkToNativePath('https://peanut.me/withdraw/be/bank#top')).toBe(
+                    '/withdraw?country=be&view=bank#top'
+                )
+            })
+
+            it('adds no stray # when the link has no fragment', () => {
+                expect(deepLinkToNativePath('https://peanut.me/claim?i=99')).toBe('/claim?i=99')
+                expect(deepLinkToNativePath('https://peanut.me/history')).toBe('/history')
+            })
+
+            it('still rejects an off-host link that carries a fragment', () => {
+                expect(deepLinkToNativePath('https://evil.com/claim?i=99#p=s3cr3t')).toBeNull()
+            })
+
             it('rejects an off-domain url rather than rewriting it into an in-app path', () => {
                 expect(deepLinkToNativePath('https://evil.com/receipt/intent-1')).toBeNull()
             })
@@ -371,6 +400,12 @@ describe('native-routes', () => {
 
             it('keeps a profile charge link on the profile route', () => {
                 expect(deepLinkToNativePath('/alice?chargeId=charge-123')).toBe('/alice?chargeId=charge-123')
+            })
+
+            it('preserves the claim-link password fragment', () => {
+                expect(deepLinkToNativePath('https://peanut.me/claim?c=42161&v=v4.2&i=99#p=s3cr3t')).toBe(
+                    '/claim?c=42161&v=v4.2&i=99#p=s3cr3t'
+                )
             })
         })
     })

--- a/src/utils/native-routes.ts
+++ b/src/utils/native-routes.ts
@@ -100,6 +100,14 @@ function mapDeepLink(url: string): string | null {
     const parsed = new URL(url, 'https://peanut.me')
     if (!APP_HOSTS.test(parsed.hostname)) return null
 
+    // The fragment is re-attached here rather than inside each branch below:
+    // a claim link's password lives in `#p=<password>` and never reaches the
+    // server, so a mapper that drops it turns the link into an unclaimable one.
+    // Appending once is the only shape a new route branch can't forget.
+    return `${mapDeepLinkPath(parsed)}${parsed.hash}`
+}
+
+function mapDeepLinkPath(parsed: URL): string {
     const path = parsed.pathname
     const extraParams = parsed.search.replace(/^\?/, '')
     const segments = path.split('/').filter(Boolean)


### PR DESCRIPTION
## Summary

`mapDeepLink()` builds its result from `parsed.pathname` + `parsed.search` and never reads `parsed.hash`, so **every** deep link loses its fragment on the way into the native app.

That matters for one link type in particular: a claim link's password lives in the fragment (`/claim?c=&v=&i=#p=<password>`) and is deliberately never sent to the server — `peanut-link.utils.ts` parses it client-side and `claim.ts` only ever relays a signature. So today, tapping a claim link on a device with the app installed opens `/claim?c=&v=&i=` **without the password**: the page loads, and there is no way to claim from it. `sanitizeRedirectURL` already preserves `.hash`, so the loss was entirely in this mapper.

## Fix

Re-attach the fragment once in `mapDeepLink`, around a new `mapDeepLinkPath` that keeps the existing branch logic untouched:

```ts
return `${mapDeepLinkPath(parsed)}${parsed.hash}`
```

Deliberately not appended inside each branch — there are six return points and a seventh is one route away. Doing it at the boundary is the only shape a future branch can't forget. `parsed.hash` is `''` when absent (and for a bare trailing `#`), so no stray `#` is introduced.

Behaviour is otherwise unchanged: off-host links still return `null`, and malformed percent-escapes still degrade to `null` via the existing guard rather than throwing during render.

## Tests

Added to `src/utils/__tests__/native-routes.test.ts` (there was no fragment coverage at all):

- claim-link password preserved, full App-Links URL and bare push-payload path
- fragment carried through a dynamic-route rewrite (`/send/bob#p=x` → `/send?recipient=bob#p=x`)
- no stray `#` when the link has no fragment
- off-host link with a fragment still rejected
- web mode preserves the fragment too

## Notes for reviewers

- **Independent of #2560.** Found while reviewing that PR's deferred-deep-linking work, but this is a pre-existing bug on `dev` and `main` that breaks *warm* claim links today, with or without deferred linking. Related to #2560; does not depend on it and is not depended on by it.
- Ships via OTA — no new binary needed.
- **Separate finding, not fixed here:** iOS AASA is `paths: ["*"]` for all three appIDs, so `peanut.me/invite?code=…` routes into the app, but `/invite` is stripped from the native build (`scripts/native-build.js`) and absent from the Android intent filter — on iOS that link dead-ends on a route that doesn't exist. Fixing it needs the invite code written to a cookie in the deep-link *handler* (`useNativePlugins`), not in this pure path mapper which runs during render, and that file overlaps #2560. Left for a follow-up so this PR stays a one-line behavioural change.
