### PR TITLE
feat: host creator contest on peanut.me

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -175,8 +175,9 @@ function contentSecurityPolicyReportOnly() {
         // Widget in Global/Layout renders. Currently unreachable (its Modal is
         // never opened), so it produces no violations today; allow-listed because
         // re-arming it is a one-line change and the failure would be a blank
-        // iframe under enforcement.
-        "frame-src 'self' https://*.crisp.chat https://*.sumsub.com https://widget.manteca.dev https://mpago.la https://*.bridge.xyz https://form.typeform.com",
+        // iframe under enforcement. The creator contest stays on its own Vercel
+        // project and is framed by /creator-contest.
+        "frame-src 'self' https://*.crisp.chat https://*.sumsub.com https://widget.manteca.dev https://mpago.la https://*.bridge.xyz https://form.typeform.com https://peanut-contest.vercel.app",
         "worker-src 'self' blob:",
         "object-src 'none'",
         "base-uri 'self'",

--- a/src/app/creator-contest/__tests__/page.test.tsx
+++ b/src/app/creator-contest/__tests__/page.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react'
+import CreatorContestPage from '../page'
+
+describe('CreatorContestPage', () => {
+    it('embeds the contest with the required iframe permissions', () => {
+        render(<CreatorContestPage />)
+
+        const iframe = screen.getByTitle('Peanut Creator Contest')
+        expect(iframe).toHaveAttribute('src', 'https://peanut-contest.vercel.app/')
+        expect(iframe).toHaveAttribute(
+            'sandbox',
+            'allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-storage-access-by-user-activation'
+        )
+        expect(iframe).toHaveAttribute('referrerpolicy', 'strict-origin-when-cross-origin')
+    })
+})

--- a/src/app/creator-contest/__tests__/page.test.tsx
+++ b/src/app/creator-contest/__tests__/page.test.tsx
@@ -7,6 +7,7 @@ describe('CreatorContestPage', () => {
 
         const iframe = screen.getByTitle('Peanut Creator Contest')
         expect(iframe).toHaveAttribute('src', 'https://peanut-contest.vercel.app/')
+        expect(iframe).toHaveAttribute('allow', 'storage-access *')
         expect(iframe).toHaveAttribute(
             'sandbox',
             'allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-storage-access-by-user-activation'

--- a/src/app/creator-contest/page.tsx
+++ b/src/app/creator-contest/page.tsx
@@ -13,6 +13,7 @@ export default function CreatorContestPage() {
                 src="https://peanut-contest.vercel.app/"
                 title="Peanut Creator Contest"
                 className="h-full w-full border-0"
+                allow="storage-access *"
                 sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-storage-access-by-user-activation"
                 referrerPolicy="strict-origin-when-cross-origin"
             />

--- a/src/app/creator-contest/page.tsx
+++ b/src/app/creator-contest/page.tsx
@@ -1,0 +1,21 @@
+import { type Metadata } from 'next'
+
+export const metadata: Metadata = {
+    title: 'Peanut Creator Contest',
+    description: 'The Peanut content contest for creators in Brazil.',
+    robots: { index: false, follow: false },
+}
+
+export default function CreatorContestPage() {
+    return (
+        <main className="h-[100dvh] w-full bg-white">
+            <iframe
+                src="https://peanut-contest.vercel.app/"
+                title="Peanut Creator Contest"
+                className="h-full w-full border-0"
+                sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-storage-access-by-user-activation"
+                referrerPolicy="strict-origin-when-cross-origin"
+            />
+        </main>
+    )
+}

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -56,6 +56,7 @@ export const DEDICATED_ROUTES = [
     'lp',
     'exchange',
     'shhhhh',
+    'creator-contest',
 
     // Future SEO routes (pre-register so catch-all doesn't intercept)
     'send-money-to',


### PR DESCRIPTION
## Summary

- add a full-viewport `/creator-contest` route on peanut.me that embeds the independently deployed contest
- reserve the route so the recipient catch-all cannot intercept it
- allow the contest origin in the report-only `frame-src` policy
- delegate the `storage-access` Permissions Policy required by the child fallback flow
- cover the iframe URL and security attributes with a unit test

The contest remains on its existing Vercel deployment, so this needs no DNS migration and does not couple its release cycle to peanut-ui.

## Merge blocker: freelancer handoff

Keep this PR in draft until the child app is updated and the authenticated flow passes in the embed. The unauthenticated page already renders; the session behavior is the blocker.

1. Send this HTTP header on every contest HTML route:
   `Content-Security-Policy: frame-ancestors 'self' https://peanut.me`
   Merge it into any existing CSP. Do not use a meta tag, and do not add `X-Frame-Options: SAMEORIGIN` or `DENY`. Add only exact preview/test parent origins in non-production environments.
2. Make the session cookie host-only and iframe-safe:
   `HttpOnly; Secure; SameSite=None; Partitioned; Path=/`
   Prefer a `__Host-` cookie name. Set and clear it with the same attributes, and rotate it on login.
3. Re-check authorization on every mutation. For custom mutating route handlers, validate `Origin` or a CSRF token because `SameSite=None` removes the usual SameSite CSRF defense. Do not put auth tokens in `postMessage` or localStorage. A direct iframe keeps Server Action requests on the child origin, so do not add `peanut.me` or a wildcard to `serverActions.allowedOrigins`.
4. Add a user-gesture Storage Access API path plus a clear “Open contest in a new tab” fallback for browsers that deny embedded storage. The parent sandbox already grants scripts, forms, same-origin, popups, and storage access by user activation.
5. Test inside `https://peanut.me/creator-contest`: home → signup/login → dashboard → reload → logout, including Chrome, Firefox, Safari/private mode, and third-party-cookie blocking. Also verify an unrelated origin cannot frame the app.

No CORS or DNS change is required for this direct iframe setup. The freelancer source repo was not found among accessible Peanut or personal repositories, so that child-side patch needs repo access or a transfer into the Peanut organization.

## Verification

- Prettier check: pass
- ESLint on changed files: pass
- TypeScript typecheck: pass
- Jest: 184 suites passed; 2,417 tests passed; 3 skipped
- Local embed smoke test at 375 × 667: parent URL remains stable, child loads, and signup navigation stays inside the iframe
- All required final-head checks pass, including Vercel production preview build, analysis, E2E, unit, typecheck, lint, format, and CodeRabbit
- Deployed smoke test: [`/creator-contest`](https://peanut-wallet-git-feat-creator-contest-embed-squirrellabs.vercel.app/creator-contest) returns 200 and loads the child frame with no child-origin request failures

## Screenshot

![Mobile creator contest embed](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2605/screenshots/pr-2605/creator-contest-mobile.png)

375 × 667 local preview. The small Next.js development indicator in the lower-left is not present in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated Creator Contest page with a full-screen embedded contest experience.
  - The contest opens in a secure, sandboxed frame with appropriate privacy and navigation protections.
  - Added page metadata to keep the contest out of search engine results.
- **Bug Fixes**
  - Reserved the contest page as a dedicated route to ensure it loads correctly without conflicting with other site paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->