### PR TITLE
feat(native): make the deferred-link match rate measurable

### DIFF
--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -270,7 +270,33 @@ export const ANALYTICS_EVENTS = {
     DELETE_ACCOUNT_INITIATED: 'delete_account_initiated',
     DELETE_ACCOUNT_CONFIRMED: 'delete_account_confirmed',
     DELETE_ACCOUNT_FAILED: 'delete_account_failed',
+
+    // ── Deferred deep linking (TASK-20772) ──
+    // Fired once per fresh install, on the one-shot restore. `outcome` is a
+    // DEFERRED_LINK_OUTCOMES value and is the whole point of the event: it's the
+    // only way to tell a working store→install hand-off from one that silently
+    // matches nothing, since a declined iOS paste prompt and an organic install
+    // both simply produce no payload.
+    DEFERRED_LINK_RESTORED: 'deferred_link_restored',
+    // Fired on the web side when a store bounce writes the hand-off.
+    DEFERRED_LINK_HANDOFF_CREATED: 'deferred_link_handoff_created',
 } as const
+
+/**
+ * Outcomes for DEFERRED_LINK_RESTORED — why a first-launch restore did or did
+ * not recover context. Distinguishing the empty cases is the reason this event
+ * exists: `clipboard_unavailable` (user declined the paste prompt, or the
+ * plugin is missing) and `no_handoff` (organic install) are indistinguishable
+ * without it, and only the first indicates a broken hand-off.
+ */
+export const DEFERRED_LINK_OUTCOMES = {
+    RESTORED: 'restored',
+    NO_HANDOFF: 'no_handoff',
+    MARKER_MISSING: 'marker_missing',
+    CLIPBOARD_UNAVAILABLE: 'clipboard_unavailable',
+} as const
+
+export type DeferredLinkOutcome = (typeof DEFERRED_LINK_OUTCOMES)[keyof typeof DEFERRED_LINK_OUTCOMES]
 
 /**
  * Valid modal_type values for MODAL_SHOWN / MODAL_DISMISSED / MODAL_CTA_CLICKED events.

--- a/src/utils/__tests__/deferred-link.test.ts
+++ b/src/utils/__tests__/deferred-link.test.ts
@@ -47,6 +47,14 @@ jest.mock('@capacitor/preferences', () => ({
     Preferences: { set: (o: unknown) => preferencesSet(o) },
 }))
 
+const posthogCapture = jest.fn()
+jest.mock('posthog-js', () => ({
+    __esModule: true,
+    default: {
+        capture: (...args: unknown[]) => posthogCapture(...args),
+    },
+}))
+
 const mockIsAndroidNative = isAndroidNative as jest.MockedFunction<typeof isAndroidNative>
 const mockIsIOSNative = isIOSNative as jest.MockedFunction<typeof isIOSNative>
 const mockClipboardHasStrings = clipboardHasStrings as jest.MockedFunction<typeof clipboardHasStrings>
@@ -247,5 +255,68 @@ describe('restoreDeferredContext', () => {
         await expect(restoreDeferredContext()).resolves.toEqual({ dest: '/home', locale: null })
         expect(mockSaveToCookie).toHaveBeenCalledWith('inviteCode', 'test', 30)
         expect(clipboardWrite).toHaveBeenCalled()
+    })
+})
+
+// The point of these: an empty clipboard and a declined paste prompt both yield
+// no payload, so without distinct outcomes a hand-off that never works is
+// indistinguishable from one nobody used.
+describe('restore telemetry', () => {
+    const lastRestoreEvent = () =>
+        posthogCapture.mock.calls.filter((c) => c[0] === 'deferred_link_restored').at(-1)?.[1]
+
+    it('reports a successful restore with which fields came back, and no payload content', async () => {
+        mockIsAndroidNative.mockReturnValue(true)
+        getReferrer.mockResolvedValue({ referrer: 'pnutdl=1&lang=pt-BR&invite=abc&dest=%2Fhome' })
+
+        await restoreDeferredContext()
+
+        expect(lastRestoreEvent()).toEqual({
+            channel: 'referrer',
+            outcome: 'restored',
+            has_dest: true,
+            has_locale: true,
+            has_invite: true,
+            has_campaign: false,
+        })
+        // the inviter and destination must never reach analytics
+        expect(JSON.stringify(posthogCapture.mock.calls)).not.toContain('abc')
+        expect(JSON.stringify(posthogCapture.mock.calls)).not.toContain('/home')
+    })
+
+    it('separates an organic install from a declined iOS paste prompt', async () => {
+        mockIsAndroidNative.mockReturnValue(true)
+        getReferrer.mockResolvedValue({ referrer: null })
+        await restoreDeferredContext()
+        expect(lastRestoreEvent()).toEqual({ channel: 'referrer', outcome: 'no_handoff' })
+
+        posthogCapture.mockClear()
+        localStorage.clear()
+        mockIsAndroidNative.mockReturnValue(false)
+        mockIsIOSNative.mockReturnValue(true)
+        mockClipboardHasStrings.mockResolvedValue(true)
+        mockClipboardHasProbableWebUrl.mockResolvedValue(true)
+        clipboardRead.mockRejectedValue(new Error('user declined'))
+
+        await restoreDeferredContext()
+        expect(lastRestoreEvent()).toEqual({ channel: 'clipboard', outcome: 'clipboard_unavailable' })
+    })
+
+    it('reports a present-but-unmarked referrer as marker_missing, not no_handoff', async () => {
+        mockIsAndroidNative.mockReturnValue(true)
+        getReferrer.mockResolvedValue({ referrer: 'utm_source=google-play&utm_medium=organic' })
+
+        await restoreDeferredContext()
+        expect(lastRestoreEvent()).toEqual({ channel: 'referrer', outcome: 'marker_missing' })
+    })
+
+    it('does not lose the restored context when posthog throws', async () => {
+        mockIsAndroidNative.mockReturnValue(true)
+        getReferrer.mockResolvedValue({ referrer: 'pnutdl=1&dest=%2Fhome' })
+        posthogCapture.mockImplementation(() => {
+            throw new Error('posthog not initialised')
+        })
+
+        await expect(restoreDeferredContext()).resolves.toEqual({ dest: '/home', locale: null })
     })
 })

--- a/src/utils/deferred-link.ts
+++ b/src/utils/deferred-link.ts
@@ -4,6 +4,8 @@
 // hand-off written on the store-bounce tap and read once on first launch.
 // TASK-20772 — the download modal (TASK-20769) is the eventual web consumer.
 import { registerPlugin } from '@capacitor/core'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS, DEFERRED_LINK_OUTCOMES, type DeferredLinkOutcome } from '@/constants/analytics.consts'
 import { PLAY_STORE_URL } from '@/constants/general.consts'
 import { isValidLocale } from '@/i18n/config'
 import { isAndroidNative, isIOSNative } from './capacitor'
@@ -53,6 +55,38 @@ export interface DeferredPayload {
     invite?: string
     campaign?: string
     dest?: string
+}
+
+/**
+ * Records the outcome of the one-shot restore. Only booleans and the channel
+ * leave the device — never the invite code, campaign tag or destination, which
+ * would put a user's inviter and intended screen into analytics.
+ *
+ * Swallows everything: this runs on the first-launch path, where a telemetry
+ * failure must not cost the user their restored context.
+ */
+function captureRestore(
+    channel: 'referrer' | 'clipboard' | 'none',
+    outcome: DeferredLinkOutcome,
+    fields?: Record<string, boolean>
+): void {
+    try {
+        posthog.capture(ANALYTICS_EVENTS.DEFERRED_LINK_RESTORED, { channel, outcome, ...fields })
+    } catch {}
+}
+
+/**
+ * Call from the store-bounce tap handler once the hand-off has been written, to
+ * give DEFERRED_LINK_RESTORED a denominator — restores alone can't distinguish
+ * "the hand-off is broken" from "nobody used it". Intentionally not fired inside
+ * `playStoreUrlWithReferrer`/`copyIOSHandoff`: the first is a pure URL builder
+ * invoked on render, so it would count impressions as taps.
+ * Consumer: the download modal (TASK-20769).
+ */
+export function trackDeferredHandoffCreated(platform: 'ios' | 'android'): void {
+    try {
+        posthog.capture(ANALYTICS_EVENTS.DEFERRED_LINK_HANDOFF_CREATED, { platform })
+    } catch {}
 }
 
 // app-local android plugin (InstallReferrerPlugin.java); throws "not
