### PR TITLE
test(csp): cover the csp-report collector's route logic + bound its invocation

### DIFF
--- a/src/app/api/csp-report/__tests__/route.test.ts
+++ b/src/app/api/csp-report/__tests__/route.test.ts
@@ -1,0 +1,305 @@
+/** @jest-environment node */
+import type { NextRequest } from 'next/server'
+import type { CspReport } from '@/utils/csp-report.utils'
+
+// The selection loop's own invariants (the per-request cap, intra-batch
+// de-duplication, the ignore filter) are pinned against selectReportsToForward
+// in src/utils/__tests__/csp-report.utils.test.ts. This file covers what only
+// the route holds: the always-204 contract, content-type gating, DSN
+// derivation, the pass-through headers, and the cross-request `seenGroups`
+// state — sampling, eviction, and the fact that a group the cap turned away is
+// not recorded as seen.
+
+const DSN = 'https://publickey@o1.ingest.sentry.io/4505'
+const INGEST_URL = 'https://o1.ingest.sentry.io/api/4505/security/?sentry_key=publickey'
+
+type RouteModule = typeof import('../route')
+let route: RouteModule
+
+// seenGroups is module-level and deliberately outlives a request, so each test
+// needs its own copy of the module.
+function loadRoute(): void {
+    jest.isolateModules(() => {
+        // isolateModules is sync-only, so this has to be require() rather than import
+        route = require('../route')
+    })
+}
+
+let fetchMock: jest.Mock
+let randomSpy: jest.SpyInstance<number, []>
+const originalDsn = process.env.NEXT_PUBLIC_SENTRY_DSN
+
+beforeEach(() => {
+    process.env.NEXT_PUBLIC_SENTRY_DSN = DSN
+    fetchMock = jest.fn().mockResolvedValue({ ok: true })
+    global.fetch = fetchMock as unknown as typeof fetch
+    // Never sample a duplicate unless a test says otherwise, so "was forwarded"
+    // means "was a first sighting" and no assertion here depends on chance.
+    randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.99)
+    loadRoute()
+})
+
+afterEach(() => {
+    jest.restoreAllMocks()
+    process.env.NEXT_PUBLIC_SENTRY_DSN = originalDsn
+})
+
+function makeRequest(
+    body: unknown,
+    { contentType = 'application/csp-report', headers = {} }: { contentType?: string; headers?: HeadersInit } = {}
+): NextRequest {
+    const requestHeaders = new Headers(headers)
+    if (contentType) requestHeaders.set('content-type', contentType)
+    return { headers: requestHeaders, json: async () => body } as unknown as NextRequest
+}
+
+const report = (blockedUri: string, directive = 'connect-src'): CspReport => ({
+    'blocked-uri': blockedUri,
+    'document-uri': 'https://peanut.me/home',
+    'effective-directive': directive,
+    'violated-directive': directive,
+})
+
+const reportingApiEntry = (report: CspReport) => ({
+    type: 'csp-violation',
+    body: {
+        blockedURL: report['blocked-uri'],
+        documentURL: report['document-uri'],
+        effectiveDirective: report['effective-directive'],
+    },
+})
+
+/** One legacy `report-uri` POST — what Firefox and Safari still send. */
+const post = (report: CspReport) => route.POST(makeRequest({ 'csp-report': report }))
+
+/** One Reporting-API (`report-to`) batch. */
+const postBatch = (...reports: CspReport[]) =>
+    route.POST(makeRequest(reports.map(reportingApiEntry), { contentType: 'application/reports+json' }))
+
+const forwardedUris = (): unknown[] =>
+    fetchMock.mock.calls.map((call) => JSON.parse(call[1].body)['csp-report']['blocked-uri'])
+
+describe('POST /api/csp-report — response contract', () => {
+    it.each([
+        ['a forwarded report', { 'csp-report': report('https://cdn.example/x.js') }],
+        ['an empty batch', []],
+        ['an unrecognised payload', { hello: 'world' }],
+    ])('answers 204 with no body for %s', async (_case, body) => {
+        const response = await route.POST(makeRequest(body))
+
+        expect(response.status).toBe(204)
+        expect(response.body).toBeNull()
+    })
+
+    it('answers 204 when the body is not JSON at all', async () => {
+        const request = {
+            headers: new Headers({ 'content-type': 'application/csp-report' }),
+            json: async () => {
+                throw new SyntaxError('Unexpected token < in JSON')
+            },
+        } as unknown as NextRequest
+
+        const response = await route.POST(request)
+
+        expect(response.status).toBe(204)
+        expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    // A non-2xx makes the browser retry and log a console error, which would be
+    // a second, self-inflicted noise source.
+    it('answers 204 when the forward to Sentry fails', async () => {
+        fetchMock.mockRejectedValue(new Error('sentry unreachable'))
+
+        const response = await post(report('https://cdn.example/x.js'))
+
+        expect(response.status).toBe(204)
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+})
+
+describe('POST /api/csp-report — content-type gating', () => {
+    it.each([
+        'application/csp-report',
+        'application/reports+json',
+        'application/json',
+        'application/csp-report; charset=utf-8',
+        'Application/CSP-Report',
+        '  application/json  ',
+    ])('accepts %p', async (contentType) => {
+        await route.POST(makeRequest({ 'csp-report': report('https://cdn.example/x.js') }, { contentType }))
+
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it.each(['text/plain', 'application/x-www-form-urlencoded', 'multipart/form-data', ''])(
+        'drops %p without reading the body',
+        async (contentType) => {
+            const json = jest.fn()
+            const request = {
+                headers: contentType ? new Headers({ 'content-type': contentType }) : new Headers(),
+                json,
+            } as unknown as NextRequest
+
+            const response = await route.POST(request)
+
+            expect(response.status).toBe(204)
+            expect(json).not.toHaveBeenCalled()
+            expect(fetchMock).not.toHaveBeenCalled()
+        }
+    )
+})
+
+describe('POST /api/csp-report — Sentry ingest target', () => {
+    it.each([
+        ['is missing', undefined],
+        ['is malformed', 'not-a-dsn'],
+    ])('forwards nothing when the DSN %s', async (_case, dsn) => {
+        if (dsn === undefined) delete process.env.NEXT_PUBLIC_SENTRY_DSN
+        else process.env.NEXT_PUBLIC_SENTRY_DSN = dsn
+
+        const response = await post(report('https://cdn.example/x.js'))
+
+        expect(response.status).toBe(204)
+        expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('posts the report to the DSN-derived security endpoint in the legacy shape', async () => {
+        const violation = report('wss://api.peanut.me/charges')
+
+        await post(violation)
+
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        const [url, init] = fetchMock.mock.calls[0]
+        expect(url).toBe(INGEST_URL)
+        expect(init.method).toBe('POST')
+        expect(init.headers['Content-Type']).toBe('application/csp-report')
+        expect(JSON.parse(init.body)).toEqual({ 'csp-report': violation })
+        expect(init.signal).toBeInstanceOf(AbortSignal)
+    })
+
+    // Sentry reads the browser and user dimensions off whoever POSTs to it,
+    // which is now us rather than the browser.
+    it('passes the reporting browser through instead of attributing every event to Vercel', async () => {
+        await route.POST(
+            makeRequest(
+                { 'csp-report': report('https://cdn.example/x.js') },
+                { headers: { 'user-agent': 'Mozilla/5.0 (iPhone)', 'x-forwarded-for': '203.0.113.7' } }
+            )
+        )
+
+        const { headers } = fetchMock.mock.calls[0][1]
+        expect(headers['User-Agent']).toBe('Mozilla/5.0 (iPhone)')
+        expect(headers['X-Forwarded-For']).toBe('203.0.113.7')
+    })
+
+    it('omits the pass-through headers rather than forwarding empty ones', async () => {
+        await post(report('https://cdn.example/x.js'))
+
+        expect(fetchMock.mock.calls[0][1].headers).toEqual({ 'Content-Type': 'application/csp-report' })
+    })
+
+    it('normalises a Reporting-API batch into the legacy shape Sentry ingests', async () => {
+        await postBatch(report('https://cdn.example/x.js', 'script-src-elem'))
+
+        expect(JSON.parse(fetchMock.mock.calls[0][1].body)['csp-report']).toEqual(
+            expect.objectContaining({
+                'blocked-uri': 'https://cdn.example/x.js',
+                'effective-directive': 'script-src-elem',
+                'violated-directive': 'script-src-elem',
+            })
+        )
+    })
+})
+
+describe('POST /api/csp-report — de-duplication across requests', () => {
+    it('forwards the first sighting of each group and drops the repeats', async () => {
+        await post(report('https://cdn.example/x.js'))
+        await post(report('https://cdn.example/other.js')) // same origin + directive → same group
+        await post(report('https://other-cdn.example/y.js'))
+
+        expect(forwardedUris()).toEqual(['https://cdn.example/x.js', 'https://other-cdn.example/y.js'])
+    })
+
+    it('lets 1% of the repeats through so a still-firing violation keeps a heartbeat', async () => {
+        await post(report('https://cdn.example/x.js'))
+        fetchMock.mockClear()
+
+        randomSpy.mockReturnValue(0.005)
+        await post(report('https://cdn.example/x.js'))
+
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    // Sentry raises two issues for these, so grouping them as one would sample
+    // whichever arrived second away — in the directive that matters most.
+    it('keeps the unsafe-inline and unsafe-eval script-src groups apart', async () => {
+        const local = (keyword: string): CspReport => ({
+            'blocked-uri': 'self',
+            'effective-directive': 'script-src-elem',
+            'violated-directive': `script-src-elem 'self' '${keyword}'`,
+        })
+
+        await post(local('unsafe-inline'))
+        await post(local('unsafe-eval'))
+
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('never forwards a violation an extension caused, whatever its batch position', async () => {
+        await postBatch(report('chrome-extension://abcdefghijklmnop/inject.js'), report('https://cdn.example/x.js'))
+
+        expect(forwardedUris()).toEqual(['https://cdn.example/x.js'])
+    })
+})
+
+describe('POST /api/csp-report — per-request fan-out cap', () => {
+    const distinct = (count: number, offset = 0) =>
+        Array.from({ length: count }, (_, index) => report(`https://cdn-${index + offset}.example/x.js`))
+
+    it('forwards at most 20 reports however large the batch', async () => {
+        await postBatch(...distinct(50))
+
+        expect(fetchMock).toHaveBeenCalledTimes(20)
+    })
+
+    // The cap counts distinct groups, so the repeats a real batch is dominated
+    // by cannot crowd out a genuinely new violation.
+    it('spends the cap on distinct groups, not on repeats', async () => {
+        const repeated = report('https://cdn.example/x.js')
+
+        await postBatch(...Array.from({ length: 30 }, () => repeated), report('https://other-cdn.example/y.js'))
+
+        expect(forwardedUris()).toEqual(['https://cdn.example/x.js', 'https://other-cdn.example/y.js'])
+    })
+
+    // The regression this ordering exists for: a group the cap turned away must
+    // NOT be recorded as seen, or its real first sighting is lost and every
+    // later repeat is sampled away at 1%.
+    it('does not burn the first sighting of a group the cap turned away', async () => {
+        await postBatch(...distinct(25))
+        expect(fetchMock).toHaveBeenCalledTimes(20)
+        fetchMock.mockClear()
+
+        await post(report('https://cdn-24.example/x.js'))
+
+        expect(forwardedUris()).toEqual(['https://cdn-24.example/x.js'])
+    })
+
+    it('bounds the memory by evicting the oldest group, not by forgetting all of them', async () => {
+        // SEEN_GROUPS_MAX is 500 and one request admits at most 20 groups.
+        for (let batch = 0; batch < 25; batch++) await postBatch(...distinct(20, batch * 20))
+        expect(fetchMock).toHaveBeenCalledTimes(500)
+
+        await post(report('https://overflow.example/x.js'))
+        fetchMock.mockClear()
+
+        // Room for the 501st group came from dropping one stale group, not from
+        // dumping all 500 and letting every still-active violation re-forward.
+        await post(report('https://cdn-499.example/x.js'))
+        expect(fetchMock).not.toHaveBeenCalled()
+
+        // The evicted group is the oldest, which reads as new again.
+        await post(report('https://cdn-0.example/x.js'))
+        expect(forwardedUris()).toEqual(['https://cdn-0.example/x.js'])
+    })
+})

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -1,14 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-import {
-    cspReportGroupKey,
-    normalizeCspReports,
-    sentryCspIngestUrl,
-    shouldIgnoreCspReport,
-    type CspReport,
-} from '@/utils/csp-report.utils'
+import { normalizeCspReports, selectReportsToForward, sentryCspIngestUrl } from '@/utils/csp-report.utils'
 
 export const dynamic = 'force-dynamic'
+
+/**
+ * One JSON parse plus at most MAX_FORWARDS_PER_REQUEST parallel fetches of
+ * FORWARD_TIMEOUT_MS each — this can never legitimately need more than a few
+ * seconds. Worth declaring on an unauthenticated route, because the fallback is
+ * a project default measured in minutes (`vercel.json` says 300s, though its
+ * `app/api/**` glob misses this project's `src/`-prefixed routes — see
+ * SERVER_FETCH_TIMEOUT_MS in sentry.utils.ts).
+ */
+export const maxDuration = 10
 
 /**
  * Collector for the report-only CSP's violation reports.
@@ -25,6 +29,17 @@ export const dynamic = 'force-dynamic'
  * extension-scheme filter in csp-report.utils.ts is a cheap extra that saves an
  * outbound request; Sentry's own default inbound filter already drops that
  * class server-side, so it is not doing the real work.
+ *
+ * Unauthenticated by necessity — browsers POST violation reports with no
+ * credentials. What that exposes is our invocation and egress cost, not Sentry
+ * quota: `report-uri` used to point straight at Sentry and that URL embeds the
+ * public DSN key shipped in every client bundle, so anyone could always POST
+ * there directly, with or without this route. The control for the cost is a
+ * Vercel WAF rate limit on this path (Firewall → Rate Limit, `/api/csp-report`,
+ * ~100 requests / 60s per IP, action deny) — it runs before the function and
+ * holds across instances, where an in-memory limiter would reset on every cold
+ * start and miss any distributed source entirely. Until that rule exists,
+ * `maxDuration` and MAX_FORWARDS_PER_REQUEST are what bound a single request.
  */
 
 /** Both wire formats, plus plain JSON from anything replaying a report. */
@@ -45,16 +60,6 @@ const SEEN_GROUPS_MAX = 500
 const seenGroups = new Set<string>()
 
 const FORWARD_TIMEOUT_MS = 3000
-
-/**
- * Hard cap on forwards per request. This endpoint is unauthenticated and a
- * Reporting-API batch is an array, so without a cap one POST could fan out
- * arbitrarily many events. That matters more than it looks: Sentry bills CSP
- * reports against the *error* quota under a per-DSN-key rate limit, so an
- * uncapped fan-out could exhaust the quota that real application exceptions
- * depend on. A genuine browser batch is a handful of reports.
- */
-const MAX_FORWARDS_PER_REQUEST = 20
 
 function shouldForward(groupKey: string): boolean {
     if (!seenGroups.has(groupKey)) {
@@ -85,27 +90,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         if (!ingestUrl) return noContent
 
         const reports = normalizeCspReports(await request.json())
-
-        const seenInBatch = new Set<string>()
-        const forwardable: CspReport[] = []
-        for (const report of reports) {
-            if (shouldIgnoreCspReport(report)) continue
-
-            const groupKey = cspReportGroupKey(report)
-            // One slot per distinct group: a batch is usually dominated by
-            // repeats of a single violation, and 20 copies of it must not
-            // crowd a genuinely new group out of the per-request cap.
-            if (seenInBatch.has(groupKey)) continue
-            seenInBatch.add(groupKey)
-
-            // Cap BEFORE shouldForward, never after: shouldForward records
-            // each group as seen, so admitting more than we can send would
-            // mark groups seen that were never actually sent — their real
-            // first sighting lost, every later repeat sampled away.
-            if (seenInBatch.size > MAX_FORWARDS_PER_REQUEST) break
-
-            if (shouldForward(groupKey)) forwardable.push(report)
-        }
+        const forwardable = selectReportsToForward(reports, shouldForward)
 
         // Sentry derives the event's browser and request context from the
         // headers of whoever POSTs to its security endpoint. That used to be

--- a/src/utils/__tests__/csp-report.utils.test.ts
+++ b/src/utils/__tests__/csp-report.utils.test.ts
@@ -1,6 +1,8 @@
 import {
     cspReportGroupKey,
+    MAX_FORWARDS_PER_REQUEST,
     normalizeCspReports,
+    selectReportsToForward,
     sentryCspIngestUrl,
     shouldIgnoreCspReport,
     type CspReport,
@@ -225,4 +227,114 @@ describe('sentryCspIngestUrl', () => {
             expect(sentryCspIngestUrl(dsn)).toBeNull()
         }
     )
+})
+
+describe('selectReportsToForward', () => {
+    const report = (blockedUri: string, directive = 'connect-src'): CspReport => ({
+        'blocked-uri': blockedUri,
+        'effective-directive': directive,
+        'violated-directive': directive,
+    })
+    const distinct = (count: number) =>
+        Array.from({ length: count }, (_, index) => report(`https://cdn-${index}.example/x.js`))
+    const uris = (reports: CspReport[]) => reports.map((report) => report['blocked-uri'])
+
+    const forwardAll = () => true
+    const forwardNone = () => false
+
+    it('returns nothing for an empty batch without consulting the predicate', () => {
+        const shouldForward = jest.fn(forwardAll)
+
+        expect(selectReportsToForward([], shouldForward)).toEqual([])
+        expect(shouldForward).not.toHaveBeenCalled()
+    })
+
+    it('forwards exactly what the predicate admits, in arrival order', () => {
+        const batch = [report('https://a.example/x.js'), report('https://b.example/y.js')]
+
+        expect(uris(selectReportsToForward(batch, (key) => key.includes('b.example')))).toEqual([
+            'https://b.example/y.js',
+        ])
+        expect(uris(selectReportsToForward(batch, forwardAll))).toEqual([
+            'https://a.example/x.js',
+            'https://b.example/y.js',
+        ])
+        expect(selectReportsToForward(batch, forwardNone)).toEqual([])
+    })
+
+    it('asks about each distinct group once, keeping the first report of it', () => {
+        const shouldForward = jest.fn(forwardAll)
+
+        const forwarded = selectReportsToForward(
+            [
+                report('https://cdn.example/first.js'),
+                report('https://cdn.example/second.js'), // same origin + directive
+                report('https://cdn.example/third.js'),
+            ],
+            shouldForward
+        )
+
+        expect(uris(forwarded)).toEqual(['https://cdn.example/first.js'])
+        expect(shouldForward).toHaveBeenCalledTimes(1)
+        expect(shouldForward).toHaveBeenCalledWith('connect-src|https://cdn.example')
+    })
+
+    it('separates groups the same origin reaches under different directives', () => {
+        const forwarded = selectReportsToForward(
+            [report('https://cdn.example/x.js', 'connect-src'), report('https://cdn.example/x.js', 'img-src')],
+            forwardAll
+        )
+
+        expect(forwarded).toHaveLength(2)
+    })
+
+    it('drops reports no allow-list entry could ever fix, before they cost a group slot', () => {
+        const forwarded = selectReportsToForward(
+            [
+                ...Array.from({ length: MAX_FORWARDS_PER_REQUEST }, (_, index) =>
+                    report(`chrome-extension://ext-${index}/inject.js`)
+                ),
+                report('https://cdn.example/x.js'),
+            ],
+            forwardAll
+        )
+
+        expect(uris(forwarded)).toEqual(['https://cdn.example/x.js'])
+    })
+
+    it('caps the fan-out at MAX_FORWARDS_PER_REQUEST distinct groups', () => {
+        const forwarded = selectReportsToForward(distinct(MAX_FORWARDS_PER_REQUEST + 30), forwardAll)
+
+        expect(forwarded).toHaveLength(MAX_FORWARDS_PER_REQUEST)
+        expect(uris(forwarded)).toEqual(uris(distinct(MAX_FORWARDS_PER_REQUEST)))
+    })
+
+    // The invariant the ordering exists for. The predicate records each group
+    // it is asked about as seen, so asking about a group past the cap would
+    // mark it seen without ever sending it: its real first sighting lost, every
+    // later repeat sampled away at 1%.
+    it('never asks about a group it cannot send', () => {
+        const asked: string[] = []
+
+        const forwarded = selectReportsToForward(distinct(MAX_FORWARDS_PER_REQUEST + 30), (key) => {
+            asked.push(key)
+            return true
+        })
+
+        expect(asked).toHaveLength(MAX_FORWARDS_PER_REQUEST)
+        expect(forwarded).toHaveLength(MAX_FORWARDS_PER_REQUEST)
+    })
+
+    // A rejected group is still spent: the predicate owns that decision, and
+    // re-offering it would let one flood re-enter every request.
+    it('counts a group the predicate rejected against the cap', () => {
+        const asked: string[] = []
+
+        selectReportsToForward(distinct(MAX_FORWARDS_PER_REQUEST + 5), (key) => {
+            asked.push(key)
+            return false
+        })
+
+        expect(asked).toHaveLength(MAX_FORWARDS_PER_REQUEST)
+    })
 })

--- a/src/utils/csp-report.utils.ts
+++ b/src/utils/csp-report.utils.ts
@@ -179,6 +179,54 @@ export function cspReportGroupKey(report: CspReport): string {
 }
 
 /**
+ * Hard cap on forwards per request. The collector is unauthenticated and a
+ * Reporting-API batch is an array, so without a cap one POST could fan out
+ * arbitrarily many events. That matters more than it looks: Sentry bills CSP
+ * reports against the *error* quota under a per-DSN-key rate limit, so an
+ * uncapped fan-out could exhaust the quota that real application exceptions
+ * depend on. A genuine browser batch is a handful of reports.
+ */
+export const MAX_FORWARDS_PER_REQUEST = 20
+
+/**
+ * Choose which reports of one inbound batch to forward.
+ *
+ * `shouldForward` is injected rather than imported: it carries the collector's
+ * cross-request state (which groups Sentry has already seen) and its own
+ * sampling, so keeping it out leaves this loop pure and its ordering invariant
+ * testable on its own. It is called at most once per distinct group, and only
+ * for groups this function is actually willing to forward.
+ */
+export function selectReportsToForward(
+    reports: CspReport[],
+    shouldForward: (groupKey: string) => boolean
+): CspReport[] {
+    const seenInBatch = new Set<string>()
+    const forwardable: CspReport[] = []
+
+    for (const report of reports) {
+        if (shouldIgnoreCspReport(report)) continue
+
+        const groupKey = cspReportGroupKey(report)
+        // One slot per distinct group: a batch is usually dominated by
+        // repeats of a single violation, and 20 copies of it must not
+        // crowd a genuinely new group out of the per-request cap.
+        if (seenInBatch.has(groupKey)) continue
+        seenInBatch.add(groupKey)
+
+        // Cap BEFORE shouldForward, never after: shouldForward records
+        // each group as seen, so admitting more than we can send would
+        // mark groups seen that were never actually sent — their real
+        // first sighting lost, every later repeat sampled away.
+        if (seenInBatch.size > MAX_FORWARDS_PER_REQUEST) break
+
+        if (shouldForward(groupKey)) forwardable.push(report)
+    }
+
+    return forwardable
+}
+
+/**
  * Sentry's CSP ingest endpoint, derived from the browser DSN
  * (`<protocol>://<publicKey>@<host><path>/<projectId>`). Returns null when the
  * DSN is absent or malformed, in which case reports are simply dropped.


### PR DESCRIPTION
Closes #2543 — the two follow-ups deliberately left out of #2519.

## 1. Route-level test coverage

`src/app/api/csp-report/route.ts` held the subtlest logic in the feature and had **no tests**. This adds 37, and extracts the part worth isolating.

**Extraction, as the issue described it.** The per-batch selection loop moves out of the handler into a pure `selectReportsToForward(reports, shouldForward)` in `csp-report.utils.ts`, taking the predicate as a parameter. `seenGroups` and the 1% sampling stay in the route — no module-level mutable state moves into a utils file. The handler is now two lines where the loop was.

**12 unit tests** for the loop:
- intra-batch de-duplication (asks about each distinct group once, keeps the first report of it)
- the cap at `MAX_FORWARDS_PER_REQUEST` distinct groups
- ignored (extension-scheme) reports never costing a cap slot
- **the ordering invariant, stated directly: it never asks the predicate about a group it cannot send.** The predicate records what it is asked about, so asking past the cap marks a group seen that was never sent — first sighting lost, every later repeat sampled away at 1%. That was the original Major on #2519.

**25 route tests** for what only the route holds:
- the always-204 contract, including a body that is not JSON and an unreachable Sentry
- content-type gating: parameters/case/padding accepted, and a rejected type never reads the body
- DSN derivation, plus the missing and malformed DSN paths
- the `User-Agent` / `X-Forwarded-For` pass-through (and that empty ones are omitted, not forwarded blank)
- 1% duplicate sampling
- oldest-group eviction at `SEEN_GROUPS_MAX` — asserting one group is dropped rather than all 500, which a `clear()` would otherwise pass unnoticed

`seenGroups` outlives a request, so each test takes a fresh module via `jest.isolateModules` + `require` (the pattern from `auth-token.test.ts`), with `Math.random` pinned so "forwarded" always means "first sighting".

**Mutation-tested rather than trusted green:** moving the cap after `shouldForward` fails 5 tests, dropping the intra-batch de-duplication fails 1, replacing oldest-eviction with `clear()` fails 1.

## 2. Rate limit

The control is a **Vercel WAF rate-limit rule** on `/api/csp-report` — it runs before the function and holds across instances, where an in-memory limiter on a `force-dynamic` route resets every cold start and misses a distributed source entirely. That is a dashboard change, not a code one, so this PR records the rule (path, ~100 req/60s per IP, action deny) next to the code that needs it and does the code half:

**`export const maxDuration = 10`.** The handler is one JSON parse plus at most 20 parallel fetches already capped at 3s each, so it can never legitimately need more.

**One correction to the issue's premise:** `vercel.json`'s `maxDuration: 300` does *not* currently apply to this route. Its glob is `app/api/**` while this project's routes live under `src/app/api/`, which Vercel does not match — already documented at `SERVER_FETCH_TIMEOUT_MS` in `sentry.utils.ts`. The real ceiling is the unverifiable project default, which is the better reason to declare one explicitly.

## Verification

- 75/75 csp tests pass; full suite 2964 passed (the 4 failures are `src/content` being uninitialized in a fresh worktree, unrelated)
- `prettier --check` clean, `eslint` clean on all four files, `tsc --noEmit` adds no errors

No behaviour change to what gets forwarded — the selection logic is moved verbatim.
