### PR TITLE
fix(send): keep the send framing past the amount step

### DIFF
--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -143,18 +143,19 @@ export default function WithdrawBankPage() {
         if (sumsubFlow.showWrapper) setShowKycModal(false)
     }, [sumsubFlow.showWrapper])
 
+    // only bank reaches this page, so the bank-specific flag is the right one here
+    const { isBankFromSend: fromSendFlow } = useSendFlowOrigin()
+
     // validate country is supported for bank withdrawals
     useEffect(() => {
         if (country) {
             const countryInfo = getCountryFromPath(country)
             if (!countryInfo || !isBridgeSupportedCountry(countryInfo.id)) {
-                router.replace('/withdraw')
+                router.replace(`/withdraw${fromSendFlow ? '?method=bank' : ''}`)
             }
         }
-    }, [country, router])
+    }, [country, router, fromSendFlow])
 
-    // only bank reaches this page, so the bank-specific flag is the right one here
-    const { isBankFromSend: fromSendFlow } = useSendFlowOrigin()
     const onBack = useSafeBack(fromSendFlow ? '/send' : '/withdraw')
 
     const nonEuroCurrency = countryCurrencyMappings.find(
@@ -178,14 +179,17 @@ export default function WithdrawBankPage() {
         // Skip redirects when on success view — clearing state during navigation
         // would race with router.push('/home') and redirect back to /withdraw
         if (view === 'SUCCESS') return
+        // Both targets keep ?method=bank: land on a bare /withdraw and the step
+        // the user is sent back to silently reverts to withdraw copy.
+        const sendMarker = fromSendFlow ? '?method=bank' : ''
         if (!amountToWithdraw) {
             // If no amount, go back to main page
-            router.replace('/withdraw')
+            router.replace(`/withdraw${sendMarker}`)
         } else if (!bankAccount && amountToWithdraw) {
             // If amount is set but no bank account, go to country method selection
-            router.replace(withdrawCountryUrl(country))
+            router.replace(withdrawCountryUrl(country, sendMarker))
         }
-    }, [bankAccount, router, amountToWithdraw, country, view])
+    }, [bankAccount, router, amountToWithdraw, country, view, fromSendFlow])
 
     const destinationDetails = (account: Account) => {
         // Derive currency + rail from the account's actual type (GB→GBP, IBAN→EUR,
@@ -539,7 +543,7 @@ export default function WithdrawBankPage() {
                             disabled={isLoading || !bankAccount || !!balanceErrorMessage}
                             className="w-full"
                         >
-                            {tNav('withdraw')}
+                            {tNav(fromSendFlow ? 'send' : 'withdraw')}
                         </Button>
                     )}
                     {submittedTxHash ? (

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -48,6 +48,7 @@ import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { withdrawCountryUrl } from '@/utils/native-routes'
 import { useSafeBack } from '@/hooks/useSafeBack'
+import { useSendFlowOrigin } from '@/hooks/useSendFlowOrigin'
 import { useTranslations } from 'next-intl'
 
 type View = 'INITIAL' | 'SUCCESS'
@@ -152,9 +153,8 @@ export default function WithdrawBankPage() {
         }
     }, [country, router])
 
