### PR TITLE
fix(qr-scanner): make onScan throws findable in Sentry

### DIFF
--- a/src/components/Global/QRScanner/__tests__/index.test.tsx
+++ b/src/components/Global/QRScanner/__tests__/index.test.tsx
@@ -124,13 +124,13 @@ it('chip tap: onScan failure is not misreported as a clipboard error', async () 
     })
     expect(mockToastError).toHaveBeenCalledWith('Error processing QR code')
     expect(mockToastError).not.toHaveBeenCalledWith('Could not access clipboard')
-    // the failure is reported to Sentry under its own tag, but the raw scan
-    // content is never sent — only derived, non-sensitive fields
+    // the failure is reported to Sentry under its own tag, with the full
+    // pasted value (accepted trade-off, PR #2757)
     expect(mockCaptureException).toHaveBeenCalledWith(
         error,
         expect.objectContaining({
             tags: { error_type: 'qr_scan_processing' },
-            extra: { qrLength: ADDRESS.length, qrKind: 'other' },
+            extra: { qrLength: ADDRESS.length, qrKind: 'other', qrPayload: ADDRESS },
         })
     )
 })
@@ -150,11 +150,11 @@ it('"Click to paste": onScan failure is not misreported as a clipboard error', a
     expect(onScan).toHaveBeenCalledWith(PIX_PAYLOAD)
     expect(mockToastError).toHaveBeenCalledWith('Error processing QR code')
     expect(mockToastError).not.toHaveBeenCalledWith('Could not access clipboard')
-    // a Pix payload is classified, never excerpted
+    // a Pix payload is classified and sent in full
     expect(mockCaptureException).toHaveBeenCalledWith(
         expect.any(Error),
         expect.objectContaining({
-            extra: { qrLength: 100, qrKind: 'pix' },
+            extra: { qrLength: 100, qrKind: 'pix', qrPayload: PIX_PAYLOAD },
         })
     )
 })

--- a/src/components/Global/QRScanner/__tests__/index.test.tsx
+++ b/src/components/Global/QRScanner/__tests__/index.test.tsx
@@ -59,7 +59,7 @@ const mockCaptureException = captureException as jest.MockedFunction<typeof capt
 // all-lowercase: viem isAddress enforces checksum on mixed-case forms
 const ADDRESS = '0xab5801a7d398351b8be11c439e05c5b3259aec9b'
 const CHIP_LABEL = 'Use copied address'
-const LONG_PAYLOAD = 'x'.repeat(100)
+const EMV_PAYLOAD = '000201' + 'x'.repeat(94)
 
 const renderScanner = (onScan = jest.fn().mockResolvedValue({ success: true })) => {
     render(<QRScanner onScan={onScan} />)
@@ -124,12 +124,13 @@ it('chip tap: onScan failure is not misreported as a clipboard error', async () 
     })
     expect(mockToastError).toHaveBeenCalledWith('Error processing QR code')
     expect(mockToastError).not.toHaveBeenCalledWith('Could not access clipboard')
-    // the failure is also reported to Sentry under its own tag, with the payload
+    // the failure is reported to Sentry under its own tag, but clipboard text is
+    // never excerpted — only EMVCo merchant QRs carry a payload prefix
     expect(mockCaptureException).toHaveBeenCalledWith(
         error,
         expect.objectContaining({
             tags: { error_type: 'qr_scan_processing' },
-            extra: expect.objectContaining({ qrLength: ADDRESS.length, qrPrefix: ADDRESS }),
+            extra: { qrLength: ADDRESS.length, qrPrefix: undefined },
         })
     )
 })
