### PR TITLE
ci: DS debt-count ratchet on every PR (TASK-21450)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,27 @@ jobs:
             - name: Validate sitemap, footer, and blog links
               run: pnpm validate-links
 
+    # DS debt ratchet (DS 10, TASK-21450). Runs scripts/ds-lint-counts.mjs
+    # --check against the committed baseline: debt counts (raw hex, inline
+    # styles, stock text sizes, non-DS classes in views, useSearchParams files)
+    # may only go down. A PR that lowers a count should also tighten the
+    # baseline (--write-baseline) so the gain locks in. Pure-node script — no
+    # pnpm install needed.
+    ds-lint:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  submodules: true
+                  token: ${{ secrets.SUBMODULE_TOKEN }}
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '20'
+
+            - name: DS lint-count ratchet
+              run: node scripts/ds-lint-counts.mjs --check
+
     # Blocking ESLint pass (DS 10, TASK-21450). Errors reached zero on
     # feat/design-system, so this gates the PR via ci-success.needs. Warnings
     # do not fail the job; add a warn floor only if the team decides one.
@@ -382,7 +403,7 @@ jobs:
     ci-success:
         name: ci-success
         if: always()
-        needs: [format, eslint, typecheck, unit, e2e, report]
+        needs: [format, ds-lint, eslint, typecheck, unit, e2e, report]
         runs-on: ubuntu-latest
         steps:
             - name: Verify all required jobs passed
@@ -391,6 +412,7 @@ jobs:
                       echo "::error::One or more required jobs failed or were cancelled"
                       echo "Job results:"
                       echo "  format:    ${{ needs.format.result }}"
+                      echo "  ds-lint:   ${{ needs['ds-lint'].result }}"
                       echo "  eslint:    ${{ needs.eslint.result }}"
                       echo "  typecheck: ${{ needs.typecheck.result }}"
                       echo "  unit:      ${{ needs.unit.result }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,8 @@ jobs:
               with:
                   submodules: true
                   token: ${{ secrets.SUBMODULE_TOKEN }}
+                  # no git ops after checkout — don't leave the token in git config
+                  persist-credentials: false
 
             - uses: actions/setup-node@v4
               with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,11 +64,11 @@ jobs:
     ds-lint:
         runs-on: ubuntu-latest
         steps:
+            # no submodules/token: the count script only reads src/**/*.ts(x)
+            # and the only submodule (src/content) holds none. no git ops after
+            # checkout either, so don't persist credentials.
             - uses: actions/checkout@v4
               with:
-                  submodules: true
-                  token: ${{ secrets.SUBMODULE_TOKEN }}
-                  # no git ops after checkout — don't leave the token in git config
                   persist-credentials: false
 
             - uses: actions/setup-node@v4

--- a/scripts/ds-lint-baseline.json
+++ b/scripts/ds-lint-baseline.json
@@ -2,9 +2,9 @@
     "rawHex": 75,
     "rawHexFiles": 38,
     "inlineStyle": 207,
-    "stockTextSize": 1392,
+    "stockTextSize": 1103,
     "dsTextScale": 21,
-    "nonDsClassesInViews": 473,
+    "nonDsClassesInViews": 439,
     "useSearchParamsFiles": 51,
     "nuqsFiles": 15
 }

--- a/scripts/ds-lint-counts.mjs
+++ b/scripts/ds-lint-counts.mjs
@@ -19,18 +19,18 @@ const SRC = join(ROOT, 'src')
 const BASELINE_PATH = join(ROOT, 'scripts', 'ds-lint-baseline.json')
 
 // allowlist for every metric: image-generation surfaces render standalone html
-// with no tailwind, raw values are the tool there, not debt.
-const GLOBAL_ALLOW = ['components/og/', 'app/api/og/', 'ImageGeneration/']
+// with no tailwind, raw values are the tool there, not debt. the ds showcase
+// pages display the token source itself (colors, spacing, type ramp rendered
+// programmatically from values), so raw values there are the feature.
+const GLOBAL_ALLOW = ['components/og/', 'app/api/og/', 'ImageGeneration/', 'dev/ds/', 'dev/components/']
 
 // extra allowlist for raw-hex only: canvas/D3/mermaid surfaces paint
-// programmatically, plus the ds showcase pages that display the palette itself.
+// programmatically.
 const HEX_ALLOW = [
     'share-asset/', // canvas card renderer
     'Global/InvitesGraph/', // d3 force graph
     'dev/kyc-flows/', // mermaid theming
     'LandingPage/PioneerCard3D', // canvas 3d card
-    'dev/ds/', // token showcase renders raw palette by design
-    'dev/components/', // component showcase ditto
 ]
 
 const HEX_RE = /#[0-9a-fA-F]{6}\b|#[0-9a-fA-F]{3}\b/g


### PR DESCRIPTION
## Summary

DS 10 (TASK-21450), item "wire the counts script into CI as a ratchet". Adds a blocking `ds-lint` job that runs `scripts/ds-lint-counts.mjs --check` on every PR: the five DS debt counts may only go down; a PR that raises any count fails `ci-success`.

Two supporting changes surfaced by turning the check on:

- **Showcase allowlist**: `/dev/ds` and `/dev/components` render token values programmatically (color swatches, spacing bars, type ramp) — raw values there are the feature, not debt. They were previously allowlisted for the hex metric only; now for all metrics. They accounted for the entire apparent `inlineStyle` 207→211 regression since the day-1 baseline.
- **Baseline tightened to current-tree truth**, locking in the DS 05/06 gains: stock text sizes 1392→1103, non-DS view classes 473→439, inlineStyle back at exactly 207 after the allowlist fix.

Workflow for future PRs: a PR that lowers a count should also run `--write-baseline` to lock the gain; an intentional, reviewed increase does the same with justification.

## Task

[DS 10: lint ratchets in CI + eslint to 0](https://app.notion.com/p/peanutprotocol/DS-10-lint-ratchets-in-CI-eslint-to-0-3bb83811757981628fbfde923cbef33c) (TASK-21450) — item 1. Item 4 (eslint gate) is #2742; items 2–3 follow separately.

## Stacked on #2742

Based on `ds/10-eslint-zero` because both edit the `ci-success.needs` line. Merge #2742 first; GitHub will retarget this PR to `feat/design-system` when that branch is deleted.

## Risks / breaking changes

- In-flight DS branches that add debt (inline styles, stock text sizes outside the showcase) will fail the new job on rebase — that is the ratchet working. Heads-up for the DS 05/06/11 sub-branches.
- CI-config + script + baseline only; no runtime code changes.

## QA

- `node scripts/ds-lint-counts.mjs --check` green on this branch (all six metrics at baseline).
- Verified the regression path: pre-allowlist run correctly failed with `inlineStyle 207→211`.

Screenshots: N/A (no visible change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a blocking design-system lint check to continuous integration.
  * Updated CI status reporting to include the design-system lint result.
  * Refreshed design-system compliance baselines, reflecting fewer legacy text-size and non-design-system class findings.
  * Excluded standalone design-system showcase code from compliance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->