### PR TITLE
fix(activation): card CTA comes after deposit, never before (TASK-20837)

### DIFF
--- a/src/app/(mobile-ui)/dev/journey/journeyData.ts
+++ b/src/app/(mobile-ui)/dev/journey/journeyData.ts
@@ -87,7 +87,8 @@ export const IN_APP_SURFACES: InAppSurface[] = [
         name: 'Activation step: card → launch banner',
         copy: '"shhhh" — "Tap to find out if you\'re in" + "Maybe later" dismiss (localStorage)',
         cta: { label: 'Try the door →', dest: '/shhhhh' },
-        condition: 'hasCardAccess && !hasCard && !dismissed && !disableCardLaunchCTA — overrides deposit/outbound',
+        condition:
+            'FUNDED (step=outbound/completed) && hasCardAccess && !hasCard && !dismissed && !disableCardLaunchCTA — card comes AFTER deposit, never overrides verify/deposit (2026-08-20)',
         sourceFile: 'src/components/Home/CardLaunchCTA/CardLaunchCTABanner.tsx (via ActivationCTAs.tsx)',
         states: ['access-pre-kyc', 'kycd-no-card'],
     },

--- a/src/app/(mobile-ui)/dev/journey/journeyData.ts
+++ b/src/app/(mobile-ui)/dev/journey/journeyData.ts
@@ -79,7 +79,7 @@ export const IN_APP_SURFACES: InAppSurface[] = [
         cta: { label: 'Unlock now', dest: '/profile/identity-verification' },
         condition: '!isActivated && step=verify (useActivationStatus); hidden while identity is mid-flight',
         sourceFile: 'src/components/Home/ActivationCTAs.tsx',
-        states: ['no-access'],
+        states: ['no-access', 'access-pre-kyc'],
     },
     {
         id: 'step-card-banner',
@@ -90,7 +90,7 @@ export const IN_APP_SURFACES: InAppSurface[] = [
         condition:
             'FUNDED (step=outbound/completed) && hasCardAccess && !hasCard && !dismissed && !disableCardLaunchCTA — card comes AFTER deposit, never overrides verify/deposit (2026-08-20)',
         sourceFile: 'src/components/Home/CardLaunchCTA/CardLaunchCTABanner.tsx (via ActivationCTAs.tsx)',
-        states: ['access-pre-kyc', 'kycd-no-card'],
+        states: ['funded-no-spend'],
     },
     {
         id: 'step-deposit',

--- a/src/components/Home/ActivationCTAs.tsx
+++ b/src/components/Home/ActivationCTAs.tsx
@@ -201,11 +201,20 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
 
     // provider rejection overrides the step copy when user is past the verify step
     // (sumsub approved but provider rejected — deposit/outbound CTAs are useless),
-    // UNLESS they can already transact via card / another rail (see above).
+    // UNLESS they can already transact via card / another rail (see above), or
+    // they have a card PATH: a card-eligible user without a card doesn't need
+    // the rejected bank rail to progress (crypto deposit → card), so nagging
+    // them with "Contact support" over a rail the old region-picker detour
+    // auto-enrolled would replace their useful deposit CTA with a dead end.
+    // (This preserves the shielding the pre-2026-08-20 card-first step gave
+    // this exact cohort; a fixable RFI still surfaces in the /add-money bank
+    // flow, in context.)
+    const hasCardPath = hasCardAccess === true
     const hasProviderRejection =
         activationStep !== 'verify' &&
         activationStep !== 'card' &&
         !canAlreadyTransact &&
+        !hasCardPath &&
         (hasFixableRejection || hasBlockedRejection)
 
     const step: StepConfig | null = useMemo(() => {

--- a/src/components/Home/__tests__/ActivationCTAs.test.tsx
+++ b/src/components/Home/__tests__/ActivationCTAs.test.tsx
@@ -123,6 +123,18 @@ describe('ActivationCTAs — rejection override respects existing transacting ab
         expect(screen.getByText('We need a valid proof of address document.')).toBeInTheDocument()
     })
 
+    it('a card-ELIGIBLE user (access, no card) with a rejected bank rail sees the deposit CTA, not the nag', () => {
+        // The 2026-08-20 deposit-first gate moved this cohort off the card
+        // step; without this shield they would trade the card banner for a
+        // "Contact support" dead end over a rail the old region-picker detour
+        // auto-enrolled. Crypto deposit → card is their working path.
+        mockRails = [bankRejected]
+        mockHasCardAccess = true
+        render(<ActivationCTAs activationStep="deposit" />)
+        expect(screen.queryByText('Complete your setup')).not.toBeInTheDocument()
+        expect(screen.getByText('Deposit')).toBeInTheDocument()
+    })
+
     it('fixable rejection: Upload document heals inline (handleSelfHealResubmit), does not navigate away', () => {
         mockRails = [bankRejected]
         render(<ActivationCTAs activationStep="deposit" />)

--- a/src/components/Profile/views/UnlockedRegions.view.tsx
+++ b/src/components/Profile/views/UnlockedRegions.view.tsx
@@ -15,6 +15,7 @@ import ActionModal from '@/components/Global/ActionModal'
 import { useModalsContext } from '@/context/ModalsContext'
 import { deriveRegionAccess, getRegionIntent, providerForRegionIntent, type Region } from '@/utils/regions.utils'
 import { useRegionLabel } from '@/hooks/useRegionLabel'
+import { useActivationStatus } from '@/hooks/useActivationStatus'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { deriveProviderRejection } from '@/utils/provider-rejection.utils'
 import { reasonCodeKey } from '@/constants/capability-reason-labels.consts'
@@ -26,9 +27,6 @@ import { useSafeBack } from '@/hooks/useSafeBack'
 import { useState, useCallback, useRef, useMemo } from 'react'
 import { type KYCRegionIntent } from '@/app/actions/types/sumsub.types'
 import { useRouter } from 'next/navigation'
-import { useCardInfo } from '@/hooks/useCardInfo'
-import { useRainCardOverview } from '@/hooks/useRainCardOverview'
-import { findActiveCard } from '@/components/Card/cardState.utils'
 
 type ModalVariant = 'start' | 'processing' | 'action_required' | 'rejected'
 
@@ -71,18 +69,11 @@ const UnlockedRegions = () => {
     const tIdentity = useTranslations('identity')
     const onBack = useSafeBack('/profile', { replace: true })
     const router = useRouter()
-    // Card-priority guard: an eligible user (skip badge / admin grant →
-    // hasCardAccess) without an active card is steered to /card from the region
-    // picker (see handleStartKyc), regardless of region. `hasActiveCard` excludes
-    // users who already hold a card so they can still unlock bank regions here.
-    const { hasCardAccess } = useCardInfo()
-    const { overview } = useRainCardOverview()
-    // Tri-state: undefined while the overview is still loading, so a card-holder
-    // isn't briefly treated as "no card" and bounced to /card before it resolves.
-    const hasActiveCard = useMemo<boolean | undefined>(() => {
-        if (!overview) return undefined
-        return !!findActiveCard(overview)
-    }, [overview])
+    // The card redirect in handleStartKyc keys on the ONE funnel resolver:
+    // activationStep === 'card' means funded + eligible + no card. While its
+    // queries load the step resolves to a non-card value, so the redirect
+    // fails toward region KYC (the trunk), never toward /card.
+    const { activationStep } = useActivationStatus()
     const { rails, isKycApproved, railsForProvider, nextActionsForRail } = useCapabilities()
     // MIGRATION-REVIEW: unlockedRegions/lockedRegions previously came from
     // `useIdentityVerification` (raw rails + Sumsub flags). Now derived from the
@@ -179,12 +170,16 @@ const UnlockedRegions = () => {
     }, [])
 
     const handleStartKyc = useCallback(async () => {
-        // Card takes priority for eligible users: if the user has card access but
-        // no active card yet, send them to /card (KYC on rain-requirements — no
-        // regionIntent, no Bridge/Manteca rail enrollment) instead of starting
-        // region KYC, for ANY region they picked. Card-holders fall through and
-        // can still unlock bank regions here.
-        if (hasCardAccess === true && hasActiveCard === false) {
+        // Card redirect ONLY when the funnel resolver says card is the step
+        // (funded, eligible, no card): send them to /card (KYC on
+        // rain-requirements — no regionIntent, no rail enrollment) instead of
+        // region KYC. Everyone else — including UNFUNDED card-eligible users —
+        // proceeds into region KYC: the trunk is verify → deposit → card
+        // (2026-08-20), and the old unconditional redirect both blocked the
+        // Brazil cohort from Manteca/PIX verification entirely and failed open
+        // toward /card while the card queries were still loading. Keying on
+        // activationStep keeps this screen and the home funnel on ONE resolver.
+        if (activationStep === 'card') {
             setSelectedRegion(null)
             router.push('/card')
             return
@@ -203,7 +198,7 @@ const UnlockedRegions = () => {
         // Fresh-KYC safe: the BE's cross-region branches all require an
         // APPROVED verification, so for first-time users the flag is a no-op.
         await flow.handleInitiateKyc(intent, undefined, true)
-    }, [flow.handleInitiateKyc, selectedRegion, hasCardAccess, hasActiveCard, router])
+    }, [flow.handleInitiateKyc, selectedRegion, activationStep, router])
 
     // ROW (rest-of-world) regions have no provider/rail, so an initiate there is a
     // terminal "not available in your region yet" — not a transient failure. Only

--- a/src/hooks/__tests__/useActivationStatus.test.tsx
+++ b/src/hooks/__tests__/useActivationStatus.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Pins the activation funnel resolver — above all the CARD GATE.
+ *
+ * The funnel trunk is verify → deposit → card → first spend. ui#2262 made the
+ * card step override every state for card-eligible users, so the Brazil
+ * campaign cohort (skip-badge holders) saw "get your card" before they had
+ * verified or deposited anything — unfunded users minting plastic with
+ * nothing to spend (~1% activation). This suite is the regression guard the
+ * override never had: card replaces only the FUNDED states.
+ */
+import { renderHook } from '@testing-library/react'
+import { useActivationStatus } from '@/hooks/useActivationStatus'
+
+const mockUseAuth = jest.fn()
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => mockUseAuth(),
+}))
+
+const mockUseWallet = jest.fn()
+jest.mock('@/hooks/wallet/useWallet', () => ({
+    useWallet: () => mockUseWallet(),
+}))
+
+const mockUseCapabilities = jest.fn()
+jest.mock('@/hooks/useCapabilities', () => ({
+    useCapabilities: () => mockUseCapabilities(),
+}))
+
+jest.mock('@/hooks/useRainCardOverview', () => ({
+    useRainCardOverview: () => ({ overview: undefined }),
+}))
+
+const mockUseQuery = jest.fn()
+jest.mock('@tanstack/react-query', () => ({
+    useQuery: () => mockUseQuery(),
+}))
+
+jest.mock('@/services/card', () => ({
+    cardApi: { getInfo: jest.fn() },
+}))
+
+const mockFindActiveCard = jest.fn()
+jest.mock('@/components/Card/cardState.utils', () => ({
+    findActiveCard: () => mockFindActiveCard(),
+}))
+
+jest.mock('@/config/underMaintenance.config', () => ({
+    __esModule: true,
+    default: { disableCardLaunchCTA: false },
+}))
+
+function setup(opts: {
+    milestone?: 'registered' | 'verified' | 'funded' | 'activated'
+    isActivated?: boolean
+    hasCardAccess?: boolean
+    hasActiveCard?: boolean
+    balance?: string
+    isKycApproved?: boolean
+}) {
+    mockUseAuth.mockReturnValue({
+        user: {
+            user: {
+                userId: 'u1',
+                isActivated: opts.isActivated ?? false,
+                activatedAt: opts.isActivated ? '2026-08-01T00:00:00Z' : null,
+                activationMilestone: opts.milestone,
+            },
+        },
+    })
+    mockUseWallet.mockReturnValue({ balance: opts.balance ?? '0', isFetchingBalance: false })
+    mockUseCapabilities.mockReturnValue({ isKycApproved: opts.isKycApproved ?? false })
+    mockUseQuery.mockReturnValue({ data: { hasCardAccess: opts.hasCardAccess ?? false } })
+    mockFindActiveCard.mockReturnValue(opts.hasActiveCard ? { id: 'card-1', status: 'active' } : undefined)
+    return renderHook(() => useActivationStatus())
+}
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    localStorage.clear()
+})
+
+describe('card gate: card comes AFTER deposit, never before', () => {
+    it('registered + card access → verify, NOT card (the #2262 regression)', () => {
+        const { result } = setup({ milestone: 'registered', hasCardAccess: true })
+        expect(result.current.activationStep).toBe('verify')
+    })
+
+    it('verified-but-unfunded + card access → deposit, NOT card (the Brazil campaign cohort)', () => {
+        const { result } = setup({ milestone: 'verified', hasCardAccess: true })
+        expect(result.current.activationStep).toBe('deposit')
+    })
+
+    it('funded + card access + no card → card (the override still fires where money exists)', () => {
+        const { result } = setup({ milestone: 'funded', hasCardAccess: true })
+        expect(result.current.activationStep).toBe('card')
+    })
+
+    it('funded without card access → outbound (first spend)', () => {
+        const { result } = setup({ milestone: 'funded' })
+        expect(result.current.activationStep).toBe('outbound')
+    })
+
+    it('funded + card access + ACTIVE card → outbound (no re-pitch of a held card)', () => {
+        const { result } = setup({ milestone: 'funded', hasCardAccess: true, hasActiveCard: true })
+        expect(result.current.activationStep).toBe('outbound')
+    })
+
+    it('activated + card access + no card → card (completed stays card-eligible)', () => {
+        const { result } = setup({ isActivated: true, hasCardAccess: true })
+        expect(result.current.activationStep).toBe('card')
+    })
+
+    it('dismissed card step stays dismissed even when funded', () => {
+        localStorage.setItem('peanut_card_activation_dismissed', 'true')
+        const { result } = setup({ milestone: 'funded', hasCardAccess: true })
+        expect(result.current.activationStep).toBe('outbound')
+    })
+})
+
+describe('card gate on the milestone-less fallback path', () => {
+    it('kyc approved + zero balance + card access → deposit (fallback agrees with the trunk)', () => {
+        const { result } = setup({ isKycApproved: true, balance: '0', hasCardAccess: true })
+        expect(result.current.activationStep).toBe('deposit')
+    })
+
+    it('kyc approved + positive balance + card access → card (fallback funded state)', () => {
+        const { result } = setup({ isKycApproved: true, balance: '25', hasCardAccess: true })
+        expect(result.current.activationStep).toBe('card')
+    })
+
+    it('not kyc approved + card access → verify', () => {
+        const { result } = setup({ isKycApproved: false, hasCardAccess: true })
+        expect(result.current.activationStep).toBe('verify')
+    })
+})

--- a/src/hooks/__tests__/useActivationStatus.test.tsx
+++ b/src/hooks/__tests__/useActivationStatus.test.tsx
@@ -48,7 +48,6 @@ jest.mock('@/config/underMaintenance.config', () => ({
     __esModule: true,
     default: { disableCardLaunchCTA: false },
 }))
-// eslint-disable-next-line import/first
 import underMaintenanceConfig from '@/config/underMaintenance.config'
 
 function setup(opts: {

--- a/src/hooks/__tests__/useActivationStatus.test.tsx
+++ b/src/hooks/__tests__/useActivationStatus.test.tsx
@@ -41,13 +41,15 @@ jest.mock('@/services/card', () => ({
 
 const mockFindActiveCard = jest.fn()
 jest.mock('@/components/Card/cardState.utils', () => ({
-    findActiveCard: () => mockFindActiveCard(),
+    findActiveCard: (overview: unknown) => mockFindActiveCard(overview),
 }))
 
 jest.mock('@/config/underMaintenance.config', () => ({
     __esModule: true,
     default: { disableCardLaunchCTA: false },
 }))
+// eslint-disable-next-line import/first
+import underMaintenanceConfig from '@/config/underMaintenance.config'
 
 function setup(opts: {
     milestone?: 'registered' | 'verified' | 'funded' | 'activated'
@@ -77,6 +79,7 @@ function setup(opts: {
 beforeEach(() => {
     jest.clearAllMocks()
     localStorage.clear()
+    ;(underMaintenanceConfig as { disableCardLaunchCTA: boolean }).disableCardLaunchCTA = false
 })
 
 describe('card gate: card comes AFTER deposit, never before', () => {
@@ -110,10 +113,35 @@ describe('card gate: card comes AFTER deposit, never before', () => {
         expect(result.current.activationStep).toBe('card')
     })
 
-    it('dismissed card step stays dismissed even when funded', () => {
-        localStorage.setItem('peanut_card_activation_dismissed', 'true')
+    it('dismissed card step stays dismissed even when funded (v2 key)', () => {
+        localStorage.setItem('peanut_card_activation_dismissed_v2', 'true')
         const { result } = setup({ milestone: 'funded', hasCardAccess: true })
         expect(result.current.activationStep).toBe('outbound')
+    })
+
+    it('the PRE-deposit v1 dismissal does not suppress the post-deposit step (key rotation)', () => {
+        // The v1 flag was set by users dismissing the mis-timed pre-deposit
+        // banner — the exact cohort the relocated step targets.
+        localStorage.setItem('peanut_card_activation_dismissed', 'true')
+        const { result } = setup({ milestone: 'funded', hasCardAccess: true })
+        expect(result.current.activationStep).toBe('card')
+    })
+
+    it('live chain balance counts as funded even when the BE milestone lags at verified', () => {
+        // Inbound mid-poller: milestone stuck at 'verified' but money is real.
+        const { result } = setup({ milestone: 'verified', balance: '40', hasCardAccess: true })
+        expect(result.current.activationStep).toBe('card')
+    })
+
+    it('the disableCardLaunchCTA kill switch mutes the card step', () => {
+        ;(underMaintenanceConfig as { disableCardLaunchCTA: boolean }).disableCardLaunchCTA = true
+        const { result } = setup({ milestone: 'funded', hasCardAccess: true })
+        expect(result.current.activationStep).toBe('outbound')
+    })
+
+    it('the hook passes the rain overview through to findActiveCard', () => {
+        setup({ milestone: 'funded', hasCardAccess: true })
+        expect(mockFindActiveCard).toHaveBeenCalledWith(undefined) // useRainCardOverview mock returns overview: undefined
     })
 })
 

--- a/src/hooks/useActivationStatus.ts
+++ b/src/hooks/useActivationStatus.ts
@@ -25,7 +25,12 @@ interface ActivationStatus {
     dismissCardStep: () => void
 }
 
-const CARD_DISMISSED_STORAGE_KEY = 'peanut_card_activation_dismissed'
+// v2 (2026-08-20): rotated when the card step moved AFTER deposit. The v1
+// flag was written by users dismissing the mis-timed PRE-deposit banner —
+// exactly the funded card-eligible cohort this change re-targets — so
+// honoring it would permanently suppress the step for the people it is for.
+// Worst case of the rotation: one extra "Maybe later".
+const CARD_DISMISSED_STORAGE_KEY = 'peanut_card_activation_dismissed_v2'
 
 /**
  * derives the user's activation status for gating rewards/referral UI.
@@ -119,15 +124,24 @@ export function useActivationStatus(): ActivationStatus {
         // replaces `outbound`/`completed` (funded states); `verify` and
         // `deposit` keep the trunk.
         //
-        // The #2262 problem this MUST not resurrect — the Bridge/region-picker
-        // KYC detour for card-only EU/NA users — is guarded independently:
-        // UnlockedRegions redirects hasCardAccess users to /card before any
-        // Bridge KYC starts, and /add-money lists the KYC-free crypto path
-        // first. Still fires for already-activated users who simply never took
-        // the card (the funnel would otherwise be `completed`).
+        // The #2262 problem this must not fully resurrect — the Bridge/
+        // region-picker KYC detour for card-only EU/NA users — is mitigated
+        // (not guaranteed) by two best-effort guards: UnlockedRegions
+        // redirects hasCardAccess users to /card before Bridge KYC starts
+        // (skipped while its card queries are still loading), and /add-money
+        // offers the KYC-free crypto path first (its bank rows still reach
+        // Bridge KYC). Residual exposure equals the pre-#2262 baseline; the
+        // full fix is the single-resolver consolidation (TASK-20837). The
+        // `completed` arm is belt-and-braces only: no shipped surface renders
+        // ActivationCTAs for an isActivated user (home swaps to the carousel),
+        // so it can only matter in the isActivated=false + milestone-lag edge.
         const hasCardAccess = cardInfo?.hasCardAccess ?? false
         const hasCard = !!findActiveCard(overview)
-        const isFunded = activationStep === 'outbound' || activationStep === 'completed'
+        // Funded = the BE milestone says so, OR the live chain balance is
+        // positive — a user whose inbound is still mid-poller (milestone stuck
+        // at 'verified') has real money and must not be told "add money"
+        // while the card step is withheld.
+        const isFunded = activationStep === 'outbound' || activationStep === 'completed' || hasBalance
         if (isFunded && hasCardAccess && !hasCard && !cardDismissed && !underMaintenanceConfig.disableCardLaunchCTA) {
             activationStep = 'card'
         }

--- a/src/hooks/useActivationStatus.ts
+++ b/src/hooks/useActivationStatus.ts
@@ -36,9 +36,10 @@ const CARD_DISMISSED_STORAGE_KEY = 'peanut_card_activation_dismissed'
  * count; the BE computes `isActivated`/`activationMilestone` on /users/me and
  * this hook just consumes them, so it inherits the definition automatically)
  *
- * The `card` step only appears when the user is eligible for a Rain card
- * (hasCardAccess) but doesn't have an active one yet, and hasn't dismissed
- * it via "Maybe later". Otherwise the funnel skips straight to the spend step
+ * The `card` step only appears when the user is FUNDED (or already activated),
+ * eligible for a Rain card (hasCardAccess), doesn't hold an active one yet,
+ * and hasn't dismissed it via "Maybe later" — card comes after deposit, never
+ * before verify/deposit. Otherwise the funnel goes to the spend step
  * (`outbound` — step id kept for continuity, it now means "make your first spend").
  *
  * if the BE omits isActivated (bug/outage), falls back to false so gated UI
@@ -105,29 +106,29 @@ export function useActivationStatus(): ActivationStatus {
             }
         }
 
-        // Card takes priority for eligible users. An eligible user is one who
-        // holds a skip badge (e.g. WAITLIST_SKIP) or an explicit admin grant —
-        // both collapse into `cardInfo.hasCardAccess` on the BE, so gating here
-        // IS gating on the badge. If they don't yet hold a card and haven't
-        // dismissed the nudge, steer them straight to the card step (→ /card),
-        // overriding verify/deposit/outbound.
+        // Card surfaces for eligible users — AFTER money is in. An eligible
+        // user holds a skip badge (e.g. WAITLIST_SKIP) or an explicit admin
+        // grant — both collapse into `cardInfo.hasCardAccess` on the BE, so
+        // gating here IS gating on the badge.
         //
-        // Why this beats the old "insert between deposit and outbound" rule:
-        // the /card flow runs KYC on the `rain-requirements` Sumsub level,
-        // which does NOT send a regionIntent and does NOT enroll Bridge bank
-        // rails. The verify step instead routes to the region picker, where an
-        // EU/NA user gets `bridge-requirements` + auto-enrolled Bridge rails —
-        // the source of the "blocked by Bridge / proof of address" detours for
-        // users who only ever wanted a card. Surfacing card first keeps them
-        // off that path. Also fires for already-activated users who simply
-        // never took the card (the funnel would otherwise be `completed`).
+        // The funnel trunk is verify → deposit → card → first spend (decided
+        // 2026-07-13, regressed by the global card-first override of #2262,
+        // reaffirmed 2026-08-20): an unfunded user who is steered to the card
+        // first mints plastic with nothing to spend — the Brazil campaign
+        // cohort showed ~1% activation on that path. So the card step only
+        // replaces `outbound`/`completed` (funded states); `verify` and
+        // `deposit` keep the trunk.
+        //
+        // The #2262 problem this MUST not resurrect — the Bridge/region-picker
+        // KYC detour for card-only EU/NA users — is guarded independently:
+        // UnlockedRegions redirects hasCardAccess users to /card before any
+        // Bridge KYC starts, and /add-money lists the KYC-free crypto path
+        // first. Still fires for already-activated users who simply never took
+        // the card (the funnel would otherwise be `completed`).
         const hasCardAccess = cardInfo?.hasCardAccess ?? false
         const hasCard = !!findActiveCard(overview)
-        // The in-app card CTA is delay-gated for launch (see disableCardLaunchCTA):
-        // muted now, flipped on a few days post-launch. While muted, badge/access
-        // users fall through to the normal verify → deposit → outbound funnel;
-        // /card itself stays reachable (door, waitlist pill, direct link).
-        if (hasCardAccess && !hasCard && !cardDismissed && !underMaintenanceConfig.disableCardLaunchCTA) {
+        const isFunded = activationStep === 'outbound' || activationStep === 'completed'
+        if (isFunded && hasCardAccess && !hasCard && !cardDismissed && !underMaintenanceConfig.disableCardLaunchCTA) {
             activationStep = 'card'
         }
 


### PR DESCRIPTION
## Summary

Card CTA comes **after** deposit, never before. The #2262 override made the card step clobber every funnel state for card-eligible users; when the Brazil campaign badge made its whole cohort card-eligible, unfunded users were steered to mint a card with nothing to spend (~1% activation on that path). The funnel trunk (decided 2026-07-13, never implemented, regressed silently) is **verify → deposit → card → first spend** — the card step now replaces only the funded states (`outbound`/`completed`).

One-condition change in `useActivationStatus.ts`. Blast radius is a single consumer: the non-activated home screen's `ActivationCTAs`. The funded (`outbound`) step already renders card-inclusive copy + a card/QR spend chooser — the funnel now lands there instead of skipping it.

**The #2262 dead-end does not come back:** the Bridge/region-picker KYC detour for card-only EU/NA users is guarded independently (`UnlockedRegions.view.tsx:182-190` redirects `hasCardAccess` users to `/card` before any Bridge KYC starts) and `/add-money` lists the KYC-free crypto path first. Residual cost: a card-only user at `registered` sees verify before card — one extra hop, guard intercepts.

## Task

[Signal consolidation pass — one brain for messages + surfaces](https://app.notion.com/p/3a78381175798159863efd64fda78e01) (TASK-20837 — carries today's full regression trace; this PR is the short-term fix, the single-resolver consolidation is the follow-up, sequenced after the ds/07-home-rebuild branch lands).

## Risks / breaking changes

- Card-eligible **unfunded** users stop seeing the card banner on home until they deposit — intended. `/card` stays directly reachable (door, profile row, direct link).
- Already-activated users without a card still get the card step (unchanged).
- Rollback lever independent of deploy: `disableCardLaunchCTA: true` mutes the card step entirely.
- Cross-system note: the lifecycle email ladder (api) still nudges create_card before fund; a follow-up aligns it with deposit-first (rides with Friday's tokenize-stage PR).

## QA

- The hook had **no test** — that is how this regression shipped. It now has 10 pins: the two regression cases (registered/verified + card access → verify/deposit, NOT card), funded → card, active-card no-re-pitch, completed inclusion, dismissal, and the milestone-less fallback path agreeing with the trunk.
- Full suite: 262 suites / 3,354 tests green; typecheck clean; prettier clean.

## Screenshots

Same user (card access granted, KYC not started, zero balance), sandbox home at 375×667:

| Before (dev — card-first) | After (this PR — deposit-first) |
|---|---|
| ![before](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2761/cta-before-dev-card-first.png) | ![after](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2761/cta-after-hotfix-deposit-first.png) |
| Card `shhhh` door banner shown to an unverified, unfunded user | The funnel trunk: "Unlock payments" (verify) — card surfaces once funded |

(Assets branch `pr-assets-2761` — delete after merge.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activation-step routing so verification and deposit requirements are completed before card access is presented.
  * Card prompts now appear only after funding or activation, when no card exists and the prompt has not been dismissed.
  * Existing cardholders and users who dismiss the card prompt are routed directly to outbound activation.
* **Tests**
  * Added coverage for milestone-based and fallback activation paths, including verification, deposit, funding, and card-access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->