### PR TITLE
fix: pwa-sunset follow-ups — /app in-app bounce, snooze tests, invite handoff

### DIFF
--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -26,8 +26,9 @@ import { Button } from '@/components/0_Bruddle/Button'
 import Loading from '@/components/Global/Loading'
 import MigrationHero from '@/components/Migration/MigrationHero'
 import { STORE_NAME, STORE_URL, type StoreKind } from '@/constants/migration.consts'
+import PeanutLoading from '@/components/Global/PeanutLoading'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
-import { isCapacitor } from '@/utils/capacitor'
+import { isNativeBridge } from '@/utils/capacitor'
 import { isPwaSunsetOn } from '@/utils/migration.utils'
 
 const FLAG_WAIT_MS = 4000
@@ -37,20 +38,23 @@ export default function SmartStoreRedirect() {
     const { deviceType } = useDeviceType()
     const router = useRouter()
 
-    const [mounted, setMounted] = useState(false)
-    useEffect(() => setMounted(true), [])
-
-    // universal links (paths: ["*"]) open this page INSIDE the native app when
-    // an installed user scans a download QR — there's no store to bounce to,
+    // universal links (paths: ["*"]) open this page inside the native app when
+    // an installed user scans a download qr — there's no store to bounce to,
     // so send them home instead of redirecting them out to the store.
-    const inNativeApp = mounted && isCapacitor()
+    // isNativeBridge, not isCapacitor: capacitor-flavored web builds bake
+    // NEXT_PUBLIC_CAPACITOR_BUILD=true with no bridge, and those visitors
+    // still need the store page.
+    const [mounted, setMounted] = useState(false)
     useEffect(() => {
-        if (inNativeApp) router.replace('/home')
-    }, [inNativeApp, router])
+        setMounted(true)
+        if (isNativeBridge()) router.replace('/home')
+    }, [router])
+    const inNativeApp = mounted && isNativeBridge()
 
     // wait for posthog to deliver flags (or time out) before judging the flag
     const [flagsSettled, setFlagsSettled] = useState(false)
     useEffect(() => {
+        if (isNativeBridge()) return // redirecting home — flag irrelevant
         if (isPwaSunsetOn()) {
             setFlagsSettled(true)
             return
@@ -84,13 +88,7 @@ export default function SmartStoreRedirect() {
         return () => clearTimeout(fallback)
     }, [inNativeApp, settled, migrationOn, targetStore])
 
-    if (inNativeApp) {
-        return (
-            <div className="flex min-h-[100dvh] w-full items-center justify-center bg-white">
-                <Loading />
-            </div>
-        )
-    }
+    if (inNativeApp) return <PeanutLoading coverFullScreen />
 
     if (settled && !migrationOn) notFound()
 

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -19,7 +19,7 @@
 // first render tripped React #418 on phones (device is WEB on the server).
 
 import { useEffect, useState } from 'react'
-import { notFound } from 'next/navigation'
+import { notFound, useRouter } from 'next/navigation'
 import posthog from 'posthog-js'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/0_Bruddle/Button'
@@ -27,6 +27,7 @@ import Loading from '@/components/Global/Loading'
 import MigrationHero from '@/components/Migration/MigrationHero'
 import { STORE_NAME, STORE_URL, type StoreKind } from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
+import { isCapacitor } from '@/utils/capacitor'
 import { isPwaSunsetOn } from '@/utils/migration.utils'
 
 const FLAG_WAIT_MS = 4000
@@ -34,9 +35,18 @@ const FLAG_WAIT_MS = 4000
 export default function SmartStoreRedirect() {
     const t = useTranslations('migration')
     const { deviceType } = useDeviceType()
+    const router = useRouter()
 
     const [mounted, setMounted] = useState(false)
     useEffect(() => setMounted(true), [])
+
+    // universal links (paths: ["*"]) open this page INSIDE the native app when
+    // an installed user scans a download QR — there's no store to bounce to,
+    // so send them home instead of redirecting them out to the store.
+    const inNativeApp = mounted && isCapacitor()
+    useEffect(() => {
+        if (inNativeApp) router.replace('/home')
+    }, [inNativeApp, router])
 
     // wait for posthog to deliver flags (or time out) before judging the flag
     const [flagsSettled, setFlagsSettled] = useState(false)
@@ -66,13 +76,21 @@ export default function SmartStoreRedirect() {
 
     const [redirecting, setRedirecting] = useState(false)
     useEffect(() => {
-        if (!settled || !migrationOn || !targetStore) return
+        if (inNativeApp || !settled || !migrationOn || !targetStore) return
         setRedirecting(true)
         window.location.replace(STORE_URL[targetStore])
         // if the store didn't take over (blocked, offline), settle to buttons
         const fallback = setTimeout(() => setRedirecting(false), 4000)
         return () => clearTimeout(fallback)
-    }, [settled, migrationOn, targetStore])
+    }, [inNativeApp, settled, migrationOn, targetStore])
+
+    if (inNativeApp) {
+        return (
+            <div className="flex min-h-[100dvh] w-full items-center justify-center bg-white">
+                <Loading />
+            </div>
+        )
+    }
 
     if (settled && !migrationOn) notFound()
 

--- a/src/components/Invites/InvitesPage.test.tsx
+++ b/src/components/Invites/InvitesPage.test.tsx
@@ -14,6 +14,7 @@ const mockQueuePendingBadgeCampaigns = jest.fn((badgeCampaigns: readonly string[
 const mockSaveToCookie = jest.fn()
 const mockSaveRedirectUrl = jest.fn()
 const mockInterceptGuestCta = jest.fn(() => false)
+const mockUseGuestStoreHandoff = jest.fn()
 
 let mockSearch = ''
 let mockAuth: {
@@ -53,7 +54,10 @@ jest.mock('@/redux/slices/setup-slice', () => ({
 }))
 jest.mock('@/hooks/useLogin', () => ({ useLogin: () => ({ handleLoginClick: mockLogin, isLoggingIn: false }) }))
 jest.mock('@/hooks/useGuestStoreHandoff', () => ({
-    useGuestStoreHandoff: () => ({ interceptGuestCta: mockInterceptGuestCta, storeHandoffModal: null }),
+    useGuestStoreHandoff: (opts: { trackImpressionWhenGuest?: boolean }) => {
+        mockUseGuestStoreHandoff(opts)
+        return { interceptGuestCta: mockInterceptGuestCta, storeHandoffModal: null }
+    },
 }))
 jest.mock('@/services/badge-campaigns', () => ({
     claimAndSettlePendingBadgeCampaigns: (badgeCampaigns: readonly string[]) => mockClaimBadgeCampaigns(badgeCampaigns),
@@ -645,6 +649,29 @@ describe('invite and badge campaign routing boundaries', () => {
         expect(mockSaveToCookie).toHaveBeenCalledWith('inviteCode', 'alice')
         expect(mockInterceptGuestCta).toHaveBeenCalledTimes(1)
         expect(mockPush).not.toHaveBeenCalledWith('/setup?step=signup')
+        // the CTA rendered for a settled guest — the impression must be armed
+        const lastOpts = mockUseGuestStoreHandoff.mock.calls.at(-1)?.[0]
+        expect(lastOpts?.trackImpressionWhenGuest).toBe(true)
+    })
+
+    it('never arms the guest impression on the invalid-invite error view', async () => {
+        mockAuth.user = null
+        mockSearch = 'code=bad'
+        mockQueryResult.data = {
+            success: false,
+            attributionResolved: false,
+            onboardingResolved: false,
+            username: '',
+        }
+        mockQueryResult.isError = true
+
+        render(<InvitesPage />)
+        expect(await screen.findByText('Invalid Invite Code')).toBeInTheDocument()
+
+        // no CTA on this view → counting it would skew the TASK-20939 funnel
+        for (const [opts] of mockUseGuestStoreHandoff.mock.calls) {
+            expect(opts?.trackImpressionWhenGuest).toBe(false)
+        }
     })
 
     it('does not persist a bad inviter alongside a valid campaign', async () => {

--- a/src/components/Invites/InvitesPage.test.tsx
+++ b/src/components/Invites/InvitesPage.test.tsx
@@ -13,6 +13,7 @@ const mockQueuePendingBadgeCampaigns = jest.fn((badgeCampaigns: readonly string[
 ])
 const mockSaveToCookie = jest.fn()
 const mockSaveRedirectUrl = jest.fn()
+const mockInterceptGuestCta = jest.fn(() => false)
 
 let mockSearch = ''
 let mockAuth: {
@@ -51,6 +52,9 @@ jest.mock('@/redux/slices/setup-slice', () => ({
     },
 }))
 jest.mock('@/hooks/useLogin', () => ({ useLogin: () => ({ handleLoginClick: mockLogin, isLoggingIn: false }) }))
+jest.mock('@/hooks/useGuestStoreHandoff', () => ({
+    useGuestStoreHandoff: () => ({ interceptGuestCta: mockInterceptGuestCta, storeHandoffModal: null }),
+}))
 jest.mock('@/services/badge-campaigns', () => ({
     claimAndSettlePendingBadgeCampaigns: (badgeCampaigns: readonly string[]) => mockClaimBadgeCampaigns(badgeCampaigns),
     destinationForConfirmedBadgeCampaignAcquisition: (
@@ -145,6 +149,7 @@ describe('invite and badge campaign routing boundaries', () => {
             fetchUser: mockFetchUser,
         }
         mockQueryResult = { isLoading: false, isError: false }
+        mockInterceptGuestCta.mockReturnValue(false)
         mockClaimBadgeCampaigns.mockResolvedValue(awardedBatch)
         mockQueuePendingBadgeCampaigns.mockImplementation((badgeCampaigns: readonly string[]) => [...badgeCampaigns])
     })
@@ -620,6 +625,26 @@ describe('invite and badge campaign routing boundaries', () => {
         expect(mockQueuePendingBadgeCampaigns).toHaveBeenCalledWith(['offramp'], 30)
         expect(mockSaveRedirectUrl).toHaveBeenCalledTimes(1)
         expect(mockLogin).toHaveBeenCalledTimes(1)
+    })
+
+    it('hands a guest Claim your spot off to the stores during the migration window', async () => {
+        mockAuth.user = null
+        mockSearch = 'code=alice'
+        mockQueryResult.data = {
+            success: true,
+            attributionResolved: true,
+            onboardingResolved: true,
+            username: 'alice',
+        }
+        mockInterceptGuestCta.mockReturnValue(true)
+
+        render(<InvitesPage />)
+        fireEvent.click(await screen.findByRole('button', { name: 'Claim your spot' }))
+
+        // invite bookkeeping still runs so post-install signup recovers context
+        expect(mockSaveToCookie).toHaveBeenCalledWith('inviteCode', 'alice')
+        expect(mockInterceptGuestCta).toHaveBeenCalledTimes(1)
+        expect(mockPush).not.toHaveBeenCalledWith('/setup?step=signup')
     })
 
     it('does not persist a bad inviter alongside a valid campaign', async () => {

--- a/src/components/Invites/InvitesPage.tsx
+++ b/src/components/Invites/InvitesPage.tsx
@@ -14,6 +14,7 @@ import { setupActions } from '@/redux/slices/setup-slice'
 import { useAuth } from '@/context/authContext'
 import { EInviteType } from '@/services/services.types'
 import { getValidRedirectUrl, saveRedirectUrl, saveToCookie } from '@/utils/general.utils'
+import { useGuestStoreHandoff } from '@/hooks/useGuestStoreHandoff'
 import { useLogin } from '@/hooks/useLogin'
 import UnsupportedBrowserModal from '../Global/UnsupportedBrowserModal'
 import posthog from 'posthog-js'
@@ -57,6 +58,13 @@ function InvitePageContent() {
 
     // Track if we should show content (prevents flash)
     const [shouldShowContent, setShouldShowContent] = useState(false)
+
+    // migration window: guest CTAs hand off to the stores like the other guest
+    // entry points (claim/request/pay). shouldShowContent is the settled guest
+    // state — the pre-auth flash never counts an impression.
+    const { interceptGuestCta, storeHandoffModal } = useGuestStoreHandoff({
+        trackImpressionWhenGuest: shouldShowContent && !user?.user,
+    })
 
     const {
         data: inviteCodeData,
@@ -249,6 +257,11 @@ function InvitePageContent() {
         // typed claim result is consumed after registration.
         if (hasUrlBadgeCampaigns) queuePendingBadgeCampaigns(urlBadgeCampaigns)
 
+        // during the migration window guests go to the stores, not signup —
+        // cookie/queue bookkeeping above still runs so a keep-web signup or
+        // post-install link re-tap recovers the invite context.
+        if (!user?.user && interceptGuestCta()) return
+
         const signupUrl = redirectUri
             ? `/setup?step=signup&redirect_uri=${encodeURIComponent(redirectUri)}`
             : '/setup?step=signup'
@@ -336,6 +349,7 @@ function InvitePageContent() {
                     </div>
                 </div>
             </div>
+            {storeHandoffModal}
             <UnsupportedBrowserModal allowClose={false} />
         </InvitesPageLayout>
     )

--- a/src/components/Invites/InvitesPage.tsx
+++ b/src/components/Invites/InvitesPage.tsx
@@ -59,13 +59,6 @@ function InvitePageContent() {
     // Track if we should show content (prevents flash)
     const [shouldShowContent, setShouldShowContent] = useState(false)
 
-    // migration window: guest CTAs hand off to the stores like the other guest
-    // entry points (claim/request/pay). shouldShowContent is the settled guest
-    // state — the pre-auth flash never counts an impression.
-    const { interceptGuestCta, storeHandoffModal } = useGuestStoreHandoff({
-        trackImpressionWhenGuest: shouldShowContent && !user?.user,
-    })
-
     const {
         data: inviteCodeData,
         isLoading,
@@ -90,6 +83,22 @@ function InvitePageContent() {
         [urlBadgeCampaigns, legacyAcquisition]
     )
     const hasAcquisitionBadgeCampaigns = acquisitionBadgeCampaigns.length > 0
+
+    // Invalid invite code (only reachable when an invite code was supplied).
+    // A badge-campaign-only link has no inviter to validate. When a code is present,
+    // it must validate independently; badge campaigns never make a bad inviter valid.
+    const hasValidInvite = !!inviteCode && !!inviteCodeData?.onboardingResolved && !!inviteCodeData.username
+    const isDeadBareLink = !inviteCode && !hasUrlBadgeCampaigns
+    const showsInvalidInvite =
+        !!inviteCode && !hasUrlBadgeCampaigns && !legacyAcquisition && (isError || !hasValidInvite)
+
+    // migration window: guest CTAs hand off to the stores like the other guest
+    // entry points (claim/request/pay). impression fires only when the CTA
+    // actually renders — never on the pre-auth flash, the invalid-invite error
+    // view, or the dead-bare-link redirect.
+    const { interceptGuestCta, storeHandoffModal } = useGuestStoreHandoff({
+        trackImpressionWhenGuest: shouldShowContent && !user?.user && !isDeadBareLink && !showsInvalidInvite,
+    })
 
     // track invite page view (ref guard prevents duplicate fires when shouldShowContent toggles)
     const hasTrackedPageView = useRef(false)
@@ -244,7 +253,6 @@ function InvitePageContent() {
             campaign_tags: acquisitionBadgeCampaigns,
         })
 
-        const hasValidInvite = !!inviteCode && !!inviteCodeData?.onboardingResolved && !!inviteCodeData.username
         const hasBackendLegacyAcceptance = !!inviteCode && !!inviteCodeData?.success && !!legacyAcquisition
         if (hasValidInvite || hasBackendLegacyAcceptance) {
             dispatch(setupActions.setInviteCode(inviteCode))
@@ -260,7 +268,12 @@ function InvitePageContent() {
         // during the migration window guests go to the stores, not signup —
         // cookie/queue bookkeeping above still runs so a keep-web signup or
         // post-install link re-tap recovers the invite context.
-        if (!user?.user && interceptGuestCta()) return
+        if (!user?.user && interceptGuestCta()) {
+            // keep the mid-flow destination (e.g. a pending claim) recoverable
+            // after the store round-trip, same as handleLoginWithBadgeCampaign
+            if (safeRedirectUri) saveRedirectUrl()
+            return
+        }
 
         const signupUrl = redirectUri
             ? `/setup?step=signup&redirect_uri=${encodeURIComponent(redirectUri)}`
@@ -282,7 +295,6 @@ function InvitePageContent() {
         void handleLoginClick()
     }
 
-    const isDeadBareLink = !inviteCode && !hasUrlBadgeCampaigns
     useEffect(() => {
         if (isDeadBareLink) router.replace('/')
     }, [isDeadBareLink, router])
@@ -291,11 +303,7 @@ function InvitePageContent() {
         return <PeanutLoading coverFullScreen />
     }
 
-    // Invalid invite code (only reachable when an invite code was supplied).
-    // A badge-campaign-only link has no inviter to validate. When a code is present,
-    // it must validate independently; badge campaigns never make a bad inviter valid.
-    const hasValidInvite = !!inviteCode && !!inviteCodeData?.onboardingResolved && !!inviteCodeData.username
-    if (inviteCode && !hasUrlBadgeCampaigns && !legacyAcquisition && (isError || !hasValidInvite)) {
+    if (showsInvalidInvite) {
         return (
             <div className="my-auto flex h-[100dvh] w-screen flex-col items-center justify-center space-y-4 px-6">
                 <ValidationErrorView

--- a/src/hooks/__tests__/useNotifications.test.ts
+++ b/src/hooks/__tests__/useNotifications.test.ts
@@ -1,0 +1,126 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+
+// pins the dismissal logic in evaluateVisibility (TASK-21145 / PR #2591):
+// the pre-prompt carries three dismissal representations — legacy
+// `notifModalClosed` bool, `notifModalClosedAt` timestamp, and the
+// flag-conditional 14-day snooze — and none of it was tested.
+//
+// the hook keeps its state in a module-level store (init runs once per page),
+// so tests share one module instance and drive a fresh evaluateVisibility via
+// refreshPermissionState() — every branch of the evaluation ends in a
+// definitive setState, so each test's outcome is recomputed from its own mocks.
+
+const mockAdapter = {
+    init: jest.fn().mockResolvedValue(undefined),
+    login: jest.fn().mockResolvedValue(undefined),
+    logout: jest.fn().mockResolvedValue(undefined),
+    requestPermission: jest.fn().mockResolvedValue('default'),
+    getPermission: jest.fn().mockResolvedValue('default'),
+    isOptedIn: jest.fn().mockResolvedValue(false),
+    onPermissionChange: jest.fn(() => () => {}),
+    onSubscriptionChange: jest.fn(() => () => {}),
+    onNotificationClick: jest.fn(() => () => {}),
+}
+jest.mock('@/services/onesignal', () => ({
+    getOneSignalAdapter: () => Promise.resolve(mockAdapter),
+}))
+
+// in-memory prefs store mirroring updateUserPreferences' merge behavior, so
+// the once-only legacy conversion is observable across re-evaluations
+let mockPrefs: Record<string, unknown> | undefined
+const mockUpdateUserPreferences = jest.fn((_userId: string | undefined, partial: Record<string, unknown>) => {
+    mockPrefs = { ...mockPrefs, ...partial }
+})
+jest.mock('@/utils/general.utils', () => ({
+    getUserPreferences: () => mockPrefs,
+    updateUserPreferences: (userId: string | undefined, partial: Record<string, unknown>) =>
+        mockUpdateUserPreferences(userId, partial),
+}))
+
+const mockIsPwaSunsetOn = jest.fn(() => false)
+jest.mock('@/utils/migration.utils', () => ({ isPwaSunsetOn: () => mockIsPwaSunsetOn() }))
+jest.mock('@/utils/demo', () => ({ isDemoMode: () => false }))
+jest.mock('@/redux/hooks', () => ({ useUserStore: () => ({ user: { user: { userId: 'user-1' } } }) }))
+jest.mock('posthog-js', () => ({ capture: jest.fn() }))
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn(), captureMessage: jest.fn() }))
+
+import { useNotifications } from '../useNotifications'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const daysAgo = (days: number) => new Date(Date.now() - days * DAY_MS).toISOString()
+
+async function renderAndEvaluate() {
+    const rendered = renderHook(() => useNotifications())
+    await waitFor(() => expect(rendered.result.current.oneSignalInitialized).toBe(true))
+    // force a full evaluateVisibility pass under THIS test's mocks (the shared
+    // module store may carry showPermissionModal from a previous test)
+    await act(async () => {
+        await rendered.result.current.refreshPermissionState()
+    })
+    return rendered
+}
+
+describe('useNotifications dismissal / snooze logic', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockPrefs = undefined
+        mockIsPwaSunsetOn.mockReturnValue(false)
+        mockAdapter.getPermission.mockResolvedValue('default')
+        mockAdapter.isOptedIn.mockResolvedValue(false)
+    })
+
+    it('shows the modal for a user who never dismissed it', async () => {
+        const { result } = await renderAndEvaluate()
+        expect(result.current.showPermissionModal).toBe(true)
+    })
+
+    it('converts legacy notifModalClosed to a timestamp exactly once', async () => {
+        mockPrefs = { notifModalClosed: true }
+
+        const { result } = await renderAndEvaluate()
+        expect(mockPrefs?.notifModalClosedAt).toEqual(expect.any(String))
+        // legacy dismissal converts to a snooze that starts now → stays closed
+        expect(result.current.showPermissionModal).toBe(false)
+
+        // re-evaluate: the timestamp is already there, no second write
+        const conversionWrites = () =>
+            mockUpdateUserPreferences.mock.calls.filter(([, partial]) => 'notifModalClosedAt' in partial)
+        expect(conversionWrites()).toHaveLength(1)
+        await act(async () => {
+            await result.current.refreshPermissionState()
+        })
+        expect(conversionWrites()).toHaveLength(1)
+    })
+
+    it('flag off: an expired snooze stays closed forever', async () => {
+        mockPrefs = { notifModalClosedAt: daysAgo(20) }
+
+        const { result } = await renderAndEvaluate()
+        expect(result.current.showPermissionModal).toBe(false)
+    })
+
+    it('flag on: an expired snooze re-asks', async () => {
+        mockIsPwaSunsetOn.mockReturnValue(true)
+        mockPrefs = { notifModalClosedAt: daysAgo(20) }
+
+        const { result } = await renderAndEvaluate()
+        expect(result.current.showPermissionModal).toBe(true)
+    })
+
+    it('flag on: a fresh snooze stays closed', async () => {
+        mockIsPwaSunsetOn.mockReturnValue(true)
+        mockPrefs = { notifModalClosedAt: daysAgo(1) }
+
+        const { result } = await renderAndEvaluate()
+        expect(result.current.showPermissionModal).toBe(false)
+    })
+
+    it('granted permission hides the modal regardless of dismissal state', async () => {
+        mockAdapter.getPermission.mockResolvedValue('granted')
+        mockIsPwaSunsetOn.mockReturnValue(true)
+        mockPrefs = { notifModalClosedAt: daysAgo(20) }
+
+        const { result } = await renderAndEvaluate()
+        expect(result.current.showPermissionModal).toBe(false)
+    })
+})

--- a/src/hooks/__tests__/useNotifications.test.ts
+++ b/src/hooks/__tests__/useNotifications.test.ts
@@ -7,8 +7,10 @@ import { act, renderHook, waitFor } from '@testing-library/react'
 //
 // the hook keeps its state in a module-level store (init runs once per page),
 // so tests share one module instance and drive a fresh evaluateVisibility via
-// refreshPermissionState() — every branch of the evaluation ends in a
-// definitive setState, so each test's outcome is recomputed from its own mocks.
+// refreshPermissionState(). tests that assert the modal stays CLOSED first
+// prove it would show under pristine mocks (baseline true), then flip the
+// mocks and re-evaluate — a false can then only be a fresh recompute, never
+// leftover store state or a silent early-return on adapter failure.
 
 const mockAdapter = {
     init: jest.fn().mockResolvedValue(undefined),
@@ -44,19 +46,29 @@ jest.mock('@/redux/hooks', () => ({ useUserStore: () => ({ user: { user: { userI
 jest.mock('posthog-js', () => ({ capture: jest.fn() }))
 jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn(), captureMessage: jest.fn() }))
 
+import { NOTIF_PROMPT_SNOOZE_DAYS } from '@/constants/migration.consts'
 import { useNotifications } from '../useNotifications'
 
 const DAY_MS = 24 * 60 * 60 * 1000
 const daysAgo = (days: number) => new Date(Date.now() - days * DAY_MS).toISOString()
+const expiredSnooze = () => daysAgo(NOTIF_PROMPT_SNOOZE_DAYS + 6)
+const freshSnooze = () => daysAgo(1)
 
-async function renderAndEvaluate() {
-    const rendered = renderHook(() => useNotifications())
-    await waitFor(() => expect(rendered.result.current.oneSignalInitialized).toBe(true))
-    // force a full evaluateVisibility pass under THIS test's mocks (the shared
-    // module store may carry showPermissionModal from a previous test)
+type Rendered = ReturnType<typeof renderHook<ReturnType<typeof useNotifications>, unknown>>
+
+async function reEvaluate(rendered: Rendered) {
     await act(async () => {
         await rendered.result.current.refreshPermissionState()
     })
+}
+
+// render with pristine mocks (no prefs, default permission) and prove the
+// modal shows — the baseline every stays-closed assertion is measured against
+async function renderWithShowingBaseline() {
+    const rendered = renderHook(() => useNotifications())
+    await waitFor(() => expect(rendered.result.current.oneSignalInitialized).toBe(true))
+    await reEvaluate(rendered)
+    expect(rendered.result.current.showPermissionModal).toBe(true)
     return rendered
 }
 
@@ -70,57 +82,65 @@ describe('useNotifications dismissal / snooze logic', () => {
     })
 
     it('shows the modal for a user who never dismissed it', async () => {
-        const { result } = await renderAndEvaluate()
-        expect(result.current.showPermissionModal).toBe(true)
+        await renderWithShowingBaseline()
     })
 
     it('converts legacy notifModalClosed to a timestamp exactly once', async () => {
-        mockPrefs = { notifModalClosed: true }
+        const rendered = await renderWithShowingBaseline()
 
-        const { result } = await renderAndEvaluate()
+        mockPrefs = { notifModalClosed: true }
+        await reEvaluate(rendered)
+
         expect(mockPrefs?.notifModalClosedAt).toEqual(expect.any(String))
         // legacy dismissal converts to a snooze that starts now → stays closed
-        expect(result.current.showPermissionModal).toBe(false)
+        expect(rendered.result.current.showPermissionModal).toBe(false)
 
         // re-evaluate: the timestamp is already there, no second write
         const conversionWrites = () =>
             mockUpdateUserPreferences.mock.calls.filter(([, partial]) => 'notifModalClosedAt' in partial)
         expect(conversionWrites()).toHaveLength(1)
-        await act(async () => {
-            await result.current.refreshPermissionState()
-        })
+        await reEvaluate(rendered)
         expect(conversionWrites()).toHaveLength(1)
     })
 
     it('flag off: an expired snooze stays closed forever', async () => {
-        mockPrefs = { notifModalClosedAt: daysAgo(20) }
+        const rendered = await renderWithShowingBaseline()
 
-        const { result } = await renderAndEvaluate()
-        expect(result.current.showPermissionModal).toBe(false)
+        mockPrefs = { notifModalClosedAt: expiredSnooze() }
+        await reEvaluate(rendered)
+
+        expect(rendered.result.current.showPermissionModal).toBe(false)
     })
 
     it('flag on: an expired snooze re-asks', async () => {
         mockIsPwaSunsetOn.mockReturnValue(true)
-        mockPrefs = { notifModalClosedAt: daysAgo(20) }
+        mockPrefs = { notifModalClosedAt: expiredSnooze() }
 
-        const { result } = await renderAndEvaluate()
-        expect(result.current.showPermissionModal).toBe(true)
+        const rendered = renderHook(() => useNotifications())
+        await waitFor(() => expect(rendered.result.current.oneSignalInitialized).toBe(true))
+        await reEvaluate(rendered)
+
+        expect(rendered.result.current.showPermissionModal).toBe(true)
     })
 
     it('flag on: a fresh snooze stays closed', async () => {
         mockIsPwaSunsetOn.mockReturnValue(true)
-        mockPrefs = { notifModalClosedAt: daysAgo(1) }
+        const rendered = await renderWithShowingBaseline()
 
-        const { result } = await renderAndEvaluate()
-        expect(result.current.showPermissionModal).toBe(false)
+        mockPrefs = { notifModalClosedAt: freshSnooze() }
+        await reEvaluate(rendered)
+
+        expect(rendered.result.current.showPermissionModal).toBe(false)
     })
 
     it('granted permission hides the modal regardless of dismissal state', async () => {
+        const rendered = await renderWithShowingBaseline()
+
         mockAdapter.getPermission.mockResolvedValue('granted')
         mockIsPwaSunsetOn.mockReturnValue(true)
-        mockPrefs = { notifModalClosedAt: daysAgo(20) }
+        mockPrefs = { notifModalClosedAt: expiredSnooze() }
+        await reEvaluate(rendered)
 
-        const { result } = await renderAndEvaluate()
-        expect(result.current.showPermissionModal).toBe(false)
+        expect(rendered.result.current.showPermissionModal).toBe(false)
     })
 })


### PR DESCRIPTION
## Summary

The three open items from the PR #2591 review audit (TASK-21145), none of which block the flag-flip individually but item 1 is strongly recommended before it:

1. **`/app` inside the native app routed installed users out to the store.** Universal links (`paths: ["*"]`) open `peanut.me/app` inside the app when an installed user scans a download QR — the launch-week cohort exactly. Now: `isCapacitor()` → `router.replace('/home')`, loading state while it happens, store redirect and 404 suppressed.
2. **`useNotifications` snooze conversion had no test.** New `useNotifications.test.ts` pins `evaluateVisibility`'s dismissal logic: legacy `notifModalClosed` bool converts to a `notifModalClosedAt` timestamp exactly once, flag-off = closed forever, flag-on + expired 14-day snooze = re-ask, flag-on + fresh snooze = closed, granted permission always hides. (The sunset-gate half of this ask shipped in #2591 as `migration.utils.test.ts`.)
3. **Invite interstitial "Claim your spot" took the scenic route.** Now wired to `useGuestStoreHandoff` like the claim/request/pay guest CTAs: desktop gets the scan-to-download QR modal, phones deep-link their store. Also emits the `migration_guest_cta_shown` impression (TASK-20939 funnel). Invite cookie/queue bookkeeping still runs first so keep-web signups and post-install link re-taps recover the invite context.

## Task

[TASK-21145 — pwa-sunset follow-ups](https://app.notion.com/p/peanutprotocol/3b283811757980b58bdbd7bba900bb17)

## Risks / breaking changes

- All three changes are inert until the `pwa-sunset` PostHog flag is ON (`useGuestStoreHandoff` and the `/app` page both gate on it; the notifications change is test-only). Flag OFF = today's behavior byte-for-byte.
- Item 1 changes what an installed user sees when a universal link opens `/app` in-app: home instead of a store bounce. No web-path change.
- No backend changes, no cross-repo deploy order.

## QA

- `npm test` — 232 suites / 2979 tests green, including the 7 new dismissal tests and the new interstitial handoff test.
- `npm run typecheck` + `npm run build` clean.
- Local override QA: `localStorage.setItem('pwa-sunset', 'true')` then visit an invite link logged-out → CTA hands off to QR modal (desktop) / store (mobile).
- ⚠️ Item 1 needs a simulator/device check (universal-link open inside the Capacitor app) — pairs with the TASK-20831 device QA pass; not verifiable in a web sandbox.

## Screenshots

N/A (no new visuals) — the interstitial handoff reuses `ScanToDownloadModal` exactly as shipped and screenshotted on the other guest surfaces in #2591; the `/app` in-app path renders the existing loading spinner during the redirect and needs a device to capture.

## Design notes / accepted trade-offs (review round 1)

Applied from the automated review: `isNativeBridge()` over `isCapacitor()` on `/app` (capacitor-flavored web previews bake `NEXT_PUBLIC_CAPACITOR_BUILD` with no bridge and still need the store page), guest impression armed only when the CTA actually renders (invalid-invite / dead-bare-link views no longer counted — pinned by test), `redirect_uri` saved before the store handoff, and stays-closed test assertions hardened against the shared module store.

Declined, with reasons:
- **`window.open` handoff can be silently blocked in some in-app webviews** — pre-existing #2591 behavior shared by all 3 guest surfaces (`openStore` → `openExternalUrl`); the fix belongs in that one chokepoint as a follow-up, not per-surface here.
- **Move the `/app`→`/home` remap into `mapDeepLinkPath`** — the mapper only runs for `appUrlOpen` events; the page-level guard covers every arrival path, and one implementation beats two.
- **Fold the guest check into `useGuestStoreHandoff` itself** — behavior-preserving refactor across 3 call sites, out of this PR's blast radius; follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native app users are now redirected directly to the home screen with a full-screen loading experience.
  * Guest invite claims can continue through the appropriate app store while preserving invite and campaign details.
  * Invalid invites are handled more consistently, and guest tracking is limited to valid invite content.

* **Bug Fixes**
  * Improved notification dismissal, snoozing, and permission-based visibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->