### PR TITLE
feat(i18n): emit device_language + platform for localization OKR

### DIFF
--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/utils/general.utils'
 import { apiFetch } from '@/utils/api-fetch'
 import { useAppLocked } from '@/hooks/useAppLocked'
-import { currentAppLocale } from '@/i18n/app/locale-store'
+import { currentAppLocale, currentDeviceContext } from '@/i18n/app/locale-store'
 import { isCapacitor } from '@/utils/capacitor'
 import { clearAuthToken } from '@/utils/auth-token'
 import { resetCrispProxySessions } from '@/utils/crisp'
@@ -267,6 +267,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
             // locale so logout-window events keep carrying app_locale
             const locale = currentAppLocale()
             if (locale) posthog.register({ app_locale: locale })
+            // same for the localization-OKR device context (device_language + platform)
+            const deviceContext = currentDeviceContext()
+            if (deviceContext) posthog.register(deviceContext)
         } catch (e) {
             console.warn('posthog reset failed:', e)
         }

--- a/src/i18n/app/AppIntlProvider.tsx
+++ b/src/i18n/app/AppIntlProvider.tsx
@@ -4,7 +4,14 @@ import { NextIntlClientProvider, IntlErrorCode, type IntlError } from 'next-intl
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { DEFAULT_APP_LOCALE, type AppLocale } from './config'
 import { loadMessages, type AppMessages } from './messages'
