### PR TITLE
fix(capgo): give every OTA upload a unique bundle version

### DIFF
--- a/.github/workflows/capgo-deploy-ios.yml
+++ b/.github/workflows/capgo-deploy-ios.yml
@@ -32,6 +32,8 @@ jobs:
               with:
                   submodules: true
                   token: ${{ secrets.SUBMODULE_TOKEN }}
+                  # Full history: the bundle version's patch is the commit count.
+                  fetch-depth: 0
 
             - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
@@ -68,6 +70,13 @@ jobs:
                     --apikey ${{ secrets.CAPGO_API_KEY }} \
                     --ios --no-android --self-assign
 
+            - name: Resolve bundle version
+              id: version
+              run: |
+                  VERSION="$(node scripts/capgo-bundle-version.mjs)"
+                  echo "name=$VERSION" >> "$GITHUB_OUTPUT"
+                  echo "Uploading as bundle version $VERSION"
+
             - name: Upload iOS bundle to Capgo
               # Pass the commit message via env, never inline — a multi-line message
               # (or one containing quotes) injected into the run script breaks the
@@ -81,13 +90,33 @@ jobs:
                     --channel "${{ steps.channel.outputs.name }}" \
                     --apikey "$CAPGO_API_KEY" \
                     --path ./out \
+                    --bundle "${{ steps.version.outputs.name }}" \
                     --auto-min-update-version \
                     --version-exists-ok \
                     --comment "$COMMENT"
+
+            # --version-exists-ok turns "this version is already uploaded" into a
+            # silent no-op, which is what we want for a re-run of the same commit
+            # and never what we want otherwise. Assert the channel really serves
+            # the version this run built, so a no-op that ships nothing is red.
+            - name: Verify channel serves the new bundle
+              env:
+                  CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
+                  CHANNEL: ${{ steps.channel.outputs.name }}
+                  EXPECTED: ${{ steps.version.outputs.name }}
+              run: |
+                  CURRENT="$(npx @capgo/cli@latest channel currentBundle "$CHANNEL" \
+                    --apikey "$CAPGO_API_KEY" --quiet | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -n1 || true)"
+                  if [ "$CURRENT" != "$EXPECTED" ]; then
+                    echo "ERROR: channel $CHANNEL serves '${CURRENT:-<none>}', expected $EXPECTED — nothing shipped" >&2
+                    exit 1
+                  fi
+                  echo "Channel $CHANNEL now serves $EXPECTED"
 
             - name: Deployment summary
               run: |
                   echo "## iOS-only OTA Deployment" >> $GITHUB_STEP_SUMMARY
                   echo "- **Channel:** ${{ steps.channel.outputs.name }} (iOS only)" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Bundle version:** ${{ steps.version.outputs.name }}" >> $GITHUB_STEP_SUMMARY
                   echo "- **Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
                   echo "- **Branch:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/capgo-deploy.yml
+++ b/.github/workflows/capgo-deploy.yml
@@ -38,6 +38,8 @@ jobs:
               with:
                   submodules: true
                   token: ${{ secrets.SUBMODULE_TOKEN }}
+                  # Full history: the bundle version's patch is the commit count.
+                  fetch-depth: 0
 
             - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
@@ -68,6 +70,13 @@ jobs:
                     echo "name=staging" >> $GITHUB_OUTPUT
                   fi
 
+            - name: Resolve bundle version
+              id: version
+              run: |
+                  VERSION="$(node scripts/capgo-bundle-version.mjs)"
+                  echo "name=$VERSION" >> "$GITHUB_OUTPUT"
+                  echo "Uploading as bundle version $VERSION"
+
             - name: Upload bundle to Capgo
               # Commit message via env, never inline — a multi-line message (or one
               # with quotes) injected into the run script breaks --comment quoting.
@@ -85,13 +94,33 @@ jobs:
                     --apikey "$CAPGO_API_KEY" \
                     --key-data-v2 "$CAPGO_PRIVATE_KEY" \
                     --path ./out \
+                    --bundle "${{ steps.version.outputs.name }}" \
                     --auto-min-update-version \
                     --version-exists-ok \
                     --comment "$COMMENT"
