### PR TITLE
fix(native): accept Bridge ToS via the system browser on android

### DIFF
--- a/src/components/Global/IframeWrapper/__tests__/IframeWrapper.test.tsx
+++ b/src/components/Global/IframeWrapper/__tests__/IframeWrapper.test.tsx
@@ -27,6 +27,10 @@ jest.mock('@/utils/capacitor', () => ({
 const mockBrowserOpen = jest.fn<Promise<void>, [{ url: string }]>(() => Promise.resolve())
 const mockRemoveListener = jest.fn()
 let browserFinished: (() => void) | undefined
+// when set, addListener does not resolve until resolveListener() is called —
+// lets tests unmount while registration is still in flight
+let deferListener = false
+let resolveListener: (() => void) | undefined
 jest.mock(
     '@capacitor/browser',
     () => ({
@@ -34,7 +38,11 @@ jest.mock(
             open: (options: { url: string }) => mockBrowserOpen(options),
             addListener: (_event: string, cb: () => void) => {
                 browserFinished = cb
-                return Promise.resolve({ remove: mockRemoveListener })
+                const handle = { remove: mockRemoveListener }
+                if (!deferListener) return Promise.resolve(handle)
+                return new Promise((resolve) => {
+                    resolveListener = () => resolve(handle)
+                })
             },
         },
     }),
@@ -46,6 +54,8 @@ beforeEach(() => {
     mockBrowserOpen.mockClear()
     mockRemoveListener.mockClear()
     browserFinished = undefined
+    deferListener = false
+    resolveListener = undefined
 })
 
 function findIframe(src: string): HTMLIFrameElement {
@@ -147,6 +157,20 @@ describe('IframeWrapper on android native', () => {
         expect(mockBrowserOpen).toHaveBeenCalledTimes(1)
 
         unmount()
+        expect(mockRemoveListener).toHaveBeenCalled()
+    })
+
+    it('does not open the browser when unmounted while listener registration is in flight', async () => {
+        mockIsAndroidNativeBridge = true
+        deferListener = true
+        const { unmount } = render(<IframeWrapper src="https://compliance.test/tos" visible onClose={jest.fn()} />)
+        await flush()
+
+        unmount()
+        resolveListener?.()
+        await flush()
+
+        expect(mockBrowserOpen).not.toHaveBeenCalled()
         expect(mockRemoveListener).toHaveBeenCalled()
     })
 

--- a/src/components/Global/IframeWrapper/__tests__/IframeWrapper.test.tsx
+++ b/src/components/Global/IframeWrapper/__tests__/IframeWrapper.test.tsx
@@ -19,6 +19,35 @@ jest.mock('@/context/ModalsContext', () => ({
     useModalsContext: () => ({ setIsSupportModalOpen: jest.fn() }),
 }))
 
+let mockIsAndroidNativeBridge = false
+jest.mock('@/utils/capacitor', () => ({
+    isAndroidNativeBridge: () => mockIsAndroidNativeBridge,
+}))
+
+const mockBrowserOpen = jest.fn<Promise<void>, [{ url: string }]>(() => Promise.resolve())
+const mockRemoveListener = jest.fn()
+let browserFinished: (() => void) | undefined
+jest.mock(
+    '@capacitor/browser',
+    () => ({
+        Browser: {
+            open: (options: { url: string }) => mockBrowserOpen(options),
+            addListener: (_event: string, cb: () => void) => {
+                browserFinished = cb
+                return Promise.resolve({ remove: mockRemoveListener })
+            },
+        },
+    }),
+    { virtual: true }
+)
+
+beforeEach(() => {
+    mockIsAndroidNativeBridge = false
+    mockBrowserOpen.mockClear()
+    mockRemoveListener.mockClear()
+    browserFinished = undefined
+})
+
 function findIframe(src: string): HTMLIFrameElement {
     // headlessui Dialog portals into document.body — search the document.
     const iframe = Array.from(document.querySelectorAll('iframe')).find((f) => f.getAttribute('src') === src)
@@ -67,5 +96,65 @@ describe('IframeWrapper message routing', () => {
         postFrom(null, { name: 'complete', metadata: { status: 'completed' } })
         postFrom(null, { signedAgreementId: 'sig-x' })
         expect(onClose).not.toHaveBeenCalled()
+    })
+})
+
+/**
+ * Android's Capacitor WebView cancels third-party SUBFRAME navigations
+ * (BridgeWebViewClient hands every request to launchIntent without checking
+ * isForMainFrame), so the ToS iframe painted pure white and acceptance was
+ * impossible in the native app. Android renders no iframe at all now — the
+ * page opens in the system browser and the close event drives the flow.
+ */
+describe('IframeWrapper on android native', () => {
+    const flush = () => act(async () => undefined)
+
+    it('opens the system browser instead of framing the page', async () => {
+        mockIsAndroidNativeBridge = true
+        const onClose = jest.fn()
+        render(<IframeWrapper src="https://compliance.test/tos" visible onClose={onClose} />)
+        await flush()
+
+        expect(document.querySelectorAll('iframe')).toHaveLength(0)
+        expect(mockBrowserOpen).toHaveBeenCalledWith({ url: 'https://compliance.test/tos' })
+    })
+
+    it("reports the return as 'returned', never as an acceptance it did not observe", async () => {
+        mockIsAndroidNativeBridge = true
+        const onClose = jest.fn()
+        render(<IframeWrapper src="https://compliance.test/tos" visible onClose={onClose} />)
+        await flush()
+
+        act(() => browserFinished?.())
+        expect(onClose).toHaveBeenCalledWith('returned')
+        expect(onClose).not.toHaveBeenCalledWith('tos_accepted')
+    })
+
+    it('does not open the browser while hidden, and drops the listener on unmount', async () => {
+        mockIsAndroidNativeBridge = true
+        const { rerender, unmount } = render(
+            <IframeWrapper src="https://compliance.test/tos" visible={false} onClose={jest.fn()} />
+        )
+        await flush()
+        expect(mockBrowserOpen).not.toHaveBeenCalled()
+
+        rerender(
+            <IntlWrapper>
+                <IframeWrapper src="https://compliance.test/tos" visible onClose={jest.fn()} />
+            </IntlWrapper>
+        )
+        await flush()
+        expect(mockBrowserOpen).toHaveBeenCalledTimes(1)
+
+        unmount()
+        expect(mockRemoveListener).toHaveBeenCalled()
+    })
+
+    it('still frames the page on every other platform', async () => {
+        render(<IframeWrapper src="https://compliance.test/tos" visible onClose={jest.fn()} />)
+        await flush()
+
+        expect(findIframe('https://compliance.test/tos')).toBeTruthy()
+        expect(mockBrowserOpen).not.toHaveBeenCalled()
     })
 })

--- a/src/components/Global/IframeWrapper/index.tsx
+++ b/src/components/Global/IframeWrapper/index.tsx
@@ -6,11 +6,22 @@ import ActionModal from '../ActionModal'
 import { useRouter } from 'next/navigation'
 import { useModalsContext } from '@/context/ModalsContext'
 import { Button, type ButtonVariant } from '@/components/0_Bruddle/Button'
+import { isAndroidNativeBridge } from '@/utils/capacitor'
+
+/**
+ * Why the wrapper closed:
+ *   - `manual`       — the user backed out
+ *   - `completed`    — the embedded flow reported completion (postMessage)
+ *   - `tos_accepted` — Bridge's iframe reported a signed agreement (postMessage)
+ *   - `returned`     — the android system-browser tab closed; carries NO
+ *                      acceptance claim, the caller must ask the provider
+ */
+export type IframeCloseSource = 'manual' | 'completed' | 'tos_accepted' | 'returned'
 
 export type IFrameWrapperProps = {
     src: string
     visible: boolean
-    onClose: (source?: 'manual' | 'completed' | 'tos_accepted') => void
+    onClose: (source?: IframeCloseSource) => void
     closeConfirmMessage?: string
 }
 
@@ -23,6 +34,51 @@ const IframeWrapper = ({ src, visible, onClose, closeConfirmMessage }: IFrameWra
     const iframeRef = useRef<HTMLIFrameElement | null>(null)
     const router = useRouter()
     const { setIsSupportModalOpen } = useModalsContext()
+
+    /*
+     * Android's Capacitor WebView cannot host a third-party subframe:
+     * BridgeWebViewClient.shouldOverrideUrlLoading hands EVERY navigation to
+     * Bridge.launchIntent — it never checks request.isForMainFrame() — which
+     * cancels the load for any host outside the app origin that isn't in
+     * server.allowNavigation. The frame paints pure white and the provider
+     * never records an acceptance. iOS gates the same detour on
+     * targetFrame.isMainFrame, so only Android needs the system-browser
+     * detour. Coming back from that tab means "the user returned", not "the
+     * user accepted" — hence a `returned` source the caller resolves against
+     * the provider rather than a fabricated `tos_accepted`.
+     */
+    const [useSystemBrowser] = useState(isAndroidNativeBridge)
+    const onCloseRef = useRef(onClose)
+    useEffect(() => {
+        onCloseRef.current = onClose
+    })
+
+    useEffect(() => {
+        if (!useSystemBrowser || !visible) return
+        let disposed = false
+        let remove: (() => void) | undefined
+        void import('@capacitor/browser')
+            .then(({ Browser }) =>
+                // Listener first: a tab the user dismisses immediately must not
+                // close before we are listening, or the flow hangs forever.
+                Browser.addListener('browserFinished', () => onCloseRef.current('returned')).then((handle) => {
+                    // Cleanup can run while the dynamic import is still in
+                    // flight; without this the listener registers after the
+                    // fact and nobody ever removes it.
+                    if (disposed) handle.remove()
+                    else remove = () => handle.remove()
+                    return Browser.open({ url: src })
+                })
+            )
+            .catch((error) => {
+                console.error('[iframe-wrapper] system browser open failed', error)
+                onCloseRef.current('manual')
+            })
+        return () => {
+            disposed = true
+            remove?.()
+        }
+    }, [useSystemBrowser, visible, src])
 
     const handleCopy = (textToCopy: string) => {
         navigator.clipboard.writeText(textToCopy).then(() => {
@@ -123,6 +179,8 @@ const IframeWrapper = ({ src, visible, onClose, closeConfirmMessage }: IFrameWra
         window.addEventListener('message', handleMessage)
         return () => window.removeEventListener('message', handleMessage)
     }, [onClose, visible])
+
+    if (useSystemBrowser) return null
 
     return (
         <Modal

--- a/src/components/Global/IframeWrapper/index.tsx
+++ b/src/components/Global/IframeWrapper/index.tsx
@@ -62,11 +62,15 @@ const IframeWrapper = ({ src, visible, onClose, closeConfirmMessage }: IFrameWra
                 // Listener first: a tab the user dismisses immediately must not
                 // close before we are listening, or the flow hangs forever.
                 Browser.addListener('browserFinished', () => onCloseRef.current('returned')).then((handle) => {
-                    // Cleanup can run while the dynamic import is still in
-                    // flight; without this the listener registers after the
-                    // fact and nobody ever removes it.
-                    if (disposed) handle.remove()
-                    else remove = () => handle.remove()
+                    // Cleanup can run while the dynamic import / listener
+                    // registration is still in flight; a late arrival must both
+                    // drop its listener AND skip the open, or a fast unmount
+                    // pops the tab after its owning flow has closed.
+                    if (disposed) {
+                        handle.remove()
+                        return
+                    }
+                    remove = () => handle.remove()
                     return Browser.open({ url: src })
                 })
             )

--- a/src/components/Kyc/BridgeTosStep.tsx
+++ b/src/components/Kyc/BridgeTosStep.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback, useEffect } from 'react'
 import { useTranslations } from 'next-intl'
 import ActionModal from '@/components/Global/ActionModal'
-import IframeWrapper from '@/components/Global/IframeWrapper'
+import IframeWrapper, { type IframeCloseSource } from '@/components/Global/IframeWrapper'
 import { type IconName } from '@/components/Global/Icons/Icon'
 import { getBridgeTosLink } from '@/app/actions/users'
 import { useAuth } from '@/context/authContext'
@@ -76,12 +76,21 @@ export const BridgeTosStep = ({ visible, onComplete, onSkip, reasonCode }: Bridg
     }, [t])
 
     const handleIframeClose = useCallback(
-        async (source?: 'manual' | 'completed' | 'tos_accepted') => {
-            if (source === 'tos_accepted') {
+        async (source?: IframeCloseSource) => {
+            if (source === 'tos_accepted' || source === 'returned') {
                 setIsConfirming(true)
                 setShowIframe(false)
                 try {
-                    await confirmBridgeTosAndAwaitRails(fetchUser)
+                    const accepted = await confirmBridgeTosAndAwaitRails(fetchUser, {
+                        observedAcceptance: source === 'tos_accepted',
+                    })
+                    // `returned` only means the system browser closed, so a user
+                    // who backed out lands back on the prompt instead of being
+                    // told the step is done.
+                    if (source === 'returned' && !accepted) {
+                        setError(t('bridgeTos.notAcceptedYet'))
+                        return
+                    }
                     onComplete()
                 } catch {
                     setError(t('bridgeTos.confirmError'))

--- a/src/components/Kyc/__tests__/BridgeTosStep.test.tsx
+++ b/src/components/Kyc/__tests__/BridgeTosStep.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * The android system-browser detour (Capacitor's WebView cancels third-party
+ * subframe navigations, so the ToS iframe painted blank) gives the step no
+ * acceptance signal — only "the user came back". These cover the resulting
+ * contract: Bridge's own answer, not the return itself, decides whether the
+ * step is done.
+ */
+import React from 'react'
+import { render, screen, act } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
+import { BridgeTosStep } from '../BridgeTosStep'
+// type-only import — the module itself is mocked below
+import { type IframeCloseSource } from '@/components/Global/IframeWrapper'
+
+const mockGetBridgeTosLink = jest.fn()
+jest.mock('@/app/actions/users', () => ({
+    getBridgeTosLink: () => mockGetBridgeTosLink(),
+}))
+
+const mockFetchUser = jest.fn().mockResolvedValue(null)
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => ({ fetchUser: mockFetchUser }),
+}))
+
+const mockConfirm = jest.fn<Promise<boolean>, [unknown, { observedAcceptance?: boolean }?]>()
+jest.mock('@/hooks/useMultiPhaseKycFlow', () => ({
+    confirmBridgeTosAndAwaitRails: (fetchUser: unknown, options?: { observedAcceptance?: boolean }) =>
+        mockConfirm(fetchUser, options),
+}))
+
+let closeIframe: ((source?: IframeCloseSource) => void) | undefined
+jest.mock('@/components/Global/IframeWrapper', () => ({
+    __esModule: true,
+    default: ({ visible, onClose }: { visible: boolean; onClose: (source?: IframeCloseSource) => void }) => {
+        closeIframe = onClose
+        return visible ? <div data-testid="tos-iframe" /> : null
+    },
+}))
+
+const openTos = async () => {
+    await act(async () => {
+        screen.getByRole('button', { name: 'Accept Terms' }).click()
+    })
+}
+
+describe('BridgeTosStep', () => {
+    beforeEach(() => {
+        closeIframe = undefined
+        mockConfirm.mockReset()
+        mockGetBridgeTosLink.mockReset()
+        mockGetBridgeTosLink.mockResolvedValue({ data: { tosLink: 'https://compliance.test/tos' } })
+    })
+
+    const renderStep = (onComplete = jest.fn(), onSkip = jest.fn()) => {
+        render(
+            <IntlWrapper>
+                <BridgeTosStep visible onComplete={onComplete} onSkip={onSkip} />
+            </IntlWrapper>
+        )
+        return { onComplete, onSkip }
+    }
+
+    it('completes when Bridge confirms the terms were signed', async () => {
+        mockConfirm.mockResolvedValue(true)
+        const { onComplete } = renderStep()
+        await openTos()
+
+        await act(async () => closeIframe?.('returned'))
+        expect(onComplete).toHaveBeenCalled()
+        // a return is not an observation — the helper must not treat a
+        // confirm miss as webhook lag on this path
+        expect(mockConfirm).toHaveBeenCalledWith(expect.anything(), { observedAcceptance: false })
+    })
+
+    it('keeps the prompt up when the user came back without signing', async () => {
+        mockConfirm.mockResolvedValue(false)
+        const { onComplete, onSkip } = renderStep()
+        await openTos()
+
+        await act(async () => closeIframe?.('returned'))
+        expect(onComplete).not.toHaveBeenCalled()
+        expect(onSkip).not.toHaveBeenCalled()
+        expect(screen.getByText(/haven't been accepted yet/i)).toBeInTheDocument()
+    })
+
+    it('trusts an observed acceptance even if the confirm race says otherwise', async () => {
+        // `tos_accepted` comes from Bridge's own postMessage (web iframe), so a
+        // still-propagating confirm must not bounce the user back to the prompt.
+        mockConfirm.mockResolvedValue(false)
+        const { onComplete } = renderStep()
+        await openTos()
+
+        await act(async () => closeIframe?.('tos_accepted'))
+        expect(onComplete).toHaveBeenCalled()
+        expect(mockConfirm).toHaveBeenCalledWith(expect.anything(), { observedAcceptance: true })
+    })
+})

--- a/src/hooks/__tests__/confirmBridgeTosAndAwaitRails.test.ts
+++ b/src/hooks/__tests__/confirmBridgeTosAndAwaitRails.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The android ToS flow runs in the system browser (Capacitor's WebView cancels
+ * third-party subframe navigations), so nothing in-app observes the signature —
+ * the caller's only source of truth is this helper's return value.
+ */
+import { confirmBridgeTosAndAwaitRails } from '@/hooks/useMultiPhaseKycFlow'
+import { markSubmitted } from '@/hooks/useSubmissionWindow'
+
+const mockConfirmBridgeTos = jest.fn()
+jest.mock('@/app/actions/users', () => ({
+    getBridgeTosLink: jest.fn(),
+    confirmBridgeTos: () => mockConfirmBridgeTos(),
+}))
+jest.mock('@/hooks/useSubmissionWindow', () => ({ markSubmitted: jest.fn(), useSubmissionWindow: jest.fn() }))
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
+
+const fetchUser = jest.fn().mockResolvedValue(null)
+
+describe('confirmBridgeTosAndAwaitRails', () => {
+    beforeEach(() => {
+        jest.useFakeTimers()
+        mockConfirmBridgeTos.mockReset()
+        fetchUser.mockClear()
+        ;(markSubmitted as jest.Mock).mockClear()
+    })
+    afterEach(() => jest.useRealTimers())
+
+    // Drives the helper to completion while its sleeps are faked away.
+    const run = async (options?: { observedAcceptance?: boolean }) => {
+        const pending = confirmBridgeTosAndAwaitRails(fetchUser, options)
+        await jest.runAllTimersAsync()
+        return pending
+    }
+
+    it("reports Bridge's yes", async () => {
+        mockConfirmBridgeTos.mockResolvedValue({ data: { accepted: true } })
+        await expect(run()).resolves.toBe(true)
+        expect(mockConfirmBridgeTos).toHaveBeenCalledTimes(1)
+    })
+
+    it('retries once and reports the retry verdict, not the first miss', async () => {
+        mockConfirmBridgeTos
+            .mockResolvedValueOnce({ data: { accepted: false } })
+            .mockResolvedValueOnce({ data: { accepted: true } })
+        await expect(run()).resolves.toBe(true)
+        expect(mockConfirmBridgeTos).toHaveBeenCalledTimes(2)
+    })
+
+    it("reports Bridge's no after the retry", async () => {
+        mockConfirmBridgeTos.mockResolvedValue({ data: { accepted: false } })
+        await expect(run()).resolves.toBe(false)
+        expect(mockConfirmBridgeTos).toHaveBeenCalledTimes(2)
+    })
+
+    it('reports no when the confirm call errored out', async () => {
+        mockConfirmBridgeTos.mockResolvedValue({ error: 'Failed to confirm Bridge ToS' })
+        await expect(run()).resolves.toBe(false)
+    })
+
+    it('still arms the submission window and polls on a lagging confirm when the acceptance was observed', async () => {
+        // web iframe race: Bridge's postMessage said "signed", the confirm
+        // endpoint hasn't caught up — the historical behavior must survive.
+        mockConfirmBridgeTos.mockResolvedValue({ data: { accepted: false } })
+        await expect(run({ observedAcceptance: true })).resolves.toBe(false)
+        expect(markSubmitted).toHaveBeenCalled()
+        expect(fetchUser).toHaveBeenCalled()
+    })
+
+    it('stops after the retry when nothing observed an acceptance and Bridge says no', async () => {
+        // android `returned` abandonment: no submission happened, so no grace
+        // window to arm and no rail change to poll for — fail fast instead.
+        mockConfirmBridgeTos.mockResolvedValue({ data: { accepted: false } })
+        await expect(run({ observedAcceptance: false })).resolves.toBe(false)
+        expect(mockConfirmBridgeTos).toHaveBeenCalledTimes(2)
+        expect(markSubmitted).not.toHaveBeenCalled()
+        expect(fetchUser).not.toHaveBeenCalled()
+    })
+
+    it('proceeds normally when nothing observed an acceptance but Bridge says yes', async () => {
+        mockConfirmBridgeTos.mockResolvedValue({ data: { accepted: true } })
+        await expect(run({ observedAcceptance: false })).resolves.toBe(true)
+        expect(markSubmitted).toHaveBeenCalled()
+        expect(fetchUser).toHaveBeenCalled()
+    })
+})

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -6,6 +6,7 @@ import { useCapabilities } from '@/hooks/useCapabilities'
 import { markSubmitted } from '@/hooks/useSubmissionWindow'
 import { deriveGate } from '@/utils/capability-gate'
 import { getBridgeTosLink, confirmBridgeTos } from '@/app/actions/users'
+import { type IframeCloseSource } from '@/components/Global/IframeWrapper'
 import { type KycModalPhase, type IUserProfile } from '@/interfaces/interfaces'
 import { type UserCapabilities } from '@/types/capabilities'
 import { type KYCRegionIntent } from '@/app/actions/types/sumsub.types'
@@ -47,13 +48,31 @@ function deriveCapabilityPhaseSignals(capabilities: UserCapabilities | undefined
 /**
  * confirms bridge ToS acceptance (with one retry) then polls fetchUser
  * until bridge rails leave the TOS-required state. max 3 attempts × 2s.
+ *
+ * Returns Bridge's own verdict on whether the terms are signed. Callers that
+ * never saw an acceptance signal (the android system-browser detour, where
+ * the only event is "the user came back") need it to tell a real acceptance
+ * from an abandoned one.
+ *
+ * `observedAcceptance` says whether the caller SAW Bridge report a signature
+ * (the iframe's `tos_accepted` postMessage). When it did, a "no" from the
+ * confirm endpoint is treated as webhook lag: we still arm the submission
+ * window and poll the rails, exactly as the web flow always has. Without it
+ * (android's `returned`), a "no" after the retry means the user backed out —
+ * marking a submission or polling for rails that will never change would arm
+ * the 30s grace window for nothing and stall the error by ~6s, so we stop.
  */
-export async function confirmBridgeTosAndAwaitRails(fetchUser: () => Promise<IUserProfile | null>) {
-    const result = await confirmBridgeTos()
-    if (!result.data?.accepted) {
+export async function confirmBridgeTosAndAwaitRails(
+    fetchUser: () => Promise<IUserProfile | null>,
+    { observedAcceptance = true }: { observedAcceptance?: boolean } = {}
+): Promise<boolean> {
+    let accepted = !!(await confirmBridgeTos()).data?.accepted
+    if (!accepted) {
         await new Promise((resolve) => setTimeout(resolve, 2000))
-        await confirmBridgeTos()
+        accepted = !!(await confirmBridgeTos()).data?.accepted
     }
+
+    if (!accepted && !observedAcceptance) return false
 
     // Arm the post-submission window only after the ToS POST has actually
     // completed (CodeRabbit feedback on #2131). Doing it before
@@ -72,6 +91,8 @@ export async function confirmBridgeTosAndAwaitRails(fetchUser: () => Promise<IUs
         if (!stillNeedsTos) break
         if (i < 2) await new Promise((resolve) => setTimeout(resolve, 2000))
     }
+
+    return accepted
 }
 
 interface UseMultiPhaseKycFlowOptions {
@@ -390,15 +411,32 @@ export const useMultiPhaseKycFlow = ({
 
     // handle ToS iframe close
     const handleTosIframeClose = useCallback(
-        async (source?: 'manual' | 'completed' | 'tos_accepted') => {
+        async (source?: IframeCloseSource) => {
             setShowTosIframe(false)
 
-            if (source === 'tos_accepted') {
-                posthog.capture(ANALYTICS_EVENTS.KYC_TOS_ACCEPTED)
+            if (source === 'tos_accepted' || source === 'returned') {
+                if (source === 'tos_accepted') posthog.capture(ANALYTICS_EVENTS.KYC_TOS_ACCEPTED)
                 // show loading state while confirming + polling
                 setModalPhase('preparing')
                 try {
-                    await confirmBridgeTosAndAwaitRails(fetchUser)
+                    const accepted = await confirmBridgeTosAndAwaitRails(fetchUser, {
+                        observedAcceptance: source === 'tos_accepted',
+                    })
+                    if (source === 'returned') {
+                        // `returned` carries no acceptance claim, so neither the
+                        // analytics event nor the flow's completion can be taken
+                        // on faith — Bridge's answer decides both. The recovery
+                        // copy stays dismissal-shaped because this modal's error
+                        // CTA closes the flow; the home ToS card owns the retry.
+                        if (!accepted) {
+                            setModalPhase('bridge_tos')
+                            setTosError(
+                                "The terms weren't accepted. You can accept them later from your activity feed."
+                            )
+                            return
+                        }
+                        posthog.capture(ANALYTICS_EVENTS.KYC_TOS_ACCEPTED)
+                    }
                     completeFlow()
                 } catch {
                     // Don't leave the modal frozen on 'preparing' with no feedback

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2284,6 +2284,7 @@
             "loadFailed": "Could not load terms. You can accept them later from your activity feed.",
             "genericError": "Something went wrong. You can accept terms later from your activity feed.",
             "confirmError": "Something went wrong confirming your terms. Please try again.",
+            "notAcceptedYet": "It looks like the terms haven't been accepted yet. Please try again.",
             "acceptTerms": "Accept Terms",
             "notNow": "Not now"
         },

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2284,6 +2284,7 @@
             "loadFailed": "No se pudieron cargar los términos. Puedes aceptarlos más tarde desde tu historial de actividad.",
             "genericError": "Algo salió mal. Puedes aceptar los términos más tarde desde tu historial de actividad.",
             "confirmError": "Algo salió mal al confirmar tus términos. Inténtalo de nuevo.",
+            "notAcceptedYet": "Parece que todavía no aceptaste los términos. Inténtalo de nuevo.",
             "acceptTerms": "Aceptar términos",
             "notNow": "Ahora no"
         },

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -825,7 +825,8 @@
             "sepaDescription": "Para habilitar las transferencias bancarias en EUR (SEPA) y GBP (Faster Payments), debés aceptar los términos de servicio actualizados de nuestro socio de pagos.",
             "loadFailed": "No se pudieron cargar los términos. Podés aceptarlos más tarde desde tu historial de actividad.",
             "genericError": "Algo salió mal. Podés aceptar los términos más tarde desde tu historial de actividad.",
-            "confirmError": "Algo salió mal al confirmar tus términos. Intentalo de nuevo."
+            "confirmError": "Algo salió mal al confirmar tus términos. Intentalo de nuevo.",
+            "notAcceptedYet": "Parece que todavía no aceptaste los términos. Intentalo de nuevo."
         },
         "reverificationPending": {
             "description": "Tu verificación está en revisión — normalmente toma unos minutos. Te avisaremos apenas puedas continuar. Podés esperar aquí o volver al inicio."

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2284,6 +2284,7 @@
             "loadFailed": "Não foi possível carregar os termos. Você pode aceitá-los depois pelo seu feed de atividades.",
             "genericError": "Algo deu errado. Você pode aceitar os termos depois pelo seu feed de atividades.",
             "confirmError": "Algo deu errado ao confirmar seus termos. Tente novamente.",
+            "notAcceptedYet": "Parece que os termos ainda não foram aceitos. Tente novamente.",
             "acceptTerms": "Aceitar termos",
             "notNow": "Agora não"
         },

--- a/src/utils/capacitor.ts
+++ b/src/utils/capacitor.ts
@@ -75,6 +75,17 @@ export function isAndroidNative(): boolean {
 }
 
 /**
+ * true only when the native bridge is live AND the platform is android.
+ *
+ * Unlike {@link isAndroidNative} this is false on capacitor-flavoured WEB
+ * builds (vercel previews opened in android chrome), where native-only
+ * signals such as the in-app browser's `browserFinished` never arrive.
+ */
+export function isAndroidNativeBridge(): boolean {
+    return isNativeBridge() && window.Capacitor?.getPlatform?.() === 'android'
+}
+
+/**
  * returns true when running on ios inside capacitor
  */
 export function isIOSNative(): boolean {


### PR DESCRIPTION
## Problem

Bridge ToS acceptance is impossible in the native Android app. Tapping "Accept Terms" (home card or post-KYC `BridgeTosStep`) shows a fully white page inside the verification chrome, and Bridge keeps the terms pending.

Root cause: Capacitor Android's `BridgeWebViewClient.shouldOverrideUrlLoading` hands **every** navigation — including iframe subframes, it never checks `request.isForMainFrame()` — to `Bridge.launchIntent`, which cancels the load for any host outside the app origin that isn't in `server.allowNavigation` (unset for us). The `compliance.bridge.xyz` iframe load is swallowed → white frame → no `signedAgreementId` postMessage → nothing confirmed.

All 39 post-deploy ToS confirmations (`user_rail_events.source = 'bridge-kyc-confirm-tos'`) are web sessions; the single native user in the stuck set is the failure. Android Chrome web converts normally (18 users), so it's the WebView, not Android. Sumsub KYC is unaffected natively because `SumsubKycWrapper` routes Capacitor to the Cordova SDK, not an iframe.

## Why not `server.allowNavigation`

- It's baked into the binary — every installed app stays broken until a store release.
- On Android it also registers the host as a `WebViewLocalServer` authority: its HTML would be proxied through `handleProxyRequest` with Capacitor's bridge JS injected, and the host is added to the `androidBridge` trusted-origin set. Correctness and security downsides for zero OTA benefit.

## Fix (ships over the air)

- **`IframeWrapper`**: on Android native only (`isAndroidNativeBridge()`, bridge-present check so capacitor-flavored web builds are excluded), render no iframe and open the URL in the system browser via `@capacitor/browser` (in the binary since April). The `browserFinished` listener registers *before* `Browser.open` so an instantly-dismissed tab can't hang the flow.
- The return is reported as a new **`returned`** close source — "the user came back", never a fabricated `tos_accepted`. `POST /users/bridge-tos-confirm` re-reads `has_accepted_terms_of_service` from Bridge, so the detour needs no postMessage channel.
- **`confirmBridgeTosAndAwaitRails`** now returns Bridge's verdict and takes `{ observedAcceptance }`:
  - `tos_accepted` (web iframe postMessage): unchanged historical behavior — a lagging confirm still arms the submission window and polls rails.
  - `returned` + Bridge says no after the retry: fail fast — no false `markSubmitted()`, no pointless rails poll; the user lands back on the prompt with new `bridgeTos.notAcceptedYet` copy (all 4 locales, es-AR as voseo delta).
- `KYC_TOS_ACCEPTED` only fires on a confirmed signature on the `returned` path — no phantom completions.
- iOS untouched (its navigation delegate gates the detour on `targetFrame.isMainFrame`, the iframe works there); web untouched.

## Tests

- `IframeWrapper`: android opens system browser / no iframe, `returned` never masquerades as acceptance, no open while hidden, listener cleanup, other platforms keep the iframe.
- `BridgeTosStep`: completes on confirmed signature, keeps prompt on abandoned return, trusts observed `tos_accepted` over a lagging confirm; asserts the `observedAcceptance` flag per source.
- `confirmBridgeTosAndAwaitRails`: verdict reporting, retry, error, lag-with-observation keeps polling, unobserved-no stops after retry without arming the window.

Full local run: tsc clean, touched-suite lint clean (one pre-existing `useMemo` warning), 420+ tests green across Kyc/IframeWrapper/Home/hooks; the 4 failing suites in my worktree are the known content-submodule/flags setup artifacts, identical without this diff.

**Before merge:** needs one on-device pass confirming Bridge's ToS page completes standalone in a Custom Tab (verified at source/unit level only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Android users now complete Bridge terms in the system browser instead of an embedded window.
  * Returning from the browser automatically resumes the KYC flow.
  * Terms acceptance is verified before continuing, with support for retrying when acceptance is not yet confirmed.

* **Bug Fixes**
  * Improved handling when the browser cannot open or when users return without accepting the terms.

* **Localization**
  * Added “terms not accepted yet” messages in English, Spanish, and Brazilian Portuguese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->