### PR TITLE
test: enforce shared locale glossary on app i18n catalogs

### DIFF
--- a/src/i18n/app/__tests__/catalog-helpers.ts
+++ b/src/i18n/app/__tests__/catalog-helpers.ts
@@ -1,0 +1,21 @@
+// shared flatten helpers for the catalog test suites — keep the recursion in
+// one place so the parity, shhhhh and glossary tests can't drift apart
+export function leafPaths(obj: Record<string, unknown>, prefix = ''): string[] {
+    return Object.entries(obj).flatMap(([key, value]) => {
+        const path = prefix ? `${prefix}.${key}` : key
+        return typeof value === 'object' && value !== null ? leafPaths(value as Record<string, unknown>, path) : [path]
+    })
+}
+
+export function leafValue(catalog: Record<string, unknown>, path: string): string {
+    return path.split('.').reduce<unknown>((node, key) => (node as Record<string, unknown>)[key], catalog) as string
+}
+
+export function leafEntries(obj: Record<string, unknown>, prefix = ''): Array<[string, string]> {
+    return Object.entries(obj).flatMap(([key, value]) => {
+        const path = prefix ? `${prefix}.${key}` : key
+        return typeof value === 'object' && value !== null
+            ? leafEntries(value as Record<string, unknown>, path)
+            : [[path, String(value)] as [string, string]]
+    })
+}

--- a/src/i18n/app/__tests__/glossary.test.ts
+++ b/src/i18n/app/__tests__/glossary.test.ts
@@ -1,6 +1,10 @@
+import { APP_LOCALES } from '../config'
+import { deepMerge, type DeepPartial } from '../messages'
+import en from '../messages/en.json'
 import es419 from '../messages/es-419.json'
 import esAR from '../messages/es-AR.json'
 import ptBR from '../messages/pt-BR.json'
+import { leafEntries } from './catalog-helpers'
 
 /**
  * Enforces the shared locale glossary (mono: content/_system/glossary/) on the
@@ -8,71 +12,102 @@ import ptBR from '../messages/pt-BR.json'
  * forms. Register and word choice for content pages and app UI must not drift
  * apart; when the glossary changes, update these lists to match (TASK-21172).
  *
- * Raw files are checked, not resolved catalogs: es-AR is a deltas-only overlay
- * and its es-419 fallback is correct by design (see loadMessages).
+ * es-AR is checked RESOLVED (en ⊕ es-419 ⊕ delta, same as loadMessages) — a new
+ * es-419 string with tuteo must get a voseo override before it reaches Argentine
+ * users. es-419 and pt-BR are full catalogs, checked raw.
+ *
+ * Patterns use \s+ between words (NBSP from CAT tools still matches) and accept
+ * accent-dropped variants where the unaccented form is not itself a legitimate
+ * word in that locale.
  */
-
-// keys that quote third-party UI verbatim — exempt from glossary rules
-const EXCEPTIONS: Record<string, string> = {
-    'card.addToWallet.iosStep3': "quotes Apple Wallet's own menu label (Cartão/Tarjeta de débito ou crédito)",
-}
 
 interface Rule {
     name: string
     pattern: RegExp
+    // keys exempt from THIS rule only — e.g. strings quoting third-party UI verbatim
+    exceptions?: string[]
 }
 
 // match whole words incl. accented letters; JS \b is ASCII-only
 const word = (terms: string) => new RegExp(`(?<!\\p{L})(?:${terms})(?!\\p{L})`, 'iu')
 
