### PR TITLE
fix(ci): make Capgo OTA uploads idempotent

### DIFF
--- a/.github/workflows/capgo-deploy-ios.yml
+++ b/.github/workflows/capgo-deploy-ios.yml
@@ -82,6 +82,7 @@ jobs:
                     --apikey "$CAPGO_API_KEY" \
                     --path ./out \
                     --auto-min-update-version \
+                    --version-exists-ok \
                     --comment "$COMMENT"
 
             - name: Deployment summary

--- a/.github/workflows/capgo-deploy.yml
+++ b/.github/workflows/capgo-deploy.yml
@@ -86,6 +86,7 @@ jobs:
                     --key-data-v2 "$CAPGO_PRIVATE_KEY" \
                     --path ./out \
                     --auto-min-update-version \
+                    --version-exists-ok \
                     --comment "$COMMENT"
 
             - name: Deployment summary


### PR DESCRIPTION
## Root cause
Repeated dev pushes upload the unchanged native app version (1.0.8). Capgo rejects an existing bundle version, leaving a non-required deploy check red.

## Fix
Pass Capgo CLI `--version-exists-ok` for Android and iOS OTA uploads. Existing versions now exit successfully; new versions still upload normally.

## Verification
- YAML parses with Ruby Psych.
- Flag is documented by Capgo for CI/CD idempotency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Capgo bundle uploads now succeed when the specified version already exists.
  * Updated both standard and iOS deployment workflows for consistent version handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->