### PR TITLE
chore: back-merge main → dev (post #2615 iOS keyboard fix)

### DIFF
--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -183,18 +183,27 @@ describe('SupportDrawer — iOS keyboard', () => {
     class FakeVisualViewport extends EventTarget {
         height = LAYOUT_HEIGHT
         offsetTop = 0
+        scale = 1
     }
 
     let viewport: FakeVisualViewport
+    let realInnerHeight: PropertyDescriptor | undefined
 
     beforeEach(() => {
         mockUseCrispUserData.mockReset().mockReturnValue({ userId: undefined, email: undefined })
         mockUseCrispTokenId.mockReset().mockReturnValue(undefined)
         mockIsCapacitor.mockReset().mockReturnValue(false)
 
+        realInnerHeight = Object.getOwnPropertyDescriptor(window, 'innerHeight')
         viewport = new FakeVisualViewport()
         Object.defineProperty(window, 'visualViewport', { value: viewport, configurable: true })
         Object.defineProperty(window, 'innerHeight', { value: LAYOUT_HEIGHT, configurable: true })
+    })
+
+    // Hand the window back untouched — later describes in this file share it.
+    afterEach(() => {
+        delete (window as { visualViewport?: unknown }).visualViewport
+        if (realInnerHeight) Object.defineProperty(window, 'innerHeight', realInnerHeight)
     })
 
     const openKeyboard = (visibleHeight: number) => {

--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -174,6 +174,54 @@ describe('SupportDrawer — pointer-events when opened inside a vaul drawer', ()
     })
 })
 
+describe('SupportDrawer — iOS keyboard', () => {
+    // iOS leaves the layout viewport at full height when the keyboard opens, so a
+    // `bottom: 0` panel keeps Crisp's composer underneath the keys. The drawer has to
+    // lift by, and shrink to, whatever the visual viewport says is still on screen.
+    const LAYOUT_HEIGHT = 800
+
+    class FakeVisualViewport extends EventTarget {
+        height = LAYOUT_HEIGHT
+        offsetTop = 0
+    }
+
+    let viewport: FakeVisualViewport
+
+    beforeEach(() => {
+        mockUseCrispUserData.mockReset().mockReturnValue({ userId: undefined, email: undefined })
+        mockUseCrispTokenId.mockReset().mockReturnValue(undefined)
+        mockIsCapacitor.mockReset().mockReturnValue(false)
+
+        viewport = new FakeVisualViewport()
+        Object.defineProperty(window, 'visualViewport', { value: viewport, configurable: true })
+        Object.defineProperty(window, 'innerHeight', { value: LAYOUT_HEIGHT, configurable: true })
+    })
+
+    const openKeyboard = (visibleHeight: number) => {
+        viewport.height = visibleHeight
+        act(() => {
+            viewport.dispatchEvent(new Event('resize'))
+        })
+    }
+
+    // Only `bottom` is assertable here: jsdom's CSS parser drops both `env()` and
+    // `min()`, so the safe-area padding and the height clamp read back as ''.
+    it('sits flush on the bottom edge while no keyboard is up', () => {
+        render(<SupportDrawer />)
+
+        expect(screen.getByRole('dialog', { name: 'Support' }).style.bottom).toBe('0px')
+    })
+
+    it('lifts by exactly the height the keyboard covers', () => {
+        render(<SupportDrawer />)
+        const panel = screen.getByRole('dialog', { name: 'Support' })
+
+        openKeyboard(460)
+
+        expect(panel.style.bottom).toBe('340px')
+    })
+})
+
 describe('SupportDrawer Crisp session gate — native (Capacitor)', () => {
     beforeEach(() => {
         mockUseCrispUserData.mockReset()

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -13,6 +13,9 @@ import { isCapacitor } from '@/utils/capacitor'
 
 const DISMISS_THRESHOLD = 100
 
+/** Backdrop left showing above the panel when the keyboard squeezes it. */
+const TOP_RESERVE = 24
+
 const SupportDrawer = () => {
     const { isSupportModalOpen, setIsSupportModalOpen, supportPrefilledMessage: prefilledMessage } = useModalsContext()
     const userData = useCrispUserData()
@@ -181,8 +184,13 @@ const SupportDrawer = () => {
                     // bottom of the *layout* viewport, which iOS leaves under the keyboard.
                     bottom: keyboardInset,
                     // …and never be taller than what's actually on screen, so lifting the
-                    // panel pushes the conversation down instead of off the top edge.
-                    height: visibleHeight ? `min(85dvh, ${visibleHeight}px)` : '85dvh',
+                    // panel pushes the conversation down instead of off the top edge. The
+                    // reserved strip keeps the drag handle out from under the notch and
+                    // leaves a backdrop target to tap-to-close; with no keyboard up it is
+                    // slack and 85dvh wins, so the resting look is unchanged.
+                    height: visibleHeight
+                        ? `min(85dvh, calc(${visibleHeight}px - env(safe-area-inset-top) - ${TOP_RESERVE}px))`
+                        : '85dvh',
                     // The keyboard already covers the home indicator; padding for it too
                     // would just wedge a dead strip between the composer and the keys.
                     paddingBottom: keyboardInset ? 0 : 'env(safe-area-inset-bottom)',

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -5,6 +5,7 @@ import { useModalsContext } from '@/context/ModalsContext'
 import { useCrispUserData } from '@/hooks/useCrispUserData'
 import { useCrispTokenId } from '@/hooks/useCrispTokenId'
 import { useCrispProxyUrl } from '@/hooks/useCrispProxyUrl'
+import { useVisualViewport } from '@/hooks/useVisualViewport'
 import PeanutLoading from '../PeanutLoading'
 import { Button } from '@/components/0_Bruddle/Button'
 import { SUPPORT_EMAIL } from '@/constants/crisp'
@@ -23,6 +24,11 @@ const SupportDrawer = () => {
     const [iframeKey, setIframeKey] = useState(0)
 
     const crispProxyUrl = useCrispProxyUrl(userData, prefilledMessage, crispTokenId)
+
+    // Crisp's composer sits at the very bottom of the iframe, so the panel's bottom
+    // edge is the thing the iOS keyboard covers. Only measured while the drawer is
+    // open — see the hook for why CSS alone can't see the keyboard.
+    const { height: visibleHeight, keyboardInset } = useVisualViewport(isSupportModalOpen)
 
     /*
      * The proxy iframe boots the ENTIRE Next.js app at /crisp-proxy, and its src
@@ -167,10 +173,19 @@ const SupportDrawer = () => {
                 role="dialog"
                 aria-label="Support"
                 aria-modal={isSupportModalOpen}
-                className={`fixed inset-x-0 bottom-0 z-[999999] flex max-h-[85vh] flex-col rounded-t-[10px] border bg-background pt-4 ${
+                className={`fixed inset-x-0 z-[999999] flex flex-col rounded-t-[10px] border bg-background pt-4 ${
                     isSupportModalOpen ? 'pointer-events-auto translate-y-0' : 'pointer-events-none translate-y-full'
                 }`}
                 style={{
+                    // Sit on top of the keyboard rather than behind it: `bottom: 0` is the
+                    // bottom of the *layout* viewport, which iOS leaves under the keyboard.
+                    bottom: keyboardInset,
+                    // …and never be taller than what's actually on screen, so lifting the
+                    // panel pushes the conversation down instead of off the top edge.
+                    height: visibleHeight ? `min(85dvh, ${visibleHeight}px)` : '85dvh',
+                    // The keyboard already covers the home indicator; padding for it too
+                    // would just wedge a dead strip between the composer and the keys.
+                    paddingBottom: keyboardInset ? 0 : 'env(safe-area-inset-bottom)',
                     transform: isSupportModalOpen ? `translateY(${dragOffset}px)` : 'translateY(100%)',
                     transition: isDragging ? 'none' : 'transform 300ms ease-out',
                 }}
@@ -185,8 +200,9 @@ const SupportDrawer = () => {
                     <div className="h-1.5 w-10 rounded-full bg-black" />
                 </div>
 
-                <div className="flex w-full justify-center">
-                    <div className="relative h-[80vh] w-full overflow-auto md:max-w-xl">
+                {/* min-h-0 lets the iframe row shrink below its content when the panel does */}
+                <div className="flex min-h-0 w-full flex-1 justify-center">
+                    <div className="relative h-full w-full overflow-hidden md:max-w-xl">
                         {(!isCrispReady || isAwaitingToken) && !isCrispFailed && (
                             <div className="absolute inset-0 z-10 flex items-center justify-center bg-background">
                                 <PeanutLoading />

--- a/src/components/Send/__tests__/send-states.test.tsx
+++ b/src/components/Send/__tests__/send-states.test.tsx
@@ -344,6 +344,27 @@ describe('GROUP 4: Method Selection', () => {
         fireEvent.click(screen.getByTestId('action-card-Exchange or Wallet'))
         expect(mockResetWithdrawFlow).toHaveBeenCalledTimes(1)
         expect(mockRouterPush).toHaveBeenCalledWith('/withdraw?method=crypto')
+        expect(mockResetWithdrawFlow.mock.invocationCallOrder[0]).toBeLessThan(
+            mockRouterPush.mock.invocationCallOrder[0]
+        )
+    })
+
+    test('Mercado Pago and Pix also reset the withdraw flow before navigating', () => {
+        mockUseGeoFilteredPaymentOptions.mockReturnValue({
+            filteredMethods: [
+                { id: 'mercadopago', title: 'Mercado Pago', description: '', icons: [], soon: false },
+                { id: 'pix', title: 'Pix', description: '', icons: [], soon: false },
+            ],
+        })
+        renderSend()
+
+        fireEvent.click(screen.getByTestId('action-card-Mercado Pago'))
+        expect(mockResetWithdrawFlow).toHaveBeenCalledTimes(1)
+        expect(mockRouterPush).toHaveBeenCalledWith('/withdraw/manteca?method=mercado-pago&country=argentina')
+
+        fireEvent.click(screen.getByTestId('action-card-Pix'))
+        expect(mockResetWithdrawFlow).toHaveBeenCalledTimes(2)
+        expect(mockRouterPush).toHaveBeenCalledWith('/withdraw/manteca?method=pix&country=brazil')
     })
 
     test('Clicking Peanut contacts navigates to /send?view=contacts without touching the withdraw flow', () => {

--- a/src/components/Send/__tests__/send-states.test.tsx
+++ b/src/components/Send/__tests__/send-states.test.tsx
@@ -169,6 +169,12 @@ jest.mock('../views/Contacts.view', () => ({
     default: () => <div data-testid="contacts-view">Contacts View</div>,
 }))
 
+// withdraw-flow context — SendRouterView resets it when a click enters the withdraw flow
+const mockResetWithdrawFlow = jest.fn()
+jest.mock('@/context/WithdrawFlowContext', () => ({
+    useWithdrawFlow: () => ({ resetWithdrawFlow: mockResetWithdrawFlow }),
+}))
+
 // ---------- import component under test AFTER all mocks ----------
 import { SendRouterView } from '../views/SendRouter.view'
 
@@ -316,25 +322,37 @@ describe('GROUP 3: Contacts View', () => {
 // GROUP 4: Method Selection Navigation
 // ============================================================
 describe('GROUP 4: Method Selection', () => {
-    test('Clicking bank navigates to /withdraw?method=bank', () => {
+    test('Clicking bank resets the withdraw flow, then navigates to /withdraw?method=bank', () => {
+        // Regression: browser back from an abandoned /withdraw?method=crypto skips the
+        // in-app NavHeader reset, so a stale selectedMethod survives in the app-wide
+        // context. Without the reset, Bank skips method selection and lands on the
+        // crypto amount step (continuing into /withdraw/crypto?method=bank).
         renderSend()
 
         fireEvent.click(screen.getByTestId('action-card-Bank'))
+        expect(mockResetWithdrawFlow).toHaveBeenCalledTimes(1)
         expect(mockRouterPush).toHaveBeenCalledWith('/withdraw?method=bank')
+        // reset must land before navigation hands off to /withdraw
+        expect(mockResetWithdrawFlow.mock.invocationCallOrder[0]).toBeLessThan(
+            mockRouterPush.mock.invocationCallOrder[0]
+        )
     })
 
-    test('Clicking exchange-or-wallet navigates to /withdraw?method=crypto', () => {
+    test('Clicking exchange-or-wallet resets the withdraw flow, then navigates to /withdraw?method=crypto', () => {
         renderSend()
 
         fireEvent.click(screen.getByTestId('action-card-Exchange or Wallet'))
+        expect(mockResetWithdrawFlow).toHaveBeenCalledTimes(1)
         expect(mockRouterPush).toHaveBeenCalledWith('/withdraw?method=crypto')
     })
 
-    test('Clicking Peanut contacts navigates to /send?view=contacts', () => {
+    test('Clicking Peanut contacts navigates to /send?view=contacts without touching the withdraw flow', () => {
         renderSend()
 
         fireEvent.click(screen.getByTestId('action-card-Peanut contacts'))
         expect(mockRouterPush).toHaveBeenCalledWith('/send?view=contacts')
+        // contacts is not a withdraw entry — never clobber an unrelated flow's state
+        expect(mockResetWithdrawFlow).not.toHaveBeenCalled()
     })
 
     test('Back from main send navigates to /home', () => {

--- a/src/components/Send/__tests__/send-states.test.tsx
+++ b/src/components/Send/__tests__/send-states.test.tsx
@@ -361,10 +361,16 @@ describe('GROUP 4: Method Selection', () => {
         fireEvent.click(screen.getByTestId('action-card-Mercado Pago'))
         expect(mockResetWithdrawFlow).toHaveBeenCalledTimes(1)
         expect(mockRouterPush).toHaveBeenCalledWith('/withdraw/manteca?method=mercado-pago&country=argentina')
+        expect(mockResetWithdrawFlow.mock.invocationCallOrder[0]).toBeLessThan(
+            mockRouterPush.mock.invocationCallOrder[0]
+        )
 
         fireEvent.click(screen.getByTestId('action-card-Pix'))
         expect(mockResetWithdrawFlow).toHaveBeenCalledTimes(2)
         expect(mockRouterPush).toHaveBeenCalledWith('/withdraw/manteca?method=pix&country=brazil')
+        expect(mockResetWithdrawFlow.mock.invocationCallOrder[1]).toBeLessThan(
+            mockRouterPush.mock.invocationCallOrder[1]
+        )
     })
 
     test('Clicking Peanut contacts navigates to /send?view=contacts without touching the withdraw flow', () => {

--- a/src/components/Send/views/SendRouter.view.tsx
+++ b/src/components/Send/views/SendRouter.view.tsx
@@ -13,6 +13,7 @@ import { ACTION_METHODS, type PaymentMethod } from '@/constants/actionlist.const
 import Image from 'next/image'
 import StatusBadge from '@/components/Global/Badges/StatusBadge'
 import { useGeoFilteredPaymentOptions } from '@/hooks/useGeoFilteredPaymentOptions'
+import { useWithdrawFlow } from '@/context/WithdrawFlowContext'
 import { useContacts } from '@/hooks/useContacts'
 import { getInitialsFromName } from '@/utils/general.utils'
 import posthog from 'posthog-js'
@@ -50,6 +51,7 @@ export const SendRouterView = () => {
             ? decodeURIComponent(window.location.pathname.replace('/send/', '').split('/')[0])
             : null
     const recipientUsername = recipientFromQuery || recipientFromPath || null
+    const { resetWithdrawFlow } = useWithdrawFlow()
     // only fetch 3 contacts for avatar display
     const { contacts, isLoading: isFetchingContacts } = useContacts({ limit: 3 })
 
@@ -127,19 +129,26 @@ export const SendRouterView = () => {
                 router.push('/send?view=contacts')
                 break
             case 'bank':
-                // navigate to send via bank flow
+                // navigate to send via bank flow.
+                // fresh click = fresh intent: browser back skips the in-app NavHeader
+                // reset, and a stale selectedMethod left in the app-wide context would
+                // hijack the routing (Bank landing on the crypto amount step)
+                resetWithdrawFlow()
                 router.push('/withdraw?method=bank')
                 break
             case 'exchange-or-wallet':
                 // navigate to external wallet send flow
+                resetWithdrawFlow()
                 router.push('/withdraw?method=crypto')
                 break
             case 'mercadopago':
                 // navigate to mercado pago send flow
+                resetWithdrawFlow()
                 router.push('/withdraw/manteca?method=mercado-pago&country=argentina')
                 break
             case 'pix':
                 // navigate to pix send flow
+                resetWithdrawFlow()
                 router.push('/withdraw/manteca?method=pix&country=brazil')
                 break
             default:

--- a/src/context/WithdrawFlowContext.tsx
+++ b/src/context/WithdrawFlowContext.tsx
@@ -101,6 +101,9 @@ export const WithdrawFlowContextProvider: React.FC<{ children: ReactNode }> = ({
 
     const resetWithdrawFlow = useCallback(() => {
         setAmountToWithdraw('')
+        // browser-back with the compatibility modal open leaves it armed for the
+        // next /withdraw/crypto entry — reset must close it like everything else
+        setShowCompatibilityModal(false)
         setCurrentView('INITIAL')
         setWithdrawData(null)
         setSelectedBankAccount(null)

--- a/src/context/__tests__/WithdrawFlowContext.test.tsx
+++ b/src/context/__tests__/WithdrawFlowContext.test.tsx
@@ -1,0 +1,42 @@
+import { render, act } from '@testing-library/react'
+import { WithdrawFlowContextProvider, useWithdrawFlow } from '../WithdrawFlowContext'
+
+// probe that surfaces the real provider's state + actions to the test
+let ctx: ReturnType<typeof useWithdrawFlow>
+function Probe() {
+    ctx = useWithdrawFlow()
+    return null
+}
+
+describe('WithdrawFlowContext resetWithdrawFlow', () => {
+    test('clears abandoned flow state, including the compatibility modal', () => {
+        render(
+            <WithdrawFlowContextProvider>
+                <Probe />
+            </WithdrawFlowContextProvider>
+        )
+
+        act(() => {
+            ctx.setSelectedMethod({ type: 'crypto', title: 'Crypto' })
+            ctx.setAmountToWithdraw('50')
+            ctx.setUsdAmount('50')
+            ctx.setShowCompatibilityModal(true)
+            ctx.setShowAllWithdrawMethods(true)
+        })
+        expect(ctx.selectedMethod).toEqual({ type: 'crypto', title: 'Crypto' })
+        expect(ctx.showCompatibilityModal).toBe(true)
+
+        act(() => {
+            ctx.resetWithdrawFlow()
+        })
+
+        expect(ctx.selectedMethod).toBeNull()
+        expect(ctx.amountToWithdraw).toBe('')
+        expect(ctx.usdAmount).toBe('')
+        expect(ctx.selectedBankAccount).toBeNull()
+        expect(ctx.showAllWithdrawMethods).toBe(false)
+        // the reset used to leave a browser-back-abandoned modal armed for the
+        // next /withdraw/crypto entry — pin that it closes with everything else
+        expect(ctx.showCompatibilityModal).toBe(false)
+    })
+})

--- a/src/hooks/__tests__/useVisualViewport.test.ts
+++ b/src/hooks/__tests__/useVisualViewport.test.ts
@@ -15,6 +15,7 @@ const LAYOUT_HEIGHT = 800
 class FakeVisualViewport extends EventTarget {
     height = LAYOUT_HEIGHT
     offsetTop = 0
+    scale = 1
 }
 
 let viewport: FakeVisualViewport
@@ -64,6 +65,38 @@ describe('useVisualViewport', () => {
         setViewport(799.4)
 
         expect(result.current.keyboardInset).toBe(0)
+    })
+
+    it('catches the shallow accessory bar iOS shows for a hardware keyboard', () => {
+        // ~45px of shortcuts bar hides a composer just as well as a full keyboard.
+        const { result } = renderHook(() => useVisualViewport(true))
+
+        setViewport(755)
+
+        expect(result.current.keyboardInset).toBe(45)
+    })
+
+    it('stands down while the user is pinch-zoomed rather than typing', () => {
+        const { result } = renderHook(() => useVisualViewport(true))
+
+        viewport.scale = 2
+        setViewport(400)
+
+        expect(result.current).toEqual({ height: 0, keyboardInset: 0 })
+    })
+
+    it('drops the measurement when disabled, so a consumer cannot stay lifted', () => {
+        // A drawer closing while the keyboard is still up unsubscribes before it sees
+        // the keyboard leave. Freezing the last inset would strand it mid-screen.
+        const { result, rerender } = renderHook(({ on }) => useVisualViewport(on), {
+            initialProps: { on: true },
+        })
+        setViewport(460)
+        expect(result.current.keyboardInset).toBe(340)
+
+        rerender({ on: false })
+
+        expect(result.current).toEqual({ height: 0, keyboardInset: 0 })
     })
 
     it('does not measure or subscribe while disabled', () => {

--- a/src/hooks/__tests__/useVisualViewport.test.ts
+++ b/src/hooks/__tests__/useVisualViewport.test.ts
@@ -1,0 +1,95 @@
+/**
+ * useVisualViewport — the keyboard measurement behind the support drawer's lift.
+ *
+ * The bug it guards: on iOS the layout viewport never shrinks for the software
+ * keyboard, so a `position: fixed; bottom: 0` drawer keeps its bottom edge — and
+ * the Crisp composer sitting on it — underneath the keys. The only signal that
+ * this happened is the gap between `window.innerHeight` and the visual viewport.
+ */
+import { renderHook, act } from '@testing-library/react'
+import { useVisualViewport } from '../useVisualViewport'
+
+const LAYOUT_HEIGHT = 800
+
+// jsdom implements no visualViewport at all — stand up a controllable stub.
+class FakeVisualViewport extends EventTarget {
+    height = LAYOUT_HEIGHT
+    offsetTop = 0
+}
+
+let viewport: FakeVisualViewport
+
+const setViewport = (height: number, offsetTop = 0) => {
+    viewport.height = height
+    viewport.offsetTop = offsetTop
+    act(() => {
+        viewport.dispatchEvent(new Event('resize'))
+    })
+}
+
+beforeEach(() => {
+    viewport = new FakeVisualViewport()
+    Object.defineProperty(window, 'visualViewport', { value: viewport, configurable: true })
+    Object.defineProperty(window, 'innerHeight', { value: LAYOUT_HEIGHT, configurable: true })
+})
+
+describe('useVisualViewport', () => {
+    it('reports no keyboard when the visual viewport fills the layout viewport', () => {
+        const { result } = renderHook(() => useVisualViewport(true))
+
+        expect(result.current).toEqual({ height: LAYOUT_HEIGHT, keyboardInset: 0 })
+    })
+
+    it('reports the covered height once the keyboard opens', () => {
+        const { result } = renderHook(() => useVisualViewport(true))
+
+        setViewport(460)
+
+        expect(result.current).toEqual({ height: 460, keyboardInset: 340 })
+    })
+
+    it('counts the scroll iOS performs to reveal the focused field', () => {
+        // iOS scrolls the visual viewport down over the layout viewport; the drawer is
+        // pinned to the layout viewport, so that offset hides it too.
+        const { result } = renderHook(() => useVisualViewport(true))
+
+        setViewport(460, 100)
+
+        expect(result.current.keyboardInset).toBe(240)
+    })
+
+    it('ignores sub-pixel / scrollbar deltas that are not a keyboard', () => {
+        const { result } = renderHook(() => useVisualViewport(true))
+
+        setViewport(799.4)
+
+        expect(result.current.keyboardInset).toBe(0)
+    })
+
+    it('does not measure or subscribe while disabled', () => {
+        const subscribe = jest.spyOn(viewport, 'addEventListener')
+
+        const { result } = renderHook(() => useVisualViewport(false))
+
+        expect(result.current).toEqual({ height: 0, keyboardInset: 0 })
+        expect(subscribe).not.toHaveBeenCalled()
+    })
+
+    it('unsubscribes on unmount', () => {
+        const unsubscribe = jest.spyOn(viewport, 'removeEventListener')
+
+        const { unmount } = renderHook(() => useVisualViewport(true))
+        unmount()
+
+        expect(unsubscribe).toHaveBeenCalledWith('resize', expect.any(Function))
+        expect(unsubscribe).toHaveBeenCalledWith('scroll', expect.any(Function))
+    })
+
+    it('survives a browser with no visualViewport', () => {
+        Object.defineProperty(window, 'visualViewport', { value: undefined, configurable: true })
+
+        const { result } = renderHook(() => useVisualViewport(true))
+
+        expect(result.current).toEqual({ height: 0, keyboardInset: 0 })
+    })
+})

--- a/src/hooks/useVisualViewport.ts
+++ b/src/hooks/useVisualViewport.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Sub-pixel rounding and desktop scrollbars leave a few px between the layout and
+ * visual viewports even with no keyboard on screen. No software keyboard is anywhere
+ * near this short, so anything below the floor is measurement noise, not a keyboard.
+ */
+const MIN_KEYBOARD_INSET_PX = 80
+
+export interface VisualViewportState {
+    /** Height actually on screen, in px. `0` until measured (SSR, or unsupported). */
+    height: number
+    /** Px of the layout viewport's bottom edge hidden behind the software keyboard. */
+    keyboardInset: number
+}
+
+/**
+ * Measures the *visual* viewport — the slice of the page actually on screen.
+ *
+ * iOS never resizes the layout viewport for the software keyboard, so `100vh`,
+ * `100dvh` and `position: fixed; bottom: 0` all keep pointing at the full,
+ * keyboard-covered window. CSS therefore cannot see the keyboard at all; only
+ * `window.visualViewport` knows how much of the screen it ate.
+ *
+ * Subscribes only while `enabled`, because these events fire on every
+ * keystroke-driven scroll and consumers here are mounted on every route.
+ */
+export function useVisualViewport(enabled: boolean): VisualViewportState {
+    const [state, setState] = useState<VisualViewportState>({ height: 0, keyboardInset: 0 })
+
+    useEffect(() => {
+        const viewport = typeof window === 'undefined' ? null : window.visualViewport
+        if (!enabled || !viewport) return
+
+        const measure = () => {
+            // The still-visible slice of the layout viewport is
+            // [offsetTop, offsetTop + height] — offsetTop goes non-zero once iOS
+            // scrolls the focused field into view. Whatever is below that slice is
+            // where a `bottom: 0` fixed element lands: behind the keyboard.
+            const hidden = window.innerHeight - viewport.height - viewport.offsetTop
+            const next: VisualViewportState = {
+                height: viewport.height,
+                keyboardInset: hidden > MIN_KEYBOARD_INSET_PX ? hidden : 0,
+            }
+            setState((prev) => (prev.height === next.height && prev.keyboardInset === next.keyboardInset ? prev : next))
+        }
+
+        measure()
+        viewport.addEventListener('resize', measure)
+        viewport.addEventListener('scroll', measure)
+        return () => {
+            viewport.removeEventListener('resize', measure)
+            viewport.removeEventListener('scroll', measure)
+        }
+    }, [enabled])
+
+    return state
+}

--- a/src/hooks/useVisualViewport.ts
+++ b/src/hooks/useVisualViewport.ts
@@ -2,13 +2,17 @@ import { useEffect, useState } from 'react'
 
 /**
  * Sub-pixel rounding and desktop scrollbars leave a few px between the layout and
- * visual viewports even with no keyboard on screen. No software keyboard is anywhere
- * near this short, so anything below the floor is measurement noise, not a keyboard.
+ * visual viewports with nothing on screen. Set below the ~45px accessory bar iOS
+ * shows for a hardware keyboard — that bar covers a composer just as effectively as
+ * the full keyboard does — but well above scrollbar and rounding noise.
  */
-const MIN_KEYBOARD_INSET_PX = 80
+const MIN_KEYBOARD_INSET_PX = 40
+
+/** Nothing is measured while unsupported, disabled, or zoomed — consumers fall back to CSS. */
+const UNMEASURED: VisualViewportState = { height: 0, keyboardInset: 0 }
 
 export interface VisualViewportState {
-    /** Height actually on screen, in px. `0` until measured (SSR, or unsupported). */
+    /** Height actually on screen, in px. `0` when unmeasured (see {@link UNMEASURED}). */
     height: number
     /** Px of the layout viewport's bottom edge hidden behind the software keyboard. */
     keyboardInset: number
@@ -26,23 +30,37 @@ export interface VisualViewportState {
  * keystroke-driven scroll and consumers here are mounted on every route.
  */
 export function useVisualViewport(enabled: boolean): VisualViewportState {
-    const [state, setState] = useState<VisualViewportState>({ height: 0, keyboardInset: 0 })
+    const [state, setState] = useState<VisualViewportState>(UNMEASURED)
 
     useEffect(() => {
+        const commit = (next: VisualViewportState) =>
+            setState((prev) => (prev.height === next.height && prev.keyboardInset === next.keyboardInset ? prev : next))
+
         const viewport = typeof window === 'undefined' ? null : window.visualViewport
-        if (!enabled || !viewport) return
+        if (!enabled || !viewport) {
+            // Drop the last measurement rather than freeze it. A consumer that lifts by
+            // `keyboardInset` has to come back down when it closes — and since we
+            // unsubscribe here, we'd never see the keyboard leave.
+            commit(UNMEASURED)
+            return
+        }
 
         const measure = () => {
+            // Pinch-zoom shrinks the visual viewport too, and a zoomed reader is not
+            // typing — adjusting for it just makes things jump. `maximum-scale=1` in the
+            // root viewport keeps iOS from auto-zooming on focus, so scale > 1 is always
+            // a deliberate pinch and never a keyboard.
+            if (viewport.scale > 1) return commit(UNMEASURED)
+
             // The still-visible slice of the layout viewport is
             // [offsetTop, offsetTop + height] — offsetTop goes non-zero once iOS
             // scrolls the focused field into view. Whatever is below that slice is
             // where a `bottom: 0` fixed element lands: behind the keyboard.
             const hidden = window.innerHeight - viewport.height - viewport.offsetTop
-            const next: VisualViewportState = {
+            commit({
                 height: viewport.height,
                 keyboardInset: hidden > MIN_KEYBOARD_INSET_PX ? hidden : 0,
-            }
-            setState((prev) => (prev.height === next.height && prev.keyboardInset === next.keyboardInset ? prev : next))
+            })
         }
 
         measure()


### PR DESCRIPTION
Restores the invariant: `dev` is a superset of `main`.

`main` had drifted 8 commits ahead. Six were already-unpaid debt from earlier hotfixes; two are the iOS keyboard fix (#2615), merged to `main` today. `dev → main` never moves code backwards, so only this PR clears it.

## What comes across

| Commits | What |
|---|---|
| `ce80d5f`, `5f4adfb` | #2615 — keep the Crisp composer above the iOS keyboard (TASK-20947) |
| `5e14652`, `8e5347a` + 3 tests | withdraw-flow reset on send-method click / compatibility modal |
| `a2860e1` | `src/content` submodule bump |

## The one place the two branches actually met

`dev`'s Sprint 154 localization and #2615 both edit `SupportDrawer/index.tsx` — `aria-label="Support"` → `t('supportDrawer.label')` sits one line above the `className`/`style` block the keyboard fix rewrites. Adjacent, not overlapping, so git merged it without a conflict; **verified by hand** that both survived rather than trusting the clean exit:

```
aria-label={t('supportDrawer.label')}          ← dev's i18n
...
bottom: keyboardInset,                          ← #2615's geometry
height: visibleHeight ? `min(85dvh, …)` : '85dvh',
paddingBottom: keyboardInset ? 0 : 'env(safe-area-inset-bottom)',
```

The test files met too, and resolved themselves: `dev` shadows `render` with an `IntlWrapper` wrapper, and #2615's new tests call bare `render(...)`, so they pick it up automatically. `getByRole('dialog', { name: 'Support' })` still resolves through the real message — no edits needed.

## Gate

Prettier ✅ · typecheck ✅ · **210/210 suites, 2691 tests** ✅ · production build ✅

No conflict resolution was performed, so there is no risk of the "blanket `--theirs`/`--ours` drops one side" failure this repo has hit before. The merge is a plain fast merge with both sides intact.
