### PR TITLE
feat(i18n): localize Sumsub SDKs

### DIFF
--- a/src/components/Kyc/SumsubKycWrapper.tsx
+++ b/src/components/Kyc/SumsubKycWrapper.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useState, useRef, useCallback } from 'react'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
 import Modal from '@/components/Global/Modal'
 import ActionModal from '@/components/Global/ActionModal'
 import { Icon, type IconName } from '@/components/Global/Icons/Icon'
@@ -11,6 +11,7 @@ import posthog from 'posthog-js'
 import { useModalsContext } from '@/context/ModalsContext'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { isCapacitor } from '@/utils/capacitor'
+import { toSumsubLocale } from '@/i18n/app/sumsub-locale'
 import { evaluateSumsubStatusEvent, type SumsubStatusEventPayload } from './sumsubStatusEvent.utils'
 import { SumsubNativeSdk } from './SumsubNativeSdk'
 import { SumsubSdkErrorView } from './SumsubSdkErrorView'
@@ -65,6 +66,8 @@ const SumsubWebSdkModal = ({
     const { setIsSupportModalOpen } = useModalsContext()
     const t = useTranslations('kyc')
     const tCommon = useTranslations('common')
+    const locale = useLocale()
+    const sumsubLocaleRef = useRef(toSumsubLocale(locale))
 
     // callback refs to avoid stale closures in sdk init effect
     const onCompleteRef = useRef(onComplete)
@@ -84,6 +87,10 @@ const SumsubWebSdkModal = ({
         onRefreshTokenRef.current = onRefreshToken
         isMultiLevelRef.current = isMultiLevel
     }, [onComplete, onError, onRefreshToken, isMultiLevel])
+
+    useEffect(() => {
+        sumsubLocaleRef.current = toSumsubLocale(locale)
+    }, [locale])
 
     // stable wrappers that read from refs
     const stableOnComplete = useCallback(() => onCompleteRef.current(), [])
@@ -194,7 +201,7 @@ const SumsubWebSdkModal = ({
 
             const sdk = window.snsWebSdk
                 .init(accessToken, stableOnRefreshToken)
-                .withConf({ lang: 'en', theme: 'light' })
+                .withConf({ lang: sumsubLocaleRef.current, theme: 'light' })
                 .withOptions({ addViewportTag: false, adaptIframeHeight: true })
                 .on('onApplicantSubmitted', handleSubmitted)
                 .on('onApplicantResubmitted', handleResubmitted)

--- a/src/components/Kyc/SumsubNativeSdk.tsx
+++ b/src/components/Kyc/SumsubNativeSdk.tsx
@@ -1,11 +1,12 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
 import * as Sentry from '@sentry/nextjs'
 import posthog from 'posthog-js'
 import Modal from '@/components/Global/Modal'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { toSumsubLocale } from '@/i18n/app/sumsub-locale'
 import { SumsubSdkErrorView } from './SumsubSdkErrorView'
 import type { SumsubSdkProps } from './sumsubSdk.types'
 
@@ -36,6 +37,7 @@ export const SumsubNativeSdk = ({
     onRefreshToken,
 }: SumsubSdkProps) => {
     const t = useTranslations('kyc')
+    const locale = useLocale()
     const [failure, setFailure] = useState<'sdk-missing' | 'launch' | null>(null)
 
     const onCloseRef = useRef(onClose)
@@ -43,6 +45,7 @@ export const SumsubNativeSdk = ({
     const onErrorRef = useRef(onError)
     const onRefreshTokenRef = useRef(onRefreshToken)
     const accessTokenRef = useRef(accessToken)
+    const sumsubLocaleRef = useRef(toSumsubLocale(locale))
 
     useEffect(() => {
         onCloseRef.current = onClose
@@ -51,6 +54,10 @@ export const SumsubNativeSdk = ({
         onRefreshTokenRef.current = onRefreshToken
         accessTokenRef.current = accessToken
     }, [onClose, onComplete, onError, onRefreshToken, accessToken])
+
+    useEffect(() => {
+        sumsubLocaleRef.current = toSumsubLocale(locale)
+    }, [locale])
 
     // Gate on token PRESENCE, not identity: refreshToken() writes a new token
     // into the same state, and re-running this effect on that would dismiss and
@@ -93,7 +100,7 @@ export const SumsubNativeSdk = ({
                         if (event?.newStatus && SUBMITTED_STATES.has(event.newStatus)) hasSubmitted = true
                     },
                 })
-                .withLocale('en')
+                .withLocale(sumsubLocaleRef.current)
                 .withDebug(process.env.NODE_ENV === 'development')
                 .build()
 

--- a/src/i18n/app/__tests__/sumsub-locale.test.ts
+++ b/src/i18n/app/__tests__/sumsub-locale.test.ts
@@ -1,0 +1,17 @@
+import { APP_LOCALES } from '../config'
+import { toSumsubLocale } from '../sumsub-locale'
+
+describe('toSumsubLocale', () => {
+    it.each([
+        ['en', 'en'],
+        ['es-419', 'es'],
+        ['es-AR', 'es'],
+        ['pt-BR', 'pt-br'],
+    ] as const)('%s → %s', (appLocale, sumsubLocale) => {
+        expect(toSumsubLocale(appLocale)).toBe(sumsubLocale)
+    })
+
+    it('maps every supported app locale to a Sumsub locale', () => {
+        for (const locale of APP_LOCALES) expect(toSumsubLocale(locale)).toBeTruthy()
+    })
+})

--- a/src/i18n/app/sumsub-locale.ts
+++ b/src/i18n/app/sumsub-locale.ts
@@ -1,0 +1,12 @@
+import type { AppLocale } from './config'
+
+const SUMSUB_LOCALES: Record<AppLocale, string> = {
+    en: 'en',
+    'es-419': 'es',
+    'es-AR': 'es',
+    'pt-BR': 'pt-br',
+}
+
+export function toSumsubLocale(locale: AppLocale): string {
+    return SUMSUB_LOCALES[locale]
+}


### PR DESCRIPTION
## Summary

Pass the active Peanut app locale to Sumsub WebSDK and the Capacitor/Cordova SDK. Spanish app variants map to `es`; Brazilian Portuguese maps to `pt-br`.

## Task

[Localize the Sumsub KYC flow](https://app.notion.com/p/peanutprotocol/Localize-the-Sumsub-KYC-flow-investigate-implement-3aa838117579810bb4d0dceb74fe603a?v=1e48381175798031a715000c233845ed&source=copy_link)

## Risks / breaking changes

No API or contract changes. Sumsub uses the selected locale when a verification session launches; an active native session is not restarted after a language change.

## QA

- `pnpm prettier --check .`
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`
- Screenshots: N/A (no visible Peanut UI change; the hosted Sumsub UI changes language.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - KYC verification now displays in the selected app language when supported by the verification provider.
  - Locale changes are applied automatically to both web and native KYC flows.

- **Tests**
  - Added coverage to verify supported application locales map correctly to verification locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->