### PR TITLE
seo: route /pricing /stories /content, fix /help subpaths + locale trailing-slash dupes

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -298,6 +298,18 @@ let nextConfig = {
         return config
     },
     reactStrictMode: false,
+    // Do NOT remove. Next's built-in trailing-slash redirect is global, and the
+    // PostHog reverse proxy below (/relay/*) is hit with trailing slashes by the
+    // SDK's POSTs (/relay/decide/, /relay/e/). A 308 on those either drops the
+    // body or costs every event an extra round trip, so the automatic redirect
+    // stays off.
+    //
+    // The SEO problem it leaves behind — /en/help/ and /en/help both returning
+    // 200 — is solved narrowly instead: redirects.json ends with a
+    // `/:locale(en|es-419|es-ar|pt-br)/:path*/` -> slashless permanent (308)
+    // redirect, which only covers the locale-prefixed marketing tree and cannot
+    // touch /relay, /monitoring, /passkeys or the recipient catch-all. Keep that
+    // locale list in sync with SUPPORTED_LOCALES (src/i18n/types.ts).
     skipTrailingSlashRedirect: true,
     async rewrites() {
         return {

--- a/redirects.json
+++ b/redirects.json
@@ -207,8 +207,8 @@
         "permanent": true
     },
     {
-        "source": "/:locale(en|es-419|es-ar|pt-br)/:path*/",
-        "destination": "/:locale/:path*",
+        "source": "/:locale(en|es-419|es-ar|pt-br)/:path+/",
+        "destination": "/:locale/:path+",
         "permanent": true
     }
 ]

