### PR TITLE
seo: noindex the username catch-all route

### DIFF
--- a/src/app/[...recipient]/page.tsx
+++ b/src/app/[...recipient]/page.tsx
@@ -21,7 +21,11 @@ type PageProps = {
 // a "<handle> on Peanut" title. Google indexed thousands of those. Every metadata
 // branch is noindex: profiles, addresses, ENS and request/receipt links are app
 // surface, not search landing pages — no carve-outs.
+// canonical: null suppresses the root layout's inherited `canonical: '/'` —
+// noindex must not ship on pages that canonicalize to the homepage, or the
+// noindex can be attributed to the canonical cluster head (the homepage itself).
 const NOINDEX = { index: false, follow: false } as const
+const NOINDEX_META = { robots: NOINDEX, alternates: { canonical: null } } as const
 
 export async function generateMetadata({ params, searchParams }: PageProps) {
     const resolvedSearchParams = await searchParams
@@ -30,18 +34,18 @@ export async function generateMetadata({ params, searchParams }: PageProps) {
     // Guard: Don't generate metadata for reserved routes (handled by their specific routes)
     const firstSegment = resolvedParams.recipient?.[0]
     if (firstSegment && isReservedRoute(`/${firstSegment}`)) {
-        return { robots: NOINDEX }
+        return { ...NOINDEX_META }
     }
 
     // Guard: Ensure recipient exists
     if (!resolvedParams.recipient?.[0]) {
-        return { robots: NOINDEX }
+        return { ...NOINDEX_META }
     }
 
     // Guard: Don't generate "X on Peanut" metadata for things that can't be recipients
     // (bare locale codes, slugs with dashes, random strings). Lets the 404 page own the tab title.
     if (!couldBeRecipient(firstSegment!)) {
-        return { robots: NOINDEX }
+        return { ...NOINDEX_META }
     }
 
     let title = 'Request Payment | Peanut'
@@ -168,6 +172,7 @@ export async function generateMetadata({ params, searchParams }: PageProps) {
         title,
         description,
         robots: NOINDEX,
+        alternates: { canonical: null },
         ...(siteUrl ? { metadataBase: new URL(siteUrl) } : {}),
         icons: {
             icon: '/favicon.ico',

--- a/src/app/[...recipient]/page.tsx
+++ b/src/app/[...recipient]/page.tsx
@@ -16,6 +16,13 @@ type PageProps = {
     searchParams: Promise<{ chargeId?: string }>
 }
 
+// This catch-all renders an indexable shell for ANY username-shaped string — the
+// existence check runs client-side, so a non-existent handle still returns 200 with
+// a "<handle> on Peanut" title. Google indexed thousands of those. Every metadata
+// branch is noindex: profiles, addresses, ENS and request/receipt links are app
+// surface, not search landing pages — no carve-outs.
+const NOINDEX = { index: false, follow: false } as const
+
 export async function generateMetadata({ params, searchParams }: PageProps) {
     const resolvedSearchParams = await searchParams
     const resolvedParams = await params
@@ -23,18 +30,18 @@ export async function generateMetadata({ params, searchParams }: PageProps) {
     // Guard: Don't generate metadata for reserved routes (handled by their specific routes)
     const firstSegment = resolvedParams.recipient?.[0]
     if (firstSegment && isReservedRoute(`/${firstSegment}`)) {
-        return {}
+        return { robots: NOINDEX }
     }
 
     // Guard: Ensure recipient exists
     if (!resolvedParams.recipient?.[0]) {
-        return {}
+        return { robots: NOINDEX }
     }
 
     // Guard: Don't generate "X on Peanut" metadata for things that can't be recipients
     // (bare locale codes, slugs with dashes, random strings). Lets the 404 page own the tab title.
     if (!couldBeRecipient(firstSegment!)) {
-        return {}
+        return { robots: NOINDEX }
     }
 
     let title = 'Request Payment | Peanut'
@@ -160,6 +167,7 @@ export async function generateMetadata({ params, searchParams }: PageProps) {
     return {
         title,
         description,
+        robots: NOINDEX,
         ...(siteUrl ? { metadataBase: new URL(siteUrl) } : {}),
         icons: {
             icon: '/favicon.ico',


### PR DESCRIPTION
## Defect (T3, layer 1)

`src/app/[...recipient]/page.tsx` is the username catch-all. Its `generateMetadata` builds a full, **indexable** "X on Peanut" shell for *any* username-shaped string — `USERNAME_PATTERN = /^[a-z][a-z0-9]{3,11}$/` in `src/constants/routes.ts:155` is the only filter. Whether the account exists is checked **client-side**, after the HTML has already been served with HTTP 200.

Two consequences, both live on peanut.me right now:

```
$ curl -s https://peanut.me/kkonrad | grep -o '<meta name="robots"[^>]*>'
<meta name="robots" content="index, follow"/>
$ curl -s https://peanut.me/kkonrad | grep -o '<title>[^<]*</title>'
<title>kkonrad on Peanut</title>

$ curl -s -o /dev/null -w '%{http_code}\n' https://peanut.me/zzqx9      # nobody owns this handle
200
$ curl -s https://peanut.me/zzqx9 | grep -o '<meta name="robots"[^>]*>'
<meta name="robots" content="index, follow"/>
$ curl -s https://peanut.me/zzqx9 | grep -o '<title>[^<]*</title>'
<title>zzqx9 on Peanut</title>
```

So Google is offered an unbounded space of soft-404 "profile" pages, plus every real profile, address, ENS name and request/receipt link — all app surface, none of it a search landing page.

The `index, follow` comes from the root layout (`src/app/layout.tsx:24`, `robots: IS_PRODUCTION_DOMAIN ? { index: true, follow: true } : …`). That is why the empty `return {}` guard branches are *not* already safe: with nothing set at page level they inherit `index, follow` from the root.

## Fix

`robots: { index: false, follow: false }` on **all four** `generateMetadata` return paths (count re-verified on current `origin/dev` @ `ad5b61b6` — `grep -n return` shows exactly 3 early returns plus the metadata object):

| line (pre-patch) | branch |
|---|---|
| 26 | reserved route |
| 31 | no recipient segment |
| 37 | `!couldBeRecipient(...)` |
| 160–186 | full metadata object (profiles, addresses, ENS, amounts, receipts) |

Extracted as one `NOINDEX` const so the four branches cannot drift apart.

Per the 12 Aug decision: **noindex everything, no carve-outs** — real profiles and `.eth` ENS pages included.

One file, +11/−3. The page component, routing, `couldBeRecipient`, and 404 behaviour are untouched.

## Verification

**A/B on a local server, same worktree, only the patch differing.** Run with `NEXT_PUBLIC_BASE_URL=https://peanut.me` — without it the root layout noindexes every page locally and the evidence would be worthless.

Before (`git checkout HEAD~1 -- src/app/[...recipient]/page.tsx`):

```
/kkonrad                                     -> HTTP 200 | robots="index, follow"  | kkonrad on Peanut
/zzqx9                                       -> HTTP 200 | robots="index, follow"  | zzqx9 on Peanut
/vitalik.eth                                 -> HTTP 200 | robots="index, follow"  | vitalik.eth is requesting funds
/kkonrad/1usdc                               -> HTTP 200 | robots="index, follow"  | kkonrad is requesting $1 via Peanut
/0x1234567890abcdef1234567890abcdef12345678  -> HTTP 200 | robots="index, follow"  | 0x1234...345678 is requesting funds
/pricing                                     -> HTTP 200 | robots="index, follow"  | pricing on Peanut
/es                                          -> HTTP 200 | robots="noindex"        | (404 page)
/some-random-slug-here                       -> HTTP 200 | robots="noindex"        | (404 page)
/en/send-money-to/brazil                     -> HTTP 200 | robots="index, follow"  | Send Money to Brazil — No IOF Tax | Peanut
```

After (this branch):

```
/kkonrad                                     -> HTTP 200 | robots="noindex, nofollow" | kkonrad on Peanut
/zzqx9                                       -> HTTP 200 | robots="noindex, nofollow" | zzqx9 on Peanut
/vitalik.eth                                 -> HTTP 200 | robots="noindex, nofollow" | vitalik.eth is requesting funds
/kkonrad/1usdc                               -> HTTP 200 | robots="noindex, nofollow" | kkonrad is requesting $1 via Peanut
/0x1234567890abcdef1234567890abcdef12345678  -> HTTP 200 | robots="noindex, nofollow" | 0x1234...345678 is requesting funds
/pricing                                     -> HTTP 200 | robots="noindex, nofollow" | pricing on Peanut
/es                                          -> HTTP 200 | robots="noindex"           | (404 page, unchanged)
/some-random-slug-here                       -> HTTP 200 | robots="noindex"           | (404 page, unchanged)
/en/send-money-to/brazil                     -> HTTP 200 | robots="index, follow"     | Send Money to Brazil — No IOF Tax | Peanut
```

`/en/send-money-to/brazil` is the control: a real content page, still `index, follow` in both runs. The blast radius is the catch-all only.

`/pricing` moving to `noindex, nofollow` is the intended read of the decision — it is a catch-all shell today, not a real pricing page (`isReservedRoute('/pricing')` is false; the server-side username list rejects it, which is why nobody owns it). Giving it a real page is PR4's job, and that PR will set its own metadata.

Gates:

```
typecheck   tsc --noEmit ................ clean, 0 errors
lint        eslint . .................... 0 errors, 64 warnings (all pre-existing, none in the changed file)
test        jest ....................... 229/229 suites, 2925 passed, 3 skipped
```

CI on this branch: `typecheck`, `eslint`, `format`, `unit`, `e2e`, `analyze`, `Deploy-Preview` and `Vercel` all green.

## Caveats

- **`next build` was never completed locally.** The dev box has ~12 GB RAM shared with several concurrent agents; every `next build --webpack` attempt was SIGTERM'd around 70 s at ~2.5 GB RSS with under 1.5 GB left free (seven attempts, including one with `webpackBuildWorker: false` to halve peak). Nothing in the failures referenced this diff — it never reached compile output. The production build is covered instead by the green `Deploy-Preview` / `Vercel` checks above.
- **Playwright was not run locally** — `globalSetup` needs a live API on `:5000` with `/dev/test-session`, which is not available here. No new specs were written; the repo's existing `e2e` job passes in CI.
- The Vercel **preview** deployment is not usable as proof: it is not `peanut.me`, so `src/app/layout.tsx:24` noindexes *every* page there — including the Brazil control page. Only the local A/B above, with `NEXT_PUBLIC_BASE_URL=https://peanut.me`, isolates this change.
- The local server 404s `/en` in **both** the before and after runs, while production serves it as a real page — a local locale-routing artifact, identical on either side of the patch, and untouched by this diff.
- This is layer 1 of T3. It stops the bleeding for new crawls, but noindex only takes effect once Googlebot re-crawls each URL; already-indexed profile URLs will age out over weeks. Layer 2 (returning a real 404 for handles that do not exist) is PR3's `loading.tsx` removal plus follow-up work.
- No open PR touches `src/app/[...recipient]/` (checked all 25 open PRs), so no conflict is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
