### PR TITLE
fix(sentry): stop dropping the errors behind "contact support" on sends

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -57,6 +57,12 @@ if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'development') {
             sampleRate: 1.0,
             tracesSampleRate: 0.1,
             beforeSend: beforeSendHandler,
+            // A WebView that can't reach the bundler can't reach ingest either,
+            // so the report of the failure died with the session. The offline
+            // transport parks undeliverable envelopes in IndexedDB and flushes
+            // them on a later launch — the failures worth reading are exactly
+            // the ones that happen while the network is misbehaving.
+            transport: Sentry.makeBrowserOfflineTransport(Sentry.makeFetchTransport),
             integrations: [Sentry.captureConsoleIntegration({ levels: ['error', 'warn'] })],
         })
     }

--- a/sentry.utils.test.ts
+++ b/sentry.utils.test.ts
@@ -1,9 +1,16 @@
 import type { ErrorEvent } from '@sentry/nextjs'
 import { shouldIgnoreError } from './sentry.utils'
+import { criticalFlowTags } from '@/utils/sentry-critical-flow'
 
-function eventWith(partial: { message?: string; type?: string; value?: string }): ErrorEvent {
+function eventWith(partial: {
+    message?: string
+    type?: string
+    value?: string
+    tags?: Record<string, string>
+}): ErrorEvent {
     return {
         message: partial.message,
+        tags: partial.tags,
         exception: { values: [{ type: partial.type, value: partial.value }] },
     } as unknown as ErrorEvent
 }
@@ -19,5 +26,29 @@ describe('shouldIgnoreError — alreadyReported (fetchWithSentry wrapper)', () =
 
     it('does not ignore an unrelated application error', () => {
         expect(shouldIgnoreError(eventWith({ type: 'TypeError', value: 'x is not a function' }))).toBe(false)
+    })
+})
+
+describe('shouldIgnoreError — critical-flow captures', () => {
+    const tags = criticalFlowTags('direct-send')
+
+    it('ignores a network failure with no critical-flow tag', () => {
+        expect(shouldIgnoreError(eventWith({ type: 'HttpRequestError', value: 'Details: Failed to fetch' }))).toBe(true)
+    })
+
+    it('keeps the same failure when captured from a money-moving flow', () => {
+        expect(
+            shouldIgnoreError(eventWith({ type: 'HttpRequestError', value: 'Details: Failed to fetch', tags }))
+        ).toBe(false)
+    })
+
+    it('keeps a wrapped ServiceUnavailableError from a money-moving flow', () => {
+        expect(shouldIgnoreError(eventWith({ type: 'ServiceUnavailableError', value: 'upstream 503', tags }))).toBe(
+            false
+        )
+    })
+
+    it('still ignores user cancellations, tagged or not', () => {
+        expect(shouldIgnoreError(eventWith({ type: 'Error', value: 'User rejected the request', tags }))).toBe(true)
     })
 })

--- a/sentry.utils.ts
+++ b/sentry.utils.ts
@@ -3,6 +3,8 @@
 
 import type { ErrorEvent } from '@sentry/nextjs'
 
