### PR TITLE
fix(ci): consolidate UI workflow reliability

### DIFF
--- a/.github/workflows/capgo-deploy-ios.yml
+++ b/.github/workflows/capgo-deploy-ios.yml
@@ -82,6 +82,7 @@ jobs:
                     --apikey "$CAPGO_API_KEY" \
                     --path ./out \
                     --auto-min-update-version \
+                    --version-exists-ok \
                     --comment "$COMMENT"
 
             - name: Deployment summary

--- a/.github/workflows/capgo-deploy.yml
+++ b/.github/workflows/capgo-deploy.yml
@@ -86,6 +86,7 @@ jobs:
                     --key-data-v2 "$CAPGO_PRIVATE_KEY" \
                     --path ./out \
                     --auto-min-update-version \
+                    --version-exists-ok \
                     --comment "$COMMENT"
 
             - name: Deployment summary

--- a/.github/workflows/content-publish-automerge.yml
+++ b/.github/workflows/content-publish-automerge.yml
@@ -61,7 +61,10 @@ jobs:
                   REPO: ${{ github.repository }}
               run: |
                   set -euo pipefail
-                  FILES=$(gh pr diff "$PR" --repo "$REPO" --name-only)
+                  # `gh pr diff` returns HTTP 406 after 300 files. The Files API
+                  # is paginated, so large code PRs reach the same fail-closed
+                  # exact-match decision instead of leaving a false-red check.
+                  FILES=$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename')
                   echo "Changed files:"
                   echo "$FILES"
                   if [ "$FILES" = "src/content" ]; then


### PR DESCRIPTION
## Changes
- Use GitHub’s paginated Files API for the content auto-merge guard, preserving its exact `src/content` fail-closed check above GitHub’s 300-file diff limit.
- Make Android and iOS Capgo uploads succeed when the bundle version already exists.

## Verification
- All three workflow YAML files parse.
- The Files API reads all 759 paths on #2624 and correctly evaluates it as not content-only.