### PR TITLE
chore(dev/journey): mirror lifecycle v2 spec — step ladder, win_back, finish_setup removal

### DIFF
--- a/src/app/(mobile-ui)/dev/journey/RulesLegend.tsx
+++ b/src/app/(mobile-ui)/dev/journey/RulesLegend.tsx
@@ -23,24 +23,28 @@ export default function RulesLegend({ rules, specError }: { rules: SpecRules | n
     }
     return (
         <div className="flex flex-wrap gap-2">
-            {/* The two nudge rules render the very badge the board stamps on each email. */}
-            <Rule label="nudge 1">
-                <StuckBadge days={rules.step1AfterDays} />
-            </Rule>
-            <Rule label="nudge 2">
-                <StuckBadge days={rules.step2AfterDays} />
-            </Rule>
+            {/* One nudge rule per ladder step — stages carry 2 or 3 steps in v2. */}
+            {rules.stepAfterDays.map((days, i) => (
+                <Rule key={i} label={`nudge ${i + 1}`}>
+                    <StuckBadge days={days} />
+                </Rule>
+            ))}
             <Rule label="governor">
                 <span className="text-xs font-bold">≥{rules.governorDays}d between emails</span>
             </Rule>
             <Rule label="freshness">
                 <span className="text-xs font-bold">{rules.freshnessDays}d window</span>
             </Rule>
+            <Rule label="dormancy">
+                <span className="text-xs font-bold">{rules.dormancyDays}d silent → win_back</span>
+            </Rule>
             <Rule label="holdout">
                 <span className="text-xs font-bold">{Math.round(rules.holdoutFraction * 100)}% control</span>
             </Rule>
             <Rule label="balance gate">
-                <span className="text-xs font-bold">fund ≤ $0.10 · spend ≥ $1 (live chain read)</span>
+                <span className="text-xs font-bold">
+                    fund ≤ $0.10 · spend ≥ $1 (live chain read; ≥ $1 re-routes fund → first_spend)
+                </span>
             </Rule>
             <Rule label="send window">
                 <span className="text-xs font-bold">
@@ -48,7 +52,9 @@ export default function RulesLegend({ rules, specError }: { rules: SpecRules | n
                 </span>
             </Rule>
             <Rule label="cap">
-                <span className="text-xs font-bold">{rules.maxSendsPerCycle}/cycle</span>
+                <span className="text-xs font-bold">
+                    {rules.maxSendsPerCycle}/cycle · {rules.maxSendsPerDay}/day
+                </span>
             </Rule>
         </div>
     )

--- a/src/app/(mobile-ui)/dev/journey/__tests__/emailReview.test.ts
+++ b/src/app/(mobile-ui)/dev/journey/__tests__/emailReview.test.ts
@@ -15,13 +15,14 @@ const step = (type: string, extra: Partial<SpecEmailStep> = {}): SpecEmailStep =
 const spec = (): JourneySpec => ({
     generatedFrom: 'test',
     rules: {
-        step1AfterDays: 2,
-        step2AfterDays: 6,
+        stepAfterDays: [2, 6, 12],
         governorDays: 3,
         freshnessDays: 30,
+        dormancyDays: 42,
         holdoutFraction: 0.1,
         sendWindowUtc: { startHour: 13, endHour: 21 },
         maxSendsPerCycle: 500,
+        maxSendsPerDay: 500,
     },
     welcome: step('lifecycle.welcome'),
     stages: [
@@ -77,9 +78,9 @@ describe('emailReview', () => {
         expect(buildEmailRenderList(withUnmapped).map((render) => render.eventType)).toContain('lifecycle.brand_new_1')
     })
 
-    it('flags exactly the two open product decisions', () => {
+    it('flags exactly the open product decisions (finish_setup settled: killed in lifecycle v2)', () => {
         expect(decisionFlagFor('lifecycle.first_spend_1')?.label).toMatch(/rewards branch/)
-        expect(decisionFlagFor('lifecycle.finish_setup_2')?.label).toMatch(/kill or keep/)
+        expect(decisionFlagFor('lifecycle.finish_setup_2')).toBeNull()
         expect(decisionFlagFor('lifecycle.welcome')).toBeNull()
     })
 })

--- a/src/app/(mobile-ui)/dev/journey/__tests__/journeyData.test.ts
+++ b/src/app/(mobile-ui)/dev/journey/__tests__/journeyData.test.ts
@@ -47,8 +47,8 @@ describe('journeyData', () => {
 
     it('maps each lifecycle spec stage to exactly one column', () => {
         const mapped = FUNNEL_STATES.flatMap((s) => s.specStages)
-        // the machine's five stages, each mapped once
-        expect([...mapped].sort()).toEqual(['create_card', 'finish_setup', 'first_spend', 'fund', 'verify'])
+        // the machine's five v2 stages, each mapped once (finish_setup deleted; win_back added)
+        expect([...mapped].sort()).toEqual(['create_card', 'first_spend', 'fund', 'verify', 'win_back'])
     })
 
     it('carries all 7 inventory findings, each source-file-annotated', () => {

--- a/src/app/(mobile-ui)/dev/journey/emailReview.ts
+++ b/src/app/(mobile-ui)/dev/journey/emailReview.ts
@@ -76,8 +76,9 @@ export function buildEmailRenderList(spec: JourneySpec | null): EmailRenderRef[]
 }
 
 /**
- * The two calls this review exists to settle. Everything else on the board is a
- * yes/no on the copy; these two are structural product decisions.
+ * The open structural product decisions. Everything else on the board is a
+ * yes/no on the copy. (finish_setup's kill-or-keep was settled: killed —
+ * lifecycle v2 deleted the stage after 0 sends ever.)
  */
 export const EMAIL_DECISION_FLAGS: Record<string, EmailDecisionFlag> = {
     'lifecycle.first_spend_1': {
@@ -87,14 +88,6 @@ export const EMAIL_DECISION_FLAGS: Record<string, EmailDecisionFlag> = {
     'lifecycle.first_spend_2': {
         label: 'decide: rewards branch keep/kill',
         note: 'Renders a second copy variant when the user has unclaimed rewards. Keep the branch or cut it to one message?',
-    },
-    'lifecycle.finish_setup_1': {
-        label: 'decide: kill or keep (0 prod audience)',
-        note: 'The finish_setup stage matches no users in prod today. Keep the pair for future card states, or drop the stage?',
-    },
-    'lifecycle.finish_setup_2': {
-        label: 'decide: kill or keep (0 prod audience)',
-        note: 'The finish_setup stage matches no users in prod today. Keep the pair for future card states, or drop the stage?',
     },
 }
 

--- a/src/app/(mobile-ui)/dev/journey/journeyData.ts
+++ b/src/app/(mobile-ui)/dev/journey/journeyData.ts
@@ -44,7 +44,9 @@ export const FUNNEL_STATES: FunnelState[] = [
         id: 'application-in-flight',
         label: 'Application in flight',
         description: 'Card exists but none ACTIVE — pending / review / RFI.',
-        specStages: ['finish_setup'],
+        specStages: [],
+        noEmailReason:
+            'finish_setup was deleted (0 sends ever — NOT_ACTIVATED is written nowhere). No stage copy is true here, so the machine is silent by design.',
     },
     {
         id: 'card-active-unfunded',
@@ -60,10 +62,10 @@ export const FUNNEL_STATES: FunnelState[] = [
     },
     {
         id: 'spent',
-        label: 'Spent — graduated',
-        description: 'First real spend done. Out of the activation machine.',
-        specStages: [],
-        noEmailReason: 'Graduated — the lifecycle machine never emails again.',
+        label: 'Spent → dormant',
+        description:
+            'First real spend done — silent while active. Going quiet for 6 weeks (any formerly-transacting spender, card or QR) re-enters as win_back.',
+        specStages: ['win_back'],
     },
 ]
 

--- a/src/app/(mobile-ui)/dev/journey/journeyTypes.ts
+++ b/src/app/(mobile-ui)/dev/journey/journeyTypes.ts
@@ -88,13 +88,16 @@ export interface SpecStage {
 }
 
 export interface SpecRules {
-    step1AfterDays: number
-    step2AfterDays: number
+    /** Per-step delay from the stage anchor, by index (lifecycle v2 — stages have 2 or 3 steps). */
+    stepAfterDays: number[]
     governorDays: number
     freshnessDays: number
+    /** Weeks-worth of silence (in days) before a formerly-transacting user is win_back-eligible. */
+    dormancyDays: number
     holdoutFraction: number
     sendWindowUtc: { startHour: number; endHour: number }
     maxSendsPerCycle: number
+    maxSendsPerDay: number
 }
 
 export interface SpecPushReminder {


### PR DESCRIPTION
## Summary

Companion to peanutprotocol/peanut-api-ts#1360 (lifecycle machine v2). The `/__dev/journey-spec` response changed shape and the dev journey board must mirror it:

- `SpecRules.stepAfterDays` (array) replaces `step1AfterDays`/`step2AfterDays` — stages now carry 2 or 3 steps; `RulesLegend` maps over the ladder and shows the new `dormancyDays` and `maxSendsPerDay` rules.
- `win_back` stage mapped to the (renamed) "Spent → dormant" column — going quiet for 6 weeks re-enters the machine.
- `finish_setup` removed: its column documents why the machine is silent there by design; its settled kill-or-keep decision flag is retired.

## Task

Notion: [Activation machine — reach the users it cannot see](https://app.notion.com/p/3bf83811757981c5a034e9ca77c16763) (Sprint 156)

## Risks / breaking changes

Dev-only surface (`/dev/journey`); no production UI touched. `useJourneySpec` degrades gracefully against an old API, so merge order with api#1360 is not load-bearing — but the board only renders the new rules once both are deployed.

## QA

Typecheck clean · full suite 3,110 passed (journey suites 24/24) · prettier applied.

Screenshots: N/A (dev-only tooling board; no customer-visible change)
