### PR TITLE
feat(ds): DS 19-22 — notification, link button, accordion + slider restyle

### DIFF
--- a/src/app/(mobile-ui)/dev/ds/_components/nav-config.ts
+++ b/src/app/(mobile-ui)/dev/ds/_components/nav-config.ts
@@ -33,6 +33,9 @@ export const SIDEBAR_CONFIG: Record<string, NavItem[]> = {
         { label: 'Checkbox', icon: 'check', href: '/dev/ds/primitives/checkbox' },
         { label: 'Toggle', icon: 'switch', href: '/dev/ds/primitives/toggle' },
         { label: 'Toast', icon: 'bell', href: '/dev/ds/primitives/toast' },
+        { label: 'Notification', icon: 'alert', href: '/dev/ds/primitives/notification' },
+        { label: 'LinkButton', icon: 'link', href: '/dev/ds/primitives/link-button' },
+        { label: 'Accordion', icon: 'chevron-down', href: '/dev/ds/primitives/accordion' },
         { label: 'Divider', icon: 'minus-circle', href: '/dev/ds/primitives/divider' },
         { label: 'Title', icon: 'docs', href: '/dev/ds/primitives/title' },
         { label: 'PageContainer', icon: 'docs', href: '/dev/ds/primitives/page-container' },
@@ -47,6 +50,7 @@ export const SIDEBAR_CONFIG: Record<string, NavItem[]> = {
         { label: 'Layouts', icon: 'switch', href: '/dev/ds/patterns/layouts' },
         { label: 'Cards (Global)', icon: 'docs', href: '/dev/ds/patterns/cards-global' },
         { label: 'AmountInput', icon: 'dollar', href: '/dev/ds/patterns/amount-input' },
+        { label: 'Slider', icon: 'meter', href: '/dev/ds/patterns/slider' },
     ],
     audit: [
         { label: 'Code Audit', icon: 'docs', href: '/dev/ds/audit' },

--- a/src/app/(mobile-ui)/dev/ds/patterns/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/patterns/page.tsx
@@ -84,6 +84,14 @@ export default function PatternsPage() {
                     status="needs-refactor"
                     quality={3}
                 />
+                <CatalogCard
+                    title="Slider"
+                    description="Percentage slider with magnetic snap points. Used by AmountInput in contribute-pot"
+                    href="/dev/ds/patterns/slider"
+                    icon="meter"
+                    status="production"
+                    usages={1}
+                />
             </CatalogGrid>
         </DocPage>
     )

--- a/src/app/(mobile-ui)/dev/ds/patterns/slider/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/patterns/slider/page.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { useState } from 'react'
+import { Slider } from '@/components/Global/Slider'
+import { DocHeader } from '../../_components/DocHeader'
+import { DocSection } from '../../_components/DocSection'
+import { SectionDivider } from '../../_components/SectionDivider'
+import { DocPage } from '../../_components/DocPage'
+import { PropsTable } from '../../_components/PropsTable'
+import { CodeBlock } from '../../_components/CodeBlock'
+import { DesignNote } from '../../_components/DesignNote'
+
+export default function SliderPage() {
+    const [value, setValue] = useState([50])
+
+    return (
+        <DocPage>
+            <DocHeader
+                title="Slider"
+                description="Percentage slider from the figma slider board (17802:61531), radix base. Magnetic snapping to 25 / 33.3 / 50 / 100%. Consumer: AmountInput (contribute-pot flow)."
+                status="production"
+            />
+
+            <DocSection title="Interactive">
+                <DocSection.Content>
+                    <div className="flex flex-col gap-8 pb-6">
+                        <Slider value={value} onValueChange={setValue} aria-label="demo slider" />
+                    </div>
+                </DocSection.Content>
+                <DocSection.Code>
+                    <CodeBlock
+                        label="Slider"
+                        code={`import { Slider } from '@/components/Global/Slider'
+
+const [value, setValue] = useState([50])
+
+<Slider value={value} onValueChange={setValue} />`}
+                    />
+                </DocSection.Code>
+            </DocSection>
+
+            <SectionDivider />
+
+            <DocSection title="Positions">
+                <DocSection.Content>
+                    <div className="flex flex-col gap-8 pb-6">
+                        <Slider value={[0]} onValueChange={() => {}} aria-label="slider at 0" />
+                        <Slider value={[25]} onValueChange={() => {}} aria-label="slider at 25" />
+                        <Slider value={[75]} onValueChange={() => {}} aria-label="slider at 75" />
+                        <Slider value={[100]} onValueChange={() => {}} aria-label="slider at 100" />
+                    </div>
+                </DocSection.Content>
+            </DocSection>
+
+            <SectionDivider />
+
+            <DocSection title="Disabled">
+                <DocSection.Content>
+                    <div className="pb-6">
+                        <Slider value={[100]} onValueChange={() => {}} disabled aria-label="disabled slider" />
+                    </div>
+                </DocSection.Content>
+            </DocSection>
+
+            <DesignNote type="info">
+                The board tops out at 100% — this consumer allows up to 120% of the suggested amount, so the right label
+                reads 120%. The fill is always pink: never recolor it green or red as an indicator.
+            </DesignNote>
+
+            <SectionDivider />
+
+            <PropsTable
+                rows={[
+                    { name: 'value', type: 'number[]', default: '(uncontrolled)', description: 'Controlled value' },
+                    { name: 'onValueChange', type: '(v: number[]) => void', default: '(none)' },
+                    { name: 'defaultValue', type: 'number[]', default: '[100]' },
+                    { name: 'disabled', type: 'boolean', default: 'false', description: '50% opacity, no drag' },
+                    {
+                        name: '...radix props',
+                        type: 'SliderPrimitive.Root',
+                        default: '—',
+                        description: 'min 0, max 120, step 1 are fixed',
+                    },
+                ]}
+            />
+        </DocPage>
+    )
+}

--- a/src/app/(mobile-ui)/dev/ds/patterns/slider/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/patterns/slider/page.tsx
@@ -34,7 +34,7 @@ export default function SliderPage() {
 
 const [value, setValue] = useState([50])
 
-<Slider value={value} onValueChange={setValue} />`}
+<Slider value={value} onValueChange={setValue} aria-label="Contribution percentage" />`}
                     />
                 </DocSection.Code>
             </DocSection>
@@ -79,7 +79,7 @@ const [value, setValue] = useState([50])
                         name: '...radix props',
                         type: 'SliderPrimitive.Root',
                         default: '—',
-                        description: 'min 0, max 120, step 1 are fixed',
+                        description: 'min 0, max 120, step 1 by default (overridable)',
                     },
                 ]}
             />

