### PR TITLE
fix(native): deferred deep-link hardening + un-prune its dev page (for v1.0.47)

### DIFF
--- a/scripts/native-build.js
+++ b/scripts/native-build.js
@@ -569,12 +569,23 @@ async function main() {
 // Web-only dead weight in the bundled export (~8 MB): /dev test pages and the
 // iOS-PWA install videos are unreachable from native flows. KEEP_DEV_PAGES=true
 // retains /dev for profiling/test builds (e.g. the confetti repro page).
+//
+// Exception: dev/deferred stays. It IS reachable from native flows — it's the
+// landing target for the deferred-deep-link e2e (dest=/dev/deferred) and the
+// AASA paths:["*"] routes it into the app on iOS. Pruning it turns those
+// navigations into a chunk-error reload loop that bounces users to setup
+// (seen on 1.0.46). It's a few KB and walled off web-prod inside the page.
 function pruneExportedAssets() {
     const outDir = path.join(__dirname, '..', 'out')
 
     const targets = []
     if (process.env.KEEP_DEV_PAGES !== 'true') {
-        targets.push(path.join(outDir, 'dev'))
+        const devDir = path.join(outDir, 'dev')
+        if (fs.existsSync(devDir)) {
+            for (const entry of fs.readdirSync(devDir)) {
+                if (entry !== 'deferred') targets.push(path.join(devDir, entry))
+            }
+        }
     }
     for (const entry of fs.readdirSync(outDir)) {
         if (entry.endsWith('.mov')) targets.push(path.join(outDir, entry))

--- a/src/hooks/__tests__/useNativePlugins.test.tsx
+++ b/src/hooks/__tests__/useNativePlugins.test.tsx
@@ -82,6 +82,23 @@ describe('useNativePlugins deferred restore wiring', () => {
         await waitFor(() => expect(push).toHaveBeenCalledWith('/claim?x=1'))
     })
 
+    it('drops the dest when the restore resolves late (user already mid-flow), cookies still applied upstream', async () => {
+        let fakeNow = 1_000
+        const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => fakeNow)
+        mockRestore.mockImplementation(() => {
+            // e.g. the paste prompt sat unanswered for 20s before the user allowed it
+            fakeNow += 20_000
+            return Promise.resolve({ dest: '/claim?x=1', locale: null })
+        })
+
+        renderHook(() => useNativePlugins())
+
+        await waitFor(() => expect(mockRestore).toHaveBeenCalled())
+        await new Promise((r) => setTimeout(r, 0))
+        expect(push).not.toHaveBeenCalledWith('/claim?x=1')
+        nowSpy.mockRestore()
+    })
+
     it('a restore failure never breaks the rest of init', async () => {
         mockRestore.mockRejectedValue(new Error('boom'))
 

--- a/src/hooks/useNativePlugins.ts
+++ b/src/hooks/useNativePlugins.ts
@@ -64,11 +64,20 @@ export function useNativePlugins() {
                 // awaited: the iOS clipboard read can sit on the system paste
                 // prompt and the android referrer service can be slow — neither
                 // may hold up the rest of init (push listener, splash hide).
+                const restoreStartedAt = Date.now()
                 import('@/utils/deferred-link')
                     .then(({ restoreDeferredContext }) => restoreDeferredContext())
                     .then((restored) => {
+                        if (!restored?.dest) return
                         // a deep link that actually navigated wins the landing
-                        if (restored?.dest && !anyDeepLinkNavigated) router.push(restored.dest)
+                        if (anyDeepLinkNavigated) return
+                        // a restore that resolves late (paste prompt left up for
+                        // minutes, sluggish referrer service) must not teleport a
+                        // user who is already tapping through onboarding — only
+                        // navigate while this still reads as "the app just opened".
+                        // cookies + locale above are applied regardless.
+                        if (Date.now() - restoreStartedAt > 10_000) return
+                        router.push(restored.dest)
                     })
                     .catch((e) => console.warn('deferred link restore failed:', e))
             } catch (e) {

--- a/src/utils/__tests__/deferred-link.test.ts
+++ b/src/utils/__tests__/deferred-link.test.ts
@@ -131,15 +131,15 @@ describe('parseDeferredPayload rejection', () => {
 })
 
 describe('applyDeferredPayload', () => {
-    it('writes durable 30-day cookies, not session cookies', () => {
+    it('writes a SESSION inviteCode cookie (matching InvitesPage — a durable one locks existing users out of login) and a 30-day campaignTag', () => {
         applyDeferredPayload({ invite: 'abc', campaign: 'off' })
-        expect(mockSaveToCookie).toHaveBeenCalledWith('inviteCode', 'abc', 30)
+        expect(mockSaveToCookie).toHaveBeenCalledWith('inviteCode', 'abc')
         expect(mockSaveToCookie).toHaveBeenCalledWith('campaignTag', 'off', 30)
     })
 
     it('normalizes invite and campaign like the existing writers', () => {
         applyDeferredPayload({ invite: ' @Alice ', campaign: ' OFFRAMP ' })
-        expect(mockSaveToCookie).toHaveBeenCalledWith('inviteCode', 'alice', 30)
+        expect(mockSaveToCookie).toHaveBeenCalledWith('inviteCode', 'alice')
         expect(mockSaveToCookie).toHaveBeenCalledWith('campaignTag', 'offramp', 30)
     })
 
@@ -147,6 +147,13 @@ describe('applyDeferredPayload', () => {
         expect(applyDeferredPayload({ dest: '/es-419/claim/XYZ?t=1' }).dest).toBe('/claim/XYZ?t=1')
         expect(applyDeferredPayload({ dest: '/pt-br/home' }).dest).toBe('/home')
         expect(applyDeferredPayload({ dest: '/claim/XYZ' }).dest).toBe('/claim/XYZ')
+        // locale with only a query after it
+        expect(applyDeferredPayload({ dest: '/pt-br?x=1' }).dest).toBe('/?x=1')
+    })
+
+    it('drops an unmappable dest instead of pushing it verbatim', () => {
+        // stray % makes decodeURIComponent throw inside deepLinkToNativePath
+        expect(applyDeferredPayload({ dest: '/send/50%' }).dest).toBeNull()
     })
 
     it('normalizes and persists supported locales under the app-locale key', async () => {
@@ -185,6 +192,20 @@ describe('restoreDeferredContext', () => {
         expect(getReferrer).not.toHaveBeenCalled()
     })
 
+    it('does NOT consume on a transient android read failure — next launch retries', async () => {
+        mockIsAndroidNative.mockReturnValue(true)
+        // timeout / SERVICE_UNAVAILABLE path: plugin resolves {referrer: null}
+        getReferrer.mockResolvedValue({ referrer: null })
+
+        await expect(restoreDeferredContext()).resolves.toBeNull()
+        expect(localStorage.getItem('deferredLinkConsumed')).toBeNull()
+
+        // "next launch": the read now succeeds and the payload still lands
+        getReferrer.mockResolvedValue({ referrer: 'pnutdl=1&dest=%2Fhome' })
+        await expect(restoreDeferredContext()).resolves.toEqual({ dest: '/home', locale: null })
+        expect(localStorage.getItem('deferredLinkConsumed')).toBe('1')
+    })
+
     it('consumes even when nothing is found (organic install)', async () => {
         mockIsAndroidNative.mockReturnValue(true)
         getReferrer.mockResolvedValue({ referrer: 'utm_source=google-play&utm_medium=organic' })
@@ -201,12 +222,28 @@ describe('restoreDeferredContext', () => {
         await expect(restoreDeferredContext()).resolves.toEqual({ dest: null, locale: null })
     })
 
-    it('survives a missing plugin (older binary) and still consumes', async () => {
+    it('survives a missing plugin (older binary) without consuming — the retry is a single cheap no-op per launch', async () => {
         mockIsAndroidNative.mockReturnValue(true)
         getReferrer.mockRejectedValue(new Error('"InstallReferrer" plugin is not implemented on android'))
 
         await expect(restoreDeferredContext()).resolves.toBeNull()
+        expect(localStorage.getItem('deferredLinkConsumed')).toBeNull()
+    })
+
+    it('iOS: consumes BEFORE the paste prompt so kill-during-prompt never re-prompts', async () => {
+        mockIsIOSNative.mockReturnValue(true)
+        mockClipboardHasStrings.mockResolvedValue(true)
+        mockClipboardHasProbableWebUrl.mockResolvedValue(true)
+        // user declined the prompt (or killed the app — read never resolves ok)
+        clipboardRead.mockRejectedValue(new Error('denied'))
+
+        await expect(restoreDeferredContext()).resolves.toBeNull()
         expect(localStorage.getItem('deferredLinkConsumed')).toBe('1')
+
+        // next launch: no clipboard access at all
+        mockClipboardHasStrings.mockClear()
+        await expect(restoreDeferredContext()).resolves.toBeNull()
+        expect(mockClipboardHasStrings).not.toHaveBeenCalled()
     })
 
     it('overlapping calls share one platform read', async () => {
@@ -245,7 +282,7 @@ describe('restoreDeferredContext', () => {
         clipboardWrite.mockResolvedValue(undefined)
 
         await expect(restoreDeferredContext()).resolves.toEqual({ dest: '/home', locale: null })
-        expect(mockSaveToCookie).toHaveBeenCalledWith('inviteCode', 'test', 30)
+        expect(mockSaveToCookie).toHaveBeenCalledWith('inviteCode', 'test')
         expect(clipboardWrite).toHaveBeenCalled()
     })
 })

--- a/src/utils/deferred-link.ts
+++ b/src/utils/deferred-link.ts
@@ -7,7 +7,7 @@ import { registerPlugin } from '@capacitor/core'
 import { PLAY_STORE_URL } from '@/constants/general.consts'
 import { isValidLocale } from '@/i18n/config'
 import { isAndroidNative, isIOSNative } from './capacitor'
-import { getFromCookie, saveToCookie, sanitizeRedirectURL } from './general.utils'
+import { getFromCookie, saveToCookie, sanitizeRedirectURL, toInviteCode } from './general.utils'
 import { deepLinkToNativePath } from './native-routes'
 
 // marker param distinguishing our payload from Play's organic referrer
@@ -77,11 +77,15 @@ export async function readInstallReferrer(): Promise<string | null> {
 /**
  * strips a leading marketing locale segment (/es-419/claim/X → /claim/X).
  * locale-prefixed routes only exist on the web — in the native static export
- * they 404, so they must never survive into a dest.
+ * they 404, so they must never survive into a dest. query/hash split off
+ * first so /pt-br?x=1 is recognized too.
  */
 function stripLocalePrefix(path: string): string {
-    const [, first, ...rest] = path.split('/')
-    return first && isValidLocale(first) ? '/' + rest.join('/') : path
+    const suffixIndex = path.search(/[?#]/)
+    const pathname = suffixIndex >= 0 ? path.slice(0, suffixIndex) : path
+    const suffix = suffixIndex >= 0 ? path.slice(suffixIndex) : ''
+    const [, first, ...rest] = pathname.split('/')
+    return first && isValidLocale(first) ? '/' + rest.join('/') + suffix : path
 }
 
 /**
@@ -188,9 +192,21 @@ async function doRestore(): Promise<RestoredContext | null> {
         return null
     }
 
+    const markConsumed = () => {
+        try {
+            localStorage.setItem(CONSUMED_KEY, '1')
+        } catch {}
+    }
+
     let raw: string | null = null
     if (isAndroidNative()) {
         raw = await readInstallReferrer()
+        // the android read is prompt-free and the referrer stays readable for
+        // ~90 days — a transient failure (5s timeout, service unavailable on
+        // a busy first boot) resolves null and must NOT burn the one-shot;
+        // the next launch retries. a definitive read (incl. play's organic
+        // utm string) consumes.
+        if (raw !== null) markConsumed()
     } else if (isIOSNative()) {
         try {
             // both gates are prompt-free metadata checks. the hand-off is
@@ -199,19 +215,22 @@ async function doRestore(): Promise<RestoredContext | null> {
             // (a password, a message draft) are never prompted.
             const { clipboardHasStrings, clipboardHasProbableWebUrl } = await import('./clipboard-detect')
             if ((await clipboardHasStrings()) && (await clipboardHasProbableWebUrl())) {
+                // consume BEFORE the prompt-raising read: killing the app while
+                // the system paste prompt is up must never cause a re-prompt on
+                // the next launch (losing the hand-off is the lesser harm).
+                markConsumed()
                 const { Clipboard } = await import('@capacitor/clipboard')
                 raw = (await Clipboard.read()).value ?? null
+            } else {
+                markConsumed()
             }
         } catch {
             // user declined the paste prompt, or clipboard unavailable
+            markConsumed()
         }
+    } else {
+        markConsumed()
     }
-
-    // one shot, even on failure: android's referrer stays readable for months
-    // and iOS must never re-prompt
-    try {
-        localStorage.setItem(CONSUMED_KEY, '1')
-    } catch {}
 
     const payload = raw ? parseDeferredPayload(raw) : null
     if (!payload) return null
@@ -237,21 +256,28 @@ async function doRestore(): Promise<RestoredContext | null> {
  * the /dev/deferred simulator so there is exactly one apply path.
  */
 export function applyDeferredPayload(payload: DeferredPayload): RestoredContext {
-    // normalize like every existing writer (InvitesPage lowercases ?code and
-    // utm_campaign; toInviteCode trims/strips @) — a hand-built referrer with
-    // an uppercase tag must not break the case-sensitive badge award.
-    // 30-day expiry matches useZeroDev's invite cookie: a session cookie would
-    // be dropped by the webview before the user finishes signup, and the
-    // one-shot consumed flag means it could never be re-read.
-    const invite = payload.invite?.trim().replace(/^@/, '').toLowerCase()
-    if (invite) saveToCookie('inviteCode', invite, 30)
+    // inviteCode: SESSION cookie, exactly matching the web invite flow
+    // (InvitesPage). the cookie routes /setup past Landing — the only screen
+    // with Log In — so a durable cookie would lock an existing user who
+    // installed via a friend's invite link out of login (the PR #2346
+    // regression class). session scope keeps attribution for the
+    // install→open→signup funnel and self-heals on app restart.
+    const invite = payload.invite ? toInviteCode(payload.invite) : ''
+    if (invite) saveToCookie('inviteCode', invite)
+    // campaignTag doesn't gate the setup step (removed in the #2346 fix), so
+    // it can safely outlive the session for badge attribution. lowercased
+    // like InvitesPage's utm_campaign handling — badge matching is
+    // case-sensitive.
     const campaign = payload.campaign?.trim().toLowerCase()
     if (campaign) saveToCookie('campaignTag', campaign, 30)
 
     const locale = payload.lang ? resolveAppLocale(payload.lang) : null
     if (locale) persistRestoredLocale(locale)
 
+    // must-map, like openDeepLink: an unmappable dest (off-host, malformed
+    // encoding) is dropped, never pushed verbatim into the static export
     const rawDest = payload.dest ? stripLocalePrefix(payload.dest) : null
-    const dest = rawDest ? sanitizeRedirectURL(deepLinkToNativePath(rawDest) ?? rawDest) : null
+    const mapped = rawDest ? deepLinkToNativePath(rawDest) : null
+    const dest = mapped ? sanitizeRedirectURL(mapped) : null
     return { dest, locale }
 }


### PR DESCRIPTION
## Summary

Two fixes for the deferred deep linking shipped in 1.0.43+ (`adb200e65` cherry-picked the pre-review version of peanut-ui#2560):

1. **`9c7bd7ebe` — the review hardening from #2560 (`ffc9e79e8`), clean cherry-pick.** The shipped builds carry the pre-review semantics, including the two that broke Kush's device test and one field-facing blocker:
   - one-shot flag burned on ANY first launch (transient/empty read included) → a single organic-looking launch permanently kills the hand-off, no retry — this is why "nothing happens" on TestFlight 1.0.46 and why it's undebuggable after the fact
   - **30-day inviteCode cookie → login lockout** (routes /setup past Landing, the only Log In screen — the #2346 regression class) → now a session cookie matching the web invite flow
   - iOS: consume-before-prompt (kill-during-prompt can't re-prompt), Android: retry on transient null, dest must-map guard, 10s late-navigation window, locale-prefix query fix, `toInviteCode` reuse

2. **`3c05197ef` — stop pruning `dev/deferred` from the native export.** `pruneExportedAssets` strips all of `/dev`; that page is the deferred-link landing target (`dest=/dev/deferred`) and AASA `paths:["*"]` routes it into the app on iOS — on 1.0.46 the navigation hits a missing route and chunk-error recovery reload-loops the user into a setup bounce (reproduced). Everything else still prunes; verified against a real export (`out/dev/` = exactly `deferred/`).

## Risks

- Restore semantics change slightly (session invite cookie, retries) — all covered by the 29 deferred/hook tests cherry-picked alongside; full suite 2345 green on this branch.
- Bundle grows by a few KB (one dev page, walled off web-prod inside the page).

## QA

- `npm test` 2345 ✅ · typecheck ✅ · native export built from this branch, prune verified
- After tag: fresh-install iOS test per TASK-20772 — use `dest=%2Fhistory` for store builds if you want a user-facing landing, or `dest=%2Fdev%2Fdeferred` now works too

@innolope-dev this touches your lane — the cherry-pick is verbatim `ffc9e79e8` from main plus the prune exemption; nothing else. Suggest this rides the next tag (v1.0.47). Your telemetry PR #2587 would rebase cleanly on top of this once retargeted.

Screenshots: N/A (no visible change)
