### PR TITLE
fix(native): route peanut.me/<username> to an in-app public profile

### DIFF
--- a/src/app/(mobile-ui)/profile/view/page.tsx
+++ b/src/app/(mobile-ui)/profile/view/page.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+/*
+ * Query-param stand-in for the web's `/<username>` public profile: the
+ * [...recipient] catch-all is disabled in native builds (scripts/native-build.js),
+ * so profileUrl() and the deep-link mapper route bare usernames here. Mirrors the
+ * profile branch of src/app/[...recipient]/client.tsx.
+ */
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useEffect } from 'react'
+import PublicProfile from '@/components/Profile/components/PublicProfile'
+import { ValidatedUsernameWrapper } from '@/components/Username/ValidatedUsernameWrapper'
+import { useAuth } from '@/context/authContext'
+import { sendUrl } from '@/utils/native-routes'
+
+export default function ProfileViewPage() {
+    const searchParams = useSearchParams()
+    const router = useRouter()
+    const { user } = useAuth()
+    const username = searchParams.get('username')
+
+    useEffect(() => {
+        if (!username) router.replace('/home')
+    }, [username, router])
+
+    if (!username) return null
+
+    return (
+        <ValidatedUsernameWrapper username={username}>
+            <div className="mx-auto h-full w-full space-y-8 self-start">
+                <PublicProfile
+                    username={username}
+                    isLoggedIn={!!user}
+                    onSendClick={() => router.push(sendUrl(username))}
+                />
+            </div>
+        </ValidatedUsernameWrapper>
+    )
+}

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -121,7 +121,7 @@ export const RESERVED_ROUTES: readonly string[] = [...DEDICATED_ROUTES, ...STATI
  * Note: Most dev tools routes are NOT public - they require both authentication and specific user authorization
  * Exception: /dev/payment-graph is public (uses API key instead of user auth)
  */
-export const PUBLIC_ROUTES_REGEX = /^\/(request\/pay|claim|pay\/.+|support|invite|qr|dev\/payment-graph)/
+export const PUBLIC_ROUTES_REGEX = /^\/(request\/pay|claim|pay\/.+|support|invite|qr|profile\/view|dev\/payment-graph)/
 
 /**
  * Regex for dev-only public routes: ALL /dev pages (index + every tool/preview).
@@ -164,6 +164,16 @@ export function isReservedRoute(path: string): boolean {
  * this server-side, update both call sites.
  */
 const USERNAME_PATTERN = /^[a-z][a-z0-9]{3,11}$/
+
+/** Whether a path segment is shaped like a bare Peanut username — as opposed
+ *  to an address, ENS name, or `user@chain` handle (see couldBeRecipient). */
+export function isPlausibleUsername(segment: string): boolean {
+    try {
+        return USERNAME_PATTERN.test(decodeURIComponent(segment).toLowerCase())
+    } catch {
+        return false
+    }
+}
 
 /**
  * Helper to check if a first segment could plausibly identify a payment recipient:

--- a/src/utils/__tests__/native-routes.test.ts
+++ b/src/utils/__tests__/native-routes.test.ts
@@ -34,8 +34,8 @@ describe('native-routes', () => {
         })
 
         describe('profileUrl', () => {
-            it('should return /send with recipient query param', () => {
-                expect(profileUrl('alice')).toBe('/send?recipient=alice')
+            it('should return the query-param public-profile stand-in', () => {
+                expect(profileUrl('alice')).toBe('/profile/view?username=alice')
             })
         })
 
@@ -315,8 +315,20 @@ describe('native-routes', () => {
             // the root recipient catch-all is pruned from the native export —
             // a passthrough would chunk-error, so recipient paths funnel into
             // /send?recipient= and anything unmappable is dropped (null)
-            it('funnels a bare profile path into /send?recipient=', () => {
-                expect(deepLinkToNativePath('/kushagra')).toBe('/send?recipient=kushagra')
+            // A bare `/<username>` is a profile link, not a payment shape — it
+            // maps to the in-app profile stand-in rather than the send form.
+            it('maps a bare username onto the in-app public profile', () => {
+                expect(deepLinkToNativePath('/kushagra')).toBe('/profile/view?username=kushagra')
+                expect(deepLinkToNativePath('https://peanut.me/brbalinda')).toBe('/profile/view?username=brbalinda')
+            })
+
+            it('funnels payment-shaped recipient paths into /send?recipient=', () => {
+                expect(deepLinkToNativePath('/alice/10USDC')).toBe(
+                    `/send?recipient=${encodeURIComponent('alice/10USDC')}`
+                )
+                expect(deepLinkToNativePath('/0x36eA9C25FA1fa0e5ea15b02cFa1d4CAaeBFa2Cf5')).toBe(
+                    `/send?recipient=${encodeURIComponent('0x36eA9C25FA1fa0e5ea15b02cFa1d4CAaeBFa2Cf5')}`
+                )
             })
 
             it('funnels a semantic pay path (user@chain/amount) into /send?recipient=', () => {

--- a/src/utils/native-routes.ts
+++ b/src/utils/native-routes.ts
@@ -2,7 +2,7 @@
 // in capacitor (static export), dynamic routes don't work — use query params instead.
 // on web, use the normal path-based urls.
 
-import { couldBeRecipient, isReservedRoute } from '@/constants/routes'
+import { couldBeRecipient, isPlausibleUsername, isReservedRoute } from '@/constants/routes'
 import { isCapacitor } from './capacitor'
 
 // Deep links are peanut.me links by definition — that's the host the Android
@@ -12,7 +12,7 @@ import { isCapacitor } from './capacitor'
 const APP_HOSTS = /^(.+\.)?peanut\.me$/
 
 export function profileUrl(username: string): string {
-    return isCapacitor() ? `/send?recipient=${encodeURIComponent(username)}` : `/${username}`
+    return isCapacitor() ? `/profile/view?username=${encodeURIComponent(username)}` : `/${username}`
 }
 
 export function sendUrl(username: string): string {
@@ -150,8 +150,17 @@ function mapDeepLinkPath(parsed: URL): string | null {
         if (couldBeRecipient(segments[0])) {
             const chargeId = parsed.searchParams.get('chargeId')
             if (chargeId) return chargePayUrl(chargeId)
-            // usernames, addresses and semantic pay paths (user@chain/amount)
-            // all funnel into /send?recipient= — SendRouterView dispatches
+            /*
+             * No charge params: a bare `/<username>` is the public profile
+             * (mirrors the web catch-all's profile branch); anything else — an
+             * amount segment, `user@chain`, address, ENS — is a payment shape
+             * and goes to the send dispatcher.
+             */
+            if (segments.length === 1 && isPlausibleUsername(segments[0])) {
+                return profileUrl(decodeURIComponent(segments[0]))
+            }
+            // addresses and semantic pay paths (user@chain/amount) all funnel
+            // into /send?recipient= — SendRouterView dispatches
             return recipientPayUrl(decodeURIComponent(segments.join('/')))
         }
         return null


