### PR TITLE
hotfix: re-consent modal polish (button squash, bold Not-now, wrapping label)

### DIFF
--- a/src/components/Global/ReConsentModal/index.tsx
+++ b/src/components/Global/ReConsentModal/index.tsx
@@ -157,7 +157,7 @@ const ReConsentModal = () => {
                 </div>
             }
             checkbox={{
-                text: 'I have read and accept the updated documents',
+                text: 'I accept the updated documents',
                 checked,
                 onChange: setChecked,
             }}
@@ -168,12 +168,17 @@ const ReConsentModal = () => {
                     shadowSize: '4',
                     disabled: !checked || submitting,
                     onClick: handleAccept,
+                    // ActionModal's sm:flex-1 (meant for its side-by-side layout)
+                    // squashes h-13 buttons when the CTAs are stacked
+                    className: 'sm:flex-none',
                 },
                 {
                     text: 'Not now',
                     variant: 'transparent',
                     disabled: submitting,
                     onClick: handlePostpone,
+                    // secondary de-emphasis: .btn is font-bold by default
+                    className: 'sm:flex-none font-normal text-grey-1',
                 },
             ]}
             ctaClassName={STACKED_CTAS}


### PR DESCRIPTION
Three visual fixes in ReConsentModal only: `sm:flex-none` on both CTAs (ActionModal's `sm:flex-1` is meant for its side-by-side layout and squashed the stacked h-13 buttons), `font-normal text-grey-1` on Not-now (every `.btn` is bold by default), and shorter checkbox copy so it fits one line on mobile.

⚠️ Note for review: checkbox copy changed "I have read and accept the updated documents" → "I accept the updated documents" (drops "have read") — the intro copy still prompts reading and the links precede the box, but it's legal-attestation wording, so judge it consciously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the consent checkbox wording for greater clarity.
  * Improved responsive layout and visual styling for consent modal buttons.
  * De-emphasized the “Not now” option with lighter text styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->