### PR TITLE
feat: carry the deferred deep-link payload on every store bounce + fix /invite native dead-end

### DIFF
--- a/src/components/Claim/Link/SendLinkActionList.tsx
+++ b/src/components/Claim/Link/SendLinkActionList.tsx
@@ -190,11 +190,15 @@ export default function SendLinkActionList({
 
     const handleContinueWithPeanut = () => {
         // migration window: web signups are closed — hand the guest to the
-        // app stores instead (QR modal on desktop, store link on mobile)
-        if (!isLoggedIn && interceptGuestCta()) return
+        // app stores instead (QR modal on desktop, store link on mobile).
+        // the sender's invite code rides the deferred hand-off explicitly —
+        // no cookie is written until /invite, which a guest never reaches.
+        // dest defaults to this claim path (the #p= secret never rides).
+        const rawUsername = claimLinkData?.sender?.username
+        const guestInvite = isInviteLink && rawUsername ? toInviteCode(rawUsername) : undefined
+        if (!isLoggedIn && interceptGuestCta({ invite: guestInvite })) return
         addParamStep('claim')
         const redirectUri = encodeURIComponent(window.location.pathname + window.location.search + window.location.hash)
-        const rawUsername = claimLinkData?.sender?.username
         if (isInviteLink && !userHasAppAccess && rawUsername) {
             const inviteCode = toInviteCode(rawUsername)
             dispatch(setupActions.setInviteCode(inviteCode))

--- a/src/components/Claim/Link/SendLinkActionList.tsx
+++ b/src/components/Claim/Link/SendLinkActionList.tsx
@@ -18,7 +18,7 @@
 import StatusBadge from '../../Global/Badges/StatusBadge'
 import IconStack from '../../Global/IconStack'
 import { ClaimBankFlowStep, useClaimBankFlow } from '@/context/ClaimBankFlowContext'
-import { toInviteCode } from '@/utils/general.utils'
+import { toInviteCode, inviteFlowUrl } from '@/utils/general.utils'
 import { type ClaimLinkData } from '@/services/sendLinks'
 import { formatUnits } from 'viem'
 import { useContext, useMemo, useState } from 'react'
@@ -203,7 +203,7 @@ export default function SendLinkActionList({
             const inviteCode = toInviteCode(rawUsername)
             dispatch(setupActions.setInviteCode(inviteCode))
             dispatch(setupActions.setInviteType(EInviteType.PAYMENT_LINK))
-            router.push(`/invite?code=${inviteCode}&redirect_uri=${redirectUri}`)
+            router.push(inviteFlowUrl(inviteCode, redirectUri))
         } else {
             router.push(`/setup?redirect_uri=${redirectUri}`)
         }

--- a/src/components/LandingPage/LandingPageClient.tsx
+++ b/src/components/LandingPage/LandingPageClient.tsx
@@ -16,7 +16,7 @@ import { MIGRATION_SURFACES, STORE_URL } from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
 import { useTranslations } from 'next-intl'
-import { trackStoreClick } from '@/utils/migration.utils'
+import { openStore } from '@/utils/migration.utils'
 
 type FAQQuestion = {
     id: string
@@ -82,8 +82,12 @@ export function LandingPageClient({
             icon: store === 'ios' ? 'apple-logo' : 'google-play',
             // keep the content-system subtext (e.g. "Join +10,000 cool people")
             subtext: heroConfig.primaryCta.subtext,
-            // the anchor navigates; only track here
-            onClick: () => trackStoreClick(store, MIGRATION_SURFACES.LANDING_HERO),
+            // route the tap through openStore so the deferred hand-off rides
+            // (tracks internally); href stays as the non-click fallback
+            onClick: (e) => {
+                e.preventDefault()
+                openStore(store, MIGRATION_SURFACES.LANDING_HERO)
+            },
         }
     }, [migrationOn, deviceType, isDesktop, heroConfig.primaryCta, tMigration])
 

--- a/src/components/LandingPage/LandingPageClient.tsx
+++ b/src/components/LandingPage/LandingPageClient.tsx
@@ -12,11 +12,11 @@ import type { LandingStrings } from './landingStrings'
 import type { Locale } from '@/i18n/types'
 import StoreBadges from '@/components/Migration/StoreBadges'
 import { type CTAButton } from '@/components/LandingPage/landing.types'
-import { MIGRATION_SURFACES, STORE_URL } from '@/constants/migration.consts'
+import { MIGRATION_SURFACES } from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
 import { useTranslations } from 'next-intl'
-import { openStore } from '@/utils/migration.utils'
+import { onStoreAnchorClick, storeAnchorHref } from '@/utils/migration.utils'
 
 type FAQQuestion = {
     id: string
@@ -77,17 +77,15 @@ export function LandingPageClient({
         const store = deviceType === DeviceType.ANDROID ? 'android' : 'ios'
         return {
             label: tMigration('downloadNow'),
-            href: STORE_URL[store],
+            href: storeAnchorHref(store),
             isExternal: true,
             icon: store === 'ios' ? 'apple-logo' : 'google-play',
             // keep the content-system subtext (e.g. "Join +10,000 cool people")
             subtext: heroConfig.primaryCta.subtext,
-            // route the tap through openStore so the deferred hand-off rides
-            // (tracks internally); href stays as the non-click fallback
-            onClick: (e) => {
-                e.preventDefault()
-                openStore(store, MIGRATION_SURFACES.LANDING_HERO)
-            },
+            // the anchor navigates itself (works even where window.open is
+            // suppressed — in-app browsers); android's hand-off rides the href,
+            // ios' rides the clipboard written here inside the tap
+            onClick: () => onStoreAnchorClick(store, MIGRATION_SURFACES.LANDING_HERO),
         }
     }, [migrationOn, deviceType, isDesktop, heroConfig.primaryCta, tMigration])
 

--- a/src/components/LandingPage/StickyMobileCTA.tsx
+++ b/src/components/LandingPage/StickyMobileCTA.tsx
@@ -9,7 +9,7 @@ import { MIGRATION_SURFACES, STORE_URL } from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
 import { useTranslations } from 'next-intl'
-import { trackStoreClick } from '@/utils/migration.utils'
+import { openStore } from '@/utils/migration.utils'
 
 export function StickyMobileCTA({ strings }: { strings: LandingStrings }) {
     const [visible, setVisible] = useState(false)
@@ -61,7 +61,12 @@ export function StickyMobileCTA({ strings }: { strings: LandingStrings }) {
                             target="_blank"
                             rel="noopener noreferrer"
                             className="pointer-events-auto block"
-                            onClick={() => trackStoreClick(store, MIGRATION_SURFACES.LANDING_HERO)}
+                            onClick={(e) => {
+                                // route through openStore so the deferred
+                                // hand-off rides; href is the fallback
+                                e.preventDefault()
+                                openStore(store, MIGRATION_SURFACES.LANDING_HERO)
+                            }}
                         >
                             <Button
                                 variant="purple"

--- a/src/components/LandingPage/StickyMobileCTA.tsx
+++ b/src/components/LandingPage/StickyMobileCTA.tsx
@@ -1,15 +1,15 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import Link from 'next/link'
 import { Button } from '@/components/0_Bruddle/Button'
 import type { LandingStrings } from './landingStrings'
-import { MIGRATION_SURFACES, STORE_URL } from '@/constants/migration.consts'
+import { MIGRATION_SURFACES } from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
 import { useTranslations } from 'next-intl'
-import { openStore } from '@/utils/migration.utils'
+import { onStoreAnchorClick, storeAnchorHref } from '@/utils/migration.utils'
 
 export function StickyMobileCTA({ strings }: { strings: LandingStrings }) {
     const [visible, setVisible] = useState(false)
@@ -19,6 +19,9 @@ export function StickyMobileCTA({ strings }: { strings: LandingStrings }) {
     const tMigration = useTranslations('migration')
     const { deviceType } = useDeviceType()
     const store = deviceType === DeviceType.ANDROID ? 'android' : 'ios'
+    // memoized: this bar re-renders through scroll-driven animation frames,
+    // and the android href builds the hand-off payload (cookie reads)
+    const storeHref = useMemo(() => storeAnchorHref(store), [store])
 
     useEffect(() => {
         const check = () => {
@@ -57,16 +60,11 @@ export function StickyMobileCTA({ strings }: { strings: LandingStrings }) {
                         // this bar is md:hidden so the visitor is on a phone —
                         // deep-link their store during the migration window
                         <a
-                            href={STORE_URL[store]}
+                            href={storeHref}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="pointer-events-auto block"
-                            onClick={(e) => {
-                                // route through openStore so the deferred
-                                // hand-off rides; href is the fallback
-                                e.preventDefault()
-                                openStore(store, MIGRATION_SURFACES.LANDING_HERO)
-                            }}
+                            onClick={() => onStoreAnchorClick(store, MIGRATION_SURFACES.LANDING_HERO)}
                         >
                             <Button
                                 variant="purple"

--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -267,6 +267,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         // Passive auth expiry does not run this cleanup and retains retries.
         clearPendingBadgeCampaigns()
 
+        // The invite cookie routes /setup past Landing — the only screen with
+        // Log In. A signed-in native user who tapped a friend's invite App Link
+        // has it set; leaving it through logout would strand them on Signup,
+        // unable to log back in until the process dies (session cookie).
+        removeFromCookie('inviteCode')
+
         // A cached step-up proof outliving the session would let the next user
         // of this device skip verification on card and withdrawal screens.
         clearStepUpToken()

--- a/src/features/payments/flows/contribute-pot/components/RequestPotActionList.tsx
+++ b/src/features/payments/flows/contribute-pot/components/RequestPotActionList.tsx
@@ -31,7 +31,7 @@ import { MIN_BANK_TRANSFER_AMOUNT, validateMinimumAmount } from '@/constants/pay
 import { useAppDispatch } from '@/redux/hooks'
 import { setupActions } from '@/redux/slices/setup-slice'
 import { EInviteType } from '@/services/services.types'
-import { saveRedirectUrl, saveToLocalStorage, toInviteCode } from '@/utils/general.utils'
+import { saveRedirectUrl, saveToLocalStorage, toInviteCode, inviteFlowUrl } from '@/utils/general.utils'
 import SendWithPeanutCta from '@/features/payments/shared/components/SendWithPeanutCta'
 import { useTranslations } from 'next-intl'
 
@@ -142,7 +142,7 @@ export function RequestPotActionList({
                         const inviteCode = toInviteCode(recipientUsername)
                         dispatch(setupActions.setInviteCode(inviteCode))
                         dispatch(setupActions.setInviteType(EInviteType.PAYMENT_LINK))
-                        router.push(`/invite?code=${inviteCode}&redirect_uri=${redirectUri}`)
+                        router.push(inviteFlowUrl(inviteCode, redirectUri))
                     } else {
                         router.push(`/setup?redirect_uri=${redirectUri}`)
                     }

--- a/src/features/payments/shared/components/SendWithPeanutCta.tsx
+++ b/src/features/payments/shared/components/SendWithPeanutCta.tsx
@@ -68,8 +68,10 @@ export default function SendWithPeanutCta({
         // if auth is required and user is not logged in, redirect to signup
         if (requiresAuth && !isLoggedIn) {
             // migration window: web signups are closed — hand the guest to the
-            // app stores instead (QR modal on desktop, store link on mobile)
-            if (interceptGuestCta()) return
+            // app stores instead (QR modal on desktop, store link on mobile).
+            // the inviter rides the deferred hand-off, mirroring the web path
+            // below that routes to /invite?code=<inviter>
+            if (interceptGuestCta({ invite: inviterUsername ? toInviteCode(inviterUsername) : undefined })) return
             const redirectUri = encodeURIComponent(
                 window.location.pathname + window.location.search + window.location.hash
             )

--- a/src/features/payments/shared/components/SendWithPeanutCta.tsx
+++ b/src/features/payments/shared/components/SendWithPeanutCta.tsx
@@ -16,7 +16,7 @@ import { useAuth } from '@/context/authContext'
 import { useAppDispatch } from '@/redux/hooks'
 import { setupActions } from '@/redux/slices/setup-slice'
 import { EInviteType } from '@/services/services.types'
-import { saveRedirectUrl, saveToLocalStorage, toInviteCode } from '@/utils/general.utils'
+import { saveRedirectUrl, saveToLocalStorage, toInviteCode, inviteFlowUrl } from '@/utils/general.utils'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { useMemo } from 'react'
@@ -79,7 +79,7 @@ export default function SendWithPeanutCta({
                 const inviteCode = toInviteCode(inviterUsername)
                 dispatch(setupActions.setInviteCode(inviteCode))
                 dispatch(setupActions.setInviteType(EInviteType.PAYMENT_LINK))
-                router.push(`/invite?code=${inviteCode}&redirect_uri=${redirectUri}`)
+                router.push(inviteFlowUrl(inviteCode, redirectUri))
             } else {
                 saveRedirectUrl()
                 router.push('/setup')

--- a/src/hooks/useGuestStoreHandoff.tsx
+++ b/src/hooks/useGuestStoreHandoff.tsx
@@ -7,7 +7,7 @@ import { MIGRATION_SURFACES } from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
 import { isCapacitor } from '@/utils/capacitor'
-import { openStore } from '@/utils/migration.utils'
+import { openStore, type StoreHandoff } from '@/utils/migration.utils'
 
 /**
  * Guest-flow store handoff for the migration window (mockup §03/§08): when a
@@ -37,13 +37,16 @@ export function useGuestStoreHandoff({
         posthog.capture(ANALYTICS_EVENTS.MIGRATION_GUEST_CTA_SHOWN, { surface: MIGRATION_SURFACES.GUEST_FLOW })
     }, [trackImpressionWhenGuest, migrationOn])
 
-    const interceptGuestCta = (): boolean => {
+    // handoff: deferred deep-link context the surface knows before any cookie is
+    // written (claim page invite CTA). the desktop QR path can't carry it — the
+    // payload would need to live on the phone that scans, not this browser.
+    const interceptGuestCta = (handoff?: StoreHandoff): boolean => {
         if (!migrationOn || isCapacitor()) return false
         if (deviceType === DeviceType.WEB) {
             setQrOpen(true)
             return true
         }
-        openStore(deviceType === DeviceType.ANDROID ? 'android' : 'ios', MIGRATION_SURFACES.GUEST_FLOW)
+        openStore(deviceType === DeviceType.ANDROID ? 'android' : 'ios', MIGRATION_SURFACES.GUEST_FLOW, handoff)
         return true
     }
 

--- a/src/hooks/useNativePlugins.ts
+++ b/src/hooks/useNativePlugins.ts
@@ -7,7 +7,7 @@ import { captureMessage } from '@sentry/nextjs'
 import { isCapacitor, getPlatform } from '@/utils/capacitor'
 import { localeApplied } from '@/i18n/app/locale-store'
 import { deepLinkToNativePath } from '@/utils/native-routes'
-import { sanitizeRedirectURL } from '@/utils/general.utils'
+import { sanitizeRedirectURL, saveToCookie, toInviteCode } from '@/utils/general.utils'
 import { getOneSignalAdapter } from '@/services/onesignal'
 
 /**
@@ -46,6 +46,19 @@ export function useNativePlugins() {
             // same-origin guard: only ever navigate to an in-app relative path
             const safe = sanitizeRedirectURL(target)
             if (!safe) return false
+            // /invite is rewritten to /setup by the mapper (the landing page is
+            // pruned from the native export) — carry the code via the SESSION
+            // invite cookie, same semantics as the deferred-link restore: it
+            // pre-fills signup but self-heals on restart, so an existing user
+            // re-tapping a friend's invite is never locked out of login. The
+            // side effect lives here because the mapper runs during render.
+            try {
+                const parsed = new URL(url, 'https://peanut.me')
+                if (parsed.pathname.split('/').filter(Boolean)[0] === 'invite') {
+                    const code = toInviteCode(parsed.searchParams.get('code') ?? '')
+                    if (code) saveToCookie('inviteCode', code)
+                }
+            } catch {}
             router.push(safe)
             anyDeepLinkNavigated = true
             return true

--- a/src/utils/__tests__/deferred-link.test.ts
+++ b/src/utils/__tests__/deferred-link.test.ts
@@ -145,6 +145,15 @@ describe('buildDeferredPayload / parseDeferredPayload round-trip', () => {
         expect(parseDeferredPayload(buildDeferredPayload())).toEqual({ lang: 'es-419', dest: '/claim/ABC?x=2' })
     })
 
+    it('omits the default dest when the page url carries a claim secret (#p=)', () => {
+        window.history.replaceState({}, '', '/claim?c=42161&i=99')
+        window.location.hash = '#p=s3cr3t'
+        expect(parseDeferredPayload(buildDeferredPayload())).toEqual({})
+        // an explicit dest still rides — only the default is suppressed
+        expect(parseDeferredPayload(buildDeferredPayload('/home'))).toEqual({ dest: '/home' })
+        window.location.hash = ''
+    })
+
     it('omits dest for the root path and non-locale first segments', () => {
         window.history.replaceState({}, '', '/')
         expect(parseDeferredPayload(buildDeferredPayload())).toEqual({})

--- a/src/utils/__tests__/deferred-link.test.ts
+++ b/src/utils/__tests__/deferred-link.test.ts
@@ -126,6 +126,14 @@ describe('buildDeferredPayload / parseDeferredPayload round-trip', () => {
         })
     })
 
+    it('invite argument overrides the cookie (claim CTA knows the code pre-cookie)', () => {
+        saveToCookie('inviteCode', 'cookiecode')
+        expect(parseDeferredPayload(buildDeferredPayload('/home', 'sendercode'))).toEqual({
+            invite: 'sendercode',
+            dest: '/home',
+        })
+    })
+
     it('defaults dest to the current path + query and skips absent fields', () => {
         window.history.replaceState({}, '', '/claim/ABC?x=2')
         const parsed = parseDeferredPayload(buildDeferredPayload())

--- a/src/utils/__tests__/invite-flow-url.test.ts
+++ b/src/utils/__tests__/invite-flow-url.test.ts
@@ -1,0 +1,29 @@
+/** @jest-environment jsdom */
+// inviteFlowUrl — the one route into the invite flow for guest CTAs. web goes
+// to the /invite landing page; native (page pruned from the export) writes the
+// session invite cookie and goes straight to signup.
+
+let mockIsCapacitor = false
+jest.mock('@/utils/capacitor', () => ({
+    isCapacitor: () => mockIsCapacitor,
+}))
+
+import { getFromCookie, inviteFlowUrl } from '@/utils/general.utils'
+
+beforeEach(() => {
+    mockIsCapacitor = false
+    document.cookie = 'inviteCode=; expires=Thu, 01 Jan 1970 00:00:00 GMT'
+})
+
+describe('inviteFlowUrl', () => {
+    it('web routes to the invite landing page and writes no cookie', () => {
+        expect(inviteFlowUrl('alice', '%2Fclaim%2FX')).toBe('/invite?code=alice&redirect_uri=%2Fclaim%2FX')
+        expect(getFromCookie('inviteCode')).toBeFalsy()
+    })
+
+    it('native writes the session cookie and goes straight to signup', () => {
+        mockIsCapacitor = true
+        expect(inviteFlowUrl('alice', '%2Fclaim%2FX')).toBe('/setup?step=signup&redirect_uri=%2Fclaim%2FX')
+        expect(getFromCookie('inviteCode')).toBe('alice')
+    })
+})

--- a/src/utils/__tests__/migration.utils.test.ts
+++ b/src/utils/__tests__/migration.utils.test.ts
@@ -39,7 +39,14 @@ jest.mock('@/utils/deferred-link', () => ({
 
 import { MIGRATION_CUTOVER_DATE, MIGRATION_SURFACES, STORE_URL } from '@/constants/migration.consts'
 import { openExternalUrl } from '@/utils/capacitor'
-import { getMigrationCutoverTime, isPwaSunsetOn, openStore, shouldShowSunsetBlock } from '@/utils/migration.utils'
+import {
+    getMigrationCutoverTime,
+    isPwaSunsetOn,
+    onStoreAnchorClick,
+    openStore,
+    shouldShowSunsetBlock,
+    storeAnchorHref,
+} from '@/utils/migration.utils'
 
 const mockOpenExternalUrl = openExternalUrl as jest.MockedFunction<typeof openExternalUrl>
 
@@ -163,5 +170,34 @@ describe('openStore deferred hand-off', () => {
         expect(mockBuildPayload).not.toHaveBeenCalled()
         expect(mockCopyIOSHandoff).not.toHaveBeenCalled()
         expect(mockOpenExternalUrl).toHaveBeenCalledWith(STORE_URL.ios)
+    })
+})
+
+describe('store anchor helpers (self-navigating CTAs)', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockBuildPayload.mockReturnValue('pnutdl=1')
+    })
+
+    it('android anchor href carries the referrer payload', () => {
+        expect(storeAnchorHref('android')).toBe(`play://listing?referrer=${encodeURIComponent('pnutdl=1')}`)
+    })
+
+    it('ios anchor href stays bare — the clipboard rides on click instead', () => {
+        expect(storeAnchorHref('ios')).toBe(STORE_URL.ios)
+        onStoreAnchorClick('ios', MIGRATION_SURFACES.LANDING_HERO)
+        expect(mockCopyIOSHandoff).toHaveBeenCalledWith('pnutdl=1')
+    })
+
+    it('android click only tracks — the href already carries the payload', () => {
+        onStoreAnchorClick('android', MIGRATION_SURFACES.LANDING_HERO)
+        expect(mockCopyIOSHandoff).not.toHaveBeenCalled()
+    })
+
+    it('a payload failure falls back to the bare store url', () => {
+        mockBuildPayload.mockImplementation(() => {
+            throw new Error('no window')
+        })
+        expect(storeAnchorHref('android')).toBe(STORE_URL.android)
     })
 })

--- a/src/utils/__tests__/migration.utils.test.ts
+++ b/src/utils/__tests__/migration.utils.test.ts
@@ -27,8 +27,21 @@ jest.mock('@/constants/general.consts', () => ({
 
 jest.mock('posthog-js', () => ({ capture: jest.fn() }))
 
-import { MIGRATION_CUTOVER_DATE } from '@/constants/migration.consts'
-import { getMigrationCutoverTime, isPwaSunsetOn, shouldShowSunsetBlock } from '@/utils/migration.utils'
+// wiring-level mock: buildDeferredPayload's own behavior is pinned in
+// deferred-link.test.ts; here we only assert openStore routes it correctly
+const mockBuildPayload = jest.fn()
+const mockCopyIOSHandoff = jest.fn().mockResolvedValue(undefined)
+jest.mock('@/utils/deferred-link', () => ({
+    buildDeferredPayload: (...args: unknown[]) => mockBuildPayload(...args),
+    playStoreUrlWithReferrer: (payload: string) => `play://listing?referrer=${encodeURIComponent(payload)}`,
+    copyIOSHandoff: (...args: unknown[]) => mockCopyIOSHandoff(...args),
+}))
+
+import { MIGRATION_CUTOVER_DATE, MIGRATION_SURFACES, STORE_URL } from '@/constants/migration.consts'
+import { openExternalUrl } from '@/utils/capacitor'
+import { getMigrationCutoverTime, isPwaSunsetOn, openStore, shouldShowSunsetBlock } from '@/utils/migration.utils'
+
+const mockOpenExternalUrl = openExternalUrl as jest.MockedFunction<typeof openExternalUrl>
 
 const CUTOVER = MIGRATION_CUTOVER_DATE.getTime()
 const AFTER = CUTOVER + 1000
@@ -108,5 +121,47 @@ describe('shouldShowSunsetBlock', () => {
     it('respects the dev cutover override', () => {
         localStorage.setItem('pwa-sunset-cutover', '2020-01-01')
         expect(shouldShowSunsetBlock({ ...base, now: BEFORE })).toBe(true)
+    })
+})
+
+describe('openStore deferred hand-off', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockBuildPayload.mockReturnValue('pnutdl=1&dest=%2Fclaim%2FXYZ')
+    })
+
+    it('android rides the payload on the play install referrer', () => {
+        openStore('android', MIGRATION_SURFACES.GUEST_FLOW)
+        expect(mockOpenExternalUrl).toHaveBeenCalledWith(
+            `play://listing?referrer=${encodeURIComponent('pnutdl=1&dest=%2Fclaim%2FXYZ')}`
+        )
+        expect(mockCopyIOSHandoff).not.toHaveBeenCalled()
+    })
+
+    it('ios copies the hand-off then opens the plain store url', () => {
+        openStore('ios', MIGRATION_SURFACES.GUEST_FLOW)
+        expect(mockCopyIOSHandoff).toHaveBeenCalledWith('pnutdl=1&dest=%2Fclaim%2FXYZ')
+        expect(mockOpenExternalUrl).toHaveBeenCalledWith(STORE_URL.ios)
+    })
+
+    it('passes surface-known invite + dest through to the payload builder', () => {
+        openStore('android', MIGRATION_SURFACES.GUEST_FLOW, { invite: 'sender', dest: '/claim/ABC?t=1' })
+        expect(mockBuildPayload).toHaveBeenCalledWith('/claim/ABC?t=1', 'sender')
+    })
+
+    it('a payload failure never blocks the store bounce', () => {
+        mockBuildPayload.mockImplementation(() => {
+            throw new Error('no window')
+        })
+        openStore('android', MIGRATION_SURFACES.GUEST_FLOW)
+        expect(mockOpenExternalUrl).toHaveBeenCalledWith(STORE_URL.android)
+    })
+
+    it('the native app opens the store with no hand-off', () => {
+        mockIsCapacitor = true
+        openStore('ios', MIGRATION_SURFACES.GUEST_FLOW)
+        expect(mockBuildPayload).not.toHaveBeenCalled()
+        expect(mockCopyIOSHandoff).not.toHaveBeenCalled()
+        expect(mockOpenExternalUrl).toHaveBeenCalledWith(STORE_URL.ios)
     })
 })

--- a/src/utils/__tests__/native-routes.test.ts
+++ b/src/utils/__tests__/native-routes.test.ts
@@ -324,6 +324,14 @@ describe('native-routes', () => {
                 )
             })
 
+            // The invite landing page is pruned from the native export, so an
+            // App Link onto it must land on signup instead of a chunk-error
+            // loop. The code itself rides the invite cookie (openDeepLink).
+            it('rewrites /invite to signup — the landing page is not in the export', () => {
+                expect(deepLinkToNativePath('https://peanut.me/invite?code=kushagra')).toBe('/setup?step=signup')
+                expect(deepLinkToNativePath('/invite')).toBe('/setup?step=signup')
+            })
+
             // The claim-link password lives in the fragment and is never sent to
             // the server (see peanut-link.utils.ts), so dropping it here yields a
             // link that resolves to a claim page with no way to claim.
@@ -390,6 +398,10 @@ describe('native-routes', () => {
         describe('web mode', () => {
             beforeEach(() => {
                 mockIsCapacitor.mockReturnValue(false)
+            })
+
+            it('keeps /invite on the web — the landing page exists there', () => {
+                expect(deepLinkToNativePath('https://peanut.me/invite?code=kushagra')).toBe('/invite?code=kushagra')
             })
 
             it('keeps the path-based receipt url', () => {

--- a/src/utils/__tests__/native-routes.test.ts
+++ b/src/utils/__tests__/native-routes.test.ts
@@ -312,6 +312,23 @@ describe('native-routes', () => {
                 expect(deepLinkToNativePath('/alice?chargeId=charge-123')).toBe('/pay-request?chargeId=charge-123')
             })
 
+            // the root recipient catch-all is pruned from the native export —
+            // a passthrough would chunk-error, so recipient paths funnel into
+            // /send?recipient= and anything unmappable is dropped (null)
+            it('funnels a bare profile path into /send?recipient=', () => {
+                expect(deepLinkToNativePath('/kushagra')).toBe('/send?recipient=kushagra')
+            })
+
+            it('funnels a semantic pay path (user@chain/amount) into /send?recipient=', () => {
+                expect(deepLinkToNativePath('/alice@42161/10usdc')).toBe(
+                    `/send?recipient=${encodeURIComponent('alice@42161/10usdc')}`
+                )
+            })
+
+            it('drops a non-recipient web-only path instead of passing it through', () => {
+                expect(deepLinkToNativePath('/not-a-valid.username')).toBeNull()
+            })
+
             it('leaves a static in-app route untouched', () => {
                 expect(deepLinkToNativePath('https://peanut.me/history')).toBe('/history')
             })

--- a/src/utils/deferred-link.ts
+++ b/src/utils/deferred-link.ts
@@ -118,8 +118,13 @@ export function buildDeferredPayload(dest?: string, invite?: string): string {
         params.append(BADGE_CAMPAIGN_QUERY_PARAM, badgeCampaign)
     }
 
+    // a page whose url carries the claim secret in the fragment (#p=) must not
+    // ride as a default dest: the fragment never rides (by design), so the
+    // restored claim page would render unclaimable. the working path is the
+    // user re-tapping the original link — a universal link with the hash intact.
+    const secretOnPage = dest === undefined && window.location.hash.startsWith('#p=')
     const destination = dest ?? stripLocalePrefix(window.location.pathname) + window.location.search
-    if (destination && destination !== '/') params.set('dest', destination)
+    if (destination && destination !== '/' && !secretOnPage) params.set('dest', destination)
 
     return params.toString()
 }

--- a/src/utils/deferred-link.ts
+++ b/src/utils/deferred-link.ts
@@ -102,15 +102,17 @@ function stripLocalePrefix(path: string): string {
  * builds the payload querystring from the current web context: locale from the
  * /{locale}/ path prefix, invite/badge campaign from their existing cookies, dest
  * from the argument (defaults to the current path + query, locale stripped).
+ * `invite` overrides the cookie for surfaces that know the code before any
+ * cookie is written (the claim page's invite-link CTA).
  */
-export function buildDeferredPayload(dest?: string): string {
+export function buildDeferredPayload(dest?: string, invite?: string): string {
     const params = new URLSearchParams({ [MARKER]: '1' })
 
     const firstSegment = window.location.pathname.split('/').filter(Boolean)[0]
     if (firstSegment && isValidLocale(firstSegment)) params.set('lang', firstSegment)
 
-    const invite = getFromCookie('inviteCode')
-    if (typeof invite === 'string' && invite) params.set('invite', invite)
+    const inviteCode = invite || getFromCookie('inviteCode')
+    if (typeof inviteCode === 'string' && inviteCode) params.set('invite', inviteCode)
 
     for (const badgeCampaign of getPendingBadgeCampaigns()) {
         params.append(BADGE_CAMPAIGN_QUERY_PARAM, badgeCampaign)

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -1,6 +1,7 @@
 import { nativeCurrencyAddresses, supportedPeanutChains, peanutTokenDetails } from '@/constants/general.consts'
 import { STABLE_COINS, ENS_NAME_REGEX } from '@/constants/general.consts'
 import { shareableUrl } from '@/utils/url.utils'
+import { isCapacitor } from '@/utils/capacitor'
 import * as Sentry from '@sentry/nextjs'
 import type { Address, TransactionReceipt } from 'viem'
 import { getAddress, isAddress, erc20Abi } from 'viem'
@@ -883,6 +884,19 @@ export function slugify(text: string): string {
  * people paste `@alice ` or ` Alice`): trims whitespace and strips a leading @.
  */
 export const toInviteCode = (username: string): string => username.trim().replace(/^@/, '').toLowerCase()
+
+/**
+ * invite-flow url for a guest CTA. web routes to the /invite landing page; in
+ * the native export that page is pruned (scripts/native-build.js), so write
+ * the SESSION invite cookie — the same hand-off openDeepLink and the deferred
+ * restore use — and go straight to signup. click handlers only: this writes a
+ * cookie on native, never call it during render.
+ */
+export const inviteFlowUrl = (inviteCode: string, redirectUri: string): string => {
+    if (!isCapacitor()) return `/invite?code=${inviteCode}&redirect_uri=${redirectUri}`
+    saveToCookie('inviteCode', inviteCode)
+    return `/setup?step=signup&redirect_uri=${redirectUri}`
+}
 
 export const generateInviteCodeLink = (username: string) => {
     const inviteCode = toInviteCode(username)

--- a/src/utils/migration.utils.ts
+++ b/src/utils/migration.utils.ts
@@ -10,6 +10,7 @@ import {
 } from '@/constants/migration.consts'
 import { isFeatureFlagEnabled } from '@/utils/featureFlag.utils'
 import { isCapacitor, openExternalUrl } from '@/utils/capacitor'
+import { buildDeferredPayload, copyIOSHandoff, playStoreUrlWithReferrer } from '@/utils/deferred-link'
 
 /**
  * Flag read with a dev-only localStorage override. Local dev never inits
@@ -61,13 +62,43 @@ export function getMigrationCutoverTime(): number {
 }
 
 /** track a store CTA click without navigating (for anchors that navigate themselves). */
-export function trackStoreClick(store: StoreKind, surface: MigrationSurface) {
-    posthog.capture(ANALYTICS_EVENTS.MIGRATION_STORE_CTA_CLICKED, { surface, store })
+export function trackStoreClick(store: StoreKind, surface: MigrationSurface, handoff = false) {
+    posthog.capture(ANALYTICS_EVENTS.MIGRATION_STORE_CTA_CLICKED, { surface, store, handoff })
 }
 
-/** navigate to the app store, tracking which surface sent the user there. */
-export function openStore(store: StoreKind, surface: MigrationSurface) {
-    trackStoreClick(store, surface)
-    // fire-and-forget: native Browser plugin or window.open on web
+/** context a bounce surface knows before any cookie is written (claim page invite CTA). */
+export interface StoreHandoff {
+    invite?: string
+    dest?: string
+}
+
+/**
+ * navigate to the app store, tracking which surface sent the user there.
+ * on web the deferred deep-link payload (TASK-20772) rides along: android via
+ * the Play install referrer, iOS via the clipboard hand-off. both the clipboard
+ * write and the store open must stay inside the tap gesture — no awaits here.
+ */
+export function openStore(store: StoreKind, surface: MigrationSurface, handoff?: StoreHandoff) {
+    // a native guest is already in the app — nothing to hand off
+    if (isCapacitor()) {
+        trackStoreClick(store, surface)
+        void openExternalUrl(STORE_URL[store])
+        return
+    }
+
+    let payload = ''
+    try {
+        payload = buildDeferredPayload(handoff?.dest, handoff?.invite)
+    } catch {
+        // a payload failure must never block the store bounce itself
+    }
+    trackStoreClick(store, surface, !!payload)
+
+    if (store === 'android') {
+        void openExternalUrl(payload ? playStoreUrlWithReferrer(payload) : STORE_URL[store])
+        return
+    }
+    // clipboard write is prompt-free on the web side; the app asks on first launch
+    if (payload) void copyIOSHandoff(payload).catch(() => {})
     void openExternalUrl(STORE_URL[store])
 }

--- a/src/utils/migration.utils.ts
+++ b/src/utils/migration.utils.ts
@@ -102,3 +102,35 @@ export function openStore(store: StoreKind, surface: MigrationSurface, handoff?:
     if (payload) void copyIOSHandoff(payload).catch(() => {})
     void openExternalUrl(STORE_URL[store])
 }
+
+/**
+ * href for a store CTA that is a real anchor and navigates itself: android
+ * carries the hand-off in the url; iOS can't (the clipboard needs the tap) —
+ * pair with onStoreAnchorClick. never preventDefault such an anchor: its own
+ * navigation is the fallback that still works where window.open is suppressed
+ * (in-app browsers, strict popup blockers).
+ */
+export function storeAnchorHref(store: StoreKind): string {
+    if (!isCapacitor() && store === 'android') {
+        try {
+            return playStoreUrlWithReferrer(buildDeferredPayload())
+        } catch {
+            // fall through to the bare url — the bounce itself never breaks
+        }
+    }
+    return STORE_URL[store]
+}
+
+/** tracking + iOS clipboard hand-off for a self-navigating store anchor. */
+export function onStoreAnchorClick(store: StoreKind, surface: MigrationSurface) {
+    if (isCapacitor()) {
+        trackStoreClick(store, surface)
+        return
+    }
+    let payload = ''
+    try {
+        payload = buildDeferredPayload()
+    } catch {}
+    trackStoreClick(store, surface, !!payload)
+    if (store === 'ios' && payload) void copyIOSHandoff(payload).catch(() => {})
+}

--- a/src/utils/native-routes.ts
+++ b/src/utils/native-routes.ts
@@ -104,10 +104,12 @@ function mapDeepLink(url: string): string | null {
     // a claim link's password lives in `#p=<password>` and never reaches the
     // server, so a mapper that drops it turns the link into an unclaimable one.
     // Appending once is the only shape a new route branch can't forget.
-    return `${mapDeepLinkPath(parsed)}${parsed.hash}`
+    const mapped = mapDeepLinkPath(parsed)
+    return mapped === null ? null : `${mapped}${parsed.hash}`
 }
 
-function mapDeepLinkPath(parsed: URL): string {
+// null = the path has no native stand-in and must not be navigated to
+function mapDeepLinkPath(parsed: URL): string | null {
     const path = parsed.pathname
     const extraParams = parsed.search.replace(/^\?/, '')
     const segments = path.split('/').filter(Boolean)
@@ -140,13 +142,19 @@ function mapDeepLinkPath(parsed: URL): string {
         const id = decodeURIComponent(segments[1])
         return appendParams(isCapacitor() ? `/receipt?id=${encodeURIComponent(id)}` : path, extraParams)
     }
-    // `/<username>?chargeId=<uuid>` — the catch-all profile route is disabled in
-    // native builds; /pay-request is its stand-in (see (mobile-ui)/pay-request).
-    // Gated by the same reserved-route/recipient rules the web catch-all uses, so
-    // `/rewards?chargeId=x` stays on /rewards instead of landing on /pay-request.
-    if (isCapacitor() && segments.length === 1 && !isReservedRoute(path) && couldBeRecipient(segments[0])) {
-        const chargeId = parsed.searchParams.get('chargeId')
-        if (chargeId) return chargePayUrl(chargeId)
+    // Non-reserved paths only exist on the web: the root recipient catch-all
+    // ([...recipient]) is pruned from the native export, so a passthrough here
+    // chunk-errors — the /invite class of dead end. Rewrite what has an in-app
+    // stand-in, drop the rest (null = the caller does not navigate).
+    if (isCapacitor() && !isReservedRoute(path)) {
+        if (couldBeRecipient(segments[0])) {
+            const chargeId = parsed.searchParams.get('chargeId')
+            if (chargeId) return chargePayUrl(chargeId)
+            // usernames, addresses and semantic pay paths (user@chain/amount)
+            // all funnel into /send?recipient= — SendRouterView dispatches
+            return recipientPayUrl(decodeURIComponent(segments.join('/')))
+        }
+        return null
     }
 
     return appendParams(path, extraParams)

--- a/src/utils/native-routes.ts
+++ b/src/utils/native-routes.ts
@@ -125,6 +125,14 @@ function mapDeepLinkPath(parsed: URL): string {
     if (segments[0] === 'add-money' || segments[0] === 'withdraw') {
         return rewriteMethodPath(path, extraParams || undefined)
     }
+    // `/invite?code=X` — the invite landing page is pruned from the native
+    // export (scripts/native-build.js), so App Links landing on it hit a
+    // chunk-error reload loop. Route straight to signup; the code travels via
+    // the session invite cookie written in openDeepLink (side effect can't
+    // live here — this mapper runs during render).
+    if (isCapacitor() && segments[0] === 'invite') {
+        return '/setup?step=signup'
+    }
     // `/receipt/<id>?kind=X` — the web receipt page is a server component and is
     // stripped from the static export (scripts/native-build.js), so native routes
     // to the client variant. `kind` rides along in extraParams.


### PR DESCRIPTION
## Summary

The deferred deep-link machinery shipped in native ≥1.0.47 (TASK-20772) but the web never sent it a payload — `openStore()` opened the bare store URL, so only `/dev/deferred` exercised the hand-off. This PR wires the payload into every store-bounce surface and fixes the `/invite` App-Link dead-end in the native app.

- `openStore()` now builds the deferred payload on web: **Android** rides it on the Play install referrer, **iOS** gets the clipboard hand-off written inside the tap gesture. All bounce CTAs (guest claim/invite/request, home banner, download modals) inherit this from the one choke point.
- Claim page guest CTA passes the sender's invite code explicitly (no cookie exists yet at intercept time); the request-page CTA (`SendWithPeanutCta`) passes its `inviterUsername` the same way. dest defaults to the current path — the claim `#p=` secret never rides, by design.
- `/invite?code=X` App Links into the native app hit a pruned route (chunk-error loop). The deep-link mapper now rewrites it to `/setup?step=signup` (capacitor only), with the code carried via the session invite cookie written in `openDeepLink` — same semantics as the deferred restore, so existing users are never locked out of login.
- Telemetry: `migration_store_cta_clicked` gains a `handoff` boolean (denominator). The full match-rate telemetry stays in #2587.

## Task

TASK-21081 — deferred deeplink next steps (Notion)

## Risks / breaking changes

- Web-only behavior change on store CTAs; native app path unchanged (guard). A payload failure falls back to the bare store URL — the bounce itself can never break.
- The `/invite` rewrite + `openDeepLink` cookie are native-side: they only reach devices with the **next mobile-release build**; merging to dev/main alone changes nothing on devices.
- No backend changes.

## QA

- Unit: 3038 pass, 10 new (payload override, openStore routing matrix, /invite mapping web vs native).
- E2E receive side already verified on device (TestFlight + Play internal, v1.0.47–52) via `/dev/deferred`.
- Full flow after this ships: claim/invite link → store bounce → install → open → state restored. Sandbox: `localStorage.setItem('pwa-sunset','true')` to force the migration flag in dev.

## Design notes / accepted trade-offs

- **PublicProfile guest CTA deliberately carries no invite**: its invite validation is async while the store bounce must run inside the tap gesture, and an unvalidated handle must not ride (the typo-fallback would credit the wrong user — same hazard its cookie logic guards, TASK-21044). Its post-intercept cookie write still covers keep-web signups.
- **Desktop QR carries no payload**: the context lives in the desktop browser, not the phone that scans. Cross-device hand-off would need a server-side link — out of scope.
- **Static import of `deferred-link` into `migration.utils`**: required to keep the clipboard write + `window.open` inside the tap gesture (no awaits). Import graph verified client-only.
- Notification `<Link>`s that could hypothetically carry `/invite` don't get the cookie write — declined as unreachable (see resolved CodeRabbit thread).

Screenshots: N/A (no visible change — bounce URLs and native routing only)
