### PR TITLE
feat: fire beta_flow_completed per native-beta checklist flow (TASK-20968)

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -42,6 +42,7 @@ import { useEeaUpliftFunnel } from '@/hooks/useEeaUpliftFunnel'
 import { upliftTriggerFromGate, upliftTriggerFromAdvisory } from '@/utils/eea-uplift.utils'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { captureBetaFlow } from '@/utils/betaFlow.utils'
 import { addMoneyCountryUrl, rewriteMethodPath } from '@/utils/native-routes'
 import { isMantecaSupportedCountryCode } from '@/constants/manteca.consts'
 import { useSafeBack } from '@/hooks/useSafeBack'
@@ -332,6 +333,9 @@ function BridgeBankOnrampPage() {
                     method_type: 'bank',
                     country: selectedCountryPath,
                 })
+                // beta checklist F7: fiat has no client-side settlement — wire
+                // details shown = the in-app flow finished
+                captureBetaFlow('deposit')
                 setUrlState({ step: 'showDetails' })
             } else {
                 setError({

--- a/src/app/(mobile-ui)/add-money/crypto/page.tsx
+++ b/src/app/(mobile-ui)/add-money/crypto/page.tsx
@@ -19,6 +19,7 @@ import { useQueryState, parseAsStringEnum } from 'nuqs'
 import { useSafeBack } from '@/hooks/useSafeBack'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { captureBetaFlow } from '@/utils/betaFlow.utils'
 import { useTranslations } from 'next-intl'
 
 // static — peanut wallet is always on arbitrum
@@ -71,6 +72,7 @@ const AddMoneyCryptoPage = () => {
                 method_type: isOfframp ? 'offramp_migration' : 'crypto',
                 acquisition_source: user?.invitedBy ? 'referred' : 'organic',
             })
+            captureBetaFlow('deposit')
             setDepositResult(statusData ?? { status: 'completed', amount })
             setShowSuccessView(true)
         },

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -46,6 +46,7 @@ import { PointsAction } from '@/services/services.types'
 import { usePointsCalculation } from '@/hooks/usePointsCalculation'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { captureBetaFlow } from '@/utils/betaFlow.utils'
 import { withdrawCountryUrl } from '@/utils/native-routes'
 import { useSafeBack } from '@/hooks/useSafeBack'
 import { useTranslations } from 'next-intl'
@@ -360,6 +361,7 @@ export default function WithdrawBankPage() {
                 method_type: 'bridge',
                 country,
             })