-import { currentAppLocale, emitLocaleToAnalytics, localeReady, markLocaleApplied, persistLocale } from './locale-store'
+import {
+    currentAppLocale,
+    emitDeviceContextToAnalytics,
+    emitLocaleToAnalytics,
+    localeReady,
+    markLocaleApplied,
+    persistLocale,
+} from './locale-store'
 import en from './messages/en.json'
 
 interface AppLocaleContextValue {
@@ -41,6 +48,9 @@ export function AppIntlProvider({ children }: { children: React.ReactNode }) {
 
     useEffect(() => {
         let cancelled = false
+        // device_language + platform super properties for the localization OKR;
+        // independent of which locale resolves, fire-and-forget
+        void emitDeviceContextToAnalytics()
         localeReady().then(async (resolved) => {
             startupLocale.current = resolved
             if (resolved === DEFAULT_APP_LOCALE) {

--- a/src/i18n/app/__tests__/locale-store.test.ts
+++ b/src/i18n/app/__tests__/locale-store.test.ts
@@ -41,7 +41,9 @@ function freshStore(): LocaleStore {
 }
 
 beforeEach(() => {
-    jest.clearAllMocks()
+    // resetAllMocks (not clearAllMocks) so a mockImplementation set in one test
+    // — e.g. the posthog-throw cases — can never leak into the next.
+    jest.resetAllMocks()
     mockIsIdentified.mockReturnValue(true)
     mockIsCapacitor.mockReturnValue(false)
     mockGetPlatform.mockReturnValue('web')
@@ -92,11 +94,12 @@ describe('emitLocaleToAnalytics', () => {
 })
 
 describe('emitDeviceContextToAnalytics', () => {
-    it('registers the raw device language and platform as super properties (web)', async () => {
+    it('registers the raw device language and platform, and exposes them for logout re-register', async () => {
         setNavigatorLanguage('es-AR')
         const store = freshStore()
         await store.emitDeviceContextToAnalytics()
         expect(mockRegister).toHaveBeenCalledWith({ device_language: 'es-ar', platform: 'web' })
+        expect(store.currentDeviceContext()).toEqual({ device_language: 'es-ar', platform: 'web' })
     })
 
     it('keeps an unsupported language as-is (never collapses to en — protects the OKR denominator)', async () => {
@@ -114,12 +117,16 @@ describe('emitDeviceContextToAnalytics', () => {
         expect(mockRegister).toHaveBeenCalledTimes(1)
     })
 
-    it('a posthog throw never propagates', async () => {
+    it('a posthog throw never propagates and leaves the context unset so a retry can register', async () => {
         setNavigatorLanguage('en-US')
-        mockRegister.mockImplementation(() => {
+        mockRegister.mockImplementationOnce(() => {
             throw new Error('sdk exploded')
         })
         const store = freshStore()
         await expect(store.emitDeviceContextToAnalytics()).resolves.toBeUndefined()
+        expect(store.currentDeviceContext()).toBeNull()
+        // guard is set only on success, so the next call retries instead of no-op
+        await store.emitDeviceContextToAnalytics()
+        expect(store.currentDeviceContext()).toEqual({ device_language: 'en-us', platform: 'web' })
     })
 })

--- a/src/i18n/app/__tests__/locale-store.test.ts
+++ b/src/i18n/app/__tests__/locale-store.test.ts
@@ -18,6 +18,18 @@ jest.mock('posthog-js', () => ({
     },
 }))
 
+const mockIsCapacitor = jest.fn()
+const mockGetPlatform = jest.fn()
+
+jest.mock('@/utils/capacitor', () => ({
+    isCapacitor: () => mockIsCapacitor(),
+    getPlatform: () => mockGetPlatform(),
+}))
+
+function setNavigatorLanguage(value: string): void {
+    Object.defineProperty(navigator, 'language', { value, configurable: true })
+}
+
 type LocaleStore = typeof import('../locale-store')
 
 function freshStore(): LocaleStore {
@@ -31,6 +43,8 @@ function freshStore(): LocaleStore {
 beforeEach(() => {
     jest.clearAllMocks()
     mockIsIdentified.mockReturnValue(true)
+    mockIsCapacitor.mockReturnValue(false)
+    mockGetPlatform.mockReturnValue('web')
 })
 
 describe('emitLocaleToAnalytics', () => {
@@ -74,5 +88,38 @@ describe('emitLocaleToAnalytics', () => {
         const store = freshStore()
         expect(() => store.emitLocaleToAnalytics('pt-BR')).not.toThrow()
         expect(store.currentAppLocale()).toBe('pt-BR')
+    })
+})
+
+describe('emitDeviceContextToAnalytics', () => {
+    it('registers the raw device language and platform as super properties (web)', async () => {
+        setNavigatorLanguage('es-AR')
+        const store = freshStore()
+        await store.emitDeviceContextToAnalytics()
+        expect(mockRegister).toHaveBeenCalledWith({ device_language: 'es-ar', platform: 'web' })
+    })
+
+    it('keeps an unsupported language as-is (never collapses to en — protects the OKR denominator)', async () => {
+        setNavigatorLanguage('fr-FR')
+        const store = freshStore()
+        await store.emitDeviceContextToAnalytics()
+        expect(mockRegister).toHaveBeenCalledWith({ device_language: 'fr-fr', platform: 'web' })
+    })
+
+    it('emits once per session', async () => {
+        setNavigatorLanguage('pt-BR')
+        const store = freshStore()
+        await store.emitDeviceContextToAnalytics()
+        await store.emitDeviceContextToAnalytics()
+        expect(mockRegister).toHaveBeenCalledTimes(1)
+    })
+
+    it('a posthog throw never propagates', async () => {
+        setNavigatorLanguage('en-US')
+        mockRegister.mockImplementation(() => {
+            throw new Error('sdk exploded')
+        })
+        const store = freshStore()
+        await expect(store.emitDeviceContextToAnalytics()).resolves.toBeUndefined()
     })
 })

--- a/src/i18n/app/__tests__/locale-store.test.ts
+++ b/src/i18n/app/__tests__/locale-store.test.ts
@@ -26,6 +26,12 @@ jest.mock('@/utils/capacitor', () => ({
     getPlatform: () => mockGetPlatform(),
 }))
 
+const mockGetLanguageTag = jest.fn()
+
+jest.mock('@capacitor/device', () => ({
+    Device: { getLanguageTag: (...args: unknown[]) => mockGetLanguageTag(...args) },
+}))
+
 function setNavigatorLanguage(value: string): void {
     Object.defineProperty(navigator, 'language', { value, configurable: true })
 }
@@ -100,6 +106,16 @@ describe('emitDeviceContextToAnalytics', () => {
         await store.emitDeviceContextToAnalytics()
         expect(mockRegister).toHaveBeenCalledWith({ device_language: 'es-ar', platform: 'web' })
         expect(store.currentDeviceContext()).toEqual({ device_language: 'es-ar', platform: 'web' })
+    })
+
+    it('reads the raw tag from the native device bridge on Capacitor', async () => {
+        mockIsCapacitor.mockReturnValue(true)
+        mockGetPlatform.mockReturnValue('ios-native')
+        mockGetLanguageTag.mockResolvedValue({ value: 'pt-BR' })
+        const store = freshStore()
+        await store.emitDeviceContextToAnalytics()
+        expect(mockGetLanguageTag).toHaveBeenCalled()
+        expect(mockRegister).toHaveBeenCalledWith({ device_language: 'pt-br', platform: 'ios-native' })
     })
 
     it('keeps an unsupported language as-is (never collapses to en — protects the OKR denominator)', async () => {

--- a/src/i18n/app/locale-store.ts
+++ b/src/i18n/app/locale-store.ts
@@ -5,7 +5,7 @@
 
 import Cookies from 'js-cookie'
 import posthog from 'posthog-js'
-import { isCapacitor } from '@/utils/capacitor'
+import { getPlatform, isCapacitor } from '@/utils/capacitor'
 import { resolveLocale, type AppLocale } from './config'
 
 const LOCALE_KEY = 'app-locale'
@@ -41,6 +41,45 @@ export function emitLocaleToAnalytics(locale: AppLocale): void {
 
 function navigatorLocale(): AppLocale {
     return resolveLocale(typeof navigator !== 'undefined' ? navigator.language : null)
+}
+
+/**
+ * Raw device/browser language tag — deliberately NOT run through resolveLocale.
+ * An unsupported language (e.g. 'fr-FR') must stay itself for the localization
+ * OKR, not collapse to 'en' and pollute the "phone set to ES/PT" denominator.
+ */
+async function deviceLanguageTag(): Promise<string | null> {
+    if (isCapacitor()) {
+        try {
+            const { Device } = await import('@capacitor/device')
+            const { value } = await Device.getLanguageTag()
+            if (value) return value
+        } catch {
+            // older binary / plugin missing — fall through to navigator
+        }
+    }
+    return typeof navigator !== 'undefined' ? navigator.language : null
+}
+
+// Device context for the localization OKR (Fit metric): device_language is the
+// language the user's phone asks for; app_locale (above) is what they actually
+// use. Both are super properties so every event carries them — the OKR filters
+// device_language ∈ {es*, pt*} and reads the app_locale=en override rate,
+// no KYC/nationality join. Registered once per session (neither value changes);
+// fenced like the locale emit so analytics can never break the app.
+let deviceContextEmitted = false
+export async function emitDeviceContextToAnalytics(): Promise<void> {
+    if (deviceContextEmitted) return
+    deviceContextEmitted = true
+    try {
+        const tag = await deviceLanguageTag()
+        posthog.register({
+            device_language: tag ? tag.trim().toLowerCase() : 'unknown',
+            platform: getPlatform(),
+        })
+    } catch {
+        // analytics failure degrades to missing data, never a broken app
+    }
 }
 
 async function resolveStartupLocale(): Promise<AppLocale> {

--- a/src/i18n/app/locale-store.ts
+++ b/src/i18n/app/locale-store.ts
@@ -47,8 +47,16 @@ function navigatorLocale(): AppLocale {
  * Raw device/browser language tag — deliberately NOT run through resolveLocale.
  * An unsupported language (e.g. 'fr-FR') must stay itself for the localization
  * OKR, not collapse to 'en' and pollute the "phone set to ES/PT" denominator.
+ * Memoized: the native Device.getLanguageTag() bridge call sits on the
+ * splash-gated startup path, so the locale resolver and the analytics emit
+ * share one round-trip instead of each making their own.
  */
-async function deviceLanguageTag(): Promise<string | null> {
+let deviceTag: Promise<string | null> | null = null
+function rawDeviceTag(): Promise<string | null> {
+    if (!deviceTag) deviceTag = readDeviceTag()
+    return deviceTag
+}
+async function readDeviceTag(): Promise<string | null> {
     if (isCapacitor()) {
         try {
             const { Device } = await import('@capacitor/device')
@@ -64,19 +72,29 @@ async function deviceLanguageTag(): Promise<string | null> {
 // Device context for the localization OKR (Fit metric): device_language is the
 // language the user's phone asks for; app_locale (above) is what they actually
 // use. Both are super properties so every event carries them — the OKR filters
-// device_language ∈ {es*, pt*} and reads the app_locale=en override rate,
-// no KYC/nationality join. Registered once per session (neither value changes);
-// fenced like the locale emit so analytics can never break the app.
-let deviceContextEmitted = false
+// device_language ∈ {es*, pt*} and reads the app_locale=en override rate, no
+// KYC/nationality join. The resolved context is cached (not just a bool) so the
+// logout handler can re-register it after posthog.reset() wipes super
+// properties, mirroring app_locale. Fenced so analytics can never break the app.
+let deviceContext: { device_language: string; platform: string } | null = null
+
+/** Last device context registered — for re-register after posthog.reset() on logout. */
+export function currentDeviceContext(): { device_language: string; platform: string } | null {
+    return deviceContext
+}
+
 export async function emitDeviceContextToAnalytics(): Promise<void> {
-    if (deviceContextEmitted) return
-    deviceContextEmitted = true
+    if (deviceContext) return
     try {
-        const tag = await deviceLanguageTag()
-        posthog.register({
+        const tag = await rawDeviceTag()
+        const context = {
             device_language: tag ? tag.trim().toLowerCase() : 'unknown',
             platform: getPlatform(),
-        })
+        }
+        posthog.register(context)
+        // set only after a successful register — a throw leaves this null so a
+        // later call can retry, instead of silently disabling the emit forever
+        deviceContext = context
     } catch {
         // analytics failure degrades to missing data, never a broken app
     }
@@ -91,14 +109,8 @@ async function resolveStartupLocale(): Promise<AppLocale> {
         } catch {
             // plugin unavailable — fall through to device language
         }
-        try {
-            const { Device } = await import('@capacitor/device')
-            const { value } = await Device.getLanguageTag()
-            return resolveLocale(value)
-        } catch {
-            // older binary running OTA'd JS without @capacitor/device
-            return navigatorLocale()
-        }
+        // shares the memoized bridge call with the analytics emit
+        return resolveLocale(await rawDeviceTag())
     }
     const stored =
         Cookies.get(LOCALE_KEY) ?? (typeof localStorage !== 'undefined' ? localStorage.getItem(LOCALE_KEY) : null)


### PR DESCRIPTION
## Summary
The localization **Fit** OKR measures: of users whose **phone is set to ES/PT**, how many actually use the app in ES/PT (i.e. did not override back to English). To read that from PostHog we need two signals per user — the language they use (`app_locale`, already shipped in #2621) and the language their device asks for (`device_language`).

This adds `device_language` + `platform` as PostHog **super properties**, emitted once per session from `AppIntlProvider` startup:
- `device_language` — the **raw** device/browser tag (`@capacitor/device` on native, `navigator.language` on web), lowercased. Deliberately **not** run through `resolveLocale`: an unsupported language (e.g. `fr-FR`) must stay `fr-fr`, not collapse to `en` and pollute the "phone set to ES/PT" denominator.
- `platform` — reuses the existing `getPlatform()` helper (`web` / `ios-native` / `android-native` / `ios-pwa` / `android-pwa`) so the OKR can be split web vs native.

The OKR then filters `device_language` starting with `es`/`pt` and reads the `app_locale = en` override rate. **No KYC/nationality join** — this supersedes the residence-property approach (closed peanut-api-ts#1295).

## Task
TASK-20776 — https://app.notion.com/p/peanutprotocol/Build-the-localization-OKR-tracking-query-dashboard-3a583811757981e1a7ecfce4b57a2287

## Risks / breaking changes
Analytics-only. No route, schema, or FE contract change. The emit is fire-and-forget and fenced (a posthog throw can never break i18n or the app). Works unchanged in the native app — the Capacitor static-export webview runs `posthog-js` exactly like the browser.

Minor pre-existing inconsistency (not fixed here, follow-up): a few `capture()` calls already pass an ad-hoc `platform` event property with a different vocabulary (`'native'`, `'unknown'`). Event properties override the super property per-event, so no data breaks; consolidating the vocabulary is out of this PR's scope.

## QA
- `npm run typecheck`, `pnpm prettier --check`, unit tests — green locally.
- New tests in `locale-store.test.ts` cover: raw tag registered, unsupported language kept as-is (OKR-denominator guard), once-per-session, posthog-throw fenced.
- Manual: load the app with the browser/device language set to `es-*` / `pt-*` / `fr-*`, confirm the `device_language` + `platform` super properties attach to events in PostHog.

Screenshots: N/A (analytics wiring, no visible change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic device language and platform context reporting during app startup.
  * Native device language is used when available, with browser language as a fallback.
  * Language values are normalized for consistent analytics reporting.
  * Device context is restored after signing out and back in.

* **Bug Fixes**
  * Analytics and platform integration errors no longer interrupt app startup or locale handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->