### PR TITLE
feat(kyc): show a region screen instead of a support dead end

### DIFF
--- a/src/components/Home/ActivationCTAs.tsx
+++ b/src/components/Home/ActivationCTAs.tsx
@@ -16,6 +16,7 @@ import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { useCardInfo } from '@/hooks/useCardInfo'
 import { useIdentityVerification } from '@/hooks/useIdentityVerification'
+import { REGION_RESTRICTED_CTA_HREF } from '@/components/Kyc/KycRegionRestrictedContent'
 import ActionModal from '@/components/Global/ActionModal'
 import { useAuth } from '@/context/authContext'
 import { buildContactSupportMessage } from '@/utils/contact-support.utils'
@@ -49,6 +50,7 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
     const t = useTranslations('home.activation')
     const tCommon = useTranslations('common')
     const tIdentity = useTranslations('identity')
+    const tRegion = useTranslations('kyc.regionRestricted')
     const router = useRouter()
     const { setIsQRScannerOpen, openSupportWithMessage } = useModalsContext()
     const { rails, channelOf, nextActions } = useCapabilities()
@@ -62,7 +64,11 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
     // (Sumsub processing / action_required). The user already took the verify
     // action; the identity-verification page surfaces the in-progress modal,
     // and bouncing them through here again would imply they need to re-act.
-    const { isProcessing: isIdentityProcessing, needsAction: isIdentityActionRequired } = useIdentityVerification()
+    const {
+        isProcessing: isIdentityProcessing,
+        needsAction: isIdentityActionRequired,
+        isRegionRestricted,
+    } = useIdentityVerification()
 
     // The activation funnel gates deposit/outbound, which routes through bank or
     // qr-only channels — never through card. Top-level status (not per-op
@@ -218,6 +224,23 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
         (hasFixableRejection || hasBlockedRejection)
 
     const step: StepConfig | null = useMemo(() => {
+        // Highest precedence, ahead of every funnel step AND every provider
+        // rejection: a region-restricted user can never finish the funnel, so
+        // "Unlock payments" is a CTA that leads nowhere. They stay on 'verify'
+        // forever (the milestone never advances past `registered`), which is
+        // exactly the state that would nag them indefinitely. Replace the card
+        // with the explanation and point them at what still works.
+        if (isRegionRestricted) {
+            return {
+                icon: 'globe-lock',
+                iconBg: 'bg-primary-1',
+                title: tRegion('title'),
+                description: tRegion('homeDescription'),
+                ctaLabel: tRegion('cta'),
+                href: REGION_RESTRICTED_CTA_HREF,
+            }
+        }
+
         if (activationStep === 'completed' && !hasProviderRejection) return null
 
         // Hide the verify CTA while identity is processing — user already
@@ -286,6 +309,8 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
         isIdentityProcessing,
         isIdentityActionRequired,
         hasCardAccess,
+        isRegionRestricted,
+        tRegion,
     ])
 
     if (!step) return null
