### PR TITLE
fix(home): open Bridge Persona verification outside the app, not in an iframe

### DIFF
--- a/src/components/Home/PendingVerificationTasks.tsx
+++ b/src/components/Home/PendingVerificationTasks.tsx
@@ -155,7 +155,15 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
             // so Safari/Firefox block it — the same "nothing happens" symptom
             // this PR exists to fix. The reserved tab is navigated once the
             // URL lands, and closed if it never does.
-            const reservedTab = isCapacitor() ? null : window.open('', '_blank')
+            const native = isCapacitor()
+            const reservedTab = native ? null : window.open('', '_blank')
+            if (!native && !reservedTab) {
+                // Pop-ups blocked. Falling back to a post-await window.open
+                // would be blocked harder AND unobservable, so we'd promise a
+                // verification page that never opened — tell the user instead.
+                setError('Please allow pop-ups for this site, then tap again to verify.')
+                return
+            }
 
             setIsStartingHosted(true)
             const { url } = await startBridgeHostedVerification()
@@ -165,15 +173,14 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
                 // means the action aged out); refetch so a stale card self-corrects.
                 reservedTab?.close()
                 setError("We couldn't start the verification. Please try again in a moment.")
-                void fetchUser()
+                void fetchUser().catch(() => undefined)
                 return
             }
             try {
-                if (reservedTab) {
-                    reservedTab.location.href = url
-                } else {
-                    // Native, or a browser that refused the reservation outright.
+                if (native) {
                     await openExternalUrl(url)
+                } else if (reservedTab) {
+                    reservedTab.location.href = url
                 }
             } catch {
                 reservedTab?.close()
@@ -196,7 +203,7 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
             // so a second visibility event could otherwise refetch twice.
             document.removeEventListener('visibilitychange', onReturn)
             setAwaitingReturn(false)
-            void fetchUser()
+            void fetchUser().catch(() => undefined)
         }
         document.addEventListener('visibilitychange', onReturn)
         return () => document.removeEventListener('visibilitychange', onReturn)

--- a/src/components/Home/PendingVerificationTasks.tsx
+++ b/src/components/Home/PendingVerificationTasks.tsx
@@ -4,14 +4,13 @@ import { useCallback, useEffect, useState } from 'react'
 import { startBridgeHostedVerification } from '@/app/actions/sumsub'
 import { Button } from '@/components/0_Bruddle/Button'
 import Carousel from '@/components/Global/Carousel'
-import IframeWrapper from '@/components/Global/IframeWrapper'
 import { Icon } from '@/components/Global/Icons/Icon'
 import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
 import { useAuth } from '@/context/authContext'
-import { confirmBridgeTosAndAwaitRails } from '@/hooks/useMultiPhaseKycFlow'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import type { NextAction } from '@/types/capabilities'
 import { bridgeTaskDismissalKey, selectBridgeTasks } from '@/utils/bridge-tasks.utils'
+import { openExternalUrl } from '@/utils/capacitor'
 import { formatEffectiveDate } from '@/utils/format.utils'
 import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils'
 import Card from '../Global/Card'
@@ -55,10 +54,10 @@ function taskCopy(task: NextAction): { title: string; description: string } {
  * as full-width horizontal carousel slides (same embla setup as
  * HomeCarouselCTA); a single task looks identical to a static card.
  *
- * Open flows are SNAPSHOTTED at tap time: the task list re-derives from every
- * user refetch (~4s auto-refresh while rails are pending), and an open
- * modal/iframe must survive its task disappearing mid-flow — the card hides,
- * the flow keeps running.
+ * The ToS flow is SNAPSHOTTED at tap time: the task list re-derives from every
+ * user refetch (~4s auto-refresh while rails are pending), and the open modal
+ * must survive its task disappearing mid-flow — the card hides, the flow keeps
+ * running. The hosted flow leaves the app entirely (see handleOpenTask).
  *
  * `dismissible` (the /home mount): each ADVISORY (future-dated) slide carries
  * its own X that dismisses ONLY that task — the other slides stay. Dismissals
@@ -73,8 +72,8 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
     const { nextActions } = useCapabilities()
     const { user, fetchUser } = useAuth()
     const [activeTosTask, setActiveTosTask] = useState<NextAction | null>(null)
-    const [hostedUrl, setHostedUrl] = useState<string | null>(null)
     const [isStartingHosted, setIsStartingHosted] = useState(false)
+    const [awaitingReturn, setAwaitingReturn] = useState(false)
     const [error, setError] = useState<string | null>(null)
     // Stored dismissals, tagged with the user they were loaded for
     // (localStorage is unreadable during SSR, hence the post-render effect).
@@ -153,41 +152,38 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
                 void fetchUser()
                 return
             }
-            setHostedUrl(url)
+            // NOT an iframe: `bridge.withpersona.com` serves
+            // `X-Frame-Options: SAMEORIGIN`, so embedding it rendered
+            // "refused to connect" for EVERY user. It has to be a real
+            // top-level page (native: the in-app browser). Bridge's ToS link
+            // (`compliance.bridge.xyz`) sends no framing header, which is why
+            // BridgeTosStep keeps its iframe.
+            await openExternalUrl(url)
+            setAwaitingReturn(true)
         },
         [fetchUser]
     )
 
