### PR TITLE
feat(split): prove isolated edge transport canary

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -29,6 +29,27 @@ jobs:
             - name: Pull Vercel Environment Information
               run: vercel pull --yes --environment=preview --scope=squirrellabs --token=${{ secrets.VERCEL_TOKEN }}
             - name: Build Project Artifacts
+              if: github.head_ref != 'feat/split-a2-edge-canary'
+              run: vercel build --target=preview --token=${{ secrets.VERCEL_TOKEN }}
+            - name: Build A2 Edge Proof Artifacts
+              if: github.head_ref == 'feat/split-a2-edge-canary'
+              env:
+                  SPLIT_CONTENT_A2_CANARY_ENABLED: '1'
+                  SPLIT_CONTENT_A2_PROOF_ONLY: '1'
+                  SPLIT_CONTENT_EDGE_MARKER: ${{ secrets.SPLIT_A2_EDGE_MARKER }}
+                  SPLIT_CONTENT_ORIGIN: https://httpbingo.org
               run: vercel build --target=preview --token=${{ secrets.VERCEL_TOKEN }}
             - name: Deploy Project Artifacts to Vercel
+              if: github.head_ref != 'feat/split-a2-edge-canary'
               run: vercel deploy --prebuilt --archive=tgz --target=preview --scope=squirrellabs --token=${{ secrets.VERCEL_TOKEN }}
+            - name: Deploy A2 Edge Proof to Vercel
+              if: github.head_ref == 'feat/split-a2-edge-canary'
+              env:
+                  SPLIT_CONTENT_EDGE_MARKER: ${{ secrets.SPLIT_A2_EDGE_MARKER }}
+              run: >-
+                  vercel deploy --prebuilt --archive=tgz --target=preview --scope=squirrellabs
+                  --env SPLIT_CONTENT_A2_CANARY_ENABLED=1
+                  --env SPLIT_CONTENT_A2_PROOF_ONLY=1
+                  --env SPLIT_CONTENT_EDGE_MARKER="$SPLIT_CONTENT_EDGE_MARKER"
+                  --env SPLIT_CONTENT_ORIGIN=https://httpbingo.org
+                  --token=${{ secrets.VERCEL_TOKEN }}

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -1,9 +1,11 @@
 /** @jest-environment node */
 import { NextRequest } from 'next/server'
-import { proxy } from '@/proxy'
+import { getRewrittenUrl, isRewrite, unstable_doesMiddlewareMatch } from 'next/experimental/testing/server'
+import { config, proxy } from '@/proxy'
+import { SPLIT_EDGE_MARKER_HEADER } from '@/utils/split-content-edge'
 
