### PR TITLE
fix: fetch Crisp support token from the API instead of deriving it client-side

### DIFF
--- a/src/hooks/__tests__/useCrispTokenId.test.ts
+++ b/src/hooks/__tests__/useCrispTokenId.test.ts
@@ -1,0 +1,60 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { useCrispTokenId } from '@/hooks/useCrispTokenId'
+
+const mockUseAuth = jest.fn()
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => mockUseAuth(),
+}))
+
+const apiFetchMock = jest.fn()
+jest.mock('@/utils/api-fetch', () => ({
+    apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+const jsonResponse = (body: unknown, ok = true) => ({ ok, json: async () => body }) as unknown as Response
+
+describe('useCrispTokenId', () => {
+    beforeEach(() => {
+        apiFetchMock.mockReset()
+        mockUseAuth.mockReset()
+    })
+
+    it('returns undefined and never calls the API when unauthenticated', () => {
+        mockUseAuth.mockReturnValue({ userId: undefined })
+        const { result } = renderHook(() => useCrispTokenId())
+        expect(result.current).toBeUndefined()
+        expect(apiFetchMock).not.toHaveBeenCalled()
+    })
+
+    it('fetches the token from the authed endpoint for a logged-in user', async () => {
+        mockUseAuth.mockReturnValue({ userId: 'user-aaa' })
+        apiFetchMock.mockResolvedValue(jsonResponse({ crispTokenId: 'tok-aaa' }))
+
+        const { result } = renderHook(() => useCrispTokenId())
+
+        await waitFor(() => expect(result.current).toBe('tok-aaa'))
+    })
+
+    it('takes the userId from the auth token, not a parameter — the call carries no userId', async () => {
+        mockUseAuth.mockReturnValue({ userId: 'user-bbb' })
+        apiFetchMock.mockResolvedValue(jsonResponse({ crispTokenId: 'tok-bbb' }))
+
+        const { result } = renderHook(() => useCrispTokenId())
+
+        await waitFor(() => expect(result.current).toBe('tok-bbb'))
+        // No userId (or any argument) is passed — the server derives it from auth,
+        // which is what stops a caller from requesting another user's token.
+        expect(apiFetchMock).toHaveBeenCalledWith('/user/crisp-token')
+        expect(apiFetchMock.mock.calls[0]).toHaveLength(1)
+    })
+
+    it('stays undefined when the endpoint fails (no fallback token)', async () => {
+        mockUseAuth.mockReturnValue({ userId: 'user-ccc' })
+        apiFetchMock.mockResolvedValue(jsonResponse({}, false))
+
+        const { result } = renderHook(() => useCrispTokenId())
+
+        await waitFor(() => expect(apiFetchMock).toHaveBeenCalled())
+        expect(result.current).toBeUndefined()
+    })
+})

--- a/src/hooks/__tests__/useCrispTokenId.test.ts
+++ b/src/hooks/__tests__/useCrispTokenId.test.ts
@@ -28,7 +28,7 @@ describe('useCrispTokenId', () => {
 
     it('fetches the token from the authed endpoint for a logged-in user', async () => {
         mockUseAuth.mockReturnValue({ userId: 'user-aaa' })
-        apiFetchMock.mockResolvedValue(jsonResponse({ crispTokenId: 'tok-aaa' }))
+        apiFetchMock.mockResolvedValue(jsonResponse({ crispTokenId: 'tok-aaa', userId: 'user-aaa' }))
 
         const { result } = renderHook(() => useCrispTokenId())
 
@@ -37,24 +37,50 @@ describe('useCrispTokenId', () => {
 
     it('takes the userId from the auth token, not a parameter — the call carries no userId', async () => {
         mockUseAuth.mockReturnValue({ userId: 'user-bbb' })
-        apiFetchMock.mockResolvedValue(jsonResponse({ crispTokenId: 'tok-bbb' }))
+        apiFetchMock.mockResolvedValue(jsonResponse({ crispTokenId: 'tok-bbb', userId: 'user-bbb' }))
 
         const { result } = renderHook(() => useCrispTokenId())
 
         await waitFor(() => expect(result.current).toBe('tok-bbb'))
-        // No userId (or any argument) is passed — the server derives it from auth,
-        // which is what stops a caller from requesting another user's token.
         expect(apiFetchMock).toHaveBeenCalledWith('/user/crisp-token')
         expect(apiFetchMock.mock.calls[0]).toHaveLength(1)
     })
 
-    it('stays undefined when the endpoint fails (no fallback token)', async () => {
+    it('discards a token minted for a different user (stale-bearer desync guard)', async () => {
         mockUseAuth.mockReturnValue({ userId: 'user-ccc' })
-        apiFetchMock.mockResolvedValue(jsonResponse({}, false))
+        // Server derived the token from a bearer that still belongs to someone else.
+        apiFetchMock.mockResolvedValue(jsonResponse({ crispTokenId: 'tok-other', userId: 'someone-else' }))
 
         const { result } = renderHook(() => useCrispTokenId())
 
         await waitFor(() => expect(apiFetchMock).toHaveBeenCalled())
+        expect(result.current).toBeUndefined()
+    })
+
+    it('does not keep the previous user’s token after an account switch', async () => {
+        mockUseAuth.mockReturnValue({ userId: 'switch-a' })
+        apiFetchMock.mockResolvedValue(jsonResponse({ crispTokenId: 'tok-a', userId: 'switch-a' }))
+
+        const { result, rerender } = renderHook(() => useCrispTokenId())
+        await waitFor(() => expect(result.current).toBe('tok-a'))
+
+        // Switch to user B: the hook must drop A's token immediately, not serve it
+        // while B's token loads.
+        mockUseAuth.mockReturnValue({ userId: 'switch-b' })
+        apiFetchMock.mockResolvedValue(jsonResponse({ crispTokenId: 'tok-b', userId: 'switch-b' }))
+        rerender()
+
+        expect(result.current).not.toBe('tok-a')
+        await waitFor(() => expect(result.current).toBe('tok-b'))
+    })
+
+    it('retries then stays undefined when the endpoint keeps failing (no fallback token)', async () => {
+        mockUseAuth.mockReturnValue({ userId: 'user-ddd' })
+        apiFetchMock.mockResolvedValue(jsonResponse({}, false))
+
+        const { result } = renderHook(() => useCrispTokenId())
+
+        await waitFor(() => expect(apiFetchMock.mock.calls.length).toBeGreaterThan(1), { timeout: 3000 })
         expect(result.current).toBeUndefined()
     })
 })

--- a/src/hooks/useCrispTokenId.ts
+++ b/src/hooks/useCrispTokenId.ts
@@ -2,6 +2,9 @@ import { useState, useEffect } from 'react'
 import { useAuth } from '@/context/authContext'
 import { apiFetch } from '@/utils/api-fetch'
 
+/** How many times to retry the token fetch before giving up for this mount. */
+const MAX_ATTEMPTS = 3
+
 /**
  * Fetch the current user's Crisp session token from the API.
  *
@@ -12,12 +15,17 @@ import { apiFetch } from '@/utils/api-fetch'
  * sees the secret. It used to be computed here from a shipped salt plus the
  * userId, which let anyone reproduce anyone's token.
  *
+ * The route echoes the userId it derived the token from. We check it against the
+ * account we are fetching for and discard a mismatch, so a stale auth token
+ * (shared-device account switch) can never bind the widget to the wrong user.
+ *
  * @see https://docs.crisp.chat/guides/chatbox-sdks/web-sdk/session-continuity/
  */
-async function fetchCrispToken(): Promise<string | undefined> {
+async function fetchCrispToken(expectedUserId: string): Promise<string | undefined> {
     const res = await apiFetch('/user/crisp-token')
     if (!res.ok) return undefined
-    const data = (await res.json()) as { crispTokenId?: unknown }
+    const data = (await res.json()) as { crispTokenId?: unknown; userId?: unknown }
+    if (data.userId !== expectedUserId) return undefined
     return typeof data.crispTokenId === 'string' ? data.crispTokenId : undefined
 }
 
@@ -39,22 +47,29 @@ export function useCrispTokenId(): string | undefined {
             return
         }
 
+        // Reset to THIS user's cached token (or undefined) before any fetch, so an
+        // account switch never leaves the previous user's token in state while the
+        // new user's token is still loading.
         const cached = tokenCache.get(userId)
-        if (cached) {
-            setTokenId(cached)
-            return
-        }
+        setTokenId(cached)
+        if (cached) return
 
         let cancelled = false
-        fetchCrispToken()
-            .then((token) => {
-                if (cancelled || !token) return
-                tokenCache.set(userId, token)
-                setTokenId(token)
-            })
-            .catch(() => {
-                if (!cancelled) setTokenId(undefined)
-            })
+        ;(async () => {
+            for (let attempt = 0; attempt < MAX_ATTEMPTS && !cancelled; attempt++) {
+                if (attempt > 0) {
+                    await new Promise((resolve) => setTimeout(resolve, 300 * attempt))
+                    if (cancelled) return
+                }
+                const token = await fetchCrispToken(userId).catch(() => undefined)
+                if (cancelled) return
+                if (token) {
+                    tokenCache.set(userId, token)
+                    setTokenId(token)
+                    return
+                }
+            }
+        })()
 
         return () => {
             cancelled = true

--- a/src/hooks/useCrispTokenId.ts
+++ b/src/hooks/useCrispTokenId.ts
@@ -1,36 +1,33 @@
 import { useState, useEffect } from 'react'
 import { useAuth } from '@/context/authContext'
-
-const CRISP_TOKEN_SALT = 'peanut-crisp-session-v1'
+import { apiFetch } from '@/utils/api-fetch'
 
 /**
- * Generates a deterministic Crisp session token from a userId using SHA-256.
- * Formatted as UUID-like string for Crisp compatibility.
+ * Fetch the current user's Crisp session token from the API.
+ *
+ * The token binds a browser to a Crisp contact, so whoever holds it can read
+ * and post in that user's support conversation. It must therefore be
+ * unguessable and issued only to the authenticated user. The API derives it
+ * from the caller's auth token with a server-only secret; the browser never
+ * sees the secret. It used to be computed here from a shipped salt plus the
+ * userId, which let anyone reproduce anyone's token.
  *
  * @see https://docs.crisp.chat/guides/chatbox-sdks/web-sdk/session-continuity/
  */
-async function generateCrispToken(userId: string): Promise<string> {
-    const data = new TextEncoder().encode(`${CRISP_TOKEN_SALT}:${userId}`)
-    const hashBuffer = await crypto.subtle.digest('SHA-256', data)
-    const hashArray = Array.from(new Uint8Array(hashBuffer))
-    const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
-
-    return [
-        hashHex.slice(0, 8),
-        hashHex.slice(8, 12),
-        hashHex.slice(12, 16),
-        hashHex.slice(16, 20),
-        hashHex.slice(20, 32),
-    ].join('-')
+async function fetchCrispToken(): Promise<string | undefined> {
+    const res = await apiFetch('/user/crisp-token')
+    if (!res.ok) return undefined
+    const data = (await res.json()) as { crispTokenId?: unknown }
+    return typeof data.crispTokenId === 'string' ? data.crispTokenId : undefined
 }
 
-// In-memory cache so the token is available synchronously after first computation,
+// In-memory cache so the token is available synchronously after the first fetch,
 // preventing an undefined→resolved state change that would cause iframe reloads.
 const tokenCache = new Map<string, string>()
 
 /**
- * Hook that returns a stable Crisp token ID derived from the current user's ID.
- * Returns undefined when not authenticated.
+ * Hook that returns a stable Crisp token ID for the current user.
+ * Returns undefined when not authenticated or before the token resolves.
  */
 export function useCrispTokenId(): string | undefined {
     const { userId } = useAuth()
@@ -48,12 +45,20 @@ export function useCrispTokenId(): string | undefined {
             return
         }
 
-        generateCrispToken(userId)
+        let cancelled = false
+        fetchCrispToken()
             .then((token) => {
+                if (cancelled || !token) return
                 tokenCache.set(userId, token)
                 setTokenId(token)
             })
-            .catch(() => setTokenId(undefined))
+            .catch(() => {
+                if (!cancelled) setTokenId(undefined)
+            })
+
+        return () => {
+            cancelled = true
+        }
     }, [userId])
 
     return tokenId


### PR DESCRIPTION
## Summary

Frontend half of the Crisp support-token IDOR hotfix. **Pairs with peanut-api-ts #1325 — that API PR (and its migration) must deploy first.**

The Crisp session token was derived **in the browser** as `SHA-256("peanut-crisp-session-v1:" + userId)`. The salt ships in the bundle and `userId` is readable, so anyone could reproduce any user's token and open their support thread via `/crisp-proxy?crisp_token_id=<token>`.

This PR removes the client-side derivation. `useCrispTokenId` now fetches the token from the authenticated `GET /user/crisp-token` (the API issues a stored per-user random token — Crisp's documented safe pattern). The hook keeps the same contract — `undefined` until it resolves, in-memory cache per userId — so `SupportDrawer`'s `isAwaitingToken` gate and reset logic are unchanged.

Hardening from code review is included:
- **Reset on account switch** — the token is reset to the current user's value before fetching, so it never serves the previous user's token while the new one loads.
- **Identity check** — the route echoes `userId`; the hook discards any token whose `userId` doesn't match the account it is fetching for (stale-bearer guard).
- **Bounded retry** — a transient failure doesn't strand the support drawer for the session.

## Task

TASK link pending — user security report. Will attach.

## Risks / breaking changes

- **Hard dependency on peanut-api-ts #1325.** The endpoint (and its migration) must be live first, or `GET /user/crisp-token` 404s and support chat stays on its loading state.
- No visible UI change — same drawer, same states; only the token's source changed.
- *Residual (follow-up, not here):* on a persistent endpoint failure the drawer still shows the spinner with no fallback UI — a small SupportDrawer change, kept out of this security PR.

## QA

- Unit (`src/hooks/__tests__/useCrispTokenId.test.ts`): fetches from the authed endpoint, passes no userId parameter, discards a token minted for a different user, drops the previous user's token on account switch, and stays undefined (with retry) on failure.
- `SupportDrawer` suite still green (it mocks the hook).

## Screenshots

N/A (no visible change) — the drawer renders identically; only the token's source changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Crisp tokens are now securely retrieved from the authenticated service.
  * Added validation to ensure tokens match the correct account and token type.
  * Added automatic retry handling for temporary token request failures.
  * Tokens are cleared when switching accounts or when authentication is unavailable.

* **Tests**
  * Added coverage for authentication states, account changes, token validation, and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->