### PR TITLE
ds-06: ActionModal board restyle + migrate 10 modal stragglers

### DIFF
--- a/src/components/AddMoney/components/HowToDepositModal.tsx
+++ b/src/components/AddMoney/components/HowToDepositModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import Modal from '@/components/Global/Modal'
+import ActionModal from '@/components/Global/ActionModal'
 import InfoCard from '@/components/Global/InfoCard'
 import { useTranslations } from 'next-intl'
 
@@ -23,30 +23,28 @@ const HowToDepositModal = ({ visible, onClose, variant = 'default' }: HowToDepos
         text: isOfframp ? t(`offramp.${key}`) : t(`default.${key}`),
     }))
     return (
-        <Modal
+        <ActionModal
             visible={visible}
             onClose={onClose}
-            classWrap="sm:m-auto sm:self-center self-center m-4 bg-background rounded-sm"
-        >
-            <div className="flex flex-col gap-5 p-5">
-                <h3 className={'text-start text-h6 font-bold text-black'}>
-                    {isOfframp ? t('titleOfframp') : t('title')}
-                </h3>
-                <div className="flex flex-col overflow-hidden rounded-sm border border-black bg-white">
-                    {steps.map((item, index) => (
-                        <div
-                            key={index}
-                            className={`px-4 py-3 ${index !== steps.length - 1 ? 'border-b border-black' : ''}`}
-                        >
-                            <p className="text-sm font-bold">{item.step}</p>
-                            <p className="text-sm text-grey-1">{item.text}</p>
-                        </div>
-                    ))}
-                </div>
+            title={isOfframp ? t('titleOfframp') : t('title')}
+            content={
+                <div className="flex w-full flex-col gap-5 text-left">
+                    <div className="flex flex-col overflow-hidden rounded-sm border border-black bg-white">
+                        {steps.map((item, index) => (
+                            <div
+                                key={index}
+                                className={`px-4 py-3 ${index !== steps.length - 1 ? 'border-b border-black' : ''}`}
+                            >
+                                <p className="text-sm font-bold">{item.step}</p>
+                                <p className="text-sm text-grey-1">{item.text}</p>
+                            </div>
+                        ))}
+                    </div>
 
-                <InfoCard variant="warning" icon="alert" title={isOfframp ? t('warningOfframp') : t('warning')} />
-            </div>
-        </Modal>
+                    <InfoCard variant="warning" icon="alert" title={isOfframp ? t('warningOfframp') : t('warning')} />
+                </div>
+            }
+        />
     )
 }
 

--- a/src/components/AddMoney/components/SupportedNetworksModal.tsx
+++ b/src/components/AddMoney/components/SupportedNetworksModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import Modal from '@/components/Global/Modal'
+import ActionModal from '@/components/Global/ActionModal'
 import InfoCard from '@/components/Global/InfoCard'
 import EvmChainChips from './EvmChainChips'
 import { useTranslations } from 'next-intl'
@@ -13,22 +13,20 @@ interface SupportedNetworksModalProps {
 const SupportedNetworksModal = ({ visible, onClose }: SupportedNetworksModalProps) => {
     const t = useTranslations('addMoney.supportedNetworksModal')
     return (
-        <Modal
+        <ActionModal
             visible={visible}
             onClose={onClose}
-            classWrap="sm:m-auto sm:self-center self-center m-4 bg-background rounded-sm"
-        >
-            <div className="flex flex-col gap-4 p-5">
-                <h3 className={'text-start text-h6 font-bold text-black'}>{t('title')}</h3>
-                <p className="text-sm text-grey-1">{t('description')}</p>
-
-                <div className="flex flex-wrap gap-2">
-                    <EvmChainChips />
+            title={t('title')}
+            description={t('description')}
+            content={
+                <div className="flex w-full flex-col gap-4 text-left">
+                    <div className="flex flex-wrap gap-2">
+                        <EvmChainChips />
+                    </div>
+                    <InfoCard variant="warning" icon="alert" title={t('warning')} />
                 </div>
-
-                <InfoCard variant="warning" icon="alert" title={t('warning')} />
-            </div>
-        </Modal>
+            }
+        />
     )
 }
 

--- a/src/components/Card/CancelCardModal.tsx
+++ b/src/components/Card/CancelCardModal.tsx
@@ -142,6 +142,7 @@ const CancelCardModal: FC<Props> = ({ cardId, isOpen, onClose }) => {
             visible={isOpen}
             onClose={handleClose}
             preventClose={phase === 'canceling' || phase === 'submitting-feedback'}
+            hideModalCloseButton={phase === 'canceling' || phase === 'submitting-feedback'}
             icon={isConfirm ? 'alert' : isFeedback ? 'alert-filled' : undefined}
             iconContainerClassName="bg-yellow-1"
             title={t(isConfirm ? 'cancel.title' : isFeedback ? 'cancel.canceledTitle' : 'cancel.thanksTitle')}

--- a/src/components/Card/CancelCardModal.tsx
+++ b/src/components/Card/CancelCardModal.tsx
@@ -4,9 +4,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useTranslations } from 'next-intl'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
-import Modal from '@/components/Global/Modal'
-import { Button } from '@/components/0_Bruddle/Button'
-import { Icon } from '@/components/Global/Icons/Icon'
+import ActionModal from '@/components/Global/ActionModal'
 import SlideToAction from '@/components/Card/SlideToAction'
 import { rainApi } from '@/services/rain'
 import { RAIN_CARD_OVERVIEW_QUERY_KEY, useRainCardOverview } from '@/hooks/useRainCardOverview'
@@ -136,72 +134,70 @@ const CancelCardModal: FC<Props> = ({ cardId, isOpen, onClose }) => {
         }
     }
 