+            captureBetaFlow('withdraw')
         } catch (e) {
             const error = toFriendlyError(e)
             posthog.capture(ANALYTICS_EVENTS.WITHDRAW_FAILED, {

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -38,6 +38,7 @@ import { appBaseUrl } from '@/utils/url.utils'
 import { useFriendlyError } from '@/hooks/useFriendlyError'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { captureBetaFlow } from '@/utils/betaFlow.utils'
 import { useTranslations } from 'next-intl'
 
 export default function WithdrawCryptoPage() {
@@ -447,6 +448,7 @@ export default function WithdrawCryptoPage() {
                 amount_usd: usdAmount,
                 method_type: 'crypto',
             })
+            captureBetaFlow('withdraw')
         } catch (err) {
             console.error('Withdrawal execution failed:', err)
             const errMsg = toFriendlyError(err)

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -58,6 +58,7 @@ import { useLimitsValidation } from '@/features/limits/hooks/useLimitsValidation
 import { MIN_MANTECA_WITHDRAW_AMOUNT } from '@/constants/payment.consts'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { captureBetaFlow } from '@/utils/betaFlow.utils'
 import LimitsWarningCard from '@/features/limits/components/LimitsWarningCard'
 import { getLimitsWarningCardProps, isBrUserEligibleForLimitIncrease } from '@/features/limits/utils'
 import { withdrawCountryUrl } from '@/utils/native-routes'
@@ -478,6 +479,7 @@ function MantecaBankWithdrawFlow() {
                 method_type: 'manteca',
                 country: countryPath,
             })
+            captureBetaFlow('withdraw')
         } catch (error) {
             console.error('Manteca withdraw error:', error)
             if (handleStaleSession(error)) return

--- a/src/components/Claim/Link/Initial.view.tsx
+++ b/src/components/Claim/Link/Initial.view.tsx
@@ -54,6 +54,7 @@ import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants/zerodev.co
 import { ROUTE_NOT_FOUND_ERROR } from '@/constants/general.consts'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { captureBetaFlow } from '@/utils/betaFlow.utils'
 import { useFormatter, useTranslations } from 'next-intl'
 
 export const InitialClaimLinkView = (props: IClaimScreenProps) => {
@@ -399,6 +400,7 @@ export const InitialClaimLinkView = (props: IClaimScreenProps) => {
                 }
 
                 setTransactionHash(claimTxHash)
+                captureBetaFlow('receive_claim')
                 onCustom('SUCCESS')
 
                 // note: with optimisticReturn, balance/transactions refresh happens in SUCCESS view

--- a/src/components/Claim/Link/Onchain/Confirm.view.tsx
+++ b/src/components/Claim/Link/Onchain/Confirm.view.tsx
@@ -23,6 +23,7 @@ import { sendLinksApi } from '@/services/sendLinks'
 import { useSearchParams } from 'next/navigation'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { captureBetaFlow } from '@/utils/betaFlow.utils'
 import underMaintenanceConfig, { CROSS_CHAIN_DISABLED_MESSAGE } from '@/config/underMaintenance.config'
 import { useTranslations } from 'next-intl'
 
@@ -149,6 +150,7 @@ export const ConfirmClaimLinkView = ({
                 chain_id: claimLinkData.chainId,
                 is_xchain: !!selectedRoute,
             })
+            captureBetaFlow('receive_claim')
             onNext()
             // Note: Balance/transaction refresh handled by mutation or SUCCESS view
         } catch (error) {

--- a/src/components/Send/link/views/Initial.link.send.view.tsx
+++ b/src/components/Send/link/views/Initial.link.send.view.tsx
@@ -22,6 +22,7 @@ import AmountInput from '../../../Global/AmountInput'
 import { usePendingTransactions } from '@/hooks/wallet/usePendingTransactions'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { captureBetaFlow } from '@/utils/betaFlow.utils'
 
 const LinkSendInitialView = () => {
     const t = useTranslations('send')
@@ -86,6 +87,7 @@ const LinkSendInitialView = () => {
                 token_address: tokenAddress,
                 has_attachment: !!attachmentOptions?.rawFile,
             })
+            captureBetaFlow('send')
 
             setLink(link)
             setView('SUCCESS')

--- a/src/components/Setup/Views/SignTestTransaction.tsx
+++ b/src/components/Setup/Views/SignTestTransaction.tsx
@@ -13,6 +13,7 @@ import { capturePasskeyDebugInfo } from '@/utils/passkeyDebug'
 import * as Sentry from '@sentry/nextjs'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { captureBetaFlow } from '@/utils/betaFlow.utils'
 import { getFromCookie } from '@/utils/general.utils'
 import { twMerge } from 'tailwind-merge'
 import { useTranslations } from 'next-intl'
@@ -139,6 +140,7 @@ const SignTestTransaction = () => {
                     acquisition_source: inviteCode ? 'referred' : 'organic',
                     invite_code: inviteCode || undefined,
                 })
+                captureBetaFlow('fresh_signup')
 
                 // keep loading state active until redirect completes
             } else {

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -270,6 +270,13 @@ export const ANALYTICS_EVENTS = {
     DELETE_ACCOUNT_INITIATED: 'delete_account_initiated',
     DELETE_ACCOUNT_CONFIRMED: 'delete_account_confirmed',
     DELETE_ACCOUNT_FAILED: 'delete_account_failed',
+
+    // ── Native-app beta (TASK-20968) ──
+    // One event per successfully completed core-checklist flow (F1–F10 in the
+    // Notion tester tracker). Fires on every platform; the beta exit gates
+    // filter `platform` to android-native / ios-native in PostHog.
+    // Props: flow (BetaFlow), platform, tester_id. See utils/betaFlow.utils.ts.
+    BETA_FLOW_COMPLETED: 'beta_flow_completed',
 } as const
 
 /**

--- a/src/features/payments/shared/components/PaymentSuccessView.tsx
+++ b/src/features/payments/shared/components/PaymentSuccessView.tsx
@@ -43,6 +43,7 @@ import { PeanutCheering } from '@/assets/mascot'
 import { useHaptic } from 'use-haptic'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { captureBetaFlow } from '@/utils/betaFlow.utils'
 import PointsCard from '@/components/Common/PointsCard'
 import { BASE_URL } from '@/constants/general.consts'
 import { TRANSACTIONS } from '@/constants/query.consts'
@@ -210,6 +211,14 @@ const PaymentSuccessView = ({
 
     const pointsDivRef = useRef<HTMLDivElement>(null)
     usePointsConfetti(points, pointsDivRef)
+
+    useEffect(() => {
+        // beta checklist F3: send/contribute/request-pay flows all land here with
+        // type SEND; withdraw reuses the view (also type SEND) so exclude it.
+        if (type === 'SEND' && !isWithdrawFlow) {
+            captureBetaFlow('send')
+        }
+    }, [type, isWithdrawFlow])
 
     useEffect(() => {
         if (points) {

--- a/src/hooks/useCardReveal.ts
+++ b/src/hooks/useCardReveal.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { captureBetaFlow } from '@/utils/betaFlow.utils'
 import { rainApi, RainCardRateLimitError, type RainCardDetailsResponse } from '@/services/rain'
 
 interface UseCardRevealArgs {
@@ -55,6 +56,8 @@ export function useCardReveal({ cardId, autoMaskMs = DEFAULT_AUTO_MASK_MS }: Use
             const data = await rainApi.getCardDetails(cardId)
             setRevealed(data)
             posthog.capture(ANALYTICS_EVENTS.CARD_PAN_REVEALED)
+            // beta checklist F6: details revealed ⇒ card was issued AND viewed
+            captureBetaFlow('card_issue_view')
             if (autoMaskMs > 0) {
                 if (timeoutRef.current) clearTimeout(timeoutRef.current)
                 timeoutRef.current = setTimeout(() => {

--- a/src/hooks/useLogin.tsx
+++ b/src/hooks/useLogin.tsx
@@ -5,6 +5,7 @@ import { useZeroDev } from './useZeroDev'
 import { captureMessage } from '@sentry/nextjs'
 import { useEffect, useState } from 'react'
 import { getRedirectUrl, getValidRedirectUrl, clearRedirectUrl } from '@/utils/general.utils'
+import { captureBetaFlow } from '@/utils/betaFlow.utils'
 import { useRouter, useSearchParams } from 'next/navigation'
 
 // how long we wait for the user object after a successful passkey ceremony
@@ -42,6 +43,8 @@ export const useLogin = () => {
     useEffect(() => {
         // run only if login button is clicked to prevent un-intentional redirects
         if (isloginClicked && user) {
+            // deliberate login only (not session resume) — the guard above scopes this
+            captureBetaFlow('returning_login')
             // redirect based on query params or saved redirect url
             const localStorageRedirect = getRedirectUrl()
             const redirect_uri = searchParams.get('redirect_uri')

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -10,6 +10,7 @@ import { type UserCapabilities } from '@/types/capabilities'
 import { type KYCRegionIntent } from '@/app/actions/types/sumsub.types'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { captureBetaFlow } from '@/utils/betaFlow.utils'
 
 const PREPARING_TIMEOUT_MS = 30000
 
@@ -258,6 +259,8 @@ export const useMultiPhaseKycFlow = ({
     // wrap handleSdkComplete to track real-time flow
     const handleSdkComplete = useCallback(() => {
         posthog.capture(ANALYTICS_EVENTS.KYC_SUBMITTED, { region_intent: lastIntentRef.current ?? regionIntent })
+        // beta checklist F5: docs submitted = camera capture worked; approval is async
+        captureBetaFlow('kyc')
         isRealtimeFlowRef.current = true
         originalHandleSdkComplete()
         // for action flows (manteca, self-heal), the base status is already APPROVED

--- a/src/hooks/useNativePlugins.ts
+++ b/src/hooks/useNativePlugins.ts
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { focusManager } from '@tanstack/react-query'
 import { captureMessage } from '@sentry/nextjs'
 import { isCapacitor, getPlatform } from '@/utils/capacitor'
+import { captureBetaFlow } from '@/utils/betaFlow.utils'
 import { localeApplied } from '@/i18n/app/locale-store'
 import { deepLinkToNativePath } from '@/utils/native-routes'
 import { sanitizeRedirectURL } from '@/utils/general.utils'
@@ -40,7 +41,11 @@ export function useNativePlugins() {
             if (!target) return
             // same-origin guard: only ever navigate to an in-app relative path
             const safe = sanitizeRedirectURL(target)
-            if (safe) router.push(safe)
+            if (safe) {
+                router.push(safe)
+                // beta checklist F10: the link routed into the app, not the browser
+                captureBetaFlow('deep_link')
+            }
         }
 
         const init = async () => {

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -8,6 +8,7 @@ import { isDemoMode } from '@/utils/demo'
 import { useUserStore } from '@/redux/hooks'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
+import { captureBetaFlow } from '@/utils/betaFlow.utils'
 import { UTM_SOURCES, UTM_MEDIUMS } from '@/utils/utm.utils'
 
 /*
@@ -210,6 +211,7 @@ async function ensureInitialized() {
                 if (typeof additionalData.utmContent === 'string') props.utm_content = additionalData.utmContent
             }
             posthog.capture(ANALYTICS_EVENTS.NOTIFICATION_CLICKED, props)
+            captureBetaFlow('push_tap')
         })
 
         setState({ oneSignalInitialized: true, sdkReady: true })

--- a/src/utils/__tests__/betaFlow.utils.test.ts
+++ b/src/utils/__tests__/betaFlow.utils.test.ts
@@ -5,7 +5,7 @@ import { captureBetaFlow } from '@/utils/betaFlow.utils'
 
 jest.mock('posthog-js', () => ({
     __esModule: true,
-    default: { capture: jest.fn() },
+    default: { capture: jest.fn(), get_distinct_id: jest.fn() },
 }))
 jest.mock('@/redux/store', () => ({
     __esModule: true,
@@ -37,7 +37,7 @@ describe('captureBetaFlow', () => {
         })
     })
 
-    it('falls back to userId, then anonymous, when username is missing', () => {
+    it('falls back to userId, then the persisted distinct_id, then anonymous', () => {
         mockGetState.mockReturnValue(stateWithUser({ user: { userId: 'uuid-2' } }))
         captureBetaFlow('deposit')
         expect(mockCapture).toHaveBeenLastCalledWith(
@@ -45,7 +45,15 @@ describe('captureBetaFlow', () => {
             expect.objectContaining({ tester_id: 'uuid-2' })
         )
 
+        // cold start: redux empty but the device was identified in a past session
         mockGetState.mockReturnValue(stateWithUser(null))
+        ;(posthog.get_distinct_id as jest.Mock).mockReturnValue('persisted-user-id')
+        captureBetaFlow('deep_link')
+        expect(mockCapture).toHaveBeenLastCalledWith(
+            'beta_flow_completed',
+            expect.objectContaining({ tester_id: 'persisted-user-id' })
+        )
+        ;(posthog.get_distinct_id as jest.Mock).mockReturnValue(undefined)
         captureBetaFlow('deep_link')
         expect(mockCapture).toHaveBeenLastCalledWith(
             'beta_flow_completed',

--- a/src/utils/__tests__/betaFlow.utils.test.ts
+++ b/src/utils/__tests__/betaFlow.utils.test.ts
@@ -1,0 +1,64 @@
+import posthog from 'posthog-js'
+import store from '@/redux/store'
+import { getPlatform } from '@/utils/capacitor'
+import { captureBetaFlow } from '@/utils/betaFlow.utils'
+
+jest.mock('posthog-js', () => ({
+    __esModule: true,
+    default: { capture: jest.fn() },
+}))
+jest.mock('@/redux/store', () => ({
+    __esModule: true,
+    default: { getState: jest.fn() },
+}))
+jest.mock('@/utils/capacitor', () => ({
+    getPlatform: jest.fn(),
+}))
+
+const mockCapture = posthog.capture as jest.Mock
+const mockGetState = store.getState as jest.Mock
+const mockGetPlatform = getPlatform as jest.Mock
+
+const stateWithUser = (user: unknown) => ({ user: { user } })
+
+describe('captureBetaFlow', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockGetPlatform.mockReturnValue('android-native')
+    })
+
+    it('fires beta_flow_completed with flow, platform and username as tester_id', () => {
+        mockGetState.mockReturnValue(stateWithUser({ user: { username: 'zeedmozaed', userId: 'uuid-1' } }))
+        captureBetaFlow('send')
+        expect(mockCapture).toHaveBeenCalledWith('beta_flow_completed', {
+            flow: 'send',
+            platform: 'android-native',
+            tester_id: 'zeedmozaed',
+        })
+    })
+
+    it('falls back to userId, then anonymous, when username is missing', () => {
+        mockGetState.mockReturnValue(stateWithUser({ user: { userId: 'uuid-2' } }))
+        captureBetaFlow('deposit')
+        expect(mockCapture).toHaveBeenLastCalledWith(
+            'beta_flow_completed',
+            expect.objectContaining({ tester_id: 'uuid-2' })
+        )
+
+        mockGetState.mockReturnValue(stateWithUser(null))
+        captureBetaFlow('deep_link')
+        expect(mockCapture).toHaveBeenLastCalledWith(
+            'beta_flow_completed',
+            expect.objectContaining({ tester_id: 'anonymous' })
+        )
+    })
+
+    it('prefers an explicit testerId over the store', () => {
+        mockGetState.mockReturnValue(stateWithUser({ user: { username: 'someone-else', userId: 'uuid-3' } }))
+        captureBetaFlow('fresh_signup', 'abalinda')
+        expect(mockCapture).toHaveBeenCalledWith(
+            'beta_flow_completed',
+            expect.objectContaining({ tester_id: 'abalinda' })
+        )
+    })
+})

--- a/src/utils/betaFlow.utils.ts
+++ b/src/utils/betaFlow.utils.ts
@@ -30,9 +30,12 @@ export type BetaFlow =
  */
 export function captureBetaFlow(flow: BetaFlow, testerId?: string): void {
     const user = store.getState().user.user
+    // deep-link / push-tap fire on cold start before /users/me populates redux;
+    // an identified device's persisted distinct_id is the userId, so fall back
+    // to it rather than losing the tester from the gate-1 matrix
     posthog.capture(ANALYTICS_EVENTS.BETA_FLOW_COMPLETED, {
         flow,
         platform: getPlatform(),
-        tester_id: testerId ?? user?.user?.username ?? user?.user?.userId ?? 'anonymous',
+        tester_id: testerId ?? user?.user?.username ?? user?.user?.userId ?? posthog.get_distinct_id?.() ?? 'anonymous',
     })
 }

--- a/src/utils/betaFlow.utils.ts
+++ b/src/utils/betaFlow.utils.ts
@@ -1,0 +1,38 @@
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import store from '@/redux/store'
+import { getPlatform } from '@/utils/capacitor'
+
+/**
+ * Native-app beta core-checklist flows — F1–F10 in the Notion tester tracker.
+ * Values are stable event-property strings; don't rename without updating the
+ * beta gate insights in PostHog.
+ */
+export type BetaFlow =
+    | 'fresh_signup' // F1 fresh signup + passkey
+    | 'returning_login' // F2 returning passkey login
+    | 'send' // F3 send (any payment flow reaching success, or send link created)
+    | 'receive_claim' // F4 receive / claim
+    | 'kyc' // F5 KYC docs submitted (camera capture done; approval is async)
+    | 'card_issue_view' // F6 card details revealed ⇒ card issued + viewed
+    | 'deposit' // F7 crypto deposit completed, or fiat wire details shown
+    | 'withdraw' // F8 withdraw completed
+    | 'push_tap' // F9 push notification received + tapped
+    | 'deep_link' // F10 deep link routed into the app
+
+/**
+ * Fire `beta_flow_completed { flow, platform, tester_id }` for a checklist
+ * flow the user just finished. Fires on every platform — gate queries filter
+ * `platform` to the native pair. `tester_id` duplicates the username onto the
+ * event so the gate-1 matrix reads straight off event properties without a
+ * person join; pass `testerId` where the redux user isn't populated yet
+ * (fresh signup).
+ */
+export function captureBetaFlow(flow: BetaFlow, testerId?: string): void {
+    const user = store.getState().user.user
+    posthog.capture(ANALYTICS_EVENTS.BETA_FLOW_COMPLETED, {
+        flow,
+        platform: getPlatform(),
+        tester_id: testerId ?? user?.user?.username ?? user?.user?.userId ?? 'anonymous',
+    })
+}


### PR DESCRIPTION
## Summary

TASK-20968 — the native-app beta's exit gates 1 (core-flow coverage) and 4 (genuine engagement) are hand-maintained checkboxes in the Notion tester tracker. This PR fires **`beta_flow_completed { flow, platform, tester_id }`** at each core-checklist flow's client-side success point so both gates read as PostHog queries.

One new helper (`src/utils/betaFlow.utils.ts`) + one-line calls at the existing success points:

| Flow value | Tracker column | Fires at |
|---|---|---|
| `fresh_signup` | F1 | `SignTestTransaction` next to `SIGNUP_COMPLETED` |
| `returning_login` | F2 | `useLogin` — deliberate login only (`isloginClicked && user`), not session resume |
| `send` | F3 | `PaymentSuccessView` (`type === 'SEND' && !isWithdrawFlow` → covers direct-send, contribute-pot, request-pay) + `SEND_LINK_CREATED` |
| `receive_claim` | F4 | Both claim paths (peanut-wallet `Initial.view`, external `Onchain/Confirm.view`) |
| `kyc` | F5 | `useMultiPhaseKycFlow.handleSdkComplete` — docs **submitted** (camera capture proven; approval is async provider-side). Covers WebSDK and native SDK paths (both route through this hook) |
| `card_issue_view` | F6 | `useCardReveal` on PAN reveal success (details revealed ⇒ card issued AND viewed) |
| `deposit` | F7 | Crypto: `DEPOSIT_COMPLETED` site. Fiat: `DEPOSIT_CONFIRMED` (wire details shown — no client-side settlement exists) |
| `withdraw` | F8 | All three `WITHDRAW_COMPLETED` sites (crypto / bridge / manteca) |
| `push_tap` | F9 | `useNotifications` OneSignal click handler (native + web adapters) |
| `deep_link` | F10 | `useNativePlugins.openDeepLink` after successful in-app route |

**Design decisions** (confirmed with Aleks, program owner):
- **Fires on every platform** — `platform` (from `getPlatform()`: `android-native` / `ios-native` / `web` / `*-pwa`) does the sorting in queries; PWA traffic doubles as a parity baseline and makes the wiring verifiable from prod web right after deploy.
- `tester_id` mirrors the username onto event properties so the gate-1 matrix needs no person join (falls back userId → `anonymous`).
- Gate insights already created + validated in PostHog project 138913: [gate 1 matrix](https://eu.posthog.com/project/138913/insights/TQdP8eLE) · [gate 4 active testers](https://eu.posthog.com/project/138913/insights/0mooICPS). They read empty until this deploys.

## Risks / breaking changes

- None functional — additive analytics only, no flow logic touched. No cross-repo impact.
- Event volume: fires for all users on ~10 already-instrumented flow endpoints (comparable to existing per-flow events).

## QA

- `npm run typecheck` 0 errors · `npm test` 184 suites / 2419 pass (new `betaFlow.utils.test.ts` covers event shape + tester_id fallback chain) · prettier clean · `npm run build` green.
- Post-deploy: complete any send on prod web → event appears with `platform: web`; Android tester session (e.g. `abalinda`) → `android-native` rows populate the gate insights.

Screenshots: N/A (no UI change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added completion tracking for native app beta flows, including sign-up, login, deposits, withdrawals, payments, claims, card reveal, KYC, notifications, and deep links.
  * Beta-flow events now include flow, platform, and tester identification details.
* **Tests**
  * Added coverage for event payloads and tester ID fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->