### PR TITLE
ci(content): scope the org-admin PAT to a main-only environment

### DIFF
--- a/.github/workflows/content-publish-automerge.yml
+++ b/.github/workflows/content-publish-automerge.yml
@@ -49,6 +49,14 @@ permissions:
 
 jobs:
     approve-and-merge:
+        # Read CONTENT_BOT_TOKEN from the `content-publish` environment, whose
+        # deployment branch policy allows `main` only. The token is an org admin
+        # (it needs the bypass to merge), and a dozen workflows in this repo carry
+        # `workflow_dispatch`, which runs a workflow FROM THE DISPATCHED REF. As a
+        # plain repo secret it was therefore readable by anyone with write access:
+        # push a branch with a workflow that echoes it, dispatch that branch, done.
+        # Scoped to the environment it is unreachable from any ref but `main`.
+        environment: content-publish
         # Same-repo PRs only — never a fork.
         if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository
         runs-on: ubuntu-latest
@@ -94,6 +102,14 @@ jobs:
                   fi
 
     merge-on-green:
+        # Read CONTENT_BOT_TOKEN from the `content-publish` environment, whose
+        # deployment branch policy allows `main` only. The token is an org admin
+        # (it needs the bypass to merge), and a dozen workflows in this repo carry
+        # `workflow_dispatch`, which runs a workflow FROM THE DISPATCHED REF. As a
+        # plain repo secret it was therefore readable by anyone with write access:
+        # push a branch with a workflow that echoes it, dispatch that branch, done.
+        # Scoped to the environment it is unreachable from any ref but `main`.
+        environment: content-publish
         # Self-approval fallback. Fires when `Tests` finishes for any commit; the
         # job itself works out whether there's a content publish to merge.
         if: github.event_name == 'workflow_run'

--- a/.github/workflows/update-content.yml
+++ b/.github/workflows/update-content.yml
@@ -20,6 +20,14 @@ concurrency:
 
 jobs:
     update:
+        # Read CONTENT_BOT_TOKEN from the `content-publish` environment, whose
+        # deployment branch policy allows `main` only. The token is an org admin
+        # (it needs the bypass to merge), and a dozen workflows in this repo carry
+        # `workflow_dispatch`, which runs a workflow FROM THE DISPATCHED REF. As a
+        # plain repo secret it was therefore readable by anyone with write access:
+        # push a branch with a workflow that echoes it, dispatch that branch, done.
+        # Scoped to the environment it is unreachable from any ref but `main`.
+        environment: content-publish
         runs-on: ubuntu-latest
         steps:
             # Base the bump on `main` — the branch peanut.me actually deploys from.


### PR DESCRIPTION
## Summary

`CONTENT_BOT_TOKEN` is an **org-admin PAT** and has to be — merging a content publish depends on the ruleset bypass. As a plain repo secret, anyone with write access to peanut-ui can read it: **12 workflows here carry `workflow_dispatch`**, and a dispatch runs the workflow *from the dispatched ref*. Push a branch whose workflow echoes the secret, dispatch that branch, done. Dropping `workflow_dispatch` from one file fixes nothing — the attacker brings their own workflow.

This moves it behind the `content-publish` environment, whose deployment branch policy allows **`main` only**. All three jobs that legitimately need it already run from main (`repository_dispatch`, `pull_request_target` and `workflow_run` all resolve `github.ref` to the default branch), so they keep working while any other ref is refused the secret.

Found while auditing unverified commits across the org (TASK-21002); unrelated to signing, and pre-existing.

## This PR alone changes nothing

It lands the `environment:` keys. Repo-level secrets remain and still take precedence, so the pipeline behaves exactly as today. Two manual steps finish it:

1. Add `CONTENT_BOT_TOKEN` as a secret **on the `content-publish` environment** (by hand — secrets are write-only, so it cannot be copied programmatically).
2. Delete the repo-level `CONTENT_BOT_TOKEN` and `CONTENT_BOT_SIGNING_KEY`.

`CONTENT_BOT_SIGNING_KEY` is already in the environment.

## Risk

Low while unmerged-and-unfinished; the real risk is step 2. If the environment lacks the token when the repo-level copy is deleted, content publishing stops — loudly, and the manual `publish-to-prod.sh` path still works. Verify with one real publish before deleting.

Screenshots: N/A (CI only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved content publishing safeguards by applying deployment environment controls to automated publishing and update workflows.
  * Restricted access to publishing credentials based on approved deployment branch policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->