### PR TITLE
fix(fx): stop the add-money and withdraw screens freezing on a rate fetch

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -19,6 +19,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import countryCurrencyMappings, { isNonEuroSepaCountry, isUKCountry } from '@/constants/countryCurrencyMapping'
 import { formatUnits } from 'viem'
 import PeanutLoading from '@/components/Global/PeanutLoading'
+import RateUnavailable from '@/components/Global/RateUnavailable'
 import EmptyState from '@/components/Global/EmptyStates/EmptyState'
 import AddMoneyBankDetails from '@/components/AddMoney/components/AddMoneyBankDetails'
 import { getCurrencyConfig, getCurrencySymbol, getMinimumAmount, railJurisdictionForBank } from '@/utils/bridge.utils'
@@ -192,7 +193,12 @@ function BridgeBankOnrampPage() {
     // deposit-side price (localCurrency per USD) for limits validation — deposits
     // execute at buy, so the USD equivalent must derive from buy, not the sell-side
     // display quote served by /fx/rate (useCurrency handles USD as 1:1)
-    const { price: localPrice, isLoading: isRateLoading, isError: isRateError } = useCurrency(localCurrency)
+    const {
+        price: localPrice,
+        isLoading: isRateLoading,
+        isError: isRateError,
+        refetch: refetchRate,
+    } = useCurrency(localCurrency)
 
     // convert input amount to USD for limits validation
     // bridge limits are always in USD, but user inputs in local currency
@@ -471,9 +477,7 @@ function BridgeBankOnrampPage() {
                     {error.showError && !!error.errorMessage && !limitsValidation.isBlocking && (
                         <ErrorAlert description={error.errorMessage} />
                     )}
-                    {localCurrency !== 'USD' && isRateError && (
-                        <ErrorAlert description="We couldn't load the exchange rate. Please try again in a moment." />
-                    )}
+                    {localCurrency !== 'USD' && isRateError && <RateUnavailable onRetry={refetchRate} />}
                 </div>
 
                 <OnrampConfirmationModal

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -1896,6 +1896,52 @@ describe('GROUP 8: InputAmountStep Component', () => {
         expect(screen.getByText('Continue')).toBeDisabled()
     })
 
+    // #1848: the error state used to be a dead end — useCurrency only refetches
+    // when the currency changes, so the user had to leave the screen to recover.
+    test('rate fetch failure offers a retry that refetches the rate', () => {
+        const refetch = jest.fn()
+        renderWithProviders(
+            <InputAmountStep
+                tokenAmount="100"
+                setTokenAmount={jest.fn()}
+                onSubmit={jest.fn()}
+                isLoading={false}
+                error={null}
+                setCurrencyAmount={jest.fn()}
+                currencyData={{ isLoading: false, isError: true, symbol: null, price: null, refetch }}
+                limitsValidation={{ isBlocking: false, isWarning: false, currency: 'USD' }}
+                limitsCurrency="USD"
+                onBack={jest.fn()}
+            />
+        )
+
+        fireEvent.click(screen.getByText('Retry'))
+
+        expect(refetch).toHaveBeenCalledTimes(1)
+    })
+
+    // A slow rate fetch can hold this screen for tens of seconds on a bad mobile
+    // connection. The header has to stay mounted or the page reads as frozen.
+    test('currency data loading keeps the back button available', () => {
+        renderWithProviders(
+            <InputAmountStep
+                tokenAmount=""
+                setTokenAmount={jest.fn()}
+                onSubmit={jest.fn()}
+                isLoading={false}
+                error={null}
+                setCurrencyAmount={jest.fn()}
+                currencyData={{ isLoading: true, symbol: null, price: null }}
+                limitsValidation={{ isBlocking: false, isWarning: false, currency: 'USD' }}
+                limitsCurrency="USD"
+                onBack={jest.fn()}
+            />
+        )
+
+        expect(screen.getByTestId('peanut-loading')).toBeInTheDocument()
+        expect(screen.getByTestId('nav-header')).toBeInTheDocument()
+    })
+
     test('onSubmit called when Continue clicked', async () => {
         const onSubmit = jest.fn()
         renderWithProviders(

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -17,6 +17,7 @@ import NavHeader from '@/components/Global/NavHeader'
 import ErrorAlert from '@/components/Global/ErrorAlert'
 import { Icon } from '@/components/Global/Icons/Icon'
 import PeanutLoading from '@/components/Global/PeanutLoading'
+import RateUnavailable from '@/components/Global/RateUnavailable'
 import { mantecaApi, type WithdrawPriceLock } from '@/services/manteca'
 import { useCurrency } from '@/hooks/useCurrency'
 import { loadingStateContext } from '@/context/loadingStates.context'
@@ -177,6 +178,7 @@ function MantecaBankWithdrawFlow() {
         code: currencyCode,
         price: currencyPrice,
         isLoading: isCurrencyLoading,
+        refetch: refetchCurrency,
     } = useCurrency(selectedCountry?.currency ?? null)
 
     // validates withdrawal against user's limits
@@ -558,6 +560,20 @@ function MantecaBankWithdrawFlow() {
             router.replace('/withdraw')
         }
     }, [countryFromUrl, selectedCountry, router])
+
+    // A failed rate fetch leaves `currencyPrice` null with `isCurrencyLoading`
+    // false. Falling through to the loader below would spin forever with no way
+    // out — the frozen withdraw screen in #1848.
+    if (!isCurrencyLoading && !currencyPrice && selectedCountry && countryConfig) {
+        return (
+            <div className="flex min-h-[inherit] flex-col gap-8">
+                <NavHeader title={tNav('withdraw')} onPrev={onBack} />
+                <div className="my-auto flex flex-col justify-center">
+                    <RateUnavailable onRetry={refetchCurrency} />
+                </div>
+            </div>
+        )
+    }
 
     if (isCurrencyLoading || !currencyPrice || !selectedCountry || !countryConfig) {
         return <PeanutLoading />

--- a/src/components/AddMoney/components/InputAmountStep.tsx
+++ b/src/components/AddMoney/components/InputAmountStep.tsx
@@ -5,6 +5,7 @@ import { Icon } from '@/components/Global/Icons/Icon'
 import NavHeader from '@/components/Global/NavHeader'
 import AmountInput from '@/components/Global/AmountInput'
 import ErrorAlert from '@/components/Global/ErrorAlert'
+import RateUnavailable from '@/components/Global/RateUnavailable'
 import { useCurrency } from '@/hooks/useCurrency'
 import PeanutLoading from '@/components/Global/PeanutLoading'
 import LimitsWarningCard from '@/features/limits/components/LimitsWarningCard'
@@ -54,8 +55,16 @@ const InputAmountStep = ({
     const t = useTranslations('addMoney')
     const tCommon = useTranslations('common')
 
+    // The rate fetch can hold this screen for tens of seconds on a slow mobile
+    // network. Keep the header mounted so "back" always works instead of the
+    // page reading as frozen (#1848).
     if (currencyData?.isLoading) {
-        return <PeanutLoading />
+        return (
+            <div className="flex min-h-[inherit] flex-col justify-start space-y-8">
+                <NavHeader title={t('title')} onPrev={onBack} />
+                <PeanutLoading />
+            </div>
+        )
     }
 
     // FX fetch failed (e.g. provider outage): price is null but not loading.
@@ -125,7 +134,7 @@ const InputAmountStep = ({
                 {/* only show error if limits blocking card is not displayed (warnings can coexist) */}
                 {error && !limitsValidation?.isBlocking && <ErrorAlert description={error} />}
                 {rateUnavailable && !error && !limitsValidation?.isBlocking && (
-                    <ErrorAlert description={t('errors.rateUnavailable')} />
+                    <RateUnavailable onRetry={() => currencyData?.refetch()} />
                 )}
             </div>
         </div>

--- a/src/components/Claim/Link/views/MantecaReviewStep.tsx
+++ b/src/components/Claim/Link/views/MantecaReviewStep.tsx
@@ -2,6 +2,7 @@ import { Button } from '@/components/0_Bruddle/Button'
 import ErrorAlert from '@/components/Global/ErrorAlert'
 import MantecaDetailsCard, { type MantecaCardRow } from '@/components/Global/MantecaDetailsCard'
 import PeanutLoading from '@/components/Global/PeanutLoading'
+import RateUnavailable from '@/components/Global/RateUnavailable'
 import { useCurrency } from '@/hooks/useCurrency'
 import { mantecaApi } from '@/services/manteca'
 import { sendLinksApi } from '@/services/sendLinks'
@@ -32,7 +33,7 @@ const MantecaReviewStep: FC<MantecaReviewStepProps> = ({
     const tCommon = useTranslations('common')
     const [isSubmitting, setIsSubmitting] = useState(false)
     const [error, setError] = useState<string | null>(null)
-    const { price, isLoading } = useCurrency(currency)
+    const { price, isLoading, refetch: refetchCurrency } = useCurrency(currency)
     const { claimLink: claimLinkSecure } = useClaimLink()
 
     const detailsCardRows: MantecaCardRow[] = [
@@ -127,6 +128,12 @@ const MantecaReviewStep: FC<MantecaReviewStepProps> = ({
 
     if (isLoading) {
         return <PeanutLoading coverFullScreen />
+    }
+
+    // Without a rate the exchange row renders "1 USD = undefined", so offer a
+    // retry rather than a review screen the user can't act on.
+    if (!price) {
+        return <RateUnavailable onRetry={refetchCurrency} />
     }
 
     return (

--- a/src/components/Global/RateUnavailable/index.tsx
+++ b/src/components/Global/RateUnavailable/index.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { Button } from '@/components/0_Bruddle/Button'
+import ErrorAlert from '@/components/Global/ErrorAlert'
+import { useTranslations } from 'next-intl'
+
+interface RateUnavailableProps {
+    onRetry: () => void
+    className?: string
+}
+
+/**
+ * Recovery affordance for a failed FX-rate fetch. Every flow that prices in a
+ * local currency needs one: the rate hook only refetches when the currency code
+ * changes, so without a retry the user is stranded until they leave the screen.
+ */
+const RateUnavailable = ({ onRetry, className }: RateUnavailableProps) => {
+    const t = useTranslations('errors')
+    const tCommon = useTranslations('common')
+
+    return (
+        <div className={className}>
+            <ErrorAlert description={t('rateUnavailable')} />
+            <Button variant="stroke" shadowSize="4" icon="retry" size="medium" onClick={onRetry} className="mt-4">
+                {tCommon('retry')}
+            </Button>
+        </div>
+    )
+}
+
+export default RateUnavailable

--- a/src/hooks/__tests__/useCurrency.test.tsx
+++ b/src/hooks/__tests__/useCurrency.test.tsx
@@ -1,0 +1,107 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { useCurrency } from '@/hooks/useCurrency'
+import { getCachedCurrencyPrice } from '@/app/actions/currency'
+
+jest.mock('@/app/actions/currency', () => ({ getCachedCurrencyPrice: jest.fn() }))
+
+const mockGetCachedCurrencyPrice = getCachedCurrencyPrice as jest.Mock
+
+describe('useCurrency', () => {
+    beforeEach(() => {
+        mockGetCachedCurrencyPrice.mockReset()
+        jest.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    afterEach(() => jest.restoreAllMocks())
+
+    it('exposes the fetched rate', async () => {
+        mockGetCachedCurrencyPrice.mockResolvedValue({ buy: 1400, sell: 1350 })
+
+        const { result } = renderHook(() => useCurrency('ars'))
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false))
+        expect(result.current.price).toEqual({ buy: 1400, sell: 1350 })
+        expect(result.current.symbol).toBe('ARS')
+        expect(result.current.isError).toBe(false)
+    })
+
+    it('flags a failed fetch instead of leaving the consumer loading forever', async () => {
+        mockGetCachedCurrencyPrice.mockRejectedValue(new Error('timeout'))
+
+        const { result } = renderHook(() => useCurrency('ARS'))
+
+        await waitFor(() => expect(result.current.isError).toBe(true))
+        expect(result.current.isLoading).toBe(false)
+        expect(result.current.price).toBeNull()
+    })
+
+    // #1848: without refetch, a rate outage strands the user on the error state
+    // until they leave the screen — the effect only re-runs when `code` changes.
+    it('refetch recovers from a failure without remounting', async () => {
+        mockGetCachedCurrencyPrice.mockRejectedValueOnce(new Error('timeout'))
+        mockGetCachedCurrencyPrice.mockResolvedValueOnce({ buy: 1400, sell: 1350 })
+
+        const { result } = renderHook(() => useCurrency('ARS'))
+
+        await waitFor(() => expect(result.current.isError).toBe(true))
+
+        act(() => result.current.refetch())
+
+        await waitFor(() => expect(result.current.price).toEqual({ buy: 1400, sell: 1350 }))
+        expect(result.current.isError).toBe(false)
+        expect(mockGetCachedCurrencyPrice).toHaveBeenCalledTimes(2)
+    })
+
+    it('ignores a superseded response that lands after a newer one', async () => {
+        let resolveArs: (value: { buy: number; sell: number }) => void = () => {}
+        mockGetCachedCurrencyPrice.mockImplementationOnce(
+            () => new Promise<{ buy: number; sell: number }>((resolve) => (resolveArs = resolve))
+        )
+        mockGetCachedCurrencyPrice.mockResolvedValueOnce({ buy: 5.4, sell: 5.3 })
+
+        const { result, rerender } = renderHook(({ code }) => useCurrency(code), {
+            initialProps: { code: 'ARS' },
+        })
+
+        rerender({ code: 'BRL' })
+        await waitFor(() => expect(result.current.price).toEqual({ buy: 5.4, sell: 5.3 }))
+
+        // The abandoned ARS request finally lands — it must not overwrite BRL.
+        act(() => resolveArs({ buy: 1400, sell: 1350 }))
+
+        await waitFor(() => expect(result.current.price).toEqual({ buy: 5.4, sell: 5.3 }))
+        expect(result.current.symbol).toBe('R$')
+    })
+
+    // #1848: callers read the currency off `useSearchParams()`, which is empty on
+    // the first render of a statically exported page. The hook used to seed
+    // `code` once and ignore the prop afterwards, so it never fetched and the
+    // withdraw screen sat on a loader that never resolved.
+    it('fetches when the currency only arrives after the first render', async () => {
+        mockGetCachedCurrencyPrice.mockResolvedValue({ buy: 1400, sell: 1350 })
+
+        const { result, rerender } = renderHook(({ code }) => useCurrency(code), {
+            initialProps: { code: null as string | null },
+        })
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false))
+        expect(mockGetCachedCurrencyPrice).not.toHaveBeenCalled()
+
+        rerender({ code: 'ARS' })
+
+        // Consumers must never see a settled no-rate state in the gap before the
+        // fetch starts — that reads as "rate unavailable" and flashes an error.
+        expect(result.current.isLoading).toBe(true)
+
+        await waitFor(() => expect(result.current.price).toEqual({ buy: 1400, sell: 1350 }))
+        expect(result.current.code).toBe('ARS')
+    })
+
+    it('short-circuits USD without a network call', async () => {
+        const { result } = renderHook(() => useCurrency('USD'))
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false))
+        expect(result.current.price).toEqual({ buy: 1, sell: 1 })
+        expect(mockGetCachedCurrencyPrice).not.toHaveBeenCalled()
+    })
+})

--- a/src/hooks/__tests__/useCurrency.test.tsx
+++ b/src/hooks/__tests__/useCurrency.test.tsx
@@ -97,6 +97,25 @@ describe('useCurrency', () => {
         expect(result.current.code).toBe('ARS')
     })
 
+    // Consumers gate on `price`, so a retained rate would price the new currency
+    // with the old one's number.
+    it('drops the previous currency rate when the next fetch fails', async () => {
+        mockGetCachedCurrencyPrice.mockResolvedValueOnce({ buy: 1400, sell: 1350 })
+        mockGetCachedCurrencyPrice.mockRejectedValueOnce(new Error('timeout'))
+
+        const { result, rerender } = renderHook(({ code }) => useCurrency(code), {
+            initialProps: { code: 'ARS' },
+        })
+
+        await waitFor(() => expect(result.current.price).toEqual({ buy: 1400, sell: 1350 }))
+
+        rerender({ code: 'BRL' })
+
+        await waitFor(() => expect(result.current.isError).toBe(true))
+        expect(result.current.price).toBeNull()
+        expect(result.current.symbol).toBeNull()
+    })
+
     it('short-circuits USD without a network call', async () => {
         const { result } = renderHook(() => useCurrency('USD'))
 

--- a/src/hooks/useCurrency.ts
+++ b/src/hooks/useCurrency.ts
@@ -94,6 +94,11 @@ export const useCurrency = (currencyCode: string | null) => {
             .catch((err) => {
                 if (cancelled) return
                 console.error(err)
+                // Drop the previous currency's rate: keeping it would let a
+                // consumer that gates on `price` alone price the new currency
+                // with the old one's number.
+                setSymbol(null)
+                setPrice(null)
                 setIsError(true)
                 setIsLoading(false)
             })

--- a/src/hooks/useCurrency.ts
+++ b/src/hooks/useCurrency.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { getCachedCurrencyPrice } from '@/app/actions/currency'
 
 export const SYMBOLS_BY_CURRENCY_CODE: Record<string, string> = {
@@ -27,6 +27,36 @@ export const useCurrency = (currencyCode: string | null) => {
     // dereferencing a null price (which crashes the render). See useCurrency
     // consumers in the add-money / withdraw flows.
     const [isError, setIsError] = useState<boolean>(false)
+    const [attempt, setAttempt] = useState<number>(0)
+
+    // Lets a consumer re-run a failed fetch in place. Without it the effect only
+    // re-runs when `code` changes, so a user who hits a rate outage is stuck on
+    // the error state until they leave the screen and come back (#1848).
+    const refetch = useCallback(() => setAttempt((n) => n + 1), [])
+
+    /**
+     * `code` seeds from the first render only, so without this the hook never
+     * sees a later currency. Callers derive theirs from `useSearchParams()`,
+     * which is empty on the first render of a statically exported page — the
+     * hook would latch `null`, never fetch, and leave the withdraw screen on a
+     * loader that never resolves (#1848).
+     *
+     * Tracking the previous prop (rather than syncing on every render) keeps the
+     * unsupported-currency branch below, which deliberately nulls `code`, from
+     * being overwritten on the next render.
+     */
+    const lastRequestedCode = useRef<string | null>(currencyCode?.toUpperCase() ?? null)
+    const requestedCode = currencyCode?.toUpperCase() ?? null
+    // The sync below only lands after this render commits. Reporting `isLoading`
+    // during the gap keeps consumers from reading the not-yet-fetched code as a
+    // settled "no rate" and flashing an error.
+    const isSyncingCode = requestedCode !== lastRequestedCode.current
+
+    useEffect(() => {
+        if (requestedCode === lastRequestedCode.current) return
+        lastRequestedCode.current = requestedCode
+        setCode(requestedCode)
+    }, [requestedCode])
 
     useEffect(() => {
         setIsError(false)
@@ -48,25 +78,37 @@ export const useCurrency = (currencyCode: string | null) => {
             return
         }
 
+        // A slow request from a superseded code/attempt must not write its
+        // result over the current one — on a flaky connection the responses can
+        // land out of order, which would show the wrong currency's rate.
+        let cancelled = false
+
         setIsLoading(true)
         getCachedCurrencyPrice(code)
             .then((price) => {
+                if (cancelled) return
                 setSymbol(SYMBOLS_BY_CURRENCY_CODE[code])
                 setPrice(price)
                 setIsLoading(false)
             })
             .catch((err) => {
+                if (cancelled) return
                 console.error(err)
                 setIsError(true)
                 setIsLoading(false)
             })
-    }, [code])
+
+        return () => {
+            cancelled = true
+        }
+    }, [code, attempt])
 
     return {
         code,
         symbol,
         price,
-        isLoading,
+        isLoading: isLoading || isSyncingCode,
         isError,
+        refetch,
     }
 }

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -1485,7 +1485,6 @@
             "minimumDeposit": "Minimum deposit is {amount}.",
             "selectCountryFirst": "Please select a country first.",
             "onrampDetails": "Could not get onramp details. Please try again.",
-            "rateUnavailable": "Exchange rates are temporarily unavailable. Please try again in a moment.",
             "bankAccountFailed": "Failed to process bank account. Please try again or contact support.",
             "bankAccountSettingUp": "Your bank account is still being set up. Please try again in a moment."
         },
@@ -3025,7 +3024,8 @@
         "cardApprovalCancelled": "Approval cancelled — you can retry anytime.",
         "cardApprovalFailed": "Card approval failed — please try again.",
         "logoutFailed": "Couldn’t log out. Please try again.",
-        "loginIncomplete": "Login didn’t complete. Please try again."
+        "loginIncomplete": "Login didn’t complete. Please try again.",
+        "rateUnavailable": "Exchange rates are temporarily unavailable. Please try again in a moment."
     },
     "appLock": {
         "title": "Welcome back!",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -1485,7 +1485,6 @@
             "minimumDeposit": "El depósito mínimo es {amount}.",
             "selectCountryFirst": "Primero selecciona un país.",
             "onrampDetails": "No pudimos obtener los datos para agregar dinero. Inténtalo de nuevo.",
-            "rateUnavailable": "Los tipos de cambio no están disponibles por el momento. Inténtalo de nuevo en un momento.",
             "bankAccountFailed": "No se pudo procesar la cuenta bancaria. Inténtalo de nuevo o contacta a soporte.",
             "bankAccountSettingUp": "Tu cuenta bancaria aún se está configurando. Inténtalo de nuevo en un momento."
         },
@@ -3025,7 +3024,8 @@
         "cardApprovalCancelled": "Aprobación cancelada: puedes volver a intentarlo cuando quieras.",
         "cardApprovalFailed": "No se pudo aprobar la tarjeta. Inténtalo de nuevo.",
         "logoutFailed": "No pudimos cerrar tu sesión. Inténtalo de nuevo.",
-        "loginIncomplete": "No se completó el inicio de sesión. Inténtalo de nuevo."
+        "loginIncomplete": "No se completó el inicio de sesión. Inténtalo de nuevo.",
+        "rateUnavailable": "Los tipos de cambio no están disponibles por el momento. Inténtalo de nuevo en un momento."
     },
     "appLock": {
         "title": "¡Hola de nuevo!",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -642,7 +642,6 @@
             "invalidNumber": "Ingresá un número válido.",
             "selectCountryFirst": "Primero seleccioná un país.",
             "onrampDetails": "No pudimos obtener los datos para agregar dinero. Intentalo de nuevo.",
-            "rateUnavailable": "Los tipos de cambio no están disponibles por el momento. Intentalo de nuevo en un momento.",
             "bankAccountFailed": "No se pudo procesar la cuenta bancaria. Intentalo de nuevo o contactá a soporte.",
             "bankAccountSettingUp": "Tu cuenta bancaria aún se está configurando. Intentalo de nuevo en un momento."
         }
@@ -1186,7 +1185,8 @@
         "cardApprovalCancelled": "Aprobación cancelada: podés volver a intentarlo cuando quieras.",
         "cardApprovalFailed": "No se pudo aprobar la tarjeta. Intentalo de nuevo.",
         "logoutFailed": "No pudimos cerrar tu sesión. Intentalo de nuevo.",
-        "loginIncomplete": "No se completó el inicio de sesión. Intentalo de nuevo."
+        "loginIncomplete": "No se completó el inicio de sesión. Intentalo de nuevo.",
+        "rateUnavailable": "Los tipos de cambio no están disponibles por el momento. Intentalo de nuevo en un momento."
     },
     "appLock": {
         "prompt": "Desbloqueá para abrir la app.",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -1485,7 +1485,6 @@
             "minimumDeposit": "O depósito mínimo é {amount}.",
             "selectCountryFirst": "Primeiro selecione um país.",
             "onrampDetails": "Não conseguimos obter os dados para adicionar dinheiro. Tente de novo.",
-            "rateUnavailable": "As taxas de câmbio estão indisponíveis no momento. Tente de novo em instantes.",
             "bankAccountFailed": "Não foi possível processar a conta bancária. Tente de novo ou fale com o suporte.",
             "bankAccountSettingUp": "Sua conta bancária ainda está sendo configurada. Tente de novo em instantes."
         },
@@ -3025,7 +3024,8 @@
         "cardApprovalCancelled": "Aprovação cancelada — você pode tentar novamente quando quiser.",
         "cardApprovalFailed": "Não foi possível aprovar o cartão. Tente novamente.",
         "logoutFailed": "Não foi possível sair da sua conta. Tente novamente.",
-        "loginIncomplete": "O login não foi concluído. Tente novamente."
+        "loginIncomplete": "O login não foi concluído. Tente novamente.",
+        "rateUnavailable": "As taxas de câmbio estão indisponíveis no momento. Tente de novo em instantes."
     },
     "appLock": {
         "title": "Olá de novo!",


### PR DESCRIPTION
Fixes #1848.

## What was already handled

Worth stating up front so the diff reads in context — most of the issue's suggested fix already landed:

- **Timeouts on both calls.** `fetchWithSentry` aborts at 20s (client) with one silent GET retry, and both `/bridge/exchange-rate` and `/users/limits` go through it.
- **`useLimits` retry.** It inherits `RETRY_STRATEGIES.FAST` (2 retries, exponential backoff) from the app `QueryClient`.
- **The null-rate crash** in `InputAmountStep` was fixed in #2325.

So the remaining freeze was not a missing timeout.

## The actual freeze

`useCurrency` seeded `code` from the prop on the first render and then ignored the prop for the rest of its life — there was no sync effect. Both callers derive the currency from `useSearchParams()`:

- `withdraw/manteca/page.tsx` → `useCurrency(selectedCountry?.currency ?? null)`
- `MantecaAddMoney.tsx` → `useCurrency(selectedCountry?.currency ?? 'ARS')`

On the first render of a statically exported page the search params are empty, so the withdraw page passed `null`, the hook latched it, never fetched, and `price` stayed null forever. Its gate is `if (isCurrencyLoading || !currencyPrice || …) return <PeanutLoading />` — an unresolvable loader with no header and no way out. That's a deterministic hang rather than a slow network, which fits "reproducible on G31 and G23" better than a timeout would.

The same latch also meant add-money would price a Brazil flow in ARS (its fallback) whenever the country arrived a render late.

## Changes

**`useCurrency`**
- Sync `code` when the prop changes, tracking the previous prop so the unsupported-currency branch (which deliberately nulls `code`) isn't clobbered on the next render.
- Report the gap between the prop landing and the fetch starting as `isLoading`, so consumers can't read it as a settled "no rate" and flash an error.
- Add `refetch()`. Previously the effect only re-ran on a currency change, so a rate outage stranded the user until they left the screen entirely.
- Ignore a superseded in-flight response so a slow request can't overwrite a newer currency's rate.

**Failure states** — new shared `RateUnavailable` (alert + retry), wired into all three rate-dependent flows:
- `InputAmountStep`: retry button instead of a bare alert; header stays mounted while loading so back always works.
- `withdraw/manteca`: had no error branch at all — a failed fetch fell into the same infinite loader. Now an error screen with back and retry.
- `MantecaReviewStep`: rendered `1 USD = undefined ARS`; now shows the retry state.

**i18n** — moved `rateUnavailable` from `addMoney.errors` to the shared `errors` namespace across all four catalogs rather than duplicating the string.

## Verification

- Full Jest suite: 238 suites / 3068 passing, including 6 new `useCurrency` tests (late-arriving currency, refetch recovery, out-of-order response) and 2 new `InputAmountStep` tests.
- `next build` succeeds; 1089 static pages generated.
- `tsc`, `eslint`, and `prettier` clean on the touched files.

## Not covered

No page-level test for `withdraw/manteca` — it has no existing suite and would need a large mock surface. The hook test covers the root cause; the page's new branch is not directly exercised.