### PR TITLE
fix(qr-drawer): stop browser hijacking the expand swipe

### DIFF
--- a/src/components/Global/Drawer/index.tsx
+++ b/src/components/Global/Drawer/index.tsx
@@ -26,10 +26,12 @@ DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName
 type DrawerContentProps = React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content> & {
     /** Screen-reader-only DialogTitle for drawers without a visible DrawerTitle (Radix a11y requirement). */
     accessibleTitle?: string
+    /** Merged onto the inner scroll wrapper — the element that owns panning when content overflows. */
+    scrollAreaClassName?: string
 }
 
 const DrawerContent = React.forwardRef<React.ElementRef<typeof DrawerPrimitive.Content>, DrawerContentProps>(
-    ({ className, children, accessibleTitle, ...props }, ref) => (
+    ({ className, children, accessibleTitle, scrollAreaClassName, ...props }, ref) => (
         <DrawerPortal>
             <DrawerOverlay />
             <DrawerPrimitive.Content
@@ -45,7 +47,12 @@ const DrawerContent = React.forwardRef<React.ElementRef<typeof DrawerPrimitive.C
                 {accessibleTitle && <DrawerTitle className="sr-only">{accessibleTitle}</DrawerTitle>}
                 <div className="mx-auto my-4 h-1.5 w-10 rounded-full bg-black" />
                 <div className="flex w-full justify-center">
-                    <div className="max-h-[80vh] w-full overflow-auto pb-[env(safe-area-inset-bottom)] md:max-w-xl">
+                    <div
+                        className={twMerge(
+                            'max-h-[80vh] w-full overflow-auto pb-[env(safe-area-inset-bottom)] md:max-w-xl',
+                            scrollAreaClassName
+                        )}
+                    >
                         {children}
                     </div>
                 </div>

--- a/src/components/Global/QRBottomDrawer/index.tsx
+++ b/src/components/Global/QRBottomDrawer/index.tsx
@@ -14,12 +14,14 @@ interface QRBottomDrawerProps {
     className?: string
 }
 
+// module scope: a per-render array changes identity every render, which makes
+// vaul's snap-sync effect refire and re-apply the transform transition
+const snapPoints = [0.75, 1]
+
 const QRBottomDrawer = ({ url, collapsedTitle, expandedTitle, text, buttonText, className }: QRBottomDrawerProps) => {
     const t = useTranslations('global')
     const tCommon = useTranslations('common')
     const contentRef = useRef<HTMLDivElement>(null)
-
-    const snapPoints = [0.75, 1]
     const [activeSnapPoint, setActiveSnapPoint] = useState<number | string | null>(snapPoints[0])
 
     const handleSnapPointChange = (snapPoint: number | string | null) => {
@@ -34,8 +36,16 @@ const QRBottomDrawer = ({ url, collapsedTitle, expandedTitle, text, buttonText, 
                 activeSnapPoint={activeSnapPoint}
                 setActiveSnapPoint={handleSnapPointChange}
                 modal={false}
+                // drag-down at the first snap point otherwise calls vaul's closeDrawer(),
+                // which collides with the forced open={true} (close/reopen flicker + a
+                // 500ms window where vaul ignores all drags after the reopen)
+                dismissible={false}
             >
-                <DrawerContent className={`min-h-[200px] p-5 ${className || ''}`}>
+                {/* touch-none: modal={false} disables vaul's scroll prevention, so without
+                    it the browser claims the swipe as a scroll and fires pointercancel —
+                    the drag aborts and the drawer needs a second swipe. content fits the
+                    drawer at full snap, so no inner scrolling is lost. */}
+                <DrawerContent className={`min-h-[200px] touch-none p-5 ${className || ''}`}>
                     <DrawerTitle className="mb-8 space-y-2">
                         <h2 className="text-lg font-bold">
                             {activeSnapPoint === snapPoints[0] ? collapsedTitle : expandedTitle}

--- a/src/components/Global/QRBottomDrawer/index.tsx
+++ b/src/components/Global/QRBottomDrawer/index.tsx
@@ -44,12 +44,13 @@ const QRBottomDrawer = ({ url, collapsedTitle, expandedTitle, text, buttonText, 
             >
                 {/* modal={false} turns off vaul's scroll prevention. without touch-none the
                     browser claims the swipe as a scroll, fires pointercancel, and the drawer
-                    needs two swipes. scrollAreaClassName repeats it on the inner scroll
-                    wrapper — the outer class stops governing touches once content overflows
-                    that wrapper (small viewports, large OS text). */}
+                    needs two swipes. the inner scroll wrapper needs its own copy — the outer
+                    class stops governing touches once content overflows that wrapper (small
+                    viewports, large OS text). only while collapsed: at full snap the wrapper
+                    must scroll again, or overflowing content is unreachable. */}
                 <DrawerContent
                     className={`min-h-[200px] touch-none p-5 ${className || ''}`}
-                    scrollAreaClassName="touch-none"
+                    scrollAreaClassName={activeSnapPoint === snapPoints[0] ? 'touch-none' : undefined}
                 >
                     <DrawerTitle className="mb-8 space-y-2">
                         <h2 className="text-lg font-bold">

--- a/src/components/Global/QRBottomDrawer/index.tsx
+++ b/src/components/Global/QRBottomDrawer/index.tsx
@@ -37,17 +37,18 @@ const QRBottomDrawer = ({ url, collapsedTitle, expandedTitle, text, buttonText, 
                 modal={false}
                 // drag-down at the first snap point otherwise calls vaul's closeDrawer().
                 // that collides with the forced open={true}: close/reopen flicker, then a
-                // 500ms window where vaul ignores all drags. dismissible={false} prevents it.
-                // vaul 1.1.2 note: a fast down-flick at the first snap then hits a benign
-                // out-of-bounds snap index inside vaul. re-test that path on a vaul upgrade.
+                // 500ms window where vaul ignores all drags. with dismissible={false} vaul
+                // ignores drag-down at the collapsed snap — the drawer does not move.
+                // vaul 1.1.2 note: releasing that drag hits a benign out-of-bounds snap
+                // index inside vaul. re-test that path on a vaul upgrade.
                 dismissible={false}
             >
                 {/* modal={false} turns off vaul's scroll prevention. without touch-none the
-                    browser claims the swipe as a scroll, fires pointercancel, and the drawer
-                    needs two swipes. the inner scroll wrapper needs its own copy — the outer
-                    class stops governing touches once content overflows that wrapper (small
-                    viewports, large OS text). only while collapsed: at full snap the wrapper
-                    must scroll again, or overflowing content is unreachable. */}
+                    browser claims a swipe as a scroll, fires pointercancel, and the drawer
+                    needs two swipes. the touch-action walk stops at the shared overflow-auto
+                    wrapper (even when nothing overflows), so the outer class only covers the
+                    drag handle area. content touches need the wrapper's own copy, applied
+                    only while collapsed so overflowing content can scroll at full snap. */}
                 <DrawerContent
                     className={`min-h-[200px] touch-none p-5 ${className || ''}`}
                     scrollAreaClassName={activeSnapPoint === snapPoints[0] ? 'touch-none' : undefined}

--- a/src/components/Global/QRBottomDrawer/index.tsx
+++ b/src/components/Global/QRBottomDrawer/index.tsx
@@ -2,7 +2,7 @@ import Divider from '@/components/0_Bruddle/Divider'
 import QRCodeWrapper from '@/components/Global/QRCodeWrapper'
 import ShareButton from '@/components/Global/ShareButton'
 import { useTranslations } from 'next-intl'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import { Drawer, DrawerContent, DrawerTitle } from '../Drawer'
 
 interface QRBottomDrawerProps {
@@ -14,14 +14,13 @@ interface QRBottomDrawerProps {
     className?: string
 }
 
-// module scope: a per-render array changes identity every render, which makes
-// vaul's snap-sync effect refire and re-apply the transform transition
+// module scope: a new array each render makes vaul's snap-sync effect refire
+// and re-apply the transform transition on every parent re-render
 const snapPoints = [0.75, 1]
 
 const QRBottomDrawer = ({ url, collapsedTitle, expandedTitle, text, buttonText, className }: QRBottomDrawerProps) => {
     const t = useTranslations('global')
     const tCommon = useTranslations('common')
-    const contentRef = useRef<HTMLDivElement>(null)
     const [activeSnapPoint, setActiveSnapPoint] = useState<number | string | null>(snapPoints[0])
 
     const handleSnapPointChange = (snapPoint: number | string | null) => {
@@ -36,22 +35,28 @@ const QRBottomDrawer = ({ url, collapsedTitle, expandedTitle, text, buttonText, 
                 activeSnapPoint={activeSnapPoint}
                 setActiveSnapPoint={handleSnapPointChange}
                 modal={false}
-                // drag-down at the first snap point otherwise calls vaul's closeDrawer(),
-                // which collides with the forced open={true} (close/reopen flicker + a
-                // 500ms window where vaul ignores all drags after the reopen)
+                // drag-down at the first snap point otherwise calls vaul's closeDrawer().
+                // that collides with the forced open={true}: close/reopen flicker, then a
+                // 500ms window where vaul ignores all drags. dismissible={false} prevents it.
+                // vaul 1.1.2 note: a fast down-flick at the first snap then hits a benign
+                // out-of-bounds snap index inside vaul. re-test that path on a vaul upgrade.
                 dismissible={false}
             >
-                {/* touch-none: modal={false} disables vaul's scroll prevention, so without
-                    it the browser claims the swipe as a scroll and fires pointercancel —
-                    the drag aborts and the drawer needs a second swipe. content fits the
-                    drawer at full snap, so no inner scrolling is lost. */}
-                <DrawerContent className={`min-h-[200px] touch-none p-5 ${className || ''}`}>
+                {/* modal={false} turns off vaul's scroll prevention. without touch-none the
+                    browser claims the swipe as a scroll, fires pointercancel, and the drawer
+                    needs two swipes. scrollAreaClassName repeats it on the inner scroll
+                    wrapper — the outer class stops governing touches once content overflows
+                    that wrapper (small viewports, large OS text). */}
+                <DrawerContent
+                    className={`min-h-[200px] touch-none p-5 ${className || ''}`}
+                    scrollAreaClassName="touch-none"
+                >
                     <DrawerTitle className="mb-8 space-y-2">
                         <h2 className="text-lg font-bold">
                             {activeSnapPoint === snapPoints[0] ? collapsedTitle : expandedTitle}
                         </h2>
                     </DrawerTitle>
-                    <div ref={contentRef}>
+                    <div>
                         <QRCodeWrapper url={url} />
                         <div className="mx-auto mt-4 w-full p-2 text-center text-base text-gray-500">{text}</div>
                         <Divider className="text-gray-500" text={tCommon('or')} />


### PR DESCRIPTION
## Summary

AB reported the "My QR" bottom drawer on the scanner often needs two upward swipes and feels laggy (TASK-20720). Root cause: the drawer runs with `modal={false}`, which disables vaul's scroll prevention, and nothing set `touch-action` on the drawer content. The browser is free to claim an upward swipe as a scroll and fire `pointercancel` — vaul aborts the drag mid-way and the drawer springs back. The second swipe works because the scroll chain is already exhausted. The abort + spring-back is also most of the perceived lag.

Three targeted changes in `QRBottomDrawer`:

1. `touch-none` on the drawer content — the browser never takes over the gesture, so the pointer stream reaches vaul intact and one swipe expands the drawer. Content fits the drawer at full snap, so no inner scrolling is lost.
2. `dismissible={false}` restored — drag-down at the first snap point was calling vaul's `closeDrawer()` against the forced `open={true}` (the exact collision #2005/#2008/#2012 fixed), causing a close/reopen flicker plus a 500ms window after reopen where vaul ignores all drags. It was dropped by accident in 80d930cf8.
3. `snapPoints` hoisted to module scope — a per-render array changes identity every render, making vaul's snap-sync effect refire and re-apply the transform transition on every parent re-render.

The title swap between "My QR" and "Show QR to Get Paid" across snap states is intended behavior and unchanged.

## Task

TASK-20720 — https://app.notion.com/p/peanutprotocol/39f83811757980a9bfa2fea6236092a7

## Risks / breaking changes

- Scoped to one component; no API or cross-repo impact.
- `touch-none` disables inner content scrolling only while the drawer is collapsed. At full snap the scroll wrapper scrolls normally, so overflowing content (SE-class viewports, large OS text) stays reachable.
- `dismissible={false}` means vaul ignores drag-down at the collapsed snap — the drawer does not move. Intended, since the drawer was never actually dismissible (`open={true}`).

## QA

Touch-cancel semantics don't reproduce in desktop emulation — verify on a real phone:

1. Open the scanner (scan button), drawer appears collapsed at "My QR".
2. One upward swipe expands it to "Show QR to Get Paid" — first try, no bounce-back.
3. Drag down from collapsed: the drawer does not move — no flicker or duplication.
4. Share button and QR render unchanged.

Screenshots: N/A (no visible change — gesture/interaction fix only, rendered output is identical).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the QR drawer’s stability when it is forced open.
  * Prevented accidental dismissal and drag-related flickering during touch interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Design notes / accepted trade-offs

- Forced `open={true}` fighting vaul's dismissal model is the recurring root of this drawer's bug history (#2005, #2008, #2012, `80d930cf8`, this PR) — flagged as a deep-dive follow-up, out of scope here.
- On SE-class viewports at full snap, a drag-down that starts on overflowing content can still race the inner scroller's overscroll. Rare, degrades to a second swipe, and the alternative (blanket `touch-none`) made content unreachable — this side of the trade-off was chosen deliberately.
- vaul 1.1.2 pinned-behavior note: with `dismissible={false}`, a fast down-flick at the collapsed snap hits a benign out-of-bounds snap index inside vaul (clamped internally). Re-test on any vaul upgrade.

