### PR TITLE
feat(support): unread badge on the Support nav icon

### DIFF
--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -10,11 +10,12 @@ import BackendErrorScreen from '@/components/Global/BackendErrorScreen'
 import { useAuth } from '@/context/authContext'
 import classNames from 'classnames'
 import { usePathname } from 'next/navigation'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { Suspense, useCallback, useEffect, useRef, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import '../../styles/globals.css'
 import QRScannerOverlay from '@/components/Global/QRScannerOverlay'
 import SecurityVerificationOverlay from '@/components/Global/SecurityVerificationOverlay'
+import SupportDeepLink from '@/components/Global/SupportDeepLink'
 import SupportDrawer from '@/components/Global/SupportDrawer'
 import JoinWaitlistPage from '@/components/Invites/JoinWaitlistPage'
 import { useRouter } from 'next/navigation'
@@ -253,6 +254,12 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
             <ReConsentModal />
 
             <SupportDrawer />
+
+            {/* Suspense is required: nuqs reads useSearchParams, which triggers
+                a client-side-rendering bailout without a boundary. */}
+            <Suspense fallback={null}>
+                <SupportDeepLink />
+            </Suspense>
 
             <QRScannerOverlay />
 

--- a/src/components/Global/IndicatorDot/__tests__/IndicatorDot.test.tsx
+++ b/src/components/Global/IndicatorDot/__tests__/IndicatorDot.test.tsx
@@ -42,4 +42,11 @@ describe('IndicatorDot', () => {
             expect.arrayContaining(['absolute', '-right-1', '-top-1', 'h-2.5', 'w-2.5', 'bg-primary-1'])
         )
     })
+
+    it('announces the support badge to assistive tech', () => {
+        // aria-label on a bare span (generic role) is ignored, so the nav badge
+        // pairs it with role="status".
+        const { getByRole } = render(<IndicatorDot role="status" aria-label="New support reply" />)
+        expect(getByRole('status')).toHaveAttribute('aria-label', 'New support reply')
+    })
 })

--- a/src/components/Global/IndicatorDot/__tests__/IndicatorDot.test.tsx
+++ b/src/components/Global/IndicatorDot/__tests__/IndicatorDot.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * Visual-parity guard for the dot extraction.
+ *
+ * The same pink dot used to be copy-pasted in three places. Collapsing them
+ * onto one component is only safe if each call site still resolves to the
+ * classes it had before — twMerge has to win the size and animation overrides
+ * rather than emit both. Asserting the resolved class string pins that more
+ * precisely than a screenshot of a 10px dot could.
+ */
+import { render } from '@testing-library/react'
+import IndicatorDot from '@/components/Global/IndicatorDot'
+
+const classesOf = (ui: React.ReactElement) => {
+    const { container } = render(ui)
+    return (container.firstChild as HTMLElement).className.split(/\s+/)
+}
+
+describe('IndicatorDot', () => {
+    it('renders the shared 10px pink dot by default (perk carousel call site)', () => {
+        const classes = classesOf(<IndicatorDot />)
+        expect(classes).toEqual(expect.arrayContaining(['block', 'h-2.5', 'w-2.5', 'rounded-full', 'bg-primary-1']))
+    })
+
+    it('lets a call site shrink the dot without leaving the old size behind', () => {
+        // TransactionCard's pending dot: h-2 w-2 animate-pulsate.
+        const classes = classesOf(<IndicatorDot className="h-2 w-2 animate-pulsate" />)
+        expect(classes).toEqual(expect.arrayContaining(['h-2', 'w-2', 'animate-pulsate', 'bg-primary-1']))
+        expect(classes).not.toContain('h-2.5')
+        expect(classes).not.toContain('w-2.5')
+    })
+
+    it('keeps the profile menu highlight animating and labelled', () => {
+        const { container } = render(<IndicatorDot className="animate-pulse" aria-label="highlight-indicator" />)
+        const dot = container.firstChild as HTMLElement
+        expect(dot.className.split(/\s+/)).toEqual(expect.arrayContaining(['animate-pulse', 'h-2.5', 'w-2.5']))
+        expect(dot).toHaveAttribute('aria-label', 'highlight-indicator')
+    })
+
+    it('positions the support nav badge without dropping the dot styling', () => {
+        const classes = classesOf(<IndicatorDot className="absolute -right-1 -top-1" />)
+        expect(classes).toEqual(
+            expect.arrayContaining(['absolute', '-right-1', '-top-1', 'h-2.5', 'w-2.5', 'bg-primary-1'])
+        )
+    })
+})

