### PR TITLE
ci: make eslint blocking on peanut-ui (dev)

### DIFF
--- a/.github/workflows/content-publish-automerge.yml
+++ b/.github/workflows/content-publish-automerge.yml
@@ -9,8 +9,8 @@ name: Content publish auto-merge
 # content publish PR is a single `src/content` gitlink bump: safe by inspection
 # and shouldn't need a second human. This workflow supplies the approval ONLY
 # when the diff is exactly that pointer, so the review requirement stays fully
-# in force for real code. eslint is already advisory (not in `ci-success`), so
-# "green tests" here means the real test/typecheck/build jobs, not lint.
+# in force for real code. eslint is in `ci-success`, so "green tests" here
+# includes lint — a lint error on `main` stalls content publishes too.
 #
 # TWO PATHS TO MERGE, because the approver can't always approve:
 #
@@ -131,10 +131,8 @@ jobs:
 
                   # Key off the `ci-success` check run, NOT `workflow_run.conclusion`.
                   # `ci-success` is the single check the "Protect Prod" ruleset gates
-                  # on; the run conclusion also folds in advisory jobs. Today eslint is
-                  # `continue-on-error: true` so it happens not to move the conclusion —
-                  # but that's an eslint config detail, not a guarantee. Gate on exactly
-                  # what the ruleset gates on.
+                  # on; the run conclusion also folds in advisory jobs (e2e). Gate on
+                  # exactly what the ruleset gates on.
                   #
                   # `Tests` runs on both `push` and `pull_request`, so a commit usually
                   # carries TWO ci-success check runs. Require at least one and ALL of

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,13 +55,11 @@ jobs:
             - name: Validate sitemap, footer, and blog links
               run: pnpm validate-links
 
-    # Advisory ESLint pass. Allowed to fail without blocking merge while the
-    # codebase is brought up to baseline. Not in ci-success.needs so a red
-    # eslint job doesn't gate the PR. Promote to blocking once errors are at
-    # zero (or after team decides a warn floor).
+    # Blocking ESLint pass. In ci-success.needs, so a red eslint job blocks the
+    # PR. `pnpm lint` fails on errors only — the remaining warnings do not gate.
+    # Ratchet to a warn floor (`--max-warnings`) once that count is down.
     eslint:
         runs-on: ubuntu-latest
-        continue-on-error: true
         steps:
             - uses: actions/checkout@v4
               with:
@@ -414,7 +412,7 @@ jobs:
     ci-success:
         name: ci-success
         if: always()
-        needs: [format, typecheck, unit, e2e, report]
+        needs: [format, eslint, typecheck, unit, e2e, report]
         runs-on: ubuntu-latest
         steps:
             - name: Verify all required jobs passed
@@ -423,6 +421,7 @@ jobs:
                       echo "::error::One or more required jobs failed or were cancelled"
                       echo "Job results:"
                       echo "  format:    ${{ needs.format.result }}"
+                      echo "  eslint:    ${{ needs.eslint.result }}"
                       echo "  typecheck: ${{ needs.typecheck.result }}"
                       echo "  unit:      ${{ needs.unit.result }}"
                       echo "  e2e:       ${{ needs.e2e.result }}"


### PR DESCRIPTION
`dev` twin of #2763 (already merged to `main` as `416ee6b9`). Same commit, cherry-picked.

Without this, the gate does nothing in practice: peanut-ui PRs target `dev`, and a
`pull_request` run uses the workflow from the head branch — which forks off `dev`. The
org ruleset already requires `ci-success` on `dev`, so landing this is the whole change.

- Drop `continue-on-error: true` from the `eslint` job.
- Add `eslint` to `ci-success.needs`.
- Refresh two now-wrong comments in `content-publish-automerge.yml`.

`pnpm lint` is at **0 errors** (64 warnings), so nothing is blocked by turning this on.

Closes the open box on TASK-21444 — "flip eslint to a hard CI gate: any error fails the PR".
