### PR TITLE
fix(kyc): keep the Sumsub SDK open through the EEA uplift questionnaire

### DIFF
--- a/src/components/Kyc/SumsubKycModals.tsx
+++ b/src/components/Kyc/SumsubKycModals.tsx
@@ -22,6 +22,7 @@ export const SumsubKycModals = ({ flow }: SumsubKycModalsProps) => {
                 accessToken={flow.accessToken}
                 onClose={flow.handleSdkClose}
                 onComplete={flow.handleSdkComplete}
+                onSubmitted={flow.handleSdkSubmitted}
                 onRefreshToken={flow.refreshToken}
                 isMultiLevel={flow.isMultiLevel}
             />

--- a/src/components/Kyc/SumsubKycWrapper.tsx
+++ b/src/components/Kyc/SumsubKycWrapper.tsx
@@ -47,6 +47,7 @@ const SumsubWebSdkModal = ({
     accessToken,
     onClose,
     onComplete,
+    onSubmitted,
     onError,
     onRefreshToken,
     isMultiLevel,
@@ -71,6 +72,7 @@ const SumsubWebSdkModal = ({
 
     // callback refs to avoid stale closures in sdk init effect
     const onCompleteRef = useRef(onComplete)
+    const onSubmittedRef = useRef(onSubmitted)
     const onErrorRef = useRef(onError)
     const onRefreshTokenRef = useRef(onRefreshToken)
     const isMultiLevelRef = useRef(isMultiLevel)
@@ -83,10 +85,11 @@ const SumsubWebSdkModal = ({
 
     useEffect(() => {
         onCompleteRef.current = onComplete
+        onSubmittedRef.current = onSubmitted
         onErrorRef.current = onError
         onRefreshTokenRef.current = onRefreshToken
         isMultiLevelRef.current = isMultiLevel
-    }, [onComplete, onError, onRefreshToken, isMultiLevel])
+    }, [onComplete, onSubmitted, onError, onRefreshToken, isMultiLevel])
 
     useEffect(() => {
         sumsubLocaleRef.current = toSumsubLocale(locale)
@@ -94,6 +97,7 @@ const SumsubWebSdkModal = ({
 
     // stable wrappers that read from refs
     const stableOnComplete = useCallback(() => onCompleteRef.current(), [])
+    const stableOnSubmitted = useCallback(() => onSubmittedRef.current?.(), [])
     const stableOnError = useCallback((error: unknown) => onErrorRef.current?.(error), [])
     const stableOnRefreshToken = useCallback(() => onRefreshTokenRef.current(), [])
 
@@ -159,10 +163,17 @@ const SumsubWebSdkModal = ({
 
             const handleSubmitted = () => {
                 console.log('[sumsub] onApplicantSubmitted fired')
+                const isFirstSubmit = !hasSubmittedRef.current
                 hasSubmittedRef.current = true
-                // for multi-level workflows (LATAM), the SDK transitions to Level 2
-                // internally. don't close the modal on Level 1 submission.
-                if (isMultiLevelRef.current) return
+                // for multi-level workflows (LATAM/EU), the SDK transitions to
+                // Level 2 internally. don't close the modal on Level 1 submission —
+                // but do report it, or the session never emits a submit signal
+                // (onComplete only fires when a close is wanted, and the APPROVED
+                // close skips it).
+                if (isMultiLevelRef.current) {
+                    if (isFirstSubmit) stableOnSubmitted()
+                    return
+                }
                 stableOnComplete()
             }
             // resubmission = user retried after rejection (ACTION_REQUIRED).
@@ -178,8 +189,12 @@ const SumsubWebSdkModal = ({
             // abandonment after a successful action submission.
             const handleActionSubmitted = () => {
                 console.log('[sumsub] action submitted fired')
+                const isFirstSubmit = !hasSubmittedRef.current
                 hasSubmittedRef.current = true
-                if (isMultiLevelRef.current) return
+                if (isMultiLevelRef.current) {
+                    if (isFirstSubmit) stableOnSubmitted()
+                    return
+                }
                 stableOnComplete()
             }
             // RED stays open so the user can resubmit; the resubmission path
@@ -271,7 +286,16 @@ const SumsubWebSdkModal = ({
                 sdkInstanceRef.current = null
             }
         }
-    }, [visible, accessToken, sdkLoaded, sdkContainer, stableOnComplete, stableOnError, stableOnRefreshToken])
+    }, [
+        visible,
+        accessToken,
+        sdkLoaded,
+        sdkContainer,
+        stableOnComplete,
+        stableOnSubmitted,
+        stableOnError,
+        stableOnRefreshToken,
+    ])
 
     // reset state when modal closes (the init effect's cleanup already
     // destroys the SDK instance — visible is one of its deps)

--- a/src/components/Kyc/__tests__/SumsubKycWrapper.test.tsx
+++ b/src/components/Kyc/__tests__/SumsubKycWrapper.test.tsx
@@ -40,12 +40,19 @@ jest.mock('@/components/Global/Loading', () => ({ __esModule: true, default: () 
 jest.mock('@/context/ModalsContext', () => ({ useModalsContext: () => ({ setIsSupportModalOpen: jest.fn() }) }))
 
 const launch = jest.fn()
+// event name → registered handler, so a test can fire SDK events (e.g.
+// onApplicantSubmitted) against the mounted wrapper.
+const sdkHandlers: Record<string, (payload?: unknown) => void> = {}
 
 function installSdk() {
+    Object.keys(sdkHandlers).forEach((key) => delete sdkHandlers[key])
     const builder: Record<string, unknown> = {}
     builder.withConf = () => builder
     builder.withOptions = () => builder
-    builder.on = () => builder
+    builder.on = (event: string, handler: (payload?: unknown) => void) => {
+        sdkHandlers[event] = handler
+        return builder
+    }
     builder.build = () => ({ launch, destroy: jest.fn() })
     ;(window as unknown as { snsWebSdk: unknown }).snsWebSdk = { init: () => builder }
 }
@@ -139,6 +146,61 @@ describe('SumsubKycWrapper', () => {
         )
         await new Promise((r) => setTimeout(r, 0))
         expect(launch).not.toHaveBeenCalled()
+    })
+
+    // A multi-level session never runs onComplete on the happy path — the SDK
+    // stays open through the follow-up level and the APPROVED websocket closes
+    // it — so the Level-1 submit must be reported through onSubmitted. Without
+    // it the whole session emits no submit signal (KYC_SUBMITTED blackout).
+    it('multi-level Level-1 submit fires onSubmitted once and does not close (no onComplete)', async () => {
+        const onComplete = jest.fn()
+        const onSubmitted = jest.fn()
+        render(
+            <SumsubKycWrapper
+                visible
+                accessToken="tok_abc"
+                onClose={jest.fn()}
+                onComplete={onComplete}
+                onSubmitted={onSubmitted}
+                onRefreshToken={jest.fn().mockResolvedValue('tok_abc')}
+                isMultiLevel
+            />
+        )
+        await waitFor(() => expect(launch).toHaveBeenCalled())
+
+        act(() => {
+            sdkHandlers['onApplicantSubmitted']?.()
+            // some SDK versions replay the idCheck-prefixed twin — one signal only
+            sdkHandlers['idCheck.onApplicantSubmitted']?.()
+        })
+
+        expect(onSubmitted).toHaveBeenCalledTimes(1)
+        expect(onComplete).not.toHaveBeenCalled()
+    })
+
+    // Single-level keeps its original contract: submit closes via onComplete,
+    // and onSubmitted stays silent (no double analytics signal).
+    it('single-level submit fires onComplete, not onSubmitted', async () => {
+        const onComplete = jest.fn()
+        const onSubmitted = jest.fn()
+        render(
+            <SumsubKycWrapper
+                visible
+                accessToken="tok_abc"
+                onClose={jest.fn()}
+                onComplete={onComplete}
+                onSubmitted={onSubmitted}
+                onRefreshToken={jest.fn().mockResolvedValue('tok_abc')}
+            />
+        )
+        await waitFor(() => expect(launch).toHaveBeenCalled())
+
+        act(() => {
+            sdkHandlers['onApplicantSubmitted']?.()
+        })
+
+        expect(onComplete).toHaveBeenCalledTimes(1)
+        expect(onSubmitted).not.toHaveBeenCalled()
     })
 
     describe('launch watchdog', () => {

--- a/src/components/Kyc/__tests__/sumsubStatusEvent.utils.test.ts
+++ b/src/components/Kyc/__tests__/sumsubStatusEvent.utils.test.ts
@@ -86,6 +86,21 @@ describe('evaluateSumsubStatusEvent', () => {
             ).toEqual({ markSubmitted: false, autoClose: false })
         })
 
+        // A multi-level flow can be declined on Level 1 (documents) before the
+        // follow-up questionnaire is ever shown — EU / NA reach this on the
+        // `bridge-requirements` workflow. The SDK must stay open so the user can
+        // retry in-session instead of being dumped back to the drawer.
+        it('multi-level + RED keeps the SDK open for an in-session retry', () => {
+            expect(
+                evaluateSumsubStatusEvent({
+                    payload: redPayload,
+                    sdkInitTime: 1000,
+                    now: 5000,
+                    isMultiLevel: true,
+                })
+            ).toEqual({ markSubmitted: false, autoClose: false })
+        })
+
         it('empty payload is a no-op', () => {
             expect(
                 evaluateSumsubStatusEvent({

--- a/src/components/Kyc/__tests__/sumsubStatusEvent.utils.test.ts
+++ b/src/components/Kyc/__tests__/sumsubStatusEvent.utils.test.ts
@@ -87,9 +87,9 @@ describe('evaluateSumsubStatusEvent', () => {
         })
 
         // A multi-level flow can be declined on Level 1 (documents) before the
-        // follow-up questionnaire is ever shown — EU / NA reach this on the
-        // `bridge-requirements` workflow. The SDK must stay open so the user can
-        // retry in-session instead of being dumped back to the drawer.
+        // follow-up questionnaire is ever shown — an EU applicant reaches this on
+        // the `bridge-requirements` workflow. The SDK must stay open so the user
+        // can retry in-session instead of being dumped back to the drawer.
         it('multi-level + RED keeps the SDK open for an in-session retry', () => {
             expect(
                 evaluateSumsubStatusEvent({

--- a/src/components/Kyc/states/KycActionRequired.tsx
+++ b/src/components/Kyc/states/KycActionRequired.tsx
@@ -28,11 +28,17 @@ export const KycActionRequired = ({
     const t = useTranslations('kyc')
     const tCommon = useTranslations('common')
 
+    // The generic card asks the user to continue — the required action can be a
+    // follow-up questionnaire, not a re-upload. Reject labels are the real
+    // re-submission case, so they keep the re-submit label. Matches the sibling
+    // KycActionRequiredModal, which pairs tCommon('continue') with the retry icon.
+    const isGenericAction = !rejectLabels?.length && !!actionMessage
+
     return (
         <div className="space-y-4 p-1">
             <KYCStatusDrawerItem status="pending" customText={t('actionNeeded')} />
 
-            {!rejectLabels?.length && actionMessage ? (
+            {isGenericAction ? (
                 <InfoCard variant="info" icon="alert" description={t('actionMessageActionRequired')} />
             ) : (
                 <RejectLabelsList rejectLabels={rejectLabels} />
@@ -45,7 +51,7 @@ export const KycActionRequired = ({
                 onClick={() => onResume()}
                 disabled={isLoading}
             >
-                {isLoading ? tCommon('loading') : t('resubmitVerification')}
+                {isLoading ? tCommon('loading') : isGenericAction ? tCommon('continue') : t('resubmitVerification')}
             </Button>
         </div>
     )

--- a/src/components/Kyc/states/__tests__/KycStates.test.tsx
+++ b/src/components/Kyc/states/__tests__/KycStates.test.tsx
@@ -73,7 +73,7 @@ describe('KYC state cards', () => {
         // backend prose must never render (it would be English in every locale).
         render(<KycActionRequired onResume={jest.fn()} actionMessage="Some backend prose." rejectLabels={[]} />)
 
-        expect(screen.getByText(/resubmit your documents/i)).toBeInTheDocument()
+        expect(screen.getByText(/tap below to continue/i)).toBeInTheDocument()
         expect(screen.queryByText('Some backend prose.')).not.toBeInTheDocument()
         expect(screen.queryByTestId('reject-labels-list')).not.toBeInTheDocument()
     })

--- a/src/components/Kyc/states/__tests__/KycStates.test.tsx
+++ b/src/components/Kyc/states/__tests__/KycStates.test.tsx
@@ -76,6 +76,10 @@ describe('KYC state cards', () => {
         expect(screen.getByText(/tap below to continue/i)).toBeInTheDocument()
         expect(screen.queryByText('Some backend prose.')).not.toBeInTheDocument()
         expect(screen.queryByTestId('reject-labels-list')).not.toBeInTheDocument()
+        // The CTA must match the copy: the required action can be a follow-up
+        // questionnaire, so this branch says "continue", not "re-submit".
+        expect(screen.getByText('Continue')).toBeInTheDocument()
+        expect(screen.queryByText('Re-submit verification')).not.toBeInTheDocument()
     })
 
     it('does not pass the click event to failed retry', () => {

--- a/src/components/Kyc/sumsubSdk.types.ts
+++ b/src/components/Kyc/sumsubSdk.types.ts
@@ -8,6 +8,14 @@ export interface SumsubSdkProps {
     accessToken: string | null
     onClose: () => void
     onComplete: () => void
+    /**
+     * Fired when a level is submitted but the SDK stays open (multi-level
+     * Level-1 submit). Single-level submits fire `onComplete` instead — without
+     * this hook a multi-level session emits no submit signal at all, because
+     * the APPROVED close never runs `onComplete`. Web SDK only: the native SDK
+     * dismisses after the LAST level, so its one `onComplete` already covers it.
+     */
+    onSubmitted?: () => void
     onError?: (error: unknown) => void
     onRefreshToken: () => Promise<string>
     /** multi-level workflow (e.g. LATAM) — don't close SDK on Level 1 submission */

--- a/src/components/Kyc/sumsubStatusEvent.utils.ts
+++ b/src/components/Kyc/sumsubStatusEvent.utils.ts
@@ -44,8 +44,9 @@ export function evaluateSumsubStatusEvent({
     if (isMultiLevel) {
         // Level 1 fires completed+GREEN before Level 2 is shown — don't close.
         // Level 2 is the Manteca questionnaire (LATAM) or the EEA uplift
-        // questionnaire (EU). NA shares the `bridge-requirements` workflow but
-        // never branches to the uplift, so it is not multi-level.
+        // questionnaire (EU). NA shares the `bridge-requirements` workflow but is
+        // deliberately not marked multi-level — its second levels are rare
+        // organic branches (see isMultiLevelIntent in useSumsubKycFlow).
         return { markSubmitted: false, autoClose: false }
     }
     if (isCompletedGreen) {

--- a/src/components/Kyc/sumsubStatusEvent.utils.ts
+++ b/src/components/Kyc/sumsubStatusEvent.utils.ts
@@ -44,7 +44,8 @@ export function evaluateSumsubStatusEvent({
     if (isMultiLevel) {
         // Level 1 fires completed+GREEN before Level 2 is shown — don't close.
         // Level 2 is the Manteca questionnaire (LATAM) or the EEA uplift
-        // questionnaire (EU / NA, both on `bridge-requirements`).
+        // questionnaire (EU). NA shares the `bridge-requirements` workflow but
+        // never branches to the uplift, so it is not multi-level.
         return { markSubmitted: false, autoClose: false }
     }
     if (isCompletedGreen) {

--- a/src/components/Kyc/sumsubStatusEvent.utils.ts
+++ b/src/components/Kyc/sumsubStatusEvent.utils.ts
@@ -43,6 +43,8 @@ export function evaluateSumsubStatusEvent({
     }
     if (isMultiLevel) {
         // Level 1 fires completed+GREEN before Level 2 is shown — don't close.
+        // Level 2 is the Manteca questionnaire (LATAM) or the EEA uplift
+        // questionnaire (EU / NA, both on `bridge-requirements`).
         return { markSubmitted: false, autoClose: false }
     }
     if (isCompletedGreen) {

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -233,6 +233,153 @@ describe('useSumsubKycFlow — terminal-error exits clear the user-initiated gua
     })
 })
 
+// Sumsub's `bridge-requirements` workflow branches every EEA applicant to the
+// `bridge-eea-uplift` questionnaire right after the documents go GREEN. The SDK
+// therefore has a SECOND level to show, exactly like LATAM's Manteca
+// questionnaire, and must not be closed on the first submit. `isMultiLevel` is
+// the flag that keeps it open (SumsubKycWrapper early-returns on it), so it has
+// to be true for the intent the SDK was actually opened with.
+describe('useSumsubKycFlow — multi-level workflows', () => {
+    beforeEach(() => {
+        mockInitiate.mockReset()
+        mockWs.handler = undefined
+        mockInitiate.mockResolvedValue({ data: { token: 'tok_1', applicantId: 'app_1', status: 'PENDING' } })
+    })
+
+    // The intent reaches the hook as a call-time override at almost every entry
+    // point (the bank / claim / add-money flows deliberately withhold the
+    // `regionIntent` prop so mounting the page does not create a backend record).
+    // Deriving multi-level from the prop alone made the flag false for all of
+    // them — the EEA questionnaire never got shown.
+    it.each([
+        ['EU', true],
+        ['NA', true],
+        ['LATAM', true],
+        ['ROW', false],
+        ['STANDARD', false],
+    ] as const)('intent %s passed as a call-time override → isMultiLevel %s', async (intent, expected) => {
+        const { result } = renderHook(() => useSumsubKycFlow({}))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc(intent)
+        })
+
+        expect(result.current.showWrapper).toBe(true)
+        expect(result.current.isMultiLevel).toBe(expected)
+    })
+
+    it('falls back to the regionIntent prop when no override is passed', async () => {
+        const { result } = renderHook(() => useSumsubKycFlow({ regionIntent: 'EU' }))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc()
+        })
+
+        expect(result.current.isMultiLevel).toBe(true)
+    })
+
+    // An applicant action is a single level whatever the region — cross-region
+    // LATAM mints a `manteca` action token, so it must still close on submit.
+    it('an applicant action is single-level even for a multi-level intent', async () => {
+        mockInitiate.mockResolvedValue({
+            data: { token: 'tok_1', applicantId: 'app_1', status: 'APPROVED', actionType: 'manteca' },
+        })
+        const { result } = renderHook(() => useSumsubKycFlow({}))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('LATAM', undefined, true, 'AR')
+        })
+
+        expect(result.current.isActionFlow).toBe(true)
+        expect(result.current.isMultiLevel).toBe(false)
+    })
+})
+
+// The companion backend change maps the follow-up level's `init` state to
+// ACTION_REQUIRED, which now lands ~3 min after the documents are submitted —
+// while the user is still filling the questionnaire in the open SDK. The
+// status-transition effect must not tear the flow down under them.
+describe('useSumsubKycFlow — ACTION_REQUIRED during a multi-level session', () => {
+    beforeEach(() => {
+        mockInitiate.mockReset()
+        mockWs.handler = undefined
+        mockInitiate.mockResolvedValue({ data: { token: 'tok_1', applicantId: 'app_1', status: 'PENDING' } })
+    })
+
+    // Reaches the both-open state the guard protects: the user submitted once
+    // (progress modal up), then re-initiated from another entry point, so the
+    // SDK is open again on top of it.
+    const openSdkOverProgressModal = async (intent: 'EU' | 'ROW') => {
+        const view = renderHook(() => useSumsubKycFlow({}))
+        act(() => {
+            view.result.current.handleSdkComplete()
+        })
+        await act(async () => {
+            await view.result.current.handleInitiateKyc(intent)
+        })
+        expect(view.result.current.showWrapper).toBe(true)
+        expect(view.result.current.isVerificationProgressModalOpen).toBe(true)
+        return view
+    }
+
+    it('holds the flow open while the SDK shows the questionnaire', async () => {
+        const { result } = await openSdkOverProgressModal('EU')
+
+        await act(async () => {
+            mockWs.handler?.('ACTION_REQUIRED')
+        })
+
+        expect(result.current.isVerificationProgressModalOpen).toBe(true)
+    })
+
+    // Boundary: the suppression is scoped to an OPEN SDK. Once the user is out of
+    // the SDK, ACTION_REQUIRED is a real drawer state and must close the modal.
+    it('still closes once the SDK is closed', async () => {
+        const { result } = renderHook(() => useSumsubKycFlow({}))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('EU')
+        })
+        expect(result.current.isMultiLevel).toBe(true)
+
+        act(() => {
+            result.current.handleSdkComplete()
+        })
+        expect(result.current.showWrapper).toBe(false)
+
+        await act(async () => {
+            mockWs.handler?.('ACTION_REQUIRED')
+        })
+
+        expect(result.current.isVerificationProgressModalOpen).toBe(false)
+    })
+
+    // Boundary: the suppression is scoped to ACTION_REQUIRED. A rejection is
+    // terminal and must still close, SDK open or not.
+    it('REJECTED still closes the modal with the SDK open', async () => {
+        const { result } = await openSdkOverProgressModal('EU')
+
+        await act(async () => {
+            mockWs.handler?.('REJECTED')
+        })
+
+        expect(result.current.isVerificationProgressModalOpen).toBe(false)
+    })
+
+    // Boundary: the suppression is scoped to multi-level flows. A single-level
+    // ROW session gets the unchanged close.
+    it('a single-level session still closes on ACTION_REQUIRED', async () => {
+        const { result } = await openSdkOverProgressModal('ROW')
+        expect(result.current.isMultiLevel).toBe(false)
+
+        await act(async () => {
+            mockWs.handler?.('ACTION_REQUIRED')
+        })
+
+        expect(result.current.isVerificationProgressModalOpen).toBe(false)
+    })
+})
+
 // Incident 2026-07-02: while the verification-progress modal was open, this hook
 // fired initiateSumsubKyc — a MUTATING endpoint — on a fixed 5s setInterval for
 // the entire modal-open, re-running provider submissions for approved-LATAM

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -251,10 +251,13 @@ describe('useSumsubKycFlow — multi-level workflows', () => {
     // `regionIntent` prop so mounting the page does not create a backend record).
     // Deriving multi-level from the prop alone made the flag false for all of
     // them — the EEA questionnaire never got shown.
+    // NA shares the `bridge-requirements` workflow with EU but is NOT multi-level:
+    // only EEA applicants branch to the uplift questionnaire. Marking NA
+    // multi-level would park every US applicant in an open SDK until approval.
     it.each([
         ['EU', true],
-        ['NA', true],
         ['LATAM', true],
+        ['NA', false],
         ['ROW', false],
         ['STANDARD', false],
     ] as const)('intent %s passed as a call-time override → isMultiLevel %s', async (intent, expected) => {
@@ -330,6 +333,28 @@ describe('useSumsubKycFlow — ACTION_REQUIRED during a multi-level session', ()
         })
 
         expect(result.current.isVerificationProgressModalOpen).toBe(true)
+    })
+
+    // The suppression must DEFER the transition, not consume it. prevStatusRef is
+    // left alone while the SDK is open, so closing the SDK re-runs the effect and
+    // the transition is evaluated for real. If the ref were advanced during the
+    // suppressed pass, a user who abandoned mid-questionnaire would be stranded on
+    // a stale "verifying" modal with nothing left to close it.
+    it('re-evaluates the deferred transition once the SDK closes', async () => {
+        const { result } = await openSdkOverProgressModal('EU')
+
+        await act(async () => {
+            mockWs.handler?.('ACTION_REQUIRED')
+        })
+        expect(result.current.isVerificationProgressModalOpen).toBe(true)
+
+        // user abandons the questionnaire — no new status event follows
+        act(() => {
+            result.current.handleClose()
+        })
+
+        expect(result.current.showWrapper).toBe(false)
+        expect(result.current.isVerificationProgressModalOpen).toBe(false)
     })
 
     // Boundary: the suppression is scoped to an OPEN SDK. Once the user is out of

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -283,6 +283,26 @@ describe('useSumsubKycFlow — multi-level workflows', () => {
 
     // An applicant action is a single level whatever the region — cross-region
     // LATAM mints a `manteca` action token, so it must still close on submit.
+    // Every path that closes the SDK must clear the flag, or a later single-level
+    // open (self-heal, restart-identity, start-action) inherits a stale true and
+    // SumsubKycWrapper suppresses its completion close — stranding the user in the
+    // SDK. Approval is the one close path that does not run a close handler.
+    it('clears isMultiLevel when approval closes the SDK', async () => {
+        const { result } = renderHook(() => useSumsubKycFlow({}))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('EU')
+        })
+        expect(result.current.isMultiLevel).toBe(true)
+
+        await act(async () => {
+            mockWs.handler?.('APPROVED')
+        })
+
+        expect(result.current.showWrapper).toBe(false)
+        expect(result.current.isMultiLevel).toBe(false)
+    })
+
     it('an applicant action is single-level even for a multi-level intent', async () => {
         mockInitiate.mockResolvedValue({
             data: { token: 'tok_1', applicantId: 'app_1', status: 'APPROVED', actionType: 'manteca' },

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -251,9 +251,10 @@ describe('useSumsubKycFlow — multi-level workflows', () => {
     // `regionIntent` prop so mounting the page does not create a backend record).
     // Deriving multi-level from the prop alone made the flag false for all of
     // them — the EEA questionnaire never got shown.
-    // NA shares the `bridge-requirements` workflow with EU but is NOT multi-level:
-    // only EEA applicants branch to the uplift questionnaire. Marking NA
-    // multi-level would park every US applicant in an open SDK until approval.
+    // NA shares the `bridge-requirements` workflow with EU but is deliberately
+    // NOT multi-level: its second levels are rare organic branches
+    // (source-of-funds, proof-of-address), and marking NA multi-level would park
+    // every US applicant in an open SDK until approval to serve them.
     it.each([
         ['EU', true],
         ['LATAM', true],
@@ -375,6 +376,28 @@ describe('useSumsubKycFlow — ACTION_REQUIRED during a multi-level session', ()
 
         expect(result.current.showWrapper).toBe(false)
         expect(result.current.isVerificationProgressModalOpen).toBe(false)
+    })
+
+    // …EXCEPT when the close is a submission. An in-session resubmit after a RED
+    // decline runs handleSdkComplete, which opens the progress modal — replaying
+    // the held (now stale) transition would close it in the same breath and dump
+    // the user on an ACTION_REQUIRED drawer for documents they just resubmitted.
+    // handleSdkComplete consumes the deferred status instead.
+    it('a submission close consumes the deferred transition — the progress modal stays open', async () => {
+        const { result } = await openSdkOverProgressModal('EU')
+
+        await act(async () => {
+            mockWs.handler?.('ACTION_REQUIRED')
+        })
+        expect(result.current.isVerificationProgressModalOpen).toBe(true)
+
+        // in-session resubmit: onApplicantResubmitted → handleSdkComplete
+        act(() => {
+            result.current.handleSdkComplete()
+        })
+
+        expect(result.current.showWrapper).toBe(false)
+        expect(result.current.isVerificationProgressModalOpen).toBe(true)
     })
 
     // Boundary: the suppression is scoped to an OPEN SDK. Once the user is out of

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -248,6 +248,15 @@ export const useMultiPhaseKycFlow = ({
     // refresh user store when kyc status transitions to a non-success state
     // so the drawer/status item reads the updated verification record
     useEffect(() => {
+        // Same defer guard as the transition effect in useSumsubKycFlow: while a
+        // multi-level SDK session is open, ACTION_REQUIRED is the routine "the
+        // follow-up questionnaire is showing" status (the backend maps the
+        // follow-up level's `init` state to it ~3 min after the documents are
+        // submitted). Acting on it here would log a bogus KYC_REJECTED for every
+        // succeeding EEA applicant and flip the user store to action_required
+        // under the open SDK. The effect re-runs when the SDK closes, so an
+        // abandoned session still gets the capture and the store refresh.
+        if (liveKycStatus === 'ACTION_REQUIRED' && showWrapper && isMultiLevel) return
         if (liveKycStatus === 'ACTION_REQUIRED' || liveKycStatus === 'REJECTED') {
             posthog.capture(ANALYTICS_EVENTS.KYC_REJECTED, {
                 region_intent: lastIntentRef.current ?? regionIntent,
@@ -255,7 +264,15 @@ export const useMultiPhaseKycFlow = ({
             })
             fetchUser()
         }
-    }, [liveKycStatus, fetchUser, regionIntent])
+    }, [liveKycStatus, fetchUser, regionIntent, showWrapper, isMultiLevel])
+
+    // A multi-level session never reaches handleSdkComplete on the happy path:
+    // the SDK stays open through the follow-up level and the APPROVED transition
+    // closes it without onComplete. The wrapper reports the Level-1 submit
+    // through onSubmitted instead, so the funnel still gets its KYC_SUBMITTED.
+    const handleSdkSubmitted = useCallback(() => {
+        posthog.capture(ANALYTICS_EVENTS.KYC_SUBMITTED, { region_intent: lastIntentRef.current ?? regionIntent })
+    }, [regionIntent])
 
     // wrap handleSdkComplete to track real-time flow
     const handleSdkComplete = useCallback(() => {
@@ -465,6 +482,7 @@ export const useMultiPhaseKycFlow = ({
         accessToken,
         handleSdkClose: handleClose,
         handleSdkComplete,
+        handleSdkSubmitted,
         refreshToken,
         isMultiLevel,
 

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -237,6 +237,7 @@ export const useMultiPhaseKycFlow = ({
         isVerificationProgressModalOpen,
         closeVerificationProgressModal,
         isActionFlow,
+        isMultiLevel,
     } = useSumsubKycFlow({ onKycSuccess: handleSumsubApproved, onManualClose, regionIntent })
 
     // keep ref in sync
@@ -441,10 +442,6 @@ export const useMultiPhaseKycFlow = ({
     }, [clearPreparingTimer, stopTracking])
 
     const isModalOpen = isVerificationProgressModalOpen || forceShowModal
-
-    // multi-level only for first-time LATAM (workflow with conditional questionnaire).
-    // cross-region LATAM uses an applicant action (single level, not multi-level).
-    const isMultiLevel = regionIntent === 'LATAM' && !isActionFlow
 
     // Derive preparing stage from elapsed time for progressive copy
     const preparingStage = useMemo<'initial' | 'configuring' | 'slow'>(() => {

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -54,6 +54,18 @@ const ACTION_ERROR_KEYS = {
     unexpected: 'unexpectedError',
 } as const satisfies Record<SumsubActionErrorCode, string>
 
+/**
+ * A workflow is multi-level when Sumsub can show a SECOND level in the same
+ * session, after the first submit:
+ *   - LATAM → `general`, which branches AR/BR applicants to `manteca-requirements`
+ *   - EU / NA → `bridge-requirements`, which branches EEA applicants to the
+ *     `bridge-eea-uplift` questionnaire
+ * ROW and STANDARD are single-level. Applicant actions are always single-level,
+ * whatever the region — see the `isActionFlow` checks at each SDK open.
+ */
+const isMultiLevelIntent = (intent: KYCRegionIntent | undefined): boolean =>
+    intent === 'LATAM' || intent === 'EU' || intent === 'NA'
+
 const getKycPollDelayMs = (elapsedMs: number): number => {
     for (const { untilMs, delayMs } of KYC_POLL_SCHEDULE) {
         if (elapsedMs < untilMs) return delayMs
@@ -83,9 +95,17 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     const [rejectLabels, setRejectLabels] = useState<string[] | undefined>(undefined)
     // true when the SDK is showing an applicant action (not a standard level)
     const [isActionFlow, setIsActionFlow] = useState(false)
+    // true when the open SDK session runs a multi-level workflow, so the SDK must
+    // stay open past the first submit and show the follow-up level. Set by each
+    // path that opens the SDK, because the answer depends on the intent that open
+    // actually used — most entry points pass it to handleInitiateKyc rather than
+    // as the `regionIntent` prop, so the prop alone is not the effective intent.
+    const [isMultiLevel, setIsMultiLevel] = useState(false)
     const prevStatusRef = useRef(liveKycStatus)
     const showWrapperRef = useRef(showWrapper)
     showWrapperRef.current = showWrapper
+    const isMultiLevelRef = useRef(isMultiLevel)
+    isMultiLevelRef.current = isMultiLevel
     // tracks the effective region intent across initiate + refresh so the correct template is always used
     const regionIntentRef = useRef<KYCRegionIntent | undefined>(regionIntent)
     // tracks the level name across initiate + refresh (e.g. 'peanut-additional-docs')
@@ -137,6 +157,13 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
             liveKycStatus !== 'PENDING' &&
             liveKycStatus !== 'REVERIFYING'
         ) {
+            // In a multi-level workflow the follow-up questionnaire IS the required
+            // action, and the backend flips to ACTION_REQUIRED while the user is
+            // still filling it in the open SDK. Tearing the flow down under them is
+            // the bug this branch would cause, so hold the state while the SDK is
+            // open. The SDK's own rejection / retry handlers still close explicitly,
+            // and every other terminal state (REJECTED, FAILED) still closes here.
+            if (liveKycStatus === 'ACTION_REQUIRED' && showWrapperRef.current && isMultiLevelRef.current) return
             // close modal for any non-success terminal state (REJECTED, ACTION_REQUIRED, FAILED, etc.)
             setIsVerificationProgressModalOpen(false)
         }
@@ -332,6 +359,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                     // not just this one — reaches the right SDK.
                     setAccessToken(response.data.token)
                     setIsActionFlow(!!response.data.actionType)
+                    setIsMultiLevel(!response.data.actionType && isMultiLevelIntent(effectiveIntent))
                     setShowWrapper(true)
                     return true
                 } else {
@@ -431,6 +459,8 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
             }
             if (response.data?.token) {
                 setAccessToken(response.data.token)
+                // a restart re-opens a single level (the IDENTITY step only)
+                setIsMultiLevel(false)
                 setShowWrapper(true)
             } else {
                 userInitiatedRef.current = false
@@ -468,6 +498,8 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
 
                 if (response.data?.token) {
                     setAccessToken(response.data.token)
+                    // self-heal mints an action token — always a single level
+                    setIsMultiLevel(false)
                     setShowWrapper(true)
                 } else {
                     userInitiatedRef.current = false
@@ -508,6 +540,8 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 levelNameRef.current = response.data.levelName
                 setAccessToken(response.data.token)
                 setIsActionFlow(true)
+                // an RFI action level — always a single level
+                setIsMultiLevel(false)
                 setShowWrapper(true)
             } catch (e: unknown) {
                 userInitiatedRef.current = false
@@ -539,5 +573,6 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         closeVerificationModalAndGoHome,
         resetError,
         isActionFlow,
+        isMultiLevel,
     }
 }

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -162,10 +162,15 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         prevStatusRef.current = liveKycStatus
 
         if (prevStatus !== 'APPROVED' && liveKycStatus === 'APPROVED') {
-            // if SDK is still open (LATAM multi-level), close it now —
+            // if SDK is still open (multi-level), close it now —
             // applicantWorkflowCompleted has fired, all levels are done.
             if (showWrapperRef.current) {
                 setShowWrapper(false)
+                // this is the third and last path that closes the SDK, so clearing
+                // here is what makes "closed ⇒ single-level" hold everywhere. A
+                // later action open (self-heal, restart-identity, start-action)
+                // would otherwise inherit a stale true and never close on submit.
+                setIsMultiLevel(false)
                 setIsVerificationProgressModalOpen(true)
                 userInitiatedRef.current = true
             }

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -62,10 +62,14 @@ const ACTION_ERROR_KEYS = {
  *     `bridge-eea-uplift` questionnaire
  *
  * NA is deliberately NOT here, even though it shares the `bridge-requirements`
- * workflow: only EEA applicants branch to the uplift questionnaire, so a US
- * applicant has no second level. Marking NA multi-level would hold every US
- * applicant in an open SDK on Sumsub's "documents submitted" screen until
- * approval, and suppress the submit handler that fires KYC_SUBMITTED.
+ * workflow. NA second levels exist but are rare organic branches — the workflow
+ * routes to `source-of-funds` (applicant age >= 60) and `proof-of-address` (POI
+ * country in the higher-risk list); see peanut-api-ts `level-registry.ts`.
+ * Marking NA multi-level would hold EVERY US applicant in an open SDK on
+ * Sumsub's "documents submitted" screen until approval to serve those rare
+ * branches. The branch cohort gets the ACTION_REQUIRED drawer round-trip
+ * instead, which converges. EU differs: every EEA applicant branches to the
+ * uplift questionnaire, so the hold serves the whole cohort.
  *
  * ROW and STANDARD are single-level. Applicant actions are always single-level,
  * whatever the region — see the `isActionFlow` check at the initiate open.
@@ -152,7 +156,12 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         // deferred, not consumed. When the SDK closes, `showWrapper` changes, this
         // effect re-runs and the branches below evaluate the same transition for
         // real. Advancing the ref first would swallow it: a user who abandoned
-        // mid-questionnaire would then sit on a stale "verifying" modal forever.
+        // mid-questionnaire (the SDK can sit on top of an open progress modal)
+        // would then sit on a stale "verifying" modal forever.
+        //
+        // The one close that must NOT replay it is a submission — the user just
+        // acted, so the held transition is stale for what they submitted.
+        // handleSdkComplete consumes it by advancing prevStatusRef itself.
         //
         // Both flags are committed state rather than refs, so an interrupted render
         // can never leak a value this guard acts on.
@@ -405,11 +414,17 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     const handleSdkComplete = useCallback(() => {
         userInitiatedRef.current = true
         selfHealProviderRef.current = null
+        // Consume a deferred ACTION_REQUIRED (see the transition effect): this
+        // close IS a submission, so the held transition is stale — replaying it
+        // would close the progress modal this handler opens (in-session resubmit
+        // after a RED decline). The manual close keeps the replay: abandoning
+        // really does leave the action required.
+        if (liveKycStatus === 'ACTION_REQUIRED') prevStatusRef.current = 'ACTION_REQUIRED'
         setShowWrapper(false)
         setIsActionFlow(false)
         setIsMultiLevel(false)
         setIsVerificationProgressModalOpen(true)
-    }, [])
+    }, [liveKycStatus])
 
     // called when user manually closes the sdk modal
     const handleClose = useCallback(() => {
@@ -481,6 +496,14 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
             }
             if (response.data?.token) {
                 setAccessToken(response.data.token)
+                // The restart reopens the SAME workflow the original initiate ran
+                // (the token targets the applicant's existing level), so re-derive
+                // the multi-level flag. Left false, a restarted LATAM `general`
+                // session would close on first submit — before the
+                // manteca-requirements questionnaire. Best-effort: the ref is
+                // undefined when this hook instance never initiated, which keeps
+                // today's single-level behavior.
+                setIsMultiLevel(isMultiLevelIntent(regionIntentRef.current))
                 setShowWrapper(true)
             } else {
                 userInitiatedRef.current = false

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -104,8 +104,6 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     const prevStatusRef = useRef(liveKycStatus)
     const showWrapperRef = useRef(showWrapper)
     showWrapperRef.current = showWrapper
-    const isMultiLevelRef = useRef(isMultiLevel)
-    isMultiLevelRef.current = isMultiLevel
     // tracks the effective region intent across initiate + refresh so the correct template is always used
     const regionIntentRef = useRef<KYCRegionIntent | undefined>(regionIntent)
     // tracks the level name across initiate + refresh (e.g. 'peanut-additional-docs')
@@ -163,11 +161,15 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
             // the bug this branch would cause, so hold the state while the SDK is
             // open. The SDK's own rejection / retry handlers still close explicitly,
             // and every other terminal state (REJECTED, FAILED) still closes here.
-            if (liveKycStatus === 'ACTION_REQUIRED' && showWrapperRef.current && isMultiLevelRef.current) return
+            // `showWrapper` and `isMultiLevel` are read as committed state, not through
+            // a ref, so an interrupted render can never leak a value this guard acts on.
+            // Both are in the dep array below: a re-run with an unchanged status is a
+            // no-op, because prevStatusRef already holds that status.
+            if (liveKycStatus === 'ACTION_REQUIRED' && showWrapper && isMultiLevel) return
             // close modal for any non-success terminal state (REJECTED, ACTION_REQUIRED, FAILED, etc.)
             setIsVerificationProgressModalOpen(false)
         }
-    }, [liveKycStatus, onKycSuccess])
+    }, [liveKycStatus, onKycSuccess, showWrapper, isMultiLevel])
 
     // fetch current status to recover from missed websocket events.
     // skip when regionIntent is undefined to avoid creating an applicant with the wrong template

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -58,13 +58,22 @@ const ACTION_ERROR_KEYS = {
  * A workflow is multi-level when Sumsub can show a SECOND level in the same
  * session, after the first submit:
  *   - LATAM → `general`, which branches AR/BR applicants to `manteca-requirements`
- *   - EU / NA → `bridge-requirements`, which branches EEA applicants to the
+ *   - EU → `bridge-requirements`, which branches EEA applicants to the
  *     `bridge-eea-uplift` questionnaire
+ *
+ * NA is deliberately NOT here, even though it shares the `bridge-requirements`
+ * workflow: only EEA applicants branch to the uplift questionnaire, so a US
+ * applicant has no second level. Marking NA multi-level would hold every US
+ * applicant in an open SDK on Sumsub's "documents submitted" screen until
+ * approval, and suppress the submit handler that fires KYC_SUBMITTED.
+ *
  * ROW and STANDARD are single-level. Applicant actions are always single-level,
- * whatever the region — see the `isActionFlow` checks at each SDK open.
+ * whatever the region — see the `isActionFlow` check at the initiate open.
+ *
+ * This list is hand-rolled workflow knowledge and will drift. The durable fix is
+ * for the initiate response to report the level / multi-level flag itself.
  */
-const isMultiLevelIntent = (intent: KYCRegionIntent | undefined): boolean =>
-    intent === 'LATAM' || intent === 'EU' || intent === 'NA'
+const isMultiLevelIntent = (intent: KYCRegionIntent | undefined): boolean => intent === 'LATAM' || intent === 'EU'
 
 const getKycPollDelayMs = (elapsedMs: number): number => {
     for (const { untilMs, delayMs } of KYC_POLL_SCHEDULE) {
@@ -96,8 +105,9 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     // true when the SDK is showing an applicant action (not a standard level)
     const [isActionFlow, setIsActionFlow] = useState(false)
     // true when the open SDK session runs a multi-level workflow, so the SDK must
-    // stay open past the first submit and show the follow-up level. Set by each
-    // path that opens the SDK, because the answer depends on the intent that open
+    // stay open past the first submit and show the follow-up level. Raised by the
+    // initiate open (the only path that can start one) and cleared by both close
+    // handlers, so "closed" always means false. It depends on the intent that open
     // actually used — most entry points pass it to handleInitiateKyc rather than
     // as the `regionIntent` prop, so the prop alone is not the effective intent.
     const [isMultiLevel, setIsMultiLevel] = useState(false)
@@ -134,6 +144,20 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
 
     // react to status transitions
     useEffect(() => {
+        // Hold an ACTION_REQUIRED transition while a multi-level SDK session is
+        // open: the follow-up questionnaire IS the required action, so acting on it
+        // here would tear the flow down under the user.
+        //
+        // This returns BEFORE prevStatusRef is advanced, so the transition is
+        // deferred, not consumed. When the SDK closes, `showWrapper` changes, this
+        // effect re-runs and the branches below evaluate the same transition for
+        // real. Advancing the ref first would swallow it: a user who abandoned
+        // mid-questionnaire would then sit on a stale "verifying" modal forever.
+        //
+        // Both flags are committed state rather than refs, so an interrupted render
+        // can never leak a value this guard acts on.
+        if (liveKycStatus === 'ACTION_REQUIRED' && showWrapper && isMultiLevel) return
+
         const prevStatus = prevStatusRef.current
         prevStatusRef.current = liveKycStatus
 
@@ -155,17 +179,6 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
             liveKycStatus !== 'PENDING' &&
             liveKycStatus !== 'REVERIFYING'
         ) {
-            // In a multi-level workflow the follow-up questionnaire IS the required
-            // action, and the backend flips to ACTION_REQUIRED while the user is
-            // still filling it in the open SDK. Tearing the flow down under them is
-            // the bug this branch would cause, so hold the state while the SDK is
-            // open. The SDK's own rejection / retry handlers still close explicitly,
-            // and every other terminal state (REJECTED, FAILED) still closes here.
-            // `showWrapper` and `isMultiLevel` are read as committed state, not through
-            // a ref, so an interrupted render can never leak a value this guard acts on.
-            // Both are in the dep array below: a re-run with an unchanged status is a
-            // no-op, because prevStatusRef already holds that status.
-            if (liveKycStatus === 'ACTION_REQUIRED' && showWrapper && isMultiLevel) return
             // close modal for any non-success terminal state (REJECTED, ACTION_REQUIRED, FAILED, etc.)
             setIsVerificationProgressModalOpen(false)
         }
@@ -389,6 +402,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         selfHealProviderRef.current = null
         setShowWrapper(false)
         setIsActionFlow(false)
+        setIsMultiLevel(false)
         setIsVerificationProgressModalOpen(true)
     }, [])
 
@@ -396,6 +410,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     const handleClose = useCallback(() => {
         setShowWrapper(false)
         setIsActionFlow(false)
+        setIsMultiLevel(false)
         onManualClose?.()
     }, [onManualClose])
 
@@ -461,8 +476,6 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
             }
             if (response.data?.token) {
                 setAccessToken(response.data.token)
-                // a restart re-opens a single level (the IDENTITY step only)
-                setIsMultiLevel(false)
                 setShowWrapper(true)
             } else {
                 userInitiatedRef.current = false
@@ -500,8 +513,6 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
 
                 if (response.data?.token) {
                     setAccessToken(response.data.token)
-                    // self-heal mints an action token — always a single level
-                    setIsMultiLevel(false)
                     setShowWrapper(true)
                 } else {
                     userInitiatedRef.current = false
@@ -542,8 +553,6 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 levelNameRef.current = response.data.levelName
                 setAccessToken(response.data.token)
                 setIsActionFlow(true)
-                // an RFI action level — always a single level
-                setIsMultiLevel(false)
                 setShowWrapper(true)
             } catch (e: unknown) {
                 userInitiatedRef.current = false

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2525,7 +2525,7 @@
         },
         "errorStartActionFailed": "Could not start verification. Please try again.",
         "errorInvalidResponse": "Invalid response from server",
-        "actionMessageActionRequired": "We need a bit more to verify your identity. Please resubmit your documents.",
+        "actionMessageActionRequired": "We need a bit more to verify your identity. Tap below to continue.",
         "actionMessageFailed": "We couldn't verify your identity. Please contact support.",
         "successTitle": "Verification successful!",
         "successCloseWindow": "You can now close this window."

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2525,7 +2525,7 @@
         },
         "errorStartActionFailed": "No pudimos iniciar la verificación. Inténtalo de nuevo.",
         "errorInvalidResponse": "Respuesta inválida del servidor",
-        "actionMessageActionRequired": "Necesitamos un poco más para verificar tu identidad. Vuelve a enviar tus documentos.",
+        "actionMessageActionRequired": "Necesitamos un poco más para verificar tu identidad. Toca abajo para continuar.",
         "actionMessageFailed": "No pudimos verificar tu identidad. Contacta a soporte.",
         "successTitle": "¡Verificación exitosa!",
         "successCloseWindow": "Ya puedes cerrar esta ventana."

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -980,7 +980,7 @@
             }
         },
         "errorStartActionFailed": "No pudimos iniciar la verificación. Intentalo de nuevo.",
-        "actionMessageActionRequired": "Necesitamos un poco más para verificar tu identidad. Volvé a enviar tus documentos.",
+        "actionMessageActionRequired": "Necesitamos un poco más para verificar tu identidad. Tocá abajo para continuar.",
         "actionMessageFailed": "No pudimos verificar tu identidad. Contactá a soporte.",
         "successCloseWindow": "Ya podés cerrar esta ventana."
     },

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2525,7 +2525,7 @@
         },
         "errorStartActionFailed": "Não conseguimos iniciar a verificação. Tente novamente.",
         "errorInvalidResponse": "Resposta inválida do servidor",
-        "actionMessageActionRequired": "Precisamos de um pouco mais para verificar sua identidade. Reenvie seus documentos.",
+        "actionMessageActionRequired": "Precisamos de um pouco mais para verificar sua identidade. Toque abaixo para continuar.",
         "actionMessageFailed": "Não conseguimos verificar sua identidade. Fale com o suporte.",
         "successTitle": "Verificação concluída!",
         "successCloseWindow": "Você já pode fechar esta janela."


### PR DESCRIPTION
## Summary

Sumsub's `bridge-requirements` workflow now branches every EEA applicant to the `bridge-eea-uplift` questionnaire as soon as the documents go GREEN. The frontend closed the SDK on the first submit for every non-LATAM flow, so the questionnaire never showed in-session. About 3 minutes later the backend poller read the follow-up level's `init` state, and the KYC drawer fell back to "Start verification". The user could not reach the questionnaire at all.

This PR keeps the SDK open through the questionnaire and fixes the drawer copy.

**Task:** TASK-21510

## What changed

**1. `isMultiLevel` now uses the intent the SDK was opened with.**

`isMultiLevel` is the flag that holds the SDK open past the first submit (`SumsubKycWrapper.handleSubmitted` returns early on it, and `evaluateSumsubStatusEvent` suppresses the `completed + GREEN` auto-close). It was `regionIntent === 'LATAM' && !isActionFlow`, read from the `regionIntent` **hook prop**.

Almost every entry point withholds that prop on purpose. The bank, claim and add-money flows pass the intent to `handleInitiateKyc` at call time, so that mounting a page does not create a backend record. The flag was therefore false for all of them — including every EU flow this fix targets. Changing only the intent list would have shipped a no-op.

The flag now lives in `useSumsubKycFlow`, where the effective intent is known. `handleInitiateKyc` raises it for **LATAM and EU**, unless the response is an applicant action; both close handlers clear it, so a closed SDK always reads false. `useMultiPhaseKycFlow` re-exports the value instead of deriving a second copy.

**NA is excluded, which deviates from the task card's "EU/NA" wording.** NA shares the `bridge-requirements` workflow, but only EEA applicants branch to the uplift questionnaire, so a US applicant has no second level. Marking NA multi-level would park every US applicant in an open SDK on Sumsub's "documents submitted" screen until approval, and would suppress the submit handler that fires `KYC_SUBMITTED`.

Known remainder: a non-EEA **EU**-intent user (UK on Faster Payments, say) also does not branch, and will wait on the SDK screen until approval. Accepted for now — see follow-up 3.

Side effect worth naming: first-time **LATAM** users on the bank / claim / add-money entry points had the same bug, for the same reason. They get the Manteca questionnaire in-session now too.

**2. ACTION_REQUIRED no longer tears down an open multi-level session.**

The companion `peanut-api-ts` PR maps the follow-up level's `init` state to `ACTION_REQUIRED`, so that status now lands about 3 minutes after the documents are submitted — while the user is still filling the questionnaire. The status-transition effect closed the flow on any non-success terminal state. It now holds the state when the status is `ACTION_REQUIRED`, the SDK is open, and the session is multi-level. The questionnaire IS the required action.

The transition is **deferred, not consumed**. The guard returns before `prevStatusRef` is advanced, so closing the SDK re-runs the effect and the same transition is evaluated for real. Advancing the ref first would swallow it, and a user who abandoned mid-questionnaire would then sit on a stale "verifying" modal with nothing left to close it.

Every other terminal state (`REJECTED`, `FAILED`) still closes, the suppression ends the moment the SDK closes, and the SDK's own rejection and retry handlers still close explicitly. Four boundary tests pin those edges.

**3. Card copy.** `kyc.actionMessageActionRequired` said "resubmit your documents", which is wrong for a questionnaire. It is now neutral: "We need a bit more to verify your identity. Tap below to continue." Translated in `es-419`, `es-AR` (voseo) and `pt-BR`.

**4. CTA copy.** `KycActionRequired`'s button said "Re-submit verification" under the new neutral card copy. The generic branch now reads "Continue" (`tCommon('continue')`, as its sibling `KycActionRequiredModal` already does). The reject-labels branch keeps "Re-submit verification" — that one genuinely is a re-submission.

## Risk

Medium, and scoped to the KYC entry flow.

- **Deploy order:** this PR is safe on its own. Change 2 only matters once the companion `peanut-api-ts` PR ships. Without it, the guard never fires.
- **Only EU and LATAM are held open.** NA, ROW and STANDARD behave exactly as before.
- **A non-EEA EU-intent user** does not branch to the questionnaire, so they wait on Sumsub's own "in review" screen until approval instead of our verification-progress modal. LATAM users already have this behavior, and approval still closes the SDK through the `APPROVED` transition. Follow-up 3 is the durable fix.
- **Native is unaffected.** `SumsubNativeSdk` never reads `isMultiLevel`. The Cordova SDK walks all levels of the workflow before it dismisses, so it calls `onComplete` only once the whole session ends.

## Design notes / accepted trade-offs

- `isMultiLevel` is raised only by the initiate open and cleared by **all three** paths that close the SDK — both close handlers and the `APPROVED` branch — so "closed implies single-level" holds by construction and no later action open can inherit a stale true. The `showWrapper` conjunct in the guard is kept as defence in depth for any future close path.
- The `ACTION_REQUIRED` guard reads `showWrapper` and `isMultiLevel` as committed state, with both in the status effect's dependency array, rather than through a render-written ref (CodeRabbit, [#discussion_r3821474016](https://github.com/peanutprotocol/peanut-ui/pull/2765#discussion_r3821474016)). The pre-existing render-time write to `showWrapperRef` is untouched — it is read by an async callback with its own documented race, and rewiring it belongs in its own PR.
- Deferring the transition means that if the status is still `ACTION_REQUIRED` when the user finishes the questionnaire, the deferred close fires as the SDK closes and the drawer shows the action state until the backend catches up. That is the honest state, and it is the safer of the two failures — the alternative strands the user on a modal that nothing can close.

## Known follow-ups

1. **Drawer resume passes no intent.** `KycStatusDrawer` calls `handleInitiateKyc()` bare, so a resumed session is single-level. Benign today: a fresh `bridge-requirements` token resumes AT the questionnaire, so the close-on-submit happens after the questionnaire is done (applicant `6a8189f7` on the task card). No code change.
2. **`handleResubmitted` closes unconditionally** in `SumsubKycWrapper`, a deliberate LATAM-era decision. An EEA user who retries a RED document in-SDK is closed before the questionnaire and re-enters through the drawer. Changing it needs sandbox verification of which Sumsub event fires first. Follow-up, not this PR.
4. **A consumed ACTION_REQUIRED cannot re-fire.** The close branch keys on a status *transition*. If `ACTION_REQUIRED` is consumed just before the SDK opens, `prevStatusRef` already holds it, so when `handleSdkComplete` opens the verification-progress modal after the questionnaire, no transition arrives to close it. The user sees "verifying" until the poll observes a different status or they dismiss the modal. Flagged by CodeRabbit as a moderate merge risk on `85e80fd2e`; **explicitly accepted here**. It predates this PR — the close branch has always been transition-keyed — but this PR makes `ACTION_REQUIRED` a routine mid-flow status, so it raises the odds. The modal stays dismissible and the poll still resolves it on any later status change. Fixing it means changing when `handleSdkComplete` opens the modal, which touches every KYC flow, so it does not belong in this diff.

3. **The frontend should stop hand-rolling workflow knowledge.** The intent list here will drift (`STANDARD` maps to `general` and already disagrees). The durable fix is for the initiate response to carry `levelName` / a multi-level flag from the backend. Cross-repo follow-up.

## QA

- `npm test` — 247 suites, 3188 tests green. `npm run typecheck` and `prettier --check .` clean. `eslint` clean on every changed file.
- `src/hooks/__tests__/useSumsubKycFlow.test.ts`:
  - Intent passed as a call-time override → `isMultiLevel` true for EU and LATAM, false for NA, ROW and STANDARD. The old prop-only derivation got this wrong for every override caller.
  - Falls back to the `regionIntent` prop when no override is passed.
  - A `manteca` applicant action stays single-level even for LATAM.
  - `ACTION_REQUIRED` with the multi-level SDK open holds the flow; **closing the SDK then re-evaluates the deferred transition** and runs the normal close; the ROW twin closes immediately; the same status closes once the SDK is closed; `REJECTED` still closes with the SDK open.
- `src/components/Kyc/__tests__/sumsubStatusEvent.utils.test.ts`: multi-level + RED keeps the SDK open for an in-session retry.
- `src/components/Kyc/states/__tests__/KycStates.test.tsx`: the generic branch renders the new card copy and a "Continue" CTA; the reject-labels branch keeps "Re-submit verification".

**Screenshots:** ⚠️ NONE. The two visible changes are the drawer card string and its button label, both inside the `action_required` KYC state — reaching it needs a live applicant the backend has flipped to `ACTION_REQUIRED`, which the local sandbox cannot produce. Both strings are asserted in `KycStates.test.tsx` instead. The questionnaire itself is Sumsub-rendered.


## Review round — Jota (`acde2e184`)

Four of the five findings were valid and are fixed; the fifth is a comment correction plus a declined scope change.

1. **The sibling effect in `useMultiPhaseKycFlow` fired `KYC_REJECTED` + `fetchUser` on every happy-path ACTION_REQUIRED.** Same defer guard as the transition effect. On the happy path the status is APPROVED by close time, so nothing fires.
2. **The deferred transition replayed on EVERY close**, so an in-session resubmit closed the progress modal it had just opened. The defer is now split by close type: a submission close (`handleSdkComplete`) **consumes** the held transition (the user just acted — it is stale); the manual close keeps the replay (abandoning really does leave the action required, and the SDK can sit on top of an open progress modal). This supersedes the "deferred, not consumed" wording above.
3. **Multi-level sessions emitted no `KYC_SUBMITTED` at all.** New optional `onSubmitted` on `SumsubSdkProps`: the wrapper reports the Level-1 submit it previously swallowed, `useMultiPhaseKycFlow` captures the event with the usual `region_intent`. Single-level and native paths unchanged.
4. **`handleRestartIdentity` reopened the SDK with `isMultiLevel` false**, closing a restarted LATAM session before the questionnaire. It re-derives the flag from `regionIntentRef` (best-effort — undefined ref keeps today's behavior).
5. **The "NA has no second level" comments were wrong** — the backend registry documents organic `source-of-funds` / `proof-of-address` branches. Comments corrected. NA stays out of the multi-level set: the hold applies to every applicant of the intent, and the rare branch cohort converges through the ACTION_REQUIRED drawer round-trip.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved multi-step verification flows so follow-up questionnaires can continue without closing the verification experience.
  * Added submission handling that keeps eligible verification sessions open for in-session retries.
  * Updated action-required prompts with clearer “Continue” guidance in English, Spanish, and Portuguese.

* **Bug Fixes**
  * Prevented premature rejection tracking and modal closure during multi-step verification.
  * Preserved document resubmission guidance for cases that specifically require it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->