-    const handleHostedClose = useCallback(
-        (source?: 'manual' | 'completed' | 'tos_accepted') => {
-            // Bridge's hosted kyc_link flow can EMBED a ToS-acceptance step
-            // before the identity steps — exactly for this cohort, which owes
-            // both. The wrapper maps that step's signedAgreementId postMessage
-            // to 'tos_accepted'; treating it as a close would kill the
-            // verification mid-flow. Keep the iframe open and CONFIRM the
-            // acceptance to the backend — fetchUser alone re-reads stored
-            // state (the resolver is pure, no Bridge calls), so without the
-            // confirm POST the accept-tos task stays visible until a Bridge
-            // webhook lands and tapping it 409s "already accepted". Same
-            // canonical path as BridgeTosStep / useMultiPhaseKycFlow; it
-            // refetches the user itself. Only 'completed' / 'manual' close.
-            if (source === 'tos_accepted') {
-                void confirmBridgeTosAndAwaitRails(fetchUser).catch(() => void fetchUser())
-                return
-            }
-            setHostedUrl(null)
-            if (source === 'completed') {
-                // Bridge re-checks the customer asynchronously — refresh so the
-                // task clears as soon as the capability model catches up.
-                void fetchUser()
-            }
-        },
-        [fetchUser]
-    )
+    // Nothing polls for this cohort — the ~4s user auto-refresh only runs
+    // while a rail is `pending`, and these are `requires-info` — so pick the
+    // result up when the user comes back from the hosted flow.
+    useEffect(() => {
+        if (!awaitingReturn) return
+        const onReturn = () => {
+            if (document.visibilityState !== 'visible') return
+            // Detach here, not just on the state flip: the re-render is async,
+            // so a second visibility event could otherwise refetch twice.
+            document.removeEventListener('visibilitychange', onReturn)
+            setAwaitingReturn(false)
+            void fetchUser()
+        }
+        document.addEventListener('visibilitychange', onReturn)
+        return () => document.removeEventListener('visibilitychange', onReturn)
+    }, [awaitingReturn, fetchUser])
 
     const closeTos = useCallback(() => setActiveTosTask(null), [])
 
-    if (visibleTasks.length === 0 && !activeTosTask && !hostedUrl) return null
+    if (visibleTasks.length === 0 && !activeTosTask) return null
 
     return (
         <>
@@ -255,8 +251,6 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
                     }
                 />
             )}
-
-            {hostedUrl && <IframeWrapper src={hostedUrl} visible onClose={handleHostedClose} />}
         </>
     )
 }

--- a/src/components/Home/PendingVerificationTasks.tsx
+++ b/src/components/Home/PendingVerificationTasks.tsx
@@ -10,7 +10,7 @@ import { useAuth } from '@/context/authContext'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import type { NextAction } from '@/types/capabilities'
 import { bridgeTaskDismissalKey, selectBridgeTasks } from '@/utils/bridge-tasks.utils'
-import { isCapacitor, openExternalUrl } from '@/utils/capacitor'
+import { isNativeBridge, openExternalUrl } from '@/utils/capacitor'
 import { formatEffectiveDate } from '@/utils/format.utils'
 import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils'
 import Card from '../Global/Card'
@@ -85,6 +85,7 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
 
     const userId = user?.user?.userId
     const tasks = selectBridgeTasks(nextActions)
+    const hasHostedTask = tasks.some((task) => task.kind === 'bridge-hosted')
     const taskKeys = tasks
         .map((task) => task.key)
         .sort()
@@ -155,15 +156,17 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
             // so Safari/Firefox block it — the same "nothing happens" symptom
             // this PR exists to fix. The reserved tab is navigated once the
             // URL lands, and closed if it never does.
-            const native = isCapacitor()
+            // isNativeBridge(), not isCapacitor(): the latter is also true for
+            // any build carrying NEXT_PUBLIC_CAPACITOR_BUILD (vercel previews),
+            // where the native apis don't exist and we'd skip the reservation
+            // in a real browser.
+            const native = isNativeBridge()
             const reservedTab = native ? null : window.open('', '_blank')
-            if (!native && !reservedTab) {
-                // Pop-ups blocked. Falling back to a post-await window.open
-                // would be blocked harder AND unobservable, so we'd promise a
-                // verification page that never opened — tell the user instead.
-                setError('Please allow pop-ups for this site, then tap again to verify.')
-                return
-            }
+            // The reserved tab can't carry `noopener` (that returns null and
+            // defeats the reservation), so sever the back-reference by hand —
+            // otherwise Persona, and anything it redirects to, holds a handle
+            // that can navigate the signed-in tab (reverse tabnabbing).
+            if (reservedTab) reservedTab.opener = null
 
             setIsStartingHosted(true)
             const { url } = await startBridgeHostedVerification()
@@ -179,11 +182,22 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
             try {
                 if (native) {
                     await openExternalUrl(url)
-                } else if (reservedTab) {
+                } else if (reservedTab && !reservedTab.closed) {
+                    // `.closed` matters: assigning href to a closed window is a
+                    // silent no-op, so without this the user would tap and see
+                    // nothing — the very failure this PR removes.
                     reservedTab.location.href = url
+                } else {
+                    // No usable tab: pop-ups blocked, a standalone PWA, or the
+                    // user closed the blank tab while we fetched. Same-tab
+                    // navigation is never gesture-gated, so it always lands.
+                    reservedTab?.close()
+                    window.location.href = url
+                    return
                 }
-            } catch {
+            } catch (error) {
                 reservedTab?.close()
+                console.error('[pending-tasks] failed to open Bridge hosted verification', error)
                 setError("We couldn't open the verification. Please try again in a moment.")
                 return
             }
