### PR TITLE
fix: reset the withdraw flow when a send method click enters it

### DIFF
--- a/src/components/Send/__tests__/send-states.test.tsx
+++ b/src/components/Send/__tests__/send-states.test.tsx
@@ -344,6 +344,27 @@ describe('GROUP 4: Method Selection', () => {
         fireEvent.click(screen.getByTestId('action-card-Exchange or Wallet'))
         expect(mockResetWithdrawFlow).toHaveBeenCalledTimes(1)
         expect(mockRouterPush).toHaveBeenCalledWith('/withdraw?method=crypto')
+        expect(mockResetWithdrawFlow.mock.invocationCallOrder[0]).toBeLessThan(
+            mockRouterPush.mock.invocationCallOrder[0]
+        )
+    })
+
+    test('Mercado Pago and Pix also reset the withdraw flow before navigating', () => {
+        mockUseGeoFilteredPaymentOptions.mockReturnValue({
+            filteredMethods: [
+                { id: 'mercadopago', title: 'Mercado Pago', description: '', icons: [], soon: false },
+                { id: 'pix', title: 'Pix', description: '', icons: [], soon: false },
+            ],
+        })
+        renderSend()
+
+        fireEvent.click(screen.getByTestId('action-card-Mercado Pago'))
+        expect(mockResetWithdrawFlow).toHaveBeenCalledTimes(1)
+        expect(mockRouterPush).toHaveBeenCalledWith('/withdraw/manteca?method=mercado-pago&country=argentina')
+
+        fireEvent.click(screen.getByTestId('action-card-Pix'))
+        expect(mockResetWithdrawFlow).toHaveBeenCalledTimes(2)
+        expect(mockRouterPush).toHaveBeenCalledWith('/withdraw/manteca?method=pix&country=brazil')
     })
 
     test('Clicking Peanut contacts navigates to /send?view=contacts without touching the withdraw flow', () => {

--- a/src/components/Send/__tests__/send-states.test.tsx
+++ b/src/components/Send/__tests__/send-states.test.tsx
@@ -169,6 +169,12 @@ jest.mock('../views/Contacts.view', () => ({
     default: () => <div data-testid="contacts-view">Contacts View</div>,
 }))
 
+// withdraw-flow context — SendRouterView resets it when a click enters the withdraw flow
+const mockResetWithdrawFlow = jest.fn()
+jest.mock('@/context/WithdrawFlowContext', () => ({
+    useWithdrawFlow: () => ({ resetWithdrawFlow: mockResetWithdrawFlow }),
+}))
+
 // ---------- import component under test AFTER all mocks ----------
 import { SendRouterView } from '../views/SendRouter.view'
 
@@ -316,25 +322,37 @@ describe('GROUP 3: Contacts View', () => {
 // GROUP 4: Method Selection Navigation
 // ============================================================
 describe('GROUP 4: Method Selection', () => {
-    test('Clicking bank navigates to /withdraw?method=bank', () => {
+    test('Clicking bank resets the withdraw flow, then navigates to /withdraw?method=bank', () => {
+        // Regression: browser back from an abandoned /withdraw?method=crypto skips the
+        // in-app NavHeader reset, so a stale selectedMethod survives in the app-wide
+        // context. Without the reset, Bank skips method selection and lands on the
+        // crypto amount step (continuing into /withdraw/crypto?method=bank).
         renderSend()
 
         fireEvent.click(screen.getByTestId('action-card-Bank'))
+        expect(mockResetWithdrawFlow).toHaveBeenCalledTimes(1)
         expect(mockRouterPush).toHaveBeenCalledWith('/withdraw?method=bank')
+        // reset must land before navigation hands off to /withdraw
+        expect(mockResetWithdrawFlow.mock.invocationCallOrder[0]).toBeLessThan(
+            mockRouterPush.mock.invocationCallOrder[0]
+        )
     })
 
-    test('Clicking exchange-or-wallet navigates to /withdraw?method=crypto', () => {
+    test('Clicking exchange-or-wallet resets the withdraw flow, then navigates to /withdraw?method=crypto', () => {
         renderSend()
 
         fireEvent.click(screen.getByTestId('action-card-Exchange or Wallet'))
+        expect(mockResetWithdrawFlow).toHaveBeenCalledTimes(1)
         expect(mockRouterPush).toHaveBeenCalledWith('/withdraw?method=crypto')
     })
 
-    test('Clicking Peanut contacts navigates to /send?view=contacts', () => {
+    test('Clicking Peanut contacts navigates to /send?view=contacts without touching the withdraw flow', () => {
         renderSend()
 
         fireEvent.click(screen.getByTestId('action-card-Peanut contacts'))
         expect(mockRouterPush).toHaveBeenCalledWith('/send?view=contacts')
+        // contacts is not a withdraw entry — never clobber an unrelated flow's state
+        expect(mockResetWithdrawFlow).not.toHaveBeenCalled()
     })
 
     test('Back from main send navigates to /home', () => {

--- a/src/components/Send/__tests__/send-states.test.tsx
+++ b/src/components/Send/__tests__/send-states.test.tsx
@@ -361,10 +361,16 @@ describe('GROUP 4: Method Selection', () => {
         fireEvent.click(screen.getByTestId('action-card-Mercado Pago'))
         expect(mockResetWithdrawFlow).toHaveBeenCalledTimes(1)
         expect(mockRouterPush).toHaveBeenCalledWith('/withdraw/manteca?method=mercado-pago&country=argentina')
+        expect(mockResetWithdrawFlow.mock.invocationCallOrder[0]).toBeLessThan(
+            mockRouterPush.mock.invocationCallOrder[0]
+        )
 
         fireEvent.click(screen.getByTestId('action-card-Pix'))
         expect(mockResetWithdrawFlow).toHaveBeenCalledTimes(2)
         expect(mockRouterPush).toHaveBeenCalledWith('/withdraw/manteca?method=pix&country=brazil')
+        expect(mockResetWithdrawFlow.mock.invocationCallOrder[1]).toBeLessThan(
+            mockRouterPush.mock.invocationCallOrder[1]
+        )
     })
 
     test('Clicking Peanut contacts navigates to /send?view=contacts without touching the withdraw flow', () => {

--- a/src/components/Send/views/SendRouter.view.tsx
+++ b/src/components/Send/views/SendRouter.view.tsx
@@ -13,6 +13,7 @@ import { ACTION_METHODS, type PaymentMethod } from '@/constants/actionlist.const
 import Image from 'next/image'
 import StatusBadge from '@/components/Global/Badges/StatusBadge'
 import { useGeoFilteredPaymentOptions } from '@/hooks/useGeoFilteredPaymentOptions'
+import { useWithdrawFlow } from '@/context/WithdrawFlowContext'
 import { useContacts } from '@/hooks/useContacts'
 import { getInitialsFromName } from '@/utils/general.utils'
 import posthog from 'posthog-js'
@@ -50,6 +51,7 @@ export const SendRouterView = () => {
             ? decodeURIComponent(window.location.pathname.replace('/send/', '').split('/')[0])
             : null
     const recipientUsername = recipientFromQuery || recipientFromPath || null
+    const { resetWithdrawFlow } = useWithdrawFlow()
     // only fetch 3 contacts for avatar display
     const { contacts, isLoading: isFetchingContacts } = useContacts({ limit: 3 })
 
@@ -127,19 +129,26 @@ export const SendRouterView = () => {
                 router.push('/send?view=contacts')
                 break
             case 'bank':
-                // navigate to send via bank flow
+                // navigate to send via bank flow.
+                // fresh click = fresh intent: browser back skips the in-app NavHeader
+                // reset, and a stale selectedMethod left in the app-wide context would
+                // hijack the routing (Bank landing on the crypto amount step)
+                resetWithdrawFlow()
                 router.push('/withdraw?method=bank')
                 break
             case 'exchange-or-wallet':
                 // navigate to external wallet send flow
+                resetWithdrawFlow()
                 router.push('/withdraw?method=crypto')
                 break
             case 'mercadopago':
                 // navigate to mercado pago send flow
+                resetWithdrawFlow()
                 router.push('/withdraw/manteca?method=mercado-pago&country=argentina')
                 break
             case 'pix':
                 // navigate to pix send flow
+                resetWithdrawFlow()
                 router.push('/withdraw/manteca?method=pix&country=brazil')
                 break
             default:

--- a/src/context/WithdrawFlowContext.tsx
+++ b/src/context/WithdrawFlowContext.tsx
@@ -101,6 +101,9 @@ export const WithdrawFlowContextProvider: React.FC<{ children: ReactNode }> = ({
 
     const resetWithdrawFlow = useCallback(() => {
         setAmountToWithdraw('')
+        // browser-back with the compatibility modal open leaves it armed for the
+        // next /withdraw/crypto entry — reset must close it like everything else
+        setShowCompatibilityModal(false)
         setCurrentView('INITIAL')
         setWithdrawData(null)
         setSelectedBankAccount(null)

--- a/src/context/__tests__/WithdrawFlowContext.test.tsx
+++ b/src/context/__tests__/WithdrawFlowContext.test.tsx
@@ -1,0 +1,42 @@
+import { render, act } from '@testing-library/react'
+import { WithdrawFlowContextProvider, useWithdrawFlow } from '../WithdrawFlowContext'
+
+// probe that surfaces the real provider's state + actions to the test
+let ctx: ReturnType<typeof useWithdrawFlow>
+function Probe() {
+    ctx = useWithdrawFlow()
+    return null
+}
+
+describe('WithdrawFlowContext resetWithdrawFlow', () => {
+    test('clears abandoned flow state, including the compatibility modal', () => {
+        render(
+            <WithdrawFlowContextProvider>
+                <Probe />
+            </WithdrawFlowContextProvider>
+        )
+
+        act(() => {
+            ctx.setSelectedMethod({ type: 'crypto', title: 'Crypto' })
+            ctx.setAmountToWithdraw('50')
+            ctx.setUsdAmount('50')
+            ctx.setShowCompatibilityModal(true)
+            ctx.setShowAllWithdrawMethods(true)
+        })
+        expect(ctx.selectedMethod).toEqual({ type: 'crypto', title: 'Crypto' })
+        expect(ctx.showCompatibilityModal).toBe(true)
+
+        act(() => {
+            ctx.resetWithdrawFlow()
+        })
+
+        expect(ctx.selectedMethod).toBeNull()
+        expect(ctx.amountToWithdraw).toBe('')
+        expect(ctx.usdAmount).toBe('')
+        expect(ctx.selectedBankAccount).toBeNull()
+        expect(ctx.showAllWithdrawMethods).toBe(false)
+        // the reset used to leave a browser-back-abandoned modal armed for the
+        // next /withdraw/crypto entry — pin that it closes with everything else
+        expect(ctx.showCompatibilityModal).toBe(false)
+    })
+})


### PR DESCRIPTION
## Summary

Browser/device back from `/withdraw?method=crypto` never runs the in-app NavHeader reset, so `selectedMethod` survives in the app-wide `WithdrawFlowContext`. The next **Bank** click on `/send` then skips method selection, lands on the **crypto amount step**, and Continue routes to `/withdraw/crypto?method=bank` — the crypto flow wearing a bank marker. The mirror direction (stale bank method hijacking an **Exchange or Wallet** click) breaks the same way.

**Fix:** a fresh method click is a fresh statement of intent. `SendRouterView.handleMethodClick` is the only click-site that mints the `?method=` marker, so call the pre-existing `resetWithdrawFlow()` there before navigating, in all four withdraw-bound cases (`bank`, `exchange-or-wallet`, `mercadopago`, `pix`). Plus one completeness fix the adversarial pass surfaced: `resetWithdrawFlow()` now also closes `showCompatibilityModal`, which every reset call site (home mount, crypto-page unmount, these clicks) was leaving armed.

`withdraw/page.tsx` is untouched: inside the withdraw flow, `selectedMethod` stays the routing source of truth (the `7edcf0919` invariant and its pinned test survive unmodified) — we only guarantee the context is fresh at entry.

## Task

TASK-21203 — https://app.notion.com/p/3b483811757981418f7ff0efe4d33221

## Verification (3-agent adversarial panel, all lenses traced to code)

- **Refute-the-fix:** HOLDS on all axes. The click-handler reset flushes in the sync lane before the `startTransition`-wrapped route render, the provider never remounts, and the step-sync effect self-heals as a third safety net. Mirror direction traced clean.
- **Regression hunt:** no real regressions. The "preserved typed amount" a reset might wipe never existed (`rawTokenAmount` is component-local; context amount is only written on Continue). The manteca page reads zero context fields and self-resets on mount. `/home` has always reset the flow on mount, so "state survives leaving the flow" was never a supported invariant, and every re-entry path guards against cleared context.
- **Test attack (empirical mutation pass):** revert, reorder-past-push, and over-eager-reset mutants all caught; the initially-untested manteca one-liners got their own test after the pass flagged them.

## Design notes / accepted trade-offs

- **Reset at the click site, not self-healing inside `/withdraw`:** the within-flow back-navigations that echo `?method=` (`AddWithdrawCountriesList`) *want* state preserved and are correctly untouched. Browser-forward cannot recreate a mismatch (a fresh click truncates forward history).
- **Known residual, same bug family, lower severity (follow-up, not this PR):** marker-less `/withdraw` entries (home tile, bottom nav, KYC modal, exchange-rate widget) still resume a stale `selectedMethod` at the amount step. That path is internally consistent (no marker/context mismatch — Continue routes where the UI says) and matches the codebase's blessed resume semantics.
- **Known larger refactor (follow-up):** the `?method=` URL marker and `WithdrawFlowContext` remain two sources of truth — this is the third bug from that split.

## Risks / breaking changes

- FE-only, no API changes, no cross-repo deploy order.
- Blast radius: the four send-method click paths + the one-line reset completeness fix (strictly closes a modal that should never be open at reset time).
- Hotfix to `main` → **back-merge debt main→dev after merge.** No conflict expected: `handleMethodClick` is byte-identical on `main` and `dev`, and open PR #2625 does not touch `SendRouter.view.tsx`.

## QA

1. `/send` → **Exchange or Wallet** → **browser back** (swipe/hardware/browser — not the in-app `‹`) → **Bank** → must land on bank method selection, not the crypto amount step.
2. Reverse: `/send` → **Bank** → pick a saved account → **browser back** → **Exchange or Wallet** → must land on the crypto amount step cleanly.
3. In-app `‹` back paths unchanged. Plain `/withdraw` (no marker) unchanged.
4. Note: do **not** QA by asserting `/withdraw/crypto?method=bank` can never occur — it is legitimately mintable (send → bank → "show all methods" → Crypto card → Continue).

Screenshots: ⚠️ NONE — the change is which pre-existing screen appears after a click given abandoned state; both screens are unchanged pixel-wise. Manual repro steps above are the visual evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Withdrawal flow state is now reset before starting bank, crypto, Mercado Pago, or Pix transfers.
  * Resetting the withdrawal flow now also closes any open compatibility modal.
  * Contact navigation remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->