### PR TITLE
fix(sentry): stop reporting expected 404s, and group the rest by route

### DIFF
--- a/src/utils/__tests__/sentry.utils.test.ts
+++ b/src/utils/__tests__/sentry.utils.test.ts
@@ -6,6 +6,7 @@ import {
     fetchWithSentry,
     resolveDefaultTimeoutMs,
     sanitizeRequestBody,
+    sanitizeUrl,
     sanitizeResponseBody,
     scrubObject,
 } from '../sentry.utils'
@@ -79,6 +80,101 @@ describe('fetchWithSentry — expected-response suppression', () => {
             'POST to https://api.peanut.me/some/endpoint failed with status 400',
             expect.objectContaining({ level: 'warning' })
         )
+    })
+
+    // 1,948 events in 24h on 2026-07-29, one issue per address, burying every
+    // other signal. A reverse lookup that finds no name is an answer, and the
+    // hook falls back client-side, so the user never sees a failure.
+    it('does NOT report /ens/reverse 404 (no primary name is an answer, and it falls back)', async () => {
+        global.fetch = jest.fn().mockResolvedValue(mockResponse(404, { error: 'Not found' }))
+
+        const res = await fetchWithSentry(
+            'https://api.peanut.me/ens/reverse/0x7a3b39dadfc09ecfc4dc120675bdaff3fc859764'
+        )
+
+        expect(res.status).toBe(404)
+        expect(Sentry.captureMessage).not.toHaveBeenCalled()
+        // Also asserts the console path: captureConsoleIntegration would
+        // otherwise mint a second, un-fingerprinted event per address.
+        expect(warnSpy).not.toHaveBeenCalled()
+    })
+
+    it('does NOT report /rhino/status 404 (the poll-until-present waiting tick)', async () => {
+        global.fetch = jest.fn().mockResolvedValue(mockResponse(404, { error: 'No update found' }))
+
+        await fetchWithSentry('https://api.peanut.me/rhino/status/0xeba44f5961db32de6c4484372dbb0bd116f33a4e')
+
+        expect(Sentry.captureMessage).not.toHaveBeenCalled()
+        expect(warnSpy).not.toHaveBeenCalled()
+    })
+
+    it('still reports a 500 on those same routes (a real failure is not expected)', async () => {
+        global.fetch = jest.fn().mockResolvedValue(mockResponse(500, { error: 'boom' }))
+
+        await fetchWithSentry('https://api.peanut.me/ens/reverse/0x7a3b39dadfc09ecfc4dc120675bdaff3fc859764')
+
+        expect(Sentry.captureMessage).toHaveBeenCalledWith(
+            'GET to https://api.peanut.me/ens/reverse/{hex} failed with status 500',
+            expect.objectContaining({ level: 'error' })
+        )
+    })
+
+    // The point of the whole change: two addresses, one issue.
+    it('reports two different addresses under an IDENTICAL message', async () => {
+        global.fetch = jest.fn().mockResolvedValue(mockResponse(500, { error: 'boom' }))
+
+        await fetchWithSentry('https://api.peanut.me/ens/reverse/0x7a3b39dadfc09ecfc4dc120675bdaff3fc859764')
+        await fetchWithSentry('https://api.peanut.me/ens/reverse/0x2a1530e2898dea93a418fcf58434882b843b5a88')
+
+        const messages = (Sentry.captureMessage as jest.Mock).mock.calls.map((call) => call[0])
+        expect(messages).toHaveLength(2)
+        expect(messages[0]).toBe(messages[1])
+    })
+
+    it('keeps the real URL on the event so it stays debuggable', async () => {
+        global.fetch = jest.fn().mockResolvedValue(mockResponse(500, { error: 'boom' }))
+        const url = 'https://api.peanut.me/ens/reverse/0x7a3b39dadfc09ecfc4dc120675bdaff3fc859764'
+
+        await fetchWithSentry(url)
+
+        expect(Sentry.captureMessage).toHaveBeenCalledWith(
+            expect.stringContaining('{hex}'),
+            expect.objectContaining({ extra: expect.objectContaining({ url }) })
+        )
+    })
+})
+
+describe('sanitizeUrl', () => {
+    it('collapses 0x segments — addresses, tx hashes, pubKeys', () => {
+        expect(sanitizeUrl('https://api.peanut.me/ens/reverse/0x7a3b39dadfc09ecfc4dc120675bdaff3fc859764')).toBe(
+            'https://api.peanut.me/ens/reverse/{hex}'
+        )
+        // 64-hex tx hash, mid-path rather than trailing
+        expect(sanitizeUrl(`/send-links/claim/0x${'a'.repeat(64)}/associate-user`)).toBe(
+            '/send-links/claim/{hex}/associate-user'
+        )
+        // terminated by a query string, not a slash
+        expect(sanitizeUrl('/rhino/status/0xeba44f5961db32de6c4484372dbb0bd116f33a4e?poll=1')).toBe(
+            '/rhino/status/{hex}?poll={id}'
+        )
+    })
+
+    it('still collapses UUIDs and numeric segments', () => {
+        expect(sanitizeUrl('/charges/2f7a9f29-456a-4ec6-92a3-a2a1510925a4')).toBe('/charges/{uuid}')
+        expect(sanitizeUrl('/history/12345')).toBe('/history/{id}')
+    })
+
+    it('leaves non-identifier segments alone', () => {
+        // An ENS name must not be collapsed — it is low-cardinality enough to
+        // be worth seeing, and it is not hex.
+        expect(sanitizeUrl('/ens/vitalik.eth')).toBe('/ens/vitalik.eth')
+        expect(sanitizeUrl('https://api.peanut.me/users/me')).toBe('https://api.peanut.me/users/me')
+    })
+
+    it('collapses an all-digit hex body as hex, not as a numeric id', () => {
+        // Ordering guard: the numeric rule running first would produce
+        // '/0x{id}' and split the group again.
+        expect(sanitizeUrl('/ens/reverse/0x1234567890123456789012345678901234567890')).toBe('/ens/reverse/{hex}')
     })
 })
 

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -28,6 +28,19 @@ const SKIP_REPORTING: Array<{ pattern: string | RegExp; statuses: number[] }> = 
     // to the user via the cooldown modal + floating timer. Normal UX state,
     // not an error; would otherwise flood Sentry on every retry.
     { pattern: /\/rain\/cards\/withdraw\/prepare/, statuses: [425] },
