### PR TITLE
fix(qr): recognize scanned Solana and Tron addresses

### DIFF
--- a/src/components/Global/QRScannerOverlay/__tests__/base58-case.test.tsx
+++ b/src/components/Global/QRScannerOverlay/__tests__/base58-case.test.tsx
@@ -13,7 +13,7 @@
  * the wiring in this component was wrong, so the guard has to live here.
  */
 import React from 'react'
-import { screen, waitFor } from '@testing-library/react'
+import { act, screen, waitFor } from '@testing-library/react'
 import { renderWithIntl } from '@/test-utils/intl'
 
 const mockPush = jest.fn()
@@ -64,10 +64,19 @@ import QRScannerOverlay from '../index'
 const SOLANA_WITH_UPPERCASE_L = '9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM'
 const TRON = 'TJRyWwFs9wTFGZg3JbrVriFbNfCug5tDeC'
 const EVM_CHECKSUMMED = '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed'
+// EIP-55 says case only carries a checksum when the address is neither all-lower
+// nor all-upper, so this one is valid and must survive.
+const EVM_UPPERCASE = '0X5AAEB6053F3E94C9B9A09F33669435E7EF1BEAED'
+// Mixed case, so the checksum is real — and wrong. viem must keep rejecting it.
+const EVM_BAD_CHECKSUM = '0xAbCdEf1234567890123456789012345678901234'
+const BECH32_UPPERCASE = 'BC1QAR0SRRR7XFKVY5L643LYDNW9RE59GTZZWF5MDQ'
+const BOLT11_UPPERCASE = 'LNBC1230N1PJJ2LX9PP5ABC123'
 
 const scan = async (data: string) => {
     renderWithIntl(<QRScannerOverlay />)
-    await onScan(data)
+    await act(async () => {
+        await onScan(data)
+    })
 }
 
 describe('QRScannerOverlay case handling', () => {
@@ -75,20 +84,47 @@ describe('QRScannerOverlay case handling', () => {
         mockPush.mockClear()
     })
 
-    it('recognizes a Solana address whose case a lowercase pass would destroy', async () => {
-        await scan(SOLANA_WITH_UPPERCASE_L)
-        await waitFor(() => expect(screen.getByText('Solana not supported yet.')).toBeInTheDocument())
-        expect(screen.queryByText('Unrecognized QR code')).not.toBeInTheDocument()
+    describe('base58 addresses — case is data, so recognize the raw scan', () => {
+        it('recognizes a Solana address whose case a lowercase pass would destroy', async () => {
+            await scan(SOLANA_WITH_UPPERCASE_L)
+            expect(screen.getByText('Solana not supported yet.')).toBeInTheDocument()
+            expect(screen.queryByText('Unrecognized QR code')).not.toBeInTheDocument()
+        })
+
+        it('recognizes a Tron address, which always starts with an uppercase T', async () => {
+            await scan(TRON)
+            expect(screen.getByText('Tron not supported yet.')).toBeInTheDocument()
+        })
     })
 
-    it('recognizes a Tron address, which always starts with an uppercase T', async () => {
-        await scan(TRON)
-        await waitFor(() => expect(screen.getByText('Tron not supported yet.')).toBeInTheDocument())
+    describe('all-uppercase payloads — QR alphanumeric mode uppercases, so retry lowercased', () => {
+        it('accepts an uppercase EVM address', async () => {
+            await scan(EVM_UPPERCASE)
+            expect(screen.getByText('ℹ️ Payment Confirmation')).toBeInTheDocument()
+        })
+
+        it('accepts an uppercase bech32 Bitcoin address', async () => {
+            await scan(BECH32_UPPERCASE)
+            expect(screen.getByText('Bitcoin not supported yet.')).toBeInTheDocument()
+        })
+
+        it('accepts an uppercase Lightning invoice', async () => {
+            await scan(BOLT11_UPPERCASE)
+            expect(screen.getByText('Bitcoin not supported yet.')).toBeInTheDocument()
+        })
     })
 
-    it('still accepts a checksummed EVM address', async () => {
-        await scan(EVM_CHECKSUMMED)
-        await waitFor(() => expect(screen.getByText('ℹ️ Payment Confirmation')).toBeInTheDocument())
+    describe('mixed case — the case is the user’s, so it must be honoured', () => {
+        it('accepts a checksummed EVM address', async () => {
+            await scan(EVM_CHECKSUMMED)
+            expect(screen.getByText('ℹ️ Payment Confirmation')).toBeInTheDocument()
+        })
+
+        it('rejects an EVM address with a bad EIP-55 checksum rather than laundering it', async () => {
+            await scan(EVM_BAD_CHECKSUM)
+            expect(screen.getByText('Unrecognized QR code')).toBeInTheDocument()
+            expect(screen.queryByText('ℹ️ Payment Confirmation')).not.toBeInTheDocument()
+        })
     })
 
     it('still routes a Peanut URL', async () => {

--- a/src/components/Global/QRScannerOverlay/__tests__/base58-case.test.tsx
+++ b/src/components/Global/QRScannerOverlay/__tests__/base58-case.test.tsx
@@ -1,0 +1,98 @@
+/** @jest-environment jsdom */
+/**
+ * QR scanner case handling (TASK-21111 regression pin).
+ *
+ * The load-bearing claim: `processQRCode` must hand the RAW scan to
+ * `recognizeQr`, never the lowercased copy it keeps for routing. Base58 chain
+ * addresses carry meaning in their case — an uppercase L is a valid Solana
+ * character while a lowercase l is not, and every Tron address starts with an
+ * uppercase T — so lowercasing first made roughly half of all Solana addresses
+ * and every Tron address fall through to "Unrecognized QR code".
+ *
+ * `recognizeQr` itself was always correct and is covered by its own suite; only
+ * the wiring in this component was wrong, so the guard has to live here.
+ */
+import React from 'react'
+import { screen, waitFor } from '@testing-library/react'
+import { renderWithIntl } from '@/test-utils/intl'
+
+const mockPush = jest.fn()
+
+jest.mock('@/assets', () => ({}))
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ push: mockPush }),
+    usePathname: () => '/home',
+    useSearchParams: () => new URLSearchParams(),
+}))
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
+jest.mock('use-haptic', () => ({ useHaptic: () => ({ triggerHaptic: jest.fn() }) }))
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }))
+jest.mock('@/app/actions/ens', () => ({ resolveEns: jest.fn() }))
+jest.mock('@/utils/api-fetch', () => ({ serverFetch: jest.fn() }))
+jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => false, openExternalUrl: jest.fn() }))
+jest.mock('@/components/0_Bruddle/Toast', () => ({ useToast: () => ({ error: jest.fn() }) }))
+jest.mock('@/context/authContext', () => ({ useAuth: () => ({ user: { user: { username: 'satoshi' } } }) }))
+jest.mock('@/context/ModalsContext', () => ({
+    useModalsContext: () => ({ isQRScannerOpen: true, setIsQRScannerOpen: jest.fn() }),
+}))
+jest.mock('@/components/Global/QRBottomDrawer', () => ({ __esModule: true, default: () => null }))
+jest.mock('@/components/Global/Modal', () => ({
+    __esModule: true,
+    default: ({ title, visible, children }: { title?: string; visible: boolean; children: React.ReactNode }) =>
+        visible ? (
+            <div>
+                <h1>{title}</h1>
+                {children}
+            </div>
+        ) : null,
+}))
+
+// Capture the scan callback so a test can feed it a payload directly.
+let onScan: (data: string) => Promise<{ success: boolean; error?: string }>
+jest.mock('@/components/Global/QRScanner', () => ({
+    __esModule: true,
+    default: (props: { onScan: (data: string) => Promise<{ success: boolean; error?: string }> }) => {
+        onScan = props.onScan
+        return null
+    },
+}))
+
+import QRScannerOverlay from '../index'
+
+// Real, publicly known addresses. The Solana one holds an uppercase L, the
+// character that a `.toLowerCase()` turns into the one letter base58 excludes.
+const SOLANA_WITH_UPPERCASE_L = '9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM'
+const TRON = 'TJRyWwFs9wTFGZg3JbrVriFbNfCug5tDeC'
+const EVM_CHECKSUMMED = '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed'
+
+const scan = async (data: string) => {
+    renderWithIntl(<QRScannerOverlay />)
+    await onScan(data)
+}
+
+describe('QRScannerOverlay case handling', () => {
+    beforeEach(() => {
+        mockPush.mockClear()
+    })
+
+    it('recognizes a Solana address whose case a lowercase pass would destroy', async () => {
+        await scan(SOLANA_WITH_UPPERCASE_L)
+        await waitFor(() => expect(screen.getByText('Solana not supported yet.')).toBeInTheDocument())
+        expect(screen.queryByText('Unrecognized QR code')).not.toBeInTheDocument()
+    })
+
+    it('recognizes a Tron address, which always starts with an uppercase T', async () => {
+        await scan(TRON)
+        await waitFor(() => expect(screen.getByText('Tron not supported yet.')).toBeInTheDocument())
+    })
+
+    it('still accepts a checksummed EVM address', async () => {
+        await scan(EVM_CHECKSUMMED)
+        await waitFor(() => expect(screen.getByText('ℹ️ Payment Confirmation')).toBeInTheDocument())
+    })
+
+    it('still routes a Peanut URL', async () => {
+        await scan('https://peanut.example.org/satoshi')
+        await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/satoshi'))
+    })
+})

