### PR TITLE
chore: back-merge main → dev (2026-08-09)

### DIFF
--- a/src/utils/__tests__/sentry.utils.test.ts
+++ b/src/utils/__tests__/sentry.utils.test.ts
@@ -90,6 +90,31 @@ describe('fetchWithSentry — expected-response suppression', () => {
         expect(warnSpy).not.toHaveBeenCalled()
     })
 
+    it('does not report a /tokens/price 404 (upstream price provider declined)', async () => {
+        // Mobula 429s surface here as a 404. The UI falls back to token
+        // denomination, so it is a degraded display and never a wrong number —
+        // and the backend already downgraded its own log for this (PEANUT-API-75).
+        global.fetch = jest.fn().mockResolvedValue(mockResponse(404, { error: 'Token price not available' }))
+
+        const response = await fetchWithSentry('https://api.peanut.me/tokens/price?address=0xaf88&chainId=42161', {})
+
+        expect(response.status).toBe(404)
+        expect(Sentry.captureMessage).not.toHaveBeenCalled()
+    })
+
+    it('reports a non-2xx exactly once, via captureMessage and never via console.warn', async () => {
+        // captureConsoleIntegration listens on ['error','warn'], so a console.warn
+        // here produced a SECOND event for every non-2xx in the app, grouped by
+        // call site instead of by request — one bucket holding ~32k events and
+        // titling itself after whatever failed last (PEANUT-UI-60Y).
+        global.fetch = jest.fn().mockResolvedValue(mockResponse(500, { error: 'boom' }))
+
+        await fetchWithSentry('https://api.peanut.me/some/endpoint', { method: 'POST', body: '{}' })
+
+        expect(Sentry.captureMessage).toHaveBeenCalledTimes(1)
+        expect(warnSpy).not.toHaveBeenCalled()
+    })
+
     it('still reports 400s from endpoints without a skip rule', async () => {
         global.fetch = jest.fn().mockResolvedValue(mockResponse(400, { error: 'bad request' }))
 

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -16,6 +16,12 @@ const SKIP_REPORTING: Array<{ pattern: string | RegExp; statuses: number[] }> = 
     // /invites/validate 400 = "Invalid Invite": the user mistyped an invite code.
     // Expected input validation, surfaced inline to the user — not a server bug.
     { pattern: /\/invites\/validate/, statuses: [400] },
+    // /tokens/price 404 means the upstream price provider declined the lookup —
+    // in practice a Mobula 429. The UI falls back to token denomination, so it is
+    // a degraded display, never a wrong number. The backend already downgraded
+    // its own log to warn for this exact reason (PEANUT-API-75); reporting it
+    // from the client re-created the same page-per-lookup noise as PEANUT-UI-QKY.
+    { pattern: /\/tokens\/price/, statuses: [404] },
     // Public FX pair misses and validation failures are expected user/input
     // outcomes, not backend incidents. 503 is included deliberately: it means a
     // provider leg is momentarily absent, which peanut-api already reports with
@@ -444,7 +450,16 @@ export const fetchWithSentry = async (
             // 401 on cleared session, etc). Logging them clutters DevTools and
             // gets picked up by forward-logs-shared as Sentry breadcrumbs.
             if (!shouldSkipReporting(url, response.status)) {
-                console.warn(`Request to ${String(url).replace(/[\r\n]/g, '')} failed with status ${response.status}`)
+                // console.info, not warn — same reason as the catch block below.
+                // captureConsoleIntegration listens on ['error','warn'], so a warn
+                // here became a SECOND Sentry event for every non-2xx in the app,
+                // grouped by this call site rather than by request. That single
+                // bucket held ~32k events across every endpoint and titled itself
+                // after whichever request failed most recently, which made it read
+                // as one huge issue with a specific URL. The explicit
+                // captureMessage below is the real report: it fingerprints on
+                // [method, url, status] and carries headers, body and response.
+                console.info(`Request to ${String(url).replace(/[\r\n]/g, '')} failed with status ${response.status}`)
 
                 let errorContent: JSONValue
                 try {

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -21,7 +21,7 @@ const SKIP_REPORTING: Array<{ pattern: string | RegExp; statuses: number[] }> = 
     // a degraded display, never a wrong number. The backend already downgraded
     // its own log to warn for this exact reason (PEANUT-API-75); reporting it
     // from the client re-created the same page-per-lookup noise as PEANUT-UI-QKY.
-    { pattern: /\/tokens\/price/, statuses: [404] },
+    { pattern: /\/tokens\/price\/?(?:[?#]|$)/, statuses: [404] },
     // Public FX pair misses and validation failures are expected user/input
     // outcomes, not backend incidents. 503 is included deliberately: it means a
     // provider leg is momentarily absent, which peanut-api already reports with


### PR DESCRIPTION
Routine back-merge. **Clean — zero conflicts.**

Supersedes #2643, which was opened 2026-08-07 17:04Z, minutes *before* the badge-platform UI merge landed, and has been `mergeable=false`/`dirty` since. The badge platform (and the `[Object]` Sentry fix, `3b80afb27`) already reached `dev` by another route, so this carries only what `main` picked up afterwards.

## What comes across

- `fix(sentry): stop one console.warn from swallowing every network error` (#2649) + the CodeRabbit follow-up anchoring the skip to the exact `/tokens/price` route, with its tests
- `src/content` pointer → `peanut-content@8a8dd1b` (the 2026-08-09 content publish)

## Verification

- **Merge: no conflicts** (`ort`, 3 files)
- `pnpm typecheck` — **clean**
- **228 suites, 2903 passed**, 3 skipped, 0 failed

Worth noting the Sentry fix coming across is adjacent to the badge warning fixed in #2647: that one made the unavailable-campaign payload readable, this one stops a `console.warn` from swallowing network errors wholesale. Both are Sentry-signal quality, and they don't overlap.