### PR TITLE
fix: open profiles for every real receipt peer

### DIFF
--- a/src/components/TransactionDetails/TransactionDetailsHeaderCard.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsHeaderCard.tsx
@@ -37,6 +37,7 @@ interface TransactionDetailsHeaderCardProps {
     transactionType?: TransactionType
     avatarUrl?: string
     haveSentMoneyToUser?: boolean
+    isNameClickable?: boolean
     isAvatarClickable?: boolean
     showProgessBar?: boolean
     progress?: number
@@ -205,6 +206,7 @@ export const TransactionDetailsHeaderCard: React.FC<TransactionDetailsHeaderCard
     transactionType,
     avatarUrl,
     haveSentMoneyToUser = false,
+    isNameClickable = false,
     isAvatarClickable = false,
     showProgessBar = false,
     progress,
@@ -232,10 +234,8 @@ export const TransactionDetailsHeaderCard: React.FC<TransactionDetailsHeaderCard
     const isTest = isTestTransaction(userName)
     const icon = getIcon(direction, isLinkTransaction, isTest)
 
-    const handleUserPfpClick = () => {
-        if (isAvatarClickable) {
-            router.push(profileUrl(userName))
-        }
+    const handleUserProfileClick = () => {
+        router.push(profileUrl(userName))
     }
 
     const isNoGoalSet = isRequestPotTransaction && goal === 0
@@ -253,7 +253,10 @@ export const TransactionDetailsHeaderCard: React.FC<TransactionDetailsHeaderCard
                 </div>
             ) : (
                 <div className="flex items-center gap-3">
-                    <div className={twMerge(isAvatarClickable && 'cursor-pointer')} onClick={handleUserPfpClick}>
+                    <div
+                        className={twMerge(isAvatarClickable && 'cursor-pointer')}
+                        onClick={isAvatarClickable ? handleUserProfileClick : undefined}
+                    >
                         {avatarUrl ? (
                             <div className="flex h-16 w-16 items-center justify-center rounded-full">
                                 <Image
@@ -297,7 +300,7 @@ export const TransactionDetailsHeaderCard: React.FC<TransactionDetailsHeaderCard
                                 className="flex items-center gap-1"
                                 haveSentMoneyToUser={haveSentMoneyToUser}
                                 iconSize={18}
-                                onNameClick={isAvatarClickable ? handleUserPfpClick : undefined}
+                                onNameClick={isNameClickable ? handleUserProfileClick : undefined}
                             />
 
                             <div className="ml-auto">

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -45,6 +45,7 @@ import { getBankAccountCountryCode } from '@/constants/countryCurrencyMapping'
 import { useToast } from '@/components/0_Bruddle/Toast'
 import {
     hasUserProfile,
+    hasUserProfileAvatar,
     isPerkReward as isPerkRewardTransaction,
     isRequestEntry,
     isSendLinkEntry,
@@ -274,10 +275,11 @@ export const TransactionDetailsReceipt = ({
         amountDisplay = t('amountCollected', { amount: formattedTotalAmountCollected })
     }
 
-    // Show profile button only if it's a send/request/receive to a real Peanut
-    // user (not a link or a raw address). Shared with the history row — see
-    // hasUserProfile.
-    const isAvatarClickable = hasUserProfile(transaction)
+    // the counterparty name links whenever the peer has a real profile. the
+    // avatar links only when it visually represents that user; bank flags and
+    // account icons stay inert.
+    const isNameClickable = hasUserProfile(transaction)
+    const isAvatarClickable = hasUserProfileAvatar(transaction)
 
     const closeRequestLink = async () => {
         if (isPendingRequester && setIsLoading && onClose) {
@@ -337,6 +339,7 @@ export const TransactionDetailsReceipt = ({
                 transactionType={transaction.extraDataForDrawer?.transactionCardType}
                 avatarUrl={avatarUrl ?? getAvatarUrl(transaction)}
                 haveSentMoneyToUser={transaction.haveSentMoneyToUser}
+                isNameClickable={isNameClickable}
                 isAvatarClickable={isAvatarClickable}
                 showProgessBar={transaction.isRequestPotLink}
                 goal={Number(transaction.amount)}

--- a/src/components/TransactionDetails/__tests__/TransactionCard.test.tsx
+++ b/src/components/TransactionDetails/__tests__/TransactionCard.test.tsx
@@ -62,11 +62,11 @@ jest.mock('next/image', () => ({
     },
 }))
 
-/** A completed P2P send to username `natalia` — the eligible (clickable) case. */
-function eligibleTx(): TransactionDetails {
+/** a completed payment to username `natalia` — the eligible (clickable) case. */
+function eligibleTx(transactionCardType: 'send' | 'bank_request_fulfillment' = 'send'): TransactionDetails {
     return {
         id: 'tx-1',
-        direction: 'send',
+        direction: transactionCardType === 'bank_request_fulfillment' ? 'bank_request_fulfillment' : 'send',
         status: 'completed',
         userName: 'natalia',
         isPeerActuallyUser: true,
@@ -77,15 +77,15 @@ function eligibleTx(): TransactionDetails {
         totalAmountCollected: 0,
         isRequestPotLink: false,
         extraDataForDrawer: {
-            transactionCardType: 'send',
+            transactionCardType,
             isLinkTransaction: false,
         },
     } as unknown as TransactionDetails
 }
 
-function renderCard(transaction: TransactionDetails) {
+function renderCard(transaction: TransactionDetails, type: 'send' | 'bank_request_fulfillment' = 'send') {
     return render(
-        <TransactionCard type="send" name="natalia" amount={10} status="completed" transaction={transaction} />
+        <TransactionCard type={type} name="natalia" amount={10} status="completed" transaction={transaction} />
     )
 }
 
@@ -105,6 +105,15 @@ describe('TransactionCard — clickable counterparty name', () => {
         expect(openTransactionDetails).not.toHaveBeenCalled()
     })
 
+    it('AC1b: a bank-fulfilled request payer name navigates to the Peanut profile', () => {
+        renderCard(eligibleTx('bank_request_fulfillment'), 'bank_request_fulfillment')
+
+        fireEvent.click(screen.getByText('natalia'))
+
+        expect(push).toHaveBeenCalledWith('/natalia')
+        expect(openTransactionDetails).not.toHaveBeenCalled()
+    })
+
     it('AC2: clicking elsewhere on the card (the amount) opens the drawer', () => {
         renderCard(eligibleTx())
 
@@ -116,7 +125,7 @@ describe('TransactionCard — clickable counterparty name', () => {
     })
 
     // Ineligible rows: the name must not be a nav target. Eligibility itself
-    // (link tx / raw address / card type / empty username) is exhaustively
+    // (link tx / raw address / non-user peer / empty username) is exhaustively
     // locked by transaction-predicates.test.ts; here we only confirm the
     // component honors it — one representative ineligible case (a link tx).
     it('AC3 (ineligible — link tx): the name is not a nav target — clicking it does not navigate', () => {

--- a/src/components/TransactionDetails/__tests__/TransactionDetailsHeaderCard.test.tsx
+++ b/src/components/TransactionDetails/__tests__/TransactionDetailsHeaderCard.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
+import { TransactionDetailsHeaderCard } from '../TransactionDetailsHeaderCard'
+
+const push = jest.fn()
+
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ push }),
+}))
+
+jest.mock('next/image', () => ({
+    __esModule: true,
+    default: (props: Record<string, unknown>) => React.createElement('img', props as Record<string, string>),
+}))
+
+jest.mock('../TransactionAvatarBadge', () => ({
+    __esModule: true,
+    default: ({ countryCode }: { countryCode?: string | null }) => (
+        <span data-testid="transaction-avatar">{countryCode ? 'bank flag' : 'user initials'}</span>
+    ),
+}))
+
+jest.mock('@/components/UserHeader', () => ({
+    VerifiedUserLabel: ({ name, onNameClick }: { name: string; onNameClick?: () => void }) => (
+        <button type="button" onClick={onNameClick}>
+            {name}
+        </button>
+    ),
+}))
+
+const renderHeader = (props: { isNameClickable: boolean; isAvatarClickable: boolean; bank?: boolean }) =>
+    render(
+        <TransactionDetailsHeaderCard
+            direction={props.bank ? 'bank_request_fulfillment' : 'send'}
+            userName="natalia"
+            amountDisplay="$25.00"
+            initials="N"
+            status="completed"
+            transactionType={props.bank ? 'bank_request_fulfillment' : 'send'}
+            countryCode={props.bank ? 'US' : undefined}
+            isNameClickable={props.isNameClickable}
+            isAvatarClickable={props.isAvatarClickable}
+            isTransactionClosed={false}
+        />,
+        { wrapper: IntlWrapper }
+    )
+
+describe('TransactionDetailsHeaderCard profile navigation', () => {
+    beforeEach(() => {
+        push.mockClear()
+    })
+
+    it('links the counterparty name but leaves a bank flag inert', () => {
+        renderHeader({ bank: true, isNameClickable: true, isAvatarClickable: false })
+
+        fireEvent.click(screen.getByTestId('transaction-avatar'))
+        expect(push).not.toHaveBeenCalled()
+
+        fireEvent.click(screen.getByRole('button', { name: 'natalia' }))
+        expect(push).toHaveBeenCalledWith('/natalia')
+    })
+
+    it('links a real user avatar or initials', () => {
+        renderHeader({ isNameClickable: true, isAvatarClickable: true })
+
+        fireEvent.click(screen.getByTestId('transaction-avatar'))
+        expect(push).toHaveBeenCalledWith('/natalia')
+    })
+
+    it('leaves the rest of the receipt header inert', () => {
+        renderHeader({ isNameClickable: true, isAvatarClickable: true })
+
+        fireEvent.click(screen.getByText('$25.00'))
+        expect(push).not.toHaveBeenCalled()
+    })
+})

--- a/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
+++ b/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
@@ -154,10 +154,10 @@ describe('isSplittable', () => {
     })
 })
 
-// Gates the clickable counterparty name/avatar in BOTH the history row
-// (TransactionCard) and the receipt header (TransactionDetailsHeaderCard): only
-// a non-link send/request/receive to a real username (not a raw address) deep-
-// links to a Peanut profile.
+// gates the clickable counterparty name/avatar in BOTH the history row
+// (TransactionCard) and the receipt header (TransactionDetailsHeaderCard): any
+// non-link transaction whose peer is a real user with a username deep-links to
+// that Peanut profile, regardless of the receipt's presentation type.
 describe('hasUserProfile', () => {
     const profileTx = (
         transactionCardType: string | undefined,
@@ -173,16 +173,23 @@ describe('hasUserProfile', () => {
             },
         }) as unknown as TransactionDetails
 
-    test.each(['send', 'request', 'receive'])('a %s to a real username has a profile', (type) => {
-        expect(hasUserProfile(profileTx(type))).toBe(true)
-    })
-
-    test.each(['withdraw', 'add', 'card_pay', 'bank_withdraw', 'claim_external'])(
-        'a %s has no peer profile',
+    test.each(['send', 'request', 'receive', 'bank_request_fulfillment', 'add'])(
+        'a %s to a real username has a profile',
         (type) => {
-            expect(hasUserProfile(profileTx(type))).toBe(false)
+            expect(hasUserProfile(profileTx(type))).toBe(true)
         }
     )
+
+    test.each(['pay', 'card_pay', 'withdraw', 'bank_withdraw', 'claim_external'])(
+        'a non-user %s counterparty has no peer profile',
+        (type) => {
+            expect(hasUserProfile(profileTx(type, { isPeerActuallyUser: false }))).toBe(false)
+        }
+    )
+
+    test('an unknown presentation type does not hide a real user profile', () => {
+        expect(hasUserProfile(profileTx(undefined))).toBe(true)
+    })
 
     test('a link send has no user profile behind it', () => {
         expect(hasUserProfile(profileTx('send', { isLinkTransaction: true }))).toBe(false)

--- a/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
+++ b/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
@@ -5,6 +5,7 @@
 
 import {
     hasUserProfile,
+    hasUserProfileAvatar,
     isCardSpend,
     isDirectSendEntry,
     isFxBearingFlow,
@@ -154,7 +155,7 @@ describe('isSplittable', () => {
     })
 })
 
-// gates the clickable counterparty name/avatar in BOTH the history row
+// gates the clickable counterparty name in BOTH the history row
 // (TransactionCard) and the receipt header (TransactionDetailsHeaderCard): any
 // non-link transaction whose peer is a real user with a username deep-links to
 // that Peanut profile, regardless of the receipt's presentation type.
@@ -219,5 +220,18 @@ describe('hasUserProfile', () => {
     // there is no /<uuid> profile page, so it must not be a nav target.
     test('a usernameless user (UUID userId fallback) has no profile', () => {
         expect(hasUserProfile(profileTx('send', { userName: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d' }))).toBe(false)
+    })
+
+    test.each(['send', 'request', 'receive'])('a %s user avatar links to the profile', (type) => {
+        expect(hasUserProfileAvatar(profileTx(type))).toBe(true)
+    })
+
+    test('a bank-request flag stays inert even when the counterparty name has a profile', () => {
+        expect(hasUserProfile(profileTx('bank_request_fulfillment'))).toBe(true)
+        expect(hasUserProfileAvatar(profileTx('bank_request_fulfillment'))).toBe(false)
+    })
+
+    test('a non-user avatar never links to a profile', () => {
+        expect(hasUserProfileAvatar(profileTx('send', { isPeerActuallyUser: false }))).toBe(false)
     })
 })

--- a/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
+++ b/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
@@ -162,10 +162,16 @@ describe('isSplittable', () => {
 describe('hasUserProfile', () => {
     const profileTx = (
         transactionCardType: string | undefined,
-        opts?: { userName?: string; isLinkTransaction?: boolean; isPeerActuallyUser?: boolean }
+        opts?: {
+            userName?: string
+            nameKey?: TransactionDetails['nameKey']
+            isLinkTransaction?: boolean
+            isPeerActuallyUser?: boolean
+        }
     ): TransactionDetails =>
         ({
             userName: opts?.userName ?? 'natalia',
+            nameKey: opts?.nameKey,
             isPeerActuallyUser: opts?.isPeerActuallyUser ?? true,
             extraDataForDrawer: {
                 originalType: 'TRANSACTION_INTENT',
@@ -208,6 +214,18 @@ describe('hasUserProfile', () => {
 
     test('a missing username has no profile', () => {
         expect(hasUserProfile(profileTx('send', { userName: '' }))).toBe(false)
+    })
+
+    test('a generated fallback label has no profile even if the peer flag is wrong', () => {
+        expect(
+            hasUserProfile(
+                profileTx('bank_request_fulfillment', {
+                    userName: 'Recipient',
+                    nameKey: 'name.recipient',
+                    isPeerActuallyUser: true,
+                })
+            )
+        ).toBe(false)
     })
 
     // A non-user peer (raw address, bank account, or a system copy string like

--- a/src/components/TransactionDetails/__tests__/transactionTransformer.test.ts
+++ b/src/components/TransactionDetails/__tests__/transactionTransformer.test.ts
@@ -326,6 +326,22 @@ const cases: TestCase[] = [
         }),
         expect: { direction: 'bank_request_fulfillment', transactionCardType: 'bank_request_fulfillment' },
     },
+    {
+        name: 'P2P_REQUEST_FULFILL × SENDER × bridge fulfilment does not treat the viewer as the peer',
+        entry: baseEntry({
+            userRole: EHistoryUserRole.SENDER,
+            senderAccount: aliceUser,
+            recipientAccount: { identifier: 'external-recipient', type: 'MERCHANT', isUser: false },
+            extraData: { kind: 'P2P_REQUEST_FULFILL', fulfillmentType: 'bridge' },
+            isVerified: true,
+        }),
+        expect: {
+            direction: 'bank_request_fulfillment',
+            transactionCardType: 'bank_request_fulfillment',
+            userName: 'external-recipient',
+            isPeerActuallyUser: false,
+        },
+    },
 
     // ───── CARD_SPEND_AUTH / CARD_AUTH_REVERSAL ─────
     {

--- a/src/components/TransactionDetails/strategies/intent/p2p-send.ts
+++ b/src/components/TransactionDetails/strategies/intent/p2p-send.ts
@@ -26,7 +26,7 @@ export const p2pSendOrRequestFulfill: TransactionStrategy = (entry: HistoryEntry
                     : TRANSACTION_NAME_KEYS.recipient,
             fullName: entry.recipientAccount?.fullName ?? '',
             showFullName: entry.recipientAccount?.showFullName,
-            isPeerActuallyUser: !!entry.recipientAccount?.isUser || !!entry.senderAccount?.isUser,
+            isPeerActuallyUser: !!entry.recipientAccount?.isUser,
             isLinkTx: false,
         }
     }

--- a/src/components/TransactionDetails/transaction-predicates.ts
+++ b/src/components/TransactionDetails/transaction-predicates.ts
@@ -126,14 +126,16 @@ export function isMantecaOnrampEntry(transaction: TransactionDetails): boolean {
 // the peer has a profile when the transformer identifies a real Peanut user
 // with a username. presentation types must not narrow that fact: bank-fulfilled
 // requests and future flows can also have a real user as their peer. links, raw
-// addresses, and userId fallbacks do not resolve to profile pages. this rule is
-// shared by the history row and receipt header so the surfaces cannot drift.
+// addresses, userId fallbacks, and generated labels do not resolve to profile
+// pages. this rule is shared by the history row and receipt header so the
+// surfaces cannot drift.
 export function hasUserProfile(transaction: TransactionDetails): boolean {
     const userName = transaction.userName
     return (
         !!transaction.isPeerActuallyUser &&
         !transaction.extraDataForDrawer?.isLinkTransaction &&
         !!userName &&
+        !transaction.nameKey &&
         !isCryptoAddress(userName) &&
         !isUuid(userName)
     )

--- a/src/components/TransactionDetails/transaction-predicates.ts
+++ b/src/components/TransactionDetails/transaction-predicates.ts
@@ -123,26 +123,18 @@ export function isMantecaOnrampEntry(transaction: TransactionDetails): boolean {
     return isKind(transaction, 'ONRAMP') && transaction.extraDataForDrawer?.provider === 'MANTECA'
 }
 
-// The counterparty is a real Peanut user with a public profile: a non-link
-// send / request / receive whose peer is an actual user (isPeerActuallyUser)
-// identified by a real username — not a raw crypto address (EVM/Solana/Tron,
-// the same rule VerifiedUserLabel renders by) and not a userId fallback
-// (usernameless users surface their UUID in `userName`, which has no profile
-// page). System copy strings ('Request', 'Recipient', reaper-fail text) are
-// already excluded because the transformer sets isPeerActuallyUser=false for
-// them. What a consumer does with the fact (clickable name, avatar, send-again
-// button) is the call site's business. Shared by the history row
-// (TransactionCard) and the receipt header (TransactionDetailsHeaderCard) —
-// keep the rule here so the two surfaces can't drift.
+// the peer has a profile when the transformer identifies a real Peanut user
+// with a username. presentation types must not narrow that fact: bank-fulfilled
+// requests and future flows can also have a real user as their peer. links, raw
+// addresses, and userId fallbacks do not resolve to profile pages. this rule is
+// shared by the history row and receipt header so the surfaces cannot drift.
 export function hasUserProfile(transaction: TransactionDetails): boolean {
-    const type = transaction.extraDataForDrawer?.transactionCardType
     const userName = transaction.userName
     return (
         !!transaction.isPeerActuallyUser &&
         !transaction.extraDataForDrawer?.isLinkTransaction &&
         !!userName &&
         !isCryptoAddress(userName) &&
-        !isUuid(userName) &&
-        (type === 'send' || type === 'request' || type === 'receive')
+        !isUuid(userName)
     )
 }

--- a/src/components/TransactionDetails/transaction-predicates.ts
+++ b/src/components/TransactionDetails/transaction-predicates.ts
@@ -138,3 +138,13 @@ export function hasUserProfile(transaction: TransactionDetails): boolean {
         !isUuid(userName)
     )
 }
+
+// these presentation types render the peer's initials/avatar. bank and wallet
+// types render a rail or account icon, which must stay inert even when the
+// counterparty name links to a real profile.
+const USER_PROFILE_AVATAR_TYPES: ReadonlySet<string> = new Set(['send', 'request', 'receive'])
+
+export function hasUserProfileAvatar(transaction: TransactionDetails): boolean {
+    const transactionCardType = transaction.extraDataForDrawer?.transactionCardType
+    return hasUserProfile(transaction) && !!transactionCardType && USER_PROFILE_AVATAR_TYPES.has(transactionCardType)
+}


### PR DESCRIPTION
## Summary

Receipt profile navigation trusted the peer identity signal, but then narrowed it with a presentation-type allowlist. This left valid Peanut users inert on bank-fulfilled request receipts and other real-user flows.

This PR removes that stale allowlist. The shared `hasUserProfile` predicate now allows any non-link transaction whose peer is a real Peanut user with a valid username. Raw addresses, UUID fallbacks, guests, links, merchants, and generated system labels stay inert.

The bank-fulfilled request strategy now derives peer identity only from `recipientAccount`. It no longer treats the logged-in sender as the peer.

The receipt header separates name and avatar navigation. A real counterparty name always links to the profile. User initials or a real user avatar also link. Bank flags, rail icons, and the rest of the receipt card stay inert.

The predicate is shared by the activity row and receipt header. The fix therefore covers the history drawer and standalone `/receipt/[entryId]` page without separate peer-identity logic.

## Task

TASK-21010

## Design decision: “To” row

The “To” detail row stays unchanged. It only renders for `claim_external`, where the recipient is not a Peanut user and no profile exists. Expanding that row to other receipt types would be separate product work.

## Risks / breaking changes

Low, frontend-only. No API, contract, dependency, or cross-repo change. The risk is an incorrect profile link if peer identity is wrong. Username, generated-label, link, crypto-address, and UUID checks remain as defense in depth.

## QA

- Added strategy coverage that a bank fulfillment never treats the logged-in sender as the peer.
- Added predicate coverage that generated fallback labels stay inert even if the peer flag is wrong.
- Added coverage for `bank_request_fulfillment`, real-user `add`, unknown future presentation types, and non-user QR/card/external flows.
- Added receipt-header coverage for linked names, linked real-user avatars/initials, inert bank flags, and an inert card body.
- Added activity-row click coverage for a bank-fulfilled request peer.
- `pnpm prettier --check .`
- `npm run typecheck`
- `npm test -- --runInBand` — 230 suites, 2,939 passed, 3 skipped.
- `npm run build`

## Screenshots

N/A — no visible change. This PR changes click targets only.

## Follow-up after release

Verify a real bank-fulfilled request receipt on production in both the history drawer and standalone receipt page. Then mark `product/feedback/problems/cant-tap-name-to-open-profile.md` as shipped in a separate content-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile availability across supported transaction types, including bank-fulfilled requests.
  * Users with valid profiles can now be selected even when transaction presentation details are unavailable.
  * Bank-fulfilled request payers now navigate directly to the payer’s profile without opening the details drawer.
  * Improved navigation consistency between clickable profile names and avatars.

* **Tests**
  * Expanded coverage for profile eligibility, navigation, and bridge-fulfilled requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
