### PR TITLE
seo: technical fix bundle — robots, canonicals, receive-from, noindex catch-all, real 404s, redirects, sitemap lastmod

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -298,6 +298,18 @@ let nextConfig = {
         return config
     },
     reactStrictMode: false,
+    // Do NOT remove. Next's built-in trailing-slash redirect is global, and the
+    // PostHog reverse proxy below (/relay/*) is hit with trailing slashes by the
+    // SDK's POSTs (/relay/decide/, /relay/e/). A 308 on those either drops the
+    // body or costs every event an extra round trip, so the automatic redirect
+    // stays off.
+    //
+    // The SEO problem it leaves behind — /en/help/ and /en/help both returning
+    // 200 — is solved narrowly instead: redirects.json ends with a
+    // `/:locale(en|es-419|es-ar|pt-br)/:path*/` -> slashless permanent (308)
+    // redirect, which only covers the locale-prefixed marketing tree and cannot
+    // touch /relay, /monitoring, /passkeys or the recipient catch-all. Keep that
+    // locale list in sync with SUPPORTED_LOCALES (src/i18n/types.ts).
     skipTrailingSlashRedirect: true,
     async rewrites() {
         return {

--- a/redirects.json
+++ b/redirects.json
@@ -207,8 +207,8 @@
         "permanent": true
     },
     {
-        "source": "/:locale(en|es-419|es-ar|pt-br)/:path*/",
-        "destination": "/:locale/:path*",
+        "source": "/:locale(en|es-419|es-ar|pt-br)/:path+/",
+        "destination": "/:locale/:path+",
         "permanent": true
     }
 ]

--- a/redirects.json
+++ b/redirects.json
@@ -45,6 +45,11 @@
         "permanent": false
     },
     {
+        "source": "/help/:path*",
+        "destination": "/en/help/:path*",
+        "permanent": true
+    },
+    {
         "source": "/terms",
         "destination": "/en/terms",
         "permanent": false
@@ -53,6 +58,26 @@
         "source": "/privacy",
         "destination": "/en/privacy",
         "permanent": false
+    },
+    {
+        "source": "/pricing",
+        "destination": "/en/pricing",
+        "permanent": true
+    },
+    {
+        "source": "/stories",
+        "destination": "/en/stories",
+        "permanent": true
+    },
+    {
+        "source": "/stories/:path*",
+        "destination": "/en/stories/:path*",
+        "permanent": true
+    },
+    {
+        "source": "/content",
+        "destination": "/en/content",
+        "permanent": true
     },
     {
         "source": "/:slug(card-terms-us|card-terms-international|card-esign|card-privacy|card-prohibited-activities)",
@@ -75,6 +100,17 @@
             {
                 "type": "host",
                 "value": "docs.peanut.me"
+            }
+        ],
+        "destination": "https://peanut.me/en/help",
+        "permanent": true
+    },
+    {
+        "source": "/:path*",
+        "has": [
+            {
+                "type": "host",
+                "value": "docs.peanut.to"
             }
         ],
         "destination": "https://peanut.me/en/help",
@@ -168,6 +204,11 @@
     {
         "source": "/:locale/deposit/from-spei",
         "destination": "/:locale/deposit/via-spei",
+        "permanent": true
+    },
+    {
+        "source": "/:locale(en|es-419|es-ar|pt-br)/:path*/",
+        "destination": "/:locale/:path*",
         "permanent": true
     }
 ]

