### PR TITLE
seo: report real content dates as sitemap lastmod

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -11,11 +11,16 @@ import {
 } from '@/data/seo'
 import { SUPPORTED_LOCALES } from '@/i18n/config'
 import {
+    contentGeneratedAt,
     hasCorridorContent,
     hasPageContent,
     hasSingletonContent,
     listContentSlugs,
     listPublishedSlugs,
+    readCorridorContent,
+    readPageContent,
+    readSingletonContent,
+    type ContentFrontmatter,
 } from '@/lib/content'
 
 // TODO (infra): Update GitHub org, Twitter bio, LinkedIn, npm package.json → peanut.me
@@ -23,6 +28,23 @@ import {
 
 /** Build date used for non-content pages that don't have their own date. */
 const BUILD_DATE = new Date()
+
+// --- lastmod sources ---
+// Content-backed URLs report the `generated_at` of the exact file that serves them, so a
+// rebuild no longer bumps every lastmod to the deploy timestamp. These read through the same
+// cache the has*Content() guards already populate, so they cost no extra file reads.
+// Each returns undefined when the file is missing or carries no usable date, in which case
+// the caller falls back to BUILD_DATE — that covers the hand-built pages (homepage, /lp/card,
+// /careers, /exchange, legal) and the index pages that aren't backed by a single file.
+
+const pageDate = (intent: string, slug: string, locale: string): Date | undefined =>
+    contentGeneratedAt(readPageContent<ContentFrontmatter>(intent, slug, locale))
+
+const corridorDate = (destination: string, origin: string, locale: string): Date | undefined =>
+    contentGeneratedAt(readCorridorContent<ContentFrontmatter>(destination, origin, locale))
+
+const singletonDate = (intent: string, locale: string): Date | undefined =>
+    contentGeneratedAt(readSingletonContent<ContentFrontmatter>(intent, locale))
 
 async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
     type SitemapEntry = {
@@ -61,7 +83,12 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
         // Country hub pages
         for (const country of Object.keys(COUNTRIES_SEO)) {
             if (!hasPageContent('countries', country, locale)) continue
-            pages.push({ path: `/${locale}/${country}`, priority: 0.9 * basePriority, changeFrequency: 'weekly' })
+            pages.push({
+                path: `/${locale}/${country}`,
+                priority: 0.9 * basePriority,
+                changeFrequency: 'weekly',
+                lastModified: pageDate('countries', country, locale),
+            })
         }
 
         // Send-money-to country pages
@@ -71,6 +98,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/send-money-to/${country}`,
                 priority: 0.8 * basePriority,
                 changeFrequency: 'weekly',
+                lastModified: pageDate('send-to', country, locale),
             })
         }
 
@@ -81,6 +109,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/send-money-from/${corridor.from}/to/${corridor.to}`,
                 priority: 0.85 * basePriority,
                 changeFrequency: 'weekly',
+                lastModified: corridorDate(corridor.to, corridor.from, locale),
             })
         }
 
@@ -91,6 +120,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/receive-money-from/${source}`,
                 priority: 0.7 * basePriority,
                 changeFrequency: 'weekly',
+                lastModified: pageDate('receive-from', source, locale),
             })
         }
 
@@ -101,6 +131,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/compare/peanut-vs-${slug}`,
                 priority: 0.7 * basePriority,
                 changeFrequency: 'monthly',
+                lastModified: pageDate('compare', slug, locale),
             })
         }
 
@@ -114,6 +145,8 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/deposit/from-${exchange}`,
                 priority: 0.7 * basePriority,
                 changeFrequency: 'monthly',
+                // Undefined for the i18n-only exchanges (no MDX at all) → BUILD_DATE.
+                lastModified: pageDate('deposit', exchange, locale),
             })
         }
         for (const rail of Object.keys(DEPOSIT_RAILS)) {
@@ -122,6 +155,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/deposit/via-${rail}`,
                 priority: 0.7 * basePriority,
                 changeFrequency: 'monthly',
+                lastModified: pageDate('deposit', rail, locale),
             })
         }
 
