### PR TITLE
fix(seo): noindex app surfaces at response layer

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@ const withBundleAnalyzer =
     process.env.ANALYZE === 'true' ? require('@next/bundle-analyzer')({ enabled: true }) : (config) => config
 
 const redirectsConfig = require('./redirects.json')
+const { buildNoindexHeaderRules } = require('./src/constants/seo-route-policy')
 const { googleAdsRemarketingHosts } = require('./csp-google-domains')
 
 /**
@@ -364,6 +365,10 @@ let nextConfig = {
     },
     async headers() {
         return [
+            // App/auth/transaction surfaces must never inherit the root
+            // marketing metadata's index directive. HTTP directives work for
+            // client layouts and preserve social-card crawling.
+            ...buildNoindexHeaderRules(),
             {
                 source: '/.well-known/apple-app-site-association',
                 headers: [

--- a/src/app/[...recipient]/page.tsx
+++ b/src/app/[...recipient]/page.tsx
@@ -21,7 +21,7 @@ type PageProps = {
 // a "<handle> on Peanut" title. Google indexed thousands of those. Every metadata
 // branch is noindex: profiles, addresses, ENS and request/receipt links are app
 // surface, not search landing pages — no carve-outs.
-// canonical: null suppresses the root layout's inherited `canonical: '/'` —
+// canonical: null is defense in depth against a future parent canonical:
 // noindex must not ship on pages that canonicalize to the homepage, or the
 // noindex can be attributed to the canonical cluster head (the homepage itself).
 const NOINDEX = { index: false, follow: false } as const

--- a/src/app/__tests__/metadata-policy.test.ts
+++ b/src/app/__tests__/metadata-policy.test.ts
@@ -15,15 +15,47 @@ jest.mock('@/constants/general.consts', () => ({
     PEANUT_API_URL: 'https://api.peanut.me',
 }))
 
-import { metadata as rootMetadata } from '../layout'
 import { metadata as lpMetadata } from '../lp/layout'
 import { DEFAULT_LOCALE } from '@/i18n/types'
 import { landingMetadata } from '@/lib/seo/landing'
 
+const ORIGINAL_BASE_URL = process.env.NEXT_PUBLIC_BASE_URL
+
+async function rootMetadataFor(baseUrl?: string) {
+    jest.resetModules()
+    if (baseUrl === undefined) delete process.env.NEXT_PUBLIC_BASE_URL
+    else process.env.NEXT_PUBLIC_BASE_URL = baseUrl
+
+    return (await import('../layout')).metadata
+}
+
 describe('route metadata ownership', () => {
-    it('keeps the production root layout route-neutral', () => {
-        expect(rootMetadata.alternates).toBeUndefined()
-        expect(rootMetadata.robots).toBeUndefined()
+    afterEach(() => {
+        if (ORIGINAL_BASE_URL === undefined) delete process.env.NEXT_PUBLIC_BASE_URL
+        else process.env.NEXT_PUBLIC_BASE_URL = ORIGINAL_BASE_URL
+    })
+
+    it.each(['https://peanut.me', 'https://peanut.me/'])(
+        'keeps the explicitly configured production root layout route-neutral (%s)',
+        async (baseUrl) => {
+            const rootMetadata = await rootMetadataFor(baseUrl)
+
+            expect(rootMetadata.alternates).toBeUndefined()
+            expect(rootMetadata.robots).toBeUndefined()
+        }
+    )
+
+    it.each([
+        undefined,
+        '',
+        'https://staging.peanut.me',
+        'https://preview.example.vercel.app',
+        'https://peanut.example.org',
+        'https://peanut.me.evil.example',
+    ])('fails closed when the production origin is not explicit (%s)', async (baseUrl) => {
+        const rootMetadata = await rootMetadataFor(baseUrl)
+
+        expect(rootMetadata.robots).toEqual({ index: false, follow: false })
     })
 
     it('lets public landing leaves own their canonical URLs', () => {

--- a/src/app/__tests__/metadata-policy.test.ts
+++ b/src/app/__tests__/metadata-policy.test.ts
@@ -1,0 +1,33 @@
+jest.mock('next/font/google', () => ({
+    Londrina_Solid: () => ({ variable: '--font-londrina' }),
+    Roboto_Flex: () => ({ variable: '--font-roboto' }),
+    Sniglet: () => ({ variable: '--font-sniglet' }),
+}))
+jest.mock('next/font/local', () => ({
+    __esModule: true,
+    default: () => ({ variable: '--font-local' }),
+}))
+jest.mock('next/script', () => ({ __esModule: true, default: jest.fn() }))
+jest.mock('../ClientProviders', () => ({ ClientProviders: jest.fn() }))
+jest.mock('../../styles/globals.css', () => ({}))
+jest.mock('@/constants/general.consts', () => ({
+    BASE_URL: 'https://peanut.me',
+    PEANUT_API_URL: 'https://api.peanut.me',
+}))
+
+import { metadata as rootMetadata } from '../layout'
+import { metadata as lpMetadata } from '../lp/layout'
+import { DEFAULT_LOCALE } from '@/i18n/types'
+import { landingMetadata } from '@/lib/seo/landing'
+
+describe('route metadata ownership', () => {
+    it('keeps the production root layout route-neutral', () => {
+        expect(rootMetadata.alternates).toBeUndefined()
+        expect(rootMetadata.robots).toBeUndefined()
+    })
+
+    it('lets public landing leaves own their canonical URLs', () => {
+        expect(landingMetadata(DEFAULT_LOCALE).alternates).toMatchObject({ canonical: '/' })
+        expect(lpMetadata.alternates).toEqual({ canonical: '/' })
+    })
+})

--- a/src/app/__tests__/robots.test.ts
+++ b/src/app/__tests__/robots.test.ts
@@ -1,0 +1,47 @@
+jest.mock('@/constants/general.consts', () => ({ BASE_URL: 'https://peanut.me' }))
+jest.mock('@/i18n/types', () => ({ SUPPORTED_LOCALES: ['en', 'es-419'] }))
+
+import { GOOGLE_DEINDEX_CRAWL_ALLOW_PATHS, ROBOTS_DISALLOWED_PATHS } from '@/constants/seo-route-policy'
+import robots from '../robots'
+
+type RobotsRule = {
+    userAgent: string | string[]
+    allow?: string | string[]
+    disallow?: string | string[]
+    crawlDelay?: number
+}
+
+const rules = robots().rules as RobotsRule[]
+
+function ruleFor(userAgent: string): RobotsRule {
+    const rule = rules.find((candidate) => candidate.userAgent === userAgent)
+    if (!rule) throw new Error(`Missing robots rule for ${userAgent}`)
+    return rule
+}
+
+describe('production robots policy', () => {
+    it('lets Google recrawl only the exact indexed app shells needed for deindexing', () => {
+        const googlebot = ruleFor('Googlebot')
+
+        expect(googlebot.allow).toEqual(['/api/og', ...GOOGLE_DEINDEX_CRAWL_ALLOW_PATHS])
+        expect(googlebot.disallow).toEqual(ROBOTS_DISALLOWED_PATHS)
+    })
+
+    it('gives generic crawlers the same narrow deindexing exceptions', () => {
+        const generic = ruleFor('*')
+
+        expect(generic.allow).toEqual(expect.arrayContaining([...GOOGLE_DEINDEX_CRAWL_ALLOW_PATHS]))
+        expect(generic.disallow).toEqual(ROBOTS_DISALLOWED_PATHS)
+    })
+
+    it.each(['AhrefsBot', 'SemrushBot', 'MJ12bot'])('%s does not bypass the shared disallow policy', (bot) => {
+        const rule = ruleFor(bot)
+
+        expect(rule.disallow).toEqual(ROBOTS_DISALLOWED_PATHS)
+        expect(rule.crawlDelay).toBe(10)
+    })
+
+    it('keeps Twitterbot unrestricted for shared-link previews', () => {
+        expect(ruleFor('Twitterbot')).toMatchObject({ allow: ['/api/og'], disallow: [] })
+    })
+})

--- a/src/app/careers/page.tsx
+++ b/src/app/careers/page.tsx
@@ -7,8 +7,7 @@ export const metadata = generateMetadata({
     description:
         'Open roles at Peanut, the money app for people who cross borders — send and receive money globally, spend with the Peanut Card, and cash in and out through local rails.',
     keywords: 'careers, jobs, remote jobs, Peanut careers, fintech jobs, stablecoin jobs, growth jobs',
-    // Without this the page inherits the root layout's `canonical: '/'` and
-    // declares the homepage as its canonical while sitting in the sitemap.
+    // Leaf pages own canonicals; this public page is also listed in the sitemap.
     canonical: '/careers',
 })
 

--- a/src/app/crisp-proxy/layout.tsx
+++ b/src/app/crisp-proxy/layout.tsx
@@ -1,10 +1,8 @@
 import { type Metadata } from 'next'
 import { generateMetadata as metadataHelper } from '@/app/metadata'
 
-// The page itself is a client component, so its metadata has to live here.
-// Without it the route inherits the root layout's `canonical: '/'` and declares
-// the homepage as its canonical while serving `index, follow` — on a route
-// robots.ts already disallows.
+// The page itself is a client component, so its route-specific canonical and
+// noindex metadata have to live here. robots.ts also disallows this app route.
 export const metadata: Metadata = {
     ...metadataHelper({
         title: 'Support Chat | Peanut',

--- a/src/app/kyc/success/layout.tsx
+++ b/src/app/kyc/success/layout.tsx
@@ -1,10 +1,8 @@
 import { type Metadata } from 'next'
 import { generateMetadata as metadataHelper } from '@/app/metadata'
 
-// The page itself is a client component, so its metadata has to live here.
-// Without it the route inherits the root layout's `canonical: '/'` and declares
-// the homepage as its canonical while serving `index, follow` — on a route
-// robots.ts already disallows.
+// The page itself is a client component, so its route-specific canonical and
+// noindex metadata have to live here. robots.ts also disallows this app route.
 export const metadata: Metadata = {
     ...metadataHelper({
         title: 'Identity Verification Complete | Peanut',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,7 +9,10 @@ import { CHUNK_ERROR_RECOVERY_SCRIPT } from '@/utils/chunk-error-recovery'
 import { type Metadata } from 'next'
 
 const baseUrl = BASE_URL || 'https://peanut.me'
-const IS_PRODUCTION_DOMAIN = baseUrl === 'https://peanut.me'
+// Fail closed: BASE_URL deliberately falls back to production for links, but
+// that fallback must not make an unset preview environment indexable.
+const configuredBaseUrl = process.env.NEXT_PUBLIC_BASE_URL?.replace(/\/$/, '')
+const IS_PRODUCTION_DOMAIN = configuredBaseUrl === 'https://peanut.me'
 
 export const metadata: Metadata = {
     title: 'Peanut - Send, Spend & Cash Out Digital Dollars',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,11 +17,13 @@ export const metadata: Metadata = {
         'Peanut is a money app for people who cross borders — send and receive money globally, spend with the Peanut Card, cash in and out through local rails.',
     metadataBase: new URL(baseUrl),
     icons: { icon: '/favicon.ico' },
-    alternates: { canonical: '/' },
     keywords:
         'peer-to-peer payments, send money instantly, request money, fast global transfers, remittances, digital dollar transfers, Latin America, Argentina, Brazil, P2P payments, crypto payments, stablecoin, digital dollars',
-    // Block staging/preview deploys from indexing (belt-and-suspenders with robots.ts)
-    robots: IS_PRODUCTION_DOMAIN ? { index: true, follow: true } : { index: false, follow: false },
+    // Canonicals belong to leaf pages: a root canonical here would be inherited
+    // by app routes and falsely cluster them with the homepage. Index/follow is
+    // also the production default, so emit robots metadata only as a staging /
+    // preview belt-and-suspenders guard.
+    ...(IS_PRODUCTION_DOMAIN ? {} : { robots: { index: false, follow: false } }),
     openGraph: {
         type: 'website',
         title: 'Peanut - Send, Spend & Cash Out Digital Dollars',

--- a/src/app/maintenance/layout.tsx
+++ b/src/app/maintenance/layout.tsx
@@ -1,10 +1,8 @@
 import { type Metadata } from 'next'
 import { generateMetadata as metadataHelper } from '@/app/metadata'
 
-// The page itself is a client component, so its metadata has to live here.
-// Without it the route inherits the root layout's `canonical: '/'` and declares
-// the homepage as its canonical while serving `index, follow` — on a route
-// robots.ts already disallows.
+// The page itself is a client component, so its route-specific canonical and
+// noindex metadata have to live here. robots.ts also disallows this app route.
 export const metadata: Metadata = {
     ...metadataHelper({
         title: 'Maintenance | Peanut',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,8 +6,8 @@ import { LocaleSuggestion } from '@/components/Marketing/LocaleSuggestion'
 import { DEFAULT_LOCALE } from '@/i18n/types'
 import { landingMetadata } from '@/lib/seo/landing'
 
-// Without this the page inherits the root layout's bare `canonical: '/'` and
-// emits no hreflang, leaving the localized landings' alternates non-reciprocal.
+// The root layout is deliberately route-neutral. The page owns its canonical
+// and hreflang so localized landing alternates stay reciprocal.
 export const metadata = landingMetadata(DEFAULT_LOCALE)
 
 export default function RootPage() {

--- a/src/app/quests/layout.tsx
+++ b/src/app/quests/layout.tsx
@@ -1,8 +1,8 @@
 import { type Metadata } from 'next'
 import { generateMetadata as metadataHelper } from '@/app/metadata'
 
-// Without this the page inherits the root layout's `canonical: '/'`. The route
-// is robots-disallowed (app surface) — noindex backs that up for URL-only hits.
+// Keep the app route self-canonical and noindex. It is also robots-disallowed;
+// metadata backs that up for URL-only hits.
 export const metadata: Metadata = {
     ...metadataHelper({
         title: 'Quests | Peanut',

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from 'next'
 import { BASE_URL } from '@/constants/general.consts'
 import { SUPPORTED_LOCALES } from '@/i18n/types'
+import { GOOGLE_DEINDEX_CRAWL_ALLOW_PATHS, ROBOTS_DISALLOWED_PATHS } from '@/constants/seo-route-policy'
 
 const IS_PRODUCTION_DOMAIN = BASE_URL === 'https://peanut.me'
 
@@ -10,34 +11,6 @@ const IS_PRODUCTION_DOMAIN = BASE_URL === 'https://peanut.me'
 // footgun when editing: a crawler only ever obeys the single most specific
 // group that matches it, so a named group that omits a path silently opts
 // that crawler out of it.
-const DISALLOWED_PATHS = [
-    '/api/',
-    '/sdk/',
-    // Auth-gated app routes
-    '/home',
-    '/profile',
-    '/settings',
-    '/send',
-    '/request',
-    '/setup',
-    '/claim',
-    '/pay',
-    '/dev/',
-    '/qr',
-    '/history',
-    '/points',
-    '/rewards',
-    '/invite',
-    '/kyc',
-    '/maintenance',
-    '/quests',
-    '/receipt',
-    '/crisp-proxy',
-    '/card-payment',
-    '/add-money',
-    '/withdraw',
-]
-
 export default function robots(): MetadataRoute.Robots {
     // Block indexing on staging, preview deploys, and non-production domains
     if (!IS_PRODUCTION_DOMAIN) {
@@ -45,6 +18,8 @@ export default function robots(): MetadataRoute.Robots {
             rules: [{ userAgent: '*', disallow: ['/'] }],
         }
     }
+
+    const disallowedPaths = [...ROBOTS_DISALLOWED_PATHS]
 
     return {
         rules: [
@@ -67,8 +42,8 @@ export default function robots(): MetadataRoute.Robots {
             // `/api/og` allow still wins over `/api/` by longest-match.
             {
                 userAgent: 'Googlebot',
-                allow: ['/api/og'],
-                disallow: DISALLOWED_PATHS,
+                allow: ['/api/og', ...GOOGLE_DEINDEX_CRAWL_ALLOW_PATHS],
+                disallow: disallowedPaths,
             },
 
             // AI search engine crawlers — explicitly welcome on all marketing
@@ -85,7 +60,7 @@ export default function robots(): MetadataRoute.Robots {
                     'Applebot-Extended',
                 ],
                 allow: ['/'],
-                disallow: DISALLOWED_PATHS,
+                disallow: disallowedPaths,
             },
 
             // Default rules for all crawlers
@@ -96,16 +71,19 @@ export default function robots(): MetadataRoute.Robots {
                     '/careers',
                     '/privacy',
                     '/terms',
+                    // Exact app shells currently present in search indexes.
+                    // Narrow crawling lets engines process and refresh noindex.
+                    ...GOOGLE_DEINDEX_CRAWL_ALLOW_PATHS,
                     // SEO routes (all locale-prefixed)
                     ...SUPPORTED_LOCALES.map((l) => `/${l}/`),
                 ],
-                disallow: DISALLOWED_PATHS,
+                disallow: disallowedPaths,
             },
 
-            // Rate-limit aggressive SEO crawlers
-            { userAgent: 'AhrefsBot', crawlDelay: 10 },
-            { userAgent: 'SemrushBot', crawlDelay: 10 },
-            { userAgent: 'MJ12bot', crawlDelay: 10 },
+            // A named group does not inherit `*`, so repeat the shared blocks.
+            { userAgent: 'AhrefsBot', disallow: disallowedPaths, crawlDelay: 10 },
+            { userAgent: 'SemrushBot', disallow: disallowedPaths, crawlDelay: 10 },
+            { userAgent: 'MJ12bot', disallow: disallowedPaths, crawlDelay: 10 },
         ],
         sitemap: `${BASE_URL}/sitemap.xml`,
     }

--- a/src/constants/__tests__/seo-route-policy.test.ts
+++ b/src/constants/__tests__/seo-route-policy.test.ts
@@ -24,10 +24,9 @@ const criticalAppRoutes = [
     '/recover-funds',
     '/card-recovery',
     '/fix-card-signature',
-    '/lp',
 ]
 
-const crawlablePublicRoutes = ['/api/og/marketing', '/m/stain', '/m/badigitalnomads']
+const crawlablePublicRoutes = ['/lp', '/api/og/marketing', '/m/stain', '/m/badigitalnomads']
 
 function receivesNoindexHeader(path: string): boolean {
     return (
@@ -82,7 +81,7 @@ describe('SEO route policy', () => {
         }
     )
 
-    it.each(['/api/og/marketing?title=Peanut', '/m/stain', '/en/pay-with/pix'])(
+    it.each(['/lp', '/api/og/marketing?title=Peanut', '/m/stain', '/en/pay-with/pix'])(
         'does not render a noindex header for %s through Next route matching',
         async (route) => {
             await expect(renderedRobotsHeader(route)).resolves.toBeNull()

--- a/src/constants/__tests__/seo-route-policy.test.ts
+++ b/src/constants/__tests__/seo-route-policy.test.ts
@@ -1,0 +1,113 @@
+/** @jest-environment node */
+
+import {
+    GOOGLE_DEINDEX_CRAWL_ALLOW_PATHS,
+    NOINDEX_EXACT_ROUTES,
+    NOINDEX_HEADER,
+    NOINDEX_ROUTE_PREFIXES,
+    ROBOTS_DISALLOWED_PATHS,
+    buildNoindexHeaderRules,
+} from '../seo-route-policy'
+import { unstable_getResponseFromNextConfig } from 'next/experimental/testing/server'
+
+const criticalAppRoutes = [
+    '/app',
+    '/home',
+    '/profile',
+    '/send',
+    '/setup',
+    '/invite',
+    '/card',
+    '/badges',
+    '/limits',
+    '/notifications',
+    '/recover-funds',
+    '/card-recovery',
+    '/fix-card-signature',
+    '/lp',
+]
+
+const crawlablePublicRoutes = ['/api/og/marketing', '/m/stain', '/m/badigitalnomads']
+
+function receivesNoindexHeader(path: string): boolean {
+    return (
+        NOINDEX_EXACT_ROUTES.includes(path) ||
+        NOINDEX_ROUTE_PREFIXES.some((prefix) => path === prefix || path.startsWith(`${prefix}/`))
+    )
+}
+
+async function renderedRobotsHeader(path: string): Promise<string | null> {
+    const response = await unstable_getResponseFromNextConfig({
+        url: `https://peanut.me${path}`,
+        nextConfig: { headers: async () => buildNoindexHeaderRules() },
+    })
+
+    return response.headers.get('x-robots-tag')
+}
+
+describe('SEO route policy', () => {
+    it('emits noindex response headers for every non-marketing route prefix', () => {
+        expect(buildNoindexHeaderRules()).toEqual([
+            ...NOINDEX_EXACT_ROUTES.map((source) => ({ source, headers: [NOINDEX_HEADER] })),
+            ...NOINDEX_ROUTE_PREFIXES.map((source) => ({
+                source: `${source}/:path*`,
+                headers: [NOINDEX_HEADER],
+            })),
+        ])
+    })
+
+    it('keeps personalized OG images private without suppressing marketing OG images', () => {
+        expect(receivesNoindexHeader('/api/og')).toBe(true)
+        expect(receivesNoindexHeader('/api/og/marketing')).toBe(false)
+    })
+
+    it.each(criticalAppRoutes)('keeps %s out of the index', (route) => {
+        expect(NOINDEX_ROUTE_PREFIXES).toContain(route)
+    })
+
+    it('also applies noindex to every robots-disallowed page surface', () => {
+        for (const path of ROBOTS_DISALLOWED_PATHS.filter((path) => path !== '/api/')) {
+            expect(NOINDEX_ROUTE_PREFIXES).toContain(path.replace(/\/$/, ''))
+        }
+    })
+
+    it.each(crawlablePublicRoutes)('does not suppress the public route %s', (route) => {
+        expect(receivesNoindexHeader(route)).toBe(false)
+    })
+
+    it.each(['/home', '/home/activity', '/invite?code=abc&lid=campaign', '/api/og?type=send&username=alice&amount=10'])(
+        'renders a noindex header for %s through Next route matching',
+        async (route) => {
+            await expect(renderedRobotsHeader(route)).resolves.toBe('noindex, nofollow')
+        }
+    )
+
+    it.each(['/api/og/marketing?title=Peanut', '/m/stain', '/en/pay-with/pix'])(
+        'does not render a noindex header for %s through Next route matching',
+        async (route) => {
+            await expect(renderedRobotsHeader(route)).resolves.toBeNull()
+        }
+    )
+
+    it('has no duplicate or malformed route entries', () => {
+        expect(new Set(NOINDEX_ROUTE_PREFIXES).size).toBe(NOINDEX_ROUTE_PREFIXES.length)
+        expect(new Set(NOINDEX_EXACT_ROUTES).size).toBe(NOINDEX_EXACT_ROUTES.length)
+        expect(new Set(ROBOTS_DISALLOWED_PATHS).size).toBe(ROBOTS_DISALLOWED_PATHS.length)
+        expect(new Set(GOOGLE_DEINDEX_CRAWL_ALLOW_PATHS).size).toBe(GOOGLE_DEINDEX_CRAWL_ALLOW_PATHS.length)
+
+        for (const path of [...NOINDEX_ROUTE_PREFIXES, ...ROBOTS_DISALLOWED_PATHS]) {
+            expect(path).toMatch(/^\/[a-z0-9/-]+\/?$/)
+        }
+    })
+
+    it('keeps crawl exceptions narrowly scoped to exact indexed shells', () => {
+        expect(GOOGLE_DEINDEX_CRAWL_ALLOW_PATHS).toEqual([
+            '/home$',
+            '/profile$',
+            '/send$',
+            '/setup$',
+            '/invite$',
+            '/invite?code=',
+        ])
+    })
+})

