### PR TITLE
fix(i18n): clear the 3 blocking eslint errors (jsx-no-literals + dead import)

### DIFF
--- a/src/components/Global/ReConsentModal/__tests__/index.test.tsx
+++ b/src/components/Global/ReConsentModal/__tests__/index.test.tsx
@@ -10,7 +10,8 @@
  * prompt must ALWAYS be escapable and must never ledger a refusal as consent.
  */
 import React from 'react'
-import { render, screen, fireEvent, act } from '@testing-library/react'
+import { screen, fireEvent, act } from '@testing-library/react'
+import { renderWithIntl as render } from '@/test-utils/intl'
 
 const mockGetStatus = jest.fn<Promise<unknown>, []>()
 const mockAccept = jest.fn<Promise<unknown>, [unknown]>()

--- a/src/components/Global/ReConsentModal/index.tsx
+++ b/src/components/Global/ReConsentModal/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
+import { useTranslations } from 'next-intl'
 import * as Sentry from '@sentry/nextjs'
 import posthog from 'posthog-js'
 import ActionModal from '../ActionModal'
@@ -37,6 +38,7 @@ const STACKED_CTAS = 'flex-col sm:flex-col'
  * exists, and dismissing never writes a ledger row (declining is not consent).
  */
 const ReConsentModal = () => {
+    const t = useTranslations('global')
     const { user } = useAuth()
     const [outdatedDocs, setOutdatedDocs] = useState<ConsentStatusDocument[]>([])
     const [checked, setChecked] = useState(false)
@@ -143,14 +145,8 @@ const ReConsentModal = () => {
                      * it when a future version bump shows this modal for a different
                      * change. "No rush" is literal: "Not now" snoozes to the effective
                      * date (see utils.ts). */}
-                    <p className="text-sm text-grey-1">
-                        Nothing changes about your fees, your funds, or how we handle your data.
-                    </p>
-                    <p className="text-sm text-grey-1">
-                        We've rewritten the documents below in plain language so they match what Peanut is today,
-                        including the Peanut Card and Rewards. There's no rush, read them whenever, and keep using
-                        Peanut as usual.
-                    </p>
+                    <p className="text-sm text-grey-1">{t('reConsent.reassurance')}</p>
+                    <p className="text-sm text-grey-1">{t('reConsent.whatChanged')}</p>
                     <ul className="space-y-1 text-sm">
                         {outdatedDocs.map((doc) => {
                             const label = DOC_LABELS[doc.slug] ?? { name: doc.slug, href: `/${doc.slug}` }

--- a/src/components/Home/PendingVerificationTasks.tsx
+++ b/src/components/Home/PendingVerificationTasks.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
+import { useTranslations } from 'next-intl'
 import { startBridgeHostedVerification } from '@/app/actions/sumsub'
 import { Button } from '@/components/0_Bruddle/Button'
 import Carousel from '@/components/Global/Carousel'
@@ -70,6 +71,7 @@ function taskCopy(task: NextAction): { title: string; description: string } {
  * non-dismissible for everything.
  */
 export default function PendingVerificationTasks({ dismissible = false }: { dismissible?: boolean }) {
+    const t = useTranslations('home')
     const { nextActions } = useCapabilities()
     const { user, fetchUser } = useAuth()
     const [activeTosTask, setActiveTosTask] = useState<NextAction | null>(null)
@@ -219,7 +221,7 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
                                             <div className="text-sm text-grey-1">{copy.description}</div>
                                             {deadline && (
                                                 <div className="mt-1 text-xs font-medium">
-                                                    Complete before {deadline}
+                                                    {t('pendingTasks.completeBefore', { deadline })}
                                                 </div>
                                             )}
                                         </div>

--- a/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
+++ b/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
@@ -10,7 +10,8 @@
  * survive the task list flapping under the ~4s user auto-refresh.
  */
 import React from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { renderWithIntl as render } from '@/test-utils/intl'
 import type { NextAction } from '@/types/capabilities'
 import PendingVerificationTasks from '../PendingVerificationTasks'
 

--- a/src/components/Kyc/AdvisoryPreemptModal.tsx
+++ b/src/components/Kyc/AdvisoryPreemptModal.tsx
@@ -1,6 +1,5 @@
 import { useFormatter, useTranslations } from 'next-intl'
 import ActionModal from '@/components/Global/ActionModal'
-import { formatEffectiveDate } from '@/utils/format.utils'
 
 interface AdvisoryPreemptModalProps {
     visible: boolean

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -201,6 +201,9 @@
             "closeVerificationPrompt": "Close verification prompt",
             "closeNotificationPrompt": "Close notification prompt",
             "claimablePerk": "Claimable perk"
+        },
+        "pendingTasks": {
+            "completeBefore": "Complete before {deadline}"
         }
     },
     "profile": {
@@ -2759,7 +2762,11 @@
         "demoBanner": "Demo mode — you're previewing Peanut with a simulated wallet. Balances and transactions aren't real.",
         "rainCooldownPill": "Card cool-down",
         "betaBannerThumbsUpAlt": "Thumbs up",
-        "easterEggImageAlt": "Easter egg illustration"
+        "easterEggImageAlt": "Easter egg illustration",
+        "reConsent": {
+            "reassurance": "Nothing changes about your fees, your funds, or how we handle your data.",
+            "whatChanged": "We've rewritten the documents below in plain language so they match what Peanut is today, including the Peanut Card and Rewards. There's no rush, read them whenever, and keep using Peanut as usual."
+        }
     },
     "errors": {
         "balanceSettling": "Your balance isn't fully available yet. Please try again in a few seconds.",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -201,6 +201,9 @@
             "closeVerificationPrompt": "Cerrar aviso de verificación",
             "closeNotificationPrompt": "Cerrar aviso de notificaciones",
             "claimablePerk": "Recompensa disponible"
+        },
+        "pendingTasks": {
+            "completeBefore": "Complete before {deadline}"
         }
     },
     "profile": {
@@ -2759,7 +2762,11 @@
         "demoBanner": "Modo demo: estás viendo Peanut con una billetera simulada. Los saldos y las transacciones no son reales.",
         "rainCooldownPill": "Enfriamiento de tarjeta",
         "betaBannerThumbsUpAlt": "Pulgar arriba",
-        "easterEggImageAlt": "Ilustración de huevo de pascua"
+        "easterEggImageAlt": "Ilustración de huevo de pascua",
+        "reConsent": {
+            "reassurance": "Nothing changes about your fees, your funds, or how we handle your data.",
+            "whatChanged": "We've rewritten the documents below in plain language so they match what Peanut is today, including the Peanut Card and Rewards. There's no rush, read them whenever, and keep using Peanut as usual."
+        }
     },
     "errors": {
         "balanceSettling": "Tu saldo aún no está totalmente disponible. Inténtalo de nuevo en unos segundos.",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -201,6 +201,9 @@
             "closeVerificationPrompt": "Fechar aviso de verificação",
             "closeNotificationPrompt": "Fechar aviso de notificações",
             "claimablePerk": "Recompensa disponível"
+        },
+        "pendingTasks": {
+            "completeBefore": "Complete before {deadline}"
         }
     },
     "profile": {
@@ -2759,7 +2762,11 @@
         "demoBanner": "Modo demo — você está testando o Peanut com uma carteira simulada. Saldos e transações não são reais.",
         "rainCooldownPill": "Resfriamento do cartão",
         "betaBannerThumbsUpAlt": "Joinha",
-        "easterEggImageAlt": "Ilustração de easter egg"
+        "easterEggImageAlt": "Ilustração de easter egg",
+        "reConsent": {
+            "reassurance": "Nothing changes about your fees, your funds, or how we handle your data.",
+            "whatChanged": "We've rewritten the documents below in plain language so they match what Peanut is today, including the Peanut Card and Rewards. There's no rush, read them whenever, and keep using Peanut as usual."
+        }
     },
     "errors": {
         "balanceSettling": "Seu saldo ainda não está totalmente disponível. Tente novamente em alguns segundos.",


### PR DESCRIPTION
Clears the 3 real `eslint` **errors** currently red on `dev` (surfaced on the Sprint 154 release PR #2624). eslint is advisory/non-gating, so this does not unblock a gate — it just makes the job green and routes two untranslated strings into the i18n catalog.

## What was failing
- `react/jsx-no-literals` (the i18n guard) — two hardcoded English blocks:
  - `Global/ReConsentModal` — the two reassurance/what-changed paragraphs
  - `Home/PendingVerificationTasks` — "Complete before {deadline}"
- `@typescript-eslint/no-unused-vars` — `AdvisoryPreemptModal` kept a `formatEffectiveDate` import after it moved to `useFormatter()`

## Fix
- Route the copy through `t()` (`global.reConsent.reassurance` / `.whatChanged`, `home.pendingTasks.completeBefore`) and drop the dead import.
- `en.json` carries the real copy. **`es-419.json` + `pt-BR.json` get the same English as placeholders** to satisfy the enforced catalog key-parity test — this is **zero behavior change** (these strings render English in every locale today), but they **need translation** in the localization pass (Glot).
- The two component suites now render via the shared `renderWithIntl` helper, since the components consume next-intl.

## Verified locally
- `eslint` on the 3 files: clean
- `npm run typecheck`: clean
- `npm test`: 208 suites / 2677 passed
- `prettier`: clean

⚠️ Follow-up for localization: translate `global.reConsent.*` and `home.pendingTasks.completeBefore` in `es-419` + `pt-BR`.