### PR TITLE
feat: add exact-locale Split guide foundation

### DIFF
--- a/scripts/__tests__/split-guide-contract.test.ts
+++ b/scripts/__tests__/split-guide-contract.test.ts
@@ -1,4 +1,8 @@
-import { findSplitGuideHeadingCollisions, remarkRejectSplitGuideH1 } from '../lib/split-guide-contract'
+import {
+    findSplitGuideHeadingCollisions,
+    remarkRejectSplitGuideH1,
+    stripSplitGuideFencedCode,
+} from '../lib/split-guide-contract'
 
 const h1 = (line: number) => ({
     type: 'heading',
@@ -24,6 +28,27 @@ describe('Split guide route-owned H1 guard', () => {
 
     it('allows ordinary content and lower-level headings', () => {
         expect(findSplitGuideHeadingCollisions('## Section\n\n### Detail\n\nPlain copy.')).toEqual([])
+    })
+
+    it('allows heading and component syntax when it is shown inside fenced code', () => {
+        expect(
+            findSplitGuideHeadingCollisions(`\`\`\`mdx
+# Example H1
+Example setext H1
+=================
+<h1>Example HTML</h1>
+<Hero title="Example component" />
+\`\`\``)
+        ).toEqual([])
+    })
+
+    it('preserves offsets while hiding fenced code, including CRLF input', () => {
+        const body = 'Before\r\n```mdx\r\n<Hero title="Example" />\r\n```\r\n<CTA />'
+        const stripped = stripSplitGuideFencedCode(body)
+
+        expect(stripped).toHaveLength(body.length)
+        expect(stripped.indexOf('<CTA />')).toBe(body.indexOf('<CTA />'))
+        expect(stripped).not.toContain('<Hero')
     })
 
     describe('authoritative remark AST traversal', () => {

--- a/scripts/__tests__/split-guide-contract.test.ts
+++ b/scripts/__tests__/split-guide-contract.test.ts
@@ -1,0 +1,53 @@
+import { findSplitGuideHeadingCollisions, remarkRejectSplitGuideH1 } from '../lib/split-guide-contract'
+
+const h1 = (line: number) => ({
+    type: 'heading',
+    depth: 1,
+    position: { start: { line } },
+    children: [{ type: 'text', value: 'Forbidden heading' }],
+})
+
+const root = (...children: unknown[]) => ({ type: 'root', children }) as never
+
+describe('Split guide route-owned H1 guard', () => {
+    it.each([
+        ['# ATX heading', 'atx-h1'],
+        ['   # indented ATX heading', 'atx-h1'],
+        ['Title\n=====', 'setext-h1'],
+        ['Title\n  =====  ', 'setext-h1'],
+        ['<h1>HTML heading</h1>', 'html-h1'],
+        ['<h1 class="title">HTML heading</h1>', 'html-h1'],
+        ['<Hero title="Guide" />', 'hero'],
+    ])('detects %s', (body, expected) => {
+        expect(findSplitGuideHeadingCollisions(body)).toContain(expected)
+    })
+
+    it('allows ordinary content and lower-level headings', () => {
+        expect(findSplitGuideHeadingCollisions('## Section\n\n### Detail\n\nPlain copy.')).toEqual([])
+    })
+
+    describe('authoritative remark AST traversal', () => {
+        const rejectH1 = remarkRejectSplitGuideH1()
+
+        it.each([
+            ['> # Quoted H1', root({ type: 'blockquote', children: [h1(1)] })],
+            ['- # List H1', root({ type: 'list', children: [{ type: 'listItem', children: [h1(1)] }] })],
+            ['> Quoted setext H1\n> =================', root({ type: 'blockquote', children: [h1(1)] })],
+        ])('rejects parsed %s', (_source, tree) => {
+            expect(() => rejectH1(tree)).toThrow(/route owns the sole H1/)
+        })
+
+        it('recursively allows lower-level headings', () => {
+            const tree = root({
+                type: 'blockquote',
+                children: [
+                    {
+                        type: 'list',
+                        children: [{ type: 'listItem', children: [{ type: 'heading', depth: 2 }] }],
+                    },
+                ],
+            })
+            expect(() => rejectH1(tree)).not.toThrow()
+        })
+    })
+})

--- a/scripts/__tests__/verify-split-guides.test.ts
+++ b/scripts/__tests__/verify-split-guides.test.ts
@@ -9,6 +9,7 @@ import { verifySplitGuides } from '../lib/verify-split-guides'
 const LOCALES = ['en', 'es-419', 'pt-br'] as const
 const SLUGS = ['first-split-guide', 'second-split-guide'] as const
 const CTA_TEXT = { en: 'Start a split', 'es-419': 'Crear un split', 'pt-br': 'Criar um split' }
+const VERIFIER_PAYLOAD_PREFIX = '__SPLIT_GUIDE_VERIFIER_PAYLOAD__'
 
 interface Diagnostic {
     check: string
@@ -189,16 +190,26 @@ function runDefaultCompilerVerifier(contentDir: string, manifestPath: string) {
             manifestPath: ${JSON.stringify(manifestPath)},
             reportError: (check, message, file) => diagnostics.push({ check, message, file }),
         });
-        process.stdout.write(JSON.stringify({ diagnostics, result }));
+        process.stdout.write(${JSON.stringify(VERIFIER_PAYLOAD_PREFIX)} + JSON.stringify({ diagnostics, result }) + '\\n');
     `
     const completed = spawnSync(process.execPath, ['--import', 'tsx', '--input-type=module', '--eval', program], {
         cwd: process.cwd(),
         encoding: 'utf8',
+        timeout: 15_000,
     })
+    if ((completed.error as NodeJS.ErrnoException | undefined)?.code === 'ETIMEDOUT') {
+        throw new Error('Default compiler subprocess timed out after 15 seconds')
+    }
+    if (completed.error) throw completed.error
     if (completed.status !== 0) {
         throw new Error(`Default compiler subprocess failed: ${completed.stderr || completed.stdout}`)
     }
-    return JSON.parse(completed.stdout) as { diagnostics: Diagnostic[]; result: { recordsChecked: number } }
+    const payload = completed.stdout.split(/\r?\n/).findLast((line) => line.startsWith(VERIFIER_PAYLOAD_PREFIX))
+    if (!payload) throw new Error(`Default compiler subprocess returned no verifier payload: ${completed.stdout}`)
+    return JSON.parse(payload.slice(VERIFIER_PAYLOAD_PREFIX.length)) as {
+        diagnostics: Diagnostic[]
+        result: { recordsChecked: number }
+    }
 }
 
 describe('Split guide manifest verifier', () => {

--- a/scripts/__tests__/verify-split-guides.test.ts
+++ b/scripts/__tests__/verify-split-guides.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'crypto'
+import { spawnSync } from 'child_process'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
@@ -34,7 +36,6 @@ function generatedFrom(slug: string, locale: (typeof LOCALES)[number]) {
         context: [
             'projects/peanut-split/seo/stylebook.md',
             ...(locale === 'en' ? [] : [`projects/peanut-split/seo/localization.${locale}.md`]),
-            'content/_system/context/valid-links.md',
         ],
         guidelines: [
             'content/_system/guidelines/seo.md',
@@ -44,7 +45,7 @@ function generatedFrom(slug: string, locale: (typeof LOCALES)[number]) {
     }
 }
 
-function manifestEntry(slug: string, locale: (typeof LOCALES)[number]) {
+function manifestEntry(slug: string, locale: (typeof LOCALES)[number], sourceSha256: string) {
     const description =
         `A practical ${locale} guide for recording group expenses, checking shared totals, and agreeing how everyone settles after a trip together`.padEnd(
             149,
@@ -68,10 +69,32 @@ function manifestEntry(slug: string, locale: (typeof LOCALES)[number]) {
             path: `content/_system/data/split-guides/${slug}${locale === 'en' ? '' : `.${locale}`}.md`,
             content_mode: 'compose',
             source_provenance: `peanutprotocol/peanutsplit@${'a'.repeat(40)}:apps/web/src/content/blog/${slug}/${locale}.md`,
+            sha256: sourceSha256,
         },
         generated_from: generatedFrom(slug, locale),
         generated_at: '2026-08-10',
     }
+}
+
+function composeSource(slug: string, locale: (typeof LOCALES)[number]) {
+    const entry = manifestEntry(slug, locale, '0'.repeat(64))
+    const sourceFrontmatter = {
+        title: entry.title,
+        description: entry.description,
+        slug: entry.slug,
+        type: entry.type,
+        lang: entry.lang,
+        author: entry.author,
+        date: entry.date,
+        tags: entry.tags,
+        schema_types: entry.schema_types,
+        content_mode: entry.source.content_mode,
+        claims: entry.claims,
+        cast: entry.cast,
+        source_provenance: entry.source.source_provenance,
+        adapted_at: entry.generated_at,
+    }
+    return matter.stringify(`## Source brief\n\nWrite the exact ${locale} guide for ${slug}.\n`, sourceFrontmatter)
 }
 
 function body(slug: string, locale: (typeof LOCALES)[number]) {
@@ -96,7 +119,16 @@ function createFixture() {
     for (const slug of SLUGS) {
         guides[slug] = {}
         for (const locale of LOCALES) {
-            const entry = manifestEntry(slug, locale)
+            const sourceContent = composeSource(slug, locale)
+            const sourceFile = path.join(
+                root,
+                `content/_system/data/split-guides/${slug}${locale === 'en' ? '' : `.${locale}`}.md`
+            )
+            fs.mkdirSync(path.dirname(sourceFile), { recursive: true })
+            fs.writeFileSync(sourceFile, sourceContent)
+
+            const sourceSha256 = createHash('sha256').update(sourceContent, 'utf8').digest('hex')
+            const entry = manifestEntry(slug, locale, sourceSha256)
             guides[slug][locale] = entry
             const { source: _source, ...frontmatter } = entry
             const file = path.join(contentDir, 'split-guides', slug, `${locale}.md`)
@@ -119,19 +151,53 @@ function createFixture() {
     return { root, contentDir, manifestPath }
 }
 
-async function runVerifier(
-    contentDir: string,
-    manifestPath: string,
-    validateMdx: (body: string) => Promise<void> = async () => {}
-) {
+interface RunVerifierOptions {
+    sourceRoot?: string
+    validateMdx?: (body: string) => Promise<void>
+}
+
+async function runVerifier(contentDir: string, manifestPath: string, options: RunVerifierOptions = {}) {
     const diagnostics: Diagnostic[] = []
     const result = await verifySplitGuides({
         contentDir,
         manifestPath,
         reportError: (check, message, file) => diagnostics.push({ check, message, file }),
-        validateMdx,
+        ...(options.sourceRoot ? { sourceRoot: options.sourceRoot } : {}),
+        ...(options.validateMdx ? { validateMdx: options.validateMdx } : {}),
     })
     return { diagnostics, result }
+}
+
+const skipMdxCompile = async () => {}
+
+async function runFastVerifier(contentDir: string, manifestPath: string, options: RunVerifierOptions = {}) {
+    return runVerifier(contentDir, manifestPath, {
+        ...options,
+        validateMdx: options.validateMdx ?? skipMdxCompile,
+    })
+}
+
+function runDefaultCompilerVerifier(contentDir: string, manifestPath: string) {
+    const verifierPath = path.resolve(__dirname, '../lib/verify-split-guides.ts')
+    const program = `
+        const imported = await import(${JSON.stringify(verifierPath)});
+        const verifySplitGuides = imported.verifySplitGuides ?? imported.default.verifySplitGuides;
+        const diagnostics = [];
+        const result = await verifySplitGuides({
+            contentDir: ${JSON.stringify(contentDir)},
+            manifestPath: ${JSON.stringify(manifestPath)},
+            reportError: (check, message, file) => diagnostics.push({ check, message, file }),
+        });
+        process.stdout.write(JSON.stringify({ diagnostics, result }));
+    `
+    const completed = spawnSync(process.execPath, ['--import', 'tsx', '--input-type=module', '--eval', program], {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+    })
+    if (completed.status !== 0) {
+        throw new Error(`Default compiler subprocess failed: ${completed.stderr || completed.stdout}`)
+    }
+    return JSON.parse(completed.stdout) as { diagnostics: Diagnostic[]; result: { recordsChecked: number } }
 }
 
 describe('Split guide manifest verifier', () => {
@@ -146,7 +212,7 @@ describe('Split guide manifest verifier', () => {
         roots.push(root)
 
         await expect(
-            runVerifier(path.join(root, 'content'), path.join(root, 'generated/manifest.json'))
+            runFastVerifier(path.join(root, 'content'), path.join(root, 'generated/manifest.json'))
         ).resolves.toEqual({
             diagnostics: [],
             result: { recordsChecked: 0 },
@@ -169,7 +235,7 @@ describe('Split guide manifest verifier', () => {
             })
         )
 
-        const { diagnostics } = await runVerifier(path.join(root, 'content'), manifestPath)
+        const { diagnostics } = await runFastVerifier(path.join(root, 'content'), manifestPath)
         expect(diagnostics).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({
@@ -184,10 +250,80 @@ describe('Split guide manifest verifier', () => {
         const fixture = createFixture()
         roots.push(fixture.root)
 
-        await expect(runVerifier(fixture.contentDir, fixture.manifestPath)).resolves.toEqual({
+        await expect(runFastVerifier(fixture.contentDir, fixture.manifestPath)).resolves.toEqual({
             diagnostics: [],
             result: { recordsChecked: 6 },
         })
+    })
+
+    it('keeps mirrored UI verification independent from an unavailable compose-source checkout', async () => {
+        const fixture = createFixture()
+        roots.push(fixture.root)
+        fs.rmSync(path.join(fixture.root, 'content/_system'), { recursive: true })
+
+        await expect(runFastVerifier(fixture.contentDir, fixture.manifestPath)).resolves.toEqual({
+            diagnostics: [],
+            result: { recordsChecked: 6 },
+        })
+    })
+
+    it('verifies exact compose-source bytes and metadata when a source root is supplied', async () => {
+        const fixture = createFixture()
+        roots.push(fixture.root)
+
+        await expect(
+            runFastVerifier(fixture.contentDir, fixture.manifestPath, { sourceRoot: fixture.root })
+        ).resolves.toEqual({
+            diagnostics: [],
+            result: { recordsChecked: 6 },
+        })
+    })
+
+    it('blocks compose-source body drift from its manifest digest', async () => {
+        const fixture = createFixture()
+        roots.push(fixture.root)
+        const sourceFile = path.join(fixture.root, `content/_system/data/split-guides/${SLUGS[0]}.md`)
+        const source = fs.readFileSync(sourceFile, 'utf8')
+        fs.writeFileSync(sourceFile, source.replace('Write the exact en guide', 'Rewrite the exact en guide'))
+
+        const { diagnostics } = await runFastVerifier(fixture.contentDir, fixture.manifestPath, {
+            sourceRoot: fixture.root,
+        })
+        expect(diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    check: 'split-guide-source',
+                    message: expect.stringContaining('digest differs from manifest'),
+                    file: sourceFile,
+                }),
+            ])
+        )
+    })
+
+    it('blocks compose-source frontmatter drift from both its digest and selected metadata', async () => {
+        const fixture = createFixture()
+        roots.push(fixture.root)
+        const sourceFile = path.join(fixture.root, `content/_system/data/split-guides/${SLUGS[0]}.md`)
+        const source = fs.readFileSync(sourceFile, 'utf8')
+        fs.writeFileSync(sourceFile, source.replace('author: Peanut', 'author: Someone Else'))
+
+        const { diagnostics } = await runFastVerifier(fixture.contentDir, fixture.manifestPath, {
+            sourceRoot: fixture.root,
+        })
+        expect(diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    check: 'split-guide-source',
+                    message: expect.stringContaining('digest differs from manifest'),
+                    file: sourceFile,
+                }),
+                expect.objectContaining({
+                    check: 'split-guide-source',
+                    message: expect.stringContaining('author differs between the selected compose source and manifest'),
+                    file: sourceFile,
+                }),
+            ])
+        )
     })
 
     it('blocks guide files when their denormalized contract manifest is missing', async () => {
@@ -195,7 +331,7 @@ describe('Split guide manifest verifier', () => {
         roots.push(fixture.root)
         fs.unlinkSync(fixture.manifestPath)
 
-        const { diagnostics } = await runVerifier(fixture.contentDir, fixture.manifestPath)
+        const { diagnostics } = await runFastVerifier(fixture.contentDir, fixture.manifestPath)
         expect(diagnostics).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({
@@ -206,20 +342,37 @@ describe('Split guide manifest verifier', () => {
         )
     })
 
-    it('blocks output metadata drift from the selected compose source', async () => {
+    it('blocks output metadata drift from the mirrored manifest contract', async () => {
         const fixture = createFixture()
         roots.push(fixture.root)
         const file = path.join(fixture.contentDir, 'split-guides', SLUGS[0], 'en.md')
-        const parsed = matter(fs.readFileSync(file, 'utf8'))
-        parsed.data.title = 'A Drifted Title'
-        fs.writeFileSync(file, matter.stringify(parsed.content, parsed.data))
+        const content = fs.readFileSync(file, 'utf8')
+        fs.writeFileSync(file, content.replace('title: How to Split the First Group Cost', 'title: A Drifted Title'))
 
-        const { diagnostics } = await runVerifier(fixture.contentDir, fixture.manifestPath)
+        const { diagnostics } = await runFastVerifier(fixture.contentDir, fixture.manifestPath)
         expect(diagnostics).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({
                     check: 'split-guide-manifest',
-                    message: expect.stringContaining('title differs from the selected compose source'),
+                    message: expect.stringContaining('title differs from the manifest contract'),
+                }),
+            ])
+        )
+    })
+
+    it('reports the effective title limit that includes the route-owned suffix', async () => {
+        const fixture = createFixture()
+        roots.push(fixture.root)
+        const file = path.join(fixture.contentDir, 'split-guides', SLUGS[0], 'en.md')
+        const content = fs.readFileSync(file, 'utf8')
+        fs.writeFileSync(file, content.replace('title: How to Split the First Group Cost', `title: ${'x'.repeat(52)}`))
+
+        const { diagnostics } = await runFastVerifier(fixture.contentDir, fixture.manifestPath)
+        expect(diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    check: 'split-guide-contract',
+                    message: expect.stringContaining('raw 52, effective 61'),
                 }),
             ])
         )
@@ -235,7 +388,7 @@ describe('Split guide manifest verifier', () => {
         manifest.allowed_product_claim_ids = ['some-other-claim']
         fs.writeFileSync(fixture.manifestPath, JSON.stringify(manifest))
 
-        const { diagnostics } = await runVerifier(fixture.contentDir, fixture.manifestPath)
+        const { diagnostics } = await runFastVerifier(fixture.contentDir, fixture.manifestPath)
         expect(diagnostics).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({ check: 'split-guide-locales', message: expect.stringContaining('es-ar.md') }),
@@ -255,7 +408,7 @@ describe('Split guide manifest verifier', () => {
             `someone/else@${'a'.repeat(40)}:apps/web/src/content/blog/${SLUGS[0]}/en.md`
         fs.writeFileSync(fixture.manifestPath, JSON.stringify(manifest))
 
-        const { diagnostics } = await runVerifier(fixture.contentDir, fixture.manifestPath)
+        const { diagnostics } = await runFastVerifier(fixture.contentDir, fixture.manifestPath)
         expect(diagnostics).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({
@@ -266,12 +419,32 @@ describe('Split guide manifest verifier', () => {
         )
     })
 
+    it('requires a deterministic source digest in the mirrored manifest', async () => {
+        const fixture = createFixture()
+        roots.push(fixture.root)
+        const manifest = JSON.parse(fs.readFileSync(fixture.manifestPath, 'utf8'))
+        delete manifest.guides[SLUGS[0]].en.source.sha256
+        fs.writeFileSync(fixture.manifestPath, JSON.stringify(manifest))
+
+        const { diagnostics } = await runFastVerifier(fixture.contentDir, fixture.manifestPath)
+        expect(diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    check: 'split-guide-provenance',
+                    message: expect.stringContaining('source.sha256 must be a lowercase SHA-256 digest'),
+                }),
+            ])
+        )
+    })
+
     it('turns an MDX compiler failure into a blocking malformed-content diagnostic', async () => {
         const fixture = createFixture()
         roots.push(fixture.root)
 
-        const { diagnostics } = await runVerifier(fixture.contentDir, fixture.manifestPath, async () => {
-            throw new SyntaxError('fixture MDX is malformed')
+        const { diagnostics } = await runFastVerifier(fixture.contentDir, fixture.manifestPath, {
+            validateMdx: async () => {
+                throw new SyntaxError('fixture MDX is malformed')
+            },
         })
         expect(diagnostics).toEqual(
             expect.arrayContaining([
@@ -281,5 +454,49 @@ describe('Split guide manifest verifier', () => {
                 }),
             ])
         )
+    })
+
+    it('uses the default runtime compiler to reject a nested H1', async () => {
+        const fixture = createFixture()
+        roots.push(fixture.root)
+        const file = path.join(fixture.contentDir, 'split-guides', SLUGS[0], 'en.md')
+        const parsed = matter(fs.readFileSync(file, 'utf8'))
+        parsed.content = `> # A nested H1\n\n${parsed.content.trimStart()}`
+        fs.writeFileSync(file, matter.stringify(parsed.content, parsed.data))
+
+        const { diagnostics } = runDefaultCompilerVerifier(fixture.contentDir, fixture.manifestPath)
+        expect(diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    check: 'split-guide-mdx',
+                    message: expect.stringContaining(
+                        'Malformed or unsafe MDX: Split guide body must not contain an H1'
+                    ),
+                }),
+            ])
+        )
+    })
+
+    it('allows forbidden page syntax when the default runtime compiler sees it inside fenced code', async () => {
+        const fixture = createFixture()
+        roots.push(fixture.root)
+        const file = path.join(fixture.contentDir, 'split-guides', SLUGS[0], 'en.md')
+        const parsed = matter(fs.readFileSync(file, 'utf8'))
+        const fencedExample = [
+            '```mdx',
+            '# Example H1',
+            'Example setext H1',
+            '=================',
+            '<h1>Example HTML</h1>',
+            '<Hero title="Example component" />',
+            '```',
+        ].join('\n')
+        parsed.content = `${fencedExample}\n\n${parsed.content.trimStart()}`
+        fs.writeFileSync(file, matter.stringify(parsed.content, parsed.data))
+
+        expect(runDefaultCompilerVerifier(fixture.contentDir, fixture.manifestPath)).toEqual({
+            diagnostics: [],
+            result: { recordsChecked: 6 },
+        })
     })
 })

--- a/scripts/__tests__/verify-split-guides.test.ts
+++ b/scripts/__tests__/verify-split-guides.test.ts
@@ -1,0 +1,285 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import matter from 'gray-matter'
+import { verifySplitGuides } from '../lib/verify-split-guides'
+
+const LOCALES = ['en', 'es-419', 'pt-br'] as const
+const SLUGS = ['first-split-guide', 'second-split-guide'] as const
+const CTA_TEXT = { en: 'Start a split', 'es-419': 'Crear un split', 'pt-br': 'Criar um split' }
+
+interface Diagnostic {
+    check: string
+    message: string
+    file?: string
+}
+
+function alternates(slug: string) {
+    return {
+        en: `content/split-guides/${slug}/en.md`,
+        'es-419': `content/split-guides/${slug}/es-419.md`,
+        'pt-br': `content/split-guides/${slug}/pt-br.md`,
+    }
+}
+
+function generatedFrom(slug: string, locale: (typeof LOCALES)[number]) {
+    return {
+        template: 'content/_system/templates/split-guide.md',
+        data: [
+            `content/_system/data/split-guides/${slug}.md`,
+            ...(locale === 'en' ? [] : [`content/_system/data/split-guides/${slug}.${locale}.md`]),
+        ],
+        product: ['product/peanut-split.md'],
+        workflow: 'content/_system/workflows/generate-content.md',
+        context: [
+            'projects/peanut-split/seo/stylebook.md',
+            ...(locale === 'en' ? [] : [`projects/peanut-split/seo/localization.${locale}.md`]),
+            'content/_system/context/valid-links.md',
+        ],
+        guidelines: [
+            'content/_system/guidelines/seo.md',
+            'content/_system/guidelines/components.md',
+            'content/_system/guidelines/locales.md',
+        ],
+    }
+}
+
+function manifestEntry(slug: string, locale: (typeof LOCALES)[number]) {
+    const description =
+        `A practical ${locale} guide for recording group expenses, checking shared totals, and agreeing how everyone settles after a trip together`.padEnd(
+            149,
+            'x'
+        )
+    return {
+        title: slug === SLUGS[0] ? 'How to Split the First Group Cost' : 'How to Split the Second Group Cost',
+        description: `${description.slice(0, 149)}.`,
+        slug,
+        type: 'guide',
+        lang: locale,
+        author: 'Peanut',
+        date: '2026-07-28',
+        tags: ['groups', 'expenses'],
+        claims: ['free-forever'],
+        cast: [],
+        schema_types: ['Article', 'BlogPosting'],
+        canonical: `peanut.me/${locale}/split/guides/${slug}`,
+        alternates: alternates(slug),
+        source: {
+            path: `content/_system/data/split-guides/${slug}${locale === 'en' ? '' : `.${locale}`}.md`,
+            content_mode: 'compose',
+            source_provenance: `peanutprotocol/peanutsplit@${'a'.repeat(40)}:apps/web/src/content/blog/${slug}/${locale}.md`,
+        },
+        generated_from: generatedFrom(slug, locale),
+        generated_at: '2026-08-10',
+    }
+}
+
+function body(slug: string, locale: (typeof LOCALES)[number]) {
+    const relatedSlug = slug === SLUGS[0] ? SLUGS[1] : SLUGS[0]
+    return `## A useful section
+
+<Callout type="info">Keep one shared record.</Callout>
+
+<CTA text="${CTA_TEXT[locale]}" subtitle="Keep the group record together." href="https://split.peanut.me/new?locale=${locale}&utm_medium=content&utm_source=split-guide&utm_campaign=${slug}&utm_content=final-cta" variant="card" />
+
+<RelatedPages title="Related guide">
+<RelatedLink href="/${locale}/split/guides/${relatedSlug}">Read the related guide</RelatedLink>
+</RelatedPages>`
+}
+
+function createFixture() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'split-guide-verifier-'))
+    const contentDir = path.join(root, 'content')
+    const manifestPath = path.join(root, 'generated/split-guide-manifest.json')
+    const guides: Record<string, Record<string, ReturnType<typeof manifestEntry>>> = {}
+
+    for (const slug of SLUGS) {
+        guides[slug] = {}
+        for (const locale of LOCALES) {
+            const entry = manifestEntry(slug, locale)
+            guides[slug][locale] = entry
+            const { source: _source, ...frontmatter } = entry
+            const file = path.join(contentDir, 'split-guides', slug, `${locale}.md`)
+            fs.mkdirSync(path.dirname(file), { recursive: true })
+            fs.writeFileSync(file, matter.stringify(body(slug, locale), frontmatter))
+        }
+    }
+
+    fs.mkdirSync(path.dirname(manifestPath), { recursive: true })
+    fs.writeFileSync(
+        manifestPath,
+        JSON.stringify({
+            version: 1,
+            intent: 'split-guides',
+            locales: LOCALES,
+            allowed_product_claim_ids: ['free-forever'],
+            guides,
+        })
+    )
+    return { root, contentDir, manifestPath }
+}
+
+async function runVerifier(
+    contentDir: string,
+    manifestPath: string,
+    validateMdx: (body: string) => Promise<void> = async () => {}
+) {
+    const diagnostics: Diagnostic[] = []
+    const result = await verifySplitGuides({
+        contentDir,
+        manifestPath,
+        reportError: (check, message, file) => diagnostics.push({ check, message, file }),
+        validateMdx,
+    })
+    return { diagnostics, result }
+}
+
+describe('Split guide manifest verifier', () => {
+    const roots: string[] = []
+
+    afterEach(() => {
+        for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true })
+    })
+
+    it('keeps an empty content family inert when no manifest exists', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'split-guide-verifier-empty-'))
+        roots.push(root)
+
+        await expect(
+            runVerifier(path.join(root, 'content'), path.join(root, 'generated/manifest.json'))
+        ).resolves.toEqual({
+            diagnostics: [],
+            result: { recordsChecked: 0 },
+        })
+    })
+
+    it('rejects an existing manifest whose guides object is empty', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'split-guide-verifier-empty-manifest-'))
+        roots.push(root)
+        const manifestPath = path.join(root, 'generated/split-guide-manifest.json')
+        fs.mkdirSync(path.dirname(manifestPath), { recursive: true })
+        fs.writeFileSync(
+            manifestPath,
+            JSON.stringify({
+                version: 1,
+                intent: 'split-guides',
+                locales: LOCALES,
+                allowed_product_claim_ids: ['free-forever'],
+                guides: {},
+            })
+        )
+
+        const { diagnostics } = await runVerifier(path.join(root, 'content'), manifestPath)
+        expect(diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    check: 'split-guide-manifest',
+                    message: expect.stringContaining('at least one guide'),
+                }),
+            ])
+        )
+    })
+
+    it('accepts a complete exact-locale cluster that matches the manifest', async () => {
+        const fixture = createFixture()
+        roots.push(fixture.root)
+
+        await expect(runVerifier(fixture.contentDir, fixture.manifestPath)).resolves.toEqual({
+            diagnostics: [],
+            result: { recordsChecked: 6 },
+        })
+    })
+
+    it('blocks guide files when their denormalized contract manifest is missing', async () => {
+        const fixture = createFixture()
+        roots.push(fixture.root)
+        fs.unlinkSync(fixture.manifestPath)
+
+        const { diagnostics } = await runVerifier(fixture.contentDir, fixture.manifestPath)
+        expect(diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    check: 'split-guide-manifest',
+                    message: expect.stringContaining('require generated/split-guide-manifest.json'),
+                }),
+            ])
+        )
+    })
+
+    it('blocks output metadata drift from the selected compose source', async () => {
+        const fixture = createFixture()
+        roots.push(fixture.root)
+        const file = path.join(fixture.contentDir, 'split-guides', SLUGS[0], 'en.md')
+        const parsed = matter(fs.readFileSync(file, 'utf8'))
+        parsed.data.title = 'A Drifted Title'
+        fs.writeFileSync(file, matter.stringify(parsed.content, parsed.data))
+
+        const { diagnostics } = await runVerifier(fixture.contentDir, fixture.manifestPath)
+        expect(diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    check: 'split-guide-manifest',
+                    message: expect.stringContaining('title differs from the selected compose source'),
+                }),
+            ])
+        )
+    })
+
+    it('blocks unexpected locales and product claims absent from the manifest registry', async () => {
+        const fixture = createFixture()
+        roots.push(fixture.root)
+        const guideDir = path.join(fixture.contentDir, 'split-guides', SLUGS[0])
+        fs.copyFileSync(path.join(guideDir, 'en.md'), path.join(guideDir, 'es-ar.md'))
+
+        const manifest = JSON.parse(fs.readFileSync(fixture.manifestPath, 'utf8'))
+        manifest.allowed_product_claim_ids = ['some-other-claim']
+        fs.writeFileSync(fixture.manifestPath, JSON.stringify(manifest))
+
+        const { diagnostics } = await runVerifier(fixture.contentDir, fixture.manifestPath)
+        expect(diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ check: 'split-guide-locales', message: expect.stringContaining('es-ar.md') }),
+                expect.objectContaining({
+                    check: 'split-guide-claims',
+                    message: expect.stringContaining('free-forever'),
+                }),
+            ])
+        )
+    })
+
+    it('rejects an arbitrary repository or source path in provenance', async () => {
+        const fixture = createFixture()
+        roots.push(fixture.root)
+        const manifest = JSON.parse(fs.readFileSync(fixture.manifestPath, 'utf8'))
+        manifest.guides[SLUGS[0]].en.source.source_provenance =
+            `someone/else@${'a'.repeat(40)}:apps/web/src/content/blog/${SLUGS[0]}/en.md`
+        fs.writeFileSync(fixture.manifestPath, JSON.stringify(manifest))
+
+        const { diagnostics } = await runVerifier(fixture.contentDir, fixture.manifestPath)
+        expect(diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    check: 'split-guide-provenance',
+                    message: expect.stringContaining('peanutprotocol/peanutsplit@{40hex}'),
+                }),
+            ])
+        )
+    })
+
+    it('turns an MDX compiler failure into a blocking malformed-content diagnostic', async () => {
+        const fixture = createFixture()
+        roots.push(fixture.root)
+
+        const { diagnostics } = await runVerifier(fixture.contentDir, fixture.manifestPath, async () => {
+            throw new SyntaxError('fixture MDX is malformed')
+        })
+        expect(diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    check: 'split-guide-mdx',
+                    message: expect.stringContaining('Malformed or unsafe MDX'),
+                }),
+            ])
+        )
+    })
+})

