### PR TITLE
fix(home): correct user-interview cal link

### DIFF
--- a/src/constants/general.consts.ts
+++ b/src/constants/general.consts.ts
@@ -248,4 +248,4 @@ export const PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=me.
 // User-interview campaign (temporary): one shared cal.com event for the
 // flag-gated team-call card on home. Delete together with the
 // `user-interviews-invite` PostHog flag when the campaign ends.
-export const USER_INTERVIEW_CAL_URL = 'https://cal.com/hugo0+abalinda/dynamic'
+export const USER_INTERVIEW_CAL_URL = 'https://cal.com/abalinda+hugo0/dynamic?user=abalinda%2Bhugo0&duration=15'


### PR DESCRIPTION
Follow-up to #2654.

The card opened `https://cal.com/hugo0+abalinda/dynamic`, which lands on the dynamic page without a host or duration preselected.

New link: `https://cal.com/abalinda+hugo0/dynamic?user=abalinda%2Bhugo0&duration=15` — 15-minute slot, both hosts preselected.

One-line constant change, no other behaviour touched.