### PR TITLE
ds(12): /dev/ds foundations generated from the @theme token source

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -17,5 +17,9 @@ src/components/TransactionDetails/__tests__/fixtures/render-baseline.json
 src/types/api.openapi.json
 src/types/api.generated.ts
 
+# generated from globals.css @theme via `pnpm gen:ds-tokens` — stable
+# JSON.stringify formatting so a prettier bump can't flip the drift gate.
+src/app/(mobile-ui)/dev/ds/foundations/tokens.generated.ts
+
 # static single-file quiz (hand-tuned inline CSS/JS; not prettier-formatted)
 public/onboarding-quiz/

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "format": "prettier --write .",
         "analyze": "ANALYZE=true next build",
         "typecheck": "tsc --noEmit",
+        "gen:ds-tokens": "node scripts/generate-ds-tokens.mjs",
         "gen:api": "openapi-typescript src/types/api.openapi.json -o src/types/api.generated.ts && prettier --write src/types/api.generated.ts",
         "gen:api:live": "curl -sSf ${PEANUT_API_OPENAPI_URL:-http://localhost:5050/openapi.json} | python3 -m json.tool > src/types/api.openapi.json && pnpm gen:api",
         "check:api": "pnpm gen:api && git diff --exit-code src/types/api.generated.ts",

--- a/scripts/__tests__/ds-tokens-drift.test.js
+++ b/scripts/__tests__/ds-tokens-drift.test.js
@@ -1,0 +1,14 @@
+const { execFileSync } = require('child_process')
+const path = require('path')
+
+// the /dev/ds foundations pages render tokens.generated.ts, which is emitted
+// from the @theme block in globals.css. this test fails CI whenever the theme
+// changes without a regen — the whole point of DS 12 is that the docs cannot
+// drift from the token source (the hand-typed colors doc had 6/12 swatches
+// wrong). fix: `pnpm gen:ds-tokens` and commit.
+describe('ds tokens drift', () => {
+    it('tokens.generated.ts matches the @theme block in globals.css', () => {
+        const script = path.join(__dirname, '..', 'generate-ds-tokens.mjs')
+        execFileSync(process.execPath, [script, '--check'], { stdio: 'pipe' })
+    })
+})

