### PR TITLE
fix(i18n): translate countries, regions and badge copy for pt-BR

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -46,7 +46,8 @@ import { addMoneyCountryUrl, rewriteMethodPath } from '@/utils/native-routes'
 import { isMantecaSupportedCountryCode } from '@/constants/manteca.consts'
 import { useSafeBack } from '@/hooks/useSafeBack'
 import { getRegionIntent } from '@/utils/regions.utils'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
+import { localizedCountryTitle } from '@/utils/country-name.utils'
 
 // Step type for URL state
 type BridgeBankStep = 'inputAmount' | 'showDetails'
@@ -57,6 +58,7 @@ type BridgeBankStep = 'inputAmount' | 'showDetails'
 function BridgeBankOnrampPage() {
     const params = useParams()
     const _searchParams = useSearchParams()
+    const locale = useLocale()
     const t = useTranslations('addMoney')
     const tCommon = useTranslations('common')
 
@@ -514,7 +516,7 @@ function BridgeBankOnrampPage() {
                     variant={resolveKycModalVariant(gate)}
                     providerMessage={getGateUserMessage(gate)}
                     reasonCode={getGateReasonCode(gate)}
-                    regionName={selectedCountry?.title}
+                    regionName={selectedCountry && localizedCountryTitle(locale, selectedCountry)}
                 />
 
                 <AdvisoryPreemptModal {...advisoryModalProps} />

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -49,11 +49,13 @@ import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { withdrawCountryUrl } from '@/utils/native-routes'
 import { useSafeBack } from '@/hooks/useSafeBack'
 import { useSendFlowOrigin } from '@/hooks/useSendFlowOrigin'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
+import { localizedCountryTitle } from '@/utils/country-name.utils'
 
 type View = 'INITIAL' | 'SUCCESS'
 
 export default function WithdrawBankPage() {
+    const locale = useLocale()
     const t = useTranslations('withdraw')
     const tNav = useTranslations('navigation')
     const tCommon = useTranslations('common')
@@ -97,6 +99,7 @@ export default function WithdrawBankPage() {
     // PENDING rail in an unrelated jurisdiction can't block this page.
     const { gateFor } = useCapabilities()
     const bankCountry = useMemo(() => railJurisdictionForBank(getCountryFromPath(country)?.id), [country])
+    const countryFromPath = getCountryFromPath(country)
     const gate = useMemo(() => gateFor('withdraw', { channel: 'bank', country: bankCountry }), [gateFor, bankCountry])
     // bridge re-verification ("we're reviewing your details") modal for the
     // waiting-on-provider gate — keeps the status poll alive + auto-dismisses.
@@ -616,7 +619,7 @@ export default function WithdrawBankPage() {
                 variant={resolveKycModalVariant(gate)}
                 providerMessage={getGateUserMessage(gate)}
                 reasonCode={getGateReasonCode(gate)}
-                regionName={getCountryFromPath(country)?.title}
+                regionName={countryFromPath && localizedCountryTitle(locale, countryFromPath)}
             />
             <AdvisoryPreemptModal {...advisoryModalProps} />
 

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -69,7 +69,8 @@ import { isVerifiedForCountry } from '@/utils/regions.utils'
 import PixKeySendView from '@/components/Withdraw/views/PixKeySend.view'
 import underMaintenanceConfig from '@/config/underMaintenance.config'
 import { MantecaTransfersMaintenanceView } from '@/components/Global/Banner/MantecaTransfersMaintenanceView'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
+import { localizedCountryTitle } from '@/utils/country-name.utils'
 import { loadingStateKey } from '@/i18n/app/loading-states'
 
 type MantecaWithdrawStep = 'amountInput' | 'bankDetails' | 'review' | 'success' | 'failure'
@@ -97,6 +98,7 @@ export default function MantecaWithdrawFlow() {
 }
 
 function MantecaBankWithdrawFlow() {
+    const locale = useLocale()
     const t = useTranslations('withdraw')
     const tNav = useTranslations('navigation')
     const tCommon = useTranslations('common')
@@ -676,7 +678,7 @@ function MantecaBankWithdrawFlow() {
                 }
                 providerMessage={mantecaRejection.userMessage ?? undefined}
                 reasonCode={mantecaRejection.reasonCode ?? undefined}
-                regionName={selectedCountry?.title}
+                regionName={selectedCountry && localizedCountryTitle(locale, selectedCountry)}
             />
             <SumsubKycModals flow={sumsubFlow} />
             <SumsubKycWrapper

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -27,7 +27,8 @@ import { useQueryStates, parseAsString, parseAsStringEnum } from 'nuqs'
 import { useLimitsValidation } from '@/features/limits/hooks/useLimitsValidation'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
+import { localizedCountryTitle } from '@/utils/country-name.utils'
 
 // Step type for URL state
 type MantecaStep = 'inputAmount' | 'depositDetails' | 'showQR'
@@ -39,6 +40,7 @@ const MantecaAddMoney: FC = () => {
     const params = useParams()
     const searchParams = useSearchParams()
     const queryClient = useQueryClient()
+    const locale = useLocale()
     const t = useTranslations('addMoney')
     const router = useRouter()
 
@@ -298,7 +300,7 @@ const MantecaAddMoney: FC = () => {
                     }
                     providerMessage={mantecaRejection.userMessage ?? undefined}
                     reasonCode={mantecaRejection.reasonCode ?? undefined}
-                    regionName={selectedCountry?.title}
+                    regionName={selectedCountry && localizedCountryTitle(locale, selectedCountry)}
                 />
                 <SumsubKycModals flow={sumsubFlow} />
                 <InputAmountStep

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -38,7 +38,8 @@ import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
 import ProvideEmailStep from '@/components/Kyc/ProvideEmailStep'
 import { useModalsContext } from '@/context/ModalsContext'
 import underMaintenanceConfig, { PIX_BRAZIL_ONRAMP_MAINTENANCE } from '@/config/underMaintenance.config'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
+import { localizedCountryTitle } from '@/utils/country-name.utils'
 
 interface AddWithdrawCountriesListProps {
     flow: 'add' | 'withdraw'
@@ -49,6 +50,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
     const params = useParams()
     const searchParams = useSearchParams()
     const onBack = useSafeBack(flow === 'add' ? '/add-money' : '/withdraw')
+    const locale = useLocale()
     const t = useTranslations('withdraw')
     const tAddMoney = useTranslations('addMoney')
     const tNav = useTranslations('navigation')
@@ -388,7 +390,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                 variant={resolveKycModalVariant(gate)}
                 providerMessage={getGateUserMessage(gate)}
                 reasonCode={getGateReasonCode(gate)}
-                regionName={currentCountry?.title}
+                regionName={currentCountry && localizedCountryTitle(locale, currentCountry)}
             />
             <BridgeTosStep
                 visible={showBridgeTos}
@@ -543,7 +545,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
     return (
         <div className="w-full space-y-8 self-start">
             <NavHeader
-                title={currentCountry.title}
+                title={localizedCountryTitle(locale, currentCountry)}
                 onPrev={() => {
                     setAmountToWithdraw('')
                     if (flow === 'add') {

--- a/src/components/Badges/BadgeEarnToast.tsx
+++ b/src/components/Badges/BadgeEarnToast.tsx
@@ -22,7 +22,8 @@ import posthog from 'posthog-js'
 import { useTranslations } from 'next-intl'
 import { useToast } from '@/components/0_Bruddle/Toast'
 import { BadgeDetailModal } from '@/components/Badges/BadgeDetailModal'
-import { getBadgeDescription, getBadgeDisplayName, getBadgeIcon } from '@/components/Badges/badge.utils'
+import { getBadgeIcon } from '@/components/Badges/badge.utils'
+import { useBadgeCopy } from '@/components/Badges/useBadgeCopy'
 import { useBadgeEarnToast } from '@/components/Badges/useBadgeEarnToast'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { BadgeImage } from '@/components/Badges/BadgeImage'
@@ -33,6 +34,7 @@ type ModalBadge = { code: string; title: string; description: string; logo: stri
 
 export default function BadgeEarnToast() {
     const t = useTranslations('badges')
+    const badgeCopy = useBadgeCopy()
     const pathname = usePathname()
     const router = useRouter()
     const { toast, dismiss } = useToast()
@@ -52,7 +54,8 @@ export default function BadgeEarnToast() {
         const codes = badges.map((b) => b.code)
         const count = badges.length
         const newest = badges[0]
-        const newestName = getBadgeDisplayName(newest.code, newest.name)
+        const newestCopy = badgeCopy(newest.code, newest.name, newest.description)
+        const newestName = newestCopy.name
         const newestIcon = getBadgeIcon(newest.code, newest.iconUrl)
         // Per-batch id (not a fixed id): a fixed id de-dupes in the Toast layer,
         // so a second badge earned within the toast's window would be marked
@@ -68,7 +71,7 @@ export default function BadgeEarnToast() {
                 setModalBadge({
                     code: newest.code,
                     title: newestName,
-                    description: getBadgeDescription(newest.description) || '',
+                    description: newestCopy.description || '',
                     logo: newestIcon,
                 })
             } else {
@@ -102,7 +105,7 @@ export default function BadgeEarnToast() {
         liveToastIdRef.current = toastId
         posthog.capture(ANALYTICS_EVENTS.BADGE_EARN_TOAST_SHOWN, { count })
         markSeen(codes)
-    }, [pathname, pending, toast, dismiss, markSeen, router, t])
+    }, [pathname, pending, toast, dismiss, markSeen, router, t, badgeCopy])
 
     // Dismiss the toast when the user leaves /home so it doesn't ride over the
     // next route for its remaining duration. Guarded on pathname so the

--- a/src/components/Badges/BadgeStatusDrawer.tsx
+++ b/src/components/Badges/BadgeStatusDrawer.tsx
@@ -5,14 +5,8 @@ import Card from '../Global/Card'
 import { PaymentInfoRow } from '../Payment/PaymentInfoRow'
 import ShareButton from '../Global/ShareButton'
 import { BadgeDetailModal } from './BadgeDetailModal'
-import {
-    captureBadgeShare,
-    getBadgeDescription,
-    getBadgeDisplayName,
-    getBadgeIcon,
-    getBadgeShareLink,
-    getBadgeShareText,
-} from './badge.utils'
+import { captureBadgeShare, getBadgeIcon, getBadgeShareLink, getBadgeShareText } from './badge.utils'
+import { useBadgeCopy } from './useBadgeCopy'
 import { useBadgeShareImpression } from './useBadgeShareImpression'
 import { REFERRAL_SOURCES } from '@/constants/analytics.consts'
 import { useAuth } from '@/context/authContext'
@@ -36,6 +30,7 @@ export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerP
     const locale = useLocale()
     const format = useFormatter()
     const { user: authUser } = useAuth()
+    const badgeCopy = useBadgeCopy()
     const [isDetailOpen, setIsDetailOpen] = useState(false)
     const username = authUser?.user.username
     const earnedAt = badge.earnedAt ? new Date(badge.earnedAt) : undefined
@@ -50,8 +45,7 @@ export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerP
                   hour12: false,
               })
             : undefined
-    const displayName = getBadgeDisplayName(badge.code, badge.name)
-    const displayDescription = getBadgeDescription(badge.description)
+    const { name: displayName, description: displayDescription } = badgeCopy(badge.code, badge.name, badge.description)
     const displayIcon = getBadgeIcon(badge.code, badge.iconUrl)
 
     // the sharer's own invite link, so a guest signup credits them

--- a/src/components/Badges/BadgeStatusItem.tsx
+++ b/src/components/Badges/BadgeStatusItem.tsx
@@ -4,7 +4,8 @@ import Card from '@/components/Global/Card'
 import { type CardPosition } from '@/components/Global/Card/card.utils'
 import { BadgeStatusDrawer } from './BadgeStatusDrawer'
 import InvitesIcon from '../Home/InvitesIcon'
-import { getBadgeDisplayName, getBadgeIcon } from './badge.utils'
+import { getBadgeIcon } from './badge.utils'
+import { useBadgeCopy } from './useBadgeCopy'
 import { type BadgeHistoryEntry } from './badge.types'
 import { BadgeImage } from './BadgeImage'
 
@@ -16,8 +17,9 @@ export const BadgeStatusItem = ({
     entry: BadgeHistoryEntry
 }) => {
     const t = useTranslations('badges')
+    const badgeCopy = useBadgeCopy()
     const [isDrawerOpen, setIsDrawerOpen] = useState(false)
-    const displayName = getBadgeDisplayName(entry.code, entry.name)
+    const displayName = badgeCopy(entry.code, entry.name).name
 
     const badge = useMemo(
         () => ({

--- a/src/components/Badges/BadgesRow.tsx
+++ b/src/components/Badges/BadgesRow.tsx
@@ -103,11 +103,17 @@ const BadgesRow = ({ badges, className, isSelfProfile = true }: BadgesRowProps) 
                     aria-label={t('collectionLabel')}
                 >
                     {visibleBadges.map((badge) => {
-                        const { name: displayName, description: displayDescription } = badgeCopy(
+                        // Same precedence as before, with the localized string standing
+                        // in for `badge.description`: the backend's third-person
+                        // `publicDescription` still wins when you are not the owner.
+                        const { name: displayName, description: selfDescription } = badgeCopy(
                             badge.code,
                             badge.name,
-                            isSelfProfile ? badge.description : (badge.publicDescription ?? badge.description)
+                            badge.description
                         )
+                        const displayDescription = isSelfProfile
+                            ? selfDescription
+                            : (badge.publicDescription ?? selfDescription)
 
                         return (
                             <Tooltip

--- a/src/components/Badges/BadgesRow.tsx
+++ b/src/components/Badges/BadgesRow.tsx
@@ -7,7 +7,8 @@ import { Tooltip } from '../Tooltip'
 import { twMerge } from 'tailwind-merge'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Icon } from '../Global/Icons/Icon'
-import { getBadgeDescription, getBadgeDisplayName, getBadgeIcon } from './badge.utils'
+import { getBadgeIcon } from './badge.utils'
+import { useBadgeCopy } from './useBadgeCopy'
 import { BadgeImage } from './BadgeImage'
 
 type UIBadge = {
@@ -35,6 +36,7 @@ interface BadgesRowProps {
  */
 const BadgesRow = ({ badges, className, isSelfProfile = true }: BadgesRowProps) => {
     const t = useTranslations('badges')
+    const badgeCopy = useBadgeCopy()
     const viewportRef = useRef<HTMLDivElement>(null)
     const [visibleCount, setVisibleCount] = useState<number>(4)
     const [startIdx, setStartIdx] = useState<number>(0)
@@ -101,10 +103,11 @@ const BadgesRow = ({ badges, className, isSelfProfile = true }: BadgesRowProps) 
                     aria-label={t('collectionLabel')}
                 >
                     {visibleBadges.map((badge) => {
-                        const displayDescription = getBadgeDescription(
+                        const { name: displayName, description: displayDescription } = badgeCopy(
+                            badge.code,
+                            badge.name,
                             isSelfProfile ? badge.description : (badge.publicDescription ?? badge.description)
                         )
-                        const displayName = getBadgeDisplayName(badge.code, badge.name)
 
                         return (
                             <Tooltip

--- a/src/components/Badges/__tests__/BadgeEarnToast.test.tsx
+++ b/src/components/Badges/__tests__/BadgeEarnToast.test.tsx
@@ -107,6 +107,15 @@ describe('BadgeEarnToast', () => {
 
         const { container } = render(mockToast.mock.calls[0][0].content)
         expect(container.querySelector('img')).toHaveAttribute('src', '/badges/backend_product_hunt.webp')
+        // a code in `badges.catalog` renders the localized name, not the backend one
+        expect(screen.getByText(/Product Hunt/)).toBeInTheDocument()
+    })
+
+    it('falls back to the backend name for a code with no catalog entry', () => {
+        mockPending = [badge('FUTURE_BADGE', 'Backend Name')]
+        render(<BadgeEarnToast />)
+
+        render(mockToast.mock.calls[0][0].content)
         expect(screen.getByText(/Backend Name/)).toBeInTheDocument()
     })
 

--- a/src/components/Badges/__tests__/BadgesRow.test.tsx
+++ b/src/components/Badges/__tests__/BadgesRow.test.tsx
@@ -62,6 +62,23 @@ describe('BadgesRow', () => {
         expect(screen.queryByText('You earned this badge.')).not.toBeInTheDocument()
     })
 
+    // The test above uses a code with no `badges.catalog` entry, so it passes even
+    // if the localized copy swallows the audience choice. This one uses a real code.
+    it('keeps the backend public description for a badge that IS in the catalog', () => {
+        const apiBadge = {
+            ...badge('VERIFIED', '2026-08-04T00:00:00.000Z'),
+            description: 'You earned this badge.',
+            publicDescription: 'They earned this badge.',
+        }
+
+        const { rerender } = render(<BadgesRow badges={[apiBadge]} isSelfProfile />)
+        expect(screen.getByText(/officially verified/)).toBeInTheDocument()
+
+        rerender(<BadgesRow badges={[apiBadge]} isSelfProfile={false} />)
+        expect(screen.getByText('They earned this badge.')).toBeInTheDocument()
+        expect(screen.queryByText(/officially verified/)).not.toBeInTheDocument()
+    })
+
     it('keeps an earned badge visible with generic art when the backend icon fails', () => {
         const apiBadge = {
             ...badge('NEW', '2026-08-04T00:00:00.000Z'),

--- a/src/components/Badges/index.tsx
+++ b/src/components/Badges/index.tsx
@@ -3,7 +3,8 @@
 import type { StaticImageData } from 'next/image'
 import NavHeader from '../Global/NavHeader'
 import { useSafeBack } from '@/hooks/useSafeBack'
-import { getBadgeDescription, getBadgeDisplayName, getBadgeIcon } from './badge.utils'
+import { getBadgeIcon } from './badge.utils'
+import { useBadgeCopy } from './useBadgeCopy'
 import { getCardPosition } from '../Global/Card/card.utils'
 import EmptyState from '../Global/EmptyStates/EmptyState'
 import { Icon } from '../Global/Icons/Icon'
@@ -19,6 +20,7 @@ type BadgeView = { code: string; title: string; description: string; logo: strin
 
 export const Badges = () => {
     const t = useTranslations('badges')
+    const badgeCopy = useBadgeCopy()
     const onBack = useSafeBack('/profile')
     const { user: authUser } = useUserStore()
     const { fetchUser } = useAuth()
@@ -34,13 +36,16 @@ export const Badges = () => {
     const badges: BadgeView[] = useMemo(() => {
         // get badges from user object and map to card fields
         const raw = authUser?.user?.badges || []
-        return raw.map((b) => ({
-            code: b.code,
-            title: getBadgeDisplayName(b.code, b.name),
-            description: getBadgeDescription(b.description) || '',
-            logo: getBadgeIcon(b.code, b.iconUrl),
-        }))
-    }, [authUser?.user?.badges])
+        return raw.map((b) => {
+            const copy = badgeCopy(b.code, b.name, b.description)
+            return {
+                code: b.code,
+                title: copy.name,
+                description: copy.description || '',
+                logo: getBadgeIcon(b.code, b.iconUrl),
+            }
+        })
+    }, [authUser?.user?.badges, badgeCopy])
 
     if (!badges.length) {
         return (

--- a/src/components/Badges/useBadgeCopy.ts
+++ b/src/components/Badges/useBadgeCopy.ts
@@ -1,0 +1,28 @@
+'use client'
+
+import { useCallback } from 'react'
+import { useTranslations } from 'next-intl'
+import { getBadgeDescription, getBadgeDisplayName } from './badge.utils'
+
+/**
+ * Localized badge name + reason, keyed by badge code.
+ *
+ * The backend catalog owns badge identity and ships display-ready English, so it
+ * stays the fallback: a code with no `badges.catalog` entry — a badge added
+ * after this build — renders the backend prose rather than a raw key path.
+ */
+export function useBadgeCopy() {
+    const t = useTranslations('badges.catalog')
+
+    return useCallback(
+        (code?: string, name?: string | null, description?: string | null) => {
+            const nameKey = `${code}.name` as Parameters<typeof t>[0]
+            const descriptionKey = `${code}.description` as Parameters<typeof t>[0]
+            return {
+                name: code && t.has(nameKey) ? t(nameKey) : getBadgeDisplayName(code, name),
+                description: code && t.has(descriptionKey) ? t(descriptionKey) : getBadgeDescription(description),
+            }
+        },
+        [t]
+    )
+}

--- a/src/components/Card/CardCountryConfirmScreen.tsx
+++ b/src/components/Card/CardCountryConfirmScreen.tsx
@@ -5,6 +5,7 @@ import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import NavHeader from '@/components/Global/NavHeader'
 import { Button } from '@/components/0_Bruddle/Button'
+import { localizedCountryName } from '@/utils/country-name.utils'
 
 interface Props {
     /** ISO-2 codes the backend derived from the applicant's own evidence. */
@@ -14,15 +15,6 @@ interface Props {
     onContactSupport: () => void
     onPrev?: () => void
     submitError?: string | null
-}
-
-/** "BR" → "Brazil", falling back to the raw code for anything unmappable. */
-const countryName = (iso2: string, locale: string): string => {
-    try {
-        return new Intl.DisplayNames([locale], { type: 'region' }).of(iso2) ?? iso2
-    } catch {
-        return iso2
-    }
 }
 
 /**
@@ -89,7 +81,7 @@ const CardCountryConfirmScreen: FC<Props> = ({ candidates, onConfirm, onContactS
                                 selected === iso2 ? 'bg-primary-3' : 'bg-white'
                             }`}
                         >
-                            {countryName(iso2, locale)}
+                            {localizedCountryName(locale, iso2, iso2)}
                         </button>
                     </li>
                 ))}

--- a/src/components/Claim/Link/MantecaFlowManager.tsx
+++ b/src/components/Claim/Link/MantecaFlowManager.tsx
@@ -18,7 +18,8 @@ import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
 import { deriveProviderRejection } from '@/utils/provider-rejection.utils'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
+import { localizedCountryTitle } from '@/utils/country-name.utils'
 
 interface MantecaFlowManagerProps {
     claimLinkData: ClaimLinkData
@@ -27,6 +28,7 @@ interface MantecaFlowManagerProps {
 }
 
 const MantecaFlowManager: FC<MantecaFlowManagerProps> = ({ claimLinkData, amount, attachment }) => {
+    const locale = useLocale()
     const t = useTranslations('claim')
     const { setClaimToMercadoPago, selectedCountry, regionalMethodType } = useClaimBankFlow()
     const [currentStep, setCurrentStep] = useState<MercadoPagoStep>(MercadoPagoStep.DETAILS)
@@ -186,7 +188,7 @@ const MantecaFlowManager: FC<MantecaFlowManagerProps> = ({ claimLinkData, amount
                 }
                 providerMessage={mantecaRejection.userMessage ?? undefined}
                 reasonCode={mantecaRejection.reasonCode ?? undefined}
-                regionName={selectedCountry?.title}
+                regionName={selectedCountry ? localizedCountryTitle(locale, selectedCountry) : undefined}
             />
             <SumsubKycModals flow={sumsubFlow} />
         </div>

--- a/src/components/Common/CountryList.tsx
+++ b/src/components/Common/CountryList.tsx
@@ -9,7 +9,7 @@ import {
 import EmptyState from '@/components/Global/EmptyStates/EmptyState'
 import { SearchInput } from '@/components/SearchInput'
 import Image from 'next/image'
-import { useMemo, useState, useDeferredValue, type ReactNode } from 'react'
+import { useCallback, useMemo, useState, useDeferredValue, type ReactNode } from 'react'
 import { getCardPosition } from '../Global/Card/card.utils'
 import { useGeoLocation } from '@/hooks/useGeoLocation'
 import { CountryListSkeleton } from './CountryListSkeleton'
@@ -19,9 +19,10 @@ import EasterEggModal, { EASTER_EGG_COUNTRIES } from '@/components/Global/Easter
 import StatusBadge from '../Global/Badges/StatusBadge'
 import Loading from '../Global/Loading'
 import { useSearchParams } from 'next/navigation'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
 import { ActionListCard } from '../ActionListCard'
 import { isMantecaSupportedCountryCode } from '@/constants/manteca.consts'
+import { localizedCountryTitle } from '@/utils/country-name.utils'
 
 // precompute bridge alpha2 values for O(1) lookup
 const BRIDGE_ALPHA2_SET = new Set(Object.values(BRIDGE_ALPHA3_TO_ALPHA2))
@@ -74,6 +75,7 @@ export const CountryList = ({
     showLoadingState = true, // true by default to show loading state when clicking a country
 }: CountryListViewProps) => {
     const t = useTranslations('global')
+    const locale = useLocale()
     const searchParams = useSearchParams()
     // get currencyCode from search params
     const currencyCode = searchParams.get('currencyCode')
@@ -89,6 +91,9 @@ export const CountryList = ({
     const [easterEggCountry, setEasterEggCountry] = useState<string | null>(null)
 
     const supportedCountries = countryData.filter((country) => country.type === 'country')
+
+    // catalog titles are English; the displayed name comes from Intl.DisplayNames
+    const countryName = useCallback((country: CountryData) => localizedCountryTitle(locale, country), [locale])
 
     // sort countries: user's geo-located country first, then preferred countries
     // (in declared order), then everyone else alphabetically.
@@ -116,20 +121,23 @@ export const CountryList = ({
             const bRank = preferredRank(b)
             if (aRank !== bRank) return aRank - bRank
 
-            return a.title.localeCompare(b.title)
+            return countryName(a).localeCompare(countryName(b), locale)
         })
-    }, [userGeoLocationCountryCode])
+    }, [userGeoLocationCountryCode, countryName, locale])
 
-    // filter countries based on deferred search term to prevent blocking ui
+    // filter countries based on deferred search term to prevent blocking ui.
+    // The English title stays searchable so "Brazil" still finds "Brasil".
     const filteredCountries = useMemo(() => {
         if (!deferredSearchTerm) return sortedCountries
 
+        const term = deferredSearchTerm.toLowerCase()
         return sortedCountries.filter(
             (country) =>
-                country.title.toLowerCase().includes(deferredSearchTerm.toLowerCase()) ||
-                country.currency?.toLowerCase().includes(deferredSearchTerm.toLowerCase())
+                countryName(country).toLowerCase().includes(term) ||
+                country.title.toLowerCase().includes(term) ||
+                country.currency?.toLowerCase().includes(term)
         )
-    }, [deferredSearchTerm, sortedCountries])
+    }, [deferredSearchTerm, sortedCountries, countryName])
 
     return (
         <div className="flex h-full w-full flex-1 flex-col justify-start gap-4">
@@ -174,6 +182,7 @@ export const CountryList = ({
                             const twoLetterCountryCode =
                                 ALL_COUNTRIES_ALPHA3_TO_ALPHA2[country.id.toUpperCase()] ?? country.id.toLowerCase()
                             const position = getCardPosition(index, filteredCountries.length)
+                            const displayName = countryName(country)
 
                             const isBridgeSupportedCountryResult = isBridgeSupportedCountry(country.id)
                             const isMantecaSupportedCountry = isMantecaSupportedCountryCode(country.id)
@@ -207,7 +216,7 @@ export const CountryList = ({
                             return (
                                 <ActionListCard
                                     key={country.id}
-                                    title={country.title}
+                                    title={displayName}
                                     rightContent={
                                         customRight ??
                                         (showLoadingState && clickedCountryId === country.id ? (
@@ -236,7 +245,7 @@ export const CountryList = ({
                                         <div className="relative h-8 w-8">
                                             <Image
                                                 src={getFlagUrl(twoLetterCountryCode)}
-                                                alt={t('countryList.flagAlt', { country: country.title })}
+                                                alt={t('countryList.flagAlt', { country: displayName })}
                                                 width={80}
                                                 height={80}
                                                 className="h-8 w-8 rounded-full object-cover"

--- a/src/components/IdentityVerification/UnlockRegionModal.tsx
+++ b/src/components/IdentityVerification/UnlockRegionModal.tsx
@@ -5,6 +5,7 @@ import ActionModal from '../Global/ActionModal'
 import InfoCard from '../Global/InfoCard'
 import { Icon } from '../Global/Icons/Icon'
 import { type Region } from '@/utils/regions.utils'
+import { useRegionLabel } from '@/hooks/useRegionLabel'
 import React from 'react'
 
 interface StartVerificationModalProps {
@@ -25,6 +26,8 @@ const UnlockRegionModal = ({
     const t = useTranslations('identity')
     const tKyc = useTranslations('kyc')
     const tCommon = useTranslations('common')
+    const regionLabel = useRegionLabel()
+    const regionName = selectedRegion && regionLabel(selectedRegion).name
 
     const bold = { b: (chunks: React.ReactNode) => <b>{chunks}</b> }
     const qrPayments = <p key="qr">{t.rich('qrPayments', bold)}</p>
@@ -54,7 +57,7 @@ const UnlockRegionModal = ({
         <ActionModal
             visible={visible}
             onClose={onClose}
-            title={selectedRegion?.name ? t('unlockTitle', { region: selectedRegion.name }) : t('unlockTitleGeneric')}
+            title={regionName ? t('unlockTitle', { region: regionName }) : t('unlockTitleGeneric')}
             description={<p>{t.rich('unlockDescription', bold)}</p>}
             descriptionClassName="text-black"
             icon="shield"

--- a/src/components/Kyc/CountryFlagAndName.tsx
+++ b/src/components/Kyc/CountryFlagAndName.tsx
@@ -1,7 +1,11 @@
+'use client'
+
 import Image from 'next/image'
+import { useLocale } from 'next-intl'
 import { countryData } from '../AddMoney/consts'
 import IconStack from '../Global/IconStack'
 import { getFlagUrl } from '@/constants/countryCurrencyMapping'
+import { localizedCountryTitle } from '@/utils/country-name.utils'
 
 interface CountryFlagAndNameProps {
     countryCode?: string
@@ -9,12 +13,13 @@ interface CountryFlagAndNameProps {
 }
 
 export const CountryFlagAndName = ({ countryCode, isBridgeRegion }: CountryFlagAndNameProps) => {
+    const locale = useLocale()
     // CR-flagged: incoming `countryCode` from `mantecaGeo` / `bridgeGeo` is
     // ISO3 (e.g. 'USA'), but `getFlagUrl` expects ISO2 (e.g. 'us'). Look up
     // the countryData entry first and pass its iso2; fall back to the raw
     // input so already-ISO2 callers keep working.
     const countryEntry = countryData.find((c) => c.id === countryCode?.toUpperCase())
-    const countryName = countryEntry?.title
+    const countryName = countryEntry && localizedCountryTitle(locale, countryEntry)
     const flagCode = countryEntry?.iso2?.toLowerCase() ?? countryCode
     return (
         <div className="flex items-center gap-2">

--- a/src/components/Profile/views/UnlockedRegions.view.tsx
+++ b/src/components/Profile/views/UnlockedRegions.view.tsx
@@ -14,6 +14,7 @@ import { KycFailedModal } from '@/components/Kyc/modals/KycFailedModal'
 import ActionModal from '@/components/Global/ActionModal'
 import { useModalsContext } from '@/context/ModalsContext'
 import { deriveRegionAccess, getRegionIntent, providerForRegionIntent, type Region } from '@/utils/regions.utils'
+import { useRegionLabel } from '@/hooks/useRegionLabel'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { deriveProviderRejection } from '@/utils/provider-rejection.utils'
 import { reasonCodeKey } from '@/constants/capability-reason-labels.consts'
@@ -376,33 +377,38 @@ interface RegionsListProps {
     onRegionClick?: (region: Region) => void
 }
 const RegionsList = ({ regions, isLocked, onRegionClick }: RegionsListProps) => {
+    const regionLabel = useRegionLabel()
+
     return (
         <div className="mt-3">
-            {regions.map((region, index) => (
-                <ActionListCard
-                    key={region.path}
-                    leftIcon={
-                        <Image
-                            src={region.icon}
-                            alt={region.name}
-                            width={36}
-                            height={36}
-                            className="size-8 rounded-full object-cover"
-                        />
-                    }
-                    position={getCardPosition(index, regions.length)}
-                    title={region.name}
-                    onClick={() => {
-                        if (isLocked && onRegionClick) {
-                            onRegionClick(region)
+            {regions.map((region, index) => {
+                const label = regionLabel(region)
+                return (
+                    <ActionListCard
+                        key={region.path}
+                        leftIcon={
+                            <Image
+                                src={region.icon}
+                                alt={label.name}
+                                width={36}
+                                height={36}
+                                className="size-8 rounded-full object-cover"
+                            />
                         }
-                    }}
-                    isDisabled={!isLocked}
-                    description={region.description}
-                    descriptionClassName="text-xs"
-                    rightContent={!isLocked ? <Icon name="check" className="size-4 text-success-1" /> : null}
-                />
-            ))}
+                        position={getCardPosition(index, regions.length)}
+                        title={label.name}
+                        onClick={() => {
+                            if (isLocked && onRegionClick) {
+                                onRegionClick(region)
+                            }
+                        }}
+                        isDisabled={!isLocked}
+                        description={label.description}
+                        descriptionClassName="text-xs"
+                        rightContent={!isLocked ? <Icon name="check" className="size-4 text-success-1" /> : null}
+                    />
+                )
+            })}
         </div>
     )
 }

--- a/src/features/limits/views/LimitsPageView.tsx
+++ b/src/features/limits/views/LimitsPageView.tsx
@@ -6,7 +6,12 @@ import { getCardPosition } from '@/components/Global/Card/card.utils'
 import { Icon } from '@/components/Global/Icons/Icon'
 import NavHeader from '@/components/Global/NavHeader'
 import StatusBadge from '@/components/Global/Badges/StatusBadge'
-import { deriveRegionAccess, pendingBankRailRegionPaths, type Region } from '@/utils/regions.utils'
+import {
+    deriveRegionAccess,
+    pendingBankRailRegionPaths,
+    REST_OF_THE_WORLD_REGION,
+    type Region,
+} from '@/utils/regions.utils'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { useLimits } from '@/hooks/useLimits'
 import { useRainCardOverview } from '@/hooks/useRainCardOverview'
@@ -52,7 +57,7 @@ const LimitsPageView = () => {
     // rest of world is rendered on its own below, never from the locked list
     const restOfWorldName = regionLabel({
         path: 'rest-of-the-world',
-        name: 'Rest of the world',
+        name: REST_OF_THE_WORLD_REGION,
         icon: REST_OF_WORLD_GLOBE_ICON,
     }).name
 

--- a/src/features/limits/views/LimitsPageView.tsx
+++ b/src/features/limits/views/LimitsPageView.tsx
@@ -15,6 +15,7 @@ import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { useMemo } from 'react'
 import { useSafeBack } from '@/hooks/useSafeBack'
+import { useRegionLabel } from '@/hooks/useRegionLabel'
 import CryptoLimitsSection from '../components/CryptoLimitsSection'
 import FiatLimitsLockedCard from '../components/FiatLimitsLockedCard'
 import REST_OF_WORLD_GLOBE_ICON from '@/assets/icons/rest-of-world-globe.svg'
@@ -47,12 +48,13 @@ const LimitsPageView = () => {
     // AR bank rail incorrectly badged Europe and North America.
     const pendingRegionPaths = useMemo(() => pendingBankRailRegionPaths(rails), [rails])
 
-    // rest of world region config (static)
-    const restOfWorldRegion: Region = {
+    const regionLabel = useRegionLabel()
+    // rest of world is rendered on its own below, never from the locked list
+    const restOfWorldName = regionLabel({
         path: 'rest-of-the-world',
-        name: t('restOfWorld'),
+        name: 'Rest of the world',
         icon: REST_OF_WORLD_GLOBE_ICON,
-    }
+    }).name
 
     // filter locked regions and check for rest of world
     const { filteredLockedRegions, hasRestOfWorld } = useMemo(() => {
@@ -95,15 +97,15 @@ const LimitsPageView = () => {
                     <ActionListCard
                         leftIcon={
                             <Image
-                                src={restOfWorldRegion.icon}
-                                alt={restOfWorldRegion.name}
+                                src={REST_OF_WORLD_GLOBE_ICON}
+                                alt={restOfWorldName}
                                 width={36}
                                 height={36}
                                 className="size-8 rounded-full object-cover"
                             />
                         }
                         position="single"
-                        title={restOfWorldRegion.name}
+                        title={restOfWorldName}
                         onClick={() => {}}
                         isDisabled={true}
                         rightContent={<StatusBadge status="custom" customText={tCommon('comingSoon')} />}
@@ -140,33 +142,37 @@ interface UnlockedRegionsListProps {
 
 const UnlockedRegionsList = ({ regions, hasMantecaKyc }: UnlockedRegionsListProps) => {
     const t = useTranslations('limits')
+    const regionLabel = useRegionLabel()
     const router = useRouter()
 
     return (
         <div>
             {regions.length > 0 && <h2 className="mb-2 font-bold">{t('unlockedRegions')}</h2>}
-            {regions.map((region, index) => (
-                <ActionListCard
-                    key={region.path}
-                    leftIcon={
-                        <Image
-                            src={region.icon}
-                            alt={region.name}
-                            width={36}
-                            height={36}
-                            className="size-8 rounded-full object-cover"
-                        />
-                    }
-                    position={getCardPosition(index, regions.length)}
-                    title={region.name}
-                    onClick={() => {
-                        const route = getProviderRoute(region.path, hasMantecaKyc)
-                        router.push(route)
-                    }}
-                    description={region.description}
-                    descriptionClassName="text-xs"
-                />
-            ))}
+            {regions.map((region, index) => {
+                const label = regionLabel(region)
+                return (
+                    <ActionListCard
+                        key={region.path}
+                        leftIcon={
+                            <Image
+                                src={region.icon}
+                                alt={label.name}
+                                width={36}
+                                height={36}
+                                className="size-8 rounded-full object-cover"
+                            />
+                        }
+                        position={getCardPosition(index, regions.length)}
+                        title={label.name}
+                        onClick={() => {
+                            const route = getProviderRoute(region.path, hasMantecaKyc)
+                            router.push(route)
+                        }}
+                        description={label.description}
+                        descriptionClassName="text-xs"
+                    />
+                )
+            })}
         </div>
     )
 }
@@ -179,6 +185,7 @@ interface LockedRegionsListProps {
 const LockedRegionsList = ({ regions, pendingRegionPaths }: LockedRegionsListProps) => {
     const t = useTranslations('limits')
     const tCommon = useTranslations('common')
+    const regionLabel = useRegionLabel()
     const router = useRouter()
 
     // a region shows pending only when one of ITS bank rails is mid-flight
@@ -189,27 +196,28 @@ const LockedRegionsList = ({ regions, pendingRegionPaths }: LockedRegionsListPro
             {regions.length > 0 && <h2 className="mb-2 font-bold">{t('lockedRegions')}</h2>}
             {regions.map((region, index) => {
                 const isPending = isPendingRegion(region.path)
+                const label = regionLabel(region)
                 return (
                     <ActionListCard
                         key={region.path}
                         leftIcon={
                             <Image
                                 src={region.icon}
-                                alt={region.name}
+                                alt={label.name}
                                 width={36}
                                 height={36}
                                 className="size-8 rounded-full object-cover"
                             />
                         }
                         position={getCardPosition(index, regions.length)}
-                        title={region.name}
+                        title={label.name}
                         onClick={() => {
                             if (!isPending) {
                                 router.push('/profile/identity-verification')
                             }
                         }}
                         isDisabled={isPending}
-                        description={region.description}
+                        description={label.description}
                         descriptionClassName="text-xs"
                         rightContent={isPending && <StatusBadge status="pending" customText={tCommon('pending')} />}
                     />

--- a/src/hooks/__tests__/useRegionLabel.test.ts
+++ b/src/hooks/__tests__/useRegionLabel.test.ts
@@ -1,0 +1,25 @@
+import { renderHookWithIntl } from '@/test-utils/intl'
+import { useRegionLabel } from '../useRegionLabel'
+
+const region = (path: string, name: string, description?: string) => ({ path, name, icon: '', description })
+
+describe('useRegionLabel', () => {
+    it('resolves catalog copy from the region path, dashes and all', () => {
+        const { result } = renderHookWithIntl(() => useRegionLabel())
+        expect(result.current(region('north-america', 'North America')).name).toBe('North America')
+        expect(result.current(region('rest-of-the-world', 'Rest of the world')).name).toBe('Rest of the world')
+    })
+
+    it('resolves the QR-only country descriptions', () => {
+        const { result } = renderHookWithIntl(() => useRegionLabel())
+        expect(result.current(region('brazil', 'Brazil', 'Only PIX QR payments')).description).toBe(
+            'Only PIX QR payments'
+        )
+    })
+
+    it('falls back to the internal name for a region with no catalog entry', () => {
+        const { result } = renderHookWithIntl(() => useRegionLabel())
+        const label = result.current(region('atlantis', 'Atlantis', 'Underwater only'))
+        expect(label).toEqual({ name: 'Atlantis', description: 'Underwater only' })
+    })
+})

--- a/src/hooks/useRegionLabel.ts
+++ b/src/hooks/useRegionLabel.ts
@@ -1,0 +1,27 @@
+'use client'
+
+import { useCallback } from 'react'
+import { useTranslations } from 'next-intl'
+import type { Region } from '@/utils/regions.utils'
+
+/**
+ * Display copy for a `Region`. `Region.name` stays the internal English
+ * identifier `deriveRegionAccess` branches on, so every render site resolves the
+ * localized label from the region's stable `path` instead. Regions with no
+ * catalog entry (none today) fall back to the English name.
+ */
+export function useRegionLabel() {
+    const t = useTranslations('common.regions')
+
+    return useCallback(
+        (region: Region): { name: string; description?: string } => {
+            const nameKey = region.path as Parameters<typeof t>[0]
+            const descriptionKey = `descriptions.${region.path}` as Parameters<typeof t>[0]
+            return {
+                name: t.has(nameKey) ? t(nameKey) : region.name,
+                description: t.has(descriptionKey) ? t(descriptionKey) : region.description,
+            }
+        },
+        [t]
+    )
+}

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -28,6 +28,19 @@
         "next": "Next",
         "notFound": "Not Found",
         "countryNotFound": "Country not found",
+        "regions": {
+            "europe": "Europe",
+            "north-america": "North America",
+            "latam": "LATAM",
+            "rest-of-the-world": "Rest of the world",
+            "argentina": "Argentina",
+            "brazil": "Brazil",
+            "mexico": "Mexico",
+            "descriptions": {
+                "argentina": "Only Mercado Pago QR payments",
+                "brazil": "Only PIX QR payments"
+            }
+        },
         "tryDifferentCountry": "Please try a different country.",
         "status": {
             "completed": "Completed",
@@ -395,7 +408,6 @@
         "unlockedRegions": "Unlocked regions",
         "lockedRegions": "Locked regions",
         "otherRegions": "Other regions",
-        "restOfWorld": "Rest of the world",
         "cardLimits": {
             "title": "Card limits",
             "manage": "Manage card limits",
@@ -1911,7 +1923,201 @@
         "shareText": "I earned {badge} badge on Peanut!\n\nJoin Peanut now and start earning points, unlocking achievements and moving money worldwide\n\n{link}",
         "toastSingle": "Badge unlocked: {name}",
         "toastMultiple": "You unlocked {count, plural, one {# badge} other {# badges}} 🎉",
-        "toastTapToView": "— tap to view"
+        "toastTapToView": "— tap to view",
+        "catalog": {
+            "FIRST_INVITE": {
+                "name": "First Invite",
+                "description": "Brought a friend to the table. One down, a whole network to go."
+            },
+            "SECOND_INVITE": {
+                "name": "Second Invite",
+                "description": "Word's getting around — two friends in and rising."
+            },
+            "THIRD_INVITE": {
+                "name": "Third Invite",
+                "description": "Three friends, no misses. Tip your hat."
+            },
+            "MINI_INFLUENCER": {
+                "name": "Mini Influencer",
+                "description": "Built a little fan club, one invite at a time."
+            },
+            "INFLUENCER_25": {
+                "name": "Influencer",
+                "description": "Twenty-five strong. The likes keep rolling in."
+            },
+            "MEGA_INFLUENCER": {
+                "name": "Mega Influencer",
+                "description": "A hundred friends in. You're kind of a big deal now."
+            },
+            "DUNBAR": {
+                "name": "Dunbar",
+                "description": "150 — more people than you can remember. They hit Dunbar's number."
+            },
+            "MOST_INVITES": {
+                "name": "Most Invites",
+                "description": "Onboarded more users than Coinbase ads!"
+            },
+            "CERTIFIED_YAPPER": {
+                "name": "Certified Yapper",
+                "description": "Certified loud. They talked about Peanut so we didn't have to."
+            },
+            "GIGA_YAPPER": {
+                "name": "Giga Yapper",
+                "description": "Giga loud. They don't mention Peanut, they broadcast it."
+            },
+            "FIRST_CRUMB": {
+                "name": "First Dollar",
+                "description": "First dollar earned. Proof it pays."
+            },
+            "DOUBLE_DIGITS": {
+                "name": "Double Digits",
+                "description": "Crossed into double digits. Real money now."
+            },
+            "CARD_FIRST_SWIPE": {
+                "name": "First Swipe",
+                "description": "You put your card to work."
+            },
+            "CARD_SPENT_1K": {
+                "name": "$1K Club",
+                "description": "$1K swiped — you put your money where your card is."
+            },
+            "CARD_PIONEER": {
+                "name": "Card Pioneer",
+                "description": "You reserved your spot for the Peanut Card. Pioneer perks await!"
+            },
+            "FOUNDING_PIONEER": {
+                "name": "Founding Pioneer",
+                "description": "You were building Peanut before it had a launch."
+            },
+            "VERIFIED": {
+                "name": "Verified",
+                "description": "ID checked, identity confirmed. You're officially verified."
+            },
+            "BETA_TESTER": {
+                "name": "Beta Tester",
+                "description": "You broke things so others don't have to. Welcome to the chaos club — Beta Tester badge unlocked."
+            },
+            "OG_2025_10_12": {
+                "name": "OG",
+                "description": "You are a real OG. You were with Peanut before it was cool."
+            },
+            "CARD_CLOSED_BETA": {
+                "name": "Closed Beta",
+                "description": "IYKYK. They were testing the card before you knew it existed."
+            },
+            "CARD_ALPHA": {
+                "name": "Closed Alpha Tester",
+                "description": "You tested the Card while it was still held together with tape and hope."
+            },
+            "BUG_WHISPERER": {
+                "name": "Bug Whisperer",
+                "description": "You found a real bug, reported it, and stayed. We owe you a beer."
+            },
+            "SUPPORT_SURVIVOR": {
+                "name": "Support Survivor",
+                "description": "You found a real bug, reported it, and stayed. We owe you a beer."
+            },
+            "SHHHHH": {
+                "name": "Shhhhh",
+                "description": "You know the secret."
+            },
+            "NOT_SO_SHHHH": {
+                "name": "Loud Mouth",
+                "description": "You couldn't keep it quiet — and you got paid for it."
+            },
+            "ARBITRUM": {
+                "name": "Arbitrum Native",
+                "description": "Found on Arbitrum — mutual onboarding achieved."
+            },
+            "FOUNDER_HOUSE": {
+                "name": "Founder Haus",
+                "description": "You were at Founder Haus. On-chain energy, off-chain handshakes."
+            },
+            "ETHFLORIPA_HUB": {
+                "name": "EthFloripa Hub",
+                "description": "Ilha da Magia, baby. Coconuts and consensus."
+            },
+            "IRL_NOMADS": {
+                "name": "Nomad Mode",
+                "description": "No fixed address, just good coffee and better wifi. Certified Nomad."
+            },
+            "EVENT_ALUMNI": {
+                "name": "Event Alumni",
+                "description": "Old school. You were in the room before most."
+            },
+            "TOUCHED_GRASS": {
+                "name": "Touched Grass",
+                "description": "You logged off and touched real grass with Peanut."
+            },
+            "OFFRAMP_USER": {
+                "name": "Offramp User",
+                "description": "You migrated to Peanut. We welcomed you."
+            },
+            "PSYOPS_DIVISION": {
+                "name": "Psyops Division",
+                "description": "Enlisted in the Psyops Division. Welcome to the influence game."
+            },
+            "TOKEN_NATION_SP_2026": {
+                "name": "Token Nation 2026",
+                "description": "São Paulo, baby. You came, you claimed, you tagged the wall."
+            },
+            "FESTA_JUNINA_2026": {
+                "name": "Arraiá Approved",
+                "description": "You danced the quadrilha with us. Arraiá unlocked."
+            },
+            "MANICERO": {
+                "name": "Manicero",
+                "description": "Small maní. Big energy. Manicero."
+            },
+            "NITA": {
+                "name": "Nita's Recommendation",
+                "description": "Nita sent you. You skipped the card line on her word."
+            },
+            "NAIJA": {
+                "name": "9JA",
+                "description": "Naija no dey carry last. You were here first."
+            },
+            "TERERE": {
+                "name": "Tereré",
+                "description": "Tereré unlocked. You were there for round one."
+            },
+            "DEVCONNECT_BA_2025": {
+                "name": "Devconnect 2025",
+                "description": "Not anon. Touched grass, shook hands, breathed the same air as Vitalik."
+            },
+            "SEEDLING_DEVCONNECT_BA_2025": {
+                "name": "Seedling",
+                "description": "You are working with us to spread the word about Peanut."
+            },
+            "ARBIVERSE_DEVCONNECT_BA_2025": {
+                "name": "Peanut 🤝 Arbiverse",
+                "description": "You joined us at the amazing Arbiverse booth at Devconnect 2025."
+            },
+            "PRODUCT_HUNT": {
+                "name": "Product Hunt",
+                "description": "Hope Dealer. Your upvote felt like a VC term sheet!"
+            },
+            "MOST_RESTAURANTS_DEVCON": {
+                "name": "Most Restaurants Devcon",
+                "description": "You are a real gourmet!"
+            },
+            "BIG_SPENDER_5K": {
+                "name": "Big Spender 5K",
+                "description": "You are a top spender."
+            },
+            "MOST_PAYMENTS_DEVCON": {
+                "name": "Most Payments Devcon",
+                "description": "Money Machine - You move money like it's light work. Most payments made!"
+            },
+            "BIGGEST_REQUEST_POT": {
+                "name": "Biggest Request Pot",
+                "description": "High Roller or Master Beggar? You created the pot with the highest number of contributors."
+            },
+            "WAITLIST_SKIP": {
+                "name": "Skip Pass",
+                "description": "You skipped the waitlist. A friend handed you the key and you walked right in."
+            }
+        }
     },
     "notifications": {
         "title": "Notifications",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -28,6 +28,19 @@
         "next": "Siguiente",
         "notFound": "No encontrado",
         "countryNotFound": "País no encontrado",
+        "regions": {
+            "europe": "Europa",
+            "north-america": "América del Norte",
+            "latam": "Latinoamérica",
+            "rest-of-the-world": "Resto del mundo",
+            "argentina": "Argentina",
+            "brazil": "Brasil",
+            "mexico": "México",
+            "descriptions": {
+                "argentina": "Solo pagos con QR de Mercado Pago",
+                "brazil": "Solo pagos con QR Pix"
+            }
+        },
         "tryDifferentCountry": "Prueba con otro país.",
         "status": {
             "completed": "Completado",
@@ -395,7 +408,6 @@
         "unlockedRegions": "Regiones desbloqueadas",
         "lockedRegions": "Regiones bloqueadas",
         "otherRegions": "Otras regiones",
-        "restOfWorld": "Resto del mundo",
         "cardLimits": {
             "title": "Límites de la tarjeta",
             "manage": "Administrar límites de la tarjeta",
@@ -1911,7 +1923,201 @@
         "shareText": "¡Gané la insignia {badge} en Peanut!\n\nÚnete a Peanut y empieza a ganar puntos, desbloquear logros y mover dinero por todo el mundo\n\n{link}",
         "toastSingle": "Insignia desbloqueada: {name}",
         "toastMultiple": "¡Desbloqueaste {count, plural, one {# insignia} other {# insignias}}! 🎉",
-        "toastTapToView": "— toca para ver"
+        "toastTapToView": "— toca para ver",
+        "catalog": {
+            "FIRST_INVITE": {
+                "name": "Primera invitación",
+                "description": "Trajiste a un amigo a la mesa. Ahora falta toda la red."
+            },
+            "SECOND_INVITE": {
+                "name": "Segunda invitación",
+                "description": "Se corre la voz: dos amigos adentro y subiendo."
+            },
+            "THIRD_INVITE": {
+                "name": "Tercera invitación",
+                "description": "Tres amigos, ningún fallo. Un aplauso."
+            },
+            "MINI_INFLUENCER": {
+                "name": "Mini influencer",
+                "description": "Armaste un pequeño club de fans, una invitación a la vez."
+            },
+            "INFLUENCER_25": {
+                "name": "Influencer",
+                "description": "Veinticinco en la cuenta. Los likes no paran."
+            },
+            "MEGA_INFLUENCER": {
+                "name": "Mega influencer",
+                "description": "Cien amigos adentro. Ahora sí es oficial."
+            },
+            "DUNBAR": {
+                "name": "Dunbar",
+                "description": "150: más gente de la que uno puede recordar. Llegaste al número de Dunbar."
+            },
+            "MOST_INVITES": {
+                "name": "Más invitaciones",
+                "description": "¡Sumaste más usuarios que los anuncios de Coinbase!"
+            },
+            "CERTIFIED_YAPPER": {
+                "name": "Charlatán certificado",
+                "description": "Ruido certificado. Habló de Peanut para que nosotros no tuviéramos que hacerlo."
+            },
+            "GIGA_YAPPER": {
+                "name": "Giga charlatán",
+                "description": "Ruido nivel giga. No menciona Peanut, la difunde."
+            },
+            "FIRST_CRUMB": {
+                "name": "Primer dólar",
+                "description": "Primer dólar ganado. Prueba de que rinde."
+            },
+            "DOUBLE_DIGITS": {
+                "name": "Dos dígitos",
+                "description": "Pasaste a dos dígitos. Ahora sí es dinero de verdad."
+            },
+            "CARD_FIRST_SWIPE": {
+                "name": "Primera compra",
+                "description": "Pusiste tu tarjeta a trabajar."
+            },
+            "CARD_SPENT_1K": {
+                "name": "Club de los $1K",
+                "description": "$1K gastados: apostaste donde estaba tu dinero."
+            },
+            "CARD_PIONEER": {
+                "name": "Pionero de la tarjeta",
+                "description": "¡Reservaste tu lugar para la tarjeta Peanut. Los beneficios de pionero ya vienen!"
+            },
+            "FOUNDING_PIONEER": {
+                "name": "Pionero fundador",
+                "description": "Ya construías Peanut antes de que existiera el lanzamiento."
+            },
+            "VERIFIED": {
+                "name": "Verificado",
+                "description": "Documento revisado, identidad confirmada. Verificación oficial completa."
+            },
+            "BETA_TESTER": {
+                "name": "Beta tester",
+                "description": "Rompiste cosas para que otros no tengan que hacerlo. Te damos la bienvenida al club del caos."
+            },
+            "OG_2025_10_12": {
+                "name": "OG",
+                "description": "Un OG de verdad. Estabas con Peanut antes de que fuera moda."
+            },
+            "CARD_CLOSED_BETA": {
+                "name": "Beta cerrada",
+                "description": "IYKYK. Probaron la tarjeta antes de que supieras que existía."
+            },
+            "CARD_ALPHA": {
+                "name": "Tester del alfa cerrado",
+                "description": "Probaste la tarjeta cuando todavía era cinta adhesiva y esperanza."
+            },
+            "BUG_WHISPERER": {
+                "name": "Cazador de bugs",
+                "description": "Encontraste un bug real, lo reportaste y te quedaste. La cerveza va por nuestra cuenta."
+            },
+            "SUPPORT_SURVIVOR": {
+                "name": "Sobreviviente de soporte",
+                "description": "Encontraste un bug real, lo reportaste y te quedaste. La cerveza va por nuestra cuenta."
+            },
+            "SHHHHH": {
+                "name": "Shhhhh",
+                "description": "El que sabe, sabe."
+            },
+            "NOT_SO_SHHHH": {
+                "name": "Bocón",
+                "description": "No pudiste quedarte callado, y encima te pagamos por eso."
+            },
+            "ARBITRUM": {
+                "name": "Nativo de Arbitrum",
+                "description": "Te encontramos en Arbitrum: onboarding mutuo logrado."
+            },
+            "FOUNDER_HOUSE": {
+                "name": "Founder Haus",
+                "description": "Estuviste en Founder Haus. Energía on-chain, apretones de mano off-chain."
+            },
+            "ETHFLORIPA_HUB": {
+                "name": "EthFloripa Hub",
+                "description": "Ilha da Magia, baby. Cocos y consenso."
+            },
+            "IRL_NOMADS": {
+                "name": "Modo nómada",
+                "description": "Sin dirección fija, solo buen café y mejor wifi. Nómada oficial."
+            },
+            "EVENT_ALUMNI": {
+                "name": "Veterano de eventos",
+                "description": "Old school. Estuviste en la sala antes que la mayoría."
+            },
+            "TOUCHED_GRASS": {
+                "name": "Tocaste pasto",
+                "description": "Te desconectaste y tocaste pasto de verdad con Peanut."
+            },
+            "OFFRAMP_USER": {
+                "name": "Usuario de retiro",
+                "description": "Migraste a Peanut. Te recibimos bien."
+            },
+            "PSYOPS_DIVISION": {
+                "name": "División Psyops",
+                "description": "Entraste a la División Psyops. Te damos la bienvenida al juego de la influencia."
+            },
+            "TOKEN_NATION_SP_2026": {
+                "name": "Token Nation 2026",
+                "description": "São Paulo, baby. Viniste, reclamaste y firmaste el muro."
+            },
+            "FESTA_JUNINA_2026": {
+                "name": "Arraiá aprobado",
+                "description": "Bailaste la quadrilha con nosotros. Arraiá desbloqueado."
+            },
+            "MANICERO": {
+                "name": "Manicero",
+                "description": "Maní chico. Energía grande. Manicero."
+            },
+            "NITA": {
+                "name": "Recomendación de Nita",
+                "description": "Nita te mandó. Te saltaste la fila de la tarjeta con su palabra."
+            },
+            "NAIJA": {
+                "name": "9JA",
+                "description": "Naija no dey carry last. Llegaste primero."
+            },
+            "TERERE": {
+                "name": "Tereré",
+                "description": "Tereré desbloqueado. Estuviste en la primera ronda."
+            },
+            "DEVCONNECT_BA_2025": {
+                "name": "Devconnect 2025",
+                "description": "Nada de anon. Tocaste pasto, diste la mano y respiraste el mismo aire que Vitalik."
+            },
+            "SEEDLING_DEVCONNECT_BA_2025": {
+                "name": "Semilla",
+                "description": "Corriendo la voz sobre Peanut junto a nosotros."
+            },
+            "ARBIVERSE_DEVCONNECT_BA_2025": {
+                "name": "Peanut 🤝 Arbiverse",
+                "description": "Nos acompañaste en el stand de Arbiverse en Devconnect 2025."
+            },
+            "PRODUCT_HUNT": {
+                "name": "Product Hunt",
+                "description": "¡Vendedor de esperanza. Tu upvote se sintió como un term sheet de un VC!"
+            },
+            "MOST_RESTAURANTS_DEVCON": {
+                "name": "Más restaurantes en Devcon",
+                "description": "¡Todo un gourmet!"
+            },
+            "BIG_SPENDER_5K": {
+                "name": "Big Spender 5K",
+                "description": "Estás entre los que más gastan."
+            },
+            "MOST_PAYMENTS_DEVCON": {
+                "name": "Más pagos en Devcon",
+                "description": "Máquina de dinero: mover dinero te sale fácil. ¡Más pagos hechos!"
+            },
+            "BIGGEST_REQUEST_POT": {
+                "name": "Bote más grande",
+                "description": "¿Alto rodador o maestro del pedido? Creaste el bote con más participantes."
+            },
+            "WAITLIST_SKIP": {
+                "name": "Pase directo",
+                "description": "Te saltaste la lista de espera. Un amigo te dio la llave y entraste directo."
+            }
+        }
     },
     "notifications": {
         "title": "Notificaciones",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2134,7 +2134,7 @@
         "migrationSetupTitle": "Receba alertas de dinheiro",
         "migrationSetupDescription": "Avisamos na hora quando o dinheiro chegar ou alguém pedir um pagamento.",
         "enable": "Ativar notificações",
-        "requesting": "Cobrando...",
+        "requesting": "Solicitando...",
         "notNow": "Agora não"
     },
     "kyc": {

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -28,6 +28,19 @@
         "next": "Avançar",
         "notFound": "Não encontrado",
         "countryNotFound": "País não encontrado",
+        "regions": {
+            "europe": "Europa",
+            "north-america": "América do Norte",
+            "latam": "América Latina",
+            "rest-of-the-world": "Resto do mundo",
+            "argentina": "Argentina",
+            "brazil": "Brasil",
+            "mexico": "México",
+            "descriptions": {
+                "argentina": "Só pagamentos com QR do Mercado Pago",
+                "brazil": "Só pagamentos com QR Pix"
+            }
+        },
         "tryDifferentCountry": "Tente outro país.",
         "status": {
             "completed": "Concluído",
@@ -359,7 +372,7 @@
             "peanutLogoTextAlt": "Logo do Peanut",
             "joinPeanutAlt": "Entre no Peanut",
             "allSetTitle": "Tudo pronto",
-            "allSetDescription": "Agora envie ou solicite dinheiro para começar.",
+            "allSetDescription": "Agora envie ou cobre dinheiro para começar.",
             "joinPeanut": "Entre no Peanut!",
             "inviteOnlyLine1": "O Peanut é só por convite.",
             "inviteOnlyLine2": "Vá implorar um link de convite para o seu amigo!",
@@ -395,7 +408,6 @@
         "unlockedRegions": "Regiões desbloqueadas",
         "lockedRegions": "Regiões bloqueadas",
         "otherRegions": "Outras regiões",
-        "restOfWorld": "Resto do mundo",
         "cardLimits": {
             "title": "Limites do cartão",
             "manage": "Gerenciar limites do cartão",
@@ -648,7 +660,7 @@
         "submittingOfframp": "Enviando o saque",
         "gettingProfile": "Obtendo o perfil",
         "registering": "Registrando",
-        "requesting": "Solicitando",
+        "requesting": "Cobrando",
         "loggingIn": "Entrando",
         "loggingOut": "Saindo",
         "paying": "Pagando",
@@ -716,7 +728,7 @@
             "noResultsTitle": "Nenhum contato encontrado",
             "noResultsDescription": "Tente buscar outro contato.",
             "emptyTitle": "Nenhum contato ainda",
-            "emptyDescription": "Os contatos aparecem quando você envia, solicita ou convida alguém"
+            "emptyDescription": "Os contatos aparecem quando você envia, cobra ou convida alguém"
         },
         "link": {
             "createLink": "Criar link",
@@ -731,26 +743,26 @@
         }
     },
     "request": {
-        "leaveEmptyHint": "Deixe vazio para quem paga escolher o valor.",
-        "createRequest": "Criar solicitação",
-        "shareOpenRequest": "Compartilhar solicitação aberta",
-        "shareAmountRequest": "Compartilhar solicitação de ${amount}",
+        "leaveEmptyHint": "Deixe sem valor para o pagador escolher.",
+        "createRequest": "Criar cobrança",
+        "shareOpenRequest": "Compartilhar cobrança aberta",
+        "shareAmountRequest": "Compartilhar cobrança de ${amount}",
         "billSplitFor": "Divisão de conta em {merchant}",
         "linkCreatedToast": "Link criado com sucesso!",
-        "requestUpdatedToast": "Solicitação atualizada com sucesso!",
+        "requestUpdatedToast": "Cobrança atualizada com sucesso!",
         "recipientPlaceholder": "Insira um nome de usuário, um endereço ou ENS",
         "errors": {
             "createFailed": "Não foi possível criar o link",
-            "updateFailed": "Não foi possível atualizar a solicitação",
+            "updateFailed": "Não foi possível atualizar a cobrança",
             "enterRecipient": "Insira um endereço de destinatário",
             "missingUsernameOrAmount": "Falta o nome de usuário ou o valor",
-            "createRequestFailed": "Não foi possível criar a solicitação.",
+            "createRequestFailed": "Não foi possível criar a cobrança.",
             "validatingRecipient": "Validando destinatário..."
         },
         "validation": {
             "invalidRecipientTitle": "Destinatário inválido",
             "missingRecipientTitle": "Destinatário ausente",
-            "invalidRecipientMessage": "O usuário de quem você está tentando solicitar não é um usuário válido do Peanut ou não existe. Confira se você tem o nome de usuário correto do Peanut.",
+            "invalidRecipientMessage": "O usuário de quem você está tentando cobrar não é um usuário válido do Peanut ou não existe. Confira se você tem o nome de usuário correto do Peanut.",
             "missingRecipientMessage": "Nenhum nome de usuário informado na URL. Verifique o link e tente de novo.",
             "goToHome": "Ir para o início",
             "createWallet": "Crie sua Peanut Wallet"
@@ -782,7 +794,7 @@
             "withdrew": "Você acabou de sacar",
             "justSent": "Você acabou de enviar",
             "sent": "Você enviou ",
-            "requested": "Você solicitou ",
+            "requested": "Você cobrou ",
             "added": "Você adicionou ",
             "toPrefix": "para",
             "forPrefix": "por",
@@ -796,7 +808,7 @@
         },
         "confirm": {
             "minReceived": "Mínimo a receber",
-            "requested": "Solicitado",
+            "requested": "Cobrado",
             "sending": "Enviando",
             "tokenAndNetwork": "Token e rede",
             "networkFee": "Taxa de rede",
@@ -824,14 +836,14 @@
         },
         "errors": {
             "insufficientPayment": "Saldo insuficiente para concluir este pagamento com a Peanut",
-            "insufficientRequest": "Saldo insuficiente para concluir esta solicitação com a Peanut",
+            "insufficientRequest": "Saldo insuficiente para concluir esta cobrança com a Peanut",
             "missingData": "dados obrigatórios ausentes",
             "pleaseLoginToContinue": "Faça login para continuar",
             "logInToContinue": "faça login para continuar",
             "paymentDetailsLoadFailed": "não foi possível carregar os detalhes do pagamento",
-            "noRequestId": "nenhum id de solicitação fornecido",
-            "requestLoadFailed": "não foi possível carregar a solicitação. ela pode não existir ou ter sido excluída.",
-            "requestNotFound": "solicitação não encontrada",
+            "noRequestId": "nenhum id de cobrança fornecido",
+            "requestLoadFailed": "não foi possível carregar a cobrança. ela pode não existir ou ter sido excluída.",
+            "requestNotFound": "cobrança não encontrada",
             "invalidUrlFormat": "Formato de URL inválido",
             "invalidPaymentUrl": "url de pagamento inválida",
             "userNotFound": "o usuário @{username} não existe ou não tem uma carteira peanut",
@@ -1761,9 +1773,9 @@
             "cancelDepositRequest": "Cancelar cobrança",
             "cancelDepositFailed": "Não conseguimos cancelar este depósito. Tente de novo ou fale com o suporte.",
             "cancelConfirm": {
-                "title": "{kind, select, deposit {Cancelar este depósito?} request {Cancelar esta solicitação?} other {Cancelar?}}",
+                "title": "{kind, select, deposit {Cancelar este depósito?} request {Cancelar esta cobrança?} other {Cancelar?}}",
                 "description": "Isso não pode ser desfeito. Se você já enviou a transferência bancária, <strong>não cancele</strong> — um depósito cancelado não pode mais ser associado à sua conta e o dinheiro voltará para o seu banco.",
-                "confirm": "{kind, select, deposit {Sim, cancelar o depósito} request {Sim, cancelar a solicitação} other {Sim, cancelar}}"
+                "confirm": "{kind, select, deposit {Sim, cancelar o depósito} request {Sim, cancelar a cobrança} other {Sim, cancelar}}"
             }
         },
         "toast": {
@@ -1911,7 +1923,201 @@
         "shareText": "Ganhei o selo {badge} no Peanut!\n\nEntre no Peanut e comece a ganhar pontos, desbloquear conquistas e movimentar dinheiro pelo mundo\n\n{link}",
         "toastSingle": "Selo desbloqueado: {name}",
         "toastMultiple": "Você desbloqueou {count, plural, one {# selo} other {# selos}} 🎉",
-        "toastTapToView": "— toque para ver"
+        "toastTapToView": "— toque para ver",
+        "catalog": {
+            "FIRST_INVITE": {
+                "name": "Primeiro convite",
+                "description": "Trouxe um amigo para a mesa. Falta só a rede inteira."
+            },
+            "SECOND_INVITE": {
+                "name": "Segundo convite",
+                "description": "A notícia corre: dois amigos dentro e subindo."
+            },
+            "THIRD_INVITE": {
+                "name": "Terceiro convite",
+                "description": "Três amigos, nenhum erro. Tire o chapéu."
+            },
+            "MINI_INFLUENCER": {
+                "name": "Mini influenciador",
+                "description": "Montou um fã-clube pequeno, um convite por vez."
+            },
+            "INFLUENCER_25": {
+                "name": "Influenciador",
+                "description": "Vinte e cinco na conta. As curtidas não param."
+            },
+            "MEGA_INFLUENCER": {
+                "name": "Mega influenciador",
+                "description": "Cem amigos dentro. Agora você é gente grande."
+            },
+            "DUNBAR": {
+                "name": "Dunbar",
+                "description": "150 — mais gente do que dá para lembrar. Chegou ao número de Dunbar."
+            },
+            "MOST_INVITES": {
+                "name": "Mais convites",
+                "description": "Trouxe mais gente do que os anúncios da Coinbase!"
+            },
+            "CERTIFIED_YAPPER": {
+                "name": "Tagarela oficial",
+                "description": "Barulho oficial. Falou de Peanut para a gente não precisar falar."
+            },
+            "GIGA_YAPPER": {
+                "name": "Giga tagarela",
+                "description": "Barulho nível giga. Não fala de Peanut, transmite."
+            },
+            "FIRST_CRUMB": {
+                "name": "Primeiro dólar",
+                "description": "Primeiro dólar ganho. Prova de que rende."
+            },
+            "DOUBLE_DIGITS": {
+                "name": "Dois dígitos",
+                "description": "Passou para dois dígitos. Agora é dinheiro de verdade."
+            },
+            "CARD_FIRST_SWIPE": {
+                "name": "Primeira compra",
+                "description": "Você colocou seu cartão para trabalhar."
+            },
+            "CARD_SPENT_1K": {
+                "name": "Clube dos $1K",
+                "description": "$1K no cartão — você apostou onde estava o seu dinheiro."
+            },
+            "CARD_PIONEER": {
+                "name": "Pioneiro do cartão",
+                "description": "Você garantiu seu lugar no cartão Peanut. As vantagens de pioneiro vêm aí!"
+            },
+            "FOUNDING_PIONEER": {
+                "name": "Pioneiro fundador",
+                "description": "Você já construía Peanut antes de existir lançamento."
+            },
+            "VERIFIED": {
+                "name": "Verificado",
+                "description": "Documento conferido, identidade confirmada. Verificação oficial concluída."
+            },
+            "BETA_TESTER": {
+                "name": "Beta tester",
+                "description": "Você quebrou as coisas para os outros não precisarem. Boas-vindas ao clube do caos."
+            },
+            "OG_2025_10_12": {
+                "name": "OG",
+                "description": "Você é OG de verdade. Estava com Peanut antes de virar moda."
+            },
+            "CARD_CLOSED_BETA": {
+                "name": "Beta fechado",
+                "description": "IYKYK. Testou o cartão antes de você saber que ele existia."
+            },
+            "CARD_ALPHA": {
+                "name": "Testador do alfa fechado",
+                "description": "Você testou o cartão quando ele ainda era fita adesiva e esperança."
+            },
+            "BUG_WHISPERER": {
+                "name": "Caçador de bugs",
+                "description": "Você achou um bug de verdade, avisou e ficou. A cerveja é por nossa conta."
+            },
+            "SUPPORT_SURVIVOR": {
+                "name": "Sobrevivente do suporte",
+                "description": "Você achou um bug de verdade, avisou e ficou. A cerveja é por nossa conta."
+            },
+            "SHHHHH": {
+                "name": "Shhhhh",
+                "description": "Quem sabe, sabe."
+            },
+            "NOT_SO_SHHHH": {
+                "name": "Boca grande",
+                "description": "Você não conseguiu ficar quieto — e ainda recebeu por isso."
+            },
+            "ARBITRUM": {
+                "name": "Nativo da Arbitrum",
+                "description": "Encontrado na Arbitrum — onboarding mútuo concluído."
+            },
+            "FOUNDER_HOUSE": {
+                "name": "Founder Haus",
+                "description": "Você esteve no Founder Haus. Energia on-chain, aperto de mão off-chain."
+            },
+            "ETHFLORIPA_HUB": {
+                "name": "EthFloripa Hub",
+                "description": "Ilha da Magia, baby. Coco e consenso."
+            },
+            "IRL_NOMADS": {
+                "name": "Modo nômade",
+                "description": "Sem endereço fixo, só café bom e wi-fi melhor. Nômade oficial."
+            },
+            "EVENT_ALUMNI": {
+                "name": "Veterano de eventos",
+                "description": "Old school. Você estava na sala antes da maioria."
+            },
+            "TOUCHED_GRASS": {
+                "name": "Pisou na grama",
+                "description": "Você saiu do online e pisou na grama de verdade com Peanut."
+            },
+            "OFFRAMP_USER": {
+                "name": "Usuário de saque",
+                "description": "Você migrou para Peanut. A gente recebeu você bem."
+            },
+            "PSYOPS_DIVISION": {
+                "name": "Divisão Psyops",
+                "description": "Você entrou para a Divisão Psyops. Boas-vindas ao jogo da influência."
+            },
+            "TOKEN_NATION_SP_2026": {
+                "name": "Token Nation 2026",
+                "description": "São Paulo, baby. Você veio, resgatou e marcou o mural."
+            },
+            "FESTA_JUNINA_2026": {
+                "name": "Arraiá aprovado",
+                "description": "Você dançou quadrilha com a gente. Arraiá desbloqueado."
+            },
+            "MANICERO": {
+                "name": "Manicero",
+                "description": "Maní pequeno. Energia grande. Manicero."
+            },
+            "NITA": {
+                "name": "Indicação da Nita",
+                "description": "A Nita indicou você. Você pulou a fila do cartão na palavra dela."
+            },
+            "NAIJA": {
+                "name": "9JA",
+                "description": "Naija no dey carry last. Você chegou primeiro."
+            },
+            "TERERE": {
+                "name": "Tereré",
+                "description": "Tereré desbloqueado. Você estava lá na primeira rodada."
+            },
+            "DEVCONNECT_BA_2025": {
+                "name": "Devconnect 2025",
+                "description": "Nada de anon. Pisou na grama, apertou mãos e respirou o mesmo ar que o Vitalik."
+            },
+            "SEEDLING_DEVCONNECT_BA_2025": {
+                "name": "Semente",
+                "description": "Você trabalha com a gente para espalhar Peanut."
+            },
+            "ARBIVERSE_DEVCONNECT_BA_2025": {
+                "name": "Peanut 🤝 Arbiverse",
+                "description": "Você esteve com a gente no estande do Arbiverse na Devconnect 2025."
+            },
+            "PRODUCT_HUNT": {
+                "name": "Product Hunt",
+                "description": "Vendedor de esperança. Seu upvote pareceu um term sheet de VC!"
+            },
+            "MOST_RESTAURANTS_DEVCON": {
+                "name": "Mais restaurantes na Devcon",
+                "description": "Você é gourmet de verdade!"
+            },
+            "BIG_SPENDER_5K": {
+                "name": "Big Spender 5K",
+                "description": "Você está entre quem mais gasta."
+            },
+            "MOST_PAYMENTS_DEVCON": {
+                "name": "Mais pagamentos na Devcon",
+                "description": "Máquina de dinheiro — você move dinheiro como quem não faz esforço. Mais pagamentos feitos!"
+            },
+            "BIGGEST_REQUEST_POT": {
+                "name": "Maior vaquinha",
+                "description": "Alto rolê ou mestre do pedido? Você criou a vaquinha com mais participantes."
+            },
+            "WAITLIST_SKIP": {
+                "name": "Passe livre",
+                "description": "Você pulou a lista de espera. Um amigo te deu a chave e você entrou direto."
+            }
+        }
     },
     "notifications": {
         "title": "Notificações",
@@ -1928,7 +2134,7 @@
         "migrationSetupTitle": "Receba alertas de dinheiro",
         "migrationSetupDescription": "Avisamos na hora quando o dinheiro chegar ou alguém pedir um pagamento.",
         "enable": "Ativar notificações",
-        "requesting": "Solicitando...",
+        "requesting": "Cobrando...",
         "notNow": "Agora não"
     },
     "kyc": {
@@ -2658,7 +2864,7 @@
         },
         "peanutActionDetailsCard": {
             "sendingTo": "Você está enviando para {recipient}",
-            "youRequested": "Você solicitou",
+            "youRequested": "Você cobrou",
             "sentYou": "{sender} enviou para você",
             "youJustClaimed": "Você acabou de resgatar",
             "youreAdding": "Você está adicionando",
@@ -2758,7 +2964,7 @@
         },
         "userCard": {
             "sendingMoneyTo": "Você está enviando dinheiro para",
-            "requestingMoneyFrom": "Solicitando dinheiro de",
+            "requestingMoneyFrom": "Cobrando de",
             "youReceived": "Você recebeu",
             "isRequesting": "{name} está cobrando",
             "sendingTo": "Enviando para {name}",

--- a/src/utils/__tests__/country-name.utils.test.ts
+++ b/src/utils/__tests__/country-name.utils.test.ts
@@ -1,0 +1,36 @@
+import { localizedCountryName, localizedCountryTitle } from '../country-name.utils'
+
+describe('localizedCountryName', () => {
+    it('translates a known ISO-2 code', () => {
+        expect(localizedCountryName('pt-BR', 'BR', 'Brazil')).toBe('Brasil')
+        expect(localizedCountryName('es-419', 'US', 'United States')).toMatch(/Estados Unidos/)
+    })
+
+    it('keeps the English catalog title in English', () => {
+        expect(localizedCountryName('en', 'BR', 'Brazil')).toBe('Brazil')
+    })
+
+    it('falls back when there is no code', () => {
+        expect(localizedCountryName('pt-BR', undefined, 'Crypto')).toBe('Crypto')
+    })
+
+    it('falls back when Intl echoes the code back instead of a name', () => {
+        // 'QM' is a valid but unassigned code, so `of` returns 'QM' — never show that.
+        expect(localizedCountryName('pt-BR', 'QM', 'Nowhere')).toBe('Nowhere')
+    })
+
+    it('falls back when Intl rejects the code outright', () => {
+        // `of` throws RangeError on an alpha-3 code.
+        expect(localizedCountryName('pt-BR', 'BRA', 'Brazil')).toBe('Brazil')
+    })
+})
+
+describe('localizedCountryTitle', () => {
+    it('reads iso2 off a catalog entry', () => {
+        expect(localizedCountryTitle('pt-BR', { iso2: 'DE', title: 'Germany' })).toBe('Alemanha')
+    })
+
+    it('keeps the title for the crypto pseudo-entry, which has no iso2', () => {
+        expect(localizedCountryTitle('pt-BR', { title: 'Crypto' })).toBe('Crypto')
+    })
+})

--- a/src/utils/country-name.utils.ts
+++ b/src/utils/country-name.utils.ts
@@ -1,0 +1,47 @@
+import { type CountryData } from '@/components/AddMoney/consts'
+
+/**
+ * Country names in `countryData` are English catalog copy. The platform already
+ * ships every translation through `Intl.DisplayNames`, so the localized name is
+ * derived from the ISO-2 code at render time — the message catalogs never carry
+ * ~250 country names per locale.
+ */
+const displayNamesByLocale = new Map<string, Intl.DisplayNames | null>()
+
+function regionDisplayNames(locale: string): Intl.DisplayNames | null {
+    const cached = displayNamesByLocale.get(locale)
+    if (cached !== undefined) return cached
+    let instance: Intl.DisplayNames | null = null
+    try {
+        instance = new Intl.DisplayNames([locale], { type: 'region' })
+    } catch {
+        instance = null
+    }
+    displayNamesByLocale.set(locale, instance)
+    return instance
+}
+
+/**
+ * "BR" → "Brasil" in pt-BR. Falls back to `fallback` when the code is missing or
+ * unmappable — `Intl.DisplayNames.of` echoes the input code back for anything it
+ * does not know, which would show "XK" where a name belongs.
+ */
+export function localizedCountryName(locale: string, iso2: string | undefined, fallback: string): string {
+    if (!iso2) return fallback
+    let name: string | undefined
+    try {
+        name = regionDisplayNames(locale)?.of(iso2)
+    } catch {
+        return fallback
+    }
+    return name && name.toUpperCase() !== iso2.toUpperCase() ? name : fallback
+}
+
+/**
+ * `localizedCountryName` for a catalog entry. Every `type: 'country'` entry
+ * carries `iso2`; the one entry without it is the `crypto` pseudo-country, which
+ * correctly keeps its own title.
+ */
+export function localizedCountryTitle(locale: string, country: Pick<CountryData, 'iso2' | 'title'>): string {
+    return localizedCountryName(locale, country.iso2, country.title)
+}

--- a/src/utils/regions.utils.ts
+++ b/src/utils/regions.utils.ts
@@ -34,9 +34,10 @@ const MANTECA_SUPPORTED_REGIONS = ['LATAM']
 const BRIDGE_SUPPORTED_REGIONS = ['North America', 'Europe']
 
 /** Internal region identifier, NOT display copy — `deriveRegionAccess` branches
- *  on it. If region names ever become localized, this comparison must move to a
- *  stable key (e.g. `path`), or the branch silently dies outside English. */
-const REST_OF_THE_WORLD_REGION = 'Rest of the world'
+ *  on it, so it must stay English. Display copy is localized at the render site
+ *  from the region's `path` (see `useRegionLabel`); exported so the one caller
+ *  that builds a synthetic rest-of-world region does not retype the string. */
+export const REST_OF_THE_WORLD_REGION = 'Rest of the world'
 
 const SUPPORTED_REGIONS: Region[] = [
     {


### PR DESCRIPTION
## Summary

QA of the app in Portuguese (TASK-20958) found four surfaces still rendering English, plus one term the **Cobrar** section names two different ways. This fixes all five.

**Countries** and **regions** were untranslated because they are static English catalog data rendered straight to the screen.

- Countries now resolve through `Intl.DisplayNames` from the ISO-2 code `countryData` already carries. No locale ships ~250 country names, and every locale we add gets country names for free. The English `title` stays searchable, so typing "Brazil" still finds "Brasil"; sorting and collation follow the active locale.
- Regions keep their English `name` — `deriveRegionAccess` branches on it, and the code comment there already warned that localizing it would silently kill that branch. Display copy resolves from the stable `path` against a new shared `common.regions` catalog, which also absorbs the old `limits.restOfWorld` so the label lives in one place.

**Badge names and reasons** come from the backend catalog, which ships English only. A `badges.catalog` namespace keyed by badge code now supplies localized copy for all 48 codes (pt-BR + es-419). The backend prose stays the fallback, so a badge added after this build still renders rather than showing a raw key.

**"Cobrar" terminology**: in Portuguese the money request a user creates from that section is a *cobrança*, not a *solicitação* (which reads as a support ticket). Aligned across the `request`, `payment`, `transaction`, `global` and `loadingStates` namespaces — one name for one thing.

## Task

TASK-20958 — https://www.notion.so/63f83811757982508d5a8131c25f12bf

## Findings → fix

| Finding (from the task) | Fix |
|---|---|
| Countries are not translated | `Intl.DisplayNames` at every country render site |
| Regions are not translated (North America, Europe, LATAM, Rest of the world) | new `common.regions` catalog, resolved by region `path` |
| Badge "Motivos" are in EN (shh = "You know the secret") | `badges.catalog` — SHHHHH now reads "Quem sabe, sabe." |
| "Deixe vazio para quem paga escolher o valor" | "Deixe sem valor para o pagador escolher." |
| "Criar solicitação" → "Criar cobrança" | done, plus the 20 sibling strings that used the same wrong term |

## Design notes / accepted trade-offs

- **`Intl.DisplayNames` over a translated country list.** The platform already ships CLDR country names for every locale. Two guards are load-bearing and tested: `of()` echoes the input back for a valid-but-unassigned code (`QM`), and throws `RangeError` on an alpha-3 code — both fall back to the English catalog title.
- **The FE badge catalog now wins over the backend name for known codes.** That is the point — the backend cannot localize. Unknown codes still fall through to backend prose, and there is a test for it. One existing test that asserted backend-name precedence was updated, and a fallback test added alongside it.
- **es-419 badge copy is deliberately neutral between tuteo and voseo**, so the deltas-only `es-AR` overlay does not have to re-translate 48 badges. The glossary test enforces this.
- **`limits.restOfWorld` was removed**, not duplicated — its one consumer now reads the shared catalog.

## Risks

- Copy-only in behavior, but it touches shared render paths (`CountryList`, region lists, all five badge surfaces). No API, no money path, no state machine.
- Country names in the picker change for every non-English locale — that is the intended fix, and the English title stays searchable so no user loses a search term they were used to.
- No cross-repo action needed. The backend badge catalog is unchanged and stays authoritative for English.

## QA

- `npm run typecheck`, `npm test` (236 suites / 3033 tests), `pnpm prettier --check .`, `npm run build` — all green locally.
- New tests: `src/utils/__tests__/country-name.utils.test.ts`, `src/hooks/__tests__/useRegionLabel.test.ts`, plus a badge-fallback case in `BadgeEarnToast.test.tsx`.
- The catalog gates already in the repo cover the rest: key parity across locales, duplicate-value drift, ICU compilation, and the pt-BR/es glossary rules.
- Manual: switch the app language to Português in Settings, then check the country picker (Add money / Withdraw), Profile → Limits, Profile → Badges, and the Cobrar flow.

## What the diff cannot show

Country names are not strings in this diff — they come out of `Intl.DisplayNames` at render time. This is what the picker actually renders in Portuguese:

| ISO-2 | before (catalog) | after (pt-BR) |
|---|---|---|
| US | United States | Estados Unidos |
| BR | Brazil | Brasil |
| DE | Germany | Alemanha |
| GB | United Kingdom | Reino Unido |
| ES | Spain | Espanha |
| NL | Netherlands | Países Baixos |
| CH | Switzerland | Suíça |
| AE | United Arab Emirates | Emirados Árabes Unidos |
| ZA | South Africa | África do Sul |
| JP | Japan | Japão |
| SE | Sweden | Suécia |
| PL | Poland | Polônia |

Regions: Europa · América do Norte · América Latina · Resto do mundo.

**Screenshots: ⚠️ NONE.** No layout, spacing, control or component changed — this is text substitution inside existing surfaces. I did try the capture pipeline: the sandbox API needs the known `TSX_TSCONFIG_PATH` workaround to boot at all, and after that the seeded users bounce to `/setup` before the target routes render. Rather than keep fighting local state for a copy-only diff, the table above covers the one thing the diff genuinely hides. Reviewing in the app: Settings → Idioma → Português, then Add money (country picker), Profile → Limits, Profile → Badges, Cobrar.

## Follow-ups (not in this PR)

- **The English badge catalog is now a second hand-synced mirror of the backend copy**, alongside the existing `src/types/badge-assets.json`. The generator that comment names (`pnpm badge:check --write-manifest`) no longer exists in peanut-api-ts, so both mirrors drift silently today. Worth one generator that emits both — a peanut-api-ts change, so it does not belong here.
- **`publicDescription` stays English for every badge.** The backend's third-person copy still wins when you view someone else's profile (that is the fix for the review finding), so those tooltips are not localized. Localizing them means a second catalog field × 48 badges — separate PR if we want it.
- **`BADGE_SHARE_LINES` in `badge.utils.ts`** is a third badge-copy mechanism (English-only bespoke share brags with a `locale !== 'en'` bail-out). It could fold into `badges.catalog`.

## Docs impact

None. This changes how existing facts are worded in the pt-BR app UI; it changes no documented customer-facing fact (no fee, limit, supported country, KYC or card rule). Checked `product/`, `content/` and `docs/` for the badge, region and request copy this PR touches — no hits.
