### PR TITLE
ci: make eslint blocking on peanut-ui

### DIFF
--- a/.github/workflows/content-publish-automerge.yml
+++ b/.github/workflows/content-publish-automerge.yml
@@ -9,8 +9,8 @@ name: Content publish auto-merge
 # content publish PR is a single `src/content` gitlink bump: safe by inspection
 # and shouldn't need a second human. This workflow supplies the approval ONLY
 # when the diff is exactly that pointer, so the review requirement stays fully
-# in force for real code. eslint is already advisory (not in `ci-success`), so
-# "green tests" here means the real test/typecheck/build jobs, not lint.
+# in force for real code. eslint is in `ci-success`, so "green tests" here
+# includes lint — a lint error on `main` stalls content publishes too.
 #
 # TWO PATHS TO MERGE, because the approver can't always approve:
 #
@@ -131,10 +131,8 @@ jobs:
 
                   # Key off the `ci-success` check run, NOT `workflow_run.conclusion`.
                   # `ci-success` is the single check the "Protect Prod" ruleset gates
-                  # on; the run conclusion also folds in advisory jobs. Today eslint is
-                  # `continue-on-error: true` so it happens not to move the conclusion —
-                  # but that's an eslint config detail, not a guarantee. Gate on exactly
-                  # what the ruleset gates on.
+                  # on; the run conclusion also folds in advisory jobs (e2e). Gate on
+                  # exactly what the ruleset gates on.
                   #
                   # `Tests` runs on both `push` and `pull_request`, so a commit usually
                   # carries TWO ci-success check runs. Require at least one and ALL of

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,13 +55,11 @@ jobs:
             - name: Validate sitemap, footer, and blog links
               run: pnpm validate-links
 
-    # Advisory ESLint pass. Allowed to fail without blocking merge while the
-    # codebase is brought up to baseline. Not in ci-success.needs so a red
-    # eslint job doesn't gate the PR. Promote to blocking once errors are at
-    # zero (or after team decides a warn floor).
+    # Blocking ESLint pass. In ci-success.needs, so a red eslint job blocks the
+    # PR. `pnpm lint` fails on errors only — the remaining warnings do not gate.
+    # Ratchet to a warn floor (`--max-warnings`) once that count is down.
     eslint:
         runs-on: ubuntu-latest
-        continue-on-error: true
         steps:
             - uses: actions/checkout@v4
               with:
@@ -441,7 +439,7 @@ jobs:
     ci-success:
         name: ci-success
         if: always()
-        needs: [format, typecheck, unit, e2e, report]
+        needs: [format, eslint, typecheck, unit, e2e, report]
         runs-on: ubuntu-latest
         steps:
             - name: Verify all required jobs passed
@@ -450,6 +448,7 @@ jobs:
                       echo "::error::One or more required jobs failed or were cancelled"
                       echo "Job results:"
                       echo "  format:    ${{ needs.format.result }}"
+                      echo "  eslint:    ${{ needs.eslint.result }}"
                       echo "  typecheck: ${{ needs.typecheck.result }}"
                       echo "  unit:      ${{ needs.unit.result }}"
                       echo "  e2e:       ${{ needs.e2e.result }}"


### PR DESCRIPTION
## What

Makes the `eslint` job blocking on `peanut-ui`.

- Drop `continue-on-error: true` from the `eslint` job.
- Add `eslint` to `ci-success.needs` (and to its failure echo).
- Refresh two now-wrong comments in `content-publish-automerge.yml`.

## Why the ruleset is not touched

The org ruleset **Require ci-success on api + ui (main, dev)** requires exactly one
context: `ci-success`. Both repos' workflows say the way to gate a new job is to add
it to `ci-success.needs`, which keeps the ruleset stable as jobs get added or renamed.
So this is a workflow change, not a settings change.

`continue-on-error` had to go first. With it set, the check reports green whatever
eslint says — marking it "required" anywhere would have been a no-op.

## Risk

`pnpm lint` on `main` today: **0 errors, 64 warnings, exit 0.** Nothing to pay down.
Warnings still do not gate; ratcheting to `--max-warnings` is a separate decision.

One behaviour change worth naming: content-publish auto-merge keys off `ci-success`,
so from now on a lint **error** on `main` also stalls content publishes. That is the
point of the gate, but it is new.

## Base

Opened against `main` on request. It needs a twin on `dev`, or the next `dev → main`
release back-merge reverts it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ESLint checks are now required for successful continuous integration.
  * Pull request merges are blocked when ESLint or other required checks fail.
  * Updated workflow guidance to reflect the enforced validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->