### PR TITLE
fix(badges): make the unavailable-campaign warning readable in Sentry

### DIFF
--- a/src/hooks/__tests__/useZeroDev-invite-onboarding.test.tsx
+++ b/src/hooks/__tests__/useZeroDev-invite-onboarding.test.tsx
@@ -175,4 +175,42 @@ describe('useZeroDev registration invite boundary', () => {
         expect(mockPersistRegistrationBadgeCampaignDestination).not.toHaveBeenCalled()
         expect(mockSetWebAuthnKey).toHaveBeenCalledWith({ id: 'new-passkey' })
     })
+
+    it('names the unavailable campaign and reason in a form Sentry can read', async () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+        mockPendingBadgeCampaigns = ['irl-nomads', 'ethfloripa']
+        mockAcceptInvite.mockResolvedValue({
+            success: true,
+            attributionResolved: true,
+            onboardingResolved: true,
+            claims: [],
+        })
+        mockClaimAndSettlePendingBadgeCampaigns.mockResolvedValue({
+            claims: [
+                { badgeCampaign: 'irl-nomads', outcome: 'inactive' },
+                { badgeCampaign: 'ethfloripa', outcome: 'unknown' },
+            ],
+            pending: [],
+            transport: 'canonical',
+        })
+        const { result } = renderHook(() => useZeroDev())
+
+        await act(async () => result.current.handleRegister('new-user'))
+
+        expect(warn).toHaveBeenCalledWith(
+            'Campaign unavailable during registration',
+            'irl-nomads=inactive, ethfloripa=unknown'
+        )
+
+        // The regression this pins. Sentry serializes each console argument, so
+        // passing objects produced the literal "[Object]" in production and the
+        // warning named neither the campaign nor the reason. A string survives.
+        const call = warn.mock.calls.find(([message]) => message === 'Campaign unavailable during registration')
+        expect(typeof call?.[1]).toBe('string')
+
+        // The message must stay constant, or Sentry opens a new issue per campaign.
+        expect(call?.[0]).toBe('Campaign unavailable during registration')
+
+        warn.mockRestore()
+    })
 })

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -211,9 +211,16 @@ export const useZeroDev = () => {
                     })
                 }
                 if (unavailable.length > 0) {
+                    // Pre-joined into ONE string on purpose. Sentry's console
+                    // integration serializes each console argument, and an array
+                    // of objects lands in the issue as the literal "[Object]" —
+                    // so the campaign and the reason, the only two facts worth
+                    // logging, were both unreadable in production. Keep the
+                    // message itself constant so Sentry still groups these
+                    // together instead of opening a new issue per campaign.
                     console.warn(
                         'Campaign unavailable during registration',
-                        unavailable.map(({ badgeCampaign, outcome }) => ({ badgeCampaign, outcome }))
+                        unavailable.map(({ badgeCampaign, outcome }) => `${badgeCampaign}=${outcome}`).join(', ')
                     )
                 }
                 if (batch.pending.length > 0) {


### PR DESCRIPTION
## The problem

`PEANUT-UI-SHW` — "Campaign unavailable during registration" — has fired for 2 users since the badge platform release. The Sentry event body is:

```
arguments: ["Campaign unavailable during registration", ["[Object]"]]
```

Sentry's console integration serializes each console argument. The second argument was an **array of objects**, which serializes to the literal `"[Object]"`. So the warning carries neither of the two facts it exists to report: **which campaign** and **why**.

The behaviour itself is correct — this is the expected path when someone registers with a link to one of the four campaigns retired in the release, and registration still completes. But as shipped the warning is unactionable: you cannot tell a retired campaign from a genuinely broken active one.

## The fix

Pre-join the pairs into a single string:

```ts
unavailable.map(({ badgeCampaign, outcome }) => `${badgeCampaign}=${outcome}`).join(', ')
```

The Sentry event now reads `"irl-nomads=inactive, ethfloripa=unknown"`.

**The message stays constant on purpose.** Interpolating campaign names into the message string would have been the obvious fix, but Sentry groups console issues by message — that would open a new issue per campaign combination and fragment a single low-volume warning into many. Keeping the message fixed and putting the detail in the argument gets readable data *and* stable grouping.

## Test

Added to `useZeroDev-invite-onboarding.test.tsx`. It asserts the payload is a `string`, that it names both campaigns and both reasons, and that the message is unchanged (the grouping guard).

**Verified non-vacuous** — reinstating the object array fails the test, restoring the join passes:

```
✕ names the unavailable campaign and reason in a form Sentry can read   <- with the bug
✓ names the unavailable campaign and reason in a form Sentry can read   <- with the fix
```

## Verification

- `tsc --noEmit` clean
- `prettier` — both files already conformant
- full suite: **225 suites, 2884 passed**, 3 skipped, 0 failed

## Risk

None to behaviour. This changes only what gets written to the console/Sentry on an already-correct branch. No control flow, no user-visible surface.

Follow-up to the badge platform release (#2613), found in the post-release Sentry sweep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registration warning details for unavailable badge campaigns, making campaign names and outcome reasons easier to read in monitoring tools.
  * Preserved the existing warning message and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->