### PR TITLE
feat: emit app_locale to PostHog

### DIFF
--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/utils/general.utils'
 import { apiFetch } from '@/utils/api-fetch'
 import { useAppLocked } from '@/hooks/useAppLocked'
+import { currentAppLocale } from '@/i18n/app/locale-store'
 import { isCapacitor } from '@/utils/capacitor'
 import { clearAuthToken } from '@/utils/auth-token'
 import { resetCrispProxySessions } from '@/utils/crisp'
@@ -121,6 +122,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
                 // catalog rail ids for joins against the rails table.
                 enabledRails: enabledRails.map((rail) => `${rail.rail.provider.code}:${rail.rail.method.code}`),
                 enabledRailIds: enabledRails.map((rail) => rail.rail.id),
+                // Client-only (locale never reaches the BE) — covers the first
+                // session, where the startup locale resolves before identify.
+                ...(currentAppLocale() ? { app_locale: currentAppLocale() } : {}),
             })
             // Sentry: every error captured from here on inherits user context
             // as searchable Sentry tags. Closes the historical gap where FE

--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -110,6 +110,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
             // `name` duplicates username because PostHog's Persons-page search is
             // hardcoded to email/name/distinct_id — username alone is not searchable.
             const enabledRails = user.rails?.filter((rail) => rail.status === 'ENABLED') ?? []
+            const appLocale = currentAppLocale()
             posthog.identify(user.user.userId, {
                 username: user.user.username,
                 name: user.user.username,
@@ -124,7 +125,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
                 enabledRailIds: enabledRails.map((rail) => rail.rail.id),
                 // Client-only (locale never reaches the BE) — covers the first
                 // session, where the startup locale resolves before identify.
-                ...(currentAppLocale() ? { app_locale: currentAppLocale() } : {}),
+                ...(appLocale ? { app_locale: appLocale } : {}),
             })
             // Sentry: every error captured from here on inherits user context
             // as searchable Sentry tags. Closes the historical gap where FE
@@ -262,6 +263,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         }
         try {
             posthog.reset()
+            // reset() wipes registered super properties — re-register the
+            // locale so logout-window events keep carrying app_locale
+            const locale = currentAppLocale()
+            if (locale) posthog.register({ app_locale: locale })
         } catch (e) {
             console.warn('posthog reset failed:', e)
         }

--- a/src/i18n/app/AppIntlProvider.tsx
+++ b/src/i18n/app/AppIntlProvider.tsx
@@ -4,7 +4,7 @@ import { NextIntlClientProvider, IntlErrorCode, type IntlError } from 'next-intl
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { DEFAULT_APP_LOCALE, type AppLocale } from './config'
 import { loadMessages, type AppMessages } from './messages'
