### PR TITLE
feat(migration): pwa-sunset surfaces behind PostHog flag (native-app migration)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -220,7 +220,7 @@ module.exports = [
         files: [
             'src/app/(mobile-ui)/**/*.tsx',
             'src/app/(setup)/**/*.tsx',
-            'src/components/{Home,Send,Request,Profile,Setup,Settings,Card,AddMoney,AddWithdraw,Withdraw,Claim,Payment,Points,Badges,Notifications,Invites,TransactionDetails,Kyc,IdentityVerification,ExchangeRate,Common,ForceIOSPWAInstall,User}/**/*.tsx',
+            'src/components/{Home,Send,Request,Profile,Setup,Settings,Card,AddMoney,AddWithdraw,Withdraw,Claim,Payment,Points,Badges,Notifications,Invites,TransactionDetails,Kyc,IdentityVerification,ExchangeRate,Common,ForceIOSPWAInstall,User,Migration}/**/*.tsx',
             'src/components/Global/**/*.tsx',
             'src/features/**/*.tsx',
         ],

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -37,6 +37,11 @@ if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'development') {
         disable_session_recording: isNativeBuild && !nativeReplayEnabled(),
     })
 
+    // expose the instance like the official snippet does — console access for
+    // QA (feature-flag overrides, e.g. pwa-sunset preview testing) and support
+    // debugging; the npm bundle doesn't attach it by itself
+    ;(window as Window & { posthog?: typeof posthog }).posthog = posthog
+
     // The web build inits Sentry via sentry.client.config.ts (injected by
     // withSentryConfig) with tunnelRoute '/monitoring'. The Capacitor static
     // export runs neither withSentryConfig nor a server for that tunnel, so

--- a/src/app/(mobile-ui)/home/page.tsx
+++ b/src/app/(mobile-ui)/home/page.tsx
@@ -38,6 +38,8 @@ import ActivationCTAs from '@/components/Home/ActivationCTAs'
 import LazyLoadErrorBoundary from '@/components/Global/LazyLoadErrorBoundary'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { MIGRATION_SURFACES } from '@/constants/migration.consts'
+import { useModalsContext } from '@/context/ModalsContext'
 
 // Lazy load heavy modal components (~20-30KB each) to reduce initial bundle size
 // Components are only loaded when user triggers them
@@ -49,6 +51,7 @@ const EarlyUserModal = lazy(() => import('@/components/Global/EarlyUserModal'))
 const WelcomeUnlockModal = lazy(() => import('@/components/Home/WelcomeUnlockModal'))
 const IosPwaInstallModal = lazy(() => import('@/components/Global/IosPwaInstallModal'))
 const MigrationDownloadModal = lazy(() => import('@/components/Migration/MigrationDownloadModal'))
+const ScanToDownloadModal = lazy(() => import('@/components/Migration/ScanToDownloadModal'))
 
 const BALANCE_WARNING_THRESHOLD = parseInt(process.env.NEXT_PUBLIC_BALANCE_WARNING_THRESHOLD ?? '500')
 const BALANCE_WARNING_EXPIRY = parseInt(process.env.NEXT_PUBLIC_BALANCE_WARNING_EXPIRY ?? '1814400') // 21 days in seconds
