### PR TITLE
fix(shhhhh): list the full waitlist-skip badge set

### DIFF
--- a/src/app/shhhhh/ShhhhhLandingPage.tsx
+++ b/src/app/shhhhh/ShhhhhLandingPage.tsx
@@ -16,6 +16,7 @@ import { cardApi } from '@/services/card'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { badgeCampaignsFromSearchParams, queuePendingBadgeCampaigns } from '@/components/Invites/badge-campaign-context'
 import { claimAndSettlePendingBadgeCampaigns, isConfirmedBadgeCampaignClaim } from '@/services/badge-campaigns'
+import { getBadgeIcon } from '@/components/Badges/badge.utils'
 import { captureException } from '@sentry/nextjs'
 import {
     destinationForShhhhhClaims,
@@ -59,21 +60,22 @@ const statLabelKeys = ['statMerchants', 'statBalance', 'statCard', 'statMiddleme
 
 const faqKeys = ['q1', 'q2', 'q3', 'q4', 'q5', 'q6', 'q7', 'q8'] as const
 
-// The full skip set from the API's badge registry (SKIP_BADGE_CODES): every
-// badge that grants `skip:card-queue`, in either launch phase.
-const badges: Array<{ code: string; name: string; src: string }> = [
-    { code: 'OG_2025_10_12', name: 'Peanut OG', src: '/badges/og_v1.svg' },
-    { code: 'DEVCONNECT_BA_2025', name: 'Devconnect BA', src: '/badges/devconnect_2025.svg' },
-    { code: 'ARBIVERSE_DEVCONNECT_BA_2025', name: 'Arbiverse', src: '/badges/arbiverse_devconnect.svg' },
-    { code: 'SEEDLING_DEVCONNECT_BA_2025', name: 'Seedling', src: '/badges/seedlings_devconnect.svg' },
-    { code: 'EVENT_ALUMNI', name: 'Event Alumni', src: '/badges/event_alumni.svg' },
-    { code: 'CARD_PIONEER', name: 'Founding Pioneer', src: '/badges/founding_pioneer.svg' },
-    { code: 'OFFRAMP_USER', name: 'Offramp User', src: '/badges/offramp_user.png' },
-    { code: 'NAIJA', name: '9JA', src: '/badges/naija.svg' },
-    { code: 'TERERE', name: 'Tereré', src: '/badges/terere.svg' },
-    { code: 'ACAI_POWERED', name: 'Açaí Powered', src: '/badges/acai_powered.svg' },
-    { code: 'NITA', name: 'Nita', src: '/badges/nita.svg' },
-    { code: 'WAITLIST_SKIP', name: 'Skip Pass', src: '/badges/skip_pass.svg' },
+// The full skip set: keep the codes in sync with SKIP_BADGE_CODES
+// (peanut-api-ts src/card/waitlist.ts, pinned in waitlist.test.ts). Icons come
+// from the generated badge-asset manifest, names are marketing-shortened.
+const badges: Array<{ code: string; name: string }> = [
+    { code: 'OG_2025_10_12', name: 'Peanut OG' },
+    { code: 'DEVCONNECT_BA_2025', name: 'Devconnect BA' },
+    { code: 'ARBIVERSE_DEVCONNECT_BA_2025', name: 'Arbiverse' },
+    { code: 'SEEDLING_DEVCONNECT_BA_2025', name: 'Seedling' },
+    { code: 'EVENT_ALUMNI', name: 'Event Alumni' },
+    { code: 'CARD_PIONEER', name: 'Founding Pioneer' },
+    { code: 'OFFRAMP_USER', name: 'Offramp User' },
+    { code: 'NAIJA', name: '9JA' },
+    { code: 'TERERE', name: 'Tereré' },
+    { code: 'ACAI_POWERED', name: 'Açaí Powered' },
+    { code: 'NITA', name: 'Nita' },
+    { code: 'WAITLIST_SKIP', name: 'Skip Pass' },
 ]
 
 const ctaButtonClassName =
@@ -463,7 +465,7 @@ export default function ShhhhhLandingPage() {
                                     >
                                         <div className="relative aspect-square w-full">
                                             <Image
-                                                src={b.src}
+                                                src={getBadgeIcon(b.code)}
                                                 alt={b.name}
                                                 fill
                                                 className="object-contain"

--- a/src/app/shhhhh/ShhhhhLandingPage.tsx
+++ b/src/app/shhhhh/ShhhhhLandingPage.tsx
@@ -160,6 +160,7 @@ export default function ShhhhhLandingPage() {
     const [joinedPosition, setJoinedPosition] = useState<number | null | undefined>(undefined)
     const [ctaBusy, setCtaBusy] = useState(false)
     const [joinError, setJoinError] = useState(false)
+    const [showAllBadges, setShowAllBadges] = useState(false)
     const isJoined = joinedPosition !== undefined
 
     const joinWaitlist = useCallback(async () => {
@@ -458,7 +459,7 @@ export default function ShhhhhLandingPage() {
                                 {t('howToGetIn.badgeBody')}
                             </p>
                             <div className="mt-6 grid grid-cols-3 gap-3">
-                                {badges.map((b) => (
+                                {(showAllBadges ? badges : badges.slice(0, 3)).map((b) => (
                                     <div
                                         key={b.code}
                                         className="flex flex-col items-center gap-2 rounded-sm border-2 border-n-1 bg-primary-3 p-3 shadow-[3px_3px_0_#000]"
@@ -478,12 +479,22 @@ export default function ShhhhhLandingPage() {
                                     </div>
                                 ))}
                             </div>
+                            <button
+                                type="button"
+                                onClick={() => setShowAllBadges((v) => !v)}
+                                aria-expanded={showAllBadges}
+                                className="font-roboto-flex mt-4 text-sm font-bold underline underline-offset-4"
+                            >
+                                {showAllBadges
+                                    ? t('howToGetIn.badgeShowLess')
+                                    : t('howToGetIn.badgeShowMore', { count: badges.length - 3 })}
+                            </button>
                             <p className="font-roboto-flex mt-5 text-base leading-relaxed">
                                 {t('howToGetIn.badgeFooter')}
                             </p>
                         </div>
 
-                        <div className="rounded-sm border-2 border-n-1 bg-white p-8 shadow-[10px_10px_0_#000] md:p-10">
+                        <div className="rounded-sm border-2 border-n-1 bg-white p-8 shadow-[10px_10px_0_#000] md:self-start md:p-10">
                             <div
                                 className="font-roboto-flex-extrabold text-6xl font-extraBlack text-primary-1"
                                 style={{ WebkitTextStroke: '2px #000' }}

--- a/src/app/shhhhh/ShhhhhLandingPage.tsx
+++ b/src/app/shhhhh/ShhhhhLandingPage.tsx
@@ -59,10 +59,21 @@ const statLabelKeys = ['statMerchants', 'statBalance', 'statCard', 'statMiddleme
 
 const faqKeys = ['q1', 'q2', 'q3', 'q4', 'q5', 'q6', 'q7', 'q8'] as const
 
+// The full skip set from the API's badge registry (SKIP_BADGE_CODES): every
+// badge that grants `skip:card-queue`, in either launch phase.
 const badges: Array<{ code: string; name: string; src: string }> = [
     { code: 'OG_2025_10_12', name: 'Peanut OG', src: '/badges/og_v1.svg' },
     { code: 'DEVCONNECT_BA_2025', name: 'Devconnect BA', src: '/badges/devconnect_2025.svg' },
     { code: 'ARBIVERSE_DEVCONNECT_BA_2025', name: 'Arbiverse', src: '/badges/arbiverse_devconnect.svg' },
+    { code: 'SEEDLING_DEVCONNECT_BA_2025', name: 'Seedling', src: '/badges/seedlings_devconnect.svg' },
+    { code: 'EVENT_ALUMNI', name: 'Event Alumni', src: '/badges/event_alumni.svg' },
+    { code: 'CARD_PIONEER', name: 'Founding Pioneer', src: '/badges/founding_pioneer.svg' },
+    { code: 'OFFRAMP_USER', name: 'Offramp User', src: '/badges/offramp_user.png' },
+    { code: 'NAIJA', name: '9JA', src: '/badges/naija.svg' },
+    { code: 'TERERE', name: 'Tereré', src: '/badges/terere.svg' },
+    { code: 'ACAI_POWERED', name: 'Açaí Powered', src: '/badges/acai_powered.svg' },
+    { code: 'NITA', name: 'Nita', src: '/badges/nita.svg' },
+    { code: 'WAITLIST_SKIP', name: 'Skip Pass', src: '/badges/skip_pass.svg' },
 ]
 
 const ctaButtonClassName =

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2900,6 +2900,8 @@
             "badgeTitle": "Got a badge.",
             "badgeBody": "You skip the line. We're whitelisting holders of:",
             "badgeFooter": "Sign in, we check the badges on your account, you go straight to verification. No peanut account yet? Sign up first — takes a minute.",
+            "badgeShowMore": "+{count} more →",
+            "badgeShowLess": "show less",
             "noBadgeTitle": "No badge.",
             "noBadgeBody": "Join the waitlist. We let people in 20 a week.",
             "noBadgeFooter": "Put your name on the list and we'll holler when your turn comes up."

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2900,6 +2900,8 @@
             "badgeTitle": "Tienes una insignia.",
             "badgeBody": "Te saltas la fila. Estamos habilitando a quienes tengan:",
             "badgeFooter": "Inicia sesión, revisamos las insignias de tu cuenta y pasas directo a la verificación. ¿Todavía no tienes cuenta de peanut? Regístrate primero: toma un minuto.",
+            "badgeShowMore": "+{count} más →",
+            "badgeShowLess": "ver menos",
             "noBadgeTitle": "Sin insignia.",
             "noBadgeBody": "Únete a la lista de espera. Dejamos entrar a 20 personas por semana.",
             "noBadgeFooter": "Anota tu nombre en la lista y te avisamos cuando llegue tu turno."

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2900,6 +2900,8 @@
             "badgeTitle": "Tem um selo.",
             "badgeBody": "Você fura a fila. Estamos liberando quem tiver:",
             "badgeFooter": "Entre, conferimos os selos da sua conta e você vai direto para a verificação. Ainda não tem conta no peanut? Crie uma primeiro — leva um minuto.",
+            "badgeShowMore": "+{count} mais →",
+            "badgeShowLess": "mostrar menos",
             "noBadgeTitle": "Sem selo.",
             "noBadgeBody": "Entre na lista de espera. Liberamos 20 pessoas por semana.",
             "noBadgeFooter": "Coloque seu nome na lista e a gente avisa quando chegar sua vez."


### PR DESCRIPTION
## Summary

The /shhhhh landing page ("How to get in" → door 01) listed only 3 of the 12 badges that skip the card queue. The set drifted as new skip badges shipped (country launches, creator collab, offramp, events). This PR lists the complete set and stops the icon paths from drifting separately.

Source of truth: `SKIP_BADGE_CODES` in peanut-api-ts (`src/card/waitlist.ts`) — the union of every badge granting `skip:card-queue` in either launch phase, pinned by `src/card/waitlist.test.ts` **on origin/main** (the post badge-registry world; the pre-registry `seed-definitions.ts` checkout is stale). All 12 codes are now on the page: OG_2025_10_12, DEVCONNECT_BA_2025, ARBIVERSE_DEVCONNECT_BA_2025, SEEDLING_DEVCONNECT_BA_2025, EVENT_ALUMNI, CARD_PIONEER, OFFRAMP_USER, NAIJA, TERERE, ACAI_POWERED, NITA, WAITLIST_SKIP.

Second commit: icon paths now come from `getBadgeIcon()` / the generated badge-asset manifest instead of a hand-copied list — all 12 resolved paths verified byte-identical, but future art re-cuts can no longer strand this page.

Third commit (Konrad's review): the grid collapses to the original 3 tiles with a "+9 more" toggle so door 01 doesn't tower over door 02, and door 02 no longer stretches to match door 01's height (`md:self-start`). Toggle copy is localized (en / es-419 / pt-BR; es-AR inherits).

## Design notes / accepted trade-offs

- **NITA is labeled "Nita"** — the registry name "Nita's Recommendation" clips on the 375px tile (screenshot-verified before shortening). Page convention already shortens names ("Arbiverse", "Devconnect BA").
- **Launch-phase nuance:** pre-launch, only the plain `skip:card-queue` badges (Skip Pass, Devconnect, Seedling, Offramp User) skip *right now*; the `@postlaunch` ones skip from public launch. The page advertised the union before this PR too (OG and Arbiverse are `@postlaunch`) — this PR keeps that stance. If you'd rather list only the 4 currently-active codes, say so and I'll trim.
- **ARBIVERSE_DEVCONNECT_BA_2025 is `active: false`** (grandfathered — existing holders keep the skip, no new awards). It was already on the page; kept deliberately.
- **WAITLIST_SKIP (Skip Pass)** included for completeness; holders skip in every phase. Drop it if listing it publicly reads as circular.
- Names stay hardcoded English (proper nouns, same as the existing 3 entries; matches the page's current i18n stance).
- **Follow-up idea (not this PR):** extend the peanut-api-ts manifest generator (`badge:check --write-manifest`) to also emit the skip-code list, so this array becomes generated instead of transcribed.

## Task

[TASK-21506](https://app.notion.com/p/3bc838117579812ea3f2ed5bbb37c582) — Sprint 180, tagged BLOCKED pending human review.

## Risks / breaking changes

None. Static data + one accessor reuse on one landing page; no logic, routes, or API changes. Base is `main` (hotfix path — prod page fix); back-merge debt main→dev after merge.

## QA

- Local gate ran twice (after each commit): `npm run typecheck`, full `npm test` (228 suites / 2925 tests), prettier — all green.
- Rendered locally (webpack dev) and screenshotted at 375×667 and 1280×900 at commit b28649635: 12 tiles in the §4 grid, every icon loads (incl. the one .png, offramp_user), labels fit without clipping. The follow-up commit resolves the exact same 12 paths (verified programmatically), so the screenshots remain accurate.
- Prod sanity: peanut.me serves these SVGs raw (no `/_next/image` wrapper), so the 9 new SVG tiles render the same way the existing 3 do.

## Screenshots

Assets live on `pr-assets-2698` (delete the branch post-merge).

| Desktop — collapsed (default) | Desktop — expanded |
|---|---|
| <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2698/toggle-desktop-collapsed.png" width="420"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2698/toggle-desktop-expanded.png" width="420"> |

| Mobile — collapsed | Mobile — expanded |
|---|---|
| <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2698/toggle-mobile-collapsed.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2698/toggle-mobile-expanded.png" width="260"> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded the available skip-badge list on the Shhhhh landing page.
  - Added controls to show or hide the full badge list, with three badges displayed initially.
  - Improved responsive alignment for the second badge card.

- **Localization**
  - Added show-more and show-less translations in English, Spanish (Latin America), and Brazilian Portuguese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->