@@ -323,7 +348,12 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
                     shadowSize="4"
                     className="mt-2 w-full"
                     onClick={() => {
-                        if (isEmailBlocked) {
+                        // Mirror the step-precedence above: whatever else is true
+                        // of this user's rails, the region card's CTA must just
+                        // navigate — never open support, never start a Sumsub flow.
+                        if (isRegionRestricted) {
+                            router.push(REGION_RESTRICTED_CTA_HREF)
+                        } else if (isEmailBlocked) {
                             setShowProvideEmail(true)
                         } else if (hasProviderRejection && hasBlockedRejection && !hasFixableRejection) {
                             // REQUIRES_SUPPORT class (or any blocked rail) — pre-fill Crisp

--- a/src/components/Home/ActivationCTAs.tsx
+++ b/src/components/Home/ActivationCTAs.tsx
@@ -319,7 +319,12 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
     // CardLaunchCTABanner) instead of the plain funnel card — so non-activated
     // card-eligible users get the same CTA as the activated launch splash.
     // Keeps the funnel's /card routing + the "Maybe later" dismissal.
-    if (activationStep === 'card') {
+    // `isRegionRestricted` deliberately re-checked here: this branch returns
+    // BEFORE reading `step`, so the region card selected in the memo above would
+    // otherwise be silently replaced by the card banner — whose CTA routes to
+    // /shhhhh. A region-restricted user can never complete a card application
+    // either, so the explanation outranks it.
+    if (activationStep === 'card' && !isRegionRestricted) {
         return (
             <CardLaunchCTABanner
                 onTryDoor={() => {

--- a/src/components/Home/__tests__/ActivationCTAs.test.tsx
+++ b/src/components/Home/__tests__/ActivationCTAs.test.tsx
@@ -41,8 +41,13 @@ jest.mock('@/hooks/useCapabilities', () => ({
 jest.mock('@/context/authContext', () => ({
     useAuth: () => ({ user: mockUser }),
 }))
+let mockRegionRestricted = false
 jest.mock('@/hooks/useIdentityVerification', () => ({
-    useIdentityVerification: () => ({ isProcessing: false, needsAction: false }),
+    useIdentityVerification: () => ({
+        isProcessing: false,
+        needsAction: false,
+        isRegionRestricted: mockRegionRestricted,
+    }),
 }))
 jest.mock('@/context/ModalsContext', () => ({
     useModalsContext: () => ({ setIsQRScannerOpen: mockSetIsQRScannerOpen, openSupportWithMessage: jest.fn() }),
@@ -98,6 +103,39 @@ beforeEach(() => {
     mockRails = []
     mockUser = { user: { isActivated: false, userId: 'u1' } }
     mockHasCardAccess = false
+    mockRegionRestricted = false
+})
+
+describe('ActivationCTAs — region-restricted outranks every funnel step', () => {
+    it('replaces the verify nag, which this user can never satisfy', () => {
+        mockRegionRestricted = true
+        render(<ActivationCTAs activationStep="verify" />)
+
+        expect(screen.getByText("We can't verify IDs from your country")).toBeInTheDocument()
+        expect(screen.queryByText('Verification issue')).not.toBeInTheDocument()
+    })
+
+    it('replaces the card banner too — its CTA would route to /shhhhh', () => {
+        // The card branch returns BEFORE reading `step`, so without an explicit
+        // guard the region card selected in the memo is silently discarded.
+        mockRegionRestricted = true
+        mockHasCardAccess = true
+        render(<ActivationCTAs activationStep="card" />)
+
+        expect(screen.getByText("We can't verify IDs from your country")).toBeInTheDocument()
+        fireEvent.click(screen.getByText('Send or request money'))
+        expect(mockPush).toHaveBeenCalledWith('/send')
+        expect(mockPush).not.toHaveBeenCalledWith('/shhhhh')
+    })
+
+    it('never opens support — support cannot lift a jurisdictional block', () => {
+        mockRegionRestricted = true
+        mockRails = [bankRejected]
+        render(<ActivationCTAs activationStep="deposit" />)
+
+        fireEvent.click(screen.getByText('Send or request money'))
+        expect(mockPush).toHaveBeenCalledWith('/send')
+    })
 })
 
 describe('ActivationCTAs — rejection override respects existing transacting ability', () => {

--- a/src/components/Kyc/InitiateKycModal.tsx
+++ b/src/components/Kyc/InitiateKycModal.tsx
@@ -7,7 +7,7 @@ import { reasonCodeKey } from '@/constants/capability-reason-labels.consts'
 import { type IconName } from '@/components/Global/Icons/Icon'
 import { PeanutDoesntStoreAnyPersonalInformation } from '@/components/Kyc/PeanutDoesntStoreAnyPersonalInformation'
 import { useIdentityVerification } from '@/hooks/useIdentityVerification'
-import { KycRegionRestrictedContent, useRegionRestrictedCta } from '@/components/Kyc/KycRegionRestrictedContent'
+import { KycRegionRestrictedModal } from '@/components/Kyc/modals/KycRegionRestrictedModal'
 
 interface InitiateKycModalProps {
     visible: boolean
@@ -46,7 +46,6 @@ export const InitiateKycModal = ({
     regionName,
 }: InitiateKycModalProps) => {
     const t = useTranslations('kyc')
-    const tRegion = useTranslations('kyc.regionRestricted')
     const tCommon = useTranslations('common')
     const tIdentity = useTranslations('identity')
     // Enforced HERE rather than at each call site on purpose. Six gates open this
@@ -59,7 +58,6 @@ export const InitiateKycModal = ({
     // component they all share makes the invariant impossible for a future call
     // site to miss.
     const { isRegionRestricted } = useIdentityVerification()
-    const regionCta = useRegionRestrictedCta(onClose)
     const reasonKey = reasonCodeKey(reasonCode)
     const resolvedProviderMessage = reasonKey ? tIdentity(reasonKey) : providerMessage
     const isProviderRejection = variant === 'provider_rejection'
@@ -141,32 +139,11 @@ export const InitiateKycModal = ({
 
     const cta = getCta()
 
+    // Render the ONE definition of this screen rather than a second copy of it:
+    // a local re-implementation could drift from the drawer/profile surface, and
+    // "these two never disagree" is the property this whole change rests on.
     if (isRegionRestricted) {
-        return (
-            <ActionModal
-                visible={visible}
-                onClose={onClose}
-                title={tRegion('title')}
-                icon="globe-lock"
-                iconContainerClassName="bg-primary-1"
-                modalPanelClassName="max-w-full m-2"
-                ctaClassName="grid grid-cols-1 gap-3"
-                content={
-                    <div className="w-full">
-                        <KycRegionRestrictedContent />
-                    </div>
-                }
-                ctas={[
-                    {
-                        text: regionCta.label,
-                        onClick: regionCta.onClick,
-                        variant: 'purple',
-                        shadowSize: '4',
-                        className: 'h-11',
-                    },
-                ]}
-            />
-        )
+        return <KycRegionRestrictedModal visible={visible} onClose={onClose} />
     }
 
     return (

--- a/src/components/Kyc/InitiateKycModal.tsx
+++ b/src/components/Kyc/InitiateKycModal.tsx
@@ -6,6 +6,8 @@ import ActionModal from '@/components/Global/ActionModal'
 import { reasonCodeKey } from '@/constants/capability-reason-labels.consts'
 import { type IconName } from '@/components/Global/Icons/Icon'
 import { PeanutDoesntStoreAnyPersonalInformation } from '@/components/Kyc/PeanutDoesntStoreAnyPersonalInformation'
+import { useIdentityVerification } from '@/hooks/useIdentityVerification'
+import { KycRegionRestrictedContent, useRegionRestrictedCta } from '@/components/Kyc/KycRegionRestrictedContent'
 
 interface InitiateKycModalProps {
     visible: boolean
@@ -44,8 +46,20 @@ export const InitiateKycModal = ({
     regionName,
 }: InitiateKycModalProps) => {
     const t = useTranslations('kyc')
+    const tRegion = useTranslations('kyc.regionRestricted')
     const tCommon = useTranslations('common')
     const tIdentity = useTranslations('identity')
+    // Enforced HERE rather than at each call site on purpose. Six gates open this
+    // modal (add-money, withdraw, the two bank pages, and both Manteca flow
+    // managers), and each one computes its variant from a rail gate that cannot
+    // see WHY identity failed: a region-restricted user reads as `needs-identity`
+    // (no rail + unverified) and would be offered "Unlock now" → the Sumsub SDK
+    // → the same guaranteed rejection, or as `blocked-rejection` → contact
+    // support. Both contradict the region screen. Short-circuiting at the one
+    // component they all share makes the invariant impossible for a future call
+    // site to miss.
+    const { isRegionRestricted } = useIdentityVerification()
+    const regionCta = useRegionRestrictedCta(onClose)
     const reasonKey = reasonCodeKey(reasonCode)
     const resolvedProviderMessage = reasonKey ? tIdentity(reasonKey) : providerMessage
     const isProviderRejection = variant === 'provider_rejection'
@@ -126,6 +140,34 @@ export const InitiateKycModal = ({
     }
 
     const cta = getCta()
+
+    if (isRegionRestricted) {
+        return (
+            <ActionModal
+                visible={visible}
+                onClose={onClose}
+                title={tRegion('title')}
+                icon="globe-lock"
+                iconContainerClassName="bg-primary-1"
+                modalPanelClassName="max-w-full m-2"
+                ctaClassName="grid grid-cols-1 gap-3"
+                content={
+                    <div className="w-full">
+                        <KycRegionRestrictedContent />
+                    </div>
+                }
+                ctas={[
+                    {
+                        text: regionCta.label,
+                        onClick: regionCta.onClick,
+                        variant: 'purple',
+                        shadowSize: '4',
+                        className: 'h-11',
+                    },
+                ]}
+            />
+        )
+    }
 
     return (
         <ActionModal

--- a/src/components/Kyc/KycRegionRestrictedContent.tsx
+++ b/src/components/Kyc/KycRegionRestrictedContent.tsx
@@ -1,0 +1,48 @@
+import { useTranslations } from 'next-intl'
+import { useRouter } from 'next/navigation'
+import { useCallback } from 'react'
+
+/**
+ * Copy + CTA for a terminal rejection caused by the document's jurisdiction.
+ *
+ * Shared by the drawer state and the modal so the two can never drift into
+ * telling the same user different things. Three rules hold everywhere this
+ * renders, and each is load-bearing:
+ *
+ *   1. NO retry. The document's country is unacceptable, not the document, so
+ *      "try again" is a promise we know we cannot keep.
+ *   2. NO contact-support CTA. Support cannot lift a jurisdictional block; the
+ *      ticket only costs the user their time and ours.
+ *   3. NO country named. The restricted set lives in the Sumsub dashboard, and
+ *      the string says "your country" — so compliance can change the list
+ *      without a copy change, a re-translation, or a deploy.
+ *
+ * What is left is the one useful thing: tell them plainly, and hand them the
+ * part of the app that still works.
+ */
+
+/** Where the CTA sends them — the capability they keep. */
+export const REGION_RESTRICTED_CTA_HREF = '/send'
+
+export const useRegionRestrictedCta = (onNavigate?: () => void) => {
+    const t = useTranslations('kyc.regionRestricted')
+    const router = useRouter()
+
+    const onClick = useCallback(() => {
+        onNavigate?.()
+        router.push(REGION_RESTRICTED_CTA_HREF)
+    }, [onNavigate, router])
+
+    return { label: t('cta'), onClick }
+}
+
+export const KycRegionRestrictedContent = () => {
+    const t = useTranslations('kyc.regionRestricted')
+
+    return (
+        <div className="space-y-3 text-center">
+            <p className="text-sm text-grey-1">{t('description')}</p>
+            <p className="text-sm text-grey-1">{t('stillAvailable')}</p>
+        </div>
+    )
+}

--- a/src/components/Kyc/KycStatusDrawer.tsx
+++ b/src/components/Kyc/KycStatusDrawer.tsx
@@ -9,6 +9,7 @@ import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { useCallback } from 'react'
 import { useIdentityVerification } from '@/hooks/useIdentityVerification'
 import { useTranslations } from 'next-intl'
+import { useModalsContext } from '@/context/ModalsContext'
 
 interface KycStatusDrawerProps {
     isOpen: boolean
@@ -22,8 +23,9 @@ interface KycStatusDrawerProps {
 // provider names, no rail reads. Resuming/retrying launches Sumsub via the kept
 // useMultiPhaseKycFlow plumbing.
 export const KycStatusDrawer = ({ isOpen, onClose, onKeepMounted }: KycStatusDrawerProps) => {
-    const { identity, status, isRegionRestricted } = useIdentityVerification()
+    const { identity, status, isRegionRestricted, isTerminalFailure } = useIdentityVerification()
     const t = useTranslations('kyc')
+    const { setIsSupportModalOpen } = useModalsContext()
 
     // close drawer and release the keep-mounted hold
     const handleFlowDone = useCallback(() => {
@@ -76,6 +78,8 @@ export const KycStatusDrawer = ({ isOpen, onClose, onKeepMounted }: KycStatusDra
                         reviewedAt={identity.reviewedAt}
                         onRetry={resumeKyc}
                         isLoading={sumsubFlow.isLoading}
+                        isTerminal={isTerminalFailure}
+                        onContactSupport={() => setIsSupportModalOpen(true)}
                     />
                 )
             default:

--- a/src/components/Kyc/KycStatusDrawer.tsx
+++ b/src/components/Kyc/KycStatusDrawer.tsx
@@ -1,6 +1,7 @@
 import { KycActionRequired } from './states/KycActionRequired'
 import { KycCompleted } from './states/KycCompleted'
 import { KycFailed } from './states/KycFailed'
+import { KycRegionRestricted } from './states/KycRegionRestricted'
 import { KycProcessing } from './states/KycProcessing'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { Drawer, DrawerContent, DrawerTitle } from '../Global/Drawer'
@@ -21,7 +22,7 @@ interface KycStatusDrawerProps {
 // provider names, no rail reads. Resuming/retrying launches Sumsub via the kept
 // useMultiPhaseKycFlow plumbing.
 export const KycStatusDrawer = ({ isOpen, onClose, onKeepMounted }: KycStatusDrawerProps) => {
-    const { identity, status } = useIdentityVerification()
+    const { identity, status, isRegionRestricted } = useIdentityVerification()
     const t = useTranslations('kyc')
 
     // close drawer and release the keep-mounted hold
@@ -63,6 +64,11 @@ export const KycStatusDrawer = ({ isOpen, onClose, onKeepMounted }: KycStatusDra
                     />
                 )
             case 'failed':
+                // Region-restricted rejections are terminal in a way KycFailed's
+                // "Retry verification" button contradicts — branch before it.
+                if (isRegionRestricted) {
+                    return <KycRegionRestricted reviewedAt={identity.reviewedAt} onNavigate={onClose} />
+                }
                 return (
                     <KycFailed
                         actionMessage={identity.actionMessage}

--- a/src/components/Kyc/modals/KycRegionRestrictedModal.tsx
+++ b/src/components/Kyc/modals/KycRegionRestrictedModal.tsx
@@ -31,7 +31,7 @@ export const KycRegionRestrictedModal = ({ visible, onClose }: KycRegionRestrict
                     <KycRegionRestrictedContent />
                 </div>
             }
-            modalPanelClassName="max-w-full"
+            modalPanelClassName="max-w-full m-2"
             ctaClassName="grid grid-cols-1 gap-3"
             ctas={[
                 {
@@ -39,6 +39,7 @@ export const KycRegionRestrictedModal = ({ visible, onClose }: KycRegionRestrict
                     onClick: cta.onClick,
                     variant: 'purple',
                     shadowSize: '4',
+                    className: 'h-11',
                 },
             ]}
         />

--- a/src/components/Kyc/modals/KycRegionRestrictedModal.tsx
+++ b/src/components/Kyc/modals/KycRegionRestrictedModal.tsx
@@ -1,0 +1,46 @@
+import { useTranslations } from 'next-intl'
+import ActionModal from '@/components/Global/ActionModal'
+import { KycRegionRestrictedContent, useRegionRestrictedCta } from '../KycRegionRestrictedContent'
+
+interface KycRegionRestrictedModalProps {
+    visible: boolean
+    onClose: () => void
+}
+
+/**
+ * Terminal rejection caused by the document's jurisdiction.
+ *
+ * Deliberately takes no `onRetry` and no `onContactSupport` — the two endings
+ * this screen exists to replace. Not offering them is the feature, so they are
+ * absent from the props rather than merely unused, and a future caller cannot
+ * quietly reintroduce either one.
+ */
+export const KycRegionRestrictedModal = ({ visible, onClose }: KycRegionRestrictedModalProps) => {
+    const t = useTranslations('kyc.regionRestricted')
+    const cta = useRegionRestrictedCta(onClose)
+
+    return (
+        <ActionModal
+            visible={visible}
+            onClose={onClose}
+            icon="globe-lock"
+            iconContainerClassName="bg-primary-1"
+            title={t('title')}
+            content={
+                <div className="w-full">
+                    <KycRegionRestrictedContent />
+                </div>
+            }
+            modalPanelClassName="max-w-full"
+            ctaClassName="grid grid-cols-1 gap-3"
+            ctas={[
+                {
+                    text: cta.label,
+                    onClick: cta.onClick,
+                    variant: 'purple',
+                    shadowSize: '4',
+                },
+            ]}
+        />
+    )
+}

--- a/src/components/Kyc/states/KycFailed.tsx
+++ b/src/components/Kyc/states/KycFailed.tsx
@@ -1,12 +1,20 @@
 import { Button } from '@/components/0_Bruddle/Button'
 import { PaymentInfoRow } from '@/components/Payment/PaymentInfoRow'
 import { KYCStatusDrawerItem } from '../KYCStatusDrawerItem'
-import { RejectLabelsList } from '../RejectLabelsList'
+import { KycFailedContent } from '../KycFailedContent'
 import Card from '@/components/Global/Card'
 import { useMemo } from 'react'
 import { useFormatter, useTranslations } from 'next-intl'
 
 // this component shows the identity-verification status when it's failed/rejected.
+//
+// `isTerminal` decides the ending, and getting it wrong is user-visible in both
+// directions. Terminal (fraud, sanctions, age, forgery) means the decision is
+// made: no retry — it cannot pass — and no reject labels, because naming the
+// cause carries compliance exposure and tips off the people it describes.
+// Support IS offered there, because a human can review a misclassification.
+// Non-terminal means our check errored, so a retry is genuinely worth offering.
+//
 // reads the provider-agnostic identity fields + normalized reject labels. The
 // backend's actionMessage is a pure function of status, so its presence gates the
 // reason row while the copy itself comes from the catalog. No provider names.
@@ -16,12 +24,17 @@ export const KycFailed = ({
     reviewedAt,
     onRetry,
     isLoading,
+    isTerminal = false,
+    onContactSupport,
 }: {
     actionMessage?: string
     rejectLabels?: string[] | null
     reviewedAt?: string
     onRetry: () => void
     isLoading?: boolean
+    isTerminal?: boolean
+    /** Required in practice when `isTerminal` — the container owns support. */
+    onContactSupport?: () => void
 }) => {
     const t = useTranslations('kyc')
     const tCommon = useTranslations('common')
@@ -50,18 +63,24 @@ export const KycFailed = ({
                 {hasReason && <PaymentInfoRow label={t('reason')} value={t('actionMessageFailed')} hideBottomBorder />}
             </Card>
 
-            <RejectLabelsList rejectLabels={rejectLabels} />
+            <KycFailedContent rejectLabels={rejectLabels} isTerminal={isTerminal} />
 
-            <Button
-                icon="retry"
-                variant="purple"
-                className="w-full"
-                shadowSize="4"
-                onClick={() => onRetry()}
-                disabled={isLoading}
-            >
-                {isLoading ? tCommon('loading') : t('retryVerification')}
-            </Button>
+            {isTerminal ? (
+                <Button variant="purple" className="w-full" shadowSize="4" onClick={() => onContactSupport?.()}>
+                    {tCommon('contactSupport')}
+                </Button>
+            ) : (
+                <Button
+                    icon="retry"
+                    variant="purple"
+                    className="w-full"
+                    shadowSize="4"
+                    onClick={() => onRetry()}
+                    disabled={isLoading}
+                >
+                    {isLoading ? tCommon('loading') : t('retryVerification')}
+                </Button>
+            )}
         </div>
     )
 }

--- a/src/components/Kyc/states/KycRegionRestricted.tsx
+++ b/src/components/Kyc/states/KycRegionRestricted.tsx
@@ -1,0 +1,45 @@
+import { useMemo } from 'react'
+import { useFormatter, useTranslations } from 'next-intl'
+import { Button } from '@/components/0_Bruddle/Button'
+import Card from '@/components/Global/Card'
+import { PaymentInfoRow } from '@/components/Payment/PaymentInfoRow'
+import { KYCStatusDrawerItem } from '../KYCStatusDrawerItem'
+import { KycRegionRestrictedContent, useRegionRestrictedCta } from '../KycRegionRestrictedContent'
+
+/**
+ * Drawer state for a terminal rejection caused by the document's jurisdiction —
+ * the sibling of {@link KycFailed}, minus the retry button.
+ *
+ * KycFailed offers "Retry verification" to everyone it renders. For this cohort
+ * that button is a promise we cannot keep, which is the whole reason this is a
+ * separate component rather than a prop on that one: the retry is not
+ * conditionally hidden here, it does not exist.
+ */
+export const KycRegionRestricted = ({ reviewedAt, onNavigate }: { reviewedAt?: string; onNavigate?: () => void }) => {
+    const t = useTranslations('kyc')
+    const format = useFormatter()
+    const cta = useRegionRestrictedCta(onNavigate)
+
+    const rejectedOn = useMemo(() => {
+        if (!reviewedAt) return t('notAvailable')
+        const date = new Date(reviewedAt)
+        if (isNaN(date.getTime())) return t('notAvailable')
+        return format.dateTime(date, { year: 'numeric', month: 'long', day: 'numeric' })
+    }, [reviewedAt, format, t])
+
+    return (
+        <div className="space-y-4">
+            <KYCStatusDrawerItem status="failed" />
+
+            <Card position="single" className="py-0">
+                <PaymentInfoRow label={t('rejectedOn')} value={rejectedOn} hideBottomBorder />
+            </Card>
+
+            <KycRegionRestrictedContent />
+
+            <Button variant="purple" className="w-full" shadowSize="4" onClick={cta.onClick}>
+                {cta.label}
+            </Button>
+        </div>
+    )
+}

--- a/src/components/Kyc/states/__tests__/KycRegionRestricted.test.tsx
+++ b/src/components/Kyc/states/__tests__/KycRegionRestricted.test.tsx
@@ -1,0 +1,158 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { renderWithIntl } from '@/test-utils/intl'
+import { type ReactNode } from 'react'
+import { KycRegionRestricted } from '../KycRegionRestricted'
+import { KycRegionRestrictedModal } from '../../modals/KycRegionRestrictedModal'
+import { InitiateKycModal } from '../../InitiateKycModal'
+
+let mockRegionRestricted = false
+jest.mock('@/hooks/useIdentityVerification', () => ({
+    useIdentityVerification: () => ({ isRegionRestricted: mockRegionRestricted }),
+}))
+
+const push = jest.fn()
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ push: (...args: unknown[]) => push(...args) }),
+}))
+
+jest.mock('../../KYCStatusDrawerItem', () => ({
+    KYCStatusDrawerItem: () => <div data-testid="kyc-status-drawer-item" />,
+}))
+
+jest.mock('@/components/Payment/PaymentInfoRow', () => ({
+    PaymentInfoRow: ({ label, value }: { label: string; value: string }) => (
+        <div>
+            {label}: {value}
+        </div>
+    ),
+}))
+
+jest.mock('@/components/Global/Card', () => ({
+    __esModule: true,
+    default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('use-haptic', () => ({ useHaptic: () => ({ triggerHaptic: jest.fn() }) }))
+jest.mock('@/hooks/useLongPress', () => ({
+    useLongPress: () => ({ isLongPressed: false, pressProgress: 0, handlers: {} }),
+}))
+
+beforeEach(() => {
+    push.mockClear()
+    mockRegionRestricted = false
+})
+
+// The surfaces differ (drawer card vs modal) but the promises they make must
+// not, so the contract assertions run against both.
+const surfaces: Array<[string, () => void]> = [
+    ['drawer state', () => renderWithIntl(<KycRegionRestricted reviewedAt="2026-08-01T10:00:00.000Z" />)],
+    ['modal', () => renderWithIntl(<KycRegionRestrictedModal visible onClose={jest.fn()} />)],
+]
+
+describe.each(surfaces)('region-restricted %s', (_name, renderSurface) => {
+    it('explains the block without naming a country', () => {
+        renderSurface()
+
+        expect(screen.getByText(/doesn't accept documents issued in your country/i)).toBeInTheDocument()
+        // The Sumsub list must be changeable without touching this copy.
+        expect(document.body.textContent).not.toMatch(/russia|china|hong kong/i)
+    })
+
+    it('tells the user what they can still do', () => {
+        renderSurface()
+        expect(screen.getByText(/funds are safe/i)).toBeInTheDocument()
+        expect(screen.getByText(/send and receive money/i)).toBeInTheDocument()
+    })
+
+    // Asserted on CONTROLS, not on prose: the body copy legitimately contains
+    // "Re-uploading won't change the result", and a text-level ban would forbid
+    // the sentence that does the explaining.
+    it('offers exactly one action, and it is not a retry or a support punt', () => {
+        renderSurface()
+
+        // The modal also renders an unlabelled X for dismissal — chrome, not an
+        // action. Count only the buttons that make an offer to the user.
+        const actions = screen.getAllByRole('button').filter((b) => b.textContent?.trim())
+        expect(actions).toHaveLength(1)
+        expect(actions[0]).toHaveTextContent('Send or request money')
+    })
+
+    it('never labels a control with a retry or support action', () => {
+        renderSurface()
+
+        for (const pattern of [/try again/i, /retry/i, /re-?submit/i, /upload/i, /support/i]) {
+            expect(screen.queryByRole('button', { name: pattern })).not.toBeInTheDocument()
+            expect(screen.queryByRole('link', { name: pattern })).not.toBeInTheDocument()
+        }
+    })
+
+    it('sends the user to the part of the app that still works', () => {
+        renderSurface()
+        fireEvent.click(screen.getByText('Send or request money'))
+        expect(push).toHaveBeenCalledWith('/send')
+    })
+})
+
+describe('region-restricted drawer state', () => {
+    it('shows when the decision landed', () => {
+        renderWithIntl(<KycRegionRestricted reviewedAt="2026-08-01T10:00:00.000Z" />)
+        expect(screen.getByText(/Rejected on: August 1, 2026/)).toBeInTheDocument()
+    })
+
+    it('degrades to N/A rather than crashing on a missing or unparseable date', () => {
+        const { unmount } = renderWithIntl(<KycRegionRestricted />)
+        expect(screen.getByText(/Rejected on: N\/A/)).toBeInTheDocument()
+        unmount()
+
+        renderWithIntl(<KycRegionRestricted reviewedAt="not-a-date" />)
+        expect(screen.getByText(/Rejected on: N\/A/)).toBeInTheDocument()
+    })
+
+    it('runs the caller hook before navigating, so the drawer closes behind it', () => {
+        const onNavigate = jest.fn()
+        renderWithIntl(<KycRegionRestricted onNavigate={onNavigate} />)
+
+        fireEvent.click(screen.getByText('Send or request money'))
+
+        expect(onNavigate).toHaveBeenCalledTimes(1)
+        expect(push).toHaveBeenCalledWith('/send')
+    })
+})
+
+describe('InitiateKycModal — region-restricted short-circuit', () => {
+    // The six bank/withdraw gates compute their variant from a rail gate that
+    // cannot see WHY identity failed. Whatever they ask for, a region-restricted
+    // user must never be offered verification or support.
+    const variants = ['default', 'blocked', 'provider_rejection', 'restart_identity', 'cross_region'] as const
+
+    it.each(variants)('overrides the %s variant with the region screen', (variant) => {
+        mockRegionRestricted = true
+        renderWithIntl(<InitiateKycModal visible onClose={jest.fn()} onVerify={jest.fn()} variant={variant} />)
+
+        expect(screen.getByText(/doesn't accept documents issued in your country/i)).toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: /unlock/i })).not.toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: /support/i })).not.toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: /upload/i })).not.toBeInTheDocument()
+    })
+
+    it('never starts a Sumsub flow — the CTA navigates instead of verifying', () => {
+        mockRegionRestricted = true
+        const onVerify = jest.fn()
+        renderWithIntl(<InitiateKycModal visible onClose={jest.fn()} onVerify={onVerify} variant="default" />)
+
+        fireEvent.click(screen.getByText('Send or request money'))
+
+        expect(onVerify).not.toHaveBeenCalled()
+        expect(push).toHaveBeenCalledWith('/send')
+    })
+
+    it('leaves every other user on the normal unlock flow', () => {
+        mockRegionRestricted = false
+        const onVerify = jest.fn()
+        renderWithIntl(<InitiateKycModal visible onClose={jest.fn()} onVerify={onVerify} variant="default" />)
+
+        expect(screen.getByText('Unlock your account')).toBeInTheDocument()
+        fireEvent.click(screen.getByText('Unlock now'))
+        expect(onVerify).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/components/Kyc/states/__tests__/KycStates.test.tsx
+++ b/src/components/Kyc/states/__tests__/KycStates.test.tsx
@@ -26,6 +26,8 @@ jest.mock('../../RejectLabelsList', () => ({
     RejectLabelsList: () => <div data-testid="reject-labels-list" />,
 }))
 
+const mockSetIsSupportModalOpen = jest.fn()
+
 jest.mock('@/components/Payment/PaymentInfoRow', () => ({
     PaymentInfoRow: () => <div data-testid="payment-info-row" />,
 }))
@@ -86,5 +88,48 @@ describe('KYC state cards', () => {
 
         expect(onRetry).toHaveBeenCalledTimes(1)
         expect(onRetry).toHaveBeenCalledWith()
+    })
+})
+
+describe('KycFailed — terminal vs retryable', () => {
+    beforeEach(() => mockSetIsSupportModalOpen.mockClear())
+
+    it('a terminal rejection offers support, never a retry', () => {
+        // Fraud / sanctions / age / forgery. The retry button here was the bug:
+        // UnlockedRegions hardcoded isTerminalRejection's inputs to null, so this
+        // branch never rendered and every terminal user was told to try again.
+        const onRetry = jest.fn()
+        render(
+            <KycFailed
+                onRetry={onRetry}
+                isTerminal
+                rejectLabels={['SANCTIONS']}
+                onContactSupport={mockSetIsSupportModalOpen}
+            />
+        )
+
+        expect(screen.queryByText('Retry verification')).not.toBeInTheDocument()
+        fireEvent.click(screen.getByText('Contact support'))
+        expect(mockSetIsSupportModalOpen).toHaveBeenCalledTimes(1)
+        expect(onRetry).not.toHaveBeenCalled()
+    })
+
+    it('a terminal rejection never names the cause', () => {
+        // Naming fraud or sanctions carries compliance exposure and tips off the
+        // people it describes — KycFailedContent shows the generic card instead.
+        render(<KycFailed onRetry={jest.fn()} isTerminal rejectLabels={['FORGERY', 'SANCTIONS']} />)
+
+        expect(screen.queryByTestId('reject-labels-list')).not.toBeInTheDocument()
+        expect(document.body.textContent).not.toMatch(/forgery|sanctions/i)
+    })
+
+    it('a retryable failure keeps the retry button and the per-label guidance', () => {
+        const onRetry = jest.fn()
+        render(<KycFailed onRetry={onRetry} rejectLabels={['DOCUMENT_BAD_QUALITY']} />)
+
+        expect(screen.getByTestId('reject-labels-list')).toBeInTheDocument()
+        expect(screen.queryByText('Contact support')).not.toBeInTheDocument()
+        fireEvent.click(screen.getByText('Retry verification'))
+        expect(onRetry).toHaveBeenCalledTimes(1)
     })
 })

--- a/src/components/Profile/views/UnlockedRegions.view.tsx
+++ b/src/components/Profile/views/UnlockedRegions.view.tsx
@@ -81,7 +81,7 @@ const UnlockedRegions = () => {
     // rail status this page otherwise keys on: the rail only says "blocked", which
     // is where the retry loop below came from. The identity block is the only
     // place that carries WHY.
-    const { isRegionRestricted } = useIdentityVerification()
+    const { identity, isRegionRestricted, isTerminalFailure } = useIdentityVerification()
     // MIGRATION-REVIEW: unlockedRegions/lockedRegions previously came from
     // `useIdentityVerification` (raw rails + Sumsub flags). Now derived from the
     // capability rails via deriveRegionAccess (same Region shape; faithful unlock
@@ -106,16 +106,22 @@ const UnlockedRegions = () => {
     // staring at a screen where "verify now" appeared to do nothing.
     const [errorAcknowledged, setErrorAcknowledged] = useState(false)
 
-    // MIGRATION-REVIEW + CONTRACT GAP: KycFailedModal's terminal-rejection heuristic used
-    // sumsubRejectLabels / sumsubRejectType / a rejected-SUMSUB-verification count, all read
-    // off raw `user.kycVerifications` via useUnifiedKycStatus. The capability model carries
-    // no per-verification Sumsub history (labels, reject type, or attempt count), so these
-    // are dropped (passed null/undefined). isTerminalRejection degrades gracefully — without
-    // a FINAL reject type or terminal labels it defaults to retryable, and the backend still
-    // flips the rail to 'blocked' (→ 'rejected' variant, contact-support CTA) on a final
-    // rejection, so a genuinely terminal user is still routed to support via the rail status.
-    const sumsubRejectLabels: string[] | null = null
-    const sumsubRejectType: 'RETRY' | 'FINAL' | null = null
+    // The terminal-vs-retryable inputs KycFailedModal needs. These were hardcoded
+    // to null/undefined during the capabilities migration, because the capability
+    // model carries no per-verification Sumsub history — which silently made
+    // isTerminalRejection ALWAYS return "retryable". Every terminal rejection
+    // (fraud, sanctions, age, forgery) has been offering "Let's try that again"
+    // on this page ever since, to users no retry can help.
+    //
+    // The history was never the right source. The BACKEND already folds the
+    // decision: Sumsub RETRY becomes ACTION_REQUIRED, FINAL becomes REJECTED, and
+    // the identity read-model now says outright whether a retry is worth offering
+    // (`canRetry`, surfaced here as isTerminalFailure). So read that instead of
+    // reconstructing it from raw labels and attempt counts.
+    const sumsubRejectLabels = identity.rejectLabels ?? null
+    const sumsubRejectType = isTerminalFailure ? ('FINAL' as const) : null
+    // Still unavailable, and no longer needed: rejectType now carries the verdict,
+    // so the attempt-count fallback inside isTerminalRejection never has to fire.
     const sumsubFailureCount: number | undefined = undefined
 
     const clickedRegionIntent = selectedRegion ? getRegionIntent(selectedRegion.path) : undefined

--- a/src/components/Profile/views/UnlockedRegions.view.tsx
+++ b/src/components/Profile/views/UnlockedRegions.view.tsx
@@ -11,12 +11,14 @@ import PendingVerificationTasks from '@/components/Home/PendingVerificationTasks
 import { KycProcessingModal } from '@/components/Kyc/modals/KycProcessingModal'
 import { KycActionRequiredModal } from '@/components/Kyc/modals/KycActionRequiredModal'
 import { KycFailedModal } from '@/components/Kyc/modals/KycFailedModal'
+import { KycRegionRestrictedModal } from '@/components/Kyc/modals/KycRegionRestrictedModal'
 import ActionModal from '@/components/Global/ActionModal'
 import { useModalsContext } from '@/context/ModalsContext'
 import { deriveRegionAccess, getRegionIntent, providerForRegionIntent, type Region } from '@/utils/regions.utils'
 import { useRegionLabel } from '@/hooks/useRegionLabel'
 import { useActivationStatus } from '@/hooks/useActivationStatus'
 import { useCapabilities } from '@/hooks/useCapabilities'
+import { useIdentityVerification } from '@/hooks/useIdentityVerification'
 import { deriveProviderRejection } from '@/utils/provider-rejection.utils'
 import { reasonCodeKey } from '@/constants/capability-reason-labels.consts'
 import { type RailCapability } from '@/types/capabilities'
@@ -75,6 +77,11 @@ const UnlockedRegions = () => {
     // fails toward region KYC (the trunk), never toward /card.
     const { activationStep } = useActivationStatus()
     const { rails, isKycApproved, railsForProvider, nextActionsForRail } = useCapabilities()
+    // Terminal-by-jurisdiction is read from the identity read-model, NOT from the
+    // rail status this page otherwise keys on: the rail only says "blocked", which
+    // is where the retry loop below came from. The identity block is the only
+    // place that carries WHY.
+    const { isRegionRestricted } = useIdentityVerification()
     // MIGRATION-REVIEW: unlockedRegions/lockedRegions previously came from
     // `useIdentityVerification` (raw rails + Sumsub flags). Now derived from the
     // capability rails via deriveRegionAccess (same Region shape; faithful unlock
@@ -258,8 +265,13 @@ const UnlockedRegions = () => {
                 rejectLabels={sumsubRejectLabels}
             />
 
+            <KycRegionRestrictedModal
+                visible={modalVariant === 'rejected' && isRegionRestricted}
+                onClose={handleModalClose}
+            />
+
             <KycFailedModal
-                visible={modalVariant === 'rejected'}
+                visible={modalVariant === 'rejected' && !isRegionRestricted}
                 onClose={handleModalClose}
                 onRetry={handleStartKyc}
                 isLoading={flow.isLoading}

--- a/src/constants/capability-reason-labels.consts.ts
+++ b/src/constants/capability-reason-labels.consts.ts
@@ -46,6 +46,9 @@ export const REASON_CODE_KEYS = {
     region_block: 'reasons.region_block',
     compliance_block: 'reasons.compliance_block',
     card_rejected: 'reasons.card_rejected',
+    // identity (Sumsub) terminal causes — sibling of the rail codes above, but
+    // sourced from `user.identityVerification.reason` rather than a rail.
+    identity_region_restricted: 'reasons.identity_region_restricted',
     // restrictions
     manteca_us_nationality: 'reasons.manteca_us_nationality',
     country_not_supported: 'reasons.country_not_supported',

--- a/src/constants/kyc.consts.ts
+++ b/src/constants/kyc.consts.ts
@@ -12,6 +12,18 @@ export type KycStatusCategory = 'completed' | 'processing' | 'failed' | 'action_
 export const MAX_SELF_HEAL_ATTEMPTS = 3
 
 /**
+ * `identityVerification.reason.code` the backend stamps on a terminal rejection
+ * caused by the document's jurisdiction (peanut-api-ts
+ * `src/kyc/restricted-regions.ts`).
+ *
+ * The country list is NOT mirrored here — it lives in the Sumsub dashboard,
+ * which is where it is enforced. The FE only learns that a regional rule fired,
+ * and the copy says "your country" without naming it, so adding a country is a
+ * Sumsub dashboard change with no deploy on either side.
+ */
+export const IDENTITY_REGION_RESTRICTED_CODE = 'identity_region_restricted'
+
+/**
  * QR-pay KYC gate states. Relocated here from the (now capability-derived)
  * useQrKycGate hook so the qr-pay page keeps a stable import after that hook is
  * deleted. The gate is now computed inline on the page from useCapabilities().

--- a/src/constants/sumsub-reject-labels.consts.ts
+++ b/src/constants/sumsub-reject-labels.consts.ts
@@ -103,6 +103,13 @@ export const TERMINAL_REJECT_LABELS = new Set([
     'PEP',
     'SANCTIONS',
     'DUPLICATE',
+    // Jurisdictional blocks. A retry cannot pass one of these — the document's
+    // country is unacceptable, not the document — so no surface may offer
+    // "try again". These two drive the region-restricted screen (the BE
+    // classifies them into identityVerification.reason); listing them here is
+    // what stops the OTHER surfaces from contradicting it with a retry CTA.
+    'WRONG_USER_REGION',
+    'REGULATIONS_VIOLATIONS',
 ])
 
 /** check if any of the reject labels indicate a terminal (permanent) rejection */

--- a/src/hooks/__tests__/useIdentityVerification.regionRestricted.test.ts
+++ b/src/hooks/__tests__/useIdentityVerification.regionRestricted.test.ts
@@ -1,0 +1,52 @@
+import { renderHook } from '@testing-library/react'
+import { useIdentityVerification } from '../useIdentityVerification'
+import { type IdentityVerification } from '@/types/capabilities'
+
+const mockUser = jest.fn()
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => mockUser(),
+}))
+
+const withIdentity = (identityVerification?: IdentityVerification) => {
+    mockUser.mockReturnValue({ user: identityVerification ? { identityVerification } : {}, isFetchingUser: false })
+    return renderHook(() => useIdentityVerification()).result.current
+}
+
+const REGION = { code: 'identity_region_restricted', userMessage: 'nope' }
+
+describe('useIdentityVerification — isRegionRestricted', () => {
+    it('is true for a failed identity carrying the region code', () => {
+        const r = withIdentity({ status: 'failed', reason: REGION })
+        expect(r.isRegionRestricted).toBe(true)
+        // strict subset of isFailed — never a replacement for it
+        expect(r.isFailed).toBe(true)
+    })
+
+    it('is false for a failed identity with no reason (older backend, unclassified)', () => {
+        const r = withIdentity({ status: 'failed' })
+        expect(r.isFailed).toBe(true)
+        expect(r.isRegionRestricted).toBe(false)
+    })
+
+    it('is false for a failed identity rejected for some other terminal cause', () => {
+        const r = withIdentity({ status: 'failed', reason: { code: 'terminal_rejection', userMessage: 'nope' } })
+        expect(r.isRegionRestricted).toBe(false)
+    })
+
+    it.each(['processing', 'action_required', 'verified', 'not_started'] as const)(
+        'is false for %s even if a region reason somehow rides along',
+        (status) => {
+            // A reason on a non-terminal status would be the backend contradicting
+            // itself. Rendering the dead-end screen on a live flow is the worse
+            // failure, so the status gate wins.
+            const r = withIdentity({ status, reason: REGION })
+            expect(r.isRegionRestricted).toBe(false)
+        }
+    )
+
+    it('is false while the user is still loading', () => {
+        const r = withIdentity(undefined)
+        expect(r.status).toBe('not_started')
+        expect(r.isRegionRestricted).toBe(false)
+    })
+})

--- a/src/hooks/__tests__/useIdentityVerification.regionRestricted.test.ts
+++ b/src/hooks/__tests__/useIdentityVerification.regionRestricted.test.ts
@@ -50,3 +50,34 @@ describe('useIdentityVerification — isRegionRestricted', () => {
         expect(r.isRegionRestricted).toBe(false)
     })
 })
+
+describe('useIdentityVerification — isTerminalFailure', () => {
+    it('is true for a decision the user cannot retry', () => {
+        const r = withIdentity({ status: 'failed', canRetry: false })
+        expect(r.isTerminalFailure).toBe(true)
+    })
+
+    it('is false when the check merely errored — a retry is worth offering', () => {
+        const r = withIdentity({ status: 'failed', canRetry: true })
+        expect(r.isFailed).toBe(true)
+        expect(r.isTerminalFailure).toBe(false)
+    })
+
+    it('defaults to terminal when an older backend omits canRetry', () => {
+        // Fail-closed on purpose: offering a retry that cannot pass is worse than
+        // a support link that was not strictly needed. This is also what makes
+        // the terminal fix land even if the FE ships ahead of the BE.
+        const r = withIdentity({ status: 'failed' })
+        expect(r.isTerminalFailure).toBe(true)
+    })
+
+    it('is false for region-restricted — that gets its own screen, with no support link', () => {
+        const r = withIdentity({ status: 'failed', canRetry: false, reason: REGION })
+        expect(r.isRegionRestricted).toBe(true)
+        expect(r.isTerminalFailure).toBe(false)
+    })
+
+    it.each(['processing', 'action_required', 'verified', 'not_started'] as const)('is false for %s', (status) => {
+        expect(withIdentity({ status, canRetry: false }).isTerminalFailure).toBe(false)
+    })
+})

--- a/src/hooks/useIdentityVerification.ts
+++ b/src/hooks/useIdentityVerification.ts
@@ -38,6 +38,16 @@ export interface UseIdentityVerificationResult {
      * offer a retry that can never pass.
      */
     isRegionRestricted: boolean
+    /**
+     * Terminal for any reason OTHER than region — fraud, sanctions, age,
+     * forgery. Distinct from `isRegionRestricted` because the right ending
+     * differs: we deliberately do NOT explain these (naming the cause carries
+     * compliance exposure and tips off the people it describes), and support IS
+     * the right route, because a human can review a misclassification.
+     *
+     * Both are terminal, so neither may offer a retry.
+     */
+    isTerminalFailure: boolean
     isLoading: boolean
 }
 
@@ -58,6 +68,14 @@ export function useIdentityVerification(): UseIdentityVerificationResult {
             // non-terminal status would be the BE contradicting itself, and
             // rendering a dead end on a live flow is the worse failure.
             isRegionRestricted: status === 'failed' && identity.reason?.code === IDENTITY_REGION_RESTRICTED_CODE,
+            // `canRetry !== true` rather than `=== false`: an older backend
+            // omits the field entirely, and defaulting those to terminal is the
+            // safe direction — a retry that cannot pass is worse than a support
+            // link that wasn't strictly needed.
+            isTerminalFailure:
+                status === 'failed' &&
+                identity.canRetry !== true &&
+                identity.reason?.code !== IDENTITY_REGION_RESTRICTED_CODE,
             isLoading: isFetchingUser,
         }
     }, [identity, isFetchingUser])

--- a/src/hooks/useIdentityVerification.ts
+++ b/src/hooks/useIdentityVerification.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useAuth } from '@/context/authContext'
+import { IDENTITY_REGION_RESTRICTED_CODE } from '@/constants/kyc.consts'
 import { type IdentityVerification, type IdentityVerificationStatus } from '@/types/capabilities'
 import { useMemo } from 'react'
 
@@ -29,6 +30,14 @@ export interface UseIdentityVerificationResult {
     needsAction: boolean
     /** terminal — cannot self-serve. */
     isFailed: boolean
+    /**
+     * Terminal AND caused by the document's jurisdiction. A strict subset of
+     * `isFailed`: these users get the region screen (an explanation, no retry,
+     * no support punt) instead of the generic failed treatment. Every surface
+     * that renders a rejection must check this BEFORE `isFailed`, or it will
+     * offer a retry that can never pass.
+     */
+    isRegionRestricted: boolean
     isLoading: boolean
 }
 
@@ -45,6 +54,10 @@ export function useIdentityVerification(): UseIdentityVerificationResult {
             isProcessing: status === 'processing',
             needsAction: status === 'action_required',
             isFailed: status === 'failed',
+            // Gated on `failed` as well as the code: a reason riding a
+            // non-terminal status would be the BE contradicting itself, and
+            // rendering a dead end on a live flow is the worse failure.
+            isRegionRestricted: status === 'failed' && identity.reason?.code === IDENTITY_REGION_RESTRICTED_CODE,
             isLoading: isFetchingUser,
         }
     }, [identity, isFetchingUser])

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2229,6 +2229,13 @@
             "ctaUnlockNow": "Unlock now",
             "ctaWithdrawFunds": "Withdraw funds"
         },
+        "regionRestricted": {
+            "title": "We can't verify IDs from your country",
+            "description": "Our verification partner doesn't accept documents issued in your country. Re-uploading won't change the result.",
+            "stillAvailable": "Your funds are safe, and you can still use Peanut to send and receive money with other people.",
+            "homeDescription": "Your funds are safe — you can still send and receive money with other people.",
+            "cta": "Send or request money"
+        },
         "advisory": {
             "title": "One quick step to continue",
             "descriptionByDate": "To continue using bank transfers, please complete a short verification (required by {deadline}). It only takes a couple of minutes.",
@@ -2593,7 +2600,8 @@
             "card_rejected": "Your card application couldn't be approved. Message support if you think this is a mistake.",
             "manteca_us_nationality": "Payments from this country are not available for US citizens at this time.",
             "country_not_supported": "This rail needs a document from a supported country. You can verify with a different ID.",
-            "uk_resident_blocked": "Due to UK regulations, bank transfers aren't available for UK residents. Your funds are safe — you can withdraw them as crypto anytime."
+            "uk_resident_blocked": "Due to UK regulations, bank transfers aren't available for UK residents. Your funds are safe — you can withdraw them as crypto anytime.",
+            "identity_region_restricted": "Our verification partner doesn't accept documents issued in your country. Re-uploading won't change the result."
         }
     },
     "recoverFunds": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2229,6 +2229,13 @@
             "ctaUnlockNow": "Desbloquear ahora",
             "ctaWithdrawFunds": "Retirar fondos"
         },
+        "regionRestricted": {
+            "title": "No podemos verificar identificaciones de tu país",
+            "description": "Nuestro proveedor de verificación no acepta documentos emitidos en tu país. Volver a subirlos no cambiará el resultado.",
+            "stillAvailable": "Tus fondos están seguros y puedes seguir usando Peanut para enviar y recibir dinero con otras personas.",
+            "homeDescription": "Tus fondos están seguros: puedes seguir enviando y recibiendo dinero con otras personas.",
+            "cta": "Enviar o solicitar dinero"
+        },
         "advisory": {
             "title": "Un paso rápido para continuar",
             "descriptionByDate": "Para seguir usando las transferencias bancarias, completa una breve verificación (obligatoria antes del {deadline}). Solo toma un par de minutos.",
@@ -2593,7 +2600,8 @@
             "card_rejected": "No se pudo aprobar tu solicitud de tarjeta. Escríbele a soporte si crees que es un error.",
             "manteca_us_nationality": "Los pagos desde este país no están disponibles para ciudadanos de EE. UU. por el momento.",
             "country_not_supported": "Este medio de pago requiere un documento de un país compatible. Puedes verificarte con otro documento.",
-            "uk_resident_blocked": "Debido a las regulaciones del Reino Unido, las transferencias bancarias no están disponibles para sus residentes. Tus fondos están seguros: puedes retirarlos como cripto en cualquier momento."
+            "uk_resident_blocked": "Debido a las regulaciones del Reino Unido, las transferencias bancarias no están disponibles para sus residentes. Tus fondos están seguros: puedes retirarlos como cripto en cualquier momento.",
+            "identity_region_restricted": "Nuestro proveedor de verificación no acepta documentos emitidos en tu país. Volver a subirlos no cambiará el resultado."
         }
     },
     "recoverFunds": {

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -797,6 +797,13 @@
             "descriptionRegionUnavailable": "Por regulaciones del Reino Unido, las transferencias bancarias no están disponibles para residentes del Reino Unido. Tus fondos están seguros: podés retirarlos como cripto en cualquier momento.",
             "descriptionDefault": "Confirmá tu identidad para desbloquear los pagos. Toma alrededor de un minuto."
         },
+        "regionRestricted": {
+            "title": "No podemos verificar identificaciones de tu país",
+            "description": "Nuestro proveedor de verificación no acepta documentos emitidos en tu país. Volver a subirlos no va a cambiar el resultado.",
+            "stillAvailable": "Tus fondos están seguros y podés seguir usando Peanut para enviar y recibir dinero con otras personas.",
+            "homeDescription": "Tus fondos están seguros: podés seguir enviando y recibiendo dinero con otras personas.",
+            "cta": "Enviar o pedir dinero"
+        },
         "advisory": {
             "descriptionByDate": "Para seguir usando las transferencias bancarias, completá una breve verificación (obligatoria antes del {deadline}). Solo toma un par de minutos.",
             "description": "Para seguir usando las transferencias bancarias, completá una breve verificación. Solo toma un par de minutos."
@@ -999,7 +1006,8 @@
             "duplicate_customer_detected": "Bridge marcó tu cuenta como posible duplicado. Escribile a soporte para verificarla y desbloquearla.",
             "card_rejected": "No se pudo aprobar tu solicitud de tarjeta. Escribile a soporte si creés que es un error.",
             "country_not_supported": "Este método necesita un documento de un país compatible. Podés verificarte con otro documento.",
-            "uk_resident_blocked": "Por regulaciones del Reino Unido, las transferencias bancarias no están disponibles para residentes del Reino Unido. Tus fondos están seguros: podés retirarlos como cripto en cualquier momento."
+            "uk_resident_blocked": "Por regulaciones del Reino Unido, las transferencias bancarias no están disponibles para residentes del Reino Unido. Tus fondos están seguros: podés retirarlos como cripto en cualquier momento.",
+            "identity_region_restricted": "Nuestro proveedor de verificación no acepta documentos emitidos en tu país. Volver a subirlos no va a cambiar el resultado."
         }
     },
     "recoverFunds": {

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2229,6 +2229,13 @@
             "ctaUnlockNow": "Desbloquear agora",
             "ctaWithdrawFunds": "Sacar fundos"
         },
+        "regionRestricted": {
+            "title": "Não conseguimos verificar documentos do seu país",
+            "description": "Nosso parceiro de verificação não aceita documentos emitidos no seu país. Enviar de novo não vai mudar o resultado.",
+            "stillAvailable": "Seu dinheiro está seguro e você ainda pode usar o Peanut para enviar e receber dinheiro de outras pessoas.",
+            "homeDescription": "Seu dinheiro está seguro — você ainda pode enviar e receber dinheiro de outras pessoas.",
+            "cta": "Enviar ou pedir dinheiro"
+        },
         "advisory": {
             "title": "Um passo rápido para continuar",
             "descriptionByDate": "Para continuar usando as transferências bancárias, conclua uma verificação rápida (obrigatória até {deadline}). Leva apenas alguns minutos.",
@@ -2593,7 +2600,8 @@
             "card_rejected": "Sua solicitação de cartão não pôde ser aprovada. Fale com o suporte se achar que isso é um engano.",
             "manteca_us_nationality": "Pagamentos deste país não estão disponíveis para cidadãos dos EUA no momento.",
             "country_not_supported": "Este método exige um documento de um país compatível. Você pode verificar com outro documento.",
-            "uk_resident_blocked": "Devido às regulamentações do Reino Unido, transferências bancárias não estão disponíveis para seus residentes. Seu dinheiro está seguro — você pode sacá-lo como cripto a qualquer momento."
+            "uk_resident_blocked": "Devido às regulamentações do Reino Unido, transferências bancárias não estão disponíveis para seus residentes. Seu dinheiro está seguro — você pode sacá-lo como cripto a qualquer momento.",
+            "identity_region_restricted": "Nosso parceiro de verificação não aceita documentos emitidos no seu país. Enviar de novo não vai mudar o resultado."
         }
     },
     "recoverFunds": {

--- a/src/types/api.generated.ts
+++ b/src/types/api.generated.ts
@@ -10868,6 +10868,11 @@ export interface paths {
                             identityVerification: {
                                 status: "not_started" | "processing" | "verified" | "action_required" | "failed";
                                 actionMessage?: string;
+                                reason?: {
+                                    code: string;
+                                    userMessage: string;
+                                    details?: string;
+                                };
                                 rejectLabels?: string[];
                                 submittedAt?: string;
                                 reviewedAt?: string;

--- a/src/types/api.generated.ts
+++ b/src/types/api.generated.ts
@@ -10873,6 +10873,7 @@ export interface paths {
                                     userMessage: string;
                                     details?: string;
                                 };
+                                canRetry?: boolean;
                                 rejectLabels?: string[];
                                 submittedAt?: string;
                                 reviewedAt?: string;

--- a/src/types/api.openapi.json
+++ b/src/types/api.openapi.json
@@ -17896,6 +17896,9 @@
                                                         "userMessage"
                                                     ]
                                                 },
+                                                "canRetry": {
+                                                    "type": "boolean"
+                                                },
                                                 "rejectLabels": {
                                                     "type": "array",
                                                     "items": {

--- a/src/types/api.openapi.json
+++ b/src/types/api.openapi.json
@@ -17878,6 +17878,24 @@
                                                 "actionMessage": {
                                                     "type": "string"
                                                 },
+                                                "reason": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "code": {
+                                                            "type": "string"
+                                                        },
+                                                        "userMessage": {
+                                                            "type": "string"
+                                                        },
+                                                        "details": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "code",
+                                                        "userMessage"
+                                                    ]
+                                                },
                                                 "rejectLabels": {
                                                     "type": "array",
                                                     "items": {

--- a/src/types/capabilities.ts
+++ b/src/types/capabilities.ts
@@ -200,6 +200,15 @@ export interface IdentityVerification {
      * today's generic contact-support ending.
      */
     reason?: CapabilityReason
+    /**
+     * For `failed` only: whether a fresh attempt could plausibly succeed.
+     *
+     * false ⇒ a decision was made (fraud, sanctions, age, jurisdiction); do NOT
+     * offer a retry. true ⇒ the check itself errored, so retrying is meaningful.
+     * Absent ⇒ an older backend that can't tell; treat as terminal, since
+     * offering a retry that cannot pass is the worse of the two mistakes.
+     */
+    canRetry?: boolean
     /** normalized rejection labels for specific guidance (action_required / failed). */
     rejectLabels?: string[]
     /** ISO timestamp the user submitted their verification. */

--- a/src/types/capabilities.ts
+++ b/src/types/capabilities.ts
@@ -192,6 +192,14 @@ export interface IdentityVerification {
     status: IdentityVerificationStatus
     /** present for action_required / failed — friendly, display-ready, provider-neutral. */
     actionMessage?: string
+    /**
+     * Stable machine code + copy for WHY a `failed` identity failed, when the BE
+     * can tell. Mirrors `reason` on the rail side: branch on `code` to pick a
+     * screen, render localized copy from the catalog, fall back to `userMessage`
+     * for codes this build doesn't know. Absent ⇒ terminal, cause unknown ⇒
+     * today's generic contact-support ending.
+     */
+    reason?: CapabilityReason
     /** normalized rejection labels for specific guidance (action_required / failed). */
     rejectLabels?: string[]
     /** ISO timestamp the user submitted their verification. */


### PR DESCRIPTION
Targets `main`. A duplicate of this branch targeting `dev` is open as peanutprotocol/peanut-ui#2778 — **merge one, close the other**; they are the identical three commits.

Backend: peanutprotocol/peanut-api-ts#1381.

## What this does

A user whose ID is rejected for its **jurisdiction** currently hits one of four endings, none of them honest:

| Surface | Today | Ending |
|---|---|---|
| Home activation card | "Verification issue — Contact support" | Ticket nobody can resolve |
| Identity row → drawer | "Retry verification" | Retry that can never pass |
| `/profile/identity-verification` | "Let's try that again" | Retry that can never pass |
| Add-money / withdraw bank gate | "We couldn't unlock this — contact support" | Ticket nobody can resolve |

All four are replaced by one screen: explains the block, **names no country**, offers no retry, offers no support link, and hands the user the part of the app that still works.

> **We can't verify IDs from your country**
>
> Our verification partner doesn't accept documents issued in your country. Re-uploading won't change the result.
>
> Your funds are safe, and you can still use Peanut to send and receive money with other people.
>
> **[ Send or request money ]**

## Two different endings, deliberately

The third commit fixes a **separate pre-existing bug** found while building this, and the two cases are deliberately handled differently:

| | Region-restricted | Fraud / sanctions / age / forgery |
|---|---|---|
| Explain the cause? | Yes, fully | **No** — compliance exposure, and it tips off actual fraudsters |
| Can support help? | No — it cannot lift a jurisdictional block | **Yes** — a human can review a misclassification |
| Retry offered? | No | No |
| Ending | Explanation + "Send or request money" | Generic + **Contact support** |

**The pre-existing bug:** `UnlockedRegions.view.tsx` hardcoded all three of `isTerminalRejection`'s inputs to `null`/`undefined` during the capabilities migration, so the check *always* returned "retryable". Every terminal rejection — fraud, sanctions, age — has been showing "Let's try that again" on that page. The drawer never had a terminal branch at all. Both now read the backend's verdict instead of reconstructing it from raw labels and attempt counts.

## Enforced at the choke point

Six gates open `InitiateKycModal`, each computing its variant from a rail gate that **cannot see why identity failed** — a region-restricted user reads as `needs-identity` and would be offered "Unlock now" straight back into the Sumsub SDK. The short-circuit lives inside the shared component, so a future call site cannot miss it. Tested against all five variants.

## Deploy-order safety

`isRegionRestricted` requires `identityVerification.reason`, which only the backend PR emits. **If this ships first, the region screen simply never renders** — every region path stays exactly as it is today. Nothing breaks.

The terminal fix is different and **does** take effect immediately, by design: `isTerminalFailure` treats a missing `canRetry` as terminal (fail-closed), on the grounds that offering a retry which cannot pass is worse than a support link that wasn't strictly needed. So the fraud/sanctions retry loop is fixed on FE deploy regardless of backend timing. The only cost in that window is the small `reviewAnswer: ERROR` cohort losing their (legitimate) retry until the backend ships. Say the word if you'd rather default the other way — it's one operator in `useIdentityVerification`.

## Verification

- **31 new tests** — 20 on the region screens (contract assertions run against every surface via `describe.each`, so drawer and modal can't drift), 8 on the hook, 3 on the home card.
- **`src/components`, `src/hooks`, `src/utils`, `src/i18n`: 2835 passed.** One pre-existing failure in `Invites/badge-campaign-context.test.ts` — fails identically on `main`, and passes in CI.
- CI: **3404 unit tests, 0 failed**; typecheck, eslint, format, e2e all green.
- Copy added to all four locales, respecting each register (es-AR voseo, es-419 tuteo). No country named in any of them.

## Review focus

1. **Is peer-to-peer actually open for a Sumsub-rejected user?** The copy promises it. This PR doesn't gate anything, but it depends on that being true.
2. Is `/send` the right destination, or would `/home` be safer for a cohort likely holding no balance?
3. The fail-closed `canRetry` default described above.