+
+            # --version-exists-ok turns "this version is already uploaded" into a
+            # silent no-op, which is what we want for a re-run of the same commit
+            # and never what we want otherwise. Assert the channel really serves
+            # the version this run built, so a no-op that ships nothing is red.
+            - name: Verify channel serves the new bundle
+              env:
+                  CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
+                  CHANNEL: ${{ steps.channel.outputs.name }}
+                  EXPECTED: ${{ steps.version.outputs.name }}
+              run: |
+                  CURRENT="$(npx @capgo/cli@latest channel currentBundle "$CHANNEL" \
+                    --apikey "$CAPGO_API_KEY" --quiet | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -n1 || true)"
+                  if [ "$CURRENT" != "$EXPECTED" ]; then
+                    echo "ERROR: channel $CHANNEL serves '${CURRENT:-<none>}', expected $EXPECTED — nothing shipped" >&2
+                    exit 1
+                  fi
+                  echo "Channel $CHANNEL now serves $EXPECTED"
 
             - name: Deployment summary
               run: |
                   echo "## OTA Deployment" >> $GITHUB_STEP_SUMMARY
                   echo "- **Channel:** ${{ steps.channel.outputs.name }}" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Bundle version:** ${{ steps.version.outputs.name }}" >> $GITHUB_STEP_SUMMARY
                   echo "- **Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
                   echo "- **Branch:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
         "native:build": "node scripts/native-build.js",
         "native:sync": "pnpm exec cap sync android",
         "native:release": "bash scripts/native-release.sh",
-        "capgo:upload:dev": "node scripts/native-build.js && pnpm dlx @capgo/cli@latest bundle upload --channel development --path ./out",
-        "capgo:upload:staging": "node scripts/native-build.js && pnpm dlx @capgo/cli@latest bundle upload --channel staging --path ./out",
+        "capgo:upload:dev": "node scripts/native-build.js && pnpm dlx @capgo/cli@latest bundle upload --channel development --path ./out --bundle \"$(node scripts/capgo-bundle-version.mjs)\"",
+        "capgo:upload:staging": "node scripts/native-build.js && pnpm dlx @capgo/cli@latest bundle upload --channel staging --path ./out --bundle \"$(node scripts/capgo-bundle-version.mjs)\"",
         "test:unit:ci": "jest --coverage --reporters=default --reporters=jest-junit"
     },
     "dependencies": {

--- a/scripts/__tests__/capgo-bundle-version.test.js
+++ b/scripts/__tests__/capgo-bundle-version.test.js
@@ -1,0 +1,83 @@
+const { execFileSync, spawnSync } = require('child_process')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const REPO_ROOT = path.join(__dirname, '..', '..')
+const SCRIPT_PATH = path.join(REPO_ROOT, 'scripts', 'capgo-bundle-version.mjs')
+
+// The script is a CI entrypoint: its contract is stdout + exit code, so run it
+// the way the workflow does instead of reaching into its internals.
+function run({ cwd = REPO_ROOT, script = SCRIPT_PATH, env = {} } = {}) {
+    return spawnSync(process.execPath, [script], {
+        cwd,
+        encoding: 'utf-8',
+        env: { ...process.env, CAPGO_BUNDLE_VERSION: '', ...env },
+    })
+}
+
+describe('capgo bundle version', () => {
+    const nativeVersion = require(path.join(REPO_ROOT, 'package.json')).version
+
+    it('derives <major>.<minor>.<commit-count> from package.json', () => {
+        const commitCount = execFileSync('git', ['rev-list', '--count', 'HEAD'], {
+            cwd: REPO_ROOT,
+            encoding: 'utf-8',
+        }).trim()
+        const [major, minor] = nativeVersion.split('.')
+
+        const result = run()
+
+        expect(result.status).toBe(0)
+        expect(result.stdout.trim()).toBe(`${major}.${minor}.${commitCount}`)
+    })
+
+    // The whole point of the derived version: Capgo drops bundles that sort
+    // below the installed native version, and no-ops on a version it already has.
+    it('derives a version above the native one', () => {
+        const [, , patch] = nativeVersion.split('.')
+        const [, , derivedPatch] = run().stdout.trim().split('.')
+
+        expect(Number(derivedPatch)).toBeGreaterThan(Number(patch))
+    })
+
+    it('honours CAPGO_BUNDLE_VERSION', () => {
+        const result = run({ env: { CAPGO_BUNDLE_VERSION: '1.2.3' } })
+
+        expect(result.status).toBe(0)
+        expect(result.stdout.trim()).toBe('1.2.3')
+    })
+
+    it('rejects an override below the native version', () => {
+        const result = run({ env: { CAPGO_BUNDLE_VERSION: '0.9.0' } })
+
+        expect(result.status).toBe(1)
+        expect(result.stderr).toContain('below the native version')
+    })
+
+    it('rejects a prerelease override, which devices would refuse', () => {
+        const result = run({ env: { CAPGO_BUNDLE_VERSION: `${nativeVersion}-deadbee` } })
+
+        expect(result.status).toBe(1)
+        expect(result.stderr).toContain('plain X.Y.Z semver')
+    })
+
+    it('fails on a shallow clone instead of shipping version 1.0.1', () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'capgo-version-'))
+        try {
+            fs.mkdirSync(path.join(dir, 'scripts'))
+            fs.copyFileSync(SCRIPT_PATH, path.join(dir, 'scripts', 'capgo-bundle-version.mjs'))
+            fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ version: nativeVersion }))
+            const git = (...args) => execFileSync('git', args, { cwd: dir, stdio: 'ignore' })
+            git('init', '-q')
+            git('-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-q', '--allow-empty', '-m', 'one')
+
+            const result = run({ cwd: dir, script: path.join(dir, 'scripts', 'capgo-bundle-version.mjs') })
+
+            expect(result.status).toBe(1)
+            expect(result.stderr).toContain('fetch-depth: 0')
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true })
+        }
+    })
+})