+import { CRITICAL_FLOW_TAG } from '@/utils/sentry-critical-flow'
+
 /**
  * Patterns to filter out from Sentry reporting.
  * These are generally noise that doesn't require action.
@@ -63,6 +65,10 @@ const IGNORED_ERRORS = {
  * Check if error message matches any ignored pattern
  */
 export function shouldIgnoreError(event: ErrorEvent): boolean {
+    // Explicit captures from money-moving flows are never noise. Cancellations
+    // stay filtered even there — a user backing out of the passkey sheet is not
+    // a defect, and those would drown out the real failures.
+    const isCriticalFlow = Boolean(event.tags?.[CRITICAL_FLOW_TAG])
     const message = event.message || ''
     const exceptionValue = event.exception?.values?.[0]?.value || ''
     const exceptionType = event.exception?.values?.[0]?.type || ''
@@ -73,13 +79,16 @@ export function shouldIgnoreError(event: ErrorEvent): boolean {
     const searchTexts = [message, exceptionValue, exceptionType, culprit]
 
     // Check all ignore patterns
-    for (const patterns of Object.values(IGNORED_ERRORS)) {
+    for (const [group, patterns] of Object.entries(IGNORED_ERRORS)) {
+        if (isCriticalFlow && group !== 'userRejected') continue
         for (const pattern of patterns) {
             if (searchTexts.some((text) => text.toLowerCase().includes(pattern.toLowerCase()))) {
                 return true
             }
         }
     }
+
+    if (isCriticalFlow) return false
 
     // Ignore errors from browser extensions (client-side only, but safe to check everywhere)
     const frames = event.exception?.values?.[0]?.stacktrace?.frames || []

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -52,6 +52,9 @@ export const ANALYTICS_EVENTS = {
 
     // ── Send ──
     SEND_METHOD_SELECTED: 'send_method_selected',
+    // Emitted for every direct send that ends in the error toast, whatever the
+    // step. Until this existed a failed send left no analytics trace at all.
+    SEND_FAILED: 'send_failed',
 
     // ── Send Link ──
     SEND_LINK_CREATED: 'send_link_created',

--- a/src/features/payments/flows/direct-send/useDirectSendFlow.ts
+++ b/src/features/payments/flows/direct-send/useDirectSendFlow.ts
@@ -22,6 +22,10 @@ import { useAuth } from '@/context/authContext'
 import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN, PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
 import { useFriendlyError } from '@/hooks/useFriendlyError'
 import { useTranslations } from 'next-intl'
+import { captureException } from '@sentry/nextjs'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { criticalFlowTags } from '@/utils/sentry-critical-flow'
 
 export function useDirectSendFlow() {
     const t = useTranslations('payment')
@@ -119,6 +123,9 @@ export function useDirectSendFlow() {
         setIsLoading(true)
         clearError()
 
+        let failedStep: 'create-charge' | 'send-money' | 'record-payment' = 'create-charge'
+        let chargeId: string | undefined
+
         try {
             // step 1: create charge
             const chargeResult = await createCharge({
@@ -136,6 +143,8 @@ export function useDirectSendFlow() {
             })
 
             setCharge(chargeResult)
+            chargeId = chargeResult.uuid
+            failedStep = 'send-money'
 
             // step 2: send money via peanut wallet
             const txResult = await sendMoney(recipient.address, amount, {
@@ -153,6 +162,7 @@ export function useDirectSendFlow() {
             const hash = (txResult.receipt?.transactionHash ?? txResult.userOpHash ?? txResult.txHash) as Hash
 
             setTxHash(hash)
+            failedStep = 'record-payment'
 
             // step 3: record payment to backend
             const paymentResult = await recordPayment({
@@ -169,6 +179,28 @@ export function useDirectSendFlow() {
         } catch (err) {
             const errorMessage = toFriendlyError(err)
             setError({ showError: true, errorMessage })
+
+            // Report here, at the flow level, rather than relying on the
+            // console-capture integration: everything below this catch either
+            // console.errors (which the noise filters then drop) or reports
+            // only WebAuthn-named failures to PostHog, so a send that ended in
+            // "contact support" left no queryable record anywhere.
+            const errorName = err instanceof Error ? err.name : 'unknown'
+            posthog.capture(ANALYTICS_EVENTS.SEND_FAILED, {
+                step: failedStep,
+                charge_id: chargeId,
+                error_name: errorName,
+            })
+            captureException(err, {
+                tags: { ...criticalFlowTags('direct-send'), send_step: failedStep },
+                extra: {
+                    chargeId,
+                    recipientAddress: recipient.address,
+                    amount,
+                    usdAmount,
+                    userId: user?.user?.userId,
+                },
+            })
         } finally {
             setIsLoading(false)
         }
@@ -190,6 +222,7 @@ export function useDirectSendFlow() {
         setIsLoading,
         clearError,
         toFriendlyError,
+        user,
         t,
     ])
 

--- a/src/utils/sentry-critical-flow.ts
+++ b/src/utils/sentry-critical-flow.ts
@@ -1,0 +1,16 @@
+/**
+ * Tag marking an event as an explicit capture from a money-moving flow (send,
+ * withdraw, card spend). `beforeSendHandler` exempts tagged events from the
+ * noise filters in sentry.utils.ts, because there the "noise" IS the signal:
+ * a send that dies on a failed fetch was being dropped by the `networkIssues`
+ * filter, leaving the user with "contact support" and us with nothing to look
+ * at.
+ *
+ * Its own module rather than sentry.utils.ts: the root file is loaded by the
+ * server and edge configs too, so it must not reach into app-layer modules.
+ */
+export const CRITICAL_FLOW_TAG = 'critical_flow'
+
+export function criticalFlowTags(flow: string): Record<string, string> {
+    return { [CRITICAL_FLOW_TAG]: flow }
+}


### PR DESCRIPTION
## Why

A user hit the generic **"There was an issue with your request. Please contact support."** toast on a $1 send. The failure left no trace: nothing in the backend (every request from her IP was 2xx), nothing on chain (no UserOperation), nothing in PostHog, nothing in Sentry.

Native reporting itself is fine — her device (`environment:native`, release `60e0e52` = mobile-release 1.0.43) delivered 6 Sentry events 20 minutes before the failed send, and native produces ~980 events/day. The blind spot is specific to the send path:

1. **The only Sentry path was a console.error.** `handleSendUserOpEncoded` does `console.error('Error sending UserOp:', error)` and only calls `captureException` on the stale-webauthn-key branch; `capturePasskeySignFailure` returns early for anything that isn't a WebAuthn `DOMException` and posts to PostHog only. So the report depended entirely on `captureConsoleIntegration`.
2. **`beforeSend` then deleted it.** viem's `HttpRequestError` message carries `Details: Failed to fetch`, which the `networkIssues` filter matches. **Zero** events matching `Failed to fetch` / `Load failed` / `Network Error` exist org-wide in the last 14 days, across every environment — the filter is absolute, and it eats real payment failures along with the noise. The same string is why the UI said "contact support": `friendlyError` doesn't map it either, so it falls through to `genericSupport`.
3. **No offline transport on native.** A WebView that can't reach the ZeroDev bundler can't reach `ingest.us.sentry.io` either, so even an unfiltered event died with the session.

## What changed

- **`src/utils/sentry-critical-flow.ts` (new)** — `CRITICAL_FLOW_TAG` + `criticalFlowTags(flow)`. Its own module because the root `sentry.utils.ts` is loaded by the server and edge configs and must not reach into app-layer code.
- **`sentry.utils.ts`** — events carrying the tag skip the noise filters. User cancellations stay filtered even for tagged events: someone backing out of the passkey sheet is not a defect and would drown out the real failures.
- **`useDirectSendFlow.ts`** — the catch now reports: `captureException` with the failing step (`create-charge` / `send-money` / `record-payment`), charge id, recipient, amount and user id, plus a `send_failed` PostHog event. Every "contact support" toast now leaves one queryable record.
- **`instrumentation-client.ts`** — native init uses `makeBrowserOfflineTransport`, so undeliverable envelopes park in IndexedDB and flush on a later launch.
- **`sentry.utils.test.ts`** — covers the exemption and the cancellation carve-out.

## Notes / follow-ups

- For error classes that *aren't* filtered today (e.g. `UserOperationExecutionError`), the console-capture event and the new explicit capture will both fire and group separately. I left the `console.error` in place deliberately — `handleSendUserOpEncoded` is also called from link creation, kernel migration and card-signature repair, none of which capture explicitly, so suppressing it globally would lose coverage there.
- Only the direct-send flow is instrumented here. `withdraw/crypto`, `qr-pay` and the contribute-pot flow have the same shape (catch → friendly copy → silence) and should get the same treatment; happy to do them in a follow-up or fold them in if you'd rather have one pass.
- This ships to native only via a build; the filter change helps web immediately.

## Testing

- `jest sentry.utils.test.ts` — 49 passed.
- `prettier --check` clean on all touched files; `tsc --noEmit` reports no errors in the touched files.
