### PR TITLE
fix(withdraw): record-only retry after an executed spend (TASK-19581 double-spend)

### DIFF
--- a/src/app/(mobile-ui)/withdraw/crypto/__tests__/crypto-withdraw-confirm.test.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/__tests__/crypto-withdraw-confirm.test.tsx
@@ -433,3 +433,54 @@ describe('crypto withdraw confirm — charge completion', () => {
         expect(mockSetWithdrawError).toHaveBeenCalledWith(expect.objectContaining({ showError: true }))
     })
 })
+
+describe('crypto withdraw retry — record-only replay (TASK-19581 double-spend)', () => {
+    // The prod incident: recordPayment times out AFTER the on-chain transfer
+    // broadcast; the user lands on Retry, and pre-fix Retry re-ran the whole
+    // flow — issuing a SECOND on-chain transfer for the same charge.
+    it('retry after a recordPayment failure never re-broadcasts — it replays only the record with the same hash', async () => {
+        mockSendMoney.mockResolvedValue({
+            txHash: undefined,
+            userOpHash: '0xuserop',
+            receipt: { transactionHash: '0xmined', status: 'success' },
+            strategy: 'smart-only',
+            intentId: undefined,
+        })
+        mockRecordPayment.mockRejectedValueOnce(new Error('Request timed out after 30000ms'))
+
+        render(<WithdrawCryptoPage />)
+        fireEvent.click(screen.getByTestId('confirm-withdraw'))
+        await waitFor(() => expect(mockPosthogCapture).toHaveBeenCalledWith('withdraw_failed', expect.anything()))
+        expect(mockSendMoney).toHaveBeenCalledTimes(1)
+
+        fireEvent.click(screen.getByTestId('confirm-withdraw'))
+        await waitFor(() => expect(mockSetCurrentView).toHaveBeenCalledWith('STATUS'))
+
+        // The on-chain leg ran exactly once across both attempts.
+        expect(mockSendMoney).toHaveBeenCalledTimes(1)
+        expect(mockSendTransactions).not.toHaveBeenCalled()
+        // The record ran twice, both times with the ORIGINAL mined hash.
+        expect(mockRecordPayment).toHaveBeenCalledTimes(2)
+        expect(mockRecordPayment).toHaveBeenLastCalledWith(expect.objectContaining({ txHash: '0xmined' }))
+    })
+
+    it('a failure BEFORE any tx identifier exists retries with a fresh broadcast (nothing was spent)', async () => {
+        mockSendMoney.mockRejectedValueOnce(new Error('user rejected signature')).mockResolvedValueOnce({
+            txHash: '0xbetx',
+            userOpHash: undefined,
+            receipt: null,
+            strategy: 'collateral-only',
+            intentId: CHARGE_UUID,
+        })
+
+        render(<WithdrawCryptoPage />)
+        fireEvent.click(screen.getByTestId('confirm-withdraw'))
+        await waitFor(() => expect(mockPosthogCapture).toHaveBeenCalledWith('withdraw_failed', expect.anything()))
+
+        fireEvent.click(screen.getByTestId('confirm-withdraw'))
+        await waitFor(() => expect(mockSetCurrentView).toHaveBeenCalledWith('STATUS'))
+
+        // No spend happened on attempt 1, so attempt 2 legitimately broadcasts.
+        expect(mockSendMoney).toHaveBeenCalledTimes(2)
+    })
+})

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -22,7 +22,7 @@ import { isAmountWithinBalance } from '@/utils/balance.utils'
 import { isBelowRhinoMinDeposit } from '@/utils/withdraw.utils'
 import * as peanutInterfaces from '@/interfaces/peanut-sdk-types'
 import { useRouter } from 'next/navigation'
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { captureMessage } from '@sentry/nextjs'
 import { useSafeBack } from '@/hooks/useSafeBack'
 import type { Address, Hex, TransactionReceipt } from 'viem'
@@ -86,6 +86,18 @@ export default function WithdrawCryptoPage() {
     } = useCrossChainTransfer()
 
     const { isRecording, error: recordError, recordPayment, reset: resetPaymentRecorder } = usePaymentRecorder()
+
+    // Once the on-chain leg has broadcast for a charge, Retry must NEVER
+    // broadcast again — a recordPayment failure after the spend used to
+    // re-run the whole flow and issue a second on-chain transfer
+    // (TASK-19581 double-spend). Stamped the moment a tx identifier
+    // exists; a retry for the same charge replays only the record.
+    const executedSpendRef = useRef<{
+        chargeId: string
+        txHash: Hex
+        minedTxHash: Hex | undefined
+        strategy: 'collateral-only' | 'smart-only' | 'mixed' | undefined
+    } | null>(null)
 
     const { triggerHaptic } = useHaptic()
 