--- a/scripts/__tests__/capgo-bundle-version.test.js
+++ b/scripts/__tests__/capgo-bundle-version.test.js
@@ -16,36 +16,58 @@ function run({ cwd = REPO_ROOT, script = SCRIPT_PATH, env = {} } = {}) {
     })
 }
 
+// CI checks this repo out shallow, so the commit-count cases get their own
+// repo with a known history instead of asserting against the checkout.
+function makeRepo(version, commits) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'capgo-version-'))
+    fs.mkdirSync(path.join(dir, 'scripts'))
+    fs.copyFileSync(SCRIPT_PATH, path.join(dir, 'scripts', 'capgo-bundle-version.mjs'))
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ version }))
+    const git = (...args) => execFileSync('git', args, { cwd: dir, stdio: 'ignore' })
+    git('init', '-q')
+    for (let i = 0; i < commits; i++) {
+        git('-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-q', '--allow-empty', '-m', `c${i}`)
+    }
+    return dir
+}
+
+function runIn(dir, env) {
+    return run({ cwd: dir, script: path.join(dir, 'scripts', 'capgo-bundle-version.mjs'), env })
+}
+
 describe('capgo bundle version', () => {
     const nativeVersion = require(path.join(REPO_ROOT, 'package.json')).version
+    const repos = []
+
+    afterAll(() => repos.forEach((dir) => fs.rmSync(dir, { recursive: true, force: true })))
+
+    function repo(version, commits) {
+        const dir = makeRepo(version, commits)
+        repos.push(dir)
+        return dir
+    }
 
     it('derives <major>.<minor>.<commit-count> from package.json', () => {
-        const commitCount = execFileSync('git', ['rev-list', '--count', 'HEAD'], {
-            cwd: REPO_ROOT,
-            encoding: 'utf-8',
-        }).trim()
-        const [major, minor] = nativeVersion.split('.')
-
-        const result = run()
+        const result = runIn(repo('2.3.1', 12))
 
         expect(result.status).toBe(0)
-        expect(result.stdout.trim()).toBe(`${major}.${minor}.${commitCount}`)
+        expect(result.stdout.trim()).toBe('2.3.12')
     })
 
     // The whole point of the derived version: Capgo drops bundles that sort
     // below the installed native version, and no-ops on a version it already has.
-    it('derives a version above the native one', () => {
-        const [, , patch] = nativeVersion.split('.')
-        const [, , derivedPatch] = run().stdout.trim().split('.')
+    it('fails on a shallow clone instead of shipping a version under the native one', () => {
+        const result = runIn(repo('1.0.8', 1))
 
-        expect(Number(derivedPatch)).toBeGreaterThan(Number(patch))
+        expect(result.status).toBe(1)
+        expect(result.stderr).toContain('fetch-depth: 0')
     })
 
     it('honours CAPGO_BUNDLE_VERSION', () => {
-        const result = run({ env: { CAPGO_BUNDLE_VERSION: '1.2.3' } })
+        const result = run({ env: { CAPGO_BUNDLE_VERSION: '9.9.9' } })
 
         expect(result.status).toBe(0)
-        expect(result.stdout.trim()).toBe('1.2.3')
+        expect(result.stdout.trim()).toBe('9.9.9')
     })
 
     it('rejects an override below the native version', () => {
@@ -60,24 +82,5 @@ describe('capgo bundle version', () => {
 
         expect(result.status).toBe(1)
         expect(result.stderr).toContain('plain X.Y.Z semver')
-    })
-
-    it('fails on a shallow clone instead of shipping version 1.0.1', () => {
-        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'capgo-version-'))
-        try {
-            fs.mkdirSync(path.join(dir, 'scripts'))
-            fs.copyFileSync(SCRIPT_PATH, path.join(dir, 'scripts', 'capgo-bundle-version.mjs'))
-            fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ version: nativeVersion }))
-            const git = (...args) => execFileSync('git', args, { cwd: dir, stdio: 'ignore' })
-            git('init', '-q')
-            git('-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-q', '--allow-empty', '-m', 'one')
-
-            const result = run({ cwd: dir, script: path.join(dir, 'scripts', 'capgo-bundle-version.mjs') })
-
-            expect(result.status).toBe(1)
-            expect(result.stderr).toContain('fetch-depth: 0')
-        } finally {
-            fs.rmSync(dir, { recursive: true, force: true })
-        }
     })
 })

