### PR TITLE
fix(passkey): stop reporting a cancelled passkey prompt as an error

### DIFF
--- a/src/components/Global/GuestLoginModal/index.tsx
+++ b/src/components/Global/GuestLoginModal/index.tsx
@@ -25,8 +25,9 @@ const GuestLoginModal = () => {
                     onClick={() => {
                         handleLogin()
                             .then(closeModal)
-                            .catch((e) => {
-                                console.error(e)
+                            .catch(() => {
+                                // useZeroDev already reported the underlying failure;
+                                // console.error here would capture the wrapper again.
                                 toast.error(t('guestLoginModal.loginError'))
                             })
                     }}

--- a/src/components/Invites/InvitesPage.test.tsx
+++ b/src/components/Invites/InvitesPage.test.tsx
@@ -53,6 +53,10 @@ jest.mock('@/redux/slices/setup-slice', () => ({
     },
 }))
 jest.mock('@/hooks/useLogin', () => ({ useLogin: () => ({ handleLoginClick: mockLogin, isLoggingIn: false }) }))
+jest.mock('@/components/0_Bruddle/Toast', () => ({
+    ...jest.requireActual('@/components/0_Bruddle/Toast'),
+    useToast: () => ({ error: jest.fn(), success: jest.fn() }),
+}))
 jest.mock('@/hooks/useGuestStoreHandoff', () => ({
     useGuestStoreHandoff: (opts: { trackImpressionWhenGuest?: boolean }) => {
         mockUseGuestStoreHandoff(opts)

--- a/src/components/Invites/InvitesPage.tsx
+++ b/src/components/Invites/InvitesPage.tsx
@@ -16,6 +16,7 @@ import { EInviteType } from '@/services/services.types'
 import { getValidRedirectUrl, saveRedirectUrl, saveToCookie } from '@/utils/general.utils'
 import { useGuestStoreHandoff } from '@/hooks/useGuestStoreHandoff'
 import { useLogin } from '@/hooks/useLogin'
+import { useToast } from '@/components/0_Bruddle/Toast'
 import UnsupportedBrowserModal from '../Global/UnsupportedBrowserModal'
 import posthog from 'posthog-js'
 import { useTranslations } from 'next-intl'
@@ -38,6 +39,7 @@ import { destinationForInviteAcquisition } from '@/services/invite-acquisition'
 function InvitePageContent() {
     const t = useTranslations('invites')
     const tSetup = useTranslations('setup')
+    const toast = useToast()
     const searchParams = useSearchParams()
     // trim trailing '?' from invite code to handle qr codes with ? at the end
     const inviteCode = searchParams.get('code')?.toLowerCase().replace(/\?+$/, '')
@@ -292,7 +294,11 @@ function InvitePageContent() {
             // normal-app fallback.
             saveRedirectUrl()
         }
-        void handleLoginClick()
+        // PasskeyError carries curated user-facing copy; without this catch a
+        // cancelled passkey prompt becomes an unhandled rejection and a Sentry event.
+        handleLoginClick().catch((error: unknown) => {
+            toast.error((error instanceof Error && error.message) || tSetup('loginFailed'))
+        })
     }
 
     useEffect(() => {

--- a/src/components/Setup/Views/JoinWaitlist.tsx
+++ b/src/components/Setup/Views/JoinWaitlist.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Button } from '@/components/0_Bruddle/Button'
+import { isAlreadyReported } from '@/utils/webauthn.utils'
 import { useToast } from '@/components/0_Bruddle/Toast'
 import ValidatedInput from '@/components/Global/ValidatedInput'
 import { useEffect, useState } from 'react'
@@ -89,7 +90,9 @@ const JoinWaitlist = () => {
                   ? t('waitlist.noPasskey')
                   : t('waitlist.loginUnexpectedError')
         toast.error(errorMessage)
-        Sentry.captureException(error, { extra: { errorCode } })
+        if (!isAlreadyReported(error)) {
+            Sentry.captureException(error, { extra: { errorCode } })
+        }
     }
 
     const _onLoginClick = async () => {

--- a/src/components/Setup/Views/Landing.tsx
+++ b/src/components/Setup/Views/Landing.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useToast } from '@/components/0_Bruddle/Toast'
+import { isAlreadyReported } from '@/utils/webauthn.utils'
 import { useSetupFlow } from '@/hooks/useSetupFlow'
 import { useLogin } from '@/hooks/useLogin'
 import * as Sentry from '@sentry/nextjs'
@@ -45,7 +46,9 @@ const LandingStep = () => {
     const handleError = (error: unknown) => {
         const errorCode = error instanceof Error && 'code' in error ? String(error.code) : undefined
         toast.error((error instanceof Error && error.message) || t('loginFailed'))
-        Sentry.captureException(error, { extra: { errorCode } })
+        if (!isAlreadyReported(error)) {
+            Sentry.captureException(error, { extra: { errorCode } })
+        }
         posthog.capture(ANALYTICS_EVENTS.SIGNUP_LOGIN_ERROR, { error_code: errorCode })
     }
 

--- a/src/utils/webauthn.utils.ts
+++ b/src/utils/webauthn.utils.ts
@@ -227,6 +227,16 @@ export const PASSKEY_WARNINGS = {
  */
 const WEBAUTHN_ERROR_NAMES = new Set<string>(Object.values(WebAuthnErrorName))
 
+/**
+ * useZeroDev captures the raw WebAuthn failure with full context before throwing
+ * the curated PasskeyError — and for a plain user cancel it deliberately captures
+ * nothing on web. Re-reporting the wrapper at a call site adds a context-free
+ * duplicate and undoes that silence.
+ */
+export function isAlreadyReported(error: unknown): boolean {
+    return error instanceof Error && error.name === 'PasskeyError'
+}
+
 export function capturePasskeySignFailure(error: unknown, context: string): void {
     if (!(error instanceof Error) || !WEBAUTHN_ERROR_NAMES.has(error.name)) return
     posthog.capture(ANALYTICS_EVENTS.PASSKEY_SIGN_FAILED, { error_name: error.name, context })


### PR DESCRIPTION
## The intent that was being undone

`useZeroDev.handleLogin` already does the right thing. It classifies the raw WebAuthn failure, captures it with full context, and throws a curated `PasskeyError` carrying user-facing copy. For a plain user cancel it captures **nothing** on web:

```ts
// Cancel saved no state; everything else clears stale state and reports the error to Sentry.
if (code !== 'LOGIN_CANCELED') {
    …
    captureException(err, { tags: { error_type: 'login_error' } })
} else if (isCapacitor()) {
    // keep visibility without alerting
    captureException(err, { level: 'warning', tags: { error_type: 'login_canceled_native' } })
}
```

Four call sites then reported the wrapper anyway, which is why `PEANUT-UI-R20` — *"Login was cancelled, or no passkey was found on this device"* — exists at **error** level despite that deliberate silence.

## What changed

| Site | Was | Now |
|---|---|---|
| `InvitesPage` | `void handleLoginClick()`, no catch → **unhandled rejection** on every cancel | caught; curated message surfaced like every other login entry point |
| `GuestLoginModal` | `console.error(e)` → `captureConsoleIntegration` event | dropped; toast unchanged |
| `Landing` | `Sentry.captureException(wrapper)` | skipped for `PasskeyError` |
| `JoinWaitlist` | `Sentry.captureException(wrapper)` | skipped for `PasskeyError` |

The guard is a named helper in `webauthn.utils.ts` rather than four inline checks, and it's narrow — `Landing` and `JoinWaitlist` still report anything that **isn't** a `PasskeyError`, so an unexpected failure in the login path is not silenced. PostHog's `SIGNUP_LOGIN_ERROR` is untouched: a failed login is still a funnel event, just not a crash report.

## Note on `InvitesPage`

That one is a real bug independent of Sentry — a floating promise with no rejection handler. It previously showed the user nothing at all on failure; it now shows the curated message, consistent with `Landing`, `SetupPasskey` and `JoinWaitlist`.

## Verification

- `src/components/Invites`: **61 passed, 1 failed** — identical to the `dev` baseline. The one failure is `badge-campaign-context.test.ts › source-qualifies every published content UTM`, which reads `@/content/generated/…` and fails in any worktree without the `src/content` submodule initialised. Confirmed pre-existing by re-running with this change reverted.
- `src/components/Setup`, `GuestLoginModal`, `webauthn`: 8 passed, 0 failed.
- `tsc --noEmit`: 231 errors, **zero in any touched file** — 229 are missing `@/assets/*` declarations in a fresh worktree, 2 are the same `src/content` submodule.
- `prettier --check`: clean.

`InvitesPage.test.tsx` gained a `useToast` mock alongside the existing `useLogin` one, since the suite renders `InvitePageContent` outside a `ToastProvider`.

## Related

#2735 adds `PasskeyError` to the `alreadyReported` beforeSend list as a backstop, so a future call site can't reintroduce this. This PR removes the reports at source; that one stops them arriving if it happens again.

## Correction to the commit message

The commit says *"PEANUT-UI-QRW and PEANUT-UI-R20: 19 events yesterday"*. The accurate figure is **13/day** — QRW 9 + R20 4.

The extra 6 was `PEANUT-UI-SFV` (*"No matching passkey was found"*), which this PR does **not** fix. SFV is the *raw* Android error captured at the throw site in `useZeroDev`, not the `PasskeyError` wrapper, so none of the four call-site changes touch it. It's arguably also an expected outcome (no passkey enrolled on this device) and worth reclassifying to `LOGIN_CANCELED`, but that changes user-facing copy and belongs in its own change.

peanut-ui blocks force-push, so the commit message stands as written.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login failure handling across invitations and setup flows.
  * Login errors now display appropriate localized messages without causing unhandled promise rejections.
  * Prevented duplicate reporting of passkey and WebAuthn errors while preserving user notifications and tracking.

* **Tests**
  * Updated invitation flow tests to safely handle toast notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->