### PR TITLE
fix(support): keep the Crisp composer above the iOS keyboard

### DIFF
--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -183,18 +183,27 @@ describe('SupportDrawer — iOS keyboard', () => {
     class FakeVisualViewport extends EventTarget {
         height = LAYOUT_HEIGHT
         offsetTop = 0
+        scale = 1
     }
 
     let viewport: FakeVisualViewport
+    let realInnerHeight: PropertyDescriptor | undefined
 
     beforeEach(() => {
         mockUseCrispUserData.mockReset().mockReturnValue({ userId: undefined, email: undefined })
         mockUseCrispTokenId.mockReset().mockReturnValue(undefined)
         mockIsCapacitor.mockReset().mockReturnValue(false)
 
+        realInnerHeight = Object.getOwnPropertyDescriptor(window, 'innerHeight')
         viewport = new FakeVisualViewport()
         Object.defineProperty(window, 'visualViewport', { value: viewport, configurable: true })
         Object.defineProperty(window, 'innerHeight', { value: LAYOUT_HEIGHT, configurable: true })
+    })
+
+    // Hand the window back untouched — later describes in this file share it.
+    afterEach(() => {
+        delete (window as { visualViewport?: unknown }).visualViewport
+        if (realInnerHeight) Object.defineProperty(window, 'innerHeight', realInnerHeight)
     })
 
     const openKeyboard = (visibleHeight: number) => {

--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -174,6 +174,54 @@ describe('SupportDrawer — pointer-events when opened inside a vaul drawer', ()
     })
 })
 
