### PR TITLE
hotfix(native): restore transaction timeout and ENS safety

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,8 +73,8 @@ export PROMO_LIST={}
 export NEXT_PUBLIC_VAPID_PUBLIC_KEY=
 export VAPID_PRIVATE_KEY=
 export NEXT_PUBLIC_VAPID_SUBJECT="mailto:hello@peanut.me"
-# Overrides BOTH fetch budgets (client 20s / server 30s, src/utils/sentry.utils.ts).
-# Positive integer of milliseconds; empty or malformed = keep the defaults.
+# Overrides BOTH fetch budgets (client 20s / server 10s, src/utils/sentry.utils.ts).
+# Positive integer of milliseconds, max 2147483647; empty or malformed = keep the defaults.
 export NEXT_PUBLIC_FETCH_TIMEOUT_MS=
 
 # one signal 

--- a/.env.example
+++ b/.env.example
@@ -73,7 +73,9 @@ export PROMO_LIST={}
 export NEXT_PUBLIC_VAPID_PUBLIC_KEY=
 export VAPID_PRIVATE_KEY=
 export NEXT_PUBLIC_VAPID_SUBJECT="mailto:hello@peanut.me"
-export NEXT_PUBLIC_FETCH_TIMEOUT_MS=10000
+# Overrides BOTH fetch budgets (client 20s / server 30s, src/utils/sentry.utils.ts).
+# Positive integer of milliseconds; empty or malformed = keep the defaults.
+export NEXT_PUBLIC_FETCH_TIMEOUT_MS=
 
 # one signal 
 export NEXT_PUBLIC_ONESIGNAL_APP_ID=