@@ -137,7 +138,7 @@ it('chip tap: onScan failure is not misreported as a clipboard error', async () 
 it('"Click to paste": onScan failure is not misreported as a clipboard error', async () => {
     mockIsAndroidNative.mockReturnValue(false)
     mockHasStrings.mockResolvedValue(false)
-    mockRead.mockResolvedValue({ value: LONG_PAYLOAD, type: 'text/plain' })
+    mockRead.mockResolvedValue({ value: EMV_PAYLOAD, type: 'text/plain' })
 
     const onScan = jest.fn().mockRejectedValue(new Error('routing exploded'))
     renderScanner(onScan)
@@ -146,14 +147,14 @@ it('"Click to paste": onScan failure is not misreported as a clipboard error', a
     await act(async () => {
         fireEvent.click(paste)
     })
-    expect(onScan).toHaveBeenCalledWith(LONG_PAYLOAD)
+    expect(onScan).toHaveBeenCalledWith(EMV_PAYLOAD)
     expect(mockToastError).toHaveBeenCalledWith('Error processing QR code')
     expect(mockToastError).not.toHaveBeenCalledWith('Could not access clipboard')
-    // long payloads are truncated to the first 64 chars before leaving the device
+    // an EMVCo merchant payload is excerpted, truncated to the first 64 chars
     expect(mockCaptureException).toHaveBeenCalledWith(
         expect.any(Error),
         expect.objectContaining({
-            extra: expect.objectContaining({ qrLength: 100, qrPrefix: LONG_PAYLOAD.slice(0, 64) }),
+            extra: expect.objectContaining({ qrLength: 100, qrPrefix: EMV_PAYLOAD.slice(0, 64) }),
         })
     )
 })

--- a/src/components/Global/QRScanner/__tests__/index.test.tsx
+++ b/src/components/Global/QRScanner/__tests__/index.test.tsx
@@ -59,7 +59,7 @@ const mockCaptureException = captureException as jest.MockedFunction<typeof capt
 // all-lowercase: viem isAddress enforces checksum on mixed-case forms
 const ADDRESS = '0xab5801a7d398351b8be11c439e05c5b3259aec9b'
 const CHIP_LABEL = 'Use copied address'
-const EMV_PAYLOAD = '000201' + 'x'.repeat(94)
+const PIX_PAYLOAD = '00020101021226' + '0014br.gov.bcb.pix' + 'x'.repeat(68)
 
 const renderScanner = (onScan = jest.fn().mockResolvedValue({ success: true })) => {
     render(<QRScanner onScan={onScan} />)
@@ -124,13 +124,13 @@ it('chip tap: onScan failure is not misreported as a clipboard error', async () 
     })
     expect(mockToastError).toHaveBeenCalledWith('Error processing QR code')
     expect(mockToastError).not.toHaveBeenCalledWith('Could not access clipboard')
-    // the failure is reported to Sentry under its own tag, but clipboard text is
-    // never excerpted — only EMVCo merchant QRs carry a payload prefix
+    // the failure is reported to Sentry under its own tag, but the raw scan
+    // content is never sent — only derived, non-sensitive fields
     expect(mockCaptureException).toHaveBeenCalledWith(
         error,
         expect.objectContaining({
             tags: { error_type: 'qr_scan_processing' },
-            extra: { qrLength: ADDRESS.length, qrPrefix: undefined },
+            extra: { qrLength: ADDRESS.length, qrKind: 'other' },
         })
     )
 })
@@ -138,7 +138,7 @@ it('chip tap: onScan failure is not misreported as a clipboard error', async () 
 it('"Click to paste": onScan failure is not misreported as a clipboard error', async () => {
     mockIsAndroidNative.mockReturnValue(false)
     mockHasStrings.mockResolvedValue(false)
-    mockRead.mockResolvedValue({ value: EMV_PAYLOAD, type: 'text/plain' })
+    mockRead.mockResolvedValue({ value: PIX_PAYLOAD, type: 'text/plain' })
 
     const onScan = jest.fn().mockRejectedValue(new Error('routing exploded'))
     renderScanner(onScan)
@@ -147,14 +147,14 @@ it('"Click to paste": onScan failure is not misreported as a clipboard error', a
     await act(async () => {
         fireEvent.click(paste)
     })
-    expect(onScan).toHaveBeenCalledWith(EMV_PAYLOAD)
+    expect(onScan).toHaveBeenCalledWith(PIX_PAYLOAD)
     expect(mockToastError).toHaveBeenCalledWith('Error processing QR code')
     expect(mockToastError).not.toHaveBeenCalledWith('Could not access clipboard')
-    // an EMVCo merchant payload is excerpted, truncated to the first 64 chars
+    // a Pix payload is classified, never excerpted
     expect(mockCaptureException).toHaveBeenCalledWith(
         expect.any(Error),
         expect.objectContaining({
-            extra: expect.objectContaining({ qrLength: 100, qrPrefix: EMV_PAYLOAD.slice(0, 64) }),
+            extra: { qrLength: 100, qrKind: 'pix' },
         })
     )
 })

--- a/src/components/Global/QRScanner/__tests__/index.test.tsx
+++ b/src/components/Global/QRScanner/__tests__/index.test.tsx
@@ -14,12 +14,14 @@ import { IntlWrapper } from '@/test-utils/intl'
 import { Clipboard } from '@capacitor/clipboard'
 import { clipboardHasStrings } from '@/utils/clipboard-detect'
 import { isAndroidNative } from '@/utils/capacitor'
+import { captureException } from '@sentry/nextjs'
 
 const mockToastError = jest.fn()
 
 jest.mock('@capacitor/clipboard', () => ({ Clipboard: { read: jest.fn() } }))
 jest.mock('@/utils/clipboard-detect', () => ({ clipboardHasStrings: jest.fn() }))
 jest.mock('@/utils/capacitor', () => ({ isAndroidNative: jest.fn() }))
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }))
 // general.utils transitively imports env-requiring constants; passthrough keeps
 // the chip text assertable as the full address.
 jest.mock('@/utils/general.utils', () => ({ printableAddress: (a: string) => a }))
