### PR TITLE
hotfix(re-consent): copy that answers the question users are actually asking

### DIFF
--- a/src/components/Global/ReConsentModal/index.tsx
+++ b/src/components/Global/ReConsentModal/index.tsx
@@ -148,7 +148,7 @@ const ReConsentModal = () => {
                     </p>
                     <p className="text-sm text-grey-1">
                         We've rewritten the documents below in plain language so they match what Peanut is today,
-                        including the Peanut Card and Rewards. There's no rush — read them whenever, and keep using
+                        including the Peanut Card and Rewards. There's no rush, read them whenever, and keep using
                         Peanut as usual.
                     </p>
                     <ul className="space-y-1 text-sm">

--- a/src/components/Global/ReConsentModal/index.tsx
+++ b/src/components/Global/ReConsentModal/index.tsx
@@ -157,7 +157,7 @@ const ReConsentModal = () => {
                 </div>
             }
             checkbox={{
-                text: 'I have read and accept the updated documents',
+                text: 'I accept the updated documents',
                 checked,
                 onChange: setChecked,
             }}
@@ -168,12 +168,17 @@ const ReConsentModal = () => {
                     shadowSize: '4',
                     disabled: !checked || submitting,
                     onClick: handleAccept,
+                    // ActionModal's sm:flex-1 (meant for its side-by-side layout)
+                    // squashes h-13 buttons when the CTAs are stacked
+                    className: 'sm:flex-none',
                 },
                 {
                     text: 'Not now',
                     variant: 'transparent',
                     disabled: submitting,
                     onClick: handlePostpone,
+                    // secondary de-emphasis: .btn is font-bold by default
+                    className: 'sm:flex-none font-normal text-grey-1',
                 },
             ]}
             ctaClassName={STACKED_CTAS}

--- a/src/components/Global/ReConsentModal/index.tsx
+++ b/src/components/Global/ReConsentModal/index.tsx
@@ -134,12 +134,22 @@ const ReConsentModal = () => {
             visible
             onClose={handlePostpone}
             icon="info"
-            title="We've updated our terms"
+            title="A small update to our terms"
             content={
                 <div className="w-full space-y-3 text-left">
+                    {/* The first sentence answers the question this modal actually raises
+                     * ("is something being taken from me?") before anything else. The
+                     * what-changed line describes the 2026-07-15 tos-v1 rewrite — revisit
+                     * it when a future version bump shows this modal for a different
+                     * change. "No rush" is literal: "Not now" snoozes to the effective
+                     * date (see utils.ts). */}
                     <p className="text-sm text-grey-1">
-                        We've refreshed the documents below. Give them a read and accept when you're ready — you can
-                        keep using Peanut in the meantime.
+                        Nothing changes about your fees, your funds, or how we handle your data.
+                    </p>
+                    <p className="text-sm text-grey-1">
+                        We've rewritten the documents below in plain language so they match what Peanut is today,
+                        including the Peanut Card and Rewards. There's no rush — read them whenever, and keep using
+                        Peanut as usual.
                     </p>
                     <ul className="space-y-1 text-sm">
                         {outdatedDocs.map((doc) => {


### PR DESCRIPTION
Per Konrad's Slack note on the terms popup: the modal announced a change without saying what changed, which for someone with money in the app reads as "are the fees going up / is my data being sold". This replaces the copy so the first sentence answers that question.

**Before**
> **We've updated our terms**
> We've refreshed the documents below. Give them a read and accept when you're ready — you can keep using Peanut in the meantime.

**After**
> **A small update to our terms**
> Nothing changes about your fees, your funds, or how we handle your data.
> We've rewritten the documents below in plain language so they match what Peanut is today, including the Peanut Card and Rewards. There's no rush — read them whenever, and keep using Peanut as usual.

Every claim is checked against what actually happened:

- **"Nothing changes about your fees, your funds, or how we handle your data"** — verified against the tos-v1 rulings (mono `inbox/tos-v1/drafts/RULINGS.md`): no fee change (there are none to change), custody model untouched, and the privacy rewrite describes existing practices accurately (real processor list) rather than changing them.
- **What changed** — the 2026-07-15 update was a full rewrite retiring the old Notion-era documents (wrong entity, DAO-era audience) so they match today's product. The copy says that, because it's the true and more reassuring story.
- **"There's no rush"** — literal, not soothing: the modal is a prompt, not a gate. "Not now" snoozes to the documents' effective date (ToS §17.2), so deferring is genuinely fine and now *sounds* fine — this also removes the dark-pattern contradiction Konrad flagged.

A code comment marks the what-changed line as specific to the 2026-07-15 rewrite, so the next document version bump revisits it instead of shipping stale reassurance.

**Hotfix, targets `main` directly** (retargeted per Konrad — the modal only exists on `main`). The branch is based on https://github.com/peanutprotocol/peanut-ui/pull/2589, so this PR carries @jjramirezn's visual-polish commit plus the copy commit; whichever of the two merges first, the other's diff shrinks accordingly. CTA labels are unchanged, so the 16 modal tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the re-consent message with clearer information about fees, funds, data handling, and continued use of Peanut.
  * Simplified the acceptance checkbox wording.
  * Improved button layout and styling for stacked actions, including the “Not now” option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->