### PR TITLE
fix(i18n): card copy that bypassed the catalog, and the prop guard that let it (main)

### DIFF
--- a/eslint-rules/__tests__/copy-props-from-catalog.test.js
+++ b/eslint-rules/__tests__/copy-props-from-catalog.test.js
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment node
+ *
+ * RuleTester needs structuredClone, which this jsdom version does not provide.
+ *
+ * The rule's value is entirely in where it draws the prose/not-prose line: too
+ * loose and every `variant="warning"` becomes an error, too tight and the bug it
+ * exists for (card balance-due notice, card-receipt adjustment) walks straight
+ * through. Both edges are pinned here.
+ */
+const { RuleTester } = require('eslint')
+const tsParser = require('@typescript-eslint/parser')
+const rule = require('../copy-props-from-catalog')
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        parser: tsParser,
+        parserOptions: { ecmaVersion: 'latest', sourceType: 'module', ecmaFeatures: { jsx: true } },
+    },
+})
+
+ruleTester.run('copy-props-from-catalog', rule, {
+    valid: [
+        // not copy props
+        '<InfoCard variant="warning" icon="credit-card" />',
+        '<button type="button" className="flex items-center" />',
+        '<a href="https://peanut.me/en/card-terms-us" />',
+        // copy props holding a single token, an id or a code
+        '<PaymentInfoRow label="CUIT" />',
+        '<PaymentInfoRow label="USD" />',
+        '<Row title="card-terms-us" />',
+        // copy props fed from the catalog
+        "<InfoCard title={t('card.yourCard.balanceDueTitle')} />",
+        "<InfoCard description={t('balanceDueBody', { amount })} />",
+        // template literals that interpolate values without prose around them
+        '<InfoCard title={`$${(cents / 100).toFixed(2)}`} />',
+        '<InfoCard title={`${a}${b}`} />',
+        '<Row label={`${count}%`} />',
+    ],
+    invalid: [
+        {
+            code: '<InfoCard description="A recent card payment ended up higher than the amount held at checkout." />',
+            errors: [{ messageId: 'literal' }],
+        },
+        {
+            code: '<ActionModal title="A small update to our terms" />',
+            errors: [{ messageId: 'literal' }],
+        },
+        {
+            code: '<PaymentInfoRow label="Exchange Rate" />',
+            errors: [{ messageId: 'literal' }],
+        },
+        {
+            // the shape that shipped: prose with one interpolated amount
+            code: '<InfoCard title={`${amount} will be debited based on your next deposit`} />',
+            errors: [{ messageId: 'literal' }],
+        },
+        {
+            // trailing interpolation still reads as prose
+            code: '<button aria-label={`Dismiss ${title}`} />',
+            errors: [{ messageId: 'literal' }],
+        },
+        {
+            code: '<Field placeholder="Address to receive the funds" />',
+            errors: [{ messageId: 'literal' }],
+        },
+        {
+            // a string literal wrapped in braces is the same bug
+            code: '<InfoCard description={"We could not load the exchange rate."} />',
+            errors: [{ messageId: 'literal' }],
+        },
+    ],
+})