--- a/src/constants/seo-route-policy.js
+++ b/src/constants/seo-route-policy.js
@@ -1,0 +1,114 @@
+/**
+ * Search-engine policy for non-marketing surfaces.
+ *
+ * Keep this file as plain CommonJS so both Next's build-time config and the
+ * TypeScript app can consume the same route inventory.
+ */
+
+const NOINDEX_ROUTE_PREFIXES = Object.freeze([
+    '/app',
+    '/sdk',
+    '/home',
+    '/profile',
+    '/settings',
+    '/send',
+    '/request',
+    '/setup',
+    '/claim',
+    '/pay',
+    '/pay-request',
+    '/dev',
+    '/qr',
+    '/qr-pay',
+    '/history',
+    '/points',
+    '/rewards',
+    '/invite',
+    '/kyc',
+    '/maintenance',
+    '/quests',
+    '/receipt',
+    '/crisp-proxy',
+    '/card',
+    '/card-payment',
+    '/add-money',
+    '/withdraw',
+    '/badges',
+    '/limits',
+    '/notifications',
+    '/recover-funds',
+    '/card-recovery',
+    '/recover-wallet',
+    '/fix-card-signature',
+    '/lp',
+])
+
+// Personalized images can include usernames and payment amounts. Keep only
+// the base endpoint out of search; `/api/og/marketing` is a separate public
+// route used by indexable landing pages.
+const NOINDEX_EXACT_ROUTES = Object.freeze(['/api/og'])
+
+// These paths should not be crawled at all. A route can be both noindex and
+// disallowed: the HTTP directive protects it if a crawler reaches it through
+// another mechanism, while robots.txt avoids routine discovery crawling.
+const ROBOTS_DISALLOWED_PATHS = Object.freeze([
+    '/api/',
+    '/sdk/',
+    '/home',
+    '/profile',
+    '/settings',
+    '/send',
+    '/request',
+    '/setup',
+    '/claim',
+    '/pay',
+    '/dev/',
+    '/qr',
+    '/history',
+    '/points',
+    '/rewards',
+    '/invite',
+    '/kyc',
+    '/maintenance',
+    '/quests',
+    '/receipt',
+    '/crisp-proxy',
+    '/card-payment',
+    '/add-money',
+    '/withdraw',
+])
+
+// GSC shows these exact shells (or their invite query variants) in Google's
+// index. They need a narrow crawl exception so search engines can observe and
+// refresh the X-Robots-Tag. Descendant transaction/profile URLs remain
+// blocked. Keep the exceptions while these routes exist; only remove one once
+// its route returns 404/410 or permanently redirects to a safe target.
+const GOOGLE_DEINDEX_CRAWL_ALLOW_PATHS = Object.freeze([
+    '/home$',
+    '/profile$',
+    '/send$',
+    '/setup$',
+    '/invite$',
+    '/invite?code=',
+])
+
+const NOINDEX_HEADER = Object.freeze({ key: 'X-Robots-Tag', value: 'noindex, nofollow' })
+
+function buildNoindexHeaderRules() {
+    return [
+        ...NOINDEX_EXACT_ROUTES.map((source) => ({ source, headers: [NOINDEX_HEADER] })),
+        ...NOINDEX_ROUTE_PREFIXES.map((source) => ({
+            source: `${source}/:path*`,
+            headers: [NOINDEX_HEADER],
+        })),
+    ]
+}
+
+module.exports = {
+    GOOGLE_DEINDEX_CRAWL_ALLOW_PATHS,
+    NOINDEX_HEADER,
+    NOINDEX_EXACT_ROUTES,
+    NOINDEX_ROUTE_PREFIXES,
+    ROBOTS_DISALLOWED_PATHS,
+    buildNoindexHeaderRules,
+}