+describe('SupportDrawer — iOS keyboard', () => {
+    // iOS leaves the layout viewport at full height when the keyboard opens, so a
+    // `bottom: 0` panel keeps Crisp's composer underneath the keys. The drawer has to
+    // lift by, and shrink to, whatever the visual viewport says is still on screen.
+    const LAYOUT_HEIGHT = 800
+
+    class FakeVisualViewport extends EventTarget {
+        height = LAYOUT_HEIGHT
+        offsetTop = 0
+    }
+
+    let viewport: FakeVisualViewport
+
+    beforeEach(() => {
+        mockUseCrispUserData.mockReset().mockReturnValue({ userId: undefined, email: undefined })
+        mockUseCrispTokenId.mockReset().mockReturnValue(undefined)
+        mockIsCapacitor.mockReset().mockReturnValue(false)
+
+        viewport = new FakeVisualViewport()
+        Object.defineProperty(window, 'visualViewport', { value: viewport, configurable: true })
+        Object.defineProperty(window, 'innerHeight', { value: LAYOUT_HEIGHT, configurable: true })
+    })
+
+    const openKeyboard = (visibleHeight: number) => {
+        viewport.height = visibleHeight
+        act(() => {
+            viewport.dispatchEvent(new Event('resize'))
+        })
+    }
+
+    // Only `bottom` is assertable here: jsdom's CSS parser drops both `env()` and
+    // `min()`, so the safe-area padding and the height clamp read back as ''.
+    it('sits flush on the bottom edge while no keyboard is up', () => {
+        render(<SupportDrawer />)
+
+        expect(screen.getByRole('dialog', { name: 'Support' }).style.bottom).toBe('0px')
+    })
+
+    it('lifts by exactly the height the keyboard covers', () => {
+        render(<SupportDrawer />)
+        const panel = screen.getByRole('dialog', { name: 'Support' })
+
+        openKeyboard(460)
+
+        expect(panel.style.bottom).toBe('340px')
+    })
+})
+
 describe('SupportDrawer Crisp session gate — native (Capacitor)', () => {
     beforeEach(() => {
         mockUseCrispUserData.mockReset()

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -13,6 +13,9 @@ import { isCapacitor } from '@/utils/capacitor'
 
 const DISMISS_THRESHOLD = 100
 
+/** Backdrop left showing above the panel when the keyboard squeezes it. */
+const TOP_RESERVE = 24
+
 const SupportDrawer = () => {
     const { isSupportModalOpen, setIsSupportModalOpen, supportPrefilledMessage: prefilledMessage } = useModalsContext()
     const userData = useCrispUserData()
@@ -181,8 +184,13 @@ const SupportDrawer = () => {
                     // bottom of the *layout* viewport, which iOS leaves under the keyboard.
                     bottom: keyboardInset,
                     // …and never be taller than what's actually on screen, so lifting the
-                    // panel pushes the conversation down instead of off the top edge.
-                    height: visibleHeight ? `min(85dvh, ${visibleHeight}px)` : '85dvh',
+                    // panel pushes the conversation down instead of off the top edge. The
+                    // reserved strip keeps the drag handle out from under the notch and
+                    // leaves a backdrop target to tap-to-close; with no keyboard up it is
+                    // slack and 85dvh wins, so the resting look is unchanged.
+                    height: visibleHeight
+                        ? `min(85dvh, calc(${visibleHeight}px - env(safe-area-inset-top) - ${TOP_RESERVE}px))`
+                        : '85dvh',
                     // The keyboard already covers the home indicator; padding for it too
                     // would just wedge a dead strip between the composer and the keys.
                     paddingBottom: keyboardInset ? 0 : 'env(safe-area-inset-bottom)',

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -5,6 +5,7 @@ import { useModalsContext } from '@/context/ModalsContext'
 import { useCrispUserData } from '@/hooks/useCrispUserData'
 import { useCrispTokenId } from '@/hooks/useCrispTokenId'
 import { useCrispProxyUrl } from '@/hooks/useCrispProxyUrl'
+import { useVisualViewport } from '@/hooks/useVisualViewport'
 import PeanutLoading from '../PeanutLoading'
 import { Button } from '@/components/0_Bruddle/Button'
 import { SUPPORT_EMAIL } from '@/constants/crisp'
@@ -23,6 +24,11 @@ const SupportDrawer = () => {
     const [iframeKey, setIframeKey] = useState(0)
 
     const crispProxyUrl = useCrispProxyUrl(userData, prefilledMessage, crispTokenId)
+
+    // Crisp's composer sits at the very bottom of the iframe, so the panel's bottom
+    // edge is the thing the iOS keyboard covers. Only measured while the drawer is
+    // open — see the hook for why CSS alone can't see the keyboard.
+    const { height: visibleHeight, keyboardInset } = useVisualViewport(isSupportModalOpen)
 
     /*
      * The proxy iframe boots the ENTIRE Next.js app at /crisp-proxy, and its src
@@ -167,10 +173,19 @@ const SupportDrawer = () => {
                 role="dialog"
                 aria-label="Support"
                 aria-modal={isSupportModalOpen}
-                className={`fixed inset-x-0 bottom-0 z-[999999] flex max-h-[85vh] flex-col rounded-t-[10px] border bg-background pt-4 ${
+                className={`fixed inset-x-0 z-[999999] flex flex-col rounded-t-[10px] border bg-background pt-4 ${
                     isSupportModalOpen ? 'pointer-events-auto translate-y-0' : 'pointer-events-none translate-y-full'
                 }`}
                 style={{
+                    // Sit on top of the keyboard rather than behind it: `bottom: 0` is the
+                    // bottom of the *layout* viewport, which iOS leaves under the keyboard.
+                    bottom: keyboardInset,
+                    // …and never be taller than what's actually on screen, so lifting the
+                    // panel pushes the conversation down instead of off the top edge.
+                    height: visibleHeight ? `min(85dvh, ${visibleHeight}px)` : '85dvh',
+                    // The keyboard already covers the home indicator; padding for it too
+                    // would just wedge a dead strip between the composer and the keys.
+                    paddingBottom: keyboardInset ? 0 : 'env(safe-area-inset-bottom)',
                     transform: isSupportModalOpen ? `translateY(${dragOffset}px)` : 'translateY(100%)',
                     transition: isDragging ? 'none' : 'transform 300ms ease-out',
                 }}
@@ -185,8 +200,9 @@ const SupportDrawer = () => {
                     <div className="h-1.5 w-10 rounded-full bg-black" />
                 </div>
 
-                <div className="flex w-full justify-center">
-                    <div className="relative h-[80vh] w-full overflow-auto md:max-w-xl">
+                {/* min-h-0 lets the iframe row shrink below its content when the panel does */}
+                <div className="flex min-h-0 w-full flex-1 justify-center">
+                    <div className="relative h-full w-full overflow-hidden md:max-w-xl">
                         {(!isCrispReady || isAwaitingToken) && !isCrispFailed && (
                             <div className="absolute inset-0 z-10 flex items-center justify-center bg-background">
                                 <PeanutLoading />

--- a/src/hooks/__tests__/useVisualViewport.test.ts
+++ b/src/hooks/__tests__/useVisualViewport.test.ts
@@ -15,6 +15,7 @@ const LAYOUT_HEIGHT = 800
 class FakeVisualViewport extends EventTarget {
     height = LAYOUT_HEIGHT
     offsetTop = 0
+    scale = 1
 }
 
 let viewport: FakeVisualViewport
@@ -64,6 +65,38 @@ describe('useVisualViewport', () => {
         setViewport(799.4)
 
         expect(result.current.keyboardInset).toBe(0)
+    })
+
+    it('catches the shallow accessory bar iOS shows for a hardware keyboard', () => {
+        // ~45px of shortcuts bar hides a composer just as well as a full keyboard.
+        const { result } = renderHook(() => useVisualViewport(true))
+
+        setViewport(755)
+
+        expect(result.current.keyboardInset).toBe(45)
+    })
+
+    it('stands down while the user is pinch-zoomed rather than typing', () => {
+        const { result } = renderHook(() => useVisualViewport(true))
+
+        viewport.scale = 2
+        setViewport(400)
+
+        expect(result.current).toEqual({ height: 0, keyboardInset: 0 })
+    })
+
+    it('drops the measurement when disabled, so a consumer cannot stay lifted', () => {
+        // A drawer closing while the keyboard is still up unsubscribes before it sees
+        // the keyboard leave. Freezing the last inset would strand it mid-screen.
+        const { result, rerender } = renderHook(({ on }) => useVisualViewport(on), {
+            initialProps: { on: true },
+        })
+        setViewport(460)
+        expect(result.current.keyboardInset).toBe(340)
+
+        rerender({ on: false })
+
+        expect(result.current).toEqual({ height: 0, keyboardInset: 0 })
     })
 
     it('does not measure or subscribe while disabled', () => {

--- a/src/hooks/__tests__/useVisualViewport.test.ts
+++ b/src/hooks/__tests__/useVisualViewport.test.ts
@@ -1,0 +1,95 @@
+/**
+ * useVisualViewport — the keyboard measurement behind the support drawer's lift.
+ *
+ * The bug it guards: on iOS the layout viewport never shrinks for the software
+ * keyboard, so a `position: fixed; bottom: 0` drawer keeps its bottom edge — and
+ * the Crisp composer sitting on it — underneath the keys. The only signal that
+ * this happened is the gap between `window.innerHeight` and the visual viewport.
+ */
+import { renderHook, act } from '@testing-library/react'
+import { useVisualViewport } from '../useVisualViewport'
+
+const LAYOUT_HEIGHT = 800
+
+// jsdom implements no visualViewport at all — stand up a controllable stub.
+class FakeVisualViewport extends EventTarget {
+    height = LAYOUT_HEIGHT
+    offsetTop = 0
+}
+
+let viewport: FakeVisualViewport
+
+const setViewport = (height: number, offsetTop = 0) => {
+    viewport.height = height
+    viewport.offsetTop = offsetTop
+    act(() => {
+        viewport.dispatchEvent(new Event('resize'))
+    })
+}
+
+beforeEach(() => {
+    viewport = new FakeVisualViewport()
+    Object.defineProperty(window, 'visualViewport', { value: viewport, configurable: true })
+    Object.defineProperty(window, 'innerHeight', { value: LAYOUT_HEIGHT, configurable: true })
+})
+
+describe('useVisualViewport', () => {
+    it('reports no keyboard when the visual viewport fills the layout viewport', () => {
+        const { result } = renderHook(() => useVisualViewport(true))
+
+        expect(result.current).toEqual({ height: LAYOUT_HEIGHT, keyboardInset: 0 })
+    })
+
+    it('reports the covered height once the keyboard opens', () => {
+        const { result } = renderHook(() => useVisualViewport(true))
+
+        setViewport(460)
+
+        expect(result.current).toEqual({ height: 460, keyboardInset: 340 })
+    })
+
+    it('counts the scroll iOS performs to reveal the focused field', () => {
+        // iOS scrolls the visual viewport down over the layout viewport; the drawer is
+        // pinned to the layout viewport, so that offset hides it too.
+        const { result } = renderHook(() => useVisualViewport(true))
+
+        setViewport(460, 100)
+
+        expect(result.current.keyboardInset).toBe(240)
+    })
+
+    it('ignores sub-pixel / scrollbar deltas that are not a keyboard', () => {
+        const { result } = renderHook(() => useVisualViewport(true))
+
+        setViewport(799.4)
+
+        expect(result.current.keyboardInset).toBe(0)
+    })
+
+    it('does not measure or subscribe while disabled', () => {
+        const subscribe = jest.spyOn(viewport, 'addEventListener')
+
+        const { result } = renderHook(() => useVisualViewport(false))
+
+        expect(result.current).toEqual({ height: 0, keyboardInset: 0 })
+        expect(subscribe).not.toHaveBeenCalled()
+    })
+
+    it('unsubscribes on unmount', () => {
+        const unsubscribe = jest.spyOn(viewport, 'removeEventListener')
+
+        const { unmount } = renderHook(() => useVisualViewport(true))
+        unmount()
+
+        expect(unsubscribe).toHaveBeenCalledWith('resize', expect.any(Function))
+        expect(unsubscribe).toHaveBeenCalledWith('scroll', expect.any(Function))
+    })
+
+    it('survives a browser with no visualViewport', () => {
+        Object.defineProperty(window, 'visualViewport', { value: undefined, configurable: true })
+
+        const { result } = renderHook(() => useVisualViewport(true))
+
+        expect(result.current).toEqual({ height: 0, keyboardInset: 0 })
+    })
+})

--- a/src/hooks/useVisualViewport.ts
+++ b/src/hooks/useVisualViewport.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Sub-pixel rounding and desktop scrollbars leave a few px between the layout and
+ * visual viewports even with no keyboard on screen. No software keyboard is anywhere
+ * near this short, so anything below the floor is measurement noise, not a keyboard.
+ */
+const MIN_KEYBOARD_INSET_PX = 80
+
+export interface VisualViewportState {
+    /** Height actually on screen, in px. `0` until measured (SSR, or unsupported). */
+    height: number
+    /** Px of the layout viewport's bottom edge hidden behind the software keyboard. */
+    keyboardInset: number
+}
+
+/**
+ * Measures the *visual* viewport — the slice of the page actually on screen.
+ *
+ * iOS never resizes the layout viewport for the software keyboard, so `100vh`,
+ * `100dvh` and `position: fixed; bottom: 0` all keep pointing at the full,
+ * keyboard-covered window. CSS therefore cannot see the keyboard at all; only
+ * `window.visualViewport` knows how much of the screen it ate.
+ *
+ * Subscribes only while `enabled`, because these events fire on every
+ * keystroke-driven scroll and consumers here are mounted on every route.
+ */
+export function useVisualViewport(enabled: boolean): VisualViewportState {
+    const [state, setState] = useState<VisualViewportState>({ height: 0, keyboardInset: 0 })
+
+    useEffect(() => {
+        const viewport = typeof window === 'undefined' ? null : window.visualViewport
+        if (!enabled || !viewport) return
+
+        const measure = () => {
+            // The still-visible slice of the layout viewport is
+            // [offsetTop, offsetTop + height] — offsetTop goes non-zero once iOS
+            // scrolls the focused field into view. Whatever is below that slice is
+            // where a `bottom: 0` fixed element lands: behind the keyboard.
+            const hidden = window.innerHeight - viewport.height - viewport.offsetTop
+            const next: VisualViewportState = {
+                height: viewport.height,
+                keyboardInset: hidden > MIN_KEYBOARD_INSET_PX ? hidden : 0,
+            }
+            setState((prev) => (prev.height === next.height && prev.keyboardInset === next.keyboardInset ? prev : next))
+        }
+
+        measure()
+        viewport.addEventListener('resize', measure)
+        viewport.addEventListener('scroll', measure)
+        return () => {
+            viewport.removeEventListener('resize', measure)
+            viewport.removeEventListener('scroll', measure)
+        }
+    }, [enabled])
+
+    return state
+}

--- a/src/hooks/useVisualViewport.ts
+++ b/src/hooks/useVisualViewport.ts
@@ -2,13 +2,17 @@ import { useEffect, useState } from 'react'
 
 /**
  * Sub-pixel rounding and desktop scrollbars leave a few px between the layout and
- * visual viewports even with no keyboard on screen. No software keyboard is anywhere
- * near this short, so anything below the floor is measurement noise, not a keyboard.
+ * visual viewports with nothing on screen. Set below the ~45px accessory bar iOS
+ * shows for a hardware keyboard — that bar covers a composer just as effectively as
+ * the full keyboard does — but well above scrollbar and rounding noise.
  */
-const MIN_KEYBOARD_INSET_PX = 80
+const MIN_KEYBOARD_INSET_PX = 40
+
+/** Nothing is measured while unsupported, disabled, or zoomed — consumers fall back to CSS. */
+const UNMEASURED: VisualViewportState = { height: 0, keyboardInset: 0 }
 
 export interface VisualViewportState {
-    /** Height actually on screen, in px. `0` until measured (SSR, or unsupported). */
+    /** Height actually on screen, in px. `0` when unmeasured (see {@link UNMEASURED}). */
     height: number
     /** Px of the layout viewport's bottom edge hidden behind the software keyboard. */
     keyboardInset: number
@@ -26,23 +30,37 @@ export interface VisualViewportState {
  * keystroke-driven scroll and consumers here are mounted on every route.
  */
 export function useVisualViewport(enabled: boolean): VisualViewportState {
-    const [state, setState] = useState<VisualViewportState>({ height: 0, keyboardInset: 0 })
+    const [state, setState] = useState<VisualViewportState>(UNMEASURED)
 
     useEffect(() => {
+        const commit = (next: VisualViewportState) =>
+            setState((prev) => (prev.height === next.height && prev.keyboardInset === next.keyboardInset ? prev : next))
+
         const viewport = typeof window === 'undefined' ? null : window.visualViewport
-        if (!enabled || !viewport) return
+        if (!enabled || !viewport) {
+            // Drop the last measurement rather than freeze it. A consumer that lifts by
+            // `keyboardInset` has to come back down when it closes — and since we
+            // unsubscribe here, we'd never see the keyboard leave.
+            commit(UNMEASURED)
+            return
+        }
 
         const measure = () => {
+            // Pinch-zoom shrinks the visual viewport too, and a zoomed reader is not
+            // typing — adjusting for it just makes things jump. `maximum-scale=1` in the
+            // root viewport keeps iOS from auto-zooming on focus, so scale > 1 is always
+            // a deliberate pinch and never a keyboard.
+            if (viewport.scale > 1) return commit(UNMEASURED)
+
             // The still-visible slice of the layout viewport is
             // [offsetTop, offsetTop + height] — offsetTop goes non-zero once iOS
             // scrolls the focused field into view. Whatever is below that slice is
             // where a `bottom: 0` fixed element lands: behind the keyboard.
             const hidden = window.innerHeight - viewport.height - viewport.offsetTop
-            const next: VisualViewportState = {
+            commit({
                 height: viewport.height,
                 keyboardInset: hidden > MIN_KEYBOARD_INSET_PX ? hidden : 0,
-            }
-            setState((prev) => (prev.height === next.height && prev.keyboardInset === next.keyboardInset ? prev : next))
+            })
         }
 
         measure()


### PR DESCRIPTION
Fixes [TASK-20947](https://app.notion.com/p/3ab83811757981359bd9e928aa3feae5) — [Crisp session](https://app.crisp.chat/website/916078be-a6af-4696-82cb-bc08d43d9125/inbox/session_19c5910c-e1ff-4ffe-9dbc-52eccb81db02/) · [Discord report](https://discord.com/channels/972435984954302464/1483085665930444944/1531596405540393133)

## The bug

Open support chat on iOS, tap the message field, and the composer disappears behind the keyboard. You can type, you just can't see what you typed.

## Why

iOS **never resizes the layout viewport** for the software keyboard — it shrinks only the *visual* viewport and scrolls. `SupportDrawer`'s panel is `position: fixed; bottom: 0`, and `bottom: 0` means the bottom of the **layout** viewport: the edge the keyboard is sitting on top of. Crisp renders its composer on exactly that edge.

`100vh` and `100dvh` are no help — `dvh` tracks browser chrome (the collapsing Safari toolbar), not the keyboard. **CSS cannot see the keyboard at all.** `window.visualViewport` is the only thing that can.

## The fix

New `useVisualViewport(enabled)` hook returns the visible height and how many px of the layout viewport's bottom edge are hidden:

```
keyboardInset = window.innerHeight − visualViewport.height − visualViewport.offsetTop
```

The `offsetTop` term matters: iOS scrolls the focused field into view, and the panel is pinned to the layout viewport, so that scroll hides it too. Values under a 40px floor are discarded as sub-pixel/scrollbar noise — without it, a 0.8px rounding delta reads as "keyboard up" on every device. The floor sits below the ~45px accessory bar iOS shows for a hardware keyboard, which hides a composer just as well as the full keyboard.

The panel then lifts by that inset and clamps its height to what's still on screen, so the conversation is pushed *down* rather than off the top edge. The clamp reserves `env(safe-area-inset-top) + 24px` so the drag handle stays clear of the notch and a backdrop strip remains tappable; with no keyboard up that reserve is slack and `85dvh` wins, leaving the resting look unchanged.

Zoom is explicitly *not* a keyboard: pinch shrinks the visual viewport identically, so `scale > 1` stands the hook down entirely and CSS takes over. `maximum-scale=1` in the root viewport rules out iOS focus auto-zoom, so a zoom is always deliberate.

## Two adjacent defects, same geometry

Both are in the ticket's scope and fall out of the same lines:

- **Overflow (reported).** The panel was `max-h-[85vh]` wrapping a fixed `h-[80vh]` iframe plus a ~38px drag handle. Below ~760px of viewport the max-height clipped its own content. Height is now explicit and the iframe row is `flex-1 min-h-0`, so it can't disagree with its parent.
- **Safe area.** `bottom: 0` with no padding put the composer under the home indicator on notched iPhones. Now `paddingBottom: env(safe-area-inset-bottom)` — dropped while the keyboard is up, since the keyboard already covers the home indicator and padding there would wedge a dead strip between composer and keys.

## Scope

- **iOS Safari + installed PWA** — the reported surface.
- **Android web is fixed too.** Chrome's default is `interactive-widget=resizes-visual` and the root viewport meta doesn't override it, so Android has the identical bug. Worth testing there as well as iOS.
- **Native app (iOS + Android): unaffected, twice over.** `isCapacitor()` opens the native Crisp SDK, never this drawer's iframe (`SupportDrawer/index.tsx:56-92`) — a synchronous gate with no detection race, since `capacitor.config.ts` sets no `server.url` and the bridge is injected before app code runs. And even if this panel *did* render there, the fix would be inert: `useNativePlugins.ts:174` sets `KeyboardResize.Native` on iOS, which shrinks the WebView itself, so `innerHeight` and `visualViewport.height` shrink together and `keyboardInset` computes to ~0. It cannot double-adjust.
- Listeners subscribe **only while the drawer is open** — `SupportDrawer` is mounted on every route, and these events fire on every keystroke-driven scroll. State updates bail on unchanged values so momentum scroll can't cause a render storm.

## Tests

`src/hooks/__tests__/useVisualViewport.test.ts` (10) — inset math, the `offsetTop` term, the noise floor, the hardware accessory bar, the zoom stand-down, reset-on-disable, unmount teardown, and browsers with no `visualViewport`.

`SupportDrawer.test.tsx` (+2) — panel is flush at `bottom: 0px` with no keyboard, lifts to `bottom: 340px` when the visual viewport drops to 460 of 800. Only `bottom` is assertable: jsdom's CSS parser drops both `env()` and `min()`.

## Local gate

Prettier ✅ · typecheck ✅ · `npm test` 179/179 suites, 2365 passed ✅ · `npm run build` ✅

## Manual QA needed

Device verification is the one thing this can't self-check — needs a real iPhone:

1. Safari + installed PWA: open support, focus the composer, confirm it sits directly above the keyboard.
2. Type, scroll the conversation, dismiss the keyboard — panel returns to 85dvh with no jump.
3. Notched device, keyboard down: composer clears the home indicator.
4. Drag-to-dismiss still works with the keyboard up.

## Note (not fixed here)

`crisp-proxy/page.tsx:12` says the proxy is embedded "from SupportDrawer and SupportPage" — there is no SupportPage; `SupportDrawer` is the only consumer. Stale comment, left alone to keep this diff surgical.


---

## Code review round (`/code-review medium`)

Five findings, four applied in `5f4adfb`:

**Reset-on-close (HIGH) — the one that mattered.** `translateY(100%)` resolves against the element's *own* height. Once the keyboard shrank the panel to ~460px it no longer travelled far enough to clear a 340px lift, so closing the drawer with the keyboard still up left an **opaque sheet over the bottom third of the app**. Worse, the hook unsubscribes on close, so it could never observe the keyboard leaving and self-correct. The measurement is now dropped rather than frozen.

**Pinch-zoom false positive (MED).** Zoom shrinks the visual viewport indistinguishably from a keyboard; `scale > 1` now stands the hook down.

**Panel filled the visible viewport exactly (MED).** The lift and the clamp are algebraically complementary, so the panel's top landed precisely on the visible top edge — drag handle under the notch, no backdrop to tap. Hence the reserved strip.

**Accessory-bar blind spot (LOW).** Noise floor 80px → 40px.

**Not applied — transitioning `bottom`/`height` (LOW).** Suggested to smooth the ~250ms keyboard animation, currently a one-frame snap. Declined: both properties trigger layout, so a transition forces the Crisp iframe to reflow every frame for the duration instead of once. This component already carries scars from WKWebView content-process crashes under memory pressure (see the eager-mount comment at the top of `SupportDrawer/index.tsx`) — one reflow beats fifteen.

---

## Screenshots — ⚠️ NONE, and this one genuinely can't have them

Not an oversight and not laziness: **the states this PR changes cannot be rendered by a headless browser.** They require a real iOS software keyboard shrinking the visual viewport, which desktop Chromium has no equivalent of. A 375×667 screenshot would show the resting drawer — which this PR deliberately leaves **pixel-identical** (with no keyboard up, the `85dvh` term wins every clamp).

Faking it by stubbing `window.visualViewport` in a page init script would produce a picture of the stub, not of iOS, and would invite more confidence than it earns.

What stands in for visual evidence instead: the geometry is asserted numerically. `SupportDrawer.test.tsx` pins the panel at `bottom: 0px` at rest and `bottom: 340px` when the visual viewport drops to 460 of 800 — the exact number a screenshot would be checked against by eye.

**The manual QA checklist above is therefore load-bearing, not optional.** Please run it on a real device before approving.

## Design notes / accepted trade-offs

**Declined: transitioning `bottom`/`height` alongside `transform`.** `/code-review` suggested it to smooth the ~250ms keyboard animation, which is currently a one-frame snap. Both properties trigger layout, so a transition makes the Crisp iframe reflow on every frame for the duration instead of exactly once. This component already carries scars from WKWebView content-process crashes under memory pressure — see the eager-mount comment at the top of `SupportDrawer/index.tsx`. One reflow beats fifteen; the snap stays.

**Declined: `'use client'` on the new hook** (flagged `nextjs-missing-use-client` by code-analysis). All three sibling Crisp hooks omit it — including `useCrispTokenId`, which is `useState`/`useEffect` exactly like this one. Next propagates the client boundary through imports from the already-`'use client'` `SupportDrawer`, and the production build confirms it. Adding it here alone would be an inconsistent one-off.

**Smell verdict: adds none.** The code-analysis `+6.71` painscore is the new file existing at all (`0 → 6.2`); its six "resolved" entries are the same pre-existing `SupportDrawer` findings re-reported at shifted line numbers, not fixes.