@@ -132,6 +166,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/pay-with/${method}`,
                 priority: 0.7 * basePriority,
                 changeFrequency: 'monthly',
+                lastModified: pageDate('pay-with', method, locale),
             })
         }
 
@@ -147,6 +182,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/help/${slug}`,
                 priority: 0.6 * basePriority,
                 changeFrequency: 'monthly',
+                lastModified: pageDate('help', slug, locale),
             })
         }
 
@@ -157,6 +193,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/use-cases/${slug}`,
                 priority: 0.7 * basePriority,
                 changeFrequency: 'monthly',
+                lastModified: pageDate('use-cases', slug, locale),
             })
         }
 
@@ -168,6 +205,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/stories/${slug}`,
                 priority: 0.6 * basePriority,
                 changeFrequency: 'monthly',
+                lastModified: pageDate('stories', slug, locale),
             })
         }
         // Stories index
@@ -184,6 +222,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/withdraw/${slug}`,
                 priority: 0.6 * basePriority,
                 changeFrequency: 'monthly',
+                lastModified: pageDate('withdraw', slug, locale),
             })
         }
 
@@ -193,6 +232,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/supported-networks`,
                 priority: 0.6 * basePriority,
                 changeFrequency: 'monthly',
+                lastModified: singletonDate('supported-networks', locale),
             })
         }
 
@@ -202,6 +242,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/pricing`,
                 priority: 0.7 * basePriority,
                 changeFrequency: 'monthly',
+                lastModified: singletonDate('pricing', locale),
             })
         }
 
@@ -223,6 +264,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/blog/${slug}`,
                 priority: 0.6 * basePriority,
                 changeFrequency: 'monthly',
+                lastModified: pageDate('blog', slug, locale),
             })
         }
 

