### PR TITLE
feat(android): sentry native crash reporting (TASK-20964)

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -114,6 +114,11 @@ jobs:
                   fi
 
             - name: Build signed AAB
+              env:
+                  # native sentry sdk dsn — read by android/app/build.gradle into a
+                  # manifest placeholder. same project dsn the js layer bakes into
+                  # the static export above; no new secret needed.
+                  SENTRY_DSN_ANDROID: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
               run: |
                   # versionName: manual dispatch input wins; else the tag name minus
                   # its leading 'v' (v1.0.10 -> 1.0.10); else build.gradle's

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -54,7 +54,11 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // sentry dsn for native crash reporting (TASK-20964). injected by ci
         // (android-release.yml); empty locally, which disables the sdk.
-        manifestPlaceholders = [sentryDsn: System.getenv('SENTRY_DSN_ANDROID') ?: '']
+        def sentryDsnEnv = System.getenv('SENTRY_DSN_ANDROID') ?: ''
+        if (sentryDsnEnv.isEmpty()) {
+            logger.error('SENTRY_DSN_ANDROID not set — native crash reporting will be DISABLED in this build. Fine locally; a release build without it ships blind.')
+        }
+        manifestPlaceholders = [sentryDsn: sentryDsnEnv]
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.
              // Default: https://android.googlesource.com/platform/frameworks/base/+/282e181b58cf72b6ca770dc7ca5f91f135444502/tools/aapt/AaptAssets.cpp#61
