### PR TITLE
ci(indexnow): pin node 20 instead of reading a nonexistent .node-version

### DIFF
--- a/.github/workflows/indexnow.yml
+++ b/.github/workflows/indexnow.yml
@@ -28,7 +28,7 @@ jobs:
             - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
             - uses: actions/setup-node@v4
               with:
-                  node-version-file: '.node-version'
+                  node-version: '20'
                   cache: 'pnpm'
 
             - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## What

The IndexNow ping workflow has failed on every real run since it landed: its setup-node step reads `node-version-file: '.node-version'`, but that file has never existed in this repo. Example failing run: [32054990081](https://github.com/peanutprotocol/peanut-ui/actions/runs/32054990081) — "The specified node version file … does not exist".

## Fix

Pin `node-version: '20'`, matching every other workflow in the repo (tests, code-analysis, capgo-deploy, sync-openapi all pin 20 explicitly).

## Notes

- The workflow only fires on successful Production deployment statuses (and manual dispatch), which is why the failure has been low-visibility — it silently skipped crawler pings on every production deploy.
- One-line change; verify by dispatching the workflow manually after merge.