--- a/src/components/Global/QRScannerOverlay/index.tsx
+++ b/src/components/Global/QRScannerOverlay/index.tsx
@@ -232,14 +232,24 @@ export default function QRScannerOverlay() {
         let redirectUrl: string | undefined = undefined
         let toConfirmUrl: string | undefined = undefined
         const normalized = data.toLowerCase()
-        // Recognize the RAW scan, never `normalized`. Base58 chain addresses carry
-        // meaning in their case: an uppercase L is a valid Solana character but a
-        // lowercase l is not, and every Tron address starts with an uppercase T.
-        // Lowercasing first therefore made ~half of all Solana addresses and every
-        // Tron address unrecognizable. `normalized` stays for routing below, where
-        // hex and ENS are case-insensitive anyway. recognizeQr lowercases the
-        // branches that need it (Peanut URL, PIX) itself.
-        const recognized = recognizeQr(data)
+        // Recognize the RAW scan first. Base58 chain addresses carry meaning in
+        // their case: an uppercase L is a valid Solana character but a lowercase l
+        // is not, and every Tron address starts with an uppercase T. Lowercasing
+        // up front made ~half of all Solana addresses and every Tron address
+        // unrecognizable.
+        //
+        // Retry lowercased ONLY for an all-uppercase payload. QR alphanumeric mode
+        // encodes uppercase only and is much denser, so bech32 addresses, BOLT-11
+        // invoices and hex addresses are often uppercased by the encoder — that
+        // case is an artifact and carries no information. A payload with any
+        // lowercase letter kept its original case, so a mixed-case EIP-55 checksum
+        // is real and viem must stay free to reject a bad one: silently lowercasing
+        // those turned a corrupted address into a valid-looking payment target.
+        //
+        // `normalized` stays for routing below, where hex and ENS are
+        // case-insensitive anyway, and recognizeQr lowercases the branches that
+        // need it (Peanut URL, PIX) itself.
+        const recognized = recognizeQr(data) ?? (data === data.toUpperCase() ? recognizeQr(normalized) : null)
 
         const getLogData = () => {
             if (recognized === EQrType.PIX_KEY) {

--- a/src/components/Global/QRScannerOverlay/index.tsx
+++ b/src/components/Global/QRScannerOverlay/index.tsx
@@ -232,23 +232,13 @@ export default function QRScannerOverlay() {
         let redirectUrl: string | undefined = undefined
         let toConfirmUrl: string | undefined = undefined
         const normalized = data.toLowerCase()
-        // Recognize the RAW scan first. Base58 chain addresses carry meaning in
-        // their case: an uppercase L is a valid Solana character but a lowercase l
-        // is not, and every Tron address starts with an uppercase T. Lowercasing
-        // up front made ~half of all Solana addresses and every Tron address
-        // unrecognizable.
-        //
-        // Retry lowercased ONLY for an all-uppercase payload. QR alphanumeric mode
-        // encodes uppercase only and is much denser, so bech32 addresses, BOLT-11
-        // invoices and hex addresses are often uppercased by the encoder — that
-        // case is an artifact and carries no information. A payload with any
-        // lowercase letter kept its original case, so a mixed-case EIP-55 checksum
-        // is real and viem must stay free to reject a bad one: silently lowercasing
-        // those turned a corrupted address into a valid-looking payment target.
-        //
-        // `normalized` stays for routing below, where hex and ENS are
-        // case-insensitive anyway, and recognizeQr lowercases the branches that
-        // need it (Peanut URL, PIX) itself.
+        // Recognize the RAW scan: in base58 the case IS the address (a lowercase l
+        // is not a Solana character, and Tron anchors on an uppercase T), so
+        // lowercasing first lost ~half of all Solana and every Tron address.
+        // Retry lowercased only when the payload is all-uppercase — QR alphanumeric
+        // mode encodes uppercase only, so that case came from the encoder. Any
+        // lowercase letter means the case is the user's, and a mixed-case EIP-55
+        // checksum must stay rejectable instead of laundered into a payable address.
         const recognized = recognizeQr(data) ?? (data === data.toUpperCase() ? recognizeQr(normalized) : null)
 
         const getLogData = () => {

--- a/src/components/Global/QRScannerOverlay/index.tsx
+++ b/src/components/Global/QRScannerOverlay/index.tsx
@@ -232,7 +232,14 @@ export default function QRScannerOverlay() {
         let redirectUrl: string | undefined = undefined
         let toConfirmUrl: string | undefined = undefined
         const normalized = data.toLowerCase()
-        const recognized = recognizeQr(normalized)
+        // Recognize the RAW scan, never `normalized`. Base58 chain addresses carry
+        // meaning in their case: an uppercase L is a valid Solana character but a
+        // lowercase l is not, and every Tron address starts with an uppercase T.
+        // Lowercasing first therefore made ~half of all Solana addresses and every
+        // Tron address unrecognizable. `normalized` stays for routing below, where
+        // hex and ENS are case-insensitive anyway. recognizeQr lowercases the
+        // branches that need it (Peanut URL, PIX) itself.
+        const recognized = recognizeQr(data)
 
         const getLogData = () => {
             if (recognized === EQrType.PIX_KEY) {


### PR DESCRIPTION
## Summary

The QR scanner rejected valid Solana deposit addresses as "Unrecognized QR code".

`processQRCode` lowercased the scanned payload and passed that copy to `recognizeQr`. Base58 carries meaning in its case, so the lowercase pass destroyed the address:

- **Solana** — an uppercase `L` is a valid base58 character, a lowercase `l` is not. Any address holding an `L` stopped matching. That is **~53% of addresses** (measured over random 44-char base58 strings).
- **Tron** — every Tron address starts with an uppercase `T`, and the pattern anchors on `^T`. Lowercasing broke **100%** of them, always.

Hex addresses were unaffected, which is why this stayed invisible: EVM survives `.toLowerCase()` because hex is case-insensitive.

## The fix

Recognize the **raw** scan first, and retry lowercased **only for an all-uppercase payload**:

```ts
const recognized = recognizeQr(data) ?? (data === data.toUpperCase() ? recognizeQr(normalized) : null)
```

The two halves encode when case is information and when it is an artifact:

| Payload | Case is… | Behavior |
|---|---|---|
| Solana / Tron base58 | **data** — `L` ≠ `l`, `T` ≠ `t` | raw pass matches (**the fix**) |
| All-uppercase bech32 / BOLT-11 / hex | **artifact** — QR alphanumeric mode encodes uppercase only, and is denser for it | retried lowercased |
| Mixed-case hex | **the user's** — EIP-55 checksum | honoured; viem rejects a bad one |

That last row is a deliberate tightening. The old blanket lowercase laundered a mixed-case address with a **broken** EIP-55 checksum into a valid-looking payment target — which is the exact corruption EIP-55 exists to catch. It now reaches the unrecognized modal instead of the send flow.

`normalized` still drives the routing below, where hex and ENS are case-insensitive anyway, and `recognizeQr` lowercases the branches that need it (Peanut URL, PIX) itself.

## Task

[TASK-21111](https://app.notion.com/p/peanutprotocol/P2-QR-scanner-does-not-recognize-Solana-deposit-addresses-3b183811757981e48e89e667fbd03ab7) — reported twice via support; reporter received the bug bounty.

## Evidence

`recognizeQr` was never the problem. Its 635-line suite passes raw mixed-case data and even asserts case-sensitivity on purpose (`'LNBC…'` must not match `BITCOIN_INVOICE`). The single call site lowercased one line earlier and had no test at all — so the new test covers the **component**, not the parser.

PostHog, last 60 days of `qr_scanned`:

| qr_type | scans | users |
|---|---|---|
| `null` (unrecognized) | 457 | 215 |
| `SOLANA_ADDRESS` | 6 | 4 |
| `TRON_ADDRESS` | **0** | **0** |

Tron has never once been recognized in production. One unrecognized scan in that window is a confirmed base58 Solana address holding an `L`.

Production sanity checks behind the design:
- **All 28** distinct mixed-case addresses scanned in 90 days carry a **valid** EIP-55 checksum — the tightening costs nothing real.
- All-uppercase payloads are genuinely common (93 in 180 days: EMVCo, FIDO, PIX), which is why the uppercase retry stays.

## Risks

Low. Frontend only, one expression, no backend or contract surface.

The one behavior change beyond recognition is the bad-checksum tightening described above — measured at zero production instances.

Recognized Solana/Tron scans now reach the existing "not supported yet / get notified" modal instead of the unrecognized one. See Design notes.

## Design notes / accepted trade-offs

**Routing is unchanged, deliberately.** After this fix a scanned Solana address lands on the existing `QR_NOT_SUPPORTED` modal. Solana and Tron *are* live withdraw destinations (`chainRegistry.consts.ts`, Rhino, behind `chain-rollout-solana` / `chain-rollout-tron`), so that copy is arguably stale — but wiring scan-to-send would need a withdraw deep-link with chain preselection plus flag gating. That is a feature, not this bug, and the reported user was scanning **Peanut's own deposit address**, for which "send to it" is not a meaningful destination anyway. Flagging it rather than scope-creeping.

**Revealed, not introduced — uppercase URL schemes.** The `PEANUT_URL` branch strips the protocol with a case-sensitive regex (`index.tsx:286`), so `HTTPS://PEANUT.ME/satoshi` routes to `//PEANUT.ME/satoshi` and 404s. Same QR-uppercasing reason as above, so it is reachable. Pre-existing and untouched by this diff — filed for a follow-up rather than bundled here.

**Solana/Bitcoin label ambiguity.** A Solana address starting with `1` or `3` (~3.4%) matches the Bitcoin pattern first and is labelled "Bitcoin". Cosmetic, on a modal that says "not supported" either way, and unfixable without real checksum validation. Pre-existing.

## QA

`npm test` — 228 suites, 2925 tests, green.

New pin: `src/components/Global/QRScannerOverlay/__tests__/base58-case.test.tsx`. It discriminates all three candidate designs — only the shipped one passes all 8:

| variant | failures |
|---|---|
| original (lowercase everything) | 3 — both base58 cases + checksum laundering |
| raw-only (no uppercase retry) | 3 — all uppercase cases |
| **shipped** | **0** |

Manual: open the scanner, scan any Solana address containing an uppercase `L` (e.g. the QR on Add money → Crypto → Solana). Before: "Unrecognized QR code". After: "Solana not supported yet."

## Screenshots

N/A — no visible change. The modal that renders was already built; this PR only changes which one is reached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QR code scanning for case-sensitive addresses and payment payloads.
  * Preserved valid uppercase and mixed-case formats, including checksummed EVM addresses.
  * Added fallback handling for fully uppercase QR contents.
  * Improved routing for Peanut URLs.
  * Improved validation and handling of invalid address checksums.
  * Enhanced support for Solana, Tron, bech32, and BOLT11 QR payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->