### PR TITLE
refactor: route remaining direct Peanut-API calls through apiFetch (TASK-21450)

### DIFF
--- a/src/app/actions/onramp-quote.ts
+++ b/src/app/actions/onramp-quote.ts
@@ -1,7 +1,5 @@
-import { fetchWithSentry } from '@/utils/sentry.utils'
+import { apiFetch } from '@/utils/api-fetch'
 import { AccountType } from '@/interfaces/interfaces'
-import { PEANUT_API_URL } from '@/constants/general.consts'
-import { authReady, getAuthHeaders } from '@/utils/auth-token'
 
 export interface OnrampQuoteResponse {
     from: string
@@ -30,18 +28,16 @@ export async function getOnrampQuote(
     sourceAmount?: number
 ): Promise<{ data?: OnrampQuoteResponse; error?: string }> {
     try {
-        const url = new URL(`${PEANUT_API_URL}/bridge/onramp/quote`)
-        url.searchParams.append('accountType', accountType)
+        const params = new URLSearchParams({ accountType })
         if (sourceAmount !== undefined) {
-            url.searchParams.append('sourceAmount', String(sourceAmount))
+            params.append('sourceAmount', String(sourceAmount))
         }
 
-        // park until the session token can legitimately be read (guarded mode
-        // holds this until unlock) so this caller never fires unauthenticated
-        await authReady()
-        const response = await fetchWithSentry(url.toString(), {
+        // apiFetch awaits authReady() (guarded mode holds it until unlock) and
+        // attaches the session token, so this caller never fires unauthenticated.
+        const response = await apiFetch(`/bridge/onramp/quote?${params.toString()}`, {
             method: 'GET',
-            headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+            headers: { 'Content-Type': 'application/json' },
         })
 
         const data = await response.json()

--- a/src/app/actions/onramp-quote.ts
+++ b/src/app/actions/onramp-quote.ts
@@ -35,10 +35,7 @@ export async function getOnrampQuote(
 
         // apiFetch awaits authReady() (guarded mode holds it until unlock) and
         // attaches the session token, so this caller never fires unauthenticated.
-        const response = await apiFetch(`/bridge/onramp/quote?${params.toString()}`, {
-            method: 'GET',
-            headers: { 'Content-Type': 'application/json' },
-        })
+        const response = await apiFetch(`/bridge/onramp/quote?${params.toString()}`, { method: 'GET' })
 
         const data = await response.json()
         if (!response.ok) {

--- a/src/components/Setup/Views/SetupPasskey.tsx
+++ b/src/components/Setup/Views/SetupPasskey.tsx
@@ -1,8 +1,7 @@
 import DocsLink from '@/components/Global/DocsLink'
 import { Button } from '@/components/0_Bruddle/Button'
-import { PEANUT_API_URL } from '@/constants/general.consts'
 import { isCapacitor } from '@/utils/capacitor'
-import { fetchWithSentry } from '@/utils/sentry.utils'
+import { apiFetch } from '@/utils/api-fetch'
 import { useSetupStore } from '@/redux/hooks'
 import { useZeroDev } from '@/hooks/useZeroDev'
 import { useLogin } from '@/hooks/useLogin'
@@ -24,9 +23,11 @@ import { useTranslations } from 'next-intl'
 // Fail-open on network errors — the server's 409 is the backstop.
 const isUsernameTaken = async (username: string): Promise<boolean> => {
     try {
-        // capacitorHttp doesn't support HEAD — use GET in native
-        const res = await fetchWithSentry(`${PEANUT_API_URL}/users/username/${username}`, {
+        // capacitorHttp doesn't support HEAD — use GET in native.
+        // includeAuth: false — public pre-auth check, no session token involved.
+        const res = await apiFetch(`/users/username/${username}`, {
             method: isCapacitor() ? 'GET' : 'HEAD',
+            includeAuth: false,
         })
         return res.status === 200
     } catch {

--- a/src/components/Setup/Views/Signup.tsx
+++ b/src/components/Setup/Views/Signup.tsx
@@ -2,12 +2,12 @@ import { Button } from '@/components/0_Bruddle/Button'
 import ErrorAlert from '@/components/Global/ErrorAlert'
 import ValidatedInput from '@/components/Global/ValidatedInput'
 import DocsLink from '@/components/Global/DocsLink'
-import { PEANUT_API_URL, USERNAME_MIN_LENGTH } from '@/constants/general.consts'
+import { USERNAME_MIN_LENGTH } from '@/constants/general.consts'
 import { isCapacitor } from '@/utils/capacitor'
 import { useSetupFlow } from '@/hooks/useSetupFlow'
 import { useAppDispatch, useSetupStore } from '@/redux/hooks'
 import { setupActions } from '@/redux/slices/setup-slice'
-import { fetchWithSentry } from '@/utils/sentry.utils'
+import { apiFetch } from '@/utils/api-fetch'
 import * as Sentry from '@sentry/nextjs'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
@@ -51,10 +51,12 @@ const SignupStep = () => {
         }
 
         try {
-            // here we expect 404 or 400 so dont use the fetchWithSentry helper
+            // public pre-auth availability check — includeAuth: false so it never
+            // waits on (or sends) a session token. 404/400 are expected statuses.
             // capacitorHttp doesn't support HEAD — use GET in native
-            const res = await fetchWithSentry(`${PEANUT_API_URL}/users/username/${username}`, {
+            const res = await apiFetch(`/users/username/${username}`, {
                 method: isCapacitor() ? 'GET' : 'HEAD',
+                includeAuth: false,
             })
             switch (res.status) {
                 case 200:

--- a/src/services/card.ts
+++ b/src/services/card.ts
@@ -9,8 +9,7 @@
  * launch — the new free badge-gated waitlist supersedes it.
  */
 
-import { PEANUT_API_KEY } from '@/constants/general.consts'
-import { authReady, getAuthHeaders } from '@/utils/auth-token'
+import { authReady, getAuthToken } from '@/utils/auth-token'
 import { apiFetch } from '@/utils/api-fetch'
 import { isDemoMode } from '@/utils/demo'
 
@@ -60,22 +59,27 @@ export interface WaitlistStateResponse {
     releasedAt: string | null
 }
 
-async function authHeaders(): Promise<Record<string, string>> {
-    // Demo mode has no JWT — skip the auth gate so the request reaches
-    // apiFetch's demo interceptor (which serves /card) instead of throwing.
-    if (isDemoMode()) return { 'api-key': PEANUT_API_KEY }
+/**
+ * Fail fast — loud and local — instead of an opaque 401 from an
+ * unauthenticated request. apiFetch itself awaits authReady() and attaches
+ * the Bearer token; this only checks one exists. Demo mode has no JWT —
+ * skip so the request reaches apiFetch's demo interceptor (which serves
+ * /card). (The old api-key header was dead weight: PEANUT_API_KEY has no
+ * NEXT_PUBLIC_ prefix so it is undefined in the client bundle, and the
+ * backend dropped its api-key requirement — see api-fetch.ts.)
+ */
+async function assertAuthenticated(): Promise<void> {
+    if (isDemoMode()) return
     await authReady()
-    const headers = getAuthHeaders({ 'api-key': PEANUT_API_KEY })
-    if (!headers['Authorization']) throw new Error('Authentication required')
-    return headers
+    if (!getAuthToken()) throw new Error('Authentication required')
 }
 
 export const cardApi = {
     /** GET /card — info + waitlist state. */
     getInfo: async (): Promise<CardInfoResponse> => {
+        await assertAuthenticated()
         const response = await apiFetch('/card', {
             method: 'GET',
-            headers: await authHeaders(),
             cache: 'no-store',
         })
         if (!response.ok) {
@@ -87,9 +91,10 @@ export const cardApi = {
 
     /** POST /card/waitlist/join — idempotent stamp + position. */
     joinWaitlist: async (): Promise<{ joinedAt: string; position: number | null }> => {
+        await assertAuthenticated()
+        // apiFetch sets Content-Type: application/json for the string body
         const response = await apiFetch('/card/waitlist/join', {
             method: 'POST',
-            headers: { ...(await authHeaders()), 'Content-Type': 'application/json' },
             body: '{}',
             cache: 'no-store',
         })
@@ -102,9 +107,9 @@ export const cardApi = {
 
     /** GET /card/waitlist/state — current waitlist state. */
     getWaitlistState: async (): Promise<WaitlistStateResponse> => {
+        await assertAuthenticated()
         const response = await apiFetch('/card/waitlist/state', {
             method: 'GET',
-            headers: await authHeaders(),
             cache: 'no-store',
         })
         if (!response.ok) {

--- a/src/services/card.ts
+++ b/src/services/card.ts
@@ -9,9 +9,9 @@
  * launch — the new free badge-gated waitlist supersedes it.
  */
 
-import { PEANUT_API_KEY, PEANUT_API_URL } from '@/constants/general.consts'
+import { PEANUT_API_KEY } from '@/constants/general.consts'
 import { authReady, getAuthHeaders } from '@/utils/auth-token'
-import { fetchWithSentry } from '@/utils/sentry.utils'
+import { apiFetch } from '@/utils/api-fetch'
 
 export interface CardInfoResponse {
     /** Inner gate: cardAccessGrantedAt set OR holds a SKIP_BADGE_CODES badge
@@ -69,7 +69,7 @@ async function authHeaders(): Promise<Record<string, string>> {
 export const cardApi = {
     /** GET /card — info + waitlist state. */
     getInfo: async (): Promise<CardInfoResponse> => {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/card`, {
+        const response = await apiFetch('/card', {
             method: 'GET',
             headers: await authHeaders(),
             cache: 'no-store',
@@ -83,7 +83,7 @@ export const cardApi = {
 
     /** POST /card/waitlist/join — idempotent stamp + position. */
     joinWaitlist: async (): Promise<{ joinedAt: string; position: number | null }> => {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/card/waitlist/join`, {
+        const response = await apiFetch('/card/waitlist/join', {
             method: 'POST',
             headers: { ...(await authHeaders()), 'Content-Type': 'application/json' },
             body: '{}',
@@ -98,7 +98,7 @@ export const cardApi = {
 
     /** GET /card/waitlist/state — current waitlist state. */
     getWaitlistState: async (): Promise<WaitlistStateResponse> => {
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/card/waitlist/state`, {
+        const response = await apiFetch('/card/waitlist/state', {
             method: 'GET',
             headers: await authHeaders(),
             cache: 'no-store',

--- a/src/services/card.ts
+++ b/src/services/card.ts
@@ -12,6 +12,7 @@
 import { PEANUT_API_KEY } from '@/constants/general.consts'
 import { authReady, getAuthHeaders } from '@/utils/auth-token'
 import { apiFetch } from '@/utils/api-fetch'
+import { isDemoMode } from '@/utils/demo'
 
 export interface CardInfoResponse {
     /** Inner gate: cardAccessGrantedAt set OR holds a SKIP_BADGE_CODES badge
@@ -60,6 +61,9 @@ export interface WaitlistStateResponse {
 }
 
 async function authHeaders(): Promise<Record<string, string>> {
+    // Demo mode has no JWT — skip the auth gate so the request reaches
+    // apiFetch's demo interceptor (which serves /card) instead of throwing.
+    if (isDemoMode()) return { 'api-key': PEANUT_API_KEY }
     await authReady()
     const headers = getAuthHeaders({ 'api-key': PEANUT_API_KEY })
     if (!headers['Authorization']) throw new Error('Authentication required')

--- a/src/services/charges.ts
+++ b/src/services/charges.ts
@@ -10,10 +10,11 @@ import { isDemoMode } from '@/utils/demo'
 
 export const chargesApi = {
     create: async (data: CreateChargeRequest): Promise<TCharge> => {
-        // The demo interceptor is invoked explicitly BEFORE apiFetch: the real
-        // request carries a multipart FormData body the demo store can't parse,
-        // so the demo path gets the JSON payload instead. Lazy import keeps the
-        // demo module out of this service's module graph on web/tests.
+        // The demo interceptor is invoked explicitly BEFORE apiFetch so the
+        // demo store gets the exact JSON payload shape (intentional mapping —
+        // parseBody now degrades gracefully for FormData callers that skip
+        // this, but this keeps the recorded charge exact). Lazy import keeps
+        // the demo module out of this service's module graph on web/tests.
         if (isDemoMode()) {
             const { demoRespond } = await import('@/utils/demo-api')
             // pass the charge data so the demo store captures the real amount.

--- a/src/services/charges.ts
+++ b/src/services/charges.ts
@@ -1,4 +1,3 @@
-import { fetchWithSentry } from '@/utils/sentry.utils'
 import { jsonParse } from '@/utils/general.utils'
 import {
     type TRequestChargeResponse,
@@ -6,15 +5,14 @@ import {
     type TCharge,
     type CreateChargeRequest,
 } from './services.types'
-import { PEANUT_API_URL } from '@/constants/general.consts'
-import { getAuthToken, authReady } from '@/utils/auth-token'
 import { apiFetch, serverFetch } from '@/utils/api-fetch'
 import { isDemoMode } from '@/utils/demo'
 
 export const chargesApi = {
     create: async (data: CreateChargeRequest): Promise<TCharge> => {
-        // This call bypasses callApi (multipart FormData via fetchWithSentry), so
-        // the demo interceptor is invoked explicitly here. Lazy import keeps the
+        // The demo interceptor is invoked explicitly BEFORE apiFetch: the real
+        // request carries a multipart FormData body the demo store can't parse,
+        // so the demo path gets the JSON payload instead. Lazy import keeps the
         // demo module out of this service's module graph on web/tests.
         if (isDemoMode()) {
             const { demoRespond } = await import('@/utils/demo-api')
@@ -35,13 +33,8 @@ export const chargesApi = {
             }
         })
 
-        await authReady()
-        const headers: Record<string, string> = {}
-        const token = getAuthToken()
-        if (token) headers['Authorization'] = `Bearer ${token}`
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/charges`, {
+        const response = await apiFetch('/charges', {
             method: 'POST',
-            headers,
             body: formData,
         })
 

--- a/src/services/rhino-bridge.ts
+++ b/src/services/rhino-bridge.ts
@@ -11,9 +11,7 @@
  * Pairs with peanut-api-ts /rhino/bridge/* routes.
  */
 
-import { PEANUT_API_URL } from '@/constants/general.consts'
-import { fetchWithSentry } from '@/utils/sentry.utils'
-import { getAuthHeaders, authReady } from '@/utils/auth-token'
+import { apiFetch } from '@/utils/api-fetch'
 
 export interface BridgeQuoteParams {
     amount: string
@@ -70,10 +68,9 @@ export interface BridgeChainConfig {
 }
 
 async function postJson<TReq, TRes>(path: string, body: TReq, errorLabel: string): Promise<TRes> {
-    await authReady()
-    const response = await fetchWithSentry(`${PEANUT_API_URL}${path}`, {
+    // apiFetch awaits authReady(), attaches the JWT, and sets Content-Type.
+    const response = await apiFetch(path, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
         body: JSON.stringify(body),
     })
     if (!response.ok) {
@@ -84,11 +81,7 @@ async function postJson<TReq, TRes>(path: string, body: TReq, errorLabel: string
 }
 
 async function getJson<TRes>(path: string, errorLabel: string): Promise<TRes> {
-    await authReady()
-    const response = await fetchWithSentry(`${PEANUT_API_URL}${path}`, {
-        method: 'GET',
-        headers: getAuthHeaders(),
-    })
+    const response = await apiFetch(path, { method: 'GET' })
     if (!response.ok) {
         const text = await response.text().catch(() => '')
         throw new Error(`${errorLabel}: ${response.status} ${text}`)

--- a/src/services/rhino-sda.ts
+++ b/src/services/rhino-sda.ts
@@ -10,9 +10,7 @@
  * Three consumers: withdraw, pay-request-x-chain, claim-link-x-chain.
  */
 
-import { PEANUT_API_URL } from '@/constants/general.consts'
-import { fetchWithSentry } from '@/utils/sentry.utils'
-import { getAuthHeaders, authReady } from '@/utils/auth-token'
+import { apiFetch } from '@/utils/api-fetch'
 import type { Address } from 'viem'
 
 export type RhinoTransferContext = 'withdraw' | 'pay-request' | 'claim-xchain'
@@ -73,13 +71,9 @@ export interface SdaPreviewResult {
 }
 
 async function postRhino<TReq, TRes>(path: string, body: TReq, errorLabel: string): Promise<TRes> {
-    await authReady()
-    const response = await fetchWithSentry(`${PEANUT_API_URL}${path}`, {
+    // apiFetch awaits authReady(), attaches the JWT, and sets Content-Type.
+    const response = await apiFetch(path, {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            ...getAuthHeaders(),
-        },
         body: JSON.stringify(body),
     })
     if (!response.ok) {

--- a/src/services/sendLinks.ts
+++ b/src/services/sendLinks.ts
@@ -2,7 +2,6 @@ import { jsonParse, jsonStringify, getFromLocalStorage, saveToLocalStorage } fro
 import { generateKeysFromString, getParamsFromLink } from '@/utils/peanut-link.utils'
 import type { SendLink } from '@/services/services.types'
 import { apiFetch, serverFetch } from '@/utils/api-fetch'
-import { isDemoMode } from '@/utils/demo'
 
 export { ESendLinkStatus } from '@/services/services.types'
 export type { SendLinkStatus, SendLink } from '@/services/services.types'
@@ -78,17 +77,7 @@ type UpdateLinkBody = {
 
 export const sendLinksApi = {
     create: async (sendLink: CreateLinkBody): Promise<SendLink> => {
-        // The demo interceptor is invoked explicitly BEFORE apiFetch: the real
-        // request may carry a multipart FormData body the demo store can't
-        // parse. Lazy import keeps the demo module out of this service's
-        // module graph on web/tests.
-        if (isDemoMode()) {
-            const { demoRespond } = await import('@/utils/demo-api')
-            return jsonParse(await (await demoRespond('/send-links', { method: 'POST' })).text())
-        }
-
         let requestBody: FormData | string
-        const headers: Record<string, string> = {}
 
         // check if attachment is a File or Blob object
         if (sendLink.attachment && (sendLink.attachment instanceof File || sendLink.attachment instanceof Blob)) {
@@ -116,15 +105,16 @@ export const sendLinksApi = {
                 }
             }
         } else {
-            // no file, or attachment is not a File/Blob, send as JSON
+            // no file, or attachment is not a File/Blob, send as JSON —
+            // apiFetch sets Content-Type: application/json for string bodies
             requestBody = jsonStringify(sendLink)
-            headers['Content-Type'] = 'application/json'
         }
 
+        // demo mode is handled inside apiFetch (the POST /send-links demo
+        // handler serves a canned link and never reads the body)
         const response = await apiFetch('/send-links', {
             method: 'POST',
             body: requestBody,
-            headers,
         })
 
         if (!response.ok) {

--- a/src/services/sendLinks.ts
+++ b/src/services/sendLinks.ts
@@ -1,10 +1,7 @@
 import { jsonParse, jsonStringify, getFromLocalStorage, saveToLocalStorage } from '@/utils/general.utils'
 import { generateKeysFromString, getParamsFromLink } from '@/utils/peanut-link.utils'
 import type { SendLink } from '@/services/services.types'
-import { serverFetch } from '@/utils/api-fetch'
-import { getAuthHeaders, authReady } from '@/utils/auth-token'
-import { fetchWithSentry } from '@/utils/sentry.utils'
-import { PEANUT_API_URL } from '@/constants/general.consts'
+import { apiFetch, serverFetch } from '@/utils/api-fetch'
 import { isDemoMode } from '@/utils/demo'
 
 export { ESendLinkStatus } from '@/services/services.types'
@@ -81,9 +78,10 @@ type UpdateLinkBody = {
 
 export const sendLinksApi = {
     create: async (sendLink: CreateLinkBody): Promise<SendLink> => {
-        // This call bypasses callApi (multipart upload), so the demo interceptor
-        // is invoked explicitly here. Lazy import keeps the demo module out of
-        // this service's module graph on web/tests.
+        // The demo interceptor is invoked explicitly BEFORE apiFetch: the real
+        // request may carry a multipart FormData body the demo store can't
+        // parse. Lazy import keeps the demo module out of this service's
+        // module graph on web/tests.
         if (isDemoMode()) {
             const { demoRespond } = await import('@/utils/demo-api')
             return jsonParse(await (await demoRespond('/send-links', { method: 'POST' })).text())
@@ -123,9 +121,7 @@ export const sendLinksApi = {
             headers['Content-Type'] = 'application/json'
         }
 
-        await authReady()
-        Object.assign(headers, getAuthHeaders())
-        const response = await fetchWithSentry(`${PEANUT_API_URL}/send-links`, {
+        const response = await apiFetch('/send-links', {
             method: 'POST',
             body: requestBody,
             headers,

--- a/src/services/tokens-price.ts
+++ b/src/services/tokens-price.ts
@@ -5,12 +5,13 @@
  * CORS + the per-IP rate limiter on /tokens/* are the gate.
  */
 
-import { PEANUT_API_URL } from '@/constants/general.consts'
-import { fetchWithSentry } from '@/utils/sentry.utils'
+import { apiFetch } from '@/utils/api-fetch'
 import { type ITokenPriceData, type IUserBalance } from '@/interfaces/interfaces'
 
 async function getJson<T>(path: string, errorLabel: string): Promise<T | null> {
-    const response = await fetchWithSentry(`${PEANUT_API_URL}${path}`, { method: 'GET' })
+    // includeAuth: false — public endpoints; a rate lookup must not queue
+    // behind auth hydration and sends no token either way.
+    const response = await apiFetch(path, { method: 'GET', includeAuth: false })
     if (response.status === 404) return null
     if (!response.ok) {
         const text = await response.text().catch(() => '')

--- a/src/utils/__tests__/api-fetch.test.ts
+++ b/src/utils/__tests__/api-fetch.test.ts
@@ -96,6 +96,13 @@ describe('apiFetch', () => {
             const callArgs = mockFetchWithSentry.mock.calls[0][1]
             expect((callArgs?.headers as Record<string, string>)['Content-Type']).toBeUndefined()
         })
+
+        it('does not add Content-Type for a FormData body (multipart boundary is fetch-owned)', async () => {
+            await apiFetch('/send-links', { method: 'POST', body: new FormData() })
+
+            const callArgs = mockFetchWithSentry.mock.calls[0][1]
+            expect((callArgs?.headers as Record<string, string>)['Content-Type']).toBeUndefined()
+        })
     })
 
     describe('request options passthrough', () => {

--- a/src/utils/__tests__/no-direct-peanut-api-fetch.test.ts
+++ b/src/utils/__tests__/no-direct-peanut-api-fetch.test.ts
@@ -1,14 +1,18 @@
 // Gate for DS 10 item 3 (TASK-21450): every peanut-api call goes through
 // apiFetch (src/utils/api-fetch.ts). One fetch path = consistent auth headers,
 // authReady gating, demo-mode routing, Content-Type handling, and Sentry
-// error reporting. A direct fetchWithSentry(`${PEANUT_API_URL}…`) call
-// bypasses all of it — this test fails the build when a new one appears.
+// error reporting. A direct fetchWithSentry(`${PEANUT_API_URL}…`) call — or a
+// raw fetch(`${PEANUT_API_URL}…`) call, which additionally skips Sentry
+// reporting and the timeout budget — bypasses all of it; this test fails the
+// build when a new one appears.
 //
-// Detection is file-level co-occurrence: a `fetchWithSentry(` CALL plus any
-// `PEANUT_API_URL` reference in the same non-test source file. That also
-// catches URLs assembled in a variable before the call. fetchWithSentry
-// against non-Peanut hosts (Uniswap, Mobula, JustaName health probes) is
-// fine and does not trip this.
+// Detection is file-level co-occurrence: a `fetchWithSentry(` or bare `fetch(`
+// CALL plus any `PEANUT_API_URL` reference in the same non-test source file.
+// That also catches URLs assembled in a variable before the call, and the
+// NEXT_PUBLIC_PEANUT_API_URL env var read. fetchWithSentry/fetch against
+// non-Peanut hosts (Uniswap, Mobula, JustaName health probes) is fine and
+// does not trip this. `apiFetch(`, `serverFetch(`, `refetch(` etc. do not
+// match the bare-fetch pattern (word boundary).
 //
 // If a file genuinely cannot use apiFetch, add it to EXEMPT below with a
 // one-line reason — do not weaken the detection.
@@ -20,9 +24,34 @@ const SRC = join(__dirname, '..', '..')
 
 // Paths relative to src/, sorted. Each entry needs a reason.
 const EXEMPT = new Set<string>([
+    // dev-only debug console POSTing harness routes with x-test-harness-secret —
+    // deliberately outside the app session layer; migration out of scope
+    'app/(mobile-ui)/dev/debug/page.tsx',
+    // server-side health probe of /healthz — runs in a route handler where the
+    // client session/Sentry wrapper does not apply
+    'app/api/health/backend/route.ts',
+    // production claim path on raw fetch — PRE-EXISTING debt, migration is a
+    // deliberate follow-up (claim moves money; not batched into this refactor)
+    'components/Claim/useClaimLink.tsx',
+    // dev debug surface (harness-gated) — migration out of scope, same class
+    // as dev/debug/page.tsx
+    'context/PeanutDebug.tsx',
+    // harness-only reproduce bootstrap reading NEXT_PUBLIC_PEANUT_API_URL —
+    // runs pre-session by design
+    'context/ReproduceBootstrap.tsx',
     // the wrapper itself — apiFetch IS the one sanctioned fetchWithSentry(PEANUT_API_URL…) call
     'utils/api-fetch.ts',
+    // sanctioned demo-mode passthrough: forwards public GETs to the real
+    // backend, deliberately without Sentry/auth (it IS the apiFetch demo leg)
+    'utils/demo-api.ts',
 ])
+
+// bare fetch( — word boundary keeps apiFetch(, serverFetch(, refetch(,
+// prefetch( and fetchWithSentry( out; window.fetch( / global.fetch( still match
+const BARE_FETCH_RE = /\bfetch\s*\(/
+
+const tripsGate = (text: string): boolean =>
+    text.includes('PEANUT_API_URL') && (text.includes('fetchWithSentry(') || BARE_FETCH_RE.test(text))
 
 function* walk(dir: string): Generator<string> {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -33,7 +62,7 @@ function* walk(dir: string): Generator<string> {
     }
 }
 
-describe('no direct fetchWithSentry calls against PEANUT_API_URL', () => {
+describe('no direct fetchWithSentry/fetch calls against PEANUT_API_URL', () => {
     it('routes every peanut-api call through apiFetch', () => {
         const offenders: string[] = []
         for (const p of walk(SRC)) {
@@ -43,8 +72,7 @@ describe('no direct fetchWithSentry calls against PEANUT_API_URL', () => {
             const rel = relative(SRC, p).split(sep).join('/')
             if (rel.includes('__tests__') || rel.includes('__mocks__')) continue
             if (EXEMPT.has(rel)) continue
-            const text = readFileSync(p, 'utf8')
-            if (text.includes('fetchWithSentry(') && text.includes('PEANUT_API_URL')) {
+            if (tripsGate(readFileSync(p, 'utf8'))) {
                 offenders.push(rel)
             }
         }
@@ -61,7 +89,7 @@ describe('no direct fetchWithSentry calls against PEANUT_API_URL', () => {
                 stale.push(`${rel} (file no longer exists)`)
                 continue
             }
-            if (!text.includes('fetchWithSentry(') || !text.includes('PEANUT_API_URL')) {
+            if (!tripsGate(text)) {
                 stale.push(`${rel} (no longer needs the exemption)`)
             }
         }

--- a/src/utils/__tests__/no-direct-peanut-api-fetch.test.ts
+++ b/src/utils/__tests__/no-direct-peanut-api-fetch.test.ts
@@ -49,9 +49,11 @@ const EXEMPT = new Set<string>([
 // bare fetch( — word boundary keeps apiFetch(, serverFetch(, refetch(,
 // prefetch( and fetchWithSentry( out; window.fetch( / global.fetch( still match
 const BARE_FETCH_RE = /\bfetch\s*\(/
+// whitespace-tolerant so `fetchWithSentry (…)` can't slip past the gate
+const FETCH_WITH_SENTRY_RE = /\bfetchWithSentry\s*\(/
 
 const tripsGate = (text: string): boolean =>
-    text.includes('PEANUT_API_URL') && (text.includes('fetchWithSentry(') || BARE_FETCH_RE.test(text))
+    text.includes('PEANUT_API_URL') && (FETCH_WITH_SENTRY_RE.test(text) || BARE_FETCH_RE.test(text))
 
 function* walk(dir: string): Generator<string> {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -100,6 +102,6 @@ describe('no direct fetchWithSentry/fetch calls against PEANUT_API_URL', () => {
         // The whole-file exemption above would hide a SECOND direct call added
         // to api-fetch.ts — pin the count so that can't happen silently.
         const text = readFileSync(join(SRC, 'utils/api-fetch.ts'), 'utf8')
-        expect(text.match(/fetchWithSentry\(/g)).toHaveLength(1)
+        expect(text.match(/\bfetchWithSentry\s*\(/g)).toHaveLength(1)
     })
 })

--- a/src/utils/__tests__/no-direct-peanut-api-fetch.test.ts
+++ b/src/utils/__tests__/no-direct-peanut-api-fetch.test.ts
@@ -14,7 +14,7 @@
 // one-line reason — do not weaken the detection.
 
 import { readdirSync, readFileSync } from 'node:fs'
-import { join, relative } from 'node:path'
+import { join, relative, sep } from 'node:path'
 
 const SRC = join(__dirname, '..', '..')
 
@@ -39,7 +39,8 @@ describe('no direct fetchWithSentry calls against PEANUT_API_URL', () => {
         for (const p of walk(SRC)) {
             if (!/\.(ts|tsx)$/.test(p)) continue
             if (/\.test\.(ts|tsx)$/.test(p)) continue
-            const rel = relative(SRC, p)
+            // posix-normalized so EXEMPT matches on Windows checkouts too
+            const rel = relative(SRC, p).split(sep).join('/')
             if (rel.includes('__tests__') || rel.includes('__mocks__')) continue
             if (EXEMPT.has(rel)) continue
             const text = readFileSync(p, 'utf8')
@@ -65,5 +66,12 @@ describe('no direct fetchWithSentry calls against PEANUT_API_URL', () => {
             }
         }
         expect(stale).toEqual([])
+    })
+
+    it('keeps the wrapper down to exactly one sanctioned direct call', () => {
+        // The whole-file exemption above would hide a SECOND direct call added
+        // to api-fetch.ts — pin the count so that can't happen silently.
+        const text = readFileSync(join(SRC, 'utils/api-fetch.ts'), 'utf8')
+        expect(text.match(/fetchWithSentry\(/g)).toHaveLength(1)
     })
 })

--- a/src/utils/__tests__/no-direct-peanut-api-fetch.test.ts
+++ b/src/utils/__tests__/no-direct-peanut-api-fetch.test.ts
@@ -1,0 +1,69 @@
+// Gate for DS 10 item 3 (TASK-21450): every peanut-api call goes through
+// apiFetch (src/utils/api-fetch.ts). One fetch path = consistent auth headers,
+// authReady gating, demo-mode routing, Content-Type handling, and Sentry
+// error reporting. A direct fetchWithSentry(`${PEANUT_API_URL}…`) call
+// bypasses all of it — this test fails the build when a new one appears.
+//
+// Detection is file-level co-occurrence: a `fetchWithSentry(` CALL plus any
+// `PEANUT_API_URL` reference in the same non-test source file. That also
+// catches URLs assembled in a variable before the call. fetchWithSentry
+// against non-Peanut hosts (Uniswap, Mobula, JustaName health probes) is
+// fine and does not trip this.
+//
+// If a file genuinely cannot use apiFetch, add it to EXEMPT below with a
+// one-line reason — do not weaken the detection.
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+const SRC = join(__dirname, '..', '..')
+
+// Paths relative to src/, sorted. Each entry needs a reason.
+const EXEMPT = new Set<string>([
+    // the wrapper itself — apiFetch IS the one sanctioned fetchWithSentry(PEANUT_API_URL…) call
+    'utils/api-fetch.ts',
+])
+
+function* walk(dir: string): Generator<string> {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue
+        const p = join(dir, entry.name)
+        if (entry.isDirectory()) yield* walk(p)
+        else yield p
+    }
+}
+
+describe('no direct fetchWithSentry calls against PEANUT_API_URL', () => {
+    it('routes every peanut-api call through apiFetch', () => {
+        const offenders: string[] = []
+        for (const p of walk(SRC)) {
+            if (!/\.(ts|tsx)$/.test(p)) continue
+            if (/\.test\.(ts|tsx)$/.test(p)) continue
+            const rel = relative(SRC, p)
+            if (rel.includes('__tests__') || rel.includes('__mocks__')) continue
+            if (EXEMPT.has(rel)) continue
+            const text = readFileSync(p, 'utf8')
+            if (text.includes('fetchWithSentry(') && text.includes('PEANUT_API_URL')) {
+                offenders.push(rel)
+            }
+        }
+        expect(offenders).toEqual([])
+    })
+
+    it('keeps the exemption list free of stale entries', () => {
+        const stale: string[] = []
+        for (const rel of EXEMPT) {
+            let text: string
+            try {
+                text = readFileSync(join(SRC, rel), 'utf8')
+            } catch {
+                stale.push(`${rel} (file no longer exists)`)
+                continue
+            }
+            if (!text.includes('fetchWithSentry(') || !text.includes('PEANUT_API_URL')) {
+                stale.push(`${rel} (no longer needs the exemption)`)
+            }
+        }
+        expect(stale).toEqual([])
+    })
+})

--- a/src/utils/api-fetch.ts
+++ b/src/utils/api-fetch.ts
@@ -32,7 +32,9 @@ async function callApi(path: string, options?: FetchOptions): Promise<Response> 
 
     const headers: Record<string, string> = {}
     const hasContentType = Object.keys(callerHeaders).some((k) => k.toLowerCase() === 'content-type')
-    if (fetchOptions.body && !hasContentType) {
+    // FormData must keep its fetch-generated multipart boundary — forcing
+    // application/json here would break attachment uploads (send-links, charges).
+    if (fetchOptions.body && !hasContentType && !(fetchOptions.body instanceof FormData)) {
         headers['Content-Type'] = 'application/json'
     }
     Object.assign(headers, includeAuth ? getAuthHeaders(callerHeaders) : callerHeaders)

--- a/src/utils/demo-api.ts
+++ b/src/utils/demo-api.ts
@@ -18,7 +18,15 @@ const PASSTHROUGH_TIMEOUT_MS = 10_000
 
 // Public read-only rate endpoints proxied to the real backend so demo shows live
 // FX rates. Best-effort: any failure falls through to the canned handler below.
-const PASSTHROUGH_GET = new Set(['/bridge/exchange-rate', '/manteca/prices', '/fx/rate'])
+// /tokens/* are public too — the canned {} fallback is NOT a valid shape for
+// them (fetchWalletBalances crashed on `{}.balances.filter` in recover-funds).
+const PASSTHROUGH_GET = new Set([
+    '/bridge/exchange-rate',
+    '/manteca/prices',
+    '/fx/rate',
+    '/tokens/price',
+    '/tokens/wallet-portfolio',
+])
 
 const EMPTY_GRAPH = {
     nodes: [] as unknown[],
@@ -46,6 +54,22 @@ type DemoRequestBody = {
 }
 
 function parseBody(options?: RequestInit): DemoRequestBody {
+    // Multipart callers (charges, send-links attachments) reach here through
+    // apiFetch's demo routing with a FormData body — read it field-by-field so
+    // a caller without an explicit JSON pre-intercept still records real
+    // values instead of silently degrading to {} (e.g. amount '0').
+    if (options?.body instanceof FormData) {
+        const out: Record<string, unknown> = {}
+        options.body.forEach((value, key) => {
+            if (typeof value !== 'string') return // File/Blob — not body data
+            try {
+                out[key] = JSON.parse(value) // objects/numbers arrive JSON-stringified
+            } catch {
+                out[key] = value // plain strings stay as-is
+            }
+        })
+        return out as DemoRequestBody
+    }
     try {
         return typeof options?.body === 'string' ? JSON.parse(options.body) : {}
     } catch {
@@ -337,7 +361,19 @@ const ROUTES: Array<{ method: string; pattern: string; handler: Handler }> = [
     { method: 'POST', pattern: '/users/initiate-kyc', handler: () => ({}) },
     { method: 'POST', pattern: '/users/interaction-status', handler: () => ({}) },
     { method: 'POST', pattern: '/users/accounts', handler: () => ({ id: 'demo-bank' }) },
-    { method: 'GET', pattern: '/users/username/:username', handler: ({ params }) => demoApiUser(params.username) },
+    {
+        method: 'GET',
+        pattern: '/users/username/:username',
+        handler: ({ params }) => {
+            // Only the demo cast resolves: the demo user plus the seeded contacts
+            // (recipient resolution + profile lookups keep working). Everything
+            // else 404s — Signup's availability probe reads 200 as "taken", so a
+            // blanket 200 blocked signup for EVERY username when the demo flag
+            // was still latched from a 'demo' invite-code entry.
+            const cast = new Set([DEMO_USER.user.username, ...DEMO_CONTACTS.map((c) => c.username)])
+            return cast.has(params.username) ? demoApiUser(params.username) : json({ error: 'not found' }, 404)
+        },
+    },
     { method: 'GET', pattern: '/users/:userId/rewards', handler: () => [] },
     { method: 'GET', pattern: '/users/:userId', handler: ({ params }) => demoCounterparty(params.userId) },
     {

--- a/src/utils/demo-api.ts
+++ b/src/utils/demo-api.ts
@@ -62,11 +62,21 @@ function parseBody(options?: RequestInit): DemoRequestBody {
         const out: Record<string, unknown> = {}
         options.body.forEach((value, key) => {
             if (typeof value !== 'string') return // File/Blob — not body data
-            try {
-                out[key] = JSON.parse(value) // objects/numbers arrive JSON-stringified
-            } catch {
-                out[key] = value // plain strings stay as-is
+            // Only object/array fields arrive JSON-stringified (charges appends
+            // non-File objects via JSON.stringify); parse just those. Parsing
+            // every string would coerce "123"/"true" into numbers/booleans and
+            // violate declared string fields (reference, username) — gating on
+            // the first char is simpler and safer than a known-field list.
+            const trimmed = value.trim()
+            if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+                try {
+                    out[key] = JSON.parse(trimmed)
+                    return
+                } catch {
+                    // malformed — keep the raw string
+                }
             }
+            out[key] = value
         })
         return out as DemoRequestBody
     }
@@ -369,9 +379,40 @@ const ROUTES: Array<{ method: string; pattern: string; handler: Handler }> = [
             // (recipient resolution + profile lookups keep working). Everything
             // else 404s — Signup's availability probe reads 200 as "taken", so a
             // blanket 200 blocked signup for EVERY username when the demo flag
-            // was still latched from a 'demo' invite-code entry.
-            const cast = new Set([DEMO_USER.user.username, ...DEMO_CONTACTS.map((c) => c.username)])
-            return cast.has(params.username) ? demoApiUser(params.username) : json({ error: 'not found' }, 404)
+            // was still latched from a 'demo' invite-code entry. Responses carry
+            // the CANONICAL record's identity — inventing one via demoApiUser
+            // gave 'demo' userId 'demo-demo' instead of 'demo-user'/DEMO_ADDRESS.
+            if (params.username === DEMO_USER.user.username) {
+                const { userId, username, fullName, showFullName } = DEMO_USER.user
+                return {
+                    userId,
+                    username,
+                    accounts: DEMO_USER.accounts.map((a) => ({ identifier: a.identifier, type: a.type })),
+                    fullName,
+                    firstName: fullName?.split(' ')[0] ?? username,
+                    lastName: fullName?.split(' ').slice(1).join(' ') ?? '',
+                    showFullName,
+                    totalUsdSentToCurrentUser: '0',
+                    totalUsdReceivedFromCurrentUser: '0',
+                    isVerified: true,
+                }
+            }
+            const contact = DEMO_CONTACTS.find((c) => c.username === params.username)
+            if (!contact) return json({ error: 'not found' }, 404)
+            return {
+                userId: contact.userId,
+                username: contact.username,
+                // contacts carry no account data — synthesize the same
+                // username-keyed peanut-wallet demoApiUser always used
+                accounts: [{ identifier: contact.username, type: 'peanut-wallet' }],
+                fullName: contact.fullName,
+                firstName: contact.fullName?.split(' ')[0] ?? contact.username,
+                lastName: contact.fullName?.split(' ').slice(1).join(' ') ?? '',
+                showFullName: contact.showFullName,
+                totalUsdSentToCurrentUser: '0',
+                totalUsdReceivedFromCurrentUser: '0',
+                isVerified: contact.isVerified,
+            }
         },
     },
     { method: 'GET', pattern: '/users/:userId/rewards', handler: () => [] },
@@ -686,6 +727,7 @@ export async function demoRespond(path: string, options?: RequestInit): Promise<
     const pathname = path.split('?')[0].replace(/\/+$/, '') || '/'
 
     // Live-rate passthrough to the real backend (best-effort).
+    let passthroughFailed = false
     if (method === 'GET' && PASSTHROUGH_GET.has(pathname)) {
         const controller = new AbortController()
         const timeout = setTimeout(() => controller.abort(), PASSTHROUGH_TIMEOUT_MS)
@@ -696,10 +738,11 @@ export async function demoRespond(path: string, options?: RequestInit): Promise<
             })
             if (res.ok) return res
         } catch {
-            // fall through to the canned handler below
+            // fall through to the canned handler below (the FX trio has one)
         } finally {
             clearTimeout(timeout)
         }
+        passthroughFailed = true
     }
 
     for (const route of compiled) {
@@ -712,6 +755,14 @@ export async function demoRespond(path: string, options?: RequestInit): Promise<
         })
         const result = route.handler({ params, options })
         return result instanceof Response ? result : json(result)
+    }
+
+    // A failed passthrough with no canned fallback (e.g. /tokens/*) must NOT
+    // degrade to the 200 defaultShape below — callers would parse {} as success
+    // and crash on missing fields (the recover-funds balances TypeError).
+    // Surface a real failure so their error paths run instead.
+    if (passthroughFailed) {
+        return json({ error: 'demo passthrough unavailable' }, 503)
     }
 
     if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
## Summary

DS 10 (TASK-21450), item "apiFetch unification". Migrates the 9 remaining direct `fetchWithSentry(PEANUT_API_URL…)` call sites (Signup, SetupPasskey, onramp-quote, tokens-price, sendLinks, charges, card, rhino-sda, rhino-bridge) to the `apiFetch` wrapper, so every Peanut-API call shares one path for auth headers, error normalization, demo routing, and tracing.

**The gate**: `src/utils/__tests__/no-direct-peanut-api-fetch.test.ts` walks `src/` and fails on any new direct `fetchWithSentry(` — or raw `fetch(` — combined with `PEANUT_API_URL`. Deliberately a jest test rather than a `tests.yml` step (three sibling DS 10 PRs touch that workflow; the unit job runs jest anyway). Six documented exemptions, each with a reason; a pin test keeps `api-fetch.ts` itself to exactly one sanctioned call.

**Enabler fixes in the wrapper/demo layer** (surfaced by review):
- `api-fetch.ts`: auto `Content-Type: application/json` now skips `FormData` bodies (fetch must own the multipart boundary).
- `demo-api.ts`: the username route now 404s for non-demo-cast names (a latched demo flag previously made every username read "taken", blocking native signup once these probes went through apiFetch); `/tokens/price` + `/tokens/wallet-portfolio` added to the public passthrough (the canned `{}` crashed recover-funds); `parseBody` reads FormData so a future multipart caller can't silently record amount "0".
- `card.ts`: duplicate auth layer collapsed to a fail-fast `assertAuthenticated()` — apiFetch owns the headers; the old `api-key` header was dead (undefined in the client bundle).

## Task

[DS 10: lint ratchets in CI + eslint to 0](https://app.notion.com/p/peanutprotocol/DS-10-lint-ratchets-in-CI-eslint-to-0-3bb83811757981628fbfde923cbef33c) (TASK-21450) — item 3. Companions: #2742, #2744, #2745.

## Design notes / accepted trade-offs

- Gate detection is file-level co-occurrence, deliberately over-sensitive: it also catches URLs assembled in variables. A false positive costs one documented EXEMPT entry; a false negative silently bypasses the contract.
- `charges.create` keeps its explicit demo pre-intercept (its JSON mapping is intentional); `sendLinks.create`'s was redundant and is gone.
- **Known debt, deliberate follow-ups (not in this PR):** `components/Claim/useClaimLink.tsx` still calls the API via raw `fetch` (claim moves money — not batched into this refactor; exempted with a comment); a shared `apiFetchJson<T>` helper should later consolidate the near-identical `postJson`/`getJson`/`postRhino` wrappers in rhino-bridge/rhino-sda/tokens-price.

## Risks / breaking changes

- Runtime change on real fetch paths (send links, charges, card, rhino, onboarding username checks). Semantics verified site-by-site old-vs-new; /code-review high pass ran with 2 correctness findings — both fixed here (demo username latch, tokens-price passthrough).
- Native demo mode now intercepts these calls by design (App-Store review only; real-user paths unchanged).

## QA

- Typecheck clean; eslint 0 errors on changed files; prettier clean.
- 25 affected suites / 245 tests green (Setup, Claim, Card, services, api-fetch, demo, views) + gate 3/3. `demo-api.test.ts`'s 20 undici failures are the known pre-existing local-env artifact (identical count/tests before the change; green in CI).

Screenshots: N/A (no visible change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved reliability and consistency for quotes, card services, charges, transfers, and account-related requests.
  - Enhanced attachment uploads by preserving multipart form data correctly.
  - Improved authentication handling across supported services and demo mode.

- **Bug Fixes**
  - Added live token pricing and portfolio data support in demo mode.
  - Improved demo username lookup, including seeded contacts and accurate not-found responses.
  - Preserved platform-specific username availability checks during signup and passkey setup.

- **Tests**
  - Added coverage for multipart uploads and safeguards against inconsistent direct API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->