### PR TITLE
feat: mirror the user's app locale to the BE for localized emails

### DIFF
--- a/src/app/ClientProviders.tsx
+++ b/src/app/ClientProviders.tsx
@@ -15,6 +15,7 @@ import { AppLockGate } from '@/components/Global/AppLock'
 import { ScreenOrientationLocker } from '@/components/Global/ScreenOrientationLocker'
 import { TranslationSafeWrapper } from '@/components/Global/TranslationSafeWrapper'
 import { AppIntlProvider } from '@/i18n/app/AppIntlProvider'
+import { LocaleSync } from '@/i18n/app/LocaleSync'
 import { PeanutProvider } from '@/config/peanut.config'
 import { ContextProvider } from '@/context/contextProvider'
 import { FooterVisibilityProvider } from '@/context/footerVisibility'
@@ -55,6 +56,7 @@ export function ClientProviders({ children }: { children: React.ReactNode }) {
                     <ContextProvider>
                         <FooterVisibilityProvider>
                             <TranslationSafeWrapper>
+                                <LocaleSync />
                                 <ConsoleGreeting />
                                 <ScreenOrientationLocker />
                                 <PeanutDebug />

--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -123,8 +123,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
                 // catalog rail ids for joins against the rails table.
                 enabledRails: enabledRails.map((rail) => `${rail.rail.provider.code}:${rail.rail.method.code}`),
                 enabledRailIds: enabledRails.map((rail) => rail.rail.id),
-                // Client-only (locale never reaches the BE) — covers the first
-                // session, where the startup locale resolves before identify.
+                // Client-set (the BE mirror lives in users.locale via LocaleSync)
+                // — covers the first session, where the startup locale resolves
+                // before identify.
                 ...(appLocale ? { app_locale: appLocale } : {}),
             })
             // Sentry: every error captured from here on inherits user context

--- a/src/i18n/app/LocaleSync.tsx
+++ b/src/i18n/app/LocaleSync.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useAuth } from '@/context/authContext'
+import { useAppLocale } from './AppIntlProvider'
+import { currentAppLocale, localeReady } from './locale-store'
+import { syncLocaleToBackend } from './locale-sync'
+
+/**
+ * Mirrors the user's last known language choice to the BE. Renders nothing.
+ * Must mount below both AppIntlProvider and AuthProvider.
+ *
+ * Keyed on the provider locale so a manual switch in Settings syncs
+ * immediately, but the synced value comes from localeReady()/currentAppLocale()
+ * — the provider briefly shows the English SSR default before the startup
+ * locale applies, and that transient value must never be persisted as a
+ * "choice".
+ */
+export function LocaleSync() {
+    const { userId } = useAuth()
+    const { locale } = useAppLocale()
+
+    useEffect(() => {
+        if (!userId) return
+        let cancelled = false
+        void localeReady().then((resolved) => {
+            // a manual setLocale (already applied and persisted) wins over the
+            // startup resolution
+            if (!cancelled) syncLocaleToBackend(userId, currentAppLocale() ?? resolved)
+        })
+        return () => {
+            cancelled = true
+        }
+    }, [userId, locale])
+
+    return null
+}

--- a/src/i18n/app/__tests__/locale-sync.test.ts
+++ b/src/i18n/app/__tests__/locale-sync.test.ts
@@ -1,0 +1,49 @@
+import { syncLocaleToBackend } from '../locale-sync'
+import { updateUserById } from '@/app/actions/users'
+
+jest.mock('@/app/actions/users', () => ({
+    updateUserById: jest.fn(),
+}))
+
+const mockUpdate = updateUserById as jest.MockedFunction<typeof updateUserById>
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+describe('syncLocaleToBackend', () => {
+    beforeEach(() => {
+        localStorage.clear()
+        mockUpdate.mockReset()
+        mockUpdate.mockResolvedValue({ data: {} as never })
+    })
+
+    it('sends the locale once and dedupes repeats', async () => {
+        syncLocaleToBackend('u1', 'pt-BR')
+        await flush()
+        expect(mockUpdate).toHaveBeenCalledWith({ userId: 'u1', locale: 'pt-BR' })
+
+        syncLocaleToBackend('u1', 'pt-BR')
+        await flush()
+        expect(mockUpdate).toHaveBeenCalledTimes(1)
+    })
+
+    it('re-syncs when the locale or user changes', async () => {
+        syncLocaleToBackend('u1', 'pt-BR')
+        await flush()
+        syncLocaleToBackend('u1', 'es-AR')
+        await flush()
+        syncLocaleToBackend('u2', 'es-AR')
+        await flush()
+        expect(mockUpdate).toHaveBeenCalledTimes(3)
+        expect(mockUpdate).toHaveBeenLastCalledWith({ userId: 'u2', locale: 'es-AR' })
+    })
+
+    it('retries after a failed write (no synced marker stored)', async () => {
+        mockUpdate.mockResolvedValueOnce({ error: 'nope' })
+        syncLocaleToBackend('u1', 'pt-BR')
+        await flush()
+
+        syncLocaleToBackend('u1', 'pt-BR')
+        await flush()
+        expect(mockUpdate).toHaveBeenCalledTimes(2)
+    })
+})

