### PR TITLE
seo: fix Googlebot disallows, missing canonicals, and 10 dropped receive-from pages

### DIFF
--- a/scripts/verify-content.ts
+++ b/scripts/verify-content.ts
@@ -74,14 +74,17 @@ function listDirs(dir: string): string[] {
 }
 
 /**
- * Receive-money-from pages render only for corridor origins that actually have
- * a receive-from article. Mirrors RECEIVE_SOURCES in src/data/seo/corridors.ts.
+ * Receive-money-from pages render for every published receive-from article.
+ * Mirrors RECEIVE_SOURCES in src/data/seo/corridors.ts (listPublishedSlugs):
+ * publication is gated on the article existing, not on corridor membership.
  * Without this gate, both the route index and the sitemap "expected URLs" would
  * agree with each other on a slug that 404s at runtime (e.g. colombia, mexico).
  */
-function gateReceiveSources(corridors: Array<{ from: string; to: string }>): string[] {
-    const origins = [...new Set(corridors.map((c) => c.from))]
-    return origins.filter((slug) => fs.existsSync(path.join(CONTENT_DIR, 'receive-from', slug, 'en.md')))
+function gateReceiveSources(): string[] {
+    return listDirs(path.join(CONTENT_DIR, 'receive-from')).filter((slug) => {
+        const en = path.join(CONTENT_DIR, 'receive-from', slug, 'en.md')
+        return fs.existsSync(en) && isPublished(fs.readFileSync(en, 'utf-8'))
+    })
 }
 
 function getAllMdFiles(dir: string): string[] {
@@ -193,7 +196,7 @@ function discoverRoutes(): Set<string> {
             corridors.push({ to: dest, from: origin })
         }
     }
-    const receiveSources = gateReceiveSources(corridors)
+    const receiveSources = gateReceiveSources()
 
     // Check which routes actually have page.tsx files
     const hasRoute = (routePath: string) => {
@@ -705,7 +708,7 @@ function expectedSitemapUrls(): string[] {
         const fromDir = path.join(CONTENT_DIR, 'send-to', dest, 'from')
         for (const origin of listDirs(fromDir)) corridors.push({ from: origin, to: dest })
     }
-    const receiveSources = gateReceiveSources(corridors)
+    const receiveSources = gateReceiveSources()
 
     for (const locale of SUPPORTED_LOCALES) {
         for (const slug of countrySlugs) {

--- a/src/app/careers/page.tsx
+++ b/src/app/careers/page.tsx
@@ -6,6 +6,9 @@ export const metadata = generateMetadata({
     description:
         'Explore career opportunities at Peanut. Join our team to build the future of fast, global peer-to-peer payments with digital dollars.',
     keywords: 'careers, jobs, employment, Peanut careers, P2P payments jobs, fintech jobs, crypto jobs, tech jobs',
+    // Without this the page inherits the root layout's `canonical: '/'` and
+    // declares the homepage as its canonical while sitting in the sitemap.
+    canonical: '/careers',
 })
 
 export default function CareersPage() {

--- a/src/app/lp/card/page.tsx
+++ b/src/app/lp/card/page.tsx
@@ -9,8 +9,9 @@ export const metadata = generateMeta({
         'Join Card Pioneers for early access to the Peanut Card. Reserve your spot with $10, earn $5 for every friend who joins, and spend your dollars globally.',
     keywords:
         'peanut card, card pioneers, crypto card, digital dollars, global spending, early access, referral rewards, international card',
-    // Without this the page inherits the root layout's `canonical: '/'` and
-    // declares the homepage as its canonical while sitting in the sitemap.
+    // Without this the page inherits lp/layout.tsx's deliberate `canonical: '/'`
+    // (the /lp subtree aliases the root landing page). That policy is wrong for
+    // /lp/card specifically: it's a distinct product page sitting in the sitemap.
     canonical: '/lp/card',
 })
 

--- a/src/app/lp/card/page.tsx
+++ b/src/app/lp/card/page.tsx
@@ -9,6 +9,9 @@ export const metadata = generateMeta({
         'Join Card Pioneers for early access to the Peanut Card. Reserve your spot with $10, earn $5 for every friend who joins, and spend your dollars globally.',
     keywords:
         'peanut card, card pioneers, crypto card, digital dollars, global spending, early access, referral rewards, international card',
+    // Without this the page inherits the root layout's `canonical: '/'` and
+    // declares the homepage as its canonical while sitting in the sitemap.
+    canonical: '/lp/card',
 })
 
 export default function CardLPPage() {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -4,6 +4,38 @@ import { SUPPORTED_LOCALES } from '@/i18n/types'
 
 const IS_PRODUCTION_DOMAIN = BASE_URL === 'https://peanut.me'
 
+// Paths kept out of the index: the API surface, the SDK bundle, and the
+// auth-gated app routes. Shared by every named crawler group — a group that
+// omits these silently opts that crawler out of ALL disallows, because a
+// user-agent only ever obeys the single most specific group that matches it.
+const DISALLOWED_PATHS = [
+    '/api/',
+    '/sdk/',
+    // Auth-gated app routes
+    '/home',
+    '/profile',
+    '/settings',
+    '/send',
+    '/request',
+    '/setup',
+    '/claim',
+    '/pay',
+    '/dev/',
+    '/qr',
+    '/history',
+    '/points',
+    '/rewards',
+    '/invite',
+    '/kyc',
+    '/maintenance',
+    '/quests',
+    '/receipt',
+    '/crisp-proxy',
+    '/card-payment',
+    '/add-money',
+    '/withdraw',
+]
+
 export default function robots(): MetadataRoute.Robots {
     // Block indexing on staging, preview deploys, and non-production domains
     if (!IS_PRODUCTION_DOMAIN) {
@@ -22,10 +54,15 @@ export default function robots(): MetadataRoute.Robots {
             },
 
             // Googlebot must be able to fetch the dynamic OG images too — the
-            // generic `disallow: /api/` below would otherwise block them.
+            // generic `disallow: /api/` below would otherwise block them. The
+            // shared disallows are repeated here on purpose: Googlebot obeys
+            // this group INSTEAD of the `*` group, so without them it would
+            // treat every auth-gated route as crawlable. The narrower
+            // `/api/og` allow still wins over `/api/` by longest-match.
             {
                 userAgent: 'Googlebot',
                 allow: ['/api/og'],
+                disallow: DISALLOWED_PATHS,
             },
 
             // AI search engine crawlers — explicitly welcome
@@ -55,33 +92,7 @@ export default function robots(): MetadataRoute.Robots {
                     // SEO routes (all locale-prefixed)
                     ...SUPPORTED_LOCALES.map((l) => `/${l}/`),
                 ],
-                disallow: [
-                    '/api/',
-                    '/sdk/',
-                    // Auth-gated app routes
-                    '/home',
-                    '/profile',
-                    '/settings',
-                    '/send',
-                    '/request',
-                    '/setup',
-                    '/claim',
-                    '/pay',
-                    '/dev/',
-                    '/qr',
-                    '/history',
-                    '/points',
-                    '/rewards',
-                    '/invite',
-                    '/kyc',
-                    '/maintenance',
-                    '/quests',
-                    '/receipt',
-                    '/crisp-proxy',
-                    '/card-payment',
-                    '/add-money',
-                    '/withdraw',
-                ],
+                disallow: DISALLOWED_PATHS,
             },
 
             // Rate-limit aggressive SEO crawlers

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -5,9 +5,10 @@ import { SUPPORTED_LOCALES } from '@/i18n/types'
 const IS_PRODUCTION_DOMAIN = BASE_URL === 'https://peanut.me'
 
 // Paths kept out of the index: the API surface, the SDK bundle, and the
-// auth-gated app routes. Shared by every named crawler group — a group that
-// omits these silently opts that crawler out of ALL disallows, because a
-// user-agent only ever obeys the single most specific group that matches it.
+// auth-gated app routes. Used by the `*` and Googlebot groups; the other named
+// groups below carry their own (narrower) lists. Mind the footgun when editing:
+// a crawler only ever obeys the single most specific group that matches it, so
+// a named group that omits a path silently opts that crawler out of it.
 const DISALLOWED_PATHS = [
     '/api/',
     '/sdk/',

--- a/src/data/seo/corridors.test.ts
+++ b/src/data/seo/corridors.test.ts
@@ -1,32 +1,44 @@
 import fs from 'fs'
 import path from 'path'
-import { CORRIDORS, RECEIVE_SOURCES } from './corridors'
+import { RECEIVE_SOURCES } from './corridors'
 
 const RECEIVE_FROM_DIR = path.join(process.cwd(), 'src/content/content/receive-from')
 
-// Regression guard for the May 2026 live 404s: receive-money-from rendered for
-// every corridor origin, but origins lacking a receive-from article (colombia,
-// mexico) 404ed. RECEIVE_SOURCES must be CORRIDORS.from gated by content.
-describe('RECEIVE_SOURCES', () => {
-    it('only contains corridor origins', () => {
-        const origins = new Set(CORRIDORS.map((c) => c.from))
-        for (const slug of RECEIVE_SOURCES) {
-            expect(origins.has(slug)).toBe(true)
-        }
-    })
+/** Re-derive the expected set straight off the filesystem, independently of
+ *  the content lib the loader uses — a guard that reuses the loader's own
+ *  helper would only prove it equals itself. */
+function publishedReceiveFromSlugs(): string[] {
+    return fs
+        .readdirSync(RECEIVE_FROM_DIR)
+        .filter((slug) => fs.statSync(path.join(RECEIVE_FROM_DIR, slug)).isDirectory())
+        .filter((slug) => fs.existsSync(path.join(RECEIVE_FROM_DIR, slug, 'en.md')))
+        .filter((slug) => {
+            const raw = fs.readFileSync(path.join(RECEIVE_FROM_DIR, slug, 'en.md'), 'utf8')
+            const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---/.exec(raw)?.[1] ?? ''
+            return !/^published:\s*false\s*$/m.test(frontmatter)
+        })
+}
 
-    it('only contains origins that have a receive-from article (no 404s)', () => {
+// Regression guard for the May 2026 live 404s: receive-money-from must only
+// render slugs that have a published article. The guard used to also require
+// RECEIVE_SOURCES ⊆ CORRIDORS.from, which was never what protected us — it was
+// an artifact of how the list was built, and it silently dropped 10 authored
+// countries whose articles were live but unreachable. What the route actually
+// needs is the both-directions equality below: nothing rendered without
+// content (no 404s), and nothing authored left behind (no orphans).
+describe('RECEIVE_SOURCES', () => {
+    it('only contains slugs that have a published receive-from article (no 404s)', () => {
         for (const slug of RECEIVE_SOURCES) {
             const enFile = path.join(RECEIVE_FROM_DIR, slug, 'en.md')
             expect(fs.existsSync(enFile)).toBe(true)
         }
     })
 
-    it('drops corridor origins with no receive-from article', () => {
-        const origins = [...new Set(CORRIDORS.map((c) => c.from))]
-        for (const slug of origins) {
-            const hasArticle = fs.existsSync(path.join(RECEIVE_FROM_DIR, slug, 'en.md'))
-            expect(RECEIVE_SOURCES.includes(slug)).toBe(hasArticle)
-        }
+    it('contains every published receive-from article (no orphaned content)', () => {
+        expect([...RECEIVE_SOURCES].sort()).toEqual(publishedReceiveFromSlugs().sort())
+    })
+
+    it('has no duplicate slugs', () => {
+        expect(RECEIVE_SOURCES.length).toBe(new Set(RECEIVE_SOURCES).size)
     })
 })

--- a/src/data/seo/corridors.ts
+++ b/src/data/seo/corridors.ts
@@ -3,6 +3,7 @@
 // Sources (all in the public mirror):
 //   content/countries/{slug}/{lang}.md      — country hub article + frontmatter
 //   content/send-to/{dst}/from/{src}/{lang}.md — corridor article + frontmatter
+//   content/receive-from/{slug}/{lang}.md   — receive-from article + frontmatter
 //
 // Country display names come from the `name:` field denormalized at
 // generation time (see mono/content/_system/templates/country-hub.md); absent
@@ -19,6 +20,7 @@
 import {
     listContentSlugs,
     listCorridorOrigins,
+    listPublishedSlugs,
     readCorridorContent,
     readPageContent,
     readPageContentLocalized,
@@ -73,24 +75,29 @@ function loadCorridors(): Corridor[] {
 }
 
 /**
- * Origins for the receive-money-from pages. The set is the corridor origins,
- * but only those that actually have a receive-from article — an origin present
- * in CORRIDORS.from but missing content/receive-from/{slug}/en.md would 404
- * (this is how colombia & mexico shipped as live 404s in May 2026). The
- * receive-from content tree is authored independently of corridors, so the two
- * sets don't line up automatically.
+ * Origins for the receive-money-from pages: every published receive-from
+ * article, read straight off the content tree.
+ *
+ * The invariant that matters is "the route has something to render" — an entry
+ * with no content/receive-from/{slug}/en.md would 404 (this is how colombia &
+ * mexico shipped as live 404s in May 2026), so publication is still gated on
+ * content presence.
+ *
+ * This used to seed from CORRIDORS.from and intersect with the content tree.
+ * That was strictly narrower than it needed to be: receive-from is authored
+ * independently of corridors, so the intersection silently dropped 10 authored
+ * countries (australia, india, kenya, malaysia, netherlands, pakistan,
+ * philippines, saudi-arabia, singapore, united-arab-emirates) whose articles
+ * were live but unreachable. Corridor membership was never a rendering
+ * requirement for these pages — only the article is.
  */
-function loadReceiveSources(corridors: Corridor[]): string[] {
-    const origins = [...new Set(corridors.map((c) => c.from))]
-    return origins.filter((slug) => {
-        const content = readPageContent<{ published?: boolean }>('receive-from', slug, 'en')
-        return content !== null && content.frontmatter.published !== false
-    })
+function loadReceiveSources(): string[] {
+    return listPublishedSlugs('receive-from')
 }
 
 export const COUNTRIES_SEO: Record<string, CountrySEO> = loadCountries()
 export const CORRIDORS: Corridor[] = loadCorridors()
-export const RECEIVE_SOURCES: string[] = loadReceiveSources(CORRIDORS)
+export const RECEIVE_SOURCES: string[] = loadReceiveSources()
 
 /**
  * Get the country display name for a slug at the given locale. Reads


### PR DESCRIPTION
Three independent SEO hygiene defects, batched because each is a few lines and they share no code.

## T1 — Googlebot ignored every disallow

**Defect.** The `Googlebot` group in `src/app/robots.ts` declared only `allow: ['/api/og']` with no `disallow` key. A crawler obeys the single most specific group that matches it, never the union — so Googlebot read that group *instead of* `*` and treated every auth-gated route (`/home`, `/profile`, `/settings`, `/kyc`, `/claim`, …) as fair game. The one crawler that matters was the one exempted. Live `robots.txt` confirms this shipped.

**Fix.** Extracted the `*` group's disallow list into a shared `DISALLOWED_PATHS` const and applied it to the Googlebot group too — mirroring how the AI-crawler group in the same file is built. The narrower `/api/og` allow still wins over `/api/` by longest-match, so OG images keep rendering in link previews.

## T2 — `/lp/card` and `/careers` declared the homepage as canonical

**Defect.** Both pages call the metadata helper without `canonical`. `src/app/layout.tsx` sets `alternates: { canonical: '/' }`, and `src/app/metadata.ts` only emits `alternates` when a canonical is passed — so both pages inherited the root value and told Google their canonical was `/` while sitting in the sitemap as indexable URLs. Self-canonical was never declared.

**Fix.** Pass the real path in each `generateMetadata()` call, matching the existing `src/app/exchange/layout.tsx` workaround (comment carried over). Neither route has a `layout.tsx`, so the fix belongs in `page.tsx`.

## T6 — 10 authored countries silently unreachable

**Defect.** `loadReceiveSources()` in `src/data/seo/corridors.ts` seeded from `CORRIDORS.map(c => c.from)` and then intersected with the receive-from content tree. But receive-from is authored independently of corridors, so the intersection dropped every article whose country was not also a corridor origin — 10 of them: australia, india, kenya, malaysia, netherlands, pakistan, philippines, saudi-arabia, singapore, united-arab-emirates. Written, published, and unreachable.

**Fix.** Enumerate published receive-from content directly via the existing `listPublishedSlugs('receive-from')` helper (same semantics the loader already applied: `en.md` present and `published !== false`). `RECEIVE_SOURCES` goes **9 → 19**. colombia and mexico stay excluded, correctly — they are corridor origins with no article, the original May-2026 404 case.

### The test that had to change

`src/data/seo/corridors.test.ts` is a checked-in regression guard from the May 2026 no-content incident, and two of its three assertions encoded the *old* invariant (`RECEIVE_SOURCES ⊆ CORRIDORS.from`). That subset relation was an artifact of how the list was built, not the thing that protected us. The real invariant is "every entry has a published article". Rewritten to assert exactly that, in both directions — nothing rendered without content (no 404s), nothing authored left behind (no orphans) — plus a duplicate check.

The new guard re-derives the expected set straight off the filesystem rather than reusing the loader's own helper, so it cannot pass by tautology. **I verified it has teeth** by temporarily restoring the old loader and confirming it goes red, naming the exact dropped countries:

```
✕ contains every published receive-from article (no orphaned content)
    -   "philippines",
        "portugal",
    -   "saudi-arabia",
    -   "singapore",
        "spain",
    -   "united-arab-emirates",
```

## Verification

```
$ npx pnpm@10.30.1 exec jest src/data/seo/corridors.test.ts --verbose
PASS src/data/seo/corridors.test.ts
  RECEIVE_SOURCES
    ✓ only contains slugs that have a published receive-from article (no 404s)
    ✓ contains every published receive-from article (no orphaned content)
    ✓ has no duplicate slugs

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
```

```
$ npx pnpm@10.30.1 run test          # full suite
Test Suites: 229 passed, 229 total
Tests:       3 skipped, 2925 passed, 2928 total
```

```
$ npx pnpm@10.30.1 run lint
✖ 64 problems (0 errors, 64 warnings)   # all pre-existing, none in the 5 changed files

$ npx pnpm@10.30.1 exec prettier --check <the 5 changed files>
All matched files use Prettier code style!

$ npx pnpm@10.30.1 run typecheck     # tsc --noEmit
(clean, exit 0)
```

### T1 — generated `robots.txt` (served from this branch)

```
User-Agent: Googlebot
Allow: /api/og
Disallow: /api/
Disallow: /sdk/
Disallow: /home
Disallow: /profile
Disallow: /settings
...
Disallow: /add-money
Disallow: /withdraw
```

All 24 disallows now present on the Googlebot group, `/api/og` allow retained, `*` group unchanged.

### T2 — canonical `<link>` grepped out of the rendered HTML body

```
$ curl -s http://localhost:4137/careers | grep -o '<link[^>]*rel="canonical"[^>]*>'
<link rel="canonical" href="https://peanut.me/careers"/>     # HTTP 200, 59930 bytes

$ curl -s http://localhost:4137/lp/card | grep -o '<link[^>]*rel="canonical"[^>]*>'
<link rel="canonical" href="https://peanut.me/lp/card"/>     # HTTP 200, 101428 bytes
```

Checked the response headers too — the only `Link:` header is font preloads, so the canonical genuinely lives in the HTML, not a header. For contrast, production today:

```
$ curl -s https://peanut.me/careers | grep -o '<link[^>]*rel="canonical"[^>]*>'
<link rel="canonical" href="https://peanut.me"/>             # the bug
$ curl -s https://peanut.me/exchange | grep -o '<link[^>]*rel="canonical"[^>]*>'
<link rel="canonical" href="https://peanut.me/exchange"/>    # the precedent this fix copies
```

### T6 — the 10 recovered countries

```
RECEIVE_SOURCES count = 19
RECEIVE_SOURCES = argentina, australia, brazil, france, germany, india, italy, kenya,
  malaysia, netherlands, pakistan, philippines, portugal, saudi-arabia, singapore, spain,
  united-arab-emirates, united-kingdom, united-states
corridor origins = argentina, brazil, colombia, france, germany, italy, mexico, portugal,
  spain, united-kingdom, united-states
NEWLY REACHABLE (has article, not a corridor origin) = australia, india, kenya, malaysia,
  netherlands, pakistan, philippines, saudi-arabia, singapore, united-arab-emirates
origins WITHOUT article (correctly still excluded) = colombia, mexico
```

The user-visible effect is confirmable on production right now. `receive-money-from/[country]` calls `notFound()` for anything outside `RECEIVE_SOURCES`, and this site's custom 404 returns HTTP 200 — so the dropped pages are *soft* 404s and status codes tell you nothing. Comparing titles instead:

```
$ curl -s https://peanut.me/en/receive-money-from/singapore  → <title>Peanut - Instant Global P2P Payments in Digital Dollars</title>
$ curl -s https://peanut.me/en/receive-money-from/zzznotacountry → <title>Peanut - Instant Global P2P Payments in Digital Dollars</title>
$ curl -s https://peanut.me/en/receive-money-from/brazil     → <title>Receive Money from Brazil | Peanut</title>
```

singapore is byte-for-byte the same shell as a garbage URL; brazil is a real article. That is the defect, live.

**e2e was not run.** The Playwright suite needs a live API on `:5000` serving `/dev/test-session` for its `globalSetup`, which isn't available in this environment. No new e2e specs were written.

## Caveats for the reviewer

- **Expect a conflict with #2671** (base `main`), which also edits `robots.ts` — different hunks (sitemap field + an import), but it lands in `dev` via back-merge on its own schedule. My hunks are deliberately minimal.
- `RECEIVE_SOURCES` growing 9 → 19 adds 10 URLs to the sitemap. That is the intended effect: the content already exists and is already published, it just had no route. Worth a glance at the sitemap diff on the preview deploy.
- **`next build` never ran to completion in my sandbox, so CI is the first green signal on the production build specifically.** Not a code problem, and I checked rather than assumed: this box runs `earlyoom` with `--prefer (^|/)(node|next-server|esbuild)`, so under memory pressure from other agents building concurrently it SIGTERMs whichever node process is largest. Its own log names the victim — `sending SIGTERM to process ... "next-server": badness 1128, VmRSS 3383 MiB` — which is exactly the `Next.js build worker exited with code: null and signal: SIGTERM` reported across three build attempts. The dev server behind the render evidence above was killed the same way twice before it survived long enough to answer. Everything else (typecheck, lint, jest, prettier, and the live render evidence) is green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **SEO Improvements**
  * Added canonical URLs for the Careers and Card landing pages.
  * Updated crawler guidance to better control access to API, SDK, and authentication routes while preserving image endpoint access.
  * Improved sitemap and route discovery for published receive-money content.

* **Bug Fixes**
  * Ensured all published receive-money source pages are represented accurately without duplicates or missing entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->