### PR TITLE
fix(history): respect hidden-balance preference on Activity

### DIFF
--- a/src/app/(mobile-ui)/history/__tests__/hidden-balance.test.tsx
+++ b/src/app/(mobile-ui)/history/__tests__/hidden-balance.test.tsx
@@ -55,9 +55,12 @@ jest.mock('@/components/TransactionDetails/transactionTransformer', () => ({
         transactionDetails: { userName: 'bob', amount: '12.5', status: 'completed', initials: 'B' },
     }),
 }))
-jest.mock('@/components/TransactionDetails/TransactionCard', () => (props: { hideTxnAmount?: boolean }) => {
-    mockTransactionCard(props)
-    return <div data-testid="txn-card">{props.hideTxnAmount ? '****' : 'amount'}</div>
+jest.mock('@/components/TransactionDetails/TransactionCard', () => {
+    function MockTransactionCard(props: { hideTxnAmount?: boolean }) {
+        mockTransactionCard(props)
+        return <div data-testid="txn-card">{props.hideTxnAmount ? '****' : 'amount'}</div>
+    }
+    return MockTransactionCard
 })
 
 import HistoryPage from '../page'

--- a/src/app/(mobile-ui)/history/__tests__/hidden-balance.test.tsx
+++ b/src/app/(mobile-ui)/history/__tests__/hidden-balance.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+const mockGetUserPreferences = jest.fn()
+const mockTransactionCard = jest.fn()
+
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }))
+jest.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+    useFormatter: () => ({ dateTime: () => 'date' }),
+}))
+jest.mock('@tanstack/react-query', () => ({
+    useQueryClient: () => ({ setQueryData: jest.fn(), invalidateQueries: jest.fn() }),
+}))
+jest.mock('@/redux/hooks', () => ({
+    useUserStore: () => ({ user: { user: { userId: 'user-1', username: 'alice', badges: [] }, accounts: [] } }),
+}))
+jest.mock('@/context/authContext', () => ({ useAuth: () => ({ fetchUser: jest.fn() }) }))
+jest.mock('@/hooks/useCardInfo', () => ({ useCardInfo: () => ({ cardInfo: undefined }) }))
+jest.mock('@/hooks/useRainCardOverview', () => ({ useRainCardOverview: () => ({ overview: undefined }) }))
+jest.mock('@/hooks/useWebSocket', () => ({ useWebSocket: jest.fn() }))
+jest.mock('@/hooks/useInfiniteScroll', () => ({ useInfiniteScroll: () => ({ loaderRef: { current: null } }) }))
+jest.mock('@/hooks/useTransactionHistory', () => ({
+    useTransactionHistory: () => ({
+        data: { pages: [{ entries: [{ uuid: 'tx-1', timestamp: '2026-01-01T00:00:00Z', type: 'SEND' }] }] },
+        hasNextPage: false,
+        fetchNextPage: jest.fn(),
+        isFetchingNextPage: false,
+        isLoading: false,
+        isError: false,
+        error: null,
+    }),
+}))
+jest.mock('@/utils/general.utils', () => ({ getUserPreferences: (id: string) => mockGetUserPreferences(id) }))
+jest.mock('@/utils/kyc-grouping.utils', () => ({ buildKycHistoryEntry: () => null }))
+jest.mock('@/utils/history.utils', () => ({
+    completeHistoryEntry: jest.fn(),
+    dedupeHistoryEntriesByUuid: (entries: unknown[]) => entries,
+}))
+jest.mock('@/components/Kyc/KycStatusItem', () => ({ KycStatusItem: () => null, isKycStatusItem: () => false }))
+jest.mock('@/components/Badges/BadgeStatusItem', () => ({ BadgeStatusItem: () => null }))
+jest.mock('@/components/Badges/badge.types', () => ({ isBadgeHistoryItem: () => false }))
+jest.mock('@/components/Card/CardUnlockHistoryItem', () => () => null)
+jest.mock('@/components/Card/cardUnlock.types', () => ({
+    deriveCardUnlockEntry: () => null,
+    isCardUnlockHistoryItem: () => false,
+}))
+jest.mock('@/components/Global/NavHeader', () => () => null)
+jest.mock('@/components/Global/PeanutLoading', () => () => null)
+jest.mock('@/components/Global/EmptyStates/EmptyState', () => () => null)
+jest.mock('@/components/Global/EmptyStates/NoDataEmptyState', () => () => null)
+jest.mock('@/components/TransactionDetails/transactionTransformer', () => ({
+    mapTransactionDataForDrawer: () => ({
+        transactionCardType: 'send',
+        transactionDetails: { userName: 'bob', amount: '12.5', status: 'completed', initials: 'B' },
+    }),
+}))
+jest.mock('@/components/TransactionDetails/TransactionCard', () => (props: { hideTxnAmount?: boolean }) => {
+    mockTransactionCard(props)
+    return <div data-testid="txn-card">{props.hideTxnAmount ? '****' : 'amount'}</div>
+})
+
+import HistoryPage from '../page'
+
+describe('HistoryPage hidden-balance preference', () => {
+    beforeEach(() => {
+        mockGetUserPreferences.mockReset()
+        mockTransactionCard.mockClear()
+    })
+
+    it('masks transaction amounts when balanceHidden is set', () => {
+        mockGetUserPreferences.mockReturnValue({ balanceHidden: true })
+        render(<HistoryPage />)
+        expect(mockGetUserPreferences).toHaveBeenCalledWith('user-1')
+        expect(mockTransactionCard).toHaveBeenCalledWith(expect.objectContaining({ hideTxnAmount: true }))
+        expect(screen.getByTestId('txn-card')).toHaveTextContent('****')
+    })
+
+    it('shows transaction amounts when the preference is unset', () => {
+        mockGetUserPreferences.mockReturnValue(undefined)
+        render(<HistoryPage />)
+        expect(mockTransactionCard).toHaveBeenCalledWith(expect.objectContaining({ hideTxnAmount: false }))
+        expect(screen.getByTestId('txn-card')).toHaveTextContent('amount')
+    })
+})

