### PR TITLE
fix(ci): retry Playwright system-deps install past apt mirror stalls

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -220,10 +220,36 @@ jobs:
 
             # The cache holds browsers, not the apt packages they link against,
             # so system deps still need installing on a cache hit.
+            #
+            # `apt-get update` inside install-deps stalls intermittently on the
+            # runner's Azure mirrors: three consecutive 6-minute timeouts on
+            # 2026-08-19 (PR #2755), all of them ignoring
+            # azure.archive.ubuntu.com and then hanging on noble-security, while
+            # sibling runs minutes apart cleared the same step in seconds. The
+            # stall is transient, so retry with a per-attempt cap — one bad
+            # mirror then costs an attempt instead of the whole job — and drop
+            # to the canonical archive after the first failure. Still exits
+            # non-zero once the attempts are spent: a genuinely missing system
+            # library must stay a red job, not a silent one.
             - name: Install Playwright system deps
               if: steps.pw-cache.outputs.cache-hit == 'true'
-              timeout-minutes: 6
-              run: npx playwright install-deps chromium
+              timeout-minutes: 9
+              run: |
+                  for attempt in 1 2 3; do
+                      if timeout 150 npx playwright install-deps chromium; then
+                          exit 0
+                      fi
+                      echo "::warning::playwright install-deps attempt ${attempt} failed or stalled; retrying"
+                      sudo pkill -9 -f '[a]pt-get' || true
+                      sudo rm -rf /var/lib/apt/lists/partial/* || true
+                      if [ "${attempt}" = 1 ]; then
+                          sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' \
+                              /etc/apt/sources.list.d/*.sources /etc/apt/sources.list || true
+                      fi
+                      sleep 5
+                  done
+                  echo "::error::playwright install-deps failed after 3 attempts"
+                  exit 1
 
             - name: Run E2E tests
               run: pnpm test:e2e

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -228,7 +228,9 @@ jobs:
             # sibling runs minutes apart cleared the same step in seconds. The
             # stall is transient, so retry with a per-attempt cap — one bad
             # mirror then costs an attempt instead of the whole job — and drop
-            # to the canonical archive after the first failure. Still exits
+            # to the canonical archive after the first failure. `timeout` owns
+            # the attempt's process group, so --kill-after reaps an apt child
+            # that ignores the SIGTERM it sends first. Still exits
             # non-zero once the attempts are spent: a genuinely missing system
             # library must stay a red job, not a silent one.
             - name: Install Playwright system deps
@@ -236,11 +238,10 @@ jobs:
               timeout-minutes: 9
               run: |
                   for attempt in 1 2 3; do
-                      if timeout 150 npx playwright install-deps chromium; then
+                      if timeout --kill-after=15s 150 npx playwright install-deps chromium; then
                           exit 0
                       fi
                       echo "::warning::playwright install-deps attempt ${attempt} failed or stalled; retrying"
-                      sudo pkill -9 -f '[a]pt-get' || true
                       sudo rm -rf /var/lib/apt/lists/partial/* || true
                       if [ "${attempt}" = 1 ]; then
                           sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' \


### PR DESCRIPTION
## Why

`apt-get update`, run inside `npx playwright install-deps chromium`, stalls intermittently on the runner's Azure mirrors and takes the whole `e2e` job down with it.

On 2026-08-19 it killed e2e **three consecutive times on a single unchanged commit** (#2755, runs `32275904840`, `32277999994`, and a re-run of the latter). Every failure has the same shape:

```
Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
...
Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
##[error]The action 'Install Playwright system deps' has timed out after 6 minutes.
##[warning]No files were found with the provided path: playwright-report/
Terminate orphan process: pid (2576) (npm exec playwright install-deps chromium)
```

It is not branch-specific — unrelated branch `feat/design-system` hit the identical failure the same afternoon (run `32273292053`), while `feat/push-provisioning` cleared the same step in seconds eleven minutes later. The stall is transient and mirror-side.

This currently blocks merges: `ci-success` aggregates `e2e`, so a mirror hiccup reds a PR whose code is fine.

## What changed

One step in `.github/workflows/tests.yml` — three attempts with a 150s per-attempt cap, dropping to the canonical archive after the first failure:

```yaml
- name: Install Playwright system deps
  if: steps.pw-cache.outputs.cache-hit == 'true'
  timeout-minutes: 9
  run: |
      for attempt in 1 2 3; do
          if timeout 150 npx playwright install-deps chromium; then
              exit 0
          fi
          ...
      done
      exit 1
```

A bad mirror now costs one attempt instead of the whole job.

## Why retry rather than `continue-on-error`

Making the step non-fatal was the obvious one-liner, and it is wrong here. `Run E2E tests` is already `continue-on-error: true`, so a **setup step is the only thing that can red this job**. Marking the install non-fatal too would leave a genuinely missing system library silently unreported — the job would go green with no browser. So the step still exits non-zero once the attempts are spent.

The cap moves 6 → 9 minutes to fit three bounded attempts (3 × 150s plus cleanup ≈ 8 min worst case). That stays well under the job's own `timeout-minutes: 20`, so the fail-fast property the existing comment describes — `ci-success` must always report, or content-publish-automerge stalls at all-green-of-zero — is preserved.

## Testing

GitHub Actions can't run locally, so I extracted the `run` block straight from the parsed YAML and exercised it under the runner's `bash -e` with fakes for `npx`/`sudo`/`timeout`:

| Scenario | Result |
| --- | --- |
| First attempt succeeds | exits 0, no retry output |
| Stalls twice (exit 124), third succeeds | exits 0 after two `::warning::` lines |
| All three stall | exits 1 with `::error::` — genuine failure stays red |

The guarded `pkill`/`sed` cleanups were faked to return non-zero to confirm they don't abort the script under `-e`. `pkill` uses the `'[a]pt-get'` bracket form so it can't match its own command line. YAML parses and `prettier --check` passes.

What this does **not** prove is behaviour against a real stalled mirror — that can only be observed in CI over time. If the mirrors are stalling for longer than 150s per attempt rather than intermittently, this will need the fallback moved earlier.

## Not addressed

The sibling `Install Playwright browsers` step (cache-miss path, `install --with-deps`) shares the same apt exposure and would hit this on any Playwright version bump. I left it alone deliberately: it also downloads browser binaries, so a 150s per-attempt cap is the wrong shape for it and it needs its own timing profile. Worth a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_018GWaH5h1Prm6zpeXkKWcZR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated browser-test environment setup reliability.
  * Added safeguards to terminate stalled dependency installations after a timeout.
  * Preserved cleanup of incomplete package data following interrupted installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->