### PR TITLE
fix(test): dev tip typecheck break — singular classifyBareCampaign call sites

### DIFF
--- a/src/components/Invites/campaign-maps.test.ts
+++ b/src/components/Invites/campaign-maps.test.ts
@@ -63,11 +63,11 @@ describe('classifyBareCampaigns', () => {
     // Mapping them in UTM_CAMPAIGN_TO_BADGE_MAP alone is not enough — without a
     // bare-campaign registration the link dead-ends on "Invalid Invite Code".
     it.each(['naija', 'terere'])('country-launch campaign "%s" is a bare claimable skip', (c) => {
-        expect(classifyBareCampaign(c, undefined)).toEqual({
+        expect(classifyBareCampaigns([c], undefined)).toEqual({
             isBareClaimCampaign: true,
             isWaitlistSkip: true,
         })
-        expect(classifyBareCampaign(c.toUpperCase(), undefined).isBareClaimCampaign).toBe(true)
+        expect(classifyBareCampaigns([c.toUpperCase()], undefined).isBareClaimCampaign).toBe(true)
     })
 
     it('only waitlist-skip campaigns promise a card-waitlist skip', () => {


### PR DESCRIPTION
## Summary
The main→dev back-merge (db961c32f) left two call sites in `campaign-maps.test.ts` on the removed singular `classifyBareCampaign` API. Every branch off `dev` currently fails typecheck and the unit suite.

Two-line fix: call `classifyBareCampaigns([c], …)`.

## Risks
None — test-only. Note #2613 rewrites this module and deletes the test block entirely; if it merges first, close this PR.

## QA
`tsc --noEmit` exit 0; `jest campaign-maps.test.ts` 52/52 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)