### PR TITLE
ci(content): sign the content bump so it stops publishing unverified commits

### DIFF
--- a/.github/workflows/update-content.yml
+++ b/.github/workflows/update-content.yml
@@ -108,18 +108,35 @@ jobs:
                   git checkout -b "$BRANCH"
                   git add src/content
                   git commit -S -m "Update content submodule to latest main"
-                  git push origin "$BRANCH"
+
+                  # Push over CONTENT_BOT_TOKEN rather than the GITHUB_TOKEN that
+                  # actions/checkout persisted as the origin credential. Two reasons:
+                  #   - A GITHUB_TOKEN push raises no workflow events, so `Tests` would
+                  #     run for the `pull_request` event only. content-publish-
+                  #     automerge.yml expects a commit to carry two `ci-success` runs
+                  #     and merges on all-green-of-N; at N=1 a single concurrency
+                  #     cancellation makes N=0, where it declines to merge and the
+                  #     publish stalls silently. Ref creation used the PAT before, so
+                  #     this keeps the two runs the automerge gate was written against.
+                  #   - It preserves the bypass ref creation used to have, so a rule
+                  #     added to the "All branches" ruleset later cannot quietly break
+                  #     the pipeline.
+                  REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+                  git push "$REMOTE" "$BRANCH"
                   COMMIT_SHA=$(git rev-parse HEAD)
 
                   # Ask GitHub, not the runner, whether the signature actually
                   # verified — the runner has no allowed-signers file and would pass
                   # a key GitHub rejects. Publishing an unverified commit is the bug
                   # this step exists to prevent, so it is a hard failure, not a
-                  # warning.
+                  # warning. Take the branch back down on the way out: it carries no
+                  # PR yet, and the superseded-PR sweep below only ever sees branches
+                  # that have one, so an abandoned branch would linger forever.
                   VERIFICATION=$(gh api "repos/${{ github.repository }}/commits/$COMMIT_SHA" \
                     --jq '.commit.verification | "\(.verified) \(.reason)"')
                   if [ "${VERIFICATION%% *}" != "true" ]; then
                     echo "::error::content bump $COMMIT_SHA is not verified (${VERIFICATION#* })"
+                    git push "$REMOTE" --delete "$BRANCH" || echo "::warning::could not delete $BRANCH"
                     exit 1
                   fi
                   echo "Signed and verified: $COMMIT_SHA"

