### PR TITLE
fix(i18n): stop the app locale overwriting <html lang> on localized pages

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,9 +13,12 @@ export const metadata = landingMetadata(DEFAULT_LOCALE)
 export default function RootPage() {
     return (
         <>
-            <HtmlLang locale={DEFAULT_LOCALE} />
             <LocaleSuggestion locale={DEFAULT_LOCALE} />
             <LandingPageCapacitorGate>
+                {/* Inside the gate: on native this route is only a bootstrap
+                    shell that redirects away, and the device locale — not this
+                    page's English — is what <html lang> should report there. */}
+                <HtmlLang locale={DEFAULT_LOCALE} />
                 <LandingPageShell>
                     <LandingPageContent locale={DEFAULT_LOCALE} />
                 </LandingPageShell>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { LandingPageShell } from '@/components/LandingPage/LandingPageShell'
 import { LandingPageCapacitorGate } from '@/components/LandingPage/LandingPageCapacitorGate'
 import { LandingPageContent } from '@/components/LandingPage/LandingPageContent'
+import { HtmlLang } from '@/components/Marketing/HtmlLang'
 import { LocaleSuggestion } from '@/components/Marketing/LocaleSuggestion'
 import { DEFAULT_LOCALE } from '@/i18n/types'
 import { landingMetadata } from '@/lib/seo/landing'
@@ -12,6 +13,7 @@ export const metadata = landingMetadata(DEFAULT_LOCALE)
 export default function RootPage() {
     return (
         <>
+            <HtmlLang locale={DEFAULT_LOCALE} />
             <LocaleSuggestion locale={DEFAULT_LOCALE} />
             <LandingPageCapacitorGate>
                 <LandingPageShell>

--- a/src/components/Marketing/HtmlLang.tsx
+++ b/src/components/Marketing/HtmlLang.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react'
 import type { Locale } from '@/i18n/types'
+import { claimHtmlLang, releaseHtmlLang } from '@/i18n/htmlLangClaim'
 
 /**
  * Stamps the page locale onto <html lang>. The root layout sits above the
@@ -10,12 +11,17 @@ import type { Locale } from '@/i18n/types'
  * static export depends on — so the SSR markup ships lang="en" and this
  * corrects it after hydration. Crawlers rely on hreflang, not lang; this is
  * for assistive tech and in-browser tooling.
+ *
+ * Claims ownership while mounted so AppIntlProvider — which sits above every
+ * route and would otherwise overwrite this with the app locale — stands down.
  */
 export function HtmlLang({ locale }: { locale: Locale }) {
     useEffect(() => {
         const previous = document.documentElement.lang
+        claimHtmlLang()
         document.documentElement.lang = locale
         return () => {
+            releaseHtmlLang()
             document.documentElement.lang = previous
         }
     }, [locale])

--- a/src/components/Marketing/HtmlLang.tsx
+++ b/src/components/Marketing/HtmlLang.tsx
@@ -21,8 +21,11 @@ export function HtmlLang({ locale }: { locale: Locale }) {
         claimHtmlLang()
         document.documentElement.lang = locale
         return () => {
-            releaseHtmlLang()
+            // Restore first: releaseHtmlLang lets AppIntlProvider re-apply the
+            // app locale over this, which is the right answer whenever one is
+            // mounted. The snapshot only stands in when none is.
             document.documentElement.lang = previous
+            releaseHtmlLang()
         }
     }, [locale])
 

--- a/src/components/Marketing/__tests__/html-lang-release.test.tsx
+++ b/src/components/Marketing/__tests__/html-lang-release.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * Releasing the <html lang> claim hands the attribute back to the app locale.
+ *
+ * Navigating off a localized landing unmounts HtmlLang. Restoring the snapshot
+ * it captured on the way in is not enough: that snapshot is the root layout's
+ * pre-hydration "en", so a pt-BR user would run the rest of the session under
+ * lang="en". AppIntlProvider's own effect keys on the app locale, which did not
+ * change, so nothing else puts it back.
+ *
+ * Its own file on purpose: the locale store memoizes the resolved startup
+ * locale for the module's lifetime, so a preceding test in the same file would
+ * change the timing this one depends on.
+ */
+import { act, render, waitFor } from '@testing-library/react'
+import { AppIntlProvider } from '@/i18n/app/AppIntlProvider'
+import { isHtmlLangClaimed } from '@/i18n/htmlLangClaim'
+import { HtmlLang } from '../HtmlLang'
+
+const APP_LOCALE = 'pt-BR'
+
+beforeAll(() => {
+    localStorage.setItem('app-locale', APP_LOCALE)
+})
+
+function Page({ onLanding }: { onLanding: boolean }) {
+    return <AppIntlProvider>{onLanding ? <HtmlLang locale="es-419" /> : null}</AppIntlProvider>
+}
+
+it('restores the app locale, not the pre-hydration snapshot', async () => {
+    // The root layout ships lang="en"; this is the snapshot HtmlLang captures.
+    document.documentElement.lang = 'en'
+
+    const { rerender } = render(<Page onLanding />)
+    await waitFor(() => expect(document.documentElement.lang).toBe('es-419'))
+
+    // Let the provider's async startup-locale resolution settle first.
+    await act(() => new Promise((resolve) => setTimeout(resolve, 60)))
+    expect(document.documentElement.lang).toBe('es-419')
+
+    // Navigate off the landing.
+    rerender(<Page onLanding={false} />)
+
+    await waitFor(() => expect(document.documentElement.lang).toBe(APP_LOCALE))
+    expect(isHtmlLangClaimed()).toBe(false)
+})

--- a/src/components/Marketing/__tests__/html-lang.test.tsx
+++ b/src/components/Marketing/__tests__/html-lang.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * <html lang> ownership.
+ *
+ * Two components write document.documentElement.lang: AppIntlProvider (the app
+ * locale, from cookie/navigator — never the URL) and HtmlLang (the page locale,
+ * from the route). AppIntlProvider sits in ClientProviders, above every route,
+ * and React commits parent effects after child ones — so it used to overwrite
+ * the page locale on every localized landing. Live peanut.me/pt-br reported
+ * lang="en" for exactly this reason.
+ *
+ * These render the REAL AppIntlProvider, not a stand-in, so deleting the guard
+ * fails the suite.
+ */
+import { render, waitFor } from '@testing-library/react'
+import { AppIntlProvider } from '@/i18n/app/AppIntlProvider'
+import { isHtmlLangClaimed } from '@/i18n/htmlLangClaim'
+import { HtmlLang } from '../HtmlLang'
+
+describe('HtmlLang', () => {
+    beforeEach(() => {
+        document.documentElement.lang = 'en'
+    })
+
+    it('stamps the page locale onto <html lang>', () => {
+        render(<HtmlLang locale="pt-br" />)
+        expect(document.documentElement.lang.toLowerCase()).toBe('pt-br')
+    })
+
+    it('restores the previous lang and releases the claim on unmount', () => {
+        const { unmount } = render(<HtmlLang locale="pt-br" />)
+        unmount()
+        expect(document.documentElement.lang).toBe('en')
+        expect(isHtmlLangClaimed()).toBe(false)
+    })
+
+    it('keeps the page locale when AppIntlProvider is mounted above it', async () => {
+        // The live failure: a direct hit on /pt-br from an English browser, so
+        // the app locale resolves to 'en' while the page locale is 'pt-br'.
+        render(
+            <AppIntlProvider>
+                <HtmlLang locale="pt-br" />
+            </AppIntlProvider>
+        )
+
+        await waitFor(() => expect(document.documentElement.lang.toLowerCase()).toBe('pt-br'))
+
+        // Hold past the provider's async startup-locale resolution, which is the
+        // second write that used to clobber the page locale.
+        await new Promise((resolve) => setTimeout(resolve, 50))
+        expect(document.documentElement.lang.toLowerCase()).toBe('pt-br')
+    })
+
+    it('leaves AppIntlProvider in charge on routes that claim nothing', async () => {
+        render(<AppIntlProvider>{null}</AppIntlProvider>)
+
+        await waitFor(() => expect(document.documentElement.lang).toBe('en'))
+        expect(isHtmlLangClaimed()).toBe(false)
+    })
+})

--- a/src/components/Marketing/__tests__/html-lang.test.tsx
+++ b/src/components/Marketing/__tests__/html-lang.test.tsx
@@ -9,12 +9,21 @@
  * lang="en" for exactly this reason.
  *
  * These render the REAL AppIntlProvider, not a stand-in, so deleting the guard
- * fails the suite.
+ * fails the suite. The app locale is forced to pt-BR — a NON-default value — so
+ * that "the app locale won" and "nothing wrote anything" can be told apart.
  */
-import { render, waitFor } from '@testing-library/react'
+import { act, render, waitFor } from '@testing-library/react'
 import { AppIntlProvider } from '@/i18n/app/AppIntlProvider'
 import { isHtmlLangClaimed } from '@/i18n/htmlLangClaim'
 import { HtmlLang } from '../HtmlLang'
+
+const APP_LOCALE = 'pt-BR'
+
+// Set before the first render: the store memoizes the startup locale for the
+// session, and the provider resolves it inside its mount effect.
+beforeAll(() => {
+    localStorage.setItem('app-locale', APP_LOCALE)
+})
 
 describe('HtmlLang', () => {
     beforeEach(() => {
@@ -26,34 +35,27 @@ describe('HtmlLang', () => {
         expect(document.documentElement.lang.toLowerCase()).toBe('pt-br')
     })
 
-    it('restores the previous lang and releases the claim on unmount', () => {
-        const { unmount } = render(<HtmlLang locale="pt-br" />)
-        unmount()
-        expect(document.documentElement.lang).toBe('en')
-        expect(isHtmlLangClaimed()).toBe(false)
-    })
-
     it('keeps the page locale when AppIntlProvider is mounted above it', async () => {
-        // The live failure: a direct hit on /pt-br from an English browser, so
-        // the app locale resolves to 'en' while the page locale is 'pt-br'.
+        // The live failure: the page is Spanish, the app locale is pt-BR, and
+        // the provider's effect commits last.
         render(
             <AppIntlProvider>
-                <HtmlLang locale="pt-br" />
+                <HtmlLang locale="es-419" />
             </AppIntlProvider>
         )
 
-        await waitFor(() => expect(document.documentElement.lang.toLowerCase()).toBe('pt-br'))
+        await waitFor(() => expect(document.documentElement.lang).toBe('es-419'))
 
-        // Hold past the provider's async startup-locale resolution, which is the
-        // second write that used to clobber the page locale.
-        await new Promise((resolve) => setTimeout(resolve, 50))
-        expect(document.documentElement.lang.toLowerCase()).toBe('pt-br')
+        // Hold past the provider's async startup-locale resolution — the second
+        // write, and the one that actually clobbered the page on live.
+        await act(() => new Promise((resolve) => setTimeout(resolve, 50)))
+        expect(document.documentElement.lang).toBe('es-419')
     })
 
     it('leaves AppIntlProvider in charge on routes that claim nothing', async () => {
         render(<AppIntlProvider>{null}</AppIntlProvider>)
 
-        await waitFor(() => expect(document.documentElement.lang).toBe('en'))
+        await waitFor(() => expect(document.documentElement.lang).toBe(APP_LOCALE))
         expect(isHtmlLangClaimed()).toBe(false)
     })
 })

--- a/src/i18n/app/AppIntlProvider.tsx
+++ b/src/i18n/app/AppIntlProvider.tsx
@@ -13,7 +13,7 @@ import {
     persistLocale,
 } from './locale-store'
 import en from './messages/en.json'
-import { isHtmlLangClaimed } from '../htmlLangClaim'
+import { isHtmlLangClaimed, setHtmlLangReleaseListener } from '../htmlLangClaim'
 
 interface AppLocaleContextValue {
     locale: AppLocale
@@ -78,13 +78,21 @@ export function AppIntlProvider({ children }: { children: React.ReactNode }) {
     }, [])
 
     useEffect(() => {
+        const applyAppLocale = () => {
+            document.documentElement.lang = locale
+        }
         // Marketing/landing routes mount <HtmlLang> and own the attribute — their
         // content language is the URL locale, not the app-locale cookie. This
         // effect runs after theirs (parent effects commit last), so without the
         // guard it would overwrite the page locale on every localized route.
-        if (!isHtmlLangClaimed()) document.documentElement.lang = locale
+        if (!isHtmlLangClaimed()) applyAppLocale()
+        // Navigating off a localized landing drops the claim, but this effect
+        // keys on the app locale, which did not change — so re-apply on release
+        // or the app would keep running under the landing's language.
+        setHtmlLangReleaseListener(applyAppLocale)
         // signal "startup locale is painted" — the native splash gates on this
         if (locale === startupLocale.current) markLocaleApplied()
+        return () => setHtmlLangReleaseListener(null)
     }, [locale])
 
     const setLocale = useCallback(async (next: AppLocale) => {

--- a/src/i18n/app/AppIntlProvider.tsx
+++ b/src/i18n/app/AppIntlProvider.tsx
@@ -13,6 +13,7 @@ import {
     persistLocale,
 } from './locale-store'
 import en from './messages/en.json'
+import { isHtmlLangClaimed } from '../htmlLangClaim'
 
 interface AppLocaleContextValue {
     locale: AppLocale
@@ -77,7 +78,11 @@ export function AppIntlProvider({ children }: { children: React.ReactNode }) {
     }, [])
 
     useEffect(() => {
-        document.documentElement.lang = locale
+        // Marketing/landing routes mount <HtmlLang> and own the attribute — their
+        // content language is the URL locale, not the app-locale cookie. This
+        // effect runs after theirs (parent effects commit last), so without the
+        // guard it would overwrite the page locale on every localized route.
+        if (!isHtmlLangClaimed()) document.documentElement.lang = locale
         // signal "startup locale is painted" — the native splash gates on this
         if (locale === startupLocale.current) markLocaleApplied()
     }, [locale])

--- a/src/i18n/htmlLangClaim.ts
+++ b/src/i18n/htmlLangClaim.ts
@@ -11,6 +11,17 @@
  * StrictMode's double-invoke and overlapping route transitions.
  */
 let claims = 0
+let onRelease: (() => void) | null = null
+
+/**
+ * Lets `AppIntlProvider` re-apply the app locale when the last page claim drops.
+ * Its own effect keys on the app locale, which does not change when the user
+ * navigates off a localized landing — so without this the attribute would keep
+ * whatever `HtmlLang` restored on the way out.
+ */
+export function setHtmlLangReleaseListener(listener: (() => void) | null): void {
+    onRelease = listener
+}
 
 export function claimHtmlLang(): void {
     claims += 1
@@ -18,6 +29,7 @@ export function claimHtmlLang(): void {
 
 export function releaseHtmlLang(): void {
     claims = Math.max(0, claims - 1)
+    if (claims === 0) onRelease?.()
 }
 
 /** True while a `HtmlLang` is mounted and owns the attribute. */

--- a/src/i18n/htmlLangClaim.ts
+++ b/src/i18n/htmlLangClaim.ts
@@ -1,0 +1,26 @@
+/**
+ * Ownership flag for `<html lang>`, shared by the two components that write it.
+ *
+ * `AppIntlProvider` stamps the *app* locale (cookie / navigator, never the URL)
+ * and lives in `ClientProviders`, above every route. `HtmlLang` stamps the
+ * *page* locale on marketing/landing routes. React commits child effects before
+ * parent ones, so without this flag the provider always runs last and silently
+ * overwrites the page locale — `peanut.me/pt-br` reports `lang="en"`.
+ *
+ * A counter rather than a boolean so paired mount/unmount survives React
+ * StrictMode's double-invoke and overlapping route transitions.
+ */
+let claims = 0
+
+export function claimHtmlLang(): void {
+    claims += 1
+}
+
+export function releaseHtmlLang(): void {
+    claims = Math.max(0, claims - 1)
+}
+
+/** True while a `HtmlLang` is mounted and owns the attribute. */
+export function isHtmlLangClaimed(): boolean {
+    return claims > 0
+}


### PR DESCRIPTION
## Summary

`peanut.me/pt-br` reports `<html lang="en">` in a real browser, seconds after hydration. Same for `/es-419` and `/es-ar`.

**The cause is not a missing mount.** `HtmlLang` *is* mounted on the landing routes — [`src/app/pt-br/page.tsx:19`](https://github.com/peanutprotocol/peanut-ui/blob/dev/src/app/pt-br/page.tsx#L19). The problem is that **two components write `document.documentElement.lang`**:

| Writer | Locale it writes | Where it sits |
|---|---|---|
| `HtmlLang` | **page** locale, from the route | inside each landing/marketing route |
| `AppIntlProvider` | **app** locale — cookie / localStorage / `navigator`, **never the URL** | `ClientProviders`, above *every* route |

React commits child effects before parent ones, so `AppIntlProvider` always ran **last** and undid the page locale. A direct hit on `/pt-br` from an English browser resolves the app locale to `en`, so the page ends up labelled English.

Fix, in two halves:

1. **`HtmlLang` claims the attribute while mounted; `AppIntlProvider` stands down while a claim is held.** A small shared module holds the claim so `src/i18n/*` doesn't have to import from `src/components/*`.
2. **On release, the provider re-applies the app locale.** Restoring the snapshot `HtmlLang` took at mount is not enough — on a direct hit that snapshot is the root layout's pre-hydration `en`, so a pt-BR user leaving a landing page would run the rest of the session under `lang="en"`. The provider's own effect keys on the app locale, which doesn't change on navigation, so nothing else would put it back.

`src/app/page.tsx` (the English landing) had no `HtmlLang` at all — it now claims too, otherwise a visitor with a `pt-BR` cookie would have the English page relabelled Portuguese. It sits **inside** `LandingPageCapacitorGate`: on native this route is only a bootstrap shell that redirects away, and the device locale — not this page's English — is what `<html lang>` should report there.

## Task

- Notion: [`lang="en"` on localized pages](https://app.notion.com/p/3c083811757981d88766d8c39b9ea2cf)
- Source: `mono/inbox/localization-launch-2026-08-18/HANDOFF-FIXES.md` (fix 2)

**Not launch-blocking.** Sibling PR #2721 is the one that gates the localization launch.

## Impact — assistive tech only, not SEO

The handoff's earlier framing called this an SEO bug. It isn't. `hreflang` is emitted correctly and is what crawlers use — verified live on `peanut.me/pt-br`: 5 correct `link rel="alternate"` tags (`x-default`, `en`, `es-419`, `es-AR`, `pt-BR`). Unchanged by this PR.

What was actually broken is screen-reader pronunciation and in-browser tooling (translate prompts, spellcheck) on the localized landings.

## Design notes / accepted trade-offs

- **A claim counter, not effect reordering.** Parent passive effects always run after child ones, and `useLayoutEffect` doesn't help — all layout effects flush before any passive effect. There is no ordering trick; one writer has to yield.
- **Counter, not a boolean.** Paired increment/decrement survives StrictMode double-invoke and overlapping route transitions. `reactStrictMode` is `false` today, so this is future-proofing, not current need.
- **Rejected alternative:** having the landing seed the app locale via `persistLocale`. That writes the `app-locale` cookie, which `src/proxy.ts` then uses to 307 `/` → `/{locale}` permanently. Much larger blast radius for a `lang` attribute.
- **Case skew is expected.** Marketing tags are lowercase (`pt-br`), app tags are `pt-BR`. BCP 47 is case-insensitive, so the tests compare lowercased and don't assert exact case.

## Risks

Low, but wider than a copy change — `AppIntlProvider` is on every route. The guard is one boolean check and it only ever *skips* a write; it cannot write a wrong value. Non-marketing routes claim nothing, so the provider keeps full control there (verified below).

No `headers()`, no `params`, no dynamic API added — the native static export (`output: 'export'`) is unaffected.

## QA

Local gate: `prettier --check .` ✅ · `typecheck` ✅ · `npm test` **239/239 suites, 3064 tests** ✅ (237 suites on the `origin/dev` baseline + two new ones).

**The new tests reproduce the live bug**, rendering the *real* `AppIntlProvider` rather than a stand-in. Both fixes are mutation-checked — each one, removed, fails its own test:

| Mutation | Result |
|---|---|
| remove the claim guard (the original bug) | 2 tests fail |
| remove the release listener | release test fails — `Expected "pt-BR", Received "en"` |

They live in two files on purpose: the locale store memoizes the resolved startup locale per module, so a preceding test in the same file shifts the timing the release case depends on. That is exactly how the release gap survived the first round of tests here.

Real browser, 375×667, `Accept-Language: en-US` (the failing condition), probed 4s after `networkidle`:

| Route | `documentElement.lang` before | after |
|---|---|---|
| `/pt-br` | `en` ❌ (live prod today) | `pt-br` ✅ |
| `/es-419` | `en` ❌ | `es-419` ✅ |
| `/es-ar` | `en` ❌ | `es-ar` ✅ |
| `/pt-br/help` | `en` ❌ | `pt-br` ✅ |
| `/` | `en` | `en` ✅ (unchanged) |

With a **pt-BR** app locale (the case the first round of QA missed, because every row above uses `en` where a stale snapshot and the correct value are the same string):

| Step | before this PR | after |
|---|---|---|
| `/es-419` | `pt-BR` ❌ (app locale won) | `es-419` ✅ |
| then navigate to `/setup` | `en` ❌ (stale snapshot) | `pt-BR` ✅ |

## Screenshots

`N/A (no visible change)` — this changes an HTML attribute, not rendered output.

## Note for the reviewer

The handoff doc this came from states the landing route "never mounts `HtmlLang` at all" and that no route serves `/[locale]`. Both are wrong, and worth correcting for anyone reading it: the routes are **literal segments** (`src/app/pt-br/`, `src/app/es-419/`, `src/app/es-ar/`) — a `[locale]/page.tsx` would shadow `[...recipient]` and break every `peanut.me/{username}` profile, which the files' own header comments explain. The middleware is `src/proxy.ts` (Next 16 renamed it from `middleware.ts`), which is likely why it wasn't found. The missing `<main>` on the landing page is real but unrelated — the landing tree renders a plain `div` by design.