@@ -103,8 +107,11 @@ dependencies {
     implementation "com.android.installreferrer:installreferrer:2.2"
 
     // sentry native crash reporting (TASK-20964) — configured via AndroidManifest
-    // meta-data, auto-inits before Application. 8.49.0 = newest version past the
-    // 14-day supply-chain floor when added (2026-08-03).
+    // meta-data, auto-inits before Application. deliberately the aggregate
+    // artifact (core + ndk): the webview renderer and capacitor plugins crash at
+    // the c/c++ level, and ndk capture is exactly the visibility the beta needs.
+    // 8.49.0 = newest version past the 14-day supply-chain floor when added
+    // (2026-08-03).
     implementation "io.sentry:sentry-android:8.49.0"
 
     testImplementation "junit:junit:$junitVersion"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -52,6 +52,9 @@ android {
         versionCode resolvedVersionCode
         versionName resolvedVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        // sentry dsn for native crash reporting (TASK-20964). injected by ci
+        // (android-release.yml); empty locally, which disables the sdk.
+        manifestPlaceholders = [sentryDsn: System.getenv('SENTRY_DSN_ANDROID') ?: '']
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.
              // Default: https://android.googlesource.com/platform/frameworks/base/+/282e181b58cf72b6ca770dc7ca5f91f135444502/tools/aapt/AaptAssets.cpp#61
@@ -98,6 +101,11 @@ dependencies {
 
     // play install referrer — deferred deep linking (InstallReferrerPlugin.java)
     implementation "com.android.installreferrer:installreferrer:2.2"
+
+    // sentry native crash reporting (TASK-20964) — configured via AndroidManifest
+    // meta-data, auto-inits before Application. 8.49.0 = newest version past the
+    // 14-day supply-chain floor when added (2026-08-03).
+    implementation "io.sentry:sentry-android:8.49.0"
 
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -82,10 +82,6 @@
                 android:resource="@xml/file_paths"
                 tools:replace="android:resource" />
         </provider>
-            <!-- CapacitorPasskey auto-configuration -->
-        <meta-data
-            android:name="asset_statements"
-            android:resource="@string/capacitor_passkey_asset_statements" />
 
         <!-- Don't let OneSignal fire its own ACTION_VIEW for a notification's
              launch URL. The tap opens the app and useNativePlugins routes on the
@@ -100,6 +96,25 @@
         <meta-data
             android:name="com.onesignal.NotificationAccentColor.DEFAULT"
             android:value="FFFFC900" />
+
+        <!-- Sentry native crash reporting (TASK-20964). Captures what the JS-layer
+             SDK in the WebView can't: process crashes, ANRs, Java/Kotlin plugin
+             exceptions — and tracks native sessions, which is what makes
+             crash-free-session % measurable per release. DSN comes from a manifest
+             placeholder (android/app/build.gradle ← SENTRY_DSN_ANDROID env, set in
+             android-release.yml); an empty DSN leaves the SDK disabled, so local
+             builds without the env stay silent. Auto-init, session tracking and
+             ANR detection are SDK defaults — no code needed. -->
+        <meta-data
+            android:name="io.sentry.dsn"
+            android:value="${sentryDsn}" />
+        <meta-data
+            android:name="io.sentry.environment"
+            android:value="native" />
+            <!-- CapacitorPasskey auto-configuration -->
+        <meta-data
+            android:name="asset_statements"
+            android:resource="@string/capacitor_passkey_asset_statements" />
     </application>
 
     <!-- Phone-only: require a telephony radio so Play filters out Wi-Fi-only

--- a/android/app/src/main/java/me/peanut/wallet/MainActivity.java
+++ b/android/app/src/main/java/me/peanut/wallet/MainActivity.java
@@ -16,6 +16,18 @@ import java.io.InputStream;
 
 public class MainActivity extends BridgeActivity {
 
+    private void maybeSentryTestCrash() {
+        if (getIntent() == null || !getIntent().getBooleanExtra("sentry_test_crash", false)) return;
+        if (getReferrer() != null) return; // app-to-app starts always carry a referrer; adb doesn't
+        boolean adbOn = Settings.Global.getInt(getContentResolver(), Settings.Global.ADB_ENABLED, 0) == 1
+                || Settings.Global.getInt(getContentResolver(), "adb_wifi_enabled", 0) == 1;
+        if (!adbOn) return;
+        android.content.SharedPreferences prefs = getSharedPreferences("sentry_test_crash", MODE_PRIVATE);
+        if (prefs.getBoolean("fired", false)) return; // one-shot: a redelivered intent can't crash-loop
+        prefs.edit().putBoolean("fired", true).commit(); // sync commit — must persist before we die
+        throw new RuntimeException("sentry native test crash (deliberate, adb-triggered)");
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         // app-local plugin, not auto-discovered — must register before super.onCreate
@@ -25,21 +37,19 @@ public class MainActivity extends BridgeActivity {
         /*
          * Sentry reconciliation hook (TASK-20964): deliberately crash the native
          * process to verify crash capture + crash-free-session accounting end to
-         * end on a real device. adb-only:
+         * end on a real device. Cold start only (singleTask routes a running app
+         * through onNewIntent, where the extra is dropped) — so force-stop first:
+         *   adb shell am force-stop me.peanut.wallet
          *   adb shell am start -n me.peanut.wallet/.MainActivity --ez sentry_test_crash true
-         * Gated on debug builds or usb-debugging-enabled devices so a third-party
-         * app firing this intent extra can't crash the app on a normal user's phone.
+         * One-shot per install (clear app data or reinstall to re-arm). Three
+         * independent gates keep this adb-only: the extra, a null referrer (an
+         * app-to-app start always carries android-app://<caller>; only a shell
+         * launch is referrer-less), and developer adb actually enabled (usb or
+         * wireless) — so a third-party app can't crash the wallet on a normal
+         * user's phone, and a recents relaunch redelivering the stored intent
+         * can't crash-loop.
          */
-        if (getIntent() != null && getIntent().getBooleanExtra("sentry_test_crash", false)) {
-            // triggering via adb implies usb debugging is on, so this gate costs
-            // nothing for the intended use while blocking third-party apps from
-            // crashing the app on a normal user's phone (adb off).
-            boolean adbEnabled = Settings.Global.getInt(
-                    getContentResolver(), Settings.Global.ADB_ENABLED, 0) == 1;
-            if (adbEnabled) {
-                throw new RuntimeException("sentry native test crash (deliberate, adb-triggered)");
-            }
-        }
+        maybeSentryTestCrash();
 
         Bridge bridge = this.getBridge();
         if (bridge != null) {

--- a/android/app/src/main/java/me/peanut/wallet/MainActivity.java
+++ b/android/app/src/main/java/me/peanut/wallet/MainActivity.java
@@ -1,6 +1,7 @@
 package me.peanut.wallet;
 
 import android.os.Bundle;
+import android.provider.Settings;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
@@ -20,6 +21,25 @@ public class MainActivity extends BridgeActivity {
         // app-local plugin, not auto-discovered — must register before super.onCreate
         registerPlugin(InstallReferrerPlugin.class);
         super.onCreate(savedInstanceState);
+
+        /*
+         * Sentry reconciliation hook (TASK-20964): deliberately crash the native
+         * process to verify crash capture + crash-free-session accounting end to
+         * end on a real device. adb-only:
+         *   adb shell am start -n me.peanut.wallet/.MainActivity --ez sentry_test_crash true
+         * Gated on debug builds or usb-debugging-enabled devices so a third-party
+         * app firing this intent extra can't crash the app on a normal user's phone.
+         */
+        if (getIntent() != null && getIntent().getBooleanExtra("sentry_test_crash", false)) {
+            // triggering via adb implies usb debugging is on, so this gate costs
+            // nothing for the intended use while blocking third-party apps from
+            // crashing the app on a normal user's phone (adb off).
+            boolean adbEnabled = Settings.Global.getInt(
+                    getContentResolver(), Settings.Global.ADB_ENABLED, 0) == 1;
+            if (adbEnabled) {
+                throw new RuntimeException("sentry native test crash (deliberate, adb-triggered)");
+            }
+        }
 
         Bridge bridge = this.getBridge();
         if (bridge != null) {


### PR DESCRIPTION
## Summary

**Why:** Gate 2 of the app beta (crash-free sessions ≥ 99% on Android, [App beta testing](https://app.notion.com/p/3a783811757980aba678e51e174256ff) / TASK-20964) is unmeasurable today. The JS-layer Sentry init in the WebView (instrumentation-client.ts) captures JS errors, but native process crashes, ANRs, and Java/Kotlin plugin exceptions never reach a JS handler — and no native release has any session data in Sentry, so there is no crash-free % anywhere.

**What:** wire `io.sentry:sentry-android` via AndroidManifest auto-init:

- `build.gradle`: `sentry-android:8.49.0` (newest version past the 14-day supply-chain floor at time of adding) + a `sentryDsn` manifest placeholder read from `SENTRY_DSN_ANDROID`.
- `AndroidManifest.xml`: `io.sentry.dsn` + `io.sentry.environment=native`. Auto-init, session tracking and ANR detection are SDK defaults — zero java config code.
- `android-release.yml`: inject `SENTRY_DSN_ANDROID` from the existing `NEXT_PUBLIC_SENTRY_DSN` secret (no new secret). Empty DSN (any local build without the env) leaves the SDK disabled.
- `MainActivity`: adb-triggered deliberate test crash (`--ez sentry_test_crash true`) — the reconciliation hook for the task's done-when. Three independent gates keep it adb-only (intent extra + null referrer + adb/wireless-debugging enabled), it's one-shot per install (no recents crash-loop), and cold-start-only under `singleTask` (force-stop first; documented in the code).

Native events auto-tag release as `me.peanut.wallet@<versionName>+<versionCode>`, which pairs with the `binaryVersion`/`binaryBuild` tags the JS layer already sets — JS errors and native crashes are joinable per binary.

## Risks / breaking changes

- Binary-level change: **ships only via a Play build** (`android-release.yml`), not Capgo OTA.
- SDK auto-init adds ~2 ContentProviders at startup; sentry-android's init is designed for this and measured in single-digit ms.
- No FE/BE cross-repo impact. iOS is intentionally untouched (Track I deferred).

## QA

- `./gradlew :app:processDebugMainManifest :app:compileDebugJavaWithJavac` green locally; merged manifest verified: DSN placeholder substituted, `environment=native`, Sentry init/NDK providers present.
- After the next internal-track build: launch app → session appears under Sentry release health; then `adb shell am force-stop me.peanut.wallet && adb shell am start -n me.peanut.wallet/.MainActivity --ez sentry_test_crash true` → relaunch → crash event lands under `environment:native` with a Java stack trace and the release's crash-free % dips. Re-arm by clearing app data.

Screenshots: N/A (no visible change)


## Design notes / accepted trade-offs

- `/code-review high` findings all addressed in 6cd4ca7: referrer-null + one-shot + wireless-adb gates on the test hook, loud configure-time error on missing DSN.
- **Kept the aggregate `io.sentry:sentry-android` (core + NDK)** over `sentry-android-core`: WebView renderer and Capacitor plugin crashes are C/C++-level, and that visibility is the point of this beta gate. Costs a few hundred KB per ABI.
- Passkey plugin's `asset_statements` meta-data block moves position in the manifest — that's `cap update`'s canonical rewrite (CI reproduces it), not a functional change.
- iOS: intentionally untouched; sentry-cocoa mirrors this when Track I starts.