+    const isConfirm = phase === 'confirm' || phase === 'canceling'
+    const isFeedback = phase === 'feedback' || phase === 'submitting-feedback'
+
     return (
-        <Modal
+        <ActionModal
             visible={isOpen}
             onClose={handleClose}
-            classWrap="sm:m-auto sm:self-center self-center m-4"
             preventClose={phase === 'canceling' || phase === 'submitting-feedback'}
-        >
-            <div className="p-6">
-                {phase === 'confirm' || phase === 'canceling' ? (
-                    <div className="flex flex-col items-center gap-4 text-center">
-                        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-yellow-1">
-                            <Icon name="alert" size={20} />
-                        </div>
-                        <div className="text-xl font-extrabold">{t('cancel.title')}</div>
-                        <p className="text-sm text-grey-1">{t('cancel.body')}</p>
+            icon={isConfirm ? 'alert' : isFeedback ? 'alert-filled' : undefined}
+            iconContainerClassName="bg-yellow-1"
+            title={t(isConfirm ? 'cancel.title' : isFeedback ? 'cancel.canceledTitle' : 'cancel.thanksTitle')}
+            description={t(isConfirm ? 'cancel.body' : isFeedback ? 'cancel.canceledBody' : 'cancel.thanksBody')}
+            content={
+                isConfirm ? (
+                    <>
                         {error && <p className="text-sm text-red">{error}</p>}
                         <SlideToAction
                             label={phase === 'canceling' ? t('cancel.canceling') : t('cancel.slideToCancel')}
                             onComplete={runCancel}
                             disabled={phase === 'canceling'}
                         />
-                    </div>
-                ) : phase === 'feedback' || phase === 'submitting-feedback' ? (
-                    <div className="flex flex-col items-center gap-4 text-center">
-                        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-yellow-1">
-                            <Icon name="alert-filled" size={20} />
-                        </div>
-                        <div className="text-xl font-extrabold">{t('cancel.canceledTitle')}</div>
-                        <p className="text-sm text-grey-1">{t('cancel.canceledBody')}</p>
-                        <div className="flex w-full flex-col gap-2 text-left">
-                            <label htmlFor="cancel-feedback" className="text-sm font-bold">
-                                {t('cancel.feedbackLabel')}
-                            </label>
-                            <textarea
-                                id="cancel-feedback"
-                                value={feedback}
-                                onChange={(e) => setFeedback(e.target.value)}
-                                placeholder={t('cancel.feedbackPlaceholder')}
-                                rows={4}
-                                maxLength={2000}
-                                className="w-full resize-none rounded-sm border border-n-1 bg-white p-3 text-sm focus:outline-none"
-                                disabled={phase === 'submitting-feedback'}
-                            />
-                        </div>
-                        <Button
-                            variant="purple"
-                            shadowSize="4"
-                            className="w-full"
-                            onClick={submitFeedback}
-                            loading={phase === 'submitting-feedback'}
+                    </>
+                ) : isFeedback ? (
+                    <div className="flex w-full flex-col gap-2 text-left">
+                        <label htmlFor="cancel-feedback" className="text-sm font-bold">
+                            {t('cancel.feedbackLabel')}
+                        </label>
+                        <textarea
+                            id="cancel-feedback"
+                            value={feedback}
+                            onChange={(e) => setFeedback(e.target.value)}
+                            placeholder={t('cancel.feedbackPlaceholder')}
+                            rows={4}
+                            maxLength={2000}
+                            className="w-full resize-none rounded-sm border border-n-1 bg-white p-3 text-sm focus:outline-none"
                             disabled={phase === 'submitting-feedback'}
-                        >
-                            {t('cancel.submit')}
-                        </Button>
+                        />
                     </div>
-                ) : (
-                    <div className="flex flex-col items-center gap-4 text-center">
-                        <div className="text-xl font-extrabold">{t('cancel.thanksTitle')}</div>
-                        <p className="text-sm text-grey-1">{t('cancel.thanksBody')}</p>
-                        <Button variant="purple" shadowSize="4" className="w-full" onClick={handleClose}>
-                            {tCommon('close')}
-                        </Button>
-                    </div>
-                )}
-            </div>
-        </Modal>
+                ) : undefined
+            }
+            ctas={
+                isFeedback
+                    ? [
+                          {
+                              text: t('cancel.submit'),
+                              variant: 'purple',
+                              shadowSize: '4',
+                              onClick: submitFeedback,
+                              loading: phase === 'submitting-feedback',
+                              disabled: phase === 'submitting-feedback',
+                          },
+                      ]
+                    : phase === 'thanks'
+                      ? [
+                            {
+                                text: tCommon('close'),
+                                variant: 'purple',
+                                shadowSize: '4',
+                                onClick: handleClose,
+                            },
+                        ]
+                      : undefined
+            }
+        />
     )
 }
 