--- a/scripts/__tests__/verify-split-guides.test.ts
+++ b/scripts/__tests__/verify-split-guides.test.ts
@@ -41,6 +41,7 @@ function generatedFrom(slug: string, locale: (typeof LOCALES)[number]) {
             'content/_system/guidelines/seo.md',
             'content/_system/guidelines/components.md',
             'content/_system/guidelines/locales.md',
+            'content/_system/guidelines/intent-taxonomy.md',
         ],
     }
 }
@@ -62,7 +63,7 @@ function manifestEntry(slug: string, locale: (typeof LOCALES)[number], sourceSha
         tags: ['groups', 'expenses'],
         claims: ['free-forever'],
         cast: [],
-        schema_types: ['Article', 'BlogPosting'],
+        schema_types: ['BlogPosting'],
         canonical: `peanut.me/${locale}/split/guides/${slug}`,
         alternates: alternates(slug),
         source: {
@@ -355,6 +356,35 @@ describe('Split guide manifest verifier', () => {
                 expect.objectContaining({
                     check: 'split-guide-manifest',
                     message: expect.stringContaining('title differs from the manifest contract'),
+                }),
+            ])
+        )
+    })
+
+    it('rejects a redundant Article schema beside BlogPosting', async () => {
+        const fixture = createFixture()
+        roots.push(fixture.root)
+        const file = path.join(fixture.contentDir, 'split-guides', SLUGS[0], 'en.md')
+        const parsed = matter(fs.readFileSync(file, 'utf8'))
+        fs.writeFileSync(
+            file,
+            matter.stringify(parsed.content, { ...parsed.data, schema_types: ['Article', 'BlogPosting'] })
+        )
+
+        const manifest = JSON.parse(fs.readFileSync(fixture.manifestPath, 'utf8'))
+        manifest.guides[SLUGS[0]].en.schema_types = ['Article', 'BlogPosting']
+        fs.writeFileSync(fixture.manifestPath, JSON.stringify(manifest))
+
+        const { diagnostics } = await runFastVerifier(fixture.contentDir, fixture.manifestPath)
+        expect(diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    check: 'split-guide-manifest',
+                    message: expect.stringContaining('exactly [BlogPosting]'),
+                }),
+                expect.objectContaining({
+                    check: 'split-guide-contract',
+                    message: expect.stringContaining('exactly [BlogPosting]'),
                 }),
             ])
         )

--- a/scripts/lib/split-guide-contract.ts
+++ b/scripts/lib/split-guide-contract.ts
@@ -7,6 +7,32 @@ interface MdastNode {
     position?: { start?: { line?: number } }
 }
 