@@ -52,10 +54,12 @@ const render = (ui: React.ReactElement, options?: Omit<Parameters<typeof rtlRend
 const mockRead = Clipboard.read as jest.MockedFunction<typeof Clipboard.read>
 const mockHasStrings = clipboardHasStrings as jest.MockedFunction<typeof clipboardHasStrings>
 const mockIsAndroidNative = isAndroidNative as jest.MockedFunction<typeof isAndroidNative>
+const mockCaptureException = captureException as jest.MockedFunction<typeof captureException>
 
 // all-lowercase: viem isAddress enforces checksum on mixed-case forms
 const ADDRESS = '0xab5801a7d398351b8be11c439e05c5b3259aec9b'
 const CHIP_LABEL = 'Use copied address'
+const LONG_PAYLOAD = 'x'.repeat(100)
 
 const renderScanner = (onScan = jest.fn().mockResolvedValue({ success: true })) => {
     render(<QRScanner onScan={onScan} />)
@@ -110,7 +114,8 @@ it('chip tap: onScan failure is not misreported as a clipboard error', async () 
     mockHasStrings.mockResolvedValue(true)
     mockRead.mockResolvedValue({ value: ADDRESS, type: 'text/plain' })
 
-    const onScan = jest.fn().mockRejectedValue(new Error('routing exploded'))
+    const error = new Error('routing exploded')
+    const onScan = jest.fn().mockRejectedValue(error)
     renderScanner(onScan)
 
     const chip = await screen.findByText(CHIP_LABEL)
@@ -119,12 +124,20 @@ it('chip tap: onScan failure is not misreported as a clipboard error', async () 
     })
     expect(mockToastError).toHaveBeenCalledWith('Error processing QR code')
     expect(mockToastError).not.toHaveBeenCalledWith('Could not access clipboard')
+    // the failure is also reported to Sentry under its own tag, with the payload
+    expect(mockCaptureException).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({
+            tags: { error_type: 'qr_scan_processing' },
+            extra: expect.objectContaining({ qrLength: ADDRESS.length, qrPrefix: ADDRESS }),
+        })
+    )
 })
 
 it('"Click to paste": onScan failure is not misreported as a clipboard error', async () => {
     mockIsAndroidNative.mockReturnValue(false)
     mockHasStrings.mockResolvedValue(false)
-    mockRead.mockResolvedValue({ value: 'some text', type: 'text/plain' })
+    mockRead.mockResolvedValue({ value: LONG_PAYLOAD, type: 'text/plain' })
 
     const onScan = jest.fn().mockRejectedValue(new Error('routing exploded'))
     renderScanner(onScan)
@@ -133,9 +146,16 @@ it('"Click to paste": onScan failure is not misreported as a clipboard error', a
     await act(async () => {
         fireEvent.click(paste)
     })
-    expect(onScan).toHaveBeenCalledWith('some text')
+    expect(onScan).toHaveBeenCalledWith(LONG_PAYLOAD)
     expect(mockToastError).toHaveBeenCalledWith('Error processing QR code')
     expect(mockToastError).not.toHaveBeenCalledWith('Could not access clipboard')
+    // long payloads are truncated to the first 64 chars before leaving the device
+    expect(mockCaptureException).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+            extra: expect.objectContaining({ qrLength: 100, qrPrefix: LONG_PAYLOAD.slice(0, 64) }),
+        })
+    )
 })
 
 it('Android chip: onScan failure surfaces a processing error instead of rejecting unhandled', async () => {

--- a/src/components/Global/QRScanner/__tests__/useQRScanner.test.ts
+++ b/src/components/Global/QRScanner/__tests__/useQRScanner.test.ts
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
 /**
  * The camera path's onScan failure is reported to Sentry under its own tag,
- * with derived payload context only — never the raw scan content.
+ * with the full scanned payload (accepted trade-off, PR #2757).
  */
 import { renderHook, act } from '@testing-library/react'
 import { captureException } from '@sentry/nextjs'
@@ -61,7 +61,7 @@ it('camera scan: onScan failure is captured with the qr_scan_processing tag', as
         error,
         expect.objectContaining({
             tags: { error_type: 'qr_scan_processing' },
-            extra: { qrLength: 100, qrKind: 'pix' },
+            extra: { qrLength: 100, qrKind: 'pix', qrPayload: PIX_PAYLOAD },
         })
     )
 })