--- a/src/components/Global/IndicatorDot/index.tsx
+++ b/src/components/Global/IndicatorDot/index.tsx
@@ -1,0 +1,14 @@
+import { twMerge } from 'tailwind-merge'
+
+/**
+ * The small pink status dot.
+ *
+ * Neutral name on purpose: it marks "pending" on a transaction card,
+ * "claimable" on a perk carousel card, and "unread" on the support nav icon.
+ * Pass className for size, animation or position overrides.
+ */
+const IndicatorDot = ({ className, ...props }: React.ComponentPropsWithoutRef<'span'>) => (
+    <span className={twMerge('block h-2.5 w-2.5 rounded-full bg-primary-1', className)} {...props} />
+)
+
+export default IndicatorDot

--- a/src/components/Global/SupportDeepLink/index.tsx
+++ b/src/components/Global/SupportDeepLink/index.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useModalsContext } from '@/context/ModalsContext'
+import { parseAsString, useQueryStates } from 'nuqs'
+import { useEffect } from 'react'
+
+/**
+ * Opens the support drawer for `/home?support=open`, the deep link a support
+ * reply push carries. The param is cleared right after so a refresh or a back
+ * navigation does not reopen the drawer. Renders nothing.
+ */
+const SupportDeepLink = () => {
+    const { setIsSupportModalOpen } = useModalsContext()
+    const [{ support }, setQuery] = useQueryStates({ support: parseAsString })
+
+    useEffect(() => {
+        if (support !== 'open') return
+        setIsSupportModalOpen(true)
+        setQuery({ support: null })
+    }, [support, setIsSupportModalOpen, setQuery])
+
+    return null
+}
+
+export default SupportDeepLink

--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -41,6 +41,15 @@ jest.mock('@/context/ModalsContext', () => ({
         supportPrefilledMessage: undefined,
     }),
 }))
+// Opening the drawer clears the support unread badge. That call is not what
+// this file guards, and serverFetch reaches for Capacitor Preferences, which
+// jsdom has no shim for.
+const mockMarkAllRead = jest.fn(async () => ({ ok: true }))
+jest.mock('@/services/notifications', () => ({
+    notificationsApi: {
+        markAllRead: (category: string) => mockMarkAllRead(category),
+    },
+}))
 jest.mock('@/hooks/useCrispUserData', () => ({
     useCrispUserData: () => mockUseCrispUserData(),
 }))
@@ -103,6 +112,27 @@ describe('SupportDrawer Crisp session gate — web iframe', () => {
         const iframe = supportIframe()
         expect(iframe).toBeInTheDocument()
         expect(iframe).toHaveAttribute('src', '/crisp-proxy')
+    })
+})
+
+describe('SupportDrawer — support unread badge', () => {
+    beforeEach(() => {
+        mockUseCrispUserData.mockReset().mockReturnValue({ userId: 'user-abc', email: 'a@b.com' })
+        mockUseCrispTokenId.mockReset().mockReturnValue('token-abc')
+        mockIsCapacitor.mockReset().mockReturnValue(false)
+        mockMarkAllRead.mockClear()
+    })
+
+    it('clears the support badge and tells the rest of the app when the drawer opens', async () => {
+        const onUpdated = jest.fn()
+        window.addEventListener('notifications:updated', onUpdated)
+
+        render(<SupportDrawer />)
+
+        await waitFor(() => expect(mockMarkAllRead).toHaveBeenCalledWith('support'))
+        await waitFor(() => expect(onUpdated).toHaveBeenCalled())
+
+        window.removeEventListener('notifications:updated', onUpdated)
     })
 })
 

