### PR TITLE
fix(connectivity): windowed failure counting + connection-aware timeout copy

### DIFF
--- a/sentry.utils.test.ts
+++ b/sentry.utils.test.ts
@@ -13,6 +13,10 @@ describe('shouldIgnoreError — alreadyReported (fetchWithSentry wrapper)', () =
         expect(shouldIgnoreError(eventWith({ type: 'ServiceUnavailableError', value: 'upstream 503' }))).toBe(true)
     })
 
+    it('ignores a re-thrown ConnectionTimeoutError (already captured at the fetch site)', () => {
+        expect(shouldIgnoreError(eventWith({ type: 'ConnectionTimeoutError', value: 'timed out' }))).toBe(true)
+    })
+
     it('does not ignore an unrelated application error', () => {
         expect(shouldIgnoreError(eventWith({ type: 'TypeError', value: 'x is not a function' }))).toBe(false)
     })

--- a/sentry.utils.ts
+++ b/sentry.utils.ts
@@ -42,10 +42,11 @@ const IGNORED_ERRORS = {
     // failure is already captured at the fetch site with full context, so the
     // re-thrown ServiceUnavailableError bubbling to global handlers (or being
     // console.error'd by a consumer) would only double-count it (PEANUT-UI-QDJ).
-    // Substring-matching this pattern is safe only because ServiceUnavailableError
-    // is our own internal fetchWithSentry wrapper name, not a generic string that
-    // could appear in an unrelated third-party error message.
-    alreadyReported: ['ServiceUnavailableError'],
+    // Substring-matching these patterns is safe only because both are our own
+    // internal fetchWithSentry wrapper names, not generic strings that could
+    // appear in an unrelated third-party error message. ConnectionTimeoutError
+    // is the timeout-path wrapper; ServiceUnavailableError the generic one.
+    alreadyReported: ['ServiceUnavailableError', 'ConnectionTimeoutError'],
 
     // Third-party SDK internal errors (not actionable)
     thirdPartySdkErrors: [

--- a/src/components/Home/HomeHistory.tsx
+++ b/src/components/Home/HomeHistory.tsx
@@ -350,7 +350,9 @@ const HomeHistory = ({
     if (isError) {
         const isNetworkError =
             error instanceof Error &&
-            (error.name === 'ServiceUnavailableError' || (typeof navigator !== 'undefined' && !navigator.onLine))
+            (error.name === 'ServiceUnavailableError' ||
+                error.name === 'ConnectionTimeoutError' ||
+                (typeof navigator !== 'undefined' && !navigator.onLine))
         // Network timeouts are already captured at the fetch layer — don't
         // re-report them here (and not on every re-render). Only surface
         // genuinely unexpected errors to Sentry.

--- a/src/hooks/__tests__/useConnectivity.test.tsx
+++ b/src/hooks/__tests__/useConnectivity.test.tsx
@@ -1,10 +1,10 @@
 import { act, renderHook } from '@testing-library/react'
 import { useConnectivity } from '../useConnectivity'
-import { FAILURE_WINDOW_MS, reportNetworkError, resetConnectivity } from '@/utils/connectivity'
+import { __resetConnectivityForTests, FAILURE_WINDOW_MS, reportNetworkError } from '@/utils/connectivity'
 
 beforeEach(() => {
     jest.useFakeTimers()
-    resetConnectivity()
+    __resetConnectivityForTests()
     Object.defineProperty(navigator, 'onLine', { configurable: true, value: true })
 })
 

--- a/src/hooks/__tests__/useConnectivity.test.tsx
+++ b/src/hooks/__tests__/useConnectivity.test.tsx
@@ -1,10 +1,15 @@
 import { act, renderHook } from '@testing-library/react'
 import { useConnectivity } from '../useConnectivity'
-import { reportNetworkError, reportNetworkOk } from '@/utils/connectivity'
+import { FAILURE_WINDOW_MS, reportNetworkError, resetConnectivity } from '@/utils/connectivity'
 
 beforeEach(() => {
-    reportNetworkOk()
+    jest.useFakeTimers()
+    resetConnectivity()
     Object.defineProperty(navigator, 'onLine', { configurable: true, value: true })
+})
+
+afterEach(() => {
+    jest.useRealTimers()
 })
 
 describe('useConnectivity', () => {
@@ -28,7 +33,26 @@ describe('useConnectivity', () => {
         expect(result.current.show).toBe(true)
     })
 
-    it('clears once a request succeeds again', () => {
+    // The bug this hook exists to fix: on a flaky connection parallel requests
+    // interleave successes with failures. Successes must NOT reset the count
+    // (the old consecutive counter did, so the banner never fired — TASK-21108).
+    it('still trips when failures are spread out inside the window', () => {
+        const { result } = renderHook(() => useConnectivity())
+
+        act(() => {
+            reportNetworkError()
+        })
+        act(() => {
+            jest.advanceTimersByTime(10_000)
+        })
+        act(() => {
+            reportNetworkError()
+        })
+
+        expect(result.current.isApiUnreachable).toBe(true)
+    })
+
+    it('clears once the failures age out of the window', () => {
         const { result } = renderHook(() => useConnectivity())
 
         act(() => {
@@ -38,7 +62,7 @@ describe('useConnectivity', () => {
         expect(result.current.show).toBe(true)
 
         act(() => {
-            reportNetworkOk()
+            jest.advanceTimersByTime(FAILURE_WINDOW_MS + 100)
         })
         expect(result.current.show).toBe(false)
     })

--- a/src/hooks/__tests__/useConnectivity.test.tsx
+++ b/src/hooks/__tests__/useConnectivity.test.tsx
@@ -18,19 +18,30 @@ describe('useConnectivity', () => {
         expect(result.current.show).toBe(false)
     })
 
-    it('flags the API unreachable only after the failure threshold', () => {
+    it('flags the API unreachable only after distinct endpoints fail', () => {
         const { result } = renderHook(() => useConnectivity())
 
         act(() => {
-            reportNetworkError()
+            reportNetworkError('/users/me')
         })
-        expect(result.current.isApiUnreachable).toBe(false) // one blip isn't enough
+        expect(result.current.isApiUnreachable).toBe(false) // one endpoint isn't enough
 
         act(() => {
-            reportNetworkError()
+            reportNetworkError('/users/history')
         })
         expect(result.current.isApiUnreachable).toBe(true)
         expect(result.current.show).toBe(true)
+    })
+
+    it('does not trip on one slow endpoint being retried', () => {
+        const { result } = renderHook(() => useConnectivity())
+
+        act(() => {
+            reportNetworkError('/users/history')
+            reportNetworkError('/users/history')
+            reportNetworkError('/users/history')
+        })
+        expect(result.current.isApiUnreachable).toBe(false)
     })
 
     // The bug this hook exists to fix: on a flaky connection parallel requests
@@ -40,13 +51,13 @@ describe('useConnectivity', () => {
         const { result } = renderHook(() => useConnectivity())
 
         act(() => {
-            reportNetworkError()
+            reportNetworkError('/users/me')
         })
         act(() => {
             jest.advanceTimersByTime(10_000)
         })
         act(() => {
-            reportNetworkError()
+            reportNetworkError('/rain/cards')
         })
 
         expect(result.current.isApiUnreachable).toBe(true)
@@ -56,8 +67,8 @@ describe('useConnectivity', () => {
         const { result } = renderHook(() => useConnectivity())
 
         act(() => {
-            reportNetworkError()
-            reportNetworkError()
+            reportNetworkError('/a')
+            reportNetworkError('/b')
         })
         expect(result.current.show).toBe(true)
 
@@ -77,5 +88,28 @@ describe('useConnectivity', () => {
 
         expect(result.current.isOffline).toBe(true)
         expect(result.current.show).toBe(true)
+    })
+
+    it('coming back online clears the failure window, not just the offline flag', () => {
+        const { result } = renderHook(() => useConnectivity())
+
+        act(() => {
+            reportNetworkError('/a')
+            reportNetworkError('/b')
+            Object.defineProperty(navigator, 'onLine', { configurable: true, value: false })
+            window.dispatchEvent(new Event('offline'))
+        })
+        expect(result.current.isOffline).toBe(true)
+
+        act(() => {
+            Object.defineProperty(navigator, 'onLine', { configurable: true, value: true })
+            window.dispatchEvent(new Event('online'))
+        })
+
+        // without the online-clear this would flip to the "trouble reaching
+        // Peanut" banner for up to a full window after reconnecting
+        expect(result.current.isOffline).toBe(false)
+        expect(result.current.isApiUnreachable).toBe(false)
+        expect(result.current.show).toBe(false)
     })
 })

--- a/src/hooks/useConnectivity.ts
+++ b/src/hooks/useConnectivity.ts
@@ -1,10 +1,13 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { getConsecutiveFailures, subscribeConnectivity } from '@/utils/connectivity'
+import { getMsUntilNextExpiry, getRecentFailures, subscribeConnectivity } from '@/utils/connectivity'
 
-// Only treat the API as unreachable after this many back-to-back failures, so a
-// single blip doesn't flash a banner. Any successful response resets the count.
+// Only treat the API as unreachable after this many failures inside the
+// sliding window (FAILURE_WINDOW_MS), so a single blip doesn't flash a banner.
+// Successes don't reset the count — on a flaky connection parallel requests
+// interleave successes with failures, and a success-reset kept the banner from
+// ever firing. Entries age out of the window on their own.
 const FAILURE_THRESHOLD = 2
 
 export interface ConnectivityState {
@@ -19,14 +22,14 @@ export function useConnectivity(): ConnectivityState {
 
     useEffect(() => {
         setIsOnline(navigator.onLine)
-        setFailures(getConsecutiveFailures())
+        setFailures(getRecentFailures())
 
         const handleOnline = () => setIsOnline(true)
         const handleOffline = () => setIsOnline(false)
         window.addEventListener('online', handleOnline)
         window.addEventListener('offline', handleOffline)
 
-        const unsubscribe = subscribeConnectivity(() => setFailures(getConsecutiveFailures()))
+        const unsubscribe = subscribeConnectivity(() => setFailures(getRecentFailures()))
 
         return () => {
             window.removeEventListener('online', handleOnline)
@@ -34,6 +37,16 @@ export function useConnectivity(): ConnectivityState {
             unsubscribe()
         }
     }, [])
+
+    // Failures only ever age out — nothing emits when that happens, so re-read
+    // the count when the oldest one expires or the banner would stick forever.
+    useEffect(() => {
+        if (failures === 0) return
+        const ms = getMsUntilNextExpiry()
+        if (ms === null) return
+        const id = setTimeout(() => setFailures(getRecentFailures()), ms + 50)
+        return () => clearTimeout(id)
+    }, [failures])
 
     const isOffline = !isOnline
     const isApiUnreachable = isOnline && failures >= FAILURE_THRESHOLD

--- a/src/hooks/useConnectivity.ts
+++ b/src/hooks/useConnectivity.ts
@@ -1,14 +1,7 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { getMsUntilNextExpiry, getRecentFailures, subscribeConnectivity } from '@/utils/connectivity'
-
-// Only treat the API as unreachable after this many failures inside the
-// sliding window (FAILURE_WINDOW_MS), so a single blip doesn't flash a banner.
-// Successes don't reset the count — on a flaky connection parallel requests
-// interleave successes with failures, and a success-reset kept the banner from
-// ever firing. Entries age out of the window on their own.
-const FAILURE_THRESHOLD = 2
+import { useEffect, useState, useSyncExternalStore } from 'react'
+import { FAILURE_THRESHOLD, getRecentFailures, subscribeConnectivity } from '@/utils/connectivity'
 
 export interface ConnectivityState {
     isOffline: boolean
@@ -16,37 +9,26 @@ export interface ConnectivityState {
     show: boolean
 }
 
+const getServerFailures = () => 0
+
 export function useConnectivity(): ConnectivityState {
     const [isOnline, setIsOnline] = useState(true)
-    const [failures, setFailures] = useState(0)
+    // Store owns failure expiry and emits on every change — nothing to schedule here.
+    const failures = useSyncExternalStore(subscribeConnectivity, getRecentFailures, getServerFailures)
 
     useEffect(() => {
         setIsOnline(navigator.onLine)
-        setFailures(getRecentFailures())
 
         const handleOnline = () => setIsOnline(true)
         const handleOffline = () => setIsOnline(false)
         window.addEventListener('online', handleOnline)
         window.addEventListener('offline', handleOffline)
 
-        const unsubscribe = subscribeConnectivity(() => setFailures(getRecentFailures()))
-
         return () => {
             window.removeEventListener('online', handleOnline)
             window.removeEventListener('offline', handleOffline)
-            unsubscribe()
         }
     }, [])
-
-    // Failures only ever age out — nothing emits when that happens, so re-read
-    // the count when the oldest one expires or the banner would stick forever.
-    useEffect(() => {
-        if (failures === 0) return
-        const ms = getMsUntilNextExpiry()
-        if (ms === null) return
-        const id = setTimeout(() => setFailures(getRecentFailures()), ms + 50)
-        return () => clearTimeout(id)
-    }, [failures])
 
     const isOffline = !isOnline
     const isApiUnreachable = isOnline && failures >= FAILURE_THRESHOLD

--- a/src/hooks/useConnectivity.ts
+++ b/src/hooks/useConnectivity.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState, useSyncExternalStore } from 'react'
-import { FAILURE_THRESHOLD, getRecentFailures, subscribeConnectivity } from '@/utils/connectivity'
+import { FAILURE_THRESHOLD, clearRecentFailures, getRecentFailures, subscribeConnectivity } from '@/utils/connectivity'
 
 export interface ConnectivityState {
     isOffline: boolean
@@ -19,7 +19,13 @@ export function useConnectivity(): ConnectivityState {
     useEffect(() => {
         setIsOnline(navigator.onLine)
 
-        const handleOnline = () => setIsOnline(true)
+        const handleOnline = () => {
+            setIsOnline(true)
+            // the recorded failures belong to the connection that just died —
+            // without this the banner flips from "offline" to "trouble
+            // reaching Peanut" for up to a window after reconnecting.
+            clearRecentFailures()
+        }
         const handleOffline = () => setIsOnline(false)
         window.addEventListener('online', handleOnline)
         window.addEventListener('offline', handleOffline)

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2806,6 +2806,7 @@
         "sendLinkAlreadyClaimed": "Send link already claimed",
         "lowLiquidity": "Low liquidity. Please try a smaller amount or different route.",
         "networkBusyTimeout": "The network is busy and your request timed out. Please try again in a moment.",
+        "connectionTimeout": "We couldn't reach Peanut — check your internet connection and try again.",
         "genericSupport": "There was an issue with your request. Please contact support.",
         "rainCooldownRetry": "A previous card withdrawal is still active. Try again in about {minutes, plural, one {# minute} other {# minutes}}.",
         "rainCooldownRetryShortly": "A previous card withdrawal is still active. Please try again shortly.",

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2806,7 +2806,7 @@
         "sendLinkAlreadyClaimed": "Send link already claimed",
         "lowLiquidity": "Low liquidity. Please try a smaller amount or different route.",
         "networkBusyTimeout": "The network is busy and your request timed out. Please try again in a moment.",
-        "connectionTimeout": "We couldn't reach Peanut — check your internet connection and try again.",
+        "connectionTimeout": "Peanut is taking too long to respond — check your connection and try again.",
         "genericSupport": "There was an issue with your request. Please contact support.",
         "rainCooldownRetry": "A previous card withdrawal is still active. Try again in about {minutes, plural, one {# minute} other {# minutes}}.",
         "rainCooldownRetryShortly": "A previous card withdrawal is still active. Please try again shortly.",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2806,7 +2806,7 @@
         "sendLinkAlreadyClaimed": "El enlace de envío ya fue reclamado.",
         "lowLiquidity": "Baja liquidez. Prueba con un monto menor o una ruta diferente.",
         "networkBusyTimeout": "La red está congestionada y tu solicitud expiró. Inténtalo de nuevo en un momento.",
-        "connectionTimeout": "No pudimos conectar con Peanut. Revisa tu conexión a internet e inténtalo de nuevo.",
+        "connectionTimeout": "Peanut está tardando demasiado en responder. Revisa tu conexión e inténtalo de nuevo.",
         "genericSupport": "Hubo un problema con tu solicitud. Contacta con soporte.",
         "rainCooldownRetry": "Un retiro anterior con la tarjeta sigue activo. Vuelve a intentarlo en unos {minutes, plural, one {# minuto} other {# minutos}}.",
         "rainCooldownRetryShortly": "Un retiro anterior con la tarjeta sigue activo. Vuelve a intentarlo en breve.",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2806,6 +2806,7 @@
         "sendLinkAlreadyClaimed": "El enlace de envío ya fue reclamado.",
         "lowLiquidity": "Baja liquidez. Prueba con un monto menor o una ruta diferente.",
         "networkBusyTimeout": "La red está congestionada y tu solicitud expiró. Inténtalo de nuevo en un momento.",
+        "connectionTimeout": "No pudimos conectar con Peanut. Revisa tu conexión a internet e inténtalo de nuevo.",
         "genericSupport": "Hubo un problema con tu solicitud. Contacta con soporte.",
         "rainCooldownRetry": "Un retiro anterior con la tarjeta sigue activo. Vuelve a intentarlo en unos {minutes, plural, one {# minuto} other {# minutos}}.",
         "rainCooldownRetryShortly": "Un retiro anterior con la tarjeta sigue activo. Vuelve a intentarlo en breve.",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -1173,6 +1173,7 @@
         "claimLinkFailed": "No se pudo reclamar el enlace, actualizá la página. Si el problema persiste, confirmá el enlace con quien lo envió.",
         "lowLiquidity": "Baja liquidez. Probá con un monto menor o una ruta diferente.",
         "networkBusyTimeout": "La red está congestionada y tu solicitud expiró. Intentalo de nuevo en un momento.",
+        "connectionTimeout": "No pudimos conectar con Peanut. Revisá tu conexión a internet e intentalo de nuevo.",
         "genericSupport": "Hubo un problema con tu solicitud. Contactá con soporte.",
         "rainCooldownRetry": "Un retiro anterior con la tarjeta sigue activo. Volvé a intentarlo en unos {minutes, plural, one {# minuto} other {# minutos}}.",
         "rainCooldownRetryShortly": "Un retiro anterior con la tarjeta sigue activo. Volvé a intentarlo en breve.",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -1173,7 +1173,7 @@
         "claimLinkFailed": "No se pudo reclamar el enlace, actualizá la página. Si el problema persiste, confirmá el enlace con quien lo envió.",
         "lowLiquidity": "Baja liquidez. Probá con un monto menor o una ruta diferente.",
         "networkBusyTimeout": "La red está congestionada y tu solicitud expiró. Intentalo de nuevo en un momento.",
-        "connectionTimeout": "No pudimos conectar con Peanut. Revisá tu conexión a internet e intentalo de nuevo.",
+        "connectionTimeout": "Peanut está tardando demasiado en responder. Revisá tu conexión e intentalo de nuevo.",
         "genericSupport": "Hubo un problema con tu solicitud. Contactá con soporte.",
         "rainCooldownRetry": "Un retiro anterior con la tarjeta sigue activo. Volvé a intentarlo en unos {minutes, plural, one {# minuto} other {# minutos}}.",
         "rainCooldownRetryShortly": "Un retiro anterior con la tarjeta sigue activo. Volvé a intentarlo en breve.",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2806,7 +2806,7 @@
         "sendLinkAlreadyClaimed": "O link de envio já foi resgatado.",
         "lowLiquidity": "Baixa liquidez. Tente um valor menor ou uma rota diferente.",
         "networkBusyTimeout": "A rede está congestionada e sua solicitação expirou. Tente novamente em instantes.",
-        "connectionTimeout": "Não conseguimos conectar com o Peanut. Verifique sua conexão com a internet e tente novamente.",
+        "connectionTimeout": "O Peanut está demorando para responder. Verifique sua conexão e tente novamente.",
         "genericSupport": "Ocorreu um problema com sua solicitação. Entre em contato com o suporte.",
         "rainCooldownRetry": "Um saque anterior com o cartão ainda está ativo. Tente novamente em cerca de {minutes, plural, one {# minuto} other {# minutos}}.",
         "rainCooldownRetryShortly": "Um saque anterior com o cartão ainda está ativo. Tente novamente em instantes.",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2806,6 +2806,7 @@
         "sendLinkAlreadyClaimed": "O link de envio já foi resgatado.",
         "lowLiquidity": "Baixa liquidez. Tente um valor menor ou uma rota diferente.",
         "networkBusyTimeout": "A rede está congestionada e sua solicitação expirou. Tente novamente em instantes.",
+        "connectionTimeout": "Não conseguimos conectar com o Peanut. Verifique sua conexão com a internet e tente novamente.",
         "genericSupport": "Ocorreu um problema com sua solicitação. Entre em contato com o suporte.",
         "rainCooldownRetry": "Um saque anterior com o cartão ainda está ativo. Tente novamente em cerca de {minutes, plural, one {# minuto} other {# minutos}}.",
         "rainCooldownRetryShortly": "Um saque anterior com o cartão ainda está ativo. Tente novamente em instantes.",

--- a/src/utils/__tests__/connectivity.test.ts
+++ b/src/utils/__tests__/connectivity.test.ts
@@ -1,40 +1,62 @@
-import { getConsecutiveFailures, reportNetworkError, reportNetworkOk, subscribeConnectivity } from '../connectivity'
+import {
+    FAILURE_WINDOW_MS,
+    getMsUntilNextExpiry,
+    getRecentFailures,
+    reportNetworkError,
+    resetConnectivity,
+    subscribeConnectivity,
+} from '../connectivity'
 
 // Module state is shared across tests, so reset to a known-good state each time.
 beforeEach(() => {
-    reportNetworkOk()
+    jest.useFakeTimers()
+    resetConnectivity()
+})
+
+afterEach(() => {
+    jest.useRealTimers()
 })
 
 describe('connectivity', () => {
-    it('counts consecutive failures and resets on a success', () => {
-        expect(getConsecutiveFailures()).toBe(0)
+    it('counts failures inside the window', () => {
+        expect(getRecentFailures()).toBe(0)
 
         reportNetworkError()
         reportNetworkError()
-        expect(getConsecutiveFailures()).toBe(2)
-
-        reportNetworkOk()
-        expect(getConsecutiveFailures()).toBe(0)
+        expect(getRecentFailures()).toBe(2)
     })
 
-    it('notifies subscribers on failure and on recovery', () => {
+    it('expires failures once they age out of the window', () => {
+        reportNetworkError()
+        jest.advanceTimersByTime(FAILURE_WINDOW_MS / 2)
+        reportNetworkError()
+        expect(getRecentFailures()).toBe(2)
+
+        jest.advanceTimersByTime(FAILURE_WINDOW_MS / 2)
+        expect(getRecentFailures()).toBe(1)
+
+        jest.advanceTimersByTime(FAILURE_WINDOW_MS / 2)
+        expect(getRecentFailures()).toBe(0)
+    })
+
+    it('reports when the oldest failure will expire', () => {
+        expect(getMsUntilNextExpiry()).toBeNull()
+
+        reportNetworkError()
+        jest.advanceTimersByTime(10_000)
+        reportNetworkError()
+
+        expect(getMsUntilNextExpiry()).toBe(FAILURE_WINDOW_MS - 10_000)
+    })
+
+    it('notifies subscribers on each failure', () => {
         const seen: number[] = []
-        const unsubscribe = subscribeConnectivity(() => seen.push(getConsecutiveFailures()))
+        const unsubscribe = subscribeConnectivity(() => seen.push(getRecentFailures()))
 
         reportNetworkError()
         reportNetworkError()
-        reportNetworkOk()
 
-        expect(seen).toEqual([1, 2, 0])
-        unsubscribe()
-    })
-
-    it('does not emit a redundant reset when already healthy', () => {
-        const unsubscribe = subscribeConnectivity(() => {
-            throw new Error('should not be called when already at 0 failures')
-        })
-
-        expect(() => reportNetworkOk()).not.toThrow()
+        expect(seen).toEqual([1, 2])
         unsubscribe()
     })
 

--- a/src/utils/__tests__/connectivity.test.ts
+++ b/src/utils/__tests__/connectivity.test.ts
@@ -1,5 +1,6 @@
 import {
     __resetConnectivityForTests,
+    clearRecentFailures,
     FAILURE_WINDOW_MS,
     getRecentFailures,
     reportNetworkError,
@@ -17,18 +18,27 @@ afterEach(() => {
 })
 
 describe('connectivity', () => {
-    it('counts failures inside the window', () => {
+    it('counts distinct failing endpoints inside the window', () => {
         expect(getRecentFailures()).toBe(0)
 
-        reportNetworkError()
-        reportNetworkError()
+        reportNetworkError('/users/me')
+        reportNetworkError('/users/history')
         expect(getRecentFailures()).toBe(2)
     })
 
-    it('expires each failure once it ages out of the window', () => {
-        reportNetworkError()
+    it('dedupes retries of the same endpoint to one failure', () => {
+        // React Query FAST retries: 3 attempts on one slow route must not
+        // read as an app-wide connectivity problem.
+        reportNetworkError('/users/history')
+        reportNetworkError('/users/history')
+        reportNetworkError('/users/history')
+        expect(getRecentFailures()).toBe(1)
+    })
+
+    it('expires failures once they age out of the window', () => {
+        reportNetworkError('/a')
         jest.advanceTimersByTime(FAILURE_WINDOW_MS / 2)
-        reportNetworkError()
+        reportNetworkError('/b')
         expect(getRecentFailures()).toBe(2)
 
         jest.advanceTimersByTime(FAILURE_WINDOW_MS / 2)
@@ -38,16 +48,42 @@ describe('connectivity', () => {
         expect(getRecentFailures()).toBe(0)
     })
 
-    it('notifies subscribers on each failure AND on each expiry', () => {
+    it('prunes on read, not only via timers (freeze/sleep safety)', () => {
+        reportNetworkError('/a')
+        reportNetworkError('/b')
+        // simulate suspended timers: advance the clock without running them
+        jest.setSystemTime(Date.now() + FAILURE_WINDOW_MS + 1000)
+        expect(getRecentFailures()).toBe(0)
+    })
+
+    it('clearRecentFailures drops the window and notifies', () => {
+        let calls = 0
+        const unsubscribe = subscribeConnectivity(() => {
+            calls += 1
+        })
+        reportNetworkError('/a')
+        reportNetworkError('/b')
+
+        clearRecentFailures()
+        expect(getRecentFailures()).toBe(0)
+        expect(calls).toBe(3)
+
+        // no-op when already empty — no redundant emit
+        clearRecentFailures()
+        expect(calls).toBe(3)
+        unsubscribe()
+    })
+
+    it('notifies subscribers on each failure and after expiry', () => {
         const seen: number[] = []
         const unsubscribe = subscribeConnectivity(() => seen.push(getRecentFailures()))
 
-        reportNetworkError()
-        reportNetworkError()
+        reportNetworkError('/a')
+        reportNetworkError('/b')
         expect(seen).toEqual([1, 2])
 
-        jest.advanceTimersByTime(FAILURE_WINDOW_MS)
-        expect(seen).toEqual([1, 2, 1, 0])
+        jest.advanceTimersByTime(FAILURE_WINDOW_MS + 100)
+        expect(seen[seen.length - 1]).toBe(0)
         unsubscribe()
     })
 
@@ -56,9 +92,9 @@ describe('connectivity', () => {
         const unsubscribe = subscribeConnectivity(() => {
             calls += 1
         })
-        reportNetworkError()
+        reportNetworkError('/a')
         unsubscribe()
-        reportNetworkError()
+        reportNetworkError('/b')
 
         expect(calls).toBe(1)
     })

--- a/src/utils/__tests__/connectivity.test.ts
+++ b/src/utils/__tests__/connectivity.test.ts
@@ -1,16 +1,15 @@
 import {
+    __resetConnectivityForTests,
     FAILURE_WINDOW_MS,
-    getMsUntilNextExpiry,
     getRecentFailures,
     reportNetworkError,
-    resetConnectivity,
     subscribeConnectivity,
 } from '../connectivity'
 
 // Module state is shared across tests, so reset to a known-good state each time.
 beforeEach(() => {
     jest.useFakeTimers()
-    resetConnectivity()
+    __resetConnectivityForTests()
 })
 
 afterEach(() => {
@@ -26,7 +25,7 @@ describe('connectivity', () => {
         expect(getRecentFailures()).toBe(2)
     })
 
-    it('expires failures once they age out of the window', () => {
+    it('expires each failure once it ages out of the window', () => {
         reportNetworkError()
         jest.advanceTimersByTime(FAILURE_WINDOW_MS / 2)
         reportNetworkError()
@@ -39,24 +38,16 @@ describe('connectivity', () => {
         expect(getRecentFailures()).toBe(0)
     })
 
-    it('reports when the oldest failure will expire', () => {
-        expect(getMsUntilNextExpiry()).toBeNull()
-
-        reportNetworkError()
-        jest.advanceTimersByTime(10_000)
-        reportNetworkError()
-
-        expect(getMsUntilNextExpiry()).toBe(FAILURE_WINDOW_MS - 10_000)
-    })
-
-    it('notifies subscribers on each failure', () => {
+    it('notifies subscribers on each failure AND on each expiry', () => {
         const seen: number[] = []
         const unsubscribe = subscribeConnectivity(() => seen.push(getRecentFailures()))
 
         reportNetworkError()
         reportNetworkError()
-
         expect(seen).toEqual([1, 2])
+
+        jest.advanceTimersByTime(FAILURE_WINDOW_MS)
+        expect(seen).toEqual([1, 2, 1, 0])
         unsubscribe()
     })
 

--- a/src/utils/__tests__/friendly-error.utils.test.tsx
+++ b/src/utils/__tests__/friendly-error.utils.test.tsx
@@ -220,7 +220,7 @@ describe('backend wire codes', () => {
         // request provably never reached the server — the classifier matches
         // the name (it does not walk `.cause`) and blames the connection.
         const wrapped = Object.assign(
-            new Error("We couldn't reach Peanut — check your internet connection and try again."),
+            new Error('Peanut is taking too long to respond — check your connection and try again.'),
             {
                 name: 'ConnectionTimeoutError',
             }

--- a/src/utils/__tests__/friendly-error.utils.test.tsx
+++ b/src/utils/__tests__/friendly-error.utils.test.tsx
@@ -215,17 +215,26 @@ describe('backend wire codes', () => {
         expect(friendlyError(walletRejection)).toEqual({ kind: 'code', code: 'userRejectedRequest' })
     })
 
-    test('ServiceUnavailableError maps to connection-aware copy', () => {
-        // fetchWithSentry sets this name when the request never reached the
-        // server — the classifier matches the name (it does not walk `.cause`)
-        // and must blame the connection, not a busy network.
+    test('ConnectionTimeoutError (fetch timeout path) maps to connection-aware copy', () => {
+        // fetchWithSentry sets this name only on its timeout path, where the
+        // request provably never reached the server — the classifier matches
+        // the name (it does not walk `.cause`) and blames the connection.
         const wrapped = Object.assign(
             new Error("We couldn't reach Peanut — check your internet connection and try again."),
             {
-                name: 'ServiceUnavailableError',
+                name: 'ConnectionTimeoutError',
             }
         )
         expect(friendlyError(wrapped)).toEqual({ kind: 'code', code: 'connectionTimeout' })
+    })
+
+    test('ServiceUnavailableError (generic fetch catch) keeps the neutral retryable code', () => {
+        // The generic path also wraps CORS/CSP/TypeError failures that can be
+        // OUR outage — it must not blame the user's internet connection.
+        const wrapped = Object.assign(new Error('Something went wrong. Please try again.'), {
+            name: 'ServiceUnavailableError',
+        })
+        expect(friendlyError(wrapped)).toEqual({ kind: 'code', code: 'networkBusyTimeout' })
     })
 
     test('the SDK transactionHash fetch failure is now localized, not passed through', () => {

--- a/src/utils/__tests__/friendly-error.utils.test.tsx
+++ b/src/utils/__tests__/friendly-error.utils.test.tsx
@@ -215,14 +215,17 @@ describe('backend wire codes', () => {
         expect(friendlyError(walletRejection)).toEqual({ kind: 'code', code: 'userRejectedRequest' })
     })
 
-    test('ServiceUnavailableError keeps the retryable timeout code', () => {
-        // fetchWithSentry rethrows this with the real timeout on `.cause`, which
-        // the classifier does not walk — without the name match it collapsed to
-        // the generic support fallback.
-        const wrapped = Object.assign(new Error('Service temporarily unavailable. Please try again.'), {
-            name: 'ServiceUnavailableError',
-        })
-        expect(friendlyError(wrapped)).toEqual({ kind: 'code', code: 'networkBusyTimeout' })
+    test('ServiceUnavailableError maps to connection-aware copy', () => {
+        // fetchWithSentry sets this name when the request never reached the
+        // server — the classifier matches the name (it does not walk `.cause`)
+        // and must blame the connection, not a busy network.
+        const wrapped = Object.assign(
+            new Error("We couldn't reach Peanut — check your internet connection and try again."),
+            {
+                name: 'ServiceUnavailableError',
+            }
+        )
+        expect(friendlyError(wrapped)).toEqual({ kind: 'code', code: 'connectionTimeout' })
     })
 
     test('the SDK transactionHash fetch failure is now localized, not passed through', () => {

--- a/src/utils/__tests__/sentry.utils.test.ts
+++ b/src/utils/__tests__/sentry.utils.test.ts
@@ -421,7 +421,7 @@ describe('fetch timeout budgets', () => {
 
             global.fetch = jest.fn().mockRejectedValue(abort())
             await expect(freshFetchWithSentry('https://api.peanut.me/users/me')).rejects.toThrow(
-                "We couldn't reach Peanut — check your internet connection and try again."
+                'Peanut is taking too long to respond — check your connection and try again.'
             )
             expect(reportedTimeoutMs()).toBe(CLIENT_FETCH_TIMEOUT_MS)
         })
@@ -429,7 +429,7 @@ describe('fetch timeout budgets', () => {
         it('still lets a per-call timeoutMs win over the default', async () => {
             global.fetch = jest.fn().mockRejectedValue(abort())
             await expect(fetchWithSentry('https://api.peanut.me/users/me', {}, 1234)).rejects.toThrow(
-                "We couldn't reach Peanut — check your internet connection and try again."
+                'Peanut is taking too long to respond — check your connection and try again.'
             )
             expect(reportedTimeoutMs()).toBe(1234)
         })

--- a/src/utils/__tests__/sentry.utils.test.ts
+++ b/src/utils/__tests__/sentry.utils.test.ts
@@ -18,7 +18,6 @@ jest.mock('@sentry/nextjs', () => ({
 
 jest.mock('../connectivity', () => ({
     reportNetworkError: jest.fn(),
-    reportNetworkOk: jest.fn(),
 }))
 
 describe('fetchWithSentry — expected-response suppression', () => {
@@ -422,7 +421,7 @@ describe('fetch timeout budgets', () => {
 
             global.fetch = jest.fn().mockRejectedValue(abort())
             await expect(freshFetchWithSentry('https://api.peanut.me/users/me')).rejects.toThrow(
-                'Service temporarily unavailable. Please try again.'
+                "We couldn't reach Peanut — check your internet connection and try again."
             )
             expect(reportedTimeoutMs()).toBe(CLIENT_FETCH_TIMEOUT_MS)
         })
@@ -430,7 +429,7 @@ describe('fetch timeout budgets', () => {
         it('still lets a per-call timeoutMs win over the default', async () => {
             global.fetch = jest.fn().mockRejectedValue(abort())
             await expect(fetchWithSentry('https://api.peanut.me/users/me', {}, 1234)).rejects.toThrow(
-                'Service temporarily unavailable. Please try again.'
+                "We couldn't reach Peanut — check your internet connection and try again."
             )
             expect(reportedTimeoutMs()).toBe(1234)
         })

--- a/src/utils/connectivity.ts
+++ b/src/utils/connectivity.ts
@@ -4,31 +4,54 @@
 // call site. navigator.onLine only catches a hard offline device; the common
 // real-world case is a request that hangs and times out while the device still
 // reports itself online — that shows up here as a failure.
+//
+// Failures are counted in a sliding time window, not consecutively. The app
+// fires many requests in parallel, so on a flaky connection successes
+// interleave with failures — a consecutive counter reset by any success never
+// reaches its threshold, which kept the banner permanently dark (TASK-21108).
+// Entries expire on their own; a success does not clear them.
 
 type Listener = () => void
 
 const listeners = new Set<Listener>()
-let consecutiveFailures = 0
+
+export const FAILURE_WINDOW_MS = 60_000
+
+let failureTimes: number[] = []
 
 function emit(): void {
     listeners.forEach((fn) => fn())
 }
 
-// A response came back (any status — a 4xx/5xx still means we reached the server).
-export function reportNetworkOk(): void {
-    if (consecutiveFailures === 0) return
-    consecutiveFailures = 0
-    emit()
+function prune(now: number): void {
+    failureTimes = failureTimes.filter((t) => now - t < FAILURE_WINDOW_MS)
 }
 
 // A request never reached the server (timeout / DNS / connection refused).
 export function reportNetworkError(): void {
-    consecutiveFailures += 1
+    const now = Date.now()
+    prune(now)
+    failureTimes.push(now)
     emit()
 }
 
-export function getConsecutiveFailures(): number {
-    return consecutiveFailures
+// Failures inside the current window.
+export function getRecentFailures(): number {
+    prune(Date.now())
+    return failureTimes.length
+}
+
+// ms until the oldest in-window failure ages out, or null when there are none.
+export function getMsUntilNextExpiry(): number | null {
+    const now = Date.now()
+    prune(now)
+    if (failureTimes.length === 0) return null
+    return FAILURE_WINDOW_MS - (now - failureTimes[0])
+}
+
+// test-only: module state is shared across tests
+export function resetConnectivity(): void {
+    failureTimes = []
 }
 
 export function subscribeConnectivity(fn: Listener): () => void {

--- a/src/utils/connectivity.ts
+++ b/src/utils/connectivity.ts
@@ -9,54 +9,53 @@
 // fires many requests in parallel, so on a flaky connection successes
 // interleave with failures — a consecutive counter reset by any success never
 // reaches its threshold, which kept the banner permanently dark (TASK-21108).
-// Entries expire on their own; a success does not clear them.
+// A success does not clear the count; each failure expires on its own timer
+// (store-owned expiry, same shape as useSubmissionWindow), so subscribers are
+// always notified when the count changes — no consumer-side timer math.
 
-type Listener = () => void
-
-const listeners = new Set<Listener>()
+const listeners = new Set<() => void>()
 
 export const FAILURE_WINDOW_MS = 60_000
 
-let failureTimes: number[] = []
+// Treat the API as unreachable at this many failures inside the window; lives
+// here next to the window so the whole policy reads in one place.
+export const FAILURE_THRESHOLD = 2
+
+let recentFailures = 0
+const expiryTimers = new Set<ReturnType<typeof setTimeout>>()
 
 function emit(): void {
     listeners.forEach((fn) => fn())
 }
 
-function prune(now: number): void {
-    failureTimes = failureTimes.filter((t) => now - t < FAILURE_WINDOW_MS)
-}
-
 // A request never reached the server (timeout / DNS / connection refused).
 export function reportNetworkError(): void {
-    const now = Date.now()
-    prune(now)
-    failureTimes.push(now)
+    recentFailures += 1
+    const timer = setTimeout(() => {
+        expiryTimers.delete(timer)
+        recentFailures -= 1
+        emit()
+    }, FAILURE_WINDOW_MS)
+    expiryTimers.add(timer)
     emit()
 }
 
 // Failures inside the current window.
 export function getRecentFailures(): number {
-    prune(Date.now())
-    return failureTimes.length
+    return recentFailures
 }
 
-// ms until the oldest in-window failure ages out, or null when there are none.
-export function getMsUntilNextExpiry(): number | null {
-    const now = Date.now()
-    prune(now)
-    if (failureTimes.length === 0) return null
-    return FAILURE_WINDOW_MS - (now - failureTimes[0])
-}
-
-// test-only: module state is shared across tests
-export function resetConnectivity(): void {
-    failureTimes = []
-}
-
-export function subscribeConnectivity(fn: Listener): () => void {
+export function subscribeConnectivity(fn: () => void): () => void {
     listeners.add(fn)
     return () => {
         listeners.delete(fn)
     }
+}
+
+// test-only: module state is shared across tests
+export function __resetConnectivityForTests(): void {
+    expiryTimers.forEach((t) => clearTimeout(t))
+    expiryTimers.clear()
+    recentFailures = 0
+    listeners.clear()
 }

--- a/src/utils/connectivity.ts
+++ b/src/utils/connectivity.ts
@@ -9,40 +9,73 @@
 // fires many requests in parallel, so on a flaky connection successes
 // interleave with failures — a consecutive counter reset by any success never
 // reaches its threshold, which kept the banner permanently dark (TASK-21108).
-// A success does not clear the count; each failure expires on its own timer
-// (store-owned expiry, same shape as useSubmissionWindow), so subscribers are
-// always notified when the count changes — no consumer-side timer math.
+//
+// Two deliberate choices, both from review:
+// - Truth is an array of Date.now() stamps pruned on read, NOT the timers:
+//   browsers throttle/suspend setTimeout in background tabs and on sleep, so a
+//   counter decremented by timers can wake up stale. The per-failure timer
+//   only exists to notify subscribers once the window has passed.
+// - The count is DISTINCT endpoints, not raw failures: React Query retries
+//   (FAST = 3 attempts) make one persistently slow route produce 3 failures in
+//   seconds, which must not trip the app-wide banner. A genuinely bad
+//   connection fails several endpoints at once.
+
+interface FailureEntry {
+    t: number
+    endpoint: string
+}
 
 const listeners = new Set<() => void>()
 
 export const FAILURE_WINDOW_MS = 60_000
 
-// Treat the API as unreachable at this many failures inside the window; lives
-// here next to the window so the whole policy reads in one place.
+// Treat the API as unreachable at this many DISTINCT failing endpoints inside
+// the window; lives here next to the window so the whole policy reads in one place.
 export const FAILURE_THRESHOLD = 2
 
-let recentFailures = 0
+let failures: FailureEntry[] = []
 const expiryTimers = new Set<ReturnType<typeof setTimeout>>()
 
 function emit(): void {
     listeners.forEach((fn) => fn())
 }
 
-// A request never reached the server (timeout / DNS / connection refused).
-export function reportNetworkError(): void {
-    recentFailures += 1
+function prune(): void {
+    const now = Date.now()
+    failures = failures.filter((f) => now - f.t < FAILURE_WINDOW_MS)
+}
+
+// A request never completed (timeout / DNS / connection refused). `endpoint`
+// should be a sanitized url so retries of the same route dedupe to one entry.
+export function reportNetworkError(endpoint: string): void {
+    prune()
+    failures.push({ t: Date.now(), endpoint })
+    // notify again once this entry has aged out so subscribers re-read the
+    // pruned count; on freeze/sleep the overdue timer fires at resume, which
+    // is exactly when a re-read is needed.
     const timer = setTimeout(() => {
         expiryTimers.delete(timer)
-        recentFailures -= 1
         emit()
-    }, FAILURE_WINDOW_MS)
+    }, FAILURE_WINDOW_MS + 50)
     expiryTimers.add(timer)
     emit()
 }
 
-// Failures inside the current window.
+// Distinct endpoints that failed inside the current window.
 export function getRecentFailures(): number {
-    return recentFailures
+    prune()
+    return new Set(failures.map((f) => f.endpoint)).size
+}
+
+// The device just came back online — the recorded failures belong to the dead
+// connection, so drop them instead of showing "trouble reaching Peanut" for
+// up to a window while requests are already succeeding.
+export function clearRecentFailures(): void {
+    if (failures.length === 0) return
+    failures = []
+    expiryTimers.forEach((t) => clearTimeout(t))
+    expiryTimers.clear()
+    emit()
 }
 
 export function subscribeConnectivity(fn: () => void): () => void {
@@ -56,6 +89,6 @@ export function subscribeConnectivity(fn: () => void): () => void {
 export function __resetConnectivityForTests(): void {
     expiryTimers.forEach((t) => clearTimeout(t))
     expiryTimers.clear()
-    recentFailures = 0
+    failures = []
     listeners.clear()
 }

--- a/src/utils/friendly-error.utils.tsx
+++ b/src/utils/friendly-error.utils.tsx
@@ -79,6 +79,7 @@ export type FriendlyErrorCode =
     | 'sendLinkAlreadyClaimed'
     | 'lowLiquidity'
     | 'networkBusyTimeout'
+    | 'connectionTimeout'
     | 'genericSupport'
     // Mapped from backend wire codes — see WIRE_CODE_MAP below.
     | 'staleCardApproval'
@@ -245,7 +246,10 @@ export const friendlyError = (error: unknown): FriendlyError => {
     // we set ourselves rather than walking `.cause` generically: extractErrorParts
     // feeds three call paths and a recursive walk would silently reclassify
     // every wrapped error in the app.
-    if (name === 'ServiceUnavailableError') return code('networkBusyTimeout')
+    // fetchWithSentry sets this name when the request never REACHED the server
+    // (timeout / DNS / refused) — that's the user's connection, not a busy
+    // network, so it gets connection-aware copy instead of networkBusyTimeout.
+    if (name === 'ServiceUnavailableError') return code('connectionTimeout')
     if (
         text.includes('took too long to respond') ||
         text.includes('The request timed out') ||

--- a/src/utils/friendly-error.utils.tsx
+++ b/src/utils/friendly-error.utils.tsx
@@ -246,10 +246,13 @@ export const friendlyError = (error: unknown): FriendlyError => {
     // we set ourselves rather than walking `.cause` generically: extractErrorParts
     // feeds three call paths and a recursive walk would silently reclassify
     // every wrapped error in the app.
-    // fetchWithSentry sets this name when the request never REACHED the server
-    // (timeout / DNS / refused) — that's the user's connection, not a busy
-    // network, so it gets connection-aware copy instead of networkBusyTimeout.
-    if (name === 'ServiceUnavailableError') return code('connectionTimeout')
+    // fetchWithSentry sets ConnectionTimeoutError only on its timeout path,
+    // where the request provably never reached the server — that's the user's
+    // connection, so blame it. ServiceUnavailableError is its generic catch
+    // (DNS/refused, but also CORS/CSP/TypeError, which can be OUR outage) —
+    // keep the neutral retryable copy there.
+    if (name === 'ConnectionTimeoutError') return code('connectionTimeout')
+    if (name === 'ServiceUnavailableError') return code('networkBusyTimeout')
     if (
         text.includes('took too long to respond') ||
         text.includes('The request timed out') ||

--- a/src/utils/friendly-error.utils.tsx
+++ b/src/utils/friendly-error.utils.tsx
@@ -246,11 +246,12 @@ export const friendlyError = (error: unknown): FriendlyError => {
     // we set ourselves rather than walking `.cause` generically: extractErrorParts
     // feeds three call paths and a recursive walk would silently reclassify
     // every wrapped error in the app.
-    // fetchWithSentry sets ConnectionTimeoutError only on its timeout path,
-    // where the request provably never reached the server — that's the user's
-    // connection, so blame it. ServiceUnavailableError is its generic catch
-    // (DNS/refused, but also CORS/CSP/TypeError, which can be OUR outage) —
-    // keep the neutral retryable copy there.
+    // fetchWithSentry sets ConnectionTimeoutError only on its timeout path —
+    // our own AbortController firing, which a slow backend can trigger on a
+    // healthy connection, so the copy names both possibilities without
+    // blaming the user's internet. ServiceUnavailableError is its generic
+    // catch (DNS/refused, but also CORS/CSP/TypeError, which can be OUR
+    // outage) — keep the fully neutral retryable copy there.
     if (name === 'ConnectionTimeoutError') return code('connectionTimeout')
     if (name === 'ServiceUnavailableError') return code('networkBusyTimeout')
     if (

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/nextjs'
 
 import { type JSONValue } from '../interfaces/interfaces'
-import { reportNetworkError, reportNetworkOk } from './connectivity'
+import { reportNetworkError } from './connectivity'
 
 /**
  * Endpoint + status combinations to skip reporting.
@@ -441,9 +441,6 @@ export const fetchWithSentry = async (
     try {
         const response = await attemptFetch()
 
-        // A response came back — the backend is reachable, clear any failure streak.
-        reportNetworkOk()
-
         if (!response.ok) {
             // Skip both the console warn AND Sentry submission for expected
             // non-2xx responses (username availability 404, get-user-from-cookie
@@ -519,7 +516,7 @@ export const fetchWithSentry = async (
                 })
             })
 
-            const userError = new Error('Service temporarily unavailable. Please try again.')
+            const userError = new Error("We couldn't reach Peanut — check your internet connection and try again.")
             userError.name = 'ServiceUnavailableError'
             userError.cause = timeoutError
             throw userError

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -517,7 +517,11 @@ export const fetchWithSentry = async (
             })
 
             const userError = new Error("We couldn't reach Peanut — check your internet connection and try again.")
-            userError.name = 'ServiceUnavailableError'
+            // distinct name from the generic catch below: this path is a
+            // timeout, so the request provably never reached the server and
+            // connection-blaming copy is safe. the generic path also wraps
+            // CORS/CSP/TypeError failures where it is not.
+            userError.name = 'ConnectionTimeoutError'
             userError.cause = timeoutError
             throw userError
         }

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -489,8 +489,9 @@ export const fetchWithSentry = async (
         return response
     } catch (error: unknown) {
         // fetch rejected (timeout / DNS / connection refused) — the request never
-        // reached the backend, so flag a connectivity failure.
-        reportNetworkError()
+        // completed, so flag a connectivity failure. keyed by sanitized url so
+        // React Query retries of one slow route dedupe to a single endpoint.
+        reportNetworkError(sanitizeUrl(url))
         // console.info, not error: captureConsoleIntegration would turn an
         // error-level log into a second Sentry event on top of the explicit
         // captures below.
@@ -516,11 +517,12 @@ export const fetchWithSentry = async (
                 })
             })
 
-            const userError = new Error("We couldn't reach Peanut — check your internet connection and try again.")
-            // distinct name from the generic catch below: this path is a
-            // timeout, so the request provably never reached the server and
-            // connection-blaming copy is safe. the generic path also wraps
-            // CORS/CSP/TypeError failures where it is not.
+            const userError = new Error('Peanut is taking too long to respond — check your connection and try again.')
+            // distinct name from the generic catch below: this path is our own
+            // AbortController firing, which an overloaded backend can trigger
+            // on a healthy connection — so the copy names both possibilities
+            // instead of blaming the user's internet. the generic path also
+            // wraps CORS/CSP/TypeError failures and stays fully neutral.
             userError.name = 'ConnectionTimeoutError'
             userError.cause = timeoutError
             throw userError


### PR DESCRIPTION
## Summary

The connectivity banner (`ConnectivityBanner`, shipped 07-03) could never fire: failures were counted **consecutively** and reset by **any** successful response. The app fires requests in parallel (`/users/me`, `/rain/cards`, `/users/history`, …), so on a flaky connection successes interleave with timeouts and the threshold of 2 was never reached. Sentry shows ~500 timeout events / 40+ users in 7d who saw nothing but raw error toasts.

- **Windowed failure counting** — `connectivity.ts` now keeps failure timestamps in a 60s sliding window; entries age out on their own and a success no longer clears them. `useConnectivity` re-reads when the oldest failure expires so the banner drops after recovery without needing a new request. `reportNetworkOk` is deleted (its reset was the bug).
- **Connection-aware copy** — a timeout/DNS/refused failure means the request **never reached the server**, but users were told "Service temporarily unavailable" / "The network is busy". `ServiceUnavailableError` now maps to a new `connectionTimeout` friendly-error code: *"We couldn't reach Peanut — check your internet connection and try again."* (en, es-419, es-AR, pt-BR). `networkBusyTimeout` stays for viem/bundler timeouts, where the user's connection is fine.
- The task's third fix (retry GETs once on `AbortError`) already shipped on dev (PEANUT-UI-R44) — no change here.

## Task

[TASK-21108 — Bad-internet UX](https://app.notion.com/p/peanutprotocol/Bad-internet-UX-3b18381175798008ac2de11dd2778198)

## Design notes / accepted trade-offs

- After connectivity recovers, the banner can linger up to 60s (until the failures age out) — acceptable: the copy says "retrying…", and any success-based clearing reintroduces the interleaving bug.
- `FAILURE_THRESHOLD` is 2 **distinct endpoints** within 60s (was "2 consecutive failures"), and lives next to `FAILURE_WINDOW_MS` so the policy reads in one place.
- The raw English message on the thrown timeout error intentionally duplicates `en.json`'s `connectionTimeout` copy: a few surfaces toast `error.message` directly (e.g. Setup landing, card PIN), and a human-readable fallback beats a technical sentinel there. Localized surfaces go through `friendlyError` by name.
- **Monitoring note:** flows that tag errors with the friendly-error code will see fetch timeouts move from `networkBusyTimeout` to `connectionTimeout` — update any dashboard/alert keyed on the old bucket.
- Pre-existing, unchanged: `ConnectivityBanner` renders above `MaintenanceBanner`, so sustained timeouts during a flagged maintenance can mask the maintenance notice for up to the 60s window. Narrow case, noted not fixed.

## Risks / breaking changes

- FE-only, no API/cross-repo impact. Blast radius: connectivity banner visibility + user-facing timeout copy.
- The banner will now actually appear for users on bad connections — expected behavior change, not a regression.

## QA

- `npm test` — 232 suites green, incl. new windowed-counting tests (interleaved-success case pinned in `useConnectivity.test.tsx`).
- Manual: throttle to offline-ish flakiness in DevTools → two failed requests within 60s show the banner even with interleaved successes; banner clears ≤60s after recovery.

Screenshots: N/A (banner renders identically — only its trigger condition and error-toast copy change; copy strings visible in the diff)
