### PR TITLE
fix(i18n): localize backend-sourced status strings across all domains

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -235,7 +235,7 @@ module.exports = [
             // fallback reached through the shared 0_Bruddle/Button.
             'src/components/Global/{Layout,AnimateOnView,MarqueeWrapper,FAQs,FooterVisibilityObserver,ExchangeRateWidget,Modal,Loading}/**',
             'src/components/Global/{Layout,AnimateOnView,MarqueeWrapper,FAQs,FooterVisibilityObserver,ExchangeRateWidget,Modal,Loading}.tsx',
-            'src/components/Global/{PeanutLoading,Icons,Badges}/**',
+            'src/components/Global/{PeanutLoading,Icons}/**',
             // InvitesGraph is a /dev-only debug visualization, not user-facing UI.
             'src/components/Global/InvitesGraph/**',
             // Hidden support tool — never linked in-app; support DMs the URL to

--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -11,7 +11,7 @@ import { formatAmount } from '@/utils/general.utils'
 import { countryData } from '@/components/AddMoney/consts'
 import { useAuth } from '@/context/authContext'
 import { useCapabilities } from '@/hooks/useCapabilities'
-import { resolveKycModalVariant, getGateUserMessage } from '@/utils/capability-gate'
+import { resolveKycModalVariant, getGateUserMessage, getGateReasonCode } from '@/utils/capability-gate'
 import { useModalsContext } from '@/context/ModalsContext'
 import { useCreateOnramp, GENERIC_ONRAMP_ERROR } from '@/hooks/useCreateOnramp'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
@@ -511,6 +511,7 @@ function BridgeBankOnrampPage() {
                     error={sumsubFlow.error}
                     variant={resolveKycModalVariant(gate)}
                     providerMessage={getGateUserMessage(gate)}
+                    reasonCode={getGateReasonCode(gate)}
                     regionName={selectedCountry?.title}
                 />
 

--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -655,13 +655,14 @@ const CardPage: FC = () => {
                         </div>
                     )
                 }
-                const cardRailReason = poaSubmitted
-                    ? 'We received your proof of address — it’s being reviewed.'
-                    : railsForProvider('rain')[0]?.reason?.userMessage
+                const cardRail = railsForProvider('rain')[0]
+                const cardRailReasonCode = poaSubmitted ? 'proof_of_address_review' : cardRail?.reason?.code
+                const cardRailReason = poaSubmitted ? undefined : cardRail?.reason?.userMessage
                 return (
                     <ApplicationStatusScreen
                         variant="requires-info"
                         reasonMessage={cardRailReason}
+                        reasonCode={cardRailReasonCode}
                         onContactSupport={() => setIsSupportModalOpen(true)}
                         onUploadProofOfAddress={onUploadProofOfAddress}
                         uploadError={poaError ?? undefined}
@@ -693,15 +694,14 @@ const CardPage: FC = () => {
                 // (meaningless without its reason), the rejected screen is useful
                 // on its own (reassurance + support CTA), so show it now and let
                 // the reason fill in once capabilities resolve.
-                const cardRailReason = poaSubmitted
-                    ? 'We received your proof of address — it’s being reviewed.'
-                    : capabilitiesLoading
-                      ? undefined
-                      : railsForProvider('rain')[0]?.reason?.userMessage
+                const cardRail = capabilitiesLoading ? undefined : railsForProvider('rain')[0]
+                const cardRailReasonCode = poaSubmitted ? 'proof_of_address_review' : cardRail?.reason?.code
+                const cardRailReason = poaSubmitted ? undefined : cardRail?.reason?.userMessage
                 return (
                     <ApplicationStatusScreen
                         variant="rejected"
                         reasonMessage={cardRailReason}
+                        reasonCode={cardRailReasonCode}
                         onContactSupport={() => setIsSupportModalOpen(true)}
                         onUploadProofOfAddress={onUploadProofOfAddress}
                         uploadError={poaError ?? undefined}

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -37,7 +37,7 @@ import { useAdvisoryPreempt } from '@/hooks/useAdvisoryPreempt'
 import { useEeaUpliftFunnel } from '@/hooks/useEeaUpliftFunnel'
 import { upliftTriggerFromGate, upliftTriggerFromAdvisory } from '@/utils/eea-uplift.utils'
 import { useCapabilities } from '@/hooks/useCapabilities'
-import { resolveKycModalVariant, getGateUserMessage } from '@/utils/capability-gate'
+import { resolveKycModalVariant, getGateUserMessage, getGateReasonCode } from '@/utils/capability-gate'
 import { useModalsContext } from '@/context/ModalsContext'
 import ExchangeRate from '@/components/ExchangeRate'
 import countryCurrencyMappings, { isNonEuroSepaCountry } from '@/constants/countryCurrencyMapping'
@@ -609,6 +609,7 @@ export default function WithdrawBankPage() {
                 error={sumsubFlow.error}
                 variant={resolveKycModalVariant(gate)}
                 providerMessage={getGateUserMessage(gate)}
+                reasonCode={getGateReasonCode(gate)}
                 regionName={getCountryFromPath(country)?.title}
             />
             <AdvisoryPreemptModal {...advisoryModalProps} />

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -675,6 +675,7 @@ function MantecaBankWithdrawFlow() {
                               : 'default'
                 }
                 providerMessage={mantecaRejection.userMessage ?? undefined}
+                reasonCode={mantecaRejection.reasonCode ?? undefined}
                 regionName={selectedCountry?.title}
             />
             <SumsubKycModals flow={sumsubFlow} />

--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -1,13 +1,45 @@
 import { type InitiateSumsubKycResponse, type KYCRegionIntent } from './types/sumsub.types'
 import { serverFetch } from '@/utils/api-fetch'
 
+/**
+ * Stable discriminant for the English fallback errors below. Server actions
+ * can't run next-intl, so alongside the prose they return a `code` the client
+ * translates (see useSumsubKycFlow). `code` is only set when we fell back to
+ * our canned copy — a backend `userMessage` is specific, display-ready prose
+ * and stays untranslated (#2554: keep BE prose as fallback where no code exists).
+ */
+export type SumsubActionErrorCode =
+    | 'initiate_failed'
+    | 'restart_failed'
+    | 'resubmit_failed'
+    | 'start_action_failed'
+    | 'invalid_response'
+    | 'unexpected'
+
+interface SumsubActionError {
+    error: string
+    code?: SumsubActionErrorCode
+}
+
+const backendOrFallback = (
+    responseJson: { userMessage?: string; error?: string },
+    fallback: string,
+    code: SumsubActionErrorCode
+): SumsubActionError => {
+    const backendMessage = responseJson.userMessage || responseJson.error
+    return backendMessage ? { error: backendMessage } : { error: fallback, code }
+}
+
+const caughtError = (e: unknown): SumsubActionError =>
+    e instanceof Error ? { error: e.message } : { error: 'An unexpected error occurred', code: 'unexpected' }
+
 // initiate kyc flow (using sumsub) and get websdk access token
 export const initiateSumsubKyc = async (params?: {
     regionIntent?: KYCRegionIntent
     levelName?: string
     crossRegion?: boolean
     targetCountry?: string
-}): Promise<{ data?: InitiateSumsubKycResponse; error?: string }> => {
+}): Promise<{ data?: InitiateSumsubKycResponse; error?: string; code?: SumsubActionErrorCode }> => {
     const body: Record<string, string | boolean | undefined> = {
         regionIntent: params?.regionIntent,
         levelName: params?.levelName,
@@ -24,9 +56,7 @@ export const initiateSumsubKyc = async (params?: {
         const responseJson = await response.json()
 
         if (!response.ok) {
-            return {
-                error: responseJson.userMessage || responseJson.error || 'Failed to initiate identity verification',
-            }
+            return backendOrFallback(responseJson, 'Failed to initiate identity verification', 'initiate_failed')
         }
 
         return {
@@ -38,8 +68,7 @@ export const initiateSumsubKyc = async (params?: {
             },
         }
     } catch (e: unknown) {
-        const message = e instanceof Error ? e.message : 'An unexpected error occurred'
-        return { error: message }
+        return caughtError(e)
     }
 }
 
@@ -68,19 +97,17 @@ export interface RestartIdentityResponse {
 export const restartIdentityVerification = async (): Promise<{
     data?: RestartIdentityResponse
     error?: string
+    code?: SumsubActionErrorCode
 }> => {
     try {
         const response = await serverFetch('/users/identity/restart', { method: 'POST' })
         const responseJson = await response.json()
         if (!response.ok) {
-            return {
-                error: responseJson.userMessage || responseJson.error || 'Failed to restart identity verification',
-            }
+            return backendOrFallback(responseJson, 'Failed to restart identity verification', 'restart_failed')
         }
         return { data: responseJson }
     } catch (e: unknown) {
-        const message = e instanceof Error ? e.message : 'An unexpected error occurred'
-        return { error: message }
+        return caughtError(e)
     }
 }
 
@@ -90,7 +117,7 @@ export const initiateSelfHealResubmission = async (
     // Optional — target a specific (e.g. future-dated advisory) Bridge requirement
     // by key. Omitted for the legacy blocking flow (current nextAction).
     requirementKey?: string
-): Promise<{ data?: SelfHealResubmissionResponse; error?: string }> => {
+): Promise<{ data?: SelfHealResubmissionResponse; error?: string; code?: SumsubActionErrorCode }> => {
     try {
         const response = await serverFetch('/users/identity/resubmit', {
             method: 'POST',
@@ -100,19 +127,16 @@ export const initiateSelfHealResubmission = async (
         const responseJson = await response.json()
 
         if (!response.ok) {
-            return {
-                error: responseJson.userMessage || responseJson.error || 'Failed to initiate document resubmission',
-            }
+            return backendOrFallback(responseJson, 'Failed to initiate document resubmission', 'resubmit_failed')
         }
 
         if (!responseJson.token || !responseJson.applicantId) {
-            return { error: 'Invalid response from server' }
+            return { error: 'Invalid response from server', code: 'invalid_response' }
         }
 
         return { data: responseJson }
     } catch (e: unknown) {
-        const message = e instanceof Error ? e.message : 'An unexpected error occurred'
-        return { error: message }
+        return caughtError(e)
     }
 }
 
@@ -131,7 +155,9 @@ export interface StartKycActionResponse {
  * future-dated RFI early, where /users/identity would short-circuit on
  * "already approved" and never mint a token.
  */
-export const startKycAction = async (key: string): Promise<{ data?: StartKycActionResponse; error?: string }> => {
+export const startKycAction = async (
+    key: string
+): Promise<{ data?: StartKycActionResponse; error?: string; code?: SumsubActionErrorCode }> => {
     try {
         const response = await serverFetch('/users/kyc/start-action', {
             method: 'POST',
@@ -139,10 +165,10 @@ export const startKycAction = async (key: string): Promise<{ data?: StartKycActi
         })
         const responseJson = await response.json()
         if (!response.ok) {
-            return { error: responseJson.userMessage || responseJson.error || 'Failed to start verification' }
+            return backendOrFallback(responseJson, 'Failed to start verification', 'start_action_failed')
         }
         if (!responseJson.sumsubAccessToken) {
-            return { error: 'Invalid response from server' }
+            return { error: 'Invalid response from server', code: 'invalid_response' }
         }
         return {
             data: {
@@ -152,7 +178,6 @@ export const startKycAction = async (key: string): Promise<{ data?: StartKycActi
             },
         }
     } catch (e: unknown) {
-        const message = e instanceof Error ? e.message : 'An unexpected error occurred'
-        return { error: message }
+        return caughtError(e)
     }
 }

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -296,6 +296,7 @@ const MantecaAddMoney: FC = () => {
                                   : 'default'
                     }
                     providerMessage={mantecaRejection.userMessage ?? undefined}
+                    reasonCode={mantecaRejection.reasonCode ?? undefined}
                     regionName={selectedCountry?.title}
                 />
                 <SumsubKycModals flow={sumsubFlow} />

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -29,7 +29,7 @@ import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
 import { useCapabilities } from '@/hooks/useCapabilities'
-import { resolveKycModalVariant, getGateUserMessage } from '@/utils/capability-gate'
+import { resolveKycModalVariant, getGateUserMessage, getGateReasonCode } from '@/utils/capability-gate'
 import { railJurisdictionForBank } from '@/utils/bridge.utils'
 import { getRegionIntent } from '@/utils/regions.utils'
 import { useTosGuard } from '@/hooks/useTosGuard'
@@ -384,6 +384,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                 error={sumsubFlow.error}
                 variant={resolveKycModalVariant(gate)}
                 providerMessage={getGateUserMessage(gate)}
+                reasonCode={getGateReasonCode(gate)}
                 regionName={currentCountry?.title}
             />
             <BridgeTosStep
@@ -507,7 +508,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                                     ) : isPixOnrampUnderMaintenance ? (
                                         <StatusBadge
                                             status="pending"
-                                            customText={PIX_BRAZIL_ONRAMP_MAINTENANCE.badge}
+                                            customText={tAddMoney(PIX_BRAZIL_ONRAMP_MAINTENANCE.badgeKey)}
                                             size="small"
                                         />
                                     ) : null

--- a/src/components/Card/ApplicationStatusScreen.tsx
+++ b/src/components/Card/ApplicationStatusScreen.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image'
 import { useTranslations } from 'next-intl'
 import { PeanutCrying } from '@/assets/mascot'
 import NavHeader from '@/components/Global/NavHeader'
+import { reasonCodeKey } from '@/constants/capability-reason-labels.consts'
 import Loading from '@/components/Global/Loading'
 import { Button } from '@/components/0_Bruddle/Button'
 
@@ -13,8 +14,12 @@ interface Props {
     variant: Variant
     /** Display-ready reason from the capabilities read-model
      *  (`rail.reason.userMessage`) — rendered above the generic body so the
-     *  user sees what specifically is missing. Provider-neutral by contract. */
+     *  user sees what specifically is missing. Provider-neutral by contract.
+     *  Fallback only: when `reasonCode` maps to catalog copy, that wins. */
     reasonMessage?: string
+    /** Stable `rail.reason.code` — mapped onto localized identity.reasons.*
+     *  copy; unknown codes fall back to `reasonMessage` prose. */
+    reasonCode?: string
     onContactSupport?: () => void
     /** When the rail carries a self-serve proof-of-address action, this opens
      *  the Sumsub upload flow — rendered as the primary CTA so users fix it
@@ -43,6 +48,7 @@ const SUPPORT_VARIANTS: ReadonlySet<Variant> = new Set(['requires-info', 'requir
 const ApplicationStatusScreen: FC<Props> = ({
     variant,
     reasonMessage,
+    reasonCode,
     onContactSupport,
     onUploadProofOfAddress,
     uploadError,
@@ -50,7 +56,10 @@ const ApplicationStatusScreen: FC<Props> = ({
 }) => {
     const t = useTranslations('card')
     const tCommon = useTranslations('common')
+    const tIdentity = useTranslations('identity')
     const copyKeys = COPY_KEYS[variant]
+    const reasonKey = reasonCodeKey(reasonCode)
+    const reasonText = reasonKey ? tIdentity(reasonKey) : reasonMessage
     return (
         <div className="flex min-h-[inherit] flex-col gap-8">
             <NavHeader title={t('navAddCard')} onPrev={onPrev} />
@@ -69,7 +78,7 @@ const ApplicationStatusScreen: FC<Props> = ({
                 )}
                 <div className="flex flex-col gap-3">
                     <h1 className="text-2xl font-extrabold text-n-1">{t(copyKeys.title)}</h1>
-                    {reasonMessage && <p className="text-grey-1">{reasonMessage}</p>}
+                    {reasonText && <p className="text-grey-1">{reasonText}</p>}
                     <p className="text-grey-1">{t(copyKeys.body)}</p>
                 </div>
                 {SUPPORT_VARIANTS.has(variant) && onUploadProofOfAddress && (

--- a/src/components/Claim/Link/MantecaFlowManager.tsx
+++ b/src/components/Claim/Link/MantecaFlowManager.tsx
@@ -185,6 +185,7 @@ const MantecaFlowManager: FC<MantecaFlowManagerProps> = ({ claimLinkData, amount
                               : 'default'
                 }
                 providerMessage={mantecaRejection.userMessage ?? undefined}
+                reasonCode={mantecaRejection.reasonCode ?? undefined}
                 regionName={selectedCountry?.title}
             />
             <SumsubKycModals flow={sumsubFlow} />

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -35,7 +35,7 @@ import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { getRegionIntent } from '@/utils/regions.utils'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { useCapabilities } from '@/hooks/useCapabilities'
-import { getKycModalVariant, getGateUserMessage } from '@/utils/capability-gate'
+import { getKycModalVariant, getGateUserMessage, getGateReasonCode } from '@/utils/capability-gate'
 import { useTosGuard } from '@/hooks/useTosGuard'
 import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
 import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
@@ -636,6 +636,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                             error={sumsubFlow.error}
                             variant={getKycModalVariant(gate.kind)}
                             providerMessage={getGateUserMessage(gate)}
+                            reasonCode={getGateReasonCode(gate)}
                         />
                     </>
                 )

--- a/src/components/Global/Badges/StatusBadge.tsx
+++ b/src/components/Global/Badges/StatusBadge.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslations } from 'next-intl'
 import { twMerge } from 'tailwind-merge'
 
 export type StatusType =
@@ -12,6 +13,22 @@ export type StatusType =
     | 'closed'
     | 'refunded'
 
+/**
+ * Status → `common.status.*` catalog key. Exhaustive over StatusType, so a new
+ * status can't compile without a label key — same pattern as TYPE_LABEL_KEYS.
+ */
+export const STATUS_LABEL_KEYS = {
+    completed: 'status.completed',
+    pending: 'status.pending',
+    processing: 'status.processing',
+    failed: 'status.failed',
+    cancelled: 'status.cancelled',
+    refunded: 'status.refunded',
+    soon: 'status.soon',
+    closed: 'status.closed',
+    custom: 'status.custom',
+} as const satisfies Record<StatusType, string>
+
 interface StatusBadgeProps {
     status: StatusType
     className?: string
@@ -20,6 +37,8 @@ interface StatusBadgeProps {
 }
 
 const StatusBadge: React.FC<StatusBadgeProps> = ({ status, className, size = 'small', customText }) => {
+    const t = useTranslations('common')
+
     const getStatusStyles = () => {
         switch (status) {
             case 'completed':
@@ -41,34 +60,13 @@ const StatusBadge: React.FC<StatusBadgeProps> = ({ status, className, size = 'sm
         }
     }
 
-    const getStatusText = () => {
-        // customText overrides the default label for any status type,
-        // allowing callers to use a specific status style with custom text
-        if (customText) return customText
-
-        switch (status) {
-            case 'completed':
-                return 'Completed'
-            case 'pending':
-                return 'Pending'
-            case 'processing':
-                return 'Processing'
-            case 'failed':
-                return 'Failed'
-            case 'cancelled':
-                return 'Cancelled'
-            case 'refunded':
-                return 'Refunded'
-            case 'soon':
-                return 'Soon!'
-            case 'closed':
-                return 'Closed'
-            case 'custom':
-                return 'Custom'
-            default:
-                return status
-        }
-    }
+    // customText overrides the default label for any status type, allowing
+    // callers to use a specific status style with custom text. The unknown
+    // guard covers values that reach here through a cast — never render a raw
+    // backend string.
+    // Truthiness on purpose: callers pass customText='' to mean "no override"
+    // (see SendLinkActionList's soon badge).
+    const label = customText || t(STATUS_LABEL_KEYS[status] ?? 'status.unknown')
 
     const getSizeClasses = () => {
         switch (size) {
@@ -93,7 +91,7 @@ const StatusBadge: React.FC<StatusBadgeProps> = ({ status, className, size = 'sm
                 className
             )}
         >
-            {getStatusText()}
+            {label}
         </span>
     )
 }

--- a/src/components/Global/DocsLink.tsx
+++ b/src/components/Global/DocsLink.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { type ReactNode } from 'react'
+import { useLocale } from 'next-intl'
 import { isCapacitor, openExternalUrl } from '@/utils/capacitor'
 import { BASE_URL } from '@/constants/general.consts'
 
@@ -13,22 +14,39 @@ interface DocsLinkProps {
 }
 
 /**
+ * Re-point an `/en/…` href at the app locale's marketing twin so a Spanish
+ * user tapping "Docs" lands on Spanish pages. App locales lowercase onto the
+ * marketing URL codes (pt-BR → pt-br), and the marketing fallback chains
+ * guarantee a missing translation serves fallback prose rather than a 404.
+ * Non-`/en/` hrefs (bare `/terms`, absolute URLs) pass through untouched.
+ */
+export function localizeDocsHref(href: string, appLocale: string): string {
+    const marketingLocale = appLocale.toLowerCase()
+    if (marketingLocale === 'en') return href
+    if (href === '/en' || href.startsWith('/en/')) return `/${marketingLocale}${href.slice(3)}`
+    return href
+}
+
+/**
  * Link to web-only pages (help center, legal) that don't exist in the native
  * static export. On web it's a normal new-tab link; in Capacitor those routes
  * 404 → SPA falls back to home, so we open the absolute production URL in the
  * in-app browser instead.
  */
 export default function DocsLink({ href, className, children, ...rest }: DocsLinkProps) {
+    const locale = useLocale()
+    const localizedHref = localizeDocsHref(href, locale)
+
     return (
         <a
-            href={href}
+            href={localizedHref}
             target="_blank"
             rel="noopener noreferrer"
             className={className}
             onClick={(e) => {
                 if (isCapacitor()) {
                     e.preventDefault()
-                    void openExternalUrl(`${BASE_URL}${href}`)
+                    void openExternalUrl(`${BASE_URL}${localizedHref}`)
                 }
             }}
             {...rest}

--- a/src/components/Global/WalletNavigation/index.tsx
+++ b/src/components/Global/WalletNavigation/index.tsx
@@ -7,7 +7,8 @@ import { useModalsContext } from '@/context/ModalsContext'
 import { useUserStore } from '@/redux/hooks'
 import classNames from 'classnames'
 import Image from 'next/image'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
+import { localizeDocsHref } from '@/components/Global/DocsLink'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import { useHaptic } from 'use-haptic'
@@ -37,13 +38,14 @@ type NavSectionProps = {
 
 const NavSection: React.FC<NavSectionProps> = ({ paths, pathName }) => {
     const t = useTranslations('navigation')
+    const locale = useLocale()
     const router = useRouter()
     return (
         <>
             {paths.map(({ labelKey, href, icon, size }, index) => (
                 <div key={`${labelKey}-${index}`}>
                     <Link
-                        href={href}
+                        href={localizeDocsHref(href, locale)}
                         className={classNames(
                             'flex items-center gap-3 text-white hover:cursor-pointer hover:text-white/80',
                             {

--- a/src/components/Global/__tests__/docs-link.test.ts
+++ b/src/components/Global/__tests__/docs-link.test.ts
@@ -1,0 +1,20 @@
+import { localizeDocsHref } from '../DocsLink'
+
+describe('localizeDocsHref', () => {
+    it('re-points /en/ hrefs at the app locale lowercase marketing twin', () => {
+        expect(localizeDocsHref('/en/help/passkeys', 'es-419')).toBe('/es-419/help/passkeys')
+        expect(localizeDocsHref('/en/help', 'pt-BR')).toBe('/pt-br/help')
+        expect(localizeDocsHref('/en', 'es-419')).toBe('/es-419')
+    })
+
+    it('leaves English and non-/en/ hrefs untouched', () => {
+        expect(localizeDocsHref('/en/help', 'en')).toBe('/en/help')
+        expect(localizeDocsHref('/terms', 'es-419')).toBe('/terms')
+        expect(localizeDocsHref('/support', 'pt-BR')).toBe('/support')
+        expect(localizeDocsHref('https://peanut.me/en/help', 'es-419')).toBe('https://peanut.me/en/help')
+    })
+
+    it('does not mangle routes that merely start with en', () => {
+        expect(localizeDocsHref('/enterprise', 'es-419')).toBe('/enterprise')
+    })
+})

--- a/src/components/Home/ActivationCTAs.tsx
+++ b/src/components/Home/ActivationCTAs.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { railUserMessage, railVerdict } from '@/utils/capability-gate'
+import { reasonCodeKey } from '@/constants/capability-reason-labels.consts'
 import { Button } from '@/components/0_Bruddle/Button'
 import { type ActivationStep } from '@/hooks/useActivationStatus'
 import { Icon, type IconName } from '@/components/Global/Icons/Icon'
@@ -47,6 +48,7 @@ interface StepConfig {
 export default function ActivationCTAs({ activationStep, onDismissCard }: ActivationCTAsProps) {
     const t = useTranslations('home.activation')
     const tCommon = useTranslations('common')
+    const tIdentity = useTranslations('identity')
     const router = useRouter()
     const { setIsQRScannerOpen, openSupportWithMessage } = useModalsContext()
     const { rails, channelOf, nextActions } = useCapabilities()
@@ -71,6 +73,7 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
         fixableProvider,
         hasBlockedRejection,
         primaryRejectionMessage,
+        primaryRejectionCode,
         blockedRail,
         isEmailBlocked,
     } = useMemo(() => {
@@ -103,10 +106,21 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
                 const surfaced = emailBlocked ?? fixableRail ?? blocked
                 return surfaced ? railUserMessage(surfaced) : null
             })(),
+            primaryRejectionCode: (() => {
+                const surfaced = emailBlocked ?? fixableRail ?? blocked
+                return surfaced ? (surfaced.reason?.code ?? surfaced.resolved?.blocking?.code ?? null) : null
+            })(),
             blockedRail: blocked,
             isEmailBlocked: !!emailBlocked,
         }
     }, [rails, channelOf, nextActions])
+
+    // Known reason codes render localized identity.reasons.* copy; unknown
+    // codes keep the backend's display-ready prose as fallback.
+    const primaryRejectionReasonKey = reasonCodeKey(primaryRejectionCode)
+    const localizedRejectionMessage = primaryRejectionReasonKey
+        ? tIdentity(primaryRejectionReasonKey)
+        : primaryRejectionMessage
 
     const [showProvideEmail, setShowProvideEmail] = useState(false)
     const [showSpendChooser, setShowSpendChooser] = useState(false)
@@ -213,7 +227,7 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
                     icon: 'globe-lock',
                     iconBg: 'bg-primary-1',
                     title: t('addEmail.title'),
-                    description: primaryRejectionMessage || t('addEmail.description'),
+                    description: localizedRejectionMessage || t('addEmail.description'),
                     ctaLabel: t('addEmail.cta'),
                     href: '', // handled in onClick
                 }
@@ -223,7 +237,7 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
                     icon: 'globe-lock',
                     iconBg: 'bg-primary-1',
                     title: t('completeSetup.title'),
-                    description: primaryRejectionMessage || t('completeSetup.description'),
+                    description: localizedRejectionMessage || t('completeSetup.description'),
                     ctaLabel: t('completeSetup.cta'),
                     href: '/profile/identity-verification',
                 }
@@ -259,7 +273,7 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
         hasProviderRejection,
         hasFixableRejection,
         isEmailBlocked,
-        primaryRejectionMessage,
+        localizedRejectionMessage,
         isIdentityProcessing,
         isIdentityActionRequired,
         hasCardAccess,
@@ -344,11 +358,11 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
                 visible={showSpendChooser && hasCardAccess === true}
                 onClose={() => setShowSpendChooser(false)}
                 icon="credit-card"
-                title="How do you want to spend?"
-                description="Both count as your first payment."
+                title={t('spendChooser.title')}
+                description={t('spendChooser.description')}
                 ctas={[
                     {
-                        text: 'Pay with your card',
+                        text: t('spendChooser.payWithCard'),
                         shadowSize: '4',
                         onClick: () => {
                             posthog.capture(ANALYTICS_EVENTS.ACTIVATION_SPEND_CHOOSER_SELECTED, { choice: 'card' })
@@ -357,7 +371,7 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
                         },
                     },
                     {
-                        text: 'Scan a QR code',
+                        text: t('spendChooser.scanQr'),
                         variant: 'stroke',
                         onClick: () => {
                             posthog.capture(ANALYTICS_EVENTS.ACTIVATION_SPEND_CHOOSER_SELECTED, { choice: 'qr' })

--- a/src/components/Kyc/InitiateKycModal.tsx
+++ b/src/components/Kyc/InitiateKycModal.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/navigation'
 import ActionModal from '@/components/Global/ActionModal'
+import { reasonCodeKey } from '@/constants/capability-reason-labels.consts'
 import { type IconName } from '@/components/Global/Icons/Icon'
 import { PeanutDoesntStoreAnyPersonalInformation } from '@/components/Kyc/PeanutDoesntStoreAnyPersonalInformation'
 
@@ -17,6 +18,9 @@ interface InitiateKycModalProps {
     /** when set, shows context-specific messaging instead of the generic "unlock" copy */
     variant?: 'default' | 'provider_rejection' | 'blocked' | 'restart_identity' | 'cross_region' | 'region-unavailable'
     providerMessage?: string
+    /** Stable `CapabilityReason.code` behind `providerMessage` — known codes
+     *  render localized identity.reasons.* copy; unknown fall back to prose. */
+    reasonCode?: string
     /** country name shown in cross_region variant (e.g. "Brazil", "Argentina") */
     regionName?: string
 }
@@ -36,10 +40,14 @@ export const InitiateKycModal = ({
     error,
     variant = 'default',
     providerMessage,
+    reasonCode,
     regionName,
 }: InitiateKycModalProps) => {
     const t = useTranslations('kyc')
     const tCommon = useTranslations('common')
+    const tIdentity = useTranslations('identity')
+    const reasonKey = reasonCodeKey(reasonCode)
+    const resolvedProviderMessage = reasonKey ? tIdentity(reasonKey) : providerMessage
     const isProviderRejection = variant === 'provider_rejection'
     const isBlocked = variant === 'blocked'
     const isRestartIdentity = variant === 'restart_identity'
@@ -63,9 +71,9 @@ export const InitiateKycModal = ({
     const getDescription = () => {
         if (error) return t('initiate.descriptionError', { error })
         if (isRegionUnavailable) return t('initiate.descriptionRegionUnavailable')
-        if (isBlocked) return providerMessage || t('initiate.descriptionBlocked')
-        if (isRestartIdentity) return providerMessage || t('initiate.descriptionRestartIdentity')
-        if (isProviderRejection) return providerMessage || t('initiate.descriptionProviderRejection')
+        if (isBlocked) return resolvedProviderMessage || t('initiate.descriptionBlocked')
+        if (isRestartIdentity) return resolvedProviderMessage || t('initiate.descriptionRestartIdentity')
+        if (isProviderRejection) return resolvedProviderMessage || t('initiate.descriptionProviderRejection')
         if (isCrossRegion) {
             return regionName
                 ? t('initiate.descriptionCrossRegion', { region: regionName })

--- a/src/components/Kyc/states/KycActionRequired.tsx
+++ b/src/components/Kyc/states/KycActionRequired.tsx
@@ -8,10 +8,10 @@ import type { IconName } from '@/components/Global/Icons/Icon'
 // this component shows the identity-verification status when more action is needed
 // from the user. Prefers the per-label copy when reject labels are present (e.g.
 // DUPLICATE_EMAIL → "Email already in use, sign in to that account or contact
-// support") and only falls back to the backend's generic actionMessage when there
-// are none. The backend (identity.ts → actionMessageFor) sends a fixed, generic
-// "resubmit your documents" message for every action_required state — it is never
-// label-specific — so checking it first would mask the actionable per-label copy.
+// support") and only falls back to a generic message when there are none. The
+// backend's actionMessage (identity.ts → actionMessageFor) is a pure function of
+// status — never label-specific — so its PRESENCE is the signal and the copy
+// itself comes from the catalog, keyed off the state we're already in.
 // RejectLabelsList already renders its own generic fallback for empty labels, so
 // the no-labels-no-actionMessage case lands there safely.
 export const KycActionRequired = ({
@@ -33,7 +33,7 @@ export const KycActionRequired = ({
             <KYCStatusDrawerItem status="pending" customText={t('actionNeeded')} />
 
             {!rejectLabels?.length && actionMessage ? (
-                <InfoCard variant="info" icon="alert" description={actionMessage} />
+                <InfoCard variant="info" icon="alert" description={t('actionMessageActionRequired')} />
             ) : (
                 <RejectLabelsList rejectLabels={rejectLabels} />
             )}

--- a/src/components/Kyc/states/KycFailed.tsx
+++ b/src/components/Kyc/states/KycFailed.tsx
@@ -7,8 +7,9 @@ import { useMemo } from 'react'
 import { useFormatter, useTranslations } from 'next-intl'
 
 // this component shows the identity-verification status when it's failed/rejected.
-// reads the provider-agnostic identity fields: a friendly actionMessage + normalized
-// reject labels. No provider names.
+// reads the provider-agnostic identity fields + normalized reject labels. The
+// backend's actionMessage is a pure function of status, so its presence gates the
+// reason row while the copy itself comes from the catalog. No provider names.
 export const KycFailed = ({
     actionMessage,
     rejectLabels,
@@ -46,7 +47,7 @@ export const KycFailed = ({
 
             <Card position="single" className="py-0">
                 <PaymentInfoRow label={t('rejectedOn')} value={rejectedOn} hideBottomBorder={!hasReason} />
-                {hasReason && <PaymentInfoRow label={t('reason')} value={actionMessage} hideBottomBorder />}
+                {hasReason && <PaymentInfoRow label={t('reason')} value={t('actionMessageFailed')} hideBottomBorder />}
             </Card>
 
             <RejectLabelsList rejectLabels={rejectLabels} />

--- a/src/components/Kyc/states/__tests__/KycStates.test.tsx
+++ b/src/components/Kyc/states/__tests__/KycStates.test.tsx
@@ -67,12 +67,14 @@ describe('KYC state cards', () => {
         expect(screen.queryByText(/resubmit your documents/i)).not.toBeInTheDocument()
     })
 
-    it('falls back to the generic actionMessage when there are no reject labels', () => {
-        render(
-            <KycActionRequired onResume={jest.fn()} actionMessage="Please resubmit your documents." rejectLabels={[]} />
-        )
+    it('renders the catalog copy when actionMessage is present and there are no reject labels', () => {
+        // The backend's actionMessage is a pure function of status: its
+        // presence gates the card, the copy comes from the catalog — raw
+        // backend prose must never render (it would be English in every locale).
+        render(<KycActionRequired onResume={jest.fn()} actionMessage="Some backend prose." rejectLabels={[]} />)
 
-        expect(screen.getByText('Please resubmit your documents.')).toBeInTheDocument()
+        expect(screen.getByText(/resubmit your documents/i)).toBeInTheDocument()
+        expect(screen.queryByText('Some backend prose.')).not.toBeInTheDocument()
         expect(screen.queryByTestId('reject-labels-list')).not.toBeInTheDocument()
     })
 

--- a/src/components/Profile/views/UnlockedRegions.view.tsx
+++ b/src/components/Profile/views/UnlockedRegions.view.tsx
@@ -15,6 +15,7 @@ import { useModalsContext } from '@/context/ModalsContext'
 import { deriveRegionAccess, getRegionIntent, providerForRegionIntent, type Region } from '@/utils/regions.utils'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { deriveProviderRejection } from '@/utils/provider-rejection.utils'
+import { reasonCodeKey } from '@/constants/capability-reason-labels.consts'
 import { type RailCapability } from '@/types/capabilities'
 import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { useTranslations } from 'next-intl'
@@ -65,6 +66,7 @@ function getModalVariant(rail: RailCapability | undefined, hasSumsubAction: bool
 const UnlockedRegions = () => {
     const t = useTranslations('profile.regions')
     const tCommon = useTranslations('common')
+    const tIdentity = useTranslations('identity')
     const onBack = useSafeBack('/profile', { replace: true })
     const router = useRouter()
     // Card-priority guard: an eligible user (skip badge / admin grant →
@@ -135,6 +137,13 @@ const UnlockedRegions = () => {
     // override modal variant when sumsub is approved but a provider rejected the user.
     // ROW has no provider (clickedRegionProvider null) → no provider rejection can apply.
     const providerRejectionForRegion = clickedRegionProvider === 'bridge' ? bridgeRejection : mantecaRejection
+    // Known reason codes render localized identity.reasons.* copy; unknown
+    // codes keep the backend's display-ready prose (#2554: key off codes,
+    // never match English text).
+    const providerRejectionReasonKey = reasonCodeKey(providerRejectionForRegion.reasonCode)
+    const providerRejectionMessage = providerRejectionReasonKey
+        ? tIdentity(providerRejectionReasonKey)
+        : providerRejectionForRegion.userMessage
     const hasProviderRejectionForRegion =
         !!selectedRegion &&
         clickedRegionProvider !== null &&
@@ -267,9 +276,9 @@ const UnlockedRegions = () => {
                 }
                 description={
                     providerRejectionForRegion.state === 'fixable'
-                        ? providerRejectionForRegion.userMessage || t('providerRejection.fixableDescription')
+                        ? providerRejectionMessage || t('providerRejection.fixableDescription')
                         : providerRejectionForRegion.state === 'restart-identity'
-                          ? providerRejectionForRegion.userMessage || t('providerRejection.restartDescription')
+                          ? providerRejectionMessage || t('providerRejection.restartDescription')
                           : t('providerRejection.unavailableDescription')
                 }
                 icon="alert"

--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -5,6 +5,7 @@ import TransactionAvatarBadge from '@/components/TransactionDetails/TransactionA
 import { getBankAccountCountryCode } from '@/constants/countryCurrencyMapping'
 import { type TransactionDirection, type TransactionType } from '@/components/TransactionDetails/transaction-types'
 import { type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
+import { translateTransactionName } from '@/components/TransactionDetails/transaction-name-keys'
 import {
     hasUserProfile,
     isCardPaymentEntry,
@@ -106,9 +107,15 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
     // check if this is a test transaction (setup confirmation)
     const isTest = isTestTransaction(name)
 
+    // FE-generated labels carry a catalog key — localize; real counterparty
+    // names (usernames, merchants, addresses) pass through as data.
+    const localizedName = transaction.nameKey
+        ? translateTransactionName(t, transaction.nameKey, transaction.nameParams)
+        : name
+
     // ENS reverse-lookup for raw addresses; hook is a no-op when name is a username.
     const { primaryName } = usePrimaryNameServer(isAddress(name) ? name : undefined)
-    let displayName = normalizeEnsName(primaryName) ?? name
+    let displayName = normalizeEnsName(primaryName) ?? localizedName
     // Shortens crypto addresses AND raw UUIDs (usernameless Peanut users whose
     // `identifier` arrives as a userId) so the feed row never renders a 36-char
     // string.

--- a/src/components/TransactionDetails/TransactionDetailsHeaderCard.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsHeaderCard.tsx
@@ -4,6 +4,11 @@ import StatusBadge, { type StatusType } from '@/components/Global/Badges/StatusB
 import { isTestTransaction } from '@/utils/history.utils'
 import TransactionAvatarBadge from '@/components/TransactionDetails/TransactionAvatarBadge'
 import { type TransactionDirection, type TransactionType } from '@/components/TransactionDetails/transaction-types'
+import {
+    TRANSACTION_NAME_KEYS,
+    translateTransactionName,
+    type TransactionNameKey,
+} from '@/components/TransactionDetails/transaction-name-keys'
 import { printableUserHandle } from '@/utils/general.utils'
 import { useTranslations } from 'next-intl'
 import Image from 'next/image'
@@ -20,6 +25,10 @@ import { profileUrl } from '@/utils/native-routes'
 interface TransactionDetailsHeaderCardProps {
     direction: TransactionDirection
     userName: string
+    /** Catalog key when `userName` is an FE-generated label — localized here;
+     *  also the locale-safe discriminant for the via-link title overrides. */
+    nameKey?: TransactionNameKey
+    nameParams?: Record<string, string>
     amountDisplay: string
     initials: string
     status?: StatusType
@@ -47,7 +56,8 @@ const getTitle = (
     direction: TransactionDirection,
     userName: string,
     isLinkTransaction?: boolean,
-    status?: StatusType
+    status?: StatusType,
+    nameKey?: TransactionNameKey
 ): React.ReactNode => {
     let titleText = userName
 
@@ -77,7 +87,9 @@ const getTitle = (
                 if (status === 'pending' || status === 'cancelled') {
                     titleText = displayName
                 } else {
-                    if (displayName === "You're sending via link") {
+                    // Locale-safe discriminant (#2554): key off nameKey, never
+                    // the (now localized) display string.
+                    if (nameKey === TRANSACTION_NAME_KEYS.sentViaLink) {
                         titleText = t('title.sentViaLink')
                     } else {
                         titleText = t(status === 'completed' ? 'title.sentTo' : 'title.sendingTo', {
@@ -90,7 +102,7 @@ const getTitle = (
                 titleText = t('title.isRequesting', { name: displayName })
                 break
             case 'receive':
-                if (displayName === 'Received via Link') {
+                if (nameKey === TRANSACTION_NAME_KEYS.receivedViaLink) {
                     titleText = t('title.receivedViaLink')
                 } else {
                     titleText = t('title.receivedFrom', { name: displayName })
@@ -183,6 +195,8 @@ const getIcon = (
 export const TransactionDetailsHeaderCard: React.FC<TransactionDetailsHeaderCardProps> = ({
     direction,
     userName,
+    nameKey,
+    nameParams,
     amountDisplay,
     initials,
     status,
@@ -204,11 +218,15 @@ export const TransactionDetailsHeaderCard: React.FC<TransactionDetailsHeaderCard
 }) => {
     const router = useRouter()
     const t = useTranslations('transaction')
+    // FE-generated labels carry a catalog key — localize for every display
+    // surface below; raw `userName` stays for data uses (test-tx marker,
+    // profile URL, verification lookups).
+    const localizedUserName = nameKey ? translateTransactionName(t, nameKey, nameParams) : userName
     const typeForAvatar =
         transactionType ?? (direction === 'add' ? 'add' : direction === 'withdraw' ? 'withdraw' : 'send')
 
     // respect user's showFullName preference: use fullName only if showFullName is true, otherwise use username
-    const nameForAvatar = showFullName && fullName ? fullName : userName
+    const nameForAvatar = showFullName && fullName ? fullName : localizedUserName
 
     // check if this is a test transaction (setup confirmation)
     const isTest = isTestTransaction(userName)
@@ -265,8 +283,15 @@ export const TransactionDetailsHeaderCard: React.FC<TransactionDetailsHeaderCard
                                 username={userName}
                                 name={
                                     isRequestPotTransaction
-                                        ? userName
-                                        : (getTitle(t, direction, userName, isLinkTransaction, status) as string)
+                                        ? localizedUserName
+                                        : (getTitle(
+                                              t,
+                                              direction,
+                                              localizedUserName,
+                                              isLinkTransaction,
+                                              status,
+                                              nameKey
+                                          ) as string)
                                 }
                                 isVerified={isVerified}
                                 className="flex items-center gap-1"

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -327,6 +327,8 @@ export const TransactionDetailsReceipt = ({
             <TransactionDetailsHeaderCard
                 direction={transaction.direction}
                 userName={transaction.userName}
+                nameKey={transaction.nameKey}
+                nameParams={transaction.nameParams}
                 amountDisplay={amountDisplay}
                 initials={transaction.initials}
                 status={transaction.status}
@@ -629,7 +631,7 @@ export const TransactionDetailsReceipt = ({
                     {rowVisibilityConfig.comment && (
                         <PaymentInfoRow
                             label={tCommon('comment')}
-                            value={transaction.memo}
+                            value={transaction.memoKey ? t(transaction.memoKey) : transaction.memo}
                             hideBottomBorder={shouldHideBorder('comment')}
                         />
                     )}

--- a/src/components/TransactionDetails/provider-receipts/PerkRewardReceipt.tsx
+++ b/src/components/TransactionDetails/provider-receipts/PerkRewardReceipt.tsx
@@ -9,6 +9,7 @@ import { PerkIcon } from '@/components/TransactionDetails/PerkIcon'
 import { type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
 import { type HistoryEntryPerkReward } from '@/services/services.types'
 import { useModalsContext } from '@/context/ModalsContext'
+import { STATUS_LABEL_KEYS } from '@/components/Global/Badges/StatusBadge'
 import { useTranslations } from 'next-intl'
 import { useReceiptDateFormatter } from '@/components/TransactionDetails/useReceiptDateFormatter'
 
@@ -34,6 +35,7 @@ export function PerkRewardReceipt({
 }) {
     const { setIsSupportModalOpen } = useModalsContext()
     const t = useTranslations('transaction')
+    const tCommon = useTranslations('common')
     const formatDate = useReceiptDateFormatter()
 
     return (
@@ -59,7 +61,9 @@ export function PerkRewardReceipt({
                             </span>
                         ) : (
                             <span className="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-700">
-                                {transaction.status}
+                                {tCommon(
+                                    (transaction.status && STATUS_LABEL_KEYS[transaction.status]) ?? 'status.unknown'
+                                )}
                             </span>
                         )}
                     </div>

--- a/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
+++ b/src/components/TransactionDetails/provider-rows/CardPaymentRows.tsx
@@ -164,7 +164,7 @@ export function CardPaymentRows({
                 const deltaCents = settledCents - authCents
                 subRows.push({
                     key: 'settlementAdjustment',
-                    label: 'Adjustment',
+                    label: t('cardRows.adjustment'),
                     value: `${deltaCents > 0 ? '+' : '-'}$${(Math.abs(deltaCents) / 100).toFixed(2)}`,
                 })
             }

--- a/src/components/TransactionDetails/strategies/fallback.ts
+++ b/src/components/TransactionDetails/strategies/fallback.ts
@@ -1,5 +1,6 @@
 import { type HistoryEntry } from '@/hooks/useTransactionHistory'
 import { type TransactionStrategy, type TransactionStrategyOutput } from './types'
+import { TRANSACTION_NAME_KEYS } from '@/components/TransactionDetails/transaction-name-keys'
 import { cardRefund } from './intent/card'
 import { pipelineAlert } from '@/utils/pipelineAlerts'
 
@@ -24,6 +25,7 @@ export const intentFallback: TransactionStrategy = (entry: HistoryEntry): Transa
         direction: 'send',
         transactionCardType: 'send',
         nameForDetails: entry.recipientAccount?.identifier || 'Transaction',
+        nameKey: entry.recipientAccount?.identifier ? undefined : TRANSACTION_NAME_KEYS.transaction,
         isPeerActuallyUser: false,
         isLinkTx: false,
     }

--- a/src/components/TransactionDetails/strategies/intent/card.ts
+++ b/src/components/TransactionDetails/strategies/intent/card.ts
@@ -1,5 +1,6 @@
 import { type HistoryEntry } from '@/hooks/useTransactionHistory'
 import { type TransactionStrategy, type TransactionStrategyOutput } from '../types'
+import { TRANSACTION_NAME_KEYS } from '@/components/TransactionDetails/transaction-name-keys'
 import { isNegativeWireAmount, normalizeMerchantName } from '@/components/TransactionDetails/transaction-details.utils'
 
 export const qrPay: TransactionStrategy = (entry: HistoryEntry): TransactionStrategyOutput => {
@@ -8,6 +9,7 @@ export const qrPay: TransactionStrategy = (entry: HistoryEntry): TransactionStra
         direction: 'qr_payment',
         transactionCardType: 'pay',
         nameForDetails: raw ? normalizeMerchantName(raw) : 'Merchant',
+        nameKey: raw ? undefined : TRANSACTION_NAME_KEYS.merchant,
         isPeerActuallyUser: false,
         isLinkTx: false,
     }
@@ -30,6 +32,7 @@ export const cardSpend: TransactionStrategy = (entry: HistoryEntry): Transaction
         // render the Mercado Pago / PIX brand mark instead.
         transactionCardType: 'card_pay',
         nameForDetails: merchantName ? normalizeMerchantName(merchantName) : 'Card payment',
+        nameKey: merchantName ? undefined : TRANSACTION_NAME_KEYS.cardPayment,
         isPeerActuallyUser: false,
         isLinkTx: false,
     }
@@ -42,6 +45,8 @@ export const cardRefund: TransactionStrategy = (entry: HistoryEntry): Transactio
         direction: 'receive',
         transactionCardType: 'refund',
         nameForDetails: cleaned ? `Refund from ${cleaned}` : 'Card refund',
+        nameKey: cleaned ? TRANSACTION_NAME_KEYS.refundFrom : TRANSACTION_NAME_KEYS.cardRefund,
+        nameParams: cleaned ? { name: cleaned } : undefined,
         isPeerActuallyUser: false,
         isLinkTx: false,
     }

--- a/src/components/TransactionDetails/strategies/intent/crypto.ts
+++ b/src/components/TransactionDetails/strategies/intent/crypto.ts
@@ -1,10 +1,15 @@
 import { EHistoryUserRole, type HistoryEntry } from '@/hooks/useTransactionHistory'
 import { type TransactionStrategy, type TransactionStrategyOutput } from '../types'
+import { TRANSACTION_NAME_KEYS } from '@/components/TransactionDetails/transaction-name-keys'
 
 export const cryptoDeposit: TransactionStrategy = (entry: HistoryEntry): TransactionStrategyOutput => ({
     direction: 'add',
     transactionCardType: 'add',
     nameForDetails: entry.senderAccount?.username || entry.senderAccount?.identifier || 'Deposit Source',
+    nameKey:
+        entry.senderAccount?.username || entry.senderAccount?.identifier
+            ? undefined
+            : TRANSACTION_NAME_KEYS.depositSource,
     fullName: entry.senderAccount?.fullName ?? '',
     showFullName: entry.senderAccount?.showFullName,
     isPeerActuallyUser: !!entry.senderAccount?.isUser,
@@ -17,6 +22,10 @@ export const cryptoWithdraw: TransactionStrategy = (entry: HistoryEntry): Transa
             direction: 'add',
             transactionCardType: 'add',
             nameForDetails: entry.senderAccount?.username || entry.senderAccount?.identifier || 'External Wallet',
+            nameKey:
+                entry.senderAccount?.username || entry.senderAccount?.identifier
+                    ? undefined
+                    : TRANSACTION_NAME_KEYS.externalWallet,
             isPeerActuallyUser: !!entry.senderAccount?.isUser,
             isLinkTx: false,
         }
@@ -25,6 +34,7 @@ export const cryptoWithdraw: TransactionStrategy = (entry: HistoryEntry): Transa
         direction: 'withdraw',
         transactionCardType: 'withdraw',
         nameForDetails: entry.recipientAccount?.identifier || 'External Account',
+        nameKey: entry.recipientAccount?.identifier ? undefined : TRANSACTION_NAME_KEYS.externalAccount,
         isPeerActuallyUser: false,
         isLinkTx: false,
     }

--- a/src/components/TransactionDetails/strategies/intent/fiat-offramp.ts
+++ b/src/components/TransactionDetails/strategies/intent/fiat-offramp.ts
@@ -1,10 +1,12 @@
 import { EHistoryUserRole, type HistoryEntry } from '@/hooks/useTransactionHistory'
 import { type TransactionStrategy, type TransactionStrategyOutput } from '../types'
+import { TRANSACTION_NAME_KEYS } from '@/components/TransactionDetails/transaction-name-keys'
 
 const BANK_CLAIM: TransactionStrategyOutput = {
     direction: 'bank_claim',
     transactionCardType: 'bank_claim',
     nameForDetails: 'Claimed to Bank',
+    nameKey: TRANSACTION_NAME_KEYS.claimedToBank,
     isPeerActuallyUser: false,
     isLinkTx: false,
 }
@@ -26,6 +28,12 @@ export const fiatOfframp: TransactionStrategy = (entry: HistoryEntry): Transacti
                     entry.recipientAccount?.fullName ??
                     entry.recipientAccount?.identifier ??
                     'Recipient',
+                nameKey:
+                    (entry.recipientAccount?.username ??
+                        entry.recipientAccount?.fullName ??
+                        entry.recipientAccount?.identifier) != null
+                        ? undefined
+                        : TRANSACTION_NAME_KEYS.recipient,
                 fullName: entry.recipientAccount?.fullName ?? '',
                 isPeerActuallyUser: true,
                 isLinkTx: false,
@@ -42,6 +50,10 @@ export const fiatOfframp: TransactionStrategy = (entry: HistoryEntry): Transacti
             direction: 'receive',
             transactionCardType: 'receive',
             nameForDetails: entry.senderAccount?.username || entry.senderAccount?.identifier || 'Bank Account',
+            nameKey:
+                entry.senderAccount?.username || entry.senderAccount?.identifier
+                    ? undefined
+                    : TRANSACTION_NAME_KEYS.bankAccount,
             isPeerActuallyUser: !!entry.senderAccount?.isUser,
             isLinkTx: false,
         }
@@ -50,6 +62,7 @@ export const fiatOfframp: TransactionStrategy = (entry: HistoryEntry): Transacti
         direction: 'bank_withdraw',
         transactionCardType: 'bank_withdraw',
         nameForDetails: 'Bank Account',
+        nameKey: TRANSACTION_NAME_KEYS.bankAccount,
         isPeerActuallyUser: false,
         isLinkTx: false,
     }

--- a/src/components/TransactionDetails/strategies/intent/fiat-onramp.ts
+++ b/src/components/TransactionDetails/strategies/intent/fiat-onramp.ts
@@ -4,12 +4,14 @@
 // for the ARS/BRL deposit-info widget.
 
 import { type TransactionStrategy, type TransactionStrategyOutput } from '../types'
+import { TRANSACTION_NAME_KEYS } from '@/components/TransactionDetails/transaction-name-keys'
 
 // No per-entry branching — onramp output is fully derivable from the kind.
 export const fiatOnramp: TransactionStrategy = (): TransactionStrategyOutput => ({
     direction: 'bank_deposit',
     transactionCardType: 'bank_deposit',
     nameForDetails: 'Bank Account',
+    nameKey: TRANSACTION_NAME_KEYS.bankAccount,
     isPeerActuallyUser: false,
     isLinkTx: false,
 })

--- a/src/components/TransactionDetails/strategies/intent/p2p-send.ts
+++ b/src/components/TransactionDetails/strategies/intent/p2p-send.ts
@@ -4,6 +4,7 @@
 
 import { EHistoryUserRole, type HistoryEntry } from '@/hooks/useTransactionHistory'
 import { type TransactionStrategy, type TransactionStrategyOutput } from '../types'
+import { TRANSACTION_NAME_KEYS } from '@/components/TransactionDetails/transaction-name-keys'
 
 export const p2pSendOrRequestFulfill: TransactionStrategy = (entry: HistoryEntry): TransactionStrategyOutput => {
     const kind = entry.extraData?.kind as string | undefined
@@ -19,6 +20,10 @@ export const p2pSendOrRequestFulfill: TransactionStrategy = (entry: HistoryEntry
             direction: 'bank_request_fulfillment',
             transactionCardType: 'bank_request_fulfillment',
             nameForDetails: entry.recipientAccount?.username ?? entry.recipientAccount?.identifier ?? 'Recipient',
+            nameKey:
+                (entry.recipientAccount?.username ?? entry.recipientAccount?.identifier) != null
+                    ? undefined
+                    : TRANSACTION_NAME_KEYS.recipient,
             fullName: entry.recipientAccount?.fullName ?? '',
             showFullName: entry.recipientAccount?.showFullName,
             isPeerActuallyUser: !!entry.recipientAccount?.isUser || !!entry.senderAccount?.isUser,
@@ -33,6 +38,10 @@ export const p2pSendOrRequestFulfill: TransactionStrategy = (entry: HistoryEntry
                 direction: 'receive',
                 transactionCardType: 'receive',
                 nameForDetails: entry.senderAccount?.username || entry.senderAccount?.identifier || 'Sender',
+                nameKey:
+                    entry.senderAccount?.username || entry.senderAccount?.identifier
+                        ? undefined
+                        : TRANSACTION_NAME_KEYS.sender,
                 fullName: entry.senderAccount?.fullName ?? '',
                 showFullName: entry.senderAccount?.showFullName,
                 isPeerActuallyUser: !!entry.senderAccount?.isUser,
@@ -44,6 +53,7 @@ export const p2pSendOrRequestFulfill: TransactionStrategy = (entry: HistoryEntry
             direction: 'request_received',
             transactionCardType: 'request',
             nameForDetails: 'Request',
+            nameKey: TRANSACTION_NAME_KEYS.request,
             isPeerActuallyUser: false,
             isLinkTx: false,
         }
@@ -53,6 +63,10 @@ export const p2pSendOrRequestFulfill: TransactionStrategy = (entry: HistoryEntry
         direction: 'send',
         transactionCardType: 'send',
         nameForDetails: entry.recipientAccount?.username || entry.recipientAccount?.identifier || 'Recipient',
+        nameKey:
+            entry.recipientAccount?.username || entry.recipientAccount?.identifier
+                ? undefined
+                : TRANSACTION_NAME_KEYS.recipient,
         fullName: entry.recipientAccount?.fullName ?? '',
         showFullName: entry.recipientAccount?.showFullName,
         isPeerActuallyUser: !!entry.recipientAccount?.isUser,

--- a/src/components/TransactionDetails/strategies/intent/perk-reward.ts
+++ b/src/components/TransactionDetails/strategies/intent/perk-reward.ts
@@ -3,11 +3,13 @@
 // "Peanut Rewards".
 
 import { type TransactionStrategy, type TransactionStrategyOutput } from '../types'
+import { TRANSACTION_NAME_KEYS } from '@/components/TransactionDetails/transaction-name-keys'
 
 export const perkReward: TransactionStrategy = (): TransactionStrategyOutput => ({
     direction: 'receive',
     transactionCardType: 'receive',
     nameForDetails: 'Peanut Reward',
+    nameKey: TRANSACTION_NAME_KEYS.peanutReward,
     fullName: 'Peanut Rewards',
     isPeerActuallyUser: false,
     isLinkTx: false,

--- a/src/components/TransactionDetails/strategies/intent/refund.ts
+++ b/src/components/TransactionDetails/strategies/intent/refund.ts
@@ -1,5 +1,6 @@
 import { type HistoryEntry } from '@/hooks/useTransactionHistory'
 import { type TransactionStrategy, type TransactionStrategyOutput } from '../types'
+import { TRANSACTION_NAME_KEYS } from '@/components/TransactionDetails/transaction-name-keys'
 import { cardRefund } from './card'
 
 // Strategy for kind=REFUND intents (any provider). Two shapes converge here:
@@ -27,6 +28,7 @@ export const refund: TransactionStrategy = (entry: HistoryEntry): TransactionStr
         direction: 'receive',
         transactionCardType: 'refund',
         nameForDetails: 'Refund',
+        nameKey: TRANSACTION_NAME_KEYS.refund,
         isPeerActuallyUser: false,
         isLinkTx: false,
     }

--- a/src/components/TransactionDetails/strategies/intent/send-link.ts
+++ b/src/components/TransactionDetails/strategies/intent/send-link.ts
@@ -5,6 +5,7 @@
 
 import { EHistoryUserRole, type HistoryEntry } from '@/hooks/useTransactionHistory'
 import { type TransactionStrategy, type TransactionStrategyOutput } from '../types'
+import { TRANSACTION_NAME_KEYS } from '@/components/TransactionDetails/transaction-name-keys'
 
 export const sendLink: TransactionStrategy = (entry: HistoryEntry): TransactionStrategyOutput => {
     if (entry.userRole === EHistoryUserRole.RECIPIENT) {
@@ -23,6 +24,10 @@ export const sendLink: TransactionStrategy = (entry: HistoryEntry): TransactionS
             direction: 'receive',
             transactionCardType: 'receive',
             nameForDetails: entry.senderAccount?.username || entry.senderAccount?.identifier || 'Received via Link',
+            nameKey:
+                entry.senderAccount?.username || entry.senderAccount?.identifier
+                    ? undefined
+                    : TRANSACTION_NAME_KEYS.receivedViaLink,
             fullName: entry.senderAccount?.fullName ?? '',
             showFullName: isPeerActuallyUser ? entry.senderAccount?.showFullName : undefined,
             isPeerActuallyUser,
@@ -36,6 +41,7 @@ export const sendLink: TransactionStrategy = (entry: HistoryEntry): TransactionS
             direction: 'send',
             transactionCardType: 'send',
             nameForDetails: 'Sent via Link',
+            nameKey: TRANSACTION_NAME_KEYS.sentViaLink,
             isPeerActuallyUser: true,
             isLinkTx: true,
             uiStatus: 'cancelled',
@@ -56,6 +62,7 @@ export const sendLink: TransactionStrategy = (entry: HistoryEntry): TransactionS
         direction: 'send',
         transactionCardType: 'send',
         nameForDetails: 'Sent via link',
+        nameKey: TRANSACTION_NAME_KEYS.sentViaLink,
         isPeerActuallyUser: false,
         isLinkTx: true,
     }

--- a/src/components/TransactionDetails/strategies/types.ts
+++ b/src/components/TransactionDetails/strategies/types.ts
@@ -11,6 +11,7 @@ import {
     type TransactionDirection,
     type TransactionType as TransactionCardType,
 } from '@/components/TransactionDetails/transaction-types'
+import { type TransactionNameKey } from '@/components/TransactionDetails/transaction-name-keys'
 import { type StatusPillType } from '@/components/Global/StatusPill'
 import { type HistoryEntry } from '@/hooks/useTransactionHistory'
 
@@ -18,6 +19,14 @@ export interface TransactionStrategyOutput {
     direction: TransactionDirection
     transactionCardType: TransactionCardType
     nameForDetails: string
+    /**
+     * Set when `nameForDetails` is an FE-generated label ('Card payment',
+     * 'Bank Account', …) rather than counterparty data. Render sites localize
+     * via `t(nameKey, nameParams)` and keep `nameForDetails` as the fallback.
+     * Dynamic parts (merchant/user names) travel in `nameParams`, not copy.
+     */
+    nameKey?: TransactionNameKey
+    nameParams?: Record<string, string>
     isPeerActuallyUser: boolean
     isLinkTx: boolean
     fullName?: string

--- a/src/components/TransactionDetails/transaction-name-keys.ts
+++ b/src/components/TransactionDetails/transaction-name-keys.ts
@@ -1,0 +1,71 @@
+/**
+ * Catalog keys (under the `transaction` namespace) for the FE-generated
+ * counterparty labels the transformer/strategies emit when the row has no real
+ * counterparty name ('Card payment', 'Bank Account', reaper-fail copy, …).
+ *
+ * The transformer keeps emitting the English string in `userName` (data
+ * fallback + initials), and additionally sets `nameKey`/`nameParams` so render
+ * sites can show localized copy: `nameKey ? t(nameKey, nameParams) : userName`.
+ * Same enum→key approach as TYPE_LABEL_KEYS / STATUS_LABEL_KEYS — never match
+ * on the English prose itself.
+ */
+
+export const TRANSACTION_NAME_KEYS = {
+    merchant: 'name.merchant',
+    cardPayment: 'name.cardPayment',
+    cardRefund: 'name.cardRefund',
+    refundFrom: 'name.refundFrom',
+    refund: 'name.refund',
+    depositSource: 'name.depositSource',
+    externalWallet: 'name.externalWallet',
+    externalAccount: 'name.externalAccount',
+    claimedToBank: 'name.claimedToBank',
+    bankAccount: 'name.bankAccount',
+    recipient: 'name.recipient',
+    sender: 'name.sender',
+    request: 'name.request',
+    peanutReward: 'name.peanutReward',
+    receivedViaLink: 'name.receivedViaLink',
+    sentViaLink: 'name.sentViaLink',
+    transaction: 'name.transaction',
+    failedQrPayment: 'name.failedQrPayment',
+} as const
+
+/**
+ * Reaper-failed rows: `entry.extraData.failReason` (the BE's stable
+ * `${kind}_timeout` discriminant) → catalog key. Unknown reasons collapse onto
+ * {@link REAPER_FAIL_FALLBACK_KEY} — a raw key path must never render.
+ */
+export const REAPER_FAIL_KEYS = {
+    p2p_send_timeout: 'failReason.p2pSendTimeout',
+    p2p_request_fulfill_timeout: 'failReason.p2pRequestFulfillTimeout',
+    send_link_timeout: 'failReason.sendLinkTimeout',
+    send_link_claim_timeout: 'failReason.sendLinkClaimTimeout',
+    crypto_withdraw_timeout: 'failReason.cryptoWithdrawTimeout',
+    qr_pay_timeout: 'failReason.qrPayTimeout',
+    onramp_timeout: 'failReason.onrampTimeout',
+    offramp_timeout: 'failReason.offrampTimeout',
+    refund_timeout: 'failReason.refundTimeout',
+} as const
+
+export const REAPER_FAIL_FALLBACK_KEY = 'failReason.generic' as const
+
+export const reaperFailKey = (failReason: string): ReaperFailKey =>
+    failReason in REAPER_FAIL_KEYS
+        ? REAPER_FAIL_KEYS[failReason as keyof typeof REAPER_FAIL_KEYS]
+        : REAPER_FAIL_FALLBACK_KEY
+
+type ReaperFailKey = (typeof REAPER_FAIL_KEYS)[keyof typeof REAPER_FAIL_KEYS] | typeof REAPER_FAIL_FALLBACK_KEY
+
+export type TransactionNameKey = (typeof TRANSACTION_NAME_KEYS)[keyof typeof TRANSACTION_NAME_KEYS] | ReaperFailKey
+
+type TransactionTranslator = ReturnType<typeof import('next-intl').useTranslations<'transaction'>>
+
+/** Localize an FE-generated transaction label; ICU params carry the data bits. */
+export function translateTransactionName(
+    t: TransactionTranslator,
+    nameKey: TransactionNameKey,
+    nameParams?: Record<string, string>
+): string {
+    return nameParams ? t(nameKey, nameParams) : t(nameKey)
+}

--- a/src/components/TransactionDetails/transactionTransformer.ts
+++ b/src/components/TransactionDetails/transactionTransformer.ts
@@ -17,6 +17,7 @@ import type { Address } from 'viem'
 import { PEANUT_WALLET_CHAIN } from '@/constants/zerodev.consts'
 import { type HistoryEntryPerkReward, type ChargeEntry } from '@/services/services.types'
 import { dispatchStrategy, isIntentKind, type IntentKind } from './strategies/registry'
+import { TRANSACTION_NAME_KEYS, reaperFailKey, type TransactionNameKey } from './transaction-name-keys'
 import { parseWireAmount } from './transaction-details.utils'
 
 /** Rain dispute lifecycle status values. Source: Rain dispute.* webhooks. */
@@ -300,6 +301,11 @@ export interface TransactionDetails {
     id: string
     direction: TransactionDirection
     userName: string
+    /** Catalog key (under `transaction`) when `userName` is an FE-generated
+     *  label rather than counterparty data. Render sites localize via
+     *  `t(nameKey, nameParams)` and fall back to `userName`. */
+    nameKey?: TransactionNameKey
+    nameParams?: Record<string, string>
     /** The counterparty is an actual Peanut user (not a raw address, bank
      *  account, or a system copy string like 'Request'/'Recipient'/reaper text).
      *  Authoritative gate for whether the name/avatar can deep-link to a
@@ -326,6 +332,9 @@ export interface TransactionDetails {
     date: string | Date
     fee?: number | string
     memo?: string
+    /** Catalog key (under `transaction`) for FE-generated memos (the test
+     *  deposit). Render sites prefer `t(memoKey)` over the raw `memo`. */
+    memoKey?: 'memoTestDeposit'
     attachmentUrl?: string
     cancelledDate?: string | Date
     txHash?: string
@@ -478,6 +487,8 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
     const displayUserRole =
         transactionCardType === 'refund' ? EHistoryUserRole.RECIPIENT : (entry.userRole as EHistoryUserRole)
     let nameForDetails = out.nameForDetails
+    let nameKey = out.nameKey
+    let nameParams = out.nameParams
     let isPeerActuallyUser = out.isPeerActuallyUser
     const isLinkTx = out.isLinkTx
     let fullName = out.fullName ?? ''
@@ -501,6 +512,8 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
     const reaperFailReason = entry.extraData?.failReason as string | undefined
     if (entry.status === 'FAILED' && reaperFailReason && reaperFailReason.endsWith('_timeout')) {
         nameForDetails = REAPER_FAIL_COPY[reaperFailReason] ?? 'Transaction did not complete'
+        nameKey = reaperFailKey(reaperFailReason)
+        nameParams = undefined
         isPeerActuallyUser = false
     } else if (entry.status === 'FAILED' && intentKindOf(entry) === 'QR_PAY') {
         // A collateral QR-pay that failed at submit (e.g. the stale-approval 403)
@@ -511,6 +524,8 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
         // settles then fails is refunded elsewhere — so "didn't complete" is honest
         // whether or not funds moved; the ledger stays the source of truth for that.
         nameForDetails = 'Failed QR payment attempt'
+        nameKey = TRANSACTION_NAME_KEYS.failedQrPayment
+        nameParams = undefined
         isPeerActuallyUser = false
     }
 
@@ -561,6 +576,8 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
         id: entry.uuid,
         direction: direction,
         userName: nameForDetails,
+        nameKey,
+        nameParams,
         amount,
         tokenAmount: entry.amount,
         fullName,
@@ -586,6 +603,7 @@ export function mapTransactionDataForDrawer(entry: HistoryEntry): MappedTransact
         // merchant name and any decline reason render inside CardPaymentRows
         // in the drawer, so a duplicate "Comment" row is just noise. Backend
         // already sets memo=undefined for card entries, but defend in depth.
+        memoKey: isTestDeposit ? 'memoTestDeposit' : undefined,
         memo: (() => {
             if (isTestDeposit) return 'Your peanut wallet is ready to use!'
             const kind = intentKindOf(entry)

--- a/src/config/underMaintenance.config.ts
+++ b/src/config/underMaintenance.config.ts
@@ -91,10 +91,11 @@ const underMaintenanceConfig: MaintenanceConfig = {
 export const CROSS_CHAIN_DISABLED_MESSAGE =
     'Cross-chain claims are temporarily unavailable. Try claiming to an external wallet on the same chain as the link, or try again later.'
 
-// user-facing copy for the BRL-via-PIX onramp maintenance tag (the in-flow banner was
-// retired when the dynamic-QR deposit flow shipped — the tag is the remaining surface)
+// Catalog key (under the `addMoney` namespace) for the BRL-via-PIX onramp
+// maintenance tag — config carries the key, the render site translates (the
+// in-flow banner was retired when the dynamic-QR deposit flow shipped).
 export const PIX_BRAZIL_ONRAMP_MAINTENANCE = {
-    badge: 'Maintenance',
-}
+    badgeKey: 'pixMaintenanceBadge',
+} as const
 
 export default underMaintenanceConfig

--- a/src/constants/capability-reason-labels.consts.ts
+++ b/src/constants/capability-reason-labels.consts.ts
@@ -1,0 +1,56 @@
+/**
+ * Registry of `CapabilityReason.code` values the backend resolver emits
+ * (peanut-api-ts `src/kyc/capabilities/resolver.ts` + `rail-state.ts` +
+ * `level-registry.ts` RequirementCode). This module stays copy-free — the
+ * user-facing line per code lives in the `identity.reasons` catalog namespace
+ * and is resolved at the render site (same pattern as sumsub-reject-labels).
+ *
+ * Unlike rejectLabelCode there is NO fallback key: an unknown code returns
+ * `undefined` and the call site renders the backend's `userMessage` prose —
+ * the BE ships vetted, display-ready copy for every reason, so unknown codes
+ * degrade to (English) prose rather than a generic line that could be wrong.
+ */
+
+export const REASON_CODE_KEYS = {
+    // RequirementCode family (fixable RFIs)
+    tax_identification_number: 'reasons.tax_identification_number',
+    address_of_residence: 'reasons.address_of_residence',
+    proof_of_address: 'reasons.proof_of_address',
+    source_of_funds: 'reasons.source_of_funds',
+    proof_of_source_of_funds: 'reasons.proof_of_source_of_funds',
+    birth_details: 'reasons.birth_details',
+    eea_uplift: 'reasons.eea_uplift',
+    eea_uplift_with_tin: 'reasons.eea_uplift_with_tin',
+    eea_tin_reupload: 'reasons.eea_tin_reupload',
+    pep_documentation: 'reasons.pep_documentation',
+    fep_documentation: 'reasons.fep_documentation',
+    // pipeline / provider states
+    email_required: 'reasons.email_required',
+    submission_failed: 'reasons.submission_failed',
+    proof_of_address_review: 'reasons.proof_of_address_review',
+    bridge_tos_required: 'reasons.bridge_tos_required',
+    bridge_tos_v2_required: 'reasons.bridge_tos_v2_required',
+    bridge_processing: 'reasons.bridge_processing',
+    // rejections
+    document_rejected: 'reasons.document_rejected',
+    verification_blocked: 'reasons.verification_blocked',
+    terminal_rejection: 'reasons.terminal_rejection',
+    bridge_terminal_rejection: 'reasons.bridge_terminal_rejection',
+    duplicate_customer_detected: 'reasons.duplicate_customer_detected',
+    // Rain card rejections
+    region_block: 'reasons.region_block',
+    compliance_block: 'reasons.compliance_block',
+    card_rejected: 'reasons.card_rejected',
+    // restrictions
+    manteca_us_nationality: 'reasons.manteca_us_nationality',
+    country_not_supported: 'reasons.country_not_supported',
+    uk_resident_blocked: 'reasons.uk_resident_blocked',
+} as const
+
+export type KnownReasonCode = keyof typeof REASON_CODE_KEYS
+
+export type ReasonCodeKey = (typeof REASON_CODE_KEYS)[KnownReasonCode]
+
+/** Catalog key for a known reason code; undefined → render the BE prose. */
+export const reasonCodeKey = (code: string | null | undefined): ReasonCodeKey | undefined =>
+    code && code in REASON_CODE_KEYS ? REASON_CODE_KEYS[code as KnownReasonCode] : undefined

--- a/src/constants/capability-reason-labels.consts.ts
+++ b/src/constants/capability-reason-labels.consts.ts
@@ -32,7 +32,12 @@ export const REASON_CODE_KEYS = {
     bridge_tos_v2_required: 'reasons.bridge_tos_v2_required',
     bridge_processing: 'reasons.bridge_processing',
     // rejections
-    document_rejected: 'reasons.document_rejected',
+    // document_rejected is deliberately NOT mapped: the backend only emits it
+    // with the self-heal classifier's fixable-specific prose ("Your ID photo
+    // was blurry. Please upload a clearer photo.") — a generic catalog line
+    // would mask the instruction. It renders the BE prose until the
+    // classifier's stable `action` code (REUPLOAD_ID, …) reaches the wire
+    // (api-ts follow-up, #1249 pattern).
     verification_blocked: 'reasons.verification_blocked',
     terminal_rejection: 'reasons.terminal_rejection',
     bridge_terminal_rejection: 'reasons.bridge_terminal_rejection',

--- a/src/hooks/__tests__/useWaitingOnProviderModal.test.ts
+++ b/src/hooks/__tests__/useWaitingOnProviderModal.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react'
+import { act } from '@testing-library/react'
+import { renderHookWithIntl as renderHook } from '@/test-utils/intl'
 import { useWaitingOnProviderModal } from '@/hooks/useWaitingOnProviderModal'
 import type { GateState } from '@/utils/capability-gate'
 

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -8,6 +8,7 @@ import {
     initiateSelfHealResubmission,
     restartIdentityVerification,
     startKycAction,
+    type SumsubActionErrorCode,
 } from '@/app/actions/sumsub'
 import { type KYCRegionIntent, type SumsubKycStatus } from '@/app/actions/types/sumsub.types'
 import { isMantecaSupportedCountryCode } from '@/constants/manteca.consts'
@@ -42,6 +43,17 @@ const KYC_POLL_SCHEDULE: ReadonlyArray<{ untilMs: number; delayMs: number }> = [
 // schedule replaced.
 const KYC_POLL_MAX_DELAY_MS = 60_000
 
+/** `code` from a sumsub action's canned English fallback → kyc.* catalog key.
+ *  Backend prose arrives without a code and renders as-is (#2554). */
+const ACTION_ERROR_KEYS = {
+    initiate_failed: 'errorInitiateFailed',
+    restart_failed: 'errorRestartFailed',
+    resubmit_failed: 'errorResubmitFailed',
+    start_action_failed: 'errorStartActionFailed',
+    invalid_response: 'errorInvalidResponse',
+    unexpected: 'unexpectedError',
+} as const satisfies Record<SumsubActionErrorCode, string>
+
 const getKycPollDelayMs = (elapsedMs: number): number => {
     for (const { untilMs, delayMs } of KYC_POLL_SCHEDULE) {
         if (elapsedMs < untilMs) return delayMs
@@ -53,6 +65,14 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     const { user } = useUserStore()
     const router = useRouter()
     const t = useTranslations('kyc')
+
+    // Localize a failed action result: known codes map onto catalog copy,
+    // codeless results keep the backend's display-ready prose.
+    const actionErrorMessage = useCallback(
+        (result: { error?: string; code?: SumsubActionErrorCode }): string | null =>
+            result.code ? t(ACTION_ERROR_KEYS[result.code]) : (result.error ?? null),
+        [t]
+    )
 
     const [accessToken, setAccessToken] = useState<string | null>(null)
     const [showWrapper, setShowWrapper] = useState(false)
@@ -251,7 +271,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                     // every terminal-error exit must clear the user-initiated guard.
                     userInitiatedRef.current = false
                     if (crossRegion) prevStatusRef.current = savedPrevStatus
-                    setError(response.error)
+                    setError(actionErrorMessage(response))
                     return
                 }
 
@@ -327,7 +347,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 initiatingRef.current = false
             }
         },
-        [regionIntent, onKycSuccess, t]
+        [regionIntent, onKycSuccess, t, actionErrorMessage]
     )
 
     // called when sdk signals applicant submitted
@@ -403,7 +423,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
             const response = await restartIdentityVerification()
             if (response.error) {
                 userInitiatedRef.current = false
-                setError(response.error)
+                setError(actionErrorMessage(response))
                 return
             }
             if (response.data?.token) {
@@ -420,7 +440,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         } finally {
             setIsLoading(false)
         }
-    }, [t])
+    }, [t, actionErrorMessage])
 
     // initiate self-heal document resubmission: calls the resubmit API
     // and opens the sumsub SDK with the action token. `requirementKey` targets a
@@ -439,7 +459,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 if (response.error) {
                     userInitiatedRef.current = false
                     selfHealProviderRef.current = null
-                    setError(response.error)
+                    setError(actionErrorMessage(response))
                     return
                 }
 
@@ -460,7 +480,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 setIsLoading(false)
             }
         },
-        [t]
+        [t, actionErrorMessage]
     )
 
     // Start a capability nextAction by key (POST /users/kyc/start-action) and
@@ -479,7 +499,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 const response = await startKycAction(key)
                 if (response.error || !response.data?.token) {
                     userInitiatedRef.current = false
-                    setError(response.error || 'Could not start verification. Please try again.')
+                    setError(response.error ? actionErrorMessage(response) : t('errorStartActionFailed'))
                     return
                 }
                 levelNameRef.current = response.data.levelName
@@ -494,7 +514,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 setIsLoading(false)
             }
         },
-        [t]
+        [t, actionErrorMessage]
     )
 
     return {

--- a/src/hooks/useWaitingOnProviderModal.ts
+++ b/src/hooks/useWaitingOnProviderModal.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
+import { useTranslations } from 'next-intl'
 import { markSubmitted } from '@/hooks/useSubmissionWindow'
+import { reasonCodeKey } from '@/constants/capability-reason-labels.consts'
 import type { GateState } from '@/utils/capability-gate'
 
 // Re-arm cadence: comfortably under SUBMISSION_WINDOW_MS (30s) so the singleton
@@ -21,12 +23,20 @@ const REARM_INTERVAL_MS = 20_000
  * so a later transient re-flip to `waiting-on-provider` can't reopen it on its own.
  */
 export function useWaitingOnProviderModal(gate: GateState) {
+    const tIdentity = useTranslations('identity')
     const [requested, setRequested] = useState(false)
     const isWaiting = gate.kind === 'waiting-on-provider'
     const isOpen = requested && isWaiting
     // narrow on the discriminated union rather than casting, so a rename of
     // `userMessage` fails the build instead of silently returning undefined.
-    const message = isOpen && gate.kind === 'waiting-on-provider' ? (gate.userMessage ?? undefined) : undefined
+    // Known reason codes render localized copy; unknown keep the BE prose.
+    const reasonKey = isOpen && gate.kind === 'waiting-on-provider' ? reasonCodeKey(gate.reason?.code) : undefined
+    const message =
+        isOpen && gate.kind === 'waiting-on-provider'
+            ? reasonKey
+                ? tIdentity(reasonKey)
+                : (gate.userMessage ?? undefined)
+            : undefined
 
     const open = useCallback(() => {
         markSubmitted() // arm the poller immediately

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2308,7 +2308,6 @@
             "bridge_tos_required": "Accept the Bridge terms of service to continue.",
             "bridge_tos_v2_required": "Accept the SEPA terms of service to enable EUR / GBP rails.",
             "bridge_processing": "We're finalizing your verification with Bridge — this usually takes a few minutes.",
-            "document_rejected": "We couldn't verify your identity documents.",
             "verification_blocked": "Verification issue — contact support for help.",
             "terminal_rejection": "Verification issue — contact support for help.",
             "bridge_terminal_rejection": "We couldn't verify your account for bank transfers. Message support if you think this is a mistake.",

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2272,7 +2272,9 @@
             }
         },
         "errorStartActionFailed": "Could not start verification. Please try again.",
-        "errorInvalidResponse": "Invalid response from server"
+        "errorInvalidResponse": "Invalid response from server",
+        "actionMessageActionRequired": "We need a bit more to verify your identity. Please resubmit your documents.",
+        "actionMessageFailed": "We couldn't verify your identity. Please contact support."
     },
     "identity": {
         "unlockTitle": "Unlock {region}",

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -25,7 +25,19 @@
         "next": "Next",
         "notFound": "Not Found",
         "countryNotFound": "Country not found",
-        "tryDifferentCountry": "Please try a different country."
+        "tryDifferentCountry": "Please try a different country.",
+        "status": {
+            "completed": "Completed",
+            "pending": "Pending",
+            "processing": "Processing",
+            "failed": "Failed",
+            "cancelled": "Cancelled",
+            "refunded": "Refunded",
+            "soon": "Soon!",
+            "closed": "Closed",
+            "custom": "Custom",
+            "unknown": "Unknown"
+        }
     },
     "navigation": {
         "home": "Home",
@@ -88,6 +100,12 @@
             "spendWithPeanut": {
                 "title": "Spend with Peanut",
                 "description": "Pay with your card or scan Pix and MercadoPago QR codes"
+            },
+            "spendChooser": {
+                "title": "How do you want to spend?",
+                "description": "Both count as your first payment.",
+                "payWithCard": "Pay with your card",
+                "scanQr": "Scan a QR code"
             }
         },
         "autoBalance": {
@@ -1415,7 +1433,8 @@
             "rateUnavailable": "Exchange rates are temporarily unavailable. Please try again in a moment.",
             "bankAccountFailed": "Failed to process bank account. Please try again or contact support.",
             "bankAccountSettingUp": "Your bank account is still being set up. Please try again in a moment."
-        }
+        },
+        "pixMaintenanceBadge": "Maintenance"
     },
     "withdraw": {
         "amountToWithdraw": "Amount to withdraw",
@@ -1616,6 +1635,38 @@
             "paidTo": "Paid to {name}",
             "payingTo": "Paying to {name}"
         },
+        "name": {
+            "merchant": "Merchant",
+            "cardPayment": "Card payment",
+            "cardRefund": "Card refund",
+            "refundFrom": "Refund from {name}",
+            "refund": "Refund",
+            "depositSource": "Deposit Source",
+            "externalWallet": "External Wallet",
+            "externalAccount": "External Account",
+            "claimedToBank": "Claimed to Bank",
+            "bankAccount": "Bank Account",
+            "recipient": "Recipient",
+            "sender": "Sender",
+            "request": "Request",
+            "peanutReward": "Peanut Reward",
+            "receivedViaLink": "Received via Link",
+            "sentViaLink": "Sent via Link",
+            "transaction": "Transaction",
+            "failedQrPayment": "Failed QR payment attempt"
+        },
+        "failReason": {
+            "p2pSendTimeout": "Send didn't complete",
+            "p2pRequestFulfillTimeout": "Payment didn't complete",
+            "sendLinkTimeout": "Link didn't complete",
+            "sendLinkClaimTimeout": "Claim didn't complete",
+            "cryptoWithdrawTimeout": "Withdrawal didn't complete",
+            "qrPayTimeout": "QR payment didn't complete",
+            "onrampTimeout": "Bank deposit didn't arrive",
+            "offrampTimeout": "Bank transfer didn't complete",
+            "refundTimeout": "Refund didn't complete",
+            "generic": "Transaction did not complete"
+        },
         "rows": {
             "created": "Created",
             "cancelled": "Cancelled",
@@ -1698,7 +1749,8 @@
             "dispute": "Dispute",
             "evidenceRequested": "Evidence requested",
             "flagAlt": "{country} flag",
-            "initialHold": "Initial hold"
+            "initialHold": "Initial hold",
+            "adjustment": "Adjustment"
         },
         "dispute": {
             "pending": "Disputed — Awaiting review",
@@ -1740,6 +1792,7 @@
             "depositAddress": "Deposit Address"
         },
         "enjoyPeanut": "Enjoy Peanut!",
+        "memoTestDeposit": "Your peanut wallet is ready to use!",
         "adjustedSuffix": "· Adjusted"
     },
     "history": {
@@ -2217,7 +2270,9 @@
                 "title": "Verification issue",
                 "description": "There was an issue with your verification. Please try again or contact support."
             }
-        }
+        },
+        "errorStartActionFailed": "Could not start verification. Please try again.",
+        "errorInvalidResponse": "Invalid response from server"
     },
     "identity": {
         "unlockTitle": "Unlock {region}",
@@ -2232,7 +2287,37 @@
         "usAchWire": "<b>United States</b> ACH and Wire transfers",
         "mxSpei": "<b>Mexico</b> SPEI transfers",
         "latamBankTransfers": "Bank transfers to your own accounts in <b>LATAM</b>",
-        "defaultUnlockItem": "Bank transfers and local payment methods"
+        "defaultUnlockItem": "Bank transfers and local payment methods",
+        "reasons": {
+            "tax_identification_number": "We need your tax identification number to continue.",
+            "address_of_residence": "We need your residential address to continue.",
+            "proof_of_address": "We need a valid proof of address document.",
+            "source_of_funds": "We need information about your source of funds.",
+            "proof_of_source_of_funds": "We need a document proving your source of funds.",
+            "birth_details": "We need to confirm your date of birth.",
+            "eea_uplift": "We need some additional information to comply with EEA regulations.",
+            "eea_uplift_with_tin": "We need some additional information to comply with EEA regulations.",
+            "eea_tin_reupload": "Please re-upload your tax identification number.",
+            "pep_documentation": "We need a document showing the source of the funds you'll be using on Peanut.",
+            "fep_documentation": "Because of your professional activity, we need proof of your UIF reporting status.",
+            "email_required": "We need an email address to finish setting up this account. Add one to your profile and we'll retry automatically.",
+            "submission_failed": "We hit a snag finishing your verification on our side. We'll get you sorted — tap below to message support.",
+            "proof_of_address_review": "We received your proof of address — it's being reviewed.",
+            "bridge_tos_required": "Accept the Bridge terms of service to continue.",
+            "bridge_tos_v2_required": "Accept the SEPA terms of service to enable EUR / GBP rails.",
+            "bridge_processing": "We're finalizing your verification with Bridge — this usually takes a few minutes.",
+            "document_rejected": "We couldn't verify your identity documents.",
+            "verification_blocked": "Verification issue — contact support for help.",
+            "terminal_rejection": "Verification issue — contact support for help.",
+            "bridge_terminal_rejection": "We couldn't verify your account for bank transfers. Message support if you think this is a mistake.",
+            "duplicate_customer_detected": "Bridge flagged your account as a possible duplicate — message support to verify and unlock.",
+            "region_block": "Peanut cards aren't available in your region yet.",
+            "compliance_block": "We couldn't approve your card application after a compliance review.",
+            "card_rejected": "Your card application couldn't be approved. Message support if you think this is a mistake.",
+            "manteca_us_nationality": "Payments from this country are not available for US citizens at this time.",
+            "country_not_supported": "This rail needs a document from a supported country. You can verify with a different ID.",
+            "uk_resident_blocked": "Due to UK regulations, bank transfers aren't available for UK residents. Your funds are safe — you can withdraw them as crypto anytime."
+        }
     },
     "recoverFunds": {
         "title": "Recover Funds",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -25,7 +25,19 @@
         "next": "Siguiente",
         "notFound": "No encontrado",
         "countryNotFound": "País no encontrado",
-        "tryDifferentCountry": "Prueba con otro país."
+        "tryDifferentCountry": "Prueba con otro país.",
+        "status": {
+            "completed": "Completado",
+            "pending": "Pendiente",
+            "processing": "Procesando",
+            "failed": "Fallido",
+            "cancelled": "Cancelado",
+            "refunded": "Reembolsado",
+            "soon": "¡Pronto!",
+            "closed": "Cerrado",
+            "custom": "Personalizado",
+            "unknown": "Desconocido"
+        }
     },
     "navigation": {
         "home": "Inicio",
@@ -88,6 +100,12 @@
             "spendWithPeanut": {
                 "title": "Paga con Peanut",
                 "description": "Paga con tu tarjeta o escanea códigos QR de Pix y MercadoPago"
+            },
+            "spendChooser": {
+                "title": "¿Cómo quieres gastar?",
+                "description": "Ambas cuentan como tu primer pago.",
+                "payWithCard": "Paga con tu tarjeta",
+                "scanQr": "Escanea un código QR"
             }
         },
         "autoBalance": {
@@ -1415,7 +1433,8 @@
             "rateUnavailable": "Los tipos de cambio no están disponibles por el momento. Inténtalo de nuevo en un momento.",
             "bankAccountFailed": "No se pudo procesar la cuenta bancaria. Inténtalo de nuevo o contacta a soporte.",
             "bankAccountSettingUp": "Tu cuenta bancaria aún se está configurando. Inténtalo de nuevo en un momento."
-        }
+        },
+        "pixMaintenanceBadge": "Mantenimiento"
     },
     "withdraw": {
         "amountToWithdraw": "Monto a retirar",
@@ -1616,6 +1635,38 @@
             "paidTo": "Pagado a {name}",
             "payingTo": "Pagando a {name}"
         },
+        "name": {
+            "merchant": "Comercio",
+            "cardPayment": "Pago con tarjeta",
+            "cardRefund": "Reembolso de tarjeta",
+            "refundFrom": "Reembolso de {name}",
+            "refund": "Reembolso",
+            "depositSource": "Origen del depósito",
+            "externalWallet": "Billetera externa",
+            "externalAccount": "Cuenta externa",
+            "claimedToBank": "Reclamado al banco",
+            "bankAccount": "Cuenta bancaria",
+            "recipient": "Destinatario",
+            "sender": "Remitente",
+            "request": "Solicitud",
+            "peanutReward": "Recompensa Peanut",
+            "receivedViaLink": "Recibido por enlace",
+            "sentViaLink": "Enviado por enlace",
+            "transaction": "Transacción",
+            "failedQrPayment": "Intento de pago QR fallido"
+        },
+        "failReason": {
+            "p2pSendTimeout": "El envío no se completó",
+            "p2pRequestFulfillTimeout": "El pago no se completó",
+            "sendLinkTimeout": "El enlace no se completó",
+            "sendLinkClaimTimeout": "El reclamo no se completó",
+            "cryptoWithdrawTimeout": "El retiro no se completó",
+            "qrPayTimeout": "El pago QR no se completó",
+            "onrampTimeout": "El depósito bancario no llegó",
+            "offrampTimeout": "La transferencia bancaria no se completó",
+            "refundTimeout": "El reembolso no se completó",
+            "generic": "La transacción no se completó"
+        },
         "rows": {
             "created": "Creado",
             "cancelled": "Cancelado",
@@ -1698,7 +1749,8 @@
             "dispute": "Disputa",
             "evidenceRequested": "Evidencia solicitada",
             "flagAlt": "Bandera de {country}",
-            "initialHold": "Retención inicial"
+            "initialHold": "Retención inicial",
+            "adjustment": "Ajuste"
         },
         "dispute": {
             "pending": "En disputa — Esperando revisión",
@@ -1740,6 +1792,7 @@
             "depositAddress": "Dirección de depósito"
         },
         "enjoyPeanut": "¡Disfruta Peanut!",
+        "memoTestDeposit": "¡Tu billetera peanut está lista para usar!",
         "adjustedSuffix": "· Ajustado"
     },
     "history": {
@@ -2217,7 +2270,9 @@
                 "title": "Problema con la verificación",
                 "description": "Hubo un problema con tu verificación. Inténtalo de nuevo o contacta a soporte."
             }
-        }
+        },
+        "errorStartActionFailed": "No pudimos iniciar la verificación. Inténtalo de nuevo.",
+        "errorInvalidResponse": "Respuesta inválida del servidor"
     },
     "identity": {
         "unlockTitle": "Desbloquea {region}",
@@ -2232,7 +2287,37 @@
         "usAchWire": "Transferencias ACH y Wire en <b>Estados Unidos</b>",
         "mxSpei": "Transferencias SPEI en <b>México</b>",
         "latamBankTransfers": "Transferencias bancarias a tus propias cuentas en <b>LATAM</b>",
-        "defaultUnlockItem": "Transferencias bancarias y métodos de pago locales"
+        "defaultUnlockItem": "Transferencias bancarias y métodos de pago locales",
+        "reasons": {
+            "tax_identification_number": "Necesitamos tu número de identificación fiscal para continuar.",
+            "address_of_residence": "Necesitamos tu dirección de residencia para continuar.",
+            "proof_of_address": "Necesitamos un comprobante de domicilio válido.",
+            "source_of_funds": "Necesitamos información sobre el origen de tus fondos.",
+            "proof_of_source_of_funds": "Necesitamos un documento que compruebe el origen de tus fondos.",
+            "birth_details": "Necesitamos confirmar tu fecha de nacimiento.",
+            "eea_uplift": "Necesitamos información adicional para cumplir con las regulaciones del EEE.",
+            "eea_uplift_with_tin": "Necesitamos información adicional para cumplir con las regulaciones del EEE.",
+            "eea_tin_reupload": "Vuelve a subir tu número de identificación fiscal.",
+            "pep_documentation": "Necesitamos un documento que muestre el origen de los fondos que usarás en Peanut.",
+            "fep_documentation": "Debido a tu actividad profesional, necesitamos un comprobante de tu situación de reporte ante la UIF.",
+            "email_required": "Necesitamos un correo electrónico para terminar de configurar esta cuenta. Agrega uno a tu perfil y lo reintentaremos automáticamente.",
+            "submission_failed": "Tuvimos un problema al finalizar tu verificación de nuestro lado. Lo vamos a resolver: toca abajo para escribirle a soporte.",
+            "proof_of_address_review": "Recibimos tu comprobante de domicilio; está en revisión.",
+            "bridge_tos_required": "Acepta los términos de servicio de Bridge para continuar.",
+            "bridge_tos_v2_required": "Acepta los términos de servicio de SEPA para habilitar transferencias en EUR / GBP.",
+            "bridge_processing": "Estamos finalizando tu verificación con Bridge; esto suele tomar unos minutos.",
+            "document_rejected": "No pudimos verificar tus documentos de identidad.",
+            "verification_blocked": "Problema de verificación: contacta a soporte para recibir ayuda.",
+            "terminal_rejection": "Problema de verificación: contacta a soporte para recibir ayuda.",
+            "bridge_terminal_rejection": "No pudimos verificar tu cuenta para transferencias bancarias. Escríbele a soporte si crees que es un error.",
+            "duplicate_customer_detected": "Bridge marcó tu cuenta como posible duplicado. Escríbele a soporte para verificarla y desbloquearla.",
+            "region_block": "Las tarjetas Peanut todavía no están disponibles en tu región.",
+            "compliance_block": "No pudimos aprobar tu solicitud de tarjeta después de una revisión de cumplimiento.",
+            "card_rejected": "No se pudo aprobar tu solicitud de tarjeta. Escríbele a soporte si crees que es un error.",
+            "manteca_us_nationality": "Los pagos desde este país no están disponibles para ciudadanos de EE. UU. por el momento.",
+            "country_not_supported": "Este método necesita un documento de un país compatible. Puedes verificarte con otro documento.",
+            "uk_resident_blocked": "Por regulaciones del Reino Unido, las transferencias bancarias no están disponibles para residentes del Reino Unido. Tus fondos están seguros: puedes retirarlos como cripto en cualquier momento."
+        }
     },
     "recoverFunds": {
         "title": "Recuperar fondos",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2272,7 +2272,9 @@
             }
         },
         "errorStartActionFailed": "No pudimos iniciar la verificación. Inténtalo de nuevo.",
-        "errorInvalidResponse": "Respuesta inválida del servidor"
+        "errorInvalidResponse": "Respuesta inválida del servidor",
+        "actionMessageActionRequired": "Necesitamos un poco más para verificar tu identidad. Vuelve a enviar tus documentos.",
+        "actionMessageFailed": "No pudimos verificar tu identidad. Contacta a soporte."
     },
     "identity": {
         "unlockTitle": "Desbloquea {region}",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2308,7 +2308,6 @@
             "bridge_tos_required": "Acepta los términos de servicio de Bridge para continuar.",
             "bridge_tos_v2_required": "Acepta los términos de servicio de SEPA para habilitar transferencias en EUR / GBP.",
             "bridge_processing": "Estamos finalizando tu verificación con Bridge; esto suele tomar unos minutos.",
-            "document_rejected": "No pudimos verificar tus documentos de identidad.",
             "verification_blocked": "Problema de verificación: contacta a soporte para recibir ayuda.",
             "terminal_rejection": "Problema de verificación: contacta a soporte para recibir ayuda.",
             "bridge_terminal_rejection": "No pudimos verificar tu cuenta para transferencias bancarias. Escríbele a soporte si crees que es un error.",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2308,7 +2308,6 @@
             "bridge_tos_required": "Aceite os termos de serviço da Bridge para continuar.",
             "bridge_tos_v2_required": "Aceite os termos de serviço do SEPA para habilitar transferências em EUR / GBP.",
             "bridge_processing": "Estamos finalizando sua verificação com a Bridge; isso costuma levar alguns minutos.",
-            "document_rejected": "Não conseguimos verificar seus documentos de identidade.",
             "verification_blocked": "Problema na verificação: fale com o suporte para receber ajuda.",
             "terminal_rejection": "Problema na verificação: fale com o suporte para receber ajuda.",
             "bridge_terminal_rejection": "Não conseguimos verificar sua conta para transferências bancárias. Fale com o suporte se achar que isso é um engano.",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2272,7 +2272,9 @@
             }
         },
         "errorStartActionFailed": "Não conseguimos iniciar a verificação. Tente novamente.",
-        "errorInvalidResponse": "Resposta inválida do servidor"
+        "errorInvalidResponse": "Resposta inválida do servidor",
+        "actionMessageActionRequired": "Precisamos de um pouco mais para verificar sua identidade. Reenvie seus documentos.",
+        "actionMessageFailed": "Não conseguimos verificar sua identidade. Fale com o suporte."
     },
     "identity": {
         "unlockTitle": "Desbloquear {region}",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -25,7 +25,19 @@
         "next": "Avançar",
         "notFound": "Não encontrado",
         "countryNotFound": "País não encontrado",
-        "tryDifferentCountry": "Tente outro país."
+        "tryDifferentCountry": "Tente outro país.",
+        "status": {
+            "completed": "Concluído",
+            "pending": "Pendente",
+            "processing": "Processando",
+            "failed": "Falhou",
+            "cancelled": "Cancelado",
+            "refunded": "Reembolsado",
+            "soon": "Em breve!",
+            "closed": "Encerrado",
+            "custom": "Personalizado",
+            "unknown": "Desconhecido"
+        }
     },
     "navigation": {
         "home": "Início",
@@ -88,6 +100,12 @@
             "spendWithPeanut": {
                 "title": "Pague com a Peanut",
                 "description": "Pague com seu cartão ou escaneie QR codes de Pix e MercadoPago"
+            },
+            "spendChooser": {
+                "title": "Como você quer gastar?",
+                "description": "As duas contam como seu primeiro pagamento.",
+                "payWithCard": "Pague com seu cartão",
+                "scanQr": "Escaneie um código QR"
             }
         },
         "autoBalance": {
@@ -1415,7 +1433,8 @@
             "rateUnavailable": "As taxas de câmbio estão indisponíveis no momento. Tente de novo em instantes.",
             "bankAccountFailed": "Não foi possível processar a conta bancária. Tente de novo ou fale com o suporte.",
             "bankAccountSettingUp": "Sua conta bancária ainda está sendo configurada. Tente de novo em instantes."
-        }
+        },
+        "pixMaintenanceBadge": "Manutenção"
     },
     "withdraw": {
         "amountToWithdraw": "Valor a sacar",
@@ -1616,6 +1635,38 @@
             "paidTo": "Pago para {name}",
             "payingTo": "Pagando para {name}"
         },
+        "name": {
+            "merchant": "Estabelecimento",
+            "cardPayment": "Pagamento com cartão",
+            "cardRefund": "Estorno no cartão",
+            "refundFrom": "Estorno de {name}",
+            "refund": "Reembolso",
+            "depositSource": "Origem do depósito",
+            "externalWallet": "Carteira externa",
+            "externalAccount": "Conta externa",
+            "claimedToBank": "Resgatado para o banco",
+            "bankAccount": "Conta bancária",
+            "recipient": "Destinatário",
+            "sender": "Remetente",
+            "request": "Solicitação",
+            "peanutReward": "Recompensa Peanut",
+            "receivedViaLink": "Recebido via link",
+            "sentViaLink": "Enviado via link",
+            "transaction": "Transação",
+            "failedQrPayment": "Tentativa de pagamento com QR falhou"
+        },
+        "failReason": {
+            "p2pSendTimeout": "O envio não foi concluído",
+            "p2pRequestFulfillTimeout": "O pagamento não foi concluído",
+            "sendLinkTimeout": "O link não foi concluído",
+            "sendLinkClaimTimeout": "O resgate não foi concluído",
+            "cryptoWithdrawTimeout": "O saque não foi concluído",
+            "qrPayTimeout": "O pagamento QR não foi concluído",
+            "onrampTimeout": "O depósito bancário não chegou",
+            "offrampTimeout": "A transferência bancária não foi concluída",
+            "refundTimeout": "O estorno não foi concluído",
+            "generic": "A transação não foi concluída"
+        },
         "rows": {
             "created": "Criado",
             "cancelled": "Cancelado",
@@ -1698,7 +1749,8 @@
             "dispute": "Contestação",
             "evidenceRequested": "Comprovação solicitada",
             "flagAlt": "Bandeira de {country}",
-            "initialHold": "Retenção inicial"
+            "initialHold": "Retenção inicial",
+            "adjustment": "Ajuste"
         },
         "dispute": {
             "pending": "Contestada — Aguardando análise",
@@ -1740,6 +1792,7 @@
             "depositAddress": "Endereço de depósito"
         },
         "enjoyPeanut": "Aproveite o Peanut!",
+        "memoTestDeposit": "Sua carteira peanut está pronta para usar!",
         "adjustedSuffix": "· Ajustado"
     },
     "history": {
@@ -2217,7 +2270,9 @@
                 "title": "Problema na verificação",
                 "description": "Houve um problema com sua verificação. Tente novamente ou fale com o suporte."
             }
-        }
+        },
+        "errorStartActionFailed": "Não conseguimos iniciar a verificação. Tente novamente.",
+        "errorInvalidResponse": "Resposta inválida do servidor"
     },
     "identity": {
         "unlockTitle": "Desbloquear {region}",
@@ -2232,7 +2287,37 @@
         "usAchWire": "Transferências ACH e Wire nos <b>Estados Unidos</b>",
         "mxSpei": "Transferências SPEI no <b>México</b>",
         "latamBankTransfers": "Transferências bancárias para suas próprias contas na <b>LATAM</b>",
-        "defaultUnlockItem": "Transferências bancárias e formas de pagamento locais"
+        "defaultUnlockItem": "Transferências bancárias e formas de pagamento locais",
+        "reasons": {
+            "tax_identification_number": "Precisamos do seu número de identificação fiscal para continuar.",
+            "address_of_residence": "Precisamos do seu endereço residencial para continuar.",
+            "proof_of_address": "Precisamos de um comprovante de residência válido.",
+            "source_of_funds": "Precisamos de informações sobre a origem dos seus fundos.",
+            "proof_of_source_of_funds": "Precisamos de um documento que comprove a origem dos seus fundos.",
+            "birth_details": "Precisamos confirmar sua data de nascimento.",
+            "eea_uplift": "Precisamos de algumas informações adicionais para cumprir as regulamentações do EEE.",
+            "eea_uplift_with_tin": "Precisamos de algumas informações adicionais para cumprir as regulamentações do EEE.",
+            "eea_tin_reupload": "Reenvie seu número de identificação fiscal.",
+            "pep_documentation": "Precisamos de um documento que mostre a origem dos fundos que você vai usar no Peanut.",
+            "fep_documentation": "Devido à sua atividade profissional, precisamos de um comprovante da sua situação de reporte à UIF.",
+            "email_required": "Precisamos de um e-mail para terminar de configurar esta conta. Adicione um ao seu perfil e tentaremos de novo automaticamente.",
+            "submission_failed": "Tivemos um problema ao finalizar sua verificação do nosso lado. Vamos resolver: toque abaixo para falar com o suporte.",
+            "proof_of_address_review": "Recebemos seu comprovante de residência; ele está em análise.",
+            "bridge_tos_required": "Aceite os termos de serviço da Bridge para continuar.",
+            "bridge_tos_v2_required": "Aceite os termos de serviço do SEPA para habilitar transferências em EUR / GBP.",
+            "bridge_processing": "Estamos finalizando sua verificação com a Bridge; isso costuma levar alguns minutos.",
+            "document_rejected": "Não conseguimos verificar seus documentos de identidade.",
+            "verification_blocked": "Problema na verificação: fale com o suporte para receber ajuda.",
+            "terminal_rejection": "Problema na verificação: fale com o suporte para receber ajuda.",
+            "bridge_terminal_rejection": "Não conseguimos verificar sua conta para transferências bancárias. Fale com o suporte se achar que isso é um engano.",
+            "duplicate_customer_detected": "A Bridge marcou sua conta como possível duplicata. Fale com o suporte para verificar e desbloquear.",
+            "region_block": "Os cartões Peanut ainda não estão disponíveis na sua região.",
+            "compliance_block": "Não conseguimos aprovar sua solicitação de cartão após uma análise de conformidade.",
+            "card_rejected": "Sua solicitação de cartão não pôde ser aprovada. Fale com o suporte se achar que isso é um engano.",
+            "manteca_us_nationality": "Pagamentos deste país não estão disponíveis para cidadãos dos EUA no momento.",
+            "country_not_supported": "Este método precisa de um documento de um país aceito. Você pode verificar com um documento diferente.",
+            "uk_resident_blocked": "Devido às regulamentações do Reino Unido, transferências bancárias não estão disponíveis para residentes do Reino Unido. Seus fundos estão seguros: você pode sacá-los como cripto a qualquer momento."
+        }
     },
     "recoverFunds": {
         "title": "Recuperar fundos",

--- a/src/utils/capability-gate.ts
+++ b/src/utils/capability-gate.ts
@@ -414,3 +414,12 @@ export function getGateUserMessage(gate: GateState): string | undefined {
 export function getGateAdvisory(gate: GateState): GateAdvisory | undefined {
     return gate.kind === 'ready' ? gate.advisory : undefined
 }
+
+/**
+ * The stable `CapabilityReason.code` behind a gate's message. Companion to
+ * {@link getGateUserMessage}: render sites map the code onto localized copy
+ * (identity.reasons.* via `reasonCodeKey`) and keep the prose as fallback.
+ */
+export function getGateReasonCode(gate: GateState): string | undefined {
+    return 'reason' in gate ? gate.reason?.code : undefined
+}

--- a/src/utils/provider-rejection.utils.ts
+++ b/src/utils/provider-rejection.utils.ts
@@ -43,6 +43,9 @@ export interface ProviderRejectionInfo {
     provider: 'BRIDGE' | 'MANTECA'
     state: ProviderRejectionState
     userMessage: string | null
+    /** Stable `CapabilityReason.code` behind `userMessage` — lets render sites
+     *  swap in localized copy (identity.reasons.*) and keep the prose fallback. */
+    reasonCode: string | null
 }
 
 const PROVIDER_CODE: Record<'BRIDGE' | 'MANTECA', 'bridge' | 'manteca'> = {
@@ -97,5 +100,6 @@ export function deriveProviderRejection(
         provider,
         state,
         userMessage: surfaced ? railUserMessage(surfaced.rail) || surfaced.verdict.blocking?.userMessage || null : null,
+        reasonCode: surfaced ? (surfaced.rail.reason?.code ?? surfaced.verdict.blocking?.code ?? null) : null,
     }
 }


### PR DESCRIPTION
## Why

Backend-sourced status strings showed in English for es-419 / pt-BR users — a transaction reading "pending", KYC status text, reason messages. The audit found the raw-English problem was narrower than expected (KYC status rendering, rail status and card status were already keyed or never rendered as text), but the sites that did leak were high-traffic: the shared `StatusBadge` (transaction drawer, receipts, KYC drawer, success views) had nine hardcoded English literals plus a raw-passthrough default — sitting in a directory excluded from the `jsx-no-literals` guard, which is exactly how it shipped unnoticed.

## What

Everything keys off **stable enums/codes, never backend prose** (#2554's rule), following the existing `TYPE_LABEL_KEYS` / `rejectLabelCode()` patterns:

- **`StatusBadge`** → exhaustive `STATUS_LABEL_KEYS` (`as const satisfies Record<StatusType, string>`) rendered via `t()` under `common.status.*`; unknown values collapse to `status.unknown` instead of rendering the raw string. The `Badges/**` lint ignore is removed. (Backend statuses were already normalized to the FE union by `mapEntryStatusToUiStatus` — no wire changes needed.)
- **`PerkRewardReceipt`** — the one genuine raw `{status}` interpolation in product code, now translated through the same table.
- **Reaper fail copy + intent-strategy display names** (`REAPER_FAIL_COPY`, 'Sent via Link', 'Card payment', …) — the transformer emits a `nameKey` (+ ICU params for dynamic parts like usernames and bank names, which are data, not copy); render sites translate. The English-literal `displayName` comparisons in `TransactionDetailsHeaderCard` are replaced with discriminants (the `isTestTransaction()` precedent) so translating the labels can't break the logic.
- **`CapabilityReason.code` → key table** with a `rejectLabelCode()`-style fallback, covering the KYC/card/region reason-message sites (ApplicationStatusScreen, InitiateKycModal, UnlockedRegions, useWaitingOnProviderModal, ActivationCTAs). Where the wire carries no code (`identity.actionMessage`, Rain dispute prompts) the backend prose remains as fallback — adding those codes is an api-ts follow-up (#1249 pattern).
- **Prop-literal stragglers** keyed: ActivationCTAs spend prompts, the 'Adjustment' card row, the PIX maintenance badge, Sumsub error fallbacks (server actions now also return a `code`, translated client-side — no server-side next-intl in this app).

Out of scope, documented: `/receipt/[entryId]` server-component titles (structurally blocked on server-side next-intl).

## Verification

- Full jest: 183 suites, 2,416 passed (includes a regression the suite caught during development: `customText=''` means "no override" — truthiness preserved).
- `tsc --noEmit` clean; eslint on all touched files: 0 errors; catalog parity + ICU compilation tests green for all three locales.