### PR TITLE
fix: block account deletion while the wallet still holds funds

### DIFF
--- a/src/components/Settings/DeleteAccountButton.tsx
+++ b/src/components/Settings/DeleteAccountButton.tsx
@@ -16,6 +16,14 @@ import { DELETION_BALANCE_DUST_UNITS } from '@/utils/balance.utils'
 
 type ModalState = 'closed' | 'blocked' | 'confirm' | 'done'
 
+type Step = {
+    mascot: string
+    mascotAlt: string
+    title: string
+    description: string
+    ctas: ActionModalButtonProps[]
+}
+
 // A big animated mascot at the top of the modal instead of the tiny alert icon.
 // `unoptimized` keeps the animated WebP playing (Next's optimizer flattens it).
 const Mascot: FC<{ src: string; alt: string }> = ({ src, alt }) => (
@@ -92,63 +100,47 @@ const DeleteAccountButton: FC = () => {
     // the user must complete the flow through the CTA.
     const lockModal = isSubmitting || modalState === 'done'
 
-    const blockedCtas: ActionModalButtonProps[] = [
-        {
-            text: t('blockedCta'),
-            variant: 'purple',
-            shadowSize: '4',
-            onClick: moveMoney,
+    // One descriptor per step, so the mascot, copy and CTAs of a step are read
+    // and edited together instead of as four parallel branches. `closed` keeps
+    // the confirm content: the modal is hidden, but it still renders.
+    const steps: Record<Exclude<ModalState, 'closed'>, Step> = {
+        blocked: {
+            mascot: PeanutPointing.src,
+            mascotAlt: t('pointingPeanutAlt'),
+            title: t('blockedTitle'),
+            description: t('blockedDescription', { amount: blockedAmount ?? formattedSpendableBalance }),
+            ctas: [
+                { text: t('blockedCta'), variant: 'purple', shadowSize: '4', onClick: moveMoney },
+                { text: t('blockedCancelCta'), variant: 'stroke', shadowSize: '4', onClick: close },
+            ],
         },
-        {
-            text: t('blockedCancelCta'),
-            variant: 'stroke',
-            shadowSize: '4',
-            onClick: close,
+        confirm: {
+            mascot: PeanutSad.src,
+            mascotAlt: t('sadPeanutAlt'),
+            title: t('confirmTitle'),
+            description: t('confirmDescription'),
+            ctas: [
+                {
+                    text: t('confirmCta'),
+                    variant: 'purple',
+                    shadowSize: '4',
+                    loading: isSubmitting,
+                    disabled: isSubmitting,
+                    onClick: confirmDelete,
+                },
+                { text: t('cancelCta'), variant: 'stroke', shadowSize: '4', disabled: isSubmitting, onClick: close },
+            ],
         },
-    ]
-
-    const confirmCtas: ActionModalButtonProps[] = [
-        {
-            text: t('confirmCta'),
-            variant: 'purple',
-            shadowSize: '4',
-            loading: isSubmitting,
-            disabled: isSubmitting,
-            onClick: confirmDelete,
+        done: {
+            mascot: PeanutCrying.src,
+            mascotAlt: t('cryingPeanutAlt'),
+            title: t('doneTitle'),
+            description: t('doneDescription'),
+            ctas: [{ text: t('doneCta'), variant: 'purple', shadowSize: '4', onClick: finish }],
         },
-        {
-            text: t('cancelCta'),
-            variant: 'stroke',
-            shadowSize: '4',
-            disabled: isSubmitting,
-            onClick: close,
-        },
-    ]
+    }
 
-    const doneCtas: ActionModalButtonProps[] = [
-        {
-            text: t('doneCta'),
-            variant: 'purple',
-            shadowSize: '4',
-            onClick: finish,
-        },
-    ]
-
-    const isBlocked = modalState === 'blocked'
-    const isDone = modalState === 'done'
-
-    const mascot = isBlocked
-        ? { src: PeanutPointing.src, alt: t('pointingPeanutAlt') }
-        : isDone
-          ? { src: PeanutCrying.src, alt: t('cryingPeanutAlt') }
-          : { src: PeanutSad.src, alt: t('sadPeanutAlt') }
-
-    const title = isBlocked ? t('blockedTitle') : isDone ? t('doneTitle') : t('confirmTitle')
-    const description = isBlocked
-        ? t('blockedDescription', { amount: blockedAmount ?? formattedSpendableBalance })
-        : isDone
-          ? t('doneDescription')
-          : t('confirmDescription')
+    const step = steps[modalState === 'closed' ? 'confirm' : modalState]
 
     return (
         <>
@@ -165,11 +157,11 @@ const DeleteAccountButton: FC = () => {
                 onClose={close}
                 preventClose={lockModal}
                 hideModalCloseButton={lockModal}
-                icon={<Mascot src={mascot.src} alt={mascot.alt} />}
+                icon={<Mascot src={step.mascot} alt={step.mascotAlt} />}
                 iconContainerClassName="size-32 rounded-none bg-transparent"
-                title={title}
-                description={description}
-                ctas={isBlocked ? blockedCtas : isDone ? doneCtas : confirmCtas}
+                title={step.title}
+                description={step.description}
+                ctas={step.ctas}
             />
         </>
     )

--- a/src/components/Settings/DeleteAccountButton.tsx
+++ b/src/components/Settings/DeleteAccountButton.tsx
@@ -3,15 +3,18 @@
 import { type FC, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import Image from 'next/image'
+import { useRouter } from 'next/navigation'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
-import { PeanutSad, PeanutCrying } from '@/assets/mascot'
+import { PeanutSad, PeanutCrying, PeanutPointing } from '@/assets/mascot'
 import { useToast } from '@/components/0_Bruddle/Toast'
 import ActionModal, { type ActionModalButtonProps } from '@/components/Global/ActionModal'
 import { useAuth } from '@/context/authContext'
-import { usersApi } from '@/services/users'
+import { useWallet } from '@/hooks/wallet/useWallet'
+import { AccountHasBalanceError, usersApi } from '@/services/users'
+import { DELETION_BALANCE_DUST_UNITS } from '@/utils/balance.utils'
 
-type ModalState = 'closed' | 'confirm' | 'done'
+type ModalState = 'closed' | 'blocked' | 'confirm' | 'done'
 
 // A big animated mascot at the top of the modal instead of the tiny alert icon.
 // `unoptimized` keeps the animated WebP playing (Next's optimizer flattens it).
@@ -22,18 +25,43 @@ const Mascot: FC<{ src: string; alt: string }> = ({ src, alt }) => (
 const DeleteAccountButton: FC = () => {
     const t = useTranslations('settings.deleteAccount')
     const { logoutUser } = useAuth()
+    const { spendableBalance, formattedSpendableBalance } = useWallet()
+    const router = useRouter()
     const toast = useToast()
     const [modalState, setModalState] = useState<ModalState>('closed')
     const [isSubmitting, setIsSubmitting] = useState(false)
+    // Amount to show on the blocked step. Null means "use the live wallet
+    // figure" — it is only set when the server refused a request the client had
+    // waved through (stale/unreadable local balance), and then the server's
+    // number is the one that actually blocked the deletion.
+    const [blockedAmount, setBlockedAmount] = useState<string | null>(null)
+
+    // Deletion is irreversible — login is blocked forever and there is no
+    // reactivation path — so funds left behind can never be reached again.
+    const hasFundsToMove = spendableBalance !== undefined && spendableBalance >= DELETION_BALANCE_DUST_UNITS
+
+    const block = (amount: string | null) => {
+        setBlockedAmount(amount)
+        setModalState('blocked')
+        posthog.capture(ANALYTICS_EVENTS.DELETE_ACCOUNT_BLOCKED_BALANCE)
+    }
 
     const open = () => {
-        setModalState('confirm')
         posthog.capture(ANALYTICS_EVENTS.DELETE_ACCOUNT_INITIATED)
+        // A balance that hasn't loaded yet falls through to the confirm step —
+        // the server runs the same gate and refuses on a live read.
+        if (hasFundsToMove) block(null)
+        else setModalState('confirm')
     }
 
     const close = () => {
         if (isSubmitting) return
         setModalState('closed')
+    }
+
+    const moveMoney = () => {
+        setModalState('closed')
+        router.push('/withdraw')
     }
 
     const confirmDelete = async () => {
@@ -42,9 +70,13 @@ const DeleteAccountButton: FC = () => {
         try {
             await usersApi.requestDeletion()
             setModalState('done')
-        } catch {
-            posthog.capture(ANALYTICS_EVENTS.DELETE_ACCOUNT_FAILED)
-            toast.error(t('error'))
+        } catch (error) {
+            if (error instanceof AccountHasBalanceError) {
+                block(error.balanceUsd)
+            } else {
+                posthog.capture(ANALYTICS_EVENTS.DELETE_ACCOUNT_FAILED)
+                toast.error(t('error'))
+            }
         } finally {
             setIsSubmitting(false)
         }
@@ -59,6 +91,21 @@ const DeleteAccountButton: FC = () => {
     // Once submitting (or on the final notice) the modal can't be dismissed —
     // the user must complete the flow through the CTA.
     const lockModal = isSubmitting || modalState === 'done'
+
+    const blockedCtas: ActionModalButtonProps[] = [
+        {
+            text: t('blockedCta'),
+            variant: 'purple',
+            shadowSize: '4',
+            onClick: moveMoney,
+        },
+        {
+            text: t('blockedCancelCta'),
+            variant: 'stroke',
+            shadowSize: '4',
+            onClick: close,
+        },
+    ]
 
     const confirmCtas: ActionModalButtonProps[] = [
         {
@@ -87,7 +134,21 @@ const DeleteAccountButton: FC = () => {
         },
     ]
 
+    const isBlocked = modalState === 'blocked'
     const isDone = modalState === 'done'
+
+    const mascot = isBlocked
+        ? { src: PeanutPointing.src, alt: t('pointingPeanutAlt') }
+        : isDone
+          ? { src: PeanutCrying.src, alt: t('cryingPeanutAlt') }
+          : { src: PeanutSad.src, alt: t('sadPeanutAlt') }
+
+    const title = isBlocked ? t('blockedTitle') : isDone ? t('doneTitle') : t('confirmTitle')
+    const description = isBlocked
+        ? t('blockedDescription', { amount: blockedAmount ?? formattedSpendableBalance })
+        : isDone
+          ? t('doneDescription')
+          : t('confirmDescription')
 
     return (
         <>
@@ -104,17 +165,11 @@ const DeleteAccountButton: FC = () => {
                 onClose={close}
                 preventClose={lockModal}
                 hideModalCloseButton={lockModal}
-                icon={
-                    isDone ? (
-                        <Mascot src={PeanutCrying.src} alt={t('cryingPeanutAlt')} />
-                    ) : (
-                        <Mascot src={PeanutSad.src} alt={t('sadPeanutAlt')} />
-                    )
-                }
+                icon={<Mascot src={mascot.src} alt={mascot.alt} />}
                 iconContainerClassName="size-32 rounded-none bg-transparent"
-                title={isDone ? t('doneTitle') : t('confirmTitle')}
-                description={isDone ? t('doneDescription') : t('confirmDescription')}
-                ctas={isDone ? doneCtas : confirmCtas}
+                title={title}
+                description={description}
+                ctas={isBlocked ? blockedCtas : isDone ? doneCtas : confirmCtas}
             />
         </>
     )

--- a/src/components/Settings/__tests__/DeleteAccountButton.test.tsx
+++ b/src/components/Settings/__tests__/DeleteAccountButton.test.tsx
@@ -1,13 +1,15 @@
 /**
  * DeleteAccountButton — modal state-machine tests.
- * Strategy: mock the deps (auth, toast, service, posthog, mascots) and stub
- * ActionModal to a minimal surface that renders the title + CTA buttons, so we
- * can drive confirm -> loading -> done -> logout and the error-toast branch.
+ * Strategy: mock the deps (auth, wallet, router, toast, service, posthog,
+ * mascots) and stub ActionModal to a minimal surface that renders the title +
+ * CTA buttons, so we can drive blocked / confirm -> loading -> done -> logout
+ * and the error-toast branch.
  */
 import React from 'react'
 import { render as rtlRender, screen, fireEvent, waitFor } from '@testing-library/react'
 import { IntlWrapper } from '@/test-utils/intl'
 import DeleteAccountButton from '@/components/Settings/DeleteAccountButton'
+import { AccountHasBalanceError } from '@/services/users'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: IntlWrapper })
@@ -16,12 +18,29 @@ const mockLogout = jest.fn()
 const mockToastError = jest.fn()
 const mockRequestDeletion = jest.fn()
 const mockCapture = jest.fn()
+const mockPush = jest.fn()
+// Mutated per-test to place the account above or below the deletion dust line.
+const mockWallet = { spendableBalance: 0n as bigint | undefined, formattedSpendableBalance: '0.00' }
 
 jest.mock('@/context/authContext', () => ({ useAuth: () => ({ logoutUser: mockLogout }) }))
+jest.mock('@/hooks/wallet/useWallet', () => ({ useWallet: () => mockWallet }))
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: mockPush }) }))
 jest.mock('@/components/0_Bruddle/Toast', () => ({ useToast: () => ({ error: mockToastError }) }))
-jest.mock('@/services/users', () => ({ usersApi: { requestDeletion: (...a: unknown[]) => mockRequestDeletion(...a) } }))
+jest.mock('@/services/users', () => ({
+    usersApi: { requestDeletion: (...a: unknown[]) => mockRequestDeletion(...a) },
+    AccountHasBalanceError: class AccountHasBalanceError extends Error {
+        constructor(public readonly balanceUsd: string | null) {
+            super('ACCOUNT_HAS_BALANCE')
+            this.name = 'AccountHasBalanceError'
+        }
+    },
+}))
 jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: (...a: unknown[]) => mockCapture(...a) } }))
-jest.mock('@/assets/mascot', () => ({ PeanutSad: { src: 'sad' }, PeanutCrying: { src: 'cry' } }))
+jest.mock('@/assets/mascot', () => ({
+    PeanutSad: { src: 'sad' },
+    PeanutCrying: { src: 'cry' },
+    PeanutPointing: { src: 'point' },
+}))
 jest.mock('next/image', () => ({ __esModule: true, default: () => null }))
 
 // Minimal ActionModal: render title + CTAs as buttons when visible, and surface
@@ -29,7 +48,7 @@ jest.mock('next/image', () => ({ __esModule: true, default: () => null }))
 // can assert the dismissal wiring without rendering the real modal.
 jest.mock('@/components/Global/ActionModal', () => ({
     __esModule: true,
-    default: ({ visible, title, ctas, preventClose, hideModalCloseButton }: any) =>
+    default: ({ visible, title, description, ctas, preventClose, hideModalCloseButton }: any) =>
         visible ? (
             <div
                 data-testid="modal"
@@ -37,6 +56,7 @@ jest.mock('@/components/Global/ActionModal', () => ({
                 data-hide-close={String(!!hideModalCloseButton)}
             >
                 <h1>{title}</h1>
+                <p>{description}</p>
                 {ctas?.map((c: any, i: number) => (
                     <button key={i} disabled={c.disabled} onClick={c.onClick}>
                         {c.text}
@@ -46,7 +66,11 @@ jest.mock('@/components/Global/ActionModal', () => ({
         ) : null,
 }))
 
-beforeEach(() => jest.clearAllMocks())
+beforeEach(() => {
+    jest.clearAllMocks()
+    mockWallet.spendableBalance = 0n
+    mockWallet.formattedSpendableBalance = '0.00'
+})
 
 describe('DeleteAccountButton', () => {
     it('opens the confirm modal and fires the initiated event', () => {
@@ -115,5 +139,65 @@ describe('DeleteAccountButton', () => {
 
         expect(screen.queryByText("Aw, you're leaving?")).not.toBeInTheDocument()
         expect(mockRequestDeletion).not.toHaveBeenCalled()
+    })
+
+    describe('balance gate', () => {
+        it('refuses to open the confirm step while the account holds funds', () => {
+            mockWallet.spendableBalance = 500_000_000n // $500
+            mockWallet.formattedSpendableBalance = '500.00'
+            render(<DeleteAccountButton />)
+
+            fireEvent.click(screen.getByText('Delete My Account'))
+
+            expect(screen.getByText('Move your money first')).toBeInTheDocument()
+            expect(screen.getByText(/You still have \$500\.00/)).toBeInTheDocument()
+            expect(screen.queryByText("Aw, you're leaving?")).not.toBeInTheDocument()
+            expect(mockRequestDeletion).not.toHaveBeenCalled()
+            expect(mockCapture).toHaveBeenCalledWith(ANALYTICS_EVENTS.DELETE_ACCOUNT_BLOCKED_BALANCE)
+        })
+
+        it('sends the user to the withdraw flow from the blocked step', () => {
+            mockWallet.spendableBalance = 500_000_000n
+            render(<DeleteAccountButton />)
+
+            fireEvent.click(screen.getByText('Delete My Account'))
+            fireEvent.click(screen.getByText('Move my money'))
+
+            expect(mockPush).toHaveBeenCalledWith('/withdraw')
+            expect(screen.queryByTestId('modal')).not.toBeInTheDocument()
+        })
+
+        it('lets sub-cent dust through — it can neither be shown nor withdrawn', () => {
+            mockWallet.spendableBalance = 9_999n
+            render(<DeleteAccountButton />)
+
+            fireEvent.click(screen.getByText('Delete My Account'))
+
+            expect(screen.getByText("Aw, you're leaving?")).toBeInTheDocument()
+        })
+
+        it('falls back to the confirm step while the balance is still unknown', () => {
+            mockWallet.spendableBalance = undefined
+            render(<DeleteAccountButton />)
+
+            fireEvent.click(screen.getByText('Delete My Account'))
+
+            expect(screen.getByText("Aw, you're leaving?")).toBeInTheDocument()
+        })
+
+        it('shows the blocked step with the server figure when the server refuses', async () => {
+            // Local balance says empty (stale), the server read says otherwise.
+            mockRequestDeletion.mockRejectedValueOnce(new AccountHasBalanceError('12.34'))
+            render(<DeleteAccountButton />)
+
+            fireEvent.click(screen.getByText('Delete My Account'))
+            fireEvent.click(screen.getByText('Yes, delete it'))
+
+            await waitFor(() => expect(screen.getByText('Move your money first')).toBeInTheDocument())
+            expect(screen.getByText(/You still have \$12\.34/)).toBeInTheDocument()
+            expect(mockToastError).not.toHaveBeenCalled()
+            expect(mockCapture).toHaveBeenCalledWith(ANALYTICS_EVENTS.DELETE_ACCOUNT_BLOCKED_BALANCE)
+            expect(mockCapture).not.toHaveBeenCalledWith(ANALYTICS_EVENTS.DELETE_ACCOUNT_FAILED)
+        })
     })
 })

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -285,6 +285,9 @@ export const ANALYTICS_EVENTS = {
     DELETE_ACCOUNT_INITIATED: 'delete_account_initiated',
     DELETE_ACCOUNT_CONFIRMED: 'delete_account_confirmed',
     DELETE_ACCOUNT_FAILED: 'delete_account_failed',
+    // Deletion refused because the account still holds funds — the user was sent
+    // to move the money out first.
+    DELETE_ACCOUNT_BLOCKED_BALANCE: 'delete_account_blocked_balance',
 
     // ── PWA sunset / app migration ──
     // Funnel: modal_shown(migration_download) → store_cta_clicked / qr_shown

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -427,11 +427,16 @@
             "confirmDescription": "Deleting your account is permanent. We'll switch it off right away and wipe your data within 30 days. This little guy would really rather you stayed.",
             "confirmCta": "Yes, delete it",
             "cancelCta": "Never mind, I'll stay",
+            "blockedTitle": "Move your money first",
+            "blockedDescription": "You still have ${amount} in your account. Deleting it is permanent — you can't get back in afterwards, and that money would stay out of reach. Send it to someone or withdraw it first.",
+            "blockedCta": "Move my money",
+            "blockedCancelCta": "Never mind",
             "doneTitle": "We'll miss you",
             "doneDescription": "Your account is off and your data will be gone within 30 days. Thanks for cracking open Peanut with us — take care out there!",
             "doneCta": "Goodbye",
             "error": "Could not delete your account. Please try again.",
             "sadPeanutAlt": "Sad peanut",
+            "pointingPeanutAlt": "Peanut pointing",
             "cryingPeanutAlt": "Crying peanut"
         }
     },

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -427,11 +427,16 @@
             "confirmDescription": "Eliminar tu cuenta es permanente. La desactivaremos de inmediato y borraremos tus datos en un plazo de 30 días. Este amiguito preferiría que te quedaras.",
             "confirmCta": "Sí, eliminarla",
             "cancelCta": "Mejor no, me quedo",
+            "blockedTitle": "Primero mueve tu dinero",
+            "blockedDescription": "Todavía tienes ${amount} en tu cuenta. Eliminarla es permanente: después no podrás volver a entrar y ese dinero quedaría fuera de tu alcance. Envíaselo a alguien o retíralo primero.",
+            "blockedCta": "Mover mi dinero",
+            "blockedCancelCta": "Mejor no",
             "doneTitle": "Te vamos a extrañar",
             "doneDescription": "Tu cuenta está desactivada y tus datos desaparecerán en un plazo de 30 días. Gracias por abrir Peanut con nosotros — ¡cuídate mucho!",
             "doneCta": "Adiós",
             "error": "No pudimos eliminar tu cuenta. Intenta de nuevo.",
             "sadPeanutAlt": "Peanut triste",
+            "pointingPeanutAlt": "Peanut señalando",
             "cryingPeanutAlt": "Peanut llorando"
         }
     },

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -222,6 +222,9 @@
     },
     "settings": {
         "deleteAccount": {
+            "blockedTitle": "Primero mové tu plata",
+            "blockedDescription": "Todavía tenés ${amount} en tu cuenta. Eliminarla es permanente: después no vas a poder volver a entrar y esa plata quedaría fuera de tu alcance. Mandásela a alguien o retirala primero.",
+            "blockedCta": "Mover mi plata",
             "doneDescription": "Tu cuenta está desactivada y tus datos desaparecerán en un plazo de 30 días. Gracias por abrir Peanut con nosotros — ¡cuidate mucho!",
             "error": "No pudimos eliminar tu cuenta. Intentá de nuevo."
         }

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -427,11 +427,16 @@
             "confirmDescription": "Excluir sua conta é permanente. Vamos desativá-la imediatamente e apagar seus dados em até 30 dias. Este carinha preferia que você ficasse.",
             "confirmCta": "Sim, excluir",
             "cancelCta": "Deixa pra lá, vou ficar",
+            "blockedTitle": "Primeiro tire seu dinheiro",
+            "blockedDescription": "Você ainda tem ${amount} na sua conta. Excluir é permanente: depois você não consegue mais entrar e esse dinheiro ficaria fora do seu alcance. Envie para alguém ou saque antes.",
+            "blockedCta": "Mover meu dinheiro",
+            "blockedCancelCta": "Deixa pra lá",
             "doneTitle": "Vamos sentir sua falta",
             "doneDescription": "Sua conta foi desativada e seus dados serão apagados em até 30 dias. Obrigado por abrir o Peanut com a gente — se cuida!",
             "doneCta": "Tchau",
             "error": "Não foi possível excluir sua conta. Tente de novo.",
             "sadPeanutAlt": "Peanut triste",
+            "pointingPeanutAlt": "Peanut apontando",
             "cryingPeanutAlt": "Peanut chorando"
         }
     },

--- a/src/services/__tests__/users.test.ts
+++ b/src/services/__tests__/users.test.ts
@@ -1,5 +1,5 @@
 /** @jest-environment jsdom */
-import { usersApi } from '@/services/users'
+import { AccountHasBalanceError, usersApi } from '@/services/users'
 import { serverFetch } from '@/utils/api-fetch'
 
 jest.mock('@/utils/api-fetch', () => ({
@@ -9,18 +9,51 @@ jest.mock('@/utils/api-fetch', () => ({
 
 const mockServerFetch = serverFetch as jest.MockedFunction<typeof serverFetch>
 
+const response = (init: { ok: boolean; body?: unknown }) =>
+    ({
+        ok: init.ok,
+        json: async () => {
+            if (init.body === undefined) throw new SyntaxError('Unexpected end of JSON input')
+            return init.body
+        },
+    }) as Response
+
 describe('usersApi.requestDeletion', () => {
     beforeEach(() => mockServerFetch.mockReset())
 
     it('POSTs to /users/me/delete and resolves on success', async () => {
-        mockServerFetch.mockResolvedValue({ ok: true } as Response)
+        mockServerFetch.mockResolvedValue(response({ ok: true }))
 
         await expect(usersApi.requestDeletion()).resolves.toBeUndefined()
         expect(mockServerFetch).toHaveBeenCalledWith('/users/me/delete', { method: 'POST' })
     })
 
     it('throws when the backend responds with an error', async () => {
-        mockServerFetch.mockResolvedValue({ ok: false } as Response)
+        mockServerFetch.mockResolvedValue(response({ ok: false }))
+
+        await expect(usersApi.requestDeletion()).rejects.toThrow('Failed to request account deletion')
+    })
+
+    // The balance refusal is what the delete modal branches on to show its
+    // "move your money first" step, so it must arrive as its own type carrying
+    // the server's figure — never as the generic failure.
+    it('throws AccountHasBalanceError with the balance when the account still holds funds', async () => {
+        mockServerFetch.mockResolvedValue(
+            response({ ok: false, body: { error: 'ACCOUNT_HAS_BALANCE', balanceUsd: '12.34' } })
+        )
+
+        await expect(usersApi.requestDeletion()).rejects.toBeInstanceOf(AccountHasBalanceError)
+        await expect(usersApi.requestDeletion()).rejects.toMatchObject({ balanceUsd: '12.34' })
+    })
+
+    it('tolerates a balance refusal that omits the amount', async () => {
+        mockServerFetch.mockResolvedValue(response({ ok: false, body: { error: 'ACCOUNT_HAS_BALANCE' } }))
+
+        await expect(usersApi.requestDeletion()).rejects.toMatchObject({ balanceUsd: null })
+    })
+
+    it('falls back to the generic failure for other error codes', async () => {
+        mockServerFetch.mockResolvedValue(response({ ok: false, body: { error: 'BALANCE_UNAVAILABLE' } }))
 
         await expect(usersApi.requestDeletion()).rejects.toThrow('Failed to request account deletion')
     })

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -44,6 +44,18 @@ export type ApiUser = {
     }>
 }
 
+/**
+ * Account deletion was refused because the account still holds spendable funds.
+ * `balanceUsd` is the server's live figure ("12.34"), or null if the response
+ * omitted it.
+ */
+export class AccountHasBalanceError extends Error {
+    constructor(public readonly balanceUsd: string | null) {
+        super('ACCOUNT_HAS_BALANCE')
+        this.name = 'AccountHasBalanceError'
+    }
+}
+
 export const usersApi = {
     getByUsername: async (username: string): Promise<ApiUser> => {
         const response = await serverFetch(`/users/username/${username}`, {
@@ -96,10 +108,18 @@ export const usersApi = {
     // Self-service account deletion (V1). Disables the account server-side and
     // starts the 30-day data-deletion clock. The user is taken from the JWT, so
     // there is no body — a user can only delete their own account.
+    //
+    // Rejects with AccountHasBalanceError when the account still holds funds:
+    // deletion is irreversible, so the server refuses until the money is moved
+    // out. The client gates on its own balance first; this covers the cases
+    // where the local figure was stale or had not loaded.
     requestDeletion: async (): Promise<void> => {
         const response = await serverFetch('/users/me/delete', { method: 'POST' })
-        if (!response.ok) {
-            throw new Error('Failed to request account deletion')
+        if (response.ok) return
+        const body = await response.json().catch(() => null)
+        if (body?.error === 'ACCOUNT_HAS_BALANCE') {
+            throw new AccountHasBalanceError(typeof body.balanceUsd === 'string' ? body.balanceUsd : null)
         }
+        throw new Error('Failed to request account deletion')
     },
 }

--- a/src/utils/balance.utils.ts
+++ b/src/utils/balance.utils.ts
@@ -19,6 +19,17 @@ export const parseUsdAmountToUnits = (amountUsd: string | number): bigint | null
     }
 }
 
+/**
+ * Balance at or above which self-service account deletion is refused (see
+ * `DeleteAccountButton`). Deletion is irreversible — login is blocked forever
+ * and there is no reactivation path — so anything left behind is unreachable.
+ * Sub-cent dust is exempt: it is neither displayable nor withdrawable, and
+ * trapping a user in an account they asked to delete over rounding beats losing
+ * it. Mirrors `DELETION_BALANCE_DUST_UNITS` in peanut-api-ts, which is the
+ * authoritative gate.
+ */
+export const DELETION_BALANCE_DUST_UNITS = parseUnits('0.01', PEANUT_WALLET_TOKEN_DECIMALS)
+
 export const printableUsdc = (balance: bigint): string => {
     // For 6 decimals, we want 2 decimal places in output
     // So we divide by 10^4 to keep only 2 decimal places, then format


### PR DESCRIPTION
## Problem

Settings offered **Delete My Account** identically to a user with $500 and a user with $0 — same modal, same copy, no mention of money. Deletion is irreversible (login is blocked forever server-side, no reactivation path), so any balance left behind is out of reach afterwards. One tap sequence, real money, no warning.

## Change

Gate the flow on the wallet's spendable balance (smart account + Rain collateral, via `useWallet`):

- **Funds present** → the button opens a *"Move your money first"* step showing the amount, with a CTA into `/withdraw` and a dismiss. The delete confirmation is unreachable until the balance is down to dust. Emits `delete_account_blocked_balance`.
- **Balance still loading** → falls through to the confirm step and relies on the backend's live read. `usersApi.requestDeletion` now surfaces the server's `409` as a typed `AccountHasBalanceError`, which flips the modal to the same blocked step using the server's figure — rather than the generic "try again" toast.
- **Dust / zero** → unchanged flow.

The `$0.01` floor mirrors the backend's authoritative threshold: sub-cent dust is neither displayable nor withdrawable, and trapping someone in an account they asked to delete over rounding is worse than losing it.

## Depends on

peanut-api-ts https://github.com/peanutprotocol/peanut-api-ts/pull/1394 — the server-side guard, which is what actually stops an old or patched client. This PR is the humane half; it degrades to the existing error toast if it ships first.

## Copy

New keys in `settings.deleteAccount` across en / es-419 / pt-BR, plus voseo deltas for es-AR (the new copy is imperative-heavy, so the tuteo inherited from es-419 reads wrong in AR).

## Testing

- 5 new `DeleteAccountButton` tests covering the blocked step, the `/withdraw` handoff, dust passing through, the unknown-balance fallthrough, and the server-refusal path — 10/10 green
- 186 i18n tests (catalog parity, duplicate-value drift, ICU compilation) green
- `tsc --noEmit` clean, `prettier --check` clean, `eslint` clean on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account deletion is now blocked when the wallet contains funds above the dust threshold.
  * A withdrawal option guides users to move remaining funds before deleting their account.
  * Balance-related deletion errors now display the reported amount when available.
  * Added localized messaging in English, Spanish, and Brazilian Portuguese.

* **Accessibility**
  * Added alternative text for the account-deletion illustration.

* **Analytics**
  * Added tracking for deletion attempts blocked by a remaining balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->