### PR TITLE
fix(sentry): stop one console.warn from swallowing every network error

### DIFF
--- a/src/utils/__tests__/sentry.utils.test.ts
+++ b/src/utils/__tests__/sentry.utils.test.ts
@@ -90,6 +90,31 @@ describe('fetchWithSentry — expected-response suppression', () => {
         expect(warnSpy).not.toHaveBeenCalled()
     })
 
+    it('does not report a /tokens/price 404 (upstream price provider declined)', async () => {
+        // Mobula 429s surface here as a 404. The UI falls back to token
+        // denomination, so it is a degraded display and never a wrong number —
+        // and the backend already downgraded its own log for this (PEANUT-API-75).
+        global.fetch = jest.fn().mockResolvedValue(mockResponse(404, { error: 'Token price not available' }))
+
+        const response = await fetchWithSentry('https://api.peanut.me/tokens/price?address=0xaf88&chainId=42161', {})
+
+        expect(response.status).toBe(404)
+        expect(Sentry.captureMessage).not.toHaveBeenCalled()
+    })
+
+    it('reports a non-2xx exactly once, via captureMessage and never via console.warn', async () => {
+        // captureConsoleIntegration listens on ['error','warn'], so a console.warn
+        // here produced a SECOND event for every non-2xx in the app, grouped by
+        // call site instead of by request — one bucket holding ~32k events and
+        // titling itself after whatever failed last (PEANUT-UI-60Y).
+        global.fetch = jest.fn().mockResolvedValue(mockResponse(500, { error: 'boom' }))
+
+        await fetchWithSentry('https://api.peanut.me/some/endpoint', { method: 'POST', body: '{}' })
+
+        expect(Sentry.captureMessage).toHaveBeenCalledTimes(1)
+        expect(warnSpy).not.toHaveBeenCalled()
+    })
+
     it('still reports 400s from endpoints without a skip rule', async () => {
         global.fetch = jest.fn().mockResolvedValue(mockResponse(400, { error: 'bad request' }))
 

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -16,6 +16,12 @@ const SKIP_REPORTING: Array<{ pattern: string | RegExp; statuses: number[] }> = 
     // /invites/validate 400 = "Invalid Invite": the user mistyped an invite code.
     // Expected input validation, surfaced inline to the user — not a server bug.
     { pattern: /\/invites\/validate/, statuses: [400] },
+    // /tokens/price 404 means the upstream price provider declined the lookup —
+    // in practice a Mobula 429. The UI falls back to token denomination, so it is
+    // a degraded display, never a wrong number. The backend already downgraded
+    // its own log to warn for this exact reason (PEANUT-API-75); reporting it
+    // from the client re-created the same page-per-lookup noise as PEANUT-UI-QKY.
+    { pattern: /\/tokens\/price/, statuses: [404] },
     // Public FX pair misses and validation failures are expected user/input
     // outcomes, not backend incidents. 503 is included deliberately: it means a
     // provider leg is momentarily absent, which peanut-api already reports with
@@ -444,7 +450,16 @@ export const fetchWithSentry = async (
             // 401 on cleared session, etc). Logging them clutters DevTools and
             // gets picked up by forward-logs-shared as Sentry breadcrumbs.
             if (!shouldSkipReporting(url, response.status)) {
-                console.warn(`Request to ${String(url).replace(/[\r\n]/g, '')} failed with status ${response.status}`)
+                // console.info, not warn — same reason as the catch block below.
+                // captureConsoleIntegration listens on ['error','warn'], so a warn
+                // here became a SECOND Sentry event for every non-2xx in the app,
+                // grouped by this call site rather than by request. That single
+                // bucket held ~32k events across every endpoint and titled itself
+                // after whichever request failed most recently, which made it read
+                // as one huge issue with a specific URL. The explicit
+                // captureMessage below is the real report: it fingerprints on
+                // [method, url, status] and carries headers, body and response.
+                console.info(`Request to ${String(url).replace(/[\r\n]/g, '')} failed with status ${response.status}`)
 
                 let errorContent: JSONValue
                 try {

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -21,7 +21,7 @@ const SKIP_REPORTING: Array<{ pattern: string | RegExp; statuses: number[] }> = 
     // a degraded display, never a wrong number. The backend already downgraded
     // its own log to warn for this exact reason (PEANUT-API-75); reporting it
     // from the client re-created the same page-per-lookup noise as PEANUT-UI-QKY.
-    { pattern: /\/tokens\/price/, statuses: [404] },
+    { pattern: /\/tokens\/price\/?(?:[?#]|$)/, statuses: [404] },
     // Public FX pair misses and validation failures are expected user/input
     // outcomes, not backend incidents. 503 is included deliberately: it means a
     // provider leg is momentarily absent, which peanut-api already reports with


### PR DESCRIPTION
**One `console.warn` was bucketing every non-2xx in the app into a single Sentry issue.**

`fetchWithSentry` logged each failed request with `console.warn`, and `captureConsoleIntegration` listens on `['error','warn']`. So every non-2xx produced a **second** Sentry event, grouped by that call site rather than by request.

That is `PEANUT-UI-60Y`: **~32,000 events / 2,494 users**, spanning every endpoint, titled after whichever request happened to fail last.

## Why this matters beyond noise

It actively misled triage. Yesterday it read as *"`invites/accept` 400 — 80 users"* and was ranked the top production issue. Real volume for that endpoint is **1 event in 7 days** (corroborated by PostHog: 8 `invite_accept_failed` in 60 days, and prod API logs: 0–2 validation 400s/day). The bucket was hiding what it contained and mislabelling itself with a specific URL.

## The signal is kept

The explicit `Sentry.captureMessage` below it is unchanged and is the real report — it fingerprints on `[method, sanitizeUrl(url), status]` and carries headers, body and response. Dropping the log to `console.info` removes the **duplicate**, not the signal. `PEANUT-UI-R0Y` is the correctly-split sibling and stays.

## Also in here

`/tokens/price` 404 added to `SKIP_REPORTING`. Those are Mobula 429s surfacing as 404 (`PEANUT-UI-QKY`, 60 users). The UI falls back to token denomination — a degraded display, never a wrong number — and the backend already downgraded its own log for exactly this reason (PEANUT-API-75). Same class of noise, same file, so it travels with this.

## Tests

- a non-2xx reports **exactly once**, via `captureMessage`, never via `console.warn`
- a `/tokens/price` 404 reports **not at all**

Typecheck clean, 2886 tests green.

## Expected effect

`PEANUT-UI-60Y` stops accumulating. Its ~32k events redistribute into per-endpoint issues that are actually triageable — expect the issue list to get longer and far more useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary error reporting for expected `/tokens/price` not-found responses.
  * Improved handling of failed requests by sending a single Sentry event without duplicate warning messages.
  * Updated request diagnostics to use informational logging for non-success responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->