### PR TITLE
fix(withdraw): map Rhino NoRouteFoundError to actionable route-not-found copy

### DIFF
--- a/src/features/payments/shared/hooks/useCrossChainTransfer.test.ts
+++ b/src/features/payments/shared/hooks/useCrossChainTransfer.test.ts
@@ -1,0 +1,79 @@
+/**
+ * useCrossChainTransfer — calculate() error mapping.
+ *
+ * Rhino tags an unroutable pair `NoRouteFoundError`; the backend surfaces the
+ * tag verbatim inside the thrown message. The hook maps it to
+ * ROUTE_NOT_FOUND_ERROR so the Confirm view's existing special-case (Retry →
+ * onBack) sends the user back to fix the input. Any other failure passes
+ * through verbatim.
+ */
+import { act, renderHook } from '@testing-library/react'
+import { useCrossChainTransfer } from './useCrossChainTransfer'
+import { ROUTE_NOT_FOUND_ERROR } from '@/constants/general.consts'
+import { previewSdaTransfer } from '@/services/rhino-sda'
+
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }))
+jest.mock('@/services/rhino-sda', () => ({
+    previewSdaTransfer: jest.fn(),
+    provisionSdaTransfer: jest.fn(),
+}))
+jest.mock('@/services/rhino-bridge', () => ({
+    getBridgeQuote: jest.fn(),
+    commitBridgeQuote: jest.fn(),
+    getBridgeStatus: jest.fn(),
+    isQuoteNearExpiry: jest.fn(() => false),
+}))
+jest.mock('@/utils/peanut-claim.utils', () => ({ prepareRequestLinkFulfillmentTransaction: jest.fn() }))
+jest.mock('@/app/actions/tokens', () => ({ estimateTransactionCostUsd: jest.fn() }))
+
+const mockPreview = previewSdaTransfer as jest.Mock
+
+// Cross-chain SDA input: Arbitrum USDC → Solana USDC. tokenSymbol is passed
+// explicitly so the test doesn't depend on token-details lookups.
+const CALC_INPUT = {
+    source: {
+        address: '0x1111111111111111111111111111111111111111' as `0x${string}`,
+        tokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831' as `0x${string}`,
+        chainId: '42161',
+    },
+    destination: {
+        recipientAddress: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        tokenAddress: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        tokenAmount: '2',
+        tokenDecimals: 6,
+        tokenType: 1,
+        chainId: 'solana',
+        tokenSymbol: 'USDC',
+    },
+    context: 'withdraw' as const,
+    contextId: 'charge-uuid-1',
+}
+
+describe('useCrossChainTransfer calculate() error mapping', () => {
+    afterEach(() => jest.clearAllMocks())
+
+    test('NoRouteFoundError from the preview maps to ROUTE_NOT_FOUND_ERROR', async () => {
+        mockPreview.mockRejectedValue(
+            new Error('Failed to preview SDA transfer: 400 {"error":"Preview quote failed: NoRouteFoundError"}')
+        )
+        const { result } = renderHook(() => useCrossChainTransfer())
+
+        await act(() => result.current.calculate(CALC_INPUT))
+
+        expect(result.current.error).toBe(ROUTE_NOT_FOUND_ERROR)
+        expect(result.current.isFeeEstimationError).toBe(true)
+    })
+
+    test('any other failure passes through verbatim', async () => {
+        mockPreview.mockRejectedValue(
+            new Error('Failed to preview SDA transfer: 400 {"error":"Preview quote failed: HTTP 404 with empty body"}')
+        )
+        const { result } = renderHook(() => useCrossChainTransfer())
+
+        await act(() => result.current.calculate(CALC_INPUT))
+
+        expect(result.current.error).toBe(
+            'Failed to preview SDA transfer: 400 {"error":"Preview quote failed: HTTP 404 with empty body"}'
+        )
+    })
+})

--- a/src/features/payments/shared/hooks/useCrossChainTransfer.ts
+++ b/src/features/payments/shared/hooks/useCrossChainTransfer.ts
@@ -45,6 +45,7 @@ import {
     type BridgeStatusResponse,
 } from '@/services/rhino-bridge'
 import { chainIdToRhinoName } from '@/constants/rhino.consts'
+import { ROUTE_NOT_FOUND_ERROR } from '@/constants/general.consts'
 import { NON_EVM_WITHDRAW_CHAINS } from '@/constants/chainRegistry.consts'
 import { areEvmAddressesEqual, getTokenSymbol } from '@/utils/general.utils'
 
@@ -356,7 +357,12 @@ export function useCrossChainTransfer(): UseCrossChainTransferReturn {
                 })
                 setPath('sda')
             } catch (err) {
-                const message = err instanceof Error ? err.message : 'failed to calculate cross-chain transfer'
+                const raw = err instanceof Error ? err.message : 'failed to calculate cross-chain transfer'
+                // Rhino tags an unroutable pair NoRouteFoundError; the backend
+                // surfaces the tag verbatim. Map it to the copy the Confirm view
+                // already special-cases — its Retry button sends the user back to
+                // fix the input for this constant.
+                const message = raw.includes('NoRouteFoundError') ? ROUTE_NOT_FOUND_ERROR : raw
                 setError(message)
                 setIsFeeEstimationError(true)
                 captureException(err)


### PR DESCRIPTION
## Summary

Companion to peanut-api-ts#1320 (TASK-21284). When Rhino cannot route a pair, the backend surfaces the provider tag (`NoRouteFoundError`) verbatim and the withdraw confirm screen shows the raw string. Map it to `ROUTE_NOT_FOUND_ERROR` in the shared `calculate()` catch, so all three consumers (withdraw, pay-request, claim-xchain) inherit the copy the Confirm view already special-cases — its Retry button calls `onBack()` for this constant, which returns the user to the amount input. No new UI code; one mapping line plus the hook's first test file.

## Task

Notion TASK-21284 — Fix Solana USDC withdrawal preview failure (DoD bullet 2: unsupported routes show a specific error and leave the user able to correct the input).

## Risks / breaking changes

- None cross-repo. Substring match on the thrown message; every other error passes through verbatim (pinned by test).
- Independent of api#1320 deploy order — before it, previews fail with the api-side message either way; after it, unroutable pairs get the actionable copy.

## QA

- New `useCrossChainTransfer.test.ts`: NoRouteFoundError → ROUTE_NOT_FOUND_ERROR; any other message passes through verbatim.
- Full local gate: typecheck clean, 226 suites / 2889 tests green.

Screenshots: N/A (no new surface — the existing ErrorAlert renders different copy on an error path that today shows a raw provider string).

## Design notes / accepted trade-offs

- `/code-review medium` (1 finding, applied-as-follow-up): the `ROUTE_NOT_FOUND_ERROR` English constant bypasses the `classifyError`/next-intl localization path. Pre-existing pattern (same constant + equality check in `Confirm.withdraw.view.tsx` and `Claim/Link/Initial.view.tsx` before this PR); migrating it to a `FriendlyErrorCode` touches the Confirm view's `error === ROUTE_NOT_FOUND_ERROR` special-case, so it goes in a separate localization follow-up rather than this hotfix. No behavior regression — users previously saw a raw JSON blob.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-chain transfer error handling by showing a clear route-not-found message when no transfer route is available.
  * Preserved the original error details for other preview and fee-estimation failures.
  * Enabled the appropriate fee-estimation error state when a route cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->