@@ -188,7 +222,13 @@ async function doRestore(): Promise<RestoredContext | null> {
         return null
     }
 
+    const channel = isAndroidNative() ? 'referrer' : isIOSNative() ? 'clipboard' : 'none'
+
     let raw: string | null = null
+    // Tracked separately from `raw === null`: a declined paste prompt is a
+    // broken hand-off, an empty clipboard is an organic install, and reporting
+    // both as "nothing found" is what makes a 0% match rate look like success.
+    let clipboardUnavailable = false
     if (isAndroidNative()) {
         raw = await readInstallReferrer()
     } else if (isIOSNative()) {
@@ -204,6 +244,7 @@ async function doRestore(): Promise<RestoredContext | null> {
             }
         } catch {
             // user declined the paste prompt, or clipboard unavailable
+            clipboardUnavailable = true
         }
     }
 
@@ -214,9 +255,27 @@ async function doRestore(): Promise<RestoredContext | null> {
     } catch {}
 
     const payload = raw ? parseDeferredPayload(raw) : null
-    if (!payload) return null
+    if (!payload) {
+        // `raw` present but unparsed means the marker was absent — an organic
+        // Play referrer, or unrelated clipboard text that passed the url gate.
+        captureRestore(
+            channel,
+            raw
+                ? DEFERRED_LINK_OUTCOMES.MARKER_MISSING
+                : clipboardUnavailable
+                  ? DEFERRED_LINK_OUTCOMES.CLIPBOARD_UNAVAILABLE
+                  : DEFERRED_LINK_OUTCOMES.NO_HANDOFF
+        )
+        return null
+    }
 
     const restored = applyDeferredPayload(payload)
