### PR TITLE
fix(seo): link localized pages to content owners

### DIFF
--- a/src/app/[locale]/(marketing)/help/page.tsx
+++ b/src/app/[locale]/(marketing)/help/page.tsx
@@ -3,7 +3,7 @@ import { type Metadata } from 'next'
 import { generateMetadata as metadataHelper } from '@/app/metadata'
 import { SUPPORTED_LOCALES, isValidLocale, getAlternates } from '@/i18n/config'
 import { getTranslations } from '@/i18n'
-import { readPageContentLocalized, listContentSlugs, resolveContentHref } from '@/lib/content'
+import { readPageContentLocalizedResolved, listContentSlugs } from '@/lib/content'
 import { notFound } from 'next/navigation'
 import { ContentPage } from '@/components/Marketing/ContentPage'
 import { Hero } from '@/components/Marketing/mdx/Hero'
@@ -91,11 +91,13 @@ export default async function HelpPage({ params }: PageProps) {
     const slugs = listContentSlugs('help')
     const articles = slugs
         .map((slug) => {
-            const content = readPageContentLocalized<HelpFrontmatter>('help', slug, locale)
-            if (!content || content.frontmatter.published === false) return null
+            const resolved = readPageContentLocalizedResolved<HelpFrontmatter>('help', slug, locale)
+            if (!resolved || resolved.content.frontmatter.published === false) return null
+            const { content, lang } = resolved
             return {
                 slug,
-                href: resolveContentHref(`/en/help/${encodeURIComponent(slug)}`, locale),
+                // The serving locale owns the prose, so link it directly.
+                href: `/${lang}/help/${encodeURIComponent(slug)}`,
                 title: content.frontmatter.title.replace(/\s*\|\s*Peanut Help$/, ''),
                 description: content.frontmatter.description,
                 category: content.frontmatter.category ?? 'General',

--- a/src/app/[locale]/(marketing)/help/page.tsx
+++ b/src/app/[locale]/(marketing)/help/page.tsx
@@ -3,7 +3,7 @@ import { type Metadata } from 'next'
 import { generateMetadata as metadataHelper } from '@/app/metadata'
 import { SUPPORTED_LOCALES, isValidLocale, getAlternates } from '@/i18n/config'
 import { getTranslations } from '@/i18n'
-import { readPageContentLocalized, listContentSlugs } from '@/lib/content'
+import { readPageContentLocalized, listContentSlugs, resolveContentHref } from '@/lib/content'
 import { notFound } from 'next/navigation'
 import { ContentPage } from '@/components/Marketing/ContentPage'
 import { Hero } from '@/components/Marketing/mdx/Hero'
@@ -95,12 +95,13 @@ export default async function HelpPage({ params }: PageProps) {
             if (!content || content.frontmatter.published === false) return null
             return {
                 slug,
+                href: resolveContentHref(`/en/help/${encodeURIComponent(slug)}`, locale),
                 title: content.frontmatter.title.replace(/\s*\|\s*Peanut Help$/, ''),
                 description: content.frontmatter.description,
                 category: content.frontmatter.category ?? 'General',
             }
         })
-        .filter(Boolean) as Array<{ slug: string; title: string; description: string; category: string }>
+        .filter(Boolean) as Array<{ slug: string; href: string; title: string; description: string; category: string }>
 
     // Translate category names
     const translatedArticles = articles.map((a) => ({
@@ -122,7 +123,6 @@ export default async function HelpPage({ params }: PageProps) {
                 <HelpLanding
                     articles={translatedArticles}
                     categories={categories}
-                    locale={locale}
                     strings={{
                         searchPlaceholder: i18n.searchHelpArticles,
                         cantFind: i18n.cantFindAnswer,

--- a/src/app/[locale]/(marketing)/stories/page.tsx
+++ b/src/app/[locale]/(marketing)/stories/page.tsx
@@ -5,12 +5,7 @@ import { getTranslations } from '@/i18n'
 import { notFound } from 'next/navigation'
 import { ContentPage } from '@/components/Marketing/ContentPage'
 import { Hero } from '@/components/Marketing/mdx/Hero'
-import {
-    readPageContentLocalized,
-    listPublishedSlugs,
-    resolveContentHref,
-    type ContentFrontmatter,
-} from '@/lib/content'
+import { readPageContentLocalizedResolved, listPublishedSlugs, type ContentFrontmatter } from '@/lib/content'
 import Link from 'next/link'
 
 interface PageProps {
@@ -50,15 +45,17 @@ export default async function StoriesIndexPage({ params }: PageProps) {
     const stories = slugs
         .map((slug) => {
             if (slug === 'index') return null // legacy stories/index/ directory
-            const content = readPageContentLocalized<ContentFrontmatter>('stories', slug, locale)
-            if (!content || content.frontmatter.published === false) return null
+            const resolved = readPageContentLocalizedResolved<ContentFrontmatter>('stories', slug, locale)
+            if (!resolved || resolved.content.frontmatter.published === false) return null
             return {
                 slug,
-                title: content.frontmatter.title,
-                description: content.frontmatter.description,
+                // The serving locale owns the prose, so link it directly.
+                href: `/${resolved.lang}/stories/${encodeURIComponent(slug)}`,
+                title: resolved.content.frontmatter.title,
+                description: resolved.content.frontmatter.description,
             }
         })
-        .filter(Boolean) as Array<{ slug: string; title: string; description: string }>
+        .filter(Boolean) as Array<{ slug: string; href: string; title: string; description: string }>
 
     return (
         <ContentPage
@@ -77,7 +74,7 @@ export default async function StoriesIndexPage({ params }: PageProps) {
                         {stories.map((story) => (
                             <Link
                                 key={story.slug}
-                                href={resolveContentHref(`/en/stories/${encodeURIComponent(story.slug)}`, locale)}
+                                href={story.href}
                                 className="flex flex-col gap-1.5 bg-white px-5 py-4 transition-colors hover:bg-gray-50"
                             >
                                 <span className="text-sm font-medium text-n-1">{story.title}</span>

--- a/src/app/[locale]/(marketing)/stories/page.tsx
+++ b/src/app/[locale]/(marketing)/stories/page.tsx
@@ -5,7 +5,12 @@ import { getTranslations } from '@/i18n'
 import { notFound } from 'next/navigation'
 import { ContentPage } from '@/components/Marketing/ContentPage'
 import { Hero } from '@/components/Marketing/mdx/Hero'
-import { readPageContentLocalized, listPublishedSlugs, type ContentFrontmatter } from '@/lib/content'
+import {
+    readPageContentLocalized,
+    listPublishedSlugs,
+    resolveContentHref,
+    type ContentFrontmatter,
+} from '@/lib/content'
 import Link from 'next/link'
 
 interface PageProps {
@@ -72,7 +77,7 @@ export default async function StoriesIndexPage({ params }: PageProps) {
                         {stories.map((story) => (
                             <Link
                                 key={story.slug}
-                                href={`/${locale}/stories/${encodeURIComponent(story.slug)}`}
+                                href={resolveContentHref(`/en/stories/${encodeURIComponent(story.slug)}`, locale)}
                                 className="flex flex-col gap-1.5 bg-white px-5 py-4 transition-colors hover:bg-gray-50"
                             >
                                 <span className="text-sm font-medium text-n-1">{story.title}</span>

--- a/src/app/quests/__tests__/footer.test.tsx
+++ b/src/app/quests/__tests__/footer.test.tsx
@@ -1,0 +1,16 @@
+import { Children, isValidElement, type ReactElement, type ReactNode } from 'react'
+import Footer from '@/components/LandingPage/Footer'
+import QuestsPage from '../page'
+
+jest.mock('next/font/google', () => ({
+    Roboto_Flex: () => ({ className: 'roboto-flex' }),
+}))
+
+describe('Quests footer composition', () => {
+    it('retains the server footer, including its SEO site directory', () => {
+        const page = QuestsPage() as ReactElement<{ children: ReactNode }>
+        const children = Children.toArray(page.props.children)
+
+        expect(children.some((child) => isValidElement(child) && child.type === Footer)).toBe(true)
+    })
+})

--- a/src/app/quests/page.tsx
+++ b/src/app/quests/page.tsx
@@ -13,7 +13,7 @@ import Footer from '@/components/LandingPage/Footer'
 import Manteca from '@/components/LandingPage/Manteca'
 import { QuestsHero } from './components/QuestsHero'
 import { EN_LANDING_STRINGS } from '@/components/LandingPage/landingStrings'
-import { DEFAULT_LOCALE } from '@/i18n/types'
+import { EN_LANDING_CONTENT_HREFS } from '@/components/LandingPage/landingContentHrefs'
 
 export default function QuestsPage() {
     const marqueeProps = {
@@ -67,7 +67,7 @@ export default function QuestsPage() {
             <Marquee {...marqueeProps} />
             <SendInSeconds />
             <Marquee {...marqueeProps} />
-            <NoFees locale={DEFAULT_LOCALE} strings={EN_LANDING_STRINGS} />
+            <NoFees strings={EN_LANDING_STRINGS} contentHrefs={EN_LANDING_CONTENT_HREFS} />
             <Marquee {...marqueeProps} />
             <FAQs heading={faqs.heading} questions={faqs.questions} marquee={faqs.marquee} />
             <Marquee {...marqueeProps} />

--- a/src/app/quests/page.tsx
+++ b/src/app/quests/page.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import Layout from '@/components/Global/Layout'
 import {
     DropLink,

--- a/src/app/quests/page.tsx
+++ b/src/app/quests/page.tsx
@@ -1,14 +1,8 @@
 import Layout from '@/components/Global/Layout'
-import {
-    DropLink,
-    FAQs,
-    Marquee,
-    NoFees,
-    SecurityBuiltIn,
-    SendInSeconds,
-    YourMoney,
-    RegulatedRails,
-} from '@/components/LandingPage'
+import { DropLink, FAQs, Marquee, NoFees, SendInSeconds } from '@/components/LandingPage'
+import { SecurityBuiltIn } from '@/components/LandingPage/securityBuiltIn'
+import { YourMoney } from '@/components/LandingPage/yourMoney'
+import { RegulatedRails } from '@/components/LandingPage/RegulatedRails'
 import Footer from '@/components/LandingPage/Footer'
 import Manteca from '@/components/LandingPage/Manteca'
 import { QuestsHero } from './components/QuestsHero'

--- a/src/components/LandingPage/Footer.tsx
+++ b/src/components/LandingPage/Footer.tsx
@@ -1,58 +1,8 @@
-import GITHUB_WHITE_ICON from '@/assets/icons/github-white.png'
-import PEANUT_LOGO from '@/assets/logos/peanut-logo.svg'
-import TELEGRAM_ICON from '@/assets/icons/telegram-white.svg'
-import X_ICON from '@/assets/icons/x-logo.svg'
-import Image from 'next/image'
-import Link from 'next/link'
-import handThumbsUp from '@/assets/illustrations/hand-thumbs-up.svg'
-import handWaving from '@/assets/illustrations/hand-waving.svg'
-import handPeace from '@/assets/illustrations/hand-peace.svg'
-import handMiddleFinger from '@/assets/illustrations/hand-middle-finger.svg'
 import { SEOFooter } from './SEOFooter'
-import { LocaleSwitcher } from '@/components/Marketing/LocaleSwitcher'
-import { getTranslations } from '@/i18n'
+import { FooterChrome } from './FooterChrome'
 import { DEFAULT_LOCALE, type Locale } from '@/i18n/types'
-
-const NAV_LINK = 'text-xl font-bold text-white'
-
-const SOCIALS = [
-    { href: 'https://t.me/clubpeanut', label: 'Join us on Telegram', icon: TELEGRAM_ICON, alt: 'Telegram' },
-    { href: 'https://x.com/joinpeanut', label: 'Follow us on X', icon: X_ICON, alt: 'X' },
-    { href: 'https://github.com/peanutprotocol', label: 'View our GitHub', icon: GITHUB_WHITE_ICON, alt: 'GitHub' },
-]
-
-const HandSigns = () => (
-    <section className="flex items-center gap-3">
-        <a
-            href="https://youtube.com/shorts/qd2FbzLS380?si=T5xk7xrTGYiIiWFu"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Watch Peanut teaser on YouTube (opens in a new tab)"
-        >
-            <Image src={handPeace} alt="" width={20} height={20} />
-        </a>
-        <Image src={handThumbsUp.src} alt="Hand thumbs up" width={20} height={20} />
-        <a
-            href="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Never gonna give you up (opens in a new tab)"
-        >
-            <Image src={handMiddleFinger.src} alt="Hand Middle finger" width={20} height={20} />
-        </a>
-        <Image src={handWaving.src} alt="Hand waving" width={25} height={25} />
-    </section>
-)
-
-const SocialLinks = () => (
-    <div className="flex items-center gap-4">
-        {SOCIALS.map((social) => (
-            <a key={social.href} href={social.href} target="_blank" rel="noopener noreferrer" aria-label={social.label}>
-                <Image src={social.icon} alt={social.alt} width={20} height={20} />
-            </a>
-        ))}
-    </div>
-)
+import { resolveContentHref } from '@/lib/content'
+import { EN_LANDING_CONTENT_HREFS } from './landingContentHrefs'
 
 const Footer = ({
     showSiteDirectory = true,
@@ -61,76 +11,12 @@ const Footer = ({
     showSiteDirectory?: boolean
     locale?: Locale
 }) => {
-    const i18n = getTranslations(locale)
-
     return (
         <>
-            {/* Nav on its own row rather than the brand row: the nav labels
-                change width per locale, so a single row overflowed once the
-                copy was translated. */}
-            <footer className="bg-black px-8 py-8 md:px-20">
-                <div className="mb-6 flex justify-center md:hidden">
-                    <HandSigns />
-                </div>
-                <div className="flex flex-wrap items-center justify-between gap-6">
-                    <section className="flex flex-col gap-1">
-                        {/* /lp, not /: the proxy bounces authenticated users from / into the
-                            app at /home, and the logo must keep them on the marketing site
-                            (see src/app/lp/page.tsx). Localized landings aren't in the
-                            proxy matcher, so /{locale} is already auth-proof. */}
-                        <Link href={locale === DEFAULT_LOCALE ? '/lp' : `/${locale}`} className="flex">
-                            <Image src={PEANUT_LOGO} alt="Peanut Logo" width={110} height={40} />
-                        </Link>
-                        <p className="text-xs text-white">
-                            {i18n.footerMadeWithLove}{' '}
-                            <a className="underline" href="https://squirrellabs.dev/" target="_blank" rel="noreferrer">
-                                Squirrel Labs
-                            </a>
-                        </p>
-                        <p className="text-xs text-white/70">{i18n.footerLegalEntity}</p>
-                    </section>
-
-                    <div className="hidden md:block">
-                        <SocialLinks />
-                    </div>
-                </div>
-
-                {/* Mobile only: socials and the language switcher share one row.
-                    On md+ the socials live in the brand row and the switcher in
-                    the nav row. */}
-                <div className="mt-6 flex items-center justify-between md:hidden">
-                    <SocialLinks />
-                    <LocaleSwitcher locale={locale} label={i18n.footerLanguage} />
-                </div>
-
-                <nav className="mt-8 flex flex-wrap items-center justify-between gap-6">
-                    <div className="flex flex-wrap items-center gap-6">
-                        <Link className={NAV_LINK} href="/support">
-                            {i18n.footerSupport}
-                        </Link>
-                        <Link className={NAV_LINK} href={`/${locale}/content`}>
-                            {i18n.content}
-                        </Link>
-                        <Link className={NAV_LINK} href={`/${locale}/help`}>
-                            {i18n.footerDocs}
-                        </Link>
-                        {/* Terms and Privacy deliberately live in the Legal column of
-                            the site directory below, not here — one home per document. */}
-                        <Link className={NAV_LINK} href={`/${locale}/help/security-disclosure`}>
-                            {i18n.footerSecurity}
-                        </Link>
-                        {/* /careers, not the Notion board: the page lists the open roles
-                            and keeps Notion as the application destination only. */}
-                        <Link className={NAV_LINK} href="/careers">
-                            {i18n.footerCareers}
-                        </Link>
-                    </div>
-                    <div className="hidden items-center gap-6 md:flex">
-                        <LocaleSwitcher locale={locale} label={i18n.footerLanguage} />
-                        <HandSigns />
-                    </div>
-                </nav>
-            </footer>
+            <FooterChrome
+                locale={locale}
+                securityDisclosureHref={resolveContentHref(EN_LANDING_CONTENT_HREFS.securityDisclosure, locale)}
+            />
             {showSiteDirectory && <SEOFooter locale={locale} />}
         </>
     )

--- a/src/components/LandingPage/Footer.tsx
+++ b/src/components/LandingPage/Footer.tsx
@@ -1,8 +1,7 @@
 import { SEOFooter } from './SEOFooter'
 import { FooterChrome } from './FooterChrome'
 import { DEFAULT_LOCALE, type Locale } from '@/i18n/types'
-import { resolveContentHref } from '@/lib/content'
-import { EN_LANDING_CONTENT_HREFS } from './landingContentHrefs'
+import { contentHrefsFor } from './landingContentHrefs.server'
 
 const Footer = ({
     showSiteDirectory = true,
@@ -13,10 +12,7 @@ const Footer = ({
 }) => {
     return (
         <>
-            <FooterChrome
-                locale={locale}
-                securityDisclosureHref={resolveContentHref(EN_LANDING_CONTENT_HREFS.securityDisclosure, locale)}
-            />
+            <FooterChrome locale={locale} securityDisclosureHref={contentHrefsFor(locale).securityDisclosure} />
             {showSiteDirectory && <SEOFooter locale={locale} />}
         </>
     )

--- a/src/components/LandingPage/FooterChrome.tsx
+++ b/src/components/LandingPage/FooterChrome.tsx
@@ -11,7 +11,6 @@ import handMiddleFinger from '@/assets/illustrations/hand-middle-finger.svg'
 import { LocaleSwitcher } from '@/components/Marketing/LocaleSwitcher'
 import { getTranslations } from '@/i18n'
 import { DEFAULT_LOCALE, type Locale } from '@/i18n/types'
-import { EN_LANDING_CONTENT_HREFS } from './landingContentHrefs'
 
 const NAV_LINK = 'text-xl font-bold text-white'
 
@@ -56,10 +55,10 @@ const SocialLinks = () => (
 
 export const FooterChrome = ({
     locale = DEFAULT_LOCALE,
-    securityDisclosureHref = EN_LANDING_CONTENT_HREFS.securityDisclosure,
+    securityDisclosureHref,
 }: {
     locale?: Locale
-    securityDisclosureHref?: string
+    securityDisclosureHref: string
 }) => {
     const i18n = getTranslations(locale)
 

--- a/src/components/LandingPage/FooterChrome.tsx
+++ b/src/components/LandingPage/FooterChrome.tsx
@@ -1,0 +1,132 @@
+import GITHUB_WHITE_ICON from '@/assets/icons/github-white.png'
+import PEANUT_LOGO from '@/assets/logos/peanut-logo.svg'
+import TELEGRAM_ICON from '@/assets/icons/telegram-white.svg'
+import X_ICON from '@/assets/icons/x-logo.svg'
+import Image from 'next/image'
+import Link from 'next/link'
+import handThumbsUp from '@/assets/illustrations/hand-thumbs-up.svg'
+import handWaving from '@/assets/illustrations/hand-waving.svg'
+import handPeace from '@/assets/illustrations/hand-peace.svg'
+import handMiddleFinger from '@/assets/illustrations/hand-middle-finger.svg'
+import { LocaleSwitcher } from '@/components/Marketing/LocaleSwitcher'
+import { getTranslations } from '@/i18n'
+import { DEFAULT_LOCALE, type Locale } from '@/i18n/types'
+import { EN_LANDING_CONTENT_HREFS } from './landingContentHrefs'
+
+const NAV_LINK = 'text-xl font-bold text-white'
+
+const SOCIALS = [
+    { href: 'https://t.me/clubpeanut', label: 'Join us on Telegram', icon: TELEGRAM_ICON, alt: 'Telegram' },
+    { href: 'https://x.com/joinpeanut', label: 'Follow us on X', icon: X_ICON, alt: 'X' },
+    { href: 'https://github.com/peanutprotocol', label: 'View our GitHub', icon: GITHUB_WHITE_ICON, alt: 'GitHub' },
+]
+
+const HandSigns = () => (
+    <section className="flex items-center gap-3">
+        <a
+            href="https://youtube.com/shorts/qd2FbzLS380?si=T5xk7xrTGYiIiWFu"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Watch Peanut teaser on YouTube (opens in a new tab)"
+        >
+            <Image src={handPeace} alt="" width={20} height={20} />
+        </a>
+        <Image src={handThumbsUp.src} alt="Hand thumbs up" width={20} height={20} />
+        <a
+            href="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Never gonna give you up (opens in a new tab)"
+        >
+            <Image src={handMiddleFinger.src} alt="Hand Middle finger" width={20} height={20} />
+        </a>
+        <Image src={handWaving.src} alt="Hand waving" width={25} height={25} />
+    </section>
+)
+
+const SocialLinks = () => (
+    <div className="flex items-center gap-4">
+        {SOCIALS.map((social) => (
+            <a key={social.href} href={social.href} target="_blank" rel="noopener noreferrer" aria-label={social.label}>
+                <Image src={social.icon} alt={social.alt} width={20} height={20} />
+            </a>
+        ))}
+    </div>
+)
+
+export const FooterChrome = ({
+    locale = DEFAULT_LOCALE,
+    securityDisclosureHref = EN_LANDING_CONTENT_HREFS.securityDisclosure,
+}: {
+    locale?: Locale
+    securityDisclosureHref?: string
+}) => {
+    const i18n = getTranslations(locale)
+
+    return (
+        // Nav is on its own row because translated labels have different widths.
+        <footer className="bg-black px-8 py-8 md:px-20">
+            <div className="mb-6 flex justify-center md:hidden">
+                <HandSigns />
+            </div>
+            <div className="flex flex-wrap items-center justify-between gap-6">
+                <section className="flex flex-col gap-1">
+                    {/* /lp, not /: the proxy bounces authenticated users from / into the
+                        app at /home, and the logo must keep them on the marketing site
+                        (see src/app/lp/page.tsx). Localized landings aren't in the
+                        proxy matcher, so /{locale} is already auth-proof. */}
+                    <Link href={locale === DEFAULT_LOCALE ? '/lp' : `/${locale}`} className="flex">
+                        <Image src={PEANUT_LOGO} alt="Peanut Logo" width={110} height={40} />
+                    </Link>
+                    <p className="text-xs text-white">
+                        {i18n.footerMadeWithLove}{' '}
+                        <a className="underline" href="https://squirrellabs.dev/" target="_blank" rel="noreferrer">
+                            Squirrel Labs
+                        </a>
+                    </p>
+                    <p className="text-xs text-white/70">{i18n.footerLegalEntity}</p>
+                </section>
+
+                <div className="hidden md:block">
+                    <SocialLinks />
+                </div>
+            </div>
+
+            {/* Mobile only: socials and the language switcher share one row.
+                On md+ the socials live in the brand row and the switcher in
+                the nav row. */}
+            <div className="mt-6 flex items-center justify-between md:hidden">
+                <SocialLinks />
+                <LocaleSwitcher locale={locale} label={i18n.footerLanguage} />
+            </div>
+
+            <nav className="mt-8 flex flex-wrap items-center justify-between gap-6">
+                <div className="flex flex-wrap items-center gap-6">
+                    <Link className={NAV_LINK} href="/support">
+                        {i18n.footerSupport}
+                    </Link>
+                    <Link className={NAV_LINK} href={`/${locale}/content`}>
+                        {i18n.content}
+                    </Link>
+                    <Link className={NAV_LINK} href={`/${locale}/help`}>
+                        {i18n.footerDocs}
+                    </Link>
+                    {/* Terms and Privacy deliberately live in the Legal column of
+                        the site directory, not here — one home per document. */}
+                    <Link className={NAV_LINK} href={securityDisclosureHref}>
+                        {i18n.footerSecurity}
+                    </Link>
+                    {/* /careers, not the Notion board: the page lists the open roles
+                        and keeps Notion as the application destination only. */}
+                    <Link className={NAV_LINK} href="/careers">
+                        {i18n.footerCareers}
+                    </Link>
+                </div>
+                <div className="hidden items-center gap-6 md:flex">
+                    <LocaleSwitcher locale={locale} label={i18n.footerLanguage} />
+                    <HandSigns />
+                </div>
+            </nav>
+        </footer>
+    )
+}

--- a/src/components/LandingPage/LandingPageClient.tsx
+++ b/src/components/LandingPage/LandingPageClient.tsx
@@ -18,7 +18,7 @@ import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
 import { useTranslations } from 'next-intl'
 import { onStoreAnchorClick, storeAnchorHref } from '@/utils/migration.utils'
-import { EN_LANDING_CONTENT_HREFS, type LandingContentHrefs } from './landingContentHrefs'
+import type { LandingContentHrefs } from './landingContentHrefs'
 
 // Split out: the carousel drags the whole testimonials manifest (~64 KB of
 // JSON) into whatever chunk imports it, and it renders far below the fold.
@@ -44,7 +44,7 @@ type LandingPageClientProps = {
     marqueeMessages: string[]
     locale: Locale
     strings: LandingStrings
-    contentHrefs?: LandingContentHrefs
+    contentHrefs: LandingContentHrefs
     // Server-rendered slots
     problemSlot: ReactNode
     mantecaSlot: ReactNode
@@ -61,7 +61,7 @@ export function LandingPageClient({
     marqueeMessages,
     locale,
     strings,
-    contentHrefs = EN_LANDING_CONTENT_HREFS,
+    contentHrefs,
     problemSlot,
     mantecaSlot,
     regulatedRailsSlot,
@@ -335,7 +335,7 @@ export function LandingPageClient({
                Without this boundary, the entire LandingPageClient suspends during SSR,
                sending an empty HTML shell to crawlers and killing SEO. */}
             <Suspense>
-                <NoFees locale={locale} strings={strings} contentHrefs={contentHrefs} />
+                <NoFees strings={strings} contentHrefs={contentHrefs} />
             </Suspense>
             <Marquee {...marqueeProps} />
             {yourMoneySlot}

--- a/src/components/LandingPage/LandingPageClient.tsx
+++ b/src/components/LandingPage/LandingPageClient.tsx
@@ -18,6 +18,7 @@ import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
 import { useTranslations } from 'next-intl'
 import { onStoreAnchorClick, storeAnchorHref } from '@/utils/migration.utils'
+import { EN_LANDING_CONTENT_HREFS, type LandingContentHrefs } from './landingContentHrefs'
 
 // Split out: the carousel drags the whole testimonials manifest (~64 KB of
 // JSON) into whatever chunk imports it, and it renders far below the fold.
@@ -43,6 +44,7 @@ type LandingPageClientProps = {
     marqueeMessages: string[]
     locale: Locale
     strings: LandingStrings
+    contentHrefs?: LandingContentHrefs
     // Server-rendered slots
     problemSlot: ReactNode
     mantecaSlot: ReactNode
@@ -59,6 +61,7 @@ export function LandingPageClient({
     marqueeMessages,
     locale,
     strings,
+    contentHrefs = EN_LANDING_CONTENT_HREFS,
     problemSlot,
     mantecaSlot,
     regulatedRailsSlot,
@@ -113,12 +116,12 @@ export function LandingPageClient({
         // the first has no single article behind it, the second already links
         // the help centre in its own answer.
         const learnMore: Record<string, string> = {
-            '1': `/${locale}/help/what-are-digital-dollars`,
-            '2': `/${locale}/help/verification`,
-            '3': `/${locale}/help/passkeys`,
-            '4': `/${locale}/help/security-custody`,
-            '5': `/${locale}/help/fees-pricing`,
-            [SUPPORTED_RAILS_FAQ_ID]: `/${locale}/help/supported-geographies`,
+            '1': contentHrefs.whatAreDigitalDollars,
+            '2': contentHrefs.verification,
+            '3': contentHrefs.passkeys,
+            '4': contentHrefs.securityCustody,
+            '5': contentHrefs.feesPricing,
+            [SUPPORTED_RAILS_FAQ_ID]: contentHrefs.supportedGeographies,
         }
         return faqData.questions.map((q) => ({
             ...q,
@@ -127,7 +130,7 @@ export function LandingPageClient({
                 : {}),
             ...(learnMore[q.id] ? { learnMoreHref: learnMore[q.id] } : {}),
         }))
-    }, [faqData.questions, locale, strings.supportedRails])
+    }, [contentHrefs, faqData.questions, strings.supportedRails])
 
     const [buttonVisible, setButtonVisible] = useState(true)
     const [isScrollFrozen, setIsScrollFrozen] = useState(false)
@@ -265,21 +268,21 @@ export function LandingPageClient({
     // edit there just drops out of this map and renders unlinked.
     const marqueeProps = useMemo(() => {
         const hrefs: Record<string, string> = {
-            'No transfer fees': `/${locale}/pricing`,
-            USD: `/${locale}/help/what-are-digital-dollars`,
-            EUR: `/${locale}/help/send-euros-argentina`,
-            'USDT/USDC': `/${locale}/blog/stablecoin-balance-visa-merchants`,
-            GLOBAL: `/${locale}/help/supported-geographies`,
-            'SELF-CUSTODIAL': `/${locale}/help/security-custody`,
+            'No transfer fees': contentHrefs.pricing,
+            USD: contentHrefs.whatAreDigitalDollars,
+            EUR: contentHrefs.sendEurosArgentina,
+            'USDT/USDC': contentHrefs.stablecoinBalanceVisaMerchants,
+            GLOBAL: contentHrefs.supportedGeographies,
+            'SELF-CUSTODIAL': contentHrefs.securityCustody,
             // /support is only a permanent redirect to /en/help, so linking it
             // would drop es/pt readers into English while its neighbours stay localized
-            '24/7': `/${locale}/help`,
+            '24/7': contentHrefs.help,
         }
         return {
             visible: true,
             message: marqueeMessages.map((word) => (hrefs[word] ? { label: word, href: hrefs[word] } : word)),
         }
-    }, [marqueeMessages, locale])
+    }, [contentHrefs, marqueeMessages])
 
     // Memoized for the same reason as faqQuestions above — this component
     // re-renders per scroll frame while the send button grows.
@@ -332,7 +335,7 @@ export function LandingPageClient({
                Without this boundary, the entire LandingPageClient suspends during SSR,
                sending an empty HTML shell to crawlers and killing SEO. */}
             <Suspense>
-                <NoFees locale={locale} strings={strings} />
+                <NoFees locale={locale} strings={strings} contentHrefs={contentHrefs} />
             </Suspense>
             <Marquee {...marqueeProps} />
             {yourMoneySlot}

--- a/src/components/LandingPage/LandingPageContent.tsx
+++ b/src/components/LandingPage/LandingPageContent.tsx
@@ -8,16 +8,23 @@ import { SendInSeconds } from './sendInSeconds'
 import { ProblemFold } from './ProblemFold'
 import Footer from './Footer'
 import { faqSchema } from '@/lib/seo/schemas'
-import { singletonLocaleFor } from '@/lib/content'
+import { resolveContentHref, singletonLocaleFor } from '@/lib/content'
 import { JsonLd } from '@/components/Marketing/JsonLd'
 import { getLandingContent } from '@/lib/landingContent'
 import { getTranslations } from '@/i18n'
 import { landingStrings } from './landingStrings'
 import type { Locale } from '@/i18n/types'
+import { EN_LANDING_CONTENT_HREFS, type LandingContentHrefs } from './landingContentHrefs'
 
 // Blue, not Manteca's default cream: on the homepage it follows RegulatedRails,
 // which is cream already.
 const MANTECA_BG_COLOR = '#90A8ED'
+
+function contentHrefsFor(locale: Locale): LandingContentHrefs {
+    return Object.fromEntries(
+        Object.entries(EN_LANDING_CONTENT_HREFS).map(([key, href]) => [key, resolveContentHref(href, locale)])
+    ) as unknown as LandingContentHrefs
+}
 
 // Shared body of the landing page, rendered by / (en) and by each per-locale
 // landing route. Reads the filesystem via getLandingContent, so this must stay
@@ -25,6 +32,7 @@ const MANTECA_BG_COLOR = '#90A8ED'
 export function LandingPageContent({ locale }: { locale: Locale }) {
     const { heroConfig, faqData, marqueeMessages } = getLandingContent(locale)
     const strings = landingStrings(getTranslations(locale))
+    const contentHrefs = contentHrefsFor(locale)
     // inLanguage reflects the language the FAQ prose actually resolved to —
     // until mono ships landing translations, that's English on every locale.
     const faqJsonLd = faqSchema(
@@ -45,11 +53,12 @@ export function LandingPageContent({ locale }: { locale: Locale }) {
                     marqueeMessages={marqueeMessages}
                     locale={locale}
                     strings={strings}
+                    contentHrefs={contentHrefs}
                     problemSlot={<ProblemFold strings={strings} />}
                     mantecaSlot={<Manteca locale={locale} backgroundColor={MANTECA_BG_COLOR} />}
-                    regulatedRailsSlot={<RegulatedRails locale={locale} />}
-                    yourMoneySlot={<YourMoney locale={locale} />}
-                    securitySlot={<SecurityBuiltIn locale={locale} />}
+                    regulatedRailsSlot={<RegulatedRails locale={locale} contentHrefs={contentHrefs} />}
+                    yourMoneySlot={<YourMoney locale={locale} contentHrefs={contentHrefs} />}
+                    securitySlot={<SecurityBuiltIn locale={locale} contentHrefs={contentHrefs} />}
                     sendInSecondsSlot={<SendInSeconds locale={locale} />}
                     footerSlot={<Footer locale={locale} />}
                 />

--- a/src/components/LandingPage/LandingPageContent.tsx
+++ b/src/components/LandingPage/LandingPageContent.tsx
@@ -8,23 +8,17 @@ import { SendInSeconds } from './sendInSeconds'
 import { ProblemFold } from './ProblemFold'
 import Footer from './Footer'
 import { faqSchema } from '@/lib/seo/schemas'
-import { resolveContentHref, singletonLocaleFor } from '@/lib/content'
+import { singletonLocaleFor } from '@/lib/content'
 import { JsonLd } from '@/components/Marketing/JsonLd'
 import { getLandingContent } from '@/lib/landingContent'
 import { getTranslations } from '@/i18n'
 import { landingStrings } from './landingStrings'
 import type { Locale } from '@/i18n/types'
-import { EN_LANDING_CONTENT_HREFS, type LandingContentHrefs } from './landingContentHrefs'
+import { contentHrefsFor } from './landingContentHrefs.server'
 
 // Blue, not Manteca's default cream: on the homepage it follows RegulatedRails,
 // which is cream already.
 const MANTECA_BG_COLOR = '#90A8ED'
-
-function contentHrefsFor(locale: Locale): LandingContentHrefs {
-    return Object.fromEntries(
-        Object.entries(EN_LANDING_CONTENT_HREFS).map(([key, href]) => [key, resolveContentHref(href, locale)])
-    ) as unknown as LandingContentHrefs
-}
 
 // Shared body of the landing page, rendered by / (en) and by each per-locale
 // landing route. Reads the filesystem via getLandingContent, so this must stay
@@ -56,9 +50,9 @@ export function LandingPageContent({ locale }: { locale: Locale }) {
                     contentHrefs={contentHrefs}
                     problemSlot={<ProblemFold strings={strings} />}
                     mantecaSlot={<Manteca locale={locale} backgroundColor={MANTECA_BG_COLOR} />}
-                    regulatedRailsSlot={<RegulatedRails locale={locale} contentHrefs={contentHrefs} />}
-                    yourMoneySlot={<YourMoney locale={locale} contentHrefs={contentHrefs} />}
-                    securitySlot={<SecurityBuiltIn locale={locale} contentHrefs={contentHrefs} />}
+                    regulatedRailsSlot={<RegulatedRails locale={locale} />}
+                    yourMoneySlot={<YourMoney locale={locale} />}
+                    securitySlot={<SecurityBuiltIn locale={locale} />}
                     sendInSecondsSlot={<SendInSeconds locale={locale} />}
                     footerSlot={<Footer locale={locale} />}
                 />

--- a/src/components/LandingPage/RegulatedRails.tsx
+++ b/src/components/LandingPage/RegulatedRails.tsx
@@ -15,7 +15,8 @@ import { CloudsCss } from './CloudsCss'
 import { AnimateOnView } from '@/components/Global/AnimateOnView'
 import { getTranslations } from '@/i18n'
 import { DEFAULT_LOCALE, type Locale } from '@/i18n/types'
-import { EN_LANDING_CONTENT_HREFS, type LandingContentHrefs, type LandingContentHrefKey } from './landingContentHrefs'
+import type { LandingContentHrefKey } from './landingContentHrefs'
+import { contentHrefsFor } from './landingContentHrefs.server'
 
 const bgColor = '#F9F4F0'
 
@@ -55,14 +56,9 @@ const regulatedRailsClouds = [
     { top: '60%', width: 220, speed: '34s', direction: 'rtl' as const },
 ]
 
-export function RegulatedRails({
-    locale = DEFAULT_LOCALE,
-    contentHrefs = EN_LANDING_CONTENT_HREFS,
-}: {
-    locale?: Locale
-    contentHrefs?: LandingContentHrefs
-}) {
+export function RegulatedRails({ locale = DEFAULT_LOCALE }: { locale?: Locale }) {
     const i18n = getTranslations(locale)
+    const contentHrefs = contentHrefsFor(locale)
 
     return (
         <section

--- a/src/components/LandingPage/RegulatedRails.tsx
+++ b/src/components/LandingPage/RegulatedRails.tsx
@@ -15,27 +15,33 @@ import { CloudsCss } from './CloudsCss'
 import { AnimateOnView } from '@/components/Global/AnimateOnView'
 import { getTranslations } from '@/i18n'
 import { DEFAULT_LOCALE, type Locale } from '@/i18n/types'
+import { EN_LANDING_CONTENT_HREFS, type LandingContentHrefs, type LandingContentHrefKey } from './landingContentHrefs'
 
 const bgColor = '#F9F4F0'
 
 /**
- * `path` is the locale-prefixed page that honestly explains what this partner
- * does with Peanut. A logo with nothing truthful to point at stays unlinked —
- * Brubank and Stripe have no article covering their rail, so they do.
+ * `hrefKey` selects the server-resolved page that honestly explains what this
+ * partner does with Peanut. A logo with nothing truthful to point at stays
+ * unlinked — Brubank and Stripe have no article covering their rail, so they do.
  *
  * `onWhite` gives a logo a white card behind it: these two are the only marks
  * in the set that are not a heavy wordmark, and they disappear on the pink.
  */
-const logos = [
-    { logo: BBVA_ICON, alt: 'BBVA', path: 'help/deposit-bank' },
+const logos: Array<{
+    logo: typeof BBVA_ICON
+    alt: string
+    hrefKey?: LandingContentHrefKey
+    onWhite?: boolean
+}> = [
+    { logo: BBVA_ICON, alt: 'BBVA', hrefKey: 'depositBank' },
     { logo: BRUBANK_ICON, alt: 'Brubank' },
-    { logo: N26_ICON, alt: 'N26', path: 'help/deposit-bank' },
-    { logo: SANTANDER_ICON, alt: 'Santander', path: 'help/deposit-bank' },
-    { logo: REVOLUT_ICON, alt: 'Revolut', path: 'compare/peanut-vs-revolut' },
+    { logo: N26_ICON, alt: 'N26', hrefKey: 'depositBank' },
+    { logo: SANTANDER_ICON, alt: 'Santander', hrefKey: 'depositBank' },
+    { logo: REVOLUT_ICON, alt: 'Revolut', hrefKey: 'revolutComparison' },
     { logo: STRIPE_ICON, alt: 'Stripe' },
-    { logo: MERCADO_PAGO_ICON, alt: 'Mercado Pago', path: 'help/mercadopago-qr', onWhite: true },
-    { logo: PIX_ICON, alt: 'PIX', path: 'brazil', onWhite: true },
-    { logo: WISE_ICON, alt: 'Wise', path: 'compare/peanut-vs-wise' },
+    { logo: MERCADO_PAGO_ICON, alt: 'Mercado Pago', hrefKey: 'mercadoPagoQr', onWhite: true },
+    { logo: PIX_ICON, alt: 'PIX', hrefKey: 'brazil', onWhite: true },
+    { logo: WISE_ICON, alt: 'Wise', hrefKey: 'wiseComparison' },
 ]
 
 // my-2, not mb-2: react-fast-marquee's container is overflow-x:hidden, which
@@ -49,7 +55,13 @@ const regulatedRailsClouds = [
     { top: '60%', width: 220, speed: '34s', direction: 'rtl' as const },
 ]
 
-export function RegulatedRails({ locale = DEFAULT_LOCALE }: { locale?: Locale }) {
+export function RegulatedRails({
+    locale = DEFAULT_LOCALE,
+    contentHrefs = EN_LANDING_CONTENT_HREFS,
+}: {
+    locale?: Locale
+    contentHrefs?: LandingContentHrefs
+}) {
     const i18n = getTranslations(locale)
 
     return (
@@ -80,7 +92,7 @@ export function RegulatedRails({ locale = DEFAULT_LOCALE }: { locale?: Locale })
                     audit alike. */}
                 <p className="font-roboto-flex mt-3 text-right text-xs md:text-lg">
                     <a
-                        href={`/${locale}/help/supported-geographies`}
+                        href={contentHrefs.supportedGeographies}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="text-n-1 underline"
@@ -106,8 +118,8 @@ export function RegulatedRails({ locale = DEFAULT_LOCALE }: { locale?: Locale })
                                 className={logo.onWhite ? 'rounded-sm border border-n-1 bg-white px-3 py-2' : ''}
                             />
                         )
-                        return logo.path ? (
-                            <Link key={logo.alt} href={`/${locale}/${logo.path}`} className={linkedTileClass}>
+                        return logo.hrefKey ? (
+                            <Link key={logo.alt} href={contentHrefs[logo.hrefKey]} className={linkedTileClass}>
                                 {mark}
                             </Link>
                         ) : (

--- a/src/components/LandingPage/SEOFooter.tsx
+++ b/src/components/LandingPage/SEOFooter.tsx
@@ -2,21 +2,17 @@ import Link from 'next/link'
 import manifest from '@/content/generated/footer-manifest.json'
 import { getTranslations, t } from '@/i18n'
 import { DEFAULT_LOCALE, type Locale, type Translations } from '@/i18n/types'
+import { resolveContentHref } from '@/lib/content'
 
-// SEO footer driven by the content manifest (peanut-content/generated/footer-manifest.json).
-// Data is imported as a JSON module — works in both client and server components
-// without fs. The manifest is bundled at build time by webpack.
+// Server-only SEO footer driven by the content manifest
+// (peanut-content/generated/footer-manifest.json). The manifest is bundled at
+// build time, while locale ownership is resolved against the content mirror.
 
 interface ManifestEntry {
     slug: string
     name: string
     href: string
     external?: boolean
-}
-
-function localizeHref(href: string, locale: Locale): string {
-    if (href.startsWith('/en/')) return `/${locale}/${href.slice(4)}`
-    return href
 }
 
 function FooterSection({ title, children }: { title: string; children: React.ReactNode }) {
@@ -41,9 +37,8 @@ const RESOURCES_MOVED_ELSEWHERE = new Set(['terms', 'jobs'])
  * that bind all users first, then the card-programme docs. Card applicants see
  * these inline at signing time (CardTermsScreen), but app-store review and the
  * issuer both expect them permanently reachable, which is what this column is.
- * Hrefs are authored `/en/…` and localized by `localizeHref` like the manifest
- * entries; the marketing pages fall back to English prose when a translation
- * is missing, so a localized URL is always safe.
+ * Hrefs are authored `/en/…`. The content resolver localizes translated prose
+ * and keeps missing translations on the locale that owns them.
  */
 const LEGAL_LINKS: Array<{ slug: string; href: string; label: (i18n: Translations) => string }> = [
     { slug: 'terms', href: '/en/terms', label: (i18n) => i18n.footerTerms },
@@ -99,7 +94,7 @@ export function SEOFooter({ locale = DEFAULT_LOCALE }: { locale?: Locale } = {})
     // itself is gone, its slot in the 4-up grid taken by Legal.
     const learnMoreResources = resources.filter((entry) => !RESOURCES_MOVED_ELSEWHERE.has(entry.slug))
 
-    const link = (entry: ManifestEntry) => (entry.external ? entry.href : localizeHref(entry.href, locale))
+    const link = (entry: ManifestEntry) => (entry.external ? entry.href : resolveContentHref(entry.href, locale))
 
     return (
         <nav aria-label={i18n.footerSiteDirectory} className="bg-black px-8 py-8 pb-24 md:px-20 md:pb-8">
@@ -146,7 +141,7 @@ export function SEOFooter({ locale = DEFAULT_LOCALE }: { locale?: Locale } = {})
 
                 <FooterSection title={i18n.footerLegalSection}>
                     {LEGAL_LINKS.map((entry) => (
-                        <FooterLink key={entry.slug} href={localizeHref(entry.href, locale)}>
+                        <FooterLink key={entry.slug} href={resolveContentHref(entry.href, locale)}>
                             {entry.label(i18n)}
                         </FooterLink>
                     ))}

--- a/src/components/LandingPage/__tests__/SEOFooter.test.tsx
+++ b/src/components/LandingPage/__tests__/SEOFooter.test.tsx
@@ -1,0 +1,32 @@
+import { render } from '@testing-library/react'
+import { resolveContentHref } from '@/lib/content'
+import { SEOFooter } from '../SEOFooter'
+
+describe('SEOFooter locale ownership', () => {
+    it('does not emit fallback-only es-ar links', () => {
+        const { container } = render(<SEOFooter locale="es-ar" />)
+        const hrefs = [...container.querySelectorAll<HTMLAnchorElement>('a[href]')].map((link) =>
+            link.getAttribute('href')
+        )
+
+        const fallbackOnly = hrefs.filter(
+            (href): href is string => href?.startsWith('/es-ar/') === true && resolveContentHref(href, 'es-ar') !== href
+        )
+
+        expect(fallbackOnly).toEqual([])
+        expect(hrefs).toContain('/es-419/pricing')
+        expect(hrefs).toContain('/en/card-terms-us')
+        expect(hrefs).not.toContain('/es-ar/pricing')
+        expect(hrefs).not.toContain('/es-ar/card-terms-us')
+    })
+
+    it('keeps links whose prose is owned by es-ar', () => {
+        const { container } = render(<SEOFooter locale="es-ar" />)
+        const hrefs = [...container.querySelectorAll<HTMLAnchorElement>('a[href]')].map((link) =>
+            link.getAttribute('href')
+        )
+
+        expect(hrefs).toContain('/es-ar/send-money-to/argentina')
+        expect(hrefs).toContain('/es-ar/compare/peanut-vs-wise')
+    })
+})

--- a/src/components/LandingPage/__tests__/landingContentHrefs.test.ts
+++ b/src/components/LandingPage/__tests__/landingContentHrefs.test.ts
@@ -1,11 +1,6 @@
 import { resolveContentHref } from '@/lib/content'
-import { EN_LANDING_CONTENT_HREFS, type LandingContentHrefKey, type LandingContentHrefs } from '../landingContentHrefs'
-
-function resolveHomepageHrefs(locale: 'en' | 'es-ar'): LandingContentHrefs {
-    return Object.fromEntries(
-        Object.entries(EN_LANDING_CONTENT_HREFS).map(([key, href]) => [key, resolveContentHref(href, locale)])
-    ) as unknown as LandingContentHrefs
-}
+import { EN_LANDING_CONTENT_HREFS, type LandingContentHrefKey } from '../landingContentHrefs'
+import { contentHrefsFor } from '../landingContentHrefs.server'
 
 describe('landing content href overrides', () => {
     it('provides canonical English defaults for client-only consumers', () => {
@@ -16,7 +11,7 @@ describe('landing content href overrides', () => {
     })
 
     it('resolves every es-ar homepage content link to its exact owner', () => {
-        const hrefs = resolveHomepageHrefs('es-ar')
+        const hrefs = contentHrefsFor('es-ar')
         const expected: Record<LandingContentHrefKey, string> = {
             pricing: '/es-419/pricing',
             whatAreDigitalDollars: '/es-419/help/what-are-digital-dollars',

--- a/src/components/LandingPage/__tests__/landingContentHrefs.test.ts
+++ b/src/components/LandingPage/__tests__/landingContentHrefs.test.ts
@@ -1,0 +1,49 @@
+import { resolveContentHref } from '@/lib/content'
+import { EN_LANDING_CONTENT_HREFS, type LandingContentHrefKey, type LandingContentHrefs } from '../landingContentHrefs'
+
+function resolveHomepageHrefs(locale: 'en' | 'es-ar'): LandingContentHrefs {
+    return Object.fromEntries(
+        Object.entries(EN_LANDING_CONTENT_HREFS).map(([key, href]) => [key, resolveContentHref(href, locale)])
+    ) as unknown as LandingContentHrefs
+}
+
+describe('landing content href overrides', () => {
+    it('provides canonical English defaults for client-only consumers', () => {
+        for (const href of Object.values(EN_LANDING_CONTENT_HREFS)) {
+            expect(href).toMatch(/^\/en\//)
+            expect(resolveContentHref(href, 'en')).toBe(href)
+        }
+    })
+
+    it('resolves every es-ar homepage content link to its exact owner', () => {
+        const hrefs = resolveHomepageHrefs('es-ar')
+        const expected: Record<LandingContentHrefKey, string> = {
+            pricing: '/es-419/pricing',
+            whatAreDigitalDollars: '/es-419/help/what-are-digital-dollars',
+            verification: '/es-419/help/verification',
+            passkeys: '/es-419/help/passkeys',
+            securityCustody: '/es-419/help/security-custody',
+            feesPricing: '/es-419/help/fees-pricing',
+            supportedGeographies: '/es-419/help/supported-geographies',
+            sendEurosArgentina: '/es-419/help/send-euros-argentina',
+            stablecoinBalanceVisaMerchants: '/en/blog/stablecoin-balance-visa-merchants',
+            help: '/es-ar/help',
+            depositBank: '/es-419/help/deposit-bank',
+            revolutComparison: '/es-419/compare/peanut-vs-revolut',
+            mercadoPagoQr: '/es-ar/help/mercadopago-qr',
+            brazil: '/es-ar/brazil',
+            wiseComparison: '/es-ar/compare/peanut-vs-wise',
+            unitedStates: '/es-419/united-states',
+            spain: '/es-419/spain',
+            mexico: '/es-419/mexico',
+            paypalComparison: '/es-419/compare/peanut-vs-paypal',
+            westernUnionComparison: '/es-419/compare/peanut-vs-western-union',
+            securityDisclosure: '/es-419/help/security-disclosure',
+        }
+
+        expect(hrefs).toEqual(expected)
+        for (const href of Object.values(hrefs)) {
+            expect(resolveContentHref(href, 'es-ar')).toBe(href)
+        }
+    })
+})

--- a/src/components/LandingPage/index.ts
+++ b/src/components/LandingPage/index.ts
@@ -1,9 +1,9 @@
+// Client-safe barrel. RegulatedRails, SecurityBuiltIn and YourMoney resolve
+// content hrefs from the filesystem, so they are imported directly by server
+// components instead of re-exported here.
 export * from './dropLink'
 export * from './faq'
 export * from './hero'
 export * from './marquee'
 export * from './noFees'
-export * from './securityBuiltIn'
 export * from './sendInSeconds'
-export * from './yourMoney'
-export * from './RegulatedRails'

--- a/src/components/LandingPage/landingContentHrefs.server.ts
+++ b/src/components/LandingPage/landingContentHrefs.server.ts
@@ -1,0 +1,20 @@
+import { resolveContentHref } from '@/lib/content'
+import type { Locale } from '@/i18n/types'
+import { EN_LANDING_CONTENT_HREFS, type LandingContentHrefs } from './landingContentHrefs'
+
+const isDev = process.env.NODE_ENV === 'development'
+
+const hrefsCache = new Map<Locale, LandingContentHrefs>()
+
+/** Homepage content links resolved to their owner locale. Server-only: reads the content mirror. */
+export function contentHrefsFor(locale: Locale): LandingContentHrefs {
+    if (!isDev) {
+        const cached = hrefsCache.get(locale)
+        if (cached) return cached
+    }
+    const resolved = Object.fromEntries(
+        Object.entries(EN_LANDING_CONTENT_HREFS).map(([key, href]) => [key, resolveContentHref(href, locale)])
+    ) as LandingContentHrefs
+    hrefsCache.set(locale, resolved)
+    return resolved
+}

--- a/src/components/LandingPage/landingContentHrefs.ts
+++ b/src/components/LandingPage/landingContentHrefs.ts
@@ -1,0 +1,55 @@
+/**
+ * Canonical English defaults for homepage content links. Client-reachable
+ * landing components use these when rendered outside the server-composed
+ * homepage (currently /quests). LandingPageContent replaces every value with
+ * the exact locale owner before passing the map across the server boundary.
+ */
+export interface LandingContentHrefs {
+    pricing: string
+    whatAreDigitalDollars: string
+    verification: string
+    passkeys: string
+    securityCustody: string
+    feesPricing: string
+    supportedGeographies: string
+    sendEurosArgentina: string
+    stablecoinBalanceVisaMerchants: string
+    help: string
+    depositBank: string
+    revolutComparison: string
+    mercadoPagoQr: string
+    brazil: string
+    wiseComparison: string
+    unitedStates: string
+    spain: string
+    mexico: string
+    paypalComparison: string
+    westernUnionComparison: string
+    securityDisclosure: string
+}
+
+export type LandingContentHrefKey = keyof LandingContentHrefs
+
+export const EN_LANDING_CONTENT_HREFS: LandingContentHrefs = {
+    pricing: '/en/pricing',
+    whatAreDigitalDollars: '/en/help/what-are-digital-dollars',
+    verification: '/en/help/verification',
+    passkeys: '/en/help/passkeys',
+    securityCustody: '/en/help/security-custody',
+    feesPricing: '/en/help/fees-pricing',
+    supportedGeographies: '/en/help/supported-geographies',
+    sendEurosArgentina: '/en/help/send-euros-argentina',
+    stablecoinBalanceVisaMerchants: '/en/blog/stablecoin-balance-visa-merchants',
+    help: '/en/help',
+    depositBank: '/en/help/deposit-bank',
+    revolutComparison: '/en/compare/peanut-vs-revolut',
+    mercadoPagoQr: '/en/help/mercadopago-qr',
+    brazil: '/en/brazil',
+    wiseComparison: '/en/compare/peanut-vs-wise',
+    unitedStates: '/en/united-states',
+    spain: '/en/spain',
+    mexico: '/en/mexico',
+    paypalComparison: '/en/compare/peanut-vs-paypal',
+    westernUnionComparison: '/en/compare/peanut-vs-western-union',
+    securityDisclosure: '/en/help/security-disclosure',
+}

--- a/src/components/LandingPage/landingContentHrefs.ts
+++ b/src/components/LandingPage/landingContentHrefs.ts
@@ -1,36 +1,10 @@
 /**
- * Canonical English defaults for homepage content links. Client-reachable
- * landing components use these when rendered outside the server-composed
- * homepage (currently /quests). LandingPageContent replaces every value with
- * the exact locale owner before passing the map across the server boundary.
+ * Canonical English homepage content links. Server components resolve these to
+ * their locale owner via contentHrefsFor (landingContentHrefs.server.ts);
+ * client-reachable consumers receive the resolved map as a prop, or this map
+ * verbatim on English-only pages (currently /quests).
  */
-export interface LandingContentHrefs {
-    pricing: string
-    whatAreDigitalDollars: string
-    verification: string
-    passkeys: string
-    securityCustody: string
-    feesPricing: string
-    supportedGeographies: string
-    sendEurosArgentina: string
-    stablecoinBalanceVisaMerchants: string
-    help: string
-    depositBank: string
-    revolutComparison: string
-    mercadoPagoQr: string
-    brazil: string
-    wiseComparison: string
-    unitedStates: string
-    spain: string
-    mexico: string
-    paypalComparison: string
-    westernUnionComparison: string
-    securityDisclosure: string
-}
-
-export type LandingContentHrefKey = keyof LandingContentHrefs
-
-export const EN_LANDING_CONTENT_HREFS: LandingContentHrefs = {
+export const EN_LANDING_CONTENT_HREFS = {
     pricing: '/en/pricing',
     whatAreDigitalDollars: '/en/help/what-are-digital-dollars',
     verification: '/en/help/verification',
@@ -53,3 +27,7 @@ export const EN_LANDING_CONTENT_HREFS: LandingContentHrefs = {
     westernUnionComparison: '/en/compare/peanut-vs-western-union',
     securityDisclosure: '/en/help/security-disclosure',
 }
+
+export type LandingContentHrefs = Record<keyof typeof EN_LANDING_CONTENT_HREFS, string>
+
+export type LandingContentHrefKey = keyof LandingContentHrefs

--- a/src/components/LandingPage/noFees.tsx
+++ b/src/components/LandingPage/noFees.tsx
@@ -15,18 +15,16 @@ import { useAuth } from '@/context/authContext'
 import { twMerge } from 'tailwind-merge'
 import { ContextualLinks } from './ContextualLinks'
 import type { LandingStrings } from './landingStrings'
-import type { Locale } from '@/i18n/types'
-import { EN_LANDING_CONTENT_HREFS, type LandingContentHrefs } from './landingContentHrefs'
+import type { LandingContentHrefs } from './landingContentHrefs'
 
 export function NoFees({
     className,
     strings,
-    contentHrefs = EN_LANDING_CONTENT_HREFS,
+    contentHrefs,
 }: {
     className?: string
-    locale: Locale
     strings: LandingStrings
-    contentHrefs?: LandingContentHrefs
+    contentHrefs: LandingContentHrefs
 }) {
     const [screenWidth, setScreenWidth] = useState(typeof window !== 'undefined' ? window.innerWidth : 1200)
     const router = useRouter()

--- a/src/components/LandingPage/noFees.tsx
+++ b/src/components/LandingPage/noFees.tsx
@@ -16,15 +16,17 @@ import { twMerge } from 'tailwind-merge'
 import { ContextualLinks } from './ContextualLinks'
 import type { LandingStrings } from './landingStrings'
 import type { Locale } from '@/i18n/types'
+import { EN_LANDING_CONTENT_HREFS, type LandingContentHrefs } from './landingContentHrefs'
 
 export function NoFees({
     className,
-    locale,
     strings,
+    contentHrefs = EN_LANDING_CONTENT_HREFS,
 }: {
     className?: string
     locale: Locale
     strings: LandingStrings
+    contentHrefs?: LandingContentHrefs
 }) {
     const [screenWidth, setScreenWidth] = useState(typeof window !== 'undefined' ? window.innerWidth : 1200)
     const router = useRouter()
@@ -177,9 +179,9 @@ export function NoFees({
                     links={[
                         // the route is `peanut-vs-<slug>` — generateStaticParams builds
                         // no bare-slug page, so the short form 404s
-                        { label: 'Wise', href: `/${locale}/compare/peanut-vs-wise` },
-                        { label: 'PayPal', href: `/${locale}/compare/peanut-vs-paypal` },
-                        { label: 'Western Union', href: `/${locale}/compare/peanut-vs-western-union` },
+                        { label: 'Wise', href: contentHrefs.wiseComparison },
+                        { label: 'PayPal', href: contentHrefs.paypalComparison },
+                        { label: 'Western Union', href: contentHrefs.westernUnionComparison },
                     ]}
                 />
             </div>

--- a/src/components/LandingPage/securityBuiltIn.tsx
+++ b/src/components/LandingPage/securityBuiltIn.tsx
@@ -9,7 +9,8 @@ import selfCustodialDesign from '@/assets/illustrations/self-custodial-design.sv
 import kycOnlyWhenRequired from '@/assets/illustrations/kyc-only-when-required.svg'
 import { getTranslations } from '@/i18n'
 import { DEFAULT_LOCALE, type Locale, type Translations } from '@/i18n/types'
-import { EN_LANDING_CONTENT_HREFS, type LandingContentHrefs } from './landingContentHrefs'
+import type { LandingContentHrefs } from './landingContentHrefs'
+import { contentHrefsFor } from './landingContentHrefs.server'
 
 interface Feature {
     id: number
@@ -52,15 +53,9 @@ function buildFeatures(i18n: Translations, contentHrefs: LandingContentHrefs): F
     ]
 }
 
-export function SecurityBuiltIn({
-    locale = DEFAULT_LOCALE,
-    contentHrefs = EN_LANDING_CONTENT_HREFS,
-}: {
-    locale?: Locale
-    contentHrefs?: LandingContentHrefs
-}) {
+export function SecurityBuiltIn({ locale = DEFAULT_LOCALE }: { locale?: Locale }) {
     const i18n = getTranslations(locale)
-    const features = buildFeatures(i18n, contentHrefs)
+    const features = buildFeatures(i18n, contentHrefsFor(locale))
 
     return (
         <section id="security" className="bg-primary-1 px-4 py-16 text-n-1 md:py-40">

--- a/src/components/LandingPage/securityBuiltIn.tsx
+++ b/src/components/LandingPage/securityBuiltIn.tsx
@@ -9,6 +9,7 @@ import selfCustodialDesign from '@/assets/illustrations/self-custodial-design.sv
 import kycOnlyWhenRequired from '@/assets/illustrations/kyc-only-when-required.svg'
 import { getTranslations } from '@/i18n'
 import { DEFAULT_LOCALE, type Locale, type Translations } from '@/i18n/types'
+import { EN_LANDING_CONTENT_HREFS, type LandingContentHrefs } from './landingContentHrefs'
 
 interface Feature {
     id: number
@@ -20,7 +21,7 @@ interface Feature {
     learnMoreHref?: string
 }
 
-function buildFeatures(i18n: Translations, locale: Locale): Feature[] {
+function buildFeatures(i18n: Translations, contentHrefs: LandingContentHrefs): Feature[] {
     return [
         {
             id: 1,
@@ -29,7 +30,7 @@ function buildFeatures(i18n: Translations, locale: Locale): Feature[] {
             description: i18n.landingSecurityTotalDesc,
             iconSrc: handThumbsUp,
             iconAlt: 'Thumbs up',
-            learnMoreHref: `/${locale}/help/passkeys`,
+            learnMoreHref: contentHrefs.passkeys,
         },
         {
             id: 2,
@@ -38,7 +39,7 @@ function buildFeatures(i18n: Translations, locale: Locale): Feature[] {
             description: i18n.landingSecurityControlDesc,
             iconSrc: handWaving,
             iconAlt: 'Hand waving',
-            learnMoreHref: `/${locale}/help/verification`,
+            learnMoreHref: contentHrefs.verification,
         },
         {
             id: 3,
@@ -51,9 +52,15 @@ function buildFeatures(i18n: Translations, locale: Locale): Feature[] {
     ]
 }
 
-export function SecurityBuiltIn({ locale = DEFAULT_LOCALE }: { locale?: Locale }) {
+export function SecurityBuiltIn({
+    locale = DEFAULT_LOCALE,
+    contentHrefs = EN_LANDING_CONTENT_HREFS,
+}: {
+    locale?: Locale
+    contentHrefs?: LandingContentHrefs
+}) {
     const i18n = getTranslations(locale)
-    const features = buildFeatures(i18n, locale)
+    const features = buildFeatures(i18n, contentHrefs)
 
     return (
         <section id="security" className="bg-primary-1 px-4 py-16 text-n-1 md:py-40">

--- a/src/components/LandingPage/yourMoney.tsx
+++ b/src/components/LandingPage/yourMoney.tsx
@@ -5,7 +5,8 @@ import { Button } from '@/components/0_Bruddle/Button'
 import { getTranslations } from '@/i18n'
 import { DEFAULT_LOCALE, type Locale } from '@/i18n/types'
 import { linkTerms, type LinkedTerm } from './landingLinks.utils'
-import { EN_LANDING_CONTENT_HREFS, type LandingContentHrefs } from './landingContentHrefs'
+import type { LandingContentHrefs } from './landingContentHrefs'
+import { contentHrefsFor } from './landingContentHrefs.server'
 
 // The three cities named in landingGlobalCashBody, each pointing at its country
 // page. Aliases cover every spelling the catalogs use, so the line stays one
@@ -16,15 +17,9 @@ const cityTerms = (contentHrefs: LandingContentHrefs): LinkedTerm[] => [
     { aliases: ['Mexico City', 'Ciudad de México', 'Cidade do México'], href: contentHrefs.mexico },
 ]
 
-export function YourMoney({
-    locale = DEFAULT_LOCALE,
-    contentHrefs = EN_LANDING_CONTENT_HREFS,
-}: {
-    locale?: Locale
-    contentHrefs?: LandingContentHrefs
-}) {
+export function YourMoney({ locale = DEFAULT_LOCALE }: { locale?: Locale }) {
     const i18n = getTranslations(locale)
-    const bodyParts = linkTerms(i18n.landingGlobalCashBody, cityTerms(contentHrefs))
+    const bodyParts = linkTerms(i18n.landingGlobalCashBody, cityTerms(contentHrefsFor(locale)))
 
     return (
         <section id="global-cash" className="bg-secondary-1 px-4 py-12 text-n-1 md:py-16">

--- a/src/components/LandingPage/yourMoney.tsx
+++ b/src/components/LandingPage/yourMoney.tsx
@@ -5,19 +5,26 @@ import { Button } from '@/components/0_Bruddle/Button'
 import { getTranslations } from '@/i18n'
 import { DEFAULT_LOCALE, type Locale } from '@/i18n/types'
 import { linkTerms, type LinkedTerm } from './landingLinks.utils'
+import { EN_LANDING_CONTENT_HREFS, type LandingContentHrefs } from './landingContentHrefs'
 
 // The three cities named in landingGlobalCashBody, each pointing at its country
 // page. Aliases cover every spelling the catalogs use, so the line stays one
 // translated string per locale.
-const cityTerms = (locale: Locale): LinkedTerm[] => [
-    { aliases: ['New York', 'Nueva York', 'Nova York'], href: `/${locale}/united-states` },
-    { aliases: ['Madrid', 'Madri'], href: `/${locale}/spain` },
-    { aliases: ['Mexico City', 'Ciudad de México', 'Cidade do México'], href: `/${locale}/mexico` },
+const cityTerms = (contentHrefs: LandingContentHrefs): LinkedTerm[] => [
+    { aliases: ['New York', 'Nueva York', 'Nova York'], href: contentHrefs.unitedStates },
+    { aliases: ['Madrid', 'Madri'], href: contentHrefs.spain },
+    { aliases: ['Mexico City', 'Ciudad de México', 'Cidade do México'], href: contentHrefs.mexico },
 ]
 
-export function YourMoney({ locale = DEFAULT_LOCALE }: { locale?: Locale }) {
+export function YourMoney({
+    locale = DEFAULT_LOCALE,
+    contentHrefs = EN_LANDING_CONTENT_HREFS,
+}: {
+    locale?: Locale
+    contentHrefs?: LandingContentHrefs
+}) {
     const i18n = getTranslations(locale)
-    const bodyParts = linkTerms(i18n.landingGlobalCashBody, cityTerms(locale))
+    const bodyParts = linkTerms(i18n.landingGlobalCashBody, cityTerms(contentHrefs))
 
     return (
         <section id="global-cash" className="bg-secondary-1 px-4 py-12 text-n-1 md:py-16">

--- a/src/components/Marketing/DestinationGrid.tsx
+++ b/src/components/Marketing/DestinationGrid.tsx
@@ -7,6 +7,7 @@ import { localizedPath } from '@/i18n/config'
 import { CARD_HOVER } from '@/components/Marketing/mdx/constants'
 import { getTranslations } from '@/i18n'
 import { DEFAULT_LOCALE, type Locale } from '@/i18n/types'
+import { resolveContentHref } from '@/lib/content'
 
 interface DestinationGridProps {
     /** If provided, only show these country slugs */
@@ -34,7 +35,10 @@ export function DestinationGrid({ countries, exclude, title, locale = DEFAULT_LO
                     const flagCode = seo.iso2
 
                     return (
-                        <Link key={slug} href={localizedPath('send-money-to', locale, slug)}>
+                        <Link
+                            key={slug}
+                            href={resolveContentHref(localizedPath('send-money-to', locale, slug), locale)}
+                        >
                             <Card shadowSize="4" className={`flex-row items-center gap-3 p-4 ${CARD_HOVER}`}>
                                 {flagCode && (
                                     <Image

--- a/src/components/Marketing/HelpLanding.tsx
+++ b/src/components/Marketing/HelpLanding.tsx
@@ -7,6 +7,7 @@ import { Icon } from '@/components/Global/Icons/Icon'
 
 interface HelpArticle {
     slug: string
+    href: string
     title: string
     description: string
     category: string
@@ -21,13 +22,12 @@ interface HelpLandingStrings {
 interface HelpLandingProps {
     articles: HelpArticle[]
     categories: string[]
-    locale: string
     strings?: HelpLandingStrings
 }
 
 const PROSE_WIDTH = 'max-w-[640px]'
 
-export default function HelpLanding({ articles, categories, locale, strings }: HelpLandingProps) {
+export default function HelpLanding({ articles, categories, strings }: HelpLandingProps) {
     const [searchTerm, setSearchTerm] = useState('')
     const searchParams = useSearchParams()
 
@@ -94,7 +94,7 @@ export default function HelpLanding({ articles, categories, locale, strings }: H
                                         .map((article) => (
                                             <Link
                                                 key={article.slug}
-                                                href={`/${locale}/help/${article.slug}`}
+                                                href={article.href}
                                                 className="group flex items-center justify-between border-b border-n-1/10 bg-white px-5 py-4 transition-colors last:border-b-0 hover:bg-primary-3/20"
                                             >
                                                 <div className="flex flex-col gap-0.5">

--- a/src/components/Marketing/__tests__/destination-grid-locale.test.tsx
+++ b/src/components/Marketing/__tests__/destination-grid-locale.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react'
+import { DestinationGrid } from '../DestinationGrid'
+
+describe('DestinationGrid locale ownership', () => {
+    it('links fallback prose to its owner while retaining owned es-ar prose', () => {
+        const { container } = render(
+            <DestinationGrid locale="es-ar" countries={['australia', 'argentina']} title="Destinations" />
+        )
+        const hrefs = [...container.querySelectorAll<HTMLAnchorElement>('a[href]')].map((link) =>
+            link.getAttribute('href')
+        )
+
+        expect(hrefs).toEqual(['/es-419/send-money-to/australia', '/es-ar/send-money-to/argentina'])
+    })
+})

--- a/src/components/Marketing/__tests__/help-landing-owner-links.test.tsx
+++ b/src/components/Marketing/__tests__/help-landing-owner-links.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react'
+import HelpLanding from '../HelpLanding'
+
+jest.mock('next/navigation', () => ({
+    useSearchParams: () => new URLSearchParams(),
+}))
+
+describe('HelpLanding owner links', () => {
+    it('renders the server-provided href instead of reconstructing it from the hub locale', () => {
+        const { container } = render(
+            <HelpLanding
+                articles={[
+                    {
+                        slug: 'passkeys',
+                        href: '/es-419/help/passkeys',
+                        title: 'Passkeys',
+                        description: 'Passkey help',
+                        category: 'Security',
+                    },
+                    {
+                        slug: 'mercadopago-qr',
+                        href: '/es-ar/help/mercadopago-qr',
+                        title: 'Mercado Pago QR',
+                        description: 'QR help',
+                        category: 'Payments',
+                    },
+                ]}
+                categories={['Security', 'Payments']}
+            />
+        )
+        const hrefs = [...container.querySelectorAll<HTMLAnchorElement>('a[href]')].map((link) =>
+            link.getAttribute('href')
+        )
+
+        expect(hrefs).toEqual(['/es-419/help/passkeys', '/es-ar/help/mercadopago-qr'])
+    })
+})

--- a/src/components/Marketing/mdx/RelatedPages.tsx
+++ b/src/components/Marketing/mdx/RelatedPages.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { Card } from '@/components/0_Bruddle/Card'
 import { PROSE_WIDTH, CARD_HOVER } from './constants'
 import { getTranslations } from '@/i18n'
-import { localizeContentHref } from '@/i18n/config'
+import { resolveContentHref } from '@/lib/content'
 import { DEFAULT_LOCALE, type Locale } from '@/i18n/types'
 
 interface RelatedLinkProps {
@@ -57,7 +57,7 @@ export function RelatedPages({ title, children, locale = DEFAULT_LOCALE }: Relat
             <h2 className="mb-5 text-xl font-bold text-n-1 md:text-2xl">{heading}</h2>
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 {links.map((link) => (
-                    <Link key={link.href} href={localizeContentHref(link.href, locale)} className="flex">
+                    <Link key={link.href} href={resolveContentHref(link.href, locale)} className="flex">
                         <Card shadowSize="4" className={`flex-1 flex-row items-center gap-3 p-4 ${CARD_HOVER}`}>
                             <span className="font-semibold">{link.text}</span>
                             <span className="ml-auto text-sm text-black/50">&rarr;</span>

--- a/src/components/Marketing/mdx/components.tsx
+++ b/src/components/Marketing/mdx/components.tsx
@@ -12,7 +12,7 @@ import { ProseStars } from './ProseStars'
 import { Tabs, TabPanel } from './Tabs'
 import { PROSE_WIDTH } from './constants'
 import { DEFAULT_LOCALE, type Locale } from '@/i18n/types'
-import { localizeContentHref } from '@/i18n/config'
+import { resolveContentHref } from '@/lib/content'
 
 /**
  * Component map for MDX content rendering.
@@ -44,7 +44,7 @@ export function createMdxComponents(locale: Locale = DEFAULT_LOCALE): MdxCompone
         // `/help/x`), so a Spanish page would otherwise link back to English.
         a: ({ href = '', ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
             <Link
-                href={localizeContentHref(href, locale)}
+                href={resolveContentHref(href, locale)}
                 className="text-n-1 underline decoration-n-1/30 underline-offset-2 hover:decoration-n-1"
                 {...props}
             />

--- a/src/i18n/__tests__/locale-bridge.test.ts
+++ b/src/i18n/__tests__/locale-bridge.test.ts
@@ -1,6 +1,5 @@
 import { toAppLocale, toMarketingLocale, withCountry } from '../localeBridge'
 import { APP_LOCALES } from '../app/config'
-import { localizeContentHref } from '../config'
 import { SUPPORTED_LOCALES } from '../types'
 
 describe('toAppLocale', () => {
@@ -94,28 +93,5 @@ describe('withCountry', () => {
         for (const country of ['AR', 'MX', 'XX', 'T1']) {
             expect(SUPPORTED_LOCALES).toContain(withCountry('es-419', country))
         }
-    })
-})
-
-describe('localizeContentHref', () => {
-    it('re-points a locale-prefixed href', () => {
-        expect(localizeContentHref('/en/help/passkeys', 'es-419')).toBe('/es-419/help/passkeys')
-        expect(localizeContentHref('/pt-br/compare/wise', 'en')).toBe('/en/compare/wise')
-    })
-
-    it('prefixes an href authored without a locale', () => {
-        // Content authors write both forms; RelatedLink hrefs use the bare form.
-        expect(localizeContentHref('/help/account-recovery', 'pt-br')).toBe('/pt-br/help/account-recovery')
-    })
-
-    it('leaves external links and anchors alone', () => {
-        for (const href of ['https://peanut.me/shhhhh', '#chat', 'mailto:hi@peanut.me']) {
-            expect(localizeContentHref(href, 'es-419')).toBe(href)
-        }
-    })
-
-    it('is idempotent', () => {
-        const once = localizeContentHref('/help/x', 'es-419')
-        expect(localizeContentHref(once, 'es-419')).toBe(once)
     })
 })

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -118,18 +118,6 @@ export function getLandingAlternates(): Record<string, string> {
     return alternates
 }
 
-/**
- * Re-point an internal content href at `locale`. Content authors write hrefs
- * both with and without a locale prefix (`/en/help/x` and `/help/x`), so strip
- * any leading locale before prefixing. External links and anchors pass through.
- */
-export function localizeContentHref(href: string, locale: Locale): string {
-    if (!href.startsWith('/')) return href
-    const segments = href.split('/').filter(Boolean)
-    if (segments.length > 0 && isValidLocale(segments[0])) segments.shift()
-    return segments.length > 0 ? `/${locale}/${segments.join('/')}` : `/${locale}`
-}
-
 export function isValidLocale(locale: string): locale is Locale {
     return SUPPORTED_LOCALES.includes(locale as Locale)
 }

--- a/src/lib/content.test.ts
+++ b/src/lib/content.test.ts
@@ -99,12 +99,46 @@ describe('resolveContentHref', () => {
         )
     })
 
-    it.each(['https://peanut.me/en/help/passkeys', '//cdn.example.com/asset', 'mailto:hi@peanut.me', '#payments'])(
+    it('resolves exact production-origin content URLs while preserving their absolute form and suffix', () => {
+        const fallbackUrl = 'https://peanut.me/es-419/card-terms-international?from=fees#terms'
+        const ownerUrl = 'https://peanut.me/en/card-terms-international?from=fees#terms'
+
+        expect(resolveContentHref(fallbackUrl, 'es-419')).toBe(ownerUrl)
+        expect(resolveContentHref(ownerUrl, 'es-419')).toBe(ownerUrl)
+        expect(resolveContentHref('https://peanut.me/en/help/passkeys', 'es-ar')).toBe(
+            'https://peanut.me/es-419/help/passkeys'
+        )
+    })
+
+    it.each([
+        'https://peanut.me/shhhhh?from=content#card',
+        'https://peanut.me/es-ar/help',
+        'https://peanut.me.evil.com/es-419/terms',
+        'https://peanut.me@evil.com/es-419/terms',
+        'http://peanut.me/es-419/terms',
+    ])('leaves non-content or non-exact production origins unchanged: %s', (href) => {
+        expect(resolveContentHref(href, 'es-419')).toBe(href)
+    })
+
+    it.each(['//cdn.example.com/asset', 'mailto:hi@peanut.me', '#payments', 'https://example.com/en/help/passkeys'])(
         'leaves external links and anchors unchanged: %s',
         (href) => {
             expect(resolveContentHref(href, 'es-ar')).toBe(href)
         }
     )
+
+    it.each([
+        ['es-419', ['https://peanut.me/es-419/card-terms-international', 'https://peanut.me/es-419/terms']],
+        ['pt-br', ['https://peanut.me/pt-br/card-terms-international', 'https://peanut.me/pt-br/terms']],
+    ] as const)('repairs the fallback-only absolute legal links authored in fees-pricing/%s.md', (locale, urls) => {
+        const content = readPageContent('help', 'fees-pricing', locale)
+        expect(content).not.toBeNull()
+        for (const url of urls) expect(content?.body).toContain(url)
+        expect(urls.map((url) => resolveContentHref(url, locale))).toEqual([
+            'https://peanut.me/en/card-terms-international',
+            'https://peanut.me/en/terms',
+        ])
+    })
 })
 
 describe('contentGeneratedAt', () => {

--- a/src/lib/content.test.ts
+++ b/src/lib/content.test.ts
@@ -1,4 +1,10 @@
-import { contentGeneratedAt, listAllContent, readPageContent, type ContentFrontmatter } from '@/lib/content'
+import {
+    contentGeneratedAt,
+    listAllContent,
+    readPageContent,
+    resolveContentHref,
+    type ContentFrontmatter,
+} from '@/lib/content'
 
 describe('listAllContent', () => {
     it('returns items across all 4 hub types for en', () => {
@@ -32,6 +38,17 @@ describe('listAllContent', () => {
         }
     })
 
+    it('links fallback items to the locale that owns their prose', () => {
+        const item = listAllContent('es-ar').find(
+            ({ type, slug }) => type === 'blog' && slug === 'stablecoin-balance-visa-merchants'
+        )
+
+        expect(item).toMatchObject({
+            lang: 'en',
+            href: '/en/blog/stablecoin-balance-visa-merchants',
+        })
+    })
+
     it('excludes the legacy stories/index slug', () => {
         const items = listAllContent('en')
         expect(items.some((i) => i.type === 'stories' && i.slug === 'index')).toBe(false)
@@ -50,6 +67,44 @@ describe('listAllContent', () => {
             expect(prev).toBeGreaterThanOrEqual(curr)
         }
     })
+})
+
+describe('resolveContentHref', () => {
+    it.each([
+        ['/en/countries-do-not-exist', '/es-ar/countries-do-not-exist'],
+        ['/en/poland', '/es-419/poland'],
+        ['/en/send-money-to/australia', '/es-419/send-money-to/australia'],
+        ['/en/send-money-from/colombia/to/argentina', '/es-419/send-money-from/colombia/to/argentina'],
+        ['/en/receive-money-from/portugal', '/es-419/receive-money-from/portugal'],
+        ['/en/compare/peanut-vs-wise', '/es-ar/compare/peanut-vs-wise'],
+        ['/en/deposit/via-spei', '/es-419/deposit/via-spei'],
+        ['/en/pay-with/mercadopago', '/es-ar/pay-with/mercadopago'],
+        ['/en/help/passkeys', '/es-419/help/passkeys'],
+        ['/en/use-cases/families', '/es-419/use-cases/families'],
+        ['/en/stories/purple', '/es-419/stories/purple'],
+        ['/en/withdraw/spei', '/es-419/withdraw/spei'],
+        ['/en/blog/stablecoin-balance-visa-merchants', '/en/blog/stablecoin-balance-visa-merchants'],
+        ['/en/card-terms-us', '/en/card-terms-us'],
+        ['/en/pricing', '/es-419/pricing'],
+        ['/en/press', '/en/press'],
+    ])('points %s at its content owner', (href, expected) => {
+        expect(resolveContentHref(href, 'es-ar')).toBe(expected)
+    })
+
+    it('preserves locale-native hubs and URL suffixes', () => {
+        expect(resolveContentHref('/en/help?from=footer#payments', 'es-ar')).toBe('/es-ar/help?from=footer#payments')
+        expect(resolveContentHref('/en/content#guides', 'es-ar')).toBe('/es-ar/content#guides')
+        expect(resolveContentHref('/en/deposit/via-spei?from=footer#limits', 'es-ar')).toBe(
+            '/es-419/deposit/via-spei?from=footer#limits'
+        )
+    })
+
+    it.each(['https://peanut.me/en/help/passkeys', '//cdn.example.com/asset', 'mailto:hi@peanut.me', '#payments'])(
+        'leaves external links and anchors unchanged: %s',
+        (href) => {
+            expect(resolveContentHref(href, 'es-ar')).toBe(href)
+        }
+    )
 })
 
 describe('contentGeneratedAt', () => {

--- a/src/lib/content.test.ts
+++ b/src/lib/content.test.ts
@@ -99,6 +99,17 @@ describe('resolveContentHref', () => {
         )
     })
 
+    it('localizes en-authored absolute URLs without a content owner, like their relative form', () => {
+        expect(resolveContentHref('https://peanut.me/en/help', 'es-ar')).toBe('https://peanut.me/es-ar/help')
+        expect(resolveContentHref('https://peanut.me/en/content#guides', 'es-419')).toBe(
+            'https://peanut.me/es-419/content#guides'
+        )
+    })
+
+    it('resolves owners for percent-encoded content segments', () => {
+        expect(resolveContentHref('/en/help/pass%6beys', 'es-ar')).toBe('/es-419/help/pass%6beys')
+    })
+
     it('resolves exact production-origin content URLs while preserving their absolute form and suffix', () => {
         const fallbackUrl = 'https://peanut.me/es-419/card-terms-international?from=fees#terms'
         const ownerUrl = 'https://peanut.me/en/card-terms-international?from=fees#terms'

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -91,37 +91,54 @@ export function singletonLocaleFor(intent: string, lang: string): string {
 
 const CONTENT_ROUTE_LOCALES = new Set([...SUPPORTED_LOCALES, 'es-es'])
 const PEANUT_PRODUCTION_ORIGIN = 'https://peanut.me'
-const LEGAL_CONTENT_SLUGS = new Set([
-    'terms',
-    'privacy',
-    'card-terms-us',
-    'card-terms-international',
-    'card-privacy',
-    'card-prohibited-activities',
-    'card-esign',
-])
 const SINGLETON_CONTENT_SLUGS = new Set(['pricing', 'supported-networks', 'press'])
 
+let legalContentSlugs: Set<string> | null = null
+function isLegalContentSlug(slug: string): boolean {
+    legalContentSlugs ??= new Set(listContentSlugs('legal'))
+    return legalContentSlugs.has(slug)
+}
+
+// Links must only target pages their routes will actually serve, so ownership
+// requires a published file, not just an existing one — routes notFound() on
+// `published: false`.
+
 function existingPageLocale(intent: string, slug: string, locale: Locale): string | null {
-    const owner = contentLocaleFor(intent, slug, locale)
-    return hasPageContent(intent, slug, owner) ? owner : null
+    for (const lang of getLocaleFallbacks(locale)) {
+        if (isPublished(readPageContent(intent, slug, lang))) return lang
+    }
+    return null
 }
 
 function existingCorridorLocale(destination: string, origin: string, locale: Locale): string | null {
-    const owner = corridorLocaleFor(destination, origin, locale)
-    return hasCorridorContent(destination, origin, owner) ? owner : null
+    for (const lang of getLocaleFallbacks(locale)) {
+        if (isPublished(readCorridorContent(destination, origin, lang))) return lang
+    }
+    return null
 }
 
 function existingSingletonLocale(intent: string, locale: Locale): string | null {
-    const owner = singletonLocaleFor(intent, locale)
-    return hasSingletonContent(intent, owner) ? owner : null
+    for (const lang of getLocaleFallbacks(locale)) {
+        if (isPublished(readSingletonContent(intent, lang))) return lang
+    }
+    return null
+}
+
+function decodedSegment(segment: string): string {
+    try {
+        return decodeURIComponent(segment)
+    } catch {
+        return segment
+    }
 }
 
 /** Return the locale that owns the content behind a localized marketing path. */
-function contentOwnerForPath(segments: string[], locale: Locale): string | null {
+function contentOwnerForPath(encodedSegments: string[], locale: Locale): string | null {
+    // Content directories are named in decoded form; hrefs arrive encoded.
+    const segments = encodedSegments.map(decodedSegment)
     if (segments.length === 1) {
         const slug = segments[0]
-        if (LEGAL_CONTENT_SLUGS.has(slug)) return existingPageLocale('legal', slug, locale)
+        if (isLegalContentSlug(slug)) return existingPageLocale('legal', slug, locale)
         if (SINGLETON_CONTENT_SLUGS.has(slug)) return existingSingletonLocale(slug, locale)
         return existingPageLocale('countries', slug, locale)
     }
@@ -158,17 +175,23 @@ function contentOwnerForPath(segments: string[], locale: Locale): string | null 
     }
 }
 
-function contentPathSegments(pathname: string): string[] {
+function contentPathSegments(pathname: string): { segments: string[]; strippedLocale: string | null } {
     const segments = pathname.split('/').filter(Boolean)
-    if (segments[0] && CONTENT_ROUTE_LOCALES.has(segments[0].toLowerCase())) segments.shift()
-    return segments
+    let strippedLocale: string | null = null
+    if (segments[0] && CONTENT_ROUTE_LOCALES.has(segments[0].toLowerCase())) {
+        strippedLocale = segments[0].toLowerCase()
+        segments.shift()
+    }
+    return { segments, strippedLocale }
 }
 
 /**
  * Localize an internal content href, then point it at the locale that owns its
  * prose. Locale-native hubs and paths without content files keep the requested
- * locale. Exact https://peanut.me content URLs retain their absolute form;
- * true external links, same-origin non-content URLs and anchors pass through.
+ * locale. Exact https://peanut.me content URLs retain their absolute form and
+ * follow the same rules when authored under /en/; non-en absolute URLs are
+ * deliberate locale pins and only move to a content owner. True external
+ * links, same-origin non-content URLs and anchors pass through.
  */
 export function resolveContentHref(href: string, locale: Locale): string {
     if (!href.startsWith('/')) {
@@ -180,11 +203,12 @@ export function resolveContentHref(href: string, locale: Locale): string {
         }
         if (absoluteHref.origin !== PEANUT_PRODUCTION_ORIGIN) return href
 
-        const segments = contentPathSegments(absoluteHref.pathname)
+        const { segments, strippedLocale } = contentPathSegments(absoluteHref.pathname)
         const owner = contentOwnerForPath(segments, locale)
-        if (!owner) return href
+        const targetLocale = owner ?? (strippedLocale === 'en' ? locale : null)
+        if (!targetLocale) return href
 
-        const ownedPath = `/${[owner, ...segments].join('/')}`
+        const ownedPath = `/${[targetLocale, ...segments].join('/')}`
         return `${PEANUT_PRODUCTION_ORIGIN}${ownedPath}${absoluteHref.search}${absoluteHref.hash}`
     }
     if (href.startsWith('//')) return href
@@ -192,7 +216,7 @@ export function resolveContentHref(href: string, locale: Locale): string {
     const suffixIndex = href.search(/[?#]/)
     const pathname = suffixIndex === -1 ? href : href.slice(0, suffixIndex)
     const suffix = suffixIndex === -1 ? '' : href.slice(suffixIndex)
-    const segments = contentPathSegments(pathname)
+    const { segments } = contentPathSegments(pathname)
 
     const owner = contentOwnerForPath(segments, locale)
     const targetLocale = owner ?? locale
@@ -282,17 +306,26 @@ export function readPageContent<T = Record<string, unknown>>(
     return result
 }
 
+/** Read page content with locale fallback, returning which locale served it. */
+export function readPageContentLocalizedResolved<T = Record<string, unknown>>(
+    intent: string,
+    slug: string,
+    lang: string
+): { content: MarkdownContent<T>; lang: string } | null {
+    for (const locale of getLocaleFallbacks(lang)) {
+        const content = readPageContent<T>(intent, slug, locale)
+        if (content) return { content, lang: locale }
+    }
+    return null
+}
+
 /** Read page content with locale fallback */
 export function readPageContentLocalized<T = Record<string, unknown>>(
     intent: string,
     slug: string,
     lang: string
 ): MarkdownContent<T> | null {
-    for (const locale of getLocaleFallbacks(lang)) {
-        const content = readPageContent<T>(intent, slug, locale)
-        if (content) return content
-    }
-    return null
+    return readPageContentLocalizedResolved<T>(intent, slug, lang)?.content ?? null
 }
 
 /** Read corridor content: content/send-to/{destination}/from/{origin}/{lang}.md */
@@ -456,19 +489,6 @@ function hrefFor(type: ContentItemType, slug: string, locale: Locale): string {
     return `/${locale}/${type}/${encodeURIComponent(slug)}`
 }
 
-/** Resolve a content page through the locale fallback chain, returning which locale was used. */
-function resolveLocalized(
-    intent: string,
-    slug: string,
-    lang: Locale
-): { content: MarkdownContent<HubFrontmatter>; lang: Locale } | null {
-    for (const locale of getLocaleFallbacks(lang)) {
-        const content = readPageContent<HubFrontmatter>(intent, slug, locale)
-        if (content) return { content, lang: locale as Locale }
-    }
-    return null
-}
-
 const HUB_TYPES: ContentItemType[] = ['blog', 'stories', 'use-cases', 'compare']
 
 /**
@@ -482,9 +502,10 @@ export function listAllContent(locale: Locale): ContentItem[] {
     for (const type of HUB_TYPES) {
         for (const slug of listContentSlugs(type)) {
             if (slug === 'index') continue // legacy stories/index/ directory
-            const resolved = resolveLocalized(type, slug, locale)
+            const resolved = readPageContentLocalizedResolved<HubFrontmatter>(type, slug, locale)
             if (!resolved) continue
-            const { content, lang } = resolved
+            const { content } = resolved
+            const lang = resolved.lang as Locale
             if (content.frontmatter.published === false) continue
 
             items.push({

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -90,6 +90,7 @@ export function singletonLocaleFor(intent: string, lang: string): string {
 }
 
 const CONTENT_ROUTE_LOCALES = new Set([...SUPPORTED_LOCALES, 'es-es'])
+const PEANUT_PRODUCTION_ORIGIN = 'https://peanut.me'
 const LEGAL_CONTENT_SLUGS = new Set([
     'terms',
     'privacy',
@@ -157,20 +158,41 @@ function contentOwnerForPath(segments: string[], locale: Locale): string | null 
     }
 }
 
+function contentPathSegments(pathname: string): string[] {
+    const segments = pathname.split('/').filter(Boolean)
+    if (segments[0] && CONTENT_ROUTE_LOCALES.has(segments[0].toLowerCase())) segments.shift()
+    return segments
+}
+
 /**
  * Localize an internal content href, then point it at the locale that owns its
  * prose. Locale-native hubs and paths without content files keep the requested
- * locale. External links and anchors pass through unchanged.
+ * locale. Exact https://peanut.me content URLs retain their absolute form;
+ * true external links, same-origin non-content URLs and anchors pass through.
  */
 export function resolveContentHref(href: string, locale: Locale): string {
-    if (!href.startsWith('/') || href.startsWith('//')) return href
+    if (!href.startsWith('/')) {
+        let absoluteHref: URL
+        try {
+            absoluteHref = new URL(href)
+        } catch {
+            return href
+        }
+        if (absoluteHref.origin !== PEANUT_PRODUCTION_ORIGIN) return href
+
+        const segments = contentPathSegments(absoluteHref.pathname)
+        const owner = contentOwnerForPath(segments, locale)
+        if (!owner) return href
+
+        const ownedPath = `/${[owner, ...segments].join('/')}`
+        return `${PEANUT_PRODUCTION_ORIGIN}${ownedPath}${absoluteHref.search}${absoluteHref.hash}`
+    }
+    if (href.startsWith('//')) return href
 
     const suffixIndex = href.search(/[?#]/)
     const pathname = suffixIndex === -1 ? href : href.slice(0, suffixIndex)
     const suffix = suffixIndex === -1 ? '' : href.slice(suffixIndex)
-    const segments = pathname.split('/').filter(Boolean)
-
-    if (segments[0] && CONTENT_ROUTE_LOCALES.has(segments[0].toLowerCase())) segments.shift()
+    const segments = contentPathSegments(pathname)
 
     const owner = contentOwnerForPath(segments, locale)
     const targetLocale = owner ?? locale

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -89,6 +89,95 @@ export function singletonLocaleFor(intent: string, lang: string): string {
     return 'en'
 }
 
+const CONTENT_ROUTE_LOCALES = new Set([...SUPPORTED_LOCALES, 'es-es'])
+const LEGAL_CONTENT_SLUGS = new Set([
+    'terms',
+    'privacy',
+    'card-terms-us',
+    'card-terms-international',
+    'card-privacy',
+    'card-prohibited-activities',
+    'card-esign',
+])
+const SINGLETON_CONTENT_SLUGS = new Set(['pricing', 'supported-networks', 'press'])
+
+function existingPageLocale(intent: string, slug: string, locale: Locale): string | null {
+    const owner = contentLocaleFor(intent, slug, locale)
+    return hasPageContent(intent, slug, owner) ? owner : null
+}
+
+function existingCorridorLocale(destination: string, origin: string, locale: Locale): string | null {
+    const owner = corridorLocaleFor(destination, origin, locale)
+    return hasCorridorContent(destination, origin, owner) ? owner : null
+}
+
+function existingSingletonLocale(intent: string, locale: Locale): string | null {
+    const owner = singletonLocaleFor(intent, locale)
+    return hasSingletonContent(intent, owner) ? owner : null
+}
+
+/** Return the locale that owns the content behind a localized marketing path. */
+function contentOwnerForPath(segments: string[], locale: Locale): string | null {
+    if (segments.length === 1) {
+        const slug = segments[0]
+        if (LEGAL_CONTENT_SLUGS.has(slug)) return existingPageLocale('legal', slug, locale)
+        if (SINGLETON_CONTENT_SLUGS.has(slug)) return existingSingletonLocale(slug, locale)
+        return existingPageLocale('countries', slug, locale)
+    }
+
+    if (segments.length === 4 && segments[0] === 'send-money-from' && segments[2] === 'to') {
+        return existingCorridorLocale(segments[3], segments[1], locale)
+    }
+
+    if (segments.length !== 2) return null
+
+    const [route, rawSlug] = segments
+    switch (route) {
+        case 'send-money-to':
+            return existingPageLocale('send-to', rawSlug, locale)
+        case 'receive-money-from':
+            return existingPageLocale('receive-from', rawSlug, locale)
+        case 'compare': {
+            const slug = rawSlug.startsWith('peanut-vs-') ? rawSlug.slice('peanut-vs-'.length) : ''
+            return slug ? existingPageLocale('compare', slug, locale) : null
+        }
+        case 'deposit': {
+            const slug = rawSlug.replace(/^(?:from-|via-)/, '')
+            return slug !== rawSlug ? existingPageLocale('deposit', slug, locale) : null
+        }
+        case 'pay-with':
+        case 'help':
+        case 'use-cases':
+        case 'stories':
+        case 'withdraw':
+        case 'blog':
+            return existingPageLocale(route, rawSlug, locale)
+        default:
+            return null
+    }
+}
+
+/**
+ * Localize an internal content href, then point it at the locale that owns its
+ * prose. Locale-native hubs and paths without content files keep the requested
+ * locale. External links and anchors pass through unchanged.
+ */
+export function resolveContentHref(href: string, locale: Locale): string {
+    if (!href.startsWith('/') || href.startsWith('//')) return href
+
+    const suffixIndex = href.search(/[?#]/)
+    const pathname = suffixIndex === -1 ? href : href.slice(0, suffixIndex)
+    const suffix = suffixIndex === -1 ? '' : href.slice(suffixIndex)
+    const segments = pathname.split('/').filter(Boolean)
+
+    if (segments[0] && CONTENT_ROUTE_LOCALES.has(segments[0].toLowerCase())) segments.shift()
+
+    const owner = contentOwnerForPath(segments, locale)
+    const targetLocale = owner ?? locale
+    const localizedPath = `/${[targetLocale, ...segments].join('/')}`
+    return `${localizedPath}${suffix}`
+}
+
 /** Supported locales whose own file exists for this page. */
 export function availableContentLocales(intent: string, slug: string): Locale[] {
     return SUPPORTED_LOCALES.filter((locale) => hasPageContent(intent, slug, locale))
@@ -381,7 +470,7 @@ export function listAllContent(locale: Locale): ContentItem[] {
                 slug,
                 title: content.frontmatter.title ?? slug,
                 description: content.frontmatter.description ?? '',
-                href: hrefFor(type, slug, locale),
+                href: hrefFor(type, slug, lang),
                 lang,
                 date: type === 'blog' ? coerceDate(content.frontmatter.date) : undefined,
                 tags: Array.isArray(content.frontmatter.tags) ? content.frontmatter.tags : undefined,


### PR DESCRIPTION
## Summary

- point localized internal content links at the locale that owns the rendered prose, instead of emitting crawlable fallback URLs that canonicalize elsewhere
- keep genuinely owned `es-ar` pages local while resolving fallback-only pages through `es-419` and then English; preserve query strings, fragments, external URLs, and anchors
- resolve exact-origin `https://peanut.me` content URLs too, while leaving app/hub URLs and lookalike or insecure origins untouched
- keep filesystem-backed resolution server-side by splitting the visual footer chrome and serializing a resolved homepage href map across the server/client boundary

## Task

[TASK-21781](https://app.notion.com/p/3c68381175798101b16ec08033342716?pvs=204)

## Risks / breaking changes

- changes link destinations across marketing homepages, content directories, help/stories listings, destination grids, related pages, and MDX links
- no copy, layout, API, or user-flow change; locale ownership follows the checked-in content mirror, so future content additions automatically retain the requested locale
- production hotfix targets `main`; back-merge to `dev` is required after merge

## Design notes / accepted trade-offs

- encoded content-path segments are currently looked up in their emitted form; the checked 763-file content inventory has no encoded, non-ASCII, or space-bearing content directories/links, so decoding and malformed-percent semantics are deferred to a follow-up rather than expanded into this hotfix

## QA

- Prettier: full repository check ✅
- TypeScript: detached `origin/main` baseline and hotfix head ✅
- Jest: 8 deterministic in-band shards, 274 suites / 3,427 passed / 3 skipped ✅
- focused locale-owner coverage: 46/46 tests ✅
- sitemap generator: exact 35 `es-ar` URLs enumerated ✅
- client dependency graph: all 489 `use client` roots traversed; 1,079 reachable modules / 5,785 runtime edges / zero `fs`, `path`, or `server-only` leaks ✅
- CI/Vercel: format, ESLint, typecheck, 3,430 unit tests, e2e, analysis, CodeQL, reports, aggregate CI, and hosted preview all green on `fa42b5bf` ✅
- hosted Vercel crawl: all 35 `es-ar` sitemap pages hydrated; 200 unique rendered internal targets checked with zero bad responses and zero fallback-canonical owner targets ✅
- hosted visual comparison at a 390×844 mobile viewport: 25/35 pages were raw pixel-identical; nine differed only in the live USD/ARS quote (0.0027–0.0032% pixels), while the homepage's decorative runtime animation differed by 0.5130%, below a production-vs-production self-noise control of 0.5209%; dimensions and non-dynamic copy/styles matched ✅
- local production build exception: three local webpack variants reached compilation without a source diagnostic, but the 11 GiB shared host killed them for memory (final documented `webpackMemoryOptimizations` run was kernel-OOM-killed at 5.36 GiB anonymous RSS); the authoritative CI/Vercel builds are green

Screenshots: quantified hosted comparison recorded above; no static artifact retained because the only observed deltas were live-rate and decorative animation noise (this PR changes href destinations, not rendered copy/layout/style)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent locale-aware links across landing pages, help articles, stories, destinations, and related content.
  * Updated landing-page navigation, comparison links, security resources, city links, and footer links to open the appropriate localized content.
  * Introduced a refreshed responsive footer with social links, legal resources, navigation, attribution, and locale switching.

* **Bug Fixes**
  * Corrected localized links to use the locale owning available content, with appropriate fallbacks.
  * Preserved query parameters and anchors when resolving localized URLs.
  * Added footer coverage for the quests page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->