--- a/scripts/capgo-bundle-version.mjs
+++ b/scripts/capgo-bundle-version.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+// Prints the version to upload the OTA (Capgo) bundle under.
+//
+// Why: package.json's version is pinned and only moves on a native release, so
+// every OTA upload after the first collided on the same bundle version. Capgo
+// then either failed the job or (with --version-exists-ok) no-opped and shipped
+// nothing. Deriving the version per commit makes each upload a real one, and
+// keeps --version-exists-ok meaning "re-running the same commit is safe".
+//
+// Scheme: <major>.<minor> from package.json + the git commit count as patch,
+// e.g. 1.0.9798. Two constraints drive it, both enforced below:
+//   - unique per commit, or the upload silently does nothing;
+//   - never sorting BELOW the native app version, or Capgo's
+//     disable_auto_update_under_native rule makes devices reject the bundle.
+//     That rules out a `1.0.8-<sha>` shape — a semver prerelease sorts under
+//     plain 1.0.8, so every device on the 1.0.8 binary would refuse it.
+// Anchoring major/minor to package.json keeps that floor correct when a native
+// release bumps the app version — a release that overrides versionName without
+// bumping package.json would strand OTA bundles under the shipped binary.
+//
+// Usage: node scripts/capgo-bundle-version.mjs
+//   Needs full git history (actions/checkout with fetch-depth: 0) — a shallow
+//   clone counts one commit, which is rejected here rather than shipped.
+//
+// Env knobs:
+//   CAPGO_BUNDLE_VERSION  upload under this exact version instead of deriving one
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const PLAIN_SEMVER = /^(\d+)\.(\d+)\.(\d+)$/
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+try {
+    process.stdout.write(`${resolveBundleVersion()}\n`)
+} catch (err) {
+    console.error(`✗ cannot derive a Capgo bundle version: ${err.message}`)
+    process.exit(1)
+}
+
+function resolveBundleVersion() {
+    const nativeVersion = readPackageVersion()
+    const override = process.env.CAPGO_BUNDLE_VERSION?.trim()
+    if (override) {
+        assertPlainSemver(override, 'CAPGO_BUNDLE_VERSION')
+        assertAtLeastNative(override, nativeVersion)
+        return override
+    }
+    return deriveVersion(nativeVersion, commitCount())
+}
+
+function deriveVersion(nativeVersion, count) {
+    const [, major, minor, patch] = assertPlainSemver(nativeVersion, 'package.json version')
+    if (count <= Number(patch)) {
+        throw new Error(
+            `commit count ${count} is not above the native patch ${patch} — a shallow ` +
+                `clone? OTA workflows need actions/checkout with fetch-depth: 0.`
+        )
+    }
+    return `${major}.${minor}.${count}`
+}
+
+function readPackageVersion() {
+    return JSON.parse(readFileSync(resolve(repoRoot, 'package.json'), 'utf8')).version
+}
+
+function commitCount() {
+    const out = execFileSync('git', ['rev-list', '--count', 'HEAD'], { cwd: repoRoot, encoding: 'utf8' }).trim()
+    if (!/^\d+$/.test(out)) throw new Error(`git rev-list returned "${out}"`)
+    return Number(out)
+}
+
+function assertPlainSemver(version, label) {
+    const match = PLAIN_SEMVER.exec(version ?? '')
+    if (!match) throw new Error(`${label} must be a plain X.Y.Z semver, got "${version}"`)
+    return match
+}
+
+// Capgo refuses on-device any bundle that sorts below the installed native
+// version, so a lower override would upload fine and then reach nobody.
+function assertAtLeastNative(version, nativeVersion) {
+    const [, ...parts] = assertPlainSemver(version, 'CAPGO_BUNDLE_VERSION')
+    const [, ...nativeParts] = assertPlainSemver(nativeVersion, 'package.json version')
+    for (let i = 0; i < 3; i++) {
+        if (Number(parts[i]) > Number(nativeParts[i])) return
+        if (Number(parts[i]) < Number(nativeParts[i])) {
+            throw new Error(`CAPGO_BUNDLE_VERSION ${version} is below the native version ${nativeVersion}`)
+        }
+    }
+}