--- a/src/app/(mobile-ui)/withdraw/crypto/__tests__/crypto-withdraw-confirm.test.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/__tests__/crypto-withdraw-confirm.test.tsx
@@ -93,6 +93,7 @@ jest.mock('@/utils/withdraw.utils', () => ({
 
 jest.mock('@/utils/general.utils', () => ({
     isTxReverted: (receipt: { status?: string } | null) => receipt?.status === 'reverted',
+    printableAddress: (address: string) => address,
 }))
 
 jest.mock('@/utils/url.utils', () => ({

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -33,7 +33,7 @@ import { useAppHaptic } from '@/hooks/useAppHaptic'
 import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN, PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
 import { useCrossChainTransfer } from '@/features/payments/shared/hooks/useCrossChainTransfer'
 import { usePaymentRecorder } from '@/features/payments/shared/hooks/usePaymentRecorder'
-import { isTxReverted } from '@/utils/general.utils'
+import { isTxReverted, printableAddress } from '@/utils/general.utils'
 import { appBaseUrl } from '@/utils/url.utils'
 import { useFriendlyError } from '@/hooks/useFriendlyError'
 import posthog from 'posthog-js'
@@ -620,7 +620,21 @@ export default function WithdrawCryptoPage() {
                 }}
                 preventClose={isPreparingReview}
                 title={t('compatibilityModal.title')}
-                description={t('compatibilityModal.description')}
+                description={
+                    <div className="space-y-2">
+                        <p>{t('compatibilityModal.description')}</p>
+                        {/* Show the concrete destination so the user confirms a real
+                            address, not an abstract warning — for ENS recipients this
+                            is the first time the resolved address is visible. */}
+                        {!!withdrawData?.address && (
+                            <p>
+                                <span className="font-mono font-medium text-n-1 dark:text-white">
+                                    {printableAddress(withdrawData.address)}
+                                </span>
+                            </p>
+                        )}
+                    </div>
+                }
                 icon="alert"
                 footer={
                     <div className="w-full">

--- a/src/app/actions/ens.ts
+++ b/src/app/actions/ens.ts
@@ -2,8 +2,13 @@ import { unstable_cache } from '@/utils/no-cache'
 import { serverFetch } from '@/utils/api-fetch'
 
 export const resolveEns = unstable_cache(
-    async (ensName: string): Promise<string | undefined> => {
-        const response = await serverFetch(`/ens/${encodeURIComponent(ensName)}`, {
+    async (ensName: string, chainId?: string): Promise<string | undefined> => {
+        // ENSIP-11: names can hold a distinct address per chain — resolve for
+        // the destination chain, not just mainnet. Backend falls back to the
+        // ETH (coinType 60) record when no chain-specific record exists.
+        const numericChainId = chainId ? Number(chainId) : undefined
+        const query = numericChainId && Number.isInteger(numericChainId) ? `?chainId=${numericChainId}` : ''
+        const response = await serverFetch(`/ens/${encodeURIComponent(ensName)}${query}`, {
             method: 'GET',
         })
         if (response.status === 404) return undefined

--- a/src/components/Global/GeneralRecipientInput/index.tsx
+++ b/src/components/Global/GeneralRecipientInput/index.tsx
@@ -23,6 +23,9 @@ type GeneralRecipientInputProps = {
      *  Solana/Tron short-circuit the IBAN/US-routing/ENS branches — a base58
      *  address is the only valid input for them. */
     addressFamily?: WithdrawAddressFamily
+    /** Destination chain id — ENS names resolve to their ENSIP-11 per-chain
+     *  address record for this chain (mainnet record when omitted). */
+    chainId?: string
 }
 
 export type GeneralRecipientUpdate = {
@@ -42,6 +45,7 @@ const GeneralRecipientInput = ({
     showInfoText = true,
     isWithdrawal = false,
     addressFamily = 'evm',
+    chainId,
 }: GeneralRecipientInputProps) => {
     const t = useTranslations('global')
     const recipientType = useRef<RecipientType>('address')
@@ -82,7 +86,12 @@ const GeneralRecipientInput = ({
                     isValid = true
                 } else {
                     try {
-                        const validation = await validateAndResolveRecipient(trimmedInput, isWithdrawal)
+                        const validation = await validateAndResolveRecipient(
+                            trimmedInput,
+                            isWithdrawal,
+                            addressFamily,
+                            chainId
+                        )
 
                         isValid = true
                         resolvedAddress.current = validation.resolvedAddress
@@ -105,7 +114,7 @@ const GeneralRecipientInput = ({
                 return false
             }
         },
-        [isWithdrawal, addressFamily, t]
+        [isWithdrawal, addressFamily, chainId, t]
     )
 
     const onInputUpdate = useCallback(

--- a/src/components/Home/PendingVerificationTasks.tsx
+++ b/src/components/Home/PendingVerificationTasks.tsx
@@ -171,7 +171,9 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
                                         <div className="text-base font-bold">{copy.title}</div>
                                         <div className="text-sm text-grey-1">{copy.description}</div>
                                         {deadline && (
-                                            <div className="mt-1 text-xs font-medium">Complete before {deadline}</div>
+                                            <div className="mt-1 text-xs font-medium">
+                                                {'Complete before'} {deadline}
+                                            </div>
                                         )}
                                     </div>
                                     <Button

--- a/src/components/Withdraw/views/Initial.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Initial.withdraw.view.tsx
@@ -9,13 +9,14 @@ import { useWithdrawFlow } from '@/context/WithdrawFlowContext'
 import { tokenSelectorContext } from '@/context/tokenSelector.context'
 import { type ITokenPriceData } from '@/interfaces/interfaces'
 import type { ChainWithTokens } from '@/interfaces/chain-meta'
-import { formatAmount } from '@/utils/general.utils'
+import { formatAmount, printableAddress } from '@/utils/general.utils'
 import { useRouter } from 'next/navigation'
 import { useContext, useEffect, useMemo, useRef } from 'react'
 import TokenSelector from '@/components/Global/TokenSelector/TokenSelector'
 import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants/zerodev.consts'
 import { addressFamilyForChainId } from '@/lib/validation/addressFamily'
 import { useTranslations } from 'next-intl'
+import { validateAndResolveRecipient } from '@/lib/validation/recipient'
 
 interface InitialWithdrawViewProps {
     amount: string
@@ -72,6 +73,38 @@ export default function InitialWithdrawView({ amount, onReview, onBack, isProces
             if (error.showError) setError({ showError: false, errorMessage: '' })
         }
     }, [selectedChainID, error.showError, setError])
+
+    // ENS names resolve per destination chain (ENSIP-11) — a validated name
+    // must re-resolve when the user switches chains after typing it, or the
+    // withdraw would go to the previous chain's address. Kept separate from the
+    // error-clearing effect above: its error.showError dep would abort an
+    // in-flight resolution via this cleanup.
+    const prevResolvedChainRef = useRef(selectedChainID)
+    useEffect(() => {
+        if (prevResolvedChainRef.current === selectedChainID) return
+        prevResolvedChainRef.current = selectedChainID
+        if (addressFamily !== 'evm' || !recipient.name) return
+
+        const name = recipient.name
+        let stale = false
+        validateAndResolveRecipient(name, true, 'evm', selectedChainID)
+            .then((validation) => {
+                if (stale) return
+                setRecipient({ name, address: validation.resolvedAddress })
+            })
+            .catch(() => {
+                if (stale) return
+                setRecipient({ name: undefined, address: '' })
+                setIsValidRecipient(false)
+                setError({
+                    showError: true,
+                    errorMessage: 'Could not resolve the ENS name for the selected network',
+                })
+            })
+        return () => {
+            stale = true
+        }
+    }, [selectedChainID, addressFamily, recipient.name, setRecipient, setIsValidRecipient, setError])
 
     const handleReview = () => {
         // Context record already includes the synthetic non-EVM withdraw
@@ -151,6 +184,7 @@ export default function InitialWithdrawView({ amount, onReview, onBack, isProces
                         addressFamily === 'evm' ? t('initial.placeholderEns') : t('initial.placeholderAddress')
                     }
                     addressFamily={addressFamily}
+                    chainId={selectedChainID}
                     recipient={recipient}
                     onUpdate={(update: GeneralRecipientUpdate) => {
                         setRecipient(update.recipient)
@@ -164,6 +198,16 @@ export default function InitialWithdrawView({ amount, onReview, onBack, isProces
                     showInfoText={false}
                     isWithdrawal
                 />
+
+                {/* Surface the resolved address as soon as an ENS name validates —
+                    the user must see where funds will actually go before any
+                    review/warning step (external tester feedback). */}
+                {!!recipient.name && !!recipient.address && isValidRecipient && !inputChanging && (
+                    <p className="text-left text-xs text-grey-1">
+                        {recipient.name} resolves to{' '}
+                        <span className="font-mono">{printableAddress(recipient.address)}</span>
+                    </p>
+                )}
 
                 <Button
                     variant="purple"

--- a/src/components/Withdraw/views/Initial.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Initial.withdraw.view.tsx
@@ -204,7 +204,7 @@ export default function InitialWithdrawView({ amount, onReview, onBack, isProces
                     review/warning step (external tester feedback). */}
                 {!!recipient.name && !!recipient.address && isValidRecipient && !inputChanging && (
                     <p className="text-left text-xs text-grey-1">
-                        {recipient.name} {t('resolvesTo')}{' '}
+                        {recipient.name} resolves to{' '}
                         <span className="font-mono">{printableAddress(recipient.address)}</span>
                     </p>
                 )}

--- a/src/components/Withdraw/views/Initial.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Initial.withdraw.view.tsx
@@ -204,7 +204,7 @@ export default function InitialWithdrawView({ amount, onReview, onBack, isProces
                     review/warning step (external tester feedback). */}
                 {!!recipient.name && !!recipient.address && isValidRecipient && !inputChanging && (
                     <p className="text-left text-xs text-grey-1">
-                        {recipient.name} resolves to{' '}
+                        {recipient.name} {'resolves to'}{' '}
                         <span className="font-mono">{printableAddress(recipient.address)}</span>
                     </p>
                 )}

--- a/src/components/Withdraw/views/Initial.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Initial.withdraw.view.tsx
@@ -204,7 +204,7 @@ export default function InitialWithdrawView({ amount, onReview, onBack, isProces
                     review/warning step (external tester feedback). */}
                 {!!recipient.name && !!recipient.address && isValidRecipient && !inputChanging && (
                     <p className="text-left text-xs text-grey-1">
-                        {recipient.name} resolves to{' '}
+                        {recipient.name} {t('resolvesTo')}{' '}
                         <span className="font-mono">{printableAddress(recipient.address)}</span>
                     </p>
                 )}

--- a/src/components/Withdraw/views/Initial.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Initial.withdraw.view.tsx
@@ -87,10 +87,13 @@ export default function InitialWithdrawView({ amount, onReview, onBack, isProces
 
         const name = recipient.name
         let stale = false
+        setRecipient({ name, address: '' })
+        setIsValidRecipient(false)
         validateAndResolveRecipient(name, true, 'evm', selectedChainID)
             .then((validation) => {
                 if (stale) return
                 setRecipient({ name, address: validation.resolvedAddress })
+                setIsValidRecipient(true)
             })
             .catch(() => {
                 if (stale) return

--- a/src/components/Withdraw/views/__tests__/Initial.withdraw.view.test.tsx
+++ b/src/components/Withdraw/views/__tests__/Initial.withdraw.view.test.tsx
@@ -1,0 +1,150 @@
+import React, { useMemo, useState } from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
+import { WithdrawFlowContextProvider } from '@/context/WithdrawFlowContext'
+import { tokenSelectorContext } from '@/context/tokenSelector.context'
+import InitialWithdrawView from '../Initial.withdraw.view'
+import { validateAndResolveRecipient } from '@/lib/validation/recipient'
+
+jest.mock('@/lib/validation/recipient', () => ({
+    validateAndResolveRecipient: jest.fn(),
+}))
+
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ push: jest.fn() }),
+}))
+
+jest.mock('@/components/0_Bruddle/Button', () => ({
+    Button: ({
+        children,
+        disabled,
+        onClick,
+    }: {
+        children: React.ReactNode
+        disabled: boolean
+        onClick: () => void
+    }) => (
+        <button disabled={disabled} onClick={onClick}>
+            {children}
+        </button>
+    ),
+}))
+
+jest.mock('@/components/Global/GeneralRecipientInput', () => ({
+    __esModule: true,
+    default: ({ onUpdate }: { onUpdate: (update: unknown) => void }) => (
+        <button
+            onClick={() =>
+                onUpdate({
+                    recipient: { name: 'alice.eth', address: '0x1111111111111111111111111111111111111111' },
+                    isValid: true,
+                    isChanging: false,
+                    errorMessage: '',
+                })
+            }
+        >
+            set ENS recipient
+        </button>
+    ),
+}))
+
+jest.mock('@/components/Global/NavHeader', () => ({
+    __esModule: true,
+    default: () => null,
+}))
+
+jest.mock('@/components/Global/PeanutActionDetailsCard', () => ({
+    __esModule: true,
+    default: () => null,
+}))
+
+jest.mock('@/components/Global/TokenSelector/TokenSelector', () => ({
+    __esModule: true,
+    default: () => null,
+}))
+
+jest.mock('@/components/Global/ErrorAlert', () => ({
+    __esModule: true,
+    default: () => null,
+}))
+
+jest.mock('@/constants/zerodev.consts', () => ({
+    PEANUT_WALLET_CHAIN: { id: 1, name: 'Ethereum' },
+    PEANUT_WALLET_TOKEN: '0x0000000000000000000000000000000000000000',
+}))
+
+const mockValidateAndResolveRecipient = validateAndResolveRecipient as jest.MockedFunction<
+    typeof validateAndResolveRecipient
+>
+
+const deferred = <T,>() => {
+    let resolve!: (value: T) => void
+    const promise = new Promise<T>((resolvePromise) => {
+        resolve = resolvePromise
+    })
+    return { promise, resolve }
+}
+
+const supportedChainsAndTokens = {
+    '1': { chainId: '1', networkName: 'Ethereum', chainIconURI: '', tokens: [] },
+    '8453': { chainId: '8453', networkName: 'Base', chainIconURI: '', tokens: [] },
+}
+
+function TestHarness() {
+    const [selectedChainID, setSelectedChainID] = useState('1')
+    const tokenContext = useMemo(
+        () =>
+            ({
+                selectedTokenData: { address: '0x0000000000000000000000000000000000000000' },
+                selectedChainID,
+                supportedChainsAndTokens,
+                setSelectedChainID: jest.fn(),
+                setSelectedTokenAddress: jest.fn(),
+            }) as unknown as React.ContextType<typeof tokenSelectorContext>,
+        [selectedChainID]
+    )
+
+    return (
+        <WithdrawFlowContextProvider>
+            <tokenSelectorContext.Provider value={tokenContext}>
+                <button onClick={() => setSelectedChainID('8453')}>switch network</button>
+                <InitialWithdrawView amount="1" onReview={jest.fn()} />
+            </tokenSelectorContext.Provider>
+        </WithdrawFlowContextProvider>
+    )
+}
+
+describe('InitialWithdrawView', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('keeps Review disabled while an ENS name resolves for a new chain', async () => {
+        const resolution = deferred<{ identifier: string; recipientType: 'ENS'; resolvedAddress: string }>()
+        mockValidateAndResolveRecipient.mockReturnValue(resolution.promise)
+
+        render(
+            <IntlWrapper>
+                <TestHarness />
+            </IntlWrapper>
+        )
+
+        fireEvent.click(screen.getByRole('button', { name: 'set ENS recipient' }))
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Review' })).toBeEnabled())
+
+        fireEvent.click(screen.getByRole('button', { name: 'switch network' }))
+
+        await waitFor(() =>
+            expect(mockValidateAndResolveRecipient).toHaveBeenCalledWith('alice.eth', true, 'evm', '8453')
+        )
+        expect(screen.getByRole('button', { name: 'Review' })).toBeDisabled()
+
+        resolution.resolve({
+            identifier: 'alice.eth',
+            recipientType: 'ENS',
+            resolvedAddress: '0x2222222222222222222222222222222222222222',
+        })
+
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Review' })).toBeEnabled())
+    })
+})

--- a/src/lib/validation/recipient.test.ts
+++ b/src/lib/validation/recipient.test.ts
@@ -1,16 +1,17 @@
 import { getRecipientType, validateAndResolveRecipient, verifyPeanutUsername } from '@/lib/validation/recipient'
 
 // Mock the external dependencies
+const mockResolveEns = jest.fn((name: string, _chainId?: string) => {
+    if (name === 'vitalik.eth') {
+        return Promise.resolve('0x1234567890123456789012345678901234567890')
+    }
+    if (name.endsWith('.testvc.eth')) {
+        return Promise.resolve('0xA4Ae9480de19bD99A55E0FdC5372B8A4151C8271')
+    }
+    return Promise.resolve(null)
+})
 jest.mock('@/app/actions/ens', () => ({
-    resolveEns: (name: string) => {
-        if (name === 'vitalik.eth') {
-            return Promise.resolve('0x1234567890123456789012345678901234567890')
-        }
-        if (name.endsWith('.testvc.eth')) {
-            return Promise.resolve('0xA4Ae9480de19bD99A55E0FdC5372B8A4151C8271')
-        }
-        return Promise.resolve(null)
-    },
+    resolveEns: (name: string, chainId?: string) => mockResolveEns(name, chainId),
 }))
 
 jest.mock('@/utils/sentry.utils', () => ({
@@ -87,6 +88,18 @@ describe('Recipient Validation', () => {
         it('should treat non-addresses as ENS in withdrawal context', async () => {
             await expect(validateAndResolveRecipient('kusharc', true)).rejects.toThrow('ENS name not found')
             await expect(validateAndResolveRecipient('someuser', true)).rejects.toThrow('ENS name not found')
+        })
+
+        it('should forward the destination chainId to ENS resolution (ENSIP-11)', async () => {
+            mockResolveEns.mockClear()
+            await validateAndResolveRecipient('vitalik.eth', true, 'evm', '42161')
+            expect(mockResolveEns).toHaveBeenCalledWith('vitalik.eth', '42161')
+        })
+
+        it('should resolve without a chainId when none is given (legacy callers)', async () => {
+            mockResolveEns.mockClear()
+            await validateAndResolveRecipient('vitalik.eth')
+            expect(mockResolveEns).toHaveBeenCalledWith('vitalik.eth', undefined)
         })
     })
 

--- a/src/lib/validation/recipient.ts
+++ b/src/lib/validation/recipient.ts
@@ -13,7 +13,10 @@ import { isValidAddressForFamily, type WithdrawAddressFamily } from './addressFa
 export async function validateAndResolveRecipient(
     recipient: string,
     isWithdrawal: boolean = false,
-    addressFamily: WithdrawAddressFamily = 'evm'
+    addressFamily: WithdrawAddressFamily = 'evm',
+    // Destination chain for ENS resolution (ENSIP-11 per-chain addresses).
+    // Omitted = mainnet record, which is correct for non-withdraw contexts.
+    chainId?: string
 ): Promise<{ identifier: string; recipientType: RecipientType; resolvedAddress: string }> {
     // Non-EVM withdraw destinations (Solana/Tron): a base58 address is the
     // only valid input — no ENS, no usernames. The family comes from the
@@ -30,7 +33,7 @@ export async function validateAndResolveRecipient(
     switch (recipientType) {
         case 'ENS':
             // resolve the ENS name to address
-            const resolvedAddress = await resolveEns(recipient)
+            const resolvedAddress = await resolveEns(recipient, chainId)
             if (!resolvedAddress) {
                 throw new RecipientValidationError('ENS name not found')
             }

--- a/src/lib/validation/recipient.ts
+++ b/src/lib/validation/recipient.ts
@@ -31,7 +31,7 @@ export async function validateAndResolveRecipient(
     const recipientType = getRecipientType(recipient, isWithdrawal)
 
     switch (recipientType) {
-        case 'ENS':
+        case 'ENS': {
             // resolve the ENS name to address
             const resolvedAddress = await resolveEns(recipient, chainId)
             if (!resolvedAddress) {
@@ -42,6 +42,7 @@ export async function validateAndResolveRecipient(
                 recipientType,
                 resolvedAddress,
             }
+        }
 
         case 'ADDRESS':
             if (!isAddress(recipient)) {

--- a/src/utils/__tests__/sentry.utils.test.ts
+++ b/src/utils/__tests__/sentry.utils.test.ts
@@ -3,6 +3,7 @@ import { RETRY_STRATEGIES } from '../retry.utils'
 import {
     CLIENT_FETCH_TIMEOUT_MS,
     SERVER_FETCH_TIMEOUT_MS,
+    TRANSPORT_TIMEOUT_RETRY_DELAY_MS,
     fetchWithSentry,
     resolveDefaultTimeoutMs,
     sanitizeRequestBody,
@@ -331,21 +332,24 @@ describe('fetch timeout budgets', () => {
         )
     })
 
-    // The client budget is per ATTEMPT, and React Query retries on top, so the
-    // real wait is timeout x attempts + backoff. Pinned here because the
-    // multiplier lives in another file: bump RETRY_STRATEGIES.FAST or the budget
-    // far enough and this fails instead of silently shipping a long spinner.
+    // The client budget is per transport attempt. GET/HEAD also get one local
+    // timeout retry before React Query retries, so account for both layers.
+    // Pinned here because the multiplier lives in another file: bump
+    // RETRY_STRATEGIES.FAST or the budget far enough and this fails instead of
+    // silently shipping a long spinner.
     // Bounds the DEFAULT strategy only — queries that set their own `retry`
     // (e.g. Claim.tsx) are not covered by this.
-    it('keeps the worst case under 70s for the default retry strategy', () => {
+    it('models the bounded worst case for the default retry strategy', () => {
         const { retry, retryDelay } = RETRY_STRATEGIES.FAST
         const attempts = retry + 1
         const backoff = Array.from({ length: retry }, (_, i) => retryDelay(i)).reduce((a, b) => a + b, 0)
+        const transportAttempts = 2
+        const transportBackoff = (transportAttempts - 1) * TRANSPORT_TIMEOUT_RETRY_DELAY_MS
 
-        const worstCaseMs = attempts * CLIENT_FETCH_TIMEOUT_MS + backoff
+        const worstCaseMs = attempts * (transportAttempts * CLIENT_FETCH_TIMEOUT_MS + transportBackoff) + backoff
 
-        expect(worstCaseMs).toBe(63_000)
-        expect(worstCaseMs).toBeLessThan(70_000)
+        expect(worstCaseMs).toBe(123_900)
+        expect(worstCaseMs).toBeLessThan(125_000)
     })
 
     describe('fetchWithSentry timeout resolution', () => {

--- a/src/utils/__tests__/sentry.utils.test.ts
+++ b/src/utils/__tests__/sentry.utils.test.ts
@@ -3,6 +3,7 @@ import { RETRY_STRATEGIES } from '../retry.utils'
 import {
     CLIENT_FETCH_TIMEOUT_MS,
     SERVER_FETCH_TIMEOUT_MS,
+    TRANSPORT_TIMEOUT_RETRY_DELAY_MS,
     fetchWithSentry,
     resolveDefaultTimeoutMs,
     sanitizeRequestBody,
@@ -331,21 +332,24 @@ describe('fetch timeout budgets', () => {
         )
     })
 
-    // The client transport makes one attempt. React Query retries on top, so the
-    // real wait is timeout x attempts + backoff. Pinned here because the
-    // multiplier lives in another file: bump RETRY_STRATEGIES.FAST or the budget
-    // far enough and this fails instead of silently shipping a long spinner.
+    // The client budget is per transport attempt. GET/HEAD also get one local
+    // timeout retry before React Query retries, so account for both layers.
+    // Pinned here because the multiplier lives in another file: bump
+    // RETRY_STRATEGIES.FAST or the budget far enough and this fails instead of
+    // silently shipping a long spinner.
     // Bounds the DEFAULT strategy only — queries that set their own `retry`
     // (e.g. Claim.tsx) are not covered by this.
-    it('keeps the worst case under 70s for the default retry strategy', () => {
+    it('models the bounded worst case for the default retry strategy', () => {
         const { retry, retryDelay } = RETRY_STRATEGIES.FAST
         const attempts = retry + 1
         const backoff = Array.from({ length: retry }, (_, i) => retryDelay(i)).reduce((a, b) => a + b, 0)
+        const transportAttempts = 2
+        const transportBackoff = (transportAttempts - 1) * TRANSPORT_TIMEOUT_RETRY_DELAY_MS
 
-        const worstCaseMs = attempts * CLIENT_FETCH_TIMEOUT_MS + backoff
+        const worstCaseMs = attempts * (transportAttempts * CLIENT_FETCH_TIMEOUT_MS + transportBackoff) + backoff
 
-        expect(worstCaseMs).toBe(63_000)
-        expect(worstCaseMs).toBeLessThan(70_000)
+        expect(worstCaseMs).toBe(123_900)
+        expect(worstCaseMs).toBeLessThan(125_000)
     })
 
     describe('fetchWithSentry timeout resolution', () => {
@@ -379,7 +383,6 @@ describe('fetch timeout budgets', () => {
             await expect(freshFetchWithSentry('https://api.peanut.me/users/me')).rejects.toThrow(
                 'Service temporarily unavailable. Please try again.'
             )
-            expect(global.fetch).toHaveBeenCalledTimes(1)
             expect(reportedTimeoutMs()).toBe(CLIENT_FETCH_TIMEOUT_MS)
         })
 

--- a/src/utils/__tests__/sentry.utils.test.ts
+++ b/src/utils/__tests__/sentry.utils.test.ts
@@ -3,7 +3,6 @@ import { RETRY_STRATEGIES } from '../retry.utils'
 import {
     CLIENT_FETCH_TIMEOUT_MS,
     SERVER_FETCH_TIMEOUT_MS,
-    TRANSPORT_TIMEOUT_RETRY_DELAY_MS,
     fetchWithSentry,
     resolveDefaultTimeoutMs,
     sanitizeRequestBody,
@@ -332,24 +331,21 @@ describe('fetch timeout budgets', () => {
         )
     })
 
-    // The client budget is per transport attempt. GET/HEAD also get one local
-    // timeout retry before React Query retries, so account for both layers.
-    // Pinned here because the multiplier lives in another file: bump
-    // RETRY_STRATEGIES.FAST or the budget far enough and this fails instead of
-    // silently shipping a long spinner.
+    // The client transport makes one attempt. React Query retries on top, so the
+    // real wait is timeout x attempts + backoff. Pinned here because the
+    // multiplier lives in another file: bump RETRY_STRATEGIES.FAST or the budget
+    // far enough and this fails instead of silently shipping a long spinner.
     // Bounds the DEFAULT strategy only — queries that set their own `retry`
     // (e.g. Claim.tsx) are not covered by this.
-    it('models the bounded worst case for the default retry strategy', () => {
+    it('keeps the worst case under 70s for the default retry strategy', () => {
         const { retry, retryDelay } = RETRY_STRATEGIES.FAST
         const attempts = retry + 1
         const backoff = Array.from({ length: retry }, (_, i) => retryDelay(i)).reduce((a, b) => a + b, 0)
-        const transportAttempts = 2
-        const transportBackoff = (transportAttempts - 1) * TRANSPORT_TIMEOUT_RETRY_DELAY_MS
 
-        const worstCaseMs = attempts * (transportAttempts * CLIENT_FETCH_TIMEOUT_MS + transportBackoff) + backoff
+        const worstCaseMs = attempts * CLIENT_FETCH_TIMEOUT_MS + backoff
 
-        expect(worstCaseMs).toBe(123_900)
-        expect(worstCaseMs).toBeLessThan(125_000)
+        expect(worstCaseMs).toBe(63_000)
+        expect(worstCaseMs).toBeLessThan(70_000)
     })
 
     describe('fetchWithSentry timeout resolution', () => {
@@ -383,6 +379,7 @@ describe('fetch timeout budgets', () => {
             await expect(freshFetchWithSentry('https://api.peanut.me/users/me')).rejects.toThrow(
                 'Service temporarily unavailable. Please try again.'
             )
+            expect(global.fetch).toHaveBeenCalledTimes(1)
             expect(reportedTimeoutMs()).toBe(CLIENT_FETCH_TIMEOUT_MS)
         })
 

--- a/src/utils/__tests__/sentry.utils.test.ts
+++ b/src/utils/__tests__/sentry.utils.test.ts
@@ -1,5 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import * as Sentry from '@sentry/nextjs'
-import { fetchWithSentry, sanitizeRequestBody, sanitizeResponseBody, scrubObject } from '../sentry.utils'
+import { RETRY_STRATEGIES } from '../retry.utils'
+import {
+    CLIENT_FETCH_TIMEOUT_MS,
+    SERVER_FETCH_TIMEOUT_MS,
+    VERCEL_FUNCTION_MAX_DURATION_MS,
+    fetchWithSentry,
+    resolveDefaultTimeoutMs,
+    sanitizeRequestBody,
+    sanitizeResponseBody,
+    scrubObject,
+} from '../sentry.utils'
 
 jest.mock('@sentry/nextjs', () => ({
     withScope: jest.fn((cb: (scope: unknown) => void) => cb({ setFingerprint: jest.fn(), setTag: jest.fn() })),
@@ -271,5 +283,109 @@ describe('scrubObject — exact-match contract', () => {
         expect(out.clean).toBe('z')
         // Global Object.prototype must NOT have been mutated
         expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+    })
+})
+
+describe('fetch timeout budgets', () => {
+    describe('resolveDefaultTimeoutMs', () => {
+        // Both branches, explicitly. An inverted check is the failure mode that
+        // actually bites: hand the server the long budget and a Vercel function
+        // hangs past its ceiling, producing exactly the opaque 504s the original
+        // 10s existed to prevent.
+        it('uses the client budget in a browser, the server budget in a function', () => {
+            expect(resolveDefaultTimeoutMs(false, undefined)).toBe(CLIENT_FETCH_TIMEOUT_MS)
+            expect(resolveDefaultTimeoutMs(true, undefined)).toBe(SERVER_FETCH_TIMEOUT_MS)
+        })
+
+        // Regression pin: 10s was smaller than a page load in high-latency
+        // markets, aborting healthy requests. Don't go back there.
+        it('keeps both budgets clear of the 10s that caused false timeouts', () => {
+            expect(CLIENT_FETCH_TIMEOUT_MS).toBeGreaterThan(10_000)
+            expect(SERVER_FETCH_TIMEOUT_MS).toBeGreaterThan(10_000)
+        })
+
+        it('lets NEXT_PUBLIC_FETCH_TIMEOUT_MS override both contexts', () => {
+            expect(resolveDefaultTimeoutMs(false, '45000')).toBe(45_000)
+            expect(resolveDefaultTimeoutMs(true, '45000')).toBe(45_000)
+        })
+
+        // parseInt would have read "30s" as 30ms and "0" as 0 — both abort every
+        // request instantly. A malformed override must fall back, not brick fetches.
+        it.each([undefined, '', 'not-a-number', '30s', '0.5', '0', '-1', 'Infinity'])(
+            'falls back to the context default for a malformed override: %p',
+            (override) => {
+                expect(resolveDefaultTimeoutMs(false, override)).toBe(CLIENT_FETCH_TIMEOUT_MS)
+                expect(resolveDefaultTimeoutMs(true, override)).toBe(SERVER_FETCH_TIMEOUT_MS)
+            }
+        )
+    })
+
+    // The client budget is per ATTEMPT, and React Query retries on top, so the
+    // real number a user waits is timeout x attempts + backoff. Pinned here
+    // because the multiplier lives in another file: bump RETRY_STRATEGIES.FAST
+    // or the budget far enough and this fails instead of silently shipping a
+    // two-minute spinner.
+    it('keeps the retried worst-case client budget under 70s', () => {
+        const { retry, retryDelay } = RETRY_STRATEGIES.FAST
+        const attempts = retry + 1
+        const backoff = Array.from({ length: retry }, (_, i) => retryDelay(i)).reduce((a, b) => a + b, 0)
+
+        const worstCaseMs = attempts * CLIENT_FETCH_TIMEOUT_MS + backoff
+
+        expect(worstCaseMs).toBe(63_000)
+        expect(worstCaseMs).toBeLessThan(70_000)
+    })
+
+    // The whole point of the server budget is to abort BEFORE Vercel kills the
+    // function, so we emit our own error instead of an opaque platform 504.
+    // The previous magic 10s encoded a platform limit (then 15s) that has since
+    // moved to 300s — this pins the constant to vercel.json so it cannot drift
+    // silently a second time.
+    it('mirrors vercel.json maxDuration and stays strictly under it', () => {
+        const vercelConfig = JSON.parse(readFileSync(join(process.cwd(), 'vercel.json'), 'utf8'))
+        const maxDurations = Object.values(vercelConfig.functions as Record<string, { maxDuration: number }>).map(
+            (fn) => fn.maxDuration
+        )
+
+        expect(maxDurations.length).toBeGreaterThan(0)
+        for (const maxDuration of maxDurations) {
+            expect(maxDuration * 1000).toBe(VERCEL_FUNCTION_MAX_DURATION_MS)
+        }
+        expect(SERVER_FETCH_TIMEOUT_MS).toBeLessThan(VERCEL_FUNCTION_MAX_DURATION_MS)
+    })
+
+    describe('fetchWithSentry timeout resolution', () => {
+        const abort = () => {
+            const error = new Error('aborted')
+            error.name = 'AbortError'
+            return error
+        }
+        let infoSpy: jest.SpyInstance
+
+        beforeEach(() => {
+            jest.clearAllMocks()
+            infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
+        })
+
+        afterEach(() => infoSpy.mockRestore())
+
+        const reportedTimeoutMs = () =>
+            (Sentry.captureException as jest.Mock).mock.calls[0][1].extra.timeoutMs as number
+
+        it('defaults to the client budget under a browser global', async () => {
+            global.fetch = jest.fn().mockRejectedValue(abort())
+            await expect(fetchWithSentry('https://api.peanut.me/users/me')).rejects.toThrow(
+                'Service temporarily unavailable. Please try again.'
+            )
+            expect(reportedTimeoutMs()).toBe(CLIENT_FETCH_TIMEOUT_MS)
+        })
+
+        it('still lets a per-call timeoutMs win over the default', async () => {
+            global.fetch = jest.fn().mockRejectedValue(abort())
+            await expect(fetchWithSentry('https://api.peanut.me/users/me', {}, 1234)).rejects.toThrow(
+                'Service temporarily unavailable. Please try again.'
+            )
+            expect(reportedTimeoutMs()).toBe(1234)
+        })
     })
 })

--- a/src/utils/__tests__/sentry.utils.test.ts
+++ b/src/utils/__tests__/sentry.utils.test.ts
@@ -315,11 +315,14 @@ describe('fetch timeout budgets', () => {
         it('lets NEXT_PUBLIC_FETCH_TIMEOUT_MS override both contexts', () => {
             expect(resolveDefaultTimeoutMs(false, '45000')).toBe(45_000)
             expect(resolveDefaultTimeoutMs(true, '45000')).toBe(45_000)
+            // Boundary: the largest value setTimeout can honour is still accepted.
+            expect(resolveDefaultTimeoutMs(false, '2147483647')).toBe(2_147_483_647)
         })
 
-        // parseInt would have read "30s" as 30ms and "0" as 0 — both abort every
+        // parseInt would have read "30s" as 30ms and "0" as 0, and anything past
+        // 2^31-1 overflows setTimeout and clamps to ~1ms — all of which abort every
         // request instantly. A malformed override must fall back, not brick fetches.
-        it.each([undefined, '', 'not-a-number', '30s', '0.5', '0', '-1', 'Infinity'])(
+        it.each([undefined, '', 'not-a-number', '30s', '0.5', '0', '-1', 'Infinity', '2147483648'])(
             'falls back to the context default for a malformed override: %p',
             (override) => {
                 expect(resolveDefaultTimeoutMs(false, override)).toBe(CLIENT_FETCH_TIMEOUT_MS)

--- a/src/utils/__tests__/sentry.utils.test.ts
+++ b/src/utils/__tests__/sentry.utils.test.ts
@@ -1,11 +1,8 @@
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
 import * as Sentry from '@sentry/nextjs'
 import { RETRY_STRATEGIES } from '../retry.utils'
 import {
     CLIENT_FETCH_TIMEOUT_MS,
     SERVER_FETCH_TIMEOUT_MS,
-    VERCEL_FUNCTION_MAX_DURATION_MS,
     fetchWithSentry,
     resolveDefaultTimeoutMs,
     sanitizeRequestBody,
@@ -287,6 +284,17 @@ describe('scrubObject — exact-match contract', () => {
 })
 
 describe('fetch timeout budgets', () => {
+    // `resolveDefaultTimeoutMs`'s default parameter reads the real process.env,
+    // so a shell or CI runner that exports NEXT_PUBLIC_FETCH_TIMEOUT_MS would
+    // otherwise fail this suite for reasons unrelated to the code under test.
+    const realOverride = process.env.NEXT_PUBLIC_FETCH_TIMEOUT_MS
+    beforeAll(() => {
+        delete process.env.NEXT_PUBLIC_FETCH_TIMEOUT_MS
+    })
+    afterAll(() => {
+        if (realOverride !== undefined) process.env.NEXT_PUBLIC_FETCH_TIMEOUT_MS = realOverride
+    })
+
     describe('resolveDefaultTimeoutMs', () => {
         // Both branches, explicitly. An inverted check is the failure mode that
         // actually bites: hand the server the long budget and a Vercel function
@@ -298,10 +306,10 @@ describe('fetch timeout budgets', () => {
         })
 
         // Regression pin: 10s was smaller than a page load in high-latency
-        // markets, aborting healthy requests. Don't go back there.
-        it('keeps both budgets clear of the 10s that caused false timeouts', () => {
+        // markets, aborting healthy browser requests. Don't go back there.
+        // (The server budget deliberately stays at 10s — see sentry.utils.ts.)
+        it('keeps the client budget clear of the 10s that caused false timeouts', () => {
             expect(CLIENT_FETCH_TIMEOUT_MS).toBeGreaterThan(10_000)
-            expect(SERVER_FETCH_TIMEOUT_MS).toBeGreaterThan(10_000)
         })
 
         it('lets NEXT_PUBLIC_FETCH_TIMEOUT_MS override both contexts', () => {
@@ -321,11 +329,12 @@ describe('fetch timeout budgets', () => {
     })
 
     // The client budget is per ATTEMPT, and React Query retries on top, so the
-    // real number a user waits is timeout x attempts + backoff. Pinned here
-    // because the multiplier lives in another file: bump RETRY_STRATEGIES.FAST
-    // or the budget far enough and this fails instead of silently shipping a
-    // two-minute spinner.
-    it('keeps the retried worst-case client budget under 70s', () => {
+    // real wait is timeout x attempts + backoff. Pinned here because the
+    // multiplier lives in another file: bump RETRY_STRATEGIES.FAST or the budget
+    // far enough and this fails instead of silently shipping a long spinner.
+    // Bounds the DEFAULT strategy only — queries that set their own `retry`
+    // (e.g. Claim.tsx) are not covered by this.
+    it('keeps the worst case under 70s for the default retry strategy', () => {
         const { retry, retryDelay } = RETRY_STRATEGIES.FAST
         const attempts = retry + 1
         const backoff = Array.from({ length: retry }, (_, i) => retryDelay(i)).reduce((a, b) => a + b, 0)
@@ -334,24 +343,6 @@ describe('fetch timeout budgets', () => {
 
         expect(worstCaseMs).toBe(63_000)
         expect(worstCaseMs).toBeLessThan(70_000)
-    })
-
-    // The whole point of the server budget is to abort BEFORE Vercel kills the
-    // function, so we emit our own error instead of an opaque platform 504.
-    // The previous magic 10s encoded a platform limit (then 15s) that has since
-    // moved to 300s — this pins the constant to vercel.json so it cannot drift
-    // silently a second time.
-    it('mirrors vercel.json maxDuration and stays strictly under it', () => {
-        const vercelConfig = JSON.parse(readFileSync(join(process.cwd(), 'vercel.json'), 'utf8'))
-        const maxDurations = Object.values(vercelConfig.functions as Record<string, { maxDuration: number }>).map(
-            (fn) => fn.maxDuration
-        )
-
-        expect(maxDurations.length).toBeGreaterThan(0)
-        for (const maxDuration of maxDurations) {
-            expect(maxDuration * 1000).toBe(VERCEL_FUNCTION_MAX_DURATION_MS)
-        }
-        expect(SERVER_FETCH_TIMEOUT_MS).toBeLessThan(VERCEL_FUNCTION_MAX_DURATION_MS)
     })
 
     describe('fetchWithSentry timeout resolution', () => {
@@ -372,9 +363,17 @@ describe('fetch timeout budgets', () => {
         const reportedTimeoutMs = () =>
             (Sentry.captureException as jest.Mock).mock.calls[0][1].extra.timeoutMs as number
 
+        // Re-imported with the env cleared: the module captures its default at
+        // LOAD time, so the surrounding beforeAll can't reach it and an ambient
+        // NEXT_PUBLIC_FETCH_TIMEOUT_MS would otherwise fail this for the wrong reason.
         it('defaults to the client budget under a browser global', async () => {
+            let freshFetchWithSentry!: typeof fetchWithSentry
+            jest.isolateModules(() => {
+                freshFetchWithSentry = require('../sentry.utils').fetchWithSentry
+            })
+
             global.fetch = jest.fn().mockRejectedValue(abort())
-            await expect(fetchWithSentry('https://api.peanut.me/users/me')).rejects.toThrow(
+            await expect(freshFetchWithSentry('https://api.peanut.me/users/me')).rejects.toThrow(
                 'Service temporarily unavailable. Please try again.'
             )
             expect(reportedTimeoutMs()).toBe(CLIENT_FETCH_TIMEOUT_MS)

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -295,28 +295,32 @@ function shouldSkipReporting(url: string, status: number): boolean {
 }
 
 /**
- * Vercel's function-duration ceiling: the `maxDuration` in `vercel.json`, in ms.
- * That glob covers route handlers; server actions and RSC renders fall back to
- * the project default, which Fluid compute also sets to 300s
- * (https://vercel.com/docs/functions/configuring-functions/duration).
- * `sentry.utils.test.ts` reads vercel.json and fails if the two drift.
+ * Server-side budget — deliberately UNCHANGED at the historical 10s.
+ *
+ * A server fetch runs inside a Vercel function, so it must abort before the
+ * platform kills the function, otherwise we leak an opaque 504 instead of
+ * owning the error. The old comment here put that ceiling at 15s; today
+ * `vercel.json` says `maxDuration: 300` — but that entry declares the glob
+ * `app/api/**` while this project keeps its routes under `src/app/api/`, and
+ * Vercel requires the `src/` prefix for src-directory projects, so the entry
+ * currently matches nothing. The real ceiling is therefore the project default
+ * (300s with Fluid compute, far lower without), which cannot be read from the
+ * repo.
+ *
+ * Raising this buys little — a Vercel→api.peanut.me call is a datacenter hop,
+ * not a mobile network — and risks sitting ABOVE an unverified ceiling, which
+ * would reintroduce exactly the 504s the original 10s existed to prevent. So it
+ * stays put until the ceiling is confirmed. See the PR for the follow-up.
  */
-export const VERCEL_FUNCTION_MAX_DURATION_MS = 300_000
+export const SERVER_FETCH_TIMEOUT_MS = 10_000
 
 /**
- * Server-side budget. Must abort well before the platform ceiling above so we
- * own the error surface instead of leaking an opaque platform 504. A Vercel
- * function calling api.peanut.me is a datacenter-to-datacenter hop, so 30s is
- * already generous — the ceiling is the safety net, not the target.
- */
-export const SERVER_FETCH_TIMEOUT_MS = 30_000
-
-/**
- * Client-side budget. No platform ceiling applies in a browser, only real
- * mobile networks — and 10s sat below the page load itself in high-latency
- * markets (Nigeria p90 LCP 11.3s vs 6.1s globally), aborting healthy requests.
- * Bounded above by React Query retries, which multiply it; the worst-case total
- * is pinned in `sentry.utils.test.ts` against RETRY_STRATEGIES.FAST.
+ * Client-side budget — the actual fix. No platform ceiling applies in a
+ * browser, only real mobile networks, and 10s sat below the page load itself in
+ * high-latency markets (Nigeria p90 LCP 11.3s vs 6.1s globally), aborting
+ * healthy requests and reporting them as failures. Bounded above by React Query
+ * retries, which multiply it; the worst-case total for the default retry
+ * strategy is pinned in `sentry.utils.test.ts`.
  */
 export const CLIENT_FETCH_TIMEOUT_MS = 20_000
 

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -318,12 +318,12 @@ export const SERVER_FETCH_TIMEOUT_MS = 10_000
  * Client-side budget — the actual fix. No platform ceiling applies in a
  * browser, only real mobile networks, and 10s sat below the page load itself in
  * high-latency markets (Nigeria p90 LCP 11.3s vs 6.1s globally), aborting
- * healthy requests and reporting them as failures. React Query retries and the
- * one idempotent transport retry multiply it; the worst-case total for the
- * default retry strategy is pinned in `sentry.utils.test.ts`.
+ * healthy requests and reporting them as failures. The transport makes one
+ * attempt only; React Query retries, where a caller opts into them, are the
+ * only multiplier. The default strategy bound is pinned in
+ * `sentry.utils.test.ts`.
  */
 export const CLIENT_FETCH_TIMEOUT_MS = 20_000
-export const TRANSPORT_TIMEOUT_RETRY_DELAY_MS = 300
 
 /**
  * `NEXT_PUBLIC_FETCH_TIMEOUT_MS` is an explicit override of both budgets. It
@@ -494,31 +494,16 @@ export const fetchWithSentry = async (
         }
     }
 
-    // Idempotent requests get one silent retry on timeout: stalled-transport
-    // failures (Android webview, flaky mobile networks) usually clear on a
-    // fresh attempt (PEANUT-UI-R44).
-    const method = (options.method || 'GET').toUpperCase()
-    const maxAttempts = method === 'GET' || method === 'HEAD' ? 2 : 1
-
     const attemptFetch = async (): Promise<Response> => {
-        for (let attempt = 1; ; attempt++) {
-            const controller = new AbortController()
-            const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
-            try {
-                return await fetch(url, {
-                    ...options,
-                    signal: controller.signal,
-                })
-            } catch (error) {
-                if (attempt < maxAttempts && error instanceof Error && error.name === 'AbortError') {
-                    console.warn(`Request to ${String(url).replace(/[\r\n]/g, '')} timed out — retrying`)
-                    await new Promise((resolve) => setTimeout(resolve, TRANSPORT_TIMEOUT_RETRY_DELAY_MS))
-                    continue
-                }
-                throw error
-            } finally {
-                clearTimeout(timeoutId)
-            }
+        const controller = new AbortController()
+        const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+        try {
+            return await fetch(url, {
+                ...options,
+                signal: controller.signal,
+            })
+        } finally {
+            clearTimeout(timeoutId)
         }
     }
 

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -318,11 +318,12 @@ export const SERVER_FETCH_TIMEOUT_MS = 10_000
  * Client-side budget — the actual fix. No platform ceiling applies in a
  * browser, only real mobile networks, and 10s sat below the page load itself in
  * high-latency markets (Nigeria p90 LCP 11.3s vs 6.1s globally), aborting
- * healthy requests and reporting them as failures. Bounded above by React Query
- * retries, which multiply it; the worst-case total for the default retry
- * strategy is pinned in `sentry.utils.test.ts`.
+ * healthy requests and reporting them as failures. React Query retries and the
+ * one idempotent transport retry multiply it; the worst-case total for the
+ * default retry strategy is pinned in `sentry.utils.test.ts`.
  */
 export const CLIENT_FETCH_TIMEOUT_MS = 20_000
+export const TRANSPORT_TIMEOUT_RETRY_DELAY_MS = 300
 
 /**
  * `NEXT_PUBLIC_FETCH_TIMEOUT_MS` is an explicit override of both budgets. It
@@ -511,7 +512,7 @@ export const fetchWithSentry = async (
             } catch (error) {
                 if (attempt < maxAttempts && error instanceof Error && error.name === 'AbortError') {
                     console.warn(`Request to ${String(url).replace(/[\r\n]/g, '')} timed out — retrying`)
-                    await new Promise((resolve) => setTimeout(resolve, 300))
+                    await new Promise((resolve) => setTimeout(resolve, TRANSPORT_TIMEOUT_RETRY_DELAY_MS))
                     continue
                 }
                 throw error

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -326,18 +326,22 @@ export const CLIENT_FETCH_TIMEOUT_MS = 20_000
 
 /**
  * `NEXT_PUBLIC_FETCH_TIMEOUT_MS` is an explicit override of both budgets. It
- * must be a positive integer of milliseconds — `parseInt` would have accepted
- * `"30s"` as 30 and `"0"` as 0, silently aborting every request instantly, so
- * anything malformed falls back to the default rather than bricking fetches.
- * Both inputs are parameters so the function stays pure: jsdom always defines
- * `window`, so the server branch is otherwise unreachable from tests.
+ * must be a positive integer of milliseconds within the 32-bit timer range:
+ * `parseInt` would have accepted `"30s"` as 30 and `"0"` as 0, and anything
+ * above 2^31-1 overflows setTimeout and clamps to ~1ms — every one of which
+ * aborts requests instantly. Malformed values fall back to the default rather
+ * than bricking fetches. Both inputs are parameters so the function stays pure:
+ * jsdom always defines `window`, so the server branch is otherwise unreachable
+ * from tests.
  */
+const MAX_TIMER_MS = 2_147_483_647
+
 export const resolveDefaultTimeoutMs = (
     isServer: boolean,
     override: string | undefined = process.env.NEXT_PUBLIC_FETCH_TIMEOUT_MS
 ): number => {
     const parsed = Number(override)
-    if (override && Number.isInteger(parsed) && parsed > 0) return parsed
+    if (override && Number.isInteger(parsed) && parsed > 0 && parsed <= MAX_TIMER_MS) return parsed
     return isServer ? SERVER_FETCH_TIMEOUT_MS : CLIENT_FETCH_TIMEOUT_MS
 }
 

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -294,15 +294,50 @@ function shouldSkipReporting(url: string, status: number): boolean {
     return false
 }
 
-/** Use configured fetch timeout or default to 10s
- * We use 10s because vercel function timout is 15s and this function
- * can be called in that context, and we preffer to have control over
- * the error message and handling
+/**
+ * Vercel's function-duration ceiling: the `maxDuration` in `vercel.json`, in ms.
+ * That glob covers route handlers; server actions and RSC renders fall back to
+ * the project default, which Fluid compute also sets to 300s
+ * (https://vercel.com/docs/functions/configuring-functions/duration).
+ * `sentry.utils.test.ts` reads vercel.json and fails if the two drift.
  */
-const DEFAULT_TIMEOUT_MS =
-    process.env.NEXT_PUBLIC_FETCH_TIMEOUT_MS && !isNaN(parseInt(process.env.NEXT_PUBLIC_FETCH_TIMEOUT_MS, 10))
-        ? parseInt(process.env.NEXT_PUBLIC_FETCH_TIMEOUT_MS, 10)
-        : 10000
+export const VERCEL_FUNCTION_MAX_DURATION_MS = 300_000
+
+/**
+ * Server-side budget. Must abort well before the platform ceiling above so we
+ * own the error surface instead of leaking an opaque platform 504. A Vercel
+ * function calling api.peanut.me is a datacenter-to-datacenter hop, so 30s is
+ * already generous — the ceiling is the safety net, not the target.
+ */
+export const SERVER_FETCH_TIMEOUT_MS = 30_000
+
+/**
+ * Client-side budget. No platform ceiling applies in a browser, only real
+ * mobile networks — and 10s sat below the page load itself in high-latency
+ * markets (Nigeria p90 LCP 11.3s vs 6.1s globally), aborting healthy requests.
+ * Bounded above by React Query retries, which multiply it; the worst-case total
+ * is pinned in `sentry.utils.test.ts` against RETRY_STRATEGIES.FAST.
+ */
+export const CLIENT_FETCH_TIMEOUT_MS = 20_000
+
+/**
+ * `NEXT_PUBLIC_FETCH_TIMEOUT_MS` is an explicit override of both budgets. It
+ * must be a positive integer of milliseconds — `parseInt` would have accepted
+ * `"30s"` as 30 and `"0"` as 0, silently aborting every request instantly, so
+ * anything malformed falls back to the default rather than bricking fetches.
+ * Both inputs are parameters so the function stays pure: jsdom always defines
+ * `window`, so the server branch is otherwise unreachable from tests.
+ */
+export const resolveDefaultTimeoutMs = (
+    isServer: boolean,
+    override: string | undefined = process.env.NEXT_PUBLIC_FETCH_TIMEOUT_MS
+): number => {
+    const parsed = Number(override)
+    if (override && Number.isInteger(parsed) && parsed > 0) return parsed
+    return isServer ? SERVER_FETCH_TIMEOUT_MS : CLIENT_FETCH_TIMEOUT_MS
+}
+
+const DEFAULT_TIMEOUT_MS = resolveDefaultTimeoutMs(typeof window === 'undefined')
 
 const getErrorLevelFromStatus = (status: number): Sentry.SeverityLevel => {
     if (status >= 500) return 'error'

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -318,12 +318,12 @@ export const SERVER_FETCH_TIMEOUT_MS = 10_000
  * Client-side budget — the actual fix. No platform ceiling applies in a
  * browser, only real mobile networks, and 10s sat below the page load itself in
  * high-latency markets (Nigeria p90 LCP 11.3s vs 6.1s globally), aborting
- * healthy requests and reporting them as failures. The transport makes one
- * attempt only; React Query retries, where a caller opts into them, are the
- * only multiplier. The default strategy bound is pinned in
- * `sentry.utils.test.ts`.
+ * healthy requests and reporting them as failures. React Query retries and the
+ * one idempotent transport retry multiply it; the worst-case total for the
+ * default retry strategy is pinned in `sentry.utils.test.ts`.
  */
 export const CLIENT_FETCH_TIMEOUT_MS = 20_000
+export const TRANSPORT_TIMEOUT_RETRY_DELAY_MS = 300
 
 /**
  * `NEXT_PUBLIC_FETCH_TIMEOUT_MS` is an explicit override of both budgets. It
@@ -494,16 +494,31 @@ export const fetchWithSentry = async (
         }
     }
 
+    // Idempotent requests get one silent retry on timeout: stalled-transport
+    // failures (Android webview, flaky mobile networks) usually clear on a
+    // fresh attempt (PEANUT-UI-R44).
+    const method = (options.method || 'GET').toUpperCase()
+    const maxAttempts = method === 'GET' || method === 'HEAD' ? 2 : 1
+
     const attemptFetch = async (): Promise<Response> => {
-        const controller = new AbortController()
-        const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
-        try {
-            return await fetch(url, {
-                ...options,
-                signal: controller.signal,
-            })
-        } finally {
-            clearTimeout(timeoutId)
+        for (let attempt = 1; ; attempt++) {
+            const controller = new AbortController()
+            const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+            try {
+                return await fetch(url, {
+                    ...options,
+                    signal: controller.signal,
+                })
+            } catch (error) {
+                if (attempt < maxAttempts && error instanceof Error && error.name === 'AbortError') {
+                    console.warn(`Request to ${String(url).replace(/[\r\n]/g, '')} timed out — retrying`)
+                    await new Promise((resolve) => setTimeout(resolve, TRANSPORT_TIMEOUT_RETRY_DELAY_MS))
+                    continue
+                }
+                throw error
+            } finally {
+                clearTimeout(timeoutId)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Restores two production fixes that are present on `main`/`dev` but absent from the active `mobile-release` branch:

- Use a 20-second client fetch budget, while keeping the 10-second server budget. This prevents slow but successful native WebView requests from appearing as network failures.
- Resolve ENS names for the selected destination chain, re-resolve them after a chain change, and display the resolved withdrawal address before confirmation.

## Task

[Prod Release Sprint 154 (#2624)](https://github.com/peanutprotocol/peanut-ui/pull/2624) — this native hotfix carries the same release fixes to the separate mobile train.

Source PRs: [#2533 timeout](https://github.com/peanutprotocol/peanut-ui/pull/2533) · [#2501 ENS](https://github.com/peanutprotocol/peanut-ui/pull/2501).

## Risks / release

- Financial mutations still do not retry. The longer budget applies to the client request deadline only.
- ENS withdrawals now use an ENSIP-11 chain-specific record. The API already accepts the optional `chainId`; absent support, the prior mainnet fallback remains.
- This PR changes only JS/TypeScript and the environment template. It requires a signed Capgo production OTA after merge, **not** a new AAB/IPA.
- Confirm `NEXT_PUBLIC_FETCH_TIMEOUT_MS` is unset in the Capgo build environment. A configured `10000` override would defeat the timeout fix.

## QA

- `pnpm prettier --check .`
- `npm run typecheck`
- `npm test` — 186 suites, 2,417 tests passed; 3 skipped
- `npm run build`

## Screenshots

The ENS surface is unchanged from the source implementation; [#2501](https://github.com/peanutprotocol/peanut-ui/pull/2501) includes sandbox evidence for both the resolved-address input state and the confirmation modal. The conflict resolution preserves `mobile-release` localization and those safety surfaces.

## Design notes / accepted trade-offs

The ENS cherry-pick conflicted only with localization changes. The resolution keeps translated strings and adds the chain-ID dependency, re-resolution effect, and resolved-address displays. No unrelated `main` changes are included.

## Docs

No customer-facing product fact changes. Native delivery remains a Capgo OTA for JS-only fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - ENS recipients now resolve against the selected destination network.
  - Withdrawal screens display resolved addresses and clearer compatibility warnings.
  - Fetch timeout settings support separate browser and server defaults with validated overrides.

- **Bug Fixes**
  - Prevented stale ENS results after network changes.
  - Invalid timeout values now fall back safely to appropriate defaults.
  - Review remains disabled while recipient resolution is in progress.
  - Failed recipient resolution clears the destination and displays an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->