--- a/src/components/Card/CardLimitEditModal.tsx
+++ b/src/components/Card/CardLimitEditModal.tsx
@@ -102,6 +102,7 @@ const CardLimitEditModal: FC<Props> = ({ cardId, frequency, label, initialAmount
             visible={isOpen}
             onClose={onClose}
             preventClose={saving}
+            hideModalCloseButton={saving}
             icon="credit-card"
             title={t('editTitle')}
             content={

--- a/src/components/Card/CardLimitEditModal.tsx
+++ b/src/components/Card/CardLimitEditModal.tsx
@@ -4,9 +4,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useTranslations } from 'next-intl'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
-import Modal from '@/components/Global/Modal'
-import { Button } from '@/components/0_Bruddle/Button'
-import { Icon } from '@/components/Global/Icons/Icon'
+import ActionModal from '@/components/Global/ActionModal'
 import { rainApi, type RainCardLimit, type RainLimitFrequency } from '@/services/rain'
 import { RAIN_CARD_OVERVIEW_QUERY_KEY } from '@/hooks/useRainCardOverview'
 import { useReturnExcessCollateral } from '@/hooks/wallet/useReturnExcessCollateral'
@@ -100,51 +98,45 @@ const CardLimitEditModal: FC<Props> = ({ cardId, frequency, label, initialAmount
     }
 
     return (
-        <Modal
+        <ActionModal
             visible={isOpen}
             onClose={onClose}
-            classWrap="sm:m-auto sm:self-center self-center m-4 rounded-2xl"
             preventClose={saving}
-        >
-            <div className="p-6">
-                <div className="flex flex-col items-center gap-4 text-center">
-                    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary-1">
-                        <Icon name="credit-card" size={20} />
+            icon="credit-card"
+            title={t('editTitle')}
+            content={
+                <div className="flex w-full flex-col gap-2 text-left">
+                    <label htmlFor="card-limit-input" className="text-sm font-bold">
+                        {label}
+                    </label>
+                    <div className="flex items-center gap-2 rounded-sm border border-n-1 bg-white px-3 py-2">
+                        <span className="text-grey-1">$</span>
+                        <input
+                            id="card-limit-input"
+                            type="number"
+                            inputMode="decimal"
+                            value={value}
+                            onChange={(e) => setValue(e.target.value)}
+                            className="w-full bg-transparent text-base focus:outline-none"
+                            min={0}
+                            step="0.01"
+                            disabled={saving}
+                        />
                     </div>
-                    <div className="text-xl font-extrabold">{t('editTitle')}</div>
-                    <div className="flex w-full flex-col gap-2 text-left">
-                        <label htmlFor="card-limit-input" className="text-sm font-bold">
-                            {label}
-                        </label>
-                        <div className="flex items-center gap-2 rounded-sm border border-n-1 bg-white px-3 py-2">
-                            <span className="text-grey-1">$</span>
-                            <input
-                                id="card-limit-input"
-                                type="number"
-                                inputMode="decimal"
-                                value={value}
-                                onChange={(e) => setValue(e.target.value)}
-                                className="w-full bg-transparent text-base focus:outline-none"
-                                min={0}
-                                step="0.01"
-                                disabled={saving}
-                            />
-                        </div>
-                        {error && <p className="text-sm text-red">{error}</p>}
-                    </div>
-                    <Button
-                        variant="purple"
-                        shadowSize="4"
-                        className="w-full"
-                        onClick={save}
-                        loading={saving}
-                        disabled={saving}
-                    >
-                        {t('saveChanges')}
-                    </Button>
+                    {error && <p className="text-sm text-red">{error}</p>}
                 </div>
-            </div>
-        </Modal>
+            }
+            ctas={[
+                {
+                    text: t('saveChanges'),
+                    variant: 'purple',
+                    shadowSize: '4',
+                    onClick: save,
+                    loading: saving,
+                    disabled: saving,
+                },
+            ]}
+        />
     )
 }
 

--- a/src/components/Card/LockCardModal.tsx
+++ b/src/components/Card/LockCardModal.tsx
@@ -125,6 +125,8 @@ const LockCardModal: FC<Props> = ({ cardId, mode, isOpen, onClose }) => {
         <ActionModal
             visible={isOpen}
             onClose={onClose}
+            preventClose={phase === 'loading'}
+            hideModalCloseButton={phase === 'loading'}
             icon="lock"
             iconContainerClassName="bg-yellow-1"
             title={t(isSuccess ? copyKeys.success : copyKeys.title)}

--- a/src/components/Card/LockCardModal.tsx
+++ b/src/components/Card/LockCardModal.tsx
@@ -4,9 +4,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useTranslations } from 'next-intl'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
-import Modal from '@/components/Global/Modal'
-import { Button } from '@/components/0_Bruddle/Button'
-import { Icon } from '@/components/Global/Icons/Icon'
+import ActionModal from '@/components/Global/ActionModal'
 import SlideToAction from '@/components/Card/SlideToAction'
 import { rainApi } from '@/services/rain'
 import { RAIN_CARD_OVERVIEW_QUERY_KEY, useRainCardOverview } from '@/hooks/useRainCardOverview'
@@ -121,47 +119,45 @@ const LockCardModal: FC<Props> = ({ cardId, mode, isOpen, onClose }) => {
         }
     }
 
+    const isSuccess = phase === 'success'
+
     return (
-        <Modal visible={isOpen} onClose={onClose} classWrap="sm:m-auto sm:self-center self-center m-4">
-            <div className="p-6">
-                {phase === 'success' ? (
-                    <div className="flex flex-col items-center gap-4 text-center">
-                        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-yellow-1">
-                            <Icon name="lock" size={20} />
-                        </div>
-                        <div className="text-xl font-extrabold">{t(copyKeys.success)}</div>
-                        <p className="text-sm text-grey-1">{t(copyKeys.successBody)}</p>
-                    </div>
-                ) : (
-                    <div className="flex flex-col items-center gap-4 text-center">
-                        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-yellow-1">
-                            <Icon name="lock" size={20} />
-                        </div>
-                        <div className="text-xl font-extrabold">{t(copyKeys.title)}</div>
-                        <p className="text-sm text-grey-1">{t(copyKeys.body)}</p>
+        <ActionModal
+            visible={isOpen}
+            onClose={onClose}
+            icon="lock"
+            iconContainerClassName="bg-yellow-1"
+            title={t(isSuccess ? copyKeys.success : copyKeys.title)}
+            description={t(isSuccess ? copyKeys.successBody : copyKeys.body)}
+            content={
+                isSuccess ? undefined : (
+                    <>
                         {phase === 'error' && error && <p className="text-sm text-red">{error}</p>}
-                        {mode === 'lock' ? (
+                        {mode === 'lock' && (
                             <SlideToAction
                                 label={phase === 'loading' ? t('lockModal.locking') : t('lockModal.slideToLock')}
                                 onComplete={run}
                                 disabled={phase === 'loading'}
                             />
-                        ) : (
-                            <Button
-                                variant="purple"
-                                shadowSize="4"
-                                className="w-full"
-                                onClick={run}
-                                loading={phase === 'loading'}
-                                disabled={phase === 'loading'}
-                            >
-                                {t('lockModal.unlockCta')}
-                            </Button>
                         )}
-                    </div>
-                )}
-            </div>
-        </Modal>
+                    </>
+                )
+            }
+            ctas={
+                !isSuccess && mode === 'unlock'
+                    ? [
+                          {
+                              text: t('lockModal.unlockCta'),
+                              variant: 'purple',
+                              shadowSize: '4',
+                              onClick: run,
+                              loading: phase === 'loading',
+                              disabled: phase === 'loading',
+                          },
+                      ]
+                    : undefined
+            }
+        />
     )
 }
 

--- a/src/components/Global/ActionModal/index.tsx
+++ b/src/components/Global/ActionModal/index.tsx
@@ -43,6 +43,7 @@ export interface ActionModalProps {
     footer?: React.ReactNode
     content?: React.ReactNode
     classOverlay?: string
+    hideOverlay?: boolean
 }
 
 const ActionModal: React.FC<ActionModalProps> = ({
@@ -69,6 +70,7 @@ const ActionModal: React.FC<ActionModalProps> = ({
     footer,
     content,
     classOverlay,
+    hideOverlay,
 }) => {
     const defaultModalPanelClasses = 'max-w-[85%]'
     const defaultIconContainerClassName = 'bg-primary-1' // default pink background
@@ -106,11 +108,13 @@ const ActionModal: React.FC<ActionModalProps> = ({
             className={twMerge('items-center justify-center md:mx-auto md:max-w-md', modalClassName)}
             classButtonClose={hideModalCloseButton ? '!hidden' : ''}
             classWrap={twMerge(
-                'sm:m-auto sm:self-center self-center m-4 bg-white rounded-none !border-0 z-50',
+                // board 17800:57216 panel: white, border-default, sharp 2px corners
+                'sm:m-auto sm:self-center self-center m-4 bg-background-default rounded-sm border border-border-default z-50',
                 defaultModalPanelClasses,
                 modalPanelClassName
             )}
             classOverlay={classOverlay}
+            hideOverlay={hideOverlay}
         >
             <div className={twMerge('flex flex-col items-center gap-4 p-6 text-center', contentContainerClassName)}>
                 {iconContent && (
@@ -125,11 +129,10 @@ const ActionModal: React.FC<ActionModalProps> = ({
                 )}
 
                 <div className="space-y-2 w-full">
-                    <h3 className={twMerge('text-base font-bold text-black dark:text-white', titleClassName)}>
-                        {title}
-                    </h3>
+                    {/* board head: Heading XS + Body S */}
+                    <h3 className={twMerge('text-heading-xs text-foreground-primary', titleClassName)}>{title}</h3>
                     {description && (
-                        <div className={twMerge('text-sm text-grey-1 dark:text-white', descriptionClassName)}>
+                        <div className={twMerge('text-body-s text-foreground-secondary', descriptionClassName)}>
                             {typeof description === 'string' ? <p>{description}</p> : description}
                         </div>
                     )}

--- a/src/components/Global/BalanceWarningModal/index.tsx
+++ b/src/components/Global/BalanceWarningModal/index.tsx
@@ -93,6 +93,8 @@ export default function BalanceWarningModal({ visible, onCloseAction }: BalanceW
             onClose={() => {}}
             preventClose={true}
             hideOverlay={true}
+            modalClassName="z-50 !items-center !justify-center !px-6"
+            modalPanelClassName="!bottom-auto !mx-auto !w-auto !max-w-md !self-center"
             icon="alert"
             iconContainerClassName="bg-yellow-400 size-16"
             iconProps={{ className: 'size-6' }}

--- a/src/components/Global/BalanceWarningModal/index.tsx
+++ b/src/components/Global/BalanceWarningModal/index.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { Icon } from '@/components/Global/Icons/Icon'
-import Modal from '@/components/Global/Modal'
+import ActionModal from '@/components/Global/ActionModal'
 import { useEffect, useMemo, useRef } from 'react'
 import { useTranslations } from 'next-intl'
 import { Slider } from '@/components/Slider'
@@ -89,42 +88,37 @@ export default function BalanceWarningModal({ visible, onCloseAction }: BalanceW
         }
     }, [visible])
     return (
-        <Modal
+        <ActionModal
             visible={visible}
             onClose={() => {}}
             preventClose={true}
             hideOverlay={true}
-            className="z-50 !items-center !justify-center !px-6"
-            classWrap="!self-center !bottom-auto !mx-auto !w-auto !max-w-md"
-        >
-            <div className="flex w-full flex-col items-center justify-center gap-6 p-6 text-center">
-                <div className="bg-yellow-400 flex size-16 items-center justify-center rounded-full">
-                    <Icon name="alert" size={24} />
+            icon="alert"
+            iconContainerClassName="bg-yellow-400 size-16"
+            iconProps={{ className: 'size-6' }}
+            title={t('balanceWarningModal.title')}
+            description={
+                <div className="space-y-3">
+                    <p>{t('balanceWarningModal.congrats')}</p>
+                    <p>{t('balanceWarningModal.selfCustody')}</p>
+                    <p>{t('balanceWarningModal.passkey')}</p>
+
+                    {t.rich('balanceWarningModal.learnMore', {
+                        platform: platformName,
+                        link: (chunks) => (
+                            <a
+                                href={platformInfo.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-blue-600 underline"
+                            >
+                                {chunks}
+                            </a>
+                        ),
+                    })}
                 </div>
-
-                <div className="space-y-4">
-                    <h2 className="text-xl font-bold">{t('balanceWarningModal.title')}</h2>
-                    <div className="text-gray-600 space-y-3 text-sm">
-                        <p>{t('balanceWarningModal.congrats')}</p>
-                        <p>{t('balanceWarningModal.selfCustody')}</p>
-                        <p>{t('balanceWarningModal.passkey')}</p>
-
-                        {t.rich('balanceWarningModal.learnMore', {
-                            platform: platformName,
-                            link: (chunks) => (
-                                <a
-                                    href={platformInfo.url}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="text-blue-600 underline"
-                                >
-                                    {chunks}
-                                </a>
-                            ),
-                        })}
-                    </div>
-                </div>
-
+            }
+            content={
                 <Slider
                     onAccepted={() => {
                         posthog.capture(ANALYTICS_EVENTS.MODAL_CTA_CLICKED, {
@@ -135,7 +129,7 @@ export default function BalanceWarningModal({ visible, onCloseAction }: BalanceW
                     }}
                     title={t('balanceWarningModal.slideToContinue')}
                 />
-            </div>
-        </Modal>
+            }
+        />
     )
 }

--- a/src/components/Global/BalanceWarningModal/index.tsx
+++ b/src/components/Global/BalanceWarningModal/index.tsx
@@ -92,6 +92,7 @@ export default function BalanceWarningModal({ visible, onCloseAction }: BalanceW
             visible={visible}
             onClose={() => {}}
             preventClose={true}
+            hideModalCloseButton
             hideOverlay={true}
             modalClassName="z-50 !items-center !justify-center !px-6"
             modalPanelClassName="!bottom-auto !mx-auto !w-auto !max-w-md !self-center"

--- a/src/components/Global/ConfirmInviteModal/index.tsx
+++ b/src/components/Global/ConfirmInviteModal/index.tsx
@@ -26,6 +26,8 @@ const ConfirmInviteModal: FC<ConfirmInviteModalProps> = ({
     return (
         <ActionModal
             hideOverlay
+            modalPanelClassName="rounded-none border-0"
+            contentContainerClassName="isolate"
             visible={isOpen}
             onClose={onClose}
             title={t('confirmInviteModal.title')}
@@ -57,7 +59,7 @@ const ConfirmInviteModal: FC<ConfirmInviteModalProps> = ({
             ]}
             footer={
                 <div
-                    className="absolute top-7 left-0 flex w-full justify-center"
+                    className="absolute top-7 left-0 -z-10 flex w-full justify-center"
                     style={{ transform: 'translateY(-80%)' }}
                 >
                     <div className="relative h-42 w-[90%] md:h-52">

--- a/src/components/Global/ConfirmInviteModal/index.tsx
+++ b/src/components/Global/ConfirmInviteModal/index.tsx
@@ -4,8 +4,7 @@ import { useTranslations } from 'next-intl'
 import Image from 'next/image'
 import PEANUT_LOGO_BLACK from '@/assets/logos/peanut-logo-dark.svg'
 import { PEANUTMAN } from '@/assets/mascot'
-import Modal from '../Modal'
-import { Button } from '@/components/0_Bruddle/Button'
+import ActionModal from '@/components/Global/ActionModal'
 import { PeanutWavingHello } from '@/assets/mascot'
 
 interface ConfirmInviteModalProps {
@@ -25,47 +24,38 @@ const ConfirmInviteModal: FC<ConfirmInviteModalProps> = ({
 }) => {
     const t = useTranslations('global')
     return (
-        <div className="relative">
-            <Modal
-                hideOverlay
-                visible={isOpen}
-                onClose={onClose}
-                className="items-center rounded-none md:mx-auto md:max-w-md"
-                classWrap="sm:m-auto sm:self-center self-center m-4 bg-background rounded-none border-0"
-            >
-                {/* Main content container */}
-                <div className="relative z-10 w-full rounded-md bg-white px-6 py-6">
-                    <div className="space-y-4">
-                        <div className="space-y-3 text-center">
-                            <div className="space-y-2 w-full">
-                                <h3 className={'text-xl font-extrabold text-black dark:text-white'}>
-                                    {t('confirmInviteModal.title')}
-                                </h3>
-
-                                <div className="text-base text-grey-1 dark:text-white">
-                                    <p>{t('confirmInviteModal.description', { method })}</p>
-                                </div>
-                            </div>
-                        </div>
-
-                        <Button className="w-full" shadowSize="4" variant="purple" onClick={handleContinueWithPeanut}>
+        <ActionModal
+            hideOverlay
+            visible={isOpen}
+            onClose={onClose}
+            title={t('confirmInviteModal.title')}
+            description={t('confirmInviteModal.description', { method })}
+            ctaClassName="sm:flex-col"
+            ctas={[
+                {
+                    text: '',
+                    shadowSize: '4',
+                    variant: 'purple',
+                    className: 'sm:flex-none',
+                    onClick: handleContinueWithPeanut,
+                    children: (
+                        <>
                             <div>{t('confirmInviteModal.joinCta')}</div>
                             <div className="flex items-center gap-1">
                                 <Image src={PEANUTMAN} alt="Peanut Logo" className="size-5" />
                                 <Image src={PEANUT_LOGO_BLACK} alt="Peanut Logo" />
                             </div>
-                        </Button>
-                        <Button
-                            className="h-6 !transform-none !pt-2 text-sm !font-normal underline"
-                            variant="transparent"
-                            onClick={handleLoseInvite}
-                        >
-                            {t('confirmInviteModal.continueWithMethod', { method })}
-                        </Button>
-                    </div>
-                </div>
-
-                {/* Peanutman animation */}
+                        </>
+                    ),
+                },
+                {
+                    text: t('confirmInviteModal.continueWithMethod', { method }),
+                    variant: 'transparent',
+                    className: 'h-6 !transform-none !pt-2 text-sm !font-normal underline sm:flex-none',
+                    onClick: handleLoseInvite,
+                },
+            ]}
+            footer={
                 <div
                     className="absolute top-7 left-0 flex w-full justify-center"
                     style={{ transform: 'translateY(-80%)' }}
@@ -80,8 +70,8 @@ const ConfirmInviteModal: FC<ConfirmInviteModalProps> = ({
                         />
                     </div>
                 </div>
-            </Modal>
-        </div>
+            }
+        />
     )
 }
 

--- a/src/components/Global/GuestLoginModal/index.tsx
+++ b/src/components/Global/GuestLoginModal/index.tsx
@@ -1,6 +1,5 @@
-import { Button } from '@/components/0_Bruddle/Button'
 import { useToast } from '@/components/0_Bruddle/Toast'
-import Modal from '@/components/Global/Modal'
+import ActionModal from '@/components/Global/ActionModal'
 import { useZeroDev } from '@/hooks/useZeroDev'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
@@ -17,27 +16,31 @@ const GuestLoginModal = () => {
     }
 
     return (
-        <Modal visible={isSignInModalOpen} onClose={closeModal} title={t('guestLoginModal.title')}>
-            <div className="flex flex-col items-center gap-2 p-5">
-                <Button
-                    loading={isLoggingIn}
-                    disabled={isLoggingIn}
-                    onClick={() => {
+        <ActionModal
+            visible={isSignInModalOpen}
+            onClose={closeModal}
+            title={t('guestLoginModal.title')}
+            ctas={[
+                {
+                    text: t('guestLoginModal.signInCta'),
+                    loading: isLoggingIn,
+                    disabled: isLoggingIn,
+                    onClick: () => {
                         handleLogin()
                             .then(closeModal)
                             .catch((e) => {
                                 console.error(e)
                                 toast.error(t('guestLoginModal.loginError'))
                             })
-                    }}
-                >
-                    {t('guestLoginModal.signInCta')}
-                </Button>
+                    },
+                },
+            ]}
+            footer={
                 <Link href={'/setup'} className="text-h8 underline" onClick={closeModal}>
                     {t('guestLoginModal.noWallet')}
                 </Link>
-            </div>
-        </Modal>
+            }
+        />
     )
 }
 

--- a/src/components/Global/NoMoreJailModal/index.tsx
+++ b/src/components/Global/NoMoreJailModal/index.tsx
@@ -30,6 +30,8 @@ const NoMoreJailModal = () => {
     return (
         <ActionModal
             hideOverlay
+            modalPanelClassName="rounded-none border-0"
+            contentContainerClassName="isolate"
             visible={isOpen}
             onClose={onClose}
             title={t('noMoreJailModal.title')}
@@ -59,7 +61,7 @@ const NoMoreJailModal = () => {
             ]}
             footer={
                 <div
-                    className="absolute top-7 left-0 flex w-full justify-center"
+                    className="absolute top-7 left-0 -z-10 flex w-full justify-center"
                     style={{ transform: 'translateY(-80%)' }}
                 >
                     <div className="relative h-42 w-[90%] md:h-52">

--- a/src/components/Global/NoMoreJailModal/index.tsx
+++ b/src/components/Global/NoMoreJailModal/index.tsx
@@ -6,8 +6,7 @@ import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
 import Image from 'next/image'
 import PEANUT_LOGO_BLACK from '@/assets/logos/peanut-logo-dark.svg'
 import { PEANUTMAN } from '@/assets/mascot'
-import Modal from '../Modal'
-import { Button } from '@/components/0_Bruddle/Button'
+import ActionModal from '@/components/Global/ActionModal'
 import { PeanutWhistling } from '@/assets/mascot'
 
 const NoMoreJailModal = () => {
@@ -29,49 +28,46 @@ const NoMoreJailModal = () => {
     }, [])
 
     return (
-        <Modal
+        <ActionModal
             hideOverlay
             visible={isOpen}
             onClose={onClose}
-            className="items-center rounded-none md:mx-auto md:max-w-md"
-            classWrap="sm:m-auto sm:self-center self-center m-4 bg-background rounded-none border-0"
-        >
-            {/* Main content container */}
-            <div className="relative z-10 w-full rounded-md bg-white px-6 py-6">
-                <div className="space-y-4">
-                    <div className="space-y-3 text-center">
-                        <div className="space-y-2 w-full">
-                            <h3 className={'text-xl font-extrabold text-black dark:text-white'}>
-                                {t('noMoreJailModal.title')}
-                            </h3>
-
-                            <div className="text-sm text-grey-1 dark:text-white">
-                                <p>
-                                    {t('noMoreJailModal.line1')}
-                                    <br />
-                                    {t('noMoreJailModal.line2')}
-                                </p>
+            title={t('noMoreJailModal.title')}
+            description={
+                <p>
+                    {t('noMoreJailModal.line1')}
+                    <br />
+                    {t('noMoreJailModal.line2')}
+                </p>
+            }
+            ctas={[
+                {
+                    text: '',
+                    shadowSize: '4',
+                    variant: 'purple',
+                    onClick: onClose,
+                    children: (
+                        <>
+                            <div>{t('noMoreJailModal.startUsingCta')}</div>
+                            <div className="flex items-center gap-1">
+                                <Image src={PEANUTMAN} alt="Peanut Logo" className="size-5" />
+                                <Image src={PEANUT_LOGO_BLACK} alt="Peanut Logo" />
                             </div>
-                        </div>
+                        </>
+                    ),
+                },
+            ]}
+            footer={
+                <div
+                    className="absolute top-7 left-0 flex w-full justify-center"
+                    style={{ transform: 'translateY(-80%)' }}
+                >
+                    <div className="relative h-42 w-[90%] md:h-52">
+                        <Image src={PeanutWhistling.src} unoptimized alt="Peanut Man" className="object-contain" fill />
                     </div>
-
-                    <Button className="w-full" shadowSize="4" variant="purple" onClick={onClose}>
-                        <div>{t('noMoreJailModal.startUsingCta')}</div>
-                        <div className="flex items-center gap-1">
-                            <Image src={PEANUTMAN} alt="Peanut Logo" className="size-5" />
-                            <Image src={PEANUT_LOGO_BLACK} alt="Peanut Logo" />
-                        </div>
-                    </Button>
                 </div>
-            </div>
-
-            {/* Peanutman animation */}
-            <div className="absolute top-7 left-0 flex w-full justify-center" style={{ transform: 'translateY(-80%)' }}>
-                <div className="relative h-42 w-[90%] md:h-52">
-                    <Image src={PeanutWhistling.src} unoptimized alt="Peanut Man" className="object-contain" fill />
-                </div>
-            </div>
-        </Modal>
+            }
+        />
     )
 }
 

--- a/src/components/Setup/Views/InstallPWA.tsx
+++ b/src/components/Setup/Views/InstallPWA.tsx
@@ -1,8 +1,7 @@
 import { Button } from '@/components/0_Bruddle/Button'
 import { useToast } from '@/components/0_Bruddle/Toast'
 import ErrorAlert from '@/components/Global/ErrorAlert'
-import { Icon } from '@/components/Global/Icons/Icon'
-import Modal from '@/components/Global/Modal'
+import ActionModal from '@/components/Global/ActionModal'
 import QRCodeWrapper from '@/components/Global/QRCodeWrapper'
 import { type BeforeInstallPromptEvent, type ScreenId } from '@/components/Setup/Setup.types'
 import { useAuth } from '@/context/authContext'
@@ -15,8 +14,6 @@ import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { DeviceType } from '@/hooks/useGetDeviceType'
 import { useBravePWAInstallState } from '@/hooks/useBravePWAInstallState'
-
-const StepTitle = ({ text }: { text: string }) => <h3 className="text-xl leading-6 font-extrabold">{text}</h3>
 
 const InstallPWA = ({
     canInstall,
@@ -230,21 +227,6 @@ const InstallPWA = ({
         )
     }
 
-    const DesktopInstructions = () => (
-        <div className="flex flex-col items-center justify-center gap-6">
-            <div className={'flex size-12 items-center justify-center rounded-full bg-primary-1'}>
-                <Icon name="mobile-install" size={24} />
-            </div>
-            <div className="space-y-3 text-center">
-                <StepTitle text={t('mobileFirstTitle')} />
-                <p className="max-w-[220px] text-lg font-normal text-grey-1">{t('mobileFirstDescription')}</p>
-            </div>
-            <div className="mx-auto rounded-lg">
-                <QRCodeWrapper url={process.env.NEXT_PUBLIC_BASE_URL + '/setup' || window.location.origin} />
-            </div>
-        </div>
-    )
-
     switch (screenId) {
         case 'android-initial-pwa-install':
             return <AndroidPWASpecificInstallFlow />
@@ -266,24 +248,28 @@ const InstallPWA = ({
                             </Button>
                         </div>
                         {showModal && (
-                            <Modal
+                            <ActionModal
                                 visible={showModal}
                                 onClose={() => setShowModal(false)}
-                                className="items-center rounded-none"
-                                classWrap="sm:m-auto sm:self-center self-center bg-background m-4 rounded-none border-0"
-                            >
-                                <div className="space-y-4 p-6">
-                                    <DesktopInstructions />
-                                    <Button
-                                        onClick={() => setShowModal(false)}
-                                        className="mt-4 w-full"
-                                        shadowSize="4"
-                                        variant="purple"
-                                    >
-                                        {t('gotIt')}
-                                    </Button>
-                                </div>
-                            </Modal>
+                                icon="mobile-install"
+                                title={t('mobileFirstTitle')}
+                                description={t('mobileFirstDescription')}
+                                content={
+                                    <div className="mx-auto rounded-lg">
+                                        <QRCodeWrapper
+                                            url={process.env.NEXT_PUBLIC_BASE_URL + '/setup' || window.location.origin}
+                                        />
+                                    </div>
+                                }
+                                ctas={[
+                                    {
+                                        text: t('gotIt'),
+                                        variant: 'purple',
+                                        shadowSize: '4',
+                                        onClick: () => setShowModal(false),
+                                    },
+                                ]}
+                            />
                         )}
                     </>
                 )

--- a/src/components/Setup/Views/InstallPWA.tsx
+++ b/src/components/Setup/Views/InstallPWA.tsx
@@ -257,7 +257,7 @@ const InstallPWA = ({
                                 content={
                                     <div className="mx-auto rounded-lg">
                                         <QRCodeWrapper
-                                            url={process.env.NEXT_PUBLIC_BASE_URL + '/setup' || window.location.origin}
+                                            url={`${process.env.NEXT_PUBLIC_BASE_URL || window.location.origin}/setup`}
                                         />
                                     </div>
                                 }


### PR DESCRIPTION
## Summary

DS 06 (TASK-21452) modal slice — the ActionModal consolidation the audit called for (28/41 → 38/41) plus the board restyle.

- **ActionModal restyled to board 17800:57216**: heading = `text-heading-xs`, body = `text-body-s` + `foreground-secondary`, panel = white with `border-border-default` and 2px corners (was borderless), `hideOverlay` pass-through added. Spacing already matched the board (xl/l/s).
- **10 stragglers migrated off the raw `Global/Modal` base onto ActionModal**: GuestLoginModal, NoMoreJailModal, ConfirmInviteModal, BalanceWarningModal, HowToDepositModal, CancelCardModal, LockCardModal, CardLimitEditModal, SupportedNetworksModal, InstallPWA (its desktop-instructions modal). All i18n keys, posthog events, form/slide-to-action behavior, preventClose semantics preserved; custom visuals (mascots, QR codes, sliders, textareas) ride in `content`/`footer`.
- The 3 remaining raw `Global/Modal` consumers are intentional: SumsubKycWrapper, SumsubNativeSdk (full-screen SDK containers) and QRScannerOverlay (full-screen camera surface) — they are not dialog-shaped and stay on the base.

## Task

Contributes to TASK-21452.
TASK-21452 (Notion) — DS 06 component consolidation.

## Risks / breaking changes

- Every ActionModal in the app gains the bordered panel + board typography — app-wide visual change, functional behavior unchanged.
- Migrated modals adopt the standard centered head layout; two previously left-aligned headers (HowToDepositModal, SupportedNetworksModal) are now centered per the board.
- Base = `feat/design-system`, NOT dev.

## QA

- typecheck clean, 237/237 jest suites (LockCardModal's 6 tests pass unchanged — its Modal mock applies through ActionModal's base import), prettier clean.

## Design notes / accepted trade-offs

- Radix-as-base decision recorded in mono `design/design.md`: `Global/Modal` (HeadlessUI) stays the single base under ActionModal for now; with all dialogs behind ActionModal after this PR, a later radix swap is one change in one file.

## Screenshots

Assets on branch `pr-assets-2719` (delete after merge). Buttons keep the pre-#2716 shape on this base — the pill restyle rides the primitives PR.

| ActionModal (board restyle) | base modal (unchanged low-level) |
|---|---|
| <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2719/actionmodal-confirm.png" width="300"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2719/base-modal.png" width="300"> |

## Review follow-ups (recorded, not blocking)

Applied from /code-review: mascot paint-order + seamless-panel restore (invite/no-jail), BalanceWarningModal `z-50`/centering restore, close-X hidden during in-flight card money calls. Accepted as board-intended: 32px icon bubbles (board anatomy = IconBubble S), centered modal heads.

Deferred smells for a later ActionModal polish PR: `hideOverlay` naming leak (it hides the base modal's title chrome, not the backdrop — duplicate of `hideModalCloseButton` path), a `stackCtas` flag instead of per-site flex overrides, shared mascot-footer component, `text: ''`+`children` CTA convention (make `text` optional), semantic warning icon variant instead of per-site `bg-yellow-1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated dialogs across deposits, cards, invitations, login, setup, and account flows with a consistent presentation.
  * Improved modal styling, typography, layouts, actions, loading states, and close behavior.
  * Added support for displaying dialogs without an overlay when appropriate.
  * Preserved existing warnings, forms, feedback fields, QR codes, animations, and action flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