+    captureRestore(channel, DEFERRED_LINK_OUTCOMES.RESTORED, {
+        has_dest: !!restored.dest,
+        has_locale: !!restored.locale,
+        has_invite: !!payload.invite,
+        has_campaign: !!payload.campaign,
+    })
 
     // privacy: clear the consumed hand-off off the clipboard. after the flag —
     // an interrupted clear can't cause a re-read. single space: some platforms


### PR DESCRIPTION
## Summary

Follow-up to #2560, stacked on `feat/deferred-deep-link-main`. Adds the telemetry the deferred-link restore path is missing.

**⚠️ Base:** targets `feat/deferred-deep-link-main`, so the diff shown includes #2560's commits until that merges. Retarget to `main` once #2560 lands — this branch's own change is 3 files / +157.

## Why

The restore path currently emits nothing, and the iOS clipboard `catch {}` swallows the one distinction that matters:

```ts
} catch {
    // user declined the paste prompt, or clipboard unavailable
}
```

A declined paste prompt and an organic install both end up as `raw === null`. So a hand-off that **never works on iOS** is indistinguishable from one **nobody used** — and the only signal either way is the absence of restores, which looks the same as success. The download modal (TASK-20769) is about to drive real volume through this, and the plan was always to measure the match rate before escalating to a blocking interstitial.

## What

`DEFERRED_LINK_RESTORED`, fired once per fresh install with `channel` (`referrer` / `clipboard` / `none`) and one of four outcomes:

| outcome | meaning |
|---|---|
| `restored` | payload found and applied |
| `no_handoff` | nothing there — organic install |
| `marker_missing` | payload present but no `pnutdl=1` — organic Play referrer, or unrelated clipboard text that passed the URL gate |
| `clipboard_unavailable` | **paste prompt declined, or plugin missing** — the broken-hand-off signal |

On `restored` it also reports `has_dest` / `has_locale` / `has_invite` / `has_campaign`.

Plus `trackDeferredHandoffCreated(platform)` as the seam for the modal to report the denominator. Deliberately **not** fired inside `playStoreUrlWithReferrer` — that's a pure URL builder invoked on render, so it would count impressions as taps.

## Privacy

Only booleans and the channel leave the device. The invite code, campaign tag and destination never do — putting a user's inviter and intended screen into analytics would be a real regression. There's a test asserting the payload values are absent from the captured events.

## Safety

`posthog.capture` is wrapped in `try {} catch {}` at both call sites. This runs on the first-launch path, where a telemetry failure must not cost the user their restored context — covered by a test that makes capture throw and asserts the restore still returns.

## Tests

4 added to the existing suite (25 pass total, including all 21 from #2560 unchanged):

- successful restore reports the right fields, and no payload content
- organic install vs declined paste prompt land on **different** outcomes
- present-but-unmarked referrer is `marker_missing`, not `no_handoff`
- a throwing posthog doesn't lose the restored context

`tsc --noEmit` clean on the touched files; prettier clean.
