### PR TITLE
docs(security): add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security policy
+
+## Report a vulnerability
+
+Report security issues here:
+
+**https://peanut.me/en/help/security-disclosure**
+
+That page is the current policy. Machine-readable contact details are at
+[`/.well-known/security.txt`](https://peanut.me/.well-known/security.txt).
+
+We read every report.
+
+## Scope
+
+In scope:
+
+- The Peanut app and website (peanut.me)
+- The Peanut API
+- The smart contracts behind Peanut accounts
+
+Out of scope:
+
+- Partner systems (identity verification, banking, card issuing)
+- Scanner output with no demonstrated impact
+- Denial of service and volumetric testing
+- Social engineering
+- Anything that needs physical access to another person's unlocked device
+
+## Rewards
+
+Rewards are discretionary. There is no fixed payout schedule and no severity
+tiers. Older pages elsewhere on the internet describe a Peanut bug bounty with
+published payout figures. That programme is retired.


### PR DESCRIPTION
GitHub surfaces a **Report a vulnerability** link only when it finds `SECURITY.md`. Researchers browsing this repo saw no intake path — even though [the disclosure page](https://peanut.me/en/help/security-disclosure) and [`/.well-known/security.txt`](https://peanut.me/.well-known/security.txt) already exist and both return 200.

That gap is concrete: of the three researchers who reported in July 2026, one mailed an unmonitored address twice, one landed in the customer support chat behind KYC tickets, and one went through a founder's Telegram. Three front doors, none of them this one.

**This file points at the existing policy rather than restating it**, so `mono/product/security.md` stays the single source of truth. Scope and reward wording are copied from it verbatim:

- discretionary rewards, no fixed schedule, no severity tiers
- the retired tiered programme explicitly named as retired
- no service promises — the only commitment is "we read every report"
