### PR TITLE
fix(qr-pay): key the success-screen receipt by the Manteca synthetic id

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
+++ b/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
@@ -1052,6 +1052,31 @@ describe('GROUP 4: Success States', () => {
         expect(screen.getByText('Split this bill')).toBeInTheDocument()
     })
 
+    test('See receipt opens the drawer keyed by the Manteca synthetic id, not externalId', async () => {
+        // getReceiptUrl builds /receipt/<id>?kind=QR_PAY, and the backend resolves
+        // that id only via the Manteca synthetic id. Stamping externalId here 404s
+        // every shared receipt.
+        const openTransactionDetails = jest.fn()
+        mockUseTransactionDetailsDrawer.mockReturnValue({
+            openTransactionDetails,
+            selectedTransaction: null,
+            isDrawerOpen: false,
+            closeTransactionDetails: jest.fn(),
+        })
+
+        await completeMantecaPayment()
+
+        await waitFor(() => {
+            expect(screen.getByText('See receipt')).toBeInTheDocument()
+        })
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('See receipt'))
+        })
+
+        expect(openTransactionDetails).toHaveBeenCalledWith(expect.objectContaining({ id: 'qp1' }))
+    })
+
     test('Manteca success, perk eligible shows hold-to-claim button', async () => {
         await completeMantecaPayment({
             perk: {

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -1440,11 +1440,10 @@ export default function QRPayPage() {
                                     onClick={() => {
                                         const now = new Date()
                                         openTransactionDetails({
-                                            // Manteca synthetic id — the only key the receipt
-                                            // lookup resolves (`metadata.mantecaSyntheticId` /
-                                            // `manteca-transfer:<id>`), and what Activity rows
-                                            // already carry. `externalId` is UUID-shaped, so it
-                                            // slips past the id-shape gate and 404s silently.
+                                            // Manteca synthetic id — the only key /receipt/<id>
+                                            // resolves, and what Activity rows already carry.
+                                            // `externalId` is UUID-shaped, so it slips past the
+                                            // id-shape gate and 404s silently instead of erroring.
                                             id: qrPayment!.id,
                                             direction: 'qr_payment',
                                             userName: qrPayment!.details.merchant.name,

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -1440,7 +1440,12 @@ export default function QRPayPage() {
                                     onClick={() => {
                                         const now = new Date()
                                         openTransactionDetails({
-                                            id: qrPayment!.externalId,
+                                            // Manteca synthetic id — the only key the receipt
+                                            // lookup resolves (`metadata.mantecaSyntheticId` /
+                                            // `manteca-transfer:<id>`), and what Activity rows
+                                            // already carry. `externalId` is UUID-shaped, so it
+                                            // slips past the id-shape gate and 404s silently.
+                                            id: qrPayment!.id,
                                             direction: 'qr_payment',
                                             userName: qrPayment!.details.merchant.name,
                                             fullName: qrPayment!.details.merchant.name,


### PR DESCRIPTION
## Summary

Every receipt shared off the QR-pay success screen 404s — 100% failure rate.

The **See receipt** button stamped the transaction drawer with `qrPayment.externalId`. `getReceiptUrl()` turns that into `/receipt/<id>?kind=QR_PAY`, and the backend (`peanut-api-ts` `src/routes/user/history.ts` → `findMantecaIntentBySyntheticId`) resolves that entryId **only** via:

- `idempotencyKey = manteca-transfer:<mantecaSyntheticId>`, or
- `metadata.mantecaSyntheticId`

Both are the **Manteca synthetic id** — `qrPayment.id`. `externalId` is a UUID we mint ourselves in `createQrPaymentSynthetic`; it *is* persisted (`metadata.externalId`) but is never a lookup key. And because it's UUID-shaped it sails past the `isValidUuidCursor` gate, hits `findFirst({ id: <externalId> })`, misses, and 404s silently rather than failing loudly.

Fix: stamp `qrPayment.id`. Activity rows already carry `metadata.mantecaSyntheticId` as their `uuid` (`src/manteca/history.ts`), so the success screen now agrees with Activity instead of diverging from it.

### Verification

- **Prod DB** (30d, `kind=QR_PAY`): 2804/3432 intents carry both keys, and they're visibly different shapes — `mantecaSyntheticId = 6a707549e091b25c7c8c5f99` (24-hex Manteca id) vs `externalId = a7344c61-3471-4798-ac12-5b8448703d90` (our UUID). Only the former appears in `idempotency_key`.
- **Regression test** added; verified it fails on the old code (`Received: { id: "ext1" }`) and passes on the new.

### Scope

Two files, no type changes, no refactors. The `if (!qrPayment?.externalId) return` guard in `claimPerk` is deliberately **left alone** — it's a truthiness check on a value Manteca does echo back, confirmed working in prod (PostHog, 30d: 423 `reward_claimed` vs 559 `reward_claim_shown`). Changing it would be unrelated churn.

## Risks / breaking changes

Low. Frontend-only, one identifier in one drawer payload. No backend change, no deploy ordering, no cross-repo coordination.

The fix is forward-only: receipts shared *before* this lands stay dead (their URLs carry an `externalId` nothing resolves). No backfill is possible or needed — the links were never valid.

## Screenshots

No visual delta — the button, drawer, and success screen render identically. The change is the identifier inside the shared URL, so the only observable difference is `/receipt/<id>` resolving instead of 404ing, which needs a full sandbox QR payment to stage end-to-end.

## QA

`npx jest qr-pay-states` — 29 passed, including the new `See receipt opens the drawer keyed by the Manteca synthetic id, not externalId`.

To verify manually: complete a sandbox QR payment, tap **See receipt** → **Share**, and open the resulting `/receipt/<id>?kind=QR_PAY` link. It should render the receipt rather than 404.

Source: Notion TASK-21023, from Crisp `session_3c4a8593` (visitor86525).

## Design notes / accepted trade-offs

**Adds no smell** — one property value plus a test. **Reveals two pre-existing ones**, both out of this PR's blast radius, both flagged rather than fixed here (repo rule: mention refactors, don't silently execute them):

1. **Second source of truth for the drawer payload.** This success screen hand-assembles a ~30-line `TransactionDetails` object inline, duplicating what `mapTransactionDataForDrawer(entry)` derives from a real history entry. The Activity path derives the id correctly (`peanut-api-ts` `src/manteca/history.ts`: `uuid = metadata.mantecaSyntheticId`); this hand-built path guessed and got it wrong. **This bug is a direct symptom of that duplication** — a shared builder, or deriving from the entry, would have made it unrepresentable. Worth a follow-up.

2. **`QrPayment.externalId` is typed `string` (non-optional)** while the provider type it mirrors is `MantecaSynthetic.externalId?: string`. The FE asserts a guarantee the backend doesn't make. It holds today — Manteca does echo it, which is why the `claimPerk` guard works — but the type is a lie that would mask a regression if Manteca ever stopped. Making it optional would correctly surface that guard as load-bearing.

**Demand link:** `mono product/feedback/problems/receipts-broken-or-unofficial.md` already tracks "receipt page 404s after a completed payment" (Emmanuel Vazquez, 2026-05-30, Discord). Linking this PR there is a mono-content follow-up — content and code never travel in the same PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the receipt drawer for completed Manteca QR payments to open using the correct transaction identifier.
  * Added regression coverage to ensure “See receipt” displays the expected transaction details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->