-function runProxy(path: string) {
-    return proxy(new NextRequest(`https://peanut.me${path}`))
+function runProxy(path: string, init?: ConstructorParameters<typeof NextRequest>[1]) {
+    return proxy(new NextRequest(`https://peanut.me${path}`, init))
 }
 
 describe('API cache policy', () => {
@@ -28,3 +30,221 @@ describe('API cache policy', () => {
         }
     )
 })
+
+describe('Split A2 preview transport', () => {
+    const previous = {
+        enabled: process.env.SPLIT_CONTENT_A2_CANARY_ENABLED,
+        marker: process.env.SPLIT_CONTENT_EDGE_MARKER,
+        origin: process.env.SPLIT_CONTENT_ORIGIN,
+        proofOnly: process.env.SPLIT_CONTENT_A2_PROOF_ONLY,
+        vercelEnv: process.env.VERCEL_ENV,
+    }
+
+    beforeEach(() => {
+        process.env.SPLIT_CONTENT_A2_CANARY_ENABLED = '1'
+        process.env.SPLIT_CONTENT_EDGE_MARKER = 'server-only-test-marker-32-bytes!!'
+        process.env.SPLIT_CONTENT_ORIGIN = 'http://localhost:8765'
+        process.env.VERCEL_ENV = 'preview'
+        delete process.env.SPLIT_CONTENT_A2_PROOF_ONLY
+    })
+
+    afterAll(() => {
+        restoreEnv('SPLIT_CONTENT_A2_CANARY_ENABLED', previous.enabled)
+        restoreEnv('SPLIT_CONTENT_EDGE_MARKER', previous.marker)
+        restoreEnv('SPLIT_CONTENT_ORIGIN', previous.origin)
+        restoreEnv('SPLIT_CONTENT_A2_PROOF_ONLY', previous.proofOnly)
+        restoreEnv('VERCEL_ENV', previous.vercelEnv)
+    })
+
+    it('rewrites the exact fixture and preserves its query', () => {
+        const response = runProxy('/en/split/a2-transport?utm_source=a2')
+
+        expect(isRewrite(response)).toBe(true)
+        expect(getRewrittenUrl(response)).toBe('http://localhost:8765/en/split/a2-transport?utm_source=a2')
+    })
+
+    it.each(['/split-static/_next/static/chunks/a.js', '/split-sitemap.xml'])(
+        'rewrites the forwarded support path %s',
+        (path) => {
+            expect(getRewrittenUrl(runProxy(path))).toBe(`http://localhost:8765${path}`)
+        }
+    )
+
+    it('maps the exact preview-only cookie proof to a fixed upstream and strips private request headers', () => {
+        const response = runProxy('/_split-a2/set-cookie?caller=cannot-change-upstream', {
+            headers: {
+                authorization: 'Bearer private',
+                cookie: 'jwt-token=private',
+                'proxy-authorization': 'Basic private',
+                [SPLIT_EDGE_MARKER_HEADER]: 'caller-spoof',
+                'x-api-key': 'private-key',
+                'x-forwarded-host': 'spoof.example',
+                'x-private-secret': 'private-value',
+                'x-vercel-protection-bypass': 'private-bypass',
+            },
+        })
+        const overriddenHeaders = (response.headers.get('x-middleware-override-headers')?.split(',') ?? []).sort()
+
+        expect(getRewrittenUrl(response)).toBe(
+            'https://httpbingo.org/response-headers?Set-Cookie=split-a2-first%3D1%3B%20Path%3D%2F&Set-Cookie=split-a2-second%3D2%3B%20Path%3D%2F'
+        )
+        expect(overriddenHeaders).toEqual(['x-split-a2-proof'])
+        expect(response.headers.get('x-middleware-request-x-split-a2-proof')).toBe('set-cookie')
+        expect(response.headers.get('x-middleware-request-authorization')).toBeNull()
+        expect(response.headers.get('x-middleware-request-cookie')).toBeNull()
+        expect(response.headers.get('x-middleware-request-proxy-authorization')).toBeNull()
+        expect(response.headers.get(`x-middleware-request-${SPLIT_EDGE_MARKER_HEADER}`)).toBeNull()
+        expect(response.headers.get('x-middleware-request-x-api-key')).toBeNull()
+        expect(response.headers.get('x-middleware-request-x-forwarded-host')).toBeNull()
+        expect(response.headers.get('x-middleware-request-x-private-secret')).toBeNull()
+        expect(response.headers.get('x-middleware-request-x-vercel-protection-bypass')).toBeNull()
+    })
+
+    it('maps the exact preview-only header proof without forwarding credentials or a server marker', () => {
+        const response = runProxy('/_split-a2/headers?caller=cannot-change-upstream', {
+            headers: {
+                authorization: 'Bearer private',
+                cookie: 'jwt-token=private',
+                'proxy-authorization': 'Basic private',
+                [SPLIT_EDGE_MARKER_HEADER]: 'caller-spoof',
+                'x-api-key': 'private-key',
+                'x-forwarded-for': 'private-client-ip',
+                'x-forwarded-host': 'spoof.example',
+                'x-private-secret': 'private-value',
+                'x-real-ip': 'private-client-ip',
+                'x-vercel-protection-bypass': 'private-bypass',
+            },
+        })
+        const overriddenHeaders = (response.headers.get('x-middleware-override-headers')?.split(',') ?? []).sort()
+
+        expect(getRewrittenUrl(response)).toBe('https://httpbingo.org/anything')
+        expect(overriddenHeaders).toEqual(['x-forwarded-host', 'x-split-a2-proof'])
+        expect(response.headers.get('x-middleware-request-x-split-a2-proof')).toBe('headers')
+        expect(response.headers.get('x-middleware-request-authorization')).toBeNull()
+        expect(response.headers.get('x-middleware-request-cookie')).toBeNull()
+        expect(response.headers.get('x-middleware-request-proxy-authorization')).toBeNull()
+        expect(response.headers.get('x-middleware-request-x-api-key')).toBeNull()
+        expect(response.headers.get('x-middleware-request-x-forwarded-for')).toBeNull()
+        expect(response.headers.get('x-middleware-request-x-private-secret')).toBeNull()
+        expect(response.headers.get('x-middleware-request-x-real-ip')).toBeNull()
+        expect(response.headers.get('x-middleware-request-x-vercel-protection-bypass')).toBeNull()
+        expect(response.headers.get('x-middleware-request-x-forwarded-host')).toBe('peanut.me')
+        expect(response.headers.get(`x-middleware-request-${SPLIT_EDGE_MARKER_HEADER}`)).toBeNull()
+    })
+
+    it('never enables the cookie proof outside a Vercel preview', () => {
+        process.env.VERCEL_ENV = 'development'
+
+        const response = runProxy('/_split-a2/set-cookie')
+
+        expect(response.status).toBe(404)
+        expect(isRewrite(response)).toBe(false)
+    })
+
+    it('keeps the real renderer paths closed during an edge-only proof', () => {
+        process.env.SPLIT_CONTENT_A2_PROOF_ONLY = '1'
+
+        const fixture = runProxy('/en/split/a2-transport')
+        const diagnostic = runProxy('/_split-a2/headers')
+
+        expect(fixture.status).toBe(404)
+        expect(isRewrite(fixture)).toBe(false)
+        expect(getRewrittenUrl(diagnostic)).toBe('https://httpbingo.org/anything')
+        delete process.env.SPLIT_CONTENT_A2_PROOF_ONLY
+    })
+
+    it.each([
+        ['/en/split/a2-transport', {}],
+        ['/en/split/a2-transport?_rsc=opaque', { rsc: '1' }],
+        ['/split-static/_next/static/chunks/a.js', {}],
+        ['/split-sitemap.xml', {}],
+    ] as const)('sanitizes every forwarded request class: %s', (path, classHeaders) => {
+        const response = runProxy(path, {
+            headers: {
+                authorization: 'Bearer private',
+                cookie: 'jwt-token=private',
+                [SPLIT_EDGE_MARKER_HEADER]: 'caller-spoof',
+                'x-forwarded-host': 'spoof.example',
+                ...classHeaders,
+            },
+        })
+        const overriddenHeaders = response.headers.get('x-middleware-override-headers')?.split(',') ?? []
+
+        expect(overriddenHeaders).not.toContain('authorization')
+        expect(overriddenHeaders).not.toContain('cookie')
+        expect(response.headers.get('x-middleware-request-authorization')).toBeNull()
+        expect(response.headers.get('x-middleware-request-cookie')).toBeNull()
+        expect(response.headers.get(`x-middleware-request-${SPLIT_EDGE_MARKER_HEADER}`)).toBe(
+            'server-only-test-marker-32-bytes!!'
+        )
+        expect(response.headers.get('x-middleware-request-x-forwarded-host')).toBe('peanut.me')
+    })
+
+    it.each(['/split', '/en/split/unknown', '/pt-br/split/a2-transport', '/split-static'])(
+        'returns a real no-store 404 for negative namespace path %s',
+        (path) => {
+            const response = runProxy(path)
+
+            expect(response.status).toBe(404)
+            expect(response.headers.get('cache-control')).toBe('no-store')
+            expect(isRewrite(response)).toBe(false)
+        }
+    )
+
+    it('rejects non-read methods', () => {
+        const response = runProxy('/en/split/a2-transport', { method: 'POST' })
+
+        expect(response.status).toBe(405)
+        expect(response.headers.get('allow')).toBe('GET, HEAD')
+    })
+
+    it.each([
+        ['missing origin', 'SPLIT_CONTENT_ORIGIN'],
+        ['missing marker', 'SPLIT_CONTENT_EDGE_MARKER'],
+    ] as const)('fails closed with no marker reflection for %s', (_label, missingKey) => {
+        delete process.env[missingKey]
+
+        const response = runProxy('/en/split/a2-transport')
+
+        expect(response.status).toBe(503)
+        expect(response.headers.get('cache-control')).toBe('no-store')
+        expect(response.headers.get(SPLIT_EDGE_MARKER_HEADER)).toBeNull()
+        expect(response.headers.get(`x-middleware-request-${SPLIT_EDGE_MARKER_HEADER}`)).toBeNull()
+    })
+
+    it('fails closed when the marker is shorter than 32 bytes', () => {
+        process.env.SPLIT_CONTENT_EDGE_MARKER = 'too-short'
+
+        expect(runProxy('/en/split/a2-transport').status).toBe(503)
+    })
+
+    it('stays inactive on production even if the canary switch is set', () => {
+        process.env.VERCEL_ENV = 'production'
+
+        const response = runProxy('/en/split/a2-transport')
+
+        expect(isRewrite(response)).toBe(false)
+        expect(response.status).toBe(200)
+    })
+
+    it('leaves unrelated routes unchanged', () => {
+        expect(isRewrite(runProxy('/home'))).toBe(false)
+    })
+
+    it.each([
+        '/en/split/a2-transport',
+        '/pt-br/split/unknown',
+        '/split',
+        '/split-static/_next/a.js',
+        '/split-sitemap.xml',
+        '/_split-a2/headers',
+        '/_split-a2/set-cookie',
+    ])('matches Split path %s before filesystem routing', (url) => {
+        expect(unstable_doesMiddlewareMatch({ config, nextConfig: {}, url })).toBe(true)
+    })
+})
+
+function restoreEnv(key: string, value: string | undefined) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+}