--- a/src/constants/seo-route-policy.js
+++ b/src/constants/seo-route-policy.js
@@ -40,7 +40,6 @@ const NOINDEX_ROUTE_PREFIXES = Object.freeze([
     '/card-recovery',
     '/recover-wallet',
     '/fix-card-signature',
-    '/lp',
 ])
 
 // Personalized images can include usernames and payment amounts. Keep only


### PR DESCRIPTION
## Summary

- Prevent app, auth, profile, account, and transaction surfaces from competing in Google by returning `X-Robots-Tag: noindex, nofollow` at the HTTP response layer.
- Keep one shared route policy for Next response headers and `robots.txt`.
- Preserve indexing for public marketing, localized content, merchant pages, and marketing OG images while keeping personalized OG responses private.
- Remove the root marketing canonical from protected routes; `/` and `/lp` retain route-owned homepage metadata.

## Why this matters

Google Search Console shows that Peanut's app shells are appearing as search results even though they are not useful public landing pages. In the current 90-day window, `/home`, `/send`, and invite-code app URLs generated 2,966 impressions and 27 clicks. This dilutes the site's search footprint, sends visitors to the wrong experience, and makes those URLs compete with the marketing and help pages that should rank.

Robots blocking and canonicals alone have not fixed this. A blocked URL can remain indexed because Google cannot recrawl it to observe a `noindex` directive, and GSC shows Google choosing `/card` despite its homepage canonical. This PR lets Google revisit only the exact leaked app shells long enough to process response-level `noindex`, while private descendants remain blocked and public surfaces remain indexable.

