### PR TITLE
fix(history): dedupe entries when flattening infinite-query pages

### DIFF
--- a/src/app/(mobile-ui)/history/page.tsx
+++ b/src/app/(mobile-ui)/history/page.tsx
@@ -33,7 +33,7 @@ import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
 import { TRANSACTIONS } from '@/constants/query.consts'
 import type { HistoryEntry, HistoryResponse } from '@/hooks/useTransactionHistory'
 import { AccountType } from '@/interfaces/interfaces'
-import { completeHistoryEntry } from '@/utils/history.utils'
+import { completeHistoryEntry, dedupeHistoryEntriesByUuid } from '@/utils/history.utils'
 import { formatUnits } from 'viem'
 import { PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
 
@@ -161,7 +161,12 @@ const HistoryPage = () => {
         },
     })
 
-    const allEntries = useMemo(() => historyData?.pages.flatMap((page) => page.entries) ?? [], [historyData])
+    // Deduped: page overlap on the API cursor would otherwise render the same
+    // payment twice in a row, which reads as a double charge.
+    const allEntries = useMemo(
+        () => dedupeHistoryEntriesByUuid(historyData?.pages.flatMap((page) => page.entries) ?? []),
+        [historyData]
+    )
 
     const combinedAndSortedEntries = useMemo(() => {
         if (isLoading) {

--- a/src/hooks/__tests__/useTransactionHistory.test.tsx
+++ b/src/hooks/__tests__/useTransactionHistory.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useTransactionHistory } from '@/hooks/useTransactionHistory'
 import type { ReactNode } from 'react'
@@ -57,5 +57,40 @@ describe('useTransactionHistory', () => {
         const { result } = renderHook(() => useTransactionHistory({ mode: 'infinite', enabled: false }), { wrapper })
         // useInfiniteQuery result — exposes fetchNextPage.
         expect(result.current).toHaveProperty('fetchNextPage')
+    })
+
+    // The API re-serves the same window when a cursor cannot advance —
+    // `openRequestLinks` is re-queried on every page with no exclusion, so a
+    // user with `limit`-many open request links gets an identical page every
+    // time. Duplicate rows used to grow the list and push the infinite-scroll
+    // loader out of the viewport; deduping removed that pacing, so an
+    // unchanged cursor would spin fetchNextPage in an unbounded loop.
+    it('stops paginating when the cursor does not advance', async () => {
+        const { serverFetch } = jest.requireMock('@/utils/api-fetch')
+        serverFetch.mockImplementation(() =>
+            Promise.resolve({
+                ok: true,
+                statusText: 'OK',
+                // Same cursor forever, hasMore never goes false.
+                json: () => Promise.resolve({ entries: [], cursor: 'STUCK::same', hasMore: true }),
+            })
+        )
+
+        const wrapper = makeWrapper()
+        const { result } = renderHook(() => useTransactionHistory({ mode: 'infinite', limit: 20 }), { wrapper })
+
+        await waitFor(() => expect(result.current.data?.pages).toHaveLength(1))
+        // First page still advances: the initial param is undefined, so the
+        // cursor is new information.
+        expect(result.current.hasNextPage).toBe(true)
+
+        await act(async () => {
+            await result.current.fetchNextPage()
+        })
+
+        // Second page came back with the same cursor it was asked for, so
+        // pagination stops instead of looping.
+        await waitFor(() => expect(result.current.hasNextPage).toBe(false))
+        expect(result.current.data?.pages).toHaveLength(2)
     })
 })

