### PR TITLE
fix(badges): make the invite-page campaign warning readable in Sentry

### DIFF
--- a/src/components/Invites/InvitesPage.test.tsx
+++ b/src/components/Invites/InvitesPage.test.tsx
@@ -565,6 +565,40 @@ describe('invite and badge campaign routing boundaries', () => {
         expect(mockPush).not.toHaveBeenCalledWith('/profile/peanut')
     })
 
+    it('names the campaign and the reason in the unavailable warning, as a string', async () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+        mockSearch = 'badge_campaign=utm:pix,retired'
+        mockQueryResult.data = { success: true, attributionResolved: true, onboardingResolved: true, username: '' }
+        mockClaimBadgeCampaigns.mockResolvedValue({
+            transport: 'canonical',
+            pending: [],
+            claims: [
+                { badgeCampaign: 'utm:pix', outcome: 'unknown' },
+                { badgeCampaign: 'retired', outcome: 'expired' },
+            ],
+        })
+
+        render(<InvitesPage />)
+
+        await waitFor(() =>
+            expect(warn).toHaveBeenCalledWith(
+                'Badge campaign unavailable; continuing normally',
+                'utm:pix=unknown, retired=expired'
+            )
+        )
+
+        // The regression this pins. Sentry serializes each console argument, so the
+        // previous object payload reached production as the literal "[object Object]"
+        // and the warning named neither the campaign nor the reason (PEANUT-UI-SJC).
+        const call = warn.mock.calls.find(([message]) => message === 'Badge campaign unavailable; continuing normally')
+        expect(typeof call?.[1]).toBe('string')
+
+        // The message must stay constant, or Sentry opens a new issue per campaign.
+        expect(call?.[0]).toBe('Badge campaign unavailable; continuing normally')
+
+        warn.mockRestore()
+    })
+
     it('returns existing-user login to code-only badge acquisition before normal fallback', async () => {
         mockAuth.user = null
         mockSearch = 'code=offramp'

--- a/src/components/Invites/InvitesPage.tsx
+++ b/src/components/Invites/InvitesPage.tsx
@@ -148,12 +148,19 @@ function InvitePageContent() {
                         }
                     }
 
-                    const unavailable = batch.claims.some(isUnavailableBadgeCampaignClaim)
+                    const unavailable = batch.claims.filter(isUnavailableBadgeCampaignClaim)
                     const retryable = batch.pending.length > 0
-                    if (unavailable) {
-                        console.warn('Badge campaign unavailable; continuing normally', {
-                            claims: batch.claims,
-                        })
+                    if (unavailable.length > 0) {
+                        // Pre-joined into ONE string, matching useZeroDev.ts. Sentry's
+                        // console integration serializes each console argument, so an
+                        // object holding an array of claims landed in the issue as the
+                        // literal "[object Object]" — which campaign and why, the only
+                        // two facts worth logging, were both unreadable. Keep the
+                        // message constant so Sentry groups these into one issue.
+                        console.warn(
+                            'Badge campaign unavailable; continuing normally',
+                            unavailable.map(({ badgeCampaign, outcome }) => `${badgeCampaign}=${outcome}`).join(', ')
+                        )
                     }
                     if (retryable) {
                         captureException(new Error('invite-page campaign claim retained for retry'), {


### PR DESCRIPTION
## What

`#2647` fixed the `[object Object]` campaign-warning defect at `useZeroDev.ts:222` but **missed its sibling** at `InvitesPage.tsx:154`. This fixes the sibling.

## Why now

`PEANUT-UI-SJC` fired **12h ago in production** still showing `Badge campaign unavailable; continuing normally [object Object]`, while the registration-side sibling now correctly reads `utm:pix=unknown`. Found during the weekend monitor sweep.

It matters because **three live marketing tags — `brazil`, `pix`, `faster-payments` — currently resolve to no campaign record at all.** The invite page was the one surface that could not tell us which campaign failed.

## The defect

Sentry's console integration serializes each console argument, so an object holding an array of claims reaches the issue as the literal `[object Object]`. Both facts the warning exists to carry — which campaign, and why — were unreadable.

Pre-joins into one string, exactly as `useZeroDev.ts` does. Message stays constant so Sentry keeps grouping into one issue.

## Verification

- `tsc --noEmit` exit 0
- prettier clean
- **225 suites / 2887 tests pass**
- New test **verified non-vacuous**: reverting to the object payload fails it, restoring the join passes

## Risk

Diagnostic-only. No user-facing behaviour changes — `.some()` → `.filter()` on a variable used nowhere else.