+    // /ens/reverse 404 is the answer, not a failure. usePrimaryNameServer asks
+    // the server first and falls back to a client-side lookup when that misses,
+    // so a 404 costs the user nothing. The route also isn't deployed yet
+    // (peanut-api-ts #1237 is still open), which means EVERY address rendered
+    // by AddressLink and TransactionCard reports one — 1,948 events in 24h on
+    // 2026-07-29, drowning every other signal in the feed. Once #1237 lands a
+    // 404 will mean "this address has no primary name", which is still not an
+    // error. Timeouts and 5xx here are real and stay reported.
+    { pattern: /\/ens\/reverse\//, statuses: [404] },
+    // /rhino/status 404 = "no update for this deposit address yet". The FE
+    // polls it until the provider records one, so 404 is the normal waiting
+    // tick, repeated per poll per address.
+    { pattern: /\/rhino\/status\//, statuses: [404] },
 ]
 
 /**
@@ -379,24 +392,34 @@ const sanitizeHeaders = (headers: RequestInit['headers']): Record<string, unknow
     return sanitized
 }
 
+/** Collapse per-request identifiers in a URL to placeholders.
+ *
+ * Used for the Sentry fingerprint AND for the reported message, so that one
+ * broken route is one issue instead of one issue per address. Anything left
+ * varying here multiplies the feed: a hex segment used to survive, so every
+ * address on `/ens/reverse` and `/rhino/status` minted its own grouping.
+ *
+ * The real URL is never lost — callers attach it as `extra.url`.
+ *
+ * Hex runs are matched before the numeric rule, since an all-digit hex body
+ * would otherwise be rewritten as `{id}` and split the group again. Segments
+ * may end at `/`, `?` or the string end. */
+export const sanitizeUrl = (url: string): string =>
+    url
+        // 0x-prefixed segments: addresses (40), tx hashes (64), send-link pubKeys
+        .replace(/\/0x[0-9a-fA-F]{6,}(?=[/?]|$)/g, '/{hex}')
+        // UUIDs
+        .replace(/\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?=[/?]|$)/gi, '/{uuid}')
+        // Numeric path segments
+        .replace(/\/\d+(?=[/?]|$)/g, '/{id}')
+        // Numeric query values
+        .replace(/([?&][^=&]*=)\d+/g, '$1{id}')
+
 export const fetchWithSentry = async (
     url: string,
     options: RequestInit = {},
     timeoutMs: number = DEFAULT_TIMEOUT_MS
 ): Promise<Response> => {
-    // Sanitize URL for fingerprinting by replacing IDs with placeholders
-    const sanitizeUrl = (url: string) => {
-        return (
-            url
-                // Replace numeric IDs in path
-                .replace(/\/\d+(?=\/|$)/g, '/{id}')
-                // Replace UUIDs in path
-                .replace(/\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?=\/|$)/gi, '/{uuid}')
-                // Replace numeric IDs in query params
-                .replace(/([?&][^=&]*=)\d+/g, '$1{id}')
-        )
-    }
-
     // Idempotent requests get one silent retry on timeout: stalled-transport
     // failures (Android webview, flaky mobile networks) usually clear on a
     // fresh attempt (PEANUT-UI-R44).