--- a/src/components/Global/QRScanner/__tests__/useQRScanner.test.ts
+++ b/src/components/Global/QRScanner/__tests__/useQRScanner.test.ts
@@ -1,0 +1,67 @@
+/** @jest-environment jsdom */
+/**
+ * The camera path's onScan failure is reported to Sentry under its own tag,
+ * with the scanned payload truncated to 64 chars.
+ */
+import { renderHook, act } from '@testing-library/react'
+import { captureException } from '@sentry/nextjs'
+import { useQRScanner } from '../useQRScanner'
+
+let onDecode: (result: { data: string }) => void
+
+jest.mock('qr-scanner', () => ({
+    __esModule: true,
+    default: class {
+        constructor(_video: HTMLVideoElement, cb: (result: { data: string }) => void) {
+            onDecode = cb
+        }
+        start = jest.fn().mockResolvedValue(undefined)
+        stop = jest.fn()
+        destroy = jest.fn()
+        setCamera = jest.fn()
+        setInversionMode = jest.fn()
+    },
+}))
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }))
+jest.mock('@/components/0_Bruddle/Toast', () => ({
+    useToast: () => ({ error: jest.fn(), info: jest.fn() }),
+}))
+jest.mock('@/hooks/useGetDeviceType', () => ({
+    useDeviceType: () => ({ deviceType: 'web' }),
+    DeviceType: { IOS: 'ios' },
+}))
+jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => false }))
+jest.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }))
+
+// jsdom implements neither, and the hook's cleanup calls both on unmount
+HTMLMediaElement.prototype.pause = jest.fn()
+HTMLMediaElement.prototype.load = jest.fn()
+
+const LONG_PAYLOAD = 'y'.repeat(100)
+
+it('camera scan: onScan failure is captured with the qr_scan_processing tag', async () => {
+    const error = new Error('routing exploded')
+    const onScan = jest.fn().mockRejectedValue(error)
+
+    const { result } = renderHook(() => useQRScanner(onScan, undefined, true))
+
+    // the hook only builds the scanner once the video element exists
+    const videoRef = result.current.videoRef as React.MutableRefObject<HTMLVideoElement | null>
+    videoRef.current = document.createElement('video')
+    await act(async () => {
+        await result.current.retryCamera()
+    })
+
+    await act(async () => {
+        onDecode({ data: LONG_PAYLOAD })
+    })
+
+    expect(onScan).toHaveBeenCalledWith(LONG_PAYLOAD)
+    expect(captureException).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({
+            tags: { error_type: 'qr_scan_processing' },
+            extra: expect.objectContaining({ qrLength: 100, qrPrefix: LONG_PAYLOAD.slice(0, 64) }),
+        })
+    )
+})

--- a/src/components/Global/QRScanner/__tests__/useQRScanner.test.ts
+++ b/src/components/Global/QRScanner/__tests__/useQRScanner.test.ts
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
 /**
  * The camera path's onScan failure is reported to Sentry under its own tag,
- * with the scanned payload truncated to 64 chars.
+ * with derived payload context only — never the raw scan content.
  */
 import { renderHook, act } from '@testing-library/react'
 import { captureException } from '@sentry/nextjs'
@@ -37,7 +37,7 @@ jest.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }))
 HTMLMediaElement.prototype.pause = jest.fn()
 HTMLMediaElement.prototype.load = jest.fn()
 
-const EMV_PAYLOAD = '000201' + 'y'.repeat(94)
+const PIX_PAYLOAD = '00020101021226' + '0014br.gov.bcb.pix' + 'y'.repeat(68)
 
 it('camera scan: onScan failure is captured with the qr_scan_processing tag', async () => {
     const error = new Error('routing exploded')
@@ -53,15 +53,15 @@ it('camera scan: onScan failure is captured with the qr_scan_processing tag', as
     })
 
     await act(async () => {
-        onDecode({ data: EMV_PAYLOAD })
+        onDecode({ data: PIX_PAYLOAD })
     })
 
-    expect(onScan).toHaveBeenCalledWith(EMV_PAYLOAD)
+    expect(onScan).toHaveBeenCalledWith(PIX_PAYLOAD)
     expect(captureException).toHaveBeenCalledWith(
         error,
         expect.objectContaining({
             tags: { error_type: 'qr_scan_processing' },
-            extra: expect.objectContaining({ qrLength: 100, qrPrefix: EMV_PAYLOAD.slice(0, 64) }),
+            extra: { qrLength: 100, qrKind: 'pix' },
         })
     )
 })

