### PR TITLE
feat(home): flag-gated user-interview invite card in the carousel

### DIFF
--- a/src/app/(mobile-ui)/dev/home-ctas/page.tsx
+++ b/src/app/(mobile-ui)/dev/home-ctas/page.tsx
@@ -128,7 +128,7 @@ const CAROUSEL_PREVIEWS: CarouselPreview[] = [
         logo: PeanutWavingHello,
         logoSize: 30,
         title: 'Help shape Peanut',
-        description: "You're one of our most active users. Book a 15-min call with the founders.",
+        description: "You're one of our most active users. Book a 15-min call with the team.",
     },
     {
         id: 'bug-bounty',

--- a/src/app/(mobile-ui)/dev/home-ctas/page.tsx
+++ b/src/app/(mobile-ui)/dev/home-ctas/page.tsx
@@ -8,6 +8,7 @@ import CarouselCTA from '@/components/Home/HomeCarouselCTA/CarouselCTA'
 import ActivationCTAs from '@/components/Home/ActivationCTAs'
 import { type ActivationStep } from '@/hooks/useActivationStatus'
 import STAR_STRAIGHT_ICON from '@/assets/icons/starStraight.svg'
+import { PeanutWavingHello } from '@/assets/mascot'
 import DevNoteCard from '../_components/DevNoteCard'
 import DevPageShell from '../_components/DevPageShell'
 import DevSectionLabel from '../_components/DevSectionLabel'
@@ -119,6 +120,15 @@ const CAROUSEL_PREVIEWS: CarouselPreview[] = [
         logoSize: 30,
         title: 'Invite friends. Earn rewards',
         description: 'Earn rewards every time your friends use Peanut.',
+    },
+    {
+        id: 'user-interview',
+        label: 'User-interview invite (flag-gated campaign, logo variant)',
+        icon: 'peanut-support',
+        logo: PeanutWavingHello,
+        logoSize: 30,
+        title: 'Help shape Peanut',
+        description: "You're one of our most active users. Book a 15-min call with the founders.",
     },
     {
         id: 'bug-bounty',

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -132,6 +132,9 @@ export const ANALYTICS_EVENTS = {
 
     // ── Home ──
     BALANCE_VISIBILITY_TOGGLED: 'balance_visibility_toggled',
+    // User-interview campaign card (temporary) — clicked = tapped through to cal.com.
+    // Impressions come free from the flag's $feature_flag_called exposure event.
+    USER_INTERVIEW_CTA_CLICKED: 'user_interview_cta_clicked',
 
     // ── Error ──
     BACKEND_ERROR_SHOWN: 'backend_error_shown',

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -133,7 +133,10 @@ export const ANALYTICS_EVENTS = {
     // ── Home ──
     BALANCE_VISIBILITY_TOGGLED: 'balance_visibility_toggled',
     // User-interview campaign card (temporary) — clicked = tapped through to cal.com.
-    // Impressions come free from the flag's $feature_flag_called exposure event.
+    // No viewed event: $feature_flag_called is only a rough impression proxy —
+    // it fires per flag evaluation (prod only, dismissed users included), not
+    // per card render. Bookings on cal.com are the campaign's real metric.
+    // Non-prod taps also capture; filter insights by $host = peanut.me.
     USER_INTERVIEW_CTA_CLICKED: 'user_interview_cta_clicked',
 
     // ── Error ──

--- a/src/constants/general.consts.ts
+++ b/src/constants/general.consts.ts
@@ -248,4 +248,4 @@ export const PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=me.
 // User-interview campaign (temporary): one shared cal.com event for the
 // flag-gated founder-call card on home. Delete together with the
 // `user-interviews-invite` PostHog flag when the campaign ends.
-export const USER_INTERVIEW_CAL_URL = 'https://cal.com/aleks-n-hugo/15min'
+export const USER_INTERVIEW_CAL_URL = 'https://cal.com/hugo0+abalinda/dynamic'

--- a/src/constants/general.consts.ts
+++ b/src/constants/general.consts.ts
@@ -244,3 +244,8 @@ export const ENS_NAME_REGEX = /^(?:[-a-zA-Z0-9]+\.)+[-a-zA-Z0-9]+$/
 export const USERNAME_MIN_LENGTH = 4
 
 export const PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=me.peanut.wallet'
+
+// User-interview campaign (temporary): one shared cal.com event for the
+// flag-gated founder-call card on home. Delete together with the
+// `user-interviews-invite` PostHog flag when the campaign ends.
+export const USER_INTERVIEW_CAL_URL = 'https://cal.com/aleks-n-hugo/15min'

--- a/src/constants/general.consts.ts
+++ b/src/constants/general.consts.ts
@@ -246,6 +246,6 @@ export const USERNAME_MIN_LENGTH = 4
 export const PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=me.peanut.wallet'
 
 // User-interview campaign (temporary): one shared cal.com event for the
-// flag-gated founder-call card on home. Delete together with the
+// flag-gated team-call card on home. Delete together with the
 // `user-interviews-invite` PostHog flag when the campaign ends.
 export const USER_INTERVIEW_CAL_URL = 'https://cal.com/hugo0+abalinda/dynamic'

--- a/src/hooks/useHomeCarouselCTAs.tsx
+++ b/src/hooks/useHomeCarouselCTAs.tsx
@@ -12,7 +12,7 @@ import type { StaticImageData } from 'next/image'
 import { useModalsContext } from '@/context/ModalsContext'
 import { DeviceType, useDeviceType } from './useGetDeviceType'
 import { usePWAStatus } from './usePWAStatus'
-import { isCapacitor } from '@/utils/capacitor'
+import { isCapacitor, openExternalUrl } from '@/utils/capacitor'
 import { useGeoLocation } from './useGeoLocation'
 import { useCardInfo } from './useCardInfo'
 import { useActivationStatus } from './useActivationStatus'
@@ -20,10 +20,14 @@ import { useTransactionHistory } from './useTransactionHistory'
 import STAR_STRAIGHT_ICON from '@/assets/icons/starStraight.svg'
 import underMaintenanceConfig from '@/config/underMaintenance.config'
 import { useToast } from '@/components/0_Bruddle/Toast'
-import { PEANUTMAN_MOBILE } from '@/assets/mascot'
+import { PEANUTMAN_MOBILE, PeanutWavingHello } from '@/assets/mascot'
 import { MIGRATION_SURFACES } from '@/constants/migration.consts'
 import { useMigrationFlag } from './useMigrationFlag'
 import { openStore } from '@/utils/migration.utils'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { USER_INTERVIEW_CAL_URL } from '@/constants/general.consts'
+import { useFeatureFlags } from './useFeatureFlag'
 
 // Days a dismissed CTA stays hidden before reappearing. Set above 1 so dismiss feels
 // "sticky" but below 14 so we still nudge users about valuable actions they haven't
@@ -79,6 +83,12 @@ export const useHomeCarouselCTAs = () => {
     const t = useTranslations('home.carousel')
     const tMigration = useTranslations('migration')
     const migrationOn = useMigrationFlag()
+    const flagEnabled = useFeatureFlags()
+    // User-interview campaign gate. nonProdBypass: previews/local always show
+    // the card for QA; on prod the PostHog `username` release condition decides.
+    // No mounted guard needed (cf. useMigrationFlag): the value is only read in
+    // generateCarouselCTAs, which runs after mount in an effect.
+    const interviewInviteOn = flagEnabled('user-interviews-invite', { nonProdBypass: true })
     const [carouselCTAs, setCarouselCTAs] = useState<CarouselCTA[]>([])
     const { user } = useAuth()
     const dismissedRef = useRef<Map<string, Date>>(new Map())
@@ -137,6 +147,27 @@ export const useHomeCarouselCTAs = () => {
     const generateCarouselCTAs = useCallback(() => {
         const _carouselCTAs: CarouselCTA[] = []
         const b = (chunks: React.ReactNode) => <b>{chunks}</b>
+
+        // User-interview invite (temporary campaign): hand-picked heavy users
+        // get asked for a 15-min founder call. The cohort lives in the PostHog
+        // flag's `username` release condition — never in code. Leads the
+        // carousel on purpose; it targets a handful of users. X-dismissal uses
+        // the standard 7-day cooldown (id filter below). Delete this block +
+        // flag + i18n keys when the campaign ends.
+        if (interviewInviteOn) {
+            _carouselCTAs.push({
+                id: 'user-interview',
+                title: t('userInterview.title'),
+                description: t('userInterview.description'),
+                icon: 'peanut-support', // required by the type; hidden — logo takes precedence
+                logo: PeanutWavingHello,
+                logoSize: 30,
+                onClick: () => {
+                    posthog.capture(ANALYTICS_EVENTS.USER_INTERVIEW_CTA_CLICKED)
+                    void openExternalUrl(USER_INTERVIEW_CAL_URL)
+                },
+            })
+        }
 
         // pwa-sunset notice window: get-the-app nudge leads the carousel and
         // supersedes the ios-pwa-install CTA below (TASK-20829). Mobile goes
@@ -355,6 +386,7 @@ export const useHomeCarouselCTAs = () => {
         dismissCTA,
         openSupportWithMessage,
         migrationOn,
+        interviewInviteOn,
         tMigration,
         setIsGetAppModalOpen,
     ])

--- a/src/hooks/useHomeCarouselCTAs.tsx
+++ b/src/hooks/useHomeCarouselCTAs.tsx
@@ -152,8 +152,9 @@ export const useHomeCarouselCTAs = () => {
         // get asked for a 15-min founder call. The cohort lives in the PostHog
         // flag's `username` release condition — never in code. Leads the
         // carousel on purpose; it targets a handful of users. X-dismissal uses
-        // the standard 7-day cooldown (id filter below). Delete this block +
-        // flag + i18n keys when the campaign ends.
+        // the standard 7-day cooldown (id filter below). Delete this block, the
+        // flag, the i18n keys, and the dev/home-ctas preview entry when the
+        // campaign ends.
         if (interviewInviteOn) {
             _carouselCTAs.push({
                 id: 'user-interview',
@@ -162,9 +163,11 @@ export const useHomeCarouselCTAs = () => {
                 icon: 'peanut-support', // required by the type; hidden — logo takes precedence
                 logo: PeanutWavingHello,
                 logoSize: 30,
-                onClick: () => {
+                onClick: async () => {
                     posthog.capture(ANALYTICS_EVENTS.USER_INTERVIEW_CTA_CLICKED)
-                    void openExternalUrl(USER_INTERVIEW_CAL_URL)
+                    // Await so a native Browser.open failure surfaces in
+                    // CarouselCTA's onClick try/catch instead of vanishing.
+                    await openExternalUrl(USER_INTERVIEW_CAL_URL)
                 },
             })
         }

--- a/src/hooks/useHomeCarouselCTAs.tsx
+++ b/src/hooks/useHomeCarouselCTAs.tsx
@@ -149,7 +149,7 @@ export const useHomeCarouselCTAs = () => {
         const b = (chunks: React.ReactNode) => <b>{chunks}</b>
 
         // User-interview invite (temporary campaign): hand-picked heavy users
-        // get asked for a 15-min founder call. The cohort lives in the PostHog
+        // get asked for a 15-min call with the team. The cohort lives in the PostHog
         // flag's `username` release condition — never in code. Leads the
         // carousel on purpose; it targets a handful of users. X-dismissal uses
         // the standard 7-day cooldown (id filter below). Delete this block, the

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -194,7 +194,7 @@
             },
             "userInterview": {
                 "title": "Help shape Peanut",
-                "description": "You're one of our most active users. Book a 15-min call with the founders."
+                "description": "You're one of our most active users. Book a 15-min call with the team."
             },
             "kyc": {
                 "title": "Unlock <b>QR code payments</b>",

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -192,6 +192,10 @@
                 "title": "Help us improve and <b>get $5!</b>",
                 "description": "Report a bug. Get rewarded! No questions asked."
             },
+            "userInterview": {
+                "title": "Help shape Peanut",
+                "description": "You're one of our most active users. Book a 15-min call with the founders."
+            },
             "kyc": {
                 "title": "Unlock <b>QR code payments</b>",
                 "description": "Confirm your ID to pay with <b>Mercado Pago</b> and <b>PIX</b> QR codes"

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -194,7 +194,7 @@
             },
             "userInterview": {
                 "title": "Ayúdanos a construir Peanut",
-                "description": "Eres uno de nuestros usuarios más activos. Agenda una llamada de 15 min con los fundadores."
+                "description": "Eres uno de nuestros usuarios más activos. Agenda una llamada de 15 min con el equipo."
             },
             "kyc": {
                 "title": "Desbloquea <b>pagos con QR</b>",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -192,6 +192,10 @@
                 "title": "Ayúdanos a mejorar y <b>¡gana $5!</b>",
                 "description": "Reporta un error. ¡Recibe una recompensa! Sin preguntas."
             },
+            "userInterview": {
+                "title": "Ayúdanos a construir Peanut",
+                "description": "Eres uno de nuestros usuarios más activos. Agenda una llamada de 15 min con los fundadores."
+            },
             "kyc": {
                 "title": "Desbloquea <b>pagos con QR</b>",
                 "description": "Confirma tu identidad para pagar códigos QR de <b>Mercado Pago</b> y <b>PIX</b>"

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -101,7 +101,7 @@
             },
             "userInterview": {
                 "title": "Ayudanos a construir Peanut",
-                "description": "Sos uno de nuestros usuarios más activos. Agendá una llamada de 15 min con los fundadores."
+                "description": "Sos uno de nuestros usuarios más activos. Agendá una llamada de 15 min con el equipo."
             },
             "kyc": {
                 "title": "Desbloqueá <b>pagos con QR</b>",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -99,6 +99,10 @@
                 "title": "Ayudanos a mejorar y <b>¡ganá $5!</b>",
                 "description": "Reportá un error. ¡Recibí una recompensa! Sin preguntas."
             },
+            "userInterview": {
+                "title": "Ayudanos a construir Peanut",
+                "description": "Sos uno de nuestros usuarios más activos. Agendá una llamada de 15 min con los fundadores."
+            },
             "kyc": {
                 "title": "Desbloqueá <b>pagos con QR</b>",
                 "description": "Confirmá tu identidad para pagar códigos QR de <b>Mercado Pago</b> y <b>PIX</b>"

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -194,7 +194,7 @@
             },
             "userInterview": {
                 "title": "Ajude a construir Peanut",
-                "description": "Você é um dos nossos usuários mais ativos. Agende um papo de 15 min com os fundadores."
+                "description": "Você é um dos nossos usuários mais ativos. Agende um papo de 15 min com a equipe."
             },
             "kyc": {
                 "title": "Desbloqueie <b>pagamentos com QR</b>",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -192,6 +192,10 @@
                 "title": "Ajude a gente a melhorar e <b>ganhe $5!</b>",
                 "description": "Relate um bug. Ganhe uma recompensa! Sem perguntas."
             },
+            "userInterview": {
+                "title": "Ajude a construir Peanut",
+                "description": "Você é um dos nossos usuários mais ativos. Agende um papo de 15 min com os fundadores."
+            },
             "kyc": {
                 "title": "Desbloqueie <b>pagamentos com QR</b>",
                 "description": "Confirme sua identidade para pagar códigos QR do <b>Mercado Pago</b> e do <b>PIX</b>"


### PR DESCRIPTION
## Summary

Ask our most active users for a 15-min call with the team ("help shape the app") — one new card in the home carousel, shown only to a hand-picked cohort. The cohort lives in the PostHog flag `user-interviews-invite` (release condition on `username`), never in code: list edits and the kill switch are one click in PostHog, and no usernames ship in the JS bundle. The card opens the shared cal.com event (https://cal.com/hugo0+abalinda/dynamic) via the Capacitor-safe `openExternalUrl` helper and inherits the carousel's standard 7-day X-dismissal.

Temporary campaign (feature-gates doctrine: flags are scaffolding) — delete the card block, flag, and i18n keys when the interview round ends.

## Task

TASK-21189 — user interviews PR (add cal./hugo+alex in carousel for quali users)

## Behavior

- Prod: card renders ONLY when the PostHog flag matches. Fail-closed — until the flag exists and flips on, this deploy is inert.
- Previews/staging/local: `nonProdBypass: true` → card always visible for QA.
- Click → `user_interview_cta_clicked` PostHog event, then cal.com in a new tab (web) / in-app browser (native).
- X → standard 7-day-cooldown dismissal, same as every carousel card.
- No viewed event: `$feature_flag_called` is only a rough impression proxy (fires per flag evaluation, prod only, dismissed users included). Bookings on cal.com are the campaign's real success metric; filter click insights by `$host = peanut.me` to exclude preview taps.

## Risks / breaking changes

None. FE-only, additive, flag-gated off on prod by default. No backend, no migrations. Hotfix to `main` → back-merge main→dev owed after merge.

## Design notes / accepted trade-offs

- `user_interview_cta_clicked` also fires from previews/staging, where the card is always on via the nonProd bypass. Deliberately not gated in code: the cohort is ~25 users and we read the metric once — filter by `$host = peanut.me`. Bookings on cal.com are ground truth.
- Dismissal uses the carousel's shared 7-day cooldown, so the card resurfaces weekly for targeted users while the flag is on. That is the intended nudge cadence for a short campaign; if it grates (cf. the open "home-screen modals and carousel misbehave" friction cluster), kill the flag or switch to a permanent dismissal.

## Launch steps (post-merge, not in this PR)

1. Deploy → verify inert (flag absent → card hidden).
2. Create flag `user-interviews-invite` in PostHog (EU, project 138913): boolean, release condition `username is one of [curated list]` — Notion engaged-user list minus exclusions; cross-check spellings against prod DB first.
3. Flip on; watch `$feature_flag_called` (impressions) and `user_interview_cta_clicked` (clicks); bookings land on cal.com.

## QA

- Local gate: prettier ✅ · `tsc --noEmit` ✅ · `npm test` 225 suites / 2886 tests ✅ (i18n parity test covers the new keys in en/es-419/pt-BR + es-AR voseo delta) · `npm run build` ✅
- `/dev/home-ctas` renders the new card variant with no auth or flag needed.
- Local/preview: card leads the carousel via the nonProd bypass; click opens cal.com; X dismisses for 7 days.

## Screenshots

From `/dev/home-ctas` (the home-CTA visual catalogue — exact `CarouselCTA` render, no gating):

| New card | In the catalogue, next to the bug-bounty card |
|---|---|
| ![user-interview card](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2654/preview-user-interview-card.png) | ![catalogue context](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2654/preview-catalog-context.png) |

⚠️ No in-situ `/home` shot: the local sandbox has no FE-activated seeded user (activation = one completed spend intent), direct DB seeding is permission-blocked for agents, and `POST /dev/seed-scenario` currently 500s (`Cannot read properties of undefined (reading 'query')`). The card mounts through the same single `if` gate as every carousel card; any Vercel preview shows it on `/home` for an activated user via the nonProd bypass. Assets branch `pr-assets-2654` — delete after merge.
