### PR TITLE
ds-06: input, toggle, badge, avatar to the figma boards

### DIFF
--- a/src/app/(mobile-ui)/dev/ds/_components/nav-config.ts
+++ b/src/app/(mobile-ui)/dev/ds/_components/nav-config.ts
@@ -29,6 +29,7 @@ export const SIDEBAR_CONFIG: Record<string, NavItem[]> = {
         { label: 'BaseInput', icon: 'clip', href: '/dev/ds/primitives/base-input' },
         { label: 'BaseSelect', icon: 'clip', href: '/dev/ds/primitives/base-select' },
         { label: 'Checkbox', icon: 'check', href: '/dev/ds/primitives/checkbox' },
+        { label: 'Toggle', icon: 'switch', href: '/dev/ds/primitives/toggle' },
         { label: 'Toast', icon: 'bell', href: '/dev/ds/primitives/toast' },
         { label: 'Divider', icon: 'minus-circle', href: '/dev/ds/primitives/divider' },
         { label: 'Title', icon: 'docs', href: '/dev/ds/primitives/title' },

--- a/src/app/(mobile-ui)/dev/ds/primitives/toggle/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/primitives/toggle/page.tsx
@@ -33,7 +33,10 @@ export default function TogglePage() {
                 <DocSection.Code>
                     <CodeBlock
                         label="Toggle"
-                        code={`import { Toggle } from '@/components/0_Bruddle/Toggle'
+                        code={`import { useState } from 'react'
+import { Toggle } from '@/components/0_Bruddle/Toggle'
+
+const [enabled, setEnabled] = useState(false)
 
 <Toggle checked={enabled} onChange={setEnabled} aria-label="Show full name" />`}
                     />

--- a/src/app/(mobile-ui)/dev/ds/primitives/toggle/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/primitives/toggle/page.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useState } from 'react'
+import { Toggle } from '@/components/0_Bruddle/Toggle'
+import { DocHeader } from '../../_components/DocHeader'
+import { DocSection } from '../../_components/DocSection'
+import { SectionDivider } from '../../_components/SectionDivider'
+import { DocPage } from '../../_components/DocPage'
+import { PropsTable } from '../../_components/PropsTable'
+import { CodeBlock } from '../../_components/CodeBlock'
+
+export default function TogglePage() {
+    const [on, setOn] = useState(true)
+    const [off, setOff] = useState(false)
+
+    return (
+        <DocPage>
+            <DocHeader
+                title="Toggle"
+                description="Switch from the figma toggle board (17802:61532). Monochrome: black knob on, outlined knob off."
+                status="production"
+            />
+
+            <DocSection title="Values & States">
+                <DocSection.Content>
+                    <div className="flex items-center gap-6">
+                        <Toggle checked={on} onChange={setOn} aria-label="demo on" />
+                        <Toggle checked={off} onChange={setOff} aria-label="demo off" />
+                        <Toggle checked={true} onChange={() => {}} disabled aria-label="demo disabled on" />
+                        <Toggle checked={false} onChange={() => {}} disabled aria-label="demo disabled off" />
+                    </div>
+                </DocSection.Content>
+                <DocSection.Code>
+                    <CodeBlock
+                        label="Toggle"
+                        code={`import { Toggle } from '@/components/0_Bruddle/Toggle'
+
+<Toggle checked={enabled} onChange={setEnabled} aria-label="Show full name" />`}
+                    />
+                </DocSection.Code>
+            </DocSection>
+
+            <SectionDivider />
+
+            <PropsTable
+                rows={[
+                    { name: 'checked', type: 'boolean', default: '(required)' },
+                    { name: 'onChange', type: '(checked: boolean) => void', default: '(required)' },
+                    { name: 'disabled', type: 'boolean', default: 'false', description: '40% opacity, no clicks' },
+                    {
+                        name: 'aria-label',
+                        type: 'string',
+                        default: '(none)',
+                        description: 'Required when no visible label',
+                    },
+                ]}
+            />
+        </DocPage>
+    )
+}

--- a/src/components/0_Bruddle/Toggle.tsx
+++ b/src/components/0_Bruddle/Toggle.tsx
@@ -1,0 +1,40 @@
+import { twMerge } from 'tailwind-merge'
+
+interface ToggleProps {
+    checked: boolean
+    onChange: (checked: boolean) => void
+    disabled?: boolean
+    className?: string
+    'aria-label'?: string
+    'data-testid'?: string
+}
+
+/**
+ * Switch from the figma toggle board (17802:61532): white pill track with a
+ * black border, black knob when on, outlined knob when off, blue focus ring,
+ * 40% opacity when disabled. 24px tall with a pseudo-element extending the
+ * hit area to 44px.
+ */
+export const Toggle = ({ checked, onChange, disabled, className, ...props }: ToggleProps) => (
+    <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        disabled={disabled}
+        onClick={() => onChange(!checked)}
+        className={twMerge(
+            'relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-round border border-border-default bg-background-default transition-colors duration-instant after:absolute after:inset-x-0 after:-inset-y-2.5 focus-visible:outline-[3px] focus-visible:outline-action-focus disabled:cursor-not-allowed disabled:opacity-40',
+            className
+        )}
+        {...props}
+    >
+        <span
+            className={twMerge(
+                'inline-block size-4 rounded-round transition-transform duration-instant',
+                checked
+                    ? 'translate-x-6 bg-foreground-primary'
+                    : 'translate-x-0.5 border border-border-default bg-background-default'
+            )}
+        />
+    </button>
+)

--- a/src/components/Global/Badges/StatusBadge.tsx
+++ b/src/components/Global/Badges/StatusBadge.tsx
@@ -39,24 +39,26 @@ interface StatusBadgeProps {
 const StatusBadge: React.FC<StatusBadgeProps> = ({ status, className, size = 'small', customText }) => {
     const t = useTranslations('common')
 
+    // board 17802:61533 colors: pending=attention, processing=info, fail=error,
+    // success=success, accent=soon/custom. borderless, dark text.
     const getStatusStyles = () => {
         switch (status) {
             case 'completed':
             case 'closed':
-                return 'bg-success-2 text-success-4 border border-success-5'
+            case 'refunded':
+                return 'bg-background-badge-success text-foreground-primary'
             case 'pending':
+                return 'bg-background-badge-attention text-foreground-primary'
             case 'processing':
-                return 'bg-secondary-4 text-yellow-6 border border-yellow-7'
+                return 'bg-background-badge-info text-foreground-primary'
             case 'failed':
             case 'cancelled':
-                return 'bg-error-1 text-error border border-error-2'
-            case 'refunded':
-                return 'bg-success-2 text-success-4 border border-success-5'
+                return 'bg-background-badge-error text-foreground-primary'
             case 'soon':
             case 'custom':
-                return 'bg-primary-3 text-primary-4'
+                return 'bg-background-badge-accent text-foreground-primary'
             default:
-                return 'bg-grey-2 text-grey-1'
+                return 'bg-background-badge-helper text-foreground-primary'
         }
     }
 

--- a/src/components/Profile/AvatarWithBadge.tsx
+++ b/src/components/Profile/AvatarWithBadge.tsx
@@ -112,7 +112,7 @@ const AvatarWithBadge: React.FC<AvatarWithBadgeProps> = ({
 
                 style={{
                     background: name ? getColorForUsername(name).lightShade : undefined,
-                    border: name && !effectiveIcon ? `1px solid ${getColorForUsername(name).darkShade}` : undefined,
+                    border: name && !effectiveIcon ? `1px solid ${getColorForUsername(name).borderShade}` : undefined,
                     color: name ? getColorForUsername(name).darkShade : !effectiveIcon ? effectiveTextColor : undefined,
                     ...effectiveInlineStyle,
                 }}

--- a/src/components/Profile/AvatarWithBadge.tsx
+++ b/src/components/Profile/AvatarWithBadge.tsx
@@ -93,6 +93,7 @@ const AvatarWithBadge: React.FC<AvatarWithBadgeProps> = ({
     // When the logo fails AND the caller supplied a `fallback`, prefer that
     // semantic visual (icon + colors) over whatever icon/colors were originally
     // passed for the no-logo case.
+    const nameColors = name ? getColorForUsername(name) : undefined
     const useFallback = logoFailed && fallback
     const effectiveIcon = useFallback ? fallback.icon : icon
     const effectiveIconFill = useFallback && fallback.iconFillColor ? fallback.iconFillColor : iconFillColor
@@ -111,9 +112,9 @@ const AvatarWithBadge: React.FC<AvatarWithBadgeProps> = ({
                 // apply dynamic styles (e.g., background color)
 
                 style={{
-                    background: name ? getColorForUsername(name).lightShade : undefined,
-                    border: name && !effectiveIcon ? `1px solid ${getColorForUsername(name).borderShade}` : undefined,
-                    color: name ? getColorForUsername(name).darkShade : !effectiveIcon ? effectiveTextColor : undefined,
+                    background: nameColors?.lightShade,
+                    border: nameColors && !effectiveIcon ? `1px solid ${nameColors.borderShade}` : undefined,
+                    color: nameColors ? nameColors.darkShade : !effectiveIcon ? effectiveTextColor : undefined,
                     ...effectiveInlineStyle,
                 }}
             >

--- a/src/components/Profile/components/ShowNameToggle.tsx
+++ b/src/components/Profile/components/ShowNameToggle.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { updateUserById } from '@/app/actions/users'
+import { Toggle } from '@/components/0_Bruddle/Toggle'
 import { useAuth } from '@/context/authContext'
 import { useState } from 'react'
 
@@ -27,18 +28,7 @@ const ShowNameToggle = () => {
                 setShowFullName(!newValue)
             })
     }
-    return (
-        <button
-            onClick={handleToggleChange}
-            className="relative inline-flex h-6 w-11 cursor-pointer items-center rounded-full border border-black transition-colors duration-200 ease-in-out focus:outline-none"
-        >
-            <span
-                className={`inline-block h-4 w-4 transform rounded-full transition-all duration-200 ease-in-out ${
-                    showFullName ? 'translate-x-6 bg-primary-1' : 'translate-x-1 bg-gray-1'
-                }`}
-            />
-        </button>
-    )
+    return <Toggle checked={showFullName} onChange={handleToggleChange} aria-label="Show full name" />
 }
 
 export default ShowNameToggle

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -990,7 +990,7 @@
        black when active, blue ring on keyboard focus, red on aria-invalid,
        gray fill when disabled. was: pink focus border. */
     .input {
-        @apply h-16 w-full rounded-sm border border-border-subtle bg-background-default px-5 text-sm font-bold text-foreground-primary transition-colors outline-none placeholder:text-foreground-secondary focus:border-border-default focus-visible:outline-[3px] focus-visible:outline-action-focus disabled:bg-background-disabled disabled:text-foreground-secondary aria-invalid:border-border-error;
+        @apply h-16 w-full rounded-sm border border-border-subtle bg-background-default px-5 text-sm font-bold text-foreground-primary transition-colors outline-none placeholder:text-foreground-secondary focus:border-border-default focus-visible:outline-[3px] focus-visible:outline-action-focus focus-visible:outline-solid disabled:bg-background-disabled disabled:text-foreground-secondary aria-invalid:border-border-error;
     }
     .bg-peanut-repeat-normal {
         @apply bg-[url('../assets/bg/peanut-bg.svg')] bg-[length:100px_100px] bg-repeat;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -986,8 +986,11 @@
     .btn-shadow-secondary-8 {
         @apply shadow-[0.5rem_-0.5rem_0_#000000] dark:shadow-[0.5rem_-0.5rem_0_rgba(255,255,255,.25)];
     }
+    /* ds-06 restyle to the input board (17802:61538): subtle border at rest,
+       black when active, blue ring on keyboard focus, red on aria-invalid,
+       gray fill when disabled. was: pink focus border. */
     .input {
-        @apply h-16 w-full rounded-sm border border-n-1 bg-white px-5 text-sm font-bold text-n-1 transition-colors outline-none placeholder:text-n-3 focus:border-primary-1 dark:border-white dark:bg-n-1 dark:text-white dark:placeholder:text-white/75 dark:focus:border-primary-1;
+        @apply h-16 w-full rounded-sm border border-border-subtle bg-background-default px-5 text-sm font-bold text-foreground-primary transition-colors outline-none placeholder:text-foreground-secondary focus:border-border-default focus-visible:outline-[3px] focus-visible:outline-action-focus disabled:bg-background-disabled disabled:text-foreground-secondary aria-invalid:border-border-error;
     }
     .bg-peanut-repeat-normal {
         @apply bg-[url('../assets/bg/peanut-bg.svg')] bg-[length:100px_100px] bg-repeat;

--- a/src/utils/color.utils.ts
+++ b/src/utils/color.utils.ts
@@ -3,40 +3,48 @@
  */
 
 // NOTE: using hex codes cuz tailwind classes works weird with dynamic colors and doesnt really apply all the time, even when using twMerge
+// values = the avatar board triplets (17802:61529): lightShade=bg, borderShade=border, darkShade=foreground
 const COLORS_MAPPING = {
     peanut_pink: {
         lightShade: '#FFD5F6',
-        darkShade: '#FF74E2',
+        borderShade: '#E06AC8',
+        darkShade: '#A42089',
     },
     yellow: {
-        lightShade: '#FFEA9A',
-        darkShade: '#FFC900',
+        lightShade: '#FAE184',
+        borderShade: '#DCAE01',
+        darkShade: '#885B00',
     },
     purple: {
-        lightShade: '#E2D9FF',
-        darkShade: '#795CD3',
+        lightShade: '#DCD6FF',
+        borderShade: '#BA8BFF',
+        darkShade: '#9333EA',
     },
-    cyan: {
-        lightShade: '#C3E8F2',
-        darkShade: '#00A5D1',
+    blue: {
+        lightShade: '#DBEAFE',
+        borderShade: '#90A8ED',
+        darkShade: '#2563EB',
     },
     red: {
-        lightShade: '#FFC2C2',
-        darkShade: '#FF0101',
+        lightShade: '#FFCCCC',
+        borderShade: '#EA8282',
+        darkShade: '#E40C0C',
     },
     orange: {
         lightShade: '#FFD3B4',
-        darkShade: '#FF6B00',
+        borderShade: '#F69855',
+        darkShade: '#B8450A',
     },
     green: {
-        lightShade: '#AAFFA7',
-        darkShade: '#00CC51',
+        lightShade: '#C7F9C6',
+        borderShade: '#29CC6A',
+        darkShade: '#3B730C',
     },
 }
 
 // specific colors for different avatar types/contexts
 export const AVATAR_LINK_BG = '#FF90E8' // peanut pink for links
-export const AVATAR_WALLET_BG = COLORS_MAPPING.yellow.darkShade // yellow for address/non-user/add/withdraw header
+export const AVATAR_WALLET_BG = '#FFC900' // yellow for address/non-user/add/withdraw header (action/secondary token)
 
 // text/icon colors
 export const AVATAR_TEXT_LIGHT = '#FFFFFF' // white
@@ -47,11 +55,15 @@ export const AVATAR_TEXT_DARK = '#000000' // black
  * @param username The username string.
  * @returns An object with { darkShade, lightShade }
  */
-export function getColorForUsername(username?: string): { darkShade: string; lightShade: string } {
+export function getColorForUsername(username?: string): {
+    darkShade: string
+    lightShade: string
+    borderShade: string
+} {
     const colors = Object.values(COLORS_MAPPING)
     if (!username) {
         // default colors if no username is provided
-        return { darkShade: colors[1].darkShade, lightShade: colors[1].lightShade } // Default to yellow bg, black text
+        return colors[1] // default to yellow
     }
 
     let hash = 0
@@ -60,9 +72,5 @@ export function getColorForUsername(username?: string): { darkShade: string; lig
         hash = hash & hash
     }
 
-    const index = Math.abs(hash) % colors.length
-    const darkShade = colors[index].darkShade
-    const lightShade = colors[index].lightShade
-
-    return { darkShade, lightShade }
+    return colors[Math.abs(hash) % colors.length]
 }

--- a/src/utils/color.utils.ts
+++ b/src/utils/color.utils.ts
@@ -53,7 +53,7 @@ export const AVATAR_TEXT_DARK = '#000000' // black
 /**
  * Generates a deterministic background color from a predefined list based on a username.
  * @param username The username string.
- * @returns An object with { darkShade, lightShade }
+ * @returns An object with { darkShade, lightShade, borderShade }
  */
 export function getColorForUsername(username?: string): {
     darkShade: string


### PR DESCRIPTION
## Summary

DS 06 (TASK-21452) third slice: input, toggle, badge, avatar to their boards.

- **Input** (board 17802:61538): `.input` gets the board state set — `border-subtle` at rest, black border when active, blue ring on keyboard focus, red on `aria-invalid`, gray fill disabled. Was: pink focus border.
- **Toggle** (board 17802:61532): new `0_Bruddle/Toggle` primitive — monochrome switch (black knob on / outlined knob off), `role="switch"`, blue focus ring, 44px hit area via pseudo-element. `ShowNameToggle` migrated to it; /dev/ds page + nav entry added.
- **Badge** (board 17802:61533): `StatusBadge` colors move to the `background-badge-*` tokens — pending=attention, processing=info (now distinct), fail=error, success=success, soon/custom=accent. Borderless, dark text, per board.
- **Avatar** (board 17802:61529): `COLORS_MAPPING` becomes the board's 7 bg/border/foreground triplets (cyan→blue); `getColorForUsername` returns `borderShade`; `AvatarWithBadge` uses it for the ring. All existing consumers already use lightShade=bg / darkShade=text, which is exactly the board semantics.

## Task

Contributes to TASK-21452.
TASK-21452 (Notion) — DS 06 component consolidation.

## Risks / breaking changes

- `AVATAR_WALLET_BG` pinned to `#FFC900` (it aliased `yellow.darkShade`, which is now the deep foreground tone).
- Avatar hues shift slightly toward the board palette everywhere avatars render; status badges lose their borders. Intended restyle.
- Base = `feat/design-system`, NOT dev.

## QA

- typecheck clean, 237/237 jest suites, prettier.
- Toggle verified on /dev/ds/primitives/toggle (on/off/disabled/focus states).

Screenshots: visible change is token-level recolors on badges/avatars + the new toggle; /dev/ds toggle page carries the live states. (Board screenshots in the figma file are the reference.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable toggle control with checked, disabled, accessibility, and styling options.
  * Added Toggle documentation with interactive examples and usage guidance.
  * Added Toggle to the design-system navigation.

* **Improvements**
  * Updated status badges with refined semantic colors and improved refunded, pending, and processing states.
  * Improved avatar color consistency and refreshed the available color palette.
  * Standardized profile name visibility controls with the shared toggle.
  * Enhanced input styling for focus, disabled, invalid, and default states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
