### PR TITLE
fix: logged-out PWA /setup redirect loop (TASK-21050)

### DIFF
--- a/e2e/flows/setup.spec.ts
+++ b/e2e/flows/setup.spec.ts
@@ -92,3 +92,41 @@ test.describe('Setup flow', () => {
         consoleLogs.flush(testInfo, 'history')
     })
 })
+
+test.describe('logged-out /setup with stale auth cookie (TASK-21050)', () => {
+    // Clean context — the shared storageState is pre-authenticated, and this
+    // regression is specifically about a cookie that does NOT authenticate.
+    test.use({ storageState: { cookies: [], origins: [] } })
+
+    test('stale jwt-token cookie must not bounce /setup to /home', async ({ page, baseURL }, testInfo) => {
+        const consoleLogs = collectConsoleLogs(page)
+
+        // Structurally valid but long-expired JWT — the "cookie present, session dead"
+        // state a half-completed signup or expired session leaves behind. The old
+        // presence-only proxy check 307'd /setup → /home on it, fighting the logged-out
+        // /home → /setup redirect in (mobile-ui)/layout.tsx: the PWA reload loop.
+        const b64 = (o: object) => Buffer.from(JSON.stringify(o)).toString('base64url')
+        const staleJwt = [
+            b64({ alg: 'HS256', typ: 'JWT' }),
+            b64({ userId: '00000000-0000-0000-0000-000000000000', exp: 1 }),
+            'stale-signature',
+        ].join('.')
+        await page
+            .context()
+            .addCookies([{ name: 'jwt-token', value: staleJwt, domain: new URL(baseURL!).hostname, path: '/' }])
+
+        // No API mocks on purpose: the real API 401s the stale token (the production
+        // condition), while the mock catch-all's `200 {}` would fake a logged-in user
+        // and trip InstallPWA's own client-side push to /home.
+        await page.goto('/setup', { waitUntil: 'domcontentloaded' })
+        await captureStep(page, testInfo, { name: '01-setup-with-stale-cookie' })
+        expect(new URL(page.url()).pathname).toBe('/setup')
+
+        // Outlast the 3s hard-nav fallback in (mobile-ui)/layout.tsx — the pump that
+        // turned a single bounce into an infinite reload loop in the installed PWA.
+        await page.waitForTimeout(4000)
+        expect(new URL(page.url()).pathname).toBe('/setup')
+
+        consoleLogs.flush(testInfo, 'setup-stale-cookie')
+    })
+})

--- a/e2e/flows/setup.spec.ts
+++ b/e2e/flows/setup.spec.ts
@@ -115,17 +115,29 @@ test.describe('logged-out /setup with stale auth cookie (TASK-21050)', () => {
             .context()
             .addCookies([{ name: 'jwt-token', value: staleJwt, domain: new URL(baseURL!).hostname, path: '/' }])
 
-        // No API mocks on purpose: the real API 401s the stale token (the production
-        // condition), while the mock catch-all's `200 {}` would fake a logged-in user
-        // and trip InstallPWA's own client-side push to /home.
+        // THE regression assertion, at the document layer: the old middleware 307'd
+        // this exact request. Post-hydration URL checks are vacuous here — a 401 from
+        // /users/me clears the cookie and the loop's own client leg can land back on
+        // /setup before the URL is read. maxRedirects: 0 sees the raw status; the
+        // request fixture shares the context cookie jar, so the stale cookie is sent.
+        const res = await page.context().request.get('/setup', { maxRedirects: 0 })
+        expect(res.status()).toBe(200)
+
+        // Browser-side smoke: stub the auth check to a deterministic 401 (keeps the
+        // forged token off any real API) and confirm the page loads, stays on /setup,
+        // and renders — no client-side redirect or crash for the stale-cookie visitor.
+        await page.route('**/users/me', (route) =>
+            route.fulfill({ status: 401, headers: { 'Access-Control-Allow-Origin': '*' }, body: '{}' })
+        )
         await page.goto('/setup', { waitUntil: 'domcontentloaded' })
+        expect(new URL(page.url()).pathname).toBe('/setup')
         await captureStep(page, testInfo, { name: '01-setup-with-stale-cookie' })
         expect(new URL(page.url()).pathname).toBe('/setup')
-
-        // Outlast the 3s hard-nav fallback in (mobile-ui)/layout.tsx — the pump that
-        // turned a single bounce into an infinite reload loop in the installed PWA.
-        await page.waitForTimeout(4000)
-        expect(new URL(page.url()).pathname).toBe('/setup')
+        const hasCrash = await page
+            .locator('text=/Application error/i')
+            .isVisible({ timeout: 1000 })
+            .catch(() => false)
+        expect(hasCrash).toBe(false)
 
         consoleLogs.flush(testInfo, 'setup-stale-cookie')
     })