--- a/src/i18n/app/locale-sync.ts
+++ b/src/i18n/app/locale-sync.ts
@@ -17,12 +17,16 @@ export function syncLocaleToBackend(userId: string, locale: AppLocale): void {
     } catch {
         // storage unavailable → sync every startup; the write is idempotent
     }
-    void updateUserById({ userId, locale }).then(({ error }) => {
-        if (error) return
-        try {
-            localStorage.setItem(SYNCED_KEY, synced)
-        } catch {
-            // marker lost → re-sync next startup, still idempotent
-        }
-    })
+    void updateUserById({ userId, locale })
+        .then(({ error }) => {
+            if (error) return
+            try {
+                localStorage.setItem(SYNCED_KEY, synced)
+            } catch {
+                // marker lost → re-sync next startup, still idempotent
+            }
+        })
+        // updateUserById resolves with { error } today, but best-effort must
+        // stay best-effort even if it ever starts rejecting
+        .catch(() => {})
 }

--- a/src/i18n/app/locale-sync.ts
+++ b/src/i18n/app/locale-sync.ts
@@ -1,0 +1,28 @@
+import { updateUserById } from '@/app/actions/users'
+import type { AppLocale } from './config'
+
+const SYNCED_KEY = 'app-locale-synced'
+
+/**
+ * Persists the user's resolved app locale to the BE (`users.locale`, via
+ * POST /update-user) so notification emails can render in their language.
+ * Best-effort and deduped: one request per (user, locale) change; a failed
+ * write retries on the next startup because the synced marker is only stored
+ * on success.
+ */
+export function syncLocaleToBackend(userId: string, locale: AppLocale): void {
+    const synced = `${userId}:${locale}`
+    try {
+        if (localStorage.getItem(SYNCED_KEY) === synced) return
+    } catch {
+        // storage unavailable → sync every startup; the write is idempotent
+    }
+    void updateUserById({ userId, locale }).then(({ error }) => {
+        if (error) return
+        try {
+            localStorage.setItem(SYNCED_KEY, synced)
+        } catch {
+            // marker lost → re-sync next startup, still idempotent
+        }
+    })
+}


### PR DESCRIPTION
## Summary

- new `LocaleSync` component (mounted in `ClientProviders`, below `AppIntlProvider` + `AuthProvider`) mirrors the user's last known language choice to the BE
- sends the resolved app locale to `POST /update-user` (`users.locale`), on startup resolution and on a manual switch in Settings
- deduped per `(user, locale)` via a localStorage marker, stored only on a successful write so failures retry next startup
- the synced value comes from `localeReady()`/`currentAppLocale()`, never the transient English SSR default the provider shows before the startup locale applies

## Why

`users.locale` was future-proofed for notification i18n but nothing ever wrote it (prod is 100% NULL). peanutprotocol/peanut-api-ts#1387 adds the `locale` field to `/update-user` and the first localized email (badge unlocked, es/pt with English fallback) — this PR is the FE half that populates it.

## QA

- new unit test covers send-once, dedupe, re-sync on user/locale change, retry after failed write
- full suite passes (276 suites), `tsc --noEmit` clean, Prettier clean

Requested by @abalinda.