+export function stripSplitGuideFencedCode(body: string): string {
+    let fence: { marker: '`' | '~'; length: number } | null = null
+
+    return body
+        .split(/(\r\n|\n)/)
+        .map((line, index) => {
+            if (index % 2 === 1) return line
+            if (fence) {
+                const closingFence = new RegExp(`^ {0,3}\\${fence.marker}{${fence.length},}[ \\t]*$`)
+                if (closingFence.test(line)) fence = null
+                return ' '.repeat(line.length)
+            }
+
+            const openingFence = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/)
+            if (!openingFence) return line
+
+            const marker = openingFence[1][0] as '`' | '~'
+            // CommonMark does not treat a backtick sequence as an opening fence
+            // when its info string contains another backtick.
+            if (marker === '`' && openingFence[2].includes('`')) return line
+            fence = { marker, length: openingFence[1].length }
+            return ' '.repeat(line.length)
+        })
+        .join('')
+}
+
 /**
  * Authoritative H1 guard for the same remark tree that is compiled into the
  * page. Walking every child catches headings nested in blockquotes and list
@@ -32,9 +58,10 @@ export function remarkRejectSplitGuideH1() {
  */
 export function findSplitGuideHeadingCollisions(body: string): SplitGuideHeadingCollision[] {
     const collisions: SplitGuideHeadingCollision[] = []
-    if (/^[ \t]*#(?:[ \t]+|$)/m.test(body)) collisions.push('atx-h1')
-    if (/^(?![ \t]*$).+\r?\n[ \t]*=+[ \t]*$/m.test(body)) collisions.push('setext-h1')
-    if (/<h1(?:\s|>)/i.test(body)) collisions.push('html-h1')
-    if (/<Hero\b/.test(body)) collisions.push('hero')
+    const scannable = stripSplitGuideFencedCode(body)
+    if (/^[ \t]*#(?:[ \t]+|$)/m.test(scannable)) collisions.push('atx-h1')
+    if (/^(?![ \t]*$).+\r?\n[ \t]*=+[ \t]*$/m.test(scannable)) collisions.push('setext-h1')
+    if (/<h1(?:\s|>)/i.test(scannable)) collisions.push('html-h1')
+    if (/<Hero\b/.test(scannable)) collisions.push('hero')
     return collisions
 }

--- a/scripts/lib/split-guide-contract.ts
+++ b/scripts/lib/split-guide-contract.ts
@@ -1,0 +1,40 @@
+export type SplitGuideHeadingCollision = 'atx-h1' | 'setext-h1' | 'html-h1' | 'hero'
+
+interface MdastNode {
+    type?: string
+    depth?: number
+    children?: MdastNode[]
+    position?: { start?: { line?: number } }
+}
+
+/**
+ * Authoritative H1 guard for the same remark tree that is compiled into the
+ * page. Walking every child catches headings nested in blockquotes and list
+ * items, and the parser normalizes both ATX and setext H1 syntax to the same
+ * `heading` node with `depth: 1`.
+ */
+export function remarkRejectSplitGuideH1() {
+    return (tree: MdastNode) => {
+        const visit = (node: MdastNode) => {
+            if (node.type === 'heading' && node.depth === 1) {
+                const location = node.position?.start?.line ? ` on line ${node.position.start.line}` : ''
+                throw new Error(`Split guide body must not contain an H1${location}; the route owns the sole H1`)
+            }
+            for (const child of node.children ?? []) visit(child)
+        }
+        visit(tree)
+    }
+}
+
+/**
+ * Cheap source-level diagnostics for fast, specific error messages. The remark
+ * plugin above remains authoritative because regex cannot understand nesting.
+ */
+export function findSplitGuideHeadingCollisions(body: string): SplitGuideHeadingCollision[] {
+    const collisions: SplitGuideHeadingCollision[] = []
+    if (/^[ \t]*#(?:[ \t]+|$)/m.test(body)) collisions.push('atx-h1')
+    if (/^(?![ \t]*$).+\r?\n[ \t]*=+[ \t]*$/m.test(body)) collisions.push('setext-h1')
+    if (/<h1(?:\s|>)/i.test(body)) collisions.push('html-h1')
+    if (/<Hero\b/.test(body)) collisions.push('hero')
+    return collisions
+}

--- a/scripts/lib/verify-split-guides.ts
+++ b/scripts/lib/verify-split-guides.ts
@@ -1,11 +1,17 @@
+import { createHash } from 'crypto'
 import fs from 'fs'
 import path from 'path'
 import { isDeepStrictEqual } from 'util'
 import matter from 'gray-matter'
 import { remarkNoExecutableContent } from '../../src/lib/mdx-security'
-import { findSplitGuideHeadingCollisions, remarkRejectSplitGuideH1 } from './split-guide-contract'
+import {
+    findSplitGuideHeadingCollisions,
+    remarkRejectSplitGuideH1,
+    stripSplitGuideFencedCode,
+} from './split-guide-contract'
 
-const LOCALES = ['en', 'es-419', 'pt-br'] as const
+export const SPLIT_GUIDE_LOCALES = ['en', 'es-419', 'pt-br'] as const
+const LOCALES = SPLIT_GUIDE_LOCALES
 type SplitGuideLocale = (typeof LOCALES)[number]
 
 const LOCALE_SET = new Set<string>(LOCALES)
@@ -60,6 +66,19 @@ const SOURCE_METADATA_FIELDS = [
     'generated_from',
     'generated_at',
 ] as const
+const SOURCE_BRIEF_METADATA_FIELDS = [
+    'title',
+    'description',
+    'slug',
+    'type',
+    'lang',
+    'author',
+    'date',
+    'tags',
+    'claims',
+    'cast',
+    'schema_types',
+] as const
 
 type ReportError = (check: string, message: string, file?: string) => void
 
@@ -67,6 +86,8 @@ export interface VerifySplitGuidesOptions {
     contentDir: string
     manifestPath: string
     reportError: ReportError
+    /** Optional mono/content checkout root for recomputing source digests. */
+    sourceRoot?: string
     /** Test seam; production uses the same compiler as the runtime MDX stack. */
     validateMdx?: (body: string) => Promise<void>
 }
@@ -106,7 +127,7 @@ interface ManifestLocaleEntry extends Record<string, unknown> {
     schema_types: string[]
     canonical: string
     alternates: Record<string, string>
-    source: { path: string; content_mode: string; source_provenance: string }
+    source: { path: string; content_mode: string; source_provenance: string; sha256: string }
     generated_from: Record<string, unknown>
     generated_at: string
 }
@@ -181,7 +202,6 @@ function expectedGeneratedFrom(slug: string, locale: SplitGuideLocale): Record<s
         data.push(`content/_system/data/split-guides/${slug}.${locale}.md`)
         context.push(`projects/peanut-split/seo/localization.${locale}.md`)
     }
-    context.push('content/_system/context/valid-links.md')
 
     return {
         template: 'content/_system/templates/split-guide.md',
@@ -331,9 +351,89 @@ function validateManifestEntry(
                 )
             }
         }
+        if (typeof entry.source.sha256 !== 'string' || !/^[0-9a-f]{64}$/.test(entry.source.sha256)) {
+            reportError('split-guide-provenance', 'source.sha256 must be a lowercase SHA-256 digest', label)
+        }
     }
 
     return true
+}
+
+function sourceFrontmatterValue(
+    content: string,
+    frontmatter: Record<string, unknown>,
+    field: (typeof SOURCE_BRIEF_METADATA_FIELDS)[number]
+): unknown {
+    return field === 'date' ? rawFrontmatterScalar(content, field) : frontmatter[field]
+}
+
+function validateManifestSource(
+    slug: string,
+    locale: SplitGuideLocale,
+    entry: unknown,
+    sourceRoot: string,
+    manifestPath: string,
+    reportError: ReportError
+) {
+    if (!isRecord(entry) || !isRecord(entry.source) || typeof entry.source.path !== 'string') return
+
+    const label = `${manifestPath}#guides.${slug}.${locale}`
+    const resolvedRoot = path.resolve(sourceRoot)
+    const sourceFile = path.resolve(resolvedRoot, entry.source.path)
+    if (!sourceFile.startsWith(`${resolvedRoot}${path.sep}`)) {
+        reportError('split-guide-source', 'source.path must stay within the configured source root', label)
+        return
+    }
+
+    let bytes: Buffer
+    try {
+        bytes = fs.readFileSync(sourceFile)
+    } catch (cause) {
+        const message = cause instanceof Error ? cause.message : String(cause)
+        reportError('split-guide-source', `Unable to read selected compose source: ${message}`, sourceFile)
+        return
+    }
+
+    const actualDigest = createHash('sha256').update(Uint8Array.from(bytes)).digest('hex')
+    if (entry.source.sha256 !== actualDigest) {
+        reportError(
+            'split-guide-source',
+            `Selected compose source digest differs from manifest (expected ${String(entry.source.sha256)}, found ${actualDigest})`,
+            sourceFile
+        )
+    }
+
+    const content = bytes.toString('utf8')
+    let frontmatter: Record<string, unknown>
+    try {
+        const parsed = matter(content)
+        if (!isRecord(parsed.data)) throw new Error('frontmatter must be an object')
+        frontmatter = parsed.data
+    } catch (cause) {
+        const message = cause instanceof Error ? cause.message : String(cause)
+        reportError('split-guide-source', `Malformed compose-source frontmatter: ${message}`, sourceFile)
+        return
+    }
+
+    for (const field of SOURCE_BRIEF_METADATA_FIELDS) {
+        const actualValue = sourceFrontmatterValue(content, frontmatter, field)
+        if (!isDeepStrictEqual(actualValue, entry[field])) {
+            reportError(
+                'split-guide-source',
+                `${field} differs between the selected compose source and manifest (expected ${JSON.stringify(entry[field])}, found ${JSON.stringify(actualValue)})`,
+                sourceFile
+            )
+        }
+    }
+    for (const field of ['content_mode', 'source_provenance'] as const) {
+        if (!isDeepStrictEqual(frontmatter[field], entry.source[field])) {
+            reportError(
+                'split-guide-source',
+                `${field} differs between the selected compose source and manifest (expected ${JSON.stringify(entry.source[field])}, found ${JSON.stringify(frontmatter[field])})`,
+                sourceFile
+            )
+        }
+    }
 }
 
 function extractJsxTags(body: string): ParsedJsxTag[] {
@@ -462,10 +562,10 @@ function validateFrontmatter(
         if (/\|\s*Peanut\s*$/i.test(fm.title)) {
             reportError('split-guide-contract', 'title must be raw; the route owns the | Peanut suffix', file)
         }
-        if (rawLength > 60 || effectiveLength > 60) {
+        if (effectiveLength > 60) {
             reportError(
                 'split-guide-contract',
-                `title is too long (raw ${rawLength}, effective ${effectiveLength}; both must be <= 60)`,
+                `title is too long (raw ${rawLength}, effective ${effectiveLength} with the " | Peanut" suffix; raw title must be <= 51)`,
                 file
             )
         }
@@ -525,7 +625,7 @@ function validateFrontmatter(
         if (!isDeepStrictEqual(actualValue, expectedValue)) {
             reportError(
                 'split-guide-manifest',
-                `${field} differs from the selected compose source (expected ${JSON.stringify(expectedValue)}, found ${JSON.stringify(actualValue)})`,
+                `${field} differs from the manifest contract (expected ${JSON.stringify(expectedValue)}, found ${JSON.stringify(actualValue)})`,
                 file
             )
         }
@@ -539,6 +639,9 @@ async function validateBody(
     validateMdx: (body: string) => Promise<void>
 ) {
     const { body, file, locale, slug } = record
+    // Examples may intentionally show forbidden page syntax. Preserve byte
+    // offsets while hiding fenced code from source-level regex/tag checks.
+    const scannableBody = stripSplitGuideFencedCode(body)
     const headingCollisionMessages = {
         'atx-h1': 'Body must not contain an ATX H1 (including indented forms)',
         'setext-h1': 'Body must not contain a CommonMark setext H1',
@@ -548,19 +651,29 @@ async function validateBody(
     for (const collision of findSplitGuideHeadingCollisions(body)) {
         reportError('split-guide-mdx', headingCollisionMessages[collision], file)
     }
-    if (/<FAQ(?:Item)?\b/.test(body)) reportError('split-guide-mdx', 'Split guides must not contain FAQ', file)
-    if (/peanutsplit\.com/i.test(body)) {
+    if (/<FAQ(?:Item)?\b/.test(scannableBody)) reportError('split-guide-mdx', 'Split guides must not contain FAQ', file)
+    if (/peanutsplit\.com/i.test(scannableBody)) {
         reportError('split-guide-contract', 'Legacy peanutsplit.com links are forbidden', file)
     }
 
     try {
         await validateMdx(body)
     } catch (cause) {
-        const message = cause instanceof Error ? cause.message.split('\n')[0] : String(cause)
+        const rawMessage = cause instanceof Error ? cause.message : String(cause)
+        const message =
+            rawMessage
+                .split('\n')
+                .map((line) => line.trim())
+                .find(
+                    (line) =>
+                        line &&
+                        line !== '[next-mdx-remote] error compiling MDX:' &&
+                        !line.startsWith('More information:')
+                ) ?? rawMessage.split('\n')[0]
         reportError('split-guide-mdx', `Malformed or unsafe MDX: ${message}`, file)
     }
 
-    const tags = extractJsxTags(body)
+    const tags = extractJsxTags(scannableBody)
     const attrsByTag = new Map<ParsedJsxTag, Record<string, string>>()
     for (const tag of tags) {
         const attrs = validateComponentProps(record, tag, reportError)
@@ -627,7 +740,7 @@ async function validateBody(
     }
 
     const related = relatedPages[0]
-    const relatedCloseMatches = [...body.matchAll(/<\/RelatedPages\s*>/g)]
+    const relatedCloseMatches = [...scannableBody.matchAll(/<\/RelatedPages\s*>/g)]
     if (relatedCloseMatches.length !== 1) {
         reportError(
             'split-guide-contract',
@@ -653,7 +766,7 @@ async function validateBody(
 
     const relatedLink = relatedLinks[0]
     const relatedAttrs = relatedLink ? attrsByTag.get(relatedLink) : undefined
-    const relatedLinkCloseMatches = [...body.matchAll(/<\/RelatedLink\s*>/g)]
+    const relatedLinkCloseMatches = [...scannableBody.matchAll(/<\/RelatedLink\s*>/g)]
     if (relatedLinkCloseMatches.length !== 1) {
         reportError(
             'split-guide-contract',
@@ -715,6 +828,7 @@ export async function verifySplitGuides({
     contentDir,
     manifestPath,
     reportError,
+    sourceRoot,
     validateMdx = compileSplitGuideMdx,
 }: VerifySplitGuidesOptions): Promise<VerifySplitGuidesResult> {
     const splitRoot = path.join(contentDir, 'split-guides')
@@ -795,6 +909,9 @@ export async function verifySplitGuides({
         for (const locale of LOCALES) {
             const manifestEntry = isRecord(manifestGuides[slug]) ? manifestGuides[slug][locale] : undefined
             validateManifestEntry(slug, locale, manifestEntry, allowedClaims, manifestPath, reportError)
+            if (sourceRoot) {
+                validateManifestSource(slug, locale, manifestEntry, sourceRoot, manifestPath, reportError)
+            }
 
             const file = path.join(slugDir, `${locale}.md`)
             if (!fs.existsSync(file)) continue

--- a/scripts/lib/verify-split-guides.ts
+++ b/scripts/lib/verify-split-guides.ts
@@ -1,0 +1,827 @@
+import fs from 'fs'
+import path from 'path'
+import { isDeepStrictEqual } from 'util'
+import matter from 'gray-matter'
+import { remarkNoExecutableContent } from '../../src/lib/mdx-security'
+import { findSplitGuideHeadingCollisions, remarkRejectSplitGuideH1 } from './split-guide-contract'
+
+const LOCALES = ['en', 'es-419', 'pt-br'] as const
+type SplitGuideLocale = (typeof LOCALES)[number]
+
+const LOCALE_SET = new Set<string>(LOCALES)
+const CTA_TEXT: Record<SplitGuideLocale, string> = {
+    en: 'Start a split',
+    'es-419': 'Crear un split',
+    'pt-br': 'Criar um split',
+}
+const COMPONENT_PROPS: Record<string, { allowed: Set<string>; required: Set<string> }> = {
+    Steps: { allowed: new Set(['title']), required: new Set() },
+    Step: { allowed: new Set(['title']), required: new Set(['title']) },
+    Callout: { allowed: new Set(['type']), required: new Set(['type']) },
+    CTA: {
+        allowed: new Set(['text', 'href', 'subtitle', 'variant']),
+        required: new Set(['text', 'href', 'subtitle', 'variant']),
+    },
+    RelatedPages: { allowed: new Set(['title']), required: new Set() },
+    RelatedLink: { allowed: new Set(['href']), required: new Set(['href']) },
+}
+const OUTPUT_FIELDS = new Set([
+    'title',
+    'description',
+    'slug',
+    'type',
+    'lang',
+    'author',
+    'date',
+    'tags',
+    'claims',
+    'cast',
+    'schema_types',
+    'canonical',
+    'alternates',
+    'generated_from',
+    'generated_at',
+    'published',
+])
+const SOURCE_METADATA_FIELDS = [
+    'title',
+    'description',
+    'slug',
+    'type',
+    'lang',
+    'author',
+    'date',
+    'tags',
+    'claims',
+    'cast',
+    'schema_types',
+    'canonical',
+    'alternates',
+    'generated_from',
+    'generated_at',
+] as const
+
+type ReportError = (check: string, message: string, file?: string) => void
+
+export interface VerifySplitGuidesOptions {
+    contentDir: string
+    manifestPath: string
+    reportError: ReportError
+    /** Test seam; production uses the same compiler as the runtime MDX stack. */
+    validateMdx?: (body: string) => Promise<void>
+}
+
+export interface VerifySplitGuidesResult {
+    recordsChecked: number
+}
+
+interface SplitGuideRecord {
+    file: string
+    slug: string
+    locale: SplitGuideLocale
+    content: string
+    body: string
+    frontmatter: Record<string, unknown>
+}
+
+interface ParsedJsxTag {
+    name: string
+    rawAttributes: string
+    start: number
+    end: number
+    selfClosing: boolean
+}
+
+interface ManifestLocaleEntry extends Record<string, unknown> {
+    title: string
+    description: string
+    slug: string
+    type: string
+    lang: string
+    author: string
+    date: string
+    tags: string[]
+    claims: string[]
+    cast: string[]
+    schema_types: string[]
+    canonical: string
+    alternates: Record<string, string>
+    source: { path: string; content_mode: string; source_provenance: string }
+    generated_from: Record<string, unknown>
+    generated_at: string
+}
+
+interface SplitGuideManifest {
+    version: number
+    intent: string
+    locales: string[]
+    allowed_product_claim_ids: string[]
+    guides: Record<string, Record<string, ManifestLocaleEntry>>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function listDirs(dir: string): string[] {
+    if (!fs.existsSync(dir)) return []
+    return fs
+        .readdirSync(dir, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name)
+        .sort()
+}
+
+function rawFrontmatterScalar(content: string, key: string): string | null {
+    const block = content.match(/^---\r?\n([\s\S]*?)\r?\n---/)
+    if (!block) return null
+    const line = block[1].match(new RegExp(`^${key}:\\s*(.*)$`, 'm'))
+    if (!line) return null
+    const value = line[1].trim()
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        return value.slice(1, -1)
+    }
+    return value
+}
+
+function isValidIsoDate(value: unknown): value is string {
+    if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
+    const parsed = new Date(`${value}T00:00:00.000Z`)
+    return Number.isFinite(parsed.getTime()) && parsed.toISOString().split('T')[0] === value
+}
+
+function isStringArray(value: unknown, allowEmpty: boolean): value is string[] {
+    return (
+        Array.isArray(value) &&
+        (allowEmpty || value.length > 0) &&
+        value.every((item) => typeof item === 'string' && item.trim().length > 0)
+    )
+}
+
+function stringLength(value: string): number {
+    return Array.from(value).length
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function expectedAlternates(slug: string): Record<SplitGuideLocale, string> {
+    return {
+        en: `content/split-guides/${slug}/en.md`,
+        'es-419': `content/split-guides/${slug}/es-419.md`,
+        'pt-br': `content/split-guides/${slug}/pt-br.md`,
+    }
+}
+
+function expectedGeneratedFrom(slug: string, locale: SplitGuideLocale): Record<string, unknown> {
+    const data = [`content/_system/data/split-guides/${slug}.md`]
+    const context = ['projects/peanut-split/seo/stylebook.md']
+    if (locale !== 'en') {
+        data.push(`content/_system/data/split-guides/${slug}.${locale}.md`)
+        context.push(`projects/peanut-split/seo/localization.${locale}.md`)
+    }
+    context.push('content/_system/context/valid-links.md')
+
+    return {
+        template: 'content/_system/templates/split-guide.md',
+        data,
+        product: ['product/peanut-split.md'],
+        workflow: 'content/_system/workflows/generate-content.md',
+        context,
+        guidelines: [
+            'content/_system/guidelines/seo.md',
+            'content/_system/guidelines/components.md',
+            'content/_system/guidelines/locales.md',
+        ],
+    }
+}
+
+function parseManifest(manifestPath: string, reportError: ReportError): SplitGuideManifest | null {
+    let raw: unknown
+    try {
+        raw = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+    } catch (cause) {
+        const message = cause instanceof Error ? cause.message : String(cause)
+        reportError('split-guide-manifest', `Manifest is not valid JSON: ${message}`, manifestPath)
+        return null
+    }
+
+    if (!isRecord(raw)) {
+        reportError('split-guide-manifest', 'Manifest root must be an object', manifestPath)
+        return null
+    }
+    if (raw.version !== 1) reportError('split-guide-manifest', 'Manifest version must be 1', manifestPath)
+    if (raw.intent !== 'split-guides') {
+        reportError('split-guide-manifest', 'Manifest intent must be split-guides', manifestPath)
+    }
+    if (!isDeepStrictEqual(raw.locales, [...LOCALES])) {
+        reportError(
+            'split-guide-manifest',
+            'Manifest locales must be exactly [en, es-419, pt-br] in that order',
+            manifestPath
+        )
+    }
+    if (!isStringArray(raw.allowed_product_claim_ids, false)) {
+        reportError(
+            'split-guide-manifest',
+            'Manifest allowed_product_claim_ids must be a nonempty string array',
+            manifestPath
+        )
+    } else {
+        if (new Set(raw.allowed_product_claim_ids).size !== raw.allowed_product_claim_ids.length) {
+            reportError('split-guide-manifest', 'Manifest product claim IDs must be unique', manifestPath)
+        }
+        for (const claim of raw.allowed_product_claim_ids) {
+            if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(claim)) {
+                reportError('split-guide-manifest', `Invalid product claim ID: ${claim}`, manifestPath)
+            }
+        }
+    }
+    if (!isRecord(raw.guides)) {
+        reportError('split-guide-manifest', 'Manifest guides must be an object', manifestPath)
+        return null
+    }
+    if (Object.keys(raw.guides).length === 0) {
+        reportError('split-guide-manifest', 'Manifest guides must contain at least one guide', manifestPath)
+    }
+
+    return raw as unknown as SplitGuideManifest
+}
+
+function validateManifestEntry(
+    slug: string,
+    locale: SplitGuideLocale,
+    entry: unknown,
+    allowedClaims: Set<string>,
+    manifestPath: string,
+    reportError: ReportError
+): entry is ManifestLocaleEntry {
+    const label = `${manifestPath}#guides.${slug}.${locale}`
+    if (!isRecord(entry)) {
+        reportError('split-guide-manifest', 'Guide locale entry must be an object', label)
+        return false
+    }
+
+    const stringFields = ['title', 'description', 'slug', 'type', 'lang', 'author', 'canonical', 'generated_at']
+    for (const field of stringFields) {
+        if (typeof entry[field] !== 'string' || !entry[field].trim()) {
+            reportError('split-guide-manifest', `${field} must be a nonempty string`, label)
+        }
+    }
+    if (!isValidIsoDate(entry.date)) reportError('split-guide-manifest', 'date must be a real YYYY-MM-DD', label)
+    if (!isValidIsoDate(entry.generated_at)) {
+        reportError('split-guide-manifest', 'generated_at must be a real YYYY-MM-DD', label)
+    }
+    if (entry.slug !== slug) reportError('split-guide-manifest', `slug must equal ${slug}`, label)
+    if (entry.lang !== locale) reportError('split-guide-manifest', `lang must equal ${locale}`, label)
+    if (entry.type !== 'guide') reportError('split-guide-manifest', 'type must be guide', label)
+    if (entry.author !== 'Peanut') reportError('split-guide-manifest', 'author must be Peanut', label)
+    if (entry.canonical !== `peanut.me/${locale}/split/guides/${slug}`) {
+        reportError('split-guide-manifest', 'canonical does not match the exact guide URL', label)
+    }
+    if (!isStringArray(entry.tags, false)) {
+        reportError('split-guide-manifest', 'tags must be a nonempty string array', label)
+    }
+    if (!isStringArray(entry.claims, false)) {
+        reportError('split-guide-manifest', 'claims must be a nonempty string array', label)
+    } else {
+        for (const claim of entry.claims) {
+            if (!allowedClaims.has(claim)) {
+                reportError(
+                    'split-guide-claims',
+                    `Claim ${claim} does not resolve to a product truth block in the manifest`,
+                    label
+                )
+            }
+        }
+    }
+    if (!isStringArray(entry.cast, true)) reportError('split-guide-manifest', 'cast must be a string array', label)
+    if (!isDeepStrictEqual(entry.schema_types, ['Article', 'BlogPosting'])) {
+        reportError('split-guide-manifest', 'schema_types must be exactly [Article, BlogPosting]', label)
+    }
+    if (!isDeepStrictEqual(entry.alternates, expectedAlternates(slug))) {
+        reportError('split-guide-manifest', 'alternates do not match the exact three locale files', label)
+    }
+    if (!isDeepStrictEqual(entry.generated_from, expectedGeneratedFrom(slug, locale))) {
+        reportError('split-guide-provenance', 'generated_from does not match the exact core source paths', label)
+    }
+
+    if (!isRecord(entry.source)) {
+        reportError('split-guide-provenance', 'source must be an object', label)
+    } else {
+        const expectedSourcePath = `content/_system/data/split-guides/${slug}${locale === 'en' ? '' : `.${locale}`}.md`
+        if (entry.source.path !== expectedSourcePath) {
+            reportError('split-guide-provenance', `source.path must be ${expectedSourcePath}`, label)
+        }
+        if (entry.source.content_mode !== 'compose') {
+            reportError('split-guide-provenance', 'source.content_mode must be compose', label)
+        }
+        if (typeof entry.source.source_provenance !== 'string' || !entry.source.source_provenance.trim()) {
+            reportError('split-guide-provenance', 'source.source_provenance must be nonempty', label)
+        } else {
+            const expectedProvenance = new RegExp(
+                `^peanutprotocol/peanutsplit@[0-9a-f]{40}:apps/web/src/content/blog/${escapeRegExp(slug)}/${escapeRegExp(locale)}\\.md$`
+            )
+            if (!expectedProvenance.test(entry.source.source_provenance)) {
+                reportError(
+                    'split-guide-provenance',
+                    `source.source_provenance must match peanutprotocol/peanutsplit@{40hex}:apps/web/src/content/blog/${slug}/${locale}.md`,
+                    label
+                )
+            }
+        }
+    }
+
+    return true
+}
+
+function extractJsxTags(body: string): ParsedJsxTag[] {
+    const tags: ParsedJsxTag[] = []
+    const tagPattern = /<([A-Za-z][A-Za-z0-9.]*)\b((?:"[^"]*"|'[^']*'|[^"'<>])*)>/g
+    let match: RegExpExecArray | null
+    while ((match = tagPattern.exec(body)) !== null) {
+        // GFM autolinks are ordinary Markdown, not authored JSX tags.
+        if (/^<(?:https?:\/\/|mailto:)[^<>\s]+>$/.test(match[0]) || /^<[^<>\s@]+@[^<>\s@]+>$/.test(match[0])) {
+            continue
+        }
+        tags.push({
+            name: match[1],
+            rawAttributes: match[2],
+            start: match.index,
+            end: tagPattern.lastIndex,
+            selfClosing: match[2].trimEnd().endsWith('/'),
+        })
+    }
+    return tags
+}
+
+function parseLiteralJsxAttributes(
+    rawAttributes: string
+): { attrs: Record<string, string>; error?: never } | { attrs?: never; error: string } {
+    let source = rawAttributes.trim()
+    if (source.endsWith('/')) source = source.slice(0, -1).trimEnd()
+
+    const attrs: Record<string, string> = {}
+    let offset = 0
+    while (offset < source.length) {
+        offset += source.slice(offset).match(/^\s*/)?.[0].length ?? 0
+        if (offset >= source.length) break
+
+        const match = source.slice(offset).match(/^([A-Za-z][A-Za-z0-9_-]*)\s*=\s*(?:"([^"]*)"|'([^']*)')/)
+        if (!match) {
+            return { error: `attributes must be literal quoted strings near: ${source.slice(offset, offset + 40)}` }
+        }
+        const name = match[1]
+        if (Object.prototype.hasOwnProperty.call(attrs, name)) return { error: `duplicate attribute: ${name}` }
+        attrs[name] = match[2] ?? match[3] ?? ''
+        offset += match[0].length
+    }
+    return { attrs }
+}
+
+function validateComponentProps(
+    record: SplitGuideRecord,
+    tag: ParsedJsxTag,
+    reportError: ReportError
+): Record<string, string> | null {
+    const contract = COMPONENT_PROPS[tag.name]
+    if (!contract) {
+        reportError('split-guide-mdx', `Unsupported MDX component <${tag.name}>`, record.file)
+        return null
+    }
+
+    const parsed = parseLiteralJsxAttributes(tag.rawAttributes)
+    if ('error' in parsed) {
+        reportError('split-guide-mdx', `<${tag.name}> ${parsed.error}`, record.file)
+        return null
+    }
+    for (const name of Object.keys(parsed.attrs)) {
+        if (!contract.allowed.has(name)) {
+            reportError('split-guide-mdx', `<${tag.name}> does not support the ${name} prop`, record.file)
+        }
+    }
+    for (const name of contract.required) {
+        if (!parsed.attrs[name]?.trim()) {
+            reportError('split-guide-mdx', `<${tag.name}> requires a nonempty ${name} prop`, record.file)
+        }
+    }
+    if (tag.name === 'Callout' && parsed.attrs.type !== 'info') {
+        reportError('split-guide-mdx', '<Callout> type must be exactly info', record.file)
+    }
+
+    const mustHaveChildren = ['Steps', 'Step', 'Callout', 'RelatedPages', 'RelatedLink'].includes(tag.name)
+    if (mustHaveChildren && tag.selfClosing) {
+        reportError('split-guide-mdx', `<${tag.name}> must contain child content`, record.file)
+    }
+    if (tag.name === 'CTA' && !tag.selfClosing) {
+        reportError('split-guide-mdx', '<CTA> must be self-closing', record.file)
+    }
+    return parsed.attrs
+}
+
+function comparableOutputValue(record: SplitGuideRecord, field: (typeof SOURCE_METADATA_FIELDS)[number]): unknown {
+    if (field === 'date' || field === 'generated_at') return rawFrontmatterScalar(record.content, field)
+    return record.frontmatter[field]
+}
+
+function validateFrontmatter(
+    record: SplitGuideRecord,
+    expected: ManifestLocaleEntry | undefined,
+    allowedClaims: Set<string>,
+    reportError: ReportError
+) {
+    const { slug, locale, content, frontmatter: fm, file } = record
+
+    for (const key of Object.keys(fm)) {
+        if (!OUTPUT_FIELDS.has(key)) {
+            reportError('split-guide-contract', `Unexpected frontmatter field: ${key}`, file)
+        }
+    }
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)) {
+        reportError('split-guide-contract', `Directory slug is not canonical kebab-case: ${slug}`, file)
+    }
+    if (fm.type !== 'guide') reportError('split-guide-contract', 'type must be guide', file)
+    if (fm.lang !== locale) reportError('split-guide-contract', `lang must exactly match filename: ${locale}`, file)
+    if (fm.slug !== slug) reportError('split-guide-contract', `slug must exactly match directory: ${slug}`, file)
+    if (fm.canonical !== `peanut.me/${locale}/split/guides/${slug}`) {
+        reportError('split-guide-contract', `canonical must be peanut.me/${locale}/split/guides/${slug}`, file)
+    }
+    if (fm.author !== 'Peanut') reportError('split-guide-contract', 'author must be Peanut', file)
+    if (fm.published !== undefined && typeof fm.published !== 'boolean') {
+        reportError('split-guide-contract', 'published must be a boolean when present', file)
+    } else if (fm.published === false) {
+        reportError('split-guide-contract', `Exact canary locale ${locale} must be published`, file)
+    }
+
+    if (typeof fm.title !== 'string' || !fm.title.trim()) {
+        reportError('split-guide-contract', 'title must be a nonempty string', file)
+    } else {
+        const rawLength = stringLength(fm.title)
+        const effectiveLength = stringLength(`${fm.title} | Peanut`)
+        if (/\|\s*Peanut\s*$/i.test(fm.title)) {
+            reportError('split-guide-contract', 'title must be raw; the route owns the | Peanut suffix', file)
+        }
+        if (rawLength > 60 || effectiveLength > 60) {
+            reportError(
+                'split-guide-contract',
+                `title is too long (raw ${rawLength}, effective ${effectiveLength}; both must be <= 60)`,
+                file
+            )
+        }
+    }
+    if (typeof fm.description !== 'string') {
+        reportError('split-guide-contract', 'description must be a string', file)
+    } else {
+        const length = stringLength(fm.description)
+        if (length < 140 || length > 160) {
+            reportError('split-guide-contract', `description must be 140-160 characters (found ${length})`, file)
+        }
+        if (!fm.description.endsWith('.')) {
+            reportError('split-guide-contract', 'description must end with a period', file)
+        }
+    }
+    if (!isValidIsoDate(rawFrontmatterScalar(content, 'date'))) {
+        reportError('split-guide-contract', 'date must be a real YYYY-MM-DD calendar date', file)
+    }
+    if (!isStringArray(fm.claims, false)) {
+        reportError('split-guide-contract', 'claims must be a nonempty array of nonempty strings', file)
+    } else {
+        if (new Set(fm.claims).size !== fm.claims.length) {
+            reportError('split-guide-claims', 'claims must not contain duplicates', file)
+        }
+        for (const claim of fm.claims) {
+            if (!allowedClaims.has(claim)) {
+                reportError('split-guide-claims', `Unknown Peanut Split product claim: ${claim}`, file)
+            }
+        }
+    }
+    if (!isStringArray(fm.cast, true)) {
+        reportError('split-guide-contract', 'cast must be an array of strings (empty is allowed)', file)
+    }
+    if (!isStringArray(fm.tags, false)) {
+        reportError('split-guide-contract', 'tags must be a nonempty array of nonempty strings', file)
+    }
+    if (!isDeepStrictEqual(fm.schema_types, ['Article', 'BlogPosting'])) {
+        reportError('split-guide-contract', 'schema_types must be exactly [Article, BlogPosting]', file)
+    }
+    if (!isDeepStrictEqual(fm.alternates, expectedAlternates(slug))) {
+        reportError('split-guide-contract', 'alternates must list exactly the three exact-locale guide files', file)
+    }
+    if (!isDeepStrictEqual(fm.generated_from, expectedGeneratedFrom(slug, locale))) {
+        reportError('split-guide-provenance', 'generated_from must contain exactly the required source paths', file)
+    }
+    if (!isValidIsoDate(rawFrontmatterScalar(content, 'generated_at'))) {
+        reportError('split-guide-provenance', 'generated_at must be a real YYYY-MM-DD', file)
+    }
+
+    if (!expected) {
+        reportError('split-guide-manifest', 'No exact slug/locale entry exists in the contract manifest', file)
+        return
+    }
+    for (const field of SOURCE_METADATA_FIELDS) {
+        const actualValue = comparableOutputValue(record, field)
+        const expectedValue = expected[field]
+        if (!isDeepStrictEqual(actualValue, expectedValue)) {
+            reportError(
+                'split-guide-manifest',
+                `${field} differs from the selected compose source (expected ${JSON.stringify(expectedValue)}, found ${JSON.stringify(actualValue)})`,
+                file
+            )
+        }
+    }
+}
+
+async function validateBody(
+    record: SplitGuideRecord,
+    recordsByKey: Map<string, SplitGuideRecord>,
+    reportError: ReportError,
+    validateMdx: (body: string) => Promise<void>
+) {
+    const { body, file, locale, slug } = record
+    const headingCollisionMessages = {
+        'atx-h1': 'Body must not contain an ATX H1 (including indented forms)',
+        'setext-h1': 'Body must not contain a CommonMark setext H1',
+        'html-h1': 'Body must not contain a literal <h1>',
+        hero: 'Body must not contain <Hero>',
+    }
+    for (const collision of findSplitGuideHeadingCollisions(body)) {
+        reportError('split-guide-mdx', headingCollisionMessages[collision], file)
+    }
+    if (/<FAQ(?:Item)?\b/.test(body)) reportError('split-guide-mdx', 'Split guides must not contain FAQ', file)
+    if (/peanutsplit\.com/i.test(body)) {
+        reportError('split-guide-contract', 'Legacy peanutsplit.com links are forbidden', file)
+    }
+
+    try {
+        await validateMdx(body)
+    } catch (cause) {
+        const message = cause instanceof Error ? cause.message.split('\n')[0] : String(cause)
+        reportError('split-guide-mdx', `Malformed or unsafe MDX: ${message}`, file)
+    }
+
+    const tags = extractJsxTags(body)
+    const attrsByTag = new Map<ParsedJsxTag, Record<string, string>>()
+    for (const tag of tags) {
+        const attrs = validateComponentProps(record, tag, reportError)
+        if (attrs) attrsByTag.set(tag, attrs)
+    }
+
+    const ctas = tags.filter((tag) => tag.name === 'CTA')
+    const relatedPages = tags.filter((tag) => tag.name === 'RelatedPages')
+    const relatedLinks = tags.filter((tag) => tag.name === 'RelatedLink')
+    if (ctas.length !== 1) reportError('split-guide-contract', `Expected exactly one CTA; found ${ctas.length}`, file)
+    if (relatedPages.length !== 1) {
+        reportError('split-guide-contract', `Expected exactly one RelatedPages; found ${relatedPages.length}`, file)
+    }
+    if (relatedLinks.length !== 1) {
+        reportError('split-guide-contract', `Expected exactly one RelatedLink; found ${relatedLinks.length}`, file)
+    }
+
+    const cta = ctas[0]
+    const ctaAttrs = cta ? attrsByTag.get(cta) : undefined
+    if (ctaAttrs) {
+        if (ctaAttrs.text !== CTA_TEXT[locale]) {
+            reportError('split-guide-contract', `CTA text must be "${CTA_TEXT[locale]}"`, file)
+        }
+        if (ctaAttrs.variant !== 'card') reportError('split-guide-contract', 'CTA variant must be card', file)
+
+        let ctaUrl: URL | null = null
+        try {
+            ctaUrl = new URL(ctaAttrs.href)
+        } catch {
+            reportError('split-guide-contract', 'CTA href must be an absolute HTTPS URL', file)
+        }
+        if (ctaUrl) {
+            if (
+                ctaUrl.origin !== 'https://split.peanut.me' ||
+                ctaUrl.pathname !== '/new' ||
+                ctaUrl.hash ||
+                ctaUrl.username ||
+                ctaUrl.password
+            ) {
+                reportError('split-guide-contract', 'CTA href must target exactly https://split.peanut.me/new', file)
+            }
+            const expectedQuery: Record<string, string> = {
+                locale,
+                utm_medium: 'content',
+                utm_source: 'split-guide',
+                utm_campaign: slug,
+                utm_content: 'final-cta',
+            }
+            const keys = [...ctaUrl.searchParams.keys()]
+            const expectedKeys = Object.keys(expectedQuery)
+            if (
+                keys.length !== expectedKeys.length ||
+                new Set(keys).size !== expectedKeys.length ||
+                expectedKeys.some((key) => !keys.includes(key))
+            ) {
+                reportError('split-guide-contract', `CTA query must contain exactly: ${expectedKeys.join(', ')}`, file)
+            }
+            for (const [key, expectedValue] of Object.entries(expectedQuery)) {
+                if (ctaUrl.searchParams.get(key) !== expectedValue) {
+                    reportError('split-guide-contract', `CTA ${key} must equal ${expectedValue}`, file)
+                }
+            }
+        }
+    }
+
+    const related = relatedPages[0]
+    const relatedCloseMatches = [...body.matchAll(/<\/RelatedPages\s*>/g)]
+    if (relatedCloseMatches.length !== 1) {
+        reportError(
+            'split-guide-contract',
+            `Expected exactly one closing </RelatedPages>; found ${relatedCloseMatches.length}`,
+            file
+        )
+    }
+    const relatedClose = relatedCloseMatches[0]
+    if (cta && related) {
+        if (related.start <= cta.end) {
+            reportError('split-guide-contract', 'RelatedPages must appear after the final CTA', file)
+        } else if (body.slice(cta.end, related.start).trim()) {
+            reportError(
+                'split-guide-contract',
+                'Only whitespace may appear between the final CTA and RelatedPages',
+                file
+            )
+        }
+    }
+    if (relatedClose && body.slice((relatedClose.index ?? 0) + relatedClose[0].length).trim()) {
+        reportError('split-guide-contract', 'RelatedPages must be the final content block', file)
+    }
+
+    const relatedLink = relatedLinks[0]
+    const relatedAttrs = relatedLink ? attrsByTag.get(relatedLink) : undefined
+    const relatedLinkCloseMatches = [...body.matchAll(/<\/RelatedLink\s*>/g)]
+    if (relatedLinkCloseMatches.length !== 1) {
+        reportError(
+            'split-guide-contract',
+            `Expected exactly one closing </RelatedLink>; found ${relatedLinkCloseMatches.length}`,
+            file
+        )
+    }
+    const relatedLinkClose = relatedLinkCloseMatches[0]
+    if (related && relatedClose && relatedLink && relatedLinkClose) {
+        const relatedCloseIndex = relatedClose.index ?? -1
+        const linkCloseIndex = relatedLinkClose.index ?? -1
+        if (
+            relatedLink.start <= related.end ||
+            relatedLink.end >= relatedCloseIndex ||
+            linkCloseIndex >= relatedCloseIndex
+        ) {
+            reportError('split-guide-contract', 'RelatedLink must be nested inside RelatedPages', file)
+        }
+        if (!body.slice(relatedLink.end, linkCloseIndex).trim()) {
+            reportError('split-guide-contract', 'RelatedLink must have nonempty link text', file)
+        }
+    }
+    if (relatedAttrs) {
+        const escapedLocale = escapeRegExp(locale)
+        const hrefMatch = relatedAttrs.href.match(new RegExp(`^/${escapedLocale}/split/guides/([a-z0-9-]+)$`))
+        if (!hrefMatch) {
+            reportError(
+                'split-guide-contract',
+                `RelatedLink must target /${locale}/split/guides/{slug} in the same locale`,
+                file
+            )
+        } else {
+            const targetSlug = hrefMatch[1]
+            if (targetSlug === slug) reportError('split-guide-contract', 'RelatedLink must not point to itself', file)
+            const target = recordsByKey.get(`${locale}/${targetSlug}`)
+            if (!target || target.frontmatter.published === false) {
+                reportError('split-guide-contract', 'RelatedLink target must be an exact-locale published guide', file)
+            }
+        }
+    }
+}
+
+async function compileSplitGuideMdx(body: string): Promise<void> {
+    // These packages are ESM-only. A dynamic import keeps verify-content
+    // runnable under the repository's tsx/CommonJS script entrypoint.
+    const [{ serialize }, { default: remarkGfm }] = await Promise.all([
+        import('next-mdx-remote/serialize'),
+        import('remark-gfm'),
+    ])
+    await serialize(body, {
+        mdxOptions: {
+            format: 'mdx',
+            remarkPlugins: [remarkNoExecutableContent, remarkRejectSplitGuideH1, remarkGfm],
+        },
+    })
+}
+
+export async function verifySplitGuides({
+    contentDir,
+    manifestPath,
+    reportError,
+    validateMdx = compileSplitGuideMdx,
+}: VerifySplitGuidesOptions): Promise<VerifySplitGuidesResult> {
+    const splitRoot = path.join(contentDir, 'split-guides')
+    const slugs = listDirs(splitRoot)
+    const hasGuideFiles = slugs.some((slug) =>
+        fs
+            .readdirSync(path.join(splitRoot, slug), { withFileTypes: true })
+            .some((entry) => entry.isFile() && /\.mdx?$/.test(entry.name))
+    )
+    if (!hasGuideFiles && !fs.existsSync(manifestPath)) return { recordsChecked: 0 }
+    if (!fs.existsSync(manifestPath)) {
+        reportError(
+            'split-guide-manifest',
+            'Split guide files require generated/split-guide-manifest.json',
+            manifestPath
+        )
+        return { recordsChecked: 0 }
+    }
+
+    const manifest = parseManifest(manifestPath, reportError)
+    if (!manifest) return { recordsChecked: 0 }
+    const allowedClaims = new Set(
+        isStringArray(manifest.allowed_product_claim_ids, false) ? manifest.allowed_product_claim_ids : []
+    )
+    const manifestGuides = isRecord(manifest.guides) ? manifest.guides : {}
+
+    const manifestSlugs = Object.keys(manifestGuides).sort()
+    for (const slug of manifestSlugs) {
+        if (!slugs.includes(slug)) {
+            reportError('split-guide-locales', `Manifest guide has no output directory: ${slug}`, manifestPath)
+        }
+    }
+    for (const slug of slugs) {
+        if (!manifestSlugs.includes(slug)) {
+            reportError(
+                'split-guide-manifest',
+                `Output slug is absent from manifest: ${slug}`,
+                path.join(splitRoot, slug)
+            )
+        }
+    }
+
+    const records: SplitGuideRecord[] = []
+    const recordsByKey = new Map<string, SplitGuideRecord>()
+    for (const slug of slugs) {
+        const slugDir = path.join(splitRoot, slug)
+        const contentFiles = fs
+            .readdirSync(slugDir, { withFileTypes: true })
+            .filter((entry) => entry.isFile() && /\.mdx?$/.test(entry.name))
+            .map((entry) => entry.name)
+            .sort()
+
+        for (const locale of LOCALES) {
+            if (!contentFiles.includes(`${locale}.md`)) {
+                reportError('split-guide-locales', `Missing required exact locale file: ${locale}.md`, slugDir)
+            }
+        }
+        for (const filename of contentFiles) {
+            const locale = filename.replace(/\.mdx?$/, '')
+            if (!LOCALE_SET.has(locale) || filename !== `${locale}.md`) {
+                reportError(
+                    'split-guide-locales',
+                    `Unexpected locale/file ${filename}; only en.md, es-419.md and pt-br.md are allowed`,
+                    path.join(slugDir, filename)
+                )
+            }
+        }
+
+        const manifestLocales = isRecord(manifestGuides[slug]) ? Object.keys(manifestGuides[slug]).sort() : []
+        if (!isDeepStrictEqual(manifestLocales, [...LOCALES].sort())) {
+            reportError(
+                'split-guide-manifest',
+                'Guide manifest locales must be exactly en, es-419 and pt-br',
+                `${manifestPath}#guides.${slug}`
+            )
+        }
+
+        for (const locale of LOCALES) {
+            const manifestEntry = isRecord(manifestGuides[slug]) ? manifestGuides[slug][locale] : undefined
+            validateManifestEntry(slug, locale, manifestEntry, allowedClaims, manifestPath, reportError)
+
+            const file = path.join(slugDir, `${locale}.md`)
+            if (!fs.existsSync(file)) continue
+            const content = fs.readFileSync(file, 'utf8')
+            let body = ''
+            let frontmatter: Record<string, unknown> = {}
+            try {
+                const parsed = matter(content)
+                body = parsed.content.trim()
+                if (isRecord(parsed.data)) frontmatter = parsed.data
+            } catch (cause) {
+                const message = cause instanceof Error ? cause.message : String(cause)
+                reportError('split-guide-contract', `Malformed frontmatter: ${message}`, file)
+            }
+            const record = { file, slug, locale, content, body, frontmatter }
+            records.push(record)
+            recordsByKey.set(`${locale}/${slug}`, record)
+        }
+    }
+
+    for (const record of records) {
+        const expected = isRecord(manifestGuides[record.slug])
+            ? (manifestGuides[record.slug][record.locale] as ManifestLocaleEntry | undefined)
+            : undefined
+        validateFrontmatter(record, expected, allowedClaims, reportError)
+    }
+    for (const record of records) await validateBody(record, recordsByKey, reportError, validateMdx)
+
+    return { recordsChecked: records.length }
+}

--- a/scripts/lib/verify-split-guides.ts
+++ b/scripts/lib/verify-split-guides.ts
@@ -213,6 +213,7 @@ function expectedGeneratedFrom(slug: string, locale: SplitGuideLocale): Record<s
             'content/_system/guidelines/seo.md',
             'content/_system/guidelines/components.md',
             'content/_system/guidelines/locales.md',
+            'content/_system/guidelines/intent-taxonomy.md',
         ],
     }
 }
@@ -317,8 +318,8 @@ function validateManifestEntry(
         }
     }
     if (!isStringArray(entry.cast, true)) reportError('split-guide-manifest', 'cast must be a string array', label)
-    if (!isDeepStrictEqual(entry.schema_types, ['Article', 'BlogPosting'])) {
-        reportError('split-guide-manifest', 'schema_types must be exactly [Article, BlogPosting]', label)
+    if (!isDeepStrictEqual(entry.schema_types, ['BlogPosting'])) {
+        reportError('split-guide-manifest', 'schema_types must be exactly [BlogPosting]', label)
     }
     if (!isDeepStrictEqual(entry.alternates, expectedAlternates(slug))) {
         reportError('split-guide-manifest', 'alternates do not match the exact three locale files', label)
@@ -602,8 +603,8 @@ function validateFrontmatter(
     if (!isStringArray(fm.tags, false)) {
         reportError('split-guide-contract', 'tags must be a nonempty array of nonempty strings', file)
     }
-    if (!isDeepStrictEqual(fm.schema_types, ['Article', 'BlogPosting'])) {
-        reportError('split-guide-contract', 'schema_types must be exactly [Article, BlogPosting]', file)
+    if (!isDeepStrictEqual(fm.schema_types, ['BlogPosting'])) {
+        reportError('split-guide-contract', 'schema_types must be exactly [BlogPosting]', file)
     }
     if (!isDeepStrictEqual(fm.alternates, expectedAlternates(slug))) {
         reportError('split-guide-contract', 'alternates must list exactly the three exact-locale guide files', file)

--- a/scripts/verify-content.ts
+++ b/scripts/verify-content.ts
@@ -22,17 +22,20 @@
  *     route AND its data source isn't empty (catches the May 2026 SEO
  *     regression where empty entity-data made `generateStaticParams` return []
  *     and 404ed ~625 pages).
+ * 12. Split guide canary contract — exact locales, frontmatter, SEO, safe MDX,
+ *     CTA attribution and reciprocal related-guide links.
  */
 
 import fs from 'fs'
 import path from 'path'
 import { RAIL_SLUGS } from '../src/data/seo/deposit-rails'
+import { verifySplitGuides } from './lib/verify-split-guides'
 
 const ROOT = path.join(process.cwd(), 'src/content')
 const CONTENT_DIR = path.join(ROOT, 'content')
 const APP_DIR = path.join(process.cwd(), 'src/app/[locale]/(marketing)')
 
-const SUPPORTED_LOCALES = ['en', 'es-419', 'es-ar', 'es-es', 'pt-br']
+const SUPPORTED_LOCALES = ['en', 'es-419', 'es-ar', 'pt-br']
 const PRIMARY_LOCALES = ['en', 'es-419', 'pt-br']
 
 // `content/deposit/` mixes two URL families on the same dynamic route:
@@ -113,6 +116,10 @@ function isContentPage(filePath: string): boolean {
     const basename = path.basename(filePath)
     if (basename === 'README.md') return false
     if (basename.endsWith('-index.md')) return false
+    // es-es is retired from the UI locale set. Keep its files in the mirror and
+    // page-count guard during cleanup, but do not validate links/content for a
+    // route family the app intentionally no longer serves.
+    if (basename === 'es-es.md') return false
     return true
 }
 
@@ -144,6 +151,12 @@ function parseFrontmatter(content: string): Record<string, unknown> {
 function isPublished(content: string): boolean {
     const fm = parseFrontmatter(content)
     return fm.published !== false
+}
+
+/** Exact locale file check for content families that never fall back. */
+function hasPublishedLocalePage(intent: string, slug: string, locale: string): boolean {
+    const file = path.join(CONTENT_DIR, intent, slug, `${locale}.md`)
+    return fs.existsSync(file) && isPublished(fs.readFileSync(file, 'utf-8'))
 }
 
 // --- Build valid paths from actual routes ---
@@ -184,6 +197,9 @@ function discoverRoutes(): Set<string> {
     const storySlugs = listDirs(path.join(CONTENT_DIR, 'stories')).filter((s) => s !== 'index')
     const withdrawSlugs = listDirs(path.join(CONTENT_DIR, 'withdraw'))
     const blogSlugs = listDirs(path.join(CONTENT_DIR, 'blog')).filter((s) => s !== 'index')
+    const splitGuideSlugs = listDirs(path.join(CONTENT_DIR, 'split-guides')).filter((slug) =>
+        hasPublishedLocalePage('split-guides', slug, 'en')
+    )
 
     // Corridors
     const corridors: Array<{ to: string; from: string }> = []
@@ -288,6 +304,16 @@ function discoverRoutes(): Set<string> {
             for (const slug of blogSlugs) routes.add(`/${locale}/blog/${slug}`)
         }
 
+        // Split guides are exact-locale only: never manufacture a route whose
+        // locale file would have to fall back.
+        if (hasRoute('split/guides/[slug]')) {
+            for (const slug of splitGuideSlugs) {
+                if (hasPublishedLocalePage('split-guides', slug, locale)) {
+                    routes.add(`/${locale}/split/guides/${slug}`)
+                }
+            }
+        }
+
         // Content hub (cross-type landing)
         if (hasRoute('content')) routes.add(`/${locale}/content`)
     }
@@ -388,6 +414,7 @@ function checkPublishedHasRoute(validPaths: Set<string>) {
         { dir: 'use-cases', urlPattern: (l, s) => `/${l}/use-cases/${s}` },
         { dir: 'stories', urlPattern: (l, s) => `/${l}/stories/${s}` },
         { dir: 'withdraw', urlPattern: (l, s) => `/${l}/withdraw/${s}` },
+        { dir: 'split-guides', urlPattern: (l, s) => `/${l}/split/guides/${s}` },
     ]
 
     let issues = 0
@@ -473,14 +500,15 @@ function checkFrontmatter() {
 
         if (!isPublished(content)) continue
 
-        if (!fm.title || (typeof fm.title === 'string' && fm.title.trim() === '')) {
+        if (typeof fm.title !== 'string' || fm.title.trim() === '') {
             error('frontmatter', 'Published file missing title', rel(file))
             issues++
         }
-        if (!fm.description || (typeof fm.description === 'string' && fm.description.trim() === '')) {
+        if (typeof fm.description !== 'string' || fm.description.trim() === '') {
             error('frontmatter', 'Published file missing description', rel(file))
             issues++
         }
+
         // published field is now optional — missing defaults to published
     }
 
@@ -698,6 +726,9 @@ function expectedSitemapUrls(): string[] {
     const storySlugs = listDirs(path.join(CONTENT_DIR, 'stories')).filter((s) => s !== 'index')
     const useCaseSlugs = listDirs(path.join(CONTENT_DIR, 'use-cases'))
     const withdrawSlugs = listDirs(path.join(CONTENT_DIR, 'withdraw'))
+    const splitGuideSlugs = listDirs(path.join(CONTENT_DIR, 'split-guides')).filter((slug) =>
+        hasPublishedLocalePage('split-guides', slug, 'en')
+    )
 
     // Corridors (send-to/{dst}/from/{origin}/{lang}.md)
     const corridors: Array<{ from: string; to: string }> = []
@@ -729,6 +760,11 @@ function expectedSitemapUrls(): string[] {
         urls.push(`/${locale}/content`)
         urls.push(`/${locale}/blog`)
         for (const slug of blogSlugs) urls.push(`/${locale}/blog/${slug}`)
+        for (const slug of splitGuideSlugs) {
+            if (hasPublishedLocalePage('split-guides', slug, locale)) {
+                urls.push(`/${locale}/split/guides/${slug}`)
+            }
+        }
     }
 
     // Asymmetry guard: if a whole family has zero slugs, the sitemap will emit
@@ -761,7 +797,7 @@ function checkSitemapCoverage(validPaths: Set<string>) {
         if (validPaths.has(url)) continue
         // Collapse identical messages across locales — one entry per pattern
         // is enough to fix; the full count is in the summary line.
-        const key = url.replace(/^\/(en|es-419|es-ar|es-es|pt-br)\//, '/{locale}/')
+        const key = url.replace(/^\/(en|es-419|es-ar|pt-br)\//, '/{locale}/')
         if (reported.has(key)) {
             missing++
             continue
@@ -777,7 +813,7 @@ function checkSitemapCoverage(validPaths: Set<string>) {
 
 // --- Main ---
 
-function main() {
+async function main() {
     console.log('Peanut Content Verification\n')
 
     console.log('Building route index from actual page.tsx files...')
@@ -796,6 +832,14 @@ function main() {
     checkSubmoduleFreshness()
     checkPageCountRegression()
     checkSitemapCoverage(validPaths)
+    const splitGuideResult = await verifySplitGuides({
+        contentDir: CONTENT_DIR,
+        manifestPath: path.join(ROOT, 'generated/split-guide-manifest.json'),
+        reportError: (check, message, file) => error(check, message, file ? rel(file) : undefined),
+    })
+    console.log(
+        `  Pass 12 — Split guide canary: ${splitGuideResult.recordsChecked === 0 ? 'no guide files yet (route remains inert)' : `${splitGuideResult.recordsChecked} exact-locale files checked`}`
+    )
 
     // Report
     const errors = diagnostics.filter((d) => d.level === 'error')
@@ -834,4 +878,7 @@ function main() {
     }
 }
 
-main()
+main().catch((cause) => {
+    console.error(cause)
+    process.exit(1)
+})

--- a/scripts/verify-content.ts
+++ b/scripts/verify-content.ts
@@ -29,7 +29,7 @@
 import fs from 'fs'
 import path from 'path'
 import { RAIL_SLUGS } from '../src/data/seo/deposit-rails'
-import { verifySplitGuides } from './lib/verify-split-guides'
+import { SPLIT_GUIDE_LOCALES, verifySplitGuides } from './lib/verify-split-guides'
 
 const ROOT = path.join(process.cwd(), 'src/content')
 const CONTENT_DIR = path.join(ROOT, 'content')
@@ -37,6 +37,7 @@ const APP_DIR = path.join(process.cwd(), 'src/app/[locale]/(marketing)')
 
 const SUPPORTED_LOCALES = ['en', 'es-419', 'es-ar', 'pt-br']
 const PRIMARY_LOCALES = ['en', 'es-419', 'pt-br']
+const SPLIT_GUIDE_LOCALE_SET = new Set<string>(SPLIT_GUIDE_LOCALES)
 
 // `content/deposit/` mixes two URL families on the same dynamic route:
 //   exchanges → /{locale}/deposit/from-{slug}
@@ -159,6 +160,12 @@ function hasPublishedLocalePage(intent: string, slug: string, locale: string): b
     return fs.existsSync(file) && isPublished(fs.readFileSync(file, 'utf-8'))
 }
 
+function publishedSplitGuideSlugs(): string[] {
+    return listDirs(path.join(CONTENT_DIR, 'split-guides')).filter((slug) =>
+        hasPublishedLocalePage('split-guides', slug, 'en')
+    )
+}
+
 // --- Build valid paths from actual routes ---
 
 function discoverRoutes(): Set<string> {
@@ -197,9 +204,7 @@ function discoverRoutes(): Set<string> {
     const storySlugs = listDirs(path.join(CONTENT_DIR, 'stories')).filter((s) => s !== 'index')
     const withdrawSlugs = listDirs(path.join(CONTENT_DIR, 'withdraw'))
     const blogSlugs = listDirs(path.join(CONTENT_DIR, 'blog')).filter((s) => s !== 'index')
-    const splitGuideSlugs = listDirs(path.join(CONTENT_DIR, 'split-guides')).filter((slug) =>
-        hasPublishedLocalePage('split-guides', slug, 'en')
-    )
+    const splitGuideSlugs = publishedSplitGuideSlugs()
 
     // Corridors
     const corridors: Array<{ to: string; from: string }> = []
@@ -306,7 +311,7 @@ function discoverRoutes(): Set<string> {
 
         // Split guides are exact-locale only: never manufacture a route whose
         // locale file would have to fall back.
-        if (hasRoute('split/guides/[slug]')) {
+        if (SPLIT_GUIDE_LOCALE_SET.has(locale) && hasRoute('split/guides/[slug]')) {
             for (const slug of splitGuideSlugs) {
                 if (hasPublishedLocalePage('split-guides', slug, locale)) {
                     routes.add(`/${locale}/split/guides/${slug}`)
@@ -726,9 +731,7 @@ function expectedSitemapUrls(): string[] {
     const storySlugs = listDirs(path.join(CONTENT_DIR, 'stories')).filter((s) => s !== 'index')
     const useCaseSlugs = listDirs(path.join(CONTENT_DIR, 'use-cases'))
     const withdrawSlugs = listDirs(path.join(CONTENT_DIR, 'withdraw'))
-    const splitGuideSlugs = listDirs(path.join(CONTENT_DIR, 'split-guides')).filter((slug) =>
-        hasPublishedLocalePage('split-guides', slug, 'en')
-    )
+    const splitGuideSlugs = publishedSplitGuideSlugs()
 
     // Corridors (send-to/{dst}/from/{origin}/{lang}.md)
     const corridors: Array<{ from: string; to: string }> = []
@@ -760,9 +763,11 @@ function expectedSitemapUrls(): string[] {
         urls.push(`/${locale}/content`)
         urls.push(`/${locale}/blog`)
         for (const slug of blogSlugs) urls.push(`/${locale}/blog/${slug}`)
-        for (const slug of splitGuideSlugs) {
-            if (hasPublishedLocalePage('split-guides', slug, locale)) {
-                urls.push(`/${locale}/split/guides/${slug}`)
+        if (SPLIT_GUIDE_LOCALE_SET.has(locale)) {
+            for (const slug of splitGuideSlugs) {
+                if (hasPublishedLocalePage('split-guides', slug, locale)) {
+                    urls.push(`/${locale}/split/guides/${slug}`)
+                }
             }
         }
     }
@@ -835,6 +840,9 @@ async function main() {
     const splitGuideResult = await verifySplitGuides({
         contentDir: CONTENT_DIR,
         manifestPath: path.join(ROOT, 'generated/split-guide-manifest.json'),
+        // The mirrored UI content checkout intentionally excludes compose
+        // briefs. Content/release audits can opt into raw source verification.
+        sourceRoot: process.env.SPLIT_GUIDE_SOURCE_ROOT,
         reportError: (check, message, file) => error(check, message, file ? rel(file) : undefined),
     })
     console.log(

--- a/src/app/[locale]/(marketing)/layout.tsx
+++ b/src/app/[locale]/(marketing)/layout.tsx
@@ -25,7 +25,7 @@ export default async function LocalizedMarketingLayout({ children, params }: Lay
     }
 
     return (
-        <main className="flex min-h-dvh flex-col bg-white" lang={locale}>
+        <main className="flex min-h-dvh flex-col bg-white" data-marketing-locale={locale} lang={locale}>
             <HtmlLang locale={locale} />
             <LocaleSuggestion locale={locale} />
             <div className="flex-1">{children}</div>

--- a/src/app/[locale]/(marketing)/split/[...path]/page.tsx
+++ b/src/app/[locale]/(marketing)/split/[...path]/page.tsx
@@ -1,0 +1,12 @@
+import { notFound } from 'next/navigation'
+
+/** Reserve the unfinished Split namespace without pre-rendering any paths. */
+export function generateStaticParams() {
+    return []
+}
+
+export const dynamicParams = false
+
+export default function SplitNamespacePlaceholder() {
+    notFound()
+}

--- a/src/app/[locale]/(marketing)/split/[...path]/page.tsx
+++ b/src/app/[locale]/(marketing)/split/[...path]/page.tsx
@@ -1,12 +1,6 @@
 import { notFound } from 'next/navigation'
 
-/** Reserve the unfinished Split namespace without pre-rendering any paths. */
-export function generateStaticParams() {
-    return []
-}
-
-export const dynamicParams = false
-
-export default function SplitNamespacePlaceholder() {
+/** Reserve every unfinished Split subtree as a real dynamic 404. */
+export default function SplitNamespacePlaceholder(): never {
     notFound()
 }

--- a/src/app/[locale]/(marketing)/split/guides/[slug]/page.tsx
+++ b/src/app/[locale]/(marketing)/split/guides/[slug]/page.tsx
@@ -87,7 +87,10 @@ export default async function SplitGuidePage({ params }: PageProps) {
                         </time>
                     </header>
                 </div>
-                {content}
+                {/* Card CTA mascots extend above their container; keep that clearance scoped to Split guides. */}
+                <div data-split-guide-body className="[&_[data-mdx-cta=card]]:!pt-24 md:[&_[data-mdx-cta=card]]:!pt-28">
+                    {content}
+                </div>
             </ContentPage>
         </>
     )

--- a/src/app/[locale]/(marketing)/split/guides/[slug]/page.tsx
+++ b/src/app/[locale]/(marketing)/split/guides/[slug]/page.tsx
@@ -1,0 +1,94 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import type { Metadata } from 'next'
+import { ContentPage } from '@/components/Marketing/ContentPage'
+import { JsonLd } from '@/components/Marketing/JsonLd'
+import { getTranslations } from '@/i18n'
+import { HREFLANG_MAP, isValidLocale } from '@/i18n/config'
+import { LOCALE_META } from '@/i18n/localeMeta'
+import { renderContent } from '@/lib/mdx'
+import {
+    buildSplitGuideBlogPosting,
+    buildSplitGuideMetadata,
+    getAvailableSplitGuideLocales,
+    getSplitGuideStaticParams,
+    readPublishedSplitGuide,
+    splitGuideDate,
+    splitGuidePath,
+} from '@/lib/split-guides'
+
+interface PageProps {
+    params: Promise<{ locale: string; slug: string }>
+}
+
+export function generateStaticParams() {
+    return getSplitGuideStaticParams()
+}
+
+export const dynamicParams = false
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { locale, slug } = await params
+    if (!isValidLocale(locale)) return {}
+
+    const guide = readPublishedSplitGuide(slug, locale)
+    if (!guide) return {}
+
+    return buildSplitGuideMetadata(guide.frontmatter, locale, slug, getAvailableSplitGuideLocales(slug))
+}
+
+export default async function SplitGuidePage({ params }: PageProps) {
+    const { locale, slug } = await params
+    if (!isValidLocale(locale)) notFound()
+
+    const guide = readPublishedSplitGuide(slug, locale)
+    if (!guide) notFound()
+
+    const { content } = await renderContent(guide.body, locale)
+    const availableLocales = getAvailableSplitGuideLocales(slug)
+    const i18n = getTranslations(locale)
+    const url = splitGuidePath(locale, slug)
+    const date = splitGuideDate(guide.frontmatter)
+    if (!date) notFound()
+
+    return (
+        <>
+            <JsonLd data={buildSplitGuideBlogPosting(guide.frontmatter, locale, slug)} />
+            <ContentPage
+                locale={locale}
+                breadcrumbs={[
+                    { name: i18n.home, href: `/${locale}` },
+                    { name: guide.frontmatter.title, href: url },
+                ]}
+            >
+                <div className="mx-auto max-w-[640px] px-6 pb-12 pt-8 md:px-4 md:pt-12">
+                    {availableLocales.length > 1 && (
+                        <nav aria-label={i18n.footerLanguage} className="mb-6 flex flex-wrap gap-2">
+                            {availableLocales.map((candidate) => (
+                                <Link
+                                    key={candidate}
+                                    href={splitGuidePath(candidate, slug)}
+                                    hrefLang={HREFLANG_MAP[candidate]}
+                                    aria-current={candidate === locale ? 'page' : undefined}
+                                    className={`rounded-sm border border-n-1 px-2 py-1 text-xs font-semibold transition-colors hover:bg-primary-3/30 ${
+                                        candidate === locale ? 'bg-primary-1/20' : 'bg-white'
+                                    }`}
+                                >
+                                    {LOCALE_META[candidate].shortLabel}
+                                </Link>
+                            ))}
+                        </nav>
+                    )}
+                    <header className="mb-8 border-b border-n-1 pb-6">
+                        <h1 className="text-3xl font-bold md:text-4xl">{guide.frontmatter.title}</h1>
+                        <p className="mt-2 text-gray-600">{guide.frontmatter.description}</p>
+                        <time dateTime={date} className="mt-3 block text-sm text-gray-400">
+                            {date}
+                        </time>
+                    </header>
+                </div>
+                {content}
+            </ContentPage>
+        </>
+    )
+}

--- a/src/app/[locale]/(marketing)/split/page.tsx
+++ b/src/app/[locale]/(marketing)/split/page.tsx
@@ -1,0 +1,10 @@
+import { notFound } from 'next/navigation'
+
+/**
+ * Reserve /{locale}/split as a literal marketing route. Until the Split landing
+ * is migrated, it must be an intentional 404 rather than falling through to the
+ * legacy country/recipient-shaped catch-all.
+ */
+export default function SplitLandingPlaceholder() {
+    notFound()
+}

--- a/src/app/__tests__/split-guides-route.test.tsx
+++ b/src/app/__tests__/split-guides-route.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen } from '@testing-library/react'
+import { notFound } from 'next/navigation'
+import SplitLandingPlaceholder from '@/app/[locale]/(marketing)/split/page'
+import SplitNamespacePlaceholder, {
+    generateStaticParams as generateNamespaceStaticParams,
+} from '@/app/[locale]/(marketing)/split/[...path]/page'
+import SplitGuidePage, {
+    generateMetadata,
+    generateStaticParams,
+} from '@/app/[locale]/(marketing)/split/guides/[slug]/page'
+import { BASE_URL } from '@/constants/general.consts'
+import type { MarkdownContent } from '@/lib/content'
+import {
+    getAvailableSplitGuideLocales,
+    getSplitGuideStaticParams,
+    readPublishedSplitGuide,
+    type SplitGuideFrontmatter,
+} from '@/lib/split-guides'
+
+jest.mock('next/navigation', () => ({
+    notFound: jest.fn(() => {
+        throw new Error('NEXT_NOT_FOUND')
+    }),
+}))
+
+jest.mock('@/lib/mdx', () => {
+    const React = jest.requireActual<typeof import('react')>('react')
+    return {
+        renderContent: jest.fn(async () => ({
+            content: React.createElement('section', null, React.createElement('h2', null, 'Guide body')),
+        })),
+    }
+})
+
+jest.mock('@/lib/split-guides', () => {
+    const actual = jest.requireActual<typeof import('@/lib/split-guides')>('@/lib/split-guides')
+    return {
+        ...actual,
+        getAvailableSplitGuideLocales: jest.fn(),
+        getSplitGuideStaticParams: jest.fn(),
+        readPublishedSplitGuide: jest.fn(),
+    }
+})
+
+const SLUG = 'split-a-group-trip-across-countries'
+const guide: MarkdownContent<SplitGuideFrontmatter> = {
+    frontmatter: {
+        title: 'How to Split a Group Trip Across Countries',
+        description: 'A precise guide to recording shared travel expenses across several countries and currencies.',
+        date: '2026-07-28',
+        author: 'Peanut',
+        published: true,
+    },
+    body: '## Guide body',
+}
+
+const mockedNotFound = jest.mocked(notFound)
+const mockedAvailableLocales = jest.mocked(getAvailableSplitGuideLocales)
+const mockedStaticParams = jest.mocked(getSplitGuideStaticParams)
+const mockedReadGuide = jest.mocked(readPublishedSplitGuide)
+
+describe('Split route ownership and guide rendering', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockedAvailableLocales.mockReturnValue(['en', 'es-419', 'pt-br'])
+        mockedStaticParams.mockReturnValue([
+            { locale: 'en', slug: SLUG },
+            { locale: 'es-419', slug: SLUG },
+            { locale: 'pt-br', slug: SLUG },
+        ])
+        mockedReadGuide.mockReturnValue(guide)
+    })
+
+    it('reserves the bare and unknown localized Split namespace as intentional 404s', () => {
+        expect(() => SplitLandingPlaceholder()).toThrow('NEXT_NOT_FOUND')
+        expect(generateNamespaceStaticParams()).toEqual([])
+        expect(() => SplitNamespacePlaceholder()).toThrow('NEXT_NOT_FOUND')
+        expect(mockedNotFound).toHaveBeenCalledTimes(2)
+    })
+
+    it('passes through only the guide params selected by the exact-file helper', () => {
+        expect(generateStaticParams()).toEqual([
+            { locale: 'en', slug: SLUG },
+            { locale: 'es-419', slug: SLUG },
+            { locale: 'pt-br', slug: SLUG },
+        ])
+    })
+
+    it('404s an exact supported locale when that locale file is missing', async () => {
+        mockedReadGuide.mockReturnValue(null)
+
+        await expect(SplitGuidePage({ params: Promise.resolve({ locale: 'es-ar', slug: SLUG }) })).rejects.toThrow(
+            'NEXT_NOT_FOUND'
+        )
+        expect(mockedReadGuide).toHaveBeenCalledWith(SLUG, 'es-ar')
+        expect(mockedNotFound).toHaveBeenCalledTimes(1)
+    })
+
+    it('renders one route-owned H1, one BlogPosting and no Article schema', async () => {
+        const { container } = render(await SplitGuidePage({ params: Promise.resolve({ locale: 'en', slug: SLUG }) }))
+
+        expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1)
+        expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(guide.frontmatter.title)
+
+        const schemas = Array.from(container.querySelectorAll('script[type="application/ld+json"]')).map(
+            (script) => JSON.parse(script.textContent ?? '{}') as Record<string, unknown>
+        )
+        expect(schemas.filter((schema) => schema['@type'] === 'BlogPosting')).toHaveLength(1)
+        expect(schemas.filter((schema) => schema['@type'] === 'BreadcrumbList')).toHaveLength(1)
+        expect(schemas.filter((schema) => schema['@type'] === 'Article')).toHaveLength(0)
+    })
+
+    it('builds exact metadata from mocked content without absent locale signals', async () => {
+        const metadata = await generateMetadata({
+            params: Promise.resolve({ locale: 'es-419', slug: SLUG }),
+        })
+
+        expect(metadata.title).toBe(`${guide.frontmatter.title} | Peanut`)
+        expect(metadata.alternates).toMatchObject({
+            canonical: `/es-419/split/guides/${SLUG}`,
+            languages: {
+                'x-default': `${BASE_URL}/en/split/guides/${SLUG}`,
+                en: `${BASE_URL}/en/split/guides/${SLUG}`,
+                'es-419': `${BASE_URL}/es-419/split/guides/${SLUG}`,
+                'pt-BR': `${BASE_URL}/pt-br/split/guides/${SLUG}`,
+            },
+        })
+        expect(metadata.alternates?.languages).not.toHaveProperty('es-AR')
+        expect(metadata.openGraph).toMatchObject({
+            locale: 'es_LA',
+            alternateLocale: ['en_US', 'pt_BR'],
+        })
+        expect(metadata.openGraph).not.toMatchObject({ alternateLocale: expect.arrayContaining(['es_AR']) })
+    })
+})

--- a/src/app/__tests__/split-guides-route.test.tsx
+++ b/src/app/__tests__/split-guides-route.test.tsx
@@ -104,6 +104,11 @@ describe('Split route ownership and guide rendering', () => {
 
         expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1)
         expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(guide.frontmatter.title)
+        expect(container.querySelector('[data-split-guide-body]')).toHaveClass(
+            '[&_[data-mdx-cta=card]]:!pt-24',
+            'md:[&_[data-mdx-cta=card]]:!pt-28'
+        )
+        expect(container.querySelector('[data-split-guide-body]')).toHaveTextContent('Guide body')
 
         const schemas = Array.from(container.querySelectorAll('script[type="application/ld+json"]')).map(
             (script) => JSON.parse(script.textContent ?? '{}') as Record<string, unknown>

--- a/src/app/__tests__/split-guides-route.test.tsx
+++ b/src/app/__tests__/split-guides-route.test.tsx
@@ -1,9 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import { notFound } from 'next/navigation'
 import SplitLandingPlaceholder from '@/app/[locale]/(marketing)/split/page'
-import SplitNamespacePlaceholder, {
-    generateStaticParams as generateNamespaceStaticParams,
-} from '@/app/[locale]/(marketing)/split/[...path]/page'
+import SplitNamespacePlaceholder from '@/app/[locale]/(marketing)/split/[...path]/page'
+import * as splitNamespaceRoute from '@/app/[locale]/(marketing)/split/[...path]/page'
 import SplitGuidePage, {
     generateMetadata,
     generateStaticParams,
@@ -73,9 +72,13 @@ describe('Split route ownership and guide rendering', () => {
 
     it('reserves the bare and unknown localized Split namespace as intentional 404s', () => {
         expect(() => SplitLandingPlaceholder()).toThrow('NEXT_NOT_FOUND')
-        expect(generateNamespaceStaticParams()).toEqual([])
         expect(() => SplitNamespacePlaceholder()).toThrow('NEXT_NOT_FOUND')
         expect(mockedNotFound).toHaveBeenCalledTimes(2)
+    })
+
+    it('keeps the Split fallback dynamic instead of opting into empty static params', () => {
+        expect(splitNamespaceRoute).not.toHaveProperty('generateStaticParams')
+        expect(splitNamespaceRoute).not.toHaveProperty('dynamicParams')
     })
 
     it('passes through only the guide params selected by the exact-file helper', () => {

--- a/src/app/es-419/page.tsx
+++ b/src/app/es-419/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = landingMetadata(LOCALE)
 
 export default function EsLatamLandingPage() {
     return (
-        <>
+        <main data-marketing-locale={LOCALE} lang={LOCALE}>
             <HtmlLang locale={LOCALE} />
             <LocaleSuggestion locale={LOCALE} />
             <LandingPageCapacitorGate>
@@ -23,6 +23,6 @@ export default function EsLatamLandingPage() {
                     <LandingPageContent locale={LOCALE} />
                 </LandingPageShell>
             </LandingPageCapacitorGate>
-        </>
+        </main>
     )
 }

--- a/src/app/es-ar/page.tsx
+++ b/src/app/es-ar/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = landingMetadata(LOCALE)
 
 export default function EsArgentinaLandingPage() {
     return (
-        <>
+        <main data-marketing-locale={LOCALE} lang={LOCALE}>
             <HtmlLang locale={LOCALE} />
             <LocaleSuggestion locale={LOCALE} />
             <LandingPageCapacitorGate>
@@ -23,6 +23,6 @@ export default function EsArgentinaLandingPage() {
                     <LandingPageContent locale={LOCALE} />
                 </LandingPageShell>
             </LandingPageCapacitorGate>
-        </>
+        </main>
     )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,13 +11,13 @@ export const metadata = landingMetadata(DEFAULT_LOCALE)
 
 export default function RootPage() {
     return (
-        <>
+        <main data-marketing-locale={DEFAULT_LOCALE} lang={DEFAULT_LOCALE}>
             <LocaleSuggestion locale={DEFAULT_LOCALE} />
             <LandingPageCapacitorGate>
                 <LandingPageShell>
                     <LandingPageContent locale={DEFAULT_LOCALE} />
                 </LandingPageShell>
             </LandingPageCapacitorGate>
-        </>
+        </main>
     )
 }

--- a/src/app/pt-br/page.tsx
+++ b/src/app/pt-br/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = landingMetadata(LOCALE)
 
 export default function PtBrLandingPage() {
     return (
-        <>
+        <main data-marketing-locale={LOCALE} lang={LOCALE}>
             <HtmlLang locale={LOCALE} />
             <LocaleSuggestion locale={LOCALE} />
             <LandingPageCapacitorGate>
@@ -23,6 +23,6 @@ export default function PtBrLandingPage() {
                     <LandingPageContent locale={LOCALE} />
                 </LandingPageShell>
             </LandingPageCapacitorGate>
-        </>
+        </main>
     )
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -17,6 +17,11 @@ import {
     listContentSlugs,
     listPublishedSlugs,
 } from '@/lib/content'
+import {
+    buildSplitGuideSitemapRows,
+    getAvailableSplitGuideLocales,
+    getSplitGuideStaticParams,
+} from '@/lib/split-guides'
 
 // TODO (infra): Update GitHub org, Twitter bio, LinkedIn, npm package.json → peanut.me
 // TODO (GA4): Create data filter to exclude trafficheap.com referral traffic
@@ -30,6 +35,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
         priority: number
         changeFrequency: MetadataRoute.Sitemap[number]['changeFrequency']
         lastModified?: Date
+        alternates?: { languages: Record<string, string> }
     }
 
     const pages: SitemapEntry[] = [
@@ -47,6 +53,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
         { path: '/en/privacy', priority: 0.5, changeFrequency: 'yearly' },
         { path: '/en/terms', priority: 0.5, changeFrequency: 'yearly' },
     ]
+    const splitGuideRows = buildSplitGuideSitemapRows(getSplitGuideStaticParams(), getAvailableSplitGuideLocales)
 
     // --- Programmatic SEO pages (all locales with /{locale}/ prefix) ---
     for (const locale of SUPPORTED_LOCALES) {
@@ -226,6 +233,17 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
             })
         }
 
+        // Split guides intentionally have no locale fallback. Only an exact,
+        // published file may enter the sitemap.
+        for (const guide of splitGuideRows.filter((row) => row.locale === locale)) {
+            pages.push({
+                path: guide.path,
+                priority: 0.6 * basePriority,
+                changeFrequency: 'monthly',
+                alternates: guide.alternates,
+            })
+        }
+
         // Team pages excluded from production sitemap (not yet launched)
     }
 
@@ -234,6 +252,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
         lastModified: page.lastModified ?? BUILD_DATE,
         changeFrequency: page.changeFrequency,
         priority: page.priority,
+        ...(page.alternates ? { alternates: page.alternates } : {}),
     }))
 }
 

--- a/src/components/Marketing/LocaleSuggestion.tsx
+++ b/src/components/Marketing/LocaleSuggestion.tsx
@@ -55,9 +55,9 @@ export function LocaleSuggestion({ locale }: { locale: Locale }) {
 
     // Always render the wrapper, even when there's nothing to suggest. Returning
     // null during SSR leaves React no anchor for the node the effect creates
-    // later, and on the landing page — whose parent container is <body>, full of
-    // Next's streamed nodes — the banner got appended at the very bottom of the
-    // page instead of the top. An empty div collapses to zero height.
+    // later. On the landing page that once made the banner jump below Next's
+    // streamed nodes instead of staying at the top. An empty div collapses to
+    // zero height and preserves the insertion point.
     if (!suggested) return <div />
 
     const i18n = STRINGS[suggested]

--- a/src/components/Marketing/LocaleSwitcher.tsx
+++ b/src/components/Marketing/LocaleSwitcher.tsx
@@ -25,6 +25,18 @@ export function localeHref(pathname: string, target: Locale): string {
     return `/${target}/${rest.join('/')}`
 }
 
+/**
+ * Exact-locale content renders its own availability-aware switcher. The global
+ * footer cannot inspect server-side content files, so it must stay out of the
+ * way instead of inventing links to missing locale variants.
+ */
+export function hasRouteScopedLocaleSwitcher(pathname: string): boolean {
+    const segments = pathname.split('/').filter(Boolean)
+    return (
+        isValidLocale(segments[0] ?? '') && segments[1] === 'split' && segments[2] === 'guides' && segments.length > 3
+    )
+}
+
 // Fixed so the trigger keeps its size whichever language is selected.
 const TRIGGER_WIDTH = 'w-40'
 
@@ -53,6 +65,8 @@ export function LocaleSwitcher({ locale, label }: { locale: Locale; label: strin
             document.removeEventListener('keydown', onKey)
         }
     }, [])
+
+    if (hasRouteScopedLocaleSwitcher(pathname)) return null
 
     return (
         <div ref={wrapperRef} className="relative">

--- a/src/components/Marketing/__tests__/html-lang.test.tsx
+++ b/src/components/Marketing/__tests__/html-lang.test.tsx
@@ -1,0 +1,100 @@
+import { render, waitFor } from '@testing-library/react'
+import { AppIntlProvider } from '@/i18n/app/AppIntlProvider'
+import { HtmlLang } from '@/components/Marketing/HtmlLang'
+import LocalizedMarketingLayout from '@/app/[locale]/(marketing)/layout'
+
+jest.mock('@/i18n/app/locale-store', () => ({
+    currentAppLocale: jest.fn(() => null),
+    emitDeviceContextToAnalytics: jest.fn(async () => {}),
+    emitLocaleToAnalytics: jest.fn(),
+    localeReady: jest.fn(async () => 'en'),
+    markLocaleApplied: jest.fn(),
+    persistLocale: jest.fn(),
+}))
+
+describe('localized marketing document language', () => {
+    beforeEach(() => {
+        document.documentElement.lang = 'en'
+    })
+
+    afterEach(() => {
+        document.body.replaceChildren()
+    })
+
+    function renderInMarketingRoot({ marker, lang }: { marker?: string; lang?: string }, children?: React.ReactNode) {
+        const marketingRoot = document.createElement('main')
+        if (marker) marketingRoot.dataset.marketingLocale = marker
+        if (lang) marketingRoot.lang = lang
+        document.body.append(marketingRoot)
+
+        return render(<AppIntlProvider>{children}</AppIntlProvider>, { container: marketingRoot })
+    }
+
+    it.each(['es-419', 'pt-br'] as const)('server-renders the %s route owner on the layout main', async (locale) => {
+        const layout = await LocalizedMarketingLayout({
+            children: <div>Guide</div>,
+            params: Promise.resolve({ locale }),
+        })
+
+        expect(layout).toMatchObject({
+            type: 'main',
+            props: {
+                'data-marketing-locale': locale,
+                lang: locale,
+            },
+        })
+    })
+
+    it.each(['es-419', 'pt-br'] as const)(
+        'keeps the route-owned %s locale after the global app locale provider hydrates',
+        async (locale) => {
+            renderInMarketingRoot({ marker: locale, lang: locale }, <HtmlLang locale={locale} />)
+
+            await waitFor(() => expect(document.documentElement.lang).toBe(locale))
+        }
+    )
+
+    it('uses the app locale when the page does not own a document language', async () => {
+        render(
+            <AppIntlProvider>
+                <div>Product UI</div>
+            </AppIntlProvider>
+        )
+
+        await waitFor(() => expect(document.documentElement.lang).toBe('en'))
+    })
+
+    it.each([
+        [
+            'an unmarked nested main',
+            <main key="unmarked" lang="pt-br">
+                Untrusted content
+            </main>,
+        ],
+        [
+            'a supported marked nested main',
+            <main key="supported-nested" data-marketing-locale="pt-br" lang="pt-br">
+                Spoofed route owner
+            </main>,
+        ],
+        [
+            'a nested mismatched marker and lang values',
+            <main key="nested-mismatched" data-marketing-locale="es-419" lang="pt-br">
+                Spoofed mismatched route
+            </main>,
+        ],
+    ])('does not let %s override the product app locale', async (_case, content) => {
+        render(<AppIntlProvider>{content}</AppIntlProvider>)
+
+        await waitFor(() => expect(document.documentElement.lang).toBe('en'))
+    })
+
+    it.each([
+        ['an unsupported direct route locale', { marker: 'fr', lang: 'fr' }],
+        ['mismatched direct route marker and lang values', { marker: 'es-419', lang: 'pt-br' }],
+    ])('does not let %s override the product app locale', async (_case, attributes) => {
+        renderInMarketingRoot(attributes)
+
+        await waitFor(() => expect(document.documentElement.lang).toBe('en'))
+    })
+})

--- a/src/components/Marketing/__tests__/html-lang.test.tsx
+++ b/src/components/Marketing/__tests__/html-lang.test.tsx
@@ -1,7 +1,14 @@
 import { render, waitFor } from '@testing-library/react'
-import { AppIntlProvider } from '@/i18n/app/AppIntlProvider'
+import { AppIntlProvider, useAppLocale } from '@/i18n/app/AppIntlProvider'
 import { HtmlLang } from '@/components/Marketing/HtmlLang'
 import LocalizedMarketingLayout from '@/app/[locale]/(marketing)/layout'
+import { localeReady } from '@/i18n/app/locale-store'
+
+let mockPathname = '/'
+
+jest.mock('next/navigation', () => ({
+    usePathname: () => mockPathname,
+}))
 
 jest.mock('@/i18n/app/locale-store', () => ({
     currentAppLocale: jest.fn(() => null),
@@ -13,8 +20,12 @@ jest.mock('@/i18n/app/locale-store', () => ({
 }))
 
 describe('localized marketing document language', () => {
+    const mockedLocaleReady = jest.mocked(localeReady)
+
     beforeEach(() => {
         document.documentElement.lang = 'en'
+        mockPathname = '/'
+        mockedLocaleReady.mockResolvedValue('en')
     })
 
     afterEach(() => {
@@ -28,6 +39,11 @@ describe('localized marketing document language', () => {
         document.body.append(marketingRoot)
 
         return render(<AppIntlProvider>{children}</AppIntlProvider>, { container: marketingRoot })
+    }
+
+    function LocaleProbe() {
+        const { locale } = useAppLocale()
+        return <span data-testid="app-locale">{locale}</span>
     }
 
     it.each(['es-419', 'pt-br'] as const)('server-renders the %s route owner on the layout main', async (locale) => {
@@ -62,6 +78,33 @@ describe('localized marketing document language', () => {
         )
 
         await waitFor(() => expect(document.documentElement.lang).toBe('en'))
+    })
+
+    it('restores the selected app locale after leaving a localized marketing route', async () => {
+        mockedLocaleReady.mockResolvedValue('pt-BR')
+        mockPathname = '/es-419/split/guides/example'
+        const view = renderInMarketingRoot(
+            { marker: 'es-419', lang: 'es-419' },
+            <>
+                <HtmlLang locale="es-419" />
+                <LocaleProbe />
+            </>
+        )
+
+        await waitFor(() => expect(view.getByTestId('app-locale')).toHaveTextContent('pt-BR'))
+        expect(document.documentElement.lang).toBe('es-419')
+
+        mockPathname = '/home'
+        view.container.removeAttribute('data-marketing-locale')
+        view.container.removeAttribute('lang')
+        view.rerender(
+            <AppIntlProvider>
+                <LocaleProbe />
+                <div>Product UI</div>
+            </AppIntlProvider>
+        )
+
+        await waitFor(() => expect(document.documentElement.lang).toBe('pt-BR'))
     })
 
     it.each([

--- a/src/components/Marketing/__tests__/html-lang.test.tsx
+++ b/src/components/Marketing/__tests__/html-lang.test.tsx
@@ -2,6 +2,10 @@ import { render, waitFor } from '@testing-library/react'
 import { AppIntlProvider, useAppLocale } from '@/i18n/app/AppIntlProvider'
 import { HtmlLang } from '@/components/Marketing/HtmlLang'
 import LocalizedMarketingLayout from '@/app/[locale]/(marketing)/layout'
+import RootPage from '@/app/page'
+import EsLatamLandingPage from '@/app/es-419/page'
+import EsArgentinaLandingPage from '@/app/es-ar/page'
+import PtBrLandingPage from '@/app/pt-br/page'
 import { localeReady } from '@/i18n/app/locale-store'
 
 let mockPathname = '/'
@@ -61,6 +65,21 @@ describe('localized marketing document language', () => {
         })
     })
 
+    it.each([
+        ['en', RootPage],
+        ['es-419', EsLatamLandingPage],
+        ['es-ar', EsArgentinaLandingPage],
+        ['pt-br', PtBrLandingPage],
+    ] as const)('marks the literal %s landing page as its document-language owner', (locale, Page) => {
+        expect(Page()).toMatchObject({
+            type: 'main',
+            props: {
+                'data-marketing-locale': locale,
+                lang: locale,
+            },
+        })
+    })
+
     it.each(['es-419', 'pt-br'] as const)(
         'keeps the route-owned %s locale after the global app locale provider hydrates',
         async (locale) => {
@@ -105,6 +124,34 @@ describe('localized marketing document language', () => {
         )
 
         await waitFor(() => expect(document.documentElement.lang).toBe('pt-BR'))
+    })
+
+    it('preserves a literal landing locale when navigating from product UI', async () => {
+        mockedLocaleReady.mockResolvedValue('pt-BR')
+        mockPathname = '/home'
+        const view = renderInMarketingRoot(
+            {},
+            <>
+                <LocaleProbe />
+                <div>Product UI</div>
+            </>
+        )
+
+        await waitFor(() => expect(view.getByTestId('app-locale')).toHaveTextContent('pt-BR'))
+        expect(document.documentElement.lang).toBe('pt-BR')
+
+        mockPathname = '/es-419'
+        view.container.dataset.marketingLocale = 'es-419'
+        view.container.lang = 'es-419'
+        view.rerender(
+            <AppIntlProvider>
+                <HtmlLang locale="es-419" />
+                <LocaleProbe />
+                <div>Localized landing</div>
+            </AppIntlProvider>
+        )
+
+        await waitFor(() => expect(document.documentElement.lang).toBe('es-419'))
     })
 
     it.each([

--- a/src/components/Marketing/__tests__/locale-switcher.test.ts
+++ b/src/components/Marketing/__tests__/locale-switcher.test.ts
@@ -53,6 +53,8 @@ describe('localeHref', () => {
         expect(hasRouteScopedLocaleSwitcher('/en/split/guides/group-trip')).toBe(true)
         expect(hasRouteScopedLocaleSwitcher('/pt-br/split/guides/group-trip')).toBe(true)
         expect(hasRouteScopedLocaleSwitcher('/en/split')).toBe(false)
+        expect(hasRouteScopedLocaleSwitcher('/en/split/guides')).toBe(false)
+        expect(hasRouteScopedLocaleSwitcher('/en/split/guides/a/b')).toBe(true)
         expect(hasRouteScopedLocaleSwitcher('/split/guides/group-trip')).toBe(false)
         expect(hasRouteScopedLocaleSwitcher('/en/blog/group-trip')).toBe(false)
     })

--- a/src/components/Marketing/__tests__/locale-switcher.test.ts
+++ b/src/components/Marketing/__tests__/locale-switcher.test.ts
@@ -1,4 +1,4 @@
-import { localeHref } from '../LocaleSwitcher'
+import { hasRouteScopedLocaleSwitcher, localeHref } from '../LocaleSwitcher'
 
 describe('localeHref', () => {
     it('swaps the locale segment and keeps the rest of the path', () => {
@@ -47,5 +47,13 @@ describe('localeHref', () => {
     it('tolerates trailing slashes and double slashes', () => {
         expect(localeHref('/es-419/help/', 'en')).toBe('/en/help')
         expect(localeHref('//es-419//help', 'en')).toBe('/en/help')
+    })
+
+    it('defers to the exact-locale switcher on Split guide routes', () => {
+        expect(hasRouteScopedLocaleSwitcher('/en/split/guides/group-trip')).toBe(true)
+        expect(hasRouteScopedLocaleSwitcher('/pt-br/split/guides/group-trip')).toBe(true)
+        expect(hasRouteScopedLocaleSwitcher('/en/split')).toBe(false)
+        expect(hasRouteScopedLocaleSwitcher('/split/guides/group-trip')).toBe(false)
+        expect(hasRouteScopedLocaleSwitcher('/en/blog/group-trip')).toBe(false)
     })
 })

--- a/src/components/Marketing/mdx/CTA.tsx
+++ b/src/components/Marketing/mdx/CTA.tsx
@@ -43,7 +43,7 @@ export function CTA({ text, href, subtitle, variant = 'primary' }: CTAProps) {
 
     if (variant === 'card') {
         return (
-            <div className={`mx-auto ${PROSE_WIDTH} px-6 py-10 md:px-4 md:py-14`}>
+            <div data-mdx-cta="card" className={`mx-auto ${PROSE_WIDTH} px-6 py-10 md:px-4 md:py-14`}>
                 <div className="relative">
                     <Image
                         src={PeanutPointingDown}

--- a/src/components/Marketing/mdx/__tests__/CTA.test.tsx
+++ b/src/components/Marketing/mdx/__tests__/CTA.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@testing-library/react'
+import { CTA } from '@/components/Marketing/mdx/CTA'
+
+describe('CTA', () => {
+    it('exposes a semantic layout hook only for the card variant', () => {
+        const { container, rerender } = render(<CTA text="Start" href="https://example.com" variant="card" />)
+
+        expect(container.querySelector('[data-mdx-cta="card"]')).toBeInTheDocument()
+
+        rerender(<CTA text="Start" href="https://example.com" variant="primary" />)
+
+        expect(container.querySelector('[data-mdx-cta]')).not.toBeInTheDocument()
+    })
+})

--- a/src/constants/__tests__/routes.test.ts
+++ b/src/constants/__tests__/routes.test.ts
@@ -122,6 +122,7 @@ describe('isReservedRoute', () => {
     test('catches DEDICATED_ROUTES entries', () => {
         expect(isReservedRoute('/home')).toBe(true)
         expect(isReservedRoute('/send')).toBe(true)
+        expect(isReservedRoute('/split')).toBe(true)
         expect(isReservedRoute('/es-419')).toBe(true)
     })
 

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -66,6 +66,7 @@ export const DEDICATED_ROUTES = [
     'convert',
     'compare',
     'blog',
+    'split',
     'help',
     'faq',
     'how-it-works',

--- a/src/i18n/app/AppIntlProvider.tsx
+++ b/src/i18n/app/AppIntlProvider.tsx
@@ -2,6 +2,7 @@
 
 import { NextIntlClientProvider, IntlErrorCode, type IntlError } from 'next-intl'
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
+import { isValidLocale as isValidMarketingLocale } from '@/i18n/config'
 import { DEFAULT_APP_LOCALE, type AppLocale } from './config'
 import { loadMessages, type AppMessages } from './messages'
 import {
@@ -77,7 +78,20 @@ export function AppIntlProvider({ children }: { children: React.ReactNode }) {
     }, [])
 
     useEffect(() => {
-        document.documentElement.lang = locale
+        // Localized marketing routes server-render their URL locale on the
+        // layout's <main>. Their child HtmlLang effect mounts before this
+        // parent effect, so blindly applying the product-app locale here would
+        // immediately clobber the route-owned language back to English.
+        // Restrict ownership to the route layout's direct body child: nested
+        // page content must not be able to spoof the document language.
+        const marketingRoot = document.body.querySelector(':scope > main[data-marketing-locale]')
+        const routeLocale = marketingRoot?.getAttribute('data-marketing-locale')
+        const routeOwnsLanguage =
+            routeLocale !== null &&
+            routeLocale !== undefined &&
+            routeLocale === marketingRoot?.getAttribute('lang') &&
+            isValidMarketingLocale(routeLocale)
+        document.documentElement.lang = routeOwnsLanguage ? routeLocale : locale
         // signal "startup locale is painted" — the native splash gates on this
         if (locale === startupLocale.current) markLocaleApplied()
     }, [locale])

--- a/src/i18n/app/AppIntlProvider.tsx
+++ b/src/i18n/app/AppIntlProvider.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { NextIntlClientProvider, IntlErrorCode, type IntlError } from 'next-intl'
+import { usePathname } from 'next/navigation'
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { isValidLocale as isValidMarketingLocale } from '@/i18n/config'
 import { DEFAULT_APP_LOCALE, type AppLocale } from './config'
@@ -46,6 +47,7 @@ export function AppIntlProvider({ children }: { children: React.ReactNode }) {
         messages: en,
     })
     const startupLocale = useRef<AppLocale | null>(null)
+    const pathname = usePathname()
 
     useEffect(() => {
         let cancelled = false
@@ -94,7 +96,7 @@ export function AppIntlProvider({ children }: { children: React.ReactNode }) {
         document.documentElement.lang = routeOwnsLanguage ? routeLocale : locale
         // signal "startup locale is painted" — the native splash gates on this
         if (locale === startupLocale.current) markLocaleApplied()
-    }, [locale])
+    }, [locale, pathname])
 
     const setLocale = useCallback(async (next: AppLocale) => {
         persistLocale(next)

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -17,6 +17,7 @@ export const ROUTE_SLUGS = [
     'use-cases',
     'withdraw',
     'stories',
+    'split',
     'pricing',
     'supported-networks',
     'terms',

--- a/src/lib/__tests__/split-guides.test.ts
+++ b/src/lib/__tests__/split-guides.test.ts
@@ -1,0 +1,127 @@
+import { BASE_URL } from '@/constants/general.consts'
+import { getAlternatesFor, type Locale } from '@/i18n/config'
+import {
+    buildSplitGuideBlogPosting,
+    buildSplitGuideAlternates,
+    buildSplitGuideMetadata,
+    buildSplitGuideParams,
+    buildSplitGuideSitemapRows,
+    isPublishedSplitGuide,
+    splitGuidePath,
+    type SplitGuideFrontmatter,
+} from '@/lib/split-guides'
+
+const frontmatter: SplitGuideFrontmatter = {
+    title: 'How to split a group trip',
+    description: 'A practical guide to keeping a group trip fair.',
+    date: '2026-07-28',
+    published: true,
+}
+
+describe('split guide routing and SEO', () => {
+    it('builds static params only for exact published locale files', () => {
+        const slugs = ['group-trip', 'currencies']
+        const locales: Locale[] = ['en', 'es-419', 'es-ar', 'pt-br']
+        const exactFiles = new Set(['en/group-trip', 'es-419/group-trip', 'pt-br/group-trip', 'en/currencies'])
+
+        expect(buildSplitGuideParams(slugs, locales, (slug, locale) => exactFiles.has(`${locale}/${slug}`))).toEqual([
+            { locale: 'en', slug: 'group-trip' },
+            { locale: 'en', slug: 'currencies' },
+            { locale: 'es-419', slug: 'group-trip' },
+            { locale: 'pt-br', slug: 'group-trip' },
+        ])
+    })
+
+    it('does not let a valid translation seed routes when English is invalid', () => {
+        const exactFiles = new Set(['es-419/orphaned-translation', 'pt-br/orphaned-translation'])
+
+        expect(
+            buildSplitGuideParams(['orphaned-translation'], ['en', 'es-419', 'pt-br'], (slug, locale) =>
+                exactFiles.has(`${locale}/${slug}`)
+            )
+        ).toEqual([])
+    })
+
+    it('uses the clean split guide path', () => {
+        expect(splitGuidePath('pt-br', 'group-trip')).toBe('/pt-br/split/guides/group-trip')
+    })
+
+    it('adds one Peanut suffix, a self-canonical and exact hreflang alternates', () => {
+        const locales: Locale[] = ['en', 'es-419', 'pt-br']
+        const metadata = buildSplitGuideMetadata(frontmatter, 'es-419', 'group-trip', locales)
+
+        expect(metadata.title).toBe('How to split a group trip | Peanut')
+        expect(metadata.alternates).toEqual({
+            canonical: '/es-419/split/guides/group-trip',
+            languages: getAlternatesFor(locales, 'split', 'guides', 'group-trip'),
+        })
+        expect(metadata.alternates?.languages).not.toHaveProperty('es-AR')
+        expect(metadata.openGraph).toMatchObject({
+            locale: 'es_LA',
+            alternateLocale: ['en_US', 'pt_BR'],
+        })
+        expect(metadata.openGraph).not.toMatchObject({ alternateLocale: expect.arrayContaining(['es_AR']) })
+    })
+
+    it.each([
+        { candidate: { ...frontmatter, title: 123 }, label: 'non-string title' },
+        { candidate: { ...frontmatter, description: { text: 'oops' } }, label: 'non-string description' },
+        { candidate: { ...frontmatter, date: '2026-02-30' }, label: 'invalid calendar date' },
+        { candidate: { ...frontmatter, date: 'July 28, 2026' }, label: 'non-ISO date' },
+        { candidate: { ...frontmatter, date: new Date(Number.NaN) }, label: 'non-finite Date' },
+        { candidate: { ...frontmatter, published: 'true' }, label: 'non-boolean publication flag' },
+        { candidate: { ...frontmatter, published: false }, label: 'unpublished guide' },
+    ])('rejects malformed or unavailable frontmatter: $label', ({ candidate }) => {
+        const content = { frontmatter: candidate, body: 'Guide body' }
+        expect(() =>
+            isPublishedSplitGuide(content as unknown as Parameters<typeof isPublishedSplitGuide>[0])
+        ).not.toThrow()
+        expect(isPublishedSplitGuide(content as unknown as Parameters<typeof isPublishedSplitGuide>[0])).toBe(false)
+    })
+
+    it('accepts a finite Date and normalizes it for schema output', () => {
+        const content = {
+            frontmatter: { ...frontmatter, date: new Date('2026-07-28T12:34:56.000Z') },
+            body: 'Guide body',
+        }
+        expect(isPublishedSplitGuide(content)).toBe(true)
+        expect(buildSplitGuideBlogPosting(content.frontmatter, 'en', 'group-trip')).toMatchObject({
+            datePublished: '2026-07-28',
+        })
+    })
+
+    it('builds the reciprocal exact-locale alternate set used by every sitemap row', () => {
+        const languages = {
+            'x-default': `${BASE_URL}/en/split/guides/group-trip`,
+            en: `${BASE_URL}/en/split/guides/group-trip`,
+            'es-419': `${BASE_URL}/es-419/split/guides/group-trip`,
+            'pt-BR': `${BASE_URL}/pt-br/split/guides/group-trip`,
+        }
+        expect(buildSplitGuideAlternates('group-trip', ['en', 'es-419', 'pt-br'])).toEqual(languages)
+
+        const rows = buildSplitGuideSitemapRows(
+            [
+                { locale: 'en', slug: 'group-trip' },
+                { locale: 'es-419', slug: 'group-trip' },
+                { locale: 'pt-br', slug: 'group-trip' },
+            ],
+            () => ['en', 'es-419', 'pt-br']
+        )
+        expect(rows.map((row) => row.path)).toEqual([
+            '/en/split/guides/group-trip',
+            '/es-419/split/guides/group-trip',
+            '/pt-br/split/guides/group-trip',
+        ])
+        for (const row of rows) expect(row.alternates.languages).toEqual(languages)
+    })
+
+    it('emits one locale-specific BlogPosting payload', () => {
+        expect(buildSplitGuideBlogPosting(frontmatter, 'pt-br', 'group-trip')).toMatchObject({
+            '@type': 'BlogPosting',
+            headline: frontmatter.title,
+            datePublished: '2026-07-28',
+            inLanguage: 'pt-BR',
+            mainEntityOfPage: `${BASE_URL}/pt-br/split/guides/group-trip`,
+        })
+    })
+})

--- a/src/lib/split-guides.ts
+++ b/src/lib/split-guides.ts
@@ -1,0 +1,167 @@
+import type { Metadata } from 'next'
+import { generateMetadata as metadataHelper } from '@/app/metadata'
+import { BASE_URL } from '@/constants/general.consts'
+import { getAlternatesFor, HREFLANG_MAP, OG_LOCALE_MAP, type Locale } from '@/i18n/config'
+import {
+    availableContentLocales,
+    hasPageContent,
+    listPublishedSlugs,
+    readPageContent,
+    type ContentFrontmatter,
+    type MarkdownContent,
+} from '@/lib/content'
+
+export const SPLIT_GUIDE_INTENT = 'split-guides'
+export const SPLIT_GUIDE_LOCALES = ['en', 'es-419', 'pt-br'] as const satisfies readonly Locale[]
+
+export interface SplitGuideFrontmatter extends ContentFrontmatter {
+    date: string | Date
+    author?: string
+}
+
+export interface SplitGuideParam {
+    locale: Locale
+    slug: string
+}
+
+export interface SplitGuideSitemapRow extends SplitGuideParam {
+    path: string
+    alternates: { languages: Record<string, string> }
+}
+
+export function splitGuidePath(locale: Locale, slug: string): string {
+    return `/${locale}/split/guides/${encodeURIComponent(slug)}`
+}
+
+export function splitGuideDate(frontmatter: { date?: unknown }): string | null {
+    const { date } = frontmatter
+    if (date instanceof Date) {
+        return Number.isFinite(date.getTime()) ? date.toISOString().split('T')[0] : null
+    }
+    if (typeof date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
+        const parsed = new Date(`${date}T00:00:00.000Z`)
+        if (Number.isFinite(parsed.getTime()) && parsed.toISOString().split('T')[0] === date) return date
+    }
+    return null
+}
+
+export function isPublishedSplitGuide(
+    content: MarkdownContent<SplitGuideFrontmatter> | null
+): content is MarkdownContent<SplitGuideFrontmatter> {
+    if (!content || !content.frontmatter || typeof content.frontmatter !== 'object') return false
+    const frontmatter = content.frontmatter as unknown as Record<string, unknown>
+    const { title, description, published } = frontmatter
+
+    if (typeof title !== 'string' || !title.trim()) return false
+    if (typeof description !== 'string' || !description.trim()) return false
+    if (published !== undefined && typeof published !== 'boolean') return false
+    if (published === false) return false
+    return splitGuideDate(frontmatter) !== null
+}
+
+/** Read only the requested locale. Split guides never fall back to another locale. */
+export function readPublishedSplitGuide(slug: string, locale: Locale): MarkdownContent<SplitGuideFrontmatter> | null {
+    const content = readPageContent<SplitGuideFrontmatter>(SPLIT_GUIDE_INTENT, slug, locale)
+    return isPublishedSplitGuide(content) ? content : null
+}
+
+/** Exact-file publication check shared by route params, hreflang and sitemap generation. */
+export function hasPublishedSplitGuide(slug: string, locale: Locale): boolean {
+    if (!hasPageContent(SPLIT_GUIDE_INTENT, slug, locale)) return false
+    return readPublishedSplitGuide(slug, locale) !== null
+}
+
+export function buildSplitGuideParams(
+    slugs: readonly string[],
+    locales: readonly Locale[],
+    hasExactPublishedGuide: (slug: string, locale: Locale) => boolean
+): SplitGuideParam[] {
+    // English owns publication for this family. A translated file can never
+    // seed a route, hreflang cluster or sitemap row when its English source is
+    // missing, unpublished or malformed.
+    const englishPublishedSlugs = slugs.filter((slug) => hasExactPublishedGuide(slug, 'en'))
+    return locales.flatMap((locale) =>
+        englishPublishedSlugs.filter((slug) => hasExactPublishedGuide(slug, locale)).map((slug) => ({ locale, slug }))
+    )
+}
+
+export function getSplitGuideStaticParams(): SplitGuideParam[] {
+    return buildSplitGuideParams(listPublishedSlugs(SPLIT_GUIDE_INTENT), SPLIT_GUIDE_LOCALES, hasPublishedSplitGuide)
+}
+
+/** Locales shown in hreflang and the guide switcher; exact published files only. */
+export function getAvailableSplitGuideLocales(slug: string): Locale[] {
+    const availableLocales = new Set(availableContentLocales(SPLIT_GUIDE_INTENT, slug))
+    return SPLIT_GUIDE_LOCALES.filter((locale) => availableLocales.has(locale) && hasPublishedSplitGuide(slug, locale))
+}
+
+export function buildSplitGuideAlternates(slug: string, locales: readonly Locale[]): Record<string, string> {
+    return getAlternatesFor(locales, 'split', 'guides', slug)
+}
+
+export function buildSplitGuideSitemapRows(
+    params: readonly SplitGuideParam[],
+    availableLocalesFor: (slug: string) => readonly Locale[]
+): SplitGuideSitemapRow[] {
+    return params.map(({ locale, slug }) => ({
+        locale,
+        slug,
+        path: splitGuidePath(locale, slug),
+        alternates: { languages: buildSplitGuideAlternates(slug, availableLocalesFor(slug)) },
+    }))
+}
+
+export function buildSplitGuideMetadata(
+    frontmatter: SplitGuideFrontmatter,
+    locale: Locale,
+    slug: string,
+    locales: readonly Locale[]
+): Metadata {
+    const canonical = splitGuidePath(locale, slug)
+    const title = `${frontmatter.title} | Peanut`
+    const baseMetadata = metadataHelper({
+        locale,
+        title,
+        description: frontmatter.description,
+        canonical,
+        dynamicOg: true,
+    })
+
+    return {
+        ...baseMetadata,
+        openGraph: {
+            ...baseMetadata.openGraph,
+            locale: OG_LOCALE_MAP[locale],
+            alternateLocale: locales
+                .filter((candidate) => candidate !== locale)
+                .map((candidate) => OG_LOCALE_MAP[candidate]),
+        },
+        alternates: {
+            canonical,
+            languages: buildSplitGuideAlternates(slug, locales),
+        },
+    }
+}
+
+export function buildSplitGuideBlogPosting(
+    frontmatter: SplitGuideFrontmatter,
+    locale: Locale,
+    slug: string
+): Record<string, unknown> {
+    const url = `${BASE_URL}${splitGuidePath(locale, slug)}`
+    const datePublished = splitGuideDate(frontmatter)
+
+    return {
+        '@context': 'https://schema.org',
+        '@type': 'BlogPosting',
+        headline: frontmatter.title,
+        description: frontmatter.description,
+        datePublished,
+        dateModified: datePublished,
+        inLanguage: HREFLANG_MAP[locale],
+        author: { '@type': 'Organization', name: frontmatter.author ?? 'Peanut' },
+        publisher: { '@type': 'Organization', name: 'Peanut', url: BASE_URL },
+        url,
+        mainEntityOfPage: url,
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the native `/{locale}/split/guides/{slug}` family for `en`, `es-419`, and `pt-br`.
- Publishes only exact locale files, with matching canonical, hreflang, sitemap, language switcher, BlogPosting, and breadcrumb signals.
- Adds a manifest-backed six-page canary contract with raw source SHA-256 verification.
- Reserves the Split namespace with true 404s and keeps the foundation inert until the separate content publish lands.
- Preserves localized document language after hydration and restores the selected app language when navigating back to product UI.
- Gives Split guide card CTAs route-scoped mascot clearance and enforces one `BlogPosting` schema contract.

## Task

- TASK-21256
- [Split content: peanut.me locale split, own end-to-end](https://www.notion.so/peanutprotocol/Split-content-peanut-me-locale-split-own-end-to-end-3b783811757981b481f1d9528c6f0600?v=8c7e4fa6376e4b17ae05a645a449cd0e&source=copy_link#3ba59eea5efc41eba7f2fc9911235cdb)

## Intentional behavior and risk

- Unknown `/split` paths return 404 instead of falling through to the generic recipient route.
- Missing locale files return 404 and never emit fallback prose or SEO URLs. Split deliberately excludes `es-ar` and `es-es` from this canary.
- The code foundation must reach production before mono publishes the content batch; reversing that order would expose missing routes.
- No old-domain redirects or compatibility shims are included. The product has negligible legacy traffic and this cutover intentionally allows breaking changes.
- The shared CTA only gains a semantic data hook. Its spacing is unchanged on the existing ~601 card CTA uses; the extra clearance is scoped to Split guide descendants.

## Verification

- Full Jest: 234 suites passed; 2,972 passed, 3 skipped.
- Focused route/CTA tests: 7/7 passed.
- Full TypeScript and ESLint passed; ESLint remains at 72 pre-existing warnings and 0 errors.
- Content verifier passed both inert and joined modes. Joined: 762 files, 954 valid paths, 898 sitemap routes, six exact Split records with source hashes and the updated intent-taxonomy provenance.
- Production webpack build passed with 1,055 static pages, including exactly six Split guide pages.
- Browser/SEO QA passed all six routes, five negative 404 routes, sitemap membership, canonical/hreflang, one H1, schemas, CTA query preservation, and no console/hydration errors.
- Responsive visual QA passed 18 CTA geometry checks at 320/375/768px, plus a non-Split regression page. The mascot now has 24px clearance.
- Formatting and diff checks passed; the content submodule and verifier baseline were restored byte-clean after joined QA.

## Screenshots

| English desktop | Spanish mobile |
|---|---|
| ![English group-trip guide on desktop](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2657/en-group-desktop.png) | ![Spanish currency guide on mobile](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2657/es-currency-mobile.png) |
| Portuguese content | English final CTA |
| ![Portuguese guide steps and currency callout](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2657/pt-group-content-desktop.png) | ![English final CTA with mascot clearance](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2657/en-currency-cta-mobile.png) |

The orphan `pr-assets-2657` branch is evidence-only and should be deleted after merge.

## Design notes

- The marketing layout and all four literal landing routes server-render `main[lang]` plus a supported locale marker. The existing platform root still emits `<html lang="en">` in raw HTML; hydration promotes the verified marketing locale to the document root. Browser QA observed the localized value within 100–250ms and gates on the hydrated state.
- The document-language owner is re-evaluated on client pathname changes, so leaving localized marketing restores the user's selected product-app locale instead of the pre-mount language.
- Split guide frontmatter declares `BlogPosting` only; the route emits that object and a separate breadcrumb. A redundant standalone `Article` object is rejected.
- The Split verifier is intentionally cohesive: manifest, provenance, MDX, route, locale, metadata, CTA, and reciprocal-link failures block in one release contract.
- No high-fan-in content loader signature changed. Split routes, loaders, switcher behavior, and CTA layout overrides remain isolated.

## Rollout

1. Merge and deploy this inert foundation to production.
2. Synchronize the reviewed mono content branch with `main`, rerun source/provenance gates, and publish the six exact-locale pages through the content pipeline.
3. Verify the six production URLs, app CTA locale handoff, sitemap, canonicals, and hreflang.
4. Expand to the Split hub, alternatives, and the already-tested calculator engines in separate slices.

## Docs and follow-up

- The separate mono content batch contains the current Split product truth, guide template, locale rules, architecture notes, six compose sources, manifest, and six generated pages.
- The content batch remains staged and unpublished until this foundation is live.