--- a/src/__tests__/vercel-split-edge.test.ts
+++ b/src/__tests__/vercel-split-edge.test.ts
@@ -1,0 +1,36 @@
+/** @jest-environment node */
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+describe('Vercel Split A2 response transform', () => {
+    const vercelConfig = JSON.parse(readFileSync(resolve(process.cwd(), 'vercel.json'), 'utf8'))
+    const transformRoute = vercelConfig.routes.find((route: { transforms?: unknown }) => route.transforms)
+
+    it('deletes the complete Set-Cookie response header after the external rewrite', () => {
+        expect(transformRoute.transforms).toEqual([
+            {
+                type: 'response.headers',
+                op: 'delete',
+                target: { key: 'set-cookie' },
+            },
+        ])
+        expect(transformRoute.continue).toBe(true)
+    })
+
+    it.each([
+        '/en/split/a2-transport',
+        '/split-static/_next/a.js',
+        '/split-sitemap.xml',
+        '/_split-a2/headers',
+        '/_split-a2/set-cookie',
+    ])('covers forwarded response path %s', (pathname) => {
+        expect(new RegExp(transformRoute.src).test(pathname)).toBe(true)
+    })
+
+    it.each(['/en/split/a2-transport/extra', '/split-sitemap.xml/extra', '/home', '/splitter'])(
+        'does not transform unrelated response path %s',
+        (pathname) => {
+            expect(new RegExp(transformRoute.src).test(pathname)).toBe(false)
+        }
+    )
+})

