### PR TITLE
fix(native): paint the status-bar strip in the app background, not black

### DIFF
--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -180,12 +180,11 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
 
     return (
         <div className="flex min-h-[100dvh] w-full bg-background pt-safe-top">
-            {/* Status-bar safe zone. On Android 15+ edge-to-edge the webview draws
-                under the status bar, where bg-background would otherwise show beige.
-                Fill the inset strip (above the feedback ribbon) with black so the top
-                always reads black. Height is the natively measured inset on Android
+            {/* Status-bar safe zone. Paints the inset strip in the app background so
+                the top matches the page even where fixed children would otherwise draw
+                under the status bar. Height is the natively measured inset on Android
                 15+ and env() elsewhere, so still a no-op on web (inset = 0). */}
-            <div aria-hidden className="pointer-events-none fixed inset-x-0 top-0 z-40 h-safe-top bg-black" />
+            <div aria-hidden className="pointer-events-none fixed inset-x-0 top-0 z-40 h-safe-top bg-background" />
             {/* Wrapper div for desktop layout */}
             <div className="flex w-full">
                 {/* Sidebar - Fixed on desktop */}

--- a/src/hooks/useNativePlugins.ts
+++ b/src/hooks/useNativePlugins.ts
@@ -18,11 +18,11 @@ export function useNativePlugins() {
             try {
                 const { StatusBar, Style } = await import('@capacitor/status-bar')
                 await StatusBar.setOverlaysWebView({ overlay: false })
-                // Black status-bar strip with light icons, everywhere. On Android 15+
+                // Status-bar strip in the app background with dark icons. On Android 15+
                 // edge-to-edge these are no-ops and the CSS safe zone in the layout
-                // paints the black behind the status bar instead.
-                await StatusBar.setStyle({ style: Style.Dark })
-                await StatusBar.setBackgroundColor({ color: '#000000' })
+                // paints the strip behind the status bar instead.
+                await StatusBar.setStyle({ style: Style.Light })
+                await StatusBar.setBackgroundColor({ color: '#FAF4F0' }) // background
             } catch (e) {
                 console.warn('failed to init status bar:', e)
             }


### PR DESCRIPTION
Rescues the one commit that was stranded on `mobile-release-fixes` with no PR. As `mobile-release` is retired into `dev`, it would otherwise have been dropped on the floor.

**Stacked on #2702** — based on that branch so the diff shows only the 2 real files. Once #2702 merges into `dev`, this should retarget to `dev` (GitHub does it automatically if the #2702 branch is deleted on merge; otherwise `gh pr edit 2750 --base dev`).

The top strip was forced black in `bd9a1b377` so it would stop flipping between black and beige above the pink beta feedback ribbon. That ribbon is now hidden on iOS (`e56254ef0`), and the underlying inconsistency was really a sizing/source problem, fixed in `9b3384e11` by reading Capacitor's natively measured insets.

Recolor only — the safe zone keeps `h-safe-top`, so the natively measured inset on Android 15+ and the `env()` fallback everywhere else are unchanged. `Style.Light` pairs dark status-bar icons with the light strip.