--- a/src/hooks/useTransactionHistory.ts
+++ b/src/hooks/useTransactionHistory.ts
@@ -113,7 +113,20 @@ export function useTransactionHistory({
         queryKey: [TRANSACTIONS, 'infinite', { limit }],
         queryFn: ({ pageParam }) => fetchHistory({ cursor: pageParam, limit }),
         initialPageParam: undefined as string | undefined,
-        getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.cursor : undefined),
+        getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+            if (!lastPage.hasMore) return undefined
+            // A cursor that did not advance means the API is re-serving the
+            // same window — `openRequestLinks` re-queries with no exclusion,
+            // so a user with `limit`-many open request links gets an identical
+            // page forever. Duplicate rows used to grow the list and push the
+            // loader out of the viewport, which paced infinite scroll; now
+            // that they are deduped the list stops growing, the loader stays
+            // intersecting, and useInfiniteScroll rebuilds its observer on
+            // every isFetchingNextPage flip — an unbounded auto-fetch loop.
+            // Stopping is correct: an unchanged cursor yields no new rows.
+            if (lastPage.cursor === lastPageParam) return undefined
+            return lastPage.cursor
+        },
         enabled: mode === 'infinite' && enabled,
         staleTime: 30 * 1000,
         gcTime: 5 * 60 * 1000,