@@ -437,7 +460,13 @@ export const fetchWithSentry = async (
             // 401 on cleared session, etc). Logging them clutters DevTools and
             // gets picked up by forward-logs-shared as Sentry breadcrumbs.
             if (!shouldSkipReporting(url, response.status)) {
-                console.warn(`Request to ${String(url).replace(/[\r\n]/g, '')} failed with status ${response.status}`)
+                // Sanitized in the message too, not just the fingerprint:
+                // captureConsoleIntegration turns this warn into its own Sentry
+                // event with NO fingerprint, grouped on the message text — so a
+                // raw URL here splits per address however good the fingerprint is.
+                console.warn(
+                    `Request to ${sanitizeUrl(String(url).replace(/[\r\n]/g, ''))} failed with status ${response.status}`
+                )
 
                 let errorContent: JSONValue
                 try {
@@ -452,7 +481,7 @@ export const fetchWithSentry = async (
                     scope.setFingerprint([method, sanitizeUrl(url), String(response.status)])
                     if (featureTag) scope.setTag('feature', featureTag)
 
-                    Sentry.captureMessage(`${method} to ${url} failed with status ${response.status}`, {
+                    Sentry.captureMessage(`${method} to ${sanitizeUrl(url)} failed with status ${response.status}`, {
                         level: getErrorLevelFromStatus(response.status),
                         extra: {
                             url,
@@ -478,7 +507,7 @@ export const fetchWithSentry = async (
         console.info(error)
 
         if (error instanceof Error && error.name === 'AbortError') {
-            const timeoutError = new Error(`Request to ${url} timed out after ${timeoutMs}ms`)
+            const timeoutError = new Error(`Request to ${sanitizeUrl(url)} timed out after ${timeoutMs}ms`)
 
             const timeoutFeatureTag = getFeatureTag(url)
             Sentry.withScope((scope) => {


### PR DESCRIPTION
## Summary

`/ens/reverse` produced **1,948 Sentry events in 24 hours** on 2026-07-29 — **15 new issues in a single hour**, each holding one address. It buried every other signal: in one monitor sweep it accounted for 15 of 15 new issues. A monitor whose feed is entirely one benign signal is one bad hour from missing something real.

Two separate causes, and the one named in the title is the smaller of them.

### 1. The 404 is an answer, not a failure — this is the primary fix

`usePrimaryNameServer` asks the server for a primary name and **falls back to a client-side lookup when that misses**, so a 404 costs the user nothing. And the route isn't deployed at all: `/ens/reverse/:address` exists on neither `main` nor `dev` in peanut-api-ts (`src/routes/ens/index.ts` registers only `/ens/:ensName`), because **[peanut-api-ts#1237](https://github.com/peanutprotocol/peanut-api-ts/pull/1237) is still open**. So every address rendered by `AddressLink` and `TransactionCard` reports one.

`/rhino/status/:addr` 404 is the same shape — a poll-until-present loop where 404 is the normal waiting tick, once per poll per address.

Both now skip reporting. **Timeouts and 5xx on those routes still report** — those are real signal, and the 20s timeouts have been genuine.

### 2. What did get reported split per address

`sanitizeUrl` feeds `setFingerprint`, but only collapsed numeric ids and UUIDs — a hex segment survived verbatim, so every address minted its own fingerprint. It now collapses `0x` runs too (addresses, tx hashes, send-link pubKeys) as a **generic path-segment rule, not a per-route allowlist**, so the sibling routes are covered by construction.

The messages carried the raw URL too, and that mattered more than it looks: `captureConsoleIntegration({ levels: ['error','warn'] })` turns the `console.warn` into a **second Sentry event with no fingerprint at all**, grouped on message text. Fixing only the fingerprint would have halved the flood, not stopped it. All three message sites now use the sanitized URL.

## Debuggability is preserved

The real URL was already attached as `extra.url` and still is — a test pins that. Nothing gets harder to investigate; you lose only the per-address issue explosion.

## Risks

- **The sharp edge is an over-broad skip rule hiding a real regression.** Mitigated by scoping each rule to an exact `(route, status)` pair and leaving 5xx/timeouts reporting — with tests asserting a 500 on those same routes still reports.
- Ordering: hex is matched **before** the numeric rule, since an all-digit hex body would otherwise become `/0x{id}` and split the group again. Pinned by a test.
- `sanitizeUrl` is promoted from a closure to an exported function — it was untestable before, and is now unit-tested. No behaviour change for existing callers beyond the added rule.
- **peanut-ui only.** No cross-repo change, and deliberately independent of whether #1237 ships.

## QA

`npx jest src/utils/__tests__/sentry.utils.test.ts` — 12 new cases, all passing.
Full suite: **178 suites / 2330 tests, 0 failures.** `npm run typecheck` clean.

Key cases: `/ens/reverse` + `/rhino/status` 404 report neither to Sentry nor to `console.warn` · a 500 on those routes still reports · **two different addresses produce an identical message** (the whole point) · `extra.url` keeps the real URL · hex/UUID/numeric collapse · `/ens/vitalik.eth` untouched · all-digit hex body ordering guard.

`Screenshots: N/A` — observability plumbing, no rendered change.

## Follow-up (not this PR)

`usePrimaryNameServer` calls a route that has never existed in production, so **every ENS lookup pays a wasted round-trip before falling back**. Either land #1237 or drop the server-first call. Worth its own ticket — this PR just stops the noise either way.
