### PR TITLE
ci: make eslint blocking now errors are at zero (TASK-21450)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,13 +55,11 @@ jobs:
             - name: Validate sitemap, footer, and blog links
               run: pnpm validate-links
 
-    # Advisory ESLint pass. Allowed to fail without blocking merge while the
-    # codebase is brought up to baseline. Not in ci-success.needs so a red
-    # eslint job doesn't gate the PR. Promote to blocking once errors are at
-    # zero (or after team decides a warn floor).
+    # Blocking ESLint pass (DS 10, TASK-21450). Errors reached zero on
+    # feat/design-system, so this gates the PR via ci-success.needs. Warnings
+    # do not fail the job; add a warn floor only if the team decides one.
     eslint:
         runs-on: ubuntu-latest
-        continue-on-error: true
         steps:
             - uses: actions/checkout@v4
               with:
@@ -384,7 +382,7 @@ jobs:
     ci-success:
         name: ci-success
         if: always()
-        needs: [format, typecheck, unit, e2e, report]
+        needs: [format, eslint, typecheck, unit, e2e, report]
         runs-on: ubuntu-latest
         steps:
             - name: Verify all required jobs passed

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     # Prettier formatting + content-link validation. Fast, no node_modules
     # needed beyond what setup-node cache restores.
     # (Renamed from "lint" — the job never actually ran a linter; ESLint now
-    # lives in its own advisory job below.)
+    # lives in its own blocking job below.)
     format:
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -391,6 +391,7 @@ jobs:
                       echo "::error::One or more required jobs failed or were cancelled"
                       echo "Job results:"
                       echo "  format:    ${{ needs.format.result }}"
+                      echo "  eslint:    ${{ needs.eslint.result }}"
                       echo "  typecheck: ${{ needs.typecheck.result }}"
                       echo "  unit:      ${{ needs.unit.result }}"
                       echo "  e2e:       ${{ needs.e2e.result }}"

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -13,7 +13,7 @@
  * Strategy: mock every hook and service at the module level, then configure
  * per-test via mockReturnValue / mockImplementation.
  */
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars, react/display-name */
+/* eslint-disable @typescript-eslint/no-unused-vars, react/display-name */
 import React from 'react'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { IntlWrapper } from '@/test-utils/intl'

--- a/src/components/AddMoney/components/__tests__/MantecaAddMoney.exits.test.tsx
+++ b/src/components/AddMoney/components/__tests__/MantecaAddMoney.exits.test.tsx
@@ -6,7 +6,6 @@
  * the destination is under test here — everything else is stubbed to the thinnest
  * thing that lets the showQR step render.
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'

--- a/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
+++ b/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any -- jest.mock factories stub component props with `any`; matches the sibling add-money-states.test.tsx style. */
 /**
  * Regression coverage for the deposit/withdraw method list's bank gate.
  *

--- a/src/components/Card/__tests__/PhysicalCardScreen.test.tsx
+++ b/src/components/Card/__tests__/PhysicalCardScreen.test.tsx
@@ -20,7 +20,6 @@ jest.mock('@/context/authContext', () => ({
 }))
 jest.mock('next/image', () => ({
     __esModule: true,
-    // eslint-disable-next-line @next/next/no-img-element -- test stub, not real markup
     default: (props: Record<string, unknown>) => <img alt={String(props.alt ?? '')} />,
 }))
 jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))

--- a/src/components/Global/InvitesGraph/index.tsx
+++ b/src/components/Global/InvitesGraph/index.tsx
@@ -1848,7 +1848,6 @@ export default function InvitesGraph(props: InvitesGraphProps) {
             // configureForces is async - must wait for it to complete before reheating
             configureForces().then(() => {
                 if (!graphRef.current) return
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 const internalGraph = graphRef.current as any
                 if (internalGraph._simulation) {
                     internalGraph._simulation.alpha(1).restart()

--- a/src/i18n/app/__tests__/messages.test.ts
+++ b/src/i18n/app/__tests__/messages.test.ts
@@ -126,7 +126,6 @@ describe('ICU message compilation', () => {
             minutes: 2,
         }
         for (const path of leafPaths(messages)) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             t(path as any, dummy)
         }
         expect(invalid).toEqual([])


### PR DESCRIPTION
## Summary

DS 10 (TASK-21450), item "eslint to 0 + hard gate". The advisory eslint job reached **0 errors** after the sprint-155 cleanup, so this flips it to blocking before new errors creep back in:

- `.github/workflows/tests.yml`: remove `continue-on-error` from the eslint job and add it to `ci-success.needs` — a PR with any eslint error now fails CI.
- Remove the 6 `eslint-disable` directives the cleanup left unused (5 full removals, 1 trimmed rule list). The branch now lints with 0 errors and 0 unused-directive warnings.

The 58 remaining warnings are all `react-hooks/exhaustive-deps`; warnings do not fail the job. Fixing those risks behavior changes, so they stay out of scope. A warn floor (`--max-warnings`) can be added later if the team wants one.

## Task

[DS 10: lint ratchets in CI + eslint to 0](https://app.notion.com/p/peanutprotocol/DS-10-lint-ratchets-in-CI-eslint-to-0-3bb83811757981628fbfde923cbef33c) (TASK-21450) — this PR covers item 4; items 1–3 (counts ratchet, nuqs rule, apiFetch gate) come as separate PRs.

## Risks / breaking changes

- Any PR into `feat/design-system` (and later `dev`/`main` once this merges through) fails CI on a single eslint error. That is the point, but branches created before the sprint-155 cleanup may go red on rebase.
- No runtime code changes — comment-only edits plus workflow config.

## QA

- `npx eslint .` → 0 errors, 58 warnings (all `exhaustive-deps`), 0 unused directives.
- `tsc --noEmit` clean. Prettier clean on changed files.
- Full jest: same pass/fail set as the pristine branch tip (verified side-by-side; the 5 locally-failing suites are pre-existing local-env artifacts — CI is green on tip commit 3d1bed831).

Screenshots: N/A (no visible change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Quality Improvements**
  * ESLint checks are now enforced as part of the continuous integration process.
  * Removed unnecessary linting exceptions across application code and tests.
* **Tests**
  * Existing test coverage and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->