@@ -57,6 +60,7 @@ export default function Home() {
     const t = useTranslations('home')
     const tNav = useTranslations('navigation')
     const { showPermissionModal } = useNotifications()
+    const { isGetAppModalOpen, setIsGetAppModalOpen } = useModalsContext()
     const { balance, isFetchingBalance, spendableBalance, isFetchingSpendableBalance } = useWallet()
     const { resetFlow: resetClaimBankFlow } = useClaimBankFlow()
     const { resetWithdrawFlow } = useWithdrawFlow()
@@ -267,6 +271,19 @@ export default function Home() {
                         <MigrationDownloadModal onVisibilityChange={setShowMigrationModal} />
                     </Suspense>
                 </LazyLoadErrorBoundary>
+
+                {/* desktop target of the get-the-app carousel CTA */}
+                {isGetAppModalOpen && (
+                    <LazyLoadErrorBoundary>
+                        <Suspense fallback={null}>
+                            <ScanToDownloadModal
+                                visible={isGetAppModalOpen}
+                                onClose={() => setIsGetAppModalOpen(false)}
+                                surface={MIGRATION_SURFACES.HOME_BANNER}
+                            />
+                        </Suspense>
+                    </LazyLoadErrorBoundary>
+                )}
             </div>
             {/* Add Money Prompt Modal */}
             {/* TODO @dev Disabling this, re-enable after properly fixing */}

--- a/src/app/(mobile-ui)/home/page.tsx
+++ b/src/app/(mobile-ui)/home/page.tsx
@@ -332,7 +332,7 @@ export default function Home() {
             <LazyLoadErrorBoundary>
                 <Suspense fallback={null}>
                     <BalanceWarningModal
-                        visible={showBalanceWarningModal}
+                        visible={showBalanceWarningModal && !showMigrationModal}
                         onCloseAction={() => {
                             setShowBalanceWarningModal(false)
                             updateUserPreferences(user!.user.userId, {

--- a/src/app/(mobile-ui)/home/page.tsx
+++ b/src/app/(mobile-ui)/home/page.tsx
@@ -52,6 +52,7 @@ const WelcomeUnlockModal = lazy(() => import('@/components/Home/WelcomeUnlockMod
 const IosPwaInstallModal = lazy(() => import('@/components/Global/IosPwaInstallModal'))
 const MigrationDownloadModal = lazy(() => import('@/components/Migration/MigrationDownloadModal'))
 const ScanToDownloadModal = lazy(() => import('@/components/Migration/ScanToDownloadModal'))
+const ReviewPromptModal = lazy(() => import('@/components/Migration/ReviewPromptModal'))
 
 const BALANCE_WARNING_THRESHOLD = parseInt(process.env.NEXT_PUBLIC_BALANCE_WARNING_THRESHOLD ?? '500')
 const BALANCE_WARNING_EXPIRY = parseInt(process.env.NEXT_PUBLIC_BALANCE_WARNING_EXPIRY ?? '1814400') // 21 days in seconds
@@ -354,6 +355,19 @@ export default function Home() {
             {/* Card Pioneer Modal - Show to all users who haven't purchased */}
             {/* Eligibility check happens during the flow (geo screen), not here */}
             <PostSignupActionManager onActionModalVisibilityChange={setIsPostSignupActionModalVisible} />
+
+            {/* App review nudge (native only, once ever) — lowest priority */}
+            {!showMigrationModal &&
+                !showPermissionModal &&
+                !showBalanceWarningModal &&
+                !showKycModal &&
+                !isPostSignupActionModalVisible && (
+                    <LazyLoadErrorBoundary>
+                        <Suspense fallback={null}>
+                            <ReviewPromptModal />
+                        </Suspense>
+                    </LazyLoadErrorBoundary>
+                )}
         </PageContainer>
     )
 }

--- a/src/app/(mobile-ui)/home/page.tsx
+++ b/src/app/(mobile-ui)/home/page.tsx
@@ -101,6 +101,13 @@ export default function Home() {
         fetchUser()
     }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
+    // the migration prompt outranks the post-signup modal; unmounting the
+    // manager skips its onVisibilityChange(false), so clear the state here or
+    // it stays stuck true and suppresses the balance-warning/review modals
+    useEffect(() => {
+        if (showMigrationModal) setIsPostSignupActionModalVisible(false)
+    }, [showMigrationModal])
+
     // Show the "You're unlocked" celebration exactly once: the user has a usable
     // rail (isKycApproved) and has never dismissed it (activationCelebratedAt is
     // null, stamped server-side on dismiss). A KYC re-approval can't resurface it
@@ -354,7 +361,11 @@ export default function Home() {
 
             {/* Card Pioneer Modal - Show to all users who haven't purchased */}
             {/* Eligibility check happens during the flow (geo screen), not here */}
-            <PostSignupActionManager onActionModalVisibilityChange={setIsPostSignupActionModalVisible} />
+            {/* unmounted while the migration prompt shows (it re-checks on
+                remount); the effect below clears its stuck visibility state */}
+            {!showMigrationModal && (
+                <PostSignupActionManager onActionModalVisibilityChange={setIsPostSignupActionModalVisible} />
+            )}
 
             {/* App review nudge (native only, once ever) — lowest priority */}
             {!showMigrationModal &&

--- a/src/app/(mobile-ui)/home/page.tsx
+++ b/src/app/(mobile-ui)/home/page.tsx
@@ -48,6 +48,7 @@ const NoMoreJailModal = lazy(() => import('@/components/Global/NoMoreJailModal')
 const EarlyUserModal = lazy(() => import('@/components/Global/EarlyUserModal'))
 const WelcomeUnlockModal = lazy(() => import('@/components/Home/WelcomeUnlockModal'))
 const IosPwaInstallModal = lazy(() => import('@/components/Global/IosPwaInstallModal'))
+const MigrationDownloadModal = lazy(() => import('@/components/Migration/MigrationDownloadModal'))
 
 const BALANCE_WARNING_THRESHOLD = parseInt(process.env.NEXT_PUBLIC_BALANCE_WARNING_THRESHOLD ?? '500')
 const BALANCE_WARNING_EXPIRY = parseInt(process.env.NEXT_PUBLIC_BALANCE_WARNING_EXPIRY ?? '1814400') // 21 days in seconds
@@ -79,6 +80,9 @@ export default function Home() {
     const [showBalanceWarningModal, setShowBalanceWarningModal] = useState(false)
     const [isPostSignupActionModalVisible, setIsPostSignupActionModalVisible] = useState(false)
     const [showKycModal, setShowKycModal] = useState(false)
+    // migration download prompt outranks every other home modal (self-gating,
+    // only during the pwa-sunset notice window)
+    const [showMigrationModal, setShowMigrationModal] = useState(false)
 
     // Track if this is a fresh signup session - captured once on mount so it persists
     // even after NoMoreJailModal clears the sessionStorage key
@@ -157,14 +161,23 @@ export default function Home() {
             if (
                 balanceInUsd > BALANCE_WARNING_THRESHOLD &&
                 !hasSeenBalanceWarning &&
-                !showPermissionModal && // highest priority
+                !showMigrationModal && // highest priority
+                !showPermissionModal &&
                 !showKycModal &&
                 !isPostSignupActionModalVisible
             ) {
                 setShowBalanceWarningModal(true)
             }
         }
-    }, [balance, isFetchingBalance, showPermissionModal, showKycModal, isPostSignupActionModalVisible, user])
+    }, [
+        balance,
+        isFetchingBalance,
+        showMigrationModal,
+        showPermissionModal,
+        showKycModal,
+        isPostSignupActionModalVisible,
+        user,
+    ])
 
     if (isLoading) {
         return <PeanutLoading coverFullScreen />
@@ -241,20 +254,26 @@ export default function Home() {
                     />
                 </div>
 
-                {showPermissionModal && !showBalanceWarningModal && (
+                {showPermissionModal && !showBalanceWarningModal && !showMigrationModal && (
                     <LazyLoadErrorBoundary>
                         <Suspense fallback={null}>
                             <SetupNotificationsModal />
                         </Suspense>
                     </LazyLoadErrorBoundary>
                 )}
+
+                <LazyLoadErrorBoundary>
+                    <Suspense fallback={null}>
+                        <MigrationDownloadModal onVisibilityChange={setShowMigrationModal} />
+                    </Suspense>
+                </LazyLoadErrorBoundary>
             </div>
             {/* Add Money Prompt Modal */}
             {/* TODO @dev Disabling this, re-enable after properly fixing */}
             {/* <AddMoneyPromptModal visible={showAddMoneyPromptModal} onClose={() => setShowAddMoneyPromptModal(false)} /> */}
 
             {/* these modals manage their own state internally */}
-            {!showBalanceWarningModal && (
+            {!showBalanceWarningModal && !showMigrationModal && (
                 <>
                     <LazyLoadErrorBoundary>
                         <Suspense fallback={null}>
@@ -273,7 +292,7 @@ export default function Home() {
             <LazyLoadErrorBoundary>
                 <Suspense fallback={null}>
                     <WelcomeUnlockModal
-                        isOpen={showKycModal && !showBalanceWarningModal}
+                        isOpen={showKycModal && !showBalanceWarningModal && !showMigrationModal}
                         onClose={async () => {
                             // close the modal immediately for better ux
                             setShowKycModal(false)

--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -32,17 +32,10 @@ import { useNativePlugins } from '@/hooks/useNativePlugins'
 import '@/hooks/useSafeBack'
 import { isCapacitor } from '@/utils/capacitor'
 import { isDemoMode, enableDemoMode } from '@/utils/demo'
-import posthog from 'posthog-js'
 import SunsetScreen from '@/components/Migration/SunsetScreen'
+import { useKeepWebBypass } from '@/hooks/useKeepWebBypass'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
-import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
-import {
-    KEEP_WEB_COOKIE,
-    KEEP_WEB_COOKIE_DAYS,
-    KEEP_WEB_TOKEN,
-    MIGRATION_CUTOVER_DATE,
-} from '@/constants/migration.consts'
-import { getFromCookie, saveToCookie } from '@/utils/general.utils'
+import { MIGRATION_CUTOVER_DATE } from '@/constants/migration.consts'
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
     useNativePlugins()
@@ -63,20 +56,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
     const router = useRouter()
     const { showIosPwaInstallScreen } = useSetupStore()
     const migrationOn = useMigrationFlag()
-
-    // support escape hatch for the sunset block: `?keep-web=<token>` (DM'd by
-    // support) persists a cookie that lets this browser keep using the web app.
-    const [hasKeepWebBypass, setHasKeepWebBypass] = useState(
-        () => typeof document !== 'undefined' && getFromCookie(KEEP_WEB_COOKIE) === KEEP_WEB_TOKEN
-    )
-    useEffect(() => {
-        const param = new URLSearchParams(window.location.search).get(KEEP_WEB_COOKIE)
-        if (param === KEEP_WEB_TOKEN) {
-            saveToCookie(KEEP_WEB_COOKIE, KEEP_WEB_TOKEN, KEEP_WEB_COOKIE_DAYS)
-            posthog.capture(ANALYTICS_EVENTS.MIGRATION_KEEP_WEB_USED)
-            setHasKeepWebBypass(true)
-        }
-    }, [])
+    const hasKeepWebBypass = useKeepWebBypass()
 
     // detect online/offline status for full-page offline screen
     const { isOnline, isInitialized } = useNetworkStatus()

--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -35,7 +35,7 @@ import { isDemoMode, enableDemoMode } from '@/utils/demo'
 import SunsetScreen from '@/components/Migration/SunsetScreen'
 import { useKeepWebBypass } from '@/hooks/useKeepWebBypass'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
-import { getMigrationCutoverTime } from '@/utils/migration.utils'
+import { shouldShowSunsetBlock } from '@/utils/migration.utils'
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
     useNativePlugins()
@@ -162,13 +162,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
     // native app is the only way forward (keep-web cookie bypasses, public
     // guest links keep working). Must precede the PWA-install and waitlist
     // screens: the web is gone either way.
-    if (
-        migrationOn &&
-        !isPublicPath &&
-        !isCapacitor() &&
-        !hasKeepWebBypass &&
-        Date.now() >= getMigrationCutoverTime()
-    ) {
+    if (shouldShowSunsetBlock({ migrationOn, hasKeepWebBypass, isPublic: isPublicPath })) {
         return <SunsetScreen />
     }
 

--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -32,6 +32,17 @@ import { useNativePlugins } from '@/hooks/useNativePlugins'
 import '@/hooks/useSafeBack'
 import { isCapacitor } from '@/utils/capacitor'
 import { isDemoMode, enableDemoMode } from '@/utils/demo'
+import posthog from 'posthog-js'
+import SunsetScreen from '@/components/Migration/SunsetScreen'
+import { useMigrationFlag } from '@/hooks/useMigrationFlag'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import {
+    KEEP_WEB_COOKIE,
+    KEEP_WEB_COOKIE_DAYS,
+    KEEP_WEB_TOKEN,
+    MIGRATION_CUTOVER_DATE,
+} from '@/constants/migration.consts'
+import { getFromCookie, saveToCookie } from '@/utils/general.utils'
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
     useNativePlugins()
@@ -51,6 +62,21 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
     const alignStart = isHome || isHistory || isSupport
     const router = useRouter()
     const { showIosPwaInstallScreen } = useSetupStore()
+    const migrationOn = useMigrationFlag()
+
+    // support escape hatch for the sunset block: `?keep-web=<token>` (DM'd by
+    // support) persists a cookie that lets this browser keep using the web app.
+    const [hasKeepWebBypass, setHasKeepWebBypass] = useState(
+        () => typeof document !== 'undefined' && getFromCookie(KEEP_WEB_COOKIE) === KEEP_WEB_TOKEN
+    )
+    useEffect(() => {
+        const param = new URLSearchParams(window.location.search).get(KEEP_WEB_COOKIE)
+        if (param === KEEP_WEB_TOKEN) {
+            saveToCookie(KEEP_WEB_COOKIE, KEEP_WEB_TOKEN, KEEP_WEB_COOKIE_DAYS)
+            posthog.capture(ANALYTICS_EVENTS.MIGRATION_KEEP_WEB_USED)
+            setHasKeepWebBypass(true)
+        }
+    }, [])
 
     // detect online/offline status for full-page offline screen
     const { isOnline, isInitialized } = useNetworkStatus()
@@ -150,6 +176,20 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
                 </div>
             )
         }
+    }
+
+    // PWA sunset: past the cutover the web app is switched off — download the
+    // native app is the only way forward (keep-web cookie bypasses, public
+    // guest links keep working). Must precede the PWA-install and waitlist
+    // screens: the web is gone either way.
+    if (
+        migrationOn &&
+        !isPublicPath &&
+        !isCapacitor() &&
+        !hasKeepWebBypass &&
+        Date.now() >= MIGRATION_CUTOVER_DATE.getTime()
+    ) {
+        return <SunsetScreen />
     }
 
     // After setup flow is completed, show ios pwa install screen if not in pwa

--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -35,7 +35,7 @@ import { isDemoMode, enableDemoMode } from '@/utils/demo'
 import SunsetScreen from '@/components/Migration/SunsetScreen'
 import { useKeepWebBypass } from '@/hooks/useKeepWebBypass'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
-import { MIGRATION_CUTOVER_DATE } from '@/constants/migration.consts'
+import { getMigrationCutoverTime } from '@/utils/migration.utils'
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
     useNativePlugins()
@@ -167,7 +167,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
         !isPublicPath &&
         !isCapacitor() &&
         !hasKeepWebBypass &&
-        Date.now() >= MIGRATION_CUTOVER_DATE.getTime()
+        Date.now() >= getMigrationCutoverTime()
     ) {
         return <SunsetScreen />
     }

--- a/src/app/(setup)/layout.tsx
+++ b/src/app/(setup)/layout.tsx
@@ -11,17 +11,18 @@ import { Banner } from '@/components/Global/Banner'
 import SupportDrawer from '@/components/Global/SupportDrawer'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { usePullToRefresh } from '@/hooks/usePullToRefresh'
+import { useKeepWebBypass } from '@/hooks/useKeepWebBypass'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
 import SunsetScreen from '@/components/Migration/SunsetScreen'
-import { KEEP_WEB_COOKIE, KEEP_WEB_TOKEN, MIGRATION_CUTOVER_DATE } from '@/constants/migration.consts'
+import { MIGRATION_CUTOVER_DATE } from '@/constants/migration.consts'
 import { isCapacitor } from '@/utils/capacitor'
-import { getFromCookie } from '@/utils/general.utils'
 
 function SetupLayoutContent({ children }: { children?: React.ReactNode }) {
     const dispatch = useAppDispatch()
     const isPWA = usePWAStatus()
     const { deviceType } = useDeviceType()
     const migrationOn = useMigrationFlag()
+    const hasKeepWebBypass = useKeepWebBypass()
 
     /*
      * Bottom-inset fill color. Periwinkle is for Android 15 edge-to-edge (matches
@@ -88,13 +89,8 @@ function SetupLayoutContent({ children }: { children?: React.ReactNode }) {
 
     // pwa-sunset: past the cutover the web signup is switched off too — same
     // block as the mobile-ui layout (this route group has its own layout, so
-    // it needs its own gate). keep-web cookie bypasses.
-    if (
-        migrationOn &&
-        !isCapacitor() &&
-        Date.now() >= MIGRATION_CUTOVER_DATE.getTime() &&
-        getFromCookie(KEEP_WEB_COOKIE) !== KEEP_WEB_TOKEN
-    ) {
+    // it needs its own gate). keep-web cookie/param bypasses.
+    if (migrationOn && !isCapacitor() && !hasKeepWebBypass && Date.now() >= MIGRATION_CUTOVER_DATE.getTime()) {
         return <SunsetScreen />
     }
 

--- a/src/app/(setup)/layout.tsx
+++ b/src/app/(setup)/layout.tsx
@@ -3,7 +3,7 @@
 import { usePWAStatus } from '@/hooks/usePWAStatus'
 import { useAppDispatch } from '@/redux/hooks'
 import { setupActions } from '@/redux/slices/setup-slice'
-import { useEffect, useState, Suspense } from 'react'
+import { useEffect, useRef, useState, Suspense } from 'react'
 import { setupSteps } from '../../components/Setup/Setup.consts'
 import '../../styles/globals.css'
 import PeanutLoading from '@/components/Global/PeanutLoading'
@@ -14,7 +14,8 @@ import { usePullToRefresh } from '@/hooks/usePullToRefresh'
 import { useKeepWebBypass } from '@/hooks/useKeepWebBypass'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
 import SunsetScreen from '@/components/Migration/SunsetScreen'
-import { MIGRATION_CUTOVER_DATE } from '@/constants/migration.consts'
+import { MIGRATION_CUTOVER_DATE, PWA_SUNSET_FLAG } from '@/constants/migration.consts'
+import { isFeatureFlagEnabled } from '@/utils/featureFlag.utils'
 import { isCapacitor } from '@/utils/capacitor'
 
 function SetupLayoutContent({ children }: { children?: React.ReactNode }) {
@@ -57,14 +58,27 @@ function SetupLayoutContent({ children }: { children?: React.ReactNode }) {
             .catch(() => {})
     }, [])
 
+    // Latched ONCE at the first effect run instead of reacting to the async
+    // PostHog flag load: a mid-load true-flip would re-dispatch setSteps, whose
+    // new identity re-runs determineInitialStep and yanks a mid-flow user back
+    // to the landing step (losing e.g. a typed username). Returning visitors
+    // read the cached flag correctly; only first-ever visitors in the seconds
+    // before flags cache get the legacy flow — acceptable transitional cohort.
+    const migrationOnAtEntry = useRef<boolean | null>(null)
+
     useEffect(() => {
+        if (migrationOnAtEntry.current === null) {
+            migrationOnAtEntry.current = isFeatureFlagEnabled(PWA_SUNSET_FLAG)
+        }
+        const migrationSteps = migrationOnAtEntry.current
+
         // filter steps and set them in redux state
         const filteredSteps = setupSteps.filter((step) => {
             // pwa-sunset notice window: stop onboarding new users into the PWA —
             // the InstallPWA screens go away, store links show on the landing
             // step instead (TASK-20830 / TASK-20600)
             if (
-                migrationOn &&
+                migrationSteps &&
                 ['pwa-install', 'android-initial-pwa-install', 'unsupported-browser'].includes(step.screenId)
             ) {
                 return false
@@ -78,12 +92,12 @@ function SetupLayoutContent({ children }: { children?: React.ReactNode }) {
 
         // if ios and not in pwa, show ios pwa install screen after setup flow is completed
         // (retired during the migration window — the app download replaces the PWA)
-        if (!migrationOn && deviceType === DeviceType.IOS && !isPWA) {
+        if (!migrationSteps && deviceType === DeviceType.IOS && !isPWA) {
             dispatch(setupActions.setShowIosPwaInstallScreen(true))
         } else {
             dispatch(setupActions.setShowIosPwaInstallScreen(false))
         }
-    }, [isPWA, deviceType, dispatch, migrationOn])
+    }, [isPWA, deviceType, dispatch])
 
     usePullToRefresh()
 

--- a/src/app/(setup)/layout.tsx
+++ b/src/app/(setup)/layout.tsx
@@ -14,7 +14,7 @@ import { usePullToRefresh } from '@/hooks/usePullToRefresh'
 import { useKeepWebBypass } from '@/hooks/useKeepWebBypass'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
 import SunsetScreen from '@/components/Migration/SunsetScreen'
-import { getMigrationCutoverTime, isPwaSunsetOn } from '@/utils/migration.utils'
+import { isPwaSunsetOn, shouldShowSunsetBlock } from '@/utils/migration.utils'
 import { isCapacitor } from '@/utils/capacitor'
 
 function SetupLayoutContent({ children }: { children?: React.ReactNode }) {
@@ -103,7 +103,7 @@ function SetupLayoutContent({ children }: { children?: React.ReactNode }) {
     // pwa-sunset: past the cutover the web signup is switched off too — same
     // block as the mobile-ui layout (this route group has its own layout, so
     // it needs its own gate). keep-web cookie/param bypasses.
-    if (migrationOn && !isCapacitor() && !hasKeepWebBypass && Date.now() >= getMigrationCutoverTime()) {
+    if (shouldShowSunsetBlock({ migrationOn, hasKeepWebBypass })) {
         return <SunsetScreen />
     }
 

--- a/src/app/(setup)/layout.tsx
+++ b/src/app/(setup)/layout.tsx
@@ -14,8 +14,7 @@ import { usePullToRefresh } from '@/hooks/usePullToRefresh'
 import { useKeepWebBypass } from '@/hooks/useKeepWebBypass'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
 import SunsetScreen from '@/components/Migration/SunsetScreen'
-import { MIGRATION_CUTOVER_DATE, PWA_SUNSET_FLAG } from '@/constants/migration.consts'
-import { isFeatureFlagEnabled } from '@/utils/featureFlag.utils'
+import { getMigrationCutoverTime, isPwaSunsetOn } from '@/utils/migration.utils'
 import { isCapacitor } from '@/utils/capacitor'
 
 function SetupLayoutContent({ children }: { children?: React.ReactNode }) {
@@ -68,7 +67,7 @@ function SetupLayoutContent({ children }: { children?: React.ReactNode }) {
 
     useEffect(() => {
         if (migrationOnAtEntry.current === null) {
-            migrationOnAtEntry.current = isFeatureFlagEnabled(PWA_SUNSET_FLAG)
+            migrationOnAtEntry.current = isPwaSunsetOn()
         }
         const migrationSteps = migrationOnAtEntry.current
 
@@ -104,7 +103,7 @@ function SetupLayoutContent({ children }: { children?: React.ReactNode }) {
     // pwa-sunset: past the cutover the web signup is switched off too — same
     // block as the mobile-ui layout (this route group has its own layout, so
     // it needs its own gate). keep-web cookie/param bypasses.
-    if (migrationOn && !isCapacitor() && !hasKeepWebBypass && Date.now() >= MIGRATION_CUTOVER_DATE.getTime()) {
+    if (migrationOn && !isCapacitor() && !hasKeepWebBypass && Date.now() >= getMigrationCutoverTime()) {
         return <SunsetScreen />
     }
 

--- a/src/app/(setup)/layout.tsx
+++ b/src/app/(setup)/layout.tsx
@@ -11,12 +11,17 @@ import { Banner } from '@/components/Global/Banner'
 import SupportDrawer from '@/components/Global/SupportDrawer'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { usePullToRefresh } from '@/hooks/usePullToRefresh'
+import { useMigrationFlag } from '@/hooks/useMigrationFlag'
+import SunsetScreen from '@/components/Migration/SunsetScreen'
+import { KEEP_WEB_COOKIE, KEEP_WEB_TOKEN, MIGRATION_CUTOVER_DATE } from '@/constants/migration.consts'
 import { isCapacitor } from '@/utils/capacitor'
+import { getFromCookie } from '@/utils/general.utils'
 
 function SetupLayoutContent({ children }: { children?: React.ReactNode }) {
     const dispatch = useAppDispatch()
     const isPWA = usePWAStatus()
     const { deviceType } = useDeviceType()
+    const migrationOn = useMigrationFlag()
 
     /*
      * Bottom-inset fill color. Periwinkle is for Android 15 edge-to-edge (matches
@@ -54,6 +59,15 @@ function SetupLayoutContent({ children }: { children?: React.ReactNode }) {
     useEffect(() => {
         // filter steps and set them in redux state
         const filteredSteps = setupSteps.filter((step) => {
+            // pwa-sunset notice window: stop onboarding new users into the PWA —
+            // the InstallPWA screens go away, store links show on the landing
+            // step instead (TASK-20830 / TASK-20600)
+            if (
+                migrationOn &&
+                ['pwa-install', 'android-initial-pwa-install', 'unsupported-browser'].includes(step.screenId)
+            ) {
+                return false
+            }
             // Filter out pwa-install if already in PWA
             if (step.screenId === 'pwa-install' && isPWA) return false
 
@@ -62,14 +76,27 @@ function SetupLayoutContent({ children }: { children?: React.ReactNode }) {
         dispatch(setupActions.setSteps(filteredSteps))
 
         // if ios and not in pwa, show ios pwa install screen after setup flow is completed
-        if (deviceType === DeviceType.IOS && !isPWA) {
+        // (retired during the migration window — the app download replaces the PWA)
+        if (!migrationOn && deviceType === DeviceType.IOS && !isPWA) {
             dispatch(setupActions.setShowIosPwaInstallScreen(true))
         } else {
             dispatch(setupActions.setShowIosPwaInstallScreen(false))
         }
-    }, [isPWA, deviceType, dispatch])
+    }, [isPWA, deviceType, dispatch, migrationOn])
 
     usePullToRefresh()
+
+    // pwa-sunset: past the cutover the web signup is switched off too — same
+    // block as the mobile-ui layout (this route group has its own layout, so
+    // it needs its own gate). keep-web cookie bypasses.
+    if (
+        migrationOn &&
+        !isCapacitor() &&
+        Date.now() >= MIGRATION_CUTOVER_DATE.getTime() &&
+        getFromCookie(KEEP_WEB_COOKIE) !== KEEP_WEB_TOKEN
+    ) {
+        return <SunsetScreen />
+    }
 
     return (
         <>

--- a/src/app/(setup)/setup/page.tsx
+++ b/src/app/(setup)/setup/page.tsx
@@ -11,6 +11,7 @@ import { setupSteps as masterSetupSteps } from '../../../components/Setup/Setup.
 import UnsupportedBrowserModal from '@/components/Global/UnsupportedBrowserModal'
 import { isLikelyWebview, isDeviceOsSupported } from '@/components/Setup/Setup.utils'
 import { isCapacitor } from '@/utils/capacitor'
+import { isPwaSunsetOn } from '@/utils/migration.utils'
 import { getFromCookie } from '@/utils/general.utils'
 import { useSearchParams } from 'next/navigation'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
@@ -100,7 +101,12 @@ function SetupPageContent() {
             // onto Signup, unable to log back in (regression from PR #2346).
             const inviteCodeFromCookie = getFromCookie('inviteCode')
             const userInviteCode = inviteCode || inviteCodeFromCookie
-            const skipInviteGate = !!userInviteCode || searchParams.get('step') === 'signup'
+            // pwa-sunset notice window: web signups are closed (Landing hides
+            // Sign up), so the ?step=signup / invite-code jump must not skip
+            // past the landing gate — otherwise claim/invite links deep-link
+            // straight into the signup form. Native app keeps the fast path.
+            const webSignupClosed = isPwaSunsetOn() && !isCapacitor()
+            const skipInviteGate = (!!userInviteCode || searchParams.get('step') === 'signup') && !webSignupClosed
 
             const localDeviceType = detectedDeviceType
 

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -2,30 +2,35 @@
 
 // smart store link: peanut.me/app — every download QR points here so a single
 // code serves both stores; the scanning device decides. phones bounce straight
-// to their store, desktop gets both store buttons. client redirect (not a
-// route handler) so the capacitor static export builds unchanged. same visual
-// language as the sunset screen (MigrationHero + 50/50 split).
+// to their store (their store button shows the loading state while the
+// redirect happens; if it doesn't take, the buttons settle clickable),
+// desktop just gets both buttons. client redirect (not a route handler) so
+// the capacitor static export builds unchanged. same visual language as the
+// sunset screen (MigrationHero + 50/50 split).
 
 import { useEffect, useState } from 'react'
 import { Button } from '@/components/0_Bruddle/Button'
-import Loading from '@/components/Global/Loading'
 import MigrationHero from '@/components/Migration/MigrationHero'
-import { STORE_NAME, STORE_URL } from '@/constants/migration.consts'
+import { STORE_NAME, STORE_URL, type StoreKind } from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 
 export default function SmartStoreRedirect() {
     const { deviceType } = useDeviceType()
-    const [redirecting, setRedirecting] = useState(true)
+    const targetStore: StoreKind | null =
+        deviceType === DeviceType.IOS ? 'ios' : deviceType === DeviceType.ANDROID ? 'android' : null
+    const [redirecting, setRedirecting] = useState(targetStore !== null)
 
     useEffect(() => {
-        if (deviceType === DeviceType.IOS) {
-            window.location.replace(STORE_URL.ios)
-        } else if (deviceType === DeviceType.ANDROID) {
-            window.location.replace(STORE_URL.android)
-        } else {
-            setRedirecting(false)
-        }
-    }, [deviceType])
+        if (!targetStore) return
+        window.location.replace(STORE_URL[targetStore])
+        // if the store didn't take over (blocked, offline), settle to buttons
+        const fallback = setTimeout(() => setRedirecting(false), 4000)
+        return () => clearTimeout(fallback)
+    }, [targetStore])
+
+    const stores: StoreKind[] = targetStore
+        ? [targetStore, targetStore === 'ios' ? 'android' : 'ios']
+        : ['ios', 'android']
 
     return (
         <div className="flex min-h-[100dvh] w-full flex-col bg-white md:flex-row">
@@ -40,24 +45,20 @@ export default function SmartStoreRedirect() {
                     </p>
                 </div>
                 <div className="mx-auto flex w-full max-w-md flex-col gap-4">
-                    {redirecting ? (
-                        <div className="flex justify-center py-2">
-                            <Loading />
-                        </div>
-                    ) : (
-                        <>
-                            <a href={STORE_URL.ios} className="block">
-                                <Button variant="purple" shadowSize="4" icon="mobile-install" className="w-full">
-                                    {STORE_NAME.ios}
-                                </Button>
-                            </a>
-                            <a href={STORE_URL.android} className="block">
-                                <Button variant="stroke" shadowSize="4" icon="mobile-install" className="w-full">
-                                    {STORE_NAME.android}
-                                </Button>
-                            </a>
-                        </>
-                    )}
+                    {stores.map((s, i) => (
+                        <a key={s} href={STORE_URL[s]} className={redirecting && i > 0 ? 'hidden' : 'block'}>
+                            <Button
+                                variant={i === 0 ? 'purple' : 'stroke'}
+                                shadowSize="4"
+                                icon={redirecting ? undefined : 'mobile-install'}
+                                className="w-full"
+                                loading={redirecting && i === 0}
+                                disabled={redirecting && i === 0}
+                            >
+                                {STORE_NAME[s]}
+                            </Button>
+                        </a>
+                    ))}
                 </div>
             </section>
         </div>

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -2,11 +2,15 @@
 
 // smart store link: peanut.me/app — every download QR points here so a single
 // code serves both stores; the scanning device decides. phones bounce straight
-// to their store, desktop gets both links. client redirect (not a route
-// handler) so the capacitor static export builds unchanged.
+// to their store, desktop gets both store buttons. client redirect (not a
+// route handler) so the capacitor static export builds unchanged. same visual
+// language as the sunset screen (MigrationHero + 50/50 split).
 
 import { useEffect, useState } from 'react'
-import { STORE_URL } from '@/constants/migration.consts'
+import { Button } from '@/components/0_Bruddle/Button'
+import Loading from '@/components/Global/Loading'
+import MigrationHero from '@/components/Migration/MigrationHero'
+import { STORE_NAME, STORE_URL } from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 
 export default function SmartStoreRedirect() {
@@ -24,20 +28,38 @@ export default function SmartStoreRedirect() {
     }, [deviceType])
 
     return (
-        <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center gap-4 bg-white p-6">
-            <h1 className="text-2xl font-bold text-n-1">Get the Peanut app</h1>
-            {redirecting ? (
-                <p className="text-sm text-grey-1">Taking you to the store…</p>
-            ) : (
-                <div className="flex items-center gap-6">
-                    <a href={STORE_URL.ios} className="text-black underline">
-                        App Store
-                    </a>
-                    <a href={STORE_URL.android} className="text-black underline">
-                        Google Play
-                    </a>
+        <div className="flex min-h-[100dvh] w-full flex-col bg-white md:flex-row">
+            <MigrationHero className="h-[50dvh] md:h-auto md:w-1/2" />
+            <section className="flex flex-1 flex-col justify-between p-6 pb-[calc(1.5rem_+_env(safe-area-inset-bottom))] md:w-1/2 md:justify-center md:gap-10">
+                <div className="mx-auto flex w-full max-w-md flex-col gap-3 md:text-center">
+                    <h1 className="text-3xl font-bold text-n-1">Get the Peanut app</h1>
+                    <p className="text-base text-grey-1">
+                        {redirecting
+                            ? 'Taking you to the store…'
+                            : 'Global cash, local feel — pick your store to download.'}
+                    </p>
                 </div>
-            )}
+                <div className="mx-auto flex w-full max-w-md flex-col gap-4">
+                    {redirecting ? (
+                        <div className="flex justify-center py-2">
+                            <Loading />
+                        </div>
+                    ) : (
+                        <>
+                            <a href={STORE_URL.ios} className="block">
+                                <Button variant="purple" shadowSize="4" icon="mobile-install" className="w-full">
+                                    {STORE_NAME.ios}
+                                </Button>
+                            </a>
+                            <a href={STORE_URL.android} className="block">
+                                <Button variant="stroke" shadowSize="4" icon="mobile-install" className="w-full">
+                                    {STORE_NAME.android}
+                                </Button>
+                            </a>
+                        </>
+                    )}
+                </div>
+            </section>
         </div>
     )
 }

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -41,7 +41,7 @@ export default function SmartStoreRedirect() {
                     <p className="text-base text-grey-1">
                         {redirecting
                             ? 'Taking you to the store…'
-                            : 'Global cash, local feel — pick your store to download.'}
+                            : 'Global cash, local feel. Pick your store to download.'}
                     </p>
                 </div>
                 <div className="mx-auto flex w-full max-w-md flex-col gap-4">
@@ -50,7 +50,7 @@ export default function SmartStoreRedirect() {
                             <Button
                                 variant={i === 0 ? 'purple' : 'stroke'}
                                 shadowSize="4"
-                                icon={redirecting ? undefined : 'mobile-install'}
+                                icon={redirecting ? undefined : s === 'ios' ? 'apple-logo' : 'google-play'}
                                 className="w-full"
                                 loading={redirecting && i === 0}
                                 disabled={redirecting && i === 0}

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+// smart store link: peanut.me/app — every download QR points here so a single
+// code serves both stores; the scanning device decides. phones bounce straight
+// to their store, desktop gets both links. client redirect (not a route
+// handler) so the capacitor static export builds unchanged.
+
+import { useEffect, useState } from 'react'
+import { STORE_URL } from '@/constants/migration.consts'
+import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
+
+export default function SmartStoreRedirect() {
+    const { deviceType } = useDeviceType()
+    const [redirecting, setRedirecting] = useState(true)
+
+    useEffect(() => {
+        if (deviceType === DeviceType.IOS) {
+            window.location.replace(STORE_URL.ios)
+        } else if (deviceType === DeviceType.ANDROID) {
+            window.location.replace(STORE_URL.android)
+        } else {
+            setRedirecting(false)
+        }
+    }, [deviceType])
+
+    return (
+        <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center gap-4 bg-white p-6">
+            <h1 className="text-2xl font-bold text-n-1">Get the Peanut app</h1>
+            {redirecting ? (
+                <p className="text-sm text-grey-1">Taking you to the store…</p>
+            ) : (
+                <div className="flex items-center gap-6">
+                    <a href={STORE_URL.ios} className="text-black underline">
+                        App Store
+                    </a>
+                    <a href={STORE_URL.android} className="text-black underline">
+                        Google Play
+                    </a>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -2,31 +2,79 @@
 
 // smart store link: peanut.me/app — every download QR points here so a single
 // code serves both stores; the scanning device decides. phones bounce straight
-// to their store (their store button shows the loading state while the
+// to their store (their store button carries the loading state while the
 // redirect happens; if it doesn't take, the buttons settle clickable),
 // desktop just gets both buttons. client redirect (not a route handler) so
 // the capacitor static export builds unchanged. same visual language as the
 // sunset screen (MigrationHero + 50/50 split).
+//
+// flag-gated like every migration surface: until the pwa-sunset flag resolves
+// ON this page 404s — otherwise merging would put a live public page with
+// dead store links on peanut.me. posthog flags arrive async for first-time
+// visitors, so we wait for the flag callback (or a short timeout when posthog
+// is blocked) before deciding page-vs-404.
+//
+// hydration: SSR and the first client render show the same neutral loading
+// state (mounted guard) — deriving the redirect state from useDeviceType at
+// first render tripped React #418 on phones (device is WEB on the server).
 
 import { useEffect, useState } from 'react'
+import { notFound } from 'next/navigation'
+import posthog from 'posthog-js'
+import { useTranslations } from 'next-intl'
 import { Button } from '@/components/0_Bruddle/Button'
+import Loading from '@/components/Global/Loading'
 import MigrationHero from '@/components/Migration/MigrationHero'
 import { STORE_NAME, STORE_URL, type StoreKind } from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
+import { isPwaSunsetOn } from '@/utils/migration.utils'
+
+const FLAG_WAIT_MS = 4000
 
 export default function SmartStoreRedirect() {
+    const t = useTranslations('migration')
     const { deviceType } = useDeviceType()
-    const targetStore: StoreKind | null =
-        deviceType === DeviceType.IOS ? 'ios' : deviceType === DeviceType.ANDROID ? 'android' : null
-    const [redirecting, setRedirecting] = useState(targetStore !== null)
 
+    const [mounted, setMounted] = useState(false)
+    useEffect(() => setMounted(true), [])
+
+    // wait for posthog to deliver flags (or time out) before judging the flag
+    const [flagsSettled, setFlagsSettled] = useState(false)
     useEffect(() => {
-        if (!targetStore) return
+        if (isPwaSunsetOn()) {
+            setFlagsSettled(true)
+            return
+        }
+        const unsubscribe = posthog.onFeatureFlags(() => setFlagsSettled(true))
+        const timeout = setTimeout(() => setFlagsSettled(true), FLAG_WAIT_MS)
+        return () => {
+            unsubscribe?.()
+            clearTimeout(timeout)
+        }
+    }, [])
+
+    const migrationOn = mounted && isPwaSunsetOn()
+    const settled = mounted && flagsSettled
+
+    const targetStore: StoreKind | null = !mounted
+        ? null
+        : deviceType === DeviceType.IOS
+          ? 'ios'
+          : deviceType === DeviceType.ANDROID
+            ? 'android'
+            : null
+
+    const [redirecting, setRedirecting] = useState(false)
+    useEffect(() => {
+        if (!settled || !migrationOn || !targetStore) return
+        setRedirecting(true)
         window.location.replace(STORE_URL[targetStore])
         // if the store didn't take over (blocked, offline), settle to buttons
         const fallback = setTimeout(() => setRedirecting(false), 4000)
         return () => clearTimeout(fallback)
-    }, [targetStore])
+    }, [settled, migrationOn, targetStore])
+
+    if (settled && !migrationOn) notFound()
 
     const stores: StoreKind[] = targetStore
         ? [targetStore, targetStore === 'ios' ? 'android' : 'ios']
@@ -37,28 +85,34 @@ export default function SmartStoreRedirect() {
             <MigrationHero className="h-[50dvh] md:h-auto md:w-1/2" />
             <section className="flex flex-1 flex-col justify-between p-6 pb-[calc(1.5rem_+_env(safe-area-inset-bottom))] md:w-1/2 md:justify-center md:gap-10">
                 <div className="mx-auto flex w-full max-w-md flex-col gap-3 md:text-center">
-                    <h1 className="text-3xl font-bold text-n-1">Get the Peanut app</h1>
-                    <p className="text-base text-grey-1">
-                        {redirecting
-                            ? 'Taking you to the store…'
-                            : 'Global cash, local feel. Pick your store to download.'}
-                    </p>
+                    <h1 className="text-3xl font-bold text-n-1">{t('qr.title')}</h1>
+                    {settled && migrationOn && (
+                        <p className="text-base text-grey-1">
+                            {redirecting ? t('smartLink.redirecting') : t('smartLink.pickStore')}
+                        </p>
+                    )}
                 </div>
                 <div className="mx-auto flex w-full max-w-md flex-col gap-4">
-                    {stores.map((s, i) => (
-                        <a key={s} href={STORE_URL[s]} className={redirecting && i > 0 ? 'hidden' : 'block'}>
-                            <Button
-                                variant={i === 0 ? 'purple' : 'stroke'}
-                                shadowSize="4"
-                                icon={redirecting ? undefined : s === 'ios' ? 'apple-logo' : 'google-play'}
-                                className="w-full"
-                                loading={redirecting && i === 0}
-                                disabled={redirecting && i === 0}
-                            >
-                                {STORE_NAME[s]}
-                            </Button>
-                        </a>
-                    ))}
+                    {settled && migrationOn ? (
+                        stores.map((s, i) => (
+                            <a key={s} href={STORE_URL[s]} className={redirecting && i > 0 ? 'hidden' : 'block'}>
+                                <Button
+                                    variant={i === 0 ? 'purple' : 'stroke'}
+                                    shadowSize="4"
+                                    icon={redirecting ? undefined : s === 'ios' ? 'apple-logo' : 'google-play'}
+                                    className="w-full"
+                                    loading={redirecting && i === 0}
+                                    disabled={redirecting && i === 0}
+                                >
+                                    {STORE_NAME[s]}
+                                </Button>
+                            </a>
+                        ))
+                    ) : (
+                        <div className="flex justify-center py-2">
+                            <Loading />
+                        </div>
+                    )}
                 </div>
             </section>
         </div>

--- a/src/components/Claim/Link/SendLinkActionList.tsx
+++ b/src/components/Claim/Link/SendLinkActionList.tsx
@@ -96,7 +96,7 @@ export default function SendLinkActionList({
     const [selectedMethod, setSelectedMethod] = useState<PaymentMethod | null>(null)
     const [showInviteModal, setShowInviteModal] = useState(false)
     const { user } = useAuth()
-    const { interceptGuestCta, storeHandoffModal } = useGuestStoreHandoff()
+    const { interceptGuestCta, storeHandoffModal } = useGuestStoreHandoff({ trackImpressionWhenGuest: !isLoggedIn })
     const {
         setSelectedTokenAddress,
         setSelectedChainID,

--- a/src/components/Claim/Link/SendLinkActionList.tsx
+++ b/src/components/Claim/Link/SendLinkActionList.tsx
@@ -52,6 +52,7 @@ import {
     validateMinimumAmount,
 } from '@/constants/payment.consts'
 import { useAppDispatch } from '@/redux/hooks'
+import { useGuestStoreHandoff } from '@/hooks/useGuestStoreHandoff'
 import { useTranslations } from 'next-intl'
 
 const SHOW_INVITE_MODAL_FOR_DEVCONNECT = false
@@ -95,6 +96,7 @@ export default function SendLinkActionList({
     const [selectedMethod, setSelectedMethod] = useState<PaymentMethod | null>(null)
     const [showInviteModal, setShowInviteModal] = useState(false)
     const { user } = useAuth()
+    const { interceptGuestCta, storeHandoffModal } = useGuestStoreHandoff()
     const {
         setSelectedTokenAddress,
         setSelectedChainID,
@@ -187,6 +189,9 @@ export default function SendLinkActionList({
     }
 
     const handleContinueWithPeanut = () => {
+        // migration window: web signups are closed — hand the guest to the
+        // app stores instead (QR modal on desktop, store link on mobile)
+        if (!isLoggedIn && interceptGuestCta()) return
         addParamStep('claim')
         const redirectUri = encodeURIComponent(window.location.pathname + window.location.search + window.location.hash)
         const rawUsername = claimLinkData?.sender?.username
@@ -214,6 +219,7 @@ export default function SendLinkActionList({
 
     return (
         <div className="space-y-2">
+            {storeHandoffModal}
             {showDevconnectMethod && (
                 <>
                     <Button

--- a/src/components/Global/Icons/Icon.tsx
+++ b/src/components/Global/Icons/Icon.tsx
@@ -76,6 +76,7 @@ import { TxnOffIcon } from './txn-off'
 import { WalletCancelIcon } from './wallet-cancel'
 import { InviteHeartIcon } from './invite-heart'
 import { BulbIcon } from './bulb'
+import { AppleLogoIcon, GooglePlayIcon } from './store-brands'
 import { DoubleCheckIcon } from './double-check'
 
 export type IconName =
@@ -154,6 +155,8 @@ export type IconName =
     | 'globe-lock'
     | 'globe'
     | 'bulb'
+    | 'apple-logo'
+    | 'google-play'
     | 'undo'
     | 'upload-cloud'
     | 'alert-filled'
@@ -298,6 +301,8 @@ const iconComponents: Record<IconName, ComponentType<SVGProps<SVGSVGElement>>> =
     'txn-off': TxnOffIcon,
     docs: DocsIcon,
     bulb: BulbIcon,
+    'apple-logo': AppleLogoIcon,
+    'google-play': GooglePlayIcon,
     undo: (props) => <LucideWrapper Icon={Undo} {...props} />,
     'upload-cloud': (props) => <LucideWrapper Icon={UploadCloud} {...props} />,
     'invite-heart': InviteHeartIcon,

--- a/src/components/Global/Icons/store-brands.tsx
+++ b/src/components/Global/Icons/store-brands.tsx
@@ -1,0 +1,22 @@
+import { type FC, type SVGProps } from 'react'
+
+// brand marks for the app-store CTAs (pwa-sunset migration surfaces).
+// monochrome (currentColor) so they follow button text color like Lucide icons.
+
+export const AppleLogoIcon: FC<SVGProps<SVGSVGElement>> = (props) => (
+    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+        <path
+            d="M17.05 12.536c-.026-2.615 2.135-3.87 2.233-3.932-1.216-1.779-3.107-2.022-3.779-2.05-1.608-.163-3.14.947-3.956.947-.815 0-2.076-.923-3.413-.898-1.756.026-3.376 1.021-4.28 2.594-1.826 3.166-.466 7.854 1.312 10.423.87 1.258 1.906 2.671 3.266 2.62 1.311-.052 1.806-.848 3.391-.848 1.585 0 2.03.848 3.417.822 1.412-.026 2.305-1.283 3.166-2.546.999-1.459 1.41-2.872 1.434-2.945-.031-.014-2.752-1.055-2.79-4.187zM14.44 4.859c.723-.876 1.21-2.093 1.077-3.306-1.04.042-2.301.693-3.048 1.568-.67.776-1.256 2.015-1.098 3.204 1.16.09 2.345-.59 3.069-1.466z"
+            fill="currentColor"
+        />
+    </svg>
+)
+
+export const GooglePlayIcon: FC<SVGProps<SVGSVGElement>> = (props) => (
+    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+        <path
+            d="M3.61 1.814L13.79 12 3.61 22.186a1.99 1.99 0 01-.61-1.437V3.25c0-.564.234-1.073.61-1.436zm11.24 11.246l2.577 2.578-11.29 6.42c-.522.297-1.122.33-1.653.117l10.366-9.115zm3.723-4.55l3.31 1.882c1.155.657 1.155 2.36 0 3.017l-3.31 1.882L15.91 12.6l2.663-2.09zm-14.09-7.03c.532-.213 1.132-.18 1.654.117l11.29 6.42-2.577 2.578L4.483 1.48z"
+            fill="currentColor"
+        />
+    </svg>
+)

--- a/src/components/LandingPage/LandingPageClient.tsx
+++ b/src/components/LandingPage/LandingPageClient.tsx
@@ -8,12 +8,18 @@ import { SUPPORTED_RAILS_FAQ_ID } from '@/constants/faq.consts'
 import TweetCarousel from '@/components/LandingPage/TweetCarousel'
 import { StickyMobileCTA } from '@/components/LandingPage/StickyMobileCTA'
 import underMaintenanceConfig from '@/config/underMaintenance.config'
+import ScanToDownloadModal from '@/components/Migration/ScanToDownloadModal'
+import { MIGRATION_SURFACES, STORE_URL } from '@/constants/migration.consts'
+import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
+import { useMigrationFlag } from '@/hooks/useMigrationFlag'
+import { trackStoreClick } from '@/utils/migration.utils'
 
 type CTAButton = {
     label: string
     href: string
     isExternal?: boolean
     subtext?: string
+    onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void
 }
 
 type FAQQuestion = {
@@ -53,6 +59,35 @@ export function LandingPageClient({
     footerSlot,
 }: LandingPageClientProps) {
     const { isFooterVisible } = useFooterVisibility()
+    const migrationOn = useMigrationFlag()
+    const { deviceType } = useDeviceType()
+    const [qrModalOpen, setQrModalOpen] = useState(false)
+
+    // pwa-sunset: the hero CTA becomes "Download now" — the visitor's store on
+    // mobile, the scan-to-download QR on desktop. English-only like the rest of
+    // this surface; the permanent label change goes through the content system
+    // post-cutover, at which point this override is deleted (TASK-20600).
+    const primaryCta = useMemo((): CTAButton => {
+        if (!migrationOn) return heroConfig.primaryCta
+        if (deviceType === DeviceType.WEB) {
+            return {
+                label: 'Download now',
+                href: '#',
+                onClick: (e) => {
+                    e.preventDefault()
+                    setQrModalOpen(true)
+                },
+            }
+        }
+        const store = deviceType === DeviceType.ANDROID ? 'android' : 'ios'
+        return {
+            label: 'Download now',
+            href: STORE_URL[store],
+            isExternal: true,
+            // the anchor navigates; only track here
+            onClick: () => trackStoreClick(store, MIGRATION_SURFACES.LANDING_HERO),
+        }
+    }, [migrationOn, deviceType, heroConfig.primaryCta])
 
     // Memoized: this component re-renders per scroll frame during the button
     // animation — don't rebuild the FAQ array + rich answer element each time.
@@ -199,7 +234,14 @@ export function LandingPageClient({
 
     return (
         <>
-            <Hero primaryCta={heroConfig.primaryCta} buttonVisible={buttonVisible} buttonScale={buttonScale} />
+            <Hero primaryCta={primaryCta} buttonVisible={buttonVisible} buttonScale={buttonScale} />
+            {qrModalOpen && (
+                <ScanToDownloadModal
+                    visible={qrModalOpen}
+                    onClose={() => setQrModalOpen(false)}
+                    surface={MIGRATION_SURFACES.LANDING_HERO}
+                />
+            )}
             <Marquee {...marqueeProps} />
             {mantecaSlot}
             <Marquee {...marqueeProps} />

--- a/src/components/LandingPage/LandingPageClient.tsx
+++ b/src/components/LandingPage/LandingPageClient.tsx
@@ -8,7 +8,6 @@ import { SUPPORTED_RAILS_FAQ_ID } from '@/constants/faq.consts'
 import TweetCarousel from '@/components/LandingPage/TweetCarousel'
 import { StickyMobileCTA } from '@/components/LandingPage/StickyMobileCTA'
 import underMaintenanceConfig from '@/config/underMaintenance.config'
-import ScanToDownloadModal from '@/components/Migration/ScanToDownloadModal'
 import StoreBadges from '@/components/Migration/StoreBadges'
 import { type CTAButton } from '@/components/LandingPage/landing.types'
 import { MIGRATION_SURFACES, STORE_URL } from '@/constants/migration.consts'
@@ -55,33 +54,26 @@ export function LandingPageClient({
     const { isFooterVisible } = useFooterVisibility()
     const migrationOn = useMigrationFlag()
     const { deviceType } = useDeviceType()
-    const [qrModalOpen, setQrModalOpen] = useState(false)
+    const isDesktop = deviceType === DeviceType.WEB
 
-    // pwa-sunset: the hero CTA becomes "Download now" — the visitor's store on
-    // mobile, the scan-to-download QR on desktop. English-only like the rest of
-    // this surface; the permanent label change goes through the content system
-    // post-cutover, at which point this override is deleted (TASK-20600).
-    const primaryCta = useMemo((): CTAButton => {
+    // pwa-sunset hero CTAs are device-based: phones get one "Download now"
+    // with their store's mark deep-linking to it; desktop drops the primary
+    // and shows the equal store-button pair instead (customCta below).
+    // English-only like the rest of this surface; the permanent CTA change
+    // goes through the content system post-cutover (TASK-20600).
+    const primaryCta = useMemo((): CTAButton | undefined => {
         if (!migrationOn) return heroConfig.primaryCta
-        if (deviceType === DeviceType.WEB) {
-            return {
-                label: 'Download now',
-                href: '#',
-                onClick: (e) => {
-                    e.preventDefault()
-                    setQrModalOpen(true)
-                },
-            }
-        }
+        if (isDesktop) return undefined
         const store = deviceType === DeviceType.ANDROID ? 'android' : 'ios'
         return {
             label: 'Download now',
             href: STORE_URL[store],
             isExternal: true,
+            icon: store === 'ios' ? 'apple-logo' : 'google-play',
             // the anchor navigates; only track here
             onClick: () => trackStoreClick(store, MIGRATION_SURFACES.LANDING_HERO),
         }
-    }, [migrationOn, deviceType, heroConfig.primaryCta])
+    }, [migrationOn, deviceType, isDesktop, heroConfig.primaryCta])
 
     // Memoized: this component re-renders per scroll frame during the button
     // animation — don't rebuild the FAQ array + rich answer element each time.
@@ -232,15 +224,12 @@ export function LandingPageClient({
                 primaryCta={primaryCta}
                 buttonVisible={buttonVisible}
                 buttonScale={buttonScale}
-                belowPrimaryCta={migrationOn ? <StoreBadges surface={MIGRATION_SURFACES.LANDING_HERO} /> : undefined}
+                customCta={
+                    migrationOn && isDesktop ? (
+                        <StoreBadges surface={MIGRATION_SURFACES.LANDING_HERO} appearance="hero" />
+                    ) : undefined
+                }
             />
-            {qrModalOpen && (
-                <ScanToDownloadModal
-                    visible={qrModalOpen}
-                    onClose={() => setQrModalOpen(false)}
-                    surface={MIGRATION_SURFACES.LANDING_HERO}
-                />
-            )}
             <Marquee {...marqueeProps} />
             {mantecaSlot}
             <Marquee {...marqueeProps} />

--- a/src/components/LandingPage/LandingPageClient.tsx
+++ b/src/components/LandingPage/LandingPageClient.tsx
@@ -70,6 +70,8 @@ export function LandingPageClient({
             href: STORE_URL[store],
             isExternal: true,
             icon: store === 'ios' ? 'apple-logo' : 'google-play',
+            // keep the content-system subtext (e.g. "Join +10,000 cool people")
+            subtext: heroConfig.primaryCta.subtext,
             // the anchor navigates; only track here
             onClick: () => trackStoreClick(store, MIGRATION_SURFACES.LANDING_HERO),
         }
@@ -226,7 +228,14 @@ export function LandingPageClient({
                 buttonScale={buttonScale}
                 customCta={
                     migrationOn && isDesktop ? (
-                        <StoreBadges surface={MIGRATION_SURFACES.LANDING_HERO} appearance="hero" />
+                        <div className="flex flex-col items-center">
+                            <StoreBadges surface={MIGRATION_SURFACES.LANDING_HERO} appearance="hero" />
+                            {heroConfig.primaryCta.subtext && (
+                                <span className="mt-2 block text-center text-sm italic text-n-1 md:text-base">
+                                    {heroConfig.primaryCta.subtext}
+                                </span>
+                            )}
+                        </div>
                     ) : undefined
                 }
             />

--- a/src/components/LandingPage/LandingPageClient.tsx
+++ b/src/components/LandingPage/LandingPageClient.tsx
@@ -13,6 +13,7 @@ import { type CTAButton } from '@/components/LandingPage/landing.types'
 import { MIGRATION_SURFACES, STORE_URL } from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
+import { useTranslations } from 'next-intl'
 import { trackStoreClick } from '@/utils/migration.utils'
 
 type FAQQuestion = {
@@ -53,20 +54,23 @@ export function LandingPageClient({
 }: LandingPageClientProps) {
     const { isFooterVisible } = useFooterVisibility()
     const migrationOn = useMigrationFlag()
+    // app-locale translation (LatAm-first funnel); the flag-off label still
+    // comes from the content system per landing locale
+    const tMigration = useTranslations('migration')
     const { deviceType } = useDeviceType()
     const isDesktop = deviceType === DeviceType.WEB
 
     // pwa-sunset hero CTAs are device-based: phones get one "Download now"
     // with their store's mark deep-linking to it; desktop drops the primary
     // and shows the equal store-button pair instead (customCta below).
-    // English-only like the rest of this surface; the permanent CTA change
-    // goes through the content system post-cutover (TASK-20600).
+    // the permanent flag-off CTA change goes through the content system
+    // post-cutover (TASK-20600).
     const primaryCta = useMemo((): CTAButton | undefined => {
         if (!migrationOn) return heroConfig.primaryCta
         if (isDesktop) return undefined
         const store = deviceType === DeviceType.ANDROID ? 'android' : 'ios'
         return {
-            label: 'Download now',
+            label: tMigration('downloadNow'),
             href: STORE_URL[store],
             isExternal: true,
             icon: store === 'ios' ? 'apple-logo' : 'google-play',
@@ -75,7 +79,7 @@ export function LandingPageClient({
             // the anchor navigates; only track here
             onClick: () => trackStoreClick(store, MIGRATION_SURFACES.LANDING_HERO),
         }
-    }, [migrationOn, deviceType, isDesktop, heroConfig.primaryCta])
+    }, [migrationOn, deviceType, isDesktop, heroConfig.primaryCta, tMigration])
 
     // Memoized: this component re-renders per scroll frame during the button
     // animation — don't rebuild the FAQ array + rich answer element each time.

--- a/src/components/LandingPage/LandingPageClient.tsx
+++ b/src/components/LandingPage/LandingPageClient.tsx
@@ -9,18 +9,11 @@ import TweetCarousel from '@/components/LandingPage/TweetCarousel'
 import { StickyMobileCTA } from '@/components/LandingPage/StickyMobileCTA'
 import underMaintenanceConfig from '@/config/underMaintenance.config'
 import ScanToDownloadModal from '@/components/Migration/ScanToDownloadModal'
+import { type CTAButton } from '@/components/LandingPage/landing.types'
 import { MIGRATION_SURFACES, STORE_URL } from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
 import { trackStoreClick } from '@/utils/migration.utils'
-
-type CTAButton = {
-    label: string
-    href: string
-    isExternal?: boolean
-    subtext?: string
-    onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void
-}
 
 type FAQQuestion = {
     id: string

--- a/src/components/LandingPage/LandingPageClient.tsx
+++ b/src/components/LandingPage/LandingPageClient.tsx
@@ -9,6 +9,7 @@ import TweetCarousel from '@/components/LandingPage/TweetCarousel'
 import { StickyMobileCTA } from '@/components/LandingPage/StickyMobileCTA'
 import underMaintenanceConfig from '@/config/underMaintenance.config'
 import ScanToDownloadModal from '@/components/Migration/ScanToDownloadModal'
+import StoreBadges from '@/components/Migration/StoreBadges'
 import { type CTAButton } from '@/components/LandingPage/landing.types'
 import { MIGRATION_SURFACES, STORE_URL } from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
@@ -227,7 +228,12 @@ export function LandingPageClient({
 
     return (
         <>
-            <Hero primaryCta={primaryCta} buttonVisible={buttonVisible} buttonScale={buttonScale} />
+            <Hero
+                primaryCta={primaryCta}
+                buttonVisible={buttonVisible}
+                buttonScale={buttonScale}
+                belowPrimaryCta={migrationOn ? <StoreBadges surface={MIGRATION_SURFACES.LANDING_HERO} /> : undefined}
+            />
             {qrModalOpen && (
                 <ScanToDownloadModal
                     visible={qrModalOpen}

--- a/src/components/LandingPage/LandingPageShell.tsx
+++ b/src/components/LandingPage/LandingPageShell.tsx
@@ -3,7 +3,11 @@ import { FooterVisibilityObserver } from '@/components/Global/FooterVisibilityOb
 
 export function LandingPageShell({ children }: { children: ReactNode }) {
     return (
-        <div className="enable-select !m-0 w-full !p-0">
+        // overflow-x-clip: decorative absolutely-positioned elements (clouds,
+        // stars) extend past the right edge and made the whole page scroll
+        // horizontally on mobile. clip (not hidden) so no scroll container is
+        // created and sticky/fixed children keep working.
+        <div className="enable-select !m-0 w-full overflow-x-clip !p-0">
             {children}
             <FooterVisibilityObserver />
         </div>

--- a/src/components/LandingPage/StickyMobileCTA.tsx
+++ b/src/components/LandingPage/StickyMobileCTA.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/0_Bruddle/Button'
 import { MIGRATION_SURFACES, STORE_URL } from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
+import { useTranslations } from 'next-intl'
 import { trackStoreClick } from '@/utils/migration.utils'
 
 export function StickyMobileCTA() {
@@ -14,6 +15,7 @@ export function StickyMobileCTA() {
     const rafId = useRef(0)
     const lastVisible = useRef(false)
     const migrationOn = useMigrationFlag()
+    const tMigration = useTranslations('migration')
     const { deviceType } = useDeviceType()
     const store = deviceType === DeviceType.ANDROID ? 'android' : 'ios'
 
@@ -64,9 +66,9 @@ export function StickyMobileCTA() {
                                 variant="purple"
                                 shadowSize="4"
                                 icon={store === 'ios' ? 'apple-logo' : 'google-play'}
-                                className="w-full py-3 text-base font-extrabold"
+                                className="w-full py-3 text-base font-extrabold uppercase"
                             >
-                                DOWNLOAD NOW
+                                {tMigration('downloadNow')}
                             </Button>
                         </a>
                     ) : (

--- a/src/components/LandingPage/StickyMobileCTA.tsx
+++ b/src/components/LandingPage/StickyMobileCTA.tsx
@@ -4,11 +4,18 @@ import { useEffect, useRef, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import Link from 'next/link'
 import { Button } from '@/components/0_Bruddle/Button'
+import { MIGRATION_SURFACES, STORE_URL } from '@/constants/migration.consts'
+import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
+import { useMigrationFlag } from '@/hooks/useMigrationFlag'
+import { trackStoreClick } from '@/utils/migration.utils'
 
 export function StickyMobileCTA() {
     const [visible, setVisible] = useState(false)
     const rafId = useRef(0)
     const lastVisible = useRef(false)
+    const migrationOn = useMigrationFlag()
+    const { deviceType } = useDeviceType()
+    const store = deviceType === DeviceType.ANDROID ? 'android' : 'ios'
 
     useEffect(() => {
         const check = () => {
@@ -43,11 +50,27 @@ export function StickyMobileCTA() {
                     transition={{ type: 'spring', damping: 20, stiffness: 300 }}
                     className="pointer-events-none fixed bottom-0 left-0 right-0 z-50 border-t-2 border-n-1 bg-white px-4 py-3 md:hidden"
                 >
-                    <Link href="/setup" className="pointer-events-auto block">
-                        <Button variant="purple" shadowSize="4" className="w-full py-3 text-base font-extrabold">
-                            SIGN UP NOW
-                        </Button>
-                    </Link>
+                    {migrationOn ? (
+                        // this bar is md:hidden so the visitor is on a phone —
+                        // deep-link their store during the migration window
+                        <a
+                            href={STORE_URL[store]}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="pointer-events-auto block"
+                            onClick={() => trackStoreClick(store, MIGRATION_SURFACES.LANDING_HERO)}
+                        >
+                            <Button variant="purple" shadowSize="4" className="w-full py-3 text-base font-extrabold">
+                                DOWNLOAD NOW
+                            </Button>
+                        </a>
+                    ) : (
+                        <Link href="/setup" className="pointer-events-auto block">
+                            <Button variant="purple" shadowSize="4" className="w-full py-3 text-base font-extrabold">
+                                SIGN UP NOW
+                            </Button>
+                        </Link>
+                    )}
                 </motion.div>
             )}
         </AnimatePresence>

--- a/src/components/LandingPage/StickyMobileCTA.tsx
+++ b/src/components/LandingPage/StickyMobileCTA.tsx
@@ -60,7 +60,12 @@ export function StickyMobileCTA() {
                             className="pointer-events-auto block"
                             onClick={() => trackStoreClick(store, MIGRATION_SURFACES.LANDING_HERO)}
                         >
-                            <Button variant="purple" shadowSize="4" className="w-full py-3 text-base font-extrabold">
+                            <Button
+                                variant="purple"
+                                shadowSize="4"
+                                icon={store === 'ios' ? 'apple-logo' : 'google-play'}
+                                className="w-full py-3 text-base font-extrabold"
+                            >
                                 DOWNLOAD NOW
                             </Button>
                         </a>

--- a/src/components/LandingPage/hero.tsx
+++ b/src/components/LandingPage/hero.tsx
@@ -78,6 +78,8 @@ type HeroProps = {
     secondaryCta?: CTAButton
     buttonVisible?: boolean
     buttonScale?: number
+    /** rendered under the primary CTA (app-store badge pair during the migration window) */
+    belowPrimaryCta?: React.ReactNode
 }
 
 const getInitialAnimation = (variant: 'primary' | 'secondary') => ({
@@ -107,7 +109,7 @@ const transitionConfig = { type: 'spring', damping: 15 } as const
 const getButtonContainerClasses = (variant: 'primary' | 'secondary') =>
     `relative z-20 mt-8 md:mt-12 flex flex-col items-center justify-center ${variant === 'primary' ? 'mx-auto w-fit' : 'right-[calc(50%-120px)]'}`
 
-export function Hero({ primaryCta, secondaryCta, buttonVisible, buttonScale = 1 }: HeroProps) {
+export function Hero({ primaryCta, secondaryCta, buttonVisible, buttonScale = 1, belowPrimaryCta }: HeroProps) {
     const renderCTAButton = (cta: CTAButton, variant: 'primary' | 'secondary') => {
         return (
             <motion.div
@@ -133,6 +135,7 @@ export function Hero({ primaryCta, secondaryCta, buttonVisible, buttonScale = 1 
                 {cta.subtext && (
                     <span className="mt-2 block text-center text-sm italic text-n-1 md:text-base">{cta.subtext}</span>
                 )}
+                {variant === 'primary' && belowPrimaryCta && <div className="mt-3">{belowPrimaryCta}</div>}
             </motion.div>
         )
     }

--- a/src/components/LandingPage/hero.tsx
+++ b/src/components/LandingPage/hero.tsx
@@ -77,6 +77,7 @@ type CTAButton = {
     href: string
     isExternal?: boolean
     subtext?: string
+    onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void
 }
 
 type HeroProps = {
@@ -127,6 +128,7 @@ export function Hero({ primaryCta, secondaryCta, buttonVisible, buttonScale = 1 
                     href={cta.href}
                     target={cta.isExternal ? '_blank' : undefined}
                     rel={cta.isExternal ? 'noopener noreferrer' : undefined}
+                    onClick={cta.onClick}
                 >
                     <Button
                         shadowSize="4"

--- a/src/components/LandingPage/hero.tsx
+++ b/src/components/LandingPage/hero.tsx
@@ -78,8 +78,8 @@ type HeroProps = {
     secondaryCta?: CTAButton
     buttonVisible?: boolean
     buttonScale?: number
-    /** rendered under the primary CTA (app-store badge pair during the migration window) */
-    belowPrimaryCta?: React.ReactNode
+    /** replaces the primary button entirely (store-button pair on desktop during the migration window) */
+    customCta?: React.ReactNode
 }
 
 const getInitialAnimation = (variant: 'primary' | 'secondary') => ({
@@ -109,7 +109,7 @@ const transitionConfig = { type: 'spring', damping: 15 } as const
 const getButtonContainerClasses = (variant: 'primary' | 'secondary') =>
     `relative z-20 mt-8 md:mt-12 flex flex-col items-center justify-center ${variant === 'primary' ? 'mx-auto w-fit' : 'right-[calc(50%-120px)]'}`
 
-export function Hero({ primaryCta, secondaryCta, buttonVisible, buttonScale = 1, belowPrimaryCta }: HeroProps) {
+export function Hero({ primaryCta, secondaryCta, buttonVisible, buttonScale = 1, customCta }: HeroProps) {
     const renderCTAButton = (cta: CTAButton, variant: 'primary' | 'secondary') => {
         return (
             <motion.div
@@ -127,6 +127,7 @@ export function Hero({ primaryCta, secondaryCta, buttonVisible, buttonScale = 1,
                 >
                     <Button
                         shadowSize="4"
+                        icon={cta.icon}
                         className="bg-white px-7 py-3 text-base font-extrabold hover:bg-white/90 md:px-9 md:py-8 md:text-xl"
                     >
                         {cta.label}
@@ -135,10 +136,20 @@ export function Hero({ primaryCta, secondaryCta, buttonVisible, buttonScale = 1,
                 {cta.subtext && (
                     <span className="mt-2 block text-center text-sm italic text-n-1 md:text-base">{cta.subtext}</span>
                 )}
-                {variant === 'primary' && belowPrimaryCta && <div className="mt-3">{belowPrimaryCta}</div>}
             </motion.div>
         )
     }
+
+    const renderCustomCta = () => (
+        <motion.div
+            className={getButtonContainerClasses('primary')}
+            initial={getInitialAnimation('primary')}
+            animate={getAnimateAnimation('primary', buttonVisible, buttonScale)}
+            transition={transitionConfig}
+        >
+            {customCta}
+        </motion.div>
+    )
 
     return (
         <section
@@ -198,7 +209,7 @@ export function Hero({ primaryCta, secondaryCta, buttonVisible, buttonScale = 1,
                 <span className="mt-2 block text-center text-sm text-n-1/70 md:text-base" style={{ fontWeight: 400 }}>
                     No local ID or bank required.
                 </span>
-                {primaryCta && renderCTAButton(primaryCta, 'primary')}
+                {primaryCta ? renderCTAButton(primaryCta, 'primary') : customCta ? renderCustomCta() : null}
                 {secondaryCta && renderCTAButton(secondaryCta, 'secondary')}
                 <motion.img
                     initial={{ opacity: 0, translateY: 20, translateX: 5 }}

--- a/src/components/LandingPage/hero.tsx
+++ b/src/components/LandingPage/hero.tsx
@@ -8,6 +8,7 @@ import Image from 'next/image'
 import { useEffect, useCallback, useRef } from 'react'
 import { Button } from '@/components/0_Bruddle/Button'
 import { CloudsCss } from './CloudsCss'
+import { type CTAButton } from '@/components/LandingPage/landing.types'
 
 /**
  * Peanut mascot that positions itself so only 6% of its height (the feet)
@@ -70,14 +71,6 @@ function PeanutMascot() {
             className="absolute left-1/2 z-10 h-auto max-h-[40vh] w-auto max-w-[90%] -translate-x-1/2 object-contain"
         />
     )
-}
-
-type CTAButton = {
-    label: string
-    href: string
-    isExternal?: boolean
-    subtext?: string
-    onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void
 }
 
 type HeroProps = {

--- a/src/components/LandingPage/landing.types.ts
+++ b/src/components/LandingPage/landing.types.ts
@@ -1,3 +1,5 @@
+import { type IconName } from '@/components/Global/Icons/Icon'
+
 // shared shape of the landing hero CTA buttons (hero.tsx renders them,
 // LandingPageClient builds them from the content system / migration override)
 export type CTAButton = {
@@ -5,5 +7,6 @@ export type CTAButton = {
     href: string
     isExternal?: boolean
     subtext?: string
+    icon?: IconName
     onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void
 }

--- a/src/components/LandingPage/landing.types.ts
+++ b/src/components/LandingPage/landing.types.ts
@@ -1,0 +1,9 @@
+// shared shape of the landing hero CTA buttons (hero.tsx renders them,
+// LandingPageClient builds them from the content system / migration override)
+export type CTAButton = {
+    label: string
+    href: string
+    isExternal?: boolean
+    subtext?: string
+    onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void
+}

--- a/src/components/Migration/DownloadQR.tsx
+++ b/src/components/Migration/DownloadQR.tsx
@@ -1,0 +1,36 @@
+'use client'
+import { useEffect, useState } from 'react'
+import posthog from 'posthog-js'
+import { useTranslations } from 'next-intl'
+import QRCodeWrapper from '@/components/Global/QRCodeWrapper'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { STORE_NAME, STORE_URL, type MigrationSurface, type StoreKind } from '@/constants/migration.consts'
+
+// scan-to-download with a store toggle. on desktop we can't know the visitor's
+// phone OS, so we show both store QRs behind a toggle instead of guessing.
+export default function DownloadQR({ surface }: { surface: MigrationSurface }) {
+    const t = useTranslations('migration')
+    const [store, setStore] = useState<StoreKind>('ios')
+
+    useEffect(() => {
+        posthog.capture(ANALYTICS_EVENTS.MIGRATION_QR_SHOWN, { surface, store })
+    }, [surface, store])
+
+    return (
+        <div className="flex flex-col items-center gap-3 py-2">
+            <div className="flex overflow-hidden rounded-sm border border-n-1">
+                {(['ios', 'android'] as const).map((s) => (
+                    <button
+                        key={s}
+                        onClick={() => setStore(s)}
+                        className={`px-4 py-1.5 text-sm font-semibold ${store === s ? 'bg-primary-1 text-n-1' : 'bg-white text-grey-1'}`}
+                    >
+                        {STORE_NAME[s]}
+                    </button>
+                ))}
+            </div>
+            <QRCodeWrapper url={STORE_URL[store]} />
+            <span className="text-xs text-grey-1">{t('qr.scanHint')}</span>
+        </div>
+    )
+}

--- a/src/components/Migration/DownloadQR.tsx
+++ b/src/components/Migration/DownloadQR.tsx
@@ -3,10 +3,10 @@ import { useEffect } from 'react'
 import posthog from 'posthog-js'
 import { useTranslations } from 'next-intl'
 import QRCodeWrapper from '@/components/Global/QRCodeWrapper'
+import StoreBadges from '@/components/Migration/StoreBadges'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { SELF_URL } from '@/constants/general.consts'
-import { STORE_URL, type MigrationSurface } from '@/constants/migration.consts'
-import { trackStoreClick } from '@/utils/migration.utils'
+import { type MigrationSurface } from '@/constants/migration.consts'
 
 // one smart QR instead of a per-store toggle: it encodes /app, which
 // redirects to the store of whichever phone scans it.
@@ -27,20 +27,7 @@ export default function DownloadQR({ surface }: { surface: MigrationSurface }) {
             <QRCodeWrapper url={`${origin}/app`} />
             <span className="text-xs text-grey-1">{t('qr.scanHint')}</span>
             {/* desktop can install directly too (e.g. Google Play from the browser) */}
-            <div className="flex items-center gap-4">
-                {(['ios', 'android'] as const).map((s) => (
-                    <a
-                        key={s}
-                        href={STORE_URL[s]}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-sm text-black underline"
-                        onClick={() => trackStoreClick(s, surface)}
-                    >
-                        {t(s === 'ios' ? 'qr.openIos' : 'qr.openAndroid')}
-                    </a>
-                ))}
-            </div>
+            <StoreBadges surface={surface} />
         </div>
     )
 }

--- a/src/components/Migration/DownloadQR.tsx
+++ b/src/components/Migration/DownloadQR.tsx
@@ -1,39 +1,25 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import posthog from 'posthog-js'
 import { useTranslations } from 'next-intl'
-import { Button } from '@/components/0_Bruddle/Button'
 import QRCodeWrapper from '@/components/Global/QRCodeWrapper'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
-import { STORE_NAME, STORE_URL, type MigrationSurface, type StoreKind } from '@/constants/migration.consts'
+import { SELF_URL } from '@/constants/general.consts'
+import { STORE_URL, type MigrationSurface } from '@/constants/migration.consts'
 import { trackStoreClick } from '@/utils/migration.utils'
 
-// scan-to-download with a store toggle. on desktop we can't know the visitor's
-// phone OS, so we show both store QRs behind a toggle instead of guessing.
+// one smart QR instead of a per-store toggle: it encodes /app, which
+// redirects to the store of whichever phone scans it.
 export default function DownloadQR({ surface }: { surface: MigrationSurface }) {
     const t = useTranslations('migration')
-    const [store, setStore] = useState<StoreKind>('ios')
 
     useEffect(() => {
-        posthog.capture(ANALYTICS_EVENTS.MIGRATION_QR_SHOWN, { surface, store })
-    }, [surface, store])
+        posthog.capture(ANALYTICS_EVENTS.MIGRATION_QR_SHOWN, { surface })
+    }, [surface])
 
     return (
         <div className="flex flex-col items-center gap-3 py-2">
-            <div className="flex overflow-hidden rounded-sm border border-n-1">
-                {(['ios', 'android'] as const).map((s) => (
-                    <Button
-                        key={s}
-                        variant={store === s ? 'purple' : 'transparent'}
-                        size="small"
-                        onClick={() => setStore(s)}
-                        className={`w-auto rounded-none px-4 text-sm font-semibold ${store === s ? '' : 'text-grey-1'}`}
-                    >
-                        {STORE_NAME[s]}
-                    </Button>
-                ))}
-            </div>
-            <QRCodeWrapper url={STORE_URL[store]} />
+            <QRCodeWrapper url={`${SELF_URL}/app`} />
             <span className="text-xs text-grey-1">{t('qr.scanHint')}</span>
             {/* desktop can install directly too (e.g. Google Play from the browser) */}
             <div className="flex items-center gap-4">

--- a/src/components/Migration/DownloadQR.tsx
+++ b/src/components/Migration/DownloadQR.tsx
@@ -17,9 +17,14 @@ export default function DownloadQR({ surface }: { surface: MigrationSurface }) {
         posthog.capture(ANALYTICS_EVENTS.MIGRATION_QR_SHOWN, { surface })
     }, [surface])
 
+    // the serving origin, not SELF_URL: a preview's QR must point at the
+    // preview (SELF_URL would send scanners to prod) and a LAN-served dev
+    // build must encode the LAN address so a real phone can scan it
+    const origin = typeof window !== 'undefined' ? window.location.origin : SELF_URL
+
     return (
         <div className="flex flex-col items-center gap-3 py-2">
-            <QRCodeWrapper url={`${SELF_URL}/app`} />
+            <QRCodeWrapper url={`${origin}/app`} />
             <span className="text-xs text-grey-1">{t('qr.scanHint')}</span>
             {/* desktop can install directly too (e.g. Google Play from the browser) */}
             <div className="flex items-center gap-4">

--- a/src/components/Migration/DownloadQR.tsx
+++ b/src/components/Migration/DownloadQR.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/0_Bruddle/Button'
 import QRCodeWrapper from '@/components/Global/QRCodeWrapper'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { STORE_NAME, STORE_URL, type MigrationSurface, type StoreKind } from '@/constants/migration.consts'
+import { trackStoreClick } from '@/utils/migration.utils'
 
 // scan-to-download with a store toggle. on desktop we can't know the visitor's
 // phone OS, so we show both store QRs behind a toggle instead of guessing.
@@ -34,6 +35,21 @@ export default function DownloadQR({ surface }: { surface: MigrationSurface }) {
             </div>
             <QRCodeWrapper url={STORE_URL[store]} />
             <span className="text-xs text-grey-1">{t('qr.scanHint')}</span>
+            {/* desktop can install directly too (e.g. Google Play from the browser) */}
+            <div className="flex items-center gap-4">
+                {(['ios', 'android'] as const).map((s) => (
+                    <a
+                        key={s}
+                        href={STORE_URL[s]}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm text-black underline"
+                        onClick={() => trackStoreClick(s, surface)}
+                    >
+                        {t(s === 'ios' ? 'qr.openIos' : 'qr.openAndroid')}
+                    </a>
+                ))}
+            </div>
         </div>
     )
 }

--- a/src/components/Migration/DownloadQR.tsx
+++ b/src/components/Migration/DownloadQR.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react'
 import posthog from 'posthog-js'
 import { useTranslations } from 'next-intl'
+import { Button } from '@/components/0_Bruddle/Button'
 import QRCodeWrapper from '@/components/Global/QRCodeWrapper'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { STORE_NAME, STORE_URL, type MigrationSurface, type StoreKind } from '@/constants/migration.consts'
@@ -20,13 +21,15 @@ export default function DownloadQR({ surface }: { surface: MigrationSurface }) {
         <div className="flex flex-col items-center gap-3 py-2">
             <div className="flex overflow-hidden rounded-sm border border-n-1">
                 {(['ios', 'android'] as const).map((s) => (
-                    <button
+                    <Button
                         key={s}
+                        variant={store === s ? 'purple' : 'transparent'}
+                        size="small"
                         onClick={() => setStore(s)}
-                        className={`px-4 py-1.5 text-sm font-semibold ${store === s ? 'bg-primary-1 text-n-1' : 'bg-white text-grey-1'}`}
+                        className={`w-auto rounded-none px-4 text-sm font-semibold ${store === s ? '' : 'text-grey-1'}`}
                     >
                         {STORE_NAME[s]}
-                    </button>
+                    </Button>
                 ))}
             </div>
             <QRCodeWrapper url={STORE_URL[store]} />

--- a/src/components/Migration/MigrationDownloadModal.tsx
+++ b/src/components/Migration/MigrationDownloadModal.tsx
@@ -5,7 +5,12 @@ import { useTranslations } from 'next-intl'
 import ActionModal from '@/components/Global/ActionModal'
 import DownloadQR from '@/components/Migration/DownloadQR'
 import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
-import { DOWNLOAD_PROMPT_SNOOZE_DAYS, MIGRATION_SURFACES, STORE_NAME } from '@/constants/migration.consts'
+import {
+    DOWNLOAD_PROMPT_SNOOZE_DAYS,
+    MIGRATION_SURFACES,
+    MIGRATION_URGENCY_THRESHOLD_DAYS,
+    STORE_NAME,
+} from '@/constants/migration.consts'
 import { getMigrationCutoverTime, openStore } from '@/utils/migration.utils'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
@@ -63,8 +68,12 @@ export default function MigrationDownloadModal({
     const isDesktop = deviceType === DeviceType.WEB
     const store = deviceType === DeviceType.ANDROID ? 'android' : 'ios'
 
+    // two-phase copy: celebrate the app while the cutover is far, switch to
+    // friendly urgency (deadline in the copy) for the final stretch
+    const isUrgent = daysLeft <= MIGRATION_URGENCY_THRESHOLD_DAYS
+
     const remindLaterCta = {
-        text: t('downloadPrompt.remindLater'),
+        text: t(isUrgent ? 'downloadPrompt.remindLater' : 'downloadPrompt.maybeLater'),
         variant: 'transparent' as const,
         className: 'underline h-6 text-sm',
         onClick: snooze,
@@ -75,8 +84,10 @@ export default function MigrationDownloadModal({
             visible={visible}
             onClose={snooze}
             icon="mobile-install"
-            title={t('downloadPrompt.title')}
-            description={t('downloadPrompt.description', { days: daysLeft })}
+            title={t(isUrgent ? 'downloadPrompt.title' : 'downloadPrompt.earlyTitle')}
+            description={
+                isUrgent ? t('downloadPrompt.description', { days: daysLeft }) : t('downloadPrompt.earlyDescription')
+            }
             content={isDesktop ? <DownloadQR surface={MIGRATION_SURFACES.DOWNLOAD_MODAL} /> : undefined}
             ctaClassName="md:flex-col gap-4"
             ctas={

--- a/src/components/Migration/MigrationDownloadModal.tsx
+++ b/src/components/Migration/MigrationDownloadModal.tsx
@@ -66,7 +66,7 @@ export default function MigrationDownloadModal({
     const remindLaterCta = {
         text: t('downloadPrompt.remindLater'),
         variant: 'transparent' as const,
-        className: 'underline h-6',
+        className: 'underline h-6 text-sm',
         onClick: snooze,
     }
 

--- a/src/components/Migration/MigrationDownloadModal.tsx
+++ b/src/components/Migration/MigrationDownloadModal.tsx
@@ -1,0 +1,98 @@
+'use client'
+import { useEffect, useState } from 'react'
+import posthog from 'posthog-js'
+import { useTranslations } from 'next-intl'
+import ActionModal from '@/components/Global/ActionModal'
+import DownloadQR from '@/components/Migration/DownloadQR'
+import { openStore } from '@/utils/migration.utils'
+import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
+import {
+    DOWNLOAD_PROMPT_SNOOZE_DAYS,
+    MIGRATION_CUTOVER_DATE,
+    MIGRATION_SURFACES,
+    STORE_NAME,
+} from '@/constants/migration.consts'
+import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
+import { useMigrationFlag } from '@/hooks/useMigrationFlag'
+import { useUserStore } from '@/redux/hooks'
+import { isCapacitor } from '@/utils/capacitor'
+import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils'
+
+const SNOOZE_MS = DOWNLOAD_PROMPT_SNOOZE_DAYS * 24 * 60 * 60 * 1000
+
+/**
+ * Post-login "Peanut is becoming an app" prompt (TASK-20826), shown on the
+ * web app during the migration notice window (flag on, cutover not reached).
+ * Self-gating; reports visibility so home can suppress lower-priority modals.
+ */
+export default function MigrationDownloadModal({
+    onVisibilityChange,
+}: {
+    onVisibilityChange?: (visible: boolean) => void
+}) {
+    const t = useTranslations('migration')
+    const migrationOn = useMigrationFlag()
+    const { deviceType } = useDeviceType()
+    const { user } = useUserStore()
+    const [visible, setVisible] = useState(false)
+
+    const userId = user?.user.userId
+
+    useEffect(() => {
+        if (!migrationOn || !userId || isCapacitor()) return
+        if (Date.now() >= MIGRATION_CUTOVER_DATE.getTime()) return // sunset block owns post-cutover
+        const snoozedAt = getUserPreferences(userId)?.migrationPromptSnoozedAt
+        if (snoozedAt && Date.now() - new Date(snoozedAt).getTime() < SNOOZE_MS) return
+        setVisible(true)
+        posthog.capture(ANALYTICS_EVENTS.MODAL_SHOWN, { modal_type: MODAL_TYPES.MIGRATION_DOWNLOAD })
+    }, [migrationOn, userId])
+
+    useEffect(() => {
+        onVisibilityChange?.(visible)
+    }, [visible, onVisibilityChange])
+
+    const snooze = () => {
+        setVisible(false)
+        updateUserPreferences(userId, { migrationPromptSnoozedAt: new Date().toISOString() })
+        posthog.capture(ANALYTICS_EVENTS.MODAL_DISMISSED, { modal_type: MODAL_TYPES.MIGRATION_DOWNLOAD })
+    }
+
+    const daysLeft = Math.max(1, Math.ceil((MIGRATION_CUTOVER_DATE.getTime() - Date.now()) / (24 * 60 * 60 * 1000)))
+    const isDesktop = deviceType === DeviceType.WEB
+    const store = deviceType === DeviceType.ANDROID ? 'android' : 'ios'
+
+    return (
+        <ActionModal
+            visible={visible}
+            onClose={snooze}
+            icon="mobile-install"
+            title={t('downloadPrompt.title')}
+            description={t('downloadPrompt.description', { days: daysLeft })}
+            content={isDesktop ? <DownloadQR surface={MIGRATION_SURFACES.DOWNLOAD_MODAL} /> : undefined}
+            ctas={
+                isDesktop
+                    ? []
+                    : [
+                          {
+                              text: STORE_NAME[store],
+                              variant: 'purple',
+                              shadowSize: '4',
+                              icon: 'mobile-install',
+                              onClick: () => {
+                                  posthog.capture(ANALYTICS_EVENTS.MODAL_CTA_CLICKED, {
+                                      modal_type: MODAL_TYPES.MIGRATION_DOWNLOAD,
+                                      cta: 'store',
+                                  })
+                                  openStore(store, MIGRATION_SURFACES.DOWNLOAD_MODAL)
+                              },
+                          },
+                      ]
+            }
+            footer={
+                <button className="mt-3 w-full text-center text-xs text-grey-1 underline" onClick={snooze}>
+                    {t('downloadPrompt.remindLater')}
+                </button>
+            }
+        />
+    )
+}

--- a/src/components/Migration/MigrationDownloadModal.tsx
+++ b/src/components/Migration/MigrationDownloadModal.tsx
@@ -98,7 +98,7 @@ export default function MigrationDownloadModal({
                               text: STORE_NAME[store],
                               variant: 'purple',
                               shadowSize: '4',
-                              icon: 'mobile-install',
+                              icon: store === 'ios' ? ('apple-logo' as const) : ('google-play' as const),
                               onClick: () => {
                                   posthog.capture(ANALYTICS_EVENTS.MODAL_CTA_CLICKED, {
                                       modal_type: MODAL_TYPES.MIGRATION_DOWNLOAD,

--- a/src/components/Migration/MigrationDownloadModal.tsx
+++ b/src/components/Migration/MigrationDownloadModal.tsx
@@ -68,6 +68,13 @@ export default function MigrationDownloadModal({
     const isDesktop = deviceType === DeviceType.WEB
     const store = deviceType === DeviceType.ANDROID ? 'android' : 'ios'
 
+    const remindLaterCta = {
+        text: t('downloadPrompt.remindLater'),
+        variant: 'transparent' as const,
+        className: 'underline h-6',
+        onClick: snooze,
+    }
+
     return (
         <ActionModal
             visible={visible}
@@ -76,9 +83,10 @@ export default function MigrationDownloadModal({
             title={t('downloadPrompt.title')}
             description={t('downloadPrompt.description', { days: daysLeft })}
             content={isDesktop ? <DownloadQR surface={MIGRATION_SURFACES.DOWNLOAD_MODAL} /> : undefined}
+            ctaClassName="md:flex-col gap-4"
             ctas={
                 isDesktop
-                    ? []
+                    ? [remindLaterCta]
                     : [
                           {
                               text: STORE_NAME[store],
@@ -93,12 +101,8 @@ export default function MigrationDownloadModal({
                                   openStore(store, MIGRATION_SURFACES.DOWNLOAD_MODAL)
                               },
                           },
+                          remindLaterCta,
                       ]
-            }
-            footer={
-                <button className="mt-3 w-full text-center text-xs text-grey-1 underline" onClick={snooze}>
-                    {t('downloadPrompt.remindLater')}
-                </button>
             }
         />
     )

--- a/src/components/Migration/MigrationDownloadModal.tsx
+++ b/src/components/Migration/MigrationDownloadModal.tsx
@@ -75,7 +75,7 @@ export default function MigrationDownloadModal({
     const remindLaterCta = {
         text: t(isUrgent ? 'downloadPrompt.remindLater' : 'downloadPrompt.maybeLater'),
         variant: 'transparent' as const,
-        className: 'underline h-6 text-sm',
+        className: 'underline h-6 text-xs font-normal',
         onClick: snooze,
     }
 

--- a/src/components/Migration/MigrationDownloadModal.tsx
+++ b/src/components/Migration/MigrationDownloadModal.tsx
@@ -4,14 +4,9 @@ import posthog from 'posthog-js'
 import { useTranslations } from 'next-intl'
 import ActionModal from '@/components/Global/ActionModal'
 import DownloadQR from '@/components/Migration/DownloadQR'
-import { openStore } from '@/utils/migration.utils'
 import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
-import {
-    DOWNLOAD_PROMPT_SNOOZE_DAYS,
-    MIGRATION_CUTOVER_DATE,
-    MIGRATION_SURFACES,
-    STORE_NAME,
-} from '@/constants/migration.consts'
+import { DOWNLOAD_PROMPT_SNOOZE_DAYS, MIGRATION_SURFACES, STORE_NAME } from '@/constants/migration.consts'
+import { getMigrationCutoverTime, openStore } from '@/utils/migration.utils'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
 import { useUserStore } from '@/redux/hooks'
@@ -41,7 +36,7 @@ export default function MigrationDownloadModal({
     useEffect(() => {
         // sunset block owns post-cutover; every ineligible path clears state so
         // an already-shown modal disappears if the flag flips off mid-session
-        if (!migrationOn || !userId || isCapacitor() || Date.now() >= MIGRATION_CUTOVER_DATE.getTime()) {
+        if (!migrationOn || !userId || isCapacitor() || Date.now() >= getMigrationCutoverTime()) {
             setVisible(false)
             return
         }
@@ -64,7 +59,7 @@ export default function MigrationDownloadModal({
         posthog.capture(ANALYTICS_EVENTS.MODAL_DISMISSED, { modal_type: MODAL_TYPES.MIGRATION_DOWNLOAD })
     }
 
-    const daysLeft = Math.max(1, Math.ceil((MIGRATION_CUTOVER_DATE.getTime() - Date.now()) / (24 * 60 * 60 * 1000)))
+    const daysLeft = Math.max(1, Math.ceil((getMigrationCutoverTime() - Date.now()) / (24 * 60 * 60 * 1000)))
     const isDesktop = deviceType === DeviceType.WEB
     const store = deviceType === DeviceType.ANDROID ? 'android' : 'ios'
 

--- a/src/components/Migration/MigrationDownloadModal.tsx
+++ b/src/components/Migration/MigrationDownloadModal.tsx
@@ -39,10 +39,17 @@ export default function MigrationDownloadModal({
     const userId = user?.user.userId
 
     useEffect(() => {
-        if (!migrationOn || !userId || isCapacitor()) return
-        if (Date.now() >= MIGRATION_CUTOVER_DATE.getTime()) return // sunset block owns post-cutover
+        // sunset block owns post-cutover; every ineligible path clears state so
+        // an already-shown modal disappears if the flag flips off mid-session
+        if (!migrationOn || !userId || isCapacitor() || Date.now() >= MIGRATION_CUTOVER_DATE.getTime()) {
+            setVisible(false)
+            return
+        }
         const snoozedAt = getUserPreferences(userId)?.migrationPromptSnoozedAt
-        if (snoozedAt && Date.now() - new Date(snoozedAt).getTime() < SNOOZE_MS) return
+        if (snoozedAt && Date.now() - new Date(snoozedAt).getTime() < SNOOZE_MS) {
+            setVisible(false)
+            return
+        }
         setVisible(true)
         posthog.capture(ANALYTICS_EVENTS.MODAL_SHOWN, { modal_type: MODAL_TYPES.MIGRATION_DOWNLOAD })
     }, [migrationOn, userId])

--- a/src/components/Migration/MigrationHero.tsx
+++ b/src/components/Migration/MigrationHero.tsx
@@ -1,0 +1,35 @@
+import Image from 'next/image'
+import { twMerge } from 'tailwind-merge'
+import { PEANUTMAN_MOBILE } from '@/assets/mascot'
+import starImage from '@/assets/icons/star.png'
+
+const STARS = [
+    'left-[8%] top-[18%] size-8',
+    'right-[12%] top-[14%] size-9',
+    'right-[14%] bottom-[16%] size-7',
+    'left-[12%] bottom-[14%] size-7',
+] as const
+
+// periwinkle mascot hero shared by the sunset block and the /app smart link
+export default function MigrationHero({ className }: { className?: string }) {
+    return (
+        <section
+            className={twMerge(
+                'relative flex w-full items-center justify-center overflow-hidden bg-secondary-3 px-6',
+                className
+            )}
+            style={{ paddingTop: 'env(safe-area-inset-top)' }}
+        >
+            {STARS.map((pos) => (
+                <Image key={pos} src={starImage.src} alt="" width={38} height={38} className={`absolute z-10 ${pos}`} />
+            ))}
+            <Image
+                src={PEANUTMAN_MOBILE}
+                alt="Peanut"
+                width={200}
+                height={200}
+                className="z-0 h-44 w-auto object-contain md:h-56"
+            />
+        </section>
+    )
+}

--- a/src/components/Migration/ReviewPromptModal.tsx
+++ b/src/components/Migration/ReviewPromptModal.tsx
@@ -19,10 +19,11 @@ import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils
  * unhappy users never reach the store.
  *
  * ponytail: "good moment" V1 = user has at least one transaction and visits
- * home (shares the useTransactionHistory cache with HomeHistory, so the read
- * is free). Wiring the exact success screens is the upgrade path. Store-page
- * deep link for the rating; @capacitor-community/in-app-review for the native
- * sheet if conversion matters.
+ * home (same {mode:'latest', limit:50} query key useHomeCarouselCTAs already
+ * fetches there, so the read is free). Wiring the exact success screens is the
+ * upgrade path. Store-page deep link for the rating;
+ * @capacitor-community/in-app-review for the native sheet if conversion
+ * matters.
  */
 export default function ReviewPromptModal() {
     const t = useTranslations('migration')

--- a/src/components/Migration/ReviewPromptModal.tsx
+++ b/src/components/Migration/ReviewPromptModal.tsx
@@ -40,13 +40,15 @@ export default function ReviewPromptModal() {
         if (!migrationOn || !userId || !isCapacitor() || !hasTransacted) return
         if (getUserPreferences(userId)?.reviewPromptShownAt) return
         setVisible(true)
-        // stamp on show — ask once, ever
-        updateUserPreferences(userId, { reviewPromptShownAt: new Date().toISOString() })
         posthog.capture(ANALYTICS_EVENTS.MODAL_SHOWN, { modal_type: MODAL_TYPES.APP_REVIEW })
     }, [migrationOn, userId, hasTransacted])
 
     const close = (cta?: 'love' | 'meh') => {
         setVisible(false)
+        // stamp on interaction, not on show — home's priority wrapper can
+        // unmount a just-shown modal, and a show-time stamp would burn the
+        // once-ever ask before the user ever saw it
+        updateUserPreferences(userId, { reviewPromptShownAt: new Date().toISOString() })
         if (cta) {
             posthog.capture(ANALYTICS_EVENTS.MODAL_CTA_CLICKED, { modal_type: MODAL_TYPES.APP_REVIEW, cta })
         } else {

--- a/src/components/Migration/ReviewPromptModal.tsx
+++ b/src/components/Migration/ReviewPromptModal.tsx
@@ -1,0 +1,86 @@
+'use client'
+import { useEffect, useState } from 'react'
+import posthog from 'posthog-js'
+import { useTranslations } from 'next-intl'
+import ActionModal from '@/components/Global/ActionModal'
+import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
+import { REVIEW_URL } from '@/constants/migration.consts'
+import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
+import { useMigrationFlag } from '@/hooks/useMigrationFlag'
+import { useTransactionHistory } from '@/hooks/useTransactionHistory'
+import { useModalsContext } from '@/context/ModalsContext'
+import { useUserStore } from '@/redux/hooks'
+import { isCapacitor, openExternalUrl } from '@/utils/capacitor'
+import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils'
+
+/**
+ * "Loving Peanut so far?" pre-prompt (TASK-20598), native app only, asked once
+ * ever. Love it → store review page; Could be better → support drawer, so
+ * unhappy users never reach the store.
+ *
+ * ponytail: "good moment" V1 = user has at least one transaction and visits
+ * home (shares the useTransactionHistory cache with HomeHistory, so the read
+ * is free). Wiring the exact success screens is the upgrade path. Store-page
+ * deep link for the rating; @capacitor-community/in-app-review for the native
+ * sheet if conversion matters.
+ */
+export default function ReviewPromptModal() {
+    const t = useTranslations('migration')
+    const migrationOn = useMigrationFlag()
+    const { deviceType } = useDeviceType()
+    const { user } = useUserStore()
+    const { setIsSupportModalOpen } = useModalsContext()
+    const { data: latestHistory } = useTransactionHistory({ mode: 'latest', limit: 50 })
+    const [visible, setVisible] = useState(false)
+
+    const userId = user?.user.userId
+    const hasTransacted = (latestHistory?.entries.length ?? 0) > 0
+
+    useEffect(() => {
+        if (!migrationOn || !userId || !isCapacitor() || !hasTransacted) return
+        if (getUserPreferences(userId)?.reviewPromptShownAt) return
+        setVisible(true)
+        // stamp on show — ask once, ever
+        updateUserPreferences(userId, { reviewPromptShownAt: new Date().toISOString() })
+        posthog.capture(ANALYTICS_EVENTS.MODAL_SHOWN, { modal_type: MODAL_TYPES.APP_REVIEW })
+    }, [migrationOn, userId, hasTransacted])
+
+    const close = (cta?: 'love' | 'meh') => {
+        setVisible(false)
+        if (cta) {
+            posthog.capture(ANALYTICS_EVENTS.MODAL_CTA_CLICKED, { modal_type: MODAL_TYPES.APP_REVIEW, cta })
+        } else {
+            posthog.capture(ANALYTICS_EVENTS.MODAL_DISMISSED, { modal_type: MODAL_TYPES.APP_REVIEW })
+        }
+    }
+
+    return (
+        <ActionModal
+            visible={visible}
+            onClose={() => close()}
+            icon="star"
+            title={t('review.title')}
+            description={t('review.description')}
+            ctas={[
+                {
+                    text: t('review.loveIt'),
+                    variant: 'purple',
+                    shadowSize: '4',
+                    onClick: () => {
+                        close('love')
+                        void openExternalUrl(REVIEW_URL[deviceType === DeviceType.ANDROID ? 'android' : 'ios'])
+                    },
+                },
+                {
+                    text: t('review.meh'),
+                    variant: 'stroke',
+                    shadowSize: '4',
+                    onClick: () => {
+                        close('meh')
+                        setIsSupportModalOpen(true)
+                    },
+                },
+            ]}
+        />
+    )
+}

--- a/src/components/Migration/ReviewPromptModal.tsx
+++ b/src/components/Migration/ReviewPromptModal.tsx
@@ -30,7 +30,7 @@ export default function ReviewPromptModal() {
     const migrationOn = useMigrationFlag()
     const { deviceType } = useDeviceType()
     const { user } = useUserStore()
-    const { setIsSupportModalOpen } = useModalsContext()
+    const { openSupportWithMessage } = useModalsContext()
     const { data: latestHistory } = useTransactionHistory({ mode: 'latest', limit: 50 })
     const [visible, setVisible] = useState(false)
 
@@ -80,7 +80,8 @@ export default function ReviewPromptModal() {
                     shadowSize: '4',
                     onClick: () => {
                         close('meh')
-                        setIsSupportModalOpen(true)
+                        // prefilled so the drawer opens ready for feedback
+                        openSupportWithMessage(t('review.supportPrefill'))
                     },
                 },
             ]}

--- a/src/components/Migration/ScanToDownloadModal.tsx
+++ b/src/components/Migration/ScanToDownloadModal.tsx
@@ -23,7 +23,6 @@ export default function ScanToDownloadModal({
             icon="qr-code"
             title={t('qr.title')}
             content={<DownloadQR surface={surface} />}
-            ctas={[{ text: t('qr.done'), variant: 'purple', shadowSize: '4', onClick: onClose }]}
         />
     )
 }

--- a/src/components/Migration/ScanToDownloadModal.tsx
+++ b/src/components/Migration/ScanToDownloadModal.tsx
@@ -1,0 +1,30 @@
+'use client'
+import { useTranslations } from 'next-intl'
+import ActionModal from '@/components/Global/ActionModal'
+import DownloadQR from '@/components/Migration/DownloadQR'
+import type { MigrationSurface } from '@/constants/migration.consts'
+
+// desktop download surface: any download CTA on a laptop opens this QR
+// instead of a dead store link.
+export default function ScanToDownloadModal({
+    visible,
+    onClose,
+    surface,
+}: {
+    visible: boolean
+    onClose: () => void
+    surface: MigrationSurface
+}) {
+    const t = useTranslations('migration')
+    return (
+        <ActionModal
+            visible={visible}
+            onClose={onClose}
+            icon="qr-code"
+            title={t('qr.title')}
+            description={t('qr.description')}
+            content={<DownloadQR surface={surface} />}
+            ctas={[{ text: t('qr.done'), variant: 'purple', shadowSize: '4', onClick: onClose }]}
+        />
+    )
+}

--- a/src/components/Migration/ScanToDownloadModal.tsx
+++ b/src/components/Migration/ScanToDownloadModal.tsx
@@ -22,7 +22,6 @@ export default function ScanToDownloadModal({
             onClose={onClose}
             icon="qr-code"
             title={t('qr.title')}
-            description={t('qr.description')}
             content={<DownloadQR surface={surface} />}
             ctas={[{ text: t('qr.done'), variant: 'purple', shadowSize: '4', onClick: onClose }]}
         />

--- a/src/components/Migration/StoreBadges.tsx
+++ b/src/components/Migration/StoreBadges.tsx
@@ -1,15 +1,10 @@
 'use client'
-import { Icon } from '@/components/Global/Icons/Icon'
-import { STORE_NAME, STORE_URL, type MigrationSurface, type StoreKind } from '@/constants/migration.consts'
+import { Button } from '@/components/0_Bruddle/Button'
+import { STORE_NAME, STORE_URL, type MigrationSurface } from '@/constants/migration.consts'
 import { trackStoreClick } from '@/utils/migration.utils'
 
-// the classic app-store badge pair (black pills with brand marks) used under
-// download CTAs and QRs. english-only on purpose: real store badges are.
-const BADGE_SUB: Record<StoreKind, string> = {
-    ios: 'Download on the',
-    android: 'GET IT ON',
-}
-
+// compact store-button pair under download CTAs and QRs — same design
+// language as /app: purple primary for the App Store, stroke for Google Play.
 export default function StoreBadges({ surface }: { surface: MigrationSurface }) {
     return (
         <div className="flex items-center justify-center gap-3">
@@ -20,13 +15,16 @@ export default function StoreBadges({ surface }: { surface: MigrationSurface }) 
                     target="_blank"
                     rel="noopener noreferrer"
                     onClick={() => trackStoreClick(s, surface)}
-                    className="flex items-center gap-2 rounded-sm border border-n-1 bg-black px-3 py-1.5 text-white"
                 >
-                    <Icon name={s === 'ios' ? 'apple-logo' : 'google-play'} size={20} className="text-white" />
-                    <span className="flex flex-col text-left leading-tight">
-                        <span className="text-[9px] uppercase tracking-wide opacity-80">{BADGE_SUB[s]}</span>
-                        <span className="text-sm font-semibold">{STORE_NAME[s]}</span>
-                    </span>
+                    <Button
+                        variant={s === 'ios' ? 'purple' : 'stroke'}
+                        shadowSize="4"
+                        size="small"
+                        icon={s === 'ios' ? 'apple-logo' : 'google-play'}
+                        className="w-auto px-4"
+                    >
+                        {STORE_NAME[s]}
+                    </Button>
                 </a>
             ))}
         </div>

--- a/src/components/Migration/StoreBadges.tsx
+++ b/src/components/Migration/StoreBadges.tsx
@@ -3,9 +3,17 @@ import { Button } from '@/components/0_Bruddle/Button'
 import { STORE_NAME, STORE_URL, type MigrationSurface } from '@/constants/migration.consts'
 import { trackStoreClick } from '@/utils/migration.utils'
 
-// compact store-button pair under download CTAs and QRs — same design
-// language as /app: purple primary for the App Store, stroke for Google Play.
-export default function StoreBadges({ surface }: { surface: MigrationSurface }) {
+// store-button pair. compact: under download CTAs and QRs, same design
+// language as /app (purple App Store, stroke Google Play). hero: the landing
+// hero's desktop CTA row — two equal white buttons on the pink hero.
+export default function StoreBadges({
+    surface,
+    appearance = 'compact',
+}: {
+    surface: MigrationSurface
+    appearance?: 'compact' | 'hero'
+}) {
+    const isHero = appearance === 'hero'
     return (
         <div className="flex items-center justify-center gap-3">
             {(['ios', 'android'] as const).map((s) => (
@@ -17,11 +25,15 @@ export default function StoreBadges({ surface }: { surface: MigrationSurface }) 
                     onClick={() => trackStoreClick(s, surface)}
                 >
                     <Button
-                        variant={s === 'ios' ? 'purple' : 'stroke'}
+                        variant={isHero ? undefined : s === 'ios' ? 'purple' : 'stroke'}
                         shadowSize="4"
-                        size="small"
+                        size={isHero ? undefined : 'small'}
                         icon={s === 'ios' ? 'apple-logo' : 'google-play'}
-                        className="w-auto px-4"
+                        className={
+                            isHero
+                                ? 'w-52 bg-white px-6 py-3 text-base font-extrabold hover:bg-white/90 md:py-7 md:text-lg'
+                                : 'w-auto px-4'
+                        }
                     >
                         {STORE_NAME[s]}
                     </Button>

--- a/src/components/Migration/StoreBadges.tsx
+++ b/src/components/Migration/StoreBadges.tsx
@@ -1,0 +1,34 @@
+'use client'
+import { Icon } from '@/components/Global/Icons/Icon'
+import { STORE_NAME, STORE_URL, type MigrationSurface, type StoreKind } from '@/constants/migration.consts'
+import { trackStoreClick } from '@/utils/migration.utils'
+
+// the classic app-store badge pair (black pills with brand marks) used under
+// download CTAs and QRs. english-only on purpose: real store badges are.
+const BADGE_SUB: Record<StoreKind, string> = {
+    ios: 'Download on the',
+    android: 'GET IT ON',
+}
+
+export default function StoreBadges({ surface }: { surface: MigrationSurface }) {
+    return (
+        <div className="flex items-center justify-center gap-3">
+            {(['ios', 'android'] as const).map((s) => (
+                <a
+                    key={s}
+                    href={STORE_URL[s]}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={() => trackStoreClick(s, surface)}
+                    className="flex items-center gap-2 rounded-sm border border-n-1 bg-black px-3 py-1.5 text-white"
+                >
+                    <Icon name={s === 'ios' ? 'apple-logo' : 'google-play'} size={20} className="text-white" />
+                    <span className="flex flex-col text-left leading-tight">
+                        <span className="text-[9px] uppercase tracking-wide opacity-80">{BADGE_SUB[s]}</span>
+                        <span className="text-sm font-semibold">{STORE_NAME[s]}</span>
+                    </span>
+                </a>
+            ))}
+        </div>
+    )
+}

--- a/src/components/Migration/StoreButtons.tsx
+++ b/src/components/Migration/StoreButtons.tsx
@@ -11,7 +11,13 @@ export default function StoreButtons({ surface }: { surface: MigrationSurface })
     if (deviceType === DeviceType.WEB) return <DownloadQR surface={surface} />
     const store: StoreKind = deviceType === DeviceType.ANDROID ? 'android' : 'ios'
     return (
-        <Button variant="purple" shadowSize="4" className="w-full" onClick={() => openStore(store, surface)}>
+        <Button
+            variant="purple"
+            shadowSize="4"
+            icon={store === 'ios' ? 'apple-logo' : 'google-play'}
+            className="w-full"
+            onClick={() => openStore(store, surface)}
+        >
             {STORE_NAME[store]}
         </Button>
     )

--- a/src/components/Migration/StoreButtons.tsx
+++ b/src/components/Migration/StoreButtons.tsx
@@ -1,0 +1,18 @@
+'use client'
+import { Button } from '@/components/0_Bruddle/Button'
+import DownloadQR from '@/components/Migration/DownloadQR'
+import { STORE_NAME, type MigrationSurface, type StoreKind } from '@/constants/migration.consts'
+import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
+import { openStore } from '@/utils/migration.utils'
+
+// one primary CTA per device: the visitor's store on mobile, scan-to-download QR on desktop.
+export default function StoreButtons({ surface }: { surface: MigrationSurface }) {
+    const { deviceType } = useDeviceType()
+    if (deviceType === DeviceType.WEB) return <DownloadQR surface={surface} />
+    const store: StoreKind = deviceType === DeviceType.ANDROID ? 'android' : 'ios'
+    return (
+        <Button variant="purple" shadowSize="4" className="w-full" onClick={() => openStore(store, surface)}>
+            {STORE_NAME[store]}
+        </Button>
+    )
+}

--- a/src/components/Migration/SunsetScreen.tsx
+++ b/src/components/Migration/SunsetScreen.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 import Image from 'next/image'
 import posthog from 'posthog-js'
 import { useTranslations } from 'next-intl'
+import { Button } from '@/components/0_Bruddle/Button'
 import StoreButtons from '@/components/Migration/StoreButtons'
 import SupportDrawer from '@/components/Global/SupportDrawer'
 import { useModalsContext } from '@/context/ModalsContext'
@@ -54,12 +55,13 @@ export default function SunsetScreen() {
                     <p className="text-base text-grey-1">{t('sunset.sub')}</p>
                     <div className="mt-4 flex flex-col gap-4">
                         <StoreButtons surface={MIGRATION_SURFACES.SUNSET_SCREEN} />
-                        <button
-                            className="text-center text-sm text-black underline"
+                        <Button
+                            variant="transparent"
+                            className="h-6 text-sm font-normal text-black underline"
                             onClick={() => setIsSupportModalOpen(true)}
                         >
                             {t('sunset.supportLink')}
-                        </button>
+                        </Button>
                     </div>
                 </section>
             </div>

--- a/src/components/Migration/SunsetScreen.tsx
+++ b/src/components/Migration/SunsetScreen.tsx
@@ -29,9 +29,12 @@ export default function SunsetScreen() {
     }, [])
 
     return (
-        <div className="flex min-h-[100dvh] w-full flex-col bg-white">
+        // mobile: 50/50 vertical split, copy at the top of the lower half and
+        // the CTA pinned to the bottom. desktop (md+): 50/50 row, hero left,
+        // content centered right.
+        <div className="flex min-h-[100dvh] w-full flex-col bg-white md:flex-row">
             <section
-                className="relative flex h-72 w-full shrink-0 items-center justify-center overflow-hidden bg-secondary-3 px-6"
+                className="relative flex h-[50dvh] w-full items-center justify-center overflow-hidden bg-secondary-3 px-6 md:h-auto md:w-1/2"
                 style={{ paddingTop: 'env(safe-area-inset-top)' }}
             >
                 {STARS.map((pos) => (
@@ -49,13 +52,15 @@ export default function SunsetScreen() {
                     alt="Peanut"
                     width={200}
                     height={200}
-                    className="z-0 h-44 w-auto object-contain"
+                    className="z-0 h-44 w-auto object-contain md:h-56"
                 />
             </section>
-            <section className="mx-auto flex w-full max-w-md flex-1 flex-col gap-3 p-6">
-                <h1 className="text-3xl font-bold text-n-1">{t('sunset.heading')}</h1>
-                <p className="text-base text-grey-1">{t('sunset.sub')}</p>
-                <div className="mt-4 flex flex-col gap-4">
+            <section className="flex flex-1 flex-col justify-between p-6 pb-[calc(1.5rem_+_env(safe-area-inset-bottom))] md:w-1/2 md:justify-center md:gap-10">
+                <div className="mx-auto flex w-full max-w-md flex-col gap-3">
+                    <h1 className="text-3xl font-bold text-n-1">{t('sunset.heading')}</h1>
+                    <p className="text-base text-grey-1">{t('sunset.sub')}</p>
+                </div>
+                <div className="mx-auto flex w-full max-w-md flex-col gap-4">
                     <StoreButtons surface={MIGRATION_SURFACES.SUNSET_SCREEN} />
                     <Button
                         variant="transparent"

--- a/src/components/Migration/SunsetScreen.tsx
+++ b/src/components/Migration/SunsetScreen.tsx
@@ -1,0 +1,70 @@
+'use client'
+import { useEffect } from 'react'
+import Image from 'next/image'
+import posthog from 'posthog-js'
+import { useTranslations } from 'next-intl'
+import StoreButtons from '@/components/Migration/StoreButtons'
+import SupportDrawer from '@/components/Global/SupportDrawer'
+import { useModalsContext } from '@/context/ModalsContext'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { MIGRATION_SURFACES } from '@/constants/migration.consts'
+import { PEANUTMAN_MOBILE } from '@/assets/mascot'
+import starImage from '@/assets/icons/star.png'
+
+const STARS = ['left-[8%] top-[18%] size-8', 'right-[12%] top-[14%] size-9', 'right-[14%] bottom-[16%] size-7'] as const
+
+/**
+ * Full-screen block once the website is switched off (TASK-20827) — rendered
+ * by the mobile-ui layout instead of the app. Download is the only way
+ * forward; the support link covers people who can't install (keep-web
+ * bypass is handed out there).
+ */
+export default function SunsetScreen() {
+    const t = useTranslations('migration')
+    const { setIsSupportModalOpen } = useModalsContext()
+
+    useEffect(() => {
+        posthog.capture(ANALYTICS_EVENTS.MIGRATION_SUNSET_VIEWED)
+    }, [])
+
+    return (
+        <div className="flex min-h-[100dvh] w-full items-center justify-center bg-background p-6">
+            <div className="mx-auto flex w-full max-w-[380px] flex-col overflow-hidden rounded-sm border border-n-1 bg-white">
+                <section className="relative flex h-64 w-full items-center justify-center overflow-hidden bg-secondary-3 px-6">
+                    {STARS.map((pos) => (
+                        <Image
+                            key={pos}
+                            src={starImage.src}
+                            alt=""
+                            width={38}
+                            height={38}
+                            className={`absolute z-10 ${pos}`}
+                        />
+                    ))}
+                    <Image
+                        src={PEANUTMAN_MOBILE}
+                        alt="Peanut"
+                        width={200}
+                        height={200}
+                        className="z-0 h-40 w-auto object-contain"
+                    />
+                </section>
+                <section className="flex flex-col gap-3 bg-white p-6">
+                    <h1 className="text-3xl font-bold text-n-1">{t('sunset.heading')}</h1>
+                    <p className="text-base text-grey-1">{t('sunset.sub')}</p>
+                    <div className="mt-4 flex flex-col gap-4">
+                        <StoreButtons surface={MIGRATION_SURFACES.SUNSET_SCREEN} />
+                        <button
+                            className="text-center text-sm text-black underline"
+                            onClick={() => setIsSupportModalOpen(true)}
+                        >
+                            {t('sunset.supportLink')}
+                        </button>
+                    </div>
+                </section>
+            </div>
+            {/* the layout's SupportDrawer never mounts when this screen replaces it */}
+            <SupportDrawer />
+        </div>
+    )
+}

--- a/src/components/Migration/SunsetScreen.tsx
+++ b/src/components/Migration/SunsetScreen.tsx
@@ -1,23 +1,14 @@
 'use client'
 import { useEffect } from 'react'
-import Image from 'next/image'
 import posthog from 'posthog-js'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/0_Bruddle/Button'
+import MigrationHero from '@/components/Migration/MigrationHero'
 import StoreButtons from '@/components/Migration/StoreButtons'
 import SupportDrawer from '@/components/Global/SupportDrawer'
 import { useModalsContext } from '@/context/ModalsContext'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { MIGRATION_SURFACES } from '@/constants/migration.consts'
-import { PEANUTMAN_MOBILE } from '@/assets/mascot'
-import starImage from '@/assets/icons/star.png'
-
-const STARS = [
-    'left-[8%] top-[18%] size-8',
-    'right-[12%] top-[14%] size-9',
-    'right-[14%] bottom-[16%] size-7',
-    'left-[12%] bottom-[14%] size-7',
-] as const
 
 /**
  * Full-screen block once the website is switched off (TASK-20827) — rendered
@@ -38,30 +29,10 @@ export default function SunsetScreen() {
         // the CTA pinned to the bottom. desktop (md+): 50/50 row, hero left,
         // content centered right.
         <div className="flex min-h-[100dvh] w-full flex-col bg-white md:flex-row">
-            <section
-                className="relative flex h-[50dvh] w-full items-center justify-center overflow-hidden bg-secondary-3 px-6 md:h-auto md:w-1/2"
-                style={{ paddingTop: 'env(safe-area-inset-top)' }}
-            >
-                {STARS.map((pos) => (
-                    <Image
-                        key={pos}
-                        src={starImage.src}
-                        alt=""
-                        width={38}
-                        height={38}
-                        className={`absolute z-10 ${pos}`}
-                    />
-                ))}
-                <Image
-                    src={PEANUTMAN_MOBILE}
-                    alt="Peanut"
-                    width={200}
-                    height={200}
-                    className="z-0 h-44 w-auto object-contain md:h-56"
-                />
-            </section>
+            <MigrationHero className="h-[50dvh] md:h-auto md:w-1/2" />
             <section className="flex flex-1 flex-col justify-between p-6 pb-[calc(1.5rem_+_env(safe-area-inset-bottom))] md:w-1/2 md:justify-center md:gap-10">
-                <div className="mx-auto flex w-full max-w-md flex-col gap-3">
+                {/* centered on desktop to match the centered store CTA below */}
+                <div className="mx-auto flex w-full max-w-md flex-col gap-3 md:text-center">
                     <h1 className="text-3xl font-bold text-n-1">{t('sunset.heading')}</h1>
                     <p className="text-base text-grey-1">{t('sunset.sub')}</p>
                 </div>

--- a/src/components/Migration/SunsetScreen.tsx
+++ b/src/components/Migration/SunsetScreen.tsx
@@ -29,42 +29,43 @@ export default function SunsetScreen() {
     }, [])
 
     return (
-        <div className="flex min-h-[100dvh] w-full items-center justify-center bg-background p-6">
-            <div className="mx-auto flex w-full max-w-[380px] flex-col overflow-hidden rounded-sm border border-n-1 bg-white">
-                <section className="relative flex h-64 w-full items-center justify-center overflow-hidden bg-secondary-3 px-6">
-                    {STARS.map((pos) => (
-                        <Image
-                            key={pos}
-                            src={starImage.src}
-                            alt=""
-                            width={38}
-                            height={38}
-                            className={`absolute z-10 ${pos}`}
-                        />
-                    ))}
+        <div className="flex min-h-[100dvh] w-full flex-col bg-white">
+            <section
+                className="relative flex h-72 w-full shrink-0 items-center justify-center overflow-hidden bg-secondary-3 px-6"
+                style={{ paddingTop: 'env(safe-area-inset-top)' }}
+            >
+                {STARS.map((pos) => (
                     <Image
-                        src={PEANUTMAN_MOBILE}
-                        alt="Peanut"
-                        width={200}
-                        height={200}
-                        className="z-0 h-40 w-auto object-contain"
+                        key={pos}
+                        src={starImage.src}
+                        alt=""
+                        width={38}
+                        height={38}
+                        className={`absolute z-10 ${pos}`}
                     />
-                </section>
-                <section className="flex flex-col gap-3 bg-white p-6">
-                    <h1 className="text-3xl font-bold text-n-1">{t('sunset.heading')}</h1>
-                    <p className="text-base text-grey-1">{t('sunset.sub')}</p>
-                    <div className="mt-4 flex flex-col gap-4">
-                        <StoreButtons surface={MIGRATION_SURFACES.SUNSET_SCREEN} />
-                        <Button
-                            variant="transparent"
-                            className="h-6 text-sm font-normal text-black underline"
-                            onClick={() => setIsSupportModalOpen(true)}
-                        >
-                            {t('sunset.supportLink')}
-                        </Button>
-                    </div>
-                </section>
-            </div>
+                ))}
+                <Image
+                    src={PEANUTMAN_MOBILE}
+                    alt="Peanut"
+                    width={200}
+                    height={200}
+                    className="z-0 h-44 w-auto object-contain"
+                />
+            </section>
+            <section className="mx-auto flex w-full max-w-md flex-1 flex-col gap-3 p-6">
+                <h1 className="text-3xl font-bold text-n-1">{t('sunset.heading')}</h1>
+                <p className="text-base text-grey-1">{t('sunset.sub')}</p>
+                <div className="mt-4 flex flex-col gap-4">
+                    <StoreButtons surface={MIGRATION_SURFACES.SUNSET_SCREEN} />
+                    <Button
+                        variant="transparent"
+                        className="h-6 text-sm font-normal text-black underline"
+                        onClick={() => setIsSupportModalOpen(true)}
+                    >
+                        {t('sunset.supportLink')}
+                    </Button>
+                </div>
+            </section>
             {/* the layout's SupportDrawer never mounts when this screen replaces it */}
             <SupportDrawer />
         </div>

--- a/src/components/Migration/SunsetScreen.tsx
+++ b/src/components/Migration/SunsetScreen.tsx
@@ -12,7 +12,12 @@ import { MIGRATION_SURFACES } from '@/constants/migration.consts'
 import { PEANUTMAN_MOBILE } from '@/assets/mascot'
 import starImage from '@/assets/icons/star.png'
 
-const STARS = ['left-[8%] top-[18%] size-8', 'right-[12%] top-[14%] size-9', 'right-[14%] bottom-[16%] size-7'] as const
+const STARS = [
+    'left-[8%] top-[18%] size-8',
+    'right-[12%] top-[14%] size-9',
+    'right-[14%] bottom-[16%] size-7',
+    'left-[12%] bottom-[14%] size-7',
+] as const
 
 /**
  * Full-screen block once the website is switched off (TASK-20827) — rendered

--- a/src/components/Migration/__tests__/MigrationDownloadModal.test.tsx
+++ b/src/components/Migration/__tests__/MigrationDownloadModal.test.tsx
@@ -44,11 +44,15 @@ jest.mock('posthog-js', () => ({ capture: jest.fn() }))
 
 jest.mock('@/components/Global/ActionModal', () => ({
     __esModule: true,
-    default: (props: { visible: boolean; title?: string; footer?: React.ReactNode }) =>
+    default: (props: { visible: boolean; title?: string; ctas?: { text: string; onClick?: () => void }[] }) =>
         props.visible ? (
             <div data-testid="modal">
                 <h3>{props.title}</h3>
-                {props.footer}
+                {props.ctas?.map((c) => (
+                    <button key={c.text} onClick={c.onClick}>
+                        {c.text}
+                    </button>
+                ))}
             </div>
         ) : null,
 }))

--- a/src/components/Migration/__tests__/MigrationDownloadModal.test.tsx
+++ b/src/components/Migration/__tests__/MigrationDownloadModal.test.tsx
@@ -9,9 +9,14 @@
 import React from 'react'
 import { render as rtlRender, screen, fireEvent } from '@testing-library/react'
 import { IntlWrapper } from '@/test-utils/intl'
-import { MIGRATION_CUTOVER_DATE } from '@/constants/migration.consts'
+import { DOWNLOAD_PROMPT_SNOOZE_DAYS, MIGRATION_CUTOVER_DATE } from '@/constants/migration.consts'
 
 const render = (ui: Parameters<typeof rtlRender>[0]) => rtlRender(ui, { wrapper: IntlWrapper })
+
+// freeze "now" 30 days before the cutover so the notice-window cases don't
+// start failing once the real calendar passes MIGRATION_CUTOVER_DATE
+const DAY_MS = 24 * 60 * 60 * 1000
+const FROZEN_NOW = MIGRATION_CUTOVER_DATE.getTime() - 30 * DAY_MS
 
 let mockFlagOn = false
 jest.mock('@/hooks/useMigrationFlag', () => ({
@@ -50,11 +55,16 @@ jest.mock('@/components/Global/ActionModal', () => ({
 
 import MigrationDownloadModal from '../MigrationDownloadModal'
 
+let nowSpy: jest.SpyInstance<number, []>
 beforeEach(() => {
     jest.clearAllMocks()
     mockFlagOn = false
     mockIsCapacitor = false
     mockGetPrefs.mockReturnValue(undefined)
+    nowSpy = jest.spyOn(Date, 'now').mockReturnValue(FROZEN_NOW)
+})
+afterEach(() => {
+    nowSpy.mockRestore()
 })
 
 describe('MigrationDownloadModal', () => {
@@ -78,24 +88,22 @@ describe('MigrationDownloadModal', () => {
 
     it('stays hidden while a recent snooze is active, reappears after it expires', () => {
         mockFlagOn = true
-        mockGetPrefs.mockReturnValue({ migrationPromptSnoozedAt: new Date().toISOString() })
+        mockGetPrefs.mockReturnValue({ migrationPromptSnoozedAt: new Date(FROZEN_NOW).toISOString() })
         const { unmount } = render(<MigrationDownloadModal />)
         expect(screen.queryByTestId('modal')).not.toBeInTheDocument()
         unmount()
 
-        const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString()
-        mockGetPrefs.mockReturnValue({ migrationPromptSnoozedAt: tenDaysAgo })
+        const justExpired = new Date(FROZEN_NOW - (DOWNLOAD_PROMPT_SNOOZE_DAYS + 1) * DAY_MS).toISOString()
+        mockGetPrefs.mockReturnValue({ migrationPromptSnoozedAt: justExpired })
         render(<MigrationDownloadModal />)
         expect(screen.getByTestId('modal')).toBeInTheDocument()
     })
 
     it('stays hidden past the cutover (the sunset block owns that state)', () => {
         mockFlagOn = true
-        const afterCutover = MIGRATION_CUTOVER_DATE.getTime() + 1000
-        const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(afterCutover)
+        nowSpy.mockReturnValue(MIGRATION_CUTOVER_DATE.getTime() + 1000)
         render(<MigrationDownloadModal />)
         expect(screen.queryByTestId('modal')).not.toBeInTheDocument()
-        nowSpy.mockRestore()
     })
 
     it('remind-me-later snoozes and reports visibility', () => {

--- a/src/components/Migration/__tests__/MigrationDownloadModal.test.tsx
+++ b/src/components/Migration/__tests__/MigrationDownloadModal.test.tsx
@@ -1,0 +1,114 @@
+/** @jest-environment jsdom */
+/**
+ * MigrationDownloadModal — the pwa-sunset "Peanut is becoming an app" prompt.
+ *
+ * Gating contract: flag ON + logged-in web user + before the cutover + snooze
+ * expired. Flag OFF (today's default) must render nothing — the key
+ * flag-off-regression check for the migration PR.
+ */
+import React from 'react'
+import { render as rtlRender, screen, fireEvent } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
+import { MIGRATION_CUTOVER_DATE } from '@/constants/migration.consts'
+
+const render = (ui: Parameters<typeof rtlRender>[0]) => rtlRender(ui, { wrapper: IntlWrapper })
+
+let mockFlagOn = false
+jest.mock('@/hooks/useMigrationFlag', () => ({
+    useMigrationFlag: () => mockFlagOn,
+}))
+
+let mockIsCapacitor = false
+jest.mock('@/utils/capacitor', () => ({
+    isCapacitor: () => mockIsCapacitor,
+    openExternalUrl: jest.fn(),
+}))
+
+jest.mock('@/redux/hooks', () => ({
+    useUserStore: () => ({ user: { user: { userId: 'user-1' } } }),
+}))
+
+const mockGetPrefs = jest.fn()
+const mockUpdatePrefs = jest.fn()
+jest.mock('@/utils/general.utils', () => ({
+    getUserPreferences: (...args: unknown[]) => mockGetPrefs(...args),
+    updateUserPreferences: (...args: unknown[]) => mockUpdatePrefs(...args),
+}))
+
+jest.mock('posthog-js', () => ({ capture: jest.fn() }))
+
+jest.mock('@/components/Global/ActionModal', () => ({
+    __esModule: true,
+    default: (props: { visible: boolean; title?: string; footer?: React.ReactNode }) =>
+        props.visible ? (
+            <div data-testid="modal">
+                <h3>{props.title}</h3>
+                {props.footer}
+            </div>
+        ) : null,
+}))
+
+import MigrationDownloadModal from '../MigrationDownloadModal'
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    mockFlagOn = false
+    mockIsCapacitor = false
+    mockGetPrefs.mockReturnValue(undefined)
+})
+
+describe('MigrationDownloadModal', () => {
+    it('renders nothing while the pwa-sunset flag is off', () => {
+        render(<MigrationDownloadModal />)
+        expect(screen.queryByTestId('modal')).not.toBeInTheDocument()
+    })
+
+    it('shows for a logged-in web user during the notice window', () => {
+        mockFlagOn = true
+        render(<MigrationDownloadModal />)
+        expect(screen.getByTestId('modal')).toBeInTheDocument()
+    })
+
+    it('stays hidden inside the native app', () => {
+        mockFlagOn = true
+        mockIsCapacitor = true
+        render(<MigrationDownloadModal />)
+        expect(screen.queryByTestId('modal')).not.toBeInTheDocument()
+    })
+
+    it('stays hidden while a recent snooze is active, reappears after it expires', () => {
+        mockFlagOn = true
+        mockGetPrefs.mockReturnValue({ migrationPromptSnoozedAt: new Date().toISOString() })
+        const { unmount } = render(<MigrationDownloadModal />)
+        expect(screen.queryByTestId('modal')).not.toBeInTheDocument()
+        unmount()
+
+        const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString()
+        mockGetPrefs.mockReturnValue({ migrationPromptSnoozedAt: tenDaysAgo })
+        render(<MigrationDownloadModal />)
+        expect(screen.getByTestId('modal')).toBeInTheDocument()
+    })
+
+    it('stays hidden past the cutover (the sunset block owns that state)', () => {
+        mockFlagOn = true
+        const afterCutover = MIGRATION_CUTOVER_DATE.getTime() + 1000
+        const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(afterCutover)
+        render(<MigrationDownloadModal />)
+        expect(screen.queryByTestId('modal')).not.toBeInTheDocument()
+        nowSpy.mockRestore()
+    })
+
+    it('remind-me-later snoozes and reports visibility', () => {
+        mockFlagOn = true
+        const onVisibilityChange = jest.fn()
+        render(<MigrationDownloadModal onVisibilityChange={onVisibilityChange} />)
+        expect(onVisibilityChange).toHaveBeenLastCalledWith(true)
+
+        fireEvent.click(screen.getByRole('button'))
+        expect(screen.queryByTestId('modal')).not.toBeInTheDocument()
+        expect(mockUpdatePrefs).toHaveBeenCalledWith('user-1', {
+            migrationPromptSnoozedAt: expect.any(String),
+        })
+        expect(onVisibilityChange).toHaveBeenLastCalledWith(false)
+    })
+})

--- a/src/components/Notifications/SetupNotificationsModal.tsx
+++ b/src/components/Notifications/SetupNotificationsModal.tsx
@@ -4,9 +4,13 @@ import ActionModal from '../Global/ActionModal'
 import posthog from 'posthog-js'
 import { useTranslations } from 'next-intl'
 import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
+import { useMigrationFlag } from '@/hooks/useMigrationFlag'
 
 export default function SetupNotificationsModal() {
     const t = useTranslations('notifications')
+    // migration-era copy ("Get money alerts") only ships when the pwa-sunset
+    // flag is on — flag off keeps today's prompt byte-for-byte (TASK-20771)
+    const migrationOn = useMigrationFlag()
     const {
         showPermissionModal,
         requestPermission,
@@ -46,8 +50,8 @@ export default function SetupNotificationsModal() {
                 visible={showPermissionModal}
                 onClose={handleCloseNotifsSetupModal}
                 modalPanelClassName="m-0 max-w-[90%]"
-                title={t('setupTitle')}
-                description={t('setupDescription')}
+                title={t(migrationOn ? 'migrationSetupTitle' : 'setupTitle')}
+                description={t(migrationOn ? 'migrationSetupDescription' : 'setupDescription')}
                 icon="bell"
                 ctaClassName="md:flex-col gap-4"
                 ctas={[

--- a/src/components/Setup/Views/Landing.tsx
+++ b/src/components/Setup/Views/Landing.tsx
@@ -14,6 +14,7 @@ import DocsLink from '@/components/Global/DocsLink'
 import { useTranslations } from 'next-intl'
 import StoreButtons from '@/components/Migration/StoreButtons'
 import { MIGRATION_SURFACES } from '@/constants/migration.consts'
+import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { useKeepWebBypass } from '@/hooks/useKeepWebBypass'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
 import { isCapacitor } from '@/utils/capacitor'
@@ -23,6 +24,7 @@ const LandingStep = () => {
     const tMigration = useTranslations('migration')
     const migrationOn = useMigrationFlag()
     const hasKeepWebBypass = useKeepWebBypass()
+    const { deviceType } = useDeviceType()
 
     // migration notice window on web (any device): NEW signups are closed —
     // don't onboard users into a product that shuts in weeks; the app is the
@@ -60,7 +62,11 @@ const LandingStep = () => {
             <Card.Content className="space-y-4 p-0 pt-4">
                 {blockSignup ? (
                     <div className="space-y-2 pb-2">
-                        <p className="text-center text-sm font-semibold text-n-1">{tMigration('banner.title')}</p>
+                        {/* heading only above the desktop QR — a lone store button
+                            explains itself */}
+                        {deviceType === DeviceType.WEB && (
+                            <p className="text-center text-sm font-semibold text-n-1">{tMigration('banner.title')}</p>
+                        )}
                         <StoreButtons surface={MIGRATION_SURFACES.SETUP} />
                     </div>
                 ) : (

--- a/src/components/Setup/Views/Landing.tsx
+++ b/src/components/Setup/Views/Landing.tsx
@@ -12,24 +12,23 @@ import { useEffect } from 'react'
 import { disableDemoMode } from '@/utils/demo'
 import DocsLink from '@/components/Global/DocsLink'
 import { useTranslations } from 'next-intl'
-import DownloadQR from '@/components/Migration/DownloadQR'
 import StoreButtons from '@/components/Migration/StoreButtons'
 import { MIGRATION_SURFACES } from '@/constants/migration.consts'
-import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { useKeepWebBypass } from '@/hooks/useKeepWebBypass'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
+import { isCapacitor } from '@/utils/capacitor'
 
 const LandingStep = () => {
     const t = useTranslations('setup')
     const tMigration = useTranslations('migration')
     const migrationOn = useMigrationFlag()
-    const { deviceType } = useDeviceType()
     const hasKeepWebBypass = useKeepWebBypass()
 
-    // migration window, desktop, no support bypass: the app is the product —
-    // web signup/login is closed, download is the only path. the keep-web
-    // link support hands out restores the normal auth screen.
-    const downloadOnly = migrationOn && deviceType === DeviceType.WEB && !hasKeepWebBypass
+    // migration notice window on web (any device): NEW signups are closed —
+    // don't onboard users into a product that shuts in weeks; the app is the
+    // path. Existing users keep Log In until the cutover. Native app and
+    // keep-web bypass users see the normal card.
+    const blockSignup = migrationOn && !isCapacitor() && !hasKeepWebBypass
     const { handleNext } = useSetupFlow()
     const { handleLoginClick, isLoggingIn } = useLogin()
     const toast = useToast()
@@ -56,30 +55,26 @@ const LandingStep = () => {
         }
     }
 
-    if (downloadOnly) {
-        return (
-            <Card className="border-0">
-                <Card.Content className="space-y-4 p-0 pt-4">
-                    <p className="text-center text-sm font-semibold text-n-1">{tMigration('banner.title')}</p>
-                    <DownloadQR surface={MIGRATION_SURFACES.SETUP} />
-                </Card.Content>
-            </Card>
-        )
-    }
-
     return (
         <Card className="border-0">
             <Card.Content className="space-y-4 p-0 pt-4">
-                <Button
-                    shadowSize="4"
-                    className="h-11"
-                    onClick={() => {
-                        posthog.capture(ANALYTICS_EVENTS.SIGNUP_CLICKED)
-                        handleNext()
-                    }}
-                >
-                    {t('landing.signUp')}
-                </Button>
+                {blockSignup ? (
+                    <div className="space-y-2 pb-2">
+                        <p className="text-center text-sm font-semibold text-n-1">{tMigration('banner.title')}</p>
+                        <StoreButtons surface={MIGRATION_SURFACES.SETUP} />
+                    </div>
+                ) : (
+                    <Button
+                        shadowSize="4"
+                        className="h-11"
+                        onClick={() => {
+                            posthog.capture(ANALYTICS_EVENTS.SIGNUP_CLICKED)
+                            handleNext()
+                        }}
+                    >
+                        {t('landing.signUp')}
+                    </Button>
+                )}
                 <Button
                     loading={isLoggingIn}
                     shadowSize="4"
@@ -98,15 +93,6 @@ const LandingStep = () => {
                         {t('landing.recoverWallet')}
                     </DocsLink>
                 </div>
-                {/* pwa-sunset notice window on mobile: signup stays open, but the
-                    store is offered up front (TASK-20600). bypass users came to
-                    keep using the web — don't push the app at them. */}
-                {migrationOn && deviceType !== DeviceType.WEB && !hasKeepWebBypass && (
-                    <div className="space-y-2 border-t border-n-1/15 pt-4">
-                        <p className="text-center text-sm font-semibold text-n-1">{tMigration('banner.title')}</p>
-                        <StoreButtons surface={MIGRATION_SURFACES.SETUP} />
-                    </div>
-                )}
             </Card.Content>
         </Card>
     )

--- a/src/components/Setup/Views/Landing.tsx
+++ b/src/components/Setup/Views/Landing.tsx
@@ -12,9 +12,14 @@ import { useEffect } from 'react'
 import { disableDemoMode } from '@/utils/demo'
 import DocsLink from '@/components/Global/DocsLink'
 import { useTranslations } from 'next-intl'
+import StoreButtons from '@/components/Migration/StoreButtons'
+import { MIGRATION_SURFACES } from '@/constants/migration.consts'
+import { useMigrationFlag } from '@/hooks/useMigrationFlag'
 
 const LandingStep = () => {
     const t = useTranslations('setup')
+    const tMigration = useTranslations('migration')
+    const migrationOn = useMigrationFlag()
     const { handleNext } = useSetupFlow()
     const { handleLoginClick, isLoggingIn } = useLogin()
     const toast = useToast()
@@ -72,6 +77,14 @@ const LandingStep = () => {
                         {t('landing.recoverWallet')}
                     </DocsLink>
                 </div>
+                {/* pwa-sunset notice window: the app replaces the PWA — offer the
+                    store up front (TASK-20600) */}
+                {migrationOn && (
+                    <div className="space-y-2 border-t border-n-1/15 pt-4">
+                        <p className="text-center text-sm font-semibold text-n-1">{tMigration('banner.title')}</p>
+                        <StoreButtons surface={MIGRATION_SURFACES.SETUP} />
+                    </div>
+                )}
             </Card.Content>
         </Card>
     )

--- a/src/components/Setup/Views/Landing.tsx
+++ b/src/components/Setup/Views/Landing.tsx
@@ -12,14 +12,24 @@ import { useEffect } from 'react'
 import { disableDemoMode } from '@/utils/demo'
 import DocsLink from '@/components/Global/DocsLink'
 import { useTranslations } from 'next-intl'
+import DownloadQR from '@/components/Migration/DownloadQR'
 import StoreButtons from '@/components/Migration/StoreButtons'
 import { MIGRATION_SURFACES } from '@/constants/migration.consts'
+import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
+import { useKeepWebBypass } from '@/hooks/useKeepWebBypass'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
 
 const LandingStep = () => {
     const t = useTranslations('setup')
     const tMigration = useTranslations('migration')
     const migrationOn = useMigrationFlag()
+    const { deviceType } = useDeviceType()
+    const hasKeepWebBypass = useKeepWebBypass()
+
+    // migration window, desktop, no support bypass: the app is the product —
+    // web signup/login is closed, download is the only path. the keep-web
+    // link support hands out restores the normal auth screen.
+    const downloadOnly = migrationOn && deviceType === DeviceType.WEB && !hasKeepWebBypass
     const { handleNext } = useSetupFlow()
     const { handleLoginClick, isLoggingIn } = useLogin()
     const toast = useToast()
@@ -44,6 +54,17 @@ const LandingStep = () => {
         } catch (e) {
             handleError(e)
         }
+    }
+
+    if (downloadOnly) {
+        return (
+            <Card className="border-0">
+                <Card.Content className="space-y-4 p-0 pt-4">
+                    <p className="text-center text-sm font-semibold text-n-1">{tMigration('banner.title')}</p>
+                    <DownloadQR surface={MIGRATION_SURFACES.SETUP} />
+                </Card.Content>
+            </Card>
+        )
     }
 
     return (
@@ -77,9 +98,10 @@ const LandingStep = () => {
                         {t('landing.recoverWallet')}
                     </DocsLink>
                 </div>
-                {/* pwa-sunset notice window: the app replaces the PWA — offer the
-                    store up front (TASK-20600) */}
-                {migrationOn && (
+                {/* pwa-sunset notice window on mobile: signup stays open, but the
+                    store is offered up front (TASK-20600). bypass users came to
+                    keep using the web — don't push the app at them. */}
+                {migrationOn && deviceType !== DeviceType.WEB && !hasKeepWebBypass && (
                     <div className="space-y-2 border-t border-n-1/15 pt-4">
                         <p className="text-center text-sm font-semibold text-n-1">{tMigration('banner.title')}</p>
                         <StoreButtons surface={MIGRATION_SURFACES.SETUP} />

--- a/src/components/Setup/components/SetupWrapper.tsx
+++ b/src/components/Setup/components/SetupWrapper.tsx
@@ -6,6 +6,9 @@ import { type BeforeInstallPromptEvent, type LayoutType, type ScreenId } from '@
 import InstallPWA from '@/components/Setup/Views/InstallPWA'
 import { useBravePWAInstallState } from '@/hooks/useBravePWAInstallState'
 import { DeviceType } from '@/hooks/useGetDeviceType'
+import { useKeepWebBypass } from '@/hooks/useKeepWebBypass'
+import { useMigrationFlag } from '@/hooks/useMigrationFlag'
+import { isCapacitor } from '@/utils/capacitor'
 import classNames from 'classnames'
 import { motion, useReducedMotion } from 'framer-motion'
 import { useTranslations } from 'next-intl'
@@ -218,6 +221,12 @@ export const SetupWrapper = memo(function SetupWrapper({
     const { isBrave } = useBravePWAInstallState()
     const [showBraveSuccessMessage, setShowBraveSuccessMessage] = useState(false)
     const prefersReducedMotion = useReducedMotion()
+    const migrationOn = useMigrationFlag()
+    const hasKeepWebBypass = useKeepWebBypass()
+    // migration notice window's download-only landing: drop the fixed-height
+    // title block (it left a big gap above the QR) and center the copy on
+    // desktop to match the centered store content. legacy landing untouched.
+    const sunsetLanding = screenId === 'landing' && migrationOn && !isCapacitor() && !hasKeepWebBypass
 
     // Slide the white panel up on first paint for a native bottom-sheet feel.
     // Mobile + landing only; read synchronously so the offset is correct on mount.
@@ -274,20 +283,31 @@ export const SetupWrapper = memo(function SetupWrapper({
                     <div
                         className={twMerge(
                             'mx-auto h-full w-full space-y-4 md:max-h-48 md:max-w-xs',
-                            (screenId === 'signup' || screenId == 'join-beta') && 'md:max-h-12'
+                            (screenId === 'signup' || screenId == 'join-beta') && 'md:max-h-12',
+                            sunsetLanding && 'md:h-auto md:max-h-none'
                         )}
                     >
                         {headingTitle && (
                             <h1
                                 className={twMerge(
                                     'w-full text-left text-xl font-extrabold leading-tight',
+                                    sunsetLanding && 'md:text-center',
                                     titleClassName
                                 )}
                             >
                                 {headingTitle}
                             </h1>
                         )}
-                        {headingDescription && <p className="text-base font-medium text-black">{headingDescription}</p>}
+                        {headingDescription && (
+                            <p
+                                className={twMerge(
+                                    'text-base font-medium text-black',
+                                    sunsetLanding && 'md:text-center'
+                                )}
+                            >
+                                {headingDescription}
+                            </p>
+                        )}
                     </div>
                     {/* main content area */}
                     <div className="mx-auto w-full md:max-w-xs">

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -270,6 +270,15 @@ export const ANALYTICS_EVENTS = {
     DELETE_ACCOUNT_INITIATED: 'delete_account_initiated',
     DELETE_ACCOUNT_CONFIRMED: 'delete_account_confirmed',
     DELETE_ACCOUNT_FAILED: 'delete_account_failed',
+
+    // ── PWA sunset / app migration ──
+    // Funnel: modal_shown(migration_download) → store_cta_clicked / qr_shown
+    // → install (first native-platform event per distinct id, PostHog-side).
+    // `surface` ∈ MIGRATION_SURFACES, `store` ∈ 'ios' | 'android'.
+    MIGRATION_SUNSET_VIEWED: 'migration_sunset_viewed',
+    MIGRATION_STORE_CTA_CLICKED: 'migration_store_cta_clicked',
+    MIGRATION_QR_SHOWN: 'migration_qr_shown',
+    MIGRATION_KEEP_WEB_USED: 'migration_keep_web_used',
 } as const
 
 /**
@@ -283,6 +292,8 @@ export const MODAL_TYPES = {
     CARD_PIONEER: 'card_pioneer',
     KYC_COMPLETED: 'kyc_completed',
     INVITE: 'invite',
+    MIGRATION_DOWNLOAD: 'migration_download',
+    APP_REVIEW: 'app_review',
 } as const
 
 /**

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -278,6 +278,9 @@ export const ANALYTICS_EVENTS = {
     // `store` ∈ 'ios' | 'android'. qr_shown fires once per QR display (the
     // smart QR serves both stores, so it has no store dimension).
     MIGRATION_SUNSET_VIEWED: 'migration_sunset_viewed',
+    // guest Join/Continue-with-Peanut CTA rendered to a logged-out web
+    // visitor during the window — the impression leg of the guest funnel
+    MIGRATION_GUEST_CTA_SHOWN: 'migration_guest_cta_shown',
     MIGRATION_STORE_CTA_CLICKED: 'migration_store_cta_clicked',
     MIGRATION_QR_SHOWN: 'migration_qr_shown',
     MIGRATION_KEEP_WEB_USED: 'migration_keep_web_used',

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -274,7 +274,9 @@ export const ANALYTICS_EVENTS = {
     // ── PWA sunset / app migration ──
     // Funnel: modal_shown(migration_download) → store_cta_clicked / qr_shown
     // → install (first native-platform event per distinct id, PostHog-side).
-    // `surface` ∈ MIGRATION_SURFACES, `store` ∈ 'ios' | 'android'.
+    // `surface` ∈ MIGRATION_SURFACES; store_cta_clicked also carries
+    // `store` ∈ 'ios' | 'android'. qr_shown fires once per QR display (the
+    // smart QR serves both stores, so it has no store dimension).
     MIGRATION_SUNSET_VIEWED: 'migration_sunset_viewed',
     MIGRATION_STORE_CTA_CLICKED: 'migration_store_cta_clicked',
     MIGRATION_QR_SHOWN: 'migration_qr_shown',

--- a/src/constants/migration.consts.ts
+++ b/src/constants/migration.consts.ts
@@ -59,6 +59,7 @@ export const MIGRATION_SURFACES = {
     LANDING_HERO: 'landing_hero',
     HOME_BANNER: 'home_banner',
     SETUP: 'setup',
+    GUEST_FLOW: 'guest_flow',
 } as const
 
 export type MigrationSurface = (typeof MIGRATION_SURFACES)[keyof typeof MIGRATION_SURFACES]

--- a/src/constants/migration.consts.ts
+++ b/src/constants/migration.consts.ts
@@ -1,0 +1,50 @@
+/**
+ * PWA → native app migration (pwa-sunset).
+ *
+ * Everything here is dark until the `pwa-sunset` PostHog flag is flipped ON
+ * (no deploy needed). Flag ON starts the notice window: download prompts +
+ * store links appear and new signups skip the PWA-install steps. Once
+ * MIGRATION_CUTOVER_DATE passes (flag still ON), the web app is replaced by
+ * the full-screen sunset block (SunsetScreen).
+ */
+
+export const PWA_SUNSET_FLAG = 'pwa-sunset'
+
+// ponytail: cutover date is a constant; move to flag payload only if the date
+// needs to move without a deploy. placeholder — set the real date before flag-on.
+export const MIGRATION_CUTOVER_DATE = new Date('2026-12-31T00:00:00Z')
+
+// how long "Remind me later" snoozes the download prompt modal
+export const DOWNLOAD_PROMPT_SNOOZE_DAYS = 3
+
+// support escape hatch for users who can't install the app: support DMs
+// `/home?keep-web=<token>`; visiting it stores a 90-day cookie that bypasses
+// the sunset block.
+// ponytail: static shared token, FE-only; per-user tokens need a BE endpoint.
+export const KEEP_WEB_COOKIE = 'keep-web'
+export const KEEP_WEB_TOKEN = 'walnut-still-cracks'
+export const KEEP_WEB_COOKIE_DAYS = 90
+
+// placeholder store URLs — real App Store numeric id + Play listing must be
+// confirmed before flag-on (also needed for the review deep link).
+export const STORE_URL = {
+    ios: 'https://apps.apple.com/app/peanut',
+    android: 'https://play.google.com/store/apps/details?id=me.peanut.wallet',
+} as const
+
+export const STORE_NAME = {
+    ios: 'App Store',
+    android: 'Google Play',
+} as const
+
+/** `surface` property for migration analytics events. */
+export const MIGRATION_SURFACES = {
+    DOWNLOAD_MODAL: 'download_modal',
+    SUNSET_SCREEN: 'sunset_screen',
+    LANDING_HERO: 'landing_hero',
+    HOME_BANNER: 'home_banner',
+    SETUP: 'setup',
+} as const
+
+export type MigrationSurface = (typeof MIGRATION_SURFACES)[keyof typeof MIGRATION_SURFACES]
+export type StoreKind = keyof typeof STORE_URL

--- a/src/constants/migration.consts.ts
+++ b/src/constants/migration.consts.ts
@@ -17,6 +17,17 @@ export const MIGRATION_CUTOVER_DATE = new Date('2026-12-31T00:00:00Z')
 // how long "Remind me later" snoozes the download prompt modal
 export const DOWNLOAD_PROMPT_SNOOZE_DAYS = 3
 
+// how long "Not now" on the notifications pre-prompt snoozes before re-asking
+// (only during the migration window; flag off keeps closed-forever)
+export const NOTIF_PROMPT_SNOOZE_DAYS = 14
+
+// store review deep links ("Love it" on the review prompt). the ios
+// write-review action needs the real numeric app id — placeholder until launch.
+export const REVIEW_URL = {
+    ios: 'https://apps.apple.com/app/peanut?action=write-review',
+    android: 'https://play.google.com/store/apps/details?id=me.peanut.wallet',
+} as const
+
 // support escape hatch for users who can't install the app: support DMs
 // `/home?keep-web=<token>`; visiting it stores a 90-day cookie that bypasses
 // the sunset block.

--- a/src/constants/migration.consts.ts
+++ b/src/constants/migration.consts.ts
@@ -17,6 +17,10 @@ export const MIGRATION_CUTOVER_DATE = new Date('2026-12-31T00:00:00Z')
 // how long "Remind me later" snoozes the download prompt modal
 export const DOWNLOAD_PROMPT_SNOOZE_DAYS = 3
 
+// download prompt copy switches from celebratory to friendly-urgency once
+// the cutover is this close (Hugo's two-phase notice window)
+export const MIGRATION_URGENCY_THRESHOLD_DAYS = 14
+
 // how long "Not now" on the notifications pre-prompt snoozes before re-asking
 // (only during the migration window; flag off keeps closed-forever)
 export const NOTIF_PROMPT_SNOOZE_DAYS = 14

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -48,6 +48,7 @@ export const DEDICATED_ROUTES = [
     'fix-card-signature',
 
     // Public pages (existing)
+    'app', // smart store link (/app) — QR codes point here, redirects by device
     'm', // merchant landing pages (/m/[slug]) — added on main; register so the catch-all never treats it as a recipient
     'careers',
     'jobs',

--- a/src/context/ModalsContext.tsx
+++ b/src/context/ModalsContext.tsx
@@ -11,6 +11,10 @@ interface ModalsContextType {
     isSignInModalOpen: boolean
     setIsSignInModalOpen: (isOpen: boolean) => void
 
+    // Get-the-app scan-to-download modal (pwa-sunset, desktop surfaces)
+    isGetAppModalOpen: boolean
+    setIsGetAppModalOpen: (isOpen: boolean) => void
+
     // Support Drawer
     isSupportModalOpen: boolean
     setIsSupportModalOpen: (isOpen: boolean) => void
@@ -38,6 +42,9 @@ export function ModalsProvider({ children }: { children: ReactNode }) {
     // Guest Login/Sign In Modal
     const [isSignInModalOpen, setIsSignInModalOpen] = useState(false)
 
+    // Get-the-app scan-to-download modal
+    const [isGetAppModalOpen, setIsGetAppModalOpen] = useState(false)
+
     // Support Drawer
     const [isSupportModalOpen, setIsSupportModalOpen] = useState(false)
     const [supportPrefilledMessage, setSupportPrefilledMessage] = useState('')
@@ -63,6 +70,10 @@ export function ModalsProvider({ children }: { children: ReactNode }) {
             isSignInModalOpen,
             setIsSignInModalOpen,
 
+            // Get-the-app scan-to-download modal
+            isGetAppModalOpen,
+            setIsGetAppModalOpen,
+
             // Support Drawer
             isSupportModalOpen,
             setIsSupportModalOpen,
@@ -81,6 +92,7 @@ export function ModalsProvider({ children }: { children: ReactNode }) {
         [
             isIosPwaInstallModalOpen,
             isSignInModalOpen,
+            isGetAppModalOpen,
             isSupportModalOpen,
             supportPrefilledMessage,
             openSupportWithMessage,

--- a/src/features/payments/shared/components/SendWithPeanutCta.tsx
+++ b/src/features/payments/shared/components/SendWithPeanutCta.tsx
@@ -57,7 +57,9 @@ export default function SendWithPeanutCta({
     const isLoggedIn = !!user?.user?.userId
     // assume logged in while fetching to prevent "Join Peanut" flash
     const showAsLoggedIn = isFetchingUser || isLoggedIn
-    const { interceptGuestCta, storeHandoffModal } = useGuestStoreHandoff()
+    const { interceptGuestCta, storeHandoffModal } = useGuestStoreHandoff({
+        trackImpressionWhenGuest: requiresAuth && !isFetchingUser && !isLoggedIn,
+    })
 
     const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
         // don't act while auth is still resolving

--- a/src/features/payments/shared/components/SendWithPeanutCta.tsx
+++ b/src/features/payments/shared/components/SendWithPeanutCta.tsx
@@ -21,6 +21,7 @@ import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { useMemo } from 'react'
 import { useTranslations } from 'next-intl'
+import { useGuestStoreHandoff } from '@/hooks/useGuestStoreHandoff'
 
 interface SendWithPeanutCtaProps extends ButtonProps {
     title?: string
@@ -56,6 +57,7 @@ export default function SendWithPeanutCta({
     const isLoggedIn = !!user?.user?.userId
     // assume logged in while fetching to prevent "Join Peanut" flash
     const showAsLoggedIn = isFetchingUser || isLoggedIn
+    const { interceptGuestCta, storeHandoffModal } = useGuestStoreHandoff()
 
     const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
         // don't act while auth is still resolving
@@ -63,6 +65,9 @@ export default function SendWithPeanutCta({
 
         // if auth is required and user is not logged in, redirect to signup
         if (requiresAuth && !isLoggedIn) {
+            // migration window: web signups are closed — hand the guest to the
+            // app stores instead (QR modal on desktop, store link on mobile)
+            if (interceptGuestCta()) return
             const redirectUri = encodeURIComponent(
                 window.location.pathname + window.location.search + window.location.hash
             )
@@ -110,31 +115,34 @@ export default function SendWithPeanutCta({
     }, [])
 
     return (
-        <Button
-            variant="purple"
-            shadowSize="4"
-            className="w-full"
-            icon={icon}
-            iconSize={16}
-            onClick={handleClick}
-            {...props}
-        >
-            {!showAsLoggedIn ? (
-                <div className="flex items-center gap-1">
-                    <div>{t('cta.join')} </div>
-                    {peanutLogo}
-                </div>
-            ) : insufficientBalance ? (
-                <div className="flex items-center gap-1">
-                    <div>{t('cta.addFundsTo')} </div>
-                    {peanutLogo}
-                </div>
-            ) : (
-                <div className="flex items-center gap-1">
-                    <div>{title || t('cta.sendWith')} </div>
-                    {peanutLogo}
-                </div>
-            )}
-        </Button>
+        <>
+            {storeHandoffModal}
+            <Button
+                variant="purple"
+                shadowSize="4"
+                className="w-full"
+                icon={icon}
+                iconSize={16}
+                onClick={handleClick}
+                {...props}
+            >
+                {!showAsLoggedIn ? (
+                    <div className="flex items-center gap-1">
+                        <div>{t('cta.join')} </div>
+                        {peanutLogo}
+                    </div>
+                ) : insufficientBalance ? (
+                    <div className="flex items-center gap-1">
+                        <div>{t('cta.addFundsTo')} </div>
+                        {peanutLogo}
+                    </div>
+                ) : (
+                    <div className="flex items-center gap-1">
+                        <div>{title || t('cta.sendWith')} </div>
+                        {peanutLogo}
+                    </div>
+                )}
+            </Button>
+        </>
     )
 }

--- a/src/hooks/useGuestStoreHandoff.tsx
+++ b/src/hooks/useGuestStoreHandoff.tsx
@@ -1,0 +1,40 @@
+'use client'
+import { useState } from 'react'
+import ScanToDownloadModal from '@/components/Migration/ScanToDownloadModal'
+import { MIGRATION_SURFACES } from '@/constants/migration.consts'
+import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
+import { useMigrationFlag } from '@/hooks/useMigrationFlag'
+import { isCapacitor } from '@/utils/capacitor'
+import { openStore } from '@/utils/migration.utils'
+
+/**
+ * Guest-flow store handoff for the migration window (mockup §03/§08): when a
+ * logged-out web visitor taps "Join Peanut" / "Continue with Peanut" on a
+ * claim/request page, don't route them into a signup that's closed — desktop
+ * opens the scan-to-download QR modal, phones deep-link their store.
+ *
+ * Returns `interceptGuestCta` (call it first in the CTA handler; true = the
+ * click was handled here) and `storeHandoffModal` (render it next to the CTA).
+ * Native app guests keep the normal in-app flow.
+ */
+export function useGuestStoreHandoff() {
+    const migrationOn = useMigrationFlag()
+    const { deviceType } = useDeviceType()
+    const [qrOpen, setQrOpen] = useState(false)
+
+    const interceptGuestCta = (): boolean => {
+        if (!migrationOn || isCapacitor()) return false
+        if (deviceType === DeviceType.WEB) {
+            setQrOpen(true)
+            return true
+        }
+        openStore(deviceType === DeviceType.ANDROID ? 'android' : 'ios', MIGRATION_SURFACES.GUEST_FLOW)
+        return true
+    }
+
+    const storeHandoffModal = qrOpen ? (
+        <ScanToDownloadModal visible onClose={() => setQrOpen(false)} surface={MIGRATION_SURFACES.GUEST_FLOW} />
+    ) : null
+
+    return { interceptGuestCta, storeHandoffModal }
+}

--- a/src/hooks/useGuestStoreHandoff.tsx
+++ b/src/hooks/useGuestStoreHandoff.tsx
@@ -1,6 +1,8 @@
 'use client'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import posthog from 'posthog-js'
 import ScanToDownloadModal from '@/components/Migration/ScanToDownloadModal'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { MIGRATION_SURFACES } from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
@@ -17,10 +19,23 @@ import { openStore } from '@/utils/migration.utils'
  * click was handled here) and `storeHandoffModal` (render it next to the CTA).
  * Native app guests keep the normal in-app flow.
  */
-export function useGuestStoreHandoff() {
+export function useGuestStoreHandoff({
+    trackImpressionWhenGuest = false,
+}: { trackImpressionWhenGuest?: boolean } = {}) {
     const migrationOn = useMigrationFlag()
     const { deviceType } = useDeviceType()
     const [qrOpen, setQrOpen] = useState(false)
+
+    // guest-funnel impression (TASK-20939): fires once per mount when the CTA
+    // is actually shown to a logged-out web visitor during the window. The
+    // caller passes its settled guest state so we don't count the pre-auth
+    // flash where every visitor briefly looks logged-out.
+    const impressionFired = useRef(false)
+    useEffect(() => {
+        if (!trackImpressionWhenGuest || !migrationOn || isCapacitor() || impressionFired.current) return
+        impressionFired.current = true
+        posthog.capture(ANALYTICS_EVENTS.MIGRATION_GUEST_CTA_SHOWN, { surface: MIGRATION_SURFACES.GUEST_FLOW })
+    }, [trackImpressionWhenGuest, migrationOn])
 
     const interceptGuestCta = (): boolean => {
         if (!migrationOn || isCapacitor()) return false

--- a/src/hooks/useHomeCarouselCTAs.tsx
+++ b/src/hooks/useHomeCarouselCTAs.tsx
@@ -20,6 +20,10 @@ import { useTransactionHistory } from './useTransactionHistory'
 import STAR_STRAIGHT_ICON from '@/assets/icons/starStraight.svg'
 import underMaintenanceConfig from '@/config/underMaintenance.config'
 import { useToast } from '@/components/0_Bruddle/Toast'
+import { PEANUTMAN_MOBILE } from '@/assets/mascot'
+import { MIGRATION_SURFACES } from '@/constants/migration.consts'
+import { useMigrationFlag } from './useMigrationFlag'
+import { openStore } from '@/utils/migration.utils'
 
 // Days a dismissed CTA stays hidden before reappearing. Set above 1 so dismiss feels
 // "sticky" but below 14 so we still nudge users about valuable actions they haven't
@@ -73,6 +77,8 @@ const getDismissedCTAs = (userId: string | undefined): Map<string, Date> => {
 
 export const useHomeCarouselCTAs = () => {
     const t = useTranslations('home.carousel')
+    const tMigration = useTranslations('migration')
+    const migrationOn = useMigrationFlag()
     const [carouselCTAs, setCarouselCTAs] = useState<CarouselCTA[]>([])
     const { user } = useAuth()
     const dismissedRef = useRef<Map<string, Date>>(new Map())
@@ -94,7 +100,7 @@ export const useHomeCarouselCTAs = () => {
     const isInFlight = rails.some((rail) => rail.status === 'pending' || rail.status === 'requires-info')
     const { deviceType } = useDeviceType()
     const isPwa = usePWAStatus()
-    const { setIsIosPwaInstallModalOpen, openSupportWithMessage } = useModalsContext()
+    const { setIsIosPwaInstallModalOpen, openSupportWithMessage, setIsGetAppModalOpen } = useModalsContext()
 
     const { setIsQRScannerOpen } = useModalsContext()
     const { countryCode: userCountryCode } = useGeoLocation()
@@ -135,6 +141,28 @@ export const useHomeCarouselCTAs = () => {
     const generateCarouselCTAs = useCallback(() => {
         const _carouselCTAs: CarouselCTA[] = []
         const b = (chunks: React.ReactNode) => <b>{chunks}</b>
+
+        // pwa-sunset notice window: get-the-app nudge leads the carousel and
+        // supersedes the ios-pwa-install CTA below (TASK-20829). Mobile goes
+        // straight to the visitor's store; desktop opens the scan-to-download QR.
+        if (migrationOn && !isCapacitor()) {
+            _carouselCTAs.push({
+                id: 'app-install',
+                title: tMigration('banner.title'),
+                description: tMigration('banner.description'),
+                iconContainerClassName: 'bg-secondary-1',
+                icon: 'mobile-install',
+                logo: PEANUTMAN_MOBILE,
+                iconSize: 16,
+                onClick: () => {
+                    if (deviceType === DeviceType.WEB) {
+                        setIsGetAppModalOpen(true)
+                    } else {
+                        openStore(deviceType === DeviceType.ANDROID ? 'android' : 'ios', MIGRATION_SURFACES.HOME_BANNER)
+                    }
+                },
+            })
+        }
 
         // Home CTAs gate on "user can do a bank deposit or a pay" — provider-blind.
         // Rain (card) does NOT count; a card-only user must still see the verify CTA.
@@ -203,7 +231,7 @@ export const useHomeCarouselCTAs = () => {
             })
         }
 
-        if (deviceType === DeviceType.IOS && !isPwa && !isCapacitor()) {
+        if (!migrationOn && deviceType === DeviceType.IOS && !isPwa && !isCapacitor()) {
             _carouselCTAs.push({
                 id: 'ios-pwa-install',
                 title: t('iosPwa.title'),
@@ -320,6 +348,9 @@ export const useHomeCarouselCTAs = () => {
         toast,
         dismissCTA,
         openSupportWithMessage,
+        migrationOn,
+        tMigration,
+        setIsGetAppModalOpen,
     ])
 
     useEffect(() => {

--- a/src/hooks/useHomeCarouselCTAs.tsx
+++ b/src/hooks/useHomeCarouselCTAs.tsx
@@ -215,8 +215,21 @@ export const useHomeCarouselCTAs = () => {
                     // the user must reinstall — so route to the install modal. On native
                     // the OS prompt falls back to the Settings app (handled in requestPermission),
                     // so let it through instead of showing a PWA-install dead end.
+                    // During the migration window the reinstall answer is the native
+                    // app, not the retiring PWA.
                     if (isPermissionDenied && !isCapacitor()) {
-                        setIsIosPwaInstallModalOpen(true)
+                        if (migrationOn) {
+                            if (deviceType === DeviceType.WEB) {
+                                setIsGetAppModalOpen(true)
+                            } else {
+                                openStore(
+                                    deviceType === DeviceType.ANDROID ? 'android' : 'ios',
+                                    MIGRATION_SURFACES.HOME_BANNER
+                                )
+                            }
+                        } else {
+                            setIsIosPwaInstallModalOpen(true)
+                        }
                         return
                     }
                     const result = await requestPermission()

--- a/src/hooks/useHomeCarouselCTAs.tsx
+++ b/src/hooks/useHomeCarouselCTAs.tsx
@@ -150,7 +150,6 @@ export const useHomeCarouselCTAs = () => {
                 id: 'app-install',
                 title: tMigration('banner.title'),
                 description: tMigration('banner.description'),
-                iconContainerClassName: 'bg-secondary-1',
                 icon: 'mobile-install',
                 logo: PEANUTMAN_MOBILE,
                 iconSize: 16,

--- a/src/hooks/useKeepWebBypass.ts
+++ b/src/hooks/useKeepWebBypass.ts
@@ -1,0 +1,27 @@
+'use client'
+import { useEffect, useState } from 'react'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { KEEP_WEB_COOKIE, KEEP_WEB_COOKIE_DAYS, KEEP_WEB_TOKEN } from '@/constants/migration.consts'
+import { getFromCookie, saveToCookie } from '@/utils/general.utils'
+
+/**
+ * Support escape hatch for the sunset block: `?keep-web=<token>` (DM'd by
+ * support) persists a 90-day cookie that lets this browser keep using the web
+ * app. Shared by every layout that renders the sunset gate so the token works
+ * no matter which route the user lands on.
+ */
+export function useKeepWebBypass(): boolean {
+    const [hasBypass, setHasBypass] = useState(
+        () => typeof document !== 'undefined' && getFromCookie(KEEP_WEB_COOKIE) === KEEP_WEB_TOKEN
+    )
+    useEffect(() => {
+        const param = new URLSearchParams(window.location.search).get(KEEP_WEB_COOKIE)
+        if (param === KEEP_WEB_TOKEN) {
+            saveToCookie(KEEP_WEB_COOKIE, KEEP_WEB_TOKEN, KEEP_WEB_COOKIE_DAYS)
+            posthog.capture(ANALYTICS_EVENTS.MIGRATION_KEEP_WEB_USED)
+            setHasBypass(true)
+        }
+    }, [])
+    return hasBypass
+}

--- a/src/hooks/useMigrationFlag.ts
+++ b/src/hooks/useMigrationFlag.ts
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
 import { useFeatureFlags } from '@/hooks/useFeatureFlag'
-import { PWA_SUNSET_FLAG } from '@/constants/migration.consts'
+import { isPwaSunsetOn } from '@/utils/migration.utils'
 
 /**
  * Is the PWA-sunset migration live? Fails closed (false) until PostHog flags
@@ -14,19 +14,24 @@ import { PWA_SUNSET_FLAG } from '@/constants/migration.consts'
  * Testing with the flag on:
  * - PostHog UI (project 138913): add a release condition on `pwa-sunset`
  *   matching your `email` at 100%.
- * - Locally / on a preview: run
+ * - On a preview/prod build: run
  *   `posthog.featureFlags.overrideFeatureFlags({ flags: { 'pwa-sunset': true } })`
  *   in the console (persists for the session; posthog-js >=1.3xx requires the
  *   `flags` wrapper — a flat object is silently ignored). Clear with
  *   `overrideFeatureFlags(false)`.
+ * - Local dev (posthog never inits): `localStorage.setItem('pwa-sunset', 'true')`
+ *   + reload; cutover via `localStorage.setItem('pwa-sunset-cutover', '2020-01-01')`.
+ *   See isPwaSunsetOn / getMigrationCutoverTime.
  */
 export function useMigrationFlag(): boolean {
-    const isEnabled = useFeatureFlags()
+    // subscribe to posthog flag-load events so consumers re-render when flags
+    // arrive; the actual read goes through isPwaSunsetOn (dev override aware)
+    useFeatureFlags()
     // hydration-safe: posthog serves CACHED flags synchronously for returning
     // visitors, so a render-time read would disagree with the flag-off SSR
     // HTML on prerendered surfaces (landing, setup) and hard-fail hydration.
     // false until mounted keeps server and first client render identical.
     const [mounted, setMounted] = useState(false)
     useEffect(() => setMounted(true), [])
-    return mounted && isEnabled(PWA_SUNSET_FLAG)
+    return mounted && isPwaSunsetOn()
 }

--- a/src/hooks/useMigrationFlag.ts
+++ b/src/hooks/useMigrationFlag.ts
@@ -15,8 +15,10 @@ import { PWA_SUNSET_FLAG } from '@/constants/migration.consts'
  * - PostHog UI (project 138913): add a release condition on `pwa-sunset`
  *   matching your `email` at 100%.
  * - Locally / on a preview: run
- *   `posthog.featureFlags.overrideFeatureFlags({ 'pwa-sunset': true })`
- *   in the console (persists for the session).
+ *   `posthog.featureFlags.overrideFeatureFlags({ flags: { 'pwa-sunset': true } })`
+ *   in the console (persists for the session; posthog-js >=1.3xx requires the
+ *   `flags` wrapper — a flat object is silently ignored). Clear with
+ *   `overrideFeatureFlags(false)`.
  */
 export function useMigrationFlag(): boolean {
     const isEnabled = useFeatureFlags()

--- a/src/hooks/useMigrationFlag.ts
+++ b/src/hooks/useMigrationFlag.ts
@@ -1,0 +1,23 @@
+'use client'
+import { useFeatureFlags } from '@/hooks/useFeatureFlag'
+import { PWA_SUNSET_FLAG } from '@/constants/migration.consts'
+
+/**
+ * Is the PWA-sunset migration live? Fails closed (false) until PostHog flags
+ * load; re-renders when they do (see useFeatureFlags).
+ *
+ * Deliberately no `nonProdBypass`: it would force the sunset block on for all
+ * of staging/previews once the cutover date passes, bricking QA of the
+ * un-flagged state.
+ *
+ * Testing with the flag on:
+ * - PostHog UI (project 138913): add a release condition on `pwa-sunset`
+ *   matching your `email` at 100%.
+ * - Locally / on a preview: run
+ *   `posthog.featureFlags.overrideFeatureFlags({ 'pwa-sunset': true })`
+ *   in the console (persists for the session).
+ */
+export function useMigrationFlag(): boolean {
+    const isEnabled = useFeatureFlags()
+    return isEnabled(PWA_SUNSET_FLAG)
+}

--- a/src/hooks/useMigrationFlag.ts
+++ b/src/hooks/useMigrationFlag.ts
@@ -1,4 +1,5 @@
 'use client'
+import { useEffect, useState } from 'react'
 import { useFeatureFlags } from '@/hooks/useFeatureFlag'
 import { PWA_SUNSET_FLAG } from '@/constants/migration.consts'
 
@@ -19,5 +20,11 @@ import { PWA_SUNSET_FLAG } from '@/constants/migration.consts'
  */
 export function useMigrationFlag(): boolean {
     const isEnabled = useFeatureFlags()
-    return isEnabled(PWA_SUNSET_FLAG)
+    // hydration-safe: posthog serves CACHED flags synchronously for returning
+    // visitors, so a render-time read would disagree with the flag-off SSR
+    // HTML on prerendered surfaces (landing, setup) and hard-fail hydration.
+    // false until mounted keeps server and first client render identical.
+    const [mounted, setMounted] = useState(false)
+    useEffect(() => setMounted(true), [])
+    return mounted && isEnabled(PWA_SUNSET_FLAG)
 }

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -291,7 +291,8 @@ function closePermissionModal() {
 
 // update permission state after user interacts with permission prompt
 async function afterPermissionAttempt() {
-    // mark modal as closed to prevent it from showing again
+    // mark modal as closed (permanent flag-off; 14-day snooze while the
+    // pwa-sunset flag is on — see evaluateVisibility)
     updateUserPreferences(currentExternalId ?? undefined, {
         notifModalClosed: true,
         notifModalClosedAt: new Date().toISOString(),

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -8,8 +8,8 @@ import { isDemoMode } from '@/utils/demo'
 import { useUserStore } from '@/redux/hooks'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
-import { NOTIF_PROMPT_SNOOZE_DAYS, PWA_SUNSET_FLAG } from '@/constants/migration.consts'
-import { isFeatureFlagEnabled } from '@/utils/featureFlag.utils'
+import { NOTIF_PROMPT_SNOOZE_DAYS } from '@/constants/migration.consts'
+import { isPwaSunsetOn } from '@/utils/migration.utils'
 import { UTM_SOURCES, UTM_MEDIUMS } from '@/utils/utm.utils'
 
 const NOTIF_PROMPT_SNOOZE_MS = NOTIF_PROMPT_SNOOZE_DAYS * 24 * 60 * 60 * 1000
@@ -133,7 +133,7 @@ async function evaluateVisibility() {
         updateUserPreferences(currentExternalId ?? undefined, { notifModalClosedAt: closedAt })
     }
     const snoozeExpired = !!closedAt && Date.now() - new Date(closedAt).getTime() >= NOTIF_PROMPT_SNOOZE_MS
-    const modalClosed = !!closedAt && !(isFeatureFlagEnabled(PWA_SUNSET_FLAG) && snoozeExpired)
+    const modalClosed = !!closedAt && !(isPwaSunsetOn() && snoozeExpired)
 
     // don't show modal if permission is denied (carousel cta will handle it)
     if (state.permissionState === 'denied') {

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -8,7 +8,11 @@ import { isDemoMode } from '@/utils/demo'
 import { useUserStore } from '@/redux/hooks'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
+import { NOTIF_PROMPT_SNOOZE_DAYS, PWA_SUNSET_FLAG } from '@/constants/migration.consts'
+import { isFeatureFlagEnabled } from '@/utils/featureFlag.utils'
 import { UTM_SOURCES, UTM_MEDIUMS } from '@/utils/utm.utils'
+
+const NOTIF_PROMPT_SNOOZE_MS = NOTIF_PROMPT_SNOOZE_DAYS * 24 * 60 * 60 * 1000
 
 /*
  * Notification state lives in a module-level store shared by every
@@ -118,7 +122,18 @@ async function evaluateVisibility() {
     }
 
     const userPreferences = getUserPreferences(currentExternalId ?? undefined)
-    const modalClosed = userPreferences?.notifModalClosed ?? false
+    // migration window (TASK-20771): "Not now" snoozes instead of dismissing
+    // forever — the custom pre-prompt exists so we CAN re-ask later. Legacy
+    // `notifModalClosed: true` (no timestamp) converts to a snooze starting
+    // now, same trick as getDismissedCTAs. Flag off keeps the old
+    // closed-forever behavior.
+    let closedAt = userPreferences?.notifModalClosedAt
+    if (!closedAt && userPreferences?.notifModalClosed) {
+        closedAt = new Date().toISOString()
+        updateUserPreferences(currentExternalId ?? undefined, { notifModalClosedAt: closedAt })
+    }
+    const snoozeExpired = !!closedAt && Date.now() - new Date(closedAt).getTime() >= NOTIF_PROMPT_SNOOZE_MS
+    const modalClosed = !!closedAt && !(isFeatureFlagEnabled(PWA_SUNSET_FLAG) && snoozeExpired)
 
     // don't show modal if permission is denied (carousel cta will handle it)
     if (state.permissionState === 'denied') {
@@ -266,14 +281,21 @@ async function requestPermission(): Promise<NotificationPermissionState> {
 // close modal when user dismisses it
 function closePermissionModal() {
     setState({ showPermissionModal: false })
-    updateUserPreferences(currentExternalId ?? undefined, { notifModalClosed: true })
+    // legacy boolean kept so bundles predating notifModalClosedAt stay closed
+    updateUserPreferences(currentExternalId ?? undefined, {
+        notifModalClosed: true,
+        notifModalClosedAt: new Date().toISOString(),
+    })
     posthog.capture(ANALYTICS_EVENTS.MODAL_DISMISSED, { modal_type: MODAL_TYPES.NOTIFICATIONS })
 }
 
 // update permission state after user interacts with permission prompt
 async function afterPermissionAttempt() {
     // mark modal as closed to prevent it from showing again
-    updateUserPreferences(currentExternalId ?? undefined, { notifModalClosed: true })
+    updateUserPreferences(currentExternalId ?? undefined, {
+        notifModalClosed: true,
+        notifModalClosedAt: new Date().toISOString(),
+    })
     await refreshPermissionState()
 }
 

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2727,7 +2727,7 @@
         },
         "banner": {
             "title": "Get the Peanut app",
-            "description": "Faster payments and alerts when money lands"
+            "description": "Peanut is moving to the app — download it for a smoother experience"
         },
         "review": {
             "title": "Loving Peanut so far?",

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2738,6 +2738,10 @@
             "meh": "Could be better",
             "supportPrefill": "I have some feedback about the app, here's what could be better: "
         },
-        "downloadNow": "Download now"
+        "downloadNow": "Download now",
+        "smartLink": {
+            "redirecting": "Taking you to the store…",
+            "pickStore": "Global cash, local feel. Pick your store to download."
+        }
     }
 }

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -1836,8 +1836,8 @@
         "today": "Today",
         "yesterday": "Yesterday",
         "iconAlt": "icon",
-        "setupTitle": "Turn on notifications?",
-        "setupDescription": "Enable notifications and get alerts for all wallet activity.",
+        "setupTitle": "Get money alerts",
+        "setupDescription": "We'll ping you the moment money lands or someone asks you to pay.",
         "enable": "Enable notifications",
         "requesting": "Requesting...",
         "notNow": "Not now"

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2710,19 +2710,23 @@
     },
     "migration": {
         "downloadPrompt": {
-            "title": "Peanut is becoming an app",
-            "description": "Peanut is moving to the App Store and Google Play. In {days, plural, one {# day} other {# days}} it will only work in the app — download it now to keep using your account.",
+            "earlyTitle": "The Peanut app is here",
+            "earlyDescription": "Peanut now lives on the App Store and Google Play — faster, smoother, and it pings you the moment money lands. Your account comes with you, nothing to set up.",
+            "maybeLater": "Maybe later",
+            "title": "Peanut is going app-only",
+            "description": "In {days, plural, one {# day} other {# days}} Peanut moves fully to the app. Download it now and pick up right where you left off — your account and money move with you automatically.",
             "remindLater": "Remind me later"
         },
         "sunset": {
-            "heading": "Peanut lives on your phone now",
-            "sub": "The website has closed. Download the app to get back into your account — your money is safe.",
-            "supportLink": "Can't download the app? Contact support"
+            "heading": "Peanut is now app-only",
+            "sub": "Download the app to pick up right where you left off — your account and money are already there waiting for you.",
+            "supportLink": "Can't use the app? We'll help — contact support"
         },
         "qr": {
-            "title": "Scan to download Peanut",
-            "description": "Pick your phone's store, then scan the code with your camera.",
-            "scanHint": "Scan with your phone camera",
+            "title": "Get the Peanut app",
+            "scanHint": "Scan with your phone camera to download.",
+            "openIos": "Open App Store ↗",
+            "openAndroid": "Open Google Play ↗",
             "done": "Done"
         },
         "banner": {
@@ -2733,7 +2737,8 @@
             "title": "Loving Peanut so far?",
             "description": "A quick rating helps other people find us.",
             "loveIt": "Love it",
-            "meh": "Could be better"
+            "meh": "Could be better",
+            "supportPrefill": "I have some feedback about the app — here's what could be better: "
         },
         "downloadNow": "Download now"
     }

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2705,5 +2705,34 @@
         "promptFailed": "Unlock again to open the app.",
         "unlock": "Unlock",
         "logOut": "Log out"
+    },
+    "migration": {
+        "downloadPrompt": {
+            "title": "Peanut is becoming an app",
+            "description": "Peanut is moving to the App Store and Google Play. In {days, plural, one {# day} other {# days}} it will only work in the app — download it now to keep using your account.",
+            "remindLater": "Remind me later"
+        },
+        "sunset": {
+            "heading": "Peanut lives on your phone now",
+            "sub": "The website has closed. Download the app to get back into your account — your money is safe.",
+            "supportLink": "Can't download the app? Contact support"
+        },
+        "qr": {
+            "title": "Scan to download Peanut",
+            "description": "Pick your phone's store, then scan the code with your camera.",
+            "scanHint": "Scan with your phone camera",
+            "done": "Done"
+        },
+        "banner": {
+            "title": "Get the Peanut app",
+            "description": "Faster payments and alerts when money lands"
+        },
+        "review": {
+            "title": "Loving Peanut so far?",
+            "description": "A quick rating helps other people find us.",
+            "loveIt": "Love it",
+            "meh": "Could be better"
+        },
+        "downloadNow": "Download now"
     }
 }

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2724,8 +2724,7 @@
         },
         "qr": {
             "title": "Get the Peanut app",
-            "scanHint": "Scan with your phone camera to download.",
-            "done": "Done"
+            "scanHint": "Scan with your phone camera to download."
         },
         "banner": {
             "title": "The Peanut app is here!",

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2710,35 +2710,33 @@
     },
     "migration": {
         "downloadPrompt": {
-            "earlyTitle": "The Peanut app is here",
-            "earlyDescription": "Peanut now lives on the App Store and Google Play — faster, smoother, and it pings you the moment money lands. Your account comes with you, nothing to set up.",
-            "maybeLater": "Maybe later",
+            "earlyTitle": "The Peanut app is here!",
+            "earlyDescription": "Peanut now lives on the App Store and Google Play. Faster, smoother, and it pings you the moment money lands. Your account comes with you, nothing to set up.",
+            "maybeLater": "I'll download it later",
             "title": "Peanut is going app-only",
-            "description": "In {days, plural, one {# day} other {# days}} Peanut moves fully to the app. Download it now and pick up right where you left off — your account and money move with you automatically.",
+            "description": "In {days, plural, one {# day} other {# days}} Peanut moves fully to the app. Download it now and pick up right where you left off. Your account and money move with you automatically.",
             "remindLater": "Remind me later"
         },
         "sunset": {
             "heading": "Peanut is now app-only",
-            "sub": "Download the app to pick up right where you left off — your account and money are already there waiting for you.",
-            "supportLink": "Can't use the app? We'll help — contact support"
+            "sub": "Download the app to pick up right where you left off. Your account and money are already there waiting for you.",
+            "supportLink": "Having trouble downloading the app? Chat with our support"
         },
         "qr": {
             "title": "Get the Peanut app",
             "scanHint": "Scan with your phone camera to download.",
-            "openIos": "Open App Store ↗",
-            "openAndroid": "Open Google Play ↗",
             "done": "Done"
         },
         "banner": {
-            "title": "Get the Peanut app",
-            "description": "Peanut is moving to the app — download it for a smoother experience"
+            "title": "The Peanut app is here!",
+            "description": "Faster, smoother, and it pings you when money lands."
         },
         "review": {
             "title": "Loving Peanut so far?",
             "description": "A quick rating helps other people find us.",
             "loveIt": "Love it",
             "meh": "Could be better",
-            "supportPrefill": "I have some feedback about the app — here's what could be better: "
+            "supportPrefill": "I have some feedback about the app, here's what could be better: "
         },
         "downloadNow": "Download now"
     }

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -1836,8 +1836,10 @@
         "today": "Today",
         "yesterday": "Yesterday",
         "iconAlt": "icon",
-        "setupTitle": "Get money alerts",
-        "setupDescription": "We'll ping you the moment money lands or someone asks you to pay.",
+        "setupTitle": "Turn on notifications?",
+        "setupDescription": "Enable notifications and get alerts for all wallet activity.",
+        "migrationSetupTitle": "Get money alerts",
+        "migrationSetupDescription": "We'll ping you the moment money lands or someone asks you to pay.",
         "enable": "Enable notifications",
         "requesting": "Requesting...",
         "notNow": "Not now"

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2710,35 +2710,33 @@
     },
     "migration": {
         "downloadPrompt": {
-            "earlyTitle": "La app de Peanut ya está aquí",
-            "earlyDescription": "Peanut ya vive en el App Store y Google Play — más rápida, más fluida y te avisa al instante cuando llega tu dinero. Tu cuenta va contigo, sin configurar nada.",
-            "maybeLater": "Quizás después",
+            "earlyTitle": "¡La app de Peanut ya está aquí!",
+            "earlyDescription": "Peanut ya vive en el App Store y Google Play. Más rápida, más fluida y te avisa al instante cuando llega tu dinero. Tu cuenta va contigo, sin configurar nada.",
+            "maybeLater": "La descargo más tarde",
             "title": "Peanut será solo app",
-            "description": "En {days, plural, one {# día} other {# días}} Peanut se muda por completo a la app. Descárgala ahora y continúa justo donde quedaste — tu cuenta y tu dinero se mudan contigo automáticamente.",
+            "description": "En {days, plural, one {# día} other {# días}} Peanut se muda por completo a la app. Descárgala ahora y continúa justo donde quedaste. Tu cuenta y tu dinero se mudan contigo automáticamente.",
             "remindLater": "Recordarme más tarde"
         },
         "sunset": {
             "heading": "Peanut ahora es solo app",
-            "sub": "Descarga la app y continúa justo donde quedaste — tu cuenta y tu dinero ya te están esperando ahí.",
-            "supportLink": "¿No puedes usar la app? Te ayudamos — contacta a soporte"
+            "sub": "Descarga la app y continúa justo donde quedaste. Tu cuenta y tu dinero ya te están esperando ahí.",
+            "supportLink": "¿Problemas para descargar la app? Habla con nuestro soporte"
         },
         "qr": {
             "title": "Descarga la app de Peanut",
             "scanHint": "Escanea con la cámara de tu celular para descargar.",
-            "openIos": "Abrir App Store ↗",
-            "openAndroid": "Abrir Google Play ↗",
             "done": "Listo"
         },
         "banner": {
-            "title": "Descarga la app de Peanut",
-            "description": "Peanut se muda a la app — descárgala para una experiencia más fluida"
+            "title": "¡La app de Peanut ya está aquí!",
+            "description": "Más rápida, más fluida y te avisa cuando llega tu dinero."
         },
         "review": {
             "title": "¿Te está gustando Peanut?",
             "description": "Una calificación rápida ayuda a que otros nos encuentren.",
             "loveIt": "Me encanta",
             "meh": "Podría mejorar",
-            "supportPrefill": "Tengo comentarios sobre la app — esto es lo que podría mejorar: "
+            "supportPrefill": "Tengo comentarios sobre la app, esto es lo que podría mejorar: "
         },
         "downloadNow": "Descargar ahora"
     }

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2727,7 +2727,7 @@
         },
         "banner": {
             "title": "Descarga la app de Peanut",
-            "description": "Pagos más rápidos y alertas cuando llega tu dinero"
+            "description": "Peanut se muda a la app — descárgala para una experiencia más fluida"
         },
         "review": {
             "title": "¿Te está gustando Peanut?",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -1836,8 +1836,10 @@
         "today": "Hoy",
         "yesterday": "Ayer",
         "iconAlt": "ícono",
-        "setupTitle": "Recibe alertas de dinero",
-        "setupDescription": "Te avisamos al instante cuando llegue dinero o alguien te pida un pago.",
+        "setupTitle": "¿Activar las notificaciones?",
+        "setupDescription": "Activa las notificaciones y recibe alertas de toda la actividad de tu billetera.",
+        "migrationSetupTitle": "Recibe alertas de dinero",
+        "migrationSetupDescription": "Te avisamos al instante cuando llegue dinero o alguien te pida un pago.",
         "enable": "Activar notificaciones",
         "requesting": "Solicitando...",
         "notNow": "Ahora no"

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2738,6 +2738,10 @@
             "meh": "Podría mejorar",
             "supportPrefill": "Tengo comentarios sobre la app, esto es lo que podría mejorar: "
         },
-        "downloadNow": "Descargar ahora"
+        "downloadNow": "Descargar ahora",
+        "smartLink": {
+            "redirecting": "Te llevamos a la tienda…",
+            "pickStore": "Elige tu tienda y descarga la app."
+        }
     }
 }

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2705,5 +2705,34 @@
         "promptFailed": "Desbloquea de nuevo para abrir la app.",
         "unlock": "Desbloquear",
         "logOut": "Cerrar sesión"
+    },
+    "migration": {
+        "downloadPrompt": {
+            "title": "Peanut se convierte en una app",
+            "description": "Peanut se muda al App Store y Google Play. En {days, plural, one {# día} other {# días}} solo funcionará en la app — descárgala ahora para seguir usando tu cuenta.",
+            "remindLater": "Recordarme más tarde"
+        },
+        "sunset": {
+            "heading": "Peanut ahora vive en tu teléfono",
+            "sub": "El sitio web cerró. Descarga la app para volver a tu cuenta — tu dinero está seguro.",
+            "supportLink": "¿No puedes descargar la app? Contacta a soporte"
+        },
+        "qr": {
+            "title": "Escanea para descargar Peanut",
+            "description": "Elige la tienda de tu teléfono y escanea el código con tu cámara.",
+            "scanHint": "Escanea con la cámara de tu teléfono",
+            "done": "Listo"
+        },
+        "banner": {
+            "title": "Descarga la app de Peanut",
+            "description": "Pagos más rápidos y alertas cuando llega tu dinero"
+        },
+        "review": {
+            "title": "¿Te está gustando Peanut?",
+            "description": "Una calificación rápida ayuda a que otros nos encuentren.",
+            "loveIt": "Me encanta",
+            "meh": "Podría mejorar"
+        },
+        "downloadNow": "Descargar ahora"
     }
 }

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -1836,8 +1836,8 @@
         "today": "Hoy",
         "yesterday": "Ayer",
         "iconAlt": "ícono",
-        "setupTitle": "¿Activar las notificaciones?",
-        "setupDescription": "Activa las notificaciones y recibe alertas de toda la actividad de tu billetera.",
+        "setupTitle": "Recibe alertas de dinero",
+        "setupDescription": "Te avisamos al instante cuando llegue dinero o alguien te pida un pago.",
         "enable": "Activar notificaciones",
         "requesting": "Solicitando...",
         "notNow": "Ahora no"

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2724,8 +2724,7 @@
         },
         "qr": {
             "title": "Descarga la app de Peanut",
-            "scanHint": "Escanea con la cámara de tu celular para descargar.",
-            "done": "Listo"
+            "scanHint": "Escanea con la cámara de tu celular para descargar."
         },
         "banner": {
             "title": "¡La app de Peanut ya está aquí!",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2710,19 +2710,23 @@
     },
     "migration": {
         "downloadPrompt": {
-            "title": "Peanut se convierte en una app",
-            "description": "Peanut se muda al App Store y Google Play. En {days, plural, one {# día} other {# días}} solo funcionará en la app — descárgala ahora para seguir usando tu cuenta.",
+            "earlyTitle": "La app de Peanut ya está aquí",
+            "earlyDescription": "Peanut ya vive en el App Store y Google Play — más rápida, más fluida y te avisa al instante cuando llega tu dinero. Tu cuenta va contigo, sin configurar nada.",
+            "maybeLater": "Quizás después",
+            "title": "Peanut será solo app",
+            "description": "En {days, plural, one {# día} other {# días}} Peanut se muda por completo a la app. Descárgala ahora y continúa justo donde quedaste — tu cuenta y tu dinero se mudan contigo automáticamente.",
             "remindLater": "Recordarme más tarde"
         },
         "sunset": {
-            "heading": "Peanut ahora vive en tu teléfono",
-            "sub": "El sitio web cerró. Descarga la app para volver a tu cuenta — tu dinero está seguro.",
-            "supportLink": "¿No puedes descargar la app? Contacta a soporte"
+            "heading": "Peanut ahora es solo app",
+            "sub": "Descarga la app y continúa justo donde quedaste — tu cuenta y tu dinero ya te están esperando ahí.",
+            "supportLink": "¿No puedes usar la app? Te ayudamos — contacta a soporte"
         },
         "qr": {
-            "title": "Escanea para descargar Peanut",
-            "description": "Elige la tienda de tu teléfono y escanea el código con tu cámara.",
-            "scanHint": "Escanea con la cámara de tu teléfono",
+            "title": "Descarga la app de Peanut",
+            "scanHint": "Escanea con la cámara de tu celular para descargar.",
+            "openIos": "Abrir App Store ↗",
+            "openAndroid": "Abrir Google Play ↗",
             "done": "Listo"
         },
         "banner": {
@@ -2733,7 +2737,8 @@
             "title": "¿Te está gustando Peanut?",
             "description": "Una calificación rápida ayuda a que otros nos encuentren.",
             "loveIt": "Me encanta",
-            "meh": "Podría mejorar"
+            "meh": "Podría mejorar",
+            "supportPrefill": "Tengo comentarios sobre la app — esto es lo que podría mejorar: "
         },
         "downloadNow": "Descargar ahora"
     }

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -1836,8 +1836,10 @@
         "today": "Hoje",
         "yesterday": "Ontem",
         "iconAlt": "ícone",
-        "setupTitle": "Receba alertas de dinheiro",
-        "setupDescription": "Avisamos na hora quando o dinheiro chegar ou alguém pedir um pagamento.",
+        "setupTitle": "Ativar as notificações?",
+        "setupDescription": "Ative as notificações e receba alertas de toda a atividade da sua carteira.",
+        "migrationSetupTitle": "Receba alertas de dinheiro",
+        "migrationSetupDescription": "Avisamos na hora quando o dinheiro chegar ou alguém pedir um pagamento.",
         "enable": "Ativar notificações",
         "requesting": "Solicitando...",
         "notNow": "Agora não"

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -1836,8 +1836,8 @@
         "today": "Hoje",
         "yesterday": "Ontem",
         "iconAlt": "ícone",
-        "setupTitle": "Ativar as notificações?",
-        "setupDescription": "Ative as notificações e receba alertas de toda a atividade da sua carteira.",
+        "setupTitle": "Receba alertas de dinheiro",
+        "setupDescription": "Avisamos na hora quando o dinheiro chegar ou alguém pedir um pagamento.",
         "enable": "Ativar notificações",
         "requesting": "Solicitando...",
         "notNow": "Agora não"

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2705,5 +2705,34 @@
         "promptFailed": "Desbloqueie novamente para abrir o app.",
         "unlock": "Desbloquear",
         "logOut": "Sair"
+    },
+    "migration": {
+        "downloadPrompt": {
+            "title": "O Peanut está virando um app",
+            "description": "O Peanut está migrando para a App Store e o Google Play. Em {days, plural, one {# dia} other {# dias}} ele só funcionará no app — baixe agora para continuar usando sua conta.",
+            "remindLater": "Lembrar depois"
+        },
+        "sunset": {
+            "heading": "O Peanut agora mora no seu celular",
+            "sub": "O site foi encerrado. Baixe o app para voltar à sua conta — seu dinheiro está seguro.",
+            "supportLink": "Não consegue baixar o app? Fale com o suporte"
+        },
+        "qr": {
+            "title": "Escaneie para baixar o Peanut",
+            "description": "Escolha a loja do seu celular e escaneie o código com a câmera.",
+            "scanHint": "Escaneie com a câmera do seu celular",
+            "done": "Pronto"
+        },
+        "banner": {
+            "title": "Baixe o app do Peanut",
+            "description": "Pagamentos mais rápidos e alertas quando o dinheiro chega"
+        },
+        "review": {
+            "title": "Está gostando do Peanut?",
+            "description": "Uma avaliação rápida ajuda outras pessoas a nos encontrar.",
+            "loveIt": "Adorei",
+            "meh": "Pode melhorar"
+        },
+        "downloadNow": "Baixar agora"
     }
 }

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2727,7 +2727,7 @@
         },
         "banner": {
             "title": "Baixe o app do Peanut",
-            "description": "Pagamentos mais rápidos e alertas quando o dinheiro chega"
+            "description": "O Peanut está migrando para o app — baixe para uma experiência mais fluida"
         },
         "review": {
             "title": "Está gostando do Peanut?",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2710,19 +2710,23 @@
     },
     "migration": {
         "downloadPrompt": {
-            "title": "O Peanut está virando um app",
-            "description": "O Peanut está migrando para a App Store e o Google Play. Em {days, plural, one {# dia} other {# dias}} ele só funcionará no app — baixe agora para continuar usando sua conta.",
+            "earlyTitle": "O app do Peanut chegou",
+            "earlyDescription": "O Peanut agora vive na App Store e no Google Play — mais rápido, mais fluido e te avisa na hora que o dinheiro chega. Sua conta vai com você, sem configurar nada.",
+            "maybeLater": "Talvez depois",
+            "title": "O Peanut vai ser só app",
+            "description": "Em {days, plural, one {# dia} other {# dias}} o Peanut se muda por completo para o app. Baixe agora e continue de onde parou — sua conta e seu dinheiro se mudam com você automaticamente.",
             "remindLater": "Lembrar depois"
         },
         "sunset": {
-            "heading": "O Peanut agora mora no seu celular",
-            "sub": "O site foi encerrado. Baixe o app para voltar à sua conta — seu dinheiro está seguro.",
-            "supportLink": "Não consegue baixar o app? Fale com o suporte"
+            "heading": "O Peanut agora é só app",
+            "sub": "Baixe o app e continue de onde parou — sua conta e seu dinheiro já estão lá esperando por você.",
+            "supportLink": "Não consegue usar o app? A gente ajuda — fale com o suporte"
         },
         "qr": {
-            "title": "Escaneie para baixar o Peanut",
-            "description": "Escolha a loja do seu celular e escaneie o código com a câmera.",
-            "scanHint": "Escaneie com a câmera do seu celular",
+            "title": "Baixe o app do Peanut",
+            "scanHint": "Escaneie com a câmera do seu celular para baixar.",
+            "openIos": "Abrir App Store ↗",
+            "openAndroid": "Abrir Google Play ↗",
             "done": "Pronto"
         },
         "banner": {
@@ -2733,7 +2737,8 @@
             "title": "Está gostando do Peanut?",
             "description": "Uma avaliação rápida ajuda outras pessoas a nos encontrar.",
             "loveIt": "Adorei",
-            "meh": "Pode melhorar"
+            "meh": "Pode melhorar",
+            "supportPrefill": "Tenho um feedback sobre o app — isso poderia melhorar: "
         },
         "downloadNow": "Baixar agora"
     }

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2710,35 +2710,33 @@
     },
     "migration": {
         "downloadPrompt": {
-            "earlyTitle": "O app do Peanut chegou",
-            "earlyDescription": "O Peanut agora vive na App Store e no Google Play — mais rápido, mais fluido e te avisa na hora que o dinheiro chega. Sua conta vai com você, sem configurar nada.",
-            "maybeLater": "Talvez depois",
+            "earlyTitle": "O app do Peanut chegou!",
+            "earlyDescription": "O Peanut agora vive na App Store e no Google Play. Mais rápido, mais fluido e te avisa na hora que o dinheiro chega. Sua conta vai com você, sem configurar nada.",
+            "maybeLater": "Baixo depois",
             "title": "O Peanut vai ser só app",
-            "description": "Em {days, plural, one {# dia} other {# dias}} o Peanut se muda por completo para o app. Baixe agora e continue de onde parou — sua conta e seu dinheiro se mudam com você automaticamente.",
+            "description": "Em {days, plural, one {# dia} other {# dias}} o Peanut se muda por completo para o app. Baixe agora e continue de onde parou. Sua conta e seu dinheiro se mudam com você automaticamente.",
             "remindLater": "Lembrar depois"
         },
         "sunset": {
             "heading": "O Peanut agora é só app",
-            "sub": "Baixe o app e continue de onde parou — sua conta e seu dinheiro já estão lá esperando por você.",
-            "supportLink": "Não consegue usar o app? A gente ajuda — fale com o suporte"
+            "sub": "Baixe o app e continue de onde parou. Sua conta e seu dinheiro já estão lá esperando por você.",
+            "supportLink": "Problemas para baixar o app? Fale com nosso suporte"
         },
         "qr": {
             "title": "Baixe o app do Peanut",
             "scanHint": "Escaneie com a câmera do seu celular para baixar.",
-            "openIos": "Abrir App Store ↗",
-            "openAndroid": "Abrir Google Play ↗",
             "done": "Pronto"
         },
         "banner": {
-            "title": "Baixe o app do Peanut",
-            "description": "O Peanut está migrando para o app — baixe para uma experiência mais fluida"
+            "title": "O app do Peanut chegou!",
+            "description": "Mais rápido, mais fluido e te avisa quando o dinheiro chega."
         },
         "review": {
             "title": "Está gostando do Peanut?",
             "description": "Uma avaliação rápida ajuda outras pessoas a nos encontrar.",
             "loveIt": "Adorei",
             "meh": "Pode melhorar",
-            "supportPrefill": "Tenho um feedback sobre o app — isso poderia melhorar: "
+            "supportPrefill": "Tenho um feedback sobre o app, isso poderia melhorar: "
         },
         "downloadNow": "Baixar agora"
     }

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2724,8 +2724,7 @@
         },
         "qr": {
             "title": "Baixe o app do Peanut",
-            "scanHint": "Escaneie com a câmera do seu celular para baixar.",
-            "done": "Pronto"
+            "scanHint": "Escaneie com a câmera do seu celular para baixar."
         },
         "banner": {
             "title": "O app do Peanut chegou!",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2738,6 +2738,10 @@
             "meh": "Pode melhorar",
             "supportPrefill": "Tenho um feedback sobre o app, isso poderia melhorar: "
         },
-        "downloadNow": "Baixar agora"
+        "downloadNow": "Baixar agora",
+        "smartLink": {
+            "redirecting": "Levando você para a loja…",
+            "pickStore": "Escolha sua loja e baixe o app."
+        }
     }
 }

--- a/src/utils/__tests__/migration.utils.test.ts
+++ b/src/utils/__tests__/migration.utils.test.ts
@@ -1,0 +1,112 @@
+/** @jest-environment jsdom */
+/**
+ * migration.utils — the pwa-sunset primitives.
+ *
+ * shouldShowSunsetBlock is the single predicate that can make the whole app
+ * inaccessible (three call sites: both layouts + implicitly /app's flag gate),
+ * so its matrix is pinned here. The dev-only localStorage overrides are what
+ * local e2e QA rides on — a silent break there blinds every future QA round.
+ */
+
+let mockFlagEnabled = false
+jest.mock('@/utils/featureFlag.utils', () => ({
+    isFeatureFlagEnabled: () => mockFlagEnabled,
+}))
+
+let mockIsCapacitor = false
+jest.mock('@/utils/capacitor', () => ({
+    isCapacitor: () => mockIsCapacitor,
+    openExternalUrl: jest.fn(),
+}))
+
+// the localStorage overrides are dev-only; force the dev branch in tests
+jest.mock('@/constants/general.consts', () => ({
+    ...jest.requireActual('@/constants/general.consts'),
+    IS_DEV: true,
+}))
+
+jest.mock('posthog-js', () => ({ capture: jest.fn() }))
+
+import { MIGRATION_CUTOVER_DATE } from '@/constants/migration.consts'
+import { getMigrationCutoverTime, isPwaSunsetOn, shouldShowSunsetBlock } from '@/utils/migration.utils'
+
+const CUTOVER = MIGRATION_CUTOVER_DATE.getTime()
+const AFTER = CUTOVER + 1000
+const BEFORE = CUTOVER - 1000
+
+beforeEach(() => {
+    localStorage.clear()
+    mockFlagEnabled = false
+    mockIsCapacitor = false
+})
+
+describe('isPwaSunsetOn', () => {
+    it('fails closed by default', () => {
+        expect(isPwaSunsetOn()).toBe(false)
+    })
+
+    it('follows the posthog flag', () => {
+        mockFlagEnabled = true
+        expect(isPwaSunsetOn()).toBe(true)
+    })
+
+    it('dev localStorage override turns it on without posthog', () => {
+        localStorage.setItem('pwa-sunset', 'true')
+        expect(isPwaSunsetOn()).toBe(true)
+    })
+
+    it('ignores non-"true" override values', () => {
+        localStorage.setItem('pwa-sunset', 'false')
+        expect(isPwaSunsetOn()).toBe(false)
+    })
+})
+
+describe('getMigrationCutoverTime', () => {
+    it('returns the constant by default', () => {
+        expect(getMigrationCutoverTime()).toBe(CUTOVER)
+    })
+
+    it('dev localStorage override moves the cutover', () => {
+        localStorage.setItem('pwa-sunset-cutover', '2020-01-01')
+        expect(getMigrationCutoverTime()).toBe(new Date('2020-01-01').getTime())
+    })
+
+    it('garbage override falls back to the constant', () => {
+        localStorage.setItem('pwa-sunset-cutover', 'not-a-date')
+        expect(getMigrationCutoverTime()).toBe(CUTOVER)
+    })
+})
+
+describe('shouldShowSunsetBlock', () => {
+    const base = { migrationOn: true, hasKeepWebBypass: false, now: AFTER }
+
+    it('blocks past the cutover with the flag on', () => {
+        expect(shouldShowSunsetBlock(base)).toBe(true)
+    })
+
+    it('never blocks with the flag off', () => {
+        expect(shouldShowSunsetBlock({ ...base, migrationOn: false })).toBe(false)
+    })
+
+    it('never blocks before the cutover (notice window)', () => {
+        expect(shouldShowSunsetBlock({ ...base, now: BEFORE })).toBe(false)
+    })
+
+    it('public guest paths pass through', () => {
+        expect(shouldShowSunsetBlock({ ...base, isPublic: true })).toBe(false)
+    })
+
+    it('the native app is never blocked', () => {
+        mockIsCapacitor = true
+        expect(shouldShowSunsetBlock(base)).toBe(false)
+    })
+
+    it('the keep-web support bypass passes through', () => {
+        expect(shouldShowSunsetBlock({ ...base, hasKeepWebBypass: true })).toBe(false)
+    })
+
+    it('respects the dev cutover override', () => {
+        localStorage.setItem('pwa-sunset-cutover', '2020-01-01')
+        expect(shouldShowSunsetBlock({ ...base, now: BEFORE })).toBe(true)
+    })
+})

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -493,6 +493,8 @@ export type UserPreferences = {
      *  Read by useHomeCarouselCTAs to apply a per-CTA cooldown before re-showing.
      *  Legacy shape was `string[]` (permanent dismissal); both are accepted on read. */
     dismissedCarouselCTAs?: string[] | Record<string, string>
+    /** ISO timestamp of the last "Remind me later" on the app-migration download prompt. */
+    migrationPromptSnoozedAt?: string
 }
 
 export const updateUserPreferences = (

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -495,6 +495,12 @@ export type UserPreferences = {
     dismissedCarouselCTAs?: string[] | Record<string, string>
     /** ISO timestamp of the last "Remind me later" on the app-migration download prompt. */
     migrationPromptSnoozedAt?: string
+    /** ISO timestamp the notifications pre-prompt was dismissed — replaces the
+     *  legacy permanent `notifModalClosed` so we can re-ask after a cooldown
+     *  during the migration window. */
+    notifModalClosedAt?: string
+    /** ISO timestamp the app-review prompt was shown (asked once, ever). */
+    reviewPromptShownAt?: string
 }
 
 export const updateUserPreferences = (

--- a/src/utils/migration.utils.ts
+++ b/src/utils/migration.utils.ts
@@ -9,7 +9,7 @@ import {
     type StoreKind,
 } from '@/constants/migration.consts'
 import { isFeatureFlagEnabled } from '@/utils/featureFlag.utils'
-import { openExternalUrl } from '@/utils/capacitor'
+import { isCapacitor, openExternalUrl } from '@/utils/capacitor'
 
 /**
  * Flag read with a dev-only localStorage override. Local dev never inits
@@ -22,6 +22,26 @@ export function isPwaSunsetOn(): boolean {
         return true
     }
     return isFeatureFlagEnabled(PWA_SUNSET_FLAG)
+}
+
+/**
+ * The one sunset-block predicate, shared by every layout that can replace the
+ * app with the download screen ((mobile-ui) and (setup)). Public paths are the
+ * caller's concern: guest claim/request links must keep working, so the
+ * mobile-ui layout passes `isPublic`.
+ */
+export function shouldShowSunsetBlock({
+    migrationOn,
+    hasKeepWebBypass,
+    isPublic = false,
+    now = Date.now(),
+}: {
+    migrationOn: boolean
+    hasKeepWebBypass: boolean
+    isPublic?: boolean
+    now?: number
+}): boolean {
+    return migrationOn && !isPublic && !isCapacitor() && !hasKeepWebBypass && now >= getMigrationCutoverTime()
 }
 
 /**

--- a/src/utils/migration.utils.ts
+++ b/src/utils/migration.utils.ts
@@ -1,7 +1,44 @@
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
-import { STORE_URL, type MigrationSurface, type StoreKind } from '@/constants/migration.consts'
+import { IS_DEV } from '@/constants/general.consts'
+import {
+    MIGRATION_CUTOVER_DATE,
+    PWA_SUNSET_FLAG,
+    STORE_URL,
+    type MigrationSurface,
+    type StoreKind,
+} from '@/constants/migration.consts'
+import { isFeatureFlagEnabled } from '@/utils/featureFlag.utils'
 import { openExternalUrl } from '@/utils/capacitor'
+
+/**
+ * Flag read with a dev-only localStorage override. Local dev never inits
+ * posthog (instrumentation-client gates on NODE_ENV), so e2e QA flips the
+ * flag with `localStorage.setItem('pwa-sunset', 'true')` + reload instead.
+ * Inert outside dev builds.
+ */
+export function isPwaSunsetOn(): boolean {
+    if (IS_DEV && typeof localStorage !== 'undefined' && localStorage.getItem(PWA_SUNSET_FLAG) === 'true') {
+        return true
+    }
+    return isFeatureFlagEnabled(PWA_SUNSET_FLAG)
+}
+
+/**
+ * Cutover timestamp with a dev-only localStorage override
+ * (`localStorage.setItem('pwa-sunset-cutover', '2020-01-01')` + reload) so the
+ * post-cutover sunset block can be QA'd locally without editing the constant.
+ */
+export function getMigrationCutoverTime(): number {
+    if (IS_DEV && typeof localStorage !== 'undefined') {
+        const iso = localStorage.getItem('pwa-sunset-cutover')
+        if (iso) {
+            const t = new Date(iso).getTime()
+            if (!Number.isNaN(t)) return t
+        }
+    }
+    return MIGRATION_CUTOVER_DATE.getTime()
+}
 
 /** track a store CTA click without navigating (for anchors that navigate themselves). */
 export function trackStoreClick(store: StoreKind, surface: MigrationSurface) {

--- a/src/utils/migration.utils.ts
+++ b/src/utils/migration.utils.ts
@@ -1,0 +1,11 @@
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { STORE_URL, type MigrationSurface, type StoreKind } from '@/constants/migration.consts'
+import { openExternalUrl } from '@/utils/capacitor'
+
+/** navigate to the app store, tracking which surface sent the user there. */
+export function openStore(store: StoreKind, surface: MigrationSurface) {
+    posthog.capture(ANALYTICS_EVENTS.MIGRATION_STORE_CTA_CLICKED, { surface, store })
+    // fire-and-forget: native Browser plugin or window.open on web
+    void openExternalUrl(STORE_URL[store])
+}

--- a/src/utils/migration.utils.ts
+++ b/src/utils/migration.utils.ts
@@ -3,9 +3,14 @@ import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { STORE_URL, type MigrationSurface, type StoreKind } from '@/constants/migration.consts'
 import { openExternalUrl } from '@/utils/capacitor'
 
+/** track a store CTA click without navigating (for anchors that navigate themselves). */
+export function trackStoreClick(store: StoreKind, surface: MigrationSurface) {
+    posthog.capture(ANALYTICS_EVENTS.MIGRATION_STORE_CTA_CLICKED, { surface, store })
+}
+
 /** navigate to the app store, tracking which surface sent the user there. */
 export function openStore(store: StoreKind, surface: MigrationSurface) {
-    posthog.capture(ANALYTICS_EVENTS.MIGRATION_STORE_CTA_CLICKED, { surface, store })
+    trackStoreClick(store, surface)
     // fire-and-forget: native Browser plugin or window.open on web
     void openExternalUrl(STORE_URL[store])
 }


### PR DESCRIPTION
## Summary

The PWA→native migration surfaces, all dark behind the `pwa-sunset` PostHog flag — launch is a flag flip in the PostHog UI, not a deploy. Extracted from the `/dev/migration` showcase (#2574) and wired into the real flows.

**Flag OFF (default, today):** no behavior change on any existing surface (pinned by test). For accuracy, the edits that DO ship flag-off: the setup step-filter conditional, the home modal-priority guards, `window.posthog` exposure (official-snippet parity, enables QA/support console access), `overflow-x-clip` on the landing shell (fixes a pre-existing mobile horizontal-scroll bug), a one-time `notifModalClosedAt` migration write for users carrying the legacy dismissal boolean, two lazily-fetched modal chunks on /home (~5-10KB, matches the existing self-gating-modal pattern), and the `/app` route existing (it 404s until the flag resolves ON).
**Flag ON (notice window):** post-login "Peanut is becoming an app" modal (3-day snooze, days-to-cutover in copy), get-the-app home-carousel banner (supersedes ios-pwa-install), landing hero CTA → "Download now" (store deep-link on mobile / scan-to-download QR on desktop), setup drops the InstallPWA steps and offers store links, notifications pre-prompt re-asks after 14 days instead of never.
**Flag ON + past `MIGRATION_CUTOVER_DATE`:** full-screen sunset block on both the app and setup layouts; `?keep-web=<token>` (support-distributed) sets a 90-day bypass cookie.
**Native app only:** review prompt, once ever, after the user has a transaction — "Love it" → store review page, "Could be better" → support drawer.

## Tasks

- **Contributes to TASK-20912** — PostHog feature-flag scaffold: `pwa-sunset` flag constant + `useMigrationFlag()` hook (hydration-safe wrapper over the existing `useFeatureFlags`); everything else in this PR gates on it.
- **Contributes to TASK-20826** — Web download-app modal: post-login "Peanut is becoming an app" prompt on /home, device-aware (store CTA on mobile, inline QR on desktop), 3-day "Remind me later" snooze, top of the home modal-priority chain.
- **Contributes to TASK-20827** — 30-day sunset block: full-screen `SunsetScreen` replaces the app (and /setup) once `MIGRATION_CUTOVER_DATE` passes with the flag on; V1 global-date constant as agreed.
- **Contributes to TASK-20828** — Support bypass link: `?keep-web=<token>` persists a 90-day cookie via the shared `useKeepWebBypass` hook and skips the sunset block on every gated layout; FE-only V1 with a static support-distributed token.
- **Contributes to TASK-20600** — Store links on landing + setup: landing hero CTA becomes "Download now" (store deep-link on mobile, scan-to-download QR on desktop) and the setup landing step offers store buttons.
- **Contributes to TASK-20830** — Retire the PWA install step: setup drops `pwa-install`/`android-initial-pwa-install`/`unsupported-browser` and the post-setup iOS force-install screen while the flag is on (latched per setup session to avoid mid-flow resets).
- **Contributes to TASK-20829** — Open-in-app banner: `app-install` home-carousel CTA (supersedes the ios-pwa-install CTA), store on mobile / QR modal on desktop, with the carousel's existing dismiss-cooldown machinery.
- **Contributes to TASK-20771** — Push opt-in pre-prompt: migration-era "Get money alerts" copy (flag-gated, all 3 locales) and "Not now" now snoozes 14 days instead of dismissing forever (legacy `notifModalClosed` converts to a snooze on read).
- **Contributes to TASK-20598** — Review nudge: native-only "Loving Peanut so far?" asked once ever after the user has a transaction; "Love it" deep-links the store review page, "Could be better" opens the support drawer so bad reviews never reach the store.
- **Contributes to TASK-20939** — Migration funnel analytics: `MODAL_SHOWN/DISMISSED/CTA_CLICKED` with new `migration_download`/`app_review` types plus `migration_sunset_viewed`, `migration_store_cta_clicked`, `migration_qr_shown`, `migration_keep_web_used`, all carrying `surface`/`store` props — instrumented inside each component.

## Risks / launch blockers (not merge blockers)

- **Store URLs are placeholders** — real App Store numeric id + Play listing must land in `migration.consts.ts` before flag-on (iOS `?action=write-review` needs the numeric id too).
- **`MIGRATION_CUTOVER_DATE` is a placeholder constant** (2026-12-31) — set the real date before flag-on; moving it requires a deploy (accepted V1 trade-off, upgrade path = flag payload).
- **The `pwa-sunset` flag must be created OFF in PostHog** (project 138913) before merge — an undefined flag fails closed, so even that is safe.
- Flag-off regression surface: see the accurate list in the Flag OFF paragraph above — behavioral risk concentrates in the setup step filter and home modal guards; the rest are inert or cosmetic-fix changes. Pinned by the gating test (flag-off renders nothing) plus the new `shouldShowSunsetBlock` matrix tests.

## Design notes / accepted trade-offs

- `useMigrationFlag` returns `false` until mounted — posthog serves cached flags synchronously for returning visitors, so render-time reads would hard-fail hydration against flag-off SSR HTML on prerendered surfaces (review finding).
- The setup step filter latches the flag at its first run instead of reacting to the async flag load — a mid-load flip re-dispatched `setSteps` and reset a mid-flow user to the landing step (review finding). First-ever visitors in the seconds before flags cache get the legacy flow; returning visitors are correct immediately.
- The review prompt stamps `reviewPromptShownAt` on interaction, not on show, so a priority-wrapper unmount can't burn the once-ever ask unseen.
- The notifications pre-prompt 14-day re-ask is bounded by the flag lifecycle: flag deleted post-launch (feature-gates doctrine) → behavior returns to closed-forever.
- Post-cutover guest story (V1): a guest hitting a link → setup is blocked with the download screen; after install, re-tapping the original link opens it in-app via universal links (invite code + redirect intact). The polished no-re-tap story is the deferred deep link (#2560) — its `deferred-link` utils live on `main` and aren't in `dev` yet, so the handoff isn't wired. Follow-up after the main→dev back-merge: attach the payload in `openStore()` (single chokepoint, upgrades every migration surface at once).
- Reviewer flag (follow-up, not this PR): `useNotifications.ts` now carries three dismissal representations (legacy `notifModalClosed` bool + `notifModalClosedAt` timestamp + flag-conditional snooze) in a historically fix-prone file — standing deep-dive candidate to consolidate once the migration flag is deleted.

- Cutover date = code constant, not flag payload (one async source, not two).
- keep-web = one static shared FE token — courtesy escape hatch, not a security control; per-user tokens need a BE endpoint.
- Review prompt "good moment" V1 = has-a-transaction + home visit (shares HomeHistory's query cache); wiring exact success screens is the upgrade path. Store-page deep link; `@capacitor-community/in-app-review` if conversion matters.
- Landing hero override is English-only like the rest of that surface; the permanent label change goes through the content system post-cutover, deleting the override.
- Legacy `notifModalClosed: true` converts to a snooze-from-now on read (same trick as `getDismissedCTAs`).
- The sunset gate reads `Date.now()` at render with no timer: a session left open across the exact cutover moment stays usable until its next navigation/reload. Accepted — the block catches everyone within one interaction.
- `/app` is flag-gated with an async-flag wait (posthog callback + 4s timeout) so first-time scanners aren't 404'd before their flags arrive; flag-off it renders `notFound()`.

## QA

1. Flag OFF (default): walk setup (PWA-install step present), home (no new modals/banners), landing (normal hero) — zero visible change.
2. Flag ON via console `posthog.featureFlags.overrideFeatureFlags({ flags: { 'pwa-sunset': true } })` (posthog-js 1.3xx needs the `flags` wrapper; a flat object is silently ignored): download modal on /home, carousel banner, "Download now" hero, setup shows store links and skips PWA steps; desktop CTAs open the QR modal.
3. Cutover: with the override on, temporarily set `MIGRATION_CUTOVER_DATE` in the past → sunset block on every route incl. /setup; `?keep-web=walnut-still-cracks` bypasses it and survives reload.
4. Events land in PostHog Activity with `surface`/`store` props.

Screenshots: ✅ embedded below (11 states, all flag-on surfaces). Flag-off renders pixel-identical (pinned by test).


## Screenshots

Captured on the branch against the local sandbox (harness debug ribbons at the top of logged-in shots are local-dev chrome, not product UI). Assets live on the `pr-assets-2591` orphan branch — **delete it after merge**.

**Download prompt (flag ON, notice window)**

| Desktop — early phase (celebrate) | Desktop — final 14 days (urgency) | Mobile — store CTA |
|---|---|---|
| ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2591/download-modal-desktop-early.png) | ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2591/download-modal-desktop-urgent.png) | ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2591/download-modal-mobile-early.png) |

**Sunset block (flag ON + past cutover)**

| Desktop (50/50 row) | Mobile (50/50 stack, pinned CTA) |
|---|---|
| ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2591/sunset-desktop.png) | ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2591/sunset-mobile.png) |

**New-user funnel (flag ON)**

| Landing hero (desktop: white store pair) | Landing hero (mobile: device store CTA) | Sticky CTA (mobile) |
|---|---|---|
| ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2591/landing-hero-desktop.png) | ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2591/landing-hero-mobile.png) | ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2591/landing-sticky-mobile.png) |

| Setup desktop (signup closed: QR + Log In) | Setup mobile (signup closed: store CTA + Log In) |
|---|---|
| ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2591/setup-desktop-download-only.png) | ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2591/setup-mobile-store-block.png) |

**Home banner + smart link**

| Get-the-app carousel card (mobile) | /app smart link (desktop) |
|---|---|
| ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2591/home-banner-mobile.png) | ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2591/smart-link-desktop.png) |

| /app smart link (mobile, mid-redirect: loading in the CTA) | /app smart link (mobile, settled) |
|---|---|
| ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2591/smart-link-mobile-redirect.png) | ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2591/smart-link-mobile.png) |

**Native nudges** (native-only gates — captured by temporarily forcing visibility on the real components in a local run; the gating logic itself is unchanged and covered above)

| Notifications pre-prompt (flag-on copy) | Review prompt (once ever, in-app) |
|---|---|
| ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2591/notifications-prompt-mobile.png) | ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2591/review-prompt-mobile.png) |

Behavior on real devices (OS permission dialog, store review page) still needs the simulator/device QA pass (TASK-20831).

**Guest claim/request flow under the cutover** (public paths bypass the sunset gate — captured with flag ON + cutover past; this PR does not modify these pages. The "Join PEANUT" CTA's app-handoff redesign belongs to the deferred-deep-link work, #2560/TASK-20772)

| Guest request page (desktop) | Guest request page (mobile) | Join PEANUT → scan-to-download modal (desktop) |
|---|---|---|
| ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2591/guest-request-desktop.png) | ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2591/guest-request-mobile.png) | ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2591/guest-join-qr-modal-desktop.png) |

During the migration window the guest CTA no longer routes into the (closed) web signup: desktop opens the QR modal above, phones deep-link straight to their store (`useGuestStoreHandoff`, wired into both the pay/request and claim-link CTAs). Native-app guests keep the normal in-app flow.