--- a/.github/workflows/update-content.yml
+++ b/.github/workflows/update-content.yml
@@ -67,39 +67,63 @@ jobs:
               # merging. One guard, in one place, on the base branch.
               env:
                   GH_TOKEN: ${{ secrets.CONTENT_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+                  SIGNING_KEY: ${{ secrets.CONTENT_BOT_SIGNING_KEY }}
               run: |
                   set -euo pipefail
                   BRANCH="auto/update-content-$(date -u +%Y%m%d-%H%M%S)"
                   SUBMODULE_SHA=$(git -C src/content rev-parse HEAD)
-                  PARENT=$(git rev-parse HEAD)   # main tip — bump is content-only vs main
-                  BASE_TREE=$(gh api repos/${{ github.repository }}/git/commits/$PARENT --jq '.tree.sha')
-                  # Create tree via API with updated submodule pointer
-                  TREE=$(gh api repos/${{ github.repository }}/git/trees \
-                    --method POST \
-                    -f "base_tree=$BASE_TREE" \
-                    -f "tree[][path]=src/content" \
-                    -f "tree[][mode]=160000" \
-                    -f "tree[][type]=commit" \
-                    -f "tree[][sha]=$SUBMODULE_SHA" \
-                    --jq '.sha')
-                  # Create the bump commit via the Git Data API. NOTE: API-created
-                  # commits are UNSIGNED, and `required_signatures` is active on both
-                  # the "All branches" and "Protect Prod" rulesets. This works only
-                  # because CONTENT_BOT_TOKEN belongs to an OrganizationAdmin, who has
-                  # `bypass_mode: always` on both. If that token is ever moved to a
-                  # non-admin account, this step starts failing at ref-creation and the
-                  # bump must be made as a locally signed commit instead.
-                  COMMIT_SHA=$(gh api repos/${{ github.repository }}/git/commits \
-                    --method POST \
-                    -f message="Update content submodule to latest main" \
-                    -f "tree=$TREE" \
-                    -f "parents[]=$PARENT" \
-                    --jq '.sha')
-                  # Create branch pointing at the bump commit
-                  gh api repos/${{ github.repository }}/git/refs \
-                    --method POST \
-                    -f "ref=refs/heads/$BRANCH" \
-                    -f "sha=$COMMIT_SHA"
+
+                  # Sign the bump with an SSH signing key. Every other route emits an
+                  # UNSIGNED commit, and `required_signatures` is active on the org
+                  # "All branches" ruleset:
+                  #   - POST /git/commits (the Git Data API) does not sign. It only
+                  #     attaches a signature you compute and pass in yourself. This
+                  #     step used that call from Feb 2026 and every content bump since
+                  #     was unsigned. It landed anyway because an org admin owns
+                  #     CONTENT_BOT_TOKEN and admins bypass the ruleset, so the
+                  #     failure was silent for six months.
+                  #   - GraphQL createCommitOnBranch, the one write path GitHub signs
+                  #     for you, cannot express a submodule pointer: its FileAddition
+                  #     input carries `path` and `contents` only, with no file mode,
+                  #     so a 160000 gitlink cannot be written through it.
+                  # A real local commit signed on the runner is the only route left.
+                  if [ -z "${SIGNING_KEY:-}" ]; then
+                    echo "::error::CONTENT_BOT_SIGNING_KEY is not set — refusing to create an unsigned content bump."
+                    exit 1
+                  fi
+                  KEY="$RUNNER_TEMP/content_signing_key"
+                  install -m 600 /dev/null "$KEY"
+                  printf '%s\n' "$SIGNING_KEY" > "$KEY"
+                  ssh-keygen -y -f "$KEY" > "$KEY.pub"
+
+                  # Same identity GitHub already stamped on these commits, so the
+                  # only change is that they are now signed. The address must stay a
+                  # verified email on the account holding the signing key, or the
+                  # signature is valid but GitHub still shows "Unverified".
+                  git config user.name "Hugo Montenegro"
+                  git config user.email "h@hugomontenegro.com"
+                  git config gpg.format ssh
+                  git config user.signingkey "$KEY.pub"
+
+                  git checkout -b "$BRANCH"
+                  git add src/content
+                  git commit -S -m "Update content submodule to latest main"
+                  git push origin "$BRANCH"
+                  COMMIT_SHA=$(git rev-parse HEAD)
+
+                  # Ask GitHub, not the runner, whether the signature actually
+                  # verified — the runner has no allowed-signers file and would pass
+                  # a key GitHub rejects. Publishing an unverified commit is the bug
+                  # this step exists to prevent, so it is a hard failure, not a
+                  # warning.
+                  VERIFICATION=$(gh api "repos/${{ github.repository }}/commits/$COMMIT_SHA" \
+                    --jq '.commit.verification | "\(.verified) \(.reason)"')
+                  if [ "${VERIFICATION%% *}" != "true" ]; then
+                    echo "::error::content bump $COMMIT_SHA is not verified (${VERIFICATION#* })"
+                    exit 1
+                  fi
+                  echo "Signed and verified: $COMMIT_SHA"
+
                   cat > /tmp/pr-body.md <<'BODY'
                   Auto-generated: bumps `src/content` to latest peanut-content `main`.
 


### PR DESCRIPTION
## Summary

Every `Update content submodule to latest main` commit since Feb 2026 has been **unsigned**, and they surface as a wall of "Unverified" whenever a `main`→`dev` back-merge carries them across (most recently #2724).

The step built its commit with `POST /git/commits`, added in fab59713 under the title *"use GitHub API for signed commits"*. That endpoint does **not** sign — it only attaches a signature the caller computes and passes in. The title has been wrong for six months.

Nothing caught it because `required_signatures` is active on the org **All branches** ruleset, but `CONTENT_BOT_TOKEN` belongs to an org admin and admins hold `bypass_mode: always`. So ref creation succeeded quietly instead of failing.

`createCommitOnBranch` — the one write path GitHub signs for you — is **not** an option here. Its `FileAddition` input carries `path` and `contents` only, with no file mode, so it cannot write a `160000` gitlink. Confirmed against the live schema. A real commit signed on the runner is the only route to a Verified submodule bump.

**This PR:** signs the bump with an SSH signing key (`CONTENT_BOT_SIGNING_KEY`), keeping the exact identity GitHub already stamped so the only change is that the commit is now signed. Then it asks GitHub whether the signature actually verified and **fails the step if it did not** — a missing key or a rejected signature now stops the publish instead of shipping another unverified commit.

## Task

TASK-21002 — [Prevent unverified commits from Hugo's account](https://app.notion.com/p/3ac83811757981a694c8cc7416400596)

## Why base `main`, not `dev`

`repository_dispatch` runs workflows from the **default branch**, which is `main`. The fix has no effect until it is on `main`. The regular `main`→`dev` back-merge carries it to `dev` afterwards.

## Prerequisites already in place

- `CONTENT_BOT_SIGNING_KEY` set on peanut-ui (2026-08-18).
- Matching public key registered as a **Signing Key** on the `Hugo0` account, fingerprint `SHA256:U6N8EsIfBAZKtLGFT9CJkYOCiJwMMFUBdD85PFdaXlY`. It is a signing key only — it is not in Authentication keys and grants no repo access.
- `h@hugomontenegro.com` confirmed Primary + Verified on that account, which is what makes GitHub accept the signature.

## Design notes / accepted trade-offs

- **The signing key lives in peanut-ui Actions secrets and carries Hugo's identity.** Anything that can read those secrets can produce commits showing *Verified · Hugo Montenegro*. Accepted because `CONTENT_BOT_TOKEN` already sits in the same store with repo write and can push as him outright — the key adds no meaningful blast radius. A dedicated bot account is the stronger alternative and was deliberately deferred: it costs an org seat and a replacement PAT.
- **`workflow_dispatch` makes this workflow reachable from any ref, so anyone with write access can run a modified copy of it with these secrets.** That means the signing key can be read, and commits can be signed as Hugo. Flagged rather than fixed, because it is pre-existing and strictly smaller than what is already exposed: `CONTENT_BOT_TOKEN`, an **org-admin PAT**, sits in the same secret store behind the same trigger. Worth addressing on its own (bot account, or drop `workflow_dispatch`), not by holding up this fix.
- **The verification gate is a hard failure, not a warning.** Publishing an unverified commit is the bug this step exists to prevent, so a silent fallback would defeat the change.

## Risk

Low, and CI-only — no app code, no runtime behavior. Worst case is that the content publish pipeline fails loudly and content stops auto-reaching peanut.me until fixed, which is the intended failure mode and strictly better than the current silent-unsigned one. No cross-repo deploy ordering.

## QA

- Signing mechanics proven locally with this exact key and the same command sequence: `gpgsig -----BEGIN SSH SIGNATURE-----` present, `git verify-commit` returns `Good "git" signature`, `%G?` = `G`.
- YAML parses; the embedded shell passes `bash -n`; the `BODY` heredoc terminator sits at column 0 after YAML dedent.
- prettier clean, 229/229 jest suites pass (unaffected — no TS touched).
- **Real proof lands post-merge:** the next content publish must open a PR whose bump commit shows **Verified**. If the key or secret were wrong, the step now fails instead of publishing.

Screenshots: N/A (no visible change — CI workflow only).

## Review

`/code-review medium` raised four findings; CodeRabbit raised none.

- **Fixed — push used the persisted `GITHUB_TOKEN`, not the PAT.** A `GITHUB_TOKEN` push raises no workflow events, so `Tests` would run for `pull_request` only. `content-publish-automerge.yml` is written for two `ci-success` runs per commit and merges on all-green-of-N, so at N=1 one concurrency cancellation gives N=0 and the publish stalls silently. It also dropped the bypass ref creation had. Now pushes over `CONTENT_BOT_TOKEN`.
- **Fixed — a failed verify left an orphan branch.** The gate ran after the push, and the superseded-PR sweep only walks branches that have an open PR, so an abandoned `auto/update-content-*` would never be collected. It is now deleted on that path.
- **Checked, no change needed — the push does not actually depend on a bypass today.** The "All branches" ruleset carries only restrict-deletions, restrict-force-push and require-signed-commits, and the bump branch matches none of the PR or status-check rulesets, so a signed push passes on its own. The PAT is belt and braces.
- **Flagged, not fixed — the `workflow_dispatch` exposure above.** Pre-existing, and smaller than the org-admin PAT already reachable the same way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the security and verification of automated content updates.
  * Content-update commits are now signed and verified before the workflow completes.
  * Failed verification now stops the process and removes the temporary branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->