--- a/scripts/verify-content.ts
+++ b/scripts/verify-content.ts
@@ -81,10 +81,12 @@ function listDirs(dir: string): string[] {
  * agree with each other on a slug that 404s at runtime (e.g. colombia, mexico).
  */
 function gateReceiveSources(): string[] {
-    return listDirs(path.join(CONTENT_DIR, 'receive-from')).filter((slug) => {
-        const en = path.join(CONTENT_DIR, 'receive-from', slug, 'en.md')
-        return fs.existsSync(en) && isPublished(fs.readFileSync(en, 'utf-8'))
-    })
+    return listDirs(path.join(CONTENT_DIR, 'receive-from'))
+        .filter((slug) => slug !== 'index')
+        .filter((slug) => {
+            const en = path.join(CONTENT_DIR, 'receive-from', slug, 'en.md')
+            return fs.existsSync(en) && isPublished(fs.readFileSync(en, 'utf-8'))
+        })
 }
 
 function getAllMdFiles(dir: string): string[] {

--- a/scripts/verify-content.ts
+++ b/scripts/verify-content.ts
@@ -74,14 +74,17 @@ function listDirs(dir: string): string[] {
 }
 
 /**
- * Receive-money-from pages render only for corridor origins that actually have
- * a receive-from article. Mirrors RECEIVE_SOURCES in src/data/seo/corridors.ts.
+ * Receive-money-from pages render for every published receive-from article.
+ * Mirrors RECEIVE_SOURCES in src/data/seo/corridors.ts (listPublishedSlugs):
+ * publication is gated on the article existing, not on corridor membership.
  * Without this gate, both the route index and the sitemap "expected URLs" would
  * agree with each other on a slug that 404s at runtime (e.g. colombia, mexico).
  */
-function gateReceiveSources(corridors: Array<{ from: string; to: string }>): string[] {
-    const origins = [...new Set(corridors.map((c) => c.from))]
-    return origins.filter((slug) => fs.existsSync(path.join(CONTENT_DIR, 'receive-from', slug, 'en.md')))
+function gateReceiveSources(): string[] {
+    return listDirs(path.join(CONTENT_DIR, 'receive-from')).filter((slug) => {
+        const en = path.join(CONTENT_DIR, 'receive-from', slug, 'en.md')
+        return fs.existsSync(en) && isPublished(fs.readFileSync(en, 'utf-8'))
+    })
 }
 
 function getAllMdFiles(dir: string): string[] {
@@ -193,7 +196,7 @@ function discoverRoutes(): Set<string> {
             corridors.push({ to: dest, from: origin })
         }
     }
-    const receiveSources = gateReceiveSources(corridors)
+    const receiveSources = gateReceiveSources()
 
     // Check which routes actually have page.tsx files
     const hasRoute = (routePath: string) => {
@@ -705,7 +708,7 @@ function expectedSitemapUrls(): string[] {
         const fromDir = path.join(CONTENT_DIR, 'send-to', dest, 'from')
         for (const origin of listDirs(fromDir)) corridors.push({ from: origin, to: dest })
     }
-    const receiveSources = gateReceiveSources(corridors)
+    const receiveSources = gateReceiveSources()
 
     for (const locale of SUPPORTED_LOCALES) {
         for (const slug of countrySlugs) {

--- a/src/app/[...recipient]/loading.tsx
+++ b/src/app/[...recipient]/loading.tsx
@@ -1,5 +1,0 @@
-import PeanutLoading from '@/components/Global/PeanutLoading'
-
-export default function Loading() {
-    return <PeanutLoading />
-}

--- a/src/app/[...recipient]/page.tsx
+++ b/src/app/[...recipient]/page.tsx
@@ -21,7 +21,11 @@ type PageProps = {
 // a "<handle> on Peanut" title. Google indexed thousands of those. Every metadata
 // branch is noindex: profiles, addresses, ENS and request/receipt links are app
 // surface, not search landing pages — no carve-outs.
+// canonical: null suppresses the root layout's inherited `canonical: '/'` —
+// noindex must not ship on pages that canonicalize to the homepage, or the
+// noindex can be attributed to the canonical cluster head (the homepage itself).
 const NOINDEX = { index: false, follow: false } as const
+const NOINDEX_META = { robots: NOINDEX, alternates: { canonical: null } } as const
 
 export async function generateMetadata({ params, searchParams }: PageProps) {
     const resolvedSearchParams = await searchParams
@@ -30,18 +34,18 @@ export async function generateMetadata({ params, searchParams }: PageProps) {
     // Guard: Don't generate metadata for reserved routes (handled by their specific routes)
     const firstSegment = resolvedParams.recipient?.[0]
     if (firstSegment && isReservedRoute(`/${firstSegment}`)) {
-        return { robots: NOINDEX }
+        return { ...NOINDEX_META }
     }
 
     // Guard: Ensure recipient exists
     if (!resolvedParams.recipient?.[0]) {
-        return { robots: NOINDEX }
+        return { ...NOINDEX_META }
     }
 
     // Guard: Don't generate "X on Peanut" metadata for things that can't be recipients
     // (bare locale codes, slugs with dashes, random strings). Lets the 404 page own the tab title.
     if (!couldBeRecipient(firstSegment!)) {
-        return { robots: NOINDEX }
+        return { ...NOINDEX_META }
     }
 
     let title = 'Request Payment | Peanut'
@@ -168,6 +172,7 @@ export async function generateMetadata({ params, searchParams }: PageProps) {
         title,
         description,
         robots: NOINDEX,
+        alternates: { canonical: null },
         ...(siteUrl ? { metadataBase: new URL(siteUrl) } : {}),
         icons: {
             icon: '/favicon.ico',

--- a/src/app/[...recipient]/page.tsx
+++ b/src/app/[...recipient]/page.tsx
@@ -16,6 +16,13 @@ type PageProps = {
     searchParams: Promise<{ chargeId?: string }>
 }
 
+// This catch-all renders an indexable shell for ANY username-shaped string — the
+// existence check runs client-side, so a non-existent handle still returns 200 with
+// a "<handle> on Peanut" title. Google indexed thousands of those. Every metadata
+// branch is noindex: profiles, addresses, ENS and request/receipt links are app
+// surface, not search landing pages — no carve-outs.
+const NOINDEX = { index: false, follow: false } as const
+
 export async function generateMetadata({ params, searchParams }: PageProps) {
     const resolvedSearchParams = await searchParams
     const resolvedParams = await params
@@ -23,18 +30,18 @@ export async function generateMetadata({ params, searchParams }: PageProps) {
     // Guard: Don't generate metadata for reserved routes (handled by their specific routes)
     const firstSegment = resolvedParams.recipient?.[0]
     if (firstSegment && isReservedRoute(`/${firstSegment}`)) {
-        return {}
+        return { robots: NOINDEX }
     }
 
     // Guard: Ensure recipient exists
     if (!resolvedParams.recipient?.[0]) {
-        return {}
+        return { robots: NOINDEX }
     }
 
     // Guard: Don't generate "X on Peanut" metadata for things that can't be recipients
     // (bare locale codes, slugs with dashes, random strings). Lets the 404 page own the tab title.
     if (!couldBeRecipient(firstSegment!)) {
-        return {}
+        return { robots: NOINDEX }
     }
 
     let title = 'Request Payment | Peanut'
@@ -160,6 +167,7 @@ export async function generateMetadata({ params, searchParams }: PageProps) {
     return {
         title,
         description,
+        robots: NOINDEX,
         ...(siteUrl ? { metadataBase: new URL(siteUrl) } : {}),
         icons: {
             icon: '/favicon.ico',

--- a/src/app/careers/page.tsx
+++ b/src/app/careers/page.tsx
@@ -6,6 +6,9 @@ export const metadata = generateMetadata({
     description:
         'Explore career opportunities at Peanut. Join our team to build the future of fast, global peer-to-peer payments with digital dollars.',
     keywords: 'careers, jobs, employment, Peanut careers, P2P payments jobs, fintech jobs, crypto jobs, tech jobs',
+    // Without this the page inherits the root layout's `canonical: '/'` and
+    // declares the homepage as its canonical while sitting in the sitemap.
+    canonical: '/careers',
 })
 
 export default function CareersPage() {

--- a/src/app/lp/card/page.tsx
+++ b/src/app/lp/card/page.tsx
@@ -9,8 +9,9 @@ export const metadata = generateMeta({
         'Join Card Pioneers for early access to the Peanut Card. Reserve your spot with $10, earn $5 for every friend who joins, and spend your dollars globally.',
     keywords:
         'peanut card, card pioneers, crypto card, digital dollars, global spending, early access, referral rewards, international card',
-    // Without this the page inherits the root layout's `canonical: '/'` and
-    // declares the homepage as its canonical while sitting in the sitemap.
+    // Without this the page inherits lp/layout.tsx's deliberate `canonical: '/'`
+    // (the /lp subtree aliases the root landing page). That policy is wrong for
+    // /lp/card specifically: it's a distinct product page sitting in the sitemap.
     canonical: '/lp/card',
 })
 

--- a/src/app/lp/card/page.tsx
+++ b/src/app/lp/card/page.tsx
@@ -9,6 +9,9 @@ export const metadata = generateMeta({
         'Join Card Pioneers for early access to the Peanut Card. Reserve your spot with $10, earn $5 for every friend who joins, and spend your dollars globally.',
     keywords:
         'peanut card, card pioneers, crypto card, digital dollars, global spending, early access, referral rewards, international card',
+    // Without this the page inherits the root layout's `canonical: '/'` and
+    // declares the homepage as its canonical while sitting in the sitemap.
+    canonical: '/lp/card',
 })
 
 export default function CardLPPage() {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -4,6 +4,38 @@ import { SUPPORTED_LOCALES } from '@/i18n/types'
 
 const IS_PRODUCTION_DOMAIN = BASE_URL === 'https://peanut.me'
 
+// Paths kept out of the index: the API surface, the SDK bundle, and the
+// auth-gated app routes. Shared by every named crawler group — a group that
+// omits these silently opts that crawler out of ALL disallows, because a
+// user-agent only ever obeys the single most specific group that matches it.
+const DISALLOWED_PATHS = [
+    '/api/',
+    '/sdk/',
+    // Auth-gated app routes
+    '/home',
+    '/profile',
+    '/settings',
+    '/send',
+    '/request',
+    '/setup',
+    '/claim',
+    '/pay',
+    '/dev/',
+    '/qr',
+    '/history',
+    '/points',
+    '/rewards',
+    '/invite',
+    '/kyc',
+    '/maintenance',
+    '/quests',
+    '/receipt',
+    '/crisp-proxy',
+    '/card-payment',
+    '/add-money',
+    '/withdraw',
+]
+
 export default function robots(): MetadataRoute.Robots {
     // Block indexing on staging, preview deploys, and non-production domains
     if (!IS_PRODUCTION_DOMAIN) {
@@ -22,10 +54,15 @@ export default function robots(): MetadataRoute.Robots {
             },
 
             // Googlebot must be able to fetch the dynamic OG images too — the
-            // generic `disallow: /api/` below would otherwise block them.
+            // generic `disallow: /api/` below would otherwise block them. The
+            // shared disallows are repeated here on purpose: Googlebot obeys
+            // this group INSTEAD of the `*` group, so without them it would
+            // treat every auth-gated route as crawlable. The narrower
+            // `/api/og` allow still wins over `/api/` by longest-match.
             {
                 userAgent: 'Googlebot',
                 allow: ['/api/og'],
+                disallow: DISALLOWED_PATHS,
             },
 
             // AI search engine crawlers — explicitly welcome
@@ -55,33 +92,7 @@ export default function robots(): MetadataRoute.Robots {
                     // SEO routes (all locale-prefixed)
                     ...SUPPORTED_LOCALES.map((l) => `/${l}/`),
                 ],
-                disallow: [
-                    '/api/',
-                    '/sdk/',
-                    // Auth-gated app routes
-                    '/home',
-                    '/profile',
-                    '/settings',
-                    '/send',
-                    '/request',
-                    '/setup',
-                    '/claim',
-                    '/pay',
-                    '/dev/',
-                    '/qr',
-                    '/history',
-                    '/points',
-                    '/rewards',
-                    '/invite',
-                    '/kyc',
-                    '/maintenance',
-                    '/quests',
-                    '/receipt',
-                    '/crisp-proxy',
-                    '/card-payment',
-                    '/add-money',
-                    '/withdraw',
-                ],
+                disallow: DISALLOWED_PATHS,
             },
 
             // Rate-limit aggressive SEO crawlers

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -5,10 +5,11 @@ import { SUPPORTED_LOCALES } from '@/i18n/types'
 const IS_PRODUCTION_DOMAIN = BASE_URL === 'https://peanut.me'
 
 // Paths kept out of the index: the API surface, the SDK bundle, and the
-// auth-gated app routes. Used by the `*` and Googlebot groups; the other named
-// groups below carry their own (narrower) lists. Mind the footgun when editing:
-// a crawler only ever obeys the single most specific group that matches it, so
-// a named group that omits a path silently opts that crawler out of it.
+// auth-gated app routes. Used by the `*`, Googlebot, and AI-crawler groups;
+// Twitterbot is the one deliberate exemption (see its comment). Mind the
+// footgun when editing: a crawler only ever obeys the single most specific
+// group that matches it, so a named group that omits a path silently opts
+// that crawler out of it.
 const DISALLOWED_PATHS = [
     '/api/',
     '/sdk/',
@@ -47,7 +48,11 @@ export default function robots(): MetadataRoute.Robots {
 
     return {
         rules: [
-            // Allow Twitterbot to fetch OG images for link previews
+            // Twitterbot is DELIBERATELY unrestricted (empty disallow): it
+            // fetches user-shared app URLs (claim links, payment requests,
+            // receipts) to render link-preview cards on X, and it does not
+            // index. Restricting it would break card unfurls on exactly the
+            // links users share most.
             {
                 userAgent: 'Twitterbot',
                 allow: ['/api/og'],
@@ -66,7 +71,10 @@ export default function robots(): MetadataRoute.Robots {
                 disallow: DISALLOWED_PATHS,
             },
 
-            // AI search engine crawlers — explicitly welcome
+            // AI search engine crawlers — explicitly welcome on all marketing
+            // and content pages, blocked from the same app/transactional
+            // surface as everyone else (they have no business in claim links,
+            // receipts, or KYC — and their answers should cite content pages).
             {
                 userAgent: [
                     'GPTBot',
@@ -77,7 +85,7 @@ export default function robots(): MetadataRoute.Robots {
                     'Applebot-Extended',
                 ],
                 allow: ['/'],
-                disallow: ['/api/', '/home', '/profile', '/settings', '/setup', '/dev/'],
+                disallow: DISALLOWED_PATHS,
             },
 
             // Default rules for all crawlers

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -5,9 +5,10 @@ import { SUPPORTED_LOCALES } from '@/i18n/types'
 const IS_PRODUCTION_DOMAIN = BASE_URL === 'https://peanut.me'
 
 // Paths kept out of the index: the API surface, the SDK bundle, and the
-// auth-gated app routes. Shared by every named crawler group — a group that
-// omits these silently opts that crawler out of ALL disallows, because a
-// user-agent only ever obeys the single most specific group that matches it.
+// auth-gated app routes. Used by the `*` and Googlebot groups; the other named
+// groups below carry their own (narrower) lists. Mind the footgun when editing:
+// a crawler only ever obeys the single most specific group that matches it, so
+// a named group that omits a path silently opts that crawler out of it.
 const DISALLOWED_PATHS = [
     '/api/',
     '/sdk/',

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -11,11 +11,16 @@ import {
 } from '@/data/seo'
 import { SUPPORTED_LOCALES } from '@/i18n/config'
 import {
+    contentGeneratedAt,
     hasCorridorContent,
     hasPageContent,
     hasSingletonContent,
     listContentSlugs,
     listPublishedSlugs,
+    readCorridorContent,
+    readPageContent,
+    readSingletonContent,
+    type ContentFrontmatter,
 } from '@/lib/content'
 
 // TODO (infra): Update GitHub org, Twitter bio, LinkedIn, npm package.json → peanut.me
@@ -23,6 +28,23 @@ import {
 
 /** Build date used for non-content pages that don't have their own date. */
 const BUILD_DATE = new Date()
+
+// --- lastmod sources ---
+// Content-backed URLs report the `generated_at` of the exact file that serves them, so a
+// rebuild no longer bumps every lastmod to the deploy timestamp. These read through the same
+// cache the has*Content() guards already populate, so they cost no extra file reads.
+// Each returns undefined when the file is missing or carries no usable date, in which case
+// the caller falls back to BUILD_DATE — that covers the hand-built pages (homepage, /lp/card,
+// /careers, /exchange, legal) and the index pages that aren't backed by a single file.
+
+const pageDate = (intent: string, slug: string, locale: string): Date | undefined =>
+    contentGeneratedAt(readPageContent<ContentFrontmatter>(intent, slug, locale))
+
+const corridorDate = (destination: string, origin: string, locale: string): Date | undefined =>
+    contentGeneratedAt(readCorridorContent<ContentFrontmatter>(destination, origin, locale))
+
+const singletonDate = (intent: string, locale: string): Date | undefined =>
+    contentGeneratedAt(readSingletonContent<ContentFrontmatter>(intent, locale))
 
 async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
     type SitemapEntry = {
@@ -61,7 +83,12 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
         // Country hub pages
         for (const country of Object.keys(COUNTRIES_SEO)) {
             if (!hasPageContent('countries', country, locale)) continue
-            pages.push({ path: `/${locale}/${country}`, priority: 0.9 * basePriority, changeFrequency: 'weekly' })
+            pages.push({
+                path: `/${locale}/${country}`,
+                priority: 0.9 * basePriority,
+                changeFrequency: 'weekly',
+                lastModified: pageDate('countries', country, locale),
+            })
         }
 
         // Send-money-to country pages
@@ -71,6 +98,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/send-money-to/${country}`,
                 priority: 0.8 * basePriority,
                 changeFrequency: 'weekly',
+                lastModified: pageDate('send-to', country, locale),
             })
         }
 
@@ -81,6 +109,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/send-money-from/${corridor.from}/to/${corridor.to}`,
                 priority: 0.85 * basePriority,
                 changeFrequency: 'weekly',
+                lastModified: corridorDate(corridor.to, corridor.from, locale),
             })
         }
 
@@ -91,6 +120,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/receive-money-from/${source}`,
                 priority: 0.7 * basePriority,
                 changeFrequency: 'weekly',
+                lastModified: pageDate('receive-from', source, locale),
             })
         }
 
@@ -101,6 +131,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/compare/peanut-vs-${slug}`,
                 priority: 0.7 * basePriority,
                 changeFrequency: 'monthly',
+                lastModified: pageDate('compare', slug, locale),
             })
         }
 
@@ -114,6 +145,8 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/deposit/from-${exchange}`,
                 priority: 0.7 * basePriority,
                 changeFrequency: 'monthly',
+                // Undefined for the i18n-only exchanges (no MDX at all) → BUILD_DATE.
+                lastModified: pageDate('deposit', exchange, locale),
             })
         }
         for (const rail of Object.keys(DEPOSIT_RAILS)) {
@@ -122,6 +155,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/deposit/via-${rail}`,
                 priority: 0.7 * basePriority,
                 changeFrequency: 'monthly',
+                lastModified: pageDate('deposit', rail, locale),
             })
         }
 
@@ -132,6 +166,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/pay-with/${method}`,
                 priority: 0.7 * basePriority,
                 changeFrequency: 'monthly',
+                lastModified: pageDate('pay-with', method, locale),
             })
         }
 
@@ -147,6 +182,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/help/${slug}`,
                 priority: 0.6 * basePriority,
                 changeFrequency: 'monthly',
+                lastModified: pageDate('help', slug, locale),
             })
         }
 
@@ -157,6 +193,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/use-cases/${slug}`,
                 priority: 0.7 * basePriority,
                 changeFrequency: 'monthly',
+                lastModified: pageDate('use-cases', slug, locale),
             })
         }
 
@@ -168,6 +205,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/stories/${slug}`,
                 priority: 0.6 * basePriority,
                 changeFrequency: 'monthly',
+                lastModified: pageDate('stories', slug, locale),
             })
         }
         // Stories index
@@ -184,6 +222,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/withdraw/${slug}`,
                 priority: 0.6 * basePriority,
                 changeFrequency: 'monthly',
+                lastModified: pageDate('withdraw', slug, locale),
             })
         }
 
@@ -193,6 +232,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/supported-networks`,
                 priority: 0.6 * basePriority,
                 changeFrequency: 'monthly',
+                lastModified: singletonDate('supported-networks', locale),
             })
         }
 
@@ -202,6 +242,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/pricing`,
                 priority: 0.7 * basePriority,
                 changeFrequency: 'monthly',
+                lastModified: singletonDate('pricing', locale),
             })
         }
 
@@ -223,6 +264,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
                 path: `/${locale}/blog/${slug}`,
                 priority: 0.6 * basePriority,
                 changeFrequency: 'monthly',
+                lastModified: pageDate('blog', slug, locale),
             })
         }
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -113,7 +113,7 @@ async function generateSitemap(): Promise<MetadataRoute.Sitemap> {
             })
         }
 
-        // Receive money pages — corridor origins that have a receive-from article
+        // Receive money pages — every published receive-from article (independent of corridors)
         for (const source of RECEIVE_SOURCES) {
             if (!hasPageContent('receive-from', source, locale)) continue
             pages.push({

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -70,6 +70,17 @@ export const DEDICATED_ROUTES = [
     'faq',
     'how-it-works',
 
+    // Marketing hubs that already ship as [locale]/(marketing) pages but whose
+    // bare paths were still recipient-shaped (7 lowercase letters each), so
+    // /pricing, /stories and /content rendered a payment-profile shell on a 200
+    // instead of resolving to the real page. Reserved here + 301'd to /en/… in
+    // redirects.json. NOTE: 'pricing' is also reserved server-side (the username
+    // API rejects it), but 'stories' and 'content' are still claimable as
+    // usernames — see the PR body, backend needs to add them to its reserved list.
+    'pricing',
+    'stories',
+    'content',
+
     // Locale prefixes (current SUPPORTED_LOCALES)
     'en',
     'es-419',

--- a/src/data/seo/corridors.test.ts
+++ b/src/data/seo/corridors.test.ts
@@ -1,32 +1,44 @@
 import fs from 'fs'
 import path from 'path'
-import { CORRIDORS, RECEIVE_SOURCES } from './corridors'
+import { RECEIVE_SOURCES } from './corridors'
 
 const RECEIVE_FROM_DIR = path.join(process.cwd(), 'src/content/content/receive-from')
 
-// Regression guard for the May 2026 live 404s: receive-money-from rendered for
-// every corridor origin, but origins lacking a receive-from article (colombia,
-// mexico) 404ed. RECEIVE_SOURCES must be CORRIDORS.from gated by content.
-describe('RECEIVE_SOURCES', () => {
-    it('only contains corridor origins', () => {
-        const origins = new Set(CORRIDORS.map((c) => c.from))
-        for (const slug of RECEIVE_SOURCES) {
-            expect(origins.has(slug)).toBe(true)
-        }
-    })
+/** Re-derive the expected set straight off the filesystem, independently of
+ *  the content lib the loader uses — a guard that reuses the loader's own
+ *  helper would only prove it equals itself. */
+function publishedReceiveFromSlugs(): string[] {
+    return fs
+        .readdirSync(RECEIVE_FROM_DIR)
+        .filter((slug) => fs.statSync(path.join(RECEIVE_FROM_DIR, slug)).isDirectory())
+        .filter((slug) => fs.existsSync(path.join(RECEIVE_FROM_DIR, slug, 'en.md')))
+        .filter((slug) => {
+            const raw = fs.readFileSync(path.join(RECEIVE_FROM_DIR, slug, 'en.md'), 'utf8')
+            const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---/.exec(raw)?.[1] ?? ''
+            return !/^published:\s*false\s*$/m.test(frontmatter)
+        })
+}
 
-    it('only contains origins that have a receive-from article (no 404s)', () => {
+// Regression guard for the May 2026 live 404s: receive-money-from must only
+// render slugs that have a published article. The guard used to also require
+// RECEIVE_SOURCES ⊆ CORRIDORS.from, which was never what protected us — it was
+// an artifact of how the list was built, and it silently dropped 10 authored
+// countries whose articles were live but unreachable. What the route actually
+// needs is the both-directions equality below: nothing rendered without
+// content (no 404s), and nothing authored left behind (no orphans).
+describe('RECEIVE_SOURCES', () => {
+    it('only contains slugs that have a published receive-from article (no 404s)', () => {
         for (const slug of RECEIVE_SOURCES) {
             const enFile = path.join(RECEIVE_FROM_DIR, slug, 'en.md')
             expect(fs.existsSync(enFile)).toBe(true)
         }
     })
 
-    it('drops corridor origins with no receive-from article', () => {
-        const origins = [...new Set(CORRIDORS.map((c) => c.from))]
-        for (const slug of origins) {
-            const hasArticle = fs.existsSync(path.join(RECEIVE_FROM_DIR, slug, 'en.md'))
-            expect(RECEIVE_SOURCES.includes(slug)).toBe(hasArticle)
-        }
+    it('contains every published receive-from article (no orphaned content)', () => {
+        expect([...RECEIVE_SOURCES].sort()).toEqual(publishedReceiveFromSlugs().sort())
+    })
+
+    it('has no duplicate slugs', () => {
+        expect(RECEIVE_SOURCES.length).toBe(new Set(RECEIVE_SOURCES).size)
     })
 })

--- a/src/data/seo/corridors.test.ts
+++ b/src/data/seo/corridors.test.ts
@@ -1,21 +1,33 @@
 import fs from 'fs'
 import path from 'path'
+import matter from 'gray-matter'
 import { RECEIVE_SOURCES } from './corridors'
 
 const RECEIVE_FROM_DIR = path.join(process.cwd(), 'src/content/content/receive-from')
 
+beforeAll(() => {
+    if (!fs.existsSync(RECEIVE_FROM_DIR)) {
+        throw new Error(
+            `content tree missing at ${RECEIVE_FROM_DIR} — the src/content submodule is not ` +
+                'initialized in this checkout. Run: git submodule update --init'
+        )
+    }
+})
+
 /** Re-derive the expected set straight off the filesystem, independently of
  *  the content lib the loader uses — a guard that reuses the loader's own
- *  helper would only prove it equals itself. */
+ *  helper would only prove it equals itself. gray-matter is used directly (not
+ *  via the lib) so YAML semantics match what the loader's parser actually does
+ *  (`published: False`, trailing comments, nesting). */
 function publishedReceiveFromSlugs(): string[] {
     return fs
         .readdirSync(RECEIVE_FROM_DIR)
+        .filter((slug) => slug !== 'index')
         .filter((slug) => fs.statSync(path.join(RECEIVE_FROM_DIR, slug)).isDirectory())
         .filter((slug) => fs.existsSync(path.join(RECEIVE_FROM_DIR, slug, 'en.md')))
         .filter((slug) => {
             const raw = fs.readFileSync(path.join(RECEIVE_FROM_DIR, slug, 'en.md'), 'utf8')
-            const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---/.exec(raw)?.[1] ?? ''
-            return !/^published:\s*false\s*$/m.test(frontmatter)
+            return matter(raw).data.published !== false
         })
 }
 

--- a/src/data/seo/corridors.ts
+++ b/src/data/seo/corridors.ts
@@ -3,6 +3,7 @@
 // Sources (all in the public mirror):
 //   content/countries/{slug}/{lang}.md      — country hub article + frontmatter
 //   content/send-to/{dst}/from/{src}/{lang}.md — corridor article + frontmatter
+//   content/receive-from/{slug}/{lang}.md   — receive-from article + frontmatter
 //
 // Country display names come from the `name:` field denormalized at
 // generation time (see mono/content/_system/templates/country-hub.md); absent
@@ -19,6 +20,7 @@
 import {
     listContentSlugs,
     listCorridorOrigins,
+    listPublishedSlugs,
     readCorridorContent,
     readPageContent,
     readPageContentLocalized,
@@ -73,24 +75,29 @@ function loadCorridors(): Corridor[] {
 }
 
 /**
- * Origins for the receive-money-from pages. The set is the corridor origins,
- * but only those that actually have a receive-from article — an origin present
- * in CORRIDORS.from but missing content/receive-from/{slug}/en.md would 404
- * (this is how colombia & mexico shipped as live 404s in May 2026). The
- * receive-from content tree is authored independently of corridors, so the two
- * sets don't line up automatically.
+ * Origins for the receive-money-from pages: every published receive-from
+ * article, read straight off the content tree.
+ *
+ * The invariant that matters is "the route has something to render" — an entry
+ * with no content/receive-from/{slug}/en.md would 404 (this is how colombia &
+ * mexico shipped as live 404s in May 2026), so publication is still gated on
+ * content presence.
+ *
+ * This used to seed from CORRIDORS.from and intersect with the content tree.
+ * That was strictly narrower than it needed to be: receive-from is authored
+ * independently of corridors, so the intersection silently dropped 10 authored
+ * countries (australia, india, kenya, malaysia, netherlands, pakistan,
+ * philippines, saudi-arabia, singapore, united-arab-emirates) whose articles
+ * were live but unreachable. Corridor membership was never a rendering
+ * requirement for these pages — only the article is.
  */
-function loadReceiveSources(corridors: Corridor[]): string[] {
-    const origins = [...new Set(corridors.map((c) => c.from))]
-    return origins.filter((slug) => {
-        const content = readPageContent<{ published?: boolean }>('receive-from', slug, 'en')
-        return content !== null && content.frontmatter.published !== false
-    })
+function loadReceiveSources(): string[] {
+    return listPublishedSlugs('receive-from')
 }
 
 export const COUNTRIES_SEO: Record<string, CountrySEO> = loadCountries()
 export const CORRIDORS: Corridor[] = loadCorridors()
-export const RECEIVE_SOURCES: string[] = loadReceiveSources(CORRIDORS)
+export const RECEIVE_SOURCES: string[] = loadReceiveSources()
 
 /**
  * Get the country display name for a slug at the given locale. Reads

--- a/src/data/seo/corridors.ts
+++ b/src/data/seo/corridors.ts
@@ -92,7 +92,9 @@ function loadCorridors(): Corridor[] {
  * requirement for these pages — only the article is.
  */
 function loadReceiveSources(): string[] {
-    return listPublishedSlugs('receive-from')
+    // 'index' skip: guards against a meta directory landing in the content
+    // tree becoming a live route (sitemap.ts applies the same skip elsewhere).
+    return listPublishedSlugs('receive-from').filter((slug) => slug !== 'index')
 }
 
 export const COUNTRIES_SEO: Record<string, CountrySEO> = loadCountries()

--- a/src/lib/content.test.ts
+++ b/src/lib/content.test.ts
@@ -1,4 +1,4 @@
-import { listAllContent } from '@/lib/content'
+import { contentGeneratedAt, listAllContent, readPageContent, type ContentFrontmatter } from '@/lib/content'
 
 describe('listAllContent', () => {
     it('returns items across all 4 hub types for en', () => {
@@ -49,5 +49,34 @@ describe('listAllContent', () => {
             const curr = new Date(blogItems[i].date ?? 0).getTime()
             expect(prev).toBeGreaterThanOrEqual(curr)
         }
+    })
+})
+
+describe('contentGeneratedAt', () => {
+    // gray-matter runs js-yaml, which turns unquoted YAML timestamps into Date objects even
+    // though ContentFrontmatter types generated_at as a string — both shapes must work.
+    it('accepts a Date (the usual runtime shape from unquoted YAML)', () => {
+        const at = contentGeneratedAt({ frontmatter: { generated_at: new Date('2026-03-27') } as never, body: '' })
+        expect(at?.toISOString().split('T')[0]).toBe('2026-03-27')
+    })
+
+    it('accepts a quoted string date', () => {
+        const at = contentGeneratedAt({ frontmatter: { generated_at: '2026-03-20T17:10:00Z' } as never, body: '' })
+        expect(at?.toISOString()).toBe('2026-03-20T17:10:00.000Z')
+    })
+
+    it('returns undefined for null content, a missing field, or an unparseable value', () => {
+        expect(contentGeneratedAt(null)).toBeUndefined()
+        expect(contentGeneratedAt({ frontmatter: {} as never, body: '' })).toBeUndefined()
+        expect(contentGeneratedAt({ frontmatter: { generated_at: 'not-a-date' } as never, body: '' })).toBeUndefined()
+        expect(contentGeneratedAt({ frontmatter: { generated_at: '' } as never, body: '' })).toBeUndefined()
+    })
+
+    it('reads a real date off a real content file', () => {
+        const at = contentGeneratedAt(readPageContent<ContentFrontmatter>('help', 'delete-account', 'en'))
+        expect(at).toBeInstanceOf(Date)
+        // A real authored date, not the build clock.
+        expect(at!.getTime()).toBeLessThan(Date.now())
+        expect(at!.getUTCFullYear()).toBeGreaterThanOrEqual(2026)
     })
 })

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -288,6 +288,27 @@ export function readSingletonContentLocalized<T = Record<string, unknown>>(
     return null
 }
 
+// --- Content freshness ---
+
+/**
+ * `generated_at` from a content file's frontmatter, as a Date.
+ *
+ * Mind the type/runtime mismatch: ContentFrontmatter declares `generated_at?: string`, but
+ * gray-matter runs js-yaml, which parses unquoted YAML timestamps into JS Date objects — both
+ * the bare `2026-03-27` form and the full `2026-03-20T17:10:00Z` form. Quoted values still
+ * arrive as strings, so both shapes are accepted here. Missing or unparseable values return
+ * undefined so callers can fall back to a default of their own.
+ */
+export function contentGeneratedAt(content: MarkdownContent<ContentFrontmatter> | null): Date | undefined {
+    const value: unknown = content?.frontmatter?.generated_at
+    if (value instanceof Date) return Number.isNaN(value.getTime()) ? undefined : value
+    if (typeof value === 'string' && value.trim() !== '') {
+        const parsed = new Date(value)
+        return Number.isNaN(parsed.getTime()) ? undefined : parsed
+    }
+    return undefined
+}
+
 // --- Content hub: cross-intent listing ---
 
 export type ContentItemType = 'blog' | 'stories' | 'use-cases' | 'compare'


### PR DESCRIPTION
Consolidates the five SEO fix PRs (#2676, #2678, #2681, #2682, #2684) into one PR at the CTO's request — **one commit per fix**, so any single change can be reverted surgically. Every fix was implemented and then adversarially reviewed by an independent agent that re-derived the evidence itself; all review catches are already folded in as their own commits. Full evidence lives on the five closed PRs; the load-bearing parts are summarized below.

## What's in here (commit order)

**1. `2648b5aaf` — robots.txt, canonicals, receive-from loader** (from #2676)
- `robots.ts`: the Googlebot group had only `Allow: /api/og`, so per the robots spec Googlebot ignored all 24 `*` disallows. Now shares the disallow list.
- `/careers` + `/lp/card` emitted `rel=canonical` → homepage (inherited); both now self-canonicalize. Verified by grepping the canonical `<link>` from rendered preview HTML vs the production defect.
- `corridors.ts`: `loadReceiveSources()` intersected receive-from content with corridor origins, silently dropping **10 fully-authored countries** (australia, india, kenya, malaysia, netherlands, pakistan, philippines, saudi-arabia, singapore, UAE). Now enumerates published content directly: `RECEIVE_SOURCES` 9 → 19. `corridors.test.ts` rewritten to the invariant it actually protects (every slug has published content — the May-2026 incident was the reverse). Review re-derived the counts and confirmed the new guard goes red on the old loader.

**2. `936b012f9` — review catch on the above:** `scripts/verify-content.ts` had a stale second copy of the old loader — Pass 11 (the **blocking** sitemap-coverage CI check) would have silently stopped covering the 10 recovered slugs. Script and app now both return the same 19; Pass 11 coverage 1115 → 1165 URLs.

**3. `153c6bae5` — noindex the username catch-all** (from #2678)
Any username-shaped string (`/brazil`, `/pricing`, `/zzzfake1`) rendered an indexable "X on Peanut" shell — the existence check is client-side, invisible to crawlers, and the root layout injects `index, follow`, so Google indexed thousands. All 4 `generateMetadata` return paths now ship `robots: {index:false, follow:false}`. Decision on record (12 Aug): no carve-outs, including real profiles and `.eth` pages.

**4. `69b3e5dbf` — HIGH review catch on the above:** the noindex was shipping alongside the inherited `rel=canonical` → homepage — a combination Google's guidance warns can attribute the noindex to the canonical cluster head (the homepage, sitemap priority 1.0). `alternates: {canonical: null}` on all four branches; noindex pages now carry no canonical.

**5. `5cb458a46` — real HTTP 404s** (from #2681)
`[...recipient]/loading.tsx` made the catch-all a Suspense boundary, so Next streamed an HTTP 200 shell before `notFound()` resolved — the site never returned a real 404 (breaks GSC soft-404 reporting, link tools, crawl budget). One file deleted; the route's render path was confirmed to have no other boundary. Preview-verified: garbage URL → **404**, real pages → 200, profiles → 200. Review verdict SHIP after independently re-probing.

**6. `74ca6e544` + **7.** `f5034b218` — redirects bundle** (from #2682)
- `/pricing`, `/stories`, `/content` added to `DEDICATED_ROUTES` + bare→`/en/…` redirects (they were being squatted by the username catch-all).
- `/help/:path*` bare→locale redirect — `/help/delete-account` (the **Google Play account-deletion compliance URL**) soft-404'd; it now resolves to the real article.
- `docs.peanut.to` host-redirect rule (inert until ops attaches the domain — see asks).
- Trailing-slash 308s scoped to the locale content tree; `skipTrailingSlashRedirect` untouched (protects the PostHog `/relay/*` proxy — probed: still proxies).
- Review caught a genuine blocker in the first cut: `:path*` matched zero segments, so `/es-ar/`, `/es-419/`, `/pt-br/` 308-looped to themselves (measured on the preview; browsers cache 308s permanently). Fixed with `:path+`; re-probed — bare locales 200, subpaths still redirect, `follow /es-ar/` = 0 hops.

**8. `8ce2b769e` — real sitemap lastmod** (from #2684)
All 709 URLs reported the deploy timestamp as `lastmod`, so Google discounts the signal. Dates now come from each page's `generated_at` frontmatter; static/legal pages keep BUILD_DATE. Review independently cross-checked **686 URLs against the content tree: 0 mismatches**; dev deploy serves 1 distinct lastmod, this branch serves 26, identical URL set.

**9. `d2765ee81`** — stale comment cleanup flagged by review.

## Verification status
- Local (this branch): jest (corridors + content) green, `validate-links` all passes (Pass 11 = 1165 URLs), `tsc --noEmit` exit 0, eslint 0 errors, all 9 commits SSH-signed.
- `next build` cannot run on the dev box (earlyoom) — CI + the Vercel preview are the build gates; each constituent branch already had them green. A fresh probe pass runs on THIS PR's preview after CI; evidence will be posted as a comment.
- Note preview limitations: `robots.txt` and the `noindex` meta can't be observed on previews (non-production BASE_URL noindexes everything) — those two rest on code + the per-branch evidence.

## Asks / follow-ups (not in this PR)
- **Backend:** add `stories` and `content` to the server-side reserved-username list (`pricing` is already reserved; the other two are claimable today, and frontend routing alone doesn't stop a signup claim).
- **Ops (needs access):** attach `docs.peanut.to` to this Vercel project + repoint DNS; flip the redirect.pizza rule for `peanut.to` deep paths to path-preserving.
- **Post-deploy checks:** X/Twitter card unfurls on payment-request/receipt links (they now carry noindex; most unfurlers ignore it, Twitterbot historically sometimes doesn't). Legal pages still report deploy-time lastmod (`last_updated` frontmatter isn't read — small follow-up).
- **Expected conflicts:** #2671 (base main) touches `robots.ts`/`redirects.json` in non-overlapping hunks; #2605 adds `creator-contest` to `DEDICATED_ROUTES` in the same region (trivial).
- The 10 recovered receive-from pages have zero inbound internal links — tracked in the content workstream.

Replaces #2676, #2678, #2681, #2682, #2684 (closed with pointers; branches kept until this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