-import { emitLocaleToAnalytics, localeReady, markLocaleApplied, persistLocale } from './locale-store'
+import { currentAppLocale, emitLocaleToAnalytics, localeReady, markLocaleApplied, persistLocale } from './locale-store'
 import en from './messages/en.json'
 
 interface AppLocaleContextValue {
@@ -44,8 +44,11 @@ export function AppIntlProvider({ children }: { children: React.ReactNode }) {
         localeReady().then(async (resolved) => {
             startupLocale.current = resolved
             if (resolved === DEFAULT_APP_LOCALE) {
-                // already rendered in English — nothing to swap
-                emitLocaleToAnalytics(resolved)
+                // already rendered in English — nothing to swap. Skip the emit
+                // if a manual setLocale won the race: this path never calls
+                // setIntlState, so the UI keeps the manual locale and emitting
+                // the startup value would record a language nobody sees.
+                if (!currentAppLocale()) emitLocaleToAnalytics(resolved)
                 markLocaleApplied()
                 return
             }

--- a/src/i18n/app/AppIntlProvider.tsx
+++ b/src/i18n/app/AppIntlProvider.tsx
@@ -4,7 +4,7 @@ import { NextIntlClientProvider, IntlErrorCode, type IntlError } from 'next-intl
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { DEFAULT_APP_LOCALE, type AppLocale } from './config'
 import { loadMessages, type AppMessages } from './messages'
-import { localeReady, markLocaleApplied, persistLocale } from './locale-store'
+import { emitLocaleToAnalytics, localeReady, markLocaleApplied, persistLocale } from './locale-store'
 import en from './messages/en.json'
 
 interface AppLocaleContextValue {
@@ -45,12 +45,18 @@ export function AppIntlProvider({ children }: { children: React.ReactNode }) {
             startupLocale.current = resolved
             if (resolved === DEFAULT_APP_LOCALE) {
                 // already rendered in English — nothing to swap
+                emitLocaleToAnalytics(resolved)
                 markLocaleApplied()
                 return
             }
             if (cancelled) return
             const loaded = await loadMessages(resolved)
-            if (!cancelled) setIntlState({ locale: resolved, messages: loaded })
+            if (!cancelled) {
+                setIntlState({ locale: resolved, messages: loaded })
+                // emit only after the catalog loaded — analytics report the
+                // language the user actually sees, not a failed swap
+                emitLocaleToAnalytics(resolved)
+            }
         })
         return () => {
             cancelled = true
@@ -67,6 +73,7 @@ export function AppIntlProvider({ children }: { children: React.ReactNode }) {
         persistLocale(next)
         const loaded = await loadMessages(next)
         setIntlState({ locale: next, messages: loaded })
+        emitLocaleToAnalytics(next)
     }, [])
 
     return (

--- a/src/i18n/app/__tests__/locale-store.test.ts
+++ b/src/i18n/app/__tests__/locale-store.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Guards the analytics-emit gating in locale-store (TASK-20922): dedupe,
+ * register-always vs $set-only-on-identified-change, and the fence that keeps
+ * a posthog failure from breaking i18n. Module state (`current`) is reset via
+ * jest.isolateModules per test.
+ */
+
+const mockRegister = jest.fn()
+const mockSetPersonProperties = jest.fn()
+const mockIsIdentified = jest.fn()
+
+jest.mock('posthog-js', () => ({
+    __esModule: true,
+    default: {
+        register: (...args: unknown[]) => mockRegister(...args),
+        setPersonProperties: (...args: unknown[]) => mockSetPersonProperties(...args),
+        _isIdentified: (...args: unknown[]) => mockIsIdentified(...args),
+    },
+}))
+
+type LocaleStore = typeof import('../locale-store')
+
+function freshStore(): LocaleStore {
+    let store: LocaleStore
+    jest.isolateModules(() => {
+        store = require('../locale-store')
+    })
+    return store!
+}
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsIdentified.mockReturnValue(true)
+})
+
+describe('emitLocaleToAnalytics', () => {
+    it('first emit registers the super property but never $sets (identify covers startup)', () => {
+        const store = freshStore()
+        store.emitLocaleToAnalytics('es-419')
+        expect(mockRegister).toHaveBeenCalledWith({ app_locale: 'es-419' })
+        expect(mockSetPersonProperties).not.toHaveBeenCalled()
+        expect(store.currentAppLocale()).toBe('es-419')
+    })
+
+    it('same-locale re-emit is a no-op', () => {
+        const store = freshStore()
+        store.emitLocaleToAnalytics('en')
+        store.emitLocaleToAnalytics('en')
+        expect(mockRegister).toHaveBeenCalledTimes(1)
+    })
+
+    it('a real change registers and $sets for an identified user', () => {
+        const store = freshStore()
+        store.emitLocaleToAnalytics('en')
+        store.emitLocaleToAnalytics('pt-BR')
+        expect(mockRegister).toHaveBeenLastCalledWith({ app_locale: 'pt-BR' })
+        expect(mockSetPersonProperties).toHaveBeenCalledTimes(1)
+        expect(mockSetPersonProperties).toHaveBeenCalledWith({ app_locale: 'pt-BR' })
+    })
+
+    it('a change by an anonymous user never $sets (would force person processing)', () => {
+        mockIsIdentified.mockReturnValue(false)
+        const store = freshStore()
+        store.emitLocaleToAnalytics('en')
+        store.emitLocaleToAnalytics('es-AR')
+        expect(mockSetPersonProperties).not.toHaveBeenCalled()
+        expect(mockRegister).toHaveBeenCalledTimes(2)
+    })
+
+    it('a posthog throw never propagates and still records the current locale', () => {
+        mockRegister.mockImplementation(() => {
+            throw new Error('sdk exploded')
+        })
+        const store = freshStore()
+        expect(() => store.emitLocaleToAnalytics('pt-BR')).not.toThrow()
+        expect(store.currentAppLocale()).toBe('pt-BR')
+    })
+})

--- a/src/i18n/app/locale-store.ts
+++ b/src/i18n/app/locale-store.ts
@@ -4,12 +4,31 @@
 // an unsupported value can never leak out.
 
 import Cookies from 'js-cookie'
+import posthog from 'posthog-js'
 import { isCapacitor } from '@/utils/capacitor'
 import { resolveLocale, type AppLocale } from './config'
 
 const LOCALE_KEY = 'app-locale'
 
 let resolution: Promise<AppLocale> | null = null
+let current: AppLocale | null = null
+
+/** Last resolved/persisted locale, or null before startup resolution. */
+export function currentAppLocale(): AppLocale | null {
+    return current
+}
+
+// Locale analytics (TASK-20922): register makes app_locale an event-time super
+// property (person-on-events preserves history); the person property feeds
+// cohorts. The person write is gated on an identified user — an unconditional
+// $set would force person processing for every anonymous visitor under
+// person_profiles: 'identified_only'. Logged-in coverage comes from the
+// identify in authContext.tsx, which also sends app_locale.
+function emitLocaleToAnalytics(locale: AppLocale): void {
+    current = locale
+    posthog.register({ app_locale: locale })
+    if (posthog._isIdentified()) posthog.setPersonProperties({ app_locale: locale })
+}
 
 function navigatorLocale(): AppLocale {
     return resolveLocale(typeof navigator !== 'undefined' ? navigator.language : null)
@@ -41,11 +60,16 @@ async function resolveStartupLocale(): Promise<AppLocale> {
 
 /** Resolves the startup locale once; memoized for the session. */
 export function localeReady(): Promise<AppLocale> {
-    if (!resolution) resolution = resolveStartupLocale()
+    if (!resolution)
+        resolution = resolveStartupLocale().then((locale) => {
+            emitLocaleToAnalytics(locale)
+            return locale
+        })
     return resolution
 }
 
 export function persistLocale(locale: AppLocale): void {
+    emitLocaleToAnalytics(locale)
     if (isCapacitor()) {
         import('@capacitor/preferences')
             .then(({ Preferences }) => Preferences.set({ key: LOCALE_KEY, value: locale }))

--- a/src/i18n/app/locale-store.ts
+++ b/src/i18n/app/locale-store.ts
@@ -13,21 +13,30 @@ const LOCALE_KEY = 'app-locale'
 let resolution: Promise<AppLocale> | null = null
 let current: AppLocale | null = null
 
-/** Last resolved/persisted locale, or null before startup resolution. */
+/** Last locale emitted to analytics (= last applied), or null before startup. */
 export function currentAppLocale(): AppLocale | null {
     return current
 }
 
-// Locale analytics (TASK-20922): register makes app_locale an event-time super
-// property (person-on-events preserves history); the person property feeds
-// cohorts. The person write is gated on an identified user — an unconditional
-// $set would force person processing for every anonymous visitor under
-// person_profiles: 'identified_only'. Logged-in coverage comes from the
-// identify in authContext.tsx, which also sends app_locale.
-function emitLocaleToAnalytics(locale: AppLocale): void {
+// Locale analytics (TASK-20922). AppIntlProvider calls this once the locale is
+// actually rendered — never on a persist whose catalog load failed — so
+// analytics report the language the user saw. register makes app_locale an
+// event-time super property (person-on-events preserves history). The person
+// property ($set) is written only on a real change by an identified user: the
+// startup value reaches the person profile via the identify in authContext.tsx
+// (which sends app_locale), and an unconditional $set would force person
+// processing for every anonymous visitor under 'identified_only'. Analytics
+// must never break i18n, so the posthog calls are fenced.
+export function emitLocaleToAnalytics(locale: AppLocale): void {
+    if (locale === current) return
+    const isChange = current !== null
     current = locale
-    posthog.register({ app_locale: locale })
-    if (posthog._isIdentified()) posthog.setPersonProperties({ app_locale: locale })
+    try {
+        posthog.register({ app_locale: locale })
+        if (isChange && posthog._isIdentified()) posthog.setPersonProperties({ app_locale: locale })
+    } catch {
+        // analytics failure degrades to missing data, never a broken locale
+    }
 }
 
 function navigatorLocale(): AppLocale {
@@ -60,16 +69,11 @@ async function resolveStartupLocale(): Promise<AppLocale> {
 
 /** Resolves the startup locale once; memoized for the session. */
 export function localeReady(): Promise<AppLocale> {
-    if (!resolution)
-        resolution = resolveStartupLocale().then((locale) => {
-            emitLocaleToAnalytics(locale)
-            return locale
-        })
+    if (!resolution) resolution = resolveStartupLocale()
     return resolution
 }
 
 export function persistLocale(locale: AppLocale): void {
-    emitLocaleToAnalytics(locale)
     if (isCapacitor()) {
         import('@capacitor/preferences')
             .then(({ Preferences }) => Preferences.set({ key: LOCALE_KEY, value: locale }))


### PR DESCRIPTION
## Summary
Locale is client-only today (cookie / native Preferences) and never reaches PostHog, so the localization OKR (50% of active ES/PT users using the app in their language) is unmeasurable — verified 2.87M events / 21 days, 100% null. This registers `app_locale` as an event-time super property at startup resolve and on manual locale change, sets the person property for identified users, and mirrors `app_locale` on the identify payload.

## Task
TASK-20922 — https://app.notion.com/p/peanutprotocol/Locale-analytics-emit-app_locale-to-PostHog-3aa838117579814ba602d5db191276da

## Design notes / accepted trade-offs
- `setPersonProperties` is gated on `posthog._isIdentified()`: an unconditional $set would force person processing for every anonymous visitor under `person_profiles: 'identified_only'` (billing + profile inflation). Anonymous coverage still exists via the super property; the identify in authContext carries `app_locale` for the first session.
- `app_locale` is FE-only in the identify payload (the BE mirror in peanut-api-ts identifyUser.ts cannot know the client locale); PostHog $set merges per-key so the BE identify never clobbers it.

## Risks / breaking changes
None functional — analytics-only wiring, no UI or flow changes. No cross-repo impact.

## QA
- `npm run typecheck`, `npm test` (203 suites), `npm run build` — all green locally.
- Manual: load the app → events carry `app_locale`; change language in /settings/language → subsequent events + person property update. Done-when: `app_locale` on live events for all locales (needs prod release).

Screenshots: N/A (no visible change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved locale detection and consistency during app startup and when language preferences are saved.
  * User language preferences are now associated with authenticated sessions when available.
  * Added more reliable locale tracking to support consistent language-related experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->