--- a/scripts/generate-ds-tokens.mjs
+++ b/scripts/generate-ds-tokens.mjs
@@ -30,6 +30,7 @@ const NAMESPACES = [
     'default-transition',
     'transition-duration',
     'border-width',
+    'font-weight',
     'animate',
     'drop-shadow',
     'spacing',

--- a/scripts/generate-ds-tokens.mjs
+++ b/scripts/generate-ds-tokens.mjs
@@ -1,0 +1,188 @@
+// generate-ds-tokens.mjs — /dev/ds foundations data generated from the @theme
+// token source in src/styles/globals.css, so the docs cannot drift from the
+// real values (the hand-typed colors doc had 6/12 swatches wrong).
+//
+//   node scripts/generate-ds-tokens.mjs           # write tokens.generated.ts
+//   node scripts/generate-ds-tokens.mjs --check   # exit 1 if the file is stale
+//
+// parseThemeTokens() is exported so other emitters (mono/design components.md,
+// DS 08) can reuse the same parse instead of re-reading the css.
+
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import prettier from 'prettier'
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..')
+const CSS_PATH = path.join(ROOT, 'src/styles/globals.css')
+const OUT_PATH = path.join(ROOT, 'src/app/(mobile-ui)/dev/ds/foundations/tokens.generated.ts')
+
+// the @theme block is organized by banner comments; tokens are classified by
+// which banner they appear under. if a banner is renamed the parse fails loud.
+const SECTION_BANNERS = [
+    ['legacy', 'LEGACY PALETTE'],
+    ['semantic', 'SEMANTIC TOKENS'],
+    ['parity', 'v3-parity theme values'],
+]
+
+// longest-first so --transition-duration-* doesn't match as shadow/etc.
+const NAMESPACES = [
+    'default-transition',
+    'transition-duration',
+    'border-width',
+    'animate',
+    'drop-shadow',
+    'spacing',
+    'radius',
+    'shadow',
+    'color',
+    'text',
+    'font',
+    'blur',
+    'ease',
+]
+
+export function parseThemeTokens(css) {
+    const start = css.indexOf('@theme {')
+    if (start === -1) throw new Error('no @theme block found in globals.css')
+    const end = css.indexOf('\n}', start)
+    if (end === -1) throw new Error('unterminated @theme block')
+    const block = css.slice(start, end)
+
+    const sections = SECTION_BANNERS.map(([name, banner]) => {
+        const offset = block.indexOf(banner)
+        if (offset === -1) throw new Error(`section banner "${banner}" not found in @theme — update SECTION_BANNERS`)
+        return { name, offset }
+    })
+    const sectionAt = (offset) => {
+        let current = sections[0].name
+        for (const s of sections) if (offset >= s.offset) current = s.name
+        return current
+    }
+
+    // blank comments (preserving offsets) so tokens named inside prose don't parse
+    const blanked = block.replace(/\/\*[\s\S]*?\*\//g, (c) => ' '.repeat(c.length))
+
+    const colors = []
+    const textByName = new Map()
+    const fontByName = new Map()
+    const groups = {}
+
+    for (const m of blanked.matchAll(/--([a-zA-Z0-9*-]+)\s*:\s*([^;]+);/g)) {
+        const [, rawName, rawValue] = m
+        if (rawName.includes('*')) continue // wildcard resets like --color-red-*: initial
+        const value = rawValue.replace(/\s+/g, ' ').trim()
+        const section = sectionAt(m.index)
+
+        const ns = NAMESPACES.find((n) => rawName === n || rawName.startsWith(n + '-'))
+        if (!ns) throw new Error(`unknown @theme namespace in --${rawName} — teach scripts/generate-ds-tokens.mjs`)
+        const rest = rawName === ns ? '' : rawName.slice(ns.length + 1)
+
+        if (ns === 'color') {
+            colors.push({ name: rest, value, section })
+        } else if (ns === 'text') {
+            // --text-<name> plus --text-<name>--<modifier> lines form one style
+            const [name, modifier] = rest.split('--')
+            const style = textByName.get(name) ?? { name, section }
+            if (!modifier) style.fontSize = value
+            else if (modifier === 'line-height') style.lineHeight = value
+            else if (modifier === 'font-weight') style.fontWeight = value
+            else style[modifier.replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = value
+            textByName.set(name, style)
+        } else if (ns === 'font') {
+            const [name, modifier] = rest.split('--')
+            const font = fontByName.get(name) ?? { name, section }
+            if (!modifier) font.stack = value
+            else font[modifier.replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = value
+            fontByName.set(name, font)
+        } else {
+            ;(groups[ns] ??= []).push({ name: rest, value, section })
+        }
+    }
+
+    const tokens = {
+        colors,
+        textStyles: [...textByName.values()],
+        fonts: [...fontByName.values()],
+        groups,
+    }
+
+    // sanity floors — a silently-broken parse must not write an empty doc
+    if (tokens.colors.length < 50) throw new Error(`parsed only ${tokens.colors.length} colors — parse broken?`)
+    if (tokens.textStyles.length < 10) throw new Error(`parsed only ${tokens.textStyles.length} text styles`)
+    if (tokens.fonts.length < 2) throw new Error(`parsed only ${tokens.fonts.length} fonts`)
+    return tokens
+}
+
+export async function renderTokensModule(tokens) {
+    const j = (v) => JSON.stringify(v, null, 4)
+    const source = `// generated from the @theme block in src/styles/globals.css by
+// scripts/generate-ds-tokens.mjs — DO NOT EDIT. run \`pnpm gen:ds-tokens\`.
+// a jest drift test (scripts/__tests__/ds-tokens-drift.test.js) fails CI when
+// this file is stale.
+
+/** which @theme banner the token sits under: legacy palette (v3 port, do not
+ * use in new code), semantic (figma-verified, use these), or v3-parity shims. */
+export type TokenSection = 'legacy' | 'semantic' | 'parity'
+
+export interface ColorToken {
+    name: string
+    value: string
+    section: TokenSection
+}
+
+export interface TextStyle {
+    name: string
+    section: TokenSection
+    fontSize?: string
+    lineHeight?: string
+    fontWeight?: string
+    [modifier: string]: string | undefined
+}
+
+export interface FontToken {
+    name: string
+    section: TokenSection
+    stack?: string
+    [modifier: string]: string | undefined
+}
+
+export const COLOR_TOKENS: ColorToken[] = ${j(tokens.colors)}
+
+export const TEXT_STYLES: TextStyle[] = ${j(tokens.textStyles)}
+
+export const FONT_TOKENS: FontToken[] = ${j(tokens.fonts)}
+
+/** radius / shadow / blur / motion / spacing token groups, keyed by @theme namespace */
+export const TOKEN_GROUPS: Record<string, ColorToken[]> = ${j(tokens.groups)}
+`
+    const config = await prettier.resolveConfig(OUT_PATH)
+    return prettier.format(source, { ...config, filepath: OUT_PATH })
+}
+
+async function main() {
+    const check = process.argv.includes('--check')
+    const tokens = parseThemeTokens(fs.readFileSync(CSS_PATH, 'utf-8'))
+    const rendered = await renderTokensModule(tokens)
+
+    if (check) {
+        const onDisk = fs.existsSync(OUT_PATH) ? fs.readFileSync(OUT_PATH, 'utf-8') : ''
+        if (onDisk !== rendered) {
+            console.error('tokens.generated.ts is stale — run `pnpm gen:ds-tokens` and commit the result')
+            process.exit(1)
+        }
+        console.log('tokens.generated.ts is in sync with globals.css')
+        return
+    }
+
+    fs.writeFileSync(OUT_PATH, rendered)
+    console.log(
+        `wrote ${path.relative(ROOT, OUT_PATH)} — ${tokens.colors.length} colors, ` +
+            `${tokens.textStyles.length} text styles, ${tokens.fonts.length} fonts, ` +
+            `${Object.keys(tokens.groups).length} other groups`
+    )
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    await main()
+}

--- a/scripts/generate-ds-tokens.mjs
+++ b/scripts/generate-ds-tokens.mjs
@@ -126,7 +126,7 @@ export async function renderTokensModule(tokens) {
  * use in new code), semantic (figma-verified, use these), or v3-parity shims. */
 export type TokenSection = 'legacy' | 'semantic' | 'parity'
 
-export interface ColorToken {
+export interface ThemeToken {
     name: string
     value: string
     section: TokenSection
@@ -148,14 +148,14 @@ export interface FontToken {
     [modifier: string]: string | undefined
 }
 
-export const COLOR_TOKENS: ColorToken[] = ${j(tokens.colors)}
+export const COLOR_TOKENS: ThemeToken[] = ${j(tokens.colors)}
 
 export const TEXT_STYLES: TextStyle[] = ${j(tokens.textStyles)}
 
 export const FONT_TOKENS: FontToken[] = ${j(tokens.fonts)}
 
 /** radius / shadow / blur / motion / spacing token groups, keyed by @theme namespace */
-export const TOKEN_GROUPS: Record<string, ColorToken[]> = ${j(tokens.groups)}
+export const TOKEN_GROUPS: Record<string, ThemeToken[]> = ${j(tokens.groups)}
 `
     const config = await prettier.resolveConfig(OUT_PATH)
     return prettier.format(source, { ...config, filepath: OUT_PATH })

--- a/scripts/generate-ds-tokens.mjs
+++ b/scripts/generate-ds-tokens.mjs
@@ -11,7 +11,6 @@
 import fs from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import prettier from 'prettier'
 
 const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..')
 const CSS_PATH = path.join(ROOT, 'src/styles/globals.css')
@@ -31,6 +30,8 @@ const NAMESPACES = [
     'transition-duration',
     'border-width',
     'font-weight',
+    'text-shadow',
+    'inset-shadow',
     'animate',
     'drop-shadow',
     'spacing',
@@ -41,12 +42,23 @@ const NAMESPACES = [
     'font',
     'blur',
     'ease',
+    'leading',
+    'tracking',
+    'breakpoint',
+    'container',
+    'aspect',
 ]
 
 export function parseThemeTokens(css) {
-    const start = css.indexOf('@theme {')
-    if (start === -1) throw new Error('no @theme block found in globals.css')
-    const end = css.indexOf('\n}', start)
+    // blanking comments (offsets preserved) keeps '@theme' in prose and tokens
+    // named inside prose from parsing; the raw block keeps the section banners.
+    const blankedCss = css.replace(/\/\*[\s\S]*?\*\//g, (c) => ' '.repeat(c.length))
+    const blockStarts = [...blankedCss.matchAll(/@theme[^{\n]*\{/g)]
+    if (blockStarts.length === 0) throw new Error('no @theme block found in globals.css')
+    if (blockStarts.length > 1)
+        throw new Error('multiple @theme blocks found — teach scripts/generate-ds-tokens.mjs to parse them all')
+    const start = blockStarts[0].index
+    const end = blankedCss.indexOf('\n}', start)
     if (end === -1) throw new Error('unterminated @theme block')
     const block = css.slice(start, end)
 
@@ -54,15 +66,16 @@ export function parseThemeTokens(css) {
         const offset = block.indexOf(banner)
         if (offset === -1) throw new Error(`section banner "${banner}" not found in @theme — update SECTION_BANNERS`)
         return { name, offset }
-    })
+    }).sort((a, b) => a.offset - b.offset)
     const sectionAt = (offset) => {
+        if (offset < sections[0].offset)
+            throw new Error('token found above the first section banner — teach SECTION_BANNERS')
         let current = sections[0].name
         for (const s of sections) if (offset >= s.offset) current = s.name
         return current
     }
 
-    // blank comments (preserving offsets) so tokens named inside prose don't parse
-    const blanked = block.replace(/\/\*[\s\S]*?\*\//g, (c) => ' '.repeat(c.length))
+    const blanked = blankedCss.slice(start, end)
 
     const colors = []
     const textByName = new Map()
@@ -115,9 +128,12 @@ export function parseThemeTokens(css) {
     return tokens
 }
 
-export async function renderTokensModule(tokens) {
+// emits stable JSON.stringify formatting on purpose — the file is in
+// .prettierignore (like api.generated.ts) so a prettier version bump can't
+// churn it or flip the drift gate.
+export function renderTokensModule(tokens) {
     const j = (v) => JSON.stringify(v, null, 4)
-    const source = `// generated from the @theme block in src/styles/globals.css by
+    return `// generated from the @theme block in src/styles/globals.css by
 // scripts/generate-ds-tokens.mjs — DO NOT EDIT. run \`pnpm gen:ds-tokens\`.
 // a jest drift test (scripts/__tests__/ds-tokens-drift.test.js) fails CI when
 // this file is stale.
@@ -157,14 +173,12 @@ export const FONT_TOKENS: FontToken[] = ${j(tokens.fonts)}
 /** radius / shadow / blur / motion / spacing token groups, keyed by @theme namespace */
 export const TOKEN_GROUPS: Record<string, ThemeToken[]> = ${j(tokens.groups)}
 `
-    const config = await prettier.resolveConfig(OUT_PATH)
-    return prettier.format(source, { ...config, filepath: OUT_PATH })
 }
 
-async function main() {
+function main() {
     const check = process.argv.includes('--check')
     const tokens = parseThemeTokens(fs.readFileSync(CSS_PATH, 'utf-8'))
-    const rendered = await renderTokensModule(tokens)
+    const rendered = renderTokensModule(tokens)
 
     if (check) {
         const onDisk = fs.existsSync(OUT_PATH) ? fs.readFileSync(OUT_PATH, 'utf-8') : ''
@@ -184,6 +198,8 @@ async function main() {
     )
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
-    await main()
+// realpath both sides: a symlinked invocation path would otherwise make this
+// guard silently skip main() — and --check would exit 0 without checking.
+if (process.argv[1] && fs.realpathSync(process.argv[1]) === fs.realpathSync(fileURLToPath(import.meta.url))) {
+    main()
 }

--- a/src/app/(mobile-ui)/dev/ds/foundations/colors/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/foundations/colors/page.tsx
@@ -7,13 +7,13 @@ import { DesignNote } from '../../_components/DesignNote'
 import { DocHeader } from '../../_components/DocHeader'
 import { DocSection } from '../../_components/DocSection'
 import { DocPage } from '../../_components/DocPage'
-import { COLOR_TOKENS, type ColorToken } from '../tokens.generated'
+import { COLOR_TOKENS, type ThemeToken } from '../tokens.generated'
 
 // group tokens by their name prefix (action, background, avatar, ...) keeping
 // source order. swatches use the token VALUE inline — class names are display/
 // copy text only, so nothing here depends on tailwind emitting the utility.
-function groupByPrefix(tokens: ColorToken[]): Map<string, ColorToken[]> {
-    const groups = new Map<string, ColorToken[]>()
+function groupByPrefix(tokens: ThemeToken[]): Map<string, ThemeToken[]> {
+    const groups = new Map<string, ThemeToken[]>()
     for (const t of tokens) {
         const prefix = t.name.split('-')[0]
         groups.set(prefix, [...(groups.get(prefix) ?? []), t])
@@ -39,7 +39,7 @@ export default function ColorsPage() {
         setTimeout(() => setCopiedColor(null), 1500)
     }
 
-    const renderGroups = (groups: Map<string, ColorToken[]>) => (
+    const renderGroups = (groups: Map<string, ThemeToken[]>) => (
         <div className="space-y-4">
             {[...groups.entries()].map(([prefix, tokens]) => (
                 <div key={prefix}>

--- a/src/app/(mobile-ui)/dev/ds/foundations/colors/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/foundations/colors/page.tsx
@@ -46,7 +46,15 @@ export default function ColorsPage() {
                     <p className="mb-1 font-mono text-[10px] font-bold text-grey-1 uppercase">{prefix}</p>
                     <div className="grid grid-cols-2 gap-2">
                         {tokens.map((token) => {
-                            const cls = `bg-${token.name}`
+                            // copy the class matching the token's intent, not blanket bg-
+                            const utility = token.name.startsWith('foreground')
+                                ? 'text'
+                                : token.name.startsWith('border')
+                                  ? 'border'
+                                  : token.name.startsWith('shadow')
+                                    ? 'shadow'
+                                    : 'bg'
+                            const cls = `${utility}-${token.name}`
                             return (
                                 <button
                                     key={token.name}

--- a/src/app/(mobile-ui)/dev/ds/foundations/colors/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/foundations/colors/page.tsx
@@ -7,21 +7,22 @@ import { DesignNote } from '../../_components/DesignNote'
 import { DocHeader } from '../../_components/DocHeader'
 import { DocSection } from '../../_components/DocSection'
 import { DocPage } from '../../_components/DocPage'
+import { COLOR_TOKENS, type ColorToken } from '../tokens.generated'
 
-const COLORS = [
-    { name: 'purple-1', bg: 'bg-purple-1', text: 'text-purple-1', hex: '#FF90E8', note: 'PINK not purple!' },
-    { name: 'primary-3', bg: 'bg-primary-3', text: 'text-primary-3', hex: '#EFE4FF', note: 'lavender' },
-    { name: 'primary-4', bg: 'bg-primary-4', text: 'text-primary-4', hex: '#D8C4F6', note: 'deeper lavender' },
-    { name: 'yellow-1', bg: 'bg-yellow-1', text: 'text-yellow-1', hex: '#FFC900', note: 'peanut yellow' },
-    { name: 'green-1', bg: 'bg-green-1', text: 'text-green-1', hex: '#98E9AB', note: 'success green' },
-    { name: 'n-1', bg: 'bg-n-1', text: 'text-n-1', hex: '#000000', note: 'black / primary text' },
-    { name: 'grey-1', bg: 'bg-grey-1', text: 'text-grey-1', hex: '#6B6B6B', note: 'secondary text' },
-    { name: 'teal-1', bg: 'bg-teal-1', text: 'text-teal-1', hex: '#C3F5E4', note: 'teal accent' },
-    { name: 'violet-1', bg: 'bg-violet-1', text: 'text-violet-1', hex: '#A78BFA', note: 'violet' },
-    { name: 'error-1', bg: 'bg-error-1', text: 'text-error-1', hex: '#FF6B6B', note: 'error red' },
-    { name: 'success-3', bg: 'bg-success-3', text: 'text-success-3', hex: '#4ADE80', note: 'success bg' },
-    { name: 'secondary-1', bg: 'bg-secondary-1', text: 'text-secondary-1', hex: '#FFC900', note: 'same as yellow-1' },
-]
+// group tokens by their name prefix (action, background, avatar, ...) keeping
+// source order. swatches use the token VALUE inline — class names are display/
+// copy text only, so nothing here depends on tailwind emitting the utility.
+function groupByPrefix(tokens: ColorToken[]): Map<string, ColorToken[]> {
+    const groups = new Map<string, ColorToken[]>()
+    for (const t of tokens) {
+        const prefix = t.name.split('-')[0]
+        groups.set(prefix, [...(groups.get(prefix) ?? []), t])
+    }
+    return groups
+}
+
+const SEMANTIC = groupByPrefix(COLOR_TOKENS.filter((t) => t.section === 'semantic'))
+const LEGACY = groupByPrefix(COLOR_TOKENS.filter((t) => t.section === 'legacy'))
 
 const BACKGROUNDS = [
     { name: 'bg-peanut-repeat-normal', description: 'Normal peanut repeat pattern' },
@@ -38,46 +39,69 @@ export default function ColorsPage() {
         setTimeout(() => setCopiedColor(null), 1500)
     }
 
+    const renderGroups = (groups: Map<string, ColorToken[]>) => (
+        <div className="space-y-4">
+            {[...groups.entries()].map(([prefix, tokens]) => (
+                <div key={prefix}>
+                    <p className="mb-1 font-mono text-[10px] font-bold text-grey-1 uppercase">{prefix}</p>
+                    <div className="grid grid-cols-2 gap-2">
+                        {tokens.map((token) => {
+                            const cls = `bg-${token.name}`
+                            return (
+                                <button
+                                    key={token.name}
+                                    onClick={() => copyClass(cls)}
+                                    className="flex items-center gap-2 rounded-sm border border-n-1/20 p-2 text-left transition-colors hover:border-n-1/40"
+                                >
+                                    <div
+                                        className="size-8 shrink-0 rounded-sm border border-n-1"
+                                        style={{ backgroundColor: token.value }}
+                                    />
+                                    <div className="min-w-0 flex-1">
+                                        <p className="text-xs font-bold break-all">{token.name}</p>
+                                        <p className="font-mono text-[9px] text-grey-1">{token.value}</p>
+                                    </div>
+                                    {copiedColor === cls ? (
+                                        <Icon name="check" size={14} className="shrink-0 text-success-3" />
+                                    ) : (
+                                        <Icon name="copy" size={12} className="shrink-0 text-grey-1" />
+                                    )}
+                                </button>
+                            )
+                        })}
+                    </div>
+                </div>
+            ))}
+        </div>
+    )
+
     return (
         <DocPage>
             <DocHeader
                 title="Colors"
-                description="Color tokens from the @theme block in globals.css. Tap any swatch to copy the class name."
+                description="Generated from the @theme block in globals.css (pnpm gen:ds-tokens) — swatches cannot drift from the source. Tap any swatch to copy the class name."
             />
 
             <DesignNote type="warning">
-                purple-1 / primary-1 = #FF90E8 — this is PINK, not purple. The naming is misleading but too widely used
+                purple-1 / primary-1 = #ff90e8 — this is PINK, not purple. The naming is misleading but too widely used
                 to rename.
             </DesignNote>
 
-            {/* Color grid */}
-            <DocSection title="Color Tokens">
-                <div className="grid grid-cols-2 gap-2">
-                    {COLORS.map((color) => (
-                        <button
-                            key={color.name}
-                            onClick={() => copyClass(color.bg)}
-                            className="flex items-center gap-2 rounded-sm border border-n-1/20 p-2 text-left transition-colors hover:border-n-1/40"
-                        >
-                            <div className={`size-8 shrink-0 rounded-sm border border-n-1 ${color.bg}`} />
-                            <div className="min-w-0 flex-1">
-                                <p className="text-xs font-bold">{color.name}</p>
-                                <p className="text-[9px] text-grey-1">
-                                    {color.hex} · {color.note}
-                                </p>
-                            </div>
-                            {copiedColor === color.bg ? (
-                                <Icon name="check" size={14} className="shrink-0 text-success-3" />
-                            ) : (
-                                <Icon
-                                    name="copy"
-                                    size={12}
-                                    className="shrink-0 text-grey-1 opacity-0 group-hover:opacity-100"
-                                />
-                            )}
-                        </button>
-                    ))}
-                </div>
+            <DocSection title="Semantic Tokens">
+                <p className="text-sm text-grey-1">
+                    1:1 with the figma variables. New screens use ONLY these — e.g.{' '}
+                    <code className="font-mono font-bold text-n-1">bg-action-primary</code>,{' '}
+                    <code className="font-mono font-bold text-n-1">text-foreground-secondary</code>.
+                </p>
+                {renderGroups(SEMANTIC)}
+            </DocSection>
+
+            <DocSection title="Legacy Palette">
+                <p className="text-sm text-grey-1">
+                    Ported verbatim from the v3 config for visual parity. Do not use in new code — consumer migration to
+                    the semantic tokens is DS 06+.
+                </p>
+                {renderGroups(LEGACY)}
             </DocSection>
 
             {/* Text / BG pairs */}
@@ -85,7 +109,7 @@ export default function ColorsPage() {
                 <div className="space-y-2 rounded-sm border border-n-1 p-3 text-xs">
                     <div className="flex items-center gap-3">
                         <span className="w-20 font-bold text-n-1">text-n-1</span>
-                        <span className="text-n-1">Primary text — headings, labels, body (134 usages)</span>
+                        <span className="text-n-1">Primary text — headings, labels, body</span>
                     </div>
                     <div className="flex items-center gap-3">
                         <span className="w-20 font-bold text-grey-1">text-grey-1</span>

--- a/src/app/(mobile-ui)/dev/ds/foundations/spacing/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/foundations/spacing/page.tsx
@@ -1,14 +1,39 @@
 'use client'
 
+import { DesignNote } from '../../_components/DesignNote'
 import { DocHeader } from '../../_components/DocHeader'
 import { DocSection } from '../../_components/DocSection'
 import { DocPage } from '../../_components/DocPage'
 import { CodeBlock } from '../../_components/CodeBlock'
+import { TOKEN_GROUPS } from '../tokens.generated'
+
+const SPACING_TOKENS = TOKEN_GROUPS['spacing'] ?? []
 
 export default function SpacingPage() {
     return (
         <DocPage>
             <DocHeader title="Spacing" description="Layout utilities and spacing conventions used across the app." />
+
+            {/* Spacing tokens — generated; empty until DS 06 lands the named scale */}
+            <DocSection title="Spacing Tokens">
+                {SPACING_TOKENS.length === 0 ? (
+                    <DesignNote type="info">
+                        No custom spacing tokens in @theme yet — the app uses the stock Tailwind 4px scale. The named
+                        scale (xs/s/m/l/…) is deferred to the DS 06 consumer sweep; this section auto-populates from
+                        globals.css when it lands (pnpm gen:ds-tokens).
+                    </DesignNote>
+                ) : (
+                    <div className="space-y-2 rounded-sm border border-n-1 p-3 text-xs">
+                        {SPACING_TOKENS.map((t) => (
+                            <div key={t.name} className="flex items-center gap-3">
+                                <code className="w-24 shrink-0 font-mono font-bold">--spacing-{t.name}</code>
+                                <span className="w-14 shrink-0 text-grey-1">{t.value}</span>
+                                <div className="h-3 bg-purple-1" style={{ width: t.value }} />
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </DocSection>
 
             {/* Custom layout classes */}
             <DocSection title="Layout Utilities">

--- a/src/app/(mobile-ui)/dev/ds/foundations/spacing/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/foundations/spacing/page.tsx
@@ -26,7 +26,9 @@ export default function SpacingPage() {
                     <div className="space-y-2 rounded-sm border border-n-1 p-3 text-xs">
                         {SPACING_TOKENS.map((t) => (
                             <div key={t.name} className="flex items-center gap-3">
-                                <code className="w-24 shrink-0 font-mono font-bold">--spacing-{t.name}</code>
+                                <code className="w-24 shrink-0 font-mono font-bold">
+                                    --spacing{t.name && `-${t.name}`}
+                                </code>
                                 <span className="w-14 shrink-0 text-grey-1">{t.value}</span>
                                 <div className="h-3 bg-purple-1" style={{ width: t.value }} />
                             </div>

--- a/src/app/(mobile-ui)/dev/ds/foundations/tokens.generated.ts
+++ b/src/app/(mobile-ui)/dev/ds/foundations/tokens.generated.ts
@@ -1,0 +1,1143 @@
+// generated from the @theme block in src/styles/globals.css by
+// scripts/generate-ds-tokens.mjs — DO NOT EDIT. run `pnpm gen:ds-tokens`.
+// a jest drift test (scripts/__tests__/ds-tokens-drift.test.js) fails CI when
+// this file is stale.
+
+/** which @theme banner the token sits under: legacy palette (v3 port, do not
+ * use in new code), semantic (figma-verified, use these), or v3-parity shims. */
+export type TokenSection = 'legacy' | 'semantic' | 'parity'
+
+export interface ColorToken {
+    name: string
+    value: string
+    section: TokenSection
+}
+
+export interface TextStyle {
+    name: string
+    section: TokenSection
+    fontSize?: string
+    lineHeight?: string
+    fontWeight?: string
+    [modifier: string]: string | undefined
+}
+
+export interface FontToken {
+    name: string
+    section: TokenSection
+    stack?: string
+    [modifier: string]: string | undefined
+}
+
+export const COLOR_TOKENS: ColorToken[] = [
+    {
+        name: 'primary-1',
+        value: '#ff90e8',
+        section: 'legacy',
+    },
+    {
+        name: 'primary-2',
+        value: '#cc73ba',
+        section: 'legacy',
+    },
+    {
+        name: 'primary-3',
+        value: '#efe4ff',
+        section: 'legacy',
+    },
+    {
+        name: 'primary-4',
+        value: '#ba8bff',
+        section: 'legacy',
+    },
+    {
+        name: 'secondary-1',
+        value: '#ffc900',
+        section: 'legacy',
+    },
+    {
+        name: 'secondary-2',
+        value: '#e99898',
+        section: 'legacy',
+    },
+    {
+        name: 'secondary-3',
+        value: '#90a8ed',
+        section: 'legacy',
+    },
+    {
+        name: 'secondary-4',
+        value: '#fff4cc',
+        section: 'legacy',
+    },
+    {
+        name: 'secondary-5',
+        value: '#fbeaea',
+        section: 'legacy',
+    },
+    {
+        name: 'secondary-6',
+        value: '#e9eefb',
+        section: 'legacy',
+    },
+    {
+        name: 'secondary-7',
+        value: '#5883ff',
+        section: 'legacy',
+    },
+    {
+        name: 'secondary-8',
+        value: '#d4b6ff',
+        section: 'legacy',
+    },
+    {
+        name: 'secondary-9',
+        value: '#d6e1ff',
+        section: 'legacy',
+    },
+    {
+        name: 'grey-1',
+        value: '#5f646d',
+        section: 'legacy',
+    },
+    {
+        name: 'grey-2',
+        value: '#e7e8e9',
+        section: 'legacy',
+    },
+    {
+        name: 'grey-3',
+        value: '#faf4f0',
+        section: 'legacy',
+    },
+    {
+        name: 'grey-4',
+        value: '#efeff0',
+        section: 'legacy',
+    },
+    {
+        name: 'outline-1',
+        value: '#98e9ab',
+        section: 'legacy',
+    },
+    {
+        name: 'outline-2',
+        value: '#ae7aff',
+        section: 'legacy',
+    },
+    {
+        name: 'outline-3',
+        value: '#e99898',
+        section: 'legacy',
+    },
+    {
+        name: 'purple-1',
+        value: '#ff90e8',
+        section: 'legacy',
+    },
+    {
+        name: 'purple-2',
+        value: '#dc78b5',
+        section: 'legacy',
+    },
+    {
+        name: 'purple-3',
+        value: '#fffae8',
+        section: 'legacy',
+    },
+    {
+        name: 'purple-4',
+        value: '#ae7aff',
+        section: 'legacy',
+    },
+    {
+        name: 'purple-5',
+        value: '#ede4fd',
+        section: 'legacy',
+    },
+    {
+        name: 'purple-6',
+        value: '#9d7efe',
+        section: 'legacy',
+    },
+    {
+        name: 'yellow-1',
+        value: '#ffc900',
+        section: 'legacy',
+    },
+    {
+        name: 'yellow-2',
+        value: '#f5ff7c',
+        section: 'legacy',
+    },
+    {
+        name: 'yellow-3',
+        value: '#fbfdd8',
+        section: 'legacy',
+    },
+    {
+        name: 'yellow-4',
+        value: '#fae8a4',
+        section: 'legacy',
+    },
+    {
+        name: 'yellow-5',
+        value: '#ffd25c',
+        section: 'legacy',
+    },
+    {
+        name: 'yellow-6',
+        value: '#885b00',
+        section: 'legacy',
+    },
+    {
+        name: 'yellow-7',
+        value: '#ffe6b3',
+        section: 'legacy',
+    },
+    {
+        name: 'yellow-8',
+        value: '#fae184',
+        section: 'legacy',
+    },
+    {
+        name: 'yellow-9',
+        value: '#fde047',
+        section: 'legacy',
+    },
+    {
+        name: 'yellow-10',
+        value: '#fefce8',
+        section: 'legacy',
+    },
+    {
+        name: 'yellow-11',
+        value: '#ca8a04',
+        section: 'legacy',
+    },
+    {
+        name: 'green-1',
+        value: '#98e9ab',
+        section: 'legacy',
+    },
+    {
+        name: 'green-2',
+        value: '#eafbee',
+        section: 'legacy',
+    },
+    {
+        name: 'teal-1',
+        value: '#23a094',
+        section: 'legacy',
+    },
+    {
+        name: 'teal-3',
+        value: '#00577d',
+        section: 'legacy',
+    },
+    {
+        name: 'gray-1',
+        value: '#5f646d',
+        section: 'legacy',
+    },
+    {
+        name: 'gray-2',
+        value: '#9ca3af',
+        section: 'legacy',
+    },
+    {
+        name: 'gray-3',
+        value: '#e5e7eb',
+        section: 'legacy',
+    },
+    {
+        name: 'gray-4',
+        value: '#d1d5db',
+        section: 'legacy',
+    },
+    {
+        name: 'gray-5',
+        value: '#60646c',
+        section: 'legacy',
+    },
+    {
+        name: 'n-1',
+        value: '#000000',
+        section: 'legacy',
+    },
+    {
+        name: 'n-2',
+        value: '#161616',
+        section: 'legacy',
+    },
+    {
+        name: 'n-3',
+        value: '#5f646d',
+        section: 'legacy',
+    },
+    {
+        name: 'n-4',
+        value: '#e7e8e9',
+        section: 'legacy',
+    },
+    {
+        name: 'violet-3',
+        value: '#6340df',
+        section: 'legacy',
+    },
+    {
+        name: 'violet-9',
+        value: '#f1ebf8',
+        section: 'legacy',
+    },
+    {
+        name: 'cyan-1',
+        value: '#4cccef',
+        section: 'legacy',
+    },
+    {
+        name: 'orange-1',
+        value: '#fe8e3e',
+        section: 'legacy',
+    },
+    {
+        name: 'orange-2',
+        value: '#ff5656',
+        section: 'legacy',
+    },
+    {
+        name: 'success-1',
+        value: '#16b413',
+        section: 'legacy',
+    },
+    {
+        name: 'success-2',
+        value: '#c7f9c6',
+        section: 'legacy',
+    },
+    {
+        name: 'success-3',
+        value: '#29cc6a',
+        section: 'legacy',
+    },
+    {
+        name: 'success-4',
+        value: '#1c6a50',
+        section: 'legacy',
+    },
+    {
+        name: 'success-5',
+        value: '#88d987',
+        section: 'legacy',
+    },
+    {
+        name: 'success-6',
+        value: '#ecffe9',
+        section: 'legacy',
+    },
+    {
+        name: 'success-7',
+        value: '#4b8a17',
+        section: 'legacy',
+    },
+    {
+        name: 'white',
+        value: '#ffffff',
+        section: 'legacy',
+    },
+    {
+        name: 'red',
+        value: '#ff0000',
+        section: 'legacy',
+    },
+    {
+        name: 'kyc-red',
+        value: '#c80000',
+        section: 'legacy',
+    },
+    {
+        name: 'black',
+        value: '#000000',
+        section: 'legacy',
+    },
+    {
+        name: 'kyc-green',
+        value: '#00c800',
+        section: 'legacy',
+    },
+    {
+        name: 'background',
+        value: '#faf4f0',
+        section: 'legacy',
+    },
+    {
+        name: 'error',
+        value: '#b3261e',
+        section: 'legacy',
+    },
+    {
+        name: 'error-1',
+        value: '#ffd8d8',
+        section: 'legacy',
+    },
+    {
+        name: 'error-2',
+        value: '#ea8282',
+        section: 'legacy',
+    },
+    {
+        name: 'error-3',
+        value: '#ff4a4a',
+        section: 'legacy',
+    },
+    {
+        name: 'error-4',
+        value: '#fc5555',
+        section: 'legacy',
+    },
+    {
+        name: 'error-5',
+        value: '#ff3b30',
+        section: 'legacy',
+    },
+    {
+        name: 'error-6',
+        value: '#ffe9e9',
+        section: 'legacy',
+    },
+    {
+        name: 'action-primary',
+        value: '#ff90e8',
+        section: 'semantic',
+    },
+    {
+        name: 'action-primary-hover',
+        value: '#ffa3ec',
+        section: 'semantic',
+    },
+    {
+        name: 'action-secondary',
+        value: '#ffc900',
+        section: 'semantic',
+    },
+    {
+        name: 'action-ghost-hover',
+        value: '#bd33a1',
+        section: 'semantic',
+    },
+    {
+        name: 'action-focus',
+        value: '#2563eb',
+        section: 'semantic',
+    },
+    {
+        name: 'background-default',
+        value: '#ffffff',
+        section: 'semantic',
+    },
+    {
+        name: 'background-page',
+        value: '#faf4f0',
+        section: 'semantic',
+    },
+    {
+        name: 'background-disabled',
+        value: '#efeff0',
+        section: 'semantic',
+    },
+    {
+        name: 'background-brand',
+        value: '#ff90e8',
+        section: 'semantic',
+    },
+    {
+        name: 'background-icon-bubble-green',
+        value: '#29cc6a',
+        section: 'semantic',
+    },
+    {
+        name: 'background-icon-bubble-red',
+        value: '#ea8282',
+        section: 'semantic',
+    },
+    {
+        name: 'background-icon-bubble-yellow',
+        value: '#ffc900',
+        section: 'semantic',
+    },
+    {
+        name: 'background-icon-bubble-gray',
+        value: '#d1d5db',
+        section: 'semantic',
+    },
+    {
+        name: 'background-icon-bubble-blue',
+        value: '#90a8ed',
+        section: 'semantic',
+    },
+    {
+        name: 'background-badge-attention',
+        value: '#ffe6b3',
+        section: 'semantic',
+    },
+    {
+        name: 'background-badge-info',
+        value: '#dbeafe',
+        section: 'semantic',
+    },
+    {
+        name: 'background-badge-error',
+        value: '#ffcccc',
+        section: 'semantic',
+    },
+    {
+        name: 'background-badge-success',
+        value: '#c7f9c6',
+        section: 'semantic',
+    },
+    {
+        name: 'background-badge-accent',
+        value: '#dcd6ff',
+        section: 'semantic',
+    },
+    {
+        name: 'background-badge-helper',
+        value: '#e7e8e9',
+        section: 'semantic',
+    },
+    {
+        name: 'foreground-primary',
+        value: '#000000',
+        section: 'semantic',
+    },
+    {
+        name: 'foreground-secondary',
+        value: '#5f646d',
+        section: 'semantic',
+    },
+    {
+        name: 'foreground-inverse',
+        value: '#ffffff',
+        section: 'semantic',
+    },
+    {
+        name: 'foreground-error',
+        value: '#ff3b30',
+        section: 'semantic',
+    },
+    {
+        name: 'foreground-over-color-primary',
+        value: '#000000',
+        section: 'semantic',
+    },
+    {
+        name: 'foreground-over-color-secondary',
+        value: '#00000099',
+        section: 'semantic',
+    },
+    {
+        name: 'border-default',
+        value: '#161616',
+        section: 'semantic',
+    },
+    {
+        name: 'border-subtle',
+        value: '#9ca3af',
+        section: 'semantic',
+    },
+    {
+        name: 'border-button',
+        value: '#000000',
+        section: 'semantic',
+    },
+    {
+        name: 'border-button-secondary',
+        value: '#000000',
+        section: 'semantic',
+    },
+    {
+        name: 'border-accent',
+        value: '#ae7aff',
+        section: 'semantic',
+    },
+    {
+        name: 'border-error',
+        value: '#ff3b30',
+        section: 'semantic',
+    },
+    {
+        name: 'border-disabled',
+        value: '#e7e8e9',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-pink',
+        value: '#ffd5f6',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-pink-border',
+        value: '#e06ac8',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-pink-foreground',
+        value: '#a42089',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-yellow',
+        value: '#fae184',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-yellow-border',
+        value: '#dcae01',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-yellow-foreground',
+        value: '#885b00',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-orange',
+        value: '#ffd3b4',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-orange-border',
+        value: '#f69855',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-orange-foreground',
+        value: '#b8450a',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-blue',
+        value: '#dbeafe',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-blue-border',
+        value: '#90a8ed',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-blue-foreground',
+        value: '#2563eb',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-purple',
+        value: '#dcd6ff',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-purple-border',
+        value: '#ba8bff',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-purple-foreground',
+        value: '#9333ea',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-red',
+        value: '#ffcccc',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-red-border',
+        value: '#ea8282',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-red-foreground',
+        value: '#e40c0c',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-green',
+        value: '#c7f9c6',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-green-border',
+        value: '#29cc6a',
+        section: 'semantic',
+    },
+    {
+        name: 'avatar-green-foreground',
+        value: '#3b730c',
+        section: 'semantic',
+    },
+    {
+        name: 'shadow-primary',
+        value: '#000000',
+        section: 'semantic',
+    },
+]
+
+export const TEXT_STYLES: TextStyle[] = [
+    {
+        name: 'heading-big-input',
+        section: 'semantic',
+        fontSize: '3.25rem',
+        lineHeight: '4rem',
+        fontWeight: '700',
+    },
+    {
+        name: 'heading-xl',
+        section: 'semantic',
+        fontSize: '2.625rem',
+        lineHeight: '3rem',
+        fontWeight: '800',
+    },
+    {
+        name: 'heading-l',
+        section: 'semantic',
+        fontSize: '2.25rem',
+        lineHeight: '2.5rem',
+        fontWeight: '800',
+    },
+    {
+        name: 'heading-m',
+        section: 'semantic',
+        fontSize: '1.875rem',
+        lineHeight: '2.25rem',
+        fontWeight: '800',
+    },
+    {
+        name: 'heading-s',
+        section: 'semantic',
+        fontSize: '1.5rem',
+        lineHeight: '2rem',
+        fontWeight: '800',
+    },
+    {
+        name: 'heading-xs',
+        section: 'semantic',
+        fontSize: '1.25rem',
+        lineHeight: '1.5rem',
+        fontWeight: '800',
+    },
+    {
+        name: 'heading-card',
+        section: 'semantic',
+        fontSize: '1.125rem',
+        lineHeight: '1.5rem',
+        fontWeight: '700',
+    },
+    {
+        name: 'body-l',
+        section: 'semantic',
+        fontSize: '1.125rem',
+        lineHeight: '1.625rem',
+        fontWeight: '400',
+    },
+    {
+        name: 'body-m',
+        section: 'semantic',
+        fontSize: '1rem',
+        lineHeight: '1.25rem',
+        fontWeight: '500',
+    },
+    {
+        name: 'body-m-semibold',
+        section: 'semantic',
+        fontSize: '1rem',
+        lineHeight: '1.25rem',
+        fontWeight: '600',
+    },
+    {
+        name: 'body-s',
+        section: 'semantic',
+        fontSize: '0.875rem',
+        lineHeight: '1.25rem',
+        fontWeight: '500',
+    },
+    {
+        name: 'body-xs',
+        section: 'semantic',
+        fontSize: '0.75rem',
+        lineHeight: '1rem',
+        fontWeight: '400',
+    },
+    {
+        name: 'label-l',
+        section: 'semantic',
+        fontSize: '0.875rem',
+        lineHeight: '1.25rem',
+        fontWeight: '700',
+    },
+    {
+        name: 'label-m',
+        section: 'semantic',
+        fontSize: '0.75rem',
+        lineHeight: '1rem',
+        fontWeight: '800',
+    },
+    {
+        name: 'button-l',
+        section: 'semantic',
+        fontSize: '1.125rem',
+        lineHeight: '1.5rem',
+        fontWeight: '700',
+    },
+    {
+        name: 'button-m',
+        section: 'semantic',
+        fontSize: '1rem',
+        lineHeight: '1rem',
+        fontWeight: '700',
+    },
+    {
+        name: 'button-s',
+        section: 'semantic',
+        fontSize: '0.875rem',
+        lineHeight: '0.875rem',
+        fontWeight: '700',
+    },
+    {
+        name: 'display',
+        section: 'semantic',
+        fontSize: '3.75rem',
+    },
+    {
+        name: '0',
+        section: 'parity',
+        fontSize: '0px',
+        lineHeight: '0px',
+    },
+    {
+        name: 'sm',
+        section: 'parity',
+        fontSize: '0.875rem',
+        lineHeight: '1.3125rem',
+    },
+    {
+        name: '6xl',
+        section: 'parity',
+        fontSize: '3rem',
+        lineHeight: '3.25rem',
+    },
+    {
+        name: '7xl',
+        section: 'parity',
+        fontSize: '7rem',
+        lineHeight: '7rem',
+    },
+    {
+        name: '8xl',
+        section: 'parity',
+        fontSize: '10rem',
+        lineHeight: '10rem',
+    },
+    {
+        name: '9xl',
+        section: 'parity',
+        fontSize: '12rem',
+        lineHeight: '0.9',
+    },
+    {
+        name: 'h1',
+        section: 'parity',
+        fontSize: '3rem',
+        lineHeight: '3.5rem',
+        fontWeight: '800',
+    },
+    {
+        name: 'h2',
+        section: 'parity',
+        fontSize: '2.25rem',
+        lineHeight: '2.875rem',
+        fontWeight: '800',
+    },
+    {
+        name: 'h3',
+        section: 'parity',
+        fontSize: '1.875rem',
+        lineHeight: '2.375rem',
+        fontWeight: '800',
+    },
+    {
+        name: 'h4',
+        section: 'parity',
+        fontSize: '1.5rem',
+        lineHeight: '2rem',
+        fontWeight: '800',
+    },
+    {
+        name: 'h5',
+        section: 'parity',
+        fontSize: '1.25rem',
+        lineHeight: '1.75rem',
+        fontWeight: '800',
+    },
+    {
+        name: 'h6',
+        section: 'parity',
+        fontSize: '1.125rem',
+        lineHeight: '1.5rem',
+        fontWeight: '800',
+    },
+    {
+        name: 'h7',
+        section: 'parity',
+        fontSize: '1rem',
+        lineHeight: '1.25rem',
+        fontWeight: '800',
+    },
+    {
+        name: 'h8',
+        section: 'parity',
+        fontSize: '0.875rem',
+        lineHeight: '1rem',
+        fontWeight: '800',
+    },
+    {
+        name: 'h9',
+        section: 'parity',
+        fontSize: '0.75rem',
+        lineHeight: '0.875rem',
+        fontWeight: '800',
+    },
+    {
+        name: 'h10',
+        section: 'parity',
+        fontSize: '0.625rem',
+        lineHeight: '0.75rem',
+        fontWeight: '800',
+    },
+    {
+        name: 'headingLarge',
+        section: 'parity',
+        fontSize: '7rem',
+        lineHeight: '6.5rem',
+    },
+    {
+        name: 'headingMedium',
+        section: 'parity',
+        fontSize: '5rem',
+        lineHeight: '4rem',
+    },
+    {
+        name: 'heading',
+        section: 'parity',
+        fontSize: '3.75rem',
+        lineHeight: '2.875rem',
+    },
+]
+
+export const FONT_TOKENS: FontToken[] = [
+    {
+        name: 'sans',
+        section: 'parity',
+        stack: "var(--font-roboto), ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'",
+    },
+    {
+        name: 'display',
+        section: 'parity',
+        stack: "var(--font-sniglet), ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'",
+    },
+    {
+        name: 'condensed',
+        section: 'parity',
+        stack: 'var(--font-roboto)',
+        fontVariationSettings: "'wdth' 50",
+    },
+    {
+        name: 'weight-extraBlack',
+        section: 'parity',
+        stack: '1000',
+    },
+]
+
+/** radius / shadow / blur / motion / spacing token groups, keyed by @theme namespace */
+export const TOKEN_GROUPS: Record<string, ColorToken[]> = {
+    radius: [
+        {
+            name: 'round',
+            value: '999px',
+            section: 'semantic',
+        },
+        {
+            name: 'sm',
+            value: '0.125rem',
+            section: 'parity',
+        },
+        {
+            name: '1',
+            value: '0.0625rem',
+            section: 'parity',
+        },
+    ],
+    'transition-duration': [
+        {
+            name: 'instant',
+            value: '100ms',
+            section: 'semantic',
+        },
+        {
+            name: 'fast',
+            value: '200ms',
+            section: 'semantic',
+        },
+        {
+            name: 'moderate',
+            value: '300ms',
+            section: 'semantic',
+        },
+        {
+            name: 'slow',
+            value: '500ms',
+            section: 'semantic',
+        },
+    ],
+    ease: [
+        {
+            name: 'spring',
+            value: 'cubic-bezier(0.34, 1.56, 0.64, 1)',
+            section: 'semantic',
+        },
+        {
+            name: 'sharp',
+            value: 'cubic-bezier(0.87, 0, 0.13, 1)',
+            section: 'semantic',
+        },
+    ],
+    shadow: [
+        {
+            name: 'sm',
+            value: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+            section: 'parity',
+        },
+        {
+            name: 'md',
+            value: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
+            section: 'parity',
+        },
+        {
+            name: 'lg',
+            value: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+            section: 'parity',
+        },
+        {
+            name: 'xl',
+            value: '0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)',
+            section: 'parity',
+        },
+        {
+            name: '2xl',
+            value: '0 25px 50px -12px rgb(0 0 0 / 0.25)',
+            section: 'parity',
+        },
+    ],
+    blur: [
+        {
+            name: 'sm',
+            value: '4px',
+            section: 'parity',
+        },
+        {
+            name: 'md',
+            value: '12px',
+            section: 'parity',
+        },
+        {
+            name: 'lg',
+            value: '16px',
+            section: 'parity',
+        },
+        {
+            name: 'xl',
+            value: '24px',
+            section: 'parity',
+        },
+        {
+            name: '2xl',
+            value: '40px',
+            section: 'parity',
+        },
+        {
+            name: '3xl',
+            value: '64px',
+            section: 'parity',
+        },
+    ],
+    'drop-shadow': [
+        {
+            name: 'sm',
+            value: '0 1px 1px rgb(0 0 0 / 0.05)',
+            section: 'parity',
+        },
+        {
+            name: 'md',
+            value: '0 4px 3px rgb(0 0 0 / 0.07), 0 2px 2px rgb(0 0 0 / 0.06)',
+            section: 'parity',
+        },
+        {
+            name: 'lg',
+            value: '0 10px 8px rgb(0 0 0 / 0.04), 0 4px 3px rgb(0 0 0 / 0.1)',
+            section: 'parity',
+        },
+        {
+            name: 'xl',
+            value: '0 20px 13px rgb(0 0 0 / 0.03), 0 8px 5px rgb(0 0 0 / 0.08)',
+            section: 'parity',
+        },
+        {
+            name: '2xl',
+            value: '0 25px 25px rgb(0 0 0 / 0.15)',
+            section: 'parity',
+        },
+    ],
+    'default-transition': [
+        {
+            name: 'duration',
+            value: '200ms',
+            section: 'parity',
+        },
+        {
+            name: 'timing-function',
+            value: 'linear',
+            section: 'parity',
+        },
+    ],
+    animate: [
+        {
+            name: 'pulsate',
+            value: 'pulsate 1.5s ease-in-out infinite',
+            section: 'parity',
+        },
+        {
+            name: 'pulse-strong',
+            value: 'pulse-strong 1s ease-in-out infinite',
+            section: 'parity',
+        },
+        {
+            name: 'blink',
+            value: 'blink 1.5s step-end infinite',
+            section: 'parity',
+        },
+        {
+            name: 'accordion-down',
+            value: 'accordion-down 0.3s cubic-bezier(0.87, 0, 0.13, 1)',
+            section: 'parity',
+        },
+        {
+            name: 'accordion-up',
+            value: 'accordion-up 0.3s cubic-bezier(0.87, 0, 0.13, 1)',
+            section: 'parity',
+        },
+        {
+            name: 'star-pulsate-wiggle',
+            value: 'starPulsateWiggle 10s ease-in-out infinite',
+            section: 'parity',
+        },
+    ],
+}

--- a/src/app/(mobile-ui)/dev/ds/foundations/tokens.generated.ts
+++ b/src/app/(mobile-ui)/dev/ds/foundations/tokens.generated.ts
@@ -950,11 +950,6 @@ export const FONT_TOKENS: FontToken[] = [
         stack: 'var(--font-roboto)',
         fontVariationSettings: "'wdth' 50",
     },
-    {
-        name: 'weight-extraBlack',
-        section: 'parity',
-        stack: '1000',
-    },
 ]
 
 /** radius / shadow / blur / motion / spacing token groups, keyed by @theme namespace */
@@ -1105,6 +1100,13 @@ export const TOKEN_GROUPS: Record<string, ColorToken[]> = {
         {
             name: 'timing-function',
             value: 'linear',
+            section: 'parity',
+        },
+    ],
+    'font-weight': [
+        {
+            name: 'extraBlack',
+            value: '1000',
             section: 'parity',
         },
     ],

--- a/src/app/(mobile-ui)/dev/ds/foundations/tokens.generated.ts
+++ b/src/app/(mobile-ui)/dev/ds/foundations/tokens.generated.ts
@@ -7,7 +7,7 @@
  * use in new code), semantic (figma-verified, use these), or v3-parity shims. */
 export type TokenSection = 'legacy' | 'semantic' | 'parity'
 
-export interface ColorToken {
+export interface ThemeToken {
     name: string
     value: string
     section: TokenSection
@@ -29,7 +29,7 @@ export interface FontToken {
     [modifier: string]: string | undefined
 }
 
-export const COLOR_TOKENS: ColorToken[] = [
+export const COLOR_TOKENS: ThemeToken[] = [
     {
         name: 'primary-1',
         value: '#ff90e8',
@@ -953,7 +953,7 @@ export const FONT_TOKENS: FontToken[] = [
 ]
 
 /** radius / shadow / blur / motion / spacing token groups, keyed by @theme namespace */
-export const TOKEN_GROUPS: Record<string, ColorToken[]> = {
+export const TOKEN_GROUPS: Record<string, ThemeToken[]> = {
     radius: [
         {
             name: 'round',

--- a/src/app/(mobile-ui)/dev/ds/foundations/tokens.generated.ts
+++ b/src/app/(mobile-ui)/dev/ds/foundations/tokens.generated.ts
@@ -31,1115 +31,1115 @@ export interface FontToken {
 
 export const COLOR_TOKENS: ThemeToken[] = [
     {
-        name: 'primary-1',
-        value: '#ff90e8',
-        section: 'legacy',
+        "name": "primary-1",
+        "value": "#ff90e8",
+        "section": "legacy"
     },
     {
-        name: 'primary-2',
-        value: '#cc73ba',
-        section: 'legacy',
+        "name": "primary-2",
+        "value": "#cc73ba",
+        "section": "legacy"
     },
     {
-        name: 'primary-3',
-        value: '#efe4ff',
-        section: 'legacy',
+        "name": "primary-3",
+        "value": "#efe4ff",
+        "section": "legacy"
     },
     {
-        name: 'primary-4',
-        value: '#ba8bff',
-        section: 'legacy',
+        "name": "primary-4",
+        "value": "#ba8bff",
+        "section": "legacy"
     },
     {
-        name: 'secondary-1',
-        value: '#ffc900',
-        section: 'legacy',
+        "name": "secondary-1",
+        "value": "#ffc900",
+        "section": "legacy"
     },
     {
-        name: 'secondary-2',
-        value: '#e99898',
-        section: 'legacy',
+        "name": "secondary-2",
+        "value": "#e99898",
+        "section": "legacy"
     },
     {
-        name: 'secondary-3',
-        value: '#90a8ed',
-        section: 'legacy',
+        "name": "secondary-3",
+        "value": "#90a8ed",
+        "section": "legacy"
     },
     {
-        name: 'secondary-4',
-        value: '#fff4cc',
-        section: 'legacy',
+        "name": "secondary-4",
+        "value": "#fff4cc",
+        "section": "legacy"
     },
     {
-        name: 'secondary-5',
-        value: '#fbeaea',
-        section: 'legacy',
+        "name": "secondary-5",
+        "value": "#fbeaea",
+        "section": "legacy"
     },
     {
-        name: 'secondary-6',
-        value: '#e9eefb',
-        section: 'legacy',
+        "name": "secondary-6",
+        "value": "#e9eefb",
+        "section": "legacy"
     },
     {
-        name: 'secondary-7',
-        value: '#5883ff',
-        section: 'legacy',
+        "name": "secondary-7",
+        "value": "#5883ff",
+        "section": "legacy"
     },
     {
-        name: 'secondary-8',
-        value: '#d4b6ff',
-        section: 'legacy',
+        "name": "secondary-8",
+        "value": "#d4b6ff",
+        "section": "legacy"
     },
     {
-        name: 'secondary-9',
-        value: '#d6e1ff',
-        section: 'legacy',
+        "name": "secondary-9",
+        "value": "#d6e1ff",
+        "section": "legacy"
     },
     {
-        name: 'grey-1',
-        value: '#5f646d',
-        section: 'legacy',
+        "name": "grey-1",
+        "value": "#5f646d",
+        "section": "legacy"
     },
     {
-        name: 'grey-2',
-        value: '#e7e8e9',
-        section: 'legacy',
+        "name": "grey-2",
+        "value": "#e7e8e9",
+        "section": "legacy"
     },
     {
-        name: 'grey-3',
-        value: '#faf4f0',
-        section: 'legacy',
+        "name": "grey-3",
+        "value": "#faf4f0",
+        "section": "legacy"
     },
     {
-        name: 'grey-4',
-        value: '#efeff0',
-        section: 'legacy',
+        "name": "grey-4",
+        "value": "#efeff0",
+        "section": "legacy"
     },
     {
-        name: 'outline-1',
-        value: '#98e9ab',
-        section: 'legacy',
+        "name": "outline-1",
+        "value": "#98e9ab",
+        "section": "legacy"
     },
     {
-        name: 'outline-2',
-        value: '#ae7aff',
-        section: 'legacy',
+        "name": "outline-2",
+        "value": "#ae7aff",
+        "section": "legacy"
     },
     {
-        name: 'outline-3',
-        value: '#e99898',
-        section: 'legacy',
+        "name": "outline-3",
+        "value": "#e99898",
+        "section": "legacy"
     },
     {
-        name: 'purple-1',
-        value: '#ff90e8',
-        section: 'legacy',
+        "name": "purple-1",
+        "value": "#ff90e8",
+        "section": "legacy"
     },
     {
-        name: 'purple-2',
-        value: '#dc78b5',
-        section: 'legacy',
+        "name": "purple-2",
+        "value": "#dc78b5",
+        "section": "legacy"
     },
     {
-        name: 'purple-3',
-        value: '#fffae8',
-        section: 'legacy',
+        "name": "purple-3",
+        "value": "#fffae8",
+        "section": "legacy"
     },
     {
-        name: 'purple-4',
-        value: '#ae7aff',
-        section: 'legacy',
+        "name": "purple-4",
+        "value": "#ae7aff",
+        "section": "legacy"
     },
     {
-        name: 'purple-5',
-        value: '#ede4fd',
-        section: 'legacy',
+        "name": "purple-5",
+        "value": "#ede4fd",
+        "section": "legacy"
     },
     {
-        name: 'purple-6',
-        value: '#9d7efe',
-        section: 'legacy',
+        "name": "purple-6",
+        "value": "#9d7efe",
+        "section": "legacy"
     },
     {
-        name: 'yellow-1',
-        value: '#ffc900',
-        section: 'legacy',
+        "name": "yellow-1",
+        "value": "#ffc900",
+        "section": "legacy"
     },
     {
-        name: 'yellow-2',
-        value: '#f5ff7c',
-        section: 'legacy',
+        "name": "yellow-2",
+        "value": "#f5ff7c",
+        "section": "legacy"
     },
     {
-        name: 'yellow-3',
-        value: '#fbfdd8',
-        section: 'legacy',
+        "name": "yellow-3",
+        "value": "#fbfdd8",
+        "section": "legacy"
     },
     {
-        name: 'yellow-4',
-        value: '#fae8a4',
-        section: 'legacy',
+        "name": "yellow-4",
+        "value": "#fae8a4",
+        "section": "legacy"
     },
     {
-        name: 'yellow-5',
-        value: '#ffd25c',
-        section: 'legacy',
+        "name": "yellow-5",
+        "value": "#ffd25c",
+        "section": "legacy"
     },
     {
-        name: 'yellow-6',
-        value: '#885b00',
-        section: 'legacy',
+        "name": "yellow-6",
+        "value": "#885b00",
+        "section": "legacy"
     },
     {
-        name: 'yellow-7',
-        value: '#ffe6b3',
-        section: 'legacy',
+        "name": "yellow-7",
+        "value": "#ffe6b3",
+        "section": "legacy"
     },
     {
-        name: 'yellow-8',
-        value: '#fae184',
-        section: 'legacy',
+        "name": "yellow-8",
+        "value": "#fae184",
+        "section": "legacy"
     },
     {
-        name: 'yellow-9',
-        value: '#fde047',
-        section: 'legacy',
+        "name": "yellow-9",
+        "value": "#fde047",
+        "section": "legacy"
     },
     {
-        name: 'yellow-10',
-        value: '#fefce8',
-        section: 'legacy',
+        "name": "yellow-10",
+        "value": "#fefce8",
+        "section": "legacy"
     },
     {
-        name: 'yellow-11',
-        value: '#ca8a04',
-        section: 'legacy',
+        "name": "yellow-11",
+        "value": "#ca8a04",
+        "section": "legacy"
     },
     {
-        name: 'green-1',
-        value: '#98e9ab',
-        section: 'legacy',
+        "name": "green-1",
+        "value": "#98e9ab",
+        "section": "legacy"
     },
     {
-        name: 'green-2',
-        value: '#eafbee',
-        section: 'legacy',
+        "name": "green-2",
+        "value": "#eafbee",
+        "section": "legacy"
     },
     {
-        name: 'teal-1',
-        value: '#23a094',
-        section: 'legacy',
+        "name": "teal-1",
+        "value": "#23a094",
+        "section": "legacy"
     },
     {
-        name: 'teal-3',
-        value: '#00577d',
-        section: 'legacy',
+        "name": "teal-3",
+        "value": "#00577d",
+        "section": "legacy"
     },
     {
-        name: 'gray-1',
-        value: '#5f646d',
-        section: 'legacy',
+        "name": "gray-1",
+        "value": "#5f646d",
+        "section": "legacy"
     },
     {
-        name: 'gray-2',
-        value: '#9ca3af',
-        section: 'legacy',
+        "name": "gray-2",
+        "value": "#9ca3af",
+        "section": "legacy"
     },
     {
-        name: 'gray-3',
-        value: '#e5e7eb',
-        section: 'legacy',
+        "name": "gray-3",
+        "value": "#e5e7eb",
+        "section": "legacy"
     },
     {
-        name: 'gray-4',
-        value: '#d1d5db',
-        section: 'legacy',
+        "name": "gray-4",
+        "value": "#d1d5db",
+        "section": "legacy"
     },
     {
-        name: 'gray-5',
-        value: '#60646c',
-        section: 'legacy',
+        "name": "gray-5",
+        "value": "#60646c",
+        "section": "legacy"
     },
     {
-        name: 'n-1',
-        value: '#000000',
-        section: 'legacy',
+        "name": "n-1",
+        "value": "#000000",
+        "section": "legacy"
     },
     {
-        name: 'n-2',
-        value: '#161616',
-        section: 'legacy',
+        "name": "n-2",
+        "value": "#161616",
+        "section": "legacy"
     },
     {
-        name: 'n-3',
-        value: '#5f646d',
-        section: 'legacy',
+        "name": "n-3",
+        "value": "#5f646d",
+        "section": "legacy"
     },
     {
-        name: 'n-4',
-        value: '#e7e8e9',
-        section: 'legacy',
+        "name": "n-4",
+        "value": "#e7e8e9",
+        "section": "legacy"
     },
     {
-        name: 'violet-3',
-        value: '#6340df',
-        section: 'legacy',
+        "name": "violet-3",
+        "value": "#6340df",
+        "section": "legacy"
     },
     {
-        name: 'violet-9',
-        value: '#f1ebf8',
-        section: 'legacy',
+        "name": "violet-9",
+        "value": "#f1ebf8",
+        "section": "legacy"
     },
     {
-        name: 'cyan-1',
-        value: '#4cccef',
-        section: 'legacy',
+        "name": "cyan-1",
+        "value": "#4cccef",
+        "section": "legacy"
     },
     {
-        name: 'orange-1',
-        value: '#fe8e3e',
-        section: 'legacy',
+        "name": "orange-1",
+        "value": "#fe8e3e",
+        "section": "legacy"
     },
     {
-        name: 'orange-2',
-        value: '#ff5656',
-        section: 'legacy',
+        "name": "orange-2",
+        "value": "#ff5656",
+        "section": "legacy"
     },
     {
-        name: 'success-1',
-        value: '#16b413',
-        section: 'legacy',
+        "name": "success-1",
+        "value": "#16b413",
+        "section": "legacy"
     },
     {
-        name: 'success-2',
-        value: '#c7f9c6',
-        section: 'legacy',
+        "name": "success-2",
+        "value": "#c7f9c6",
+        "section": "legacy"
     },
     {
-        name: 'success-3',
-        value: '#29cc6a',
-        section: 'legacy',
+        "name": "success-3",
+        "value": "#29cc6a",
+        "section": "legacy"
     },
     {
-        name: 'success-4',
-        value: '#1c6a50',
-        section: 'legacy',
+        "name": "success-4",
+        "value": "#1c6a50",
+        "section": "legacy"
     },
     {
-        name: 'success-5',
-        value: '#88d987',
-        section: 'legacy',
+        "name": "success-5",
+        "value": "#88d987",
+        "section": "legacy"
     },
     {
-        name: 'success-6',
-        value: '#ecffe9',
-        section: 'legacy',
+        "name": "success-6",
+        "value": "#ecffe9",
+        "section": "legacy"
     },
     {
-        name: 'success-7',
-        value: '#4b8a17',
-        section: 'legacy',
+        "name": "success-7",
+        "value": "#4b8a17",
+        "section": "legacy"
     },
     {
-        name: 'white',
-        value: '#ffffff',
-        section: 'legacy',
+        "name": "white",
+        "value": "#ffffff",
+        "section": "legacy"
     },
     {
-        name: 'red',
-        value: '#ff0000',
-        section: 'legacy',
+        "name": "red",
+        "value": "#ff0000",
+        "section": "legacy"
     },
     {
-        name: 'kyc-red',
-        value: '#c80000',
-        section: 'legacy',
+        "name": "kyc-red",
+        "value": "#c80000",
+        "section": "legacy"
     },
     {
-        name: 'black',
-        value: '#000000',
-        section: 'legacy',
+        "name": "black",
+        "value": "#000000",
+        "section": "legacy"
     },
     {
-        name: 'kyc-green',
-        value: '#00c800',
-        section: 'legacy',
+        "name": "kyc-green",
+        "value": "#00c800",
+        "section": "legacy"
     },
     {
-        name: 'background',
-        value: '#faf4f0',
-        section: 'legacy',
+        "name": "background",
+        "value": "#faf4f0",
+        "section": "legacy"
     },
     {
-        name: 'error',
-        value: '#b3261e',
-        section: 'legacy',
+        "name": "error",
+        "value": "#b3261e",
+        "section": "legacy"
     },
     {
-        name: 'error-1',
-        value: '#ffd8d8',
-        section: 'legacy',
+        "name": "error-1",
+        "value": "#ffd8d8",
+        "section": "legacy"
     },
     {
-        name: 'error-2',
-        value: '#ea8282',
-        section: 'legacy',
+        "name": "error-2",
+        "value": "#ea8282",
+        "section": "legacy"
     },
     {
-        name: 'error-3',
-        value: '#ff4a4a',
-        section: 'legacy',
+        "name": "error-3",
+        "value": "#ff4a4a",
+        "section": "legacy"
     },
     {
-        name: 'error-4',
-        value: '#fc5555',
-        section: 'legacy',
+        "name": "error-4",
+        "value": "#fc5555",
+        "section": "legacy"
     },
     {
-        name: 'error-5',
-        value: '#ff3b30',
-        section: 'legacy',
+        "name": "error-5",
+        "value": "#ff3b30",
+        "section": "legacy"
     },
     {
-        name: 'error-6',
-        value: '#ffe9e9',
-        section: 'legacy',
+        "name": "error-6",
+        "value": "#ffe9e9",
+        "section": "legacy"
     },
     {
-        name: 'action-primary',
-        value: '#ff90e8',
-        section: 'semantic',
+        "name": "action-primary",
+        "value": "#ff90e8",
+        "section": "semantic"
     },
     {
-        name: 'action-primary-hover',
-        value: '#ffa3ec',
-        section: 'semantic',
+        "name": "action-primary-hover",
+        "value": "#ffa3ec",
+        "section": "semantic"
     },
     {
-        name: 'action-secondary',
-        value: '#ffc900',
-        section: 'semantic',
+        "name": "action-secondary",
+        "value": "#ffc900",
+        "section": "semantic"
     },
     {
-        name: 'action-ghost-hover',
-        value: '#bd33a1',
-        section: 'semantic',
+        "name": "action-ghost-hover",
+        "value": "#bd33a1",
+        "section": "semantic"
     },
     {
-        name: 'action-focus',
-        value: '#2563eb',
-        section: 'semantic',
+        "name": "action-focus",
+        "value": "#2563eb",
+        "section": "semantic"
     },
     {
-        name: 'background-default',
-        value: '#ffffff',
-        section: 'semantic',
+        "name": "background-default",
+        "value": "#ffffff",
+        "section": "semantic"
     },
     {
-        name: 'background-page',
-        value: '#faf4f0',
-        section: 'semantic',
+        "name": "background-page",
+        "value": "#faf4f0",
+        "section": "semantic"
     },
     {
-        name: 'background-disabled',
-        value: '#efeff0',
-        section: 'semantic',
+        "name": "background-disabled",
+        "value": "#efeff0",
+        "section": "semantic"
     },
     {
-        name: 'background-brand',
-        value: '#ff90e8',
-        section: 'semantic',
+        "name": "background-brand",
+        "value": "#ff90e8",
+        "section": "semantic"
     },
     {
-        name: 'background-icon-bubble-green',
-        value: '#29cc6a',
-        section: 'semantic',
+        "name": "background-icon-bubble-green",
+        "value": "#29cc6a",
+        "section": "semantic"
     },
     {
-        name: 'background-icon-bubble-red',
-        value: '#ea8282',
-        section: 'semantic',
+        "name": "background-icon-bubble-red",
+        "value": "#ea8282",
+        "section": "semantic"
     },
     {
-        name: 'background-icon-bubble-yellow',
-        value: '#ffc900',
-        section: 'semantic',
+        "name": "background-icon-bubble-yellow",
+        "value": "#ffc900",
+        "section": "semantic"
     },
     {
-        name: 'background-icon-bubble-gray',
-        value: '#d1d5db',
-        section: 'semantic',
+        "name": "background-icon-bubble-gray",
+        "value": "#d1d5db",
+        "section": "semantic"
     },
     {
-        name: 'background-icon-bubble-blue',
-        value: '#90a8ed',
-        section: 'semantic',
+        "name": "background-icon-bubble-blue",
+        "value": "#90a8ed",
+        "section": "semantic"
     },
     {
-        name: 'background-badge-attention',
-        value: '#ffe6b3',
-        section: 'semantic',
+        "name": "background-badge-attention",
+        "value": "#ffe6b3",
+        "section": "semantic"
     },
     {
-        name: 'background-badge-info',
-        value: '#dbeafe',
-        section: 'semantic',
+        "name": "background-badge-info",
+        "value": "#dbeafe",
+        "section": "semantic"
     },
     {
-        name: 'background-badge-error',
-        value: '#ffcccc',
-        section: 'semantic',
+        "name": "background-badge-error",
+        "value": "#ffcccc",
+        "section": "semantic"
     },
     {
-        name: 'background-badge-success',
-        value: '#c7f9c6',
-        section: 'semantic',
+        "name": "background-badge-success",
+        "value": "#c7f9c6",
+        "section": "semantic"
     },
     {
-        name: 'background-badge-accent',
-        value: '#dcd6ff',
-        section: 'semantic',
+        "name": "background-badge-accent",
+        "value": "#dcd6ff",
+        "section": "semantic"
     },
     {
-        name: 'background-badge-helper',
-        value: '#e7e8e9',
-        section: 'semantic',
+        "name": "background-badge-helper",
+        "value": "#e7e8e9",
+        "section": "semantic"
     },
     {
-        name: 'foreground-primary',
-        value: '#000000',
-        section: 'semantic',
+        "name": "foreground-primary",
+        "value": "#000000",
+        "section": "semantic"
     },
     {
-        name: 'foreground-secondary',
-        value: '#5f646d',
-        section: 'semantic',
+        "name": "foreground-secondary",
+        "value": "#5f646d",
+        "section": "semantic"
     },
     {
-        name: 'foreground-inverse',
-        value: '#ffffff',
-        section: 'semantic',
+        "name": "foreground-inverse",
+        "value": "#ffffff",
+        "section": "semantic"
     },
     {
-        name: 'foreground-error',
-        value: '#ff3b30',
-        section: 'semantic',
+        "name": "foreground-error",
+        "value": "#ff3b30",
+        "section": "semantic"
     },
     {
-        name: 'foreground-over-color-primary',
-        value: '#000000',
-        section: 'semantic',
+        "name": "foreground-over-color-primary",
+        "value": "#000000",
+        "section": "semantic"
     },
     {
-        name: 'foreground-over-color-secondary',
-        value: '#00000099',
-        section: 'semantic',
+        "name": "foreground-over-color-secondary",
+        "value": "#00000099",
+        "section": "semantic"
     },
     {
-        name: 'border-default',
-        value: '#161616',
-        section: 'semantic',
+        "name": "border-default",
+        "value": "#161616",
+        "section": "semantic"
     },
     {
-        name: 'border-subtle',
-        value: '#9ca3af',
-        section: 'semantic',
+        "name": "border-subtle",
+        "value": "#9ca3af",
+        "section": "semantic"
     },
     {
-        name: 'border-button',
-        value: '#000000',
-        section: 'semantic',
+        "name": "border-button",
+        "value": "#000000",
+        "section": "semantic"
     },
     {
-        name: 'border-button-secondary',
-        value: '#000000',
-        section: 'semantic',
+        "name": "border-button-secondary",
+        "value": "#000000",
+        "section": "semantic"
     },
     {
-        name: 'border-accent',
-        value: '#ae7aff',
-        section: 'semantic',
+        "name": "border-accent",
+        "value": "#ae7aff",
+        "section": "semantic"
     },
     {
-        name: 'border-error',
-        value: '#ff3b30',
-        section: 'semantic',
+        "name": "border-error",
+        "value": "#ff3b30",
+        "section": "semantic"
     },
     {
-        name: 'border-disabled',
-        value: '#e7e8e9',
-        section: 'semantic',
+        "name": "border-disabled",
+        "value": "#e7e8e9",
+        "section": "semantic"
     },
     {
-        name: 'avatar-pink',
-        value: '#ffd5f6',
-        section: 'semantic',
+        "name": "avatar-pink",
+        "value": "#ffd5f6",
+        "section": "semantic"
     },
     {
-        name: 'avatar-pink-border',
-        value: '#e06ac8',
-        section: 'semantic',
+        "name": "avatar-pink-border",
+        "value": "#e06ac8",
+        "section": "semantic"
     },
     {
-        name: 'avatar-pink-foreground',
-        value: '#a42089',
-        section: 'semantic',
+        "name": "avatar-pink-foreground",
+        "value": "#a42089",
+        "section": "semantic"
     },
     {
-        name: 'avatar-yellow',
-        value: '#fae184',
-        section: 'semantic',
+        "name": "avatar-yellow",
+        "value": "#fae184",
+        "section": "semantic"
     },
     {
-        name: 'avatar-yellow-border',
-        value: '#dcae01',
-        section: 'semantic',
+        "name": "avatar-yellow-border",
+        "value": "#dcae01",
+        "section": "semantic"
     },
     {
-        name: 'avatar-yellow-foreground',
-        value: '#885b00',
-        section: 'semantic',
+        "name": "avatar-yellow-foreground",
+        "value": "#885b00",
+        "section": "semantic"
     },
     {
-        name: 'avatar-orange',
-        value: '#ffd3b4',
-        section: 'semantic',
+        "name": "avatar-orange",
+        "value": "#ffd3b4",
+        "section": "semantic"
     },
     {
-        name: 'avatar-orange-border',
-        value: '#f69855',
-        section: 'semantic',
+        "name": "avatar-orange-border",
+        "value": "#f69855",
+        "section": "semantic"
     },
     {
-        name: 'avatar-orange-foreground',
-        value: '#b8450a',
-        section: 'semantic',
+        "name": "avatar-orange-foreground",
+        "value": "#b8450a",
+        "section": "semantic"
     },
     {
-        name: 'avatar-blue',
-        value: '#dbeafe',
-        section: 'semantic',
+        "name": "avatar-blue",
+        "value": "#dbeafe",
+        "section": "semantic"
     },
     {
-        name: 'avatar-blue-border',
-        value: '#90a8ed',
-        section: 'semantic',
+        "name": "avatar-blue-border",
+        "value": "#90a8ed",
+        "section": "semantic"
     },
     {
-        name: 'avatar-blue-foreground',
-        value: '#2563eb',
-        section: 'semantic',
+        "name": "avatar-blue-foreground",
+        "value": "#2563eb",
+        "section": "semantic"
     },
     {
-        name: 'avatar-purple',
-        value: '#dcd6ff',
-        section: 'semantic',
+        "name": "avatar-purple",
+        "value": "#dcd6ff",
+        "section": "semantic"
     },
     {
-        name: 'avatar-purple-border',
-        value: '#ba8bff',
-        section: 'semantic',
+        "name": "avatar-purple-border",
+        "value": "#ba8bff",
+        "section": "semantic"
     },
     {
-        name: 'avatar-purple-foreground',
-        value: '#9333ea',
-        section: 'semantic',
+        "name": "avatar-purple-foreground",
+        "value": "#9333ea",
+        "section": "semantic"
     },
     {
-        name: 'avatar-red',
-        value: '#ffcccc',
-        section: 'semantic',
+        "name": "avatar-red",
+        "value": "#ffcccc",
+        "section": "semantic"
     },
     {
-        name: 'avatar-red-border',
-        value: '#ea8282',
-        section: 'semantic',
+        "name": "avatar-red-border",
+        "value": "#ea8282",
+        "section": "semantic"
     },
     {
-        name: 'avatar-red-foreground',
-        value: '#e40c0c',
-        section: 'semantic',
+        "name": "avatar-red-foreground",
+        "value": "#e40c0c",
+        "section": "semantic"
     },
     {
-        name: 'avatar-green',
-        value: '#c7f9c6',
-        section: 'semantic',
+        "name": "avatar-green",
+        "value": "#c7f9c6",
+        "section": "semantic"
     },
     {
-        name: 'avatar-green-border',
-        value: '#29cc6a',
-        section: 'semantic',
+        "name": "avatar-green-border",
+        "value": "#29cc6a",
+        "section": "semantic"
     },
     {
-        name: 'avatar-green-foreground',
-        value: '#3b730c',
-        section: 'semantic',
+        "name": "avatar-green-foreground",
+        "value": "#3b730c",
+        "section": "semantic"
     },
     {
-        name: 'shadow-primary',
-        value: '#000000',
-        section: 'semantic',
-    },
+        "name": "shadow-primary",
+        "value": "#000000",
+        "section": "semantic"
+    }
 ]
 
 export const TEXT_STYLES: TextStyle[] = [
     {
-        name: 'heading-big-input',
-        section: 'semantic',
-        fontSize: '3.25rem',
-        lineHeight: '4rem',
-        fontWeight: '700',
+        "name": "heading-big-input",
+        "section": "semantic",
+        "fontSize": "3.25rem",
+        "lineHeight": "4rem",
+        "fontWeight": "700"
     },
     {
-        name: 'heading-xl',
-        section: 'semantic',
-        fontSize: '2.625rem',
-        lineHeight: '3rem',
-        fontWeight: '800',
+        "name": "heading-xl",
+        "section": "semantic",
+        "fontSize": "2.625rem",
+        "lineHeight": "3rem",
+        "fontWeight": "800"
     },
     {
-        name: 'heading-l',
-        section: 'semantic',
-        fontSize: '2.25rem',
-        lineHeight: '2.5rem',
-        fontWeight: '800',
+        "name": "heading-l",
+        "section": "semantic",
+        "fontSize": "2.25rem",
+        "lineHeight": "2.5rem",
+        "fontWeight": "800"
     },
     {
-        name: 'heading-m',
-        section: 'semantic',
-        fontSize: '1.875rem',
-        lineHeight: '2.25rem',
-        fontWeight: '800',
+        "name": "heading-m",
+        "section": "semantic",
+        "fontSize": "1.875rem",
+        "lineHeight": "2.25rem",
+        "fontWeight": "800"
     },
     {
-        name: 'heading-s',
-        section: 'semantic',
-        fontSize: '1.5rem',
-        lineHeight: '2rem',
-        fontWeight: '800',
+        "name": "heading-s",
+        "section": "semantic",
+        "fontSize": "1.5rem",
+        "lineHeight": "2rem",
+        "fontWeight": "800"
     },
     {
-        name: 'heading-xs',
-        section: 'semantic',
-        fontSize: '1.25rem',
-        lineHeight: '1.5rem',
-        fontWeight: '800',
+        "name": "heading-xs",
+        "section": "semantic",
+        "fontSize": "1.25rem",
+        "lineHeight": "1.5rem",
+        "fontWeight": "800"
     },
     {
-        name: 'heading-card',
-        section: 'semantic',
-        fontSize: '1.125rem',
-        lineHeight: '1.5rem',
-        fontWeight: '700',
+        "name": "heading-card",
+        "section": "semantic",
+        "fontSize": "1.125rem",
+        "lineHeight": "1.5rem",
+        "fontWeight": "700"
     },
     {
-        name: 'body-l',
-        section: 'semantic',
-        fontSize: '1.125rem',
-        lineHeight: '1.625rem',
-        fontWeight: '400',
+        "name": "body-l",
+        "section": "semantic",
+        "fontSize": "1.125rem",
+        "lineHeight": "1.625rem",
+        "fontWeight": "400"
     },
     {
-        name: 'body-m',
-        section: 'semantic',
-        fontSize: '1rem',
-        lineHeight: '1.25rem',
-        fontWeight: '500',
+        "name": "body-m",
+        "section": "semantic",
+        "fontSize": "1rem",
+        "lineHeight": "1.25rem",
+        "fontWeight": "500"
     },
     {
-        name: 'body-m-semibold',
-        section: 'semantic',
-        fontSize: '1rem',
-        lineHeight: '1.25rem',
-        fontWeight: '600',
+        "name": "body-m-semibold",
+        "section": "semantic",
+        "fontSize": "1rem",
+        "lineHeight": "1.25rem",
+        "fontWeight": "600"
     },
     {
-        name: 'body-s',
-        section: 'semantic',
-        fontSize: '0.875rem',
-        lineHeight: '1.25rem',
-        fontWeight: '500',
+        "name": "body-s",
+        "section": "semantic",
+        "fontSize": "0.875rem",
+        "lineHeight": "1.25rem",
+        "fontWeight": "500"
     },
     {
-        name: 'body-xs',
-        section: 'semantic',
-        fontSize: '0.75rem',
-        lineHeight: '1rem',
-        fontWeight: '400',
+        "name": "body-xs",
+        "section": "semantic",
+        "fontSize": "0.75rem",
+        "lineHeight": "1rem",
+        "fontWeight": "400"
     },
     {
-        name: 'label-l',
-        section: 'semantic',
-        fontSize: '0.875rem',
-        lineHeight: '1.25rem',
-        fontWeight: '700',
+        "name": "label-l",
+        "section": "semantic",
+        "fontSize": "0.875rem",
+        "lineHeight": "1.25rem",
+        "fontWeight": "700"
     },
     {
-        name: 'label-m',
-        section: 'semantic',
-        fontSize: '0.75rem',
-        lineHeight: '1rem',
-        fontWeight: '800',
+        "name": "label-m",
+        "section": "semantic",
+        "fontSize": "0.75rem",
+        "lineHeight": "1rem",
+        "fontWeight": "800"
     },
     {
-        name: 'button-l',
-        section: 'semantic',
-        fontSize: '1.125rem',
-        lineHeight: '1.5rem',
-        fontWeight: '700',
+        "name": "button-l",
+        "section": "semantic",
+        "fontSize": "1.125rem",
+        "lineHeight": "1.5rem",
+        "fontWeight": "700"
     },
     {
-        name: 'button-m',
-        section: 'semantic',
-        fontSize: '1rem',
-        lineHeight: '1rem',
-        fontWeight: '700',
+        "name": "button-m",
+        "section": "semantic",
+        "fontSize": "1rem",
+        "lineHeight": "1rem",
+        "fontWeight": "700"
     },
     {
-        name: 'button-s',
-        section: 'semantic',
-        fontSize: '0.875rem',
-        lineHeight: '0.875rem',
-        fontWeight: '700',
+        "name": "button-s",
+        "section": "semantic",
+        "fontSize": "0.875rem",
+        "lineHeight": "0.875rem",
+        "fontWeight": "700"
     },
     {
-        name: 'display',
-        section: 'semantic',
-        fontSize: '3.75rem',
+        "name": "display",
+        "section": "semantic",
+        "fontSize": "3.75rem"
     },
     {
-        name: '0',
-        section: 'parity',
-        fontSize: '0px',
-        lineHeight: '0px',
+        "name": "0",
+        "section": "parity",
+        "fontSize": "0px",
+        "lineHeight": "0px"
     },
     {
-        name: 'sm',
-        section: 'parity',
-        fontSize: '0.875rem',
-        lineHeight: '1.3125rem',
+        "name": "sm",
+        "section": "parity",
+        "fontSize": "0.875rem",
+        "lineHeight": "1.3125rem"
     },
     {
-        name: '6xl',
-        section: 'parity',
-        fontSize: '3rem',
-        lineHeight: '3.25rem',
+        "name": "6xl",
+        "section": "parity",
+        "fontSize": "3rem",
+        "lineHeight": "3.25rem"
     },
     {
-        name: '7xl',
-        section: 'parity',
-        fontSize: '7rem',
-        lineHeight: '7rem',
+        "name": "7xl",
+        "section": "parity",
+        "fontSize": "7rem",
+        "lineHeight": "7rem"
     },
     {
-        name: '8xl',
-        section: 'parity',
-        fontSize: '10rem',
-        lineHeight: '10rem',
+        "name": "8xl",
+        "section": "parity",
+        "fontSize": "10rem",
+        "lineHeight": "10rem"
     },
     {
-        name: '9xl',
-        section: 'parity',
-        fontSize: '12rem',
-        lineHeight: '0.9',
+        "name": "9xl",
+        "section": "parity",
+        "fontSize": "12rem",
+        "lineHeight": "0.9"
     },
     {
-        name: 'h1',
-        section: 'parity',
-        fontSize: '3rem',
-        lineHeight: '3.5rem',
-        fontWeight: '800',
+        "name": "h1",
+        "section": "parity",
+        "fontSize": "3rem",
+        "lineHeight": "3.5rem",
+        "fontWeight": "800"
     },
     {
-        name: 'h2',
-        section: 'parity',
-        fontSize: '2.25rem',
-        lineHeight: '2.875rem',
-        fontWeight: '800',
+        "name": "h2",
+        "section": "parity",
+        "fontSize": "2.25rem",
+        "lineHeight": "2.875rem",
+        "fontWeight": "800"
     },
     {
-        name: 'h3',
-        section: 'parity',
-        fontSize: '1.875rem',
-        lineHeight: '2.375rem',
-        fontWeight: '800',
+        "name": "h3",
+        "section": "parity",
+        "fontSize": "1.875rem",
+        "lineHeight": "2.375rem",
+        "fontWeight": "800"
     },
     {
-        name: 'h4',
-        section: 'parity',
-        fontSize: '1.5rem',
-        lineHeight: '2rem',
-        fontWeight: '800',
+        "name": "h4",
+        "section": "parity",
+        "fontSize": "1.5rem",
+        "lineHeight": "2rem",
+        "fontWeight": "800"
     },
     {
-        name: 'h5',
-        section: 'parity',
-        fontSize: '1.25rem',
-        lineHeight: '1.75rem',
-        fontWeight: '800',
+        "name": "h5",
+        "section": "parity",
+        "fontSize": "1.25rem",
+        "lineHeight": "1.75rem",
+        "fontWeight": "800"
     },
     {
-        name: 'h6',
-        section: 'parity',
-        fontSize: '1.125rem',
-        lineHeight: '1.5rem',
-        fontWeight: '800',
+        "name": "h6",
+        "section": "parity",
+        "fontSize": "1.125rem",
+        "lineHeight": "1.5rem",
+        "fontWeight": "800"
     },
     {
-        name: 'h7',
-        section: 'parity',
-        fontSize: '1rem',
-        lineHeight: '1.25rem',
-        fontWeight: '800',
+        "name": "h7",
+        "section": "parity",
+        "fontSize": "1rem",
+        "lineHeight": "1.25rem",
+        "fontWeight": "800"
     },
     {
-        name: 'h8',
-        section: 'parity',
-        fontSize: '0.875rem',
-        lineHeight: '1rem',
-        fontWeight: '800',
+        "name": "h8",
+        "section": "parity",
+        "fontSize": "0.875rem",
+        "lineHeight": "1rem",
+        "fontWeight": "800"
     },
     {
-        name: 'h9',
-        section: 'parity',
-        fontSize: '0.75rem',
-        lineHeight: '0.875rem',
-        fontWeight: '800',
+        "name": "h9",
+        "section": "parity",
+        "fontSize": "0.75rem",
+        "lineHeight": "0.875rem",
+        "fontWeight": "800"
     },
     {
-        name: 'h10',
-        section: 'parity',
-        fontSize: '0.625rem',
-        lineHeight: '0.75rem',
-        fontWeight: '800',
+        "name": "h10",
+        "section": "parity",
+        "fontSize": "0.625rem",
+        "lineHeight": "0.75rem",
+        "fontWeight": "800"
     },
     {
-        name: 'headingLarge',
-        section: 'parity',
-        fontSize: '7rem',
-        lineHeight: '6.5rem',
+        "name": "headingLarge",
+        "section": "parity",
+        "fontSize": "7rem",
+        "lineHeight": "6.5rem"
     },
     {
-        name: 'headingMedium',
-        section: 'parity',
-        fontSize: '5rem',
-        lineHeight: '4rem',
+        "name": "headingMedium",
+        "section": "parity",
+        "fontSize": "5rem",
+        "lineHeight": "4rem"
     },
     {
-        name: 'heading',
-        section: 'parity',
-        fontSize: '3.75rem',
-        lineHeight: '2.875rem',
-    },
+        "name": "heading",
+        "section": "parity",
+        "fontSize": "3.75rem",
+        "lineHeight": "2.875rem"
+    }
 ]
 
 export const FONT_TOKENS: FontToken[] = [
     {
-        name: 'sans',
-        section: 'parity',
-        stack: "var(--font-roboto), ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'",
+        "name": "sans",
+        "section": "parity",
+        "stack": "var(--font-roboto), ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'"
     },
     {
-        name: 'display',
-        section: 'parity',
-        stack: "var(--font-sniglet), ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'",
+        "name": "display",
+        "section": "parity",
+        "stack": "var(--font-sniglet), ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'"
     },
     {
-        name: 'condensed',
-        section: 'parity',
-        stack: 'var(--font-roboto)',
-        fontVariationSettings: "'wdth' 50",
-    },
+        "name": "condensed",
+        "section": "parity",
+        "stack": "var(--font-roboto)",
+        "fontVariationSettings": "'wdth' 50"
+    }
 ]
 
 /** radius / shadow / blur / motion / spacing token groups, keyed by @theme namespace */
 export const TOKEN_GROUPS: Record<string, ThemeToken[]> = {
-    radius: [
+    "radius": [
         {
-            name: 'round',
-            value: '999px',
-            section: 'semantic',
+            "name": "round",
+            "value": "999px",
+            "section": "semantic"
         },
         {
-            name: 'sm',
-            value: '0.125rem',
-            section: 'parity',
+            "name": "sm",
+            "value": "0.125rem",
+            "section": "parity"
         },
         {
-            name: '1',
-            value: '0.0625rem',
-            section: 'parity',
-        },
+            "name": "1",
+            "value": "0.0625rem",
+            "section": "parity"
+        }
     ],
-    'transition-duration': [
+    "transition-duration": [
         {
-            name: 'instant',
-            value: '100ms',
-            section: 'semantic',
+            "name": "instant",
+            "value": "100ms",
+            "section": "semantic"
         },
         {
-            name: 'fast',
-            value: '200ms',
-            section: 'semantic',
+            "name": "fast",
+            "value": "200ms",
+            "section": "semantic"
         },
         {
-            name: 'moderate',
-            value: '300ms',
-            section: 'semantic',
+            "name": "moderate",
+            "value": "300ms",
+            "section": "semantic"
         },
         {
-            name: 'slow',
-            value: '500ms',
-            section: 'semantic',
-        },
+            "name": "slow",
+            "value": "500ms",
+            "section": "semantic"
+        }
     ],
-    ease: [
+    "ease": [
         {
-            name: 'spring',
-            value: 'cubic-bezier(0.34, 1.56, 0.64, 1)',
-            section: 'semantic',
+            "name": "spring",
+            "value": "cubic-bezier(0.34, 1.56, 0.64, 1)",
+            "section": "semantic"
         },
         {
-            name: 'sharp',
-            value: 'cubic-bezier(0.87, 0, 0.13, 1)',
-            section: 'semantic',
-        },
+            "name": "sharp",
+            "value": "cubic-bezier(0.87, 0, 0.13, 1)",
+            "section": "semantic"
+        }
     ],
-    shadow: [
+    "shadow": [
         {
-            name: 'sm',
-            value: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
-            section: 'parity',
+            "name": "sm",
+            "value": "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+            "section": "parity"
         },
         {
-            name: 'md',
-            value: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
-            section: 'parity',
+            "name": "md",
+            "value": "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
+            "section": "parity"
         },
         {
-            name: 'lg',
-            value: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
-            section: 'parity',
+            "name": "lg",
+            "value": "0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)",
+            "section": "parity"
         },
         {
-            name: 'xl',
-            value: '0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)',
-            section: 'parity',
+            "name": "xl",
+            "value": "0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)",
+            "section": "parity"
         },
         {
-            name: '2xl',
-            value: '0 25px 50px -12px rgb(0 0 0 / 0.25)',
-            section: 'parity',
-        },
+            "name": "2xl",
+            "value": "0 25px 50px -12px rgb(0 0 0 / 0.25)",
+            "section": "parity"
+        }
     ],
-    blur: [
+    "blur": [
         {
-            name: 'sm',
-            value: '4px',
-            section: 'parity',
+            "name": "sm",
+            "value": "4px",
+            "section": "parity"
         },
         {
-            name: 'md',
-            value: '12px',
-            section: 'parity',
+            "name": "md",
+            "value": "12px",
+            "section": "parity"
         },
         {
-            name: 'lg',
-            value: '16px',
-            section: 'parity',
+            "name": "lg",
+            "value": "16px",
+            "section": "parity"
         },
         {
-            name: 'xl',
-            value: '24px',
-            section: 'parity',
+            "name": "xl",
+            "value": "24px",
+            "section": "parity"
         },
         {
-            name: '2xl',
-            value: '40px',
-            section: 'parity',
+            "name": "2xl",
+            "value": "40px",
+            "section": "parity"
         },
         {
-            name: '3xl',
-            value: '64px',
-            section: 'parity',
-        },
+            "name": "3xl",
+            "value": "64px",
+            "section": "parity"
+        }
     ],
-    'drop-shadow': [
+    "drop-shadow": [
         {
-            name: 'sm',
-            value: '0 1px 1px rgb(0 0 0 / 0.05)',
-            section: 'parity',
+            "name": "sm",
+            "value": "0 1px 1px rgb(0 0 0 / 0.05)",
+            "section": "parity"
         },
         {
-            name: 'md',
-            value: '0 4px 3px rgb(0 0 0 / 0.07), 0 2px 2px rgb(0 0 0 / 0.06)',
-            section: 'parity',
+            "name": "md",
+            "value": "0 4px 3px rgb(0 0 0 / 0.07), 0 2px 2px rgb(0 0 0 / 0.06)",
+            "section": "parity"
         },
         {
-            name: 'lg',
-            value: '0 10px 8px rgb(0 0 0 / 0.04), 0 4px 3px rgb(0 0 0 / 0.1)',
-            section: 'parity',
+            "name": "lg",
+            "value": "0 10px 8px rgb(0 0 0 / 0.04), 0 4px 3px rgb(0 0 0 / 0.1)",
+            "section": "parity"
         },
         {
-            name: 'xl',
-            value: '0 20px 13px rgb(0 0 0 / 0.03), 0 8px 5px rgb(0 0 0 / 0.08)',
-            section: 'parity',
+            "name": "xl",
+            "value": "0 20px 13px rgb(0 0 0 / 0.03), 0 8px 5px rgb(0 0 0 / 0.08)",
+            "section": "parity"
         },
         {
-            name: '2xl',
-            value: '0 25px 25px rgb(0 0 0 / 0.15)',
-            section: 'parity',
-        },
+            "name": "2xl",
+            "value": "0 25px 25px rgb(0 0 0 / 0.15)",
+            "section": "parity"
+        }
     ],
-    'default-transition': [
+    "default-transition": [
         {
-            name: 'duration',
-            value: '200ms',
-            section: 'parity',
+            "name": "duration",
+            "value": "200ms",
+            "section": "parity"
         },
         {
-            name: 'timing-function',
-            value: 'linear',
-            section: 'parity',
-        },
+            "name": "timing-function",
+            "value": "linear",
+            "section": "parity"
+        }
     ],
-    'font-weight': [
+    "font-weight": [
         {
-            name: 'extraBlack',
-            value: '1000',
-            section: 'parity',
-        },
+            "name": "extraBlack",
+            "value": "1000",
+            "section": "parity"
+        }
     ],
-    animate: [
+    "animate": [
         {
-            name: 'pulsate',
-            value: 'pulsate 1.5s ease-in-out infinite',
-            section: 'parity',
+            "name": "pulsate",
+            "value": "pulsate 1.5s ease-in-out infinite",
+            "section": "parity"
         },
         {
-            name: 'pulse-strong',
-            value: 'pulse-strong 1s ease-in-out infinite',
-            section: 'parity',
+            "name": "pulse-strong",
+            "value": "pulse-strong 1s ease-in-out infinite",
+            "section": "parity"
         },
         {
-            name: 'blink',
-            value: 'blink 1.5s step-end infinite',
-            section: 'parity',
+            "name": "blink",
+            "value": "blink 1.5s step-end infinite",
+            "section": "parity"
         },
         {
-            name: 'accordion-down',
-            value: 'accordion-down 0.3s cubic-bezier(0.87, 0, 0.13, 1)',
-            section: 'parity',
+            "name": "accordion-down",
+            "value": "accordion-down 0.3s cubic-bezier(0.87, 0, 0.13, 1)",
+            "section": "parity"
         },
         {
-            name: 'accordion-up',
-            value: 'accordion-up 0.3s cubic-bezier(0.87, 0, 0.13, 1)',
-            section: 'parity',
+            "name": "accordion-up",
+            "value": "accordion-up 0.3s cubic-bezier(0.87, 0, 0.13, 1)",
+            "section": "parity"
         },
         {
-            name: 'star-pulsate-wiggle',
-            value: 'starPulsateWiggle 10s ease-in-out infinite',
-            section: 'parity',
-        },
-    ],
+            "name": "star-pulsate-wiggle",
+            "value": "starPulsateWiggle 10s ease-in-out infinite",
+            "section": "parity"
+        }
+    ]
 }

--- a/src/app/(mobile-ui)/dev/ds/foundations/typography/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/foundations/typography/page.tsx
@@ -34,12 +34,28 @@ export default function TypographyPage() {
                     <div className="space-y-2 rounded-sm border border-n-1 p-3">
                         {FONT_TOKENS.map((font) => (
                             <div key={font.name}>
-                                <p className="text-sm font-bold" style={{ fontFamily: font.stack }}>
+                                <p
+                                    className="text-sm font-bold"
+                                    style={{
+                                        fontFamily: font.stack,
+                                        fontVariationSettings: font.fontVariationSettings,
+                                    }}
+                                >
                                     font-{font.name}
                                 </p>
-                                <p className="font-mono text-[10px] break-all text-grey-1">{font.stack}</p>
+                                <p className="font-mono text-[10px] break-all text-grey-1">
+                                    {font.stack}
+                                    {font.fontVariationSettings && ` · ${font.fontVariationSettings}`}
+                                </p>
                             </div>
                         ))}
+                        <div>
+                            <p className="font-mono text-sm font-bold">font-mono</p>
+                            <p className="text-sm text-grey-1">
+                                Stock Tailwind monospace — code, addresses, amounts. Not a theme token but part of the
+                                system.
+                            </p>
+                        </div>
                         <div className="rounded-sm bg-purple-1 p-3">
                             <Title text="KNERD FONT" />
                             <p className="mt-1 text-sm text-n-1">
@@ -79,6 +95,17 @@ export default function TypographyPage() {
                         </div>
                     ))}
                 </div>
+            </DocSection>
+
+            {/* weight conventions — guidance, not token data */}
+            <DocSection title="Font Weights">
+                <p className="text-sm text-grey-1">
+                    The semantic styles above carry their own weight. For ad-hoc text:{' '}
+                    <code className="font-mono font-bold text-n-1">font-bold</code> for labels and headings,{' '}
+                    <code className="font-mono font-bold text-n-1">font-medium</code> for secondary text. The theme also
+                    defines <code className="font-mono font-bold text-n-1">font-weight-extraBlack</code> (1000) for
+                    display moments.
+                </p>
             </DocSection>
 
             {/* v3 parity overrides */}

--- a/src/app/(mobile-ui)/dev/ds/foundations/typography/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/foundations/typography/page.tsx
@@ -5,47 +5,41 @@ import { DocHeader } from '../../_components/DocHeader'
 import { DocSection } from '../../_components/DocSection'
 import { DocPage } from '../../_components/DocPage'
 import { CodeBlock } from '../../_components/CodeBlock'
+import { FONT_TOKENS, TEXT_STYLES, type TextStyle } from '../tokens.generated'
 
-const WEIGHTS = [
-    { class: 'font-light', label: 'Light', usages: 5 },
-    { class: 'font-normal', label: 'Normal', usages: 50 },
-    { class: 'font-medium', label: 'Medium', usages: 104 },
-    { class: 'font-semibold', label: 'Semibold', usages: 66 },
-    { class: 'font-bold', label: 'Bold', usages: 304 },
-    { class: 'font-extrabold', label: 'Extrabold', usages: 55 },
-    { class: 'font-black', label: 'Black', usages: 16 },
-]
+const SEMANTIC_STYLES = TEXT_STYLES.filter((t) => t.section === 'semantic')
+const PARITY_STYLES = TEXT_STYLES.filter((t) => t.section === 'parity')
 
-const SIZES = [
-    { class: 'text-xs', example: 'Extra small (12px)', note: 'metadata, badges, hints' },
-    { class: 'text-sm', example: 'Small (14px)', note: 'body text, descriptions' },
-    { class: 'text-base', example: 'Base (16px)', note: 'default' },
-    { class: 'text-lg', example: 'Large (18px)', note: 'section headings' },
-    { class: 'text-xl', example: 'Extra large (20px)', note: 'page titles' },
-    { class: 'text-2xl', example: '2XL (24px)', note: 'hero text' },
-]
+// previews render from the token values inline, so they cannot drift and don't
+// depend on tailwind emitting a utility for every style.
+const px = (rem?: string) => (rem?.endsWith('rem') ? `${parseFloat(rem) * 16}px` : rem)
+
+function styleSpec(t: TextStyle) {
+    return [px(t.fontSize), t.lineHeight && `lh ${px(t.lineHeight)}`, t.fontWeight && `w${t.fontWeight}`]
+        .filter(Boolean)
+        .join(' · ')
+}
 
 export default function TypographyPage() {
     return (
         <DocPage>
-            <DocHeader title="Typography" description="Font families, weights, and text sizes used across the app." />
+            <DocHeader
+                title="Typography"
+                description="Generated from the @theme block in globals.css (pnpm gen:ds-tokens) — previews render the real token values."
+            />
 
             {/* Font families */}
             <DocSection title="Font Families">
                 <DocSection.Content>
                     <div className="space-y-2 rounded-sm border border-n-1 p-3">
-                        <div>
-                            <p className="text-sm font-bold">System Default</p>
-                            <p className="text-sm text-grey-1">Primary body font. Used everywhere by default.</p>
-                        </div>
-                        <div>
-                            <p className="font-mono text-sm font-bold">font-mono</p>
-                            <p className="text-sm text-grey-1">Monospace for code, addresses, amounts. 21 usages.</p>
-                        </div>
-                        <div>
-                            <p className="font-roboto-flex text-sm font-bold">font-roboto-flex</p>
-                            <p className="text-sm text-grey-1">Roboto Flex for specific UI elements. 16 usages.</p>
-                        </div>
+                        {FONT_TOKENS.map((font) => (
+                            <div key={font.name}>
+                                <p className="text-sm font-bold" style={{ fontFamily: font.stack }}>
+                                    font-{font.name}
+                                </p>
+                                <p className="font-mono text-[10px] break-all text-grey-1">{font.stack}</p>
+                            </div>
+                        ))}
                         <div className="rounded-sm bg-purple-1 p-3">
                             <Title text="KNERD FONT" />
                             <p className="mt-1 text-sm text-n-1">
@@ -55,7 +49,7 @@ export default function TypographyPage() {
                     </div>
                 </DocSection.Content>
                 <DocSection.Code>
-                    <CodeBlock label="Font Mono" code='className="font-mono"' />
+                    <CodeBlock label="Font Display" code='className="font-display"' />
                     <CodeBlock
                         label="Title Component"
                         code={`import Title from '@/components/0_Bruddle/Title'\n<Title text="PEANUT" />`}
@@ -63,33 +57,41 @@ export default function TypographyPage() {
                 </DocSection.Code>
             </DocSection>
 
-            {/* Font weights */}
-            <DocSection title="Font Weights">
-                <div className="space-y-1 rounded-sm border border-n-1 p-3">
-                    {WEIGHTS.map((w) => (
-                        <div key={w.class} className="flex items-baseline justify-between">
-                            <p className={`text-sm ${w.class}`}>
-                                {w.label} <span className="font-mono text-[10px] text-grey-1">.{w.class}</span>
+            {/* Semantic type scale */}
+            <DocSection title="Semantic Type Scale">
+                <p className="text-sm text-grey-1">
+                    1:1 with the figma Heading/Body/Label/Button styles. New screens use these — e.g.{' '}
+                    <code className="font-mono font-bold text-n-1">text-heading-m</code>,{' '}
+                    <code className="font-mono font-bold text-n-1">text-body-s</code>.
+                </p>
+                <div className="space-y-3 rounded-sm border border-n-1 p-3">
+                    {SEMANTIC_STYLES.map((t) => (
+                        <div key={t.name} className="min-w-0">
+                            <p
+                                className="truncate"
+                                style={{ fontSize: t.fontSize, lineHeight: t.lineHeight, fontWeight: t.fontWeight }}
+                            >
+                                {t.name}
                             </p>
-                            <span className="text-xs text-grey-1">{w.usages}</span>
+                            <p className="font-mono text-[10px] text-grey-1">
+                                .text-{t.name} — {styleSpec(t)}
+                            </p>
                         </div>
                     ))}
                 </div>
-                <p className="text-sm text-grey-1">
-                    font-bold dominates (304 usages). Use font-bold for labels and headings, font-medium for secondary
-                    text.
-                </p>
             </DocSection>
 
-            {/* Text sizes */}
-            <DocSection title="Text Sizes">
-                <div className="space-y-2 rounded-sm border border-n-1 p-3">
-                    {SIZES.map((s) => (
-                        <div key={s.class}>
-                            <p className={`${s.class} font-bold`}>{s.example}</p>
-                            <p className="text-xs text-grey-1">
-                                .{s.class} — {s.note}
-                            </p>
+            {/* v3 parity overrides */}
+            <DocSection title="v3 Parity Sizes">
+                <p className="text-sm text-grey-1">
+                    Overrides ported from the v3 config (text-h1…h7 and changed stock sizes). Existing code only —
+                    prefer the semantic scale above.
+                </p>
+                <div className="space-y-1 rounded-sm border border-n-1 p-3 text-xs">
+                    {PARITY_STYLES.map((t) => (
+                        <div key={t.name} className="flex items-baseline justify-between">
+                            <code className="font-mono font-bold">.text-{t.name}</code>
+                            <span className="text-grey-1">{styleSpec(t)}</span>
                         </div>
                     ))}
                 </div>


### PR DESCRIPTION
## Summary

The /dev/ds foundations pages (colors, typography, spacing) were hand-typed and drifted — 6 of 12 color swatches showed wrong hex values, one documented token (`violet-1`) does not exist in the theme at all. This PR generates the page data from the `@theme` block in `globals.css` so the docs cannot drift from the token source.

- `scripts/generate-ds-tokens.mjs` parses the `@theme` block (colors, text styles, fonts, radius/shadow/motion groups, sectioned legacy/semantic/parity by the source banners) and emits `tokens.generated.ts`. Run with `pnpm gen:ds-tokens`.
- A jest drift gate (`scripts/__tests__/ds-tokens-drift.test.js`) fails CI whenever the theme changes without a regen.
- Colors page: all 130 tokens, grouped semantic (figma-verified, use these) vs legacy palette (v3 port, do not use in new code). Typography page: the semantic type scale + v3 parity sizes from real values. Spacing page: wired to the (currently empty) spacing token group with a note — auto-populates when DS 06 lands the named scale.
- `parseThemeTokens()` is exported for reuse by the mono/design components.md emitter (DS 08).

## Task

TASK-21455 (DS 12) — https://app.notion.com/p/3bb83811757981a39178e14f8d109c02

## Design notes / accepted trade-offs

- Swatches and type previews render token **values** inline (`style={{...}}`) instead of utility classes: Tailwind purges dynamically-built class names, and safelisting all 130 tokens would ship dead CSS. Class names are shown as copy-to-clipboard text only.
- Curated guidance that is not token data (text-color conventions, the dead `bg-peanut-repeat-*` warning, KNERD/Title demo) stays as hand-written prose.
- Stale hand-typed usage counts (e.g. "font-bold: 304 usages") were dropped rather than regenerated — counts belong to the DS 02 lint-baseline tooling, not this page.

## Risks / breaking changes

None. Dev-only pages (`/dev/ds/foundations/*`) plus a new script, a generated data module, and a test. No app code paths touched. No cross-repo impact.

## QA

- `pnpm gen:ds-tokens` — regenerates; `node scripts/generate-ds-tokens.mjs --check` exits 0 in sync, 1 on drift.
- Local gate green: typecheck, full jest (238 suites / 3061 tests), prod build, prettier check.
- Visual: /dev/ds/foundations/{colors,typography,spacing} on the sandbox — screenshots below.

## Screenshots

375×667, worktree dev server against the sandbox. Long pages tiled top→bottom. Assets branch `pr-assets-2715` — delete after merge.

| Colors (1/4) | Colors (2/4) | Colors (3/4) | Colors (4/4) |
|---|---|---|---|
| ![c1](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2715/shots/colors-1.png) | ![c2](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2715/shots/colors-2.png) | ![c3](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2715/shots/colors-3.png) | ![c4](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2715/shots/colors-4.png) |

| Typography (1/2) | Typography (2/2) | Spacing |
|---|---|---|
| ![t1](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2715/shots/typography-1.png) | ![t2](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2715/shots/typography-2.png) | ![s1](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2715/shots/spacing-1.png) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated generation and validation of design tokens from the theme definitions.
  - Added generated spacing tokens to the spacing documentation.
  - Updated color and typography documentation to display generated tokens, semantic groupings, previews, and copyable utility classes.

- **Documentation**
  - Clarified token sources, naming conventions, legacy palette usage, and typography guidance.

- **Tests**
  - Added validation to detect outdated generated design-token output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Contributes to TASK-21455