--- a/eslint-rules/copy-props-from-catalog.js
+++ b/eslint-rules/copy-props-from-catalog.js
@@ -1,0 +1,79 @@
+/**
+ * Copy handed to a component as a PROP must come from next-intl.
+ *
+ * `react/jsx-no-literals` runs with `ignoreProps: true` — it cannot be flipped,
+ * since every non-copy prop (`variant="warning"`, `icon="info"`, `type="button"`)
+ * is a string literal too. That blind spot shipped English to every locale from
+ * screens that were otherwise fully translated: the card balance-due notice and
+ * the card-receipt adjustment notice both passed `title`/`description` as
+ * literals on a page where all other copy went through `t()`.
+ *
+ * Only props that carry prose are checked, and only values that look like prose
+ * (two or more words), so ids, slugs, enum-ish values and single tokens like
+ * `label="USD"` stay legal.
+ */
+
+const COPY_PROPS = new Set([
+    'title',
+    'description',
+    'subtitle',
+    'heading',
+    'placeholder',
+    'label',
+    'ariaLabel',
+    'aria-label',
+    'message',
+    'cta',
+    'caption',
+    'helperText',
+    'emptyMessage',
+])
+
+// Two adjacent words: the cheapest signal that separates prose from a token.
+// Deliberately not anchored — "Add money to your account" and "Razón Social"
+// both match, "USD", "peanut.me/" and "card-terms-us" do not.
+const PROSE = /[\p{L}]\s+[\p{L}]/u
+
+const MESSAGE =
+    "Copy passed as `{{prop}}` must come from next-intl, not a literal — react/jsx-no-literals only inspects JSX children, so prop copy reaches every locale in English. Use t('…') from the right namespace. If this string is not copy (an id, a slug, a currency code), it does not need to be a full phrase."
+
+module.exports = {
+    meta: {
+        type: 'problem',
+        docs: { description: 'require next-intl for copy passed as a JSX prop' },
+        schema: [],
+        messages: { literal: MESSAGE },
+    },
+    create(context) {
+        const report = (node, prop) => context.report({ node, messageId: 'literal', data: { prop } })
+
+        return {
+            JSXAttribute(node) {
+                const name = node.name && node.name.type === 'JSXIdentifier' ? node.name.name : null
+                if (!name || !COPY_PROPS.has(name)) return
+                const value = node.value
+                if (!value) return
+
+                if (value.type === 'Literal') {
+                    if (typeof value.value === 'string' && PROSE.test(value.value)) report(value, name)
+                    return
+                }
+                if (value.type !== 'JSXExpressionContainer') return
+
+                const expression = value.expression
+                if (expression.type === 'Literal') {
+                    if (typeof expression.value === 'string' && PROSE.test(expression.value)) report(expression, name)
+                    return
+                }
+                // Template literals are the other half of the bug: the card notices
+                // interpolated an amount into an otherwise-hardcoded sentence. Each
+                // interpolation stands in as one word, so `Dismiss ${name}` reads as
+                // prose while `$${amount}` and `${a}${b}` do not.
+                if (expression.type === 'TemplateLiteral') {
+                    const asWords = expression.quasis.map((quasi) => quasi.value.raw).join('X')
+                    if (PROSE.test(asWords)) report(expression, name)
+                }
+            },
+        }
+    },
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,7 @@ const reactHooksPlugin = require('eslint-plugin-react-hooks')
 const nextPlugin = require('@next/eslint-plugin-next')
 const importPlugin = require('eslint-plugin-import-x')
 const globals = require('globals')
+const copyPropsFromCatalog = require('./eslint-rules/copy-props-from-catalog')
 
 // Barrel paths banned by CLAUDE.md ("no barrel imports — never `import * as X from
 // '@/constants'` or create `index.ts` barrels. Import from specific files"). The bare
@@ -248,7 +249,11 @@ module.exports = [
             // affected users, so the copy stays English-only.
             'src/app/(mobile-ui)/fix-card-signature/**',
         ],
+        plugins: { local: { rules: { 'copy-props-from-catalog': copyPropsFromCatalog } } },
         rules: {
+            // Companion to jsx-no-literals below, which only sees JSX children:
+            // this catches copy handed to a component as a prop.
+            'local/copy-props-from-catalog': 'error',
             'react/jsx-no-literals': [
                 'error',
                 {

--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -469,9 +469,7 @@ function BridgeBankOnrampPage() {
                     {error.showError && !!error.errorMessage && !limitsValidation.isBlocking && (
                         <ErrorAlert description={error.errorMessage} />
                     )}
-                    {localCurrency !== 'USD' && isRateError && (
-                        <ErrorAlert description="We couldn't load the exchange rate. Please try again in a moment." />
-                    )}
+                    {localCurrency !== 'USD' && isRateError && <ErrorAlert description={t('errors.rateUnavailable')} />}
                 </div>
 
                 <OnrampConfirmationModal

--- a/src/components/Card/CancelCardModal.tsx
+++ b/src/components/Card/CancelCardModal.tsx
@@ -64,7 +64,7 @@ const CancelCardModal: FC<Props> = ({ cardId, isOpen, onClose }) => {
             // would skip the withdrawal and get the cancel rejected by the
             // backend ("Withdrawal signature required"). Fail closed instead.
             if (!overview) {
-                throw new Error('Card details still loading — please retry in a moment')
+                throw new Error(t('errors.cardDetailsLoading'))
             }
             // Cancel can be terminal on Rain's side (collateral contract may
             // become unreachable), so we MUST drain it BEFORE the cancel.

--- a/src/components/Card/CardTermsScreen.tsx
+++ b/src/components/Card/CardTermsScreen.tsx
@@ -1,11 +1,13 @@
 'use client'
 import { type FC, type ReactNode, useEffect, useMemo, useState } from 'react'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import NavHeader from '@/components/Global/NavHeader'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Checkbox } from '@/components/0_Bruddle/Checkbox'
+import { toMarketingLocale } from '@/i18n/localeBridge'
+import type { Locale as MarketingLocale } from '@/i18n/types'
 
 interface Props {
     isUsResident: boolean
@@ -19,13 +21,16 @@ interface Props {
 const CARD_PARTNER_NAME = 'Peanut'
 
 // US and international cardholders accept different card-terms documents.
-const LINKS = {
-    eSign: 'https://peanut.me/en/card-esign',
+// The marketing pages are locale-routed and fall back to English prose when a
+// legal doc has no translation yet, so linking the user's own locale is always
+// safe — hardcoding /en/ was not.
+const linksFor = (locale: MarketingLocale) => ({
+    eSign: `https://peanut.me/${locale}/card-esign`,
     issuerPrivacy: 'https://www.third-national.com/privacypolicy',
-    cardTermsUs: 'https://peanut.me/en/card-terms-us',
-    cardTermsInternational: 'https://peanut.me/en/card-terms-international',
-    accountOpeningPrivacy: 'https://peanut.me/en/card-privacy',
-}
+    cardTermsUs: `https://peanut.me/${locale}/card-terms-us`,
+    cardTermsInternational: `https://peanut.me/${locale}/card-terms-international`,
+    accountOpeningPrivacy: `https://peanut.me/${locale}/card-privacy`,
+})
 
 interface Term {
     id: string
@@ -42,14 +47,17 @@ const CardTermsScreen: FC<Props> = ({ isUsResident, onAccept, onPrev, submitErro
     const t = useTranslations('card.terms')
     const tCard = useTranslations('card')
     const tCommon = useTranslations('common')
+    const locale = useLocale()
     const [checked, setChecked] = useState<Record<string, boolean>>({})
     const [submitting, setSubmitting] = useState(false)
+
+    const links = useMemo(() => linksFor(toMarketingLocale(locale)), [locale])
 
     const terms = useMemo<Term[]>(() => {
         const esignTerm: Term = {
             id: 'esign',
             label: t.rich('esign', {
-                link: (chunks) => <ExternalLink href={LINKS.eSign}>{chunks}</ExternalLink>,
+                link: (chunks) => <ExternalLink href={links.eSign}>{chunks}</ExternalLink>,
             }),
         }
         const cardTermsIssuerTerm: Term = {
@@ -57,11 +65,11 @@ const CardTermsScreen: FC<Props> = ({ isUsResident, onAccept, onPrev, submitErro
             label: t.rich('cardTermsIssuer', {
                 partner: CARD_PARTNER_NAME,
                 terms: (chunks) => (
-                    <ExternalLink href={isUsResident ? LINKS.cardTermsUs : LINKS.cardTermsInternational}>
+                    <ExternalLink href={isUsResident ? links.cardTermsUs : links.cardTermsInternational}>
                         {chunks}
                     </ExternalLink>
                 ),
-                privacy: (chunks) => <ExternalLink href={LINKS.issuerPrivacy}>{chunks}</ExternalLink>,
+                privacy: (chunks) => <ExternalLink href={links.issuerPrivacy}>{chunks}</ExternalLink>,
             }),
         }
         const accuracyTerm: Term = { id: 'accuracy', label: t('accuracy', { partner: CARD_PARTNER_NAME }) }
@@ -73,11 +81,11 @@ const CardTermsScreen: FC<Props> = ({ isUsResident, onAccept, onPrev, submitErro
         const accountOpeningPrivacyTerm: Term = {
             id: 'accountOpeningPrivacy',
             label: t.rich('accountOpeningPrivacy', {
-                link: (chunks) => <ExternalLink href={LINKS.accountOpeningPrivacy}>{chunks}</ExternalLink>,
+                link: (chunks) => <ExternalLink href={links.accountOpeningPrivacy}>{chunks}</ExternalLink>,
             }),
         }
         return [esignTerm, accountOpeningPrivacyTerm, cardTermsIssuerTerm, accuracyTerm, solicitationTerm]
-    }, [isUsResident, t])
+    }, [isUsResident, t, links])
 
     useEffect(() => {
         posthog.capture(ANALYTICS_EVENTS.CARD_TERMS_VIEWED, {

--- a/src/components/Card/LockCardModal.tsx
+++ b/src/components/Card/LockCardModal.tsx
@@ -70,7 +70,7 @@ const LockCardModal: FC<Props> = ({ cardId, mode, isOpen, onClose }) => {
                 // would skip the withdrawal and get the lock rejected by the
                 // backend ("Withdrawal signature required"). Fail closed instead.
                 if (!overview) {
-                    throw new Error('Card details still loading — please retry in a moment')
+                    throw new Error(t('errors.cardDetailsLoading'))
                 }
                 // If the user has spending power, return collateral to their
                 // smart wallet BEFORE locking so funds stay liquid. The

--- a/src/components/Card/YourCardScreen.tsx
+++ b/src/components/Card/YourCardScreen.tsx
@@ -93,8 +93,8 @@ const YourCardScreen: FC<Props> = ({ overview, card, onPrev }) => {
                 <InfoCard
                     variant="warning"
                     icon="credit-card"
-                    title={`$${(balanceDueCents / 100).toFixed(2)} will be debited based on your next deposit`}
-                    description="A recent card payment ended up higher than the amount held at checkout. This happens with tips or updated totals. We'll cover the difference automatically."
+                    title={t('balanceDueTitle', { amount: `$${(balanceDueCents / 100).toFixed(2)}` })}
+                    description={t('balanceDueBody')}
                 />
             )}
 

--- a/src/components/Card/__tests__/CardTermsScreen.test.tsx
+++ b/src/components/Card/__tests__/CardTermsScreen.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * CardTermsScreen — legal-document links must follow the user's language.
+ *
+ * The five peanut.me legal pages are locale-routed; hardcoding /en/ sent
+ * es-419 / pt-BR cardholders to the English documents from a screen that was
+ * otherwise fully translated. The marketing locale set spells the tags
+ * differently from the app's (`pt-br` vs `pt-BR`), so the mapping — not just
+ * the raw locale — is what this pins down.
+ */
+import React, { type ReactNode } from 'react'
+import { render as rtlRender, screen } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import type { AppLocale } from '@/i18n/app/config'
+import { deepMerge } from '@/i18n/app/messages'
+import en from '@/i18n/app/messages/en.json'
+import es419 from '@/i18n/app/messages/es-419.json'
+import ptBR from '@/i18n/app/messages/pt-BR.json'
+import CardTermsScreen from '@/components/Card/CardTermsScreen'
+
+// NavHeader reads useAuth; stub it so the presentational screen renders alone.
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => ({ user: { accounts: [] }, fetchUser: jest.fn() }),
+}))
+jest.mock('posthog-js', () => ({
+    __esModule: true,
+    default: { capture: jest.fn() },
+}))
+
+// The shared IntlWrapper is pinned to en — this suite is about locale routing.
+const CATALOGS: Record<string, unknown> = {
+    en,
+    'es-419': deepMerge(en, es419 as never),
+    'pt-BR': deepMerge(en, ptBR as never),
+}
+
+const renderAt = (locale: AppLocale) => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+        <NextIntlClientProvider locale={locale} messages={CATALOGS[locale] as never} timeZone="UTC">
+            {children}
+        </NextIntlClientProvider>
+    )
+    return rtlRender(<CardTermsScreen isUsResident onAccept={jest.fn()} />, { wrapper })
+}
+
+const hrefs = () => screen.getAllByRole('link').map((link) => link.getAttribute('href'))
+
+describe('CardTermsScreen legal links', () => {
+    it('points at the English documents for en', () => {
+        renderAt('en')
+        expect(hrefs()).toEqual(
+            expect.arrayContaining([
+                'https://peanut.me/en/card-esign',
+                'https://peanut.me/en/card-terms-us',
+                'https://peanut.me/en/card-privacy',
+            ])
+        )
+    })
+
+    it('follows the active locale for es-419', () => {
+        renderAt('es-419')
+        const peanutLinks = hrefs().filter((href) => href?.startsWith('https://peanut.me/'))
+        expect(peanutLinks.length).toBeGreaterThan(0)
+        expect(peanutLinks.every((href) => href?.startsWith('https://peanut.me/es-419/'))).toBe(true)
+    })
+
+    it('maps pt-BR onto the marketing tag pt-br', () => {
+        renderAt('pt-BR')
+        const peanutLinks = hrefs().filter((href) => href?.startsWith('https://peanut.me/'))
+        expect(peanutLinks.length).toBeGreaterThan(0)
+        expect(peanutLinks.every((href) => href?.startsWith('https://peanut.me/pt-br/'))).toBe(true)
+    })
+
+    it('leaves the issuer policy on the issuer domain', () => {
+        renderAt('pt-BR')
+        expect(hrefs()).toContain('https://www.third-national.com/privacypolicy')
+    })
+})

--- a/src/components/ExchangeRate/index.tsx
+++ b/src/components/ExchangeRate/index.tsx
@@ -1,14 +1,10 @@
+import { useTranslations } from 'next-intl'
 import { AccountType } from '@/interfaces/interfaces'
 import { PaymentInfoRow } from '@/components/Payment/PaymentInfoRow'
 import useGetExchangeRate, { type IExchangeRate } from '@/hooks/useGetExchangeRate'
 import { useExchangeRate } from '@/hooks/useExchangeRate'
 import { SYMBOLS_BY_CURRENCY_CODE } from '@/hooks/useCurrency'
 import { applyBridgeCrossCurrencyFee } from '@/utils/bridge.utils'
-
-// constants for exchange rate messages, specific to ExchangeRate component
-const APPROXIMATE_VALUE_MESSAGE =
-    "This is an approximate value. The actual amount received may vary based on your bank's exchange rate"
-const LOCAL_CURRENCY_LABEL = 'Amount you will receive'
 
 interface IExchangeRateProps extends Omit<IExchangeRate, 'enabled'> {
     nonEuroCurrency?: string
@@ -22,6 +18,8 @@ const ExchangeRate = ({
     sourceCurrency = 'USD',
     amountToConvert,
 }: IExchangeRateProps) => {
+    const t = useTranslations('exchangeRate.row')
+    const tCommon = useTranslations('common')
     const { exchangeRate, isFetchingRate } = useGetExchangeRate({ accountType, enabled: !nonEuroCurrency })
     const { exchangeRate: nonEruoExchangeRate, isLoading } = useExchangeRate({
         sourceCurrency,
@@ -33,7 +31,7 @@ const ExchangeRate = ({
     const toCurrency = accountType === AccountType.IBAN ? 'EUR' : accountType === AccountType.CLABE ? 'MXN' : 'USD'
 
     if (accountType === AccountType.US) {
-        return <PaymentInfoRow loading={isFetchingRate} label="Exchange Rate" value={`1 USD`} />
+        return <PaymentInfoRow loading={isFetchingRate} label={tCommon('exchangeRate')} value={`1 USD`} />
     }
 
     let displayValue = '-'
@@ -47,12 +45,12 @@ const ExchangeRate = ({
             : '-'
         isLoadingRate = isLoading
         rate = nonEruoExchangeRate
-        moreInfoText = APPROXIMATE_VALUE_MESSAGE
+        moreInfoText = t('approximate')
     } else {
         displayValue = exchangeRate ? `1 USD = ${parseFloat(exchangeRate).toFixed(4)} ${toCurrency}` : '-'
         isLoadingRate = isFetchingRate
         rate = exchangeRate ? parseFloat(exchangeRate) : null
-        moreInfoText = `Exchange rates apply when converting to ${toCurrency}`
+        moreInfoText = t('appliesWhenConverting', { currency: toCurrency })
     }
 
     const currency = nonEuroCurrency || toCurrency
@@ -82,16 +80,16 @@ const ExchangeRate = ({
         <>
             <PaymentInfoRow
                 loading={isLoadingRate}
-                label="Exchange Rate"
+                label={tCommon('exchangeRate')}
                 moreInfoText={moreInfoText}
                 value={displayValue}
             />
             {localCurrencyAmount && (
                 <PaymentInfoRow
                     loading={isLoadingRate}
-                    label={LOCAL_CURRENCY_LABEL}
+                    label={t('amountYouReceive')}
                     value={`~ ${currencySymbol}${localCurrencyAmount}`}
-                    moreInfoText={APPROXIMATE_VALUE_MESSAGE}
+                    moreInfoText={t('approximate')}
                 />
             )}
         </>

--- a/src/components/Global/Banner/MaintenanceBanner.tsx
+++ b/src/components/Global/Banner/MaintenanceBanner.tsx
@@ -1,5 +1,7 @@
+import { useTranslations } from 'next-intl'
 import { GenericBanner } from './GenericBanner'
 
 export function MaintenanceBanner() {
-    return <GenericBanner message="Maintenance mode, some functionalities won't be available. Funds safe" icon="⚠️" />
+    const t = useTranslations('global')
+    return <GenericBanner message={t('maintenanceBanner')} icon="⚠️" />
 }

--- a/src/components/Global/ReConsentModal/index.tsx
+++ b/src/components/Global/ReConsentModal/index.tsx
@@ -136,7 +136,7 @@ const ReConsentModal = () => {
             visible
             onClose={handlePostpone}
             icon="info"
-            title="A small update to our terms"
+            title={t('reConsent.title')}
             content={
                 <div className="w-full space-y-3 text-left">
                     {/* The first sentence answers the question this modal actually raises

--- a/src/components/Home/PendingVerificationTasks.tsx
+++ b/src/components/Home/PendingVerificationTasks.tsx
@@ -288,7 +288,7 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
                                         {dismissible && !!task.effectiveDate && (
                                             <button
                                                 type="button"
-                                                aria-label={`Dismiss ${copy.title}`}
+                                                aria-label={t('pendingTasks.dismiss', { task: copy.title })}
                                                 onClick={() => handleDismissTask(task)}
                                                 className="absolute right-3 top-3 z-10 cursor-pointer p-0 text-black outline-none"
                                             >

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -561,7 +561,7 @@ export const TransactionDetailsReceipt = ({
                             {/* TODO: stop using snake_case!!!!! */}
                             {transaction.extraDataForDrawer?.receipt?.exchange_rate && (
                                 <PaymentInfoRow
-                                    label={t('rows.exchangeRate')}
+                                    label={tCommon('exchangeRate')}
                                     value={`1 USD = ${transaction.currency!.code?.toUpperCase()} ${formatCurrency(transaction.extraDataForDrawer.receipt.exchange_rate, 4)}`}
                                     hideBottomBorder={shouldHideBorder('exchangeRate')}
                                 />

--- a/src/components/TransactionDetails/provider-rows/CardAdjustmentNotice.tsx
+++ b/src/components/TransactionDetails/provider-rows/CardAdjustmentNotice.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useTranslations } from 'next-intl'
 import InfoCard from '@/components/Global/InfoCard'
 import { type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
 import { parseCents } from '@/components/TransactionDetails/transaction-details.utils'
@@ -19,6 +20,7 @@ import { parseCents } from '@/components/TransactionDetails/transaction-details.
  * totals") without asserting one — Rain doesn't report why capture ≠ auth.
  */
 export function CardAdjustmentNotice({ transaction }: { transaction: TransactionDetails }) {
+    const t = useTranslations('transaction.cardRows')
     const card = transaction.extraDataForDrawer?.cardPayment
     if (!card?.settlementAdjusted || card.isRefund) return null
 
@@ -33,7 +35,7 @@ export function CardAdjustmentNotice({ transaction }: { transaction: Transaction
         <InfoCard
             variant="info"
             icon="info"
-            description={`The final amount was $${(deltaCents / 100).toFixed(2)} higher than the initial hold. This is common with tips and updated totals. Don’t recognize it? Contact the merchant.`}
+            description={t('settlementAdjustedNotice', { amount: `$${(deltaCents / 100).toFixed(2)}` })}
         />
     )
 }

--- a/src/components/TransactionDetails/provider-rows/MantecaDepositInfo.tsx
+++ b/src/components/TransactionDetails/provider-rows/MantecaDepositInfo.tsx
@@ -48,6 +48,9 @@ export function MantecaDepositInfo({
             )}
             {country?.id === 'AR' && (
                 <>
+                    {/* Not copy: the field name the user's Argentine banking app shows.
+                        Translating it would break the match they are transcribing. */}
+                    {/* eslint-disable-next-line local/copy-props-from-catalog */}
                     <PaymentInfoRow label="Razón Social" value={MANTECA_ARG_DEPOSIT_NAME} />
                     <PaymentInfoRow label="CUIT" value={MANTECA_ARG_DEPOSIT_CUIT} />
                 </>

--- a/src/components/TransactionDetails/provider-rows/__tests__/CardAdjustmentNotice.test.tsx
+++ b/src/components/TransactionDetails/provider-rows/__tests__/CardAdjustmentNotice.test.tsx
@@ -4,7 +4,8 @@
  * sentence is the receipt's only action, so it must not hide behind a tap.
  */
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import { renderWithIntl as render } from '@/test-utils/intl'
 
 jest.mock('@/components/Global/InfoCard', () => ({
     __esModule: true,

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -40,7 +40,8 @@
             "closed": "Closed",
             "custom": "Custom",
             "unknown": "Unknown"
-        }
+        },
+        "exchangeRate": "Exchange rate"
     },
     "navigation": {
         "home": "Home",
@@ -207,7 +208,8 @@
             "claimablePerk": "Claimable perk"
         },
         "pendingTasks": {
-            "completeBefore": "Complete before {deadline}"
+            "completeBefore": "Complete before {deadline}",
+            "dismiss": "Dismiss {task}"
         }
     },
     "profile": {
@@ -460,6 +462,11 @@
             "free": "Free!",
             "arrivesHours": "Should arrive in hours.",
             "arrivesMinutes": "Should arrive in minutes."
+        },
+        "row": {
+            "approximate": "This is an approximate value. The actual amount received may vary based on your bank's exchange rate",
+            "amountYouReceive": "Amount you will receive",
+            "appliesWhenConverting": "Exchange rates apply when converting to {currency}"
         }
     },
     "setup": {
@@ -1720,7 +1727,6 @@
             "tokenOnChain": "{token} on {chain}",
             "txId": "TX ID",
             "fee": "Fee",
-            "exchangeRate": "Exchange rate",
             "transferId": "Transfer ID",
             "pointsEarned": "Points earned",
             "networkFee": "Network fee",
@@ -2773,8 +2779,10 @@
         "easterEggImageAlt": "Easter egg illustration",
         "reConsent": {
             "reassurance": "Nothing changes about your fees, your funds, or how we handle your data.",
-            "whatChanged": "We've rewritten the documents below in plain language so they match what Peanut is today, including the Peanut Card and Rewards. There's no rush, read them whenever, and keep using Peanut as usual."
-        }
+            "whatChanged": "We've rewritten the documents below in plain language so they match what Peanut is today, including the Peanut Card and Rewards. There's no rush, read them whenever, and keep using Peanut as usual.",
+            "title": "A small update to our terms"
+        },
+        "maintenanceBanner": "Maintenance mode, some functionalities won't be available. Funds safe"
     },
     "errors": {
         "balanceSettling": "Your balance isn't fully available yet. Please try again in a few seconds.",

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -1127,7 +1127,8 @@
             "balanceReturnFailed": "Could not return your card balance. Please try again or contact support.",
             "authorizationFailed": "Card authorization failed. Please try again or contact support.",
             "walletNotReady": "Wallet not ready — please retry in a moment",
-            "unexpectedStrategy": "Unexpected withdrawal strategy — please contact support"
+            "unexpectedStrategy": "Unexpected withdrawal strategy — please contact support",
+            "cardDetailsLoading": "Card details still loading — please retry in a moment"
         },
         "countryConfirm": {
             "noCandidatesTitle": "We need to check your details",
@@ -1251,6 +1252,8 @@
             "autoRenewTitle": "Card auto renews soon",
             "autoRenewBody": "Your card will automatically renew in {days, plural, one {# day} other {# days}}, expiration date will change.",
             "dismiss": "Dismiss",
+            "balanceDueTitle": "{amount} will be debited based on your next deposit",
+            "balanceDueBody": "A recent card payment ended up higher than the amount held at checkout. This happens with tips or updated totals. We'll cover the difference automatically.",
             "payAsCreditTitle": "Pay as credit",
             "payAsCreditBody": "When a terminal asks debit or credit, choose credit — your Peanut card runs on the credit network.",
             "managementTitle": "Card management",
@@ -1782,7 +1785,8 @@
             "evidenceRequested": "Evidence requested",
             "flagAlt": "{country} flag",
             "initialHold": "Initial hold",
-            "adjustment": "Adjustment"
+            "adjustment": "Adjustment",
+            "settlementAdjustedNotice": "The final amount was {amount} higher than the initial hold. This is common with tips and updated totals. Don’t recognize it? Contact the merchant."
         },
         "dispute": {
             "pending": "Disputed — Awaiting review",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -40,7 +40,8 @@
             "closed": "Cerrado",
             "custom": "Personalizado",
             "unknown": "Desconocido"
-        }
+        },
+        "exchangeRate": "Tipo de cambio"
     },
     "navigation": {
         "home": "Inicio",
@@ -207,7 +208,8 @@
             "claimablePerk": "Recompensa disponible"
         },
         "pendingTasks": {
-            "completeBefore": "Complete before {deadline}"
+            "completeBefore": "Complete before {deadline}",
+            "dismiss": "Descartar {task}"
         }
     },
     "profile": {
@@ -460,6 +462,11 @@
             "free": "¡Gratis!",
             "arrivesHours": "Debería llegar en horas.",
             "arrivesMinutes": "Debería llegar en minutos."
+        },
+        "row": {
+            "approximate": "Este es un valor aproximado. El monto que recibas puede variar según el tipo de cambio de tu banco.",
+            "amountYouReceive": "Monto que vas a recibir",
+            "appliesWhenConverting": "Se aplica el tipo de cambio al convertir a {currency}"
         }
     },
     "setup": {
@@ -1720,7 +1727,6 @@
             "tokenOnChain": "{token} en {chain}",
             "txId": "ID de TX",
             "fee": "Comisión",
-            "exchangeRate": "Tipo de cambio",
             "transferId": "ID de transferencia",
             "pointsEarned": "Puntos ganados",
             "networkFee": "Comisión de red",
@@ -2773,8 +2779,10 @@
         "easterEggImageAlt": "Ilustración de huevo de pascua",
         "reConsent": {
             "reassurance": "Nothing changes about your fees, your funds, or how we handle your data.",
-            "whatChanged": "We've rewritten the documents below in plain language so they match what Peanut is today, including the Peanut Card and Rewards. There's no rush, read them whenever, and keep using Peanut as usual."
-        }
+            "whatChanged": "We've rewritten the documents below in plain language so they match what Peanut is today, including the Peanut Card and Rewards. There's no rush, read them whenever, and keep using Peanut as usual.",
+            "title": "Una pequeña actualización de nuestros términos"
+        },
+        "maintenanceBanner": "Modo mantenimiento: algunas funciones no estarán disponibles. Tus fondos están seguros."
     },
     "errors": {
         "balanceSettling": "Tu saldo aún no está totalmente disponible. Inténtalo de nuevo en unos segundos.",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -1127,7 +1127,8 @@
             "balanceReturnFailed": "No pudimos devolver el saldo de tu tarjeta. Inténtalo de nuevo o contacta a soporte.",
             "authorizationFailed": "Falló la autorización de la tarjeta. Inténtalo de nuevo o contacta a soporte.",
             "walletNotReady": "La billetera no está lista — vuelve a intentarlo en un momento",
-            "unexpectedStrategy": "Estrategia de retiro inesperada — contacta a soporte"
+            "unexpectedStrategy": "Estrategia de retiro inesperada — contacta a soporte",
+            "cardDetailsLoading": "Los datos de la tarjeta aún se están cargando — vuelve a intentarlo en un momento"
         },
         "countryConfirm": {
             "noCandidatesTitle": "Necesitamos revisar tus datos",
@@ -1251,6 +1252,8 @@
             "autoRenewTitle": "Tu tarjeta se renueva pronto",
             "autoRenewBody": "Tu tarjeta se renovará automáticamente en {days, plural, one {# día} other {# días}}, la fecha de vencimiento cambiará.",
             "dismiss": "Descartar",
+            "balanceDueTitle": "Se debitarán {amount} de tu próximo depósito",
+            "balanceDueBody": "Un pago reciente con la tarjeta terminó siendo mayor que el monto retenido al momento de pagar. Esto pasa con propinas o totales actualizados. Cubrimos la diferencia automáticamente.",
             "payAsCreditTitle": "Paga como crédito",
             "payAsCreditBody": "Cuando la terminal pregunte débito o crédito, elige crédito — tu tarjeta Peanut corre en la red de crédito.",
             "managementTitle": "Gestión de la tarjeta",
@@ -1782,7 +1785,8 @@
             "evidenceRequested": "Evidencia solicitada",
             "flagAlt": "Bandera de {country}",
             "initialHold": "Retención inicial",
-            "adjustment": "Ajuste"
+            "adjustment": "Ajuste",
+            "settlementAdjustedNotice": "El monto final fue {amount} mayor que la retención inicial. Es común con propinas y totales actualizados. ¿No lo reconoces? Contacta al comercio."
         },
         "dispute": {
             "pending": "En disputa — Esperando revisión",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -515,7 +515,8 @@
             "balanceReturnFailed": "No pudimos devolver el saldo de tu tarjeta. Intentalo de nuevo o contactá a soporte.",
             "authorizationFailed": "Falló la autorización de la tarjeta. Intentalo de nuevo o contactá a soporte.",
             "walletNotReady": "La billetera no está lista — volvé a intentarlo en un momento",
-            "unexpectedStrategy": "Estrategia de retiro inesperada — contactá a soporte"
+            "unexpectedStrategy": "Estrategia de retiro inesperada — contactá a soporte",
+            "cardDetailsLoading": "Los datos de la tarjeta todavía se están cargando — volvé a intentarlo en un momento"
         },
         "countryConfirm": {
             "noCandidatesBody": "No pudimos confirmar tu país de residencia con tu verificación. Nuestro equipo lo resolverá — escribile a soporte para continuar.",
@@ -721,7 +722,10 @@
         "bridge": {
             "depositMessageInfo": "Asegurate de ingresar este mensaje exacto como concepto o descripción de la transferencia. Si no se incluye, el depósito no se puede procesar."
         },
-        "enjoyPeanut": "¡Disfrutá Peanut!"
+        "enjoyPeanut": "¡Disfrutá Peanut!",
+        "cardRows": {
+            "settlementAdjustedNotice": "El monto final fue {amount} mayor que la retención inicial. Es común con propinas y totales actualizados. ¿No lo reconocés? Contactá al comercio."
+        }
     },
     "history": {
         "errorDescription": "Contactá a soporte.",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -40,7 +40,8 @@
             "closed": "Encerrado",
             "custom": "Personalizado",
             "unknown": "Desconhecido"
-        }
+        },
+        "exchangeRate": "Taxa de câmbio"
     },
     "navigation": {
         "home": "Início",
@@ -207,7 +208,8 @@
             "claimablePerk": "Recompensa disponível"
         },
         "pendingTasks": {
-            "completeBefore": "Complete before {deadline}"
+            "completeBefore": "Complete before {deadline}",
+            "dismiss": "Dispensar {task}"
         }
     },
     "profile": {
@@ -460,6 +462,11 @@
             "free": "Grátis!",
             "arrivesHours": "Deve chegar em horas.",
             "arrivesMinutes": "Deve chegar em minutos."
+        },
+        "row": {
+            "approximate": "Este é um valor aproximado. O valor recebido pode variar conforme a taxa de câmbio do seu banco.",
+            "amountYouReceive": "Valor que você vai receber",
+            "appliesWhenConverting": "A taxa de câmbio se aplica na conversão para {currency}"
         }
     },
     "setup": {
@@ -1720,7 +1727,6 @@
             "tokenOnChain": "{token} na {chain}",
             "txId": "ID da TX",
             "fee": "Taxa",
-            "exchangeRate": "Taxa de câmbio",
             "transferId": "ID da transferência",
             "pointsEarned": "Pontos ganhos",
             "networkFee": "Taxa de rede",
@@ -2773,8 +2779,10 @@
         "easterEggImageAlt": "Ilustração de easter egg",
         "reConsent": {
             "reassurance": "Nothing changes about your fees, your funds, or how we handle your data.",
-            "whatChanged": "We've rewritten the documents below in plain language so they match what Peanut is today, including the Peanut Card and Rewards. There's no rush, read them whenever, and keep using Peanut as usual."
-        }
+            "whatChanged": "We've rewritten the documents below in plain language so they match what Peanut is today, including the Peanut Card and Rewards. There's no rush, read them whenever, and keep using Peanut as usual.",
+            "title": "Uma pequena atualização dos nossos termos"
+        },
+        "maintenanceBanner": "Modo manutenção: algumas funções ficarão indisponíveis. Seu dinheiro está seguro."
     },
     "errors": {
         "balanceSettling": "Seu saldo ainda não está totalmente disponível. Tente novamente em alguns segundos.",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -1127,7 +1127,8 @@
             "balanceReturnFailed": "Não conseguimos devolver o saldo do seu cartão. Tente de novo ou fale com o suporte.",
             "authorizationFailed": "A autorização do cartão falhou. Tente de novo ou fale com o suporte.",
             "walletNotReady": "A carteira não está pronta — tente de novo em um instante",
-            "unexpectedStrategy": "Estratégia de saque inesperada — fale com o suporte"
+            "unexpectedStrategy": "Estratégia de saque inesperada — fale com o suporte",
+            "cardDetailsLoading": "Os dados do cartão ainda estão carregando — tente de novo em um instante"
         },
         "countryConfirm": {
             "noCandidatesTitle": "Precisamos conferir seus dados",
@@ -1251,6 +1252,8 @@
             "autoRenewTitle": "Seu cartão renova em breve",
             "autoRenewBody": "Seu cartão vai renovar automaticamente em {days, plural, one {# dia} other {# dias}}, a data de validade vai mudar.",
             "dismiss": "Dispensar",
+            "balanceDueTitle": "{amount} serão debitados no seu próximo depósito",
+            "balanceDueBody": "Um pagamento recente com o cartão ficou maior que o valor reservado no momento da compra. Isso acontece com gorjetas ou totais atualizados. A gente cobre a diferença automaticamente.",
             "payAsCreditTitle": "Pague como crédito",
             "payAsCreditBody": "Quando a maquininha perguntar débito ou crédito, escolha crédito — seu cartão Peanut roda na rede de crédito.",
             "managementTitle": "Gerenciar cartão",
@@ -1782,7 +1785,8 @@
             "evidenceRequested": "Comprovação solicitada",
             "flagAlt": "Bandeira de {country}",
             "initialHold": "Retenção inicial",
-            "adjustment": "Ajuste"
+            "adjustment": "Ajuste",
+            "settlementAdjustedNotice": "O valor final ficou {amount} maior que a reserva inicial. Isso é comum com gorjetas e totais atualizados. Não reconhece? Fale com o estabelecimento."
         },
         "dispute": {
             "pending": "Contestada — Aguardando análise",


### PR DESCRIPTION
## Why

The card page reads as untranslated for es-419 / pt-BR users, and it is not the plumbing: every screen under `src/components/Card/` calls `useTranslations`, the `card` namespace has 232 genuinely translated keys, and there is exactly one `NextIntlClientProvider` — above every route. What leaks is copy that never reaches the catalog.

The common cause is a guard gap. `react/jsx-no-literals` runs with `ignoreProps: true`, so it only inspects JSX **children**. Copy handed to a component as a prop is invisible to it, and that is precisely the shape that shipped English:

```tsx
<InfoCard
    title={`$${(balanceDueCents / 100).toFixed(2)} will be debited based on your next deposit`}
    description="A recent card payment ended up higher than the amount held at checkout. …"
/>
```

`ignoreProps` cannot simply be flipped — `variant="warning"`, `icon="info"` and `type="button"` are string literals too.

## What changed

**Card surface**

| Fix | Where |
|---|---|
| Balance-due notice → `card.yourCard.balanceDueTitle` / `balanceDueBody` | `YourCardScreen` |
| Card-receipt adjustment notice → `transaction.cardRows.settlementAdjustedNotice` | `CardAdjustmentNotice` |
| Legal links follow the user's locale instead of hardcoded `/en/` | `CardTermsScreen` |
| Loading-overview error → `card.errors.cardDetailsLoading` | `LockCardModal`, `CancelCardModal` |

The five card-terms links pointed at `peanut.me/en/card-esign`, `/en/card-terms-us`, `/en/card-privacy` and friends. Those marketing pages are locale-routed and fall back to English prose when a document has no translation, so linking the user's own locale is strictly better than pinning `/en/`. The marketing locale set spells its tags differently from the app's (`pt-br` vs `pt-BR`), so the href goes through `toMarketingLocale` rather than the raw locale — pinned by a new test.

The two modal errors are worth a look: they sat two lines above siblings already using `t('errors.*')`, and unlike most throws in this codebase they are rendered straight into the modal's error slot rather than collapsed by the friendly-error mapper.

**The guard**

A local ESLint rule (`eslint-rules/copy-props-from-catalog.js`) covers the gap. It checks only props that carry prose, and only values that read as prose — two or more words, with each interpolation standing in as one word. `label="CUIT"` and ``title={`$${cents}`}`` stay legal; ``title={`${amount} will be debited …`}`` does not. Both edges are pinned by RuleTester cases.

It is a **named rule** rather than another `no-restricted-syntax` selector for a reason worth flagging in review: that array lives in the repo-wide `src/**` block, and flat config *replaces* rule options instead of merging them. Scoping a second `no-restricted-syntax` to the localized surface would have silently dropped the `router.back`, nuqs and toast guards exactly where they matter most.

**Everything the rule found is fixed** — no exception list, no follow-up debt:

- `add-money/[country]/bank` reuses `addMoney.errors.rateUnavailable`, which already said this in three languages
- `ExchangeRate` had two hardcoded labels **plus three module-level English constants the rule structurally cannot see**; all five now come from the catalog
- `"Exchange rate"` existed twice once `ExchangeRate` needed it, so the transaction-row key moved to `common` — the duplicate-value drift test allows one key per string, and this is one string
- `MaintenanceBanner`, the `ReConsentModal` title, and the dismiss `aria-label` on pending-task cards

## Deliberately not changed

- **`MantecaDepositInfo` keeps `"Razón Social"`** behind a documented one-line disable. It is the field name the user's Argentine banking app displays; translating it breaks the match they are transcribing. Same precedent as the glossary's verbatim Apple Wallet quote.
- **`recover-wallet` stays outside the guard's globs.** It has zero `useTranslations` — an English-only recovery tool, like the `fix-card-signature` page already exempted right above it. Localizing it is its own job, not a silent glob widening that reds the build.
- **Backend reason prose on the application-status screen.** Every code the API resolver emits already maps to `identity.reasons.*` except `document_rejected`, which is unmapped on purpose: it only ships with the self-heal classifier's specific instruction ("Your ID photo was blurry…"), and a generic catalog line would mask it. Closing that needs the classifier's stable action code on the wire — an api-ts change.

## Locales

Keys added to en / es-419 / pt-BR. es-AR takes voseo overrides only where the es-419 string it inherits carries a tuteo verb (`vuelve`→`volvé`, `reconoces`→`reconocés`, `contacta`→`contactá`) — the glossary test checks es-AR **resolved**, so tuteo leaking through the fallback would fail.

## Verification

- `pnpm jest` — all suites green (note: `git submodule update --init src/content` is required or three suites fail on missing content)
- `tsc --noEmit` clean
- `eslint .` — 0 errors
- `prettier --check .` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localized messaging across exchange rates, card management, transactions, maintenance notices, consent updates, and pending tasks.
  - Card terms now link to locale-specific legal documents.
  - Added validation to help ensure user-facing JSX text uses translations.

- **Bug Fixes**
  - Replaced several hardcoded English messages with localized alternatives.
  - Corrected exchange-rate labeling and card adjustment notices across supported languages.

- **Tests**
  - Added coverage for localized card terms links and translation enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->