--- a/src/components/Global/QRScanner/__tests__/useQRScanner.test.ts
+++ b/src/components/Global/QRScanner/__tests__/useQRScanner.test.ts
@@ -37,7 +37,7 @@ jest.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }))
 HTMLMediaElement.prototype.pause = jest.fn()
 HTMLMediaElement.prototype.load = jest.fn()
 
-const LONG_PAYLOAD = 'y'.repeat(100)
+const EMV_PAYLOAD = '000201' + 'y'.repeat(94)
 
 it('camera scan: onScan failure is captured with the qr_scan_processing tag', async () => {
     const error = new Error('routing exploded')
@@ -53,15 +53,15 @@ it('camera scan: onScan failure is captured with the qr_scan_processing tag', as
     })
 
     await act(async () => {
-        onDecode({ data: LONG_PAYLOAD })
+        onDecode({ data: EMV_PAYLOAD })
     })
 
-    expect(onScan).toHaveBeenCalledWith(LONG_PAYLOAD)
+    expect(onScan).toHaveBeenCalledWith(EMV_PAYLOAD)
     expect(captureException).toHaveBeenCalledWith(
         error,
         expect.objectContaining({
             tags: { error_type: 'qr_scan_processing' },
-            extra: expect.objectContaining({ qrLength: 100, qrPrefix: LONG_PAYLOAD.slice(0, 64) }),
+            extra: expect.objectContaining({ qrLength: 100, qrPrefix: EMV_PAYLOAD.slice(0, 64) }),
         })
     )
 })

--- a/src/components/Global/QRScanner/__tests__/utils.test.ts
+++ b/src/components/Global/QRScanner/__tests__/utils.test.ts
@@ -13,15 +13,17 @@ it.each([
     ['emv', '000201' + '0014com.mercadolibre' + 'x'.repeat(20)],
     ['url', CLAIM_URL],
     ['other', '0xab5801a7d398351b8be11c439e05c5b3259aec9b'],
-])('classifies a payload as %s', (kind, payload) => {
+])('classifies a payload as %s and sends it in full', (kind, payload) => {
     reportQrScanError(new Error('boom'), payload)
     expect(mockCaptureException.mock.calls[0][1]).toEqual({
         tags: { error_type: 'qr_scan_processing' },
-        extra: { qrLength: payload.length, qrKind: kind },
+        extra: { qrLength: payload.length, qrKind: kind, qrPayload: payload },
     })
 })
 
-it('never ships raw scan content — a claim link secret stays on-device', () => {
+it('sends the full payload, claim-link fragment included — accepted trade-off (PR #2757)', () => {
     reportQrScanError(new Error('boom'), CLAIM_URL)
-    expect(JSON.stringify(mockCaptureException.mock.calls[0][1])).not.toContain('secret')
+    expect(mockCaptureException.mock.calls[0][1]).toEqual(
+        expect.objectContaining({ extra: expect.objectContaining({ qrPayload: CLAIM_URL }) })
+    )
 })

--- a/src/components/Global/QRScanner/__tests__/utils.test.ts
+++ b/src/components/Global/QRScanner/__tests__/utils.test.ts
@@ -1,0 +1,27 @@
+import { captureException } from '@sentry/nextjs'
+import { reportQrScanError } from '../utils'
+
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }))
+
+const mockCaptureException = captureException as jest.MockedFunction<typeof captureException>
+const CLAIM_URL = 'https://peanut.me/claim?id=42#p=secret'
+
+beforeEach(() => jest.clearAllMocks())
+
+it.each([
+    ['pix', '00020101021226' + '0014br.gov.bcb.pix' + 'x'.repeat(68)],
+    ['emv', '000201' + '0014com.mercadolibre' + 'x'.repeat(20)],
+    ['url', CLAIM_URL],
+    ['other', '0xab5801a7d398351b8be11c439e05c5b3259aec9b'],
+])('classifies a payload as %s', (kind, payload) => {
+    reportQrScanError(new Error('boom'), payload)
+    expect(mockCaptureException.mock.calls[0][1]).toEqual({
+        tags: { error_type: 'qr_scan_processing' },
+        extra: { qrLength: payload.length, qrKind: kind },
+    })
+})
+
+it('never ships raw scan content — a claim link secret stays on-device', () => {
+    reportQrScanError(new Error('boom'), CLAIM_URL)
+    expect(JSON.stringify(mockCaptureException.mock.calls[0][1])).not.toContain('secret')
+})