--- a/src/app/(mobile-ui)/history/page.tsx
+++ b/src/app/(mobile-ui)/history/page.tsx
@@ -10,6 +10,7 @@ import TransactionCard from '@/components/TransactionDetails/TransactionCard'
 import { mapTransactionDataForDrawer } from '@/components/TransactionDetails/transactionTransformer'
 import { useTransactionHistory } from '@/hooks/useTransactionHistory'
 import { useUserStore } from '@/redux/hooks'
+import { getUserPreferences } from '@/utils/general.utils'
 import { DateGroup, getDateGroup, getDateGroupKey } from '@/utils/dateGrouping.utils'
 import * as Sentry from '@sentry/nextjs'
 import { isKycStatusItem, type KycHistoryEntry } from '@/components/Kyc/KycStatusItem'
@@ -49,6 +50,8 @@ const HistoryPage = () => {
     // Synthetic card-unlock row inputs — same cached queries HomeHistory uses.
     const { cardInfo } = useCardInfo()
     const { overview: rainOverview } = useRainCardOverview()
+    const userId = user?.user.userId
+    const hideTxnAmount = useMemo(() => getUserPreferences(userId)?.balanceHidden ?? false, [userId])
 
     const {
         data: historyData,
@@ -326,6 +329,7 @@ const HistoryPage = () => {
                                             transaction={transactionDetails}
                                             position={position}
                                             haveSentMoneyToUser={transactionDetails.haveSentMoneyToUser}
+                                            hideTxnAmount={hideTxnAmount}
                                         />
                                     )
                                 })()


### PR DESCRIPTION
## Summary

P2 — `/history` (Activity) ignored the hidden-balance privacy setting and showed transaction amounts in the clear, while `/home` masked them via `hideTxnAmount`.

- Read `balanceHidden` from user preferences on the history page and pass `hideTxnAmount` to every `TransactionCard`, matching `HomeHistory`.
- Add a render test covering both the hidden and default states.

Visual exposure only; no funds impact.

## Test plan

- [x] `jest --testPathPattern history/__tests__` — 7 passed
- [x] prettier clean; no tsc errors in touched files
- [ ] Manual: hide balance on Home → open Activity → amounts show `****`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction amounts in History are now hidden when the user’s balance-visibility preference is enabled.
  * Transaction amounts remain visible when the preference is disabled or unset.

* **Tests**
  * Added coverage to verify transaction amount masking behavior in History.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->