### PR TITLE
fix(dev/journey): render the balance-gate hold (pairs api#1309)

### DIFF
--- a/src/app/(mobile-ui)/dev/journey/RulesLegend.tsx
+++ b/src/app/(mobile-ui)/dev/journey/RulesLegend.tsx
@@ -39,6 +39,9 @@ export default function RulesLegend({ rules, specError }: { rules: SpecRules | n
             <Rule label="holdout">
                 <span className="text-xs font-bold">{Math.round(rules.holdoutFraction * 100)}% control</span>
             </Rule>
+            <Rule label="balance gate">
+                <span className="text-xs font-bold">fund ≤ $0.10 · spend ≥ $1 (live chain read)</span>
+            </Rule>
             <Rule label="send window">
                 <span className="text-xs font-bold">
                     {rules.sendWindowUtc.startHour}–{rules.sendWindowUtc.endHour}h UTC

--- a/src/app/(mobile-ui)/dev/journey/UserInspector.tsx
+++ b/src/app/(mobile-ui)/dev/journey/UserInspector.tsx
@@ -46,6 +46,8 @@ export default function UserInspector() {
         if (!result.due) return 'none due (graduated, not in audience, or up to date)'
         if (result.due.skip === 'holdout') return `${result.due.type} — HELD (holdout control group)`
         if (result.due.skip === 'governor') return `${result.due.type} — HELD (governor: too soon after last email)`
+        if (result.due.skip === 'balance')
+            return `${result.due.type} — HELD (balance gate: live balance contradicts the copy)`
         return `${result.due.type} — due now${result.due.hasPendingRewards ? ' (rewards variant)' : ''}`
     })()
 

--- a/src/app/(mobile-ui)/dev/journey/journeyTypes.ts
+++ b/src/app/(mobile-ui)/dev/journey/journeyTypes.ts
@@ -150,7 +150,7 @@ export interface InspectDue {
     userId: string
     type: string
     hasPendingRewards?: boolean
-    skip?: 'holdout' | 'governor'
+    skip?: 'holdout' | 'governor' | 'balance'
 }
 
 export interface InspectHistoryRow {


### PR DESCRIPTION
## Summary
peanut-api-ts#1309 adds a third `DueSend.skip` reason, `'balance'` (live-balance gate on the money steps). The journey Explorer hand-mirrors that union and fell through to `due now` for balance-held users — the opposite of the truth, in the tool an operator uses to verify the api hotfix. Adds the union member, an explicit HELD label, and a legend rule.

## Task
TASK-20596 (lifecycle machine). Pairs: peanutprotocol/peanut-api-ts#1309 — deploy order irrelevant (unknown skip values previously fell through to a wrong label; with this, label is correct whichever ships first).

## Risks
Dev-only tooling (`/dev/journey`), no user-facing surface.

## QA
typecheck ✅ · full jest 2761 ✅ · Screenshots: N/A (dev-only tool, 3-line label/legend change)