### PR TITLE
fix(ci): handle content guard diffs above 300 files

### DIFF
--- a/.github/workflows/content-publish-automerge.yml
+++ b/.github/workflows/content-publish-automerge.yml
@@ -61,7 +61,10 @@ jobs:
                   REPO: ${{ github.repository }}
               run: |
                   set -euo pipefail
-                  FILES=$(gh pr diff "$PR" --repo "$REPO" --name-only)
+                  # `gh pr diff` returns HTTP 406 after 300 files. The Files API
+                  # is paginated, so large code PRs reach the same fail-closed
+                  # exact-match decision instead of leaving a false-red check.
+                  FILES=$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename')
                   echo "Changed files:"
                   echo "$FILES"
                   if [ "$FILES" = "src/content" ]; then


### PR DESCRIPTION
## Root cause
`gh pr diff --name-only` returns HTTP 406 for pull requests with more than 300 files. Under `set -e`, that harmless non-content PR becomes a false-red `approve-and-merge` check.

## Fix
Use GitHubs paginated pull-request Files API. The guard still auto-merges only when the complete file list is exactly `src/content`.

## Verification
- YAML parses with Ruby Psych.
- The API returned 759 paths for release PR #2624 and correctly evaluated it as not content-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated content-only change detection for large pull requests.
  * Ensured validation continues to require exactly one eligible file change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->