--- a/src/components/Global/QRScanner/index.tsx
+++ b/src/components/Global/QRScanner/index.tsx
@@ -1,4 +1,5 @@
 import { createPortal } from 'react-dom'
+import { captureException } from '@sentry/nextjs'
 import { useTranslations } from 'next-intl'
 import { useEffect, useState } from 'react'
 import { Button } from '@/components/0_Bruddle/Button'
@@ -240,7 +241,13 @@ export default function QRScanner({ onScan, onClose, isOpen = true }: QRScannerP
         try {
             await onScan(data)
         } catch (err) {
-            console.error('Error processing QR code:', err)
+            // console.info, not error: captureConsoleIntegration would turn an
+            // error-level log into a second Sentry event on top of the capture below.
+            console.info('Error processing QR code:', err)
+            captureException(err, {
+                tags: { error_type: 'qr_scan_processing' },
+                extra: { qrLength: data.length, qrPrefix: data.slice(0, 64) },
+            })
             toast.error(t('qrScanner.qrProcessingError'))
         }
     }

--- a/src/components/Global/QRScanner/index.tsx
+++ b/src/components/Global/QRScanner/index.tsx
@@ -1,5 +1,4 @@
 import { createPortal } from 'react-dom'
-import { captureException } from '@sentry/nextjs'
 import { useTranslations } from 'next-intl'
 import { useEffect, useState } from 'react'
 import { Button } from '@/components/0_Bruddle/Button'
@@ -16,6 +15,7 @@ import { clipboardHasStrings } from '@/utils/clipboard-detect'
 import { extractPaymentValue, readClipboard } from '@/utils/clipboard-extract.utils'
 import { isAndroidNative } from '@/utils/capacitor'
 import { printableAddress } from '@/utils/general.utils'
+import { reportQrScanError } from './utils'
 
 // ============================================================================
 // Configuration
@@ -244,10 +244,7 @@ export default function QRScanner({ onScan, onClose, isOpen = true }: QRScannerP
             // console.info, not error: captureConsoleIntegration would turn an
             // error-level log into a second Sentry event on top of the capture below.
             console.info('Error processing QR code:', err)
-            captureException(err, {
-                tags: { error_type: 'qr_scan_processing' },
-                extra: { qrLength: data.length, qrPrefix: data.slice(0, 64) },
-            })
+            reportQrScanError(err, data)
             toast.error(t('qrScanner.qrProcessingError'))
         }
     }

--- a/src/components/Global/QRScanner/useQRScanner.ts
+++ b/src/components/Global/QRScanner/useQRScanner.ts
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { captureException } from '@sentry/nextjs'
 import { useTranslations } from 'next-intl'
 import { useToast } from '@/components/0_Bruddle/Toast'
 import QrScannerLib from 'qr-scanner'
 import { useDeviceType, DeviceType } from '@/hooks/useGetDeviceType'
 import { isCapacitor } from '@/utils/capacitor'
+import { reportQrScanError } from './utils'
 
 // ============================================================================
 // Configuration
@@ -183,10 +183,7 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
                 // console.info, not error: captureConsoleIntegration would turn an
                 // error-level log into a second Sentry event on top of the capture below.
                 console.info('Error processing QR code:', err)
-                captureException(err, {
-                    tags: { error_type: 'qr_scan_processing' },
-                    extra: { qrLength: data.length, qrPrefix: data.slice(0, 64) },
-                })
+                reportQrScanError(err, data)
                 toast.error(t('qrScanner.qrProcessingError'))
                 processingQRRef.current = false
                 // Resume scanner on error so user can try again

--- a/src/components/Global/QRScanner/useQRScanner.ts
+++ b/src/components/Global/QRScanner/useQRScanner.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { captureException } from '@sentry/nextjs'
 import { useTranslations } from 'next-intl'
 import { useToast } from '@/components/0_Bruddle/Toast'
 import QrScannerLib from 'qr-scanner'