--- a/src/utils/__tests__/history.utils.test.ts
+++ b/src/utils/__tests__/history.utils.test.ts
@@ -175,8 +175,8 @@ describe('getAvatarUrl', () => {
 /**
  * The history page concatenates infinite-query pages. If the API cursor serves
  * an entry on two pages, the row renders twice — byte-identical, so it reads
- * as a double charge. Real report: a BRL 909.00 PIX payment shown twice with
- * one debit in the database (2026-07-27).
+ * as a double charge. Users have reported exactly that on a PIX payment the
+ * ledger had only debited once.
  */
 describe('dedupeHistoryEntriesByUuid', () => {
     const entry = (uuid: string, amount = '1') => ({ uuid, amount })

--- a/src/utils/__tests__/history.utils.test.ts
+++ b/src/utils/__tests__/history.utils.test.ts
@@ -12,7 +12,13 @@
  * If a future refactor reintroduces a wei assumption here, this fails.
  */
 
-import { completeHistoryEntry, getAvatarUrl, getReceiptUrl, getTransactionSign } from '../history.utils'
+import {
+    completeHistoryEntry,
+    dedupeHistoryEntriesByUuid,
+    getAvatarUrl,
+    getReceiptUrl,
+    getTransactionSign,
+} from '../history.utils'
 import type { HistoryEntry } from '../history.utils'
 import type { TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
 
@@ -163,5 +169,37 @@ describe('getAvatarUrl', () => {
 
     it('falls back to undefined (generic avatar) for historical DEPRECATED_SIMPLEFI rows', () => {
         expect(getAvatarUrl(tx('DEPRECATED_SIMPLEFI', 'ARS'))).toBeUndefined()
+    })
+})
+
+/**
+ * The history page concatenates infinite-query pages. If the API cursor serves
+ * an entry on two pages, the row renders twice — byte-identical, so it reads
+ * as a double charge. Real report: a BRL 909.00 PIX payment shown twice with
+ * one debit in the database (2026-07-27).
+ */
+describe('dedupeHistoryEntriesByUuid', () => {
+    const entry = (uuid: string, amount = '1') => ({ uuid, amount })
+
+    it('drops a boundary row the API served on two pages', () => {
+        const page1 = [entry('a'), entry('b'), entry('c')]
+        const page2 = [entry('c'), entry('d')] // 'c' repeated at the page boundary
+
+        expect(dedupeHistoryEntriesByUuid([...page1, ...page2]).map((e) => e.uuid)).toEqual(['a', 'b', 'c', 'd'])
+    })
+
+    it('keeps the first copy, so newer page-1 data wins over a stale refetch', () => {
+        const deduped = dedupeHistoryEntriesByUuid([entry('a', '909.00'), entry('a', '0')])
+
+        expect(deduped).toHaveLength(1)
+        expect(deduped[0].amount).toBe('909.00')
+    })
+
+    it('keeps distinct entries that only look alike', () => {
+        expect(dedupeHistoryEntriesByUuid([entry('a', '5'), entry('b', '5')])).toHaveLength(2)
+    })
+
+    it('handles an empty feed', () => {
+        expect(dedupeHistoryEntriesByUuid([])).toEqual([])
     })
 })

--- a/src/utils/__tests__/history.utils.test.ts
+++ b/src/utils/__tests__/history.utils.test.ts
@@ -188,20 +188,30 @@ describe('dedupeHistoryEntriesByUuid', () => {
         expect(dedupeHistoryEntriesByUuid([...page1, ...page2]).map((e) => e.uuid)).toEqual(['a', 'b', 'c', 'd'])
     })
 
-    it('keeps the first position but the freshest copy', () => {
-        // Page 2 is fetched after page 1, so its copy of a repeated entry has
-        // the newer status. Position must not move, or rows jump on scroll.
-        const page1 = [
-            { uuid: 'a', status: 'PENDING' },
+    it('keeps a websocket-prepended copy over a stale one from a later page', () => {
+        // The websocket prepends full updated entries to page 0, so for that
+        // source the FRESHEST copy is the first one. An in-flight page-2
+        // response carrying the pre-update row must not overwrite it.
+        const page0 = [
+            { uuid: 'a', status: 'COMPLETED' }, // just pushed over the socket
             { uuid: 'b', status: 'COMPLETED' },
         ]
-        const page2 = [{ uuid: 'a', status: 'COMPLETED' }]
+        const page2 = [{ uuid: 'a', status: 'PENDING' }] // already in flight, stale
 
-        const deduped = dedupeHistoryEntriesByUuid([...page1, ...page2])
+        const deduped = dedupeHistoryEntriesByUuid([...page0, ...page2])
 
         expect(deduped).toHaveLength(2)
         expect(deduped[0]).toEqual({ uuid: 'a', status: 'COMPLETED' })
-        expect(deduped[1].uuid).toBe('b')
+    })
+
+    it('keeps the fuller request-pot rollup from the earlier page', () => {
+        // Rollups reuse link.uuid on every page holding any of that pot's
+        // charges, and each copy aggregates only its own page window. The
+        // earlier copy holds the most recent charge and the larger total.
+        const page1 = [{ uuid: 'pot-1', totalAmountCollected: 250 }]
+        const page2 = [{ uuid: 'pot-1', totalAmountCollected: 40 }]
+
+        expect(dedupeHistoryEntriesByUuid([...page1, ...page2])).toEqual([{ uuid: 'pot-1', totalAmountCollected: 250 }])
     })
 
     it('keeps distinct entries that only look alike', () => {

--- a/src/utils/__tests__/history.utils.test.ts
+++ b/src/utils/__tests__/history.utils.test.ts
@@ -188,11 +188,20 @@ describe('dedupeHistoryEntriesByUuid', () => {
         expect(dedupeHistoryEntriesByUuid([...page1, ...page2]).map((e) => e.uuid)).toEqual(['a', 'b', 'c', 'd'])
     })
 
-    it('keeps the first copy, so newer page-1 data wins over a stale refetch', () => {
-        const deduped = dedupeHistoryEntriesByUuid([entry('a', '909.00'), entry('a', '0')])
+    it('keeps the first position but the freshest copy', () => {
+        // Page 2 is fetched after page 1, so its copy of a repeated entry has
+        // the newer status. Position must not move, or rows jump on scroll.
+        const page1 = [
+            { uuid: 'a', status: 'PENDING' },
+            { uuid: 'b', status: 'COMPLETED' },
+        ]
+        const page2 = [{ uuid: 'a', status: 'COMPLETED' }]
 
-        expect(deduped).toHaveLength(1)
-        expect(deduped[0].amount).toBe('909.00')
+        const deduped = dedupeHistoryEntriesByUuid([...page1, ...page2])
+
+        expect(deduped).toHaveLength(2)
+        expect(deduped[0]).toEqual({ uuid: 'a', status: 'COMPLETED' })
+        expect(deduped[1].uuid).toBe('b')
     })
 
     it('keeps distinct entries that only look alike', () => {

--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -473,17 +473,35 @@ export async function completeHistoryEntry(entry: HistoryEntry): Promise<History
  *
  * The API cursor is over-inclusive on purpose — it is keyed on the later of
  * the two timestamps so that no entry can fall through the crack between
- * pages, and re-serving the boundary row is the price. Page overlap has other
- * sources too (`openRequestLinks` is re-queried on every page), so deduping
- * where the pages get flattened covers all of them at once.
+ * pages, and re-serving the boundary row is the price. `openRequestLinks` is
+ * re-queried on every page with no exclusion at all, so it repeats too.
+ * Deduping where the pages get flattened covers both.
  *
- * Keeps the FIRST position but the LAST copy: a later page is fetched later,
- * so its copy of a repeated entry carries the fresher status. `Map` gives both
- * — re-setting a key updates the value without moving it.
+ * It does NOT cover the send-link claim websocket push, which keys the entry
+ * by `fullSendLink.pubKey` while the REST row for the same transaction uses
+ * the intent id. Those two never collide, so that pair still renders twice
+ * until the next refetch — it needs the uuids aligned on the API side.
+ *
+ * Keeps the FIRST copy. Earlier in the flattened array means closer to page 0,
+ * and for both known repeat sources the earlier copy is the better one:
+ *   - websocket updates are PREPENDED to page 0, so the freshest copy of an
+ *     entry is the first one, not the last. Last-wins let an in-flight page-2
+ *     response overwrite a just-pushed COMPLETED row with its stale PENDING
+ *     copy, visibly regressing the status.
+ *   - request-pot rollups reuse `link.uuid` on every page holding any of that
+ *     pot's charges, and each copy only aggregates its own page window. The
+ *     page-1 copy carries the most recent charge and the larger total; taking
+ *     the later one shrinks the collected amount and moves the row.
+ * A page-1 row that was PENDING when fetched and COMPLETED by the time page 2
+ * arrives keeps the stale status until the next refetch (30s staleTime). That
+ * is not a regression — before this dedupe both rows rendered and the stale
+ * one was already among them.
  */
 export function dedupeHistoryEntriesByUuid<T extends { uuid: string }>(entries: T[]): T[] {
     const byUuid = new Map<string, T>()
-    for (const entry of entries) byUuid.set(entry.uuid, entry)
+    for (const entry of entries) {
+        if (!byUuid.has(entry.uuid)) byUuid.set(entry.uuid, entry)
+    }
     return [...byUuid.values()]
 }
 

--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -471,19 +471,20 @@ export async function completeHistoryEntry(entry: HistoryEntry): Promise<History
  * double charge. Real report: a BRL 909.00 PIX payment shown twice, one debit
  * in the database (2026-07-27).
  *
- * The API-side cursor is fixed separately (peanut-api-ts, buildHistoryCursor),
- * but page overlap has more than one source: the feed sorts on `timestamp`
- * while the API paginates on `createdAt`, and those differ for Manteca and for
- * completed intents. Deduping where the pages get flattened covers every
- * source at once. First uuid wins, order is kept.
+ * The API cursor is over-inclusive on purpose — it is keyed on the later of
+ * the two timestamps so that no entry can fall through the crack between
+ * pages, and re-serving the boundary row is the price. Page overlap has other
+ * sources too (`openRequestLinks` is re-queried on every page), so deduping
+ * where the pages get flattened covers all of them at once.
+ *
+ * Keeps the FIRST position but the LAST copy: a later page is fetched later,
+ * so its copy of a repeated entry carries the fresher status. `Map` gives both
+ * — re-setting a key updates the value without moving it.
  */
 export function dedupeHistoryEntriesByUuid<T extends { uuid: string }>(entries: T[]): T[] {
-    const seen = new Set<string>()
-    return entries.filter((entry) => {
-        if (seen.has(entry.uuid)) return false
-        seen.add(entry.uuid)
-        return true
-    })
+    const byUuid = new Map<string, T>()
+    for (const entry of entries) byUuid.set(entry.uuid, entry)
+    return [...byUuid.values()]
 }
 
 /** Marker `userName` the backend sends for the onboarding test transaction.

--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -468,8 +468,8 @@ export async function completeHistoryEntry(entry: HistoryEntry): Promise<History
  *
  * `useInfiniteQuery` concatenates pages, so anything the cursor hands back
  * twice renders twice — and the rows are byte-identical, which reads as a
- * double charge. Real report: a BRL 909.00 PIX payment shown twice, one debit
- * in the database (2026-07-27).
+ * double charge. Users have reported exactly that on a PIX payment the ledger
+ * had only debited once.
  *
  * The API cursor is over-inclusive on purpose — it is keyed on the later of
  * the two timestamps so that no entry can fall through the crack between

--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -463,6 +463,29 @@ export async function completeHistoryEntry(entry: HistoryEntry): Promise<History
     }
 }
 
+/**
+ * Drops repeats of a history entry the API served on more than one page.
+ *
+ * `useInfiniteQuery` concatenates pages, so anything the cursor hands back
+ * twice renders twice — and the rows are byte-identical, which reads as a
+ * double charge. Real report: a BRL 909.00 PIX payment shown twice, one debit
+ * in the database (2026-07-27).
+ *
+ * The API-side cursor is fixed separately (peanut-api-ts, buildHistoryCursor),
+ * but page overlap has more than one source: the feed sorts on `timestamp`
+ * while the API paginates on `createdAt`, and those differ for Manteca and for
+ * completed intents. Deduping where the pages get flattened covers every
+ * source at once. First uuid wins, order is kept.
+ */
+export function dedupeHistoryEntriesByUuid<T extends { uuid: string }>(entries: T[]): T[] {
+    const seen = new Set<string>()
+    return entries.filter((entry) => {
+        if (seen.has(entry.uuid)) return false
+        seen.add(entry.uuid)
+        return true
+    })
+}
+
 /** Marker `userName` the backend sends for the onboarding test transaction.
  *  Compared against BACKEND data, never against localized copy, so this is
  *  locale-safe — but it is still a magic string the backend owns. Follow-up:


### PR DESCRIPTION
## Summary

The history page concatenates infinite-query pages with a bare `flatMap`. Anything the API cursor serves on two pages therefore renders twice — byte-identical rows, one under the other, which reads as a double charge.

Adds `dedupeHistoryEntriesByUuid()` and applies it where the pages get flattened. Keeps the first position (rows must not jump on scroll) and the last copy (a later page is the fresher fetch, so a boundary row that was `PENDING` on page 1 renders as `COMPLETED`).

## Task

TASK-21039 — https://app.notion.com/p/3ae83811757981348353f498ee69eeb5

## Evidence

Reported by a user via support (Crisp thread linked on TASK-21039), with a screenshot of two identical rows for one PIX payment. The prod ledger has exactly **one** debit for it. Nothing was double-charged; the feed drew one payment twice.

## Why here and not only in the API

The API-side cursor bug is documented and guarded in peanut-api-ts#1334, but page overlap has more than one source:

1. the API cursor is **deliberately over-inclusive** — it is keyed on the later of `timestamp`/`createdAt` so that no entry can fall through the crack between pages, and re-serving the boundary row is the price. Tightening it silently drops payments, which peanut-api-ts#1334 documents and locks with a test;
2. `openRequestLinks` in the intent fetcher re-queries with `createdAt <= dateCursor` and no tie-break exclusion at all;
3. websocket-pushed entries racing a REST page.

Deduping at the flatten covers all three, needs no deploy-order coupling with the API, and the websocket path in the same file already dedupes by uuid for the same reason — this makes the REST path consistent with it.

## Risks

Low. Pure function, no network or state change. Two entries only collide if they share a uuid, which by contract means they are the same entry.

## Screenshots

N/A — no visible change. The fix removes a duplicated row; nothing new renders.

## QA

`npm test` — 4 new cases in `src/utils/__tests__/history.utils.test.ts` (boundary repeat, first-position/freshest-copy, distinct-but-similar entries, empty feed). Full suite green.
