### PR TITLE
ci(tests): cache the Playwright browsers and cap the e2e job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -177,6 +177,13 @@ jobs:
     # reachability are wired in repo settings (per the prior comment).
     e2e:
         runs-on: ubuntu-latest
+        # Without a cap a stalled step runs to the 6h default. "Install
+        # Playwright browsers" hung three times on 2026-08-18 (~30min each)
+        # while sibling runs cleared it in under two minutes. An unbounded hang
+        # is worse than a failure here: `ci-success` never reports, and
+        # content-publish-automerge merges on all-green-of-N, so N stays 0 and
+        # a content publish stalls with no error anywhere. Fail fast instead.
+        timeout-minutes: 20
         steps:
             - uses: actions/checkout@v4
               with:
@@ -192,8 +199,31 @@ jobs:
 
             - run: pnpm install --frozen-lockfile
 
+            # Cache the browser binaries — the download is the step that hangs,
+            # so the cheapest fix is to not do it on most runs. Keyed on the
+            # Playwright version, because browser builds are pinned to it.
+            - name: Resolve Playwright version
+              id: pw
+              run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+            - name: Cache Playwright browsers
+              id: pw-cache
+              uses: actions/cache@v4
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
             - name: Install Playwright browsers
+              if: steps.pw-cache.outputs.cache-hit != 'true'
+              timeout-minutes: 6
               run: npx playwright install --with-deps chromium
+
+            # The cache holds browsers, not the apt packages they link against,
+            # so system deps still need installing on a cache hit.
+            - name: Install Playwright system deps
+              if: steps.pw-cache.outputs.cache-hit == 'true'
+              timeout-minutes: 6
+              run: npx playwright install-deps chromium
 
             - name: Run E2E tests
               run: pnpm test:e2e


### PR DESCRIPTION
## Summary

`Install Playwright browsers` hung **three times on 2026-08-18**, ~30 minutes each, while sibling runs cleared the same step in under two minutes. It's an unguarded network download with no cache and no timeout, and the job inherits the 6h default.

**Why this is more than a nuisance:** an unbounded hang means `ci-success` never reports. `content-publish-automerge` merges on all-green-of-N `ci-success` runs, and a bot-pushed bump branch has exactly **one** — so N stays 0 and a content publish stalls with **no error anywhere**. Bounding the job converts a silent stall into a visible red run.

## Changes

- `timeout-minutes: 20` on the `e2e` job, plus 6 minutes on each install step. First `timeout-minutes` in this workflow.
- Cache `~/.cache/ms-playwright`, keyed on the resolved `@playwright/test` version, so most runs skip the download entirely.
- On a cache hit, run `playwright install-deps` only — the cache holds browser binaries, not the apt packages they link against.

## Risk

Low, CI-only. Worst case is a cache miss, which is exactly today's behaviour. The one behaviour change to know about: a genuinely slow e2e run now fails at 20 minutes instead of hanging — intended, and well above the ~2 minute norm.

Found while auditing unverified commits (TASK-21002) — unrelated to signing, but it threatens the same pipeline.

Screenshots: N/A (CI only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved end-to-end test reliability by adding execution time limits.
  * Added browser caching to reduce setup time for repeated test runs.
  * Separated browser and system dependency installation with dedicated time limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->