--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -44,7 +44,7 @@ jest.mock('@/context/ModalsContext', () => ({
 // Opening the drawer clears the support unread badge. That call is not what
 // this file guards, and serverFetch reaches for Capacitor Preferences, which
 // jsdom has no shim for.
-const mockMarkAllRead = jest.fn(async () => ({ ok: true }))
+const mockMarkAllRead = jest.fn(async (_category: string) => ({ ok: true }))
 jest.mock('@/services/notifications', () => ({
     notificationsApi: {
         markAllRead: (category: string) => mockMarkAllRead(category),

--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -116,6 +116,8 @@ describe('SupportDrawer Crisp session gate — web iframe', () => {
 })
 
 describe('SupportDrawer — support unread badge', () => {
+    // Opening the drawer is not the same as reading the reply: the chat has to
+    // actually render. Clearing too eagerly buries a reply nobody saw.
     beforeEach(() => {
         mockUseCrispUserData.mockReset().mockReturnValue({ userId: 'user-abc', email: 'a@b.com' })
         mockUseCrispTokenId.mockReset().mockReturnValue('token-abc')
@@ -123,16 +125,38 @@ describe('SupportDrawer — support unread badge', () => {
         mockMarkAllRead.mockClear()
     })
 
-    it('clears the support badge and tells the rest of the app when the drawer opens', async () => {
+    it('clears the badge and tells the rest of the app once the chat renders', async () => {
         const onUpdated = jest.fn()
         window.addEventListener('notifications:updated', onUpdated)
 
         render(<SupportDrawer />)
+        expect(mockMarkAllRead).not.toHaveBeenCalled()
+
+        postCrispMessage('CRISP_READY')
 
         await waitFor(() => expect(mockMarkAllRead).toHaveBeenCalledWith('support'))
         await waitFor(() => expect(onUpdated).toHaveBeenCalled())
 
         window.removeEventListener('notifications:updated', onUpdated)
+    })
+
+    it('does NOT clear the badge when Crisp fails and the user only sees the email fallback', async () => {
+        render(<SupportDrawer />)
+        postCrispMessage('CRISP_FAILED')
+
+        await waitFor(() => expect(screen.getByText(SUPPORT_EMAIL)).toBeInTheDocument())
+        expect(mockMarkAllRead).not.toHaveBeenCalled()
+    })
+
+    it('does not clear the badge for a logged-out visitor', async () => {
+        mockUseCrispUserData.mockReturnValue({ userId: undefined, email: undefined })
+        mockUseCrispTokenId.mockReturnValue(undefined)
+
+        render(<SupportDrawer />)
+        postCrispMessage('CRISP_READY')
+
+        await waitFor(() => expect(supportIframe()).toBeInTheDocument())
+        expect(mockMarkAllRead).not.toHaveBeenCalled()
     })
 })
 

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -10,6 +10,7 @@ import { useVisualViewport } from '@/hooks/useVisualViewport'
 import PeanutLoading from '../PeanutLoading'
 import { Button } from '@/components/0_Bruddle/Button'
 import { SUPPORT_EMAIL } from '@/constants/crisp'
+import { notificationsApi } from '@/services/notifications'
 import { isCapacitor } from '@/utils/capacitor'
 
 const DISMISS_THRESHOLD = 100
@@ -49,6 +50,21 @@ const SupportDrawer = () => {
     const [hasBeenOpened, setHasBeenOpened] = useState(false)
     useEffect(() => {
         if (isSupportModalOpen) setHasBeenOpened(true)
+    }, [isSupportModalOpen])
+
+    /*
+     * Clear the support unread badge. This flag is the single choke point for
+     * "the user opened the chat" — the nav tap, openSupportWithMessage(), the
+     * push deep link and the Capacitor path all set it before anything opens,
+     * so one effect covers every entry.
+     */
+    useEffect(() => {
+        if (!isSupportModalOpen) return
+        notificationsApi
+            .markAllRead('support')
+            .then(() => window.dispatchEvent(new CustomEvent('notifications:updated')))
+            // A failed mark-read only means the badge stays on a bit longer.
+            .catch(() => {})
     }, [isSupportModalOpen])
 
     const handleRetry = useCallback(() => {

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -52,20 +52,44 @@ const SupportDrawer = () => {
         if (isSupportModalOpen) setHasBeenOpened(true)
     }, [isSupportModalOpen])
 
-    /*
-     * Clear the support unread badge. This flag is the single choke point for
-     * "the user opened the chat" — the nav tap, openSupportWithMessage(), the
-     * push deep link and the Capacitor path all set it before anything opens,
-     * so one effect covers every entry.
-     */
-    useEffect(() => {
-        if (!isSupportModalOpen) return
+    // Guests reach this drawer too (claim and pay links mount the same layout),
+    // and they have no notifications — the call would just 401.
+    const isLoggedIn = Boolean(userData.userId)
+
+    const clearSupportBadge = useCallback(() => {
+        if (!isLoggedIn) return
         notificationsApi
             .markAllRead('support')
             .then(() => window.dispatchEvent(new CustomEvent('notifications:updated')))
             // A failed mark-read only means the badge stays on a bit longer.
             .catch(() => {})
-    }, [isSupportModalOpen])
+    }, [isLoggedIn])
+
+    /*
+     * Clear the support unread badge — on the web path only; the Capacitor
+     * effect below clears its own once the native messenger actually opens.
+     *
+     * "Opened the drawer" is not the same as "read the reply". When the Crisp
+     * bundle fails to load, this same component shows the email fallback
+     * instead, and clearing then would bury a reply nobody saw. So wait until
+     * the chat is really in front of the user.
+     *
+     * The closing edge matters just as much: a reply arriving while the drawer
+     * is open — the normal case in a live conversation — would otherwise light
+     * the badge with nothing new behind it, and leave it lit until the user
+     * opened support again.
+     */
+    const wasShowingChat = useRef(false)
+    useEffect(() => {
+        const isShowingChat = isSupportModalOpen && isCrispReady && !isCrispFailed
+        if (isShowingChat) {
+            wasShowingChat.current = true
+            clearSupportBadge()
+        } else if (wasShowingChat.current && !isSupportModalOpen) {
+            wasShowingChat.current = false
+            clearSupportBadge()
+        }
+    }, [isSupportModalOpen, isCrispReady, isCrispFailed, clearSupportBadge])
 
     const handleRetry = useCallback(() => {
         setIsCrispFailed(false)
@@ -114,10 +138,23 @@ const SupportDrawer = () => {
             }
 
             CapacitorCrisp.openMessenger()
+            // The chat is now in front of the user, so the badge has done its
+            // job. There is no isCrispReady on this path — the native messenger
+            // reports nothing back — so clear it here rather than in the web
+            // effect above.
+            clearSupportBadge()
             // close our drawer since native UI takes over
             setIsSupportModalOpen(false)
         })
-    }, [isSupportModalOpen, isAwaitingToken, userData, crispTokenId, prefilledMessage, setIsSupportModalOpen])
+    }, [
+        isSupportModalOpen,
+        isAwaitingToken,
+        userData,
+        crispTokenId,
+        prefilledMessage,
+        setIsSupportModalOpen,
+        clearSupportBadge,
+    ])
 
     // drag-to-dismiss state
     const panelRef = useRef<HTMLDivElement>(null)

--- a/src/components/Global/WalletNavigation/index.tsx
+++ b/src/components/Global/WalletNavigation/index.tsx
@@ -116,8 +116,14 @@ const MobileNav: React.FC<MobileNavProps> = ({ pathName }) => {
             >
                 <span className="relative">
                     <NavIcon name="peanut-support" size={24} />
+                    {/* role="status" so the dot is announced. aria-label alone on a
+                        bare span is ignored by assistive tech (generic role). */}
                     {hasUnreadSupport && (
-                        <IndicatorDot className="absolute -right-1 -top-1" aria-label="unread-support-indicator" />
+                        <IndicatorDot
+                            className="absolute -right-1 -top-1"
+                            role="status"
+                            aria-label={t('supportUnread')}
+                        />
                     )}
                 </span>
                 <span className="mx-auto mt-1 block pl-1 text-center text-xs font-medium">{t('support')}</span>

--- a/src/components/Global/WalletNavigation/index.tsx
+++ b/src/components/Global/WalletNavigation/index.tsx
@@ -2,8 +2,10 @@
 import PEANUT_LOGO from '@/assets/logos/peanut-logo.svg'
 import DirectSendQr from '@/components/Global/DirectSendQR'
 import { Icon, type IconName, Icon as NavIcon } from '@/components/Global/Icons/Icon'
+import IndicatorDot from '@/components/Global/IndicatorDot'
 import underMaintenanceConfig from '@/config/underMaintenance.config'
 import { useModalsContext } from '@/context/ModalsContext'
+import { useSupportUnread } from '@/hooks/useSupportUnread'
 import { useUserStore } from '@/redux/hooks'
 import classNames from 'classnames'
 import Image from 'next/image'
@@ -76,6 +78,7 @@ const MobileNav: React.FC<MobileNavProps> = ({ pathName }) => {
     const t = useTranslations('navigation')
     const { setIsSupportModalOpen } = useModalsContext()
     const { triggerHaptic } = useHaptic()
+    const hasUnreadSupport = useSupportUnread()
 
     return (
         <div className="z-1 grid h-20 grid-cols-3 border-t border-black bg-background md:hidden">
@@ -111,7 +114,12 @@ const MobileNav: React.FC<MobileNavProps> = ({ pathName }) => {
                     { 'text-primary-1': pathName === '/support' }
                 )}
             >
-                <NavIcon name="peanut-support" size={24} />
+                <span className="relative">
+                    <NavIcon name="peanut-support" size={24} />
+                    {hasUnreadSupport && (
+                        <IndicatorDot className="absolute -right-1 -top-1" aria-label="unread-support-indicator" />
+                    )}
+                </span>
                 <span className="mx-auto mt-1 block pl-1 text-center text-xs font-medium">{t('support')}</span>
             </button>
         </div>

--- a/src/components/Home/HomeCarouselCTA/CarouselCTA.tsx
+++ b/src/components/Home/HomeCarouselCTA/CarouselCTA.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Icon, type IconName } from '@/components/Global/Icons/Icon'
+import IndicatorDot from '@/components/Global/IndicatorDot'
 import type { StaticImageData } from 'next/image'
 import Image from 'next/image'
 import { useTranslations } from 'next-intl'
@@ -80,7 +81,7 @@ const CarouselCTA = ({
             {/* Close button or pink dot indicator for perk claims */}
             {isPerkClaim ? (
                 <div className={twMerge(CAROUSEL_CLOSE_BUTTON_POSITION, 'z-10')} aria-label={t('claimablePerk')}>
-                    <div className="h-2.5 w-2.5 rounded-full bg-primary-1" />
+                    <IndicatorDot />
                 </div>
             ) : (
                 <button

--- a/src/components/Profile/components/ProfileMenuItem.tsx
+++ b/src/components/Profile/components/ProfileMenuItem.tsx
@@ -2,6 +2,7 @@ import StatusBadge from '@/components/Global/Badges/StatusBadge'
 import Card from '@/components/Global/Card'
 import { type CardPosition } from '@/components/Global/Card/card.utils'
 import { Icon, type IconName } from '@/components/Global/Icons/Icon'
+import IndicatorDot from '@/components/Global/IndicatorDot'
 import NavigationArrow from '@/components/Global/NavigationArrow'
 import { Tooltip } from '@/components/Tooltip'
 import Link from 'next/link'
@@ -55,11 +56,7 @@ const ProfileMenuItem: React.FC<ProfileMenuItemProps> = ({
                 )}
                 <div className="flex items-center gap-2">
                     <label className="text-base font-medium">{label}</label>
-                    {highlight && (
-                        <div className={'animate-pulse'} aria-label="highlight-indicator">
-                            <div className="h-2.5 w-2.5 rounded-full bg-primary-1" />
-                        </div>
-                    )}
+                    {highlight && <IndicatorDot className="animate-pulse" aria-label="highlight-indicator" />}
                 </div>
                 {badge && <StatusBadge status="custom" customText={badge} />}
                 {showTooltip && (

--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -1,6 +1,7 @@
 import Card from '@/components/Global/Card'
 import { type CardPosition } from '@/components/Global/Card/card.utils'
 import { Icon, type IconName } from '@/components/Global/Icons/Icon'
+import IndicatorDot from '@/components/Global/IndicatorDot'
 import TransactionAvatarBadge from '@/components/TransactionDetails/TransactionAvatarBadge'
 import { getBankAccountCountryCode } from '@/constants/countryCurrencyMapping'
 import { type TransactionDirection, type TransactionType } from '@/components/TransactionDetails/transaction-types'
@@ -237,7 +238,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
                         <div className="flex flex-col">
                             {/* display formatted name (address or username) */}
                             <div className="flex flex-row items-center gap-2">
-                                {isPending && <div className="h-2 w-2 animate-pulsate rounded-full bg-primary-1" />}
+                                {isPending && <IndicatorDot className="h-2 w-2 animate-pulsate" />}
                                 <div className="min-w-0 flex-1 truncate font-roboto text-[16px] font-medium">
                                     <VerifiedUserLabel
                                         username={transaction.userName}

--- a/src/hooks/__tests__/useSupportUnread.test.ts
+++ b/src/hooks/__tests__/useSupportUnread.test.ts
@@ -1,0 +1,72 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useSupportUnread } from '@/hooks/useSupportUnread'
+
+const mockUnreadCount = jest.fn()
+jest.mock('@/services/notifications', () => ({
+    notificationsApi: {
+        unreadCount: (category?: string) => mockUnreadCount(category),
+    },
+}))
+
+beforeEach(() => {
+    mockUnreadCount.mockReset()
+    mockUnreadCount.mockResolvedValue({ count: 0 })
+})
+
+describe('useSupportUnread', () => {
+    it('asks only for the support category', async () => {
+        renderHook(() => useSupportUnread())
+        await waitFor(() => expect(mockUnreadCount).toHaveBeenCalledWith('support'))
+    })
+
+    it('is false while nothing is unread', async () => {
+        const { result } = renderHook(() => useSupportUnread())
+        await waitFor(() => expect(mockUnreadCount).toHaveBeenCalled())
+        expect(result.current).toBe(false)
+    })
+
+    it('is true once support has replied', async () => {
+        mockUnreadCount.mockResolvedValue({ count: 2 })
+        const { result } = renderHook(() => useSupportUnread())
+        await waitFor(() => expect(result.current).toBe(true))
+    })
+
+    it('refetches when the notifications list changes', async () => {
+        const { result } = renderHook(() => useSupportUnread())
+        await waitFor(() => expect(result.current).toBe(false))
+
+        // The drawer marks the category read, then fires this event.
+        mockUnreadCount.mockResolvedValue({ count: 1 })
+        act(() => {
+            window.dispatchEvent(new CustomEvent('notifications:updated'))
+        })
+        await waitFor(() => expect(result.current).toBe(true))
+    })
+
+    it('refetches when the app comes back to the foreground', async () => {
+        const { result } = renderHook(() => useSupportUnread())
+        await waitFor(() => expect(result.current).toBe(false))
+
+        mockUnreadCount.mockResolvedValue({ count: 1 })
+        act(() => {
+            document.dispatchEvent(new Event('visibilitychange'))
+        })
+        await waitFor(() => expect(result.current).toBe(true))
+    })
+
+    it('stays false when the count request fails', async () => {
+        mockUnreadCount.mockRejectedValue(new Error('offline'))
+        const { result } = renderHook(() => useSupportUnread())
+        await waitFor(() => expect(mockUnreadCount).toHaveBeenCalled())
+        expect(result.current).toBe(false)
+    })
+
+    it('stops listening after unmount', async () => {
+        const { unmount } = renderHook(() => useSupportUnread())
+        await waitFor(() => expect(mockUnreadCount).toHaveBeenCalledTimes(1))
+
+        unmount()
+        window.dispatchEvent(new CustomEvent('notifications:updated'))
+        expect(mockUnreadCount).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/hooks/useSupportUnread.ts
+++ b/src/hooks/useSupportUnread.ts
@@ -1,0 +1,45 @@
+'use client'
+
+import { notificationsApi } from '@/services/notifications'
+import { useCallback, useEffect, useState } from 'react'
+
+/**
+ * True when support has replied since the user last opened the chat.
+ *
+ * The count is server-side truth. Neither client can work it out alone: the web
+ * Crisp widget lives in a sandboxed iframe that mounts only after the drawer is
+ * first opened, and the native plugin exposes no message events. The backend
+ * writes one in-app notification row per support reply, and this reads the
+ * count for the `support` category.
+ *
+ * No polling. It refetches on mount, when the notifications list changes, and
+ * when the tab or app comes back to the foreground.
+ */
+export const useSupportUnread = (): boolean => {
+    const [hasUnread, setHasUnread] = useState(false)
+
+    const refresh = useCallback(() => {
+        notificationsApi
+            .unreadCount('support')
+            .then(({ count }) => setHasUnread(count > 0))
+            // A failed count must never break the nav bar.
+            .catch(() => {})
+    }, [])
+
+    useEffect(() => {
+        refresh()
+
+        const onVisibilityChange = () => {
+            if (document.visibilityState === 'visible') refresh()
+        }
+
+        window.addEventListener('notifications:updated', refresh)
+        document.addEventListener('visibilitychange', onVisibilityChange)
+        return () => {
+            window.removeEventListener('notifications:updated', refresh)
+            document.removeEventListener('visibilitychange', onVisibilityChange)
+        }
+    }, [refresh])
+
+    return hasUnread
+}

--- a/src/hooks/useSupportUnread.ts
+++ b/src/hooks/useSupportUnread.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { notificationsApi } from '@/services/notifications'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 /**
  * True when support has replied since the user last opened the chat.
@@ -17,11 +17,23 @@ import { useCallback, useEffect, useState } from 'react'
  */
 export const useSupportUnread = (): boolean => {
     const [hasUnread, setHasUnread] = useState(false)
+    /*
+     * Responses can land out of order, and the stale one would win. Tapping a
+     * push on a backgrounded app fires a foreground refetch (count 1), then the
+     * deep link opens the drawer, which clears the badge and fires a second
+     * refetch (count 0). If the first response arrives last — routine on a
+     * mobile radio — the badge sticks on with nothing behind it, and with no
+     * polling nothing corrects it until the next foreground.
+     */
+    const latestRequestId = useRef(0)
 
     const refresh = useCallback(() => {
+        const requestId = ++latestRequestId.current
         notificationsApi
             .unreadCount('support')
-            .then(({ count }) => setHasUnread(count > 0))
+            .then(({ count }) => {
+                if (requestId === latestRequestId.current) setHasUnread(count > 0)
+            })
             // A failed count must never break the nav bar.
             .catch(() => {})
     }, [])

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -58,7 +58,8 @@
         "cashout": "Cashout",
         "claim": "Claim",
         "peanutLogoAlt": "Peanut Logo",
-        "receipt": "Receipt"
+        "receipt": "Receipt",
+        "supportUnread": "New support reply"
     },
     "home": {
         "rewards": "Rewards",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -58,7 +58,8 @@
         "cashout": "Retiro",
         "claim": "Reclamar",
         "peanutLogoAlt": "Logo de Peanut",
-        "receipt": "Recibo"
+        "receipt": "Recibo",
+        "supportUnread": "Nueva respuesta de soporte"
     },
     "home": {
         "rewards": "Recompensas",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -58,7 +58,8 @@
         "cashout": "Saque",
         "claim": "Resgatar",
         "peanutLogoAlt": "Logo da Peanut",
-        "receipt": "Recibo"
+        "receipt": "Recibo",
+        "supportUnread": "Nova resposta do suporte"
     },
     "home": {
         "rewards": "Recompensas",

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -36,8 +36,10 @@ export const notificationsApi = {
         }
     },
 
-    async unreadCount(): Promise<{ count: number }> {
-        const response = await serverFetch('/notifications/unread-count', {
+    /** Pass a category (e.g. 'support') to count only that category's unread rows. */
+    async unreadCount(category?: string): Promise<{ count: number }> {
+        const query = category ? `?category=${encodeURIComponent(category)}` : ''
+        const response = await serverFetch(`/notifications/unread-count${query}`, {
             method: 'GET',
         })
         if (!response.ok) throw new Error('failed to fetch unread count')
@@ -48,6 +50,19 @@ export const notificationsApi = {
         const response = await serverFetch('/notifications/mark-read', {
             method: 'POST',
             body: JSON.stringify({ ids }),
+        })
+        if (!response.ok) throw new Error('failed to mark read')
+        return await response.json()
+    },
+
+    /**
+     * Mark every unread row in a category as read. Used by the support drawer,
+     * which never sees the row ids — the conversation itself lives in Crisp.
+     */
+    async markAllRead(category: string) {
+        const response = await serverFetch('/notifications/mark-read', {
+            method: 'POST',
+            body: JSON.stringify({ category }),
         })
         if (!response.ok) throw new Error('failed to mark read')
         return await response.json()


### PR DESCRIPTION
Notion: TASK-21141 — notify users when support replies. Frontend half.

Backend: peanutprotocol/peanut-api-ts#1303.

## ⛔ Merge order

**Do not merge before peanut-api-ts#1303 is deployed.** An old backend ignores the `category` query param, so the badge would show the *global* unread count — a dot on the Support icon for any unread notification at all, and opening support would never clear it.

**This PR is deliberately left as a draft** so that ordering cannot be lost to a stray click. The code is finished and green — CI, review and tests are all done. Mark it ready once #1303 is live.

## What this does

1. A pink dot on the Support icon in the mobile nav while support has replied and the user has not opened the chat.
2. The dot clears when the chat opens.
3. `/home?support=open` opens the support drawer — the deep link a support-reply push carries.

The count is server truth: `GET /notifications/unread-count?category=support`. The client cannot work it out for itself — the web Crisp widget is a sandboxed iframe that mounts only after the drawer is first opened, and the native plugin exposes no message events.

## Files

| File | Role |
|---|---|
| `hooks/useSupportUnread.ts` | `hasUnread`. Fetches on mount, on `notifications:updated`, and when the app returns to the foreground. No polling. |
| `components/Global/SupportDeepLink/index.tsx` | Reads `?support=open`, opens the drawer, clears the param. Renders null. |
| `components/Global/IndicatorDot/index.tsx` | The pink dot, now one component. |
| `components/Global/SupportDrawer/index.tsx` | Clears the badge on open. |
| `components/Global/WalletNavigation/index.tsx` | Renders the badge. |
| `services/notifications.ts` | `unreadCount(category?)`, new `markAllRead(category)`. |

## Why clearing hangs off `isSupportModalOpen`

It is the one flag every entry point sets before anything opens — the nav tap, `openSupportWithMessage()`, the push deep link, and the Capacitor path (which sets it before handing over to the native messenger). One effect covers all four, so there is no entry that lights the chat without clearing the badge.

`markAllRead` takes a category rather than ids because the drawer never sees notification ids. The conversation lives in Crisp, not in our inbox.

## The dot extraction

The same pink dot was copy-pasted in three places and the badge would have made a fourth, so it is now `IndicatorDot`. Approved by Aleks before the work started.

All three call sites render the same as before — `twMerge` resolves the size and animation overrides:

- `ProfileMenuItem` — the `animate-pulse` wrapper collapses onto the dot. Same visual; `aria-label="highlight-indicator"` preserved.
- `CarouselCTA` — the positioned wrapper stays (it owns `CAROUSEL_CLOSE_BUTTON_POSITION`, `z-10` and the aria-label); only the inner div is replaced.
- `TransactionCard` — `h-2 w-2 animate-pulsate` passed through as className.

The name is neutral on purpose: on a transaction card the dot means pending, on the perk carousel it means claimable, on the nav it means unread.

## Verification

- `npm test` — 212 suites, 2706 tests pass. New: 7 for `useSupportUnread` (category scoping, both refetch triggers, listener cleanup, failure path), 5 for `IndicatorDot` (class resolution at all four call sites + the announced badge), and 3 for the drawer (clears once the chat renders, does NOT clear on the Crisp-failure fallback, does NOT clear for a guest).
- `npm run typecheck` clean, `prettier --check .` clean, `npm run build` clean.
- The existing `SupportDrawer` suite needed a `@/services/notifications` mock — the drawer now makes a request on open, and `serverFetch` reaches for Capacitor Preferences, which jsdom has no shim for.

## Screenshots

⚠️ **None, and here is why.** A truthful shot of the badge needs the backend deployed — the count comes from `?category=support`, which only exists on peanut-api-ts#1303. Against today's backend the dot would light for *any* unread notification, so a screenshot would show the wrong thing and read as proof.

The dot extraction is the part that actually carries visual risk, and it is covered by something stronger than a screenshot: `IndicatorDot.test.tsx` asserts the resolved class string for all four call sites, so a twMerge override that stopped winning (leaving `h-2.5` next to `h-2`) fails CI rather than needing an eye. That check is permanent; a screenshot is a one-off.

**Still to do by hand after the backend deploys:** visual check at 375×667 on the three migrated dots (profile menu highlight, perk carousel dot, pending transaction dot) next to the new nav badge. Then the live path: real support reply → push + badge; second reply without opening → no second push; open chat → badge clears.

## Known gaps, not in scope

- The desktop sidebar still links to a dead `/support` route. Pre-existing.
- `notificationsApi.list()` already sends `filter` and `category` params the backend ignores. Pre-existing.
- Peanut-ui gets **no CodeRabbit pass** on a dev-base PR (the check reports "reviews are disabled for this base branch"), so `/code-review` was the only automated reviewer here.
- The green `e2e` check is vacuous — that job aborts before running any test. Do not read it as e2e coverage.


## Review fixes applied

`/code-review medium` returned 6 findings. The deploy-ordering one is the ⛔ at the top of this description. The other five are fixed:

- **The badge cleared even when the reply was never seen.** When the Crisp bundle fails to load, this component shows the email fallback instead — and the badge cleared anyway, burying the reply. The web path now waits for `CRISP_READY`; the native path has no such signal, so it clears right after `openMessenger()`.
- **A reply arriving while the drawer was open was never marked read** — the normal case in a live conversation. The badge would light with nothing new behind it and stay lit until the next open. Clearing now also fires on the closing edge.
- **Concurrent refreshes could resurrect a cleared badge.** Tapping a push fires a foreground refetch (count 1); the deep link then clears and refetches (count 0); if the first response lands last it won, and with no polling nothing corrected it. Responses now carry a request id and stale ones are dropped.
- **Guests were sending an unauthenticated mark-read** on every support open (claim and pay links mount this layout). Gated on a resolved userId.
- **The nav badge announced nothing.** `aria-label` on a bare span is ignored by assistive tech and is an `aria-prohibited-attr` violation. It now carries `role="status"` with a translated label. `es-AR` has no `navigation` block and falls back, so only the three locales that have one were touched.