--- a/src/app/(mobile-ui)/dev/ds/primitives/accordion/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/primitives/accordion/page.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useState } from 'react'
+import { Accordion } from '@/components/0_Bruddle/Accordion'
+import { DocHeader } from '../../_components/DocHeader'
+import { DocSection } from '../../_components/DocSection'
+import { SectionDivider } from '../../_components/SectionDivider'
+import { DocPage } from '../../_components/DocPage'
+import { PropsTable } from '../../_components/PropsTable'
+import { CodeBlock } from '../../_components/CodeBlock'
+
+export default function AccordionPage() {
+    const [value, setValue] = useState<string>('expanded')
+
+    return (
+        <DocPage>
+            <DocHeader
+                title="Accordion"
+                description="From the figma accordion board (17802:61540), radix headless base. Users scan section titles and expand only what they need. Consumer: BridgeLimitsView (limits QR countries)."
+                status="production"
+            />
+
+            <DocSection title="States">
+                <DocSection.Content>
+                    <Accordion type="single" collapsible value={value} onValueChange={setValue}>
+                        <Accordion.Item value="collapsed">
+                            <Accordion.Trigger>Collapsed accordion header</Accordion.Trigger>
+                            <Accordion.Content>
+                                Content goes here. This area can hold any component or text style.
+                            </Accordion.Content>
+                        </Accordion.Item>
+                        <Accordion.Item value="expanded">
+                            <Accordion.Trigger>Expanded accordion header</Accordion.Trigger>
+                            <Accordion.Content>
+                                Content goes here. This area can hold any component or text style. Longer text has more
+                                place under it.
+                            </Accordion.Content>
+                        </Accordion.Item>
+                        <Accordion.Item value="disabled" disabled>
+                            <Accordion.Trigger>Disabled accordion header</Accordion.Trigger>
+                            <Accordion.Content>Never shown.</Accordion.Content>
+                        </Accordion.Item>
+                    </Accordion>
+                </DocSection.Content>
+                <DocSection.Code>
+                    <CodeBlock
+                        label="Accordion"
+                        code={`import { Accordion } from '@/components/0_Bruddle/Accordion'
+
+<Accordion type="single" collapsible value={open} onValueChange={setOpen}>
+    <Accordion.Item value="ar">
+        <Accordion.Trigger>Argentina</Accordion.Trigger>
+        <Accordion.Content>Pay up to $500 per QR payment.</Accordion.Content>
+    </Accordion.Item>
+    <Accordion.Item value="br" disabled>
+        <Accordion.Trigger>Brazil</Accordion.Trigger>
+        <Accordion.Content>Coming soon.</Accordion.Content>
+    </Accordion.Item>
+</Accordion>`}
+                    />
+                </DocSection.Code>
+            </DocSection>
+
+            <SectionDivider />
+
+            <PropsTable
+                rows={[
+                    {
+                        name: 'Accordion',
+                        type: 'radix Root props',
+                        default: '—',
+                        description: 'type="single" collapsible + value/onValueChange, or type="multiple"',
+                    },
+                    {
+                        name: 'Accordion.Item',
+                        type: 'radix Item props',
+                        default: '—',
+                        description: 'value (required), disabled',
+                    },
+                    {
+                        name: 'Accordion.Trigger',
+                        type: 'radix Trigger props',
+                        default: '—',
+                        description: 'Header row; chevron is built in',
+                    },
+                    {
+                        name: 'Accordion.Content',
+                        type: 'radix Content props',
+                        default: '—',
+                        description: 'Divider + padded body, animated',
+                    },
+                ]}
+            />
+        </DocPage>
+    )
+}

--- a/src/app/(mobile-ui)/dev/ds/primitives/link-button/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/primitives/link-button/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import { LinkButton } from '@/components/0_Bruddle/LinkButton'
 import { DocHeader } from '../../_components/DocHeader'
 import { DocSection } from '../../_components/DocSection'
@@ -52,9 +53,9 @@ export default function LinkButtonPage() {
                 <DocSection.Content>
                     <p className="text-body-m text-foreground-primary">
                         Inline links inherit the surrounding text:{' '}
-                        <a href="/dev/ds" className="text-foreground-secondary underline">
+                        <Link href="/dev/ds" className="text-foreground-secondary underline">
                             transaction history
-                        </a>{' '}
+                        </Link>{' '}
                         stays in the sentence. Do not embed the standalone LinkButton inline — its fixed size and icon
                         break the sentence.
                     </p>
@@ -63,9 +64,9 @@ export default function LinkButtonPage() {
                     <CodeBlock
                         label="Inline"
                         code={`You can view your{' '}
-<a href="/history" className="text-foreground-secondary underline">
+<Link href="/history" className="text-foreground-secondary underline">
     transaction history
-</a>{' '}
+</Link>{' '}
 at any time.`}
                     />
                 </DocSection.Code>

--- a/src/app/(mobile-ui)/dev/ds/primitives/link-button/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/primitives/link-button/page.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import { LinkButton } from '@/components/0_Bruddle/LinkButton'
+import { DocHeader } from '../../_components/DocHeader'
+import { DocSection } from '../../_components/DocSection'
+import { SectionDivider } from '../../_components/SectionDivider'
+import { DocPage } from '../../_components/DocPage'
+import { PropsTable } from '../../_components/PropsTable'
+import { CodeBlock } from '../../_components/CodeBlock'
+import { DesignNote } from '../../_components/DesignNote'
+
+const noop = () => {}
+
+export default function LinkButtonPage() {
+    return (
+        <DocPage>
+            <DocHeader
+                title="LinkButton"
+                description="Standalone link from the figma link board (17980:17351). Body/XS underlined, gray at rest, black on hover. Navigation only — never an action."
+                status="limited"
+            />
+
+            <DocSection title="Usage & states">
+                <DocSection.Content>
+                    <div className="flex flex-col items-start gap-4">
+                        <LinkButton onClick={noop}>Default</LinkButton>
+                        <LinkButton onClick={noop} icon>
+                            View transaction
+                        </LinkButton>
+                        <LinkButton href="/dev/ds" icon>
+                            As a Next.js link
+                        </LinkButton>
+                        <LinkButton onClick={noop} disabled>
+                            Disabled
+                        </LinkButton>
+                    </div>
+                </DocSection.Content>
+                <DocSection.Code>
+                    <CodeBlock
+                        label="LinkButton"
+                        code={`import { LinkButton } from '@/components/0_Bruddle/LinkButton'
+
+<LinkButton href="/history" icon>View transaction</LinkButton>
+<LinkButton onClick={openDetails}>See details</LinkButton>`}
+                    />
+                </DocSection.Code>
+            </DocSection>
+
+            <SectionDivider />
+
+            <DocSection title="Inline links">
+                <DocSection.Content>
+                    <p className="text-body-m text-foreground-primary">
+                        Inline links inherit the surrounding text:{' '}
+                        <a href="/dev/ds" className="text-foreground-secondary underline">
+                            transaction history
+                        </a>{' '}
+                        stays in the sentence. Do not embed the standalone LinkButton inline — its fixed size and icon
+                        break the sentence.
+                    </p>
+                </DocSection.Content>
+                <DocSection.Code>
+                    <CodeBlock
+                        label="Inline"
+                        code={`You can view your{' '}
+<a href="/history" className="text-foreground-secondary underline">
+    transaction history
+</a>{' '}
+at any time.`}
+                    />
+                </DocSection.Code>
+            </DocSection>
+
+            <DesignNote type="warning">
+                The board colors links foreground/secondary (gray) at rest — the older app law said links are black +
+                underline. This page follows the board; the conflict is flagged for a design decision.
+            </DesignNote>
+
+            <SectionDivider />
+
+            <PropsTable
+                rows={[
+                    { name: 'children', type: 'ReactNode', default: '(required)', description: 'Link text' },
+                    {
+                        name: 'href',
+                        type: 'string',
+                        default: '(none)',
+                        description: 'Renders a Next.js Link; omit for a button',
+                    },
+                    { name: 'onClick', type: '() => void', default: '(none)' },
+                    { name: 'icon', type: 'boolean', default: 'false', description: 'Trailing arrow-up-right' },
+                    { name: 'disabled', type: 'boolean', default: 'false', description: '40% opacity, no clicks' },
+                    { name: 'external', type: 'boolean', default: 'false', description: 'Opens href in a new tab' },
+                ]}
+            />
+        </DocPage>
+    )
+}

--- a/src/app/(mobile-ui)/dev/ds/primitives/notification/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/primitives/notification/page.tsx
@@ -140,9 +140,9 @@ export default function NotificationPage() {
                     },
                     {
                         name: 'ctas',
-                        type: '{ label, onClick }[]',
+                        type: '1-2 × { label, onClick }',
                         default: '(none)',
-                        description: 'Up to 2: first purple, second stroke',
+                        description: 'First renders purple, second stroke',
                     },
                 ]}
             />