--- a/src/lib/content.test.ts
+++ b/src/lib/content.test.ts
@@ -1,4 +1,4 @@
-import { listAllContent } from '@/lib/content'
+import { contentGeneratedAt, listAllContent, readPageContent, type ContentFrontmatter } from '@/lib/content'
 
 describe('listAllContent', () => {
     it('returns items across all 4 hub types for en', () => {
@@ -49,5 +49,34 @@ describe('listAllContent', () => {
             const curr = new Date(blogItems[i].date ?? 0).getTime()
             expect(prev).toBeGreaterThanOrEqual(curr)
         }
+    })
+})
+
+describe('contentGeneratedAt', () => {
+    // gray-matter runs js-yaml, which turns unquoted YAML timestamps into Date objects even
+    // though ContentFrontmatter types generated_at as a string — both shapes must work.
+    it('accepts a Date (the usual runtime shape from unquoted YAML)', () => {
+        const at = contentGeneratedAt({ frontmatter: { generated_at: new Date('2026-03-27') } as never, body: '' })
+        expect(at?.toISOString().split('T')[0]).toBe('2026-03-27')
+    })
+
+    it('accepts a quoted string date', () => {
+        const at = contentGeneratedAt({ frontmatter: { generated_at: '2026-03-20T17:10:00Z' } as never, body: '' })
+        expect(at?.toISOString()).toBe('2026-03-20T17:10:00.000Z')
+    })
+
+    it('returns undefined for null content, a missing field, or an unparseable value', () => {
+        expect(contentGeneratedAt(null)).toBeUndefined()
+        expect(contentGeneratedAt({ frontmatter: {} as never, body: '' })).toBeUndefined()
+        expect(contentGeneratedAt({ frontmatter: { generated_at: 'not-a-date' } as never, body: '' })).toBeUndefined()
+        expect(contentGeneratedAt({ frontmatter: { generated_at: '' } as never, body: '' })).toBeUndefined()
+    })
+
+    it('reads a real date off a real content file', () => {
+        const at = contentGeneratedAt(readPageContent<ContentFrontmatter>('help', 'delete-account', 'en'))
+        expect(at).toBeInstanceOf(Date)
+        // A real authored date, not the build clock.
+        expect(at!.getTime()).toBeLessThan(Date.now())
+        expect(at!.getUTCFullYear()).toBeGreaterThanOrEqual(2026)
     })
 })

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -288,6 +288,27 @@ export function readSingletonContentLocalized<T = Record<string, unknown>>(
     return null
 }
 
+// --- Content freshness ---
+
+/**
+ * `generated_at` from a content file's frontmatter, as a Date.
+ *
+ * Mind the type/runtime mismatch: ContentFrontmatter declares `generated_at?: string`, but
+ * gray-matter runs js-yaml, which parses unquoted YAML timestamps into JS Date objects — both
+ * the bare `2026-03-27` form and the full `2026-03-20T17:10:00Z` form. Quoted values still
+ * arrive as strings, so both shapes are accepted here. Missing or unparseable values return
+ * undefined so callers can fall back to a default of their own.
+ */
+export function contentGeneratedAt(content: MarkdownContent<ContentFrontmatter> | null): Date | undefined {
+    const value: unknown = content?.frontmatter?.generated_at
+    if (value instanceof Date) return Number.isNaN(value.getTime()) ? undefined : value
+    if (typeof value === 'string' && value.trim() !== '') {
+        const parsed = new Date(value)
+        return Number.isNaN(parsed.getTime()) ? undefined : parsed
+    }
+    return undefined
+}
+
 // --- Content hub: cross-intent listing ---
 
 export type ContentItemType = 'blog' | 'stories' | 'use-cases' | 'compare'


### PR DESCRIPTION
## Defect (T5)

`src/app/sitemap.ts` set `lastModified` to `BUILD_DATE` for **every** URL:

```ts
const BUILD_DATE = new Date()
...
lastModified: page.lastModified ?? BUILD_DATE   // no call site ever passed lastModified
```

`SitemapEntry.lastModified` existed but was dead — nothing populated it. So every deploy
republished all 709 URLs claiming they had just changed. A `lastmod` that always equals the
deploy timestamp is noise: crawlers learn nothing from it, and the pages that genuinely did
change lose the signal they should have had.

## Fix

Content-backed URLs now report the `generated_at` of the exact file that serves them.

- `contentGeneratedAt()` in `src/lib/content.ts` — coerces a content file's `generated_at`
  frontmatter to a `Date`, returning `undefined` when missing or unparseable.
- Three one-line lookups in `sitemap.ts` (`pageDate` / `corridorDate` / `singletonDate`) pair
  the right reader with that coercion. The readers were **not** all imported before; this adds
  `readPageContent`, `readCorridorContent`, `readSingletonContent`.
- 15 of the 20 `pages.push()` call sites now pass a real date. Hand-built pages (homepage,
  `/lp/card`, `/careers`, `/exchange`, legal) and index pages with no single backing file keep
  `BUILD_DATE` via the existing `?? BUILD_DATE` fallback — untouched.

The lookups read through the same cache the `has*Content()` guards already populate, so they
add no extra file reads.

### One subtlety worth reviewing

`ContentFrontmatter` declares `generated_at?: string`, but that is **wrong at runtime**:
gray-matter runs js-yaml, which parses unquoted YAML timestamps into JS `Date` objects. Proven
against the real submodule:

```
src/content/content/blog/earn-with-peanut-3min-setup/en.md
  YAML source : generated_at: 2026-03-27
  typeof      : object   instanceof Date: true

src/content/content/send-to/argentina/from/colombia/en.md
  YAML source : generated_at: 2026-02-21T15:00:00Z
  typeof      : object   instanceof Date: true
```

A naive `new Date(frontmatter.generated_at)` would still work, but the helper handles `Date`,
quoted string, missing and unparseable inputs explicitly so this cannot regress silently.

I deliberately did **not** correct the declared type: `generated_at` is consumed as JSON-LD
`datePublished` in 12 page files that expect a string, so retyping it belongs in its own PR.
Flagging for a follow-up.

## Verification

Local `next build` is impossible on this box (earlyoom SIGTERMs it under memory contention from
other agents), so this is unit-level proof plus the Deploy Preview below.

**1. The real `generateSitemap()` run against the pinned content submodule (2a1c5937), via tsx:**

```
total sitemap URLs      : 709
real content dates      : 684
BUILD_DATE fallback     : 25  (today = 2026-08-12)
distinct lastmod values : 21

--- lastmod distribution (top 8) ---
  2026-03-27  163
  2026-03-26  118
  2026-02-23  92
  2026-07-05  80
  2026-07-06  62
  2026-03-10  28
  2026-03-13  28
  2026-08-12  25   <- BUILD_DATE fallback
```

The 25 fallbacks are exactly the intended set: 6 static entries + 3 non-default-locale landings
+ 4 locales x 4 index pages (`/help`, `/stories`, `/content`, `/blog`).

**2. Sitemap `lastmod` cross-checked against `generated_at` on disk:**

```
PASS  /en/help/delete-account
      sitemap lastmod=2026-07-05  frontmatter generated_at=2026-07-05
PASS  /en/send-money-to/brazil
      sitemap lastmod=2026-02-23  frontmatter generated_at=2026-02-23
PASS  /en/pricing
      sitemap lastmod=2026-07-05  frontmatter generated_at=2026-07-05
PASS  /en/supported-networks
      sitemap lastmod=2026-07-05  frontmatter generated_at=2026-07-05
PASS  /en/send-money-from/brazil/to/argentina
      sitemap lastmod=2026-02-20  frontmatter generated_at=2026-02-20

5/5 cross-checks passed
```

Static pages keep `BUILD_DATE` as intended:

```
/careers -> 2026-08-12   /exchange -> 2026-08-12   /lp/card -> 2026-08-12
/en/privacy -> 2026-08-12   /en/terms -> 2026-08-12
```

**3. Gates**

```
jest src/lib/content.test.ts   9 passed, 9 total   (5 pre-existing + 4 new)
tsc --noEmit (scoped to sitemap.ts, content.ts, content.test.ts + transitive deps)   0 errors
eslint src/app/sitemap.ts src/lib/content.ts src/lib/content.test.ts   clean
prettier --check   All matched files use Prettier code style!
```

**4. Deploy Preview** — confirmed on the built artifact. Full output in the
[evidence comment](https://github.com/peanutprotocol/peanut-ui/pull/2684#issuecomment-5268175429).
The build stamped `BUILD_DATE` at `2026-08-12T14:26:32.623Z`; all 6 sampled content URLs report a
different, correct date:

```
PASS  /en/help/delete-account                    lastmod 2026-07-05  = generated_at 2026-07-05
PASS  /en/send-money-to/brazil                   lastmod 2026-02-23  = generated_at 2026-02-23
PASS  /en/pricing                                lastmod 2026-07-05  = generated_at 2026-07-05
PASS  /en/supported-networks                     lastmod 2026-07-05  = generated_at 2026-07-05
PASS  /en/send-money-from/brazil/to/argentina    lastmod 2026-02-20  = generated_at 2026-02-20
PASS  /en/blog/earn-with-peanut-3min-setup       lastmod 2026-03-27  = generated_at 2026-03-27
6/6 matched   (709 URLs total, 21 distinct lastmod values)

/careers /exchange /lp/card /en/privacy /en/terms  -> 2026-08-12T14:26:32.623Z (BUILD_DATE)
```

CI is green across `typecheck`, `eslint`, `format`, `unit`, `e2e`, `analyze`, `report` and
`Deploy-Preview`.

## Caveats

- **Full-project `tsc --noEmit` could not complete locally** — earlyoom killed it (exit 143,
  `mem avail: 855 of 11960 MiB`) across repeated attempts while other agents held the box. The
  scoped typecheck above covers both changed files and everything they import, and **CI's
  full typecheck passed** (1m3s), so this gap is closed.
- `lastmod` is only as honest as `generated_at`. A content edit that does not refresh that field
  will now show a stale date rather than a falsely fresh one — the better failure direction, but
  it does move the burden onto the content pipeline.
- Branched from `origin/dev` @ `6e14a490d`, which is 7 commits past the SHA in the plan
  (`ad5b61b6`). That drift is entirely transaction-details and i18n test work; it does not touch
  `sitemap.ts`, `lib/content.ts`, or the content submodule pin.
- Touches no files under `src/content` (separate pipeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