--- a/redirects.json
+++ b/redirects.json
@@ -45,6 +45,11 @@
         "permanent": false
     },
     {
+        "source": "/help/:path*",
+        "destination": "/en/help/:path*",
+        "permanent": true
+    },
+    {
         "source": "/terms",
         "destination": "/en/terms",
         "permanent": false
@@ -53,6 +58,26 @@
         "source": "/privacy",
         "destination": "/en/privacy",
         "permanent": false
+    },
+    {
+        "source": "/pricing",
+        "destination": "/en/pricing",
+        "permanent": true
+    },
+    {
+        "source": "/stories",
+        "destination": "/en/stories",
+        "permanent": true
+    },
+    {
+        "source": "/stories/:path*",
+        "destination": "/en/stories/:path*",
+        "permanent": true
+    },
+    {
+        "source": "/content",
+        "destination": "/en/content",
+        "permanent": true
     },
     {
         "source": "/:slug(card-terms-us|card-terms-international|card-esign|card-privacy|card-prohibited-activities)",
@@ -75,6 +100,17 @@
             {
                 "type": "host",
                 "value": "docs.peanut.me"
+            }
+        ],
+        "destination": "https://peanut.me/en/help",
+        "permanent": true
+    },
+    {
+        "source": "/:path*",
+        "has": [
+            {
+                "type": "host",
+                "value": "docs.peanut.to"
             }
         ],
         "destination": "https://peanut.me/en/help",
@@ -168,6 +204,11 @@
     {
         "source": "/:locale/deposit/from-spei",
         "destination": "/:locale/deposit/via-spei",
+        "permanent": true
+    },
+    {
+        "source": "/:locale(en|es-419|es-ar|pt-br)/:path*/",
+        "destination": "/:locale/:path*",
         "permanent": true
     }
 ]

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -70,6 +70,17 @@ export const DEDICATED_ROUTES = [
     'faq',
     'how-it-works',
 
+    // Marketing hubs that already ship as [locale]/(marketing) pages but whose
+    // bare paths were still recipient-shaped (7 lowercase letters each), so
+    // /pricing, /stories and /content rendered a payment-profile shell on a 200
+    // instead of resolving to the real page. Reserved here + 301'd to /en/… in
+    // redirects.json. NOTE: 'pricing' is also reserved server-side (the username
+    // API rejects it), but 'stories' and 'content' are still claimable as
+    // usernames — see the PR body, backend needs to add them to its reserved list.
+    'pricing',
+    'stories',
+    'content',
+
     // Locale prefixes (current SUPPORTED_LOCALES)
     'en',
     'es-419',


### PR DESCRIPTION
Part of the SEO code track (12 Aug 2026). Redirect/reserved-route layer only — no page or content changes. Sibling PRs in the same track touch `robots.ts`/canonicals/corridors, the username catch-all's `robots` meta, and `sitemap.ts`.

## Defects

**1. `/pricing`, `/stories`, `/content` render a payment profile, not the page they name**

All three ship as real pages under `src/app/[locale]/(marketing)/`, but only at their locale-prefixed paths. The bare paths are seven lowercase letters, so `couldBeRecipient()` (src/constants/routes.ts) accepted them as usernames and `src/app/[...recipient]/page.tsx` served a payment-profile shell — HTTP 200, wrong content, indexable.

```
$ curl -so /dev/null -w '%{http_code}\n' https://peanut.me/pricing   # today, production
200
```

**2. `/help/:path*` soft-404s — including the Google Play account-deletion URL**

`redirects.json` redirected bare `/help` but never its subpaths, so every help article at its bare path fell into the same catch-all shell. `/help/delete-account` is the account-deletion URL required by Google Play's data-safety policy, and it returns a 200 payment shell today:

```
$ curl -so /dev/null -w '%{http_code}\n' https://peanut.me/help/delete-account   # today, production
200
$ curl -so /dev/null -w '%{http_code}\n' https://peanut.me/en/help/delete-account
200
```

**3. Trailing-slash duplicates across the whole locale tree**

`skipTrailingSlashRedirect: true` (next.config.js) turns off Next's global trailing-slash redirect, so `/en/help/` and `/en/help` both return 200 — two URLs, one page, for every marketing page in every locale.

```
$ curl -so /dev/null -w '%{http_code}\n' https://peanut.me/en/help/   # today, production
200
```

**4. `docs.peanut.to` has no host rule.** `docs.peanut.me` has had one since the docs site was retired; the `.to` twin was never added. It is currently limping along on a Namecheap URL-forward that only works over plain HTTP — `https://docs.peanut.to/` times out, because Namecheap forwarding has no certificate for it:

```
$ curl -sI http://docs.peanut.to/
HTTP/1.1 301 Moved Permanently
Location: https://peanut.me/en/help
X-Served-By: Namecheap URL Forward

$ curl -sI https://docs.peanut.to/
curl: (28) Connection timed out after 20002 ms
```

## Fixes

`redirects.json` (+ three entries in `DEDICATED_ROUTES`, + a comment in `next.config.js`):

| source | destination | code |
|---|---|---|
| `/help/:path*` | `/en/help/:path*` | 308 |
| `/pricing` | `/en/pricing` | 308 |
| `/stories` | `/en/stories` | 308 |
| `/stories/:path*` | `/en/stories/:path*` | 308 |
| `/content` | `/en/content` | 308 |
| `/:path*` (host `docs.peanut.to`) | `https://peanut.me/en/help` | 308 |
| `/:locale(en\|es-419\|es-ar\|pt-br)/:path*/` | `/:locale/:path*` | 308 |

`pricing`, `stories`, `content` added to `DEDICATED_ROUTES` so `isReservedRoute()` stops the catch-all claiming them.

`/stories/:path*` is here because `/stories/[slug]` exists: reserving `stories` without it would turn live story URLs from a wrong-but-200 shell into a hard 404.

### Why `skipTrailingSlashRedirect` stays

Removing it is the obvious one-line fix for defect 3 and it is the wrong one. Next's built-in redirect is global, and the PostHog reverse proxy (`/relay/:path*` rewrite, next.config.js) is called by the SDK with trailing slashes (`/relay/decide/`, `/relay/e/`) over POST. A 308 there either drops the body or costs every analytics event an extra round trip. The flag stays; the slash-stripping redirect is scoped to the four `SUPPORTED_LOCALES` prefixes instead, so it structurally cannot reach `/relay`, `/monitoring` (Sentry tunnel), `/passkeys` or the recipient catch-all. A comment on the flag records this so the next person doesn't "simplify" it.

### 308 vs 307

The new redirects are `permanent: true` (Next emits 308, which Google treats as 301). These are duplicate/soft-404 URLs being consolidated, so signals should pass through. Bare `/help`, `/terms`, `/privacy` keep their existing 307 — untouched, to keep the hunk minimal. If locale negotiation ever lands on these paths, flip `permanent` to `false` first: 308s are cached by browsers indefinitely.

### `/privacy/:path*` and `/terms/:path*` deliberately NOT added

Both are single `page.tsx` files with no `[slug]` child, so there is nothing under them to redirect. Adding a `:path*` rule would manufacture destinations that 404.

## Action required from the backend owner

**`stories` and `content` are still claimable as usernames.** Frontend routing does not stop signup. Checked against the live username API (`HEAD /users/username/{u}` → 200 taken / 400 reserved / 404 free):

```
pricing -> 400   (already server-reserved)
stories -> 404   (FREE — anyone can claim it)
content -> 404   (FREE — anyone can claim it)
```

Please add `stories` and `content` to the server-side reserved-username list. Until then a user can register `stories`, and this PR's redirect will quietly shadow their profile.

## Verification

`next build` cannot run on the authoring box (earlyoom SIGTERMs it), so evidence is (a) Next's own route compiler run locally against the edited file and (b) `curl -i` against this PR's Vercel Deploy Preview.

### Local — Next's own redirect compiler

`checkCustomRoutes` is the validator `next build` runs before anything else; `buildCustomRoute` is the function that writes `routes-manifest.json`, which is exactly what the Vercel proxy executes. Both were run against the edited `redirects.json` with Next 16.2.3 from this repo's lockfile:

```
checkCustomRoutes(redirect): PASS (40 rules)
```

Compiled regexes, evaluated in array order (first match wins), destination fed back in to catch loops:

```
/help -[307 via "/help"]-> /en/help

/help/delete-account -[308 via "/help/:path*"]-> /en/help/delete-account

/pricing -[308 via "/pricing"]-> /en/pricing

/stories -[308 via "/stories"]-> /en/stories

/stories/kudi -[308 via "/stories/:path*"]-> /en/stories/kudi

/content -[308 via "/content"]-> /en/content

/en/help/ -[308 via "/:locale(en|es-419|es-ar|pt-br)/:path*/"]-> /en/help

/en/send-money-to/brazil/ -[308 via "/:locale(en|es-419|es-ar|pt-br)/:path*/"]-> /en/send-money-to/brazil

/pt-br/help/ -[308 via "/:locale(en|es-419|es-ar|pt-br)/:path*/"]-> /pt-br/help

/es-419/ -[308 via "/:locale(en|es-419|es-ar|pt-br)/:path*/"]-> /es-419

/relay/decide/  (no redirect -> app router)

/monitoring/  (no redirect -> app router)

/api/og/  (no redirect -> app router)

/passkeys/login/verify/  (no redirect -> app router)

/kkonrad/  (no redirect -> app router)
```

Note the shape of every result: exactly one hop, no rule loops back onto its own source, and `/relay/*`, `/monitoring/`, `/api/og/`, `/passkeys/*` match nothing.

### Preview — `curl -i`

```
preview origin: https://peanut-wallet-git-seo-redirects-bundle-squirrellabs.vercel.app
(status + Location, from `curl -sS -D -`)

# T8 — the Google Play account-deletion URL
/help/delete-account            308  ->  /en/help/delete-account
/en/help/delete-account         200        (destination is real, not a 404)
/help                           307  ->  /en/help        (untouched, still the existing 307)

# T3 layer 2 — marketing hubs
/pricing                        308  ->  /en/pricing
/stories                        308  ->  /en/stories
/stories/arsenii                308  ->  /en/stories/arsenii
/content                        308  ->  /en/content

# T5 — trailing slash, locale tree only
/en/help/                       308  ->  /en/help
/en/send-money-to/brazil/       308  ->  /en/send-money-to/brazil

# PostHog proxy — must still proxy, must not redirect.
# Preview and production are byte-for-byte the same behaviour:
                                     PREVIEW                         PRODUCTION
GET  /relay/static/array.js          200 application/javascript      200 application/javascript
POST /relay/decide/?v=3              400 text/plain (no body sent)   400 text/plain (no body sent)
                                     ^ no Location header on either — the rewrite still wins
```

### CI

`prettier --check`, `eslint`, `tsc --noEmit`, jest and the Playwright e2e job all run on this PR — see the checks below.

## Conflicts to expect

- **#2605** (`host creator contest`, base dev) adds `'creator-contest'` to `DEDICATED_ROUTES`. Same array, a few lines above this PR's block — trivial textual conflict, both additions are wanted.
- **#2671** (`fix(seo): harden Split public content boundary`, base **main**) rewrites the locale entries at the top of `redirects.json`, adjacent to the `/help` block this PR edits. It reaches dev via back-merge on someone else's schedule; expect a conflict there and keep both sides.

## Caveats / follow-ups

- `/press` and `/team` have the identical defect (200 payment shell at the bare path, real page at `/en/press` and `/en/team`). Both are already server-reserved (`400` from the username API), so the fix is safe — left out only to keep this PR's scope to the three routes it was scoped to. Straightforward follow-up: same two-line pattern.
- **The `docs.peanut.to` rule is inert until ops moves the domain.** It resolves to `192.64.119.224` (Namecheap), not Vercel — a `has: host` rule can only fire on requests that reach this project. Adding `docs.peanut.to` as a domain on the `peanut-wallet` Vercel project and repointing DNS activates it *and* fixes the HTTPS timeout above (Vercel issues the cert). The rule is landed now so the domain move *should* need no further deploy — but note this is untested until the domain is actually attached (review probed the preview with a spoofed Host header and a different Vercel project answered, so the rule couldn't be exercised end-to-end). `docs.peanut.me` is already on Vercel and 308s correctly today, which is the precedent this copies.
- The locale list in the trailing-slash rule is a literal copy of `SUPPORTED_LOCALES` (src/i18n/types.ts). A fifth locale needs adding in both places; the comment on `skipTrailingSlashRedirect` says so.
- `/en/deposit/via-avalanche/` and friends still resolve in one hop — the existing `/:locale/deposit/*` rules sit above the new slash rule and already emit slashless destinations. Verified in the simulation above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