@@ -329,12 +341,25 @@ export default function WithdrawCryptoPage() {
             // sendTransactions mixed path.
             let finalTxHash: Hex | undefined
             let receipt: TransactionReceipt | null = null
+            let minedTxHash: Hex | undefined
             // 'collateral-only' | 'smart-only' | 'mixed' — how the spend was
             // funded; drives how strictly the recordPayment result is treated
             // (see the recordPayment note below).
             let strategy: 'collateral-only' | 'smart-only' | 'mixed' | undefined
 
-            if (!isCrossChainWithdrawal) {
+            const executedSpend =
+                executedSpendRef.current?.chargeId === chargeDetails.uuid ? executedSpendRef.current : null
+            if (executedSpend) {
+                // A previous attempt already moved funds for this charge and
+                // failed at bookkeeping — replay ONLY the record.
+                finalTxHash = executedSpend.txHash
+                minedTxHash = executedSpend.minedTxHash
+                strategy = executedSpend.strategy
+                captureMessage('withdraw: retry with executed spend — record-only, skipping broadcast', {
+                    level: 'info',
+                    extra: { chargeId: chargeDetails.uuid, txHash: finalTxHash, strategy },
+                })
+            } else if (!isCrossChainWithdrawal) {
                 const {
                     userOpHash,
                     txHash,
@@ -379,6 +404,11 @@ export default function WithdrawCryptoPage() {
 
             if (!finalTxHash) throw new Error('Withdrawal returned no transaction identifier')
 
+            // Funds are (or are about to be) moving on-chain — from here on,
+            // any failure must retry as record-only, never as a re-broadcast.
+            minedTxHash ??= receipt?.transactionHash as Hex | undefined
+            executedSpendRef.current = { chargeId: chargeDetails.uuid, txHash: finalTxHash, minedTxHash, strategy }
+
             // Record the payment against the charge on EVERY path — completing
             // the user-facing charge is what makes the withdrawal appear in
             // Activity:
@@ -406,7 +436,7 @@ export default function WithdrawCryptoPage() {
             // and leave a breadcrumb. collateral-only is safe regardless: its
             // hash is a backend-broadcast EVM tx and the tagged charge settles
             // via the trusted path.
-            const mixedWithoutMinedHash = strategy === 'mixed' && !isCrossChainWithdrawal && !receipt?.transactionHash
+            const mixedWithoutMinedHash = strategy === 'mixed' && !isCrossChainWithdrawal && !minedTxHash
 
             let payment: Awaited<ReturnType<typeof recordPayment>> | null = null
             if (mixedWithoutMinedHash) {
@@ -439,6 +469,7 @@ export default function WithdrawCryptoPage() {
                 }
             }
 
+            executedSpendRef.current = null
             setTransactionHash(finalTxHash)
             setPaymentDetails(payment)
             triggerHaptic()

--- a/src/services/charges.ts
+++ b/src/services/charges.ts
@@ -95,6 +95,12 @@ export const chargesApi = {
     }): Promise<PaymentCreationResponse> => {
         const response = await apiFetch(`/charges/${chargeId}/payments`, {
             method: 'POST',
+            // The write the whole flow hinges on: funds have already moved
+            // on-chain when this fires. The 20s default abort has fired while
+            // the API had long since committed (Vercel proxy cold-start ate
+            // the budget — TASK-19581), which reads as a failed withdrawal.
+            // Give bookkeeping room to succeed instead of surfacing Retry.
+            timeoutMs: 30_000,
             body: JSON.stringify({
                 chainId,
                 hash,


### PR DESCRIPTION
## Summary

Withdraw double-spend (TASK-19581, P0): when `recordPayment` fails AFTER the on-chain transfer broadcast (the prod incident: FE proxy timeout while the API had committed in 49ms), the user lands on Retry — and Retry re-ran `handleConfirmWithdrawal` from the top, broadcasting a **second** on-chain transfer for the same charge. Confirmed on-chain: two Rhino bridges 30s apart, $10 moved instead of $5.

- **Executed-spend cache:** the moment a tx identifier exists, the spend (charge uuid, tx hash, mined hash, strategy) is stamped in a ref. A retry for the same charge skips the broadcast entirely and replays only the record. A failure before any tx identifier (e.g. rejected signature) still retries with a fresh broadcast. Sentry breadcrumb on every record-only replay.
- **`createPayment` gets 30s** (was the 20s client default): funds have already moved when this write fires — aborting it early only manufactures scary Retries. Vercel proxy cold-start ate most of the old budget.

Sibling BE PR: peanutprotocol/peanut-api-ts#1290 (payer-hash audit trail + replay warning). Neither depends on the other; API deploys first per convention. A record-only retry re-POSTs the SAME hash, which the BE handles idempotently today (identical metadata rewrite → 201).

## Risks / breaking changes

- Scope: withdraw/crypto flow only. The ref is per-mount and keyed by charge uuid — going back and creating a new charge broadcasts fresh (pre-existing behavior).
- Cross-repo: none required.

## QA

- `crypto-withdraw-confirm.test.tsx`: 2 new tests — retry after post-spend record failure broadcasts exactly once across both attempts and re-records the original mined hash; pre-spend failure still re-broadcasts. All 10 suite tests green.
- Full suite: 2631 passed locally; 1 pre-existing failure in `add-money-states.test.tsx` (fails identically on base — unrelated to this diff).

Screenshots: N/A (no visible change — behavioral fix; the error/Retry surface is unchanged, it just stops double-spending).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crypto withdrawals from being broadcast more than once when retrying after payment-recording failures.
  * Improved retry handling by reusing completed transaction details and allowing fresh broadcasts when no transaction was created.
  * Increased the payment creation request timeout from 20 to 30 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->