This is technical SEO hygiene, not an instant ranking claim. After deployment we still need to verify the live headers and measure deindexing/recrawl in finalized GSC data.

## Task

[TASK-21781 — Ship GSC-backed peanut.me SEO improvements](https://app.notion.com/p/3c68381175798101b16ec08033342716?pvs=204)

## Risks / design notes

- Route classification is the main risk: an overly broad rule could hide a public page. Exact route tests and deployed HTTP/browser matrices cover protected routes and public controls.
- Crawl exceptions are deliberately narrow and apply only to app shells already surfaced in GSC, so Google can observe the new directive; account and transaction descendants remain blocked.
- Unknown or missing deployment origins fail closed. Only exact `https://peanut.me` is treated as production-indexable.
- The shared inventory is plain CommonJS so Next build configuration and TypeScript application code consume one source of truth.
- No API contract, database, visible UI, or user-flow changes.

## QA

- Exact head: `658ba00561a1295ab535f1432260f831f487ad5d` (signed, clean worktree).
- Focused SEO regression matrix: 3 suites / 45 tests passed.
- Prettier, changed-file ESLint, strict TypeScript, and `git diff --check` passed.
- Full unit gate: 272 suites / 3,428 tests passed / 3 skipped.
- Exact-head GitHub CI: 24 passed, 0 pending, 0 failed; Vercel build and preview deployment succeeded.
- Preview verification: all 37 protected probes returned exactly `X-Robots-Tag: noindex, nofollow`; all seven public controls avoided the app policy's `nofollow` directive.
- Metadata verification: protected `/home` has no canonical; public `/` and `/lp` retain their route-owned canonical behavior.
- Independent review approved the route inventory, metadata, header behavior, and public-route controls.
- CodeRabbit reviewed through exact head. Its earlier review found the valid fail-open origin issue; the fix was bot-confirmed and the only thread resolved. After the normal manual retries were rate-limited, the ready-for-review automatic run `204dfd15-cb86-4f81-a3b6-1a91749fef26` reviewed the exact two-file delta (`689e36d..658ba005`) and generated no actionable comments; the formal-review and inline-comment endpoints added no new findings.
- Local production build was terminated by host early-OOM at 5.48–5.84 GiB without a compiler diagnostic; the exact-head Vercel production build/deploy is green and the deployed preview supplied the runtime proof.

Screenshots: N/A (response headers, crawler policy, and metadata only; no visible change).

## Follow-up after merge

- Verify the response headers on production.
- Monitor `/home`, `/card`, `/send`, and invite variants in GSC for natural recrawl/deindexing.
- Compare finalized GSC data after 14–28 days; do not claim an SEO uplift before that measurement exists.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **SEO Improvements**
  * Added consistent noindex protections for private, application, and non-production routes.
  * Improved crawler directives, including shared disallow rules, crawl delays, and approved exceptions for search and social bots.
  * Production domains now receive appropriate indexing metadata, while preview or misconfigured environments default to noindex/nofollow.
  * Preserved canonical and crawlable behavior for public landing pages and localized routes.

* **Reliability**
  * Expanded automated coverage for robots, metadata, canonical, and route-policy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