--- a/src/app/(mobile-ui)/dev/ds/primitives/notification/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/primitives/notification/page.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+import { Notification } from '@/components/0_Bruddle/Notification'
+import { DocHeader } from '../../_components/DocHeader'
+import { DocSection } from '../../_components/DocSection'
+import { SectionDivider } from '../../_components/SectionDivider'
+import { DocPage } from '../../_components/DocPage'
+import { PropsTable } from '../../_components/PropsTable'
+import { CodeBlock } from '../../_components/CodeBlock'
+
+const noop = () => {}
+
+export default function NotificationPage() {
+    return (
+        <DocPage>
+            <DocHeader
+                title="Notification"
+                description="Inline notification banner from the figma notification board (17802:61535). Priority sets tone and icon; supports body or title + body, optional dismiss, and up to two CTAs. No prod consumer yet — this page is its consumer."
+                status="limited"
+            />
+
+            <DocSection title="Priority">
+                <DocSection.Content>
+                    <div className="flex flex-col gap-3">
+                        <Notification priority="info">Just letting you know about this</Notification>
+                        <Notification priority="success">Success, details changed</Notification>
+                        <Notification priority="attention">Pay attention, this is important</Notification>
+                        <Notification priority="helper">Leave empty to let payers choose amount</Notification>
+                        <Notification priority="error">Ups, something went wrong</Notification>
+                    </div>
+                </DocSection.Content>
+                <DocSection.Code>
+                    <CodeBlock
+                        label="Notification"
+                        code={`import { Notification } from '@/components/0_Bruddle/Notification'
+
+<Notification priority="success">Success, details changed</Notification>`}
+                    />
+                </DocSection.Code>
+            </DocSection>
+
+            <SectionDivider />
+
+            <DocSection title="Build: body vs title + body">
+                <DocSection.Content>
+                    <div className="flex flex-col gap-3">
+                        <Notification priority="helper">Body text only, no separate title</Notification>
+                        <Notification priority="attention" title="Title">
+                            Body text can be longer, but try not to go over two lines.
+                        </Notification>
+                    </div>
+                </DocSection.Content>
+                <DocSection.Code>
+                    <CodeBlock
+                        label="Title + body"
+                        code={`<Notification priority="attention" title="Title">
+    Body text can be longer, but try not to go over two lines.
+</Notification>`}
+                    />
+                </DocSection.Code>
+            </DocSection>
+
+            <SectionDivider />
+
+            <DocSection title="Dismiss">
+                <DocSection.Content>
+                    <div className="flex flex-col gap-3">
+                        <Notification priority="info">Not dismissible, no close button</Notification>
+                        <Notification priority="info" onDismiss={noop}>
+                            Dismissible, includes a close button
+                        </Notification>
+                    </div>
+                </DocSection.Content>
+                <DocSection.Code>
+                    <CodeBlock
+                        label="Dismissible"
+                        code={`<Notification priority="info" onDismiss={() => setShown(false)}>
+    Dismissible, includes a close button
+</Notification>`}
+                    />
+                </DocSection.Code>
+            </DocSection>
+
+            <SectionDivider />
+
+            <DocSection title="CTAs">
+                <DocSection.Content>
+                    <div className="flex flex-col gap-3">
+                        <Notification priority="attention" ctas={[{ label: 'CTA1', onClick: noop }]}>
+                            Single call-to-action button
+                        </Notification>
+                        <Notification
+                            priority="attention"
+                            title="Title"
+                            onDismiss={noop}
+                            ctas={[
+                                { label: 'CTA1', onClick: noop },
+                                { label: 'CTA2', onClick: noop },
+                            ]}
+                        >
+                            Two buttons: a primary and a secondary action.
+                        </Notification>
+                    </div>
+                </DocSection.Content>
+                <DocSection.Code>
+                    <CodeBlock
+                        label="CTAs"
+                        code={`<Notification
+    priority="attention"
+    title="Title"
+    onDismiss={dismiss}
+    ctas={[
+        { label: 'Verify', onClick: verify },
+        { label: 'Later', onClick: dismiss },
+    ]}
+>
+    Two buttons: a primary and a secondary action.
+</Notification>`}
+                    />
+                </DocSection.Code>
+            </DocSection>
+
+            <SectionDivider />
+
+            <PropsTable
+                rows={[
+                    {
+                        name: 'priority',
+                        type: "'info' | 'success' | 'attention' | 'helper' | 'error'",
+                        default: "'info'",
+                        description: 'Tone, background, and leading icon',
+                    },
+                    { name: 'title', type: 'string', default: '(none)', description: 'Bold first line' },
+                    { name: 'children', type: 'ReactNode', default: '(required)', description: 'Body text' },
+                    {
+                        name: 'onDismiss',
+                        type: '() => void',
+                        default: '(none)',
+                        description: 'Shows the close button',
+                    },
+                    {
+                        name: 'ctas',
+                        type: '{ label, onClick }[]',
+                        default: '(none)',
+                        description: 'Up to 2: first purple, second stroke',
+                    },
+                ]}
+            />
+        </DocPage>
+    )
+}