### PR DESCRIPTION
## Why

Two users reported in the last 24h that `peanut.me/jwei` opens the app with no visible content. The backend is healthy (public URL and profile API both return `200` with profile data) — the failure is native deep-link routing.

`/<username>` only exists on the web as the `[...recipient]` catch-all, which `scripts/native-build.js` prunes from the static export. On `dev` today the mapper's recipient block funnels a bare username into `/send?recipient=`, so a scanned or deep-linked profile link lands on the send form instead of the profile; on the builds users are running now it fell through to the raw web path and left them on a blank screen.

## What

- New `/profile/view?username=` page — the same `ValidatedUsernameWrapper` + `PublicProfile` pair the web catch-all's profile branch renders. Public route, so a logged-out deep link still resolves (guest view).
- `profileUrl()` points at it in Capacitor, so in-app call sites (history, rewards, invites, contributors) open the profile instead of the send form.
- The deep-link mapper's recipient block is split: a single, username-shaped segment → the profile; everything else (amount segment, `user@chain`, address, ENS) → the send dispatcher, unchanged.

## Scope

Cherry-picked from `21ad30ae0` on `mobile-release`, narrowed to the profile fix — the `/invite` half of that commit is already on `dev` via #2697. The same change reaches `dev` eventually through #2702 (the 232-file `mobile-release` → `dev` merge); this is the small, reviewable slice so the fix doesn't wait on that.

## Verification

- `native-routes`, `TransactionCard`, `InvitesPage` suites: 122 tests pass.
- `tsc --noEmit` clean for the touched files (only pre-existing `TS2307` asset/submodule errors in a fresh worktree).
- `prettier --write` run on all touched files.