@@ -195,19 +209,41 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
     // Nothing polls for this cohort — the ~4s user auto-refresh only runs
     // while a rail is `pending`, and these are `requires-info` — so pick the
     // result up when the user comes back from the hosted flow.
+    //
+    // Deliberately NOT one-shot: the first return is often incidental (a quick
+    // tab switch back, or Persona telling them to continue on their phone).
+    // Burning the single refetch there would leave the card up forever, so we
+    // keep listening and stop only once the task is actually gone (below).
     useEffect(() => {
         if (!awaitingReturn) return
+        const refresh = () => void fetchUser().catch(() => undefined)
+
+        if (isNativeBridge()) {
+            // Android WebViews don't reliably fire `visibilitychange` on
+            // resume — the same defect that makes useNativePlugins drive
+            // TanStack's focusManager off `appStateChange`. The in-app
+            // browser's own close event is the precise signal here.
+            let remove: (() => void) | undefined
+            void import('@capacitor/browser')
+                .then(({ Browser }) => Browser.addListener('browserFinished', refresh))
+                .then((handle) => {
+                    remove = () => handle.remove()
+                })
+                .catch((error) => console.error('[pending-tasks] browserFinished listener failed', error))
+            return () => remove?.()
+        }
+
         const onReturn = () => {
-            if (document.visibilityState !== 'visible') return
-            // Detach here, not just on the state flip: the re-render is async,
-            // so a second visibility event could otherwise refetch twice.
-            document.removeEventListener('visibilitychange', onReturn)
-            setAwaitingReturn(false)
-            void fetchUser().catch(() => undefined)
+            if (document.visibilityState === 'visible') refresh()
         }
         document.addEventListener('visibilitychange', onReturn)
         return () => document.removeEventListener('visibilitychange', onReturn)
     }, [awaitingReturn, fetchUser])
+
+    // Stop listening once the hosted task clears — that's the success signal.
+    useEffect(() => {
+        if (awaitingReturn && !hasHostedTask) setAwaitingReturn(false)
+    }, [awaitingReturn, hasHostedTask])
 
     const closeTos = useCallback(() => setActiveTosTask(null), [])
 

--- a/src/components/Home/PendingVerificationTasks.tsx
+++ b/src/components/Home/PendingVerificationTasks.tsx
@@ -10,7 +10,7 @@ import { useAuth } from '@/context/authContext'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import type { NextAction } from '@/types/capabilities'
 import { bridgeTaskDismissalKey, selectBridgeTasks } from '@/utils/bridge-tasks.utils'
-import { openExternalUrl } from '@/utils/capacitor'
+import { isCapacitor, openExternalUrl } from '@/utils/capacitor'
 import { formatEffectiveDate } from '@/utils/format.utils'
 import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils'
 import Card from '../Global/Card'
@@ -142,23 +142,44 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
                 setActiveTosTask(task)
                 return
             }
-            setIsStartingHosted(true)
-            const { url } = await startBridgeHostedVerification()
-            setIsStartingHosted(false)
-            if (!url) {
-                // Friendly copy regardless of the server detail (a 403 here just
-                // means the action aged out); refetch so a stale card self-corrects.
-                setError("We couldn't start the verification. Please try again in a moment.")
-                void fetchUser()
-                return
-            }
             // NOT an iframe: `bridge.withpersona.com` serves
             // `X-Frame-Options: SAMEORIGIN`, so embedding it rendered
             // "refused to connect" for EVERY user. It has to be a real
             // top-level page (native: the in-app browser). Bridge's ToS link
             // (`compliance.bridge.xyz`) sends no framing header, which is why
             // BridgeTosStep keeps its iframe.
-            await openExternalUrl(url)
+            //
+            // On web, reserve the tab HERE — synchronously, inside the click's
+            // user-activation window. Fetching the link takes ~800ms, and a
+            // window.open() after that await is no longer gesture-initiated,
+            // so Safari/Firefox block it — the same "nothing happens" symptom
+            // this PR exists to fix. The reserved tab is navigated once the
+            // URL lands, and closed if it never does.
+            const reservedTab = isCapacitor() ? null : window.open('', '_blank')
+
+            setIsStartingHosted(true)
+            const { url } = await startBridgeHostedVerification()
+            setIsStartingHosted(false)
+            if (!url) {
+                // Friendly copy regardless of the server detail (a 403 here just
+                // means the action aged out); refetch so a stale card self-corrects.
+                reservedTab?.close()
+                setError("We couldn't start the verification. Please try again in a moment.")
+                void fetchUser()
+                return
+            }
+            try {
+                if (reservedTab) {
+                    reservedTab.location.href = url
+                } else {
+                    // Native, or a browser that refused the reservation outright.
+                    await openExternalUrl(url)
+                }
+            } catch {
+                reservedTab?.close()
+                setError("We couldn't open the verification. Please try again in a moment.")
+                return
+            }
             setAwaitingReturn(true)
         },
         [fetchUser]