-    // check if we came from send flow - using method param to detect (only bank goes through this page)
-    const methodParam = searchParams.get('method')
-    const fromSendFlow = methodParam === 'bank'
+    // only bank reaches this page, so the bank-specific flag is the right one here
+    const { isBankFromSend: fromSendFlow } = useSendFlowOrigin()
     const onBack = useSafeBack(fromSendFlow ? '/send' : '/withdraw')
 
     const nonEuroCurrency = countryCurrencyMappings.find(
@@ -448,6 +448,7 @@ export default function WithdrawBankPage() {
                         recipientName={bankAccount?.identifier ?? t('bank.bankAccount')}
                         amount={amountToWithdraw}
                         tokenSymbol={PEANUT_WALLET_TOKEN_SYMBOL}
+                        isFromSendFlow={fromSendFlow}
                     />
 
                     {/* Warning for non-EUR SEPA countries (not UK — UK uses Faster Payments with GBP) */}
@@ -558,6 +559,7 @@ export default function WithdrawBankPage() {
             {view === 'SUCCESS' && (
                 <PaymentSuccessView
                     isWithdrawFlow
+                    isFromSendFlow={fromSendFlow}
                     currencyAmount={`$${amountToWithdraw}`}
                     message={bankAccount ? shortenStringLong(bankAccount.identifier.toUpperCase()) : ''}
                     points={pointsData?.estimatedPoints}

--- a/src/app/(mobile-ui)/withdraw/__tests__/withdraw-states.test.tsx
+++ b/src/app/(mobile-ui)/withdraw/__tests__/withdraw-states.test.tsx
@@ -407,6 +407,20 @@ describe('GROUP 3: Amount Validation', () => {
         expect(mockRouterPush).toHaveBeenCalledWith('/withdraw/crypto')
     })
 
+    test('Crypto send forwards the send marker to the next step', () => {
+        // `?method=` is the ONLY send-vs-withdraw signal. Drop it on this hop and
+        // every screen after the amount step reverts to withdraw copy — the user
+        // picks "Send -> Exchange or Wallet" and the next screen says
+        // "You're withdrawing". Losing it here is the original bug.
+        mockWithdrawFlow.selectedMethod = { type: 'crypto' }
+        mockWithdrawFlow.amountToWithdraw = '25'
+
+        renderWithdraw({ method: 'crypto' })
+
+        fireEvent.click(screen.getByText('Continue'))
+        expect(mockRouterPush).toHaveBeenCalledWith('/withdraw/crypto?method=crypto')
+    })
+
     test('Bank withdrawal keeps the $1 minimum for sub-$1 amounts', async () => {
         mockWithdrawFlow.selectedMethod = { type: 'bridge', countryPath: 'us' }
         mockWithdrawFlow.amountToWithdraw = '0.5'

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -49,8 +49,11 @@ export default function WithdrawCryptoPage() {
     // Send → Exchange or Wallet lands here as /withdraw/crypto?method=crypto.
     // Every back/redirect target below keeps the marker, or the amount step it
     // returns to silently reverts to withdraw copy.
-    const { isFromSendFlow } = useSendFlowOrigin()
-    const amountStepHref = isFromSendFlow ? '/withdraw?method=crypto' : '/withdraw'
+    // Forward the marker verbatim rather than assuming crypto: entering as
+    // /withdraw?method=bank and then picking Crypto lands here as method=bank,
+    // and rewriting it to crypto would change the amount step's back behaviour.
+    const { isFromSendFlow, sendFlowMethod } = useSendFlowOrigin()
+    const amountStepHref = isFromSendFlow ? `/withdraw?method=${sendFlowMethod}` : '/withdraw'
     const onBack = useSafeBack(amountStepHref)
     const { address, sendTransactions, sendMoney, spendableBalance } = useWallet()
     const { resetTokenContextProvider } = useContext(tokenSelectorContext)

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -25,6 +25,7 @@ import { useRouter } from 'next/navigation'
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { captureMessage } from '@sentry/nextjs'
 import { useSafeBack } from '@/hooks/useSafeBack'
+import { useSendFlowOrigin } from '@/hooks/useSendFlowOrigin'
 import type { Address, Hex, TransactionReceipt } from 'viem'
 import { parseUnits } from 'viem'
 import { Slider } from '@/components/Slider'
@@ -45,7 +46,12 @@ export default function WithdrawCryptoPage() {
     const t = useTranslations('withdraw')
     const tNav = useTranslations('navigation')
     const toFriendlyError = useFriendlyError()
-    const onBack = useSafeBack('/withdraw')
+    // Send → Exchange or Wallet lands here as /withdraw/crypto?method=crypto.
+    // Every back/redirect target below keeps the marker, or the amount step it
+    // returns to silently reverts to withdraw copy.
+    const { isFromSendFlow } = useSendFlowOrigin()
+    const amountStepHref = isFromSendFlow ? '/withdraw?method=crypto' : '/withdraw'
+    const onBack = useSafeBack(amountStepHref)
     const { address, sendTransactions, sendMoney, spendableBalance } = useWallet()
     const { resetTokenContextProvider } = useContext(tokenSelectorContext)
     const {
@@ -582,8 +588,8 @@ export default function WithdrawCryptoPage() {
     // which would override the router.push('/home') in handleDone
     const needsAmountRedirect = !amountToWithdraw && currentView !== 'STATUS'
     useEffect(() => {
-        if (needsAmountRedirect) router.push('/withdraw')
-    }, [needsAmountRedirect, router])
+        if (needsAmountRedirect) router.push(amountStepHref)
+    }, [needsAmountRedirect, router, amountStepHref])
 
     if (needsAmountRedirect) {
         return <PeanutLoading />
@@ -597,6 +603,7 @@ export default function WithdrawCryptoPage() {
                     onReview={handleSetupReview}
                     onBack={onBack}
                     isProcessing={isPreparingReview}
+                    isFromSendFlow={isFromSendFlow}
                 />
             )}
 
@@ -618,17 +625,23 @@ export default function WithdrawCryptoPage() {
                     showHighFeeWarning={showHighFeeWarning}
                     insufficientBalance={insufficientForFee}
                     belowMinimumMessage={belowMinimumMessage}
+                    isFromSendFlow={isFromSendFlow}
                 />
             )}
 
             {currentView === 'STATUS' && withdrawData && chargeDetails && (
                 <>
                     <PaymentSuccessView
-                        headerTitle={tNav('withdraw')}
+                        headerTitle={isFromSendFlow ? tNav('send') : tNav('withdraw')}
                         recipientType="ADDRESS"
                         type="SEND"
                         amount={usdAmount}
+                        // Stays true even from the send flow: it also suppresses the
+                        // recipient render (no recipientName is passed here) and picks
+                        // the "to" prefix, both correct for a send to an address.
+                        // Only the title needs the send framing.
                         isWithdrawFlow={true}
+                        isFromSendFlow={isFromSendFlow}
                         redirectTo="/home"
                         chargeDetails={chargeDetails}
                         paymentDetails={paymentDetails}

--- a/src/app/(mobile-ui)/withdraw/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/page.tsx
@@ -11,6 +11,7 @@ import { useWallet } from '@/hooks/wallet/useWallet'
 import { tokenSelectorContext } from '@/context/tokenSelector.context'
 import { getCountryFromAccount, getCountryFromPath, getMinimumAmount } from '@/utils/bridge.utils'
 import useGetExchangeRate from '@/hooks/useGetExchangeRate'
+import { useSendFlowOrigin } from '@/hooks/useSendFlowOrigin'
 import { AccountType } from '@/interfaces/interfaces'
 import { useRouter, useSearchParams } from 'next/navigation'
 import React, { useCallback, useContext, useEffect, useMemo, useState, useRef } from 'react'
@@ -36,9 +37,7 @@ export default function WithdrawPage() {
 
     // check if coming from send flow based on method query param
     const methodParam = searchParams.get('method')
-    const isFromSendFlow = !!(methodParam && ['bank', 'crypto'].includes(methodParam))
-    const isCryptoFromSend = methodParam === 'crypto' && isFromSendFlow
-    const isBankFromSend = methodParam === 'bank' && isFromSendFlow
+    const { isFromSendFlow, isCryptoFromSend, isBankFromSend } = useSendFlowOrigin()
 
     // native app passes country as query param instead of path segment
     const countryFromQuery = searchParams.get('country')

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -56,7 +56,10 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
 
     // check if coming from send flow and what type
     const methodParam = searchParams.get('method')
-    const { isBankFromSend } = useSendFlowOrigin()
+    // this list also serves the add-money flow, which navigates with its own
+    // ?method=bank — so the marker alone doesn't mean "send". Same guard as
+    // AddWithdrawRouterView.
+    const isBankFromSend = useSendFlowOrigin().isBankFromSend && flow === 'withdraw'
 
     // hooks
     const { deviceType } = useDeviceType()

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -8,6 +8,7 @@ import AvatarWithBadge from '@/components/Profile/AvatarWithBadge'
 import { getColorForUsername } from '@/utils/color.utils'
 import Image, { type StaticImageData } from 'next/image'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
+import { useSendFlowOrigin } from '@/hooks/useSendFlowOrigin'
 import { useSafeBack } from '@/hooks/useSafeBack'
 import { withdrawBankUrl, rewriteMethodPath } from '@/utils/native-routes'
 import { isCapacitor } from '@/utils/capacitor'
@@ -55,8 +56,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
 
     // check if coming from send flow and what type
     const methodParam = searchParams.get('method')
-    const isFromSendFlow = !!(methodParam && ['bank', 'crypto'].includes(methodParam))
-    const isBankFromSend = methodParam === 'bank' && isFromSendFlow
+    const { isBankFromSend } = useSendFlowOrigin()
 
     // hooks
     const { deviceType } = useDeviceType()

--- a/src/components/AddWithdraw/AddWithdrawRouterView.tsx
+++ b/src/components/AddWithdraw/AddWithdrawRouterView.tsx
@@ -9,6 +9,7 @@ import {
     getFromLocalStorage,
 } from '@/utils/general.utils'
 import { useRouter, useSearchParams } from 'next/navigation'
+import { useSendFlowOrigin } from '@/hooks/useSendFlowOrigin'
 import { addMoneyCountryUrl, withdrawCountryUrl, rewriteMethodPath } from '@/utils/native-routes'
 import { type FC, useEffect, useRef, useState, useTransition, useCallback } from 'react'
 import { useUserStore } from '@/redux/hooks'
@@ -82,7 +83,8 @@ export const AddWithdrawRouterView: FC<AddWithdrawRouterViewProps> = ({
 
     // check if coming from send flow
     const methodParam = searchParams.get('method')
-    const isBankFromSend = methodParam === 'bank' && flow === 'withdraw'
+    // this view also serves the add-money flow, so the flow guard stays local
+    const isBankFromSend = useSendFlowOrigin().isBankFromSend && flow === 'withdraw'
 
     // determine if we should show the full list of methods (countries/crypto) instead of the default view
     let shouldShowAllMethods = flow === 'withdraw' ? showAllWithdrawMethods : localShowAllMethods

--- a/src/components/AddWithdraw/DynamicBankAccountForm.tsx
+++ b/src/components/AddWithdraw/DynamicBankAccountForm.tsx
@@ -193,7 +193,8 @@ export const DynamicBankAccountForm = forwardRef<{ handleSubmit: () => void }, D
                 // Skip adding account if the account already exists for the logged in user
                 if (existingAccount) {
                     setSelectedBankAccount(existingAccount)
-                    router.push(withdrawBankUrl(country))
+                    // keep the send marker, or the review screen it lands on reverts to withdraw copy
+                    router.push(withdrawBankUrl(country, framedAsSend ? '?method=bank' : ''))
                     return
                 }
 

--- a/src/components/AddWithdraw/DynamicBankAccountForm.tsx
+++ b/src/components/AddWithdraw/DynamicBankAccountForm.tsx
@@ -442,8 +442,10 @@ export const DynamicBankAccountForm = forwardRef<{ handleSubmit: () => void }, D
                     recipientName={country}
                     amount={amountToWithdraw}
                     tokenSymbol={PEANUT_WALLET_TOKEN_SYMBOL}
-                    isFromSendFlow={framedAsSend}
                     {...actionDetailsProps}
+                    // after the spread: the flow-guarded value stays authoritative even
+                    // though actionDetailsProps is a Partial of the card's full props
+                    isFromSendFlow={framedAsSend}
                 />
 
                 <div className="space-y-4">

--- a/src/components/AddWithdraw/DynamicBankAccountForm.tsx
+++ b/src/components/AddWithdraw/DynamicBankAccountForm.tsx
@@ -8,6 +8,7 @@ import BaseInput from '@/components/0_Bruddle/BaseInput'
 import BaseSelect, { type BaseSelectOption } from '@/components/0_Bruddle/BaseSelect'
 import { BRIDGE_ALPHA3_TO_ALPHA2, ALL_COUNTRIES_ALPHA3_TO_ALPHA2 } from '@/components/AddMoney/consts'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
+import { useSendFlowOrigin } from '@/hooks/useSendFlowOrigin'
 import {
     validateIban,
     validateBankAccount,
@@ -103,6 +104,9 @@ export const DynamicBankAccountForm = forwardRef<{ handleSubmit: () => void }, D
         // useParams() is empty there — fall back to searchParams and finally the
         // `country` prop so this never derefs undefined (white-screen crash).
         const searchParams = useSearchParams()
+        // This form also serves the claim flow, where the send marker is meaningless.
+        const { isFromSendFlow } = useSendFlowOrigin()
+        const framedAsSend = isFromSendFlow && flow === 'withdraw'
         const { amountToWithdraw, setSelectedBankAccount } = useWithdrawFlow()
         const router = useRouter()
         const savedAccounts = useSavedAccounts()
@@ -437,6 +441,7 @@ export const DynamicBankAccountForm = forwardRef<{ handleSubmit: () => void }, D
                     recipientName={country}
                     amount={amountToWithdraw}
                     tokenSymbol={PEANUT_WALLET_TOKEN_SYMBOL}
+                    isFromSendFlow={framedAsSend}
                     {...actionDetailsProps}
                 />
 

--- a/src/components/Global/PeanutActionDetailsCard/__tests__/index.test.tsx
+++ b/src/components/Global/PeanutActionDetailsCard/__tests__/index.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * PeanutActionDetailsCard — title copy.
+ *
+ * REGRESSION GUARD. This card's WITHDRAW title has been flipped in opposite
+ * directions twice by two different engineers:
+ *
+ *   abd71b882 (2026-03-20) "you're withdrawing" -> "you're sending"
+ *   d532b6a65 (2026-07-13) "You're sending"     -> "You're withdrawing"
+ *
+ * Both were right about the flow in front of them: Send -> Exchange or Wallet /
+ * Bank navigates into the withdraw routes, so this one card serves two user
+ * intents. With a single transactionType it can only ever be correct for one of
+ * them, and the word gets flipped again. `isFromSendFlow` is that missing
+ * discriminator — if you are here because the copy "looks wrong", fix the caller
+ * that fails to pass it, not the word.
+ */
+import { screen } from '@testing-library/react'
+import { renderWithIntl } from '@/test-utils/intl'
+import PeanutActionDetailsCard from '../index'
+
+jest.mock('next/image', () => ({
+    __esModule: true,
+    default: (props: any) => {
+        const { priority, layout, objectFit, fill, ...rest } = props
+        return <img {...rest} />
+    },
+}))
+
+const baseProps = {
+    recipientType: 'USERNAME' as const,
+    recipientName: '',
+    amount: '50.00',
+    tokenSymbol: 'USDC',
+}
+
+describe('PeanutActionDetailsCard — withdraw vs send framing', () => {
+    describe.each(['WITHDRAW', 'WITHDRAW_BANK_ACCOUNT'] as const)('%s', (transactionType) => {
+        it('reads as a withdrawal by default', () => {
+            renderWithIntl(<PeanutActionDetailsCard {...baseProps} transactionType={transactionType} />)
+
+            expect(screen.getByText(/You're withdrawing/i)).toBeInTheDocument()
+            expect(screen.queryByText(/You're sending/i)).not.toBeInTheDocument()
+        })
+
+        it('reads as a send when reached through the send flow', () => {
+            renderWithIntl(<PeanutActionDetailsCard {...baseProps} transactionType={transactionType} isFromSendFlow />)
+
+            expect(screen.getByText(/You're sending/i)).toBeInTheDocument()
+            expect(screen.queryByText(/You're withdrawing/i)).not.toBeInTheDocument()
+        })
+    })
+
+    it('leaves non-withdraw transaction types alone', () => {
+        // ADD_MONEY has no send framing — the flag must not leak across the map.
+        renderWithIntl(<PeanutActionDetailsCard {...baseProps} transactionType="ADD_MONEY" isFromSendFlow />)
+
+        expect(screen.getByText(/You're adding/i)).toBeInTheDocument()
+    })
+})

--- a/src/components/Global/PeanutActionDetailsCard/index.tsx
+++ b/src/components/Global/PeanutActionDetailsCard/index.tsx
@@ -51,6 +51,16 @@ export interface PeanutActionDetailsCardProps {
     timerError?: string | null
     isLoading?: boolean
     logo?: StaticImageData
+    /**
+     * A withdraw the user reached through the send flow (Send → Exchange or
+     * Wallet / Bank). Mechanically identical to a withdraw — only the verb
+     * differs, so this branches the title and nothing else.
+     *
+     * Without it this card can only ever be right for one of its two callers,
+     * which is why the copy has already been flipped in opposite directions
+     * twice (abd71b882 → "sending", d532b6a65 → "withdrawing").
+     */
+    isFromSendFlow?: boolean
 }
 
 export default function PeanutActionDetailsCard({
@@ -75,6 +85,7 @@ export default function PeanutActionDetailsCard({
     currencySymbol,
     isLoading = false,
     logo,
+    isFromSendFlow = false,
 }: PeanutActionDetailsCardProps) {
     const t = useTranslations('global')
     const renderRecipient = () => {
@@ -112,7 +123,9 @@ export default function PeanutActionDetailsCard({
         if (transactionType === 'ADD_MONEY' || transactionType === 'ADD_MONEY_BANK_ACCOUNT')
             title = t('peanutActionDetailsCard.youreAdding')
         if (transactionType === 'WITHDRAW' || transactionType === 'WITHDRAW_BANK_ACCOUNT')
-            title = t('peanutActionDetailsCard.youreWithdrawing')
+            title = isFromSendFlow
+                ? t('peanutActionDetailsCard.youreSending')
+                : t('peanutActionDetailsCard.youreWithdrawing')
         if (transactionType === 'CLAIM_LINK_BANK_ACCOUNT') {
             if (viewType === 'SUCCESS') {
                 title = t('peanutActionDetailsCard.youWillReceive')

--- a/src/components/Withdraw/views/Confirm.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Confirm.withdraw.view.tsx
@@ -62,6 +62,8 @@ interface WithdrawConfirmViewProps {
      * CTA and shows the message.
      */
     belowMinimumMessage?: string | null
+    /** Reached via Send → Exchange or Wallet, so the copy says send, not withdraw. */
+    isFromSendFlow?: boolean
 }
 
 export default function ConfirmWithdrawView({
@@ -82,6 +84,7 @@ export default function ConfirmWithdrawView({
     showHighFeeWarning = false,
     insufficientBalance = false,
     belowMinimumMessage = null,
+    isFromSendFlow = false,
 }: WithdrawConfirmViewProps) {
     const t = useTranslations('withdraw')
     const tNav = useTranslations('navigation')
@@ -122,7 +125,7 @@ export default function ConfirmWithdrawView({
 
     return (
         <div className="space-y-8">
-            <NavHeader title={tNav('withdraw')} onPrev={onBack} />
+            <NavHeader title={isFromSendFlow ? tNav('send') : tNav('withdraw')} onPrev={onBack} />
 
             <div className="space-y-4 pb-5">
                 <PeanutActionDetailsCard
@@ -132,6 +135,7 @@ export default function ConfirmWithdrawView({
                     recipientName={''}
                     amount={formatAmount(amount)}
                     tokenSymbol="USDC"
+                    isFromSendFlow={isFromSendFlow}
                 />
 
                 <Card className="rounded-sm">
@@ -225,7 +229,9 @@ export default function ConfirmWithdrawView({
                         loading={isProcessing}
                         className="w-full"
                     >
-                        {isProcessing ? tLoading('withdrawing') : tNav('withdraw')}
+                        {isProcessing
+                            ? tLoading(isFromSendFlow ? 'sending' : 'withdrawing')
+                            : tNav(isFromSendFlow ? 'send' : 'withdraw')}
                     </Button>
                 )}
 

--- a/src/components/Withdraw/views/Initial.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Initial.withdraw.view.tsx
@@ -23,9 +23,17 @@ interface InitialWithdrawViewProps {
     onReview: (data: { token: ITokenPriceData; chain: ChainWithTokens; address: string }) => void
     onBack?: () => void
     isProcessing?: boolean
+    /** Reached via Send → Exchange or Wallet, so the copy says send, not withdraw. */
+    isFromSendFlow?: boolean
 }
 
-export default function InitialWithdrawView({ amount, onReview, onBack, isProcessing }: InitialWithdrawViewProps) {
+export default function InitialWithdrawView({
+    amount,
+    onReview,
+    onBack,
+    isProcessing,
+    isFromSendFlow = false,
+}: InitialWithdrawViewProps) {
     const { usdAmount, withdrawData } = useWithdrawFlow()
     const t = useTranslations('withdraw')
     const tNav = useTranslations('navigation')
@@ -169,7 +177,7 @@ export default function InitialWithdrawView({ amount, onReview, onBack, isProces
         // flex/gap shell per the page-layout rules — space-y on the outer div
         // conflicts with centering and clipped the CTA on short viewports
         <div className="flex min-h-[inherit] flex-col gap-8">
-            <NavHeader title={tNav('withdraw')} onPrev={onBack || defaultOnBack} />
+            <NavHeader title={isFromSendFlow ? tNav('send') : tNav('withdraw')} onPrev={onBack || defaultOnBack} />
 
             <div className="space-y-4">
                 <PeanutActionDetailsCard
@@ -179,6 +187,7 @@ export default function InitialWithdrawView({ amount, onReview, onBack, isProces
                     recipientName={''}
                     amount={`${formatAmount(parseFloat(usdAmount || amount))}`}
                     tokenSymbol="USDC"
+                    isFromSendFlow={isFromSendFlow}
                 />
 
                 <TokenSelector viewType="withdraw" />

--- a/src/features/payments/shared/components/PaymentSuccessView.tsx
+++ b/src/features/payments/shared/components/PaymentSuccessView.tsx
@@ -64,6 +64,13 @@ type DirectSuccessViewProps = {
     currencyAmount?: string
     isExternalWalletFlow?: boolean
     isWithdrawFlow?: boolean
+    /**
+     * A withdraw the user reached through the send flow. Narrow on purpose: it
+     * only reframes the title. `isWithdrawFlow` still governs layout (it
+     * suppresses the recipient render and picks the "to" prefix), both of which
+     * remain correct for a send to an address.
+     */
+    isFromSendFlow?: boolean
     redirectTo?: string
     // When true, the "Done"/cancel navigation replaces the current history entry instead of
     // pushing. Use for terminal flows (e.g. deposit success) so browser/device back doesn't
@@ -90,6 +97,7 @@ const PaymentSuccessView = ({
     currencyAmount,
     isExternalWalletFlow,
     isWithdrawFlow,
+    isFromSendFlow,
     redirectTo = '/home',
     replaceOnDone = false,
     onComplete,
@@ -262,7 +270,7 @@ const PaymentSuccessView = ({
 
     const getTitle = () => {
         if (isExternalWalletFlow) return t('success.addedExternal')
-        if (isWithdrawFlow) return t('success.withdrew')
+        if (isWithdrawFlow) return isFromSendFlow ? t('success.justSent') : t('success.withdrew')
         if (type === 'SEND') return t('success.sent')
         if (type === 'REQUEST') return t('success.requested')
         if (type === 'DEPOSIT') return t('success.added')

--- a/src/hooks/useSendFlowOrigin.test.ts
+++ b/src/hooks/useSendFlowOrigin.test.ts
@@ -1,0 +1,55 @@
+/**
+ * useSendFlowOrigin — the single owner of the send-vs-withdraw marker.
+ *
+ * The send flow has no destination screens of its own; it navigates into the
+ * withdraw routes carrying `?method=`. This rule used to be re-derived in four
+ * places with three different definitions, which is exactly how the copy drifted
+ * apart between consecutive screens.
+ */
+import { renderHook } from '@testing-library/react'
+import { useSendFlowOrigin } from './useSendFlowOrigin'
+
+const mockSearchParams = new Map<string, string>()
+
+jest.mock('next/navigation', () => ({
+    useSearchParams: () => ({
+        get: (key: string) => mockSearchParams.get(key) ?? null,
+    }),
+}))
+
+describe('useSendFlowOrigin', () => {
+    beforeEach(() => mockSearchParams.clear())
+
+    it('flags a crypto send (Send → Exchange or Wallet)', () => {
+        mockSearchParams.set('method', 'crypto')
+        expect(renderHook(() => useSendFlowOrigin()).result.current).toEqual({
+            isFromSendFlow: true,
+            isBankFromSend: false,
+            isCryptoFromSend: true,
+        })
+    })
+
+    it('flags a bank send (Send → Bank)', () => {
+        mockSearchParams.set('method', 'bank')
+        expect(renderHook(() => useSendFlowOrigin()).result.current).toEqual({
+            isFromSendFlow: true,
+            isBankFromSend: true,
+            isCryptoFromSend: false,
+        })
+    })
+
+    it('treats a bare /withdraw as a real withdraw', () => {
+        expect(renderHook(() => useSendFlowOrigin()).result.current.isFromSendFlow).toBe(false)
+    })
+
+    it('does not treat an unrecognised method as a send', () => {
+        // manteca rails (pix, mercado-pago) route to their own page and are not
+        // covered by this marker yet — they must not silently read as sends.
+        mockSearchParams.set('method', 'pix')
+        expect(renderHook(() => useSendFlowOrigin()).result.current).toEqual({
+            isFromSendFlow: false,
+            isBankFromSend: false,
+            isCryptoFromSend: false,
+        })
+    })
+})

--- a/src/hooks/useSendFlowOrigin.test.ts
+++ b/src/hooks/useSendFlowOrigin.test.ts
@@ -26,6 +26,7 @@ describe('useSendFlowOrigin', () => {
             isFromSendFlow: true,
             isBankFromSend: false,
             isCryptoFromSend: true,
+            sendFlowMethod: 'crypto',
         })
     })
 
@@ -35,11 +36,21 @@ describe('useSendFlowOrigin', () => {
             isFromSendFlow: true,
             isBankFromSend: true,
             isCryptoFromSend: false,
+            sendFlowMethod: 'bank',
         })
     })
 
     it('treats a bare /withdraw as a real withdraw', () => {
-        expect(renderHook(() => useSendFlowOrigin()).result.current.isFromSendFlow).toBe(false)
+        const { result } = renderHook(() => useSendFlowOrigin())
+        expect(result.current.isFromSendFlow).toBe(false)
+        expect(result.current.sendFlowMethod).toBeNull()
+    })
+
+    it('forwards the marker verbatim so downstream never rewrites bank to crypto', () => {
+        // /withdraw?method=bank → pick Crypto → lands on /withdraw/crypto?method=bank.
+        // Hard-coding 'crypto' on the way back would change the amount step's back behaviour.
+        mockSearchParams.set('method', 'bank')
+        expect(renderHook(() => useSendFlowOrigin()).result.current.sendFlowMethod).toBe('bank')
     })
 
     it('does not treat an unrecognised method as a send', () => {
@@ -50,6 +61,7 @@ describe('useSendFlowOrigin', () => {
             isFromSendFlow: false,
             isBankFromSend: false,
             isCryptoFromSend: false,
+            sendFlowMethod: null,
         })
     })
 })

--- a/src/hooks/useSendFlowOrigin.ts
+++ b/src/hooks/useSendFlowOrigin.ts
@@ -1,0 +1,22 @@
+'use client'
+
+import { useSearchParams } from 'next/navigation'
+
+/**
+ * The send flow has no destination screens of its own — SendRouter navigates
+ * into the withdraw routes (`/withdraw?method=crypto`, `/withdraw?method=bank`).
+ * `?method=` is therefore the ONLY signal that the user framed this as a send,
+ * and it has to survive every hop for the copy to stay honest.
+ *
+ * This rule used to be re-derived in four places with three different
+ * definitions, which is how the copy drifted apart between screens. One owner.
+ */
+export function useSendFlowOrigin() {
+    const method = useSearchParams().get('method')
+
+    return {
+        isFromSendFlow: method === 'bank' || method === 'crypto',
+        isBankFromSend: method === 'bank',
+        isCryptoFromSend: method === 'crypto',
+    }
+}

--- a/src/hooks/useSendFlowOrigin.ts
+++ b/src/hooks/useSendFlowOrigin.ts
@@ -18,5 +18,7 @@ export function useSendFlowOrigin() {
         isFromSendFlow: method === 'bank' || method === 'crypto',
         isBankFromSend: method === 'bank',
         isCryptoFromSend: method === 'crypto',
+        /** The raw marker, for callers that must forward it verbatim rather than re-derive it. */
+        sendFlowMethod: method === 'bank' || method === 'crypto' ? method : null,
     }
 }

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -643,7 +643,8 @@
         "loggingIn": "Logging in",
         "loggingOut": "Logging out",
         "paying": "Paying",
-        "withdrawing": "Withdrawing"
+        "withdrawing": "Withdrawing",
+        "sending": "Sending"
     },
     "paymentLoading": {
         "cracking": "Cracking",
@@ -770,6 +771,7 @@
         "success": {
             "addedExternal": "You successfully added",
             "withdrew": "You just withdrew",
+            "justSent": "You just sent",
             "sent": "You sent ",
             "requested": "You requested ",
             "added": "You added ",
@@ -2672,6 +2674,7 @@
             "youJustClaimed": "You just claimed",
             "youreAdding": "You're adding",
             "youreWithdrawing": "You're withdrawing",
+            "youreSending": "You're sending",
             "youWillReceive": "You will receive",
             "youreAboutToReceive": "You're about to receive"
         },

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -643,7 +643,8 @@
         "loggingIn": "Iniciando sesión",
         "loggingOut": "Cerrando sesión",
         "paying": "Pagando",
-        "withdrawing": "Retirando"
+        "withdrawing": "Retirando",
+        "sending": "Enviando"
     },
     "paymentLoading": {
         "cracking": "Abriendo maníes",
@@ -770,6 +771,7 @@
         "success": {
             "addedExternal": "Agregaste con éxito",
             "withdrew": "Acabas de retirar",
+            "justSent": "Acabas de enviar",
             "sent": "Enviaste ",
             "requested": "Solicitaste ",
             "added": "Agregaste ",
@@ -2672,6 +2674,7 @@
             "youJustClaimed": "Acabas de reclamar",
             "youreAdding": "Estás agregando",
             "youreWithdrawing": "Estás retirando",
+            "youreSending": "Estás enviando",
             "youWillReceive": "Recibirás",
             "youreAboutToReceive": "Estás por recibir"
         },

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -643,7 +643,8 @@
         "loggingIn": "Entrando",
         "loggingOut": "Saindo",
         "paying": "Pagando",
-        "withdrawing": "Sacando"
+        "withdrawing": "Sacando",
+        "sending": "Enviando"
     },
     "paymentLoading": {
         "cracking": "Quebrando a casca",
@@ -770,6 +771,7 @@
         "success": {
             "addedExternal": "Você adicionou com sucesso",
             "withdrew": "Você acabou de sacar",
+            "justSent": "Você acabou de enviar",
             "sent": "Você enviou ",
             "requested": "Você solicitou ",
             "added": "Você adicionou ",
@@ -2672,6 +2674,7 @@
             "youJustClaimed": "Você acabou de resgatar",
             "youreAdding": "Você está adicionando",
             "youreWithdrawing": "Você está sacando",
+            "youreSending": "Você está enviando",
             "youWillReceive": "Você vai receber",
             "youreAboutToReceive": "Você está prestes a receber"
         },


### PR DESCRIPTION
## Summary

Pick **Send → Exchange or Wallet**, enter an amount, and the next screen says **"You're withdrawing"**.

Send has no destination screens of its own — `SendRouter` navigates into the withdraw routes:

```ts
case 'exchange-or-wallet': router.push('/withdraw?method=crypto')
case 'bank':               router.push('/withdraw?method=bank')
```

`?method=` is therefore the **only** signal that the user framed this as a send. `/withdraw` honours it (NavHeader "Send", "Amount to send") and forwards it to `/withdraw/crypto?method=crypto` — but that page never called `useSearchParams()`. The marker arrived and was dropped, so every screen after the amount step reverted to withdraw copy. That's what makes it jarring: the screen *before* says Send, the screen after says Withdrawing.

## Why this isn't a one-word fix

`PeanutActionDetailsCard` maps one `transactionType` to one title, and `WITHDRAW` is genuinely *both* a withdrawal and a send depending on how the user arrived. So the line has already been flipped in opposite directions twice:

| Commit | Author | Date | Change |
|---|---|---|---|
| `abd71b882` | kushagrasarathe | 2026-03-20 | "you're withdrawing" → **"you're sending"** |
| `d532b6a65` | 0xkkonrad | 2026-07-13 | "You're sending" → **"You're withdrawing"** |

`d532b6a65` names the seam exactly — *"the frame is named by user intent while the card was named by the underlying mechanism"* — and then picks a side. Both engineers were right about the flow in front of them. Flipping it a third time would re-break the real withdraw flow and get flipped again. This PR adds the discriminator that was missing instead.

## Design notes / accepted trade-offs

- **`isFromSendFlow` is a presentation flag, not a new `transactionType`.** The transaction really *is* a withdraw; only the verb differs. A new union member would have forced matching edits in `getIcon` / `getAvatarIcon` / `getAvatarBackgroundColor` / `getAvatarTextColor` purely to reproduce identical visuals — `arrow-up` and `wallet-outline` are already right for both framings. One ternary also covers `WITHDRAW_BANK_ACCOUNT`, which is why the bank path came nearly free.
- **`PaymentSuccessView` keeps `isWithdrawFlow={true}`.** Tempting to flip it, but it also suppresses the recipient render (this caller passes no `recipientName`, so flipping renders `<AddressLink>` with an undefined address) and selects the **"to"** prefix over "for" — both correct for a send to an address. Only the title needed reframing, so `isFromSendFlow` is deliberately narrow.
- **`useSendFlowOrigin` replaces four copies of the marker rule** that had drifted into three different definitions (`['bank','crypto'].includes(m)` vs `m === 'bank'` vs `m === 'bank' && flow === 'withdraw'`). That drift is how the screens came apart. Each call site keeps its own local guard, so this is a **zero-behaviour-change** consolidation.
- **Back/redirect targets now preserve `?method=`.** Otherwise back from the recipient screen lands on a bare `/withdraw` and the amount step silently reverts to withdraw copy — the same bug one hop earlier.

**Smell verdict — adds none; reveals one, deliberately not fixed here.** This PR gives the
marker a single *reader* (`useSendFlowOrigin`), but nothing owns *writing* it: the
`?method=…` query string is now hand-built at six call sites (three pre-existing, three
added here). A `sendFlowQuery()` writer alongside the hook would close that, but doing it
properly means editing the three pre-existing sites too — scope creep on a copy fix. The
three new sites deliberately match the surrounding style, so this is not made worse.
Worth a small follow-up, and it would be the natural companion to the deferred Manteca work.

## Risks / breaking changes

**Low — copy and one optional prop only.** No route, ledger, transaction, or backend behaviour is touched. `isFromSendFlow` defaults to `false` everywhere, so every existing caller keeps today's wording. No cross-repo action needed.

The one behaviour worth reviewing: back-navigation targets from `/withdraw/crypto` now carry `?method=crypto` when the user came from send.

## QA

- **Send → Exchange or Wallet** → amount → recipient / confirm / CTA / success all read **Send** / **You're sending**.
- **Send → Bank** → same, end to end.
- **Regression:** `/withdraw` directly (no `?method=`) still reads **Withdraw** / **You're withdrawing** everywhere — this is the half `d532b6a65` was protecting.
- Success screen still reads "**to** 0x…", not "for".

Gate: prettier ✅ · typecheck ✅ · 206 suites / 2647 tests ✅ · `next build` ✅ · eslint 0 new errors (5 remaining warnings are pre-existing `exhaustive-deps` in touched files).

### Tests

- `src/hooks/useSendFlowOrigin.test.ts` — the marker rule, incl. that an unrecognised `method` (e.g. `pix`) must **not** read as a send.
- `src/components/Global/PeanutActionDetailsCard/__tests__/index.test.tsx` — the regression guard against the ping-pong, covering both `WITHDRAW` and `WITHDRAW_BANK_ACCOUNT` in both framings. Verified non-vacuous by mutation: removing the fix fails exactly the two send assertions.
- `withdraw-states.test.tsx` — asserts the `?method=crypto` marker survives the Continue hop, which is the hop that dropped it.

## Out of scope

**Manteca (Pix / Mercado Pago)** — reached from Send → Pix / Mercado Pago and has the identical defect, but `withdraw/manteca/page.tsx` never reads `?method=` at all and carries ~6 hardcoded withdraw strings plus its own success screen. Deferred deliberately; `useSendFlowOrigin` makes it a small follow-up.

---

## Screenshots

Captured against a **real local sandbox** 

![Send → Exchange or Wallet, recipient step](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2625/send-recipient-fixed.png)
<img width="753" height="1022" alt="image" src="https://github.com/user-attachments/assets/42773dc2-fefe-4688-916b-7acad4328d5b" />
<img width="641" height="1015" alt="image" src="https://github.com/user-attachments/assets/111ca0aa-16b0-4aee-b36c-ad36c687497b" />

Header reads **Send**; card reads **You're sending**. Before this PR the same screen read
**Withdraw** / **You're withdrawing** — the user had just come from a step that said "Send".

Also verified live in the same session:

- `/withdraw?method=crypto` → **"Send" / "Amount to send"**
- Continue → navigates to **`/withdraw/crypto?method=crypto`**, marker intact
- Bouncing off `/withdraw/crypto` returns to **`/withdraw?method=crypto`** — pre-PR this went to a bare `/withdraw` and flipped back to "Withdraw"
- **Regression:** bare `/withdraw` (no marker) still reads **"Withdraw"** — the half `d532b6a65` was protecting

### Before → after 

Entering via **Send → Exchange or Wallet** (`?method=crypto`) or **Send → Bank** (`?method=bank`):

| Screen | Element | Before | After |
|---|---|---|---|
| Amount | header / heading | Send / Amount to send | *(unchanged — already correct)* |
| Recipient (`Initial.withdraw.view`) | NavHeader | **Withdraw** | **Send** |
| Recipient | card title | **You're withdrawing** | **You're sending** |
| Confirm (`Confirm.withdraw.view`) | NavHeader | **Withdraw** | **Send** |
| Confirm | card title | **You're withdrawing** | **You're sending** |
| Confirm | CTA (idle) | **Withdraw** | **Send** |
| Confirm | CTA (processing) | **Withdrawing** | **Sending** |
| Success | header | **Withdraw** | **Send** |
| Success | title | **You just withdrew** | **You just sent** |
| Success | amount prefix | to 0x… | *(unchanged — "to" is correct)* |
| Bank review | card title | **You're withdrawing** | **You're sending** |
| Bank review | CTA | **Withdraw** | **Send** |
| Bank success | title | **You just withdrew** | **You just sent** |

Entering via **`/withdraw` directly** (no `?method=`): **every one of the above is unchanged.** That regression is covered by unit tests and is the half `d532b6a65` was protecting.

Translations added for `es-419` and `pt-BR` alongside `en`. `es-AR` is a 2 KB partial locale that does not carry the sibling `youreWithdrawing` / `withdrew` keys either, so it is intentionally untouched and falls back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved send-flow navigation across bank and crypto withdrawals.
  - Send actions now retain their originating method when navigating between steps.
  - Updated titles, buttons, loading states, action details, and success messages to reflect “sending” versus “withdrawing.”
  - Added English, Spanish (Latin America), and Portuguese (Brazil) translations.

- **Bug Fixes**
  - Fixed navigation losing the selected send method during withdrawal flows.

- **Tests**
  - Added regression coverage for send-method preservation and send-flow messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->