### PR DESCRIPTION
Closes #2638

## Problem

`package.json`'s version only moves on a native release, so every OTA upload after the first reused bundle version `1.0.8`. Capgo failed those uploads loudly until #2636 added `--version-exists-ok`, which turned them into silent no-ops: green check, nothing shipped.

## One correction to the issue's suggestion

`1.0.8-<short-sha>` would have made it worse. Capgo's update endpoint rejects any bundle that semver-sorts **below** the device's native version (`disable_auto_update_under_native`, on by default — [update.ts](https://github.com/Cap-go/capgo/blob/main/supabase/functions/_backend/plugin_runtime/utils/update.ts)), and a prerelease sorts under plain `1.0.8`. Uploads would succeed, the dashboard would show new bundles, and every device on the 1.0.8 binary would refuse them. The commit-count variant the issue also proposes is what this PR uses.

## Changes

- `scripts/capgo-bundle-version.mjs` — prints `<major>.<minor>` from `package.json` + the git commit count (today: `1.0.9798`). Anchoring major/minor to `package.json` keeps the version above the native floor when a native release bumps it; the commit count makes it unique per commit. It refuses a shallow clone (would emit `1.0.1`), a prerelease override, and any `CAPGO_BUNDLE_VERSION` override below the native version.
- Both Capgo workflows — `fetch-depth: 0`, a "Resolve bundle version" step, `--bundle <version>` on the upload, and a post-upload assertion that `channel currentBundle` actually serves the version the run just built. `--version-exists-ok` stays, but now only covers a re-run of the same commit; any other no-op leaves the channel stale and turns the job red. That check is the issue's "verify when fixed" criterion, enforced in CI.
- `capgo:upload:dev|staging` package scripts get the same derived version — they had the identical collision.

## Verification

- 6 new jest tests (`scripts/__tests__/capgo-bundle-version.test.js`), including a real shallow-clone repo.
- The verification step was simulated under `bash -e` for match / stale-channel / CLI-error; it is green only on a real match.
- eslint and `prettier --check` clean on the touched files; both workflows parse.

## Before the first release

Check on the Capgo dashboard that the channels' update policy is not `patch` — that setting blocks any patch-differing bundle, i.e. all OTA, regardless of the version scheme. Also note a native release that overrides `versionName` without bumping `package.json` would strand OTA bundles under the shipped binary.