### PR TITLE
fix(landing): keep the hero CTA inside the first fold on laptop viewports

### DIFF
--- a/src/components/LandingPage/hero.tsx
+++ b/src/components/LandingPage/hero.tsx
@@ -111,7 +111,7 @@ const getHoverAnimation = (variant: 'primary' | 'secondary') => ({
 const transitionConfig = { type: 'spring', damping: 15 } as const
 
 const getButtonContainerClasses = (variant: 'primary' | 'secondary') =>
-    `relative z-20 mt-8 md:mt-12 flex flex-col items-center justify-center ${variant === 'primary' ? 'mx-auto w-fit' : 'right-[calc(50%-120px)]'}`
+    `relative z-20 mt-8 flex flex-col items-center justify-center ${variant === 'primary' ? 'mx-auto w-fit' : 'right-[calc(50%-120px)]'}`
 
 export function Hero({
     primaryCta,
@@ -170,11 +170,12 @@ export function Hero({
         >
             <CloudsCss />
             <div className="relative mt-10 w-full md:mt-0">
+                {/* 23rem = the fixed stack below the artwork (h2 -> CTA) + 3rem slack, so the CTA stays inside the first fold on short laptop viewports */}
                 <Image
                     src={GlobalCashLocalFeel}
                     priority
                     sizes="(min-width: 768px) 50vw, 100vw"
-                    className="z-0 mx-auto h-auto w-full max-w-[1000px] object-contain md:w-[50%]"
+                    className="z-0 mx-auto h-auto max-h-[calc(100svh-23rem)] w-full max-w-[1000px] object-contain md:w-[50%]"
                     alt="Global Cash Local Feel"
                 />
 
@@ -198,7 +199,7 @@ export function Hero({
             <PeanutMascot />
 
             <div className="relative z-20 flex w-full flex-col items-center justify-center">
-                <h2 className="font-roboto-flex-extrabold mt-18 text-center text-[2.375rem] font-extraBlack text-black md:text-heading">
+                <h2 className="font-roboto-flex-extrabold mt-18 text-center text-[2.375rem] font-extraBlack text-black md:mt-12 md:text-heading">
                     {strings.heroTapScan}
                 </h2>
                 <span

--- a/src/components/LandingPage/hero.tsx
+++ b/src/components/LandingPage/hero.tsx
@@ -70,7 +70,7 @@ function PeanutMascot() {
             src={PeanutWhistling}
             unoptimized
             alt="Peanut Guy"
-            className="absolute left-1/2 z-10 h-auto max-h-[40vh] w-auto max-w-[90%] -translate-x-1/2 object-contain"
+            className="absolute left-1/2 z-10 h-auto max-h-[40vh] w-auto max-w-[90%] -translate-x-1/2 object-contain md:max-h-[min(40vh,calc(100svh-28rem))]"
         />
     )
 }


### PR DESCRIPTION
## What
Slava flagged on Discord that the homepage shows no CTA without scrolling on his MacBook (Notion TASK-21626). Measured on prod today — it's not one machine, it's every common laptop:

| Viewport (inner) | Device | SIGN UP on prod |
|---|---|---|
| 1280×689 | MacBook 13" | below fold |
| 1366×657 | Windows laptop | below fold |
| 1536×753 | Windows @125% | below fold |
| 1440×760 | MacBook Air 13" + bookmarks bar | 27% visible |
| 1440×789 | MacBook Air 13" | 71% visible |
| 1920×969 | FHD desktop | fits, 2px to spare |
| 375×553 | iPhone SE | 56% visible |
| 390×664 / 360×700 | phones | fits |

## Why
`hero.tsx`: the headline artwork is `md:w-[50%]` with no height cap, so its height tracks viewport **width** (412px at 1280w → 623px at 1920w), while the stack under it (`mt-18` + h2 + tagline + `md:mt-12` + 66px button) is 344px of fixed height. Nothing in the fold responds to viewport **height**.

## Change (4 classes)
- artwork: `+ max-h-[calc(100svh-23rem)]` — 23rem = fixed stack below it + 3rem slack
- h2: `mt-18` → `mt-18 md:mt-12`
- CTA container: `mt-8 md:mt-12` → `mt-8`
- mascot (follow-up commit): `+ md:max-h-[min(40vh,calc(100svh-28rem))]` — keeps the peanut ~0.7× the artwork on short laptops so "LOCAL FEEL" stays legible; ≥789px-tall viewports unchanged. **Note for #2728**: that PR replaces this `<Image>` with a `h-[40vh]` host div — carry the cap over as `md:h-[min(40vh,calc(100svh-28rem))]` on the host when resolving the conflict.

Result: CTA bottom lands ~64px above the fold at every desktop viewport ≥ ~600px tall; tall screens barely change (FHD artwork 623 → 601px). Mobile only changes on SE-class heights (cap doesn't bite at 664+). Mascot (`max-h-[40vh]`, anchored to the h2 by JS) and stars untouched — deliberately stays clear of #2728's mascot rewrite.

## Verify
Vercel preview at 1366×657, 1280×689, 1440×789, 1536×753, 1920×969, 390×664, 375×553 — SIGN UP fully visible without scrolling on all; compare against peanut.me at the same sizes.
