### PR TITLE
fix(send): stop over-promising account-less claims and surface the $5 fiat minimum at send time

### DIFF
--- a/src/components/Send/link/views/Initial.link.send.view.tsx
+++ b/src/components/Send/link/views/Initial.link.send.view.tsx
@@ -2,7 +2,9 @@
 
 import { useCreateLink } from '@/components/Create/useCreateLink'
 import ErrorAlert from '@/components/Global/ErrorAlert'
+import InfoCard from '@/components/Global/InfoCard'
 import PeanutActionCard from '@/components/Global/PeanutActionCard'
+import { MIN_BANK_TRANSFER_AMOUNT, MIN_MERCADOPAGO_AMOUNT, MIN_PIX_AMOUNT } from '@/constants/payment.consts'
 import { PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
 import { TRANSACTIONS } from '@/constants/query.consts'
 import { loadingStateContext } from '@/context/loadingStates.context'
@@ -22,6 +24,12 @@ import AmountInput from '../../../Global/AmountInput'
 import { usePendingTransactions } from '@/hooks/wallet/usePendingTransactions'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+
+// Below the smallest fiat minimum the recipient loses every fiat claim rail
+// (bank / Pix / Mercado Pago all reject at claim time) and is left with only
+// Peanut-account or wallet claims. Warn the sender here — the claim screen is
+// too late, the money is already locked in the link.
+const MIN_FIAT_CLAIM_AMOUNT = Math.min(MIN_BANK_TRANSFER_AMOUNT, MIN_MERCADOPAGO_AMOUNT, MIN_PIX_AMOUNT)
 
 const LinkSendInitialView = () => {
     const t = useTranslations('send')
@@ -53,6 +61,13 @@ const LinkSendInitialView = () => {
     const peanutWalletBalance = useMemo(() => {
         return balance === undefined ? '' : formattedSpendableBalance
     }, [balance, formattedSpendableBalance])
+
+    // Informational only — small links are legitimate (Peanut-account / wallet
+    // claims have no minimum), so this never blocks Create link.
+    const isBelowFiatClaimMinimum = useMemo(() => {
+        const amount = parseFloat(tokenValue ?? '')
+        return amount > 0 && amount < MIN_FIAT_CLAIM_AMOUNT
+    }, [tokenValue])
 
     const handleOnNext = useCallback(async () => {
         try {
@@ -227,6 +242,14 @@ const LinkSendInitialView = () => {
                 attachmentOptions={attachmentOptions}
                 setAttachmentOptions={setAttachmentOptions}
             />
+
+            {isBelowFiatClaimMinimum && (
+                <InfoCard
+                    variant="warning"
+                    icon="info"
+                    description={t('link.minFiatClaimWarning', { amount: MIN_FIAT_CLAIM_AMOUNT })}
+                />
+            )}
 
             <div className="flex flex-col gap-4">
                 {errorState?.showError ? (

--- a/src/components/Send/link/views/__tests__/Initial.link.send.view.test.tsx
+++ b/src/components/Send/link/views/__tests__/Initial.link.send.view.test.tsx
@@ -96,6 +96,11 @@ jest.mock('@/components/Global/ErrorAlert', () => ({
     default: ({ description }: { description: string }) => <div data-testid="error-alert">{description}</div>,
 }))
 
+jest.mock('@/components/Global/InfoCard', () => ({
+    __esModule: true,
+    default: ({ description }: { description: React.ReactNode }) => <div data-testid="info-card">{description}</div>,
+}))
+
 import LinkSendInitialView from '../Initial.link.send.view'
 
 // ---------- helpers ----------
@@ -211,5 +216,31 @@ describe('LinkSendInitialView error ownership', () => {
         mockUseWallet.mockReturnValue(walletState(100))
         rerenderView(utils, '20')
         await waitFor(() => expect(screen.queryByTestId('error-alert')).not.toBeInTheDocument())
+    })
+})
+
+// TASK-21724: a $3 link leaves the recipient with no bank / Pix / Mercado Pago
+// claim route (all three minimums are $5) and nothing told the sender. The
+// warning is informational — small links stay sendable.
+describe('LinkSendInitialView sub-minimum fiat-claim warning', () => {
+    test('amount below the fiat minimum shows the warning without blocking Create link', async () => {
+        mockUseWallet.mockReturnValue(walletState(100))
+
+        renderView('3')
+        await waitFor(() =>
+            expect(screen.getByTestId('info-card')).toHaveTextContent(
+                "Amounts under $5 can't be claimed to a bank, Pix or Mercado Pago"
+            )
+        )
+        expect(screen.queryByTestId('error-alert')).not.toBeInTheDocument()
+        expect(screen.getByText('Create link')).toBeEnabled()
+    })
+
+    test('amount at the fiat minimum shows no warning', async () => {
+        mockUseWallet.mockReturnValue(walletState(100))
+
+        renderView('5')
+        await waitFor(() => expect(screen.getByText('Create link')).toBeEnabled())
+        expect(screen.queryByTestId('info-card')).not.toBeInTheDocument()
     })
 })

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -744,7 +744,7 @@
     "send": {
         "linkCard": {
             "title": "Send money with a link",
-            "description": "No account needed to receive.",
+            "description": "No account needed for bank or wallet claims. Pix and Mercado Pago need a Peanut account.",
             "cta": "Send via link"
         },
         "methods": {
@@ -777,7 +777,8 @@
             "cancelled": "Cancelled",
             "cancelSuccess": "Link cancelled successfully!",
             "cancelSuccessRefresh": "Link cancelled! Refresh to see updated balance.",
-            "cancelFailed": "Failed to cancel link. Please try again."
+            "cancelFailed": "Failed to cancel link. Please try again.",
+            "minFiatClaimWarning": "Amounts under ${amount} can't be claimed to a bank, Pix or Mercado Pago — the recipient can still claim to a Peanut account or crypto wallet."
         }
     },
     "request": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -744,7 +744,7 @@
     "send": {
         "linkCard": {
             "title": "Envía dinero con un enlace",
-            "description": "No se necesita cuenta para recibir.",
+            "description": "No se necesita cuenta para reclamar en banco o billetera. Pix y Mercado Pago requieren una cuenta Peanut.",
             "cta": "Enviar por enlace"
         },
         "methods": {
@@ -777,7 +777,8 @@
             "cancelled": "Cancelado",
             "cancelSuccess": "¡Enlace cancelado con éxito!",
             "cancelSuccessRefresh": "¡Enlace cancelado! Actualiza para ver tu saldo al día.",
-            "cancelFailed": "No se pudo cancelar el enlace. Inténtalo de nuevo."
+            "cancelFailed": "No se pudo cancelar el enlace. Inténtalo de nuevo.",
+            "minFiatClaimWarning": "Los montos menores a ${amount} no se pueden reclamar en banco, Pix o Mercado Pago; el destinatario igual puede reclamar en una cuenta Peanut o billetera cripto."
         }
     },
     "request": {

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -744,7 +744,7 @@
     "send": {
         "linkCard": {
             "title": "Envie dinheiro com um link",
-            "description": "Não precisa de conta para receber.",
+            "description": "Não precisa de conta para resgatar em banco ou carteira. Pix e Mercado Pago exigem uma conta Peanut.",
             "cta": "Enviar por link"
         },
         "methods": {
@@ -777,7 +777,8 @@
             "cancelled": "Cancelado",
             "cancelSuccess": "Link cancelado com sucesso!",
             "cancelSuccessRefresh": "Link cancelado! Atualize para ver o saldo atualizado.",
-            "cancelFailed": "Não foi possível cancelar o link. Tente de novo."
+            "cancelFailed": "Não foi possível cancelar o link. Tente de novo.",
+            "minFiatClaimWarning": "Valores abaixo de ${amount} não podem ser resgatados em banco, Pix ou Mercado Pago — o destinatário ainda pode resgatar em uma conta Peanut ou carteira cripto."
         }
     },
     "request": {


### PR DESCRIPTION
Closes out the send-flow half of TASK-21724 (Michael Koh's report). The claim side is behaving as designed — Pix/Mercado Pago claims require a Peanut account, and the fiat rails have a $5 minimum — but the send flow set the wrong expectation on both counts.

## 1. The "no account needed" over-promise

The send-via-link card said **"No account needed to receive."**, which is only true for bank and external-wallet claims. Pix and Mercado Pago claims require a Peanut account (claim to balance first), so Michael's recipient hit "requires verification" on Mercado Pago and concluded the link was broken.

The copy now scopes the promise and names the caveat:

> No account needed for bank or wallet claims. Pix and Mercado Pago need a Peanut account.

Updated in `en`, `es-419`, and `pt-BR`. `es-AR` inherits the `es-419` string through the deltas-only overlay — the new copy has no second-person forms, so no voseo override is needed (the resolved-catalog glossary test confirms).

## 2. The invisible $5 fiat-claim minimum

`MIN_BANK_TRANSFER_AMOUNT`, `MIN_MERCADOPAGO_AMOUNT` and `MIN_PIX_AMOUNT` are all $5, but nothing surfaced this at send time — a sender could create a $3 link and strand the recipient with no fiat claim route (the "$5 minimum … but it didn't work" half of the report). The claim screen is too late: the money is already locked in the link.

`Initial.link.send.view.tsx` now shows a **non-blocking** warning `InfoCard` when the entered amount is below the smallest fiat minimum, telling the sender the recipient will only be able to claim to a Peanut account or crypto wallet. Small links stay sendable — account and wallet claims have no minimum — so Create link is never disabled by this. The threshold is `Math.min` of the three constants, so it tracks any future value change.

## Not in this PR

- Juan's peer-send failure (6cfc9e) is a different surface with no reproduction yet — split into its own task.
- The backend half of the claim-failure cluster (retryable paymaster failures, parked Bridge profiles) is peanut-api-ts#1382.

## Testing

- Two new tests in the existing view suite: the warning shows at $3 without disabling Create link; absent at $5.
- All 202 tests across the 15 `src/i18n` + `src/components/Send` suites pass on this branch, including catalog key parity, glossary compliance, and ICU compilation for the new keys.
- ESLint and Prettier clean on changed files; typecheck error set verified byte-identical before/after the change (pre-existing failures are missing generated assets in the sandbox).

Same change is also on `claude/send-link-claim-failures-ocfjvf` (main-based) if a production hotfix PR is wanted, mirroring the #2776/#2777 split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BLNUBFAcvLkHKdMMawQ1Zv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLNUBFAcvLkHKdMMawQ1Zv)_