--- a/src/app/(mobile-ui)/dev/ds/primitives/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/primitives/page.tsx
@@ -84,6 +84,28 @@ export default function PrimitivesPage() {
                     icon="docs"
                     status="production"
                 />
+                <CatalogCard
+                    title="Notification"
+                    description="Inline notification banner. 5 priorities, title + body, dismiss, up to 2 CTAs"
+                    href="/dev/ds/primitives/notification"
+                    icon="alert"
+                    status="limited"
+                />
+                <CatalogCard
+                    title="LinkButton"
+                    description="Standalone underlined link for lightweight navigation. Optional trailing icon"
+                    href="/dev/ds/primitives/link-button"
+                    icon="link"
+                    status="limited"
+                />
+                <CatalogCard
+                    title="Accordion"
+                    description="Expand/collapse sections over the radix base. Single or multiple, disabled items"
+                    href="/dev/ds/primitives/accordion"
+                    icon="chevron-down"
+                    status="production"
+                    usages={1}
+                />
             </CatalogGrid>
         </DocPage>
     )

--- a/src/components/0_Bruddle/Accordion.tsx
+++ b/src/components/0_Bruddle/Accordion.tsx
@@ -33,10 +33,15 @@ const AccordionTrigger = ({
 }: React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>) => (
     <AccordionPrimitive.Header className="flex">
         <AccordionPrimitive.Trigger
-            className={twMerge(
-                'group flex w-full items-center justify-between gap-2 p-4 text-left text-body-s text-foreground-primary focus-visible:outline-2 focus-visible:outline-action-focus data-[disabled]:text-foreground-secondary',
-                className
-            )}
+            // text-body-s sits outside twMerge: stock tailwind-merge misreads it as a
+            // text-color class and strips it against text-foreground-primary
+            className={
+                'text-body-s ' +
+                twMerge(
+                    'group flex w-full items-center justify-between gap-2 p-4 text-left text-foreground-primary focus-visible:outline-2 focus-visible:outline-action-focus data-[disabled]:text-foreground-secondary',
+                    className
+                )
+            }
             {...props}
         >
             {children}
@@ -58,7 +63,12 @@ const AccordionContent = ({
         className="overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
         {...props}
     >
-        <div className={twMerge('border-t border-border-default p-4 text-body-s text-foreground-primary', className)}>
+        {/* text-body-s outside twMerge — see the trigger note */}
+        <div
+            className={
+                'text-body-s ' + twMerge('border-t border-border-default p-4 text-foreground-primary', className)
+            }
+        >
             {children}
         </div>
     </AccordionPrimitive.Content>

--- a/src/components/0_Bruddle/Accordion.tsx
+++ b/src/components/0_Bruddle/Accordion.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import React from 'react'
+import * as AccordionPrimitive from '@radix-ui/react-accordion'
+import { twMerge } from 'tailwind-merge'
+import { Icon } from '../Global/Icons/Icon'
+
+/**
+ * Accordion from the figma accordion board (17802:61540), styled over the
+ * radix headless base. Items are white cards with a bottom border; hover
+ * tints the item, keyboard focus draws the blue ring, disabled items go
+ * gray. Compound API: Accordion > Accordion.Item > Accordion.Trigger +
+ * Accordion.Content.
+ */
+const AccordionRoot = ({ className, ...props }: React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Root>) => (
+    <AccordionPrimitive.Root className={twMerge('flex flex-col gap-2', className)} {...props} />
+)
+
+const AccordionItem = ({ className, ...props }: React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>) => (
+    <AccordionPrimitive.Item
+        className={twMerge(
+            'rounded-sm border-b border-border-default bg-background-default transition-colors duration-instant hover:bg-background-disabled data-[disabled]:border-border-subtle data-[disabled]:bg-background-disabled data-[disabled]:hover:bg-background-disabled',
+            className
+        )}
+        {...props}
+    />
+)
+
+const AccordionTrigger = ({
+    className,
+    children,
+    ...props
+}: React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>) => (
+    <AccordionPrimitive.Header className="flex">
+        <AccordionPrimitive.Trigger
+            className={twMerge(
+                'group flex w-full items-center justify-between gap-2 p-4 text-left text-body-s text-foreground-primary focus-visible:outline-2 focus-visible:outline-action-focus data-[disabled]:text-foreground-secondary',
+                className
+            )}
+            {...props}
+        >
+            {children}
+            <Icon
+                name="chevron-down"
+                size={20}
+                className="shrink-0 transition-transform duration-moderate group-data-[state=open]:rotate-180"
+            />
+        </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+)
+
+const AccordionContent = ({
+    className,
+    children,
+    ...props
+}: React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>) => (
+    <AccordionPrimitive.Content
+        className="overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+        {...props}
+    >
+        <div className={twMerge('border-t border-border-default p-4 text-body-s text-foreground-primary', className)}>
+            {children}
+        </div>
+    </AccordionPrimitive.Content>
+)
+
+export const Accordion = Object.assign(AccordionRoot, {
+    Item: AccordionItem,
+    Trigger: AccordionTrigger,
+    Content: AccordionContent,
+})

--- a/src/components/0_Bruddle/LinkButton.tsx
+++ b/src/components/0_Bruddle/LinkButton.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import React from 'react'
+import Link from 'next/link'
+import { twMerge } from 'tailwind-merge'
+import { Icon } from '../Global/Icons/Icon'
+
+interface LinkButtonProps {
+    /** Link text. */
+    children: React.ReactNode
+    /** Renders a Next.js <Link>. Omit to render a <button> with onClick. */
+    href?: string
+    onClick?: () => void
+    /** Shows the trailing arrow-up-right icon. */
+    icon?: boolean
+    disabled?: boolean
+    /** Opens href in a new tab. */
+    external?: boolean
+    className?: string
+    'data-testid'?: string
+}
+
+/**
+ * Standalone link button from the figma link board (17980:17351): Body/XS
+ * underlined, foreground/secondary at rest, foreground/primary on hover,
+ * optional trailing icon. A lightweight navigation action that sits on its
+ * own — never use it as an action button, and never embed it inline in a
+ * sentence (inline links just underline the surrounding text).
+ */
+export const LinkButton = ({
+    children,
+    href,
+    onClick,
+    icon,
+    disabled,
+    external,
+    className,
+    ...props
+}: LinkButtonProps) => {
+    const classes = twMerge(
+        // after: pseudo-element extends the 16px text row to a 44px hit area
+        'relative inline-flex items-center gap-1 rounded-sm text-body-xs text-foreground-secondary underline transition-colors duration-instant after:absolute after:inset-x-0 after:-inset-y-3.5 hover:text-foreground-primary focus-visible:outline-2 focus-visible:outline-action-focus',
+        disabled && 'pointer-events-none opacity-40',
+        className
+    )
+    const content = (
+        <>
+            {children}
+            {icon && <Icon name="arrow-up-right" size={14} className="shrink-0" />}
+        </>
+    )
+    if (href && !disabled) {
+        return (
+            <Link
+                href={href}
+                onClick={onClick}
+                className={classes}
+                {...(external && { target: '_blank', rel: 'noopener noreferrer' })}
+                {...props}
+            >
+                {content}
+            </Link>
+        )
+    }
+    return (
+        <button type="button" onClick={onClick} disabled={disabled} className={classes} {...props}>
+            {content}
+        </button>
+    )
+}

--- a/src/components/0_Bruddle/LinkButton.tsx
+++ b/src/components/0_Bruddle/LinkButton.tsx
@@ -37,12 +37,18 @@ export const LinkButton = ({
     className,
     ...props
 }: LinkButtonProps) => {
-    const classes = twMerge(
-        // after: pseudo-element extends the 16px text row to a 44px hit area
-        'relative inline-flex items-center gap-1 rounded-sm text-body-xs text-foreground-secondary underline transition-colors duration-instant after:absolute after:inset-x-0 after:-inset-y-3.5 hover:text-foreground-primary focus-visible:outline-2 focus-visible:outline-action-focus',
-        disabled && 'pointer-events-none opacity-40',
-        className
-    )
+    // text-body-xs sits outside twMerge: stock tailwind-merge misreads it as a
+    // text-color class and strips it against text-foreground-secondary
+    const classes =
+        'text-body-xs ' +
+        twMerge(
+            // after: pseudo-element extends the 16px text row to a 44px hit area.
+            // that hit area extends 14px past each edge — keep stacked LinkButtons
+            // at least ~28px apart so hit areas do not overlap.
+            'relative inline-flex items-center gap-1 rounded-sm text-foreground-secondary underline transition-colors duration-instant after:absolute after:inset-x-0 after:-inset-y-3.5 hover:text-foreground-primary focus-visible:outline-2 focus-visible:outline-action-focus',
+            disabled && 'pointer-events-none opacity-40',
+            className
+        )
     const content = (
         <>
             {children}

--- a/src/components/0_Bruddle/Notification.tsx
+++ b/src/components/0_Bruddle/Notification.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import React from 'react'
+import { twMerge } from 'tailwind-merge'
+import { Icon, type IconName } from '../Global/Icons/Icon'
+import { Button } from './Button'
+
+type NotificationPriority = 'info' | 'success' | 'attention' | 'helper' | 'error'
+
+interface NotificationCta {
+    label: string
+    onClick: () => void
+}
+
+interface NotificationProps {
+    /** Sets the tone, background, and leading icon. */
+    priority?: NotificationPriority
+    /** Optional bold first line. Body renders indented under it. */
+    title?: string
+    /** Body text. */
+    children: React.ReactNode
+    /** When set, shows a close button (dismissible variant). */
+    onDismiss?: () => void
+    /** Up to two actions: first renders purple (primary), second stroke (secondary). */
+    ctas?: NotificationCta[]
+    className?: string
+    'data-testid'?: string
+}
+
+const PRIORITY_STYLES: Record<NotificationPriority, { icon: IconName; bg: string }> = {
+    info: { icon: 'info', bg: 'bg-background-badge-info' },
+    success: { icon: 'check', bg: 'bg-background-badge-success' },
+    attention: { icon: 'alert', bg: 'bg-background-badge-attention' },
+    helper: { icon: 'info', bg: 'bg-background-badge-helper' },
+    error: { icon: 'error', bg: 'bg-background-badge-error' },
+}
+
+const CTA_VARIANTS = ['purple', 'stroke'] as const
+
+/**
+ * Inline notification banner from the figma notification board (17802:61535):
+ * priority (info/success/attention/helper/error) sets the tone and icon;
+ * supports body or title + body, optional dismiss, and up to two CTAs.
+ */
+export const Notification = ({
+    priority = 'info',
+    title,
+    children,
+    onDismiss,
+    ctas,
+    className,
+    ...props
+}: NotificationProps) => {
+    const { icon, bg } = PRIORITY_STYLES[priority]
+    return (
+        <div
+            role={priority === 'error' || priority === 'attention' ? 'alert' : 'status'}
+            className={twMerge(
+                'flex items-start gap-2 rounded-sm border border-foreground-over-color-secondary p-3 text-foreground-over-color-secondary',
+                bg,
+                className
+            )}
+            {...props}
+        >
+            <div className="flex min-w-0 flex-1 flex-col gap-2">
+                <div className="flex items-center gap-2">
+                    <Icon name={icon} size={20} className="shrink-0" />
+                    {title ? (
+                        <span className="text-body-m-semibold">{title}</span>
+                    ) : (
+                        <span className="text-body-m">{children}</span>
+                    )}
+                </div>
+                {title && <div className="pl-7 text-body-m">{children}</div>}
+                {!!ctas?.length && (
+                    <div className="flex gap-2 pl-7">
+                        {ctas.slice(0, 2).map((cta, i) => (
+                            <Button
+                                key={cta.label}
+                                size="small"
+                                variant={CTA_VARIANTS[i]}
+                                icon="chevron-right"
+                                iconPosition="right"
+                                onClick={cta.onClick}
+                                className="w-auto min-w-28"
+                            >
+                                {cta.label}
+                            </Button>
+                        ))}
+                    </div>
+                )}
+            </div>
+            {onDismiss && (
+                <button
+                    type="button"
+                    aria-label="Dismiss"
+                    onClick={onDismiss}
+                    className="-m-2.5 flex size-11 shrink-0 items-center justify-center rounded-round text-foreground-over-color-secondary"
+                >
+                    <Icon name="cancel" size={16} />
+                </button>
+            )}
+        </div>
+    )
+}

--- a/src/components/0_Bruddle/Notification.tsx
+++ b/src/components/0_Bruddle/Notification.tsx
@@ -73,7 +73,7 @@ export const Notification = ({
                 </div>
                 {title && <div className="pl-7 text-body-m">{children}</div>}
                 {!!ctas?.length && (
-                    <div className="flex gap-2 pl-7">
+                    <div className="flex flex-wrap gap-2 pl-7">
                         {ctas.slice(0, 2).map((cta, i) => (
                             <Button
                                 key={cta.label}

--- a/src/components/0_Bruddle/Notification.tsx
+++ b/src/components/0_Bruddle/Notification.tsx
@@ -21,8 +21,8 @@ interface NotificationProps {
     children: React.ReactNode
     /** When set, shows a close button (dismissible variant). */
     onDismiss?: () => void
-    /** Up to two actions: first renders purple (primary), second stroke (secondary). */
-    ctas?: NotificationCta[]
+    /** One or two actions: first renders purple (primary), second stroke (secondary). */
+    ctas?: [NotificationCta] | [NotificationCta, NotificationCta]
     className?: string
     'data-testid'?: string
 }
@@ -76,7 +76,7 @@ export const Notification = ({
                     <div className="flex flex-wrap gap-2 pl-7">
                         {ctas.slice(0, 2).map((cta, i) => (
                             <Button
-                                key={cta.label}
+                                key={i}
                                 size="small"
                                 variant={CTA_VARIANTS[i]}
                                 icon="chevron-right"

--- a/src/components/0_Bruddle/__tests__/Accordion.test.tsx
+++ b/src/components/0_Bruddle/__tests__/Accordion.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { Accordion } from '../Accordion'
+
+const renderAccordion = () =>
+    render(
+        <Accordion type="single" collapsible>
+            <Accordion.Item value="one">
+                <Accordion.Trigger>First section</Accordion.Trigger>
+                <Accordion.Content>First content</Accordion.Content>
+            </Accordion.Item>
+            <Accordion.Item value="two" disabled>
+                <Accordion.Trigger>Disabled section</Accordion.Trigger>
+                <Accordion.Content>Hidden content</Accordion.Content>
+            </Accordion.Item>
+        </Accordion>
+    )
+
+describe('Accordion', () => {
+    test('starts collapsed, expands on trigger click, collapses on second click', () => {
+        renderAccordion()
+        expect(screen.queryByText('First content')).not.toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button', { name: /First section/ }))
+        expect(screen.getByText('First content')).toBeVisible()
+
+        fireEvent.click(screen.getByRole('button', { name: /First section/ }))
+        expect(screen.queryByText('First content')).not.toBeInTheDocument()
+    })
+
+    test('disabled item cannot be expanded', () => {
+        renderAccordion()
+        const trigger = screen.getByRole('button', { name: /Disabled section/ })
+        expect(trigger).toBeDisabled()
+        fireEvent.click(trigger)
+        expect(screen.queryByText('Hidden content')).not.toBeInTheDocument()
+    })
+})

--- a/src/components/0_Bruddle/__tests__/LinkButton.test.tsx
+++ b/src/components/0_Bruddle/__tests__/LinkButton.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { LinkButton } from '../LinkButton'
+
+describe('LinkButton', () => {
+    test('renders a link when href is set', () => {
+        render(<LinkButton href="/history">View transaction</LinkButton>)
+        expect(screen.getByRole('link', { name: /View transaction/ })).toHaveAttribute('href', '/history')
+    })
+
+    test('renders a button when no href, wires onClick', () => {
+        const onClick = jest.fn()
+        render(<LinkButton onClick={onClick}>See details</LinkButton>)
+        fireEvent.click(screen.getByRole('button', { name: /See details/ }))
+        expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    test('disabled wins over href: renders a disabled button, not a link', () => {
+        render(
+            <LinkButton href="/history" disabled>
+                View transaction
+            </LinkButton>
+        )
+        expect(screen.queryByRole('link')).not.toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /View transaction/ })).toBeDisabled()
+    })
+
+    test('external adds new-tab attributes', () => {
+        render(
+            <LinkButton href="https://docs.peanut.me" external>
+                Docs
+            </LinkButton>
+        )
+        const link = screen.getByRole('link', { name: /Docs/ })
+        expect(link).toHaveAttribute('target', '_blank')
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    })
+})

--- a/src/components/0_Bruddle/__tests__/Notification.test.tsx
+++ b/src/components/0_Bruddle/__tests__/Notification.test.tsx
@@ -36,15 +36,15 @@ describe('Notification', () => {
 
     test('renders at most two CTAs and wires their clicks', () => {
         const first = jest.fn()
+        // the tuple type caps ctas at two at compile time; the cast proves the
+        // runtime slice also guards plain-js callers
+        const threeCtas = [
+            { label: 'One', onClick: first },
+            { label: 'Two', onClick: () => {} },
+            { label: 'Three', onClick: () => {} },
+        ] as unknown as [{ label: string; onClick: () => void }]
         render(
-            <Notification
-                priority="success"
-                ctas={[
-                    { label: 'One', onClick: first },
-                    { label: 'Two', onClick: () => {} },
-                    { label: 'Three', onClick: () => {} },
-                ]}
-            >
+            <Notification priority="success" ctas={threeCtas}>
                 Done
             </Notification>
         )

--- a/src/components/0_Bruddle/__tests__/Notification.test.tsx
+++ b/src/components/0_Bruddle/__tests__/Notification.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { Notification } from '../Notification'
+
+describe('Notification', () => {
+    test('body-only renders as a status with the body text', () => {
+        render(<Notification priority="info">Just letting you know</Notification>)
+        expect(screen.getByRole('status')).toHaveTextContent('Just letting you know')
+    })
+
+    test('error and attention priorities render as alerts', () => {
+        render(<Notification priority="error">Something went wrong</Notification>)
+        expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+
+    test('title + body renders both, no dismiss button unless onDismiss is set', () => {
+        render(
+            <Notification priority="attention" title="Heads up">
+                Body text
+            </Notification>
+        )
+        expect(screen.getByText('Heads up')).toBeInTheDocument()
+        expect(screen.getByText('Body text')).toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: 'Dismiss' })).not.toBeInTheDocument()
+    })
+
+    test('dismiss button calls onDismiss', () => {
+        const onDismiss = jest.fn()
+        render(
+            <Notification priority="info" onDismiss={onDismiss}>
+                Bye
+            </Notification>
+        )
+        fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+        expect(onDismiss).toHaveBeenCalledTimes(1)
+    })
+
+    test('renders at most two CTAs and wires their clicks', () => {
+        const first = jest.fn()
+        render(
+            <Notification
+                priority="success"
+                ctas={[
+                    { label: 'One', onClick: first },
+                    { label: 'Two', onClick: () => {} },
+                    { label: 'Three', onClick: () => {} },
+                ]}
+            >
+                Done
+            </Notification>
+        )
+        expect(screen.getByRole('button', { name: /One/ })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /Two/ })).toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: /Three/ })).not.toBeInTheDocument()
+        fireEvent.click(screen.getByRole('button', { name: /One/ }))
+        expect(first).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/components/Global/Slider/index.tsx
+++ b/src/components/Global/Slider/index.tsx
@@ -62,7 +62,7 @@ function Slider({
 
     return (
         <div className="w-full">
-            <div className="mb-2 flex w-full items-center justify-between text-xs font-bold">
+            <div className="mb-2 flex w-full items-center justify-between text-body-s text-foreground-primary">
                 <p>0%</p>
                 <p>120%</p>
             </div>
@@ -81,30 +81,31 @@ function Slider({
             >
                 <SliderPrimitive.Track
                     data-slot="slider-track"
-                    className="relative h-1.5 w-full overflow-visible rounded-full bg-grey-2"
+                    className="relative h-1.5 w-full overflow-visible rounded-full bg-border-disabled"
                 >
                     <SliderPrimitive.Range
                         data-slot="slider-range"
-                        className="absolute h-full rounded-full bg-primary-1 transition-all duration-150 ease-out"
+                        className="absolute h-full rounded-full bg-action-primary transition-all duration-fast ease-out"
                     />
                 </SliderPrimitive.Track>
 
                 <SliderPrimitive.Thumb
                     data-slot="slider-thumb"
                     className={twMerge(
-                        'relative isolate block size-4 cursor-pointer rounded-full bg-white shadow-lg ring-0 transition-all duration-150 ease-out outline-none disabled:pointer-events-none disabled:opacity-50'
+                        // after: pseudo-element extends the 16px thumb to a 44px hit area
+                        'relative isolate block size-4 cursor-pointer rounded-full transition-all duration-fast ease-out outline-none after:absolute after:-inset-3.5 focus-visible:outline-2 focus-visible:outline-action-focus disabled:pointer-events-none disabled:opacity-50'
                     )}
                 >
-                    {/* Vertical tick mark - only visible when at a snap point */}
+                    {/* Vertical snap tick - only visible when at a snap point */}
                     {activeSnapPoint !== undefined && (
-                        <div className="pointer-events-none absolute top-1/2 left-1/2 z-0 h-6 w-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary-1 transition-all duration-150" />
+                        <div className="pointer-events-none absolute top-1/2 left-1/2 z-0 h-6 w-1 -translate-x-1/2 -translate-y-1/2 rounded-sm bg-action-primary transition-all duration-fast" />
                     )}
 
                     {/* White circle with border on top of the tick */}
-                    <div className="absolute inset-0 z-10 rounded-full border-2 border-black bg-white" />
+                    <div className="shadow-2 absolute inset-0 z-10 rounded-full border border-border-default bg-background-default" />
 
                     {/* Current value label */}
-                    <div className="absolute top-full left-1/2 z-20 mt-2 -translate-x-1/2 text-xs whitespace-nowrap text-black">
+                    <div className="absolute top-full left-1/2 z-20 mt-2 -translate-x-1/2 text-label-l whitespace-nowrap text-foreground-primary">
                         {internalValue[0] % 1 === 0 ? internalValue[0].toFixed(0) : internalValue[0].toFixed(2)}%
                     </div>
                 </SliderPrimitive.Thumb>

--- a/src/components/Global/Slider/index.tsx
+++ b/src/components/Global/Slider/index.tsx
@@ -12,6 +12,8 @@ function Slider({
     defaultValue = [100],
     value: controlledValue,
     onValueChange,
+    // radix renders role="slider" on the Thumb, so the accessible name must land there
+    'aria-label': ariaLabel,
     ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
     // Use internal state for the slider value to enable magnetic snapping
@@ -91,6 +93,7 @@ function Slider({
 
                 <SliderPrimitive.Thumb
                     data-slot="slider-thumb"
+                    aria-label={ariaLabel}
                     className={twMerge(
                         // after: pseudo-element extends the 16px thumb to a 44px hit area
                         'relative isolate block size-4 cursor-pointer rounded-full transition-all duration-fast ease-out outline-none after:absolute after:-inset-3.5 focus-visible:outline-2 focus-visible:outline-action-focus disabled:pointer-events-none disabled:opacity-50'

--- a/src/components/Global/Slider/index.tsx
+++ b/src/components/Global/Slider/index.tsx
@@ -16,8 +16,10 @@ function Slider({
     'aria-label': ariaLabel,
     ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
-    // Use internal state for the slider value to enable magnetic snapping
-    const [internalValue, setInternalValue] = React.useState<number[]>(defaultValue || controlledValue)
+    // Use internal state for the slider value to enable magnetic snapping.
+    // Seed from the controlled value when given, so a controlled slider does
+    // not first paint at defaultValue (100) and visibly jump after mount.
+    const [internalValue, setInternalValue] = React.useState<number[]>(controlledValue ?? defaultValue)
 
     // Sync internal state when controlled value changes from external source.
     // The parent derives the controlled value from a cent-rounded amount, so a
@@ -96,7 +98,9 @@ function Slider({
                     aria-label={ariaLabel}
                     className={twMerge(
                         // after: pseudo-element extends the 16px thumb to a 44px hit area
-                        'relative isolate block size-4 cursor-pointer rounded-full transition-all duration-fast ease-out outline-none after:absolute after:-inset-3.5 focus-visible:outline-2 focus-visible:outline-action-focus disabled:pointer-events-none disabled:opacity-50'
+                        // outline-none poisons --tw-outline-style, so the ring needs an
+                        // explicit focus-visible:outline-solid to paint (globals.css convention)
+                        'relative isolate block size-4 cursor-pointer rounded-full transition-all duration-fast ease-out outline-none after:absolute after:-inset-3.5 focus-visible:outline-2 focus-visible:outline-action-focus focus-visible:outline-solid disabled:pointer-events-none disabled:opacity-50'
                     )}
                 >
                     {/* Vertical snap tick - only visible when at a snap point */}

--- a/src/features/limits/views/BridgeLimitsView.tsx
+++ b/src/features/limits/views/BridgeLimitsView.tsx
@@ -107,7 +107,7 @@ const BridgeLimitsView = () => {
                                             <div className="flex items-center gap-2">
                                                 <Image
                                                     src={country.flag}
-                                                    alt={country.name}
+                                                    alt=""
                                                     width={24}
                                                     height={24}
                                                     className="size-5 rounded-full object-cover"

--- a/src/features/limits/views/BridgeLimitsView.tsx
+++ b/src/features/limits/views/BridgeLimitsView.tsx
@@ -8,7 +8,7 @@ import { useSafeBack } from '@/hooks/useSafeBack'
 import { MAX_QR_PAYMENT_AMOUNT_FOREIGN } from '@/constants/payment.consts'
 import { useTranslations } from 'next-intl'
 import Image from 'next/image'
-import * as Accordion from '@radix-ui/react-accordion'
+import { Accordion } from '@/components/0_Bruddle/Accordion'
 import { useQueryState, parseAsStringEnum } from 'nuqs'
 import { useState, useMemo } from 'react'
 import Loading from '@/components/Global/Loading'
@@ -95,52 +95,39 @@ const BridgeLimitsView = () => {
                     {!hasMantecaLimits && (
                         <div className="space-y-2">
                             <h3 className="font-bold">{t('qrPaymentLimits')}</h3>
-                            <Card position="single" className="p-0">
-                                <Accordion.Root
-                                    type="single"
-                                    collapsible
-                                    value={expandedCountry}
-                                    onValueChange={(value) => setExpandedCountry(value as QrCountryId | undefined)}
-                                >
-                                    {qrCountries.map((country, index) => (
-                                        <Accordion.Item
-                                            key={country.id}
-                                            value={country.id}
-                                            className={index < qrCountries.length - 1 ? 'border-b border-gray-2' : ''}
-                                        >
-                                            <Accordion.Header>
-                                                <Accordion.Trigger className="group flex w-full items-center justify-between px-4 py-3">
-                                                    <div className="flex items-center gap-2">
-                                                        <Image
-                                                            src={country.flag}
-                                                            alt={country.name}
-                                                            width={24}
-                                                            height={24}
-                                                            className="size-5 rounded-full object-cover"
-                                                        />
-                                                        <span className="text-sm font-medium">{country.name}</span>
-                                                    </div>
-                                                    <Icon
-                                                        name="chevron-down"
-                                                        size={16}
-                                                        className="transition-transform duration-300 group-data-[state=open]:rotate-180"
-                                                    />
-                                                </Accordion.Trigger>
-                                            </Accordion.Header>
-                                            <Accordion.Content className="overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
-                                                <div className="flex items-center gap-2 px-4 pb-3">
-                                                    <Icon name="check" className="text-success-1" size={16} />
-                                                    <span className="text-sm">
-                                                        {t('qrPayLimit', {
-                                                            amount: `$${MAX_QR_PAYMENT_AMOUNT_FOREIGN.toLocaleString()}`,
-                                                        })}
-                                                    </span>
-                                                </div>
-                                            </Accordion.Content>
-                                        </Accordion.Item>
-                                    ))}
-                                </Accordion.Root>
-                            </Card>
+                            <Accordion
+                                type="single"
+                                collapsible
+                                value={expandedCountry}
+                                onValueChange={(value) => setExpandedCountry(value as QrCountryId | undefined)}
+                            >
+                                {qrCountries.map((country) => (
+                                    <Accordion.Item key={country.id} value={country.id}>
+                                        <Accordion.Trigger>
+                                            <div className="flex items-center gap-2">
+                                                <Image
+                                                    src={country.flag}
+                                                    alt={country.name}
+                                                    width={24}
+                                                    height={24}
+                                                    className="size-5 rounded-full object-cover"
+                                                />
+                                                <span>{country.name}</span>
+                                            </div>
+                                        </Accordion.Trigger>
+                                        <Accordion.Content>
+                                            <div className="flex items-center gap-2">
+                                                <Icon name="check" className="text-success-1" size={16} />
+                                                <span>
+                                                    {t('qrPayLimit', {
+                                                        amount: `$${MAX_QR_PAYMENT_AMOUNT_FOREIGN.toLocaleString()}`,
+                                                    })}
+                                                </span>
+                                            </div>
+                                        </Accordion.Content>
+                                    </Accordion.Item>
+                                ))}
+                            </Accordion>
                         </div>
                     )}
 


### PR DESCRIPTION
## Summary

Build the four missing DS components from the figma boards (file `IBevOyWuFyP3KcEYuQufi1`), so every board in the design.md map has a code counterpart except the carousel (pending ownership decision, untouched here).

- **Notification** (`0_Bruddle/Notification.tsx`, board `17802:61535`) — inline banner. 5 priorities (`info` / `success` / `attention` / `helper` / `error`) on the `background-badge-*` tokens, body or title + body, optional dismiss, up to 2 CTAs. CTAs reuse `Button size="small"` (purple then stroke). Placed in `0_Bruddle` next to Toast/Toggle because it is a leaf primitive with no app state. **No prod consumer yet** — the board is new and `Global/Banner` is a marquee, a different pattern. The `/dev/ds` page is the consumer for now; first real consumer lands with a page rebuild.
- **LinkButton** (`0_Bruddle/LinkButton.tsx`, board `17980:17351`) — standalone underlined navigation link, Body/XS, `foreground-secondary` at rest → `foreground-primary` on hover, optional trailing `arrow-up-right`, 44px hit area via pseudo-element. Renders a Next `Link` when `href` is set, a button otherwise.
- **Accordion** (`0_Bruddle/Accordion.tsx`, board `17802:61540`) — styled compound wrapper (`Accordion` / `.Item` / `.Trigger` / `.Content`) over the radix headless base. Hover tint, focus ring, disabled state, built-in chevron + expand animation. `BridgeLimitsView` (the only radix-accordion consumer) migrated off its inline styling.
- **Slider** (`Global/Slider/index.tsx`, board `17802:61531`) — restyle to tokens: track `border-disabled`, fill + snap tick `action-primary`, thumb white circle with `border-default` + `shadow-2` and a 44px hit area, value label `label-l`. The magnetic-snap logic (and its regression test) is untouched. Consumer (`AmountInput` in contribute-pot) needs no change.

Each component has a `/dev/ds` page with all board variants (primitives: notification, link-button, accordion; patterns: slider — grouped by folder convention: Global composites live under patterns). Nav wiring is additive-only (new rows + new pages) to limit conflicts with the concurrent `ds/07-home-rebuild` branch.

## Tasks

- DS 19 notification — https://app.notion.com/p/3c083811757981f982aee67a749f3bf5
- DS 20 link button — https://app.notion.com/p/3c0838117579817ea49bfcc8e9d43ca1
- DS 21 accordion restyle — https://app.notion.com/p/3c083811757981db9c38f1eba4ac7ace
- DS 22 slider restyle — https://app.notion.com/p/3c08381175798196801fcb17be3cd4d4

## ❓ Design decision needed — link color law conflict

The link board (`17980:17351`) colors links **`foreground/secondary` (gray) at rest, black on hover**. The standing app law (design.md "component quick facts") says links are **`text-black underline`**. This PR implements the board (component-level figma truth wins per the sync rule) and flags the conflict instead of silently deciding. If the board wins, the design.md law line and existing `text-black underline` call-sites need a follow-up; if the law wins, `LinkButton` needs a one-line color change.

## Design notes / accepted trade-offs

- Notification CTA height is 40px (`Button size="small"`) vs the board's 38px — reusing the Button primitive beats a bespoke 38px pill.
- Focus rings use `outline-2` (board draws 3px) — the stock utility avoids adding new arbitrary-value classes that the ds-lint ratchet counts.
- Slider labels read 0%–120% (consumer allows 120% of the suggested amount); the board tops out at 100%. Noted on the /dev/ds page.
- Board's `Notification` board also defines a hidden "Toast" column — existing `0_Bruddle/Toast` stays as-is; only the inline notification is in scope here.
- **`Global/InfoCard` overlap:** InfoCard's ds-06 variant pass reused the same `background-badge-*` tokens, so the codebase now has two banner-ish components on the board's palette. InfoCard is a legacy kitchen-sink card (items lists, custom content, ~23 consumers, borderless) — not the board component. Follow-up: migrate InfoCard consumers to `Notification` during page rebuilds, then retire InfoCard. Not bundled here.
- **/limits mixed card treatments:** the fiat-limits `Global/Card` (full black frame) now sits above board-style accordion items (border-b only). The accordion follows its board; the sibling card migrates with the limits page rebuild. ❓ flagged for design eyes.

## Risks / breaking changes

- Low. New components have no prod consumers yet. Behavior-affecting changes are limited to two consumers: `BridgeLimitsView` (accordion visuals — QR-limits list now renders as board-style items instead of rows inside one Card) and the contribute-pot slider (visuals only, same interaction).
- No cross-repo impact, no API changes, no migrations.

## QA

- `npm test` 241/241 suites (13 new tests: Notification roles/dismiss/CTA cap, LinkButton link-vs-button/disabled/external, Accordion expand/collapse/disabled).
- `npm run typecheck`, `pnpm prettier --check .`, `npm run build` green.
- `node scripts/ds-lint-counts.mjs --check`: only the pre-existing `inlineStyle 211 > 207` baseline failure (present on `feat/design-system` before this branch; this PR adds zero inline styles, and `stockTextSize` / `nonDsClassesInViews` go down).
- Visual check on `/dev/ds` (screenshots below) + `/limits` bridge view.

## Screenshots

/dev/ds pages at 375px (full pages, all board variants). Assets branch `pr-assets-2733` — delete after merge.

| Notification | LinkButton |
|---|---|
| <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2733/ds-notification.png" width="320"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2733/ds-link-button.png" width="320"> |

| Accordion | Slider |
|---|---|
| <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2733/ds-accordion.png" width="320"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2733/ds-slider.png" width="320"> |