--- a/src/app/(setup)/setup/page.tsx
+++ b/src/app/(setup)/setup/page.tsx
@@ -62,6 +62,11 @@ function SetupPageContent() {
 
     const handleContinueSession = () => {
         posthog.capture(ANALYTICS_EVENTS.SIGNUP_EXISTING_SESSION_CONTINUED)
+        // Mounting the (setup) layout armed the post-setup iOS install wall
+        // (setShowIosPwaInstallScreen in (setup)/layout.tsx). This visit was not a
+        // setup session and the soft nav keeps the store alive, so disarm it —
+        // otherwise /home renders the no-escape ForceIOSPWAInstall screen.
+        dispatch(setupActions.setShowIosPwaInstallScreen(false))
         router.push('/home')
     }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -41,9 +41,11 @@ export function proxy(request: NextRequest) {
         return NextResponse.redirect(new URL('/home', request.url))
     }
 
-    if (isAuthenticated && request.nextUrl.pathname === '/setup') {
-        return NextResponse.redirect(new URL('/home', request.url))
-    }
+    // NOTE: deliberately NO cookie-based /setup → /home bounce here. Cookie presence
+    // says nothing about session validity; bouncing on it looped forever against the
+    // logged-out `/home → /setup` redirect in (mobile-ui)/layout.tsx (TASK-21050,
+    // logged-out PWA lockout). The authenticated-at-/setup case is handled client-side
+    // by the existing-session prompt in (setup)/setup/page.tsx, which trusts /users/me.
 
     // Handle promo link redirection
     if (isPromoLink(url)) {


### PR DESCRIPTION
## Summary

Logged-out installed-PWA users were locked out of `/setup` by an infinite redirect/reload loop ([TASK-21050](https://app.notion.com/p/3b0838117579812dad3ccf117fa6fd3a), reproduced 3 Aug).

Two redirects trusted **different sources of auth truth** and chased each other:

| Leg | Code | Trusts |
|---|---|---|
| `/setup` → 307 → `/home` | `src/proxy.ts` | `jwt-token` cookie **presence** (value never validated) |
| `/home` → `/setup` | `(mobile-ui)/layout.tsx` (+3s hard-nav fallback) | `/users/me` returned no user |

Any *cookie present but session dead* state (expired JWT, half-completed signup, `/users/me` 5xx/offline — the cookie is only cleared on 401/404) loops forever. PWA-specific because `start_url: '/home'` cold-starts into the loop with no URL bar to escape; the serwist page cache then stores the followed redirect (`/home` HTML under the `/setup` key), making it durable offline.

**Fix: delete the presence-based bounce.** The authenticated-at-/setup case is handled client-side by the existing-session prompt (`(setup)/setup/page.tsx`, added in `aa44a14f5` for Capacitor) — which trusts `/users/me` and which this middleware rule was shadowing on web. One authority instead of two.

Proof the bounce is the bug:
```
# prod (old code):
$ curl -sI -H 'Cookie: jwt-token=bogus' https://peanut.me/setup | grep -iE 'HTTP|location'
HTTP/2 307
location: /home
# this PR's Vercel preview (fix):
$ curl -sI -H 'Cookie: jwt-token=bogus' https://peanut-wallet-git-fix-setup-redirect-loop-squirrellabs.vercel.app/setup | head -1
HTTP/2 200
```

## Adversarial review (3 independent Opus agents: flow-regression / security / test-validity)

- **Flow lens — 1 MAJOR, fixed in `d83dd5bb0`:** with the bounce gone, an authenticated iOS-Safari (non-PWA) user opening `/setup` mounts the `(setup)` layout, which arms `showIosPwaInstallScreen`; "Continue as X" soft-navs to `/home` where the singleton Redux store still holds the flag → escape-proof `ForceIOSPWAInstall` wall. Fixed by disarming the flag in `handleContinueSession` (clearing on layout unmount would break the intended post-signup install wall).
- **Security lens — no majors.** The deleted 307 was routing convenience, not a control: passkey re-registration 409s server-side, `add-account` 403s cross-user, `/setup` renders nothing session-derived server-side, no client-side JWT decodes exist, no open-redirect exposure.
- **Test lens — the first version of the regression test was vacuous** (a 401 clears the cookie and the loop's own client leg restores the URL before assertion) — rewritten in `64c21bcff` to assert the raw document response.

## Risks / breaking changes

- **Intentional UX change:** a validly logged-in user navigating to `/setup` on web now sees the existing "You're already signed in — Continue as @x / Log out & start fresh" card (1 click) instead of a silent 307 to `/home`. This is the behavior `aa44a14f5` built (already live in the native app, where no middleware runs). Web becomes consistent with native.
- The `/` → `/home` cookie-presence bounce is deliberately untouched (not loop-forming: the chain now terminates at `/setup`).
- Rollout: SW-cache-poisoned clients (`/home` HTML cached under `/setup`) self-heal on their first online navigation post-deploy (NetworkFirst).
- Hotfix to `main` → **back-merge main→dev debt** after merge.

## Design notes / accepted trade-offs

- If `/users/me` **errors** (≠401/404) while a valid-session user sits on `/setup`, the existing-session latch can miss and show signup instead of the prompt. Pre-PR that same population was in the redirect loop, so this trades a hard lockout for a rare footgun; durable state is protected server-side regardless (second-account-at-worst, old account untouched). Hardening the latch is deliberately out of scope — blocking the latch on error would re-lock the offline stale-cookie PWA users this PR rescues.
- Follow-ups (separate PRs, not bundled): `redirect_uri`/query-string loss through the existing-session prompt's two buttons (pre-existing for Continue; new for Log-out path); e2e CI job currently aborts in global-setup before running any test (`continue-on-error`, no `TEST_HARNESS_SECRET`/API) — wire it or keep the suite local; stale `MIDDLEWARE_ROUTES` comment in `proxy.ts`; `test:e2e` script runs the mobile project only.

## QA

- **Regression test** (`e2e/flows/setup.spec.ts`): stale forged JWT in the cookie jar → `context.request.get('/setup', { maxRedirects: 0 })` must be **200** (old middleware: 307). Deterministic — no timing, no live API. Browser-side smoke on top: `/users/me` stubbed to 401, page loads, stays on `/setup`, no crash. Note: the CI e2e job currently aborts before running any Playwright test (see follow-ups), so this guard is effective in local runs; the curl matrix above is the deploy-level proof.
- Local: typecheck + jest clean for changed files (2 pre-existing env-only failures in a fresh worktree: `@capacitor/preferences` missing from shared node_modules, ungenerated `public/flags/`).
- Verify on preview: `curl -sI -H 'Cookie: jwt-token=bogus' <preview>/setup` → `200`, no `location: /home`; `/` with cookie still 307s to `/home`.
- Ticket scope on device: logged-out PWA reaches `/setup`; logged-in and fresh-install paths unchanged; native (Capacitor) unaffected — static export, middleware never runs there.

## Video recording of the issue

https://github.com/user-attachments/assets/3341312c-0dd1-44d8-bd93-3b3287941a5b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed setup-page redirect loops caused by expired authentication cookies.
  * Users with invalid sessions can now remain on the setup page while their session is validated.
  * Continuing an existing setup session now correctly clears the iOS PWA installation prompt before navigating home.

* **Tests**
  * Added end-to-end coverage for setup access with expired session credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->