### PR TITLE
ds 14: activity surfaces — states rules, list restyle, ?tx= deep-link, drawer chrome

### DIFF
--- a/src/app/(mobile-ui)/dev/ds/patterns/feedback/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/patterns/feedback/page.tsx
@@ -104,8 +104,9 @@ export default function FeedbackPage() {
             <DocSection title="StatusPill">
                 <DocSection.Content>
                     <p className="text-sm text-grey-1">
-                        Tiny 14px circular icon indicator. Uses the same StatusType as StatusBadge (minus
-                        &quot;custom&quot;). Pairs well with list items.
+                        20px round icon chip (3px padding, 14px icon) on the badge background tokens — states board
+                        17966:12128. Uses the same StatusType as StatusBadge (minus &quot;custom&quot;). Pairs well with
+                        list items.
                     </p>
 
                     <div className="space-y-4">

--- a/src/app/(mobile-ui)/history/page.tsx
+++ b/src/app/(mobile-ui)/history/page.tsx
@@ -268,7 +268,7 @@ const HistoryPage = () => {
     const today = new Date()
 
     return (
-        <div className="flex min-h-[inherit] w-full flex-col gap-6">
+        <div className="flex min-h-[inherit] w-full flex-col gap-8">
             <NavHeader title={t('title')} />
             <div className="h-full w-full">
                 {combinedAndSortedEntries.map((item, index) => {

--- a/src/app/(mobile-ui)/history/page.tsx
+++ b/src/app/(mobile-ui)/history/page.tsx
@@ -34,6 +34,7 @@ import { TRANSACTIONS } from '@/constants/query.consts'
 import type { HistoryEntry, HistoryResponse } from '@/hooks/useTransactionHistory'
 import { AccountType } from '@/interfaces/interfaces'
 import { completeHistoryEntry, dedupeHistoryEntriesByUuid } from '@/utils/history.utils'
+import { twMerge } from 'tailwind-merge'
 import { formatUnits } from 'viem'
 import { PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
 
@@ -240,7 +241,7 @@ const HistoryPage = () => {
         Sentry.captureException(error)
         return (
             <div className="mx-auto space-y-3 mt-6 w-full md:max-w-2xl">
-                <h2 className="text-base font-bold">{t('transactions')}</h2>{' '}
+                <h2 className="text-heading-card text-foreground-primary">{t('transactions')}</h2>{' '}
                 <EmptyState icon="alert" title={t('errorTitle')} description={t('errorDescription')} />
             </div>
         )
@@ -267,7 +268,7 @@ const HistoryPage = () => {
     const today = new Date()
 
     return (
-        <div className="mx-auto space-y-6 w-full md:space-y-3 md:max-w-2xl">
+        <div className="flex min-h-[inherit] w-full flex-col gap-6">
             <NavHeader title={t('title')} />
             <div className="h-full w-full">
                 {combinedAndSortedEntries.map((item, index) => {
@@ -296,8 +297,14 @@ const HistoryPage = () => {
 
                     return (
                         <React.Fragment key={item.uuid}>
+                            {/* date group header — board 17966:12128: Label/M, 8px above the group's rows */}
                             {showHeader && (
-                                <div className="mt-4 mb-2 px-1 text-sm font-semibold">
+                                <div
+                                    className={twMerge(
+                                        'mb-2 text-label-m text-foreground-primary',
+                                        index > 0 && 'mt-2'
+                                    )}
+                                >
                                     {groupHeader(itemDate, group)}
                                 </div>
                             )}

--- a/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
+++ b/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
@@ -581,8 +581,7 @@ function applyDefaults() {
 
     mockUseTransactionDetailsDrawer.mockReturnValue({
         openTransactionDetails: jest.fn(),
-        selectedTransaction: null,
-        isDrawerOpen: false,
+        selectedTxId: null,
         closeTransactionDetails: jest.fn(),
     })
 
@@ -1067,8 +1066,7 @@ describe('GROUP 4: Success States', () => {
         const openTransactionDetails = jest.fn()
         mockUseTransactionDetailsDrawer.mockReturnValue({
             openTransactionDetails,
-            selectedTransaction: null,
-            isDrawerOpen: false,
+            selectedTxId: null,
             closeTransactionDetails: jest.fn(),
         })
 

--- a/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
+++ b/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
@@ -582,6 +582,7 @@ function applyDefaults() {
     mockUseTransactionDetailsDrawer.mockReturnValue({
         openTransactionDetails: jest.fn(),
         selectedTxId: null,
+        isTransactionSelected: () => false,
         closeTransactionDetails: jest.fn(),
     })
 
@@ -1067,6 +1068,7 @@ describe('GROUP 4: Success States', () => {
         mockUseTransactionDetailsDrawer.mockReturnValue({
             openTransactionDetails,
             selectedTxId: null,
+            isTransactionSelected: () => false,
             closeTransactionDetails: jest.fn(),
         })
 

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -132,7 +132,7 @@ export default function QRPayPage() {
     const [currencyAmount, setCurrencyAmount] = useState<string | undefined>(undefined)
     const [qrPayment, setQrPayment] = useState<QrPayment | null>(null)
     const [currency, setCurrency] = useState<{ code: string; symbol: string; price: number } | undefined>(undefined)
-    const { openTransactionDetails, selectedTxId, closeTransactionDetails } = useTransactionDetailsDrawer()
+    const { openTransactionDetails, isTransactionSelected, closeTransactionDetails } = useTransactionDetailsDrawer()
     const { isLoading, loadingState, setLoadingState } = useContext(loadingStateContext)
 
     const paymentProcessor: PaymentProcessor | null = useMemo(() => {
@@ -553,7 +553,7 @@ export default function QRPayPage() {
                 },
             },
             totalAmountCollected: Number(usdAmount),
-        } as TransactionDetails
+        }
     }, [qrPayment, currency, usdAmount, methodIcon])
 
     // Fetch Manteca payment lock immediately on QR scan (Manteca only)
@@ -1521,7 +1521,7 @@ export default function QRPayPage() {
                     </div>
                 </div>
                 <TransactionDetailsDrawer
-                    isOpen={!!receiptTransaction && selectedTxId === receiptTransaction.id}
+                    isOpen={isTransactionSelected(receiptTransaction?.id)}
                     onClose={closeTransactionDetails}
                     transaction={receiptTransaction}
                 />

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -39,6 +39,7 @@ import { isPixRecurringCode } from '@/utils/withdraw.utils'
 import { formatUnits, parseUnits } from 'viem'
 import { useTransactionDetailsDrawer } from '@/hooks/useTransactionDetailsDrawer'
 import { TransactionDetailsDrawer } from '@/components/TransactionDetails/TransactionDetailsDrawer'
+import { type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
 import { EHistoryUserRole } from '@/hooks/useTransactionHistory'
 import { loadingStateContext } from '@/context/loadingStates.context'
 import { getCurrencyPrice } from '@/app/actions/currency'
@@ -131,8 +132,7 @@ export default function QRPayPage() {
     const [currencyAmount, setCurrencyAmount] = useState<string | undefined>(undefined)
     const [qrPayment, setQrPayment] = useState<QrPayment | null>(null)
     const [currency, setCurrency] = useState<{ code: string; symbol: string; price: number } | undefined>(undefined)
-    const { openTransactionDetails, selectedTransaction, isDrawerOpen, closeTransactionDetails } =
-        useTransactionDetailsDrawer()
+    const { openTransactionDetails, selectedTxId, closeTransactionDetails } = useTransactionDetailsDrawer()
     const { isLoading, loadingState, setLoadingState } = useContext(loadingStateContext)
 
     const paymentProcessor: PaymentProcessor | null = useMemo(() => {
@@ -517,6 +517,44 @@ export default function QRPayPage() {
                 return null
         }
     }, [qrType])
+
+    // receipt transaction for the success drawer — built up-front (not in the
+    // cta's onClick) because the drawer opens off the url's `?tx=` match.
+    const receiptTransaction: TransactionDetails | null = useMemo(() => {
+        if (!qrPayment || !currency) return null
+        const now = new Date()
+        return {
+            // Manteca synthetic id — the only key /receipt/<id>
+            // resolves, and what Activity rows already carry.
+            // `externalId` is UUID-shaped, so it slips past the
+            // id-shape gate and 404s silently instead of erroring.
+            id: qrPayment.id,
+            direction: 'qr_payment',
+            userName: qrPayment.details.merchant.name,
+            fullName: qrPayment.details.merchant.name,
+            amount: Number(usdAmount),
+            currency: {
+                amount: qrPayment.details.paymentAssetAmount,
+                code: currency.code,
+            },
+            initials: 'QR',
+            currencySymbol: currency.symbol,
+            status: 'completed',
+            date: now,
+            createdAt: now,
+            extraDataForDrawer: {
+                originalType: 'TRANSACTION_INTENT',
+                originalUserRole: EHistoryUserRole.SENDER,
+                kind: 'QR_PAY',
+                provider: 'MANTECA',
+                avatarUrl: methodIcon,
+                receipt: {
+                    exchange_rate: currency.price.toString(),
+                },
+            },
+            totalAmountCollected: Number(usdAmount),
+        } as TransactionDetails
+    }, [qrPayment, currency, usdAmount, methodIcon])
 
     // Fetch Manteca payment lock immediately on QR scan (Manteca only)
     // OPTIMIZATION: We fetch payment details BEFORE KYC check completes for faster UX
@@ -1457,38 +1495,9 @@ export default function QRPayPage() {
                                     shadowSize="4"
                                     disabled={false}
                                     onClick={() => {
-                                        const now = new Date()
-                                        openTransactionDetails({
-                                            // Manteca synthetic id — the only key /receipt/<id>
-                                            // resolves, and what Activity rows already carry.
-                                            // `externalId` is UUID-shaped, so it slips past the
-                                            // id-shape gate and 404s silently instead of erroring.
-                                            id: qrPayment!.id,
-                                            direction: 'qr_payment',
-                                            userName: qrPayment!.details.merchant.name,
-                                            fullName: qrPayment!.details.merchant.name,
-                                            amount: Number(usdAmount),
-                                            currency: {
-                                                amount: qrPayment!.details.paymentAssetAmount,
-                                                code: currency.code,
-                                            },
-                                            initials: 'QR',
-                                            currencySymbol: currency.symbol,
-                                            status: 'completed',
-                                            date: now,
-                                            createdAt: now,
-                                            extraDataForDrawer: {
-                                                originalType: 'TRANSACTION_INTENT',
-                                                originalUserRole: EHistoryUserRole.SENDER,
-                                                kind: 'QR_PAY',
-                                                provider: 'MANTECA',
-                                                avatarUrl: methodIcon,
-                                                receipt: {
-                                                    exchange_rate: currency.price.toString(),
-                                                },
-                                            },
-                                            totalAmountCollected: Number(usdAmount),
-                                        })
+                                        if (receiptTransaction) {
+                                            openTransactionDetails(receiptTransaction)
+                                        }
                                     }}
                                 >
                                     {t('success.seeReceipt')}
@@ -1512,9 +1521,9 @@ export default function QRPayPage() {
                     </div>
                 </div>
                 <TransactionDetailsDrawer
-                    isOpen={isDrawerOpen}
+                    isOpen={!!receiptTransaction && selectedTxId === receiptTransaction.id}
                     onClose={closeTransactionDetails}
-                    transaction={selectedTransaction}
+                    transaction={receiptTransaction}
                 />
                 {/* Mounted only while open: the modal's shown-guard is a ref that lives
                     for the mount, so a persistent mount would swallow the MODAL_SHOWN /

--- a/src/components/Claim/Claim.tsx
+++ b/src/components/Claim/Claim.tsx
@@ -9,7 +9,6 @@ import { TransactionDetailsReceipt } from '@/components/TransactionDetails/Trans
 import { type TransactionDetails, REWARD_TOKENS } from '@/components/TransactionDetails/transactionTransformer'
 import { tokenSelectorContext } from '@/context/tokenSelector.context'
 import { useAuth } from '@/context/authContext'
-import { useTransactionDetailsDrawer } from '@/hooks/useTransactionDetailsDrawer'
 import { EHistoryUserRole } from '@/hooks/useTransactionHistory'
 import { useUserInteractions } from '@/hooks/useUserInteractions'
 import { useWallet } from '@/hooks/wallet/useWallet'
@@ -83,7 +82,6 @@ export const Claim = ({}) => {
     })
 
     const { setSelectedChainID, setSelectedTokenAddress } = useContext(tokenSelectorContext)
-    const { selectedTransaction, openTransactionDetails } = useTransactionDetailsDrawer()
 
     const [initialKYCStep, setInitialKYCStep] = useState<number>(0)
 
@@ -263,6 +261,15 @@ export const Claim = ({}) => {
         }))
     }
 
+    // the receipt shown on sender/already-claimed states — pure derivation
+    // (used to be pushed into the drawer hook's state via an effect)
+    const selectedTransaction = useMemo(() => {
+        const isReceiptState =
+            linkState === _consts.claimLinkStateType.CLAIM_SENDER ||
+            linkState === _consts.claimLinkStateType.ALREADY_CLAIMED
+        return isReceiptState ? transactionForDrawer : null
+    }, [linkState, transactionForDrawer])
+
     const showTransactionReceipt = useMemo(() => {
         if (!selectedTransaction) return false
         // check for showing txn receipt only to the creator after link is claimed
@@ -422,16 +429,6 @@ export const Claim = ({}) => {
             setLinkUrl(resolveClaimLink(pageUrl)) // TanStack Query will automatically fetch when linkUrl changes
         }
     }, [])
-
-    useEffect(() => {
-        if (!transactionForDrawer) return
-        if (
-            linkState === _consts.claimLinkStateType.CLAIM_SENDER ||
-            linkState === _consts.claimLinkStateType.ALREADY_CLAIMED
-        ) {
-            openTransactionDetails(transactionForDrawer)
-        }
-    }, [linkState, transactionForDrawer])
 
     // redirect to bank flow if user is KYC approved and step is bank
     useEffect(() => {

--- a/src/components/Claim/__tests__/claim-states.test.tsx
+++ b/src/components/Claim/__tests__/claim-states.test.tsx
@@ -489,7 +489,6 @@ describe('GROUP 5: User-Dependent States', () => {
         })
         mockSendLinksApi.get.mockResolvedValue(link)
 
-        const mockOpenDetails = jest.fn()
         renderClaim()
 
         // Sender should see receipt, NOT the ClaimedView

--- a/src/components/Claim/__tests__/claim-states.test.tsx
+++ b/src/components/Claim/__tests__/claim-states.test.tsx
@@ -74,11 +74,6 @@ jest.mock('@/hooks/wallet/useWallet', () => ({
     useWallet: () => mockUseWallet(),
 }))
 
-const mockUseTransactionDetailsDrawer = jest.fn()
-jest.mock('@/hooks/useTransactionDetailsDrawer', () => ({
-    useTransactionDetailsDrawer: () => mockUseTransactionDetailsDrawer(),
-}))
-
 jest.mock('@/hooks/useTransactionHistory', () => ({
     EHistoryUserRole: { SENDER: 'SENDER' },
 }))
@@ -301,13 +296,6 @@ function applyDefaults() {
         balance: BigInt(100000000),
     })
 
-    mockUseTransactionDetailsDrawer.mockReturnValue({
-        openTransactionDetails: jest.fn(),
-        selectedTransaction: null,
-        isDrawerOpen: false,
-        closeTransactionDetails: jest.fn(),
-    })
-
     // Default: API returns nothing (not called yet)
     mockSendLinksApi.get.mockResolvedValue(undefined)
 }
@@ -379,14 +367,6 @@ describe('GROUP 3: Already Claimed / Cancelled', () => {
         const link = makeSendLink({ status: 'CLAIMED', claim: { txHash: '0xCLAIM' } })
         mockSendLinksApi.get.mockResolvedValue(link)
 
-        // Mock transaction drawer to provide selectedTransaction
-        mockUseTransactionDetailsDrawer.mockReturnValue({
-            openTransactionDetails: jest.fn(),
-            selectedTransaction: { amount: 10, tokenSymbol: 'USDC' },
-            isDrawerOpen: false,
-            closeTransactionDetails: jest.fn(),
-        })
-
         renderClaim()
 
         await waitFor(() => {
@@ -397,13 +377,6 @@ describe('GROUP 3: Already Claimed / Cancelled', () => {
     test('CANCELLED link shows ClaimedView (link no longer available)', async () => {
         const link = makeSendLink({ status: 'CANCELLED' })
         mockSendLinksApi.get.mockResolvedValue(link)
-
-        mockUseTransactionDetailsDrawer.mockReturnValue({
-            openTransactionDetails: jest.fn(),
-            selectedTransaction: { amount: 10, tokenSymbol: 'USDC' },
-            isDrawerOpen: false,
-            closeTransactionDetails: jest.fn(),
-        })
 
         renderClaim()
 
@@ -416,13 +389,6 @@ describe('GROUP 3: Already Claimed / Cancelled', () => {
         const link = makeSendLink({ status: 'CLAIMING' })
         mockSendLinksApi.get.mockResolvedValue(link)
 
-        mockUseTransactionDetailsDrawer.mockReturnValue({
-            openTransactionDetails: jest.fn(),
-            selectedTransaction: { amount: 10, tokenSymbol: 'USDC' },
-            isDrawerOpen: false,
-            closeTransactionDetails: jest.fn(),
-        })
-
         renderClaim()
 
         await waitFor(() => {
@@ -433,13 +399,6 @@ describe('GROUP 3: Already Claimed / Cancelled', () => {
     test('FAILED link with txHash shows as already claimed (funds left)', async () => {
         const link = makeSendLink({ status: 'FAILED', claim: { txHash: '0xFAILED' } })
         mockSendLinksApi.get.mockResolvedValue(link)
-
-        mockUseTransactionDetailsDrawer.mockReturnValue({
-            openTransactionDetails: jest.fn(),
-            selectedTransaction: { amount: 10, tokenSymbol: 'USDC' },
-            isDrawerOpen: false,
-            closeTransactionDetails: jest.fn(),
-        })
 
         renderClaim()
 
@@ -531,13 +490,6 @@ describe('GROUP 5: User-Dependent States', () => {
         mockSendLinksApi.get.mockResolvedValue(link)
 
         const mockOpenDetails = jest.fn()
-        mockUseTransactionDetailsDrawer.mockReturnValue({
-            openTransactionDetails: mockOpenDetails,
-            selectedTransaction: { amount: 10, tokenSymbol: 'USDC' },
-            isDrawerOpen: true,
-            closeTransactionDetails: jest.fn(),
-        })
-
         renderClaim()
 
         // Sender should see receipt, NOT the ClaimedView

--- a/src/components/Global/Drawer/index.tsx
+++ b/src/components/Global/Drawer/index.tsx
@@ -37,7 +37,9 @@ const DrawerContent = React.forwardRef<React.ElementRef<typeof DrawerPrimitive.C
             <DrawerPrimitive.Content
                 ref={ref}
                 className={twMerge(
-                    'fixed inset-x-0 bottom-0 z-50 mt-24 flex flex-col rounded-t-[10px] border bg-background',
+                    // chrome per the TX Details board (17490:115877): page background,
+                    // no border, handle 32x5 sitting 8px from the top with 24px below.
+                    'fixed inset-x-0 bottom-0 z-50 mt-24 flex flex-col rounded-t-[10px] bg-background-page',
                     className
                 )}
                 aria-describedby={undefined}
@@ -45,7 +47,7 @@ const DrawerContent = React.forwardRef<React.ElementRef<typeof DrawerPrimitive.C
                 onTouchMove={(e) => e.stopPropagation()}
             >
                 {accessibleTitle && <DrawerTitle className="sr-only">{accessibleTitle}</DrawerTitle>}
-                <div className="mx-auto my-4 h-1.5 w-10 rounded-full bg-black" />
+                <div className="mx-auto mt-2 mb-6 h-[5px] w-8 rounded-round bg-foreground-secondary" />
                 <div className="flex w-full justify-center">
                     <div
                         className={twMerge(

--- a/src/components/Global/StatusPill/index.tsx
+++ b/src/components/Global/StatusPill/index.tsx
@@ -8,16 +8,21 @@ interface StatusPillProps {
     status: StatusPillType
 }
 
+/**
+ * icon-only status chip per the states board (17966:12128): 3px padding,
+ * 14px icon, round, on the badge background tokens — same status → color
+ * mapping as StatusBadge.
+ */
 const StatusPill = ({ status }: StatusPillProps) => {
-    const colorClasses: Record<StatusPillType, string> = {
-        completed: 'border-success-5 bg-success-2 text-success-4',
-        pending: 'border-yellow-8 bg-secondary-4 text-yellow-6',
-        cancelled: 'border-error-2 bg-error-1 text-error',
-        refunded: 'border-success-5 bg-success-2 text-success-4',
-        failed: 'border-error-2 bg-error-1 text-error',
-        processing: 'border-yellow-8 bg-secondary-4 text-yellow-6',
-        soon: 'border-yellow-8 bg-secondary-4 text-yellow-6',
-        closed: 'border-success-5 bg-success-2 text-success-4',
+    const bgClasses: Record<StatusPillType, string> = {
+        completed: 'bg-background-badge-success',
+        closed: 'bg-background-badge-success',
+        refunded: 'bg-background-badge-success',
+        pending: 'bg-background-badge-attention',
+        processing: 'bg-background-badge-info',
+        soon: 'bg-background-badge-accent',
+        cancelled: 'bg-background-badge-error',
+        failed: 'bg-background-badge-error',
     }
 
     const iconClasses: Record<StatusPillType, IconName> = {
@@ -31,25 +36,14 @@ const StatusPill = ({ status }: StatusPillProps) => {
         closed: 'success',
     }
 
-    const iconSize: Record<StatusPillType, number> = {
-        completed: 7,
-        failed: 6,
-        processing: 10,
-        soon: 7,
-        pending: 8,
-        cancelled: 6,
-        refunded: 8,
-        closed: 7,
-    }
-
     return (
         <div
             className={twMerge(
-                'flex size-[14px] items-center justify-center rounded-full border',
-                colorClasses[status]
+                'flex items-center justify-center rounded-round p-[3px] text-foreground-primary',
+                bgClasses[status]
             )}
         >
-            <Icon name={iconClasses[status]} size={iconSize[status]} />
+            <Icon name={iconClasses[status]} size={14} />
         </div>
     )
 }

--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -28,7 +28,7 @@ import {
     PENDING_AMOUNT_STATUSES,
     STRUCK_AMOUNT_STATUSES,
 } from '@/utils/history.utils'
-import React, { lazy, Suspense, useRef } from 'react'
+import React, { lazy, Suspense, useEffect, useRef } from 'react'
 import { twMerge } from 'tailwind-merge'
 import Image from 'next/image'
 import { isAddress } from 'viem'
@@ -89,9 +89,12 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
     const isSelected = isTransactionSelected(transaction.id)
     // mount the (lazy, vaul) drawer only once this row has been selected —
     // keeps N history rows from each carrying a mounted dialog, while the
-    // ref keeps it mounted through the close animation.
+    // ref keeps it mounted through the close animation. Written in an effect
+    // (not during render) so a discarded render can't leak the flag.
     const hasBeenSelectedRef = useRef(false)
-    if (isSelected) hasBeenSelectedRef.current = true
+    useEffect(() => {
+        if (isSelected) hasBeenSelectedRef.current = true
+    }, [isSelected])
     const { triggerHaptic } = useHaptic()
     const router = useRouter()
     const t = useTranslations('transaction')

--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -77,9 +77,9 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
     haveSentMoneyToUser = false,
     hideTxnAmount = false,
 }) => {
-    // hook to manage the state of the details drawer (open/closed, selected transaction)
-    const { isDrawerOpen, selectedTransaction, openTransactionDetails, closeTransactionDetails } =
-        useTransactionDetailsDrawer()
+    // drawer selection lives in the url (`?tx=<id>`) — an open receipt
+    // survives refresh and deep-links (states/receipt boards, url-as-state).
+    const { selectedTxId, openTransactionDetails, closeTransactionDetails } = useTransactionDetailsDrawer()
     const { triggerHaptic } = useHaptic()
     const router = useRouter()
     const t = useTranslations('transaction')
@@ -173,12 +173,16 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
         currencyDisplayAmount = `≈ ${formattedTokenAmount} ${tokenSymbolUpper}`
     }
 
-    // Spec §4.4: declined card transactions stay in the feed but are visually
-    // de-emphasized so they don't compete with successful items. Scope to
-    // declined SPENDS specifically — refunds also populate cardPayment, but
-    // a failed refund (e.g. processing error) shouldn't be greyed out.
-    const isDeclinedCardSpend =
-        status === 'failed' && isCardPaymentEntry(transaction) && !transaction.extraDataForDrawer?.cardPayment?.isRefund
+    // States board 17966:12128 amount treatment — the single place both the
+    // home widget and the history page inherit:
+    //   incoming successful = base state (no "+", no badge — see getTransactionSign)
+    //   pending family      = greyed amount + pending chip
+    //   cancelled           = strikethrough, no chip
+    //   failed              = strikethrough + failed chip
+    //   refunded            = strikethrough + refund chip (board is silent; kept from before)
+    const isPendingAmount = status === 'pending' || status === 'processing' || status === 'soon'
+    const isStruckAmount = status === 'cancelled' || status === 'failed' || status === 'refunded'
+    const showStatusChip = !!status && status !== 'completed' && status !== 'closed' && status !== 'cancelled'
 
     // Settlement cleared at a different amount than authorized (tip / FX
     // true-up) — flag the row so the balance impact isn't invisible in the
@@ -245,7 +249,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
                                   ? t('type.reward')
                                   : t(getActionLabelKey(type, status))}
                         </span>
-                        {status && <StatusPill status={status} />}
+                        {showStatusChip && status && <StatusPill status={status} />}
                         {isAdjustedCardSpend && <span>{t('adjustedSuffix')}</span>}
                     </div>
                 }
@@ -260,13 +264,9 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
                                 <>
                                     <span
                                         className={twMerge(
-                                            'text-body-m-semibold',
-                                            status === 'refunded' && 'text-gray-1 line-through',
-                                            // Declined card spends: gray the amount so the row reads
-                                            // as "didn't go through" without the opacity-60 wash
-                                            // we used before (which dimmed merchant name + icons
-                                            // too and made the row hard to read at a glance).
-                                            isDeclinedCardSpend && 'text-gray-1'
+                                            'text-body-m-semibold text-foreground-primary',
+                                            isPendingAmount && 'opacity-40',
+                                            isStruckAmount && 'line-through'
                                         )}
                                     >
                                         {displayAmount}
@@ -274,8 +274,9 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
                                     {currencyDisplayAmount && (
                                         <span
                                             className={twMerge(
-                                                'text-body-s text-gray-1',
-                                                status === 'refunded' && 'line-through'
+                                                'text-body-s text-foreground-secondary',
+                                                isPendingAmount && 'opacity-40',
+                                                isStruckAmount && 'line-through'
                                             )}
                                         >
                                             {currencyDisplayAmount}
@@ -292,9 +293,9 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
             <LazyLoadErrorBoundary>
                 <Suspense fallback={null}>
                     <TransactionDetailsDrawer
-                        isOpen={isDrawerOpen && selectedTransaction?.id === transaction.id}
+                        isOpen={selectedTxId === transaction.id}
                         onClose={closeTransactionDetails}
-                        transaction={selectedTransaction}
+                        transaction={transaction}
                         transactionAmount={displayAmount}
                         avatarUrl={avatarUrl}
                     />

--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -21,8 +21,14 @@ import {
     isStableCoin,
     shortenStringLong,
 } from '@/utils/general.utils'
-import { getAvatarUrl, getTransactionSign, isTestTransaction } from '@/utils/history.utils'
-import React, { lazy, Suspense } from 'react'
+import {
+    getAvatarUrl,
+    getTransactionSign,
+    isTestTransaction,
+    PENDING_AMOUNT_STATUSES,
+    STRUCK_AMOUNT_STATUSES,
+} from '@/utils/history.utils'
+import React, { lazy, Suspense, useRef } from 'react'
 import { twMerge } from 'tailwind-merge'
 import Image from 'next/image'
 import { isAddress } from 'viem'
@@ -79,7 +85,13 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
 }) => {
     // drawer selection lives in the url (`?tx=<id>`) — an open receipt
     // survives refresh and deep-links (states/receipt boards, url-as-state).
-    const { selectedTxId, openTransactionDetails, closeTransactionDetails } = useTransactionDetailsDrawer()
+    const { isTransactionSelected, openTransactionDetails, closeTransactionDetails } = useTransactionDetailsDrawer()
+    const isSelected = isTransactionSelected(transaction.id)
+    // mount the (lazy, vaul) drawer only once this row has been selected —
+    // keeps N history rows from each carrying a mounted dialog, while the
+    // ref keeps it mounted through the close animation.
+    const hasBeenSelectedRef = useRef(false)
+    if (isSelected) hasBeenSelectedRef.current = true
     const { triggerHaptic } = useHaptic()
     const router = useRouter()
     const t = useTranslations('transaction')
@@ -180,14 +192,24 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
     //   cancelled           = strikethrough, no chip
     //   failed              = strikethrough + failed chip
     //   refunded            = strikethrough + refund chip (board is silent; kept from before)
-    const isPendingAmount = status === 'pending' || status === 'processing' || status === 'soon'
-    const isStruckAmount = status === 'cancelled' || status === 'failed' || status === 'refunded'
+    // Status families come from history.utils so they stay in lockstep with
+    // STATUS_SHOWS_SIGN (the sign rule) — don't re-list statuses here.
+    //
+    // Carve-out (kept from the old isDeclinedCardSpend rule): a FAILED card
+    // REFUND is money still owed to the user — striking it through reads as
+    // "this credit never counted". It keeps the failed chip but not the strike.
+    const isFailedCardRefund =
+        status === 'failed' &&
+        isCardPaymentEntry(transaction) &&
+        !!transaction.extraDataForDrawer?.cardPayment?.isRefund
+    const isPendingAmount = !!status && PENDING_AMOUNT_STATUSES.has(status)
+    const isStruckAmount = !!status && STRUCK_AMOUNT_STATUSES.has(status) && !isFailedCardRefund
     const showStatusChip = !!status && status !== 'completed' && status !== 'closed' && status !== 'cancelled'
 
     // Settlement cleared at a different amount than authorized (tip / FX
     // true-up) — flag the row so the balance impact isn't invisible in the
     // feed; the receipt carries the authorized/adjustment breakdown. Refunds
-    // excluded like isDeclinedCardSpend above — a refund-auth that clears at
+    // excluded like isFailedCardRefund above — a refund-auth that clears at
     // a different amount would otherwise render "Refund · Adjusted".
     const isAdjustedCardSpend =
         isCardPaymentEntry(transaction) &&
@@ -293,9 +315,9 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
             <LazyLoadErrorBoundary>
                 <Suspense fallback={null}>
                     <TransactionDetailsDrawer
-                        isOpen={selectedTxId === transaction.id}
+                        isOpen={isSelected}
                         onClose={closeTransactionDetails}
-                        transaction={transaction}
+                        transaction={isSelected || hasBeenSelectedRef.current ? transaction : null}
                         transactionAmount={displayAmount}
                         avatarUrl={avatarUrl}
                     />

--- a/src/components/TransactionDetails/TransactionDetailsDrawer.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsDrawer.tsx
@@ -47,7 +47,8 @@ export const TransactionDetailsDrawer: React.FC<TransactionDetailsDrawerProps> =
                 }
             }}
         >
-            <DrawerContent className={`py-5 ${isModalOpen ? '!z-[10]' : ''}`}>
+            {/* pb only — the drawer chrome owns the space above (handle 8px top / 24px below, per board) */}
+            <DrawerContent className={`pb-5 ${isModalOpen ? '!z-[10]' : ''}`}>
                 <DrawerTitle className="sr-only">{t('drawerTitle')}</DrawerTitle>
                 <TransactionDetailsReceipt
                     isLoading={isLoading}

--- a/src/components/TransactionDetails/__tests__/TransactionCard.test.tsx
+++ b/src/components/TransactionDetails/__tests__/TransactionCard.test.tsx
@@ -34,8 +34,7 @@ jest.mock('use-haptic', () => ({
 
 jest.mock('@/hooks/useTransactionDetailsDrawer', () => ({
     useTransactionDetailsDrawer: () => ({
-        isDrawerOpen: false,
-        selectedTransaction: null,
+        selectedTxId: null,
         openTransactionDetails,
         closeTransactionDetails: jest.fn(),
     }),

--- a/src/components/TransactionDetails/__tests__/TransactionCard.test.tsx
+++ b/src/components/TransactionDetails/__tests__/TransactionCard.test.tsx
@@ -35,6 +35,7 @@ jest.mock('use-haptic', () => ({
 jest.mock('@/hooks/useTransactionDetailsDrawer', () => ({
     useTransactionDetailsDrawer: () => ({
         selectedTxId: null,
+        isTransactionSelected: () => false,
         openTransactionDetails,
         closeTransactionDetails: jest.fn(),
     }),
@@ -170,5 +171,27 @@ describe('TransactionCard — settlement-adjusted flag', () => {
     it('hides it for an adjusted card REFUND', () => {
         renderCard(cardSpendTx({ settlementAdjusted: true, isRefund: true }))
         expect(screen.queryByText('· Adjusted')).not.toBeInTheDocument()
+    })
+})
+
+// States board 17966:12128: failed amounts strike through — EXCEPT a failed
+// card REFUND (credit still owed to the user; striking it reads as "this
+// credit never counted"). Locks the carve-out kept from isDeclinedCardSpend.
+describe('TransactionCard — failed strike-through and the refund carve-out', () => {
+    function renderFailed(tx: TransactionDetails) {
+        const failedTx = { ...tx, status: 'failed' } as TransactionDetails
+        return render(
+            <TransactionCard type="card_pay" name="natalia" amount={10} status="failed" transaction={failedTx} />
+        )
+    }
+
+    it('strikes the amount of a failed card spend', () => {
+        renderFailed(cardSpendTx({}))
+        expect(screen.getByText('$10')).toHaveClass('line-through')
+    })
+
+    it('does NOT strike the amount of a failed card refund', () => {
+        renderFailed(cardSpendTx({ isRefund: true }))
+        expect(screen.getByText('$10')).not.toHaveClass('line-through')
     })
 })

--- a/src/components/TransactionDetails/__tests__/transactionTransformer.test.ts
+++ b/src/components/TransactionDetails/__tests__/transactionTransformer.test.ts
@@ -522,13 +522,13 @@ describe('mapTransactionDataForDrawer', () => {
             extraData: { kind: 'CARD_SPEND_AUTH', provider: 'RAIN', merchantName: 'Acme Coffee', usdAmount: '-14.68' },
         })
 
-        it('a negative auth stays pending (never "refunded") so the + sign shows', () => {
+        it('a negative auth stays pending (never "refunded") and reads as an incoming base-state amount', () => {
             const result = mapTransactionDataForDrawer(negativeAuth).transactionDetails
             expect(result.status).toBe('pending')
             expect(result.direction).toBe('receive')
-            // 'refunded'/'failed'/'cancelled' would suppress the sign; a pending
-            // receive keeps the '+'. This is what makes the credit read as +$14.68.
-            expect(getTransactionSign(result)).toBe('+')
+            // incoming carries no sign (states board 17966:12128 base state) —
+            // the point is it must NOT read as an outgoing '-' spend.
+            expect(getTransactionSign(result)).toBe('')
         })
 
         it('flags the drawer cardPayment as a refund', () => {

--- a/src/features/payments/shared/components/PaymentSuccessView.tsx
+++ b/src/features/payments/shared/components/PaymentSuccessView.tsx
@@ -110,8 +110,7 @@ const PaymentSuccessView = ({
 }: DirectSuccessViewProps) => {
     const router = useRouter()
     const t = useTranslations('payment')
-    const { isDrawerOpen, selectedTransaction, openTransactionDetails, closeTransactionDetails } =
-        useTransactionDetailsDrawer()
+    const { selectedTxId, openTransactionDetails, closeTransactionDetails } = useTransactionDetailsDrawer()
     const { user: authUser } = useUserStore()
     const queryClient = useQueryClient()
     const { triggerHaptic } = useHaptic()
@@ -164,7 +163,9 @@ const PaymentSuccessView = ({
             : undefined
 
         let details: Partial<TransactionDetails> = {
-            id: paymentDetails?.payerTransactionHash,
+            // the drawer selection is `?tx=<id>` in the url — fall back to the
+            // charge uuid so the receipt stays openable when the hash is absent
+            id: paymentDetails?.payerTransactionHash ?? chargeDetails.uuid,
             txHash: paymentDetails?.payerTransactionHash,
             status: 'completed' as StatusPillType,
             amount: parseFloat(amountValue),
@@ -221,6 +222,10 @@ const PaymentSuccessView = ({
         usdAmount,
         t,
     ])
+
+    // the one transaction this view's receipt drawer shows — the drawer opens
+    // when the url's `?tx=` matches its id (see useTransactionDetailsDrawer)
+    const receiptTransaction = transactionDetailsProp ?? transactionForDrawer
 
     const pointsDivRef = useRef<HTMLDivElement>(null)
     usePointsConfetti(points, pointsDivRef)
@@ -344,14 +349,13 @@ const PaymentSuccessView = ({
                     ) : (
                         <CreateAccountButton onClick={() => router.push('/setup')} />
                     )}
-                    {!isExternalWalletFlow && (transactionDetailsProp || transactionForDrawer) && (
+                    {!isExternalWalletFlow && receiptTransaction && (
                         <Button
                             variant="primary-soft"
                             shadowSize="4"
                             onClick={() => {
-                                const txDetails = transactionDetailsProp ?? transactionForDrawer
-                                if (txDetails) {
-                                    openTransactionDetails(txDetails)
+                                if (receiptTransaction) {
+                                    openTransactionDetails(receiptTransaction)
                                 }
                             }}
                         >
@@ -363,9 +367,9 @@ const PaymentSuccessView = ({
 
             {/* Transaction Details Drawer */}
             <TransactionDetailsDrawer
-                isOpen={isDrawerOpen}
+                isOpen={!!receiptTransaction && selectedTxId === receiptTransaction.id}
                 onClose={closeTransactionDetails}
-                transaction={selectedTransaction}
+                transaction={receiptTransaction}
             />
         </div>
     )

--- a/src/features/payments/shared/components/PaymentSuccessView.tsx
+++ b/src/features/payments/shared/components/PaymentSuccessView.tsx
@@ -110,7 +110,7 @@ const PaymentSuccessView = ({
 }: DirectSuccessViewProps) => {
     const router = useRouter()
     const t = useTranslations('payment')
-    const { selectedTxId, openTransactionDetails, closeTransactionDetails } = useTransactionDetailsDrawer()
+    const { isTransactionSelected, openTransactionDetails, closeTransactionDetails } = useTransactionDetailsDrawer()
     const { user: authUser } = useUserStore()
     const queryClient = useQueryClient()
     const { triggerHaptic } = useHaptic()
@@ -367,7 +367,7 @@ const PaymentSuccessView = ({
 
             {/* Transaction Details Drawer */}
             <TransactionDetailsDrawer
-                isOpen={!!receiptTransaction && selectedTxId === receiptTransaction.id}
+                isOpen={isTransactionSelected(receiptTransaction?.id)}
                 onClose={closeTransactionDetails}
                 transaction={receiptTransaction}
             />

--- a/src/hooks/useTransactionDetailsDrawer.ts
+++ b/src/hooks/useTransactionDetailsDrawer.ts
@@ -1,21 +1,25 @@
 import { type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
-import { useState } from 'react'
+import { parseAsString, useQueryStates } from 'nuqs'
+
+/**
+ * the selected receipt lives in the url (`?tx=<id>`), so an open transaction
+ * drawer survives a refresh and can be deep-linked/shared. consumers own the
+ * transaction data; this hook only owns which id is selected.
+ */
 export const useTransactionDetailsDrawer = () => {
-    const [isDrawerOpen, setIsDrawerOpen] = useState(false)
-    const [selectedTransaction, setSelectedTransaction] = useState<TransactionDetails | null>(null)
+    const [{ tx }, setParams] = useQueryStates({ tx: parseAsString })
 
     const openTransactionDetails = (transaction: TransactionDetails) => {
-        setSelectedTransaction(transaction)
-        setIsDrawerOpen(true)
+        setParams({ tx: transaction.id })
     }
 
     const closeTransactionDetails = () => {
-        setIsDrawerOpen(false)
+        setParams({ tx: null })
     }
 
     return {
-        isDrawerOpen,
-        selectedTransaction,
+        /** id from `?tx=` — compare against a row's transaction id to decide if its drawer is open. */
+        selectedTxId: tx,
         openTransactionDetails,
         closeTransactionDetails,
     }

--- a/src/hooks/useTransactionDetailsDrawer.ts
+++ b/src/hooks/useTransactionDetailsDrawer.ts
@@ -2,24 +2,31 @@ import { type TransactionDetails } from '@/components/TransactionDetails/transac
 import { parseAsString, useQueryStates } from 'nuqs'
 
 /**
- * the selected receipt lives in the url (`?tx=<id>`), so an open transaction
- * drawer survives a refresh and can be deep-linked/shared. consumers own the
- * transaction data; this hook only owns which id is selected.
+ * the selected receipt lives in the url (`?tx=<id>`). for surfaces whose rows
+ * come from fetched data (history page, home widget) that makes an open
+ * receipt survive refresh and deep-link. flow surfaces (qr-pay success,
+ * payment success) build their receipt from in-memory state — there the url
+ * only drives open/closed within the session, not across a refresh.
+ * consumers own the transaction data; this hook only owns which id is selected.
  */
 export const useTransactionDetailsDrawer = () => {
     const [{ tx }, setParams] = useQueryStates({ tx: parseAsString })
 
     const openTransactionDetails = (transaction: TransactionDetails) => {
-        setParams({ tx: transaction.id })
+        setParams({ tx: transaction.id ?? null })
     }
 
     const closeTransactionDetails = () => {
         setParams({ tx: null })
     }
 
+    /** one match rule for every consumer — null/undefined ids never match. */
+    const isTransactionSelected = (id?: string | null) => tx != null && tx === id
+
     return {
-        /** id from `?tx=` — compare against a row's transaction id to decide if its drawer is open. */
+        /** id from `?tx=` — prefer isTransactionSelected over comparing this by hand. */
         selectedTxId: tx,
+        isTransactionSelected,
         openTransactionDetails,
         closeTransactionDetails,
     }

--- a/src/utils/__tests__/history.utils.test.ts
+++ b/src/utils/__tests__/history.utils.test.ts
@@ -89,7 +89,10 @@ describe('completeHistoryEntry amount-contract guards', () => {
 })
 
 /**
- * getTransactionSign drives the +/- prefix on the activity-feed amount.
+ * getTransactionSign drives the "-" prefix on the activity-feed amount.
+ *
+ * States board 17966:12128: incoming is the base state and never carries a
+ * "+" — only outgoing amounts get a sign.
  *
  * Regression: a Rain card AUTH sits in `pending` for hours until the CLEAR
  * webhook settles it. The old guard suppressed the sign for anything that
@@ -110,8 +113,9 @@ describe('getTransactionSign', () => {
         expect(sign('qr_payment', 'completed')).toBe('-')
     })
 
-    it('shows the inflow sign for a pending receive', () => {
-        expect(sign('receive', 'pending')).toBe('+')
+    it('keeps incoming sign-less (base state, board rule) even while pending', () => {
+        expect(sign('receive', 'pending')).toBe('')
+        expect(sign('receive', 'completed')).toBe('')
     })
 
     it.each(['cancelled', 'failed', 'refunded'])('suppresses the sign for status=%s', (status) => {

--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -302,7 +302,9 @@ const STATUS_SHOWS_SIGN: Record<StatusPillType, boolean> = {
 // Direction → balance-change sign. A `Record` (not a switch) so the compiler
 // enforces exhaustiveness: adding a `TransactionDirection` without a sign is a
 // build error, not a silent `''` at runtime.
-const DIRECTION_TO_SIGN: Record<TransactionDirection, '-' | '+'> = {
+// States board 17966:12128: an incoming transaction is the base state and
+// carries NO "+" prefix — only outgoing amounts get a sign ("-$38").
+const DIRECTION_TO_SIGN: Record<TransactionDirection, '-' | ''> = {
     send: '-',
     request_received: '-',
     withdraw: '-',
@@ -310,15 +312,15 @@ const DIRECTION_TO_SIGN: Record<TransactionDirection, '-' | '+'> = {
     bank_claim: '-',
     claim_external: '-',
     qr_payment: '-',
-    receive: '+',
-    request_sent: '+',
-    add: '+',
-    bank_deposit: '+',
-    bank_request_fulfillment: '+',
+    receive: '',
+    request_sent: '',
+    add: '',
+    bank_deposit: '',
+    bank_request_fulfillment: '',
 }
 
 /** Returns the sign of the transaction, based on the direction and status of the transaction. */
-export function getTransactionSign(transaction: Pick<TransactionDetails, 'direction' | 'status'>): '-' | '+' | '' {
+export function getTransactionSign(transaction: Pick<TransactionDetails, 'direction' | 'status'>): '-' | '' {
     if (transaction.status && !STATUS_SHOWS_SIGN[transaction.status]) {
         return ''
     }

--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -299,6 +299,12 @@ const STATUS_SHOWS_SIGN: Record<StatusPillType, boolean> = {
     refunded: false,
 }
 
+// Status families for the states-board amount treatment (board 17966:12128).
+// One source next to STATUS_SHOWS_SIGN so sign, strikethrough, and grey-out
+// stay in lockstep — TransactionCard consumes these instead of re-listing.
+export const PENDING_AMOUNT_STATUSES: ReadonlySet<StatusPillType> = new Set(['pending', 'processing', 'soon'])
+export const STRUCK_AMOUNT_STATUSES: ReadonlySet<StatusPillType> = new Set(['cancelled', 'failed', 'refunded'])
+
 // Direction → balance-change sign. A `Record` (not a switch) so the compiler
 // enforces exhaustiveness: adding a `TransactionDirection` without a sign is a
 // build error, not a silent `''` at runtime.


### PR DESCRIPTION
# DS 14 — activity surfaces (TASK-21459)

> **STACKED PR — base is `ds/07-home-rebuild` (PR #2727).**
> If #2727 merges while this PR is open, RETARGET this PR to `feat/design-system` before any merge — never merge into a stale stacked base.

## Task
TASK-21459 — https://app.notion.com/3bb83811757981e3a252d10a0bbcdb0a

## What changed

**1. States & badges on activity rows** — states board `17966:12128`:

| state | board rule | before | now |
|---|---|---|---|
| incoming successful | base state — no `+`, no success badge | `+$25` + green check chip | `$25`, no chip |
| outgoing successful | minus | `-$38` + green check chip | `-$38`, no chip |
| pending | greyed amount + pending chip | full-black amount + chip | `opacity-40` amount + attention chip |
| cancelled | strikethrough | sign-suppressed plain amount + chip | strikethrough, no chip |
| failed | strikethrough + failed indicator | grey amount (card spends only) | strikethrough + error chip |
| refunded | (board silent — kept a chip) | grey strikethrough + chip | strikethrough + refund chip |

The amount treatment lives in ONE place (`TransactionCard`), so the home widget and the history page inherit it. The sign rule lives in `getTransactionSign` (`DIRECTION_TO_SIGN` incoming entries are now `''`), which the receipt head also reads — list and receipt can't drift.

`StatusPill` restyled to the board's icon chip: 3px padding, 14px icon, round, on `bg-background-badge-*` tokens (same status→color mapping as `StatusBadge`). Border/`success-*` legacy classes gone.

**2. History page + HomeHistory** — date group headers on `text-label-m` (12px extrabold, board Label/M) with the board's 8px rhythm; page shell moved to the design.md outer-shell recipe. HomeHistory's section header (title + chevron icon button) already matched the home board from DS 07; its rows inherit the new TransactionCard styling with zero changes.

**3. Selected receipt → nuqs (`?tx=<id>`)** — `useTransactionDetailsDrawer` no longer holds `useState`; the selected transaction id lives in the url via `useQueryStates`. An open receipt survives refresh and is deep-linkable: `/history?tx=<id>` cold-loads with the drawer open. Consumers updated:
- `TransactionCard` — `isOpen = selectedTxId === transaction.id`, passes its own row transaction.
- `PaymentSuccessView` / `qr-pay` — receipt transaction hoisted to a memo (id fallback: charge uuid for direct sends), drawer keyed off the url.
- `Claim.tsx` — dropped the hook entirely; its "selected transaction" was a pure derivation of `linkState` + `transactionForDrawer` (one less effect).

**4. Drawer chrome** — TX Details board `17490:115877`: handle is now 32x5, 8px from the top, 24px above content, `foreground-secondary`; drawer background `bg-background-page`; border removed. This is `Global/Drawer`, so all vaul drawers get the board chrome (WARN: app-wide visual change, intentional). Receipt internals (DS 09) untouched.

## Screenshots

_Assets live on branch `pr-assets-2748` — delete after merge. "before" = feat/design-system tip on :3051; "after" = this branch prod build on :3054. Seeded: bridge onramp completed ($25, incoming), offramp completed (-$38), onramp AWAITING_FUNDS ($45, pending), offramp ERROR ($350.05, failed), pending send link (-$2)._

### History page — mixed states (390x844)

| before (`+$25`/`+$45` + success chips, failed not struck) | after (board rules) |
|---|---|
| <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2748/shots/before-history-mixed-states-390x844.png" width="300" /> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2748/shots/history-mixed-states-390x844.png" width="300" /> |

### Home activity widget (390x844)

| before | after |
|---|---|
| <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2748/shots/before-home-activity-widget-390x844.png" width="300" /> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2748/shots/home-activity-widget-390x844.png" width="300" /> |

### Drawer — old vs new chrome + `?tx=` deep link

| old chrome (base branch: black 40x6 handle, border, 20px top pad) | new chrome via `/history?tx=<id>` COLD LOAD (32x5 grey handle 8px from top, page bg, no border) — drawer opened purely from the url |
|---|---|
| <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2748/shots/drawer-old-chrome-send-link.png" width="300" /> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2748/shots/deeplink-tx-cold-load-390x844.png" width="300" /> |

### Multinut widths — /history

| 360x800 | 430x932 |
|---|---|
| <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2748/shots/history-360x800.png" width="280" /> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2748/shots/history-430x932.png" width="280" /> |

## Gates

- `pnpm prettier --check .` clean
- `npm run typecheck` clean
- `npm test` — 240 suites, 3073 passed (adds tests for the failed-refund strike carve-out)
- `node scripts/ds-lint-counts.mjs --check` — no metric increased (stockTextSize and nonDsClassesInViews decreased)
- Nutcracker on a prod build @ :3054: `e2e-fresh-user-empty-states`, `authenticated-shell`, `e2e-receipt-drawer-{bridge-offramp,manteca-transfer,send-link}`, `e2e-history-pagination-cursor` all green, plus NEW `e2e-receipt-deep-link-tx` (surface-only; TRUST entry added, `bin/qa lint-trust` 63/63)

## Design notes / accepted trade-offs (post-review)

- **Failed card REFUND carve-out** — a failed refund keeps the failed chip but is NOT struck through: the credit is still owed, and a strike reads as "this never counted". Kept from the old `isDeclinedCardSpend` product intent; locked by two new TransactionCard tests.
- **Status families in one place** — `PENDING_AMOUNT_STATUSES` / `STRUCK_AMOUNT_STATUSES` exported from `history.utils` next to `STATUS_SHOWS_SIGN`, so sign + grey-out + strikethrough can't drift. The receipt head (`amountStateClasses`, DS 09) keeps its own copy for now — receipt internals deliberately untouched here; dedup is a follow-up.
- **Per-row drawer stays** (pre-existing pattern) — but each row now mounts its (lazy, vaul) drawer only after first selection, ref-latched via an effect so the close animation survives. The remaining cost: every row's nuqs `?tx=` subscription re-renders the list on drawer open/close. **Follow-up:** hoist a single drawer + the subscription to the list container.
- **Deep-link resolver scope** — `?tx=` matches only rows in the rendered list; a fetch-by-id resolver for paginated-out or session-built receipts is a follow-up, not in this PR.

## Flags (not silently decided)

- **Cancelled rows are not seedable** by the harness today (send-link `CANCELLED` seeds a `PENDING` intent; bridge factory has no cancelled state) — cancelled strikethrough is covered by unit tests + the shared `isStruckAmount` path, not by a seeded screenshot.
- **Refunded** has no slot on the states board — kept a chip (undo icon on success bg) + strikethrough; flag for Vlad/Hugo if refunded should be chip-less like cancelled.
- **Failed amount size**: the board renders the failed amount at 14px bold; I kept the row's 16px `text-body-m-semibold` and applied only the strikethrough (one amount type-scale for all rows). Easy to change if the 14px is intentional.
- **Deep-link scope**: `?tx=` opens the drawer only if the row is in the rendered list (first page / top-5 on home). A tx buried behind pagination doesn't auto-open — same data the user can see.
- **Over-cap legacy files** (pre-existing): `HomeHistory.tsx` 546 LoC (untouched — rows inherit), `history/page.tsx` 352, `TransactionCard.tsx` 374, `qr-pay/page.tsx` 1711. Not rewritten wholesale in this task; flagged for the KR3 ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