-const RULES: Record<'es-419' | 'es-AR' | 'pt-BR', Rule[]> = {
+// quotes Apple Wallet's own menu label ("Tarjeta/Cartão de débito o crédito")
+const APPLE_WALLET_QUOTE = ['card.addToWallet.iosStep3']
+
+// rules shared by every Spanish locale (glossary.es-419.md is the base layer)
+const ES_COMMON: Rule[] = [
+    { name: 'wallet is "billetera", never "monedero"', pattern: word('monederos?') },
+    { name: 'usted is too formal for the app voice', pattern: word('usted') },
+    { name: '"enviar dinero", never "transferir fondos"', pattern: word('transferir\\s+fondos') },
+    {
+        name: 'the card is "tarjeta virtual", never debit/prepaid',
+        pattern: word('tarjeta\\s+(?:de\\s+d[eé]bito|prepaga)'),
+        exceptions: APPLE_WALLET_QUOTE,
+    },
+]
+
+const RULES: Record<Exclude<(typeof APP_LOCALES)[number], 'en'>, Rule[]> = {
     'es-419': [
-        { name: 'wallet is "billetera", never "monedero"', pattern: word('monederos?') },
-        { name: 'voseo is es-AR only', pattern: word('vos|podés|tenés|enviás|pagás|enviá|pagá|cargá|tocá|fijate') },
+        ...ES_COMMON,
+        // pagás/enviá/pagá NOT accent-folded: "pagas"/"envia"/"paga" are legitimate tuteo forms
+        {
+            name: 'voseo is es-AR only',
+            pattern: word('vos|pod[eé]s|ten[eé]s|envi[aá]s|pagás|enviá|pagá|cargá|tocá|fijate'),
+        },
         { name: 'vosotros is es-ES only', pattern: word('vosotr[oa]s|podéis|tenéis|enviáis') },
-        { name: 'usted is too formal for the app voice', pattern: word('usted') },
         { name: '"computadora", never "ordenador" (Spain)', pattern: word('ordenador(?:es)?') },
-        { name: '"tipo de cambio", never "tasa de cambio"', pattern: word('tasa de cambio') },
-        { name: '"enviar dinero", never "transferir fondos"', pattern: word('transferir fondos') },
+        { name: '"tipo de cambio", never "tasa de cambio"', pattern: word('tasa\\s+de\\s+cambio') },
     ],
     'es-AR': [
-        { name: 'wallet is "billetera", never "monedero"', pattern: word('monederos?') },
-        { name: 'tú-forms sound foreign in es-AR (use voseo)', pattern: word('tú|puedes|tienes|envías|sáltate') },
-        { name: 'usted is too formal for the app voice', pattern: word('usted') },
-        { name: '"dólar cripto", never "cripto dólar"', pattern: word('cripto\\s*dólar') },
+        ...ES_COMMON,
+        // "tú" not folded to "tu": the possessive "tu" is correct in voseo too.
+        // "sáltate" not folded: "saltate" is the correct voseo imperative.
+        { name: 'tú-forms sound foreign in es-AR (use voseo)', pattern: word('tú|puedes|tienes|env[ií]as|sáltate') },
+        { name: '"dólar cripto", never "cripto dólar"', pattern: word('cripto\\s*d[oó]lar') },
     ],
     'pt-BR': [
-        { name: '"celular", never "telemóvel" (Portugal)', pattern: word('telemóve(?:l|is)') },
+        { name: '"celular", never "telemóvel" (Portugal)', pattern: word('telem[oó]ve(?:l|is)') },
         { name: '"dinheiro", never "grana" (too slangy)', pattern: word('grana') },
-        { name: '"enviar dinheiro", never "transferir fundos"', pattern: word('transferir fundos') },
+        { name: '"enviar dinheiro", never "transferir fundos"', pattern: word('transferir\\s+fundos') },
+        { name: 'tu-conjugations are not pt-BR (use você)', pattern: word('tu\\s+(?:podes|tens|envias|pagas)') },
         {
             name: 'the card is "cartão virtual", never debit/prepaid',
-            pattern: word('cartão (?:de débito|pré[- ]pago)'),
+            pattern: word('cart[aã]o\\s+(?:de\\s+d[eé]bito|pr[eé][-\\s]pago)'),
+            exceptions: APPLE_WALLET_QUOTE,
         },
-        { name: '"pular a lista", never "furar a fila"', pattern: word('furar a fila') },
-        { name: '"sem CPF" framing is banned (trust rules)', pattern: word('sem CPF') },
+        { name: '"pular a lista", never "furar a fila"', pattern: word('furar\\s+a\\s+fila') },
+        // stricter than glossary.pt-br.md (which allows one positively-framed body
+        // use): app strings are short CTA-like copy — exempt per key if ever needed
+        { name: '"sem CPF" framing is banned (trust rules)', pattern: word('sem\\s+CPF') },
+        {
+            name: 'no circumvention language (trust rules)',
+            pattern: word('sem\\s+documentos|elimina\\s+essa\\s+barreira|sem\\s+verifica[cç][aã]o|sem\\s+burocracia'),
+        },
     ],
 }
 
-const CATALOGS = { 'es-419': es419, 'es-AR': esAR, 'pt-BR': ptBR } as const
-
-function leafEntries(obj: Record<string, unknown>, prefix = ''): Array<[string, string]> {
-    return Object.entries(obj).flatMap(([key, value]) => {
-        const path = prefix ? `${prefix}.${key}` : key
-        return typeof value === 'object' && value !== null
-            ? leafEntries(value as Record<string, unknown>, path)
-            : [[path, String(value)] as [string, string]]
-    })
+// es-AR resolved exactly as loadMessages resolves it — the delta alone would
+// hide tuteo leaking through the es-419 fallback
+const CATALOGS: Record<keyof typeof RULES, Record<string, unknown>> = {
+    'es-419': es419,
+    'es-AR': deepMerge(deepMerge(en, es419 as DeepPartial<typeof en>), esAR as DeepPartial<typeof en>),
+    'pt-BR': ptBR,
 }
 
+it('every non-en app locale has glossary rules', () => {
+    const expected = APP_LOCALES.filter((locale) => locale !== 'en').sort()
+    expect(Object.keys(RULES).sort()).toEqual(expected)
+})
+
 describe.each(Object.keys(RULES) as Array<keyof typeof RULES>)('%s glossary compliance', (locale) => {
-    const entries = leafEntries(CATALOGS[locale]).filter(([path]) => !(path in EXCEPTIONS))
+    const entries = leafEntries(CATALOGS[locale])
 
     it.each(RULES[locale].map((rule) => [rule.name, rule] as const))('%s', (_name, rule) => {
         const violations = entries
+            .filter(([path]) => !rule.exceptions?.includes(path))
             .filter(([, value]) => rule.pattern.test(value))
             .map(([path, value]) => `${path}: ${value}`)
-        // fix the string, or — if it quotes third-party UI — add the key to EXCEPTIONS
+        // fix the string, or — if it quotes third-party UI — add the key to the rule's exceptions
         expect(violations).toEqual([])
     })
 })

--- a/src/i18n/app/__tests__/glossary.test.ts
+++ b/src/i18n/app/__tests__/glossary.test.ts
@@ -1,0 +1,78 @@
+import es419 from '../messages/es-419.json'
+import esAR from '../messages/es-AR.json'
+import ptBR from '../messages/pt-BR.json'
+
+/**
+ * Enforces the shared locale glossary (mono: content/_system/glossary/) on the
+ * app catalogs — the deterministic subset: banned terms and wrong-register verb
+ * forms. Register and word choice for content pages and app UI must not drift
+ * apart; when the glossary changes, update these lists to match (TASK-21172).
+ *
+ * Raw files are checked, not resolved catalogs: es-AR is a deltas-only overlay
+ * and its es-419 fallback is correct by design (see loadMessages).
+ */
+
+// keys that quote third-party UI verbatim — exempt from glossary rules
+const EXCEPTIONS: Record<string, string> = {
+    'card.addToWallet.iosStep3': "quotes Apple Wallet's own menu label (Cartão/Tarjeta de débito ou crédito)",
+}
+
+interface Rule {
+    name: string
+    pattern: RegExp
+}
+
+// match whole words incl. accented letters; JS \b is ASCII-only
+const word = (terms: string) => new RegExp(`(?<!\\p{L})(?:${terms})(?!\\p{L})`, 'iu')
+
+const RULES: Record<'es-419' | 'es-AR' | 'pt-BR', Rule[]> = {
+    'es-419': [
+        { name: 'wallet is "billetera", never "monedero"', pattern: word('monederos?') },
+        { name: 'voseo is es-AR only', pattern: word('vos|podés|tenés|enviás|pagás|enviá|pagá|cargá|tocá|fijate') },
+        { name: 'vosotros is es-ES only', pattern: word('vosotr[oa]s|podéis|tenéis|enviáis') },
+        { name: 'usted is too formal for the app voice', pattern: word('usted') },
+        { name: '"computadora", never "ordenador" (Spain)', pattern: word('ordenador(?:es)?') },
+        { name: '"tipo de cambio", never "tasa de cambio"', pattern: word('tasa de cambio') },
+        { name: '"enviar dinero", never "transferir fondos"', pattern: word('transferir fondos') },
+    ],
+    'es-AR': [
+        { name: 'wallet is "billetera", never "monedero"', pattern: word('monederos?') },
+        { name: 'tú-forms sound foreign in es-AR (use voseo)', pattern: word('tú|puedes|tienes|envías|sáltate') },
+        { name: 'usted is too formal for the app voice', pattern: word('usted') },
+        { name: '"dólar cripto", never "cripto dólar"', pattern: word('cripto\\s*dólar') },
+    ],
+    'pt-BR': [
+        { name: '"celular", never "telemóvel" (Portugal)', pattern: word('telemóve(?:l|is)') },
+        { name: '"dinheiro", never "grana" (too slangy)', pattern: word('grana') },
+        { name: '"enviar dinheiro", never "transferir fundos"', pattern: word('transferir fundos') },
+        {
+            name: 'the card is "cartão virtual", never debit/prepaid',
+            pattern: word('cartão (?:de débito|pré[- ]pago)'),
+        },
+        { name: '"pular a lista", never "furar a fila"', pattern: word('furar a fila') },
+        { name: '"sem CPF" framing is banned (trust rules)', pattern: word('sem CPF') },
+    ],
+}
+
+const CATALOGS = { 'es-419': es419, 'es-AR': esAR, 'pt-BR': ptBR } as const
+
+function leafEntries(obj: Record<string, unknown>, prefix = ''): Array<[string, string]> {
+    return Object.entries(obj).flatMap(([key, value]) => {
+        const path = prefix ? `${prefix}.${key}` : key
+        return typeof value === 'object' && value !== null
+            ? leafEntries(value as Record<string, unknown>, path)
+            : [[path, String(value)] as [string, string]]
+    })
+}
+
+describe.each(Object.keys(RULES) as Array<keyof typeof RULES>)('%s glossary compliance', (locale) => {
+    const entries = leafEntries(CATALOGS[locale]).filter(([path]) => !(path in EXCEPTIONS))
+
+    it.each(RULES[locale].map((rule) => [rule.name, rule] as const))('%s', (_name, rule) => {
+        const violations = entries
+            .filter(([, value]) => rule.pattern.test(value))
+            .map(([path, value]) => `${path}: ${value}`)
+        // fix the string, or — if it quotes third-party UI — add the key to EXCEPTIONS
+        expect(violations).toEqual([])
+    })
+})

--- a/src/i18n/app/__tests__/messages.test.ts
+++ b/src/i18n/app/__tests__/messages.test.ts
@@ -5,6 +5,7 @@ import en from '../messages/en.json'
 import es419 from '../messages/es-419.json'
 import esAR from '../messages/es-AR.json'
 import ptBR from '../messages/pt-BR.json'
+import { leafPaths, leafValue } from './catalog-helpers'
 
 const CATALOGS = { en, 'es-419': es419, 'es-AR': esAR, 'pt-BR': ptBR } as const
 
@@ -12,17 +13,6 @@ const CATALOGS = { en, 'es-419': es419, 'es-AR': esAR, 'pt-BR': ptBR } as const
 // holds a subset of the en key set rather than all of it.
 const DELTA_LOCALES: readonly AppLocale[] = ['es-AR']
 const FULL_LOCALES = APP_LOCALES.filter((locale) => !DELTA_LOCALES.includes(locale))
-
-function leafPaths(obj: Record<string, unknown>, prefix = ''): string[] {
-    return Object.entries(obj).flatMap(([key, value]) => {
-        const path = prefix ? `${prefix}.${key}` : key
-        return typeof value === 'object' && value !== null ? leafPaths(value as Record<string, unknown>, path) : [path]
-    })
-}
-
-function leafValue(catalog: Record<string, unknown>, path: string): string {
-    return path.split('.').reduce<unknown>((node, key) => (node as Record<string, unknown>)[key], catalog) as string
-}
 
 /**
  * English strings that legitimately carry more than one translation. Spanish and

--- a/src/i18n/app/__tests__/shhhhh-catalog.test.ts
+++ b/src/i18n/app/__tests__/shhhhh-catalog.test.ts
@@ -2,13 +2,7 @@ import { APP_LOCALES } from '../config'
 import { loadMessages } from '../messages'
 import es419 from '../messages/es-419.json'
 import esAR from '../messages/es-AR.json'
-
-function leafPaths(obj: Record<string, unknown>, prefix = ''): string[] {
-    return Object.entries(obj).flatMap(([key, value]) => {
-        const path = prefix ? `${prefix}.${key}` : key
-        return typeof value === 'object' && value !== null ? leafPaths(value as Record<string, unknown>, path) : [path]
-    })
-}
+import { leafPaths } from './catalog-helpers'
 
 describe('/shhhhh catalog', () => {
     it.each(APP_LOCALES)('%s keeps the <counter> tag the hero interpolates', async (locale) => {

--- a/src/i18n/app/messages.ts
+++ b/src/i18n/app/messages.ts
@@ -3,7 +3,7 @@ import en from './messages/en.json'
 
 export type AppMessages = typeof en
 
-type DeepPartial<T> = { [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K] }
+export type DeepPartial<T> = { [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K] }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value)


### PR DESCRIPTION
## Summary

App UI strings (~2,200 keys × 3 locales) and marketing/content prose sit on the same screen but had no shared terminology governance — terms and register could drift ("monedero" vs "billetera", tuteo leaking into es-AR). The glossary now lives in mono `content/_system/glossary/glossary.{es-419,es-ar,pt-br}.md` (extracted from the locale context files). This PR adds the enforcement half: a jest suite that checks the app catalogs against the glossary's deterministic subset — banned terms and wrong-register verb forms.

An audit of the current catalogs on dev found zero real violations, so this PR is the test only. Key design points (hardened after automated review):

- **es-AR is checked resolved** (en ⊕ es-419 ⊕ delta, same as `loadMessages`) — a new es-419 string with tuteo needs a voseo override before it reaches Argentine users.
- **Exceptions are per-rule**, not global — `card.addToWallet.iosStep3` (quotes Apple Wallet's own menu label) is exempt only from the debit/prepaid-card rule.
- Patterns are NBSP-proof (`\s+` between phrase words) and accept accent-dropped variants where the unaccented form is not a legitimate word in that locale.
- A guard test fails when a new locale JSON ships without glossary rules.
- Shared catalog flatten helpers extracted to `catalog-helpers.ts` (messages/shhhhh tests had two private copies; this PR would have added a third).

## Task

TASK-21172 — Localization governance: shared glossary + tone (app ↔ content)

## Design notes / accepted trade-offs

- Term lists are hardcoded here rather than parsed from mono (mono is not available in CI); the glossary files are the source of truth and both sides say to keep them in sync.
- The "sem CPF" rule is stricter than the glossary (which allows one positively-framed body use) — app strings are short CTA-like copy; per-rule exceptions handle any future legit use.
- `DeepPartial` is now exported from `messages.ts` (type-only, no runtime change) so the test can resolve es-AR synchronously.

## Risks / breaking changes

None — test-only plus one type export. No runtime code touched.

## QA

`npx jest src/i18n/app/__tests__` — 90 tests including 20 glossary checks across es-419 / es-AR / pt-BR. Regexes negative-tested (accented-word boundaries: "vosotros" does not false-positive the `vos` rule; "Pagas" tuteo does not false-positive the voseo rule).

Screenshots: N/A (no visible change)