--- a/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
+++ b/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
@@ -5,9 +5,11 @@
  * Reads top-level capability nextActions (not rail gates) so it catches both
  * blocking tasks and advisory orphans (future-dated tasks on fully-enabled
  * users, which no rail references). accept-tos routes into the existing
- * BridgeTosStep; bridge-hosted exchanges the key for a hosted URL and opens
- * it in the IframeWrapper. Open flows are snapshotted at tap time so they
- * survive the task list flapping under the ~4s user auto-refresh.
+ * BridgeTosStep (its compliance.bridge.xyz link frames fine); bridge-hosted
+ * exchanges the key for a Persona URL and opens it in an EXTERNAL browser —
+ * bridge.withpersona.com sends X-Frame-Options: SAMEORIGIN and cannot be
+ * embedded. The ToS modal is snapshotted at tap time so it survives the task
+ * list flapping under the ~4s user auto-refresh.
  */
 import React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
@@ -34,24 +36,13 @@ jest.mock('@/utils/general.utils', () => ({
 jest.mock('@/app/actions/sumsub', () => ({
     startBridgeHostedVerification: () => mockStartHosted(),
 }))
-const mockConfirmTos = jest.fn<Promise<void>, [unknown]>()
-jest.mock('@/hooks/useMultiPhaseKycFlow', () => ({
-    confirmBridgeTosAndAwaitRails: (fetchUser: () => Promise<unknown>) => mockConfirmTos(fetchUser),
-}))
 jest.mock('@/components/Kyc/BridgeTosStep', () => ({
     BridgeTosStep: (props: { visible: boolean; reasonCode?: string }) =>
         props.visible ? <div data-testid="tos-step">{props.reasonCode}</div> : null,
 }))
-jest.mock('@/components/Global/IframeWrapper', () => ({
-    __esModule: true,
-    default: (props: { src: string; visible: boolean; onClose: (source?: string) => void }) =>
-        props.visible ? (
-            <div data-testid="hosted-iframe" data-src={props.src}>
-                <button onClick={() => props.onClose('completed')}>finish</button>
-                <button onClick={() => props.onClose('manual')}>close</button>
-                <button onClick={() => props.onClose('tos_accepted')}>accept-embedded-tos</button>
-            </div>
-        ) : null,
+const mockOpenExternalUrl = jest.fn<Promise<void>, [string]>()
+jest.mock('@/utils/capacitor', () => ({
+    openExternalUrl: (url: string) => mockOpenExternalUrl(url),
 }))
 
 const tosAction: NextAction = { key: 'accept-tos', kind: 'accept-tos', purpose: 'accept-bridge-tos' }
@@ -72,8 +63,8 @@ describe('PendingVerificationTasks', () => {
         mockNextActions = []
         mockFetchUser.mockReset()
         mockStartHosted.mockReset()
-        mockConfirmTos.mockReset()
-        mockConfirmTos.mockResolvedValue(undefined)
+        mockOpenExternalUrl.mockReset()
+        mockOpenExternalUrl.mockResolvedValue(undefined)
         mockStoredDismissal = undefined
         mockUpdatePreferences.mockReset()
         mockUserId = 'user-1'
@@ -106,7 +97,9 @@ describe('PendingVerificationTasks', () => {
         expect(screen.getByTestId('tos-step')).toHaveTextContent('bridge_tos_v2_required')
     })
 
-    it('bridge-hosted task fetches the hosted URL, opens the iframe, and refreshes the user on completion', async () => {
+    it('bridge-hosted opens the Persona URL in an EXTERNAL browser, never an iframe', async () => {
+        // bridge.withpersona.com sends X-Frame-Options: SAMEORIGIN — embedding
+        // it rendered "refused to connect" for every user in prod.
         mockNextActions = [hostedAction]
         mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
         render(<PendingVerificationTasks />)
@@ -114,44 +107,33 @@ describe('PendingVerificationTasks', () => {
         expect(screen.getByText('Additional verification needed')).toBeInTheDocument()
         fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
 
-        const iframe = await screen.findByTestId('hosted-iframe')
-        expect(iframe).toHaveAttribute('data-src', 'https://bridge.withpersona.com/verify?x=1')
-
-        fireEvent.click(screen.getByText('finish'))
-        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
-        expect(screen.queryByTestId('hosted-iframe')).not.toBeInTheDocument()
+        await waitFor(() =>
+            expect(mockOpenExternalUrl).toHaveBeenCalledWith('https://bridge.withpersona.com/verify?x=1')
+        )
+        expect(document.querySelector('iframe')).toBeNull()
     })
 
-    it('an open hosted iframe SURVIVES its task disappearing from nextActions (auto-refresh flap)', async () => {
-        mockNextActions = [hostedAction]
-        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
-        const { rerender } = render(<PendingVerificationTasks />)
-
-        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
-        await screen.findByTestId('hosted-iframe')
-
-        // Bridge reclassifies mid-flow → the task vanishes on the next refetch.
-        mockNextActions = []
-        rerender(<PendingVerificationTasks />)
-
-        expect(screen.queryByText('Additional verification needed')).not.toBeInTheDocument()
-        expect(screen.getByTestId('hosted-iframe')).toBeInTheDocument()
-
-        fireEvent.click(screen.getByText('close'))
-        expect(screen.queryByTestId('hosted-iframe')).not.toBeInTheDocument()
-    })
-
-    it('manual iframe close does not refetch the user', async () => {
+    it('refetches the user when they come back to the app (nothing polls a requires-info rail)', async () => {
         mockNextActions = [hostedAction]
         mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
         render(<PendingVerificationTasks />)
 
         fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
-        await screen.findByTestId('hosted-iframe')
-        fireEvent.click(screen.getByText('close'))
-
-        expect(screen.queryByTestId('hosted-iframe')).not.toBeInTheDocument()
+        await waitFor(() => expect(mockOpenExternalUrl).toHaveBeenCalled())
         expect(mockFetchUser).not.toHaveBeenCalled()
+
+        // Leaving the app fires visibilitychange too — only the return refetches.
+        Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true })
+        document.dispatchEvent(new Event('visibilitychange'))
+        expect(mockFetchUser).not.toHaveBeenCalled()
+
+        Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
+        document.dispatchEvent(new Event('visibilitychange'))
+        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
+
+        // One-shot: the listener removes itself, so later returns don't spam.
+        document.dispatchEvent(new Event('visibilitychange'))
+        expect(mockFetchUser).toHaveBeenCalledTimes(1)
     })
 
     it('start-action failure surfaces FRIENDLY copy (never the raw server error) and resyncs the user', async () => {
@@ -162,45 +144,8 @@ describe('PendingVerificationTasks', () => {
         fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
         expect(await screen.findByText(/couldn't start the verification/i)).toBeInTheDocument()
         expect(screen.queryByText('Action not allowed for this user')).not.toBeInTheDocument()
-        expect(screen.queryByTestId('hosted-iframe')).not.toBeInTheDocument()
+        expect(mockOpenExternalUrl).not.toHaveBeenCalled()
         expect(mockFetchUser).toHaveBeenCalledTimes(1)
-    })
-
-    it('an EMBEDDED ToS step inside the hosted flow CONFIRMS to the backend and does NOT close the iframe', async () => {
-        mockNextActions = [hostedAction]
-        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
-        render(<PendingVerificationTasks />)
-
-        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
-        await screen.findByTestId('hosted-iframe')
-
-        // Bridge's hosted kyc_link flow can open with a ToS-acceptance page;
-        // its signedAgreementId postMessage maps to onClose('tos_accepted').
-        // A bare fetchUser would NOT record the acceptance (the resolver is
-        // pure) — the canonical confirm path must run, and it refetches.
-        fireEvent.click(screen.getByText('accept-embedded-tos'))
-        expect(screen.getByTestId('hosted-iframe')).toBeInTheDocument()
-        await waitFor(() => expect(mockConfirmTos).toHaveBeenCalledTimes(1))
-        expect(mockConfirmTos).toHaveBeenCalledWith(mockFetchUser)
-
-        // The user then finishes the identity steps — completion still closes.
-        fireEvent.click(screen.getByText('finish'))
-        expect(screen.queryByTestId('hosted-iframe')).not.toBeInTheDocument()
-        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
-    })
-
-    it('a failed embedded-ToS confirm still resyncs the user and keeps the flow alive', async () => {
-        mockNextActions = [hostedAction]
-        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
-        mockConfirmTos.mockRejectedValue(new Error('confirm blew up'))
-        render(<PendingVerificationTasks />)
-
-        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
-        await screen.findByTestId('hosted-iframe')
-
-        fireEvent.click(screen.getByText('accept-embedded-tos'))
-        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
-        expect(screen.getByTestId('hosted-iframe')).toBeInTheDocument()
     })
 
     it('advisory task renders its deadline and keep-access copy; blocking renders enable copy', () => {

--- a/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
+++ b/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
@@ -20,6 +20,8 @@ let mockNextActions: NextAction[] = []
 const mockFetchUser = jest.fn()
 const mockStartHosted = jest.fn<Promise<{ url?: string; error?: string }>, []>()
 let mockStoredDismissal: string[] | undefined
+let mockReservedTab: { location: { href: string }; close: jest.Mock }
+let mockWindowOpen: jest.SpyInstance
 const mockUpdatePreferences = jest.fn()
 
 jest.mock('@/hooks/useCapabilities', () => ({
@@ -41,7 +43,9 @@ jest.mock('@/components/Kyc/BridgeTosStep', () => ({
         props.visible ? <div data-testid="tos-step">{props.reasonCode}</div> : null,
 }))
 const mockOpenExternalUrl = jest.fn<Promise<void>, [string]>()
+let mockIsCapacitor = false
 jest.mock('@/utils/capacitor', () => ({
+    isCapacitor: () => mockIsCapacitor,
     openExternalUrl: (url: string) => mockOpenExternalUrl(url),
 }))
 
@@ -65,6 +69,10 @@ describe('PendingVerificationTasks', () => {
         mockStartHosted.mockReset()
         mockOpenExternalUrl.mockReset()
         mockOpenExternalUrl.mockResolvedValue(undefined)
+        mockIsCapacitor = false
+        mockReservedTab = { location: { href: '' }, close: jest.fn() }
+        mockWindowOpen = jest.spyOn(window, 'open').mockReturnValue(mockReservedTab as unknown as Window)
+        mockWindowOpen.mockClear()
         mockStoredDismissal = undefined
         mockUpdatePreferences.mockReset()
         mockUserId = 'user-1'
@@ -97,20 +105,48 @@ describe('PendingVerificationTasks', () => {
         expect(screen.getByTestId('tos-step')).toHaveTextContent('bridge_tos_v2_required')
     })
 
-    it('bridge-hosted opens the Persona URL in an EXTERNAL browser, never an iframe', async () => {
+    it('bridge-hosted reserves a tab IN the click, then navigates it — never an iframe', async () => {
         // bridge.withpersona.com sends X-Frame-Options: SAMEORIGIN — embedding
-        // it rendered "refused to connect" for every user in prod.
+        // it rendered "refused to connect" for every user in prod. And the tab
+        // must be reserved inside the user gesture: after the ~800ms
+        // start-action round-trip, window.open() is popup-blocked on Safari.
+        mockNextActions = [hostedAction]
+        let resolveUrl: (v: { url: string }) => void = () => {}
+        mockStartHosted.mockReturnValue(new Promise((r) => (resolveUrl = r)))
+        render(<PendingVerificationTasks />)
+
+        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
+        // Reserved synchronously, BEFORE the URL exists.
+        expect(mockWindowOpen).toHaveBeenCalledWith('', '_blank')
+        expect(mockReservedTab.location.href).toBe('')
+
+        resolveUrl({ url: 'https://bridge.withpersona.com/verify?x=1' })
+        await waitFor(() => expect(mockReservedTab.location.href).toBe('https://bridge.withpersona.com/verify?x=1'))
+        expect(document.querySelector('iframe')).toBeNull()
+        expect(mockReservedTab.close).not.toHaveBeenCalled()
+    })
+
+    it('closes the reserved tab when the hosted URL never arrives', async () => {
+        mockNextActions = [hostedAction]
+        mockStartHosted.mockResolvedValue({ error: 'Action not allowed for this user' })
+        render(<PendingVerificationTasks />)
+
+        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
+        expect(await screen.findByText(/couldn't start the verification/i)).toBeInTheDocument()
+        await waitFor(() => expect(mockReservedTab.close).toHaveBeenCalledTimes(1))
+    })
+
+    it('native (Capacitor) skips the tab reservation and uses the in-app browser', async () => {
+        mockIsCapacitor = true
         mockNextActions = [hostedAction]
         mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
         render(<PendingVerificationTasks />)
 
-        expect(screen.getByText('Additional verification needed')).toBeInTheDocument()
         fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
-
         await waitFor(() =>
             expect(mockOpenExternalUrl).toHaveBeenCalledWith('https://bridge.withpersona.com/verify?x=1')
         )
-        expect(document.querySelector('iframe')).toBeNull()
+        expect(mockWindowOpen).not.toHaveBeenCalled()
     })
 
     it('refetches the user when they come back to the app (nothing polls a requires-info rail)', async () => {
@@ -119,7 +155,7 @@ describe('PendingVerificationTasks', () => {
         render(<PendingVerificationTasks />)
 
         fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
-        await waitFor(() => expect(mockOpenExternalUrl).toHaveBeenCalled())
+        await waitFor(() => expect(mockReservedTab.location.href).toContain('withpersona'))
         expect(mockFetchUser).not.toHaveBeenCalled()
 
         // Leaving the app fires visibilitychange too — only the return refetches.

--- a/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
+++ b/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
@@ -17,7 +17,7 @@ import type { NextAction } from '@/types/capabilities'
 import PendingVerificationTasks from '../PendingVerificationTasks'
 
 let mockNextActions: NextAction[] = []
-const mockFetchUser = jest.fn()
+const mockFetchUser = jest.fn(() => Promise.resolve(null))
 const mockStartHosted = jest.fn<Promise<{ url?: string; error?: string }>, []>()
 let mockStoredDismissal: string[] | undefined
 let mockReservedTab: { location: { href: string }; close: jest.Mock }
@@ -66,6 +66,7 @@ describe('PendingVerificationTasks', () => {
     beforeEach(() => {
         mockNextActions = []
         mockFetchUser.mockReset()
+        mockFetchUser.mockResolvedValue(null)
         mockStartHosted.mockReset()
         mockOpenExternalUrl.mockReset()
         mockOpenExternalUrl.mockResolvedValue(undefined)
@@ -124,6 +125,21 @@ describe('PendingVerificationTasks', () => {
         await waitFor(() => expect(mockReservedTab.location.href).toBe('https://bridge.withpersona.com/verify?x=1'))
         expect(document.querySelector('iframe')).toBeNull()
         expect(mockReservedTab.close).not.toHaveBeenCalled()
+    })
+
+    it('pop-ups blocked → tells the user, and never fires the side-effecting Bridge call', async () => {
+        // openExternalUrl would just call window.open again AFTER the await —
+        // blocked harder, and its null result is unobservable, so we would have
+        // promised a page that never opened.
+        mockWindowOpen.mockReturnValue(null)
+        mockNextActions = [hostedAction]
+        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
+        render(<PendingVerificationTasks />)
+
+        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
+        expect(await screen.findByText(/allow pop-ups/i)).toBeInTheDocument()
+        expect(mockStartHosted).not.toHaveBeenCalled()
+        expect(mockOpenExternalUrl).not.toHaveBeenCalled()
     })
 
     it('closes the reserved tab when the hosted URL never arrives', async () => {

--- a/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
+++ b/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
@@ -20,7 +20,8 @@ let mockNextActions: NextAction[] = []
 const mockFetchUser = jest.fn(() => Promise.resolve(null))
 const mockStartHosted = jest.fn<Promise<{ url?: string; error?: string }>, []>()
 let mockStoredDismissal: string[] | undefined
-let mockReservedTab: { location: { href: string }; close: jest.Mock }
+let mockReservedTab: { location: { href: string }; close: jest.Mock; closed: boolean; opener: unknown }
+const mockAssignHref = jest.fn()
 let mockWindowOpen: jest.SpyInstance
 const mockUpdatePreferences = jest.fn()
 
@@ -45,9 +46,20 @@ jest.mock('@/components/Kyc/BridgeTosStep', () => ({
 const mockOpenExternalUrl = jest.fn<Promise<void>, [string]>()
 let mockIsCapacitor = false
 jest.mock('@/utils/capacitor', () => ({
-    isCapacitor: () => mockIsCapacitor,
+    isNativeBridge: () => mockIsCapacitor,
     openExternalUrl: (url: string) => mockOpenExternalUrl(url),
 }))
+const mockBrowserListener = { remove: jest.fn() }
+const mockBrowserAddListener = jest.fn<Promise<{ remove: jest.Mock }>, [string, () => void]>(() =>
+    Promise.resolve(mockBrowserListener)
+)
+jest.mock(
+    '@capacitor/browser',
+    () => ({
+        Browser: { addListener: (event: string, cb: () => void) => mockBrowserAddListener(event, cb) },
+    }),
+    { virtual: true }
+)
 
 const tosAction: NextAction = { key: 'accept-tos', kind: 'accept-tos', purpose: 'accept-bridge-tos' }
 const sepaTosAction: NextAction = {
@@ -71,7 +83,21 @@ describe('PendingVerificationTasks', () => {
         mockOpenExternalUrl.mockReset()
         mockOpenExternalUrl.mockResolvedValue(undefined)
         mockIsCapacitor = false
-        mockReservedTab = { location: { href: '' }, close: jest.fn() }
+        mockAssignHref.mockReset()
+        // jsdom refuses real navigation; capture the same-tab fallback instead.
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: {
+                get href() {
+                    return 'http://localhost/home'
+                },
+                set href(value: string) {
+                    mockAssignHref(value)
+                },
+            },
+        })
+        mockBrowserAddListener.mockClear()
+        mockReservedTab = { location: { href: '' }, close: jest.fn(), closed: false, opener: {} }
         mockWindowOpen = jest.spyOn(window, 'open').mockReturnValue(mockReservedTab as unknown as Window)
         mockWindowOpen.mockClear()
         mockStoredDismissal = undefined
@@ -127,19 +153,59 @@ describe('PendingVerificationTasks', () => {
         expect(mockReservedTab.close).not.toHaveBeenCalled()
     })
 
-    it('pop-ups blocked → tells the user, and never fires the side-effecting Bridge call', async () => {
-        // openExternalUrl would just call window.open again AFTER the await —
-        // blocked harder, and its null result is unobservable, so we would have
-        // promised a page that never opened.
+    it('no usable tab (pop-up blocked / standalone PWA) falls back to same-tab navigation', async () => {
+        // A post-await window.open would be blocked and its null return is
+        // unobservable; same-tab navigation is never gesture-gated.
         mockWindowOpen.mockReturnValue(null)
         mockNextActions = [hostedAction]
         mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
         render(<PendingVerificationTasks />)
 
         fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
-        expect(await screen.findByText(/allow pop-ups/i)).toBeInTheDocument()
-        expect(mockStartHosted).not.toHaveBeenCalled()
+        await waitFor(() => expect(mockAssignHref).toHaveBeenCalledWith('https://bridge.withpersona.com/verify?x=1'))
         expect(mockOpenExternalUrl).not.toHaveBeenCalled()
+    })
+
+    it('a tab closed mid-fetch falls back instead of silently navigating a dead window', async () => {
+        mockNextActions = [hostedAction]
+        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
+        mockReservedTab.closed = true
+        render(<PendingVerificationTasks />)
+
+        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
+        await waitFor(() => expect(mockAssignHref).toHaveBeenCalledWith('https://bridge.withpersona.com/verify?x=1'))
+        expect(mockReservedTab.location.href).toBe('')
+        expect(mockReservedTab.close).toHaveBeenCalled()
+    })
+
+    it('severs window.opener on the reserved tab (reverse tabnabbing)', async () => {
+        mockNextActions = [hostedAction]
+        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
+        render(<PendingVerificationTasks />)
+
+        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
+        expect(mockReservedTab.opener).toBeNull()
+    })
+
+    it('native waits on the in-app browser close event, not visibilitychange', async () => {
+        mockIsCapacitor = true
+        mockNextActions = [hostedAction]
+        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
+        render(<PendingVerificationTasks />)
+
+        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
+        await waitFor(() =>
+            expect(mockBrowserAddListener).toHaveBeenCalledWith('browserFinished', expect.any(Function))
+        )
+
+        // Android WebViews may never fire visibilitychange on resume.
+        Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
+        document.dispatchEvent(new Event('visibilitychange'))
+        expect(mockFetchUser).not.toHaveBeenCalled()
+
+        const onFinished = mockBrowserAddListener.mock.calls[0][1]
+        onFinished()
+        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
     })
 
     it('closes the reserved tab when the hosted URL never arrives', async () => {
@@ -183,9 +249,10 @@ describe('PendingVerificationTasks', () => {
         document.dispatchEvent(new Event('visibilitychange'))
         await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
 
-        // One-shot: the listener removes itself, so later returns don't spam.
+        // NOT one-shot: an incidental switch-back must not burn the refetch,
+        // so a later real return refreshes again.
         document.dispatchEvent(new Event('visibilitychange'))
-        expect(mockFetchUser).toHaveBeenCalledTimes(1)
+        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(2))
     })
 
     it('start-action failure surfaces FRIENDLY copy (never the raw server error) and resyncs the user', async () => {

--- a/src/utils/capacitor.ts
+++ b/src/utils/capacitor.ts
@@ -22,6 +22,19 @@ export function isCapacitor(): boolean {
 }
 
 /**
+ * true ONLY when the capacitor native bridge is actually present.
+ *
+ * Unlike {@link isCapacitor}, this ignores NEXT_PUBLIC_CAPACITOR_BUILD, which
+ * is baked into web builds (vercel previews) where there is no bridge at all.
+ * Use this to decide whether a NATIVE api will really work; use isCapacitor()
+ * for build-flavor questions.
+ */
+export function isNativeBridge(): boolean {
+    if (typeof window === 'undefined') return false
+    return !!(window as any).Capacitor?.isNativePlatform?.()
+}
+
+/**
  * returns the platform the app is running on
  */
 export function getPlatform(): 'web' | 'ios-native' | 'android-native' | 'ios-pwa' | 'android-pwa' {


### PR DESCRIPTION
## Summary

The "Additional verification needed" card (shipped yesterday in #2549) opens Bridge's hosted Persona URL inside `IframeWrapper`. **`bridge.withpersona.com` serves `X-Frame-Options: SAMEORIGIN`**, so every browser refuses to render it — users see `bridge.withpersona.com refused to connect` inside our verification chrome. This has been broken for **100% of users** since the merge; the link itself is fine and resolves normally when opened top-level.

```
$ curl -sSI https://bridge.withpersona.com/verify | grep -i x-frame
x-frame-options: SAMEORIGIN

$ curl -sSI https://compliance.bridge.xyz/accept-terms-of-service | grep -i x-frame
(none)   ← which is why the ToS card works and this one never did
```

Prod confirms the split: of 11 users confirmed to have tapped the hosted card, **9 produced zero Bridge-side activity** (no webhook, no re-adjudication). The only in-app success in 25h came through the **ToS** card, whose link frames fine.

## The fix

Route the `bridge-hosted` action through the existing **`openExternalUrl()`** helper (`src/utils/capacitor.ts`) — `window.open(_blank)` on web, `@capacitor/browser` in the native app — and refetch the user when they come back. The `accept-tos` branch is untouched and keeps its iframe.

The refetch is needed because nothing polls this cohort: the ~4s user auto-refresh only runs while a rail is `pending`, and these rails are `requires-info`. A one-shot `visibilitychange` listener (registered in an effect, detached on fire and on unmount) picks up the result.

Also deletes the hosted iframe's `onClose` handler including its embedded-ToS confirm branch — with the flow out-of-app there is no `postMessage` to receive, and Bridge's webhook carries the acceptance.

**Diff: 2 files, +63 / −124.**

## Risks / breaking changes

- **Low.** The failure mode being replaced is a total one (nothing worked); anything that renders is an improvement.
- Behavioural change: tapping now **leaves the app** (native: in-app browser overlay). That is the only way to load a `SAMEORIGIN` page.
- No API/contract change, no `NEXT_PUBLIC_API_VERSION` bump.
- **Base is `main`** (hotfix) → back-merge debt `main` → `dev` after merge.

## QA

- 19 Jest cases in `PendingVerificationTasks.test.tsx`, incl. three rewritten for this path: opens via `openExternalUrl` and renders **no iframe**; refetch fires on return-to-app but not on leaving, and only once; start-action failure still shows friendly copy and never opens a browser.
- Full suite 179/179 green; typecheck + prettier clean.
- Header behaviour verified directly against both hosts (`curl -I`, output above) — this is the class of bug no unit test can catch, since it only exists in a real browser against the real Persona host.

## Screenshots

**N/A — no visible change to the card.** The rendered card is byte-identical; what changes is where the tap goes (external browser instead of an embedded frame that could never paint). The broken state is the user-reported screenshot above.

## Design notes / accepted trade-offs

- **Why not fix the iframe?** Not possible from our side — `X-Frame-Options` is set by Persona on every response; only Persona/Bridge could allowlist `peanut.me`. Worth asking them for a framable embed long-term, but that's a provider conversation, not a code change.
- **Why `visibilitychange` and not `focus`?** `focus` is unreliable when returning from the Capacitor in-app browser overlay; `visibilitychange` covers both web tab-return and native app-resume.

## Follow-ups (NOT in this PR)

- No analytics on this surface — there is no impression/tap event, which is why diagnosing this took log-timestamp archaeology instead of one PostHog query.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hosted Bridge verification now opens in a separate browser page instead of an embedded frame.
  * Verification status refreshes automatically when you return to the app.
  * Terms of Service steps remain available within the app.
  * External verification supports native in-app browsing experiences.

* **Bug Fixes**
  * Improved recovery when verification cannot be started or a browser popup is blocked.
  * Prevented reserved browser tabs from remaining open after startup failures.
  * Prevented stale verification states after returning from the external flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->