### PR TITLE
fix(badges): register naija and terere as bare claimable campaigns

### DIFF
--- a/src/components/Invites/campaign-maps.test.ts
+++ b/src/components/Invites/campaign-maps.test.ts
@@ -59,6 +59,17 @@ describe('classifyBareCampaign', () => {
         })
     })
 
+    // Regression: both country-launch cohorts ship BARE links with no inviter.
+    // Mapping them in UTM_CAMPAIGN_TO_BADGE_MAP alone is not enough — without a
+    // bare-campaign registration the link dead-ends on "Invalid Invite Code".
+    it.each(['naija', 'terere'])('country-launch campaign "%s" is a bare claimable skip', (c) => {
+        expect(classifyBareCampaign(c, undefined)).toEqual({
+            isBareClaimCampaign: true,
+            isWaitlistSkip: true,
+        })
+        expect(classifyBareCampaign(c.toUpperCase(), undefined).isBareClaimCampaign).toBe(true)
+    })
+
     it('only waitlist-skip campaigns promise a card-waitlist skip', () => {
         for (const c of BARE_VANITY_CAMPAIGNS) {
             expect(classifyBareCampaign(c, undefined).isWaitlistSkip).toBe(false)

--- a/src/components/Invites/campaign-maps.ts
+++ b/src/components/Invites/campaign-maps.ts
@@ -90,7 +90,12 @@ export function resolveCampaign(
 //  - Vanity: a commemorative badge with NO card-waitlist skip. Claimable from a
 //    bare link, but `/invite` shows generic badge-claim copy (not "skip").
 export const SKIP_CAMPAIGN = 'skip'
-export const WAITLIST_SKIP_CAMPAIGNS: ReadonlySet<string> = new Set([SKIP_CAMPAIGN, 'event_alumni'])
+// naija and terere are the country-launch cohorts. Both are distributed as BARE
+// campaign links with no inviter, and both are in peanut-api-ts
+// POSTLAUNCH_SKIP_BADGE_CODES — so they belong here, not in BARE_VANITY_CAMPAIGNS
+// (that set is for badges with no card-waitlist skip, and would show the wrong
+// copy while the backend granted a skip anyway).
+export const WAITLIST_SKIP_CAMPAIGNS: ReadonlySet<string> = new Set([SKIP_CAMPAIGN, 'event_alumni', 'naija', 'terere'])
 export const BARE_VANITY_CAMPAIGNS: ReadonlySet<string> = new Set([
     'touched_grass',
     'card_alpha',


### PR DESCRIPTION
Follow-up hotfix to #2608. Both country-launch badges are live in prod but their **bare campaign links do not work**.

## The bug

`?campaign=naija` and `?campaign=terere` with no `?code=` hit **"Invalid Invite Code"** instead of awarding the badge.

Mapping them in `UTM_CAMPAIGN_TO_BADGE_MAP` resolves the tag to a badge code, but `classifyBareCampaign` only bypasses the invite gate for campaigns registered in `WAITLIST_SKIP_CAMPAIGNS` or `BARE_VANITY_CAMPAIGNS`. Neither badge was in either set, so the invite flow treated the visitor as carrying an invalid invite. This is the same bug the existing comment records for `touched_grass`.

It matters because both cohorts get **bare links with no inviter** — that is the whole distribution mechanism for the Nigeria and Paraguay launches.

## Why WAITLIST_SKIP_CAMPAIGNS and not BARE_VANITY_CAMPAIGNS

Both badges are in peanut-api-ts `POSTLAUNCH_SKIP_BADGE_CODES`. The vanity set is documented as "a commemorative badge with NO card-waitlist skip" and drives generic claim copy on `/invite`. Filing them there would render copy that says nothing about the queue while the backend silently granted a skip — so they belong in the skip set, which the comment already says to keep in sync with `SKIP_BADGE_CODES`.

## Verified

- prod DB `acknowledgment_definitions` has both `NAIJA` and `TERERE` seeded with the shipped copy, so the API half is deployed and healthy
- `peanut.me/badges/naija.svg` and `terere.svg` both return 200 at the expected byte sizes
- typecheck clean, Invites suite 49/49 including a new regression test covering both codes and their uppercase forms

## Still open, not in this PR

A bare campaign claim does **not** set `hasAppAccess` — `FULL_BYPASS_BADGE_CODES` holds only `WAITLIST_SKIP` and `OFFRAMP_USER`. Prod shows 9 users currently waiting on app access, the oldest 41.6h old, which matches the "up to 48h jail" the `badge.ts` comment describes for exactly this bare-link case. For an event where someone signs up and pays within minutes that is fatal, but widening the full bypass is Konrad's call, not a hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eligible Naija and Terere country-launch campaigns now skip the waitlist.
  * Campaign matching is handled case-insensitively for these campaigns.

* **Tests**
  * Added regression coverage to verify waitlist-skipping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->