@@ -179,7 +180,13 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
                     scannerRef.current?.start()
                 }
             } catch (err) {
-                console.error('Error processing QR code:', err)
+                // console.info, not error: captureConsoleIntegration would turn an
+                // error-level log into a second Sentry event on top of the capture below.
+                console.info('Error processing QR code:', err)
+                captureException(err, {
+                    tags: { error_type: 'qr_scan_processing' },
+                    extra: { qrLength: data.length, qrPrefix: data.slice(0, 64) },
+                })
                 toast.error(t('qrScanner.qrProcessingError'))
                 processingQRRef.current = false
                 // Resume scanner on error so user can try again

--- a/src/components/Global/QRScanner/utils.ts
+++ b/src/components/Global/QRScanner/utils.ts
@@ -1,0 +1,16 @@
+import { captureException } from '@sentry/nextjs'
+
+/**
+ * Reports an onScan throw to Sentry under its own tag so the family is
+ * searchable (error_type:qr_scan_processing). Only EMVCo merchant QRs carry a
+ * payload excerpt — Pix / Mercado Pago / QR3 all start with the "000201"
+ * payload-format indicator and hold machine-generated merchant data. Anything
+ * else (clipboard text, claim links, raw PIX keys) could hold a secret or PII
+ * and stays on-device; qrLength alone is still useful there.
+ */
+export function reportQrScanError(err: unknown, data: string): void {
+    captureException(err, {
+        tags: { error_type: 'qr_scan_processing' },
+        extra: { qrLength: data.length, qrPrefix: data.startsWith('000201') ? data.slice(0, 64) : undefined },
+    })
+}

--- a/src/components/Global/QRScanner/utils.ts
+++ b/src/components/Global/QRScanner/utils.ts
@@ -1,16 +1,24 @@
 import { captureException } from '@sentry/nextjs'
 
+type QrKind = 'pix' | 'emv' | 'url' | 'other'
+
+// Derived, PII-free shape of what was scanned. Raw payload excerpts are
+// deliberately NOT sent: clipboard text, claim links and raw PIX keys can hold
+// secrets, and even an EMVCo merchant payload embeds the payee's key.
+function qrKind(data: string): QrKind {
+    if (data.startsWith('000201')) return data.includes('br.gov.bcb.pix') ? 'pix' : 'emv'
+    if (/^https?:\/\//i.test(data)) return 'url'
+    return 'other'
+}
+
 /**
  * Reports an onScan throw to Sentry under its own tag so the family is
- * searchable (error_type:qr_scan_processing). Only EMVCo merchant QRs carry a
- * payload excerpt — Pix / Mercado Pago / QR3 all start with the "000201"
- * payload-format indicator and hold machine-generated merchant data. Anything
- * else (clipboard text, claim links, raw PIX keys) could hold a secret or PII
- * and stays on-device; qrLength alone is still useful there.
+ * searchable (error_type:qr_scan_processing), with only derived,
+ * non-sensitive context about the payload.
  */
 export function reportQrScanError(err: unknown, data: string): void {
     captureException(err, {
         tags: { error_type: 'qr_scan_processing' },
-        extra: { qrLength: data.length, qrPrefix: data.startsWith('000201') ? data.slice(0, 64) : undefined },
+        extra: { qrLength: data.length, qrKind: qrKind(data) },
     })
 }

--- a/src/components/Global/QRScanner/utils.ts
+++ b/src/components/Global/QRScanner/utils.ts
@@ -2,9 +2,7 @@ import { captureException } from '@sentry/nextjs'
 
 type QrKind = 'pix' | 'emv' | 'url' | 'other'
 
-// Derived, PII-free shape of what was scanned. Raw payload excerpts are
-// deliberately NOT sent: clipboard text, claim links and raw PIX keys can hold
-// secrets, and even an EMVCo merchant payload embeds the payee's key.
+// Coarse family of the payload, for filtering in Sentry.
 function qrKind(data: string): QrKind {
     if (data.startsWith('000201')) return data.includes('br.gov.bcb.pix') ? 'pix' : 'emv'
     if (/^https?:\/\//i.test(data)) return 'url'
@@ -13,12 +11,17 @@ function qrKind(data: string): QrKind {
 
 /**
  * Reports an onScan throw to Sentry under its own tag so the family is
- * searchable (error_type:qr_scan_processing), with only derived,
- * non-sensitive context about the payload.
+ * searchable (error_type:qr_scan_processing), with the full scanned payload.
+ *
+ * Deliberate: scan failures cannot be diagnosed without the payload, and it
+ * carries payee/merchant data (Pix keys, merchant names), a claim link's
+ * fragment, or whatever the paste path hands in. Sentry is a private processor
+ * already trusted with user identity; the trade-off was accepted by the code
+ * owner (PR #2757).
  */
 export function reportQrScanError(err: unknown, data: string): void {
     captureException(err, {
         tags: { error_type: 'qr_scan_processing' },
-        extra: { qrLength: data.length, qrKind: qrKind(data) },
+        extra: { qrLength: data.length, qrKind: qrKind(data), qrPayload: data },
     })
 }


### PR DESCRIPTION
## Summary

The QR scanner has two catch blocks that run when `onScan` (`processQRCode`) throws — `useQRScanner.ts` (camera path) and `QRScanner/index.tsx` (paste/chip path). Both only `console.error('Error processing QR code:', err)`.

Sentry's `captureConsoleIntegration` already forwards that as `captureException(err)`, but the event is titled by the *inner* error, carries no tag and no payload, and sits under `logger:console`. So "show me QR-scanner processing failures, and what was scanned" has no answer in Sentry — which is exactly what a live support case hit this week (user sees the toast repeatedly on Itaú Pix terminals, we could not find a trace).

This PR makes those failures findable and diagnosable:

- both catch sites call `reportQrScanError(err, data)` (`QRScanner/utils.ts`) → `captureException(err, { tags: { error_type: 'qr_scan_processing' }, extra: { qrLength, qrKind, qrPayload } })`
- `qrPayload` is the **full scanned payload, unmodified** (see Risks — deliberate); `qrKind` (`pix` | `emv` | `url` | `other`) is a coarse family for filtering
- `console.error` → `console.info` at the same sites, so the console integration does not emit a second event for the same throw (same rule `fetchWithSentry` already follows)
- tests pin the exact `extra` object on both paths (camera + paste) and the four `qrKind` branches

Query afterwards: `error_type:qr_scan_processing` in the `peanut-ui` project (web `environment:production`, app `environment:native`).

## Task

TASK-21676 — https://app.notion.com/p/3c18381175798139a653c9b433b14de1

## Risks / breaking changes

- Telemetry only. No behaviour change for the user: toast, scanner restart and `processingQRRef` handling are untouched.
- **Privacy — decided, not accidental.** `qrPayload` carries whatever the scanner was asked to process: a Pix/MP payload (which embeds the payee's key — CPF/phone/email — and merchant name), a Peanut claim link including its `#p=` redeem key (so, on the scan-failure path only, Sentry becomes the one server-side place that key exists), a raw PIX key, or on the paste path whatever text the user pasted. CodeRabbit flagged this three times (prefix → gated prefix → derived enum) and its reads were correct each time. The code owner decided on 2026-08-19, with those points in front of him, that scan failures cannot be diagnosed without the full payload, and that the residual risk — a third-party processor (Sentry, which already holds user id/username/email) and teammates with Sentry access seeing it — is accepted. PostHog's `qr_scanned` already receives the full raw payload (PIX keys and claim links masked there); Sentry now receives it unmasked on the failure path only. If that call is reversed later, the helper is the single place to change (e.g. `data.split('#')[0]` drops the redeem key at zero diagnostic cost).
- Hotfix → `main`. Native ships the same bundle (`instrumentation-client.ts` inits Sentry for the Capacitor build with the same console integration, `environment:native`): needs the next `sync/main-into-mobile-release` + Capgo OTA (iOS) / store build (Android). Back-merge `main → dev` touches a refactored `QRScanner/index.tsx` on `dev` (catch block at :280) — small hand-merge.

## QA

- `npm test -- src/components/Global/QRScanner` — 4 suites: `captureException` called with the tag and exact `{ qrLength, qrKind, qrPayload }` on camera + paste paths; `utils.test.ts` pins the four `qrKind` branches and that a claim link is sent in full (documents the accepted trade-off).
- Sandbox: Sentry is disabled in `development`, so the observable effect locally is the `console.info` line; the Sentry event shape is covered by the unit tests.

Screenshots: N/A (no visible change)

## Design notes / accepted trade-offs

- **Full payload to Sentry** — see Risks. Accepted by the code owner; recorded here so the reviewer sees it without reading the CodeRabbit threads.
- One helper for two call sites: the sites exist because the paste/chip path (`scanValue` in `index.tsx`) bypasses the hook's `handleScan`. That pre-existing split is out of scope; the helper keeps the tag and the payload rule in one place.
- Tag, not fingerprint: distinct inner errors stay distinct Sentry issues (different root causes), and `error_type:qr_scan_processing` groups the family for search.
- `console.info` is kept so local dev (Sentry disabled in `development`) still shows the failure.
- Reveals, not fixed here: across peanut-ui any `console.error(msg, err)` is an untagged Sentry event via `captureConsoleIntegration`. Same blind spot exists elsewhere; worth a separate pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QR scan failure diagnostics by recording the complete scanned or pasted payload, its length, and its classification.
  * Preserved existing error notifications and logging when QR processing fails.

* **Tests**
  * Expanded coverage for camera scans, pasted QR content, processing failures, and diagnostic reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->