### PR TITLE
fix(qr-scanner): anchor paste actions to a deterministic drawer peek (dev port of #2766)

### DIFF
--- a/src/components/Global/QRBottomDrawer/index.tsx
+++ b/src/components/Global/QRBottomDrawer/index.tsx
@@ -4,6 +4,7 @@ import ShareButton from '@/components/Global/ShareButton'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 import { Drawer, DrawerContent, DrawerTitle } from '../Drawer'
+import { QR_DRAWER_EXPANDED_PX, QR_DRAWER_PEEK_PX } from '@/constants/qr-drawer.consts'
 
 interface QRBottomDrawerProps {
     url: string
@@ -14,9 +15,24 @@ interface QRBottomDrawerProps {
     className?: string
 }
 
-// module scope: a new array each render makes vaul's snap-sync effect refire
-// and re-apply the transform transition on every parent re-render
-const snapPoints = [0.75, 1]
+/*
+ * Fractional snap points made the collapsed height depend on the viewport AND
+ * the locale: vaul applies `windowHeight - snap * windowHeight` to a
+ * content-sized drawer, so the visible peek came out as
+ * `contentHeight - 0.25 * windowHeight` — 212px on a 932px screen in English,
+ * 309px on a 640px screen in pt-BR, whose "let others scan this" line wraps to
+ * two. A px snap on a viewport-height drawer is the same number everywhere.
+ *
+ * Only the COLLAPSED point has to be deterministic — it is what the paste
+ * actions are anchored to. The expanded point is sized to the content so the
+ * sheet still reads as a panel; it is safe to keep it that small because the
+ * scroll area below is capped to the same window, so a longer translation or a
+ * larger font-size setting scrolls instead of being clipped.
+ *
+ * module scope: a new array each render makes vaul's snap-sync effect refire
+ * and re-apply the transform transition on every parent re-render
+ */
+const snapPoints = [`${QR_DRAWER_PEEK_PX}px`, `${QR_DRAWER_EXPANDED_PX}px`]
 
 const QRBottomDrawer = ({ url, collapsedTitle, expandedTitle, text, buttonText, className }: QRBottomDrawerProps) => {
     const t = useTranslations('global')
@@ -49,9 +65,29 @@ const QRBottomDrawer = ({ url, collapsedTitle, expandedTitle, text, buttonText, 
                     wrapper (even when nothing overflows), so the outer class only covers the
                     drag handle area. content touches need the wrapper's own copy, applied
                     only while collapsed so overflowing content can scroll at full snap. */}
+                {/* mt-0 + full height (twMerge drops the wrapper's mt-24): vaul resolves a
+                    snap point as `window.innerHeight - snapPoint`, so the drawer has to be
+                    exactly innerHeight tall for a px snap to equal the visible height.
+                    It must be dvh, NOT h-full: a percentage height on a fixed element
+                    resolves against the initial containing block, which on a mobile browser
+                    with a retractable toolbar is the LARGE viewport — taller than
+                    innerHeight — and the peek would grow by the toolbar's height, putting
+                    the drawer back over the paste link. dvh tracks innerHeight. h-screen
+                    (100vh) is the fallback for iOS 15.0–15.3 WebViews, which predate dvh —
+                    without a valid height the drawer translates entirely off-screen. Inside
+                    a WebView there is no retractable toolbar, so there vh == dvh exactly.
+
+                    The scroll area is capped to the expanded window instead of the shared
+                    80vh: 3.625rem is the drag-handle block above it (p-5 top + my-4 + the
+                    handle), and being rem-based it grows with the reader's font size, so
+                    the scroll region lands on the bottom of the viewport at any setting.
+                    Without this, content taller than the window is simply cut off — the
+                    80vh cap is never reached, so nothing scrolls. The 520px is
+                    QR_DRAWER_EXPANDED_PX, spelled out because Tailwind only emits an
+                    arbitrary value it can read literally in the source. */}
                 <DrawerContent
-                    className={`min-h-[200px] touch-none p-5 ${className || ''}`}
-                    scrollAreaClassName={activeSnapPoint === snapPoints[0] ? 'touch-none' : undefined}
+                    className={`mt-0 h-screen touch-none p-5 supports-[height:100dvh]:h-[100dvh] ${className || ''}`}
+                    scrollAreaClassName={`max-h-[calc(520px-3.625rem)] ${activeSnapPoint === snapPoints[0] ? 'touch-none' : ''}`}
                 >
                     <DrawerTitle className="mb-8 space-y-2">
                         <h2 className="text-lg font-bold">

--- a/src/components/Global/QRBottomDrawer/index.tsx
+++ b/src/components/Global/QRBottomDrawer/index.tsx
@@ -2,7 +2,7 @@ import Divider from '@/components/0_Bruddle/Divider'
 import QRCodeWrapper from '@/components/Global/QRCodeWrapper'
 import ShareButton from '@/components/Global/ShareButton'
 import { useTranslations } from 'next-intl'
-import { useState } from 'react'
+import { useState, type CSSProperties } from 'react'
 import { Drawer, DrawerContent, DrawerTitle } from '../Drawer'
 import { QR_DRAWER_EXPANDED_PX, QR_DRAWER_PEEK_PX } from '@/constants/qr-drawer.consts'
 
@@ -82,12 +82,13 @@ const QRBottomDrawer = ({ url, collapsedTitle, expandedTitle, text, buttonText, 
                     handle), and being rem-based it grows with the reader's font size, so
                     the scroll region lands on the bottom of the viewport at any setting.
                     Without this, content taller than the window is simply cut off — the
-                    80vh cap is never reached, so nothing scrolls. The 520px is
-                    QR_DRAWER_EXPANDED_PX, spelled out because Tailwind only emits an
+                    80vh cap is never reached, so nothing scrolls. QR_DRAWER_EXPANDED_PX
+                    reaches the cap through a CSS variable because Tailwind only emits an
                     arbitrary value it can read literally in the source. */}
                 <DrawerContent
                     className={`mt-0 h-screen touch-none p-5 supports-[height:100dvh]:h-[100dvh] ${className || ''}`}
-                    scrollAreaClassName={`max-h-[calc(520px-3.625rem)] ${activeSnapPoint === snapPoints[0] ? 'touch-none' : ''}`}
+                    style={{ '--qr-drawer-expanded': `${QR_DRAWER_EXPANDED_PX}px` } as CSSProperties}
+                    scrollAreaClassName={`max-h-[calc(var(--qr-drawer-expanded)-3.625rem)] ${activeSnapPoint === snapPoints[0] ? 'touch-none' : ''}`}
                 >
                     <DrawerTitle className="mb-8 space-y-2">
                         <h2 className="text-lg font-bold">

--- a/src/components/Global/QRScanner/__tests__/index.test.tsx
+++ b/src/components/Global/QRScanner/__tests__/index.test.tsx
@@ -51,6 +51,7 @@ jest.mock('../useQRScanner', () => ({
 }))
 
 import QRScanner from '../index'
+import { QR_DRAWER_PASTE_GAP_PX, QR_DRAWER_PEEK_PX } from '@/constants/qr-drawer.consts'
 
 const render = (ui: React.ReactElement, options?: Omit<Parameters<typeof rtlRender>[1], 'wrapper'>) =>
     rtlRender(ui, { wrapper: IntlWrapper, ...options })
@@ -229,4 +230,27 @@ it('chip tap: empty clipboard maps to the same copy as "Click to paste"', async 
     })
     expect(mockToastError).toHaveBeenCalledWith('Clipboard is empty')
     await waitFor(() => expect(screen.queryByText(CHIP_LABEL)).toBeNull())
+})
+
+/*
+ * The bug this pins: the paste link used to be positioned from the top of the
+ * viewport while the My QR drawer's collapsed peek grew from the bottom, so the
+ * drawer covered the link on short screens and in locales whose drawer text
+ * wraps. The link is now anchored to the peek instead. jsdom has no layout, so
+ * the geometry itself was verified in a browser — what is worth pinning here is
+ * the coupling: the offset must be DERIVED from the drawer's exported peek, so
+ * changing the peek can never silently leave the link behind.
+ */
+it('paste actions are anchored a fixed gap above the drawer peek', async () => {
+    mockIsAndroidNative.mockReturnValue(false)
+    mockHasStrings.mockResolvedValue(false)
+
+    renderScanner()
+
+    const link = await screen.findByText('Click to paste')
+    const anchored = link.closest('[style*="bottom"]') as HTMLElement | null
+    expect(anchored).not.toBeNull()
+    expect(anchored!.style.bottom).toBe(`${QR_DRAWER_PEEK_PX + QR_DRAWER_PASTE_GAP_PX}px`)
+    // fixed to the viewport, not to the scan square
+    expect(anchored!.className).toContain('fixed')
 })

--- a/src/components/Global/QRScanner/index.tsx
+++ b/src/components/Global/QRScanner/index.tsx
@@ -7,6 +7,7 @@ import { PEANUTMAN } from '@/assets/mascot'
 import { ETHEREUM_ICON } from '@/assets/icons'
 import Image from 'next/image'
 import { Icon } from '../Icons/Icon'
+import { QR_DRAWER_PASTE_GAP_PX, QR_DRAWER_PEEK_PX } from '@/constants/qr-drawer.consts'
 import { useQRScanner, type QRScanHandler } from './useQRScanner'
 import { useToast } from '@/components/0_Bruddle/Toast'
 import CameraPermissionModal from './CameraPermissionModal'
@@ -159,36 +160,60 @@ function ScanRegionOverlay({
 }) {
     const t = useTranslations('global')
     return (
-        <div className="fixed left-1/2 flex h-64 w-64 -translate-x-1/2 translate-y-1/2 justify-center">
-            {/* Darkened background with transparent scan region */}
-            <div className="absolute inset-0">
-                <div className="absolute inset-0 rounded-2xl shadow-[0_0_0_9999px_rgba(0,0,0,0.8)]" />
-                {CORNER_POSITIONS.map(({ position, rotation }, index) => (
-                    <PinkCorner key={index} className={`absolute ${position} ${rotation}`} />
-                ))}
-            </div>
-
-            {/* Supported payment methods and paste option */}
-            <div className="flex-column z-50 translate-y-[100%] transform items-center text-center">
-                <div className="mt-10 flex flex-wrap justify-center gap-2">
-                    {PAYMENT_METHODS.map((method) => (
-                        <PaymentMethodBadge
-                            key={method.name ?? 'evm'}
-                            src={method.src}
-                            alt={method.alt ?? t('qrScanner.paymentMethods.evmAlt')}
-                            name={method.name ?? t('qrScanner.paymentMethods.evmName')}
-                        />
+        <>
+            <div className="fixed left-1/2 flex h-64 w-64 -translate-x-1/2 translate-y-1/2 justify-center">
+                {/* Darkened background with transparent scan region */}
+                <div className="absolute inset-0">
+                    <div className="absolute inset-0 rounded-2xl shadow-[0_0_0_9999px_rgba(0,0,0,0.8)]" />
+                    {CORNER_POSITIONS.map(({ position, rotation }, index) => (
+                        <PinkCorner key={index} className={`absolute ${position} ${rotation}`} />
                     ))}
                 </div>
-                <PasteActions
-                    onPaste={onPaste}
-                    detectedAddress={detectedAddress}
-                    onUseDetected={onUseDetected}
-                    showPasteChip={showPasteChip}
-                    onUsePasteChip={onUsePasteChip}
-                />
+
+                {/* Supported payment methods. This row is pinned to the top of the
+                    viewport while the paste actions rise from the bottom, so on a short
+                    screen the two meet. Measured: the gap between them is
+                    `viewportHeight - 714` px with the clipboard chip showing, so below
+                    730px it drops under the 16px this layout keeps elsewhere — hide the
+                    row rather than let it collide. */}
+                <div className="flex-column z-50 translate-y-[100%] transform items-center text-center">
+                    <div className="mt-10 flex flex-wrap justify-center gap-2 [@media(max-height:729px)]:hidden">
+                        {PAYMENT_METHODS.map((method) => (
+                            <PaymentMethodBadge
+                                key={method.name ?? 'evm'}
+                                src={method.src}
+                                alt={method.alt ?? t('qrScanner.paymentMethods.evmAlt')}
+                                name={method.name ?? t('qrScanner.paymentMethods.evmName')}
+                            />
+                        ))}
+                    </div>
+                </div>
             </div>
-        </div>
+
+            {/* The paste link and clipboard chips sit a fixed gap above the My QR
+                drawer's collapsed peek, so no locale's text length and no screen
+                height can push them underneath it. They used to hang off the scan
+                square, which is pinned to the top of the viewport, while the peek
+                grows from the bottom — two coordinate systems that only lined up
+                on a tall screen in English. Tailwind cannot JIT an interpolated
+                arbitrary value, so the offset is an inline style. The strip is
+                full-width and transparent, so it is click-through except for the
+                actions themselves. */}
+            <div
+                className="pointer-events-none fixed inset-x-0 z-50 flex flex-col items-center"
+                style={{ bottom: QR_DRAWER_PEEK_PX + QR_DRAWER_PASTE_GAP_PX }}
+            >
+                <div className="pointer-events-auto flex flex-col items-center">
+                    <PasteActions
+                        onPaste={onPaste}
+                        detectedAddress={detectedAddress}
+                        onUseDetected={onUseDetected}
+                        showPasteChip={showPasteChip}
+                        onUsePasteChip={onUsePasteChip}
+                    />
+                </div>
+            </div>
+        </>
     )
 }
 

--- a/src/constants/qr-drawer.consts.ts
+++ b/src/constants/qr-drawer.consts.ts
@@ -1,0 +1,39 @@
+/**
+ * Geometry shared by the QR scanner and the "My QR" bottom drawer.
+ *
+ * These live here rather than in either component because both need them and
+ * neither should import the other: the scanner anchors its paste actions to the
+ * drawer's collapsed peek, and if the two numbers ever drift apart the drawer
+ * covers the paste link again.
+ *
+ * vaul resolves a snap point as `window.innerHeight - snapPoint`, so the drawer
+ * has to be exactly `innerHeight` tall (`h-[100dvh]`) for a px snap point to
+ * equal the visible height. Fractional snap points were the original bug: on a
+ * content-height drawer they made the peek depend on both the locale's text
+ * length and the screen height.
+ */
+
+/**
+ * Visible height of the collapsed drawer.
+ *
+ * 87px to the bottom of the collapsed title, + 34px for the iOS home indicator
+ * that sits inside the peek, + slack so a title that wraps to two lines in some
+ * future translation still clears it.
+ */
+export const QR_DRAWER_PEEK_PX = 150
+
+/** Gap between the paste actions and the top edge of the collapsed drawer. */
+export const QR_DRAWER_PASTE_GAP_PX = 16
+
+/**
+ * Visible height of the expanded drawer. Sized to the content so the sheet
+ * still looks like a panel rather than a full-screen takeover: 469px for the
+ * tallest locale (pt-BR wraps the body text) + the 34px iOS safe-area pad.
+ *
+ * It does NOT have to be big enough for every future string — the drawer's
+ * scroll area is capped to `this - 3.625rem` (the drag-handle block: p-5 top +
+ * my-4 + the handle itself, all rem-based), which lands the scroll region
+ * exactly on the bottom of the viewport at any font-size setting. Content that
+ * outgrows the window scrolls instead of being clipped.
+ */
+export const QR_DRAWER_EXPANDED_PX = 520


### PR DESCRIPTION
## Summary

Port of #2766's geometry fix onto `dev`, composed with `dev`'s newer paste behaviour. This is the planned manual back-merge done as its own PR instead of a `main → dev` merge commit, because the resolution isn't mechanical: `dev` already reworked `PasteActions` (raw-clipboard pass-through, `useCopiedCode` chip, error/permission-denied entry points) and none of that should be overwritten by the hotfix's behaviour-frozen copy.

**Problem being ported:** the My QR drawer's fractional snap points made the collapsed peek a function of both locale text length and viewport height (212–309px measured on `main`), while the paste link hung off the top-anchored scan square — so the drawer covered the link on short screens in every locale, and on tall phones in locales whose drawer text wraps (pt-BR on a Galaxy S24 Ultra, TASK-21651). `dev` has the identical geometry today; full root-cause analysis and the 36-combination locale × viewport measurement matrix are in #2766.

## Composition

**Taken from #2766, verbatim:**

- `QRBottomDrawer`: px snap points (`150px` / `520px`) on a viewport-height drawer — the peek becomes the same number on every device in every locale. Includes the scroll-area cap (`calc(520px - 3.625rem)`, rem-based so it tracks font-size settings) that keeps the share button reachable when content outgrows the fixed window.
- `src/constants/qr-drawer.consts.ts`: shared geometry constants, so the scanner and drawer agree without importing each other.
- `QRScanner`: the bottom-anchored container at `peek + 16px`, and the payment-method badge row hidden below 730px viewports (measured collision threshold).
- The regression test pinning that the anchor offset is *derived from* `QR_DRAWER_PEEK_PX` — the failure mode that would actually recur.

**Kept from `dev`, untouched:** the `PasteActions` component body and all call sites — the `useCopiedCode` chip and `paste` icon, raw clipboard text handed to `scanValue` (so Pix copia-e-cola works, not just EVM addresses), and the `ErrorView` / `CameraPermissionModal` paste entry points. Only the happy-path render location moved (into the anchored container).

**Two deliberate additions over #2766** (dev-only for now; worth folding back into `main` if it gets another hotfix):

1. **`h-screen` fallback under the `dvh` sizing** — `supports-[height:100dvh]:h-[100dvh]` with `h-screen` as base. `dvh` needs iOS 15.4+ / WebView Chromium 108+, and the app's deployment target is iOS 15.0; without a valid height the drawer would translate entirely off-screen on a 15.0–15.3 WebView (worse than the bug being fixed). Inside a WebView there is no retractable toolbar, so `100vh == 100dvh` exactly where the fallback applies. Verified against the compiled project CSS that the `@supports` rule lands after `.h-screen` in the cascade, so `dvh` still wins everywhere it exists.
2. **`pointer-events-none` on the anchor strip** (re-enabled on the actions wrapper) — the strip is full-width and transparent; without this it would swallow taps landing beside the buttons.

## Not changed / follow-ups

- `ErrorView`'s `PasteActions` instance stays in-flow near the top of the screen (dev's placement). It renders far from the drawer, but its geometry has never been measured the way the happy path now is — worth a look if that state ever gets layout complaints.
- Same accepted trade-offs as #2766: shorter collapsed peek (less QR visible), badge row also hides in short landscape/desktop windows, and the vaul 1.1.2 hard-fling note.

## QA

- `tsc --noEmit` clean; `jest` QRScanner suites 26/26 (includes the new anchoring pin); `eslint` and `prettier` clean on the touched files.
- Real-browser checks against the compiled project CSS: `@supports` cascade order for the dvh fallback; hit-testing on the anchor strip (paste link and chip receive the pointer, the empty band beside them clicks through); strip anchored exactly 166px above the viewport bottom, full width.
- The geometry itself (peek = 150px in all 36 locale × viewport combinations, +16px link gap) was measured in #2766 against the running app; the constants and layout are ported unchanged, so those measurements carry over. A device pass on iOS (notch) and Android 15 (gesture nav) before the next native/OTA release is still the recommended final check for both PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QR scanner drawer positioning across screen sizes and mobile WebViews.
  * Kept “Click to paste” controls consistently visible above the collapsed drawer.
  * Prevented content from overflowing when the drawer is expanded.
  * Improved handling of short screens, safe-area spacing, and longer localized text.
* **Tests**
  * Added coverage to verify QR paste controls remain correctly positioned relative to the drawer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->