--- a/src/app/sw.ts
+++ b/src/app/sw.ts
@@ -1,6 +1,7 @@
 import { defaultCache } from '@serwist/next/worker'
 import type { PrecacheEntry, SerwistGlobalConfig } from 'serwist'
 import { NetworkOnly, Serwist } from 'serwist'
+import { isSplitContentPathname } from '@/utils/split-content-edge'
 
 // This declares the value of `injectionPoint` to TypeScript.
 // `injectionPoint` is the string that will be replaced by the
@@ -30,6 +31,10 @@ const serwist = new Serwist({
     // own versioning + cache headers; let the network handle them. NetworkOnly
     // first so it wins ahead of any defaultCache JS-asset rule.
     runtimeCaching: [
+        {
+            matcher: ({ url }) => isSplitContentPathname(url.pathname),
+            handler: new NetworkOnly(),
+        },
         {
             matcher: ({ url }) => url.pathname.startsWith('/relay/'),
             handler: new NetworkOnly(),

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,9 +6,18 @@ import { NextResponse } from 'next/server'
 import maintenanceConfig from '@/config/underMaintenance.config'
 import { LOCALE_COOKIE, toAppLocale, toMarketingLocale } from '@/i18n/localeBridge'
 import { DEFAULT_LOCALE, type Locale } from '@/i18n/types'
+import {
+    classifySplitA2Request,
+    isSplitA2CanaryEnabled,
+    SPLIT_EDGE_MARKER_HEADER,
+    splitContentOrigin,
+} from '@/utils/split-content-edge'
 
 export function proxy(request: NextRequest) {
     const { pathname } = request.nextUrl
+
+    const splitResponse = handleSplitA2Canary(request)
+    if (splitResponse) return splitResponse
 
     // /dev/ routes are now accessible in production for testing
     // Uncomment below to block /dev/ routes in production if needed
@@ -110,6 +119,74 @@ export function proxy(request: NextRequest) {
     return response
 }
 
+function handleSplitA2Canary(request: NextRequest): NextResponse | null {
+    if (!isSplitA2CanaryEnabled(process.env.SPLIT_CONTENT_A2_CANARY_ENABLED, process.env.VERCEL_ENV)) return null
+
+    const route = classifySplitA2Request(request.nextUrl.pathname, request.headers.get('rsc'))
+    if (route.action === 'pass') return null
+
+    if (route.action === 'not-found') {
+        return new NextResponse(null, { status: 404, headers: { 'Cache-Control': 'no-store' } })
+    }
+
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+        return new NextResponse(null, { status: 405, headers: { Allow: 'GET, HEAD', 'Cache-Control': 'no-store' } })
+    }
+
+    const marker = process.env.SPLIT_CONTENT_EDGE_MARKER
+    if (!marker || marker.length < 32) {
+        return new NextResponse(null, { status: 503, headers: { 'Cache-Control': 'no-store' } })
+    }
+
+    if (route.kind === 'headers-proof' || route.kind === 'set-cookie-proof') {
+        if (process.env.VERCEL_ENV !== 'preview') {
+            return new NextResponse(null, { status: 404, headers: { 'Cache-Control': 'no-store' } })
+        }
+
+        // External proof origins must never receive the caller's arbitrary
+        // headers. Keep this list deliberately tiny and non-empty: Next only
+        // applies its request-header override when the override list has at
+        // least one entry.
+        const proofHeaders = new Headers({
+            'x-split-a2-proof': route.kind === 'headers-proof' ? 'headers' : 'set-cookie',
+        })
+        if (route.kind === 'headers-proof') proofHeaders.set('x-forwarded-host', request.nextUrl.host)
+        const proofDestination =
+            route.kind === 'headers-proof'
+                ? new URL('https://httpbingo.org/anything')
+                : new URL(
+                      'https://httpbingo.org/response-headers?Set-Cookie=split-a2-first%3D1%3B%20Path%3D%2F&Set-Cookie=split-a2-second%3D2%3B%20Path%3D%2F'
+                  )
+        return NextResponse.rewrite(proofDestination, { request: { headers: proofHeaders } })
+    }
+
+    if (process.env.SPLIT_CONTENT_A2_PROOF_ONLY === '1') {
+        return new NextResponse(null, { status: 404, headers: { 'Cache-Control': 'no-store' } })
+    }
+
+    const origin = splitContentOrigin(process.env.SPLIT_CONTENT_ORIGIN)
+    if (!origin || origin.origin === request.nextUrl.origin) {
+        return new NextResponse(null, { status: 503, headers: { 'Cache-Control': 'no-store' } })
+    }
+
+    const destination = new URL(`${request.nextUrl.pathname}${request.nextUrl.search}`, origin)
+    return NextResponse.rewrite(destination, { request: { headers: splitForwardHeaders(request, marker) } })
+}
+
+function splitForwardHeaders(request: NextRequest, marker?: string): Headers {
+    const requestHeaders = new Headers(request.headers)
+    requestHeaders.delete('authorization')
+    requestHeaders.delete('cookie')
+    requestHeaders.delete('host')
+    requestHeaders.delete('x-forwarded-host')
+    requestHeaders.delete(SPLIT_EDGE_MARKER_HEADER)
+    if (marker) {
+        requestHeaders.set('x-forwarded-host', request.nextUrl.host)
+        requestHeaders.set(SPLIT_EDGE_MARKER_HEADER, marker)
+    }
+    return requestHeaders
+}
+
 const CRAWLER_UA =
     /bot|crawler|spider|crawling|slurp|bingpreview|facebookexternalhit|whatsapp|telegram|linkedinbot|embedly|quora link preview|pinterest|vkshare|redditbot|applebot|semrush|ahrefs|screaming frog/i
 
@@ -174,5 +251,15 @@ export const config = {
         '/link/:path*',
         '/dev/:path*',
         '/qr/:path*',
+        '/split',
+        '/split/:path*',
+        '/:locale/split',
+        '/:locale/split/:path*',
+        '/split-static',
+        '/split-static/:path*',
+        '/split-sitemap.xml',
+        '/split-sitemap.xml/:path*',
+        '/_split-a2/headers',
+        '/_split-a2/set-cookie',
     ],
 }

--- a/src/utils/__tests__/split-content-edge.test.ts
+++ b/src/utils/__tests__/split-content-edge.test.ts
@@ -1,0 +1,71 @@
+import {
+    classifySplitA2Request,
+    isSplitA2CanaryEnabled,
+    isSplitContentPathname,
+    splitContentOrigin,
+} from '@/utils/split-content-edge'
+
+describe('Split A2 edge route classification', () => {
+    it('classifies the exact fixture as HTML or RSC without reading its query', () => {
+        expect(classifySplitA2Request('/en/split/a2-transport', null)).toEqual({ action: 'forward', kind: 'html' })
+        expect(classifySplitA2Request('/en/split/a2-transport', '1')).toEqual({ action: 'forward', kind: 'rsc' })
+    })
+
+    it.each([
+        ['/split-static/_next/static/chunks/a.js', 'asset'],
+        ['/split-static/images/a.png', 'asset'],
+        ['/split-sitemap.xml', 'sitemap'],
+        ['/_split-a2/headers', 'headers-proof'],
+        ['/_split-a2/set-cookie', 'set-cookie-proof'],
+    ] as const)('forwards %s as %s', (pathname, kind) => {
+        expect(classifySplitA2Request(pathname, null)).toEqual({ action: 'forward', kind })
+    })
+
+    it.each([
+        '/split',
+        '/split/anything',
+        '/en/split',
+        '/en/split/unknown',
+        '/en/split/a2-transport/',
+        '/pt-br/split/a2-transport',
+        '/split-static',
+        '/split-sitemap.xml/extra',
+    ])('firewalls the unowned Split namespace path %s', (pathname) => {
+        expect(classifySplitA2Request(pathname, null)).toEqual({ action: 'not-found' })
+    })
+
+    it.each(['/splitter', '/en/splitter/page', '/foo/split-static/file.js', '/split-sitemap.xmlx'])(
+        'passes unrelated path %s',
+        (pathname) => {
+            expect(classifySplitA2Request(pathname, null)).toEqual({ action: 'pass' })
+        }
+    )
+
+    it('exposes the same namespace matcher for service-worker isolation', () => {
+        expect(isSplitContentPathname('/en/split/a2-transport')).toBe(true)
+        expect(isSplitContentPathname('/split-static/_next/a.js')).toBe(true)
+        expect(isSplitContentPathname('/split-sitemap.xml')).toBe(true)
+        expect(isSplitContentPathname('/_split-a2/headers')).toBe(true)
+        expect(isSplitContentPathname('/_split-a2/set-cookie')).toBe(true)
+        expect(isSplitContentPathname('/home')).toBe(false)
+    })
+})
+
+describe('Split A2 edge configuration', () => {
+    it('requires an explicit non-production canary switch', () => {
+        expect(isSplitA2CanaryEnabled('1', 'preview')).toBe(true)
+        expect(isSplitA2CanaryEnabled('1', 'production')).toBe(false)
+        expect(isSplitA2CanaryEnabled(undefined, 'preview')).toBe(false)
+    })
+
+    it('accepts only an HTTP origin with no path, credentials, query, or fragment', () => {
+        expect(splitContentOrigin('https://split.example/')).toEqual(new URL('https://split.example/'))
+        expect(splitContentOrigin('http://localhost:8765')).toEqual(new URL('http://localhost:8765'))
+        expect(splitContentOrigin('http://split.example/')).toBeNull()
+        expect(splitContentOrigin('ftp://split.example/')).toBeNull()
+        expect(splitContentOrigin('https://user:pass@split.example/')).toBeNull()
+        expect(splitContentOrigin('https://split.example/base')).toBeNull()
+        expect(splitContentOrigin('https://split.example/?token=x')).toBeNull()
+        expect(splitContentOrigin(undefined)).toBeNull()
+    })
+})

--- a/src/utils/split-content-edge.ts
+++ b/src/utils/split-content-edge.ts
@@ -1,0 +1,82 @@
+export const SPLIT_A2_FIXTURE_PATH = '/en/split/a2-transport'
+export const SPLIT_A2_HEADERS_PROOF_PATH = '/_split-a2/headers'
+export const SPLIT_A2_SET_COOKIE_PROOF_PATH = '/_split-a2/set-cookie'
+export const SPLIT_ASSET_PREFIX = '/split-static'
+export const SPLIT_SITEMAP_PATH = '/split-sitemap.xml'
+export const SPLIT_EDGE_MARKER_HEADER = 'x-peanut-split-edge-marker'
+
+export type SplitA2RequestKind = 'html' | 'rsc' | 'asset' | 'sitemap' | 'headers-proof' | 'set-cookie-proof'
+
+export type SplitA2Route =
+    | { action: 'forward'; kind: SplitA2RequestKind }
+    | { action: 'not-found' }
+    | { action: 'pass' }
+
+function isSplitPageNamespace(pathname: string): boolean {
+    if (pathname === '/split' || pathname.startsWith('/split/')) return true
+
+    const segments = pathname.split('/')
+    return segments[0] === '' && Boolean(segments[1]) && segments[2] === 'split'
+}
+
+export function classifySplitA2Request(pathname: string, rscHeader: string | null): SplitA2Route {
+    if (pathname === SPLIT_A2_HEADERS_PROOF_PATH) {
+        return { action: 'forward', kind: 'headers-proof' }
+    }
+
+    if (pathname === SPLIT_A2_SET_COOKIE_PROOF_PATH) {
+        return { action: 'forward', kind: 'set-cookie-proof' }
+    }
+
+    if (pathname === SPLIT_A2_FIXTURE_PATH) {
+        return { action: 'forward', kind: rscHeader === '1' ? 'rsc' : 'html' }
+    }
+
+    if (pathname.startsWith(`${SPLIT_ASSET_PREFIX}/`)) {
+        return { action: 'forward', kind: 'asset' }
+    }
+
+    if (pathname === SPLIT_SITEMAP_PATH) {
+        return { action: 'forward', kind: 'sitemap' }
+    }
+
+    if (
+        pathname === SPLIT_ASSET_PREFIX ||
+        pathname.startsWith(`${SPLIT_SITEMAP_PATH}/`) ||
+        isSplitPageNamespace(pathname)
+    ) {
+        return { action: 'not-found' }
+    }
+
+    return { action: 'pass' }
+}
+
+export function isSplitContentPathname(pathname: string): boolean {
+    return classifySplitA2Request(pathname, null).action !== 'pass'
+}
+
+export function isSplitA2CanaryEnabled(enabled: string | undefined, vercelEnv: string | undefined): boolean {
+    return enabled === '1' && vercelEnv !== 'production'
+}
+
+export function splitContentOrigin(value: string | undefined): URL | null {
+    if (!value) return null
+
+    try {
+        const url = new URL(value)
+        const isLoopback = ['localhost', '127.0.0.1', '[::1]'].includes(url.hostname)
+        if (
+            (url.protocol !== 'https:' && !(url.protocol === 'http:' && isLoopback)) ||
+            url.username ||
+            url.password ||
+            url.pathname !== '/' ||
+            url.search ||
+            url.hash
+        ) {
+            return null
+        }
+        return url
+    } catch {
+        return null
+    }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://openapi.vercel.sh/vercel.json",
     "rewrites": [
         {
             "source": "/",
@@ -16,6 +17,21 @@
             "maxDuration": 300
         }
     },
+    "routes": [
+        {
+            "src": "^/(?:en/split/a2-transport|split-static(?:/.*)?|split-sitemap\\.xml|_split-a2/(?:headers|set-cookie))$",
+            "transforms": [
+                {
+                    "type": "response.headers",
+                    "op": "delete",
+                    "target": {
+                        "key": "set-cookie"
+                    }
+                }
+            ],
+            "continue": true
+        }
+    ],
     "headers": [
         {
             "source": "/(.*)",


### PR DESCRIPTION
Task: https://app.notion.com/p/3b783811757981b481f1d9528c6f0600?pvs=204

## Summary
- adds an exact preview-only Split edge canary and namespace 404 firewall
- strips caller credentials and spoofed marker headers before the trusted Split renderer rewrite
- keeps Split paths NetworkOnly in the parent service worker and deletes upstream Set-Cookie at the Vercel response layer
- adds disposable Vercel proof routes with a strict non-secret request-header allowlist

## Verification
- 63 focused tests pass
- TypeScript typecheck passes
- changed-file Prettier and git diff checks pass
- local two-port seam passes HTML, RSC, assets, sitemap, credential stripping, marker validation, and real 404 propagation
- full production build previously passed before the disposable proof-route addition; the final local retry was SIGTERM under unrelated workspace memory pressure, so CI is the isolated build gate

## Safety
**DO NOT MERGE. Disposable A2 preview proof only; close after Vercel evidence.** The workflow injection is exact-branch-only, the canary is disabled in production, real renderer paths are proof-only 404s in this preview, and no production route ownership changes. The httpbingo echo receives only fixed non-secret canary headers; the public preview must be removed after evidence.