### PR TITLE
fix(login): unwedge a never-settling native passkey ceremony

### DIFF
--- a/src/components/Setup/Views/Landing.tsx
+++ b/src/components/Setup/Views/Landing.tsx
@@ -73,9 +73,11 @@ const LandingStep = () => {
                     <Button
                         shadowSize="4"
                         className="h-11"
-                        // a pending login ceremony must not be navigated away from —
-                        // mid-ceremony Sign Up taps flashed the waitlist step (TASK-21782)
-                        disabled={isLoggingIn}
+                        // native only: mid-ceremony Sign Up taps flashed the waitlist
+                        // step (TASK-21782). On web an abandoned hybrid/QR ceremony can
+                        // pend minutes — Sign Up must stay an escape hatch there, and a
+                        // mid-ceremony register fails cleanly as CeremonyConflictError.
+                        disabled={isLoggingIn && isCapacitor()}
                         onClick={() => {
                             posthog.capture(ANALYTICS_EVENTS.SIGNUP_CLICKED)
                             handleNext()

--- a/src/components/Setup/Views/Landing.tsx
+++ b/src/components/Setup/Views/Landing.tsx
@@ -73,6 +73,9 @@ const LandingStep = () => {
                     <Button
                         shadowSize="4"
                         className="h-11"
+                        // a pending login ceremony must not be navigated away from —
+                        // mid-ceremony Sign Up taps flashed the waitlist step (TASK-21782)
+                        disabled={isLoggingIn}
                         onClick={() => {
                             posthog.capture(ANALYTICS_EVENTS.SIGNUP_CLICKED)
                             handleNext()

--- a/src/components/Setup/Views/SetupPasskey.tsx
+++ b/src/components/Setup/Views/SetupPasskey.tsx
@@ -11,7 +11,7 @@ import { useDeviceType } from '@/hooks/useGetDeviceType'
 import { useEffect, useRef, useState } from 'react'
 import { capturePasskeyDebugInfo } from '@/utils/passkeyDebug'
 import { checkPasskeySupport } from '@/utils/passkeyPreflight'
-import { classifyPasskeyError, WebAuthnErrorName, withWebAuthnRetry } from '@/utils/webauthn.utils'
+import { WebAuthnErrorName, withWebAuthnRetry } from '@/utils/webauthn.utils'
 import { isCeremonyGuardError } from '@/utils/passkeyCeremony.utils'
 import { PasskeySetupHelpModal } from './PasskeySetupHelpModal'
 import ErrorAlert from '@/components/Global/ErrorAlert'
@@ -128,8 +128,14 @@ const SetupPasskey = () => {
             if (isCeremonyGuardError(error)) {
                 if (error.name === 'CeremonyTimeoutError' && (await isUsernameTaken(username))) {
                     setUsernameTaken(true)
+                } else if (error.name === 'CeremonyTimeoutError') {
+                    setInlineError(t('passkey.tookTooLong'))
+                } else if (error.name === 'PasskeyShimNotReadyError') {
+                    setInlineError(t('passkey.notReady'))
+                } else if (error.name === 'CeremonyConflictError') {
+                    setInlineError(t('passkey.interrupted'))
                 } else {
-                    setInlineError(classifyPasskeyError(error).message)
+                    setInlineError(t('passkey.deviceState'))
                 }
                 return
             }

--- a/src/components/Setup/Views/SetupPasskey.tsx
+++ b/src/components/Setup/Views/SetupPasskey.tsx
@@ -11,7 +11,8 @@ import { useDeviceType } from '@/hooks/useGetDeviceType'
 import { useEffect, useRef, useState } from 'react'
 import { capturePasskeyDebugInfo } from '@/utils/passkeyDebug'
 import { checkPasskeySupport } from '@/utils/passkeyPreflight'
-import { WebAuthnErrorName, withWebAuthnRetry } from '@/utils/webauthn.utils'
+import { classifyPasskeyError, WebAuthnErrorName, withWebAuthnRetry } from '@/utils/webauthn.utils'
+import { isCeremonyGuardError } from '@/utils/passkeyCeremony.utils'
 import { PasskeySetupHelpModal } from './PasskeySetupHelpModal'
 import ErrorAlert from '@/components/Global/ErrorAlert'
 import * as Sentry from '@sentry/nextjs'
@@ -117,6 +118,21 @@ const SetupPasskey = () => {
 
             // capture debug info for all failures
             await capturePasskeyDebugInfo('passkey-registration-failed')
+
+            // Ceremony-guard errors (shim race / timeout, TASK-21782) are already
+            // reported with a discriminating tag inside handleRegister — surface
+            // the curated retry copy instead of the generic help modal. A timed-out
+            // register may have completed server-side (its verify can land after
+            // the cutoff), so the username check routes the user to login instead
+            // of a colliding re-register.
+            if (isCeremonyGuardError(error)) {
+                if (error.name === 'CeremonyTimeoutError' && (await isUsernameTaken(username))) {
+                    setUsernameTaken(true)
+                } else {
+                    setInlineError(classifyPasskeyError(error).message)
+                }
+                return
+            }
 
             // notallowederror can mean two things:
             // 1. user actually cancelled (most common)

--- a/src/config/peanut.config.tsx
+++ b/src/config/peanut.config.tsx
@@ -31,67 +31,68 @@ export function PeanutProvider({ children }: { children: React.ReactNode }) {
             void authReady() // start Preferences hydration before any API call needs it
             installNativeAuthCapture()
             scheduleDirectFetchCanary()
-            import('@capgo/capacitor-passkey')
-                .then(({ CapacitorPasskey }) => {
-                    const nativeRpId = getNativeRpId()
+            const installPasskeyShim = async () => {
+                const { CapacitorPasskey } = await import('@capgo/capacitor-passkey')
+                const nativeRpId = getNativeRpId()
 
-                    // check native passkey support first
-                    CapacitorPasskey.isSupported()
-                        .then((support) => {
-                            console.log('[PeanutProvider] passkey support:', JSON.stringify(support))
-                        })
-                        .catch((err: unknown) => {
-                            console.warn('[PeanutProvider] passkey isSupported check failed:', err)
-                        })
+                // check native passkey support first
+                CapacitorPasskey.isSupported()
+                    .then((support) => {
+                        console.log('[PeanutProvider] passkey support:', JSON.stringify(support))
+                    })
+                    .catch((err: unknown) => {
+                        console.warn('[PeanutProvider] passkey isSupported check failed:', err)
+                    })
 
-                    CapacitorPasskey.autoShimWebAuthn({ origin: `https://${nativeRpId}` })
-                        .then(() => {
-                            // verify the shim actually installed by checking if credentials was patched
-                            const shimInstalled =
-                                (globalThis as { __capgoPasskeyShimInstalled?: unknown })
-                                    .__capgoPasskeyShimInstalled === true
-                            console.log('[PeanutProvider] passkey shim installed:', shimInstalled)
+                await CapacitorPasskey.autoShimWebAuthn({ origin: `https://${nativeRpId}` })
 
-                            // the shim's credentialFromJSON replaces its credential's prototype with
-                            // PublicKeyCredential.prototype. WKWebView's native getClientExtensionResults
-                            // brand-checks `this` and throws on shim credentials ("Can only call ... on
-                            // instances of PublicKeyCredential"), breaking both registration and login.
-                            // Wrap it unconditionally: native credentials keep the real behavior, shim
-                            // credentials fall back to their JSON payload.
-                            const PKC = globalThis.PublicKeyCredential
-                            if (PKC) {
-                                const nativeGetter = PKC.prototype.getClientExtensionResults
-                                PKC.prototype.getClientExtensionResults = function () {
-                                    try {
-                                        return nativeGetter ? nativeGetter.call(this) : {}
-                                    } catch {
-                                        return (
-                                            (
-                                                this as PublicKeyCredential & {
-                                                    json?: {
-                                                        clientExtensionResults?: AuthenticationExtensionsClientOutputs
-                                                    }
-                                                }
-                                            ).json?.clientExtensionResults ?? {}
-                                        )
+                // verify the shim actually installed by checking if credentials was patched
+                const shimInstalled =
+                    (globalThis as { __capgoPasskeyShimInstalled?: unknown }).__capgoPasskeyShimInstalled === true
+                console.log('[PeanutProvider] passkey shim installed:', shimInstalled)
+
+                // the shim's credentialFromJSON replaces its credential's prototype with
+                // PublicKeyCredential.prototype. WKWebView's native getClientExtensionResults
+                // brand-checks `this` and throws on shim credentials ("Can only call ... on
+                // instances of PublicKeyCredential"), breaking both registration and login.
+                // Wrap it unconditionally: native credentials keep the real behavior, shim
+                // credentials fall back to their JSON payload.
+                const PKC = globalThis.PublicKeyCredential
+                if (PKC) {
+                    const nativeGetter = PKC.prototype.getClientExtensionResults
+                    PKC.prototype.getClientExtensionResults = function () {
+                        try {
+                            return nativeGetter ? nativeGetter.call(this) : {}
+                        } catch {
+                            return (
+                                (
+                                    this as PublicKeyCredential & {
+                                        json?: {
+                                            clientExtensionResults?: AuthenticationExtensionsClientOutputs
+                                        }
                                     }
-                                }
-                            }
-                        })
-                        .catch((err: unknown) => {
-                            // known-dead install: waitForPasskeyShim fails a login tap
-                            // immediately with restart copy instead of polling out 3s
-                            // on a shim that will never arrive (TASK-21782)
-                            markPasskeyShimFailed()
-                            console.warn('[PeanutProvider] passkey shim init failed:', err)
-                        })
-                })
-                .catch((err: unknown) => {
-                    // chunk import / plugin resolution failed — previously an
-                    // unhandled rejection, leaving the shim flag unset forever
-                    markPasskeyShimFailed()
-                    console.warn('[PeanutProvider] passkey plugin import failed:', err)
-                })
+                                ).json?.clientExtensionResults ?? {}
+                            )
+                        }
+                    }
+                }
+            }
+
+            // One bounded re-attempt before declaring the install dead: a single
+            // transient import/bridge failure at cold start must not convert every
+            // tap for the rest of the session into "restart the app" copy. Only a
+            // failure of BOTH attempts marks the flag (which fails login taps
+            // immediately with restart copy instead of polling out 3s, TASK-21782).
+            const SHIM_INSTALL_RETRY_DELAY_MS = 1_500
+            installPasskeyShim().catch((firstErr: unknown) => {
+                console.warn('[PeanutProvider] passkey shim install failed, retrying once:', firstErr)
+                setTimeout(() => {
+                    installPasskeyShim().catch((err: unknown) => {
+                        markPasskeyShimFailed()
+                        console.warn('[PeanutProvider] passkey shim install failed:', err)
+                    })
+                }, SHIM_INSTALL_RETRY_DELAY_MS)
+            })
         }
     }, [])
 

--- a/src/config/peanut.config.tsx
+++ b/src/config/peanut.config.tsx
@@ -11,6 +11,7 @@ import { isCapacitor, getNativeRpId } from '@/utils/capacitor'
 import { authReady } from '@/utils/auth-token'
 import { installNativeAuthCapture } from '@/utils/native-auth-capture'
 import { scheduleDirectFetchCanary } from '@/utils/native-canary'
+import { markPasskeyShimFailed } from '@/utils/passkeyCeremony.utils'
 // Note: Sentry configs are auto-loaded by @sentry/nextjs via next.config.js
 // DO NOT import them here - it bundles server/edge configs into client code
 
@@ -30,56 +31,67 @@ export function PeanutProvider({ children }: { children: React.ReactNode }) {
             void authReady() // start Preferences hydration before any API call needs it
             installNativeAuthCapture()
             scheduleDirectFetchCanary()
-            import('@capgo/capacitor-passkey').then(({ CapacitorPasskey }) => {
-                const nativeRpId = getNativeRpId()
+            import('@capgo/capacitor-passkey')
+                .then(({ CapacitorPasskey }) => {
+                    const nativeRpId = getNativeRpId()
 
-                // check native passkey support first
-                CapacitorPasskey.isSupported()
-                    .then((support) => {
-                        console.log('[PeanutProvider] passkey support:', JSON.stringify(support))
-                    })
-                    .catch((err: unknown) => {
-                        console.warn('[PeanutProvider] passkey isSupported check failed:', err)
-                    })
+                    // check native passkey support first
+                    CapacitorPasskey.isSupported()
+                        .then((support) => {
+                            console.log('[PeanutProvider] passkey support:', JSON.stringify(support))
+                        })
+                        .catch((err: unknown) => {
+                            console.warn('[PeanutProvider] passkey isSupported check failed:', err)
+                        })
 
-                CapacitorPasskey.autoShimWebAuthn({ origin: `https://${nativeRpId}` })
-                    .then(() => {
-                        // verify the shim actually installed by checking if credentials was patched
-                        const shimInstalled =
-                            (globalThis as { __capgoPasskeyShimInstalled?: unknown }).__capgoPasskeyShimInstalled ===
-                            true
-                        console.log('[PeanutProvider] passkey shim installed:', shimInstalled)
+                    CapacitorPasskey.autoShimWebAuthn({ origin: `https://${nativeRpId}` })
+                        .then(() => {
+                            // verify the shim actually installed by checking if credentials was patched
+                            const shimInstalled =
+                                (globalThis as { __capgoPasskeyShimInstalled?: unknown })
+                                    .__capgoPasskeyShimInstalled === true
+                            console.log('[PeanutProvider] passkey shim installed:', shimInstalled)
 
-                        // the shim's credentialFromJSON replaces its credential's prototype with
-                        // PublicKeyCredential.prototype. WKWebView's native getClientExtensionResults
-                        // brand-checks `this` and throws on shim credentials ("Can only call ... on
-                        // instances of PublicKeyCredential"), breaking both registration and login.
-                        // Wrap it unconditionally: native credentials keep the real behavior, shim
-                        // credentials fall back to their JSON payload.
-                        const PKC = globalThis.PublicKeyCredential
-                        if (PKC) {
-                            const nativeGetter = PKC.prototype.getClientExtensionResults
-                            PKC.prototype.getClientExtensionResults = function () {
-                                try {
-                                    return nativeGetter ? nativeGetter.call(this) : {}
-                                } catch {
-                                    return (
-                                        (
-                                            this as PublicKeyCredential & {
-                                                json?: {
-                                                    clientExtensionResults?: AuthenticationExtensionsClientOutputs
+                            // the shim's credentialFromJSON replaces its credential's prototype with
+                            // PublicKeyCredential.prototype. WKWebView's native getClientExtensionResults
+                            // brand-checks `this` and throws on shim credentials ("Can only call ... on
+                            // instances of PublicKeyCredential"), breaking both registration and login.
+                            // Wrap it unconditionally: native credentials keep the real behavior, shim
+                            // credentials fall back to their JSON payload.
+                            const PKC = globalThis.PublicKeyCredential
+                            if (PKC) {
+                                const nativeGetter = PKC.prototype.getClientExtensionResults
+                                PKC.prototype.getClientExtensionResults = function () {
+                                    try {
+                                        return nativeGetter ? nativeGetter.call(this) : {}
+                                    } catch {
+                                        return (
+                                            (
+                                                this as PublicKeyCredential & {
+                                                    json?: {
+                                                        clientExtensionResults?: AuthenticationExtensionsClientOutputs
+                                                    }
                                                 }
-                                            }
-                                        ).json?.clientExtensionResults ?? {}
-                                    )
+                                            ).json?.clientExtensionResults ?? {}
+                                        )
+                                    }
                                 }
                             }
-                        }
-                    })
-                    .catch((err: unknown) => {
-                        console.warn('[PeanutProvider] passkey shim init failed:', err)
-                    })
-            })
+                        })
+                        .catch((err: unknown) => {
+                            // known-dead install: waitForPasskeyShim fails a login tap
+                            // immediately with restart copy instead of polling out 3s
+                            // on a shim that will never arrive (TASK-21782)
+                            markPasskeyShimFailed()
+                            console.warn('[PeanutProvider] passkey shim init failed:', err)
+                        })
+                })
+                .catch((err: unknown) => {
+                    // chunk import / plugin resolution failed — previously an
+                    // unhandled rejection, leaving the shim flag unset forever
+                    markPasskeyShimFailed()
+                    console.warn('[PeanutProvider] passkey plugin import failed:', err)
+                })
         }
     }, [])
 

--- a/src/config/peanut.config.tsx
+++ b/src/config/peanut.config.tsx
@@ -46,10 +46,14 @@ export function PeanutProvider({ children }: { children: React.ReactNode }) {
 
                 await CapacitorPasskey.autoShimWebAuthn({ origin: `https://${nativeRpId}` })
 
-                // verify the shim actually installed by checking if credentials was patched
+                // verify the shim actually installed by checking if credentials was
+                // patched — a resolved call that did NOT patch (e.g. a binary config
+                // with autoShim disabled) must go through the retry/failed path, not
+                // leave taps polling out on a flag that will never flip
                 const shimInstalled =
                     (globalThis as { __capgoPasskeyShimInstalled?: unknown }).__capgoPasskeyShimInstalled === true
                 console.log('[PeanutProvider] passkey shim installed:', shimInstalled)
+                if (!shimInstalled) throw new Error('autoShimWebAuthn resolved without patching navigator.credentials')
 
                 // the shim's credentialFromJSON replaces its credential's prototype with
                 // PublicKeyCredential.prototype. WKWebView's native getClientExtensionResults

--- a/src/hooks/__tests__/usePWAStatus.test.ts
+++ b/src/hooks/__tests__/usePWAStatus.test.ts
@@ -1,0 +1,36 @@
+import { isStandaloneDisplayMode } from '../usePWAStatus'
+
+jest.mock('@/utils/capacitor', () => ({ isCapacitor: jest.fn(() => false) }))
+
+const setHref = (path: string) => {
+    window.history.pushState({}, '', path)
+}
+
+beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn(() => ({ matches: false, addEventListener: jest.fn(), removeEventListener: jest.fn() })),
+    })
+})
+
+afterEach(() => {
+    setHref('/')
+})
+
+describe('isStandaloneDisplayMode', () => {
+    it('is false in a plain browser tab', () => {
+        expect(isStandaloneDisplayMode()).toBe(false)
+    })
+
+    it('detects mode=pwa regardless of query-parameter order', () => {
+        setHref('/?mode=pwa')
+        expect(isStandaloneDisplayMode()).toBe(true)
+        setHref('/?utm_source=x&mode=pwa')
+        expect(isStandaloneDisplayMode()).toBe(true)
+    })
+
+    it('does not match a mode value that merely contains pwa', () => {
+        setHref('/?mode=pwabc')
+        expect(isStandaloneDisplayMode()).toBe(false)
+    })
+})

--- a/src/hooks/query/__tests__/user.test.tsx
+++ b/src/hooks/query/__tests__/user.test.tsx
@@ -13,7 +13,7 @@ jest.mock('@/utils/auth-token', () => ({
     getAuthToken: jest.fn(() => null),
     getClearEpoch: jest.fn(() => 0),
 }))
-jest.mock('@/hooks/usePWAStatus', () => ({ usePWAStatus: () => false }))
+jest.mock('@/hooks/usePWAStatus', () => ({ usePWAStatus: () => false, isStandaloneDisplayMode: () => false }))
 jest.mock('@/hooks/useGetDeviceType', () => ({ useDeviceType: () => ({ deviceType: 'desktop' }) }))
 jest.mock('@/redux/hooks', () => ({
     useAppDispatch: () => jest.fn(),

--- a/src/hooks/query/user.ts
+++ b/src/hooks/query/user.ts
@@ -10,6 +10,7 @@ import { USER } from '@/constants/query.consts'
 import { apiFetch } from '@/utils/api-fetch'
 import { clearAuthToken, getAuthToken, getClearEpoch, setAuthToken } from '@/utils/auth-token'
 import { isDemoMode } from '@/utils/demo'
+import { isCapacitor } from '@/utils/capacitor'
 import { DEMO_USER } from '@/constants/demo-data'
 
 // custom error class for backend errors (5xx) that should trigger retry
@@ -57,7 +58,9 @@ export const useUserQuery = (dependsOn: boolean = true) => {
             if (payload) {
                 // Was: hitUserMetric(userData.user.userId, 'login', ...) → POST /users/:id/metrics/login.
                 // DB `user_metrics` table deprecated 2026-04-24; analytics is PostHog's job.
-                posthog.capture(ANALYTICS_EVENTS.LOGIN, { isPwa, deviceType })
+                // usePWAStatus matches display-mode standalone inside the Capacitor
+                // webview too — the native app is not a PWA (TASK-21782 telemetry fix)
+                posthog.capture(ANALYTICS_EVENTS.LOGIN, { isPwa: isCapacitor() ? false : isPwa, deviceType })
                 dispatch(userActions.setUser(payload))
             }
             return payload

--- a/src/hooks/query/user.ts
+++ b/src/hooks/query/user.ts
@@ -4,7 +4,7 @@ import { userActions } from '@/redux/slices/user-slice'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { useQuery } from '@tanstack/react-query'
-import { usePWAStatus } from '../usePWAStatus'
+import { isStandaloneDisplayMode } from '../usePWAStatus'
 import { useDeviceType } from '../useGetDeviceType'
 import { USER } from '@/constants/query.consts'
 import { apiFetch } from '@/utils/api-fetch'
@@ -24,7 +24,6 @@ export class BackendError extends Error {
 }
 
 export const useUserQuery = (dependsOn: boolean = true) => {
-    const isPwa = usePWAStatus()
     const { deviceType } = useDeviceType()
     const dispatch = useAppDispatch()
     const { user: authUser } = useUserStore()
@@ -58,12 +57,14 @@ export const useUserQuery = (dependsOn: boolean = true) => {
             if (payload) {
                 // Was: hitUserMetric(userData.user.userId, 'login', ...) → POST /users/:id/metrics/login.
                 // DB `user_metrics` table deprecated 2026-04-24; analytics is PostHog's job.
-                // usePWAStatus deliberately returns true for the Capacitor shell
-                // (it means "standalone app-like shell", which layouts rely on) —
-                // but for analytics the native app is not a PWA. isNativeBridge()
-                // not isCapacitor(): capacitor-flavored WEB builds must keep real
-                // PWA semantics (TASK-21782 telemetry fix).
-                posthog.capture(ANALYTICS_EVENTS.LOGIN, { isPwa: isNativeBridge() ? false : isPwa, deviceType })
+                // For analytics the native app is not a PWA, and a capacitor-
+                // flavored WEB build in a plain browser tab isn't either — use
+                // real display-mode detection, not usePWAStatus's Capacitor
+                // short-circuit (TASK-21782 telemetry fix).
+                posthog.capture(ANALYTICS_EVENTS.LOGIN, {
+                    isPwa: isNativeBridge() ? false : isStandaloneDisplayMode(),
+                    deviceType,
+                })
                 dispatch(userActions.setUser(payload))
             }
             return payload

--- a/src/hooks/query/user.ts
+++ b/src/hooks/query/user.ts
@@ -10,7 +10,7 @@ import { USER } from '@/constants/query.consts'
 import { apiFetch } from '@/utils/api-fetch'
 import { clearAuthToken, getAuthToken, getClearEpoch, setAuthToken } from '@/utils/auth-token'
 import { isDemoMode } from '@/utils/demo'
-import { isCapacitor } from '@/utils/capacitor'
+import { isNativeBridge } from '@/utils/capacitor'
 import { DEMO_USER } from '@/constants/demo-data'
 
 // custom error class for backend errors (5xx) that should trigger retry
@@ -58,9 +58,12 @@ export const useUserQuery = (dependsOn: boolean = true) => {
             if (payload) {
                 // Was: hitUserMetric(userData.user.userId, 'login', ...) → POST /users/:id/metrics/login.
                 // DB `user_metrics` table deprecated 2026-04-24; analytics is PostHog's job.
-                // usePWAStatus matches display-mode standalone inside the Capacitor
-                // webview too — the native app is not a PWA (TASK-21782 telemetry fix)
-                posthog.capture(ANALYTICS_EVENTS.LOGIN, { isPwa: isCapacitor() ? false : isPwa, deviceType })
+                // usePWAStatus deliberately returns true for the Capacitor shell
+                // (it means "standalone app-like shell", which layouts rely on) —
+                // but for analytics the native app is not a PWA. isNativeBridge()
+                // not isCapacitor(): capacitor-flavored WEB builds must keep real
+                // PWA semantics (TASK-21782 telemetry fix).
+                posthog.capture(ANALYTICS_EVENTS.LOGIN, { isPwa: isNativeBridge() ? false : isPwa, deviceType })
                 dispatch(userActions.setUser(payload))
             }
             return payload

--- a/src/hooks/usePWAStatus.ts
+++ b/src/hooks/usePWAStatus.ts
@@ -1,15 +1,23 @@
 import { useSyncExternalStore } from 'react'
 import { isCapacitor } from '@/utils/capacitor'
 
-const detectIsPWA = (): boolean => {
+// Real display-mode detection, without the Capacitor short-circuit below —
+// for analytics, where "built with the Capacitor env flag" must not read as
+// PWA when the page is actually a plain browser tab.
+export const isStandaloneDisplayMode = (): boolean => {
     if (typeof window === 'undefined') return false
-    if (isCapacitor()) return true
     return (
         window.matchMedia('(display-mode: standalone)').matches ||
         window.navigator.standalone ||
         document.referrer.includes('android-app://') ||
         window.location.href.includes('?mode=pwa')
     )
+}
+
+const detectIsPWA = (): boolean => {
+    if (typeof window === 'undefined') return false
+    if (isCapacitor()) return true
+    return isStandaloneDisplayMode()
 }
 
 // Cache the detection so multiple consumers share one read per page. The cache

--- a/src/hooks/usePWAStatus.ts
+++ b/src/hooks/usePWAStatus.ts
@@ -10,7 +10,7 @@ export const isStandaloneDisplayMode = (): boolean => {
         window.matchMedia('(display-mode: standalone)').matches ||
         window.navigator.standalone ||
         document.referrer.includes('android-app://') ||
-        window.location.href.includes('?mode=pwa')
+        new URLSearchParams(window.location.search).get('mode') === 'pwa'
     )
 }
 

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -11,7 +11,12 @@ import { getFromCookie, removeFromCookie, saveToCookie, saveToLocalStorage } fro
 import { clearAuthState } from '@/utils/auth.utils'
 import { isStaleKeyError, createStaleSessionError } from '@/utils/walletCredential.utils'
 import { capturePasskeySignFailure, classifyPasskeyError } from '@/utils/webauthn.utils'
-import { guardPasskeyCeremony, isCeremonyGuardError, isPasskeyShimInstalled } from '@/utils/passkeyCeremony.utils'
+import {
+    captureCeremonyGuardError,
+    guardPasskeyCeremony,
+    isCeremonyGuardError,
+    isPasskeyShimInstalled,
+} from '@/utils/passkeyCeremony.utils'
 import { toWebAuthnKey, WebAuthnMode } from '@zerodev/passkey-validator'
 import { useCallback, useContext } from 'react'
 import type { TransactionReceipt, Hex, Hash } from 'viem'
@@ -241,24 +246,16 @@ export const useZeroDev = () => {
             saveToCookie(WEB_AUTHN_COOKIE_KEY, webAuthnKey, 90)
         } catch (e) {
             if ((e as Error).message.includes('pending')) {
+                // the concurrent-request bail must still release the button
+                dispatch(zerodevActions.setIsRegistering(false))
                 return
             }
             const err = e as Error
             console.error('[useZeroDev] registration failed:', err.name, err.message, err, {
                 shimInstalled: isPasskeyShimInstalled(),
             })
-            // Same discriminating telemetry as the login guard — the register
-            // path previously produced zero signal for a hung ceremony.
             if (isCeremonyGuardError(err)) {
-                captureException(err, {
-                    tags: {
-                        error_type:
-                            err.name === 'CeremonyTimeoutError'
-                                ? 'register_ceremony_timeout'
-                                : 'register_shim_not_ready',
-                    },
-                    extra: { shimInstalled: isPasskeyShimInstalled(), isCapacitor: isCapacitor() },
-                })
+                captureCeremonyGuardError(err, 'register')
             }
             dispatch(zerodevActions.setIsRegistering(false))
             throw e
@@ -312,17 +309,7 @@ export const useZeroDev = () => {
             // state (no clearAuthState) and report with a discriminating tag —
             // this is the telemetry that tells us WHERE native logins hang.
             if (isCeremonyGuardError(err)) {
-                captureException(err, {
-                    tags: {
-                        error_type:
-                            err.name === 'CeremonyTimeoutError' ? 'login_ceremony_timeout' : 'login_shim_not_ready',
-                    },
-                    extra: {
-                        shimInstalled: isPasskeyShimInstalled(),
-                        isCapacitor: isCapacitor(),
-                        elapsedMs: Date.now() - ceremonyStartedAt,
-                    },
-                })
+                captureCeremonyGuardError(err, 'login', { elapsedMs: Date.now() - ceremonyStartedAt })
             } else if (code !== 'LOGIN_CANCELED') {
                 console.error('Error logging in', err)
                 await clearAuthState(user?.user.userId)

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -11,7 +11,7 @@ import { getFromCookie, removeFromCookie, saveToCookie, saveToLocalStorage } fro
 import { clearAuthState } from '@/utils/auth.utils'
 import { isStaleKeyError, createStaleSessionError } from '@/utils/walletCredential.utils'
 import { capturePasskeySignFailure, classifyPasskeyError } from '@/utils/webauthn.utils'
-import { isPasskeyShimInstalled, raceCeremonyTimeout, waitForPasskeyShim } from '@/utils/passkeyCeremony.utils'
+import { guardPasskeyCeremony, isCeremonyGuardError, isPasskeyShimInstalled } from '@/utils/passkeyCeremony.utils'
 import { toWebAuthnKey, WebAuthnMode } from '@zerodev/passkey-validator'
 import { useCallback, useContext } from 'react'
 import type { TransactionReceipt, Hex, Hash } from 'viem'
@@ -82,16 +82,20 @@ export const useZeroDev = () => {
 
             // @capgo/capacitor-passkey shim patches navigator.credentials on native,
             // so toWebAuthnKey works on all platforms (web, android, ios).
-            const webAuthnKey = await toWebAuthnKey({
-                passkeyName: _getPasskeyName(username),
-                passkeyServerUrl: PASSKEY_SERVER_URL as string,
-                mode: WebAuthnMode.Register,
-                // Consent-ledger echo (tos-v1 phase 2): the ZeroDev SDK owns the
-                // register/verify request body, so the terms+privacy versions the
-                // signup screen displayed ride in a header the backend ledgers.
-                passkeyServerHeaders: { 'x-accepted-legal': JSON.stringify(signupConsentDocuments()) },
-                rpID: rpId,
-            })
+            // Same TASK-21782 guard as login: native shim gate + 60s bound —
+            // signup is the tightest shim race (first tap after a fresh install).
+            const webAuthnKey = await guardPasskeyCeremony(() =>
+                toWebAuthnKey({
+                    passkeyName: _getPasskeyName(username),
+                    passkeyServerUrl: PASSKEY_SERVER_URL as string,
+                    mode: WebAuthnMode.Register,
+                    // Consent-ledger echo (tos-v1 phase 2): the ZeroDev SDK owns the
+                    // register/verify request body, so the terms+privacy versions the
+                    // signup screen displayed ride in a header the backend ledgers.
+                    passkeyServerHeaders: { 'x-accepted-legal': JSON.stringify(signupConsentDocuments()) },
+                    rpID: rpId,
+                })
+            )
 
             const inviteCodeFromCookie = getFromCookie('inviteCode')
 
@@ -241,9 +245,21 @@ export const useZeroDev = () => {
             }
             const err = e as Error
             console.error('[useZeroDev] registration failed:', err.name, err.message, err, {
-                shimInstalled: (globalThis as typeof globalThis & { __capgoPasskeyShimInstalled?: boolean })
-                    .__capgoPasskeyShimInstalled,
+                shimInstalled: isPasskeyShimInstalled(),
             })
+            // Same discriminating telemetry as the login guard — the register
+            // path previously produced zero signal for a hung ceremony.
+            if (isCeremonyGuardError(err)) {
+                captureException(err, {
+                    tags: {
+                        error_type:
+                            err.name === 'CeremonyTimeoutError'
+                                ? 'register_ceremony_timeout'
+                                : 'register_shim_not_ready',
+                    },
+                    extra: { shimInstalled: isPasskeyShimInstalled(), isCapacitor: isCapacitor() },
+                })
+            }
             dispatch(zerodevActions.setIsRegistering(false))
             throw e
         }
@@ -262,17 +278,13 @@ export const useZeroDev = () => {
 
             const rpId = isCapacitor() ? getNativeRpId() : window.location.hostname.replace(/^www\./, '')
 
-            // A tap that races the async autoShimWebAuthn install would run the
-            // webview's raw WebAuthn, which silently hangs in Capacitor — the
-            // TASK-21782 wedge. Fail fast with a retryable error instead.
-            if (isCapacitor()) await waitForPasskeyShim()
-
-            // zerodev's toWebAuthnKey has no timeout of its own; without this
-            // race a never-settling ceremony leaves isLoggingIn true forever
-            // and the user cannot retry without killing the app (TASK-21782).
-            // On timeout the late result is discarded, so a ceremony that
-            // completes after we gave up can never log the user in.
-            const webAuthnKey = await raceCeremonyTimeout(
+            // TASK-21782: on native, gate on the shim being installed (a tap
+            // racing autoShimWebAuthn runs the webview's raw WebAuthn, which
+            // silently hangs in Capacitor) and bound the ceremony to 60s so a
+            // never-settling toWebAuthnKey can't leave isLoggingIn true until
+            // app kill. A late result is discarded and its verify token is not
+            // captured (ceremony window closed) — see passkeyCeremony.utils.
+            const webAuthnKey = await guardPasskeyCeremony(() =>
                 toWebAuthnKey({
                     passkeyName: '[]',
                     passkeyServerUrl: PASSKEY_SERVER_URL as string,
@@ -299,10 +311,11 @@ export const useZeroDev = () => {
             // Ceremony guards: nothing was authenticated, so keep any existing
             // state (no clearAuthState) and report with a discriminating tag —
             // this is the telemetry that tells us WHERE native logins hang.
-            if (code === 'CEREMONY_TIMEOUT' || code === 'PASSKEY_NOT_READY') {
+            if (isCeremonyGuardError(err)) {
                 captureException(err, {
                     tags: {
-                        error_type: code === 'CEREMONY_TIMEOUT' ? 'login_ceremony_timeout' : 'login_shim_not_ready',
+                        error_type:
+                            err.name === 'CeremonyTimeoutError' ? 'login_ceremony_timeout' : 'login_shim_not_ready',
                     },
                     extra: {
                         shimInstalled: isPasskeyShimInstalled(),

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -11,6 +11,7 @@ import { getFromCookie, removeFromCookie, saveToCookie, saveToLocalStorage } fro
 import { clearAuthState } from '@/utils/auth.utils'
 import { isStaleKeyError, createStaleSessionError } from '@/utils/walletCredential.utils'
 import { capturePasskeySignFailure, classifyPasskeyError } from '@/utils/webauthn.utils'
+import { isPasskeyShimInstalled, raceCeremonyTimeout, waitForPasskeyShim } from '@/utils/passkeyCeremony.utils'
 import { toWebAuthnKey, WebAuthnMode } from '@zerodev/passkey-validator'
 import { useCallback, useContext } from 'react'
 import type { TransactionReceipt, Hex, Hash } from 'viem'
@@ -251,6 +252,7 @@ export const useZeroDev = () => {
     // login function
     const handleLogin = async () => {
         dispatch(zerodevActions.setIsLoggingIn(true))
+        const ceremonyStartedAt = Date.now()
         try {
             const passkeyServerHeaders: Record<string, string> = {}
 
@@ -260,13 +262,25 @@ export const useZeroDev = () => {
 
             const rpId = isCapacitor() ? getNativeRpId() : window.location.hostname.replace(/^www\./, '')
 
-            const webAuthnKey = await toWebAuthnKey({
-                passkeyName: '[]',
-                passkeyServerUrl: PASSKEY_SERVER_URL as string,
-                mode: WebAuthnMode.Login,
-                passkeyServerHeaders,
-                rpID: rpId,
-            })
+            // A tap that races the async autoShimWebAuthn install would run the
+            // webview's raw WebAuthn, which silently hangs in Capacitor — the
+            // TASK-21782 wedge. Fail fast with a retryable error instead.
+            if (isCapacitor()) await waitForPasskeyShim()
+
+            // zerodev's toWebAuthnKey has no timeout of its own; without this
+            // race a never-settling ceremony leaves isLoggingIn true forever
+            // and the user cannot retry without killing the app (TASK-21782).
+            // On timeout the late result is discarded, so a ceremony that
+            // completes after we gave up can never log the user in.
+            const webAuthnKey = await raceCeremonyTimeout(
+                toWebAuthnKey({
+                    passkeyName: '[]',
+                    passkeyServerUrl: PASSKEY_SERVER_URL as string,
+                    mode: WebAuthnMode.Login,
+                    passkeyServerHeaders,
+                    rpID: rpId,
+                })
+            )
 
             setWebAuthnKey(webAuthnKey)
             saveToCookie(WEB_AUTHN_COOKIE_KEY, webAuthnKey, 90)
@@ -282,8 +296,21 @@ export const useZeroDev = () => {
                     : e
             const { code, message } = classifyPasskeyError(err)
             dispatch(zerodevActions.setIsLoggingIn(false))
-            // Cancel saved no state; everything else clears stale state and reports the error to Sentry.
-            if (code !== 'LOGIN_CANCELED') {
+            // Ceremony guards: nothing was authenticated, so keep any existing
+            // state (no clearAuthState) and report with a discriminating tag —
+            // this is the telemetry that tells us WHERE native logins hang.
+            if (code === 'CEREMONY_TIMEOUT' || code === 'PASSKEY_NOT_READY') {
+                captureException(err, {
+                    tags: {
+                        error_type: code === 'CEREMONY_TIMEOUT' ? 'login_ceremony_timeout' : 'login_shim_not_ready',
+                    },
+                    extra: {
+                        shimInstalled: isPasskeyShimInstalled(),
+                        isCapacitor: isCapacitor(),
+                        elapsedMs: Date.now() - ceremonyStartedAt,
+                    },
+                })
+            } else if (code !== 'LOGIN_CANCELED') {
                 console.error('Error logging in', err)
                 await clearAuthState(user?.user.userId)
                 captureException(err, { tags: { error_type: 'login_error' } })

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -583,6 +583,10 @@
             "setItUp": "Set it up",
             "notAvailable": "Passkeys aren't available on this device yet. Please try again.",
             "cancelled": "Passkey setup was cancelled. Please try again when ready.",
+            "tookTooLong": "This is taking longer than it should. Please try again.",
+            "notReady": "The app is still getting ready for passkeys. Wait a moment and try again.",
+            "deviceState": "There was a problem with the passkey on this device. Restart the app and try again.",
+            "interrupted": "Something interrupted the passkey prompt. Please try again.",
             "usernameTaken": "This username is already registered — possibly from an earlier attempt on this device. If that was you, your passkey is ready: just log in.",
             "learnMore": "Learn more about what Passkeys are",
             "help": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -583,6 +583,10 @@
             "setItUp": "Configurar",
             "notAvailable": "Las passkeys aún no están disponibles en este dispositivo. Inténtalo de nuevo.",
             "cancelled": "La configuración de la passkey fue cancelada. Inténtalo de nuevo cuando quieras.",
+            "tookTooLong": "Esto está tardando más de lo esperado. Inténtalo de nuevo.",
+            "notReady": "La app todavía se está preparando para las passkeys. Espera un momento e inténtalo de nuevo.",
+            "deviceState": "Hubo un problema con la passkey en este dispositivo. Reinicia la app e inténtalo de nuevo.",
+            "interrupted": "Algo interrumpió la solicitud de la passkey. Inténtalo de nuevo.",
             "usernameTaken": "Este nombre de usuario ya está registrado, posiblemente por un intento anterior en este dispositivo. Si fuiste tú, tu passkey está lista: solo inicia sesión.",
             "learnMore": "Aprende más sobre qué son las passkeys",
             "help": {

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -583,6 +583,10 @@
             "setItUp": "Configurar",
             "notAvailable": "As passkeys ainda não estão disponíveis neste dispositivo. Tente de novo.",
             "cancelled": "A configuração da passkey foi cancelada. Tente de novo quando quiser.",
+            "tookTooLong": "Isso está demorando mais do que deveria. Tente de novo.",
+            "notReady": "O app ainda está se preparando para as passkeys. Aguarde um momento e tente de novo.",
+            "deviceState": "Houve um problema com a passkey neste dispositivo. Reinicie o app e tente de novo.",
+            "interrupted": "Algo interrompeu a solicitação da passkey. Tente de novo.",
             "usernameTaken": "Este nome de usuário já está registrado — possivelmente de uma tentativa anterior neste dispositivo. Se foi você, sua passkey está pronta: é só fazer login.",
             "learnMore": "Saiba mais sobre o que são as passkeys",
             "help": {

--- a/src/utils/__tests__/passkeyCeremony.utils.test.ts
+++ b/src/utils/__tests__/passkeyCeremony.utils.test.ts
@@ -2,9 +2,10 @@ import {
     CeremonyTimeoutError,
     PasskeyShimFailedError,
     PasskeyShimNotReadyError,
+    currentCeremonyId,
     guardPasskeyCeremony,
     isCeremonyGuardError,
-    isPasskeyCeremonyActive,
+    isCeremonyStillActive,
     isPasskeyShimInstalled,
     markPasskeyShimFailed,
     raceCeremonyTimeout,
@@ -120,8 +121,8 @@ describe('guardPasskeyCeremony', () => {
         await expect(guardPasskeyCeremony(() => Promise.resolve('key'))).resolves.toBe('key')
     })
 
-    it('marks the ceremony active only while in flight (token-capture window)', async () => {
-        expect(isPasskeyCeremonyActive()).toBe(false)
+    it('registers a ceremony id only while in flight (token-capture window)', async () => {
+        expect(currentCeremonyId()).toBeNull()
         let resolveCeremony!: (v: string) => void
         const pending = guardPasskeyCeremony(
             () =>
@@ -131,21 +132,56 @@ describe('guardPasskeyCeremony', () => {
         )
         // ceremony started (web path: no shim wait, so the window is open synchronously-ish)
         await Promise.resolve()
-        expect(isPasskeyCeremonyActive()).toBe(true)
+        const id = currentCeremonyId()
+        expect(id).not.toBeNull()
+        expect(isCeremonyStillActive(id)).toBe(true)
         resolveCeremony('done')
         await pending
-        expect(isPasskeyCeremonyActive()).toBe(false)
+        expect(currentCeremonyId()).toBeNull()
+        expect(isCeremonyStillActive(id)).toBe(false)
     })
 
-    it('closes the active window when the ceremony times out (late token must not be captured)', async () => {
+    it('closes the window when the ceremony times out (late token must not be captured)', async () => {
         mockIsCapacitor.mockReturnValue(true)
         setGlobal(SHIM_INSTALLED, true)
         jest.useFakeTimers()
         const pending = guardPasskeyCeremony(() => new Promise<never>(() => {}))
         const assertion = expect(pending).rejects.toBeInstanceOf(CeremonyTimeoutError)
+        await Promise.resolve()
+        const idA = currentCeremonyId()
         await jest.advanceTimersByTimeAsync(60_000)
         await assertion
-        expect(isPasskeyCeremonyActive()).toBe(false)
+        expect(isCeremonyStillActive(idA)).toBe(false)
+        expect(currentCeremonyId()).toBeNull()
+    })
+
+    it('A times out, retry B starts, A’s late verify must still be rejected while B is active', async () => {
+        mockIsCapacitor.mockReturnValue(true)
+        setGlobal(SHIM_INSTALLED, true)
+        jest.useFakeTimers()
+        // ceremony A: hangs, times out at 60s
+        const pendingA = guardPasskeyCeremony(() => new Promise<never>(() => {}))
+        const assertionA = expect(pendingA).rejects.toBeInstanceOf(CeremonyTimeoutError)
+        await Promise.resolve()
+        const idA = currentCeremonyId() // what A's verify request was issued under
+        await jest.advanceTimersByTimeAsync(60_000)
+        await assertionA
+        // ceremony B (the retry) starts and is in flight
+        let resolveB!: (v: string) => void
+        const pendingB = guardPasskeyCeremony(
+            () =>
+                new Promise<string>((resolve) => {
+                    resolveB = resolve
+                })
+        )
+        await Promise.resolve()
+        const idB = currentCeremonyId()
+        // A's late verify response lands now: bound to idA, NOT accepted just
+        // because B holds the window open
+        expect(isCeremonyStillActive(idA)).toBe(false)
+        expect(isCeremonyStillActive(idB)).toBe(true)
+        resolveB('done')
+        await pendingB
     })
 })
 

--- a/src/utils/__tests__/passkeyCeremony.utils.test.ts
+++ b/src/utils/__tests__/passkeyCeremony.utils.test.ts
@@ -1,0 +1,78 @@
+import {
+    CeremonyTimeoutError,
+    PasskeyShimNotReadyError,
+    isPasskeyShimInstalled,
+    raceCeremonyTimeout,
+    waitForPasskeyShim,
+} from '../passkeyCeremony.utils'
+
+const SHIM_FLAG = '__capgoPasskeyShimInstalled'
+
+const setShimFlag = (value: unknown) => {
+    ;(globalThis as Record<string, unknown>)[SHIM_FLAG] = value
+}
+
+afterEach(() => {
+    delete (globalThis as Record<string, unknown>)[SHIM_FLAG]
+    jest.useRealTimers()
+})
+
+describe('isPasskeyShimInstalled', () => {
+    it('is true only for the exact boolean true', () => {
+        expect(isPasskeyShimInstalled()).toBe(false)
+        setShimFlag('true')
+        expect(isPasskeyShimInstalled()).toBe(false)
+        setShimFlag(true)
+        expect(isPasskeyShimInstalled()).toBe(true)
+    })
+})
+
+describe('waitForPasskeyShim', () => {
+    it('resolves immediately when the shim is already installed', async () => {
+        setShimFlag(true)
+        await expect(waitForPasskeyShim(50)).resolves.toBeUndefined()
+    })
+
+    it('resolves when the shim installs mid-wait', async () => {
+        const pending = waitForPasskeyShim(2000)
+        setTimeout(() => setShimFlag(true), 150)
+        await expect(pending).resolves.toBeUndefined()
+    })
+
+    it('rejects with PasskeyShimNotReadyError when the shim never installs', async () => {
+        await expect(waitForPasskeyShim(250)).rejects.toBeInstanceOf(PasskeyShimNotReadyError)
+    })
+})
+
+describe('raceCeremonyTimeout', () => {
+    it('passes through a resolving promise', async () => {
+        await expect(raceCeremonyTimeout(Promise.resolve('key'), 1000)).resolves.toBe('key')
+    })
+
+    it('passes through a rejecting promise', async () => {
+        await expect(raceCeremonyTimeout(Promise.reject(new Error('boom')), 1000)).rejects.toThrow('boom')
+    })
+
+    it('rejects with CeremonyTimeoutError when the ceremony never settles', async () => {
+        jest.useFakeTimers()
+        const never = new Promise<never>(() => {})
+        const raced = raceCeremonyTimeout(never, 60_000)
+        const assertion = expect(raced).rejects.toBeInstanceOf(CeremonyTimeoutError)
+        jest.advanceTimersByTime(60_000)
+        await assertion
+    })
+
+    it('a late resolution after timeout is discarded (rejection already settled the race)', async () => {
+        jest.useFakeTimers()
+        let resolveLate!: (v: string) => void
+        const late = new Promise<string>((resolve) => {
+            resolveLate = resolve
+        })
+        const raced = raceCeremonyTimeout(late, 1_000)
+        const assertion = expect(raced).rejects.toBeInstanceOf(CeremonyTimeoutError)
+        jest.advanceTimersByTime(1_000)
+        await assertion
+        resolveLate('too-late') // must not turn the settled rejection into a success
+        await expect(raced).rejects.toBeInstanceOf(CeremonyTimeoutError)
+    })
+})

--- a/src/utils/__tests__/passkeyCeremony.utils.test.ts
+++ b/src/utils/__tests__/passkeyCeremony.utils.test.ts
@@ -1,4 +1,5 @@
 import {
+    CeremonyConflictError,
     CeremonyTimeoutError,
     PasskeyShimFailedError,
     PasskeyShimNotReadyError,
@@ -9,12 +10,17 @@ import {
     isPasskeyShimInstalled,
     markPasskeyShimFailed,
     raceCeremonyTimeout,
+    stashCeremonyVerifyToken,
     waitForPasskeyShim,
 } from '../passkeyCeremony.utils'
 import { isCapacitor } from '@/utils/capacitor'
+import { setAuthToken } from '@/utils/auth-token'
 
 jest.mock('@/utils/capacitor', () => ({ isCapacitor: jest.fn(() => false) }))
+jest.mock('@/utils/auth-token', () => ({ setAuthToken: jest.fn() }))
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }))
 const mockIsCapacitor = isCapacitor as jest.Mock
+const mockSetAuthToken = setAuthToken as jest.Mock
 
 const SHIM_INSTALLED = '__capgoPasskeyShimInstalled'
 const SHIM_FAILED = '__capgoPasskeyShimFailed'
@@ -28,6 +34,7 @@ afterEach(() => {
     delete (globalThis as Record<string, unknown>)[SHIM_FAILED]
     mockIsCapacitor.mockReset()
     mockIsCapacitor.mockReturnValue(false)
+    mockSetAuthToken.mockReset()
     jest.useRealTimers()
 })
 
@@ -103,7 +110,7 @@ describe('raceCeremonyTimeout', () => {
 })
 
 describe('guardPasskeyCeremony', () => {
-    it('web: runs the ceremony unraced and untracked-gated (no shim requirement)', async () => {
+    it('web: runs the ceremony without a shim requirement', async () => {
         await expect(guardPasskeyCeremony(() => Promise.resolve('ok'))).resolves.toBe('ok')
     })
 
@@ -182,6 +189,65 @@ describe('guardPasskeyCeremony', () => {
         expect(isCeremonyStillActive(idB)).toBe(true)
         resolveB('done')
         await pendingB
+    })
+
+    it('rejects a second concurrent ceremony instead of evicting the first', async () => {
+        let resolveA!: (v: string) => void
+        const pendingA = guardPasskeyCeremony(
+            () =>
+                new Promise<string>((resolve) => {
+                    resolveA = resolve
+                })
+        )
+        await Promise.resolve()
+        const idA = currentCeremonyId()
+        const ceremonyB = jest.fn()
+        await expect(guardPasskeyCeremony(ceremonyB)).rejects.toBeInstanceOf(CeremonyConflictError)
+        expect(ceremonyB).not.toHaveBeenCalled()
+        // A's window survived the conflict
+        expect(isCeremonyStillActive(idA)).toBe(true)
+        resolveA('done')
+        await pendingA
+    })
+
+    it('persists a stashed verify token only when the ceremony resolves', async () => {
+        let resolveCeremony!: (v: string) => void
+        const pending = guardPasskeyCeremony(
+            () =>
+                new Promise<string>((resolve) => {
+                    resolveCeremony = resolve
+                })
+        )
+        await Promise.resolve()
+        stashCeremonyVerifyToken('jwt-abc')
+        expect(mockSetAuthToken).not.toHaveBeenCalled()
+        resolveCeremony('key')
+        await pending
+        expect(mockSetAuthToken).toHaveBeenCalledWith('jwt-abc')
+    })
+
+    it('discards a stashed verify token when the ceremony times out', async () => {
+        mockIsCapacitor.mockReturnValue(true)
+        setGlobal(SHIM_INSTALLED, true)
+        jest.useFakeTimers()
+        const pending = guardPasskeyCeremony(() => new Promise<never>(() => {}))
+        const assertion = expect(pending).rejects.toBeInstanceOf(CeremonyTimeoutError)
+        await Promise.resolve()
+        stashCeremonyVerifyToken('jwt-stale')
+        await jest.advanceTimersByTimeAsync(60_000)
+        await assertion
+        expect(mockSetAuthToken).not.toHaveBeenCalled()
+        // a token landing with no ceremony active is refused outright
+        stashCeremonyVerifyToken('jwt-late')
+        expect(mockSetAuthToken).not.toHaveBeenCalled()
+    })
+
+    it('bounds a web ceremony with the generous web timeout', async () => {
+        jest.useFakeTimers()
+        const pending = guardPasskeyCeremony(() => new Promise<never>(() => {}))
+        const assertion = expect(pending).rejects.toBeInstanceOf(CeremonyTimeoutError)
+        await jest.advanceTimersByTimeAsync(300_000)
+        await assertion
     })
 })
 

--- a/src/utils/__tests__/passkeyCeremony.utils.test.ts
+++ b/src/utils/__tests__/passkeyCeremony.utils.test.ts
@@ -219,7 +219,7 @@ describe('guardPasskeyCeremony', () => {
                 })
         )
         await Promise.resolve()
-        stashCeremonyVerifyToken('jwt-abc')
+        stashCeremonyVerifyToken('jwt-abc', currentCeremonyId())
         expect(mockSetAuthToken).not.toHaveBeenCalled()
         resolveCeremony('key')
         await pending
@@ -233,12 +233,40 @@ describe('guardPasskeyCeremony', () => {
         const pending = guardPasskeyCeremony(() => new Promise<never>(() => {}))
         const assertion = expect(pending).rejects.toBeInstanceOf(CeremonyTimeoutError)
         await Promise.resolve()
-        stashCeremonyVerifyToken('jwt-stale')
+        stashCeremonyVerifyToken('jwt-stale', currentCeremonyId())
         await jest.advanceTimersByTimeAsync(60_000)
         await assertion
         expect(mockSetAuthToken).not.toHaveBeenCalled()
         // a token landing with no ceremony active is refused outright
-        stashCeremonyVerifyToken('jwt-late')
+        stashCeremonyVerifyToken('jwt-late', null)
+        expect(mockSetAuthToken).not.toHaveBeenCalled()
+    })
+
+    it('refuses a token whose request was issued outside the active window', async () => {
+        // A's verify request went out before B's window opened (issue id null
+        // or A's dead id) — even though B is active, A's token must not enter
+        // B's stash and be committed by B's success.
+        mockIsCapacitor.mockReturnValue(true)
+        setGlobal(SHIM_INSTALLED, true)
+        jest.useFakeTimers()
+        const pendingA = guardPasskeyCeremony(() => new Promise<never>(() => {}))
+        const assertionA = expect(pendingA).rejects.toBeInstanceOf(CeremonyTimeoutError)
+        await Promise.resolve()
+        const idA = currentCeremonyId()
+        await jest.advanceTimersByTimeAsync(60_000)
+        await assertionA
+        let resolveB!: (v: string) => void
+        const pendingB = guardPasskeyCeremony(
+            () =>
+                new Promise<string>((resolve) => {
+                    resolveB = resolve
+                })
+        )
+        await Promise.resolve()
+        stashCeremonyVerifyToken('jwt-from-A', idA)
+        stashCeremonyVerifyToken('jwt-from-nowhere', null)
+        resolveB('done')
+        await pendingB
         expect(mockSetAuthToken).not.toHaveBeenCalled()
     })
 

--- a/src/utils/__tests__/passkeyCeremony.utils.test.ts
+++ b/src/utils/__tests__/passkeyCeremony.utils.test.ts
@@ -1,46 +1,70 @@
 import {
     CeremonyTimeoutError,
+    PasskeyShimFailedError,
     PasskeyShimNotReadyError,
+    guardPasskeyCeremony,
+    isCeremonyGuardError,
+    isPasskeyCeremonyActive,
     isPasskeyShimInstalled,
+    markPasskeyShimFailed,
     raceCeremonyTimeout,
     waitForPasskeyShim,
 } from '../passkeyCeremony.utils'
+import { isCapacitor } from '@/utils/capacitor'
 
-const SHIM_FLAG = '__capgoPasskeyShimInstalled'
+jest.mock('@/utils/capacitor', () => ({ isCapacitor: jest.fn(() => false) }))
+const mockIsCapacitor = isCapacitor as jest.Mock
 
-const setShimFlag = (value: unknown) => {
-    ;(globalThis as Record<string, unknown>)[SHIM_FLAG] = value
+const SHIM_INSTALLED = '__capgoPasskeyShimInstalled'
+const SHIM_FAILED = '__capgoPasskeyShimFailed'
+
+const setGlobal = (key: string, value: unknown) => {
+    ;(globalThis as Record<string, unknown>)[key] = value
 }
 
 afterEach(() => {
-    delete (globalThis as Record<string, unknown>)[SHIM_FLAG]
+    delete (globalThis as Record<string, unknown>)[SHIM_INSTALLED]
+    delete (globalThis as Record<string, unknown>)[SHIM_FAILED]
+    mockIsCapacitor.mockReset()
+    mockIsCapacitor.mockReturnValue(false)
     jest.useRealTimers()
 })
 
 describe('isPasskeyShimInstalled', () => {
     it('is true only for the exact boolean true', () => {
         expect(isPasskeyShimInstalled()).toBe(false)
-        setShimFlag('true')
+        setGlobal(SHIM_INSTALLED, 'true')
         expect(isPasskeyShimInstalled()).toBe(false)
-        setShimFlag(true)
+        setGlobal(SHIM_INSTALLED, true)
         expect(isPasskeyShimInstalled()).toBe(true)
     })
 })
 
 describe('waitForPasskeyShim', () => {
     it('resolves immediately when the shim is already installed', async () => {
-        setShimFlag(true)
+        setGlobal(SHIM_INSTALLED, true)
         await expect(waitForPasskeyShim(50)).resolves.toBeUndefined()
     })
 
     it('resolves when the shim installs mid-wait', async () => {
+        jest.useFakeTimers()
         const pending = waitForPasskeyShim(2000)
-        setTimeout(() => setShimFlag(true), 150)
+        setTimeout(() => setGlobal(SHIM_INSTALLED, true), 300)
+        await jest.advanceTimersByTimeAsync(500)
         await expect(pending).resolves.toBeUndefined()
     })
 
     it('rejects with PasskeyShimNotReadyError when the shim never installs', async () => {
-        await expect(waitForPasskeyShim(250)).rejects.toBeInstanceOf(PasskeyShimNotReadyError)
+        jest.useFakeTimers()
+        const pending = waitForPasskeyShim(250)
+        const assertion = expect(pending).rejects.toBeInstanceOf(PasskeyShimNotReadyError)
+        await jest.advanceTimersByTimeAsync(400)
+        await assertion
+    })
+
+    it('rejects immediately with PasskeyShimFailedError when the install is known-dead', async () => {
+        markPasskeyShimFailed()
+        await expect(waitForPasskeyShim(3000)).rejects.toBeInstanceOf(PasskeyShimFailedError)
     })
 })
 
@@ -74,5 +98,63 @@ describe('raceCeremonyTimeout', () => {
         await assertion
         resolveLate('too-late') // must not turn the settled rejection into a success
         await expect(raced).rejects.toBeInstanceOf(CeremonyTimeoutError)
+    })
+})
+
+describe('guardPasskeyCeremony', () => {
+    it('web: runs the ceremony unraced and untracked-gated (no shim requirement)', async () => {
+        await expect(guardPasskeyCeremony(() => Promise.resolve('ok'))).resolves.toBe('ok')
+    })
+
+    it('native: rejects before starting the ceremony when the shim install failed', async () => {
+        mockIsCapacitor.mockReturnValue(true)
+        markPasskeyShimFailed()
+        const ceremony = jest.fn()
+        await expect(guardPasskeyCeremony(ceremony)).rejects.toBeInstanceOf(PasskeyShimFailedError)
+        expect(ceremony).not.toHaveBeenCalled()
+    })
+
+    it('native: runs and resolves when the shim is installed', async () => {
+        mockIsCapacitor.mockReturnValue(true)
+        setGlobal(SHIM_INSTALLED, true)
+        await expect(guardPasskeyCeremony(() => Promise.resolve('key'))).resolves.toBe('key')
+    })
+
+    it('marks the ceremony active only while in flight (token-capture window)', async () => {
+        expect(isPasskeyCeremonyActive()).toBe(false)
+        let resolveCeremony!: (v: string) => void
+        const pending = guardPasskeyCeremony(
+            () =>
+                new Promise<string>((resolve) => {
+                    resolveCeremony = resolve
+                })
+        )
+        // ceremony started (web path: no shim wait, so the window is open synchronously-ish)
+        await Promise.resolve()
+        expect(isPasskeyCeremonyActive()).toBe(true)
+        resolveCeremony('done')
+        await pending
+        expect(isPasskeyCeremonyActive()).toBe(false)
+    })
+
+    it('closes the active window when the ceremony times out (late token must not be captured)', async () => {
+        mockIsCapacitor.mockReturnValue(true)
+        setGlobal(SHIM_INSTALLED, true)
+        jest.useFakeTimers()
+        const pending = guardPasskeyCeremony(() => new Promise<never>(() => {}))
+        const assertion = expect(pending).rejects.toBeInstanceOf(CeremonyTimeoutError)
+        await jest.advanceTimersByTimeAsync(60_000)
+        await assertion
+        expect(isPasskeyCeremonyActive()).toBe(false)
+    })
+})
+
+describe('isCeremonyGuardError', () => {
+    it('recognizes exactly the guard errors', () => {
+        expect(isCeremonyGuardError(new CeremonyTimeoutError(1))).toBe(true)
+        expect(isCeremonyGuardError(new PasskeyShimNotReadyError(1))).toBe(true)
+        expect(isCeremonyGuardError(new PasskeyShimFailedError())).toBe(true)
+        expect(isCeremonyGuardError(new Error('NotAllowedError'))).toBe(false)
+        expect(isCeremonyGuardError('nope')).toBe(false)
     })
 })

--- a/src/utils/app-lock.ts
+++ b/src/utils/app-lock.ts
@@ -13,6 +13,8 @@
 // gaps the guarded mode closes.
 
 import { base64URLToBytes } from './native-webauthn'
+import { isCapacitor } from './capacitor'
+import { raceCeremonyTimeout, waitForPasskeyShim } from './passkeyCeremony.utils'
 
 /** How long the app may sit in the background before it relocks. */
 export const LOCK_AFTER_BACKGROUND_MS = 5 * 60 * 1000
@@ -40,16 +42,23 @@ export async function requestLocalUserPresence(credentialId?: string): Promise<U
     crypto.getRandomValues(challenge)
 
     try {
-        const assertion = await navigator.credentials.get({
-            publicKey: {
-                challenge,
-                // Copy into a fresh buffer: BufferSource wants Uint8Array<ArrayBuffer>,
-                // and base64URLToBytes is typed over the wider ArrayBufferLike.
-                allowCredentials: [{ id: new Uint8Array(base64URLToBytes(credentialId)), type: 'public-key' }],
-                userVerification: 'required',
-                timeout: 60_000,
-            },
-        })
+        // Fires at app open — the exact window where autoShimWebAuthn is still
+        // installing on native. Gate on the shim and bound the ceremony (same
+        // guard class as login, TASK-21782): an un-shimmed webview get() hangs
+        // silently and would strand the user behind the lock with no retry.
+        if (isCapacitor()) await waitForPasskeyShim()
+        const assertion = await raceCeremonyTimeout(
+            navigator.credentials.get({
+                publicKey: {
+                    challenge,
+                    // Copy into a fresh buffer: BufferSource wants Uint8Array<ArrayBuffer>,
+                    // and base64URLToBytes is typed over the wider ArrayBufferLike.
+                    allowCredentials: [{ id: new Uint8Array(base64URLToBytes(credentialId)), type: 'public-key' }],
+                    userVerification: 'required',
+                    timeout: 60_000,
+                },
+            })
+        )
         return assertion ? 'unlocked' : 'dismissed'
     } catch (error) {
         // A cancelled prompt and a genuinely broken authenticator are
@@ -57,7 +66,10 @@ export async function requestLocalUserPresence(credentialId?: string): Promise<U
         // is the safe direction. NotSupportedError is the exception: it fails
         // open (like the pre-flight checks), since it means this device cannot
         // complete the ceremony at all and retrying would strand the user.
-        if (error instanceof Error && error.name === 'NotSupportedError') return 'unsupported'
+        // PasskeyShimFailedError joins it: the install is dead for this session,
+        // so no retry can ever succeed — a lock we can't lift must not engage.
+        if (error instanceof Error && (error.name === 'NotSupportedError' || error.name === 'PasskeyShimFailedError'))
+            return 'unsupported'
         return 'dismissed'
     }
 }

--- a/src/utils/native-auth-capture.ts
+++ b/src/utils/native-auth-capture.ts
@@ -9,7 +9,6 @@ import * as Sentry from '@sentry/nextjs'
 import { isCapacitor } from './capacitor'
 import { currentCeremonyId, stashCeremonyVerifyToken } from './passkeyCeremony.utils'
 
-const VERIFY_URL_PATTERN = /\/passkeys\/(login|register)\/verify/
 // ZeroDev swallows the status/body of these fetches, so a rejected ceremony
 // reaches Sentry only as an opaque "Login not verified" (PEANUT-UI-R0X) with
 // no hint of WHICH server check failed — report non-2xx responses here.

--- a/src/utils/native-auth-capture.ts
+++ b/src/utils/native-auth-capture.ts
@@ -8,6 +8,7 @@
 import * as Sentry from '@sentry/nextjs'
 import { isCapacitor } from './capacitor'
 import { setAuthToken } from './auth-token'
+import { isPasskeyCeremonyActive } from './passkeyCeremony.utils'
 
 const VERIFY_URL_PATTERN = /\/passkeys\/(login|register)\/verify/
 // ZeroDev swallows the status/body of these fetches, so a rejected ceremony
@@ -79,7 +80,11 @@ export function installNativeAuthCapture(): void {
                     .catch(() => '')
                 reportPasskeyHttpFailure(passkeyPath, response.status, body)
             }
-            if (response.ok && VERIFY_URL_PATTERN.test(url)) {
+            // Only persist a verify token while a ceremony is actually in
+            // flight: a verify response landing after the 60s ceremony timeout
+            // already told the user "failed" must not leave a half-authenticated
+            // session behind (TASK-21782).
+            if (response.ok && VERIFY_URL_PATTERN.test(url) && isPasskeyCeremonyActive()) {
                 const body = await response.clone().json()
                 if (body && typeof body.token === 'string' && body.token) {
                     setAuthToken(body.token)

--- a/src/utils/native-auth-capture.ts
+++ b/src/utils/native-auth-capture.ts
@@ -7,7 +7,7 @@
 
 import * as Sentry from '@sentry/nextjs'
 import { isCapacitor } from './capacitor'
-import { stashCeremonyVerifyToken } from './passkeyCeremony.utils'
+import { currentCeremonyId, stashCeremonyVerifyToken } from './passkeyCeremony.utils'
 
 const VERIFY_URL_PATTERN = /\/passkeys\/(login|register)\/verify/
 // ZeroDev swallows the status/body of these fetches, so a rejected ceremony
@@ -58,6 +58,10 @@ export function installNativeAuthCapture(): void {
     window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
         const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
         const passkeyPath = PASSKEY_URL_PATTERN.exec(url)?.[0] ?? null
+        const isVerify = passkeyPath !== null && passkeyPath.endsWith('/verify')
+        // Bind the request to the ceremony active at ISSUE time: a verify whose
+        // request predates the current ceremony's window must not enter its stash.
+        const issuingCeremonyId = isVerify ? currentCeremonyId() : null
 
         let response: Response
         try {
@@ -79,14 +83,15 @@ export function installNativeAuthCapture(): void {
                     .catch(() => '')
                 reportPasskeyHttpFailure(passkeyPath, response.status, body)
             }
-            // The token is only STASHED here; guardPasskeyCeremony persists it
-            // when the owning ceremony resolves and discards it on failure —
-            // so a verify landing after its ceremony was reported "failed"
-            // can never leave a half-authenticated session (TASK-21782).
-            if (response.ok && VERIFY_URL_PATTERN.test(url)) {
+            // The token is only STASHED here (keyed to the issuing ceremony);
+            // guardPasskeyCeremony persists it when the owning ceremony resolves
+            // and discards it on failure — so a verify landing after its
+            // ceremony was reported "failed" can never leave a
+            // half-authenticated session (TASK-21782).
+            if (response.ok && isVerify) {
                 const body = await response.clone().json()
                 if (body && typeof body.token === 'string' && body.token) {
-                    stashCeremonyVerifyToken(body.token)
+                    stashCeremonyVerifyToken(body.token, issuingCeremonyId)
                 }
             }
         } catch {

--- a/src/utils/native-auth-capture.ts
+++ b/src/utils/native-auth-capture.ts
@@ -8,7 +8,7 @@
 import * as Sentry from '@sentry/nextjs'
 import { isCapacitor } from './capacitor'
 import { setAuthToken } from './auth-token'
-import { isPasskeyCeremonyActive } from './passkeyCeremony.utils'
+import { currentCeremonyId, isCeremonyStillActive } from './passkeyCeremony.utils'
 
 const VERIFY_URL_PATTERN = /\/passkeys\/(login|register)\/verify/
 // ZeroDev swallows the status/body of these fetches, so a rejected ceremony
@@ -59,6 +59,10 @@ export function installNativeAuthCapture(): void {
     window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
         const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
         const passkeyPath = PASSKEY_URL_PATTERN.exec(url)?.[0] ?? null
+        // Bind a verify request to the ceremony that issued it (TASK-21782):
+        // its token is only persisted if that SAME ceremony is still active
+        // when the response lands — see passkeyCeremony.utils.
+        const issuingCeremonyId = VERIFY_URL_PATTERN.test(url) ? currentCeremonyId() : null
 
         let response: Response
         try {
@@ -80,11 +84,12 @@ export function installNativeAuthCapture(): void {
                     .catch(() => '')
                 reportPasskeyHttpFailure(passkeyPath, response.status, body)
             }
-            // Only persist a verify token while a ceremony is actually in
-            // flight: a verify response landing after the 60s ceremony timeout
-            // already told the user "failed" must not leave a half-authenticated
-            // session behind (TASK-21782).
-            if (response.ok && VERIFY_URL_PATTERN.test(url) && isPasskeyCeremonyActive()) {
+            // Only persist a verify token when the ceremony that issued the
+            // request is STILL the active one: a response landing after its
+            // ceremony timed out already told the user "failed" and must not
+            // leave a half-authenticated session — even if a retry ceremony
+            // is running by then (TASK-21782).
+            if (response.ok && VERIFY_URL_PATTERN.test(url) && isCeremonyStillActive(issuingCeremonyId)) {
                 const body = await response.clone().json()
                 if (body && typeof body.token === 'string' && body.token) {
                     setAuthToken(body.token)

--- a/src/utils/native-auth-capture.ts
+++ b/src/utils/native-auth-capture.ts
@@ -7,8 +7,7 @@
 
 import * as Sentry from '@sentry/nextjs'
 import { isCapacitor } from './capacitor'
-import { setAuthToken } from './auth-token'
-import { currentCeremonyId, isCeremonyStillActive } from './passkeyCeremony.utils'
+import { stashCeremonyVerifyToken } from './passkeyCeremony.utils'
 
 const VERIFY_URL_PATTERN = /\/passkeys\/(login|register)\/verify/
 // ZeroDev swallows the status/body of these fetches, so a rejected ceremony
@@ -59,10 +58,6 @@ export function installNativeAuthCapture(): void {
     window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
         const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
         const passkeyPath = PASSKEY_URL_PATTERN.exec(url)?.[0] ?? null
-        // Bind a verify request to the ceremony that issued it (TASK-21782):
-        // its token is only persisted if that SAME ceremony is still active
-        // when the response lands — see passkeyCeremony.utils.
-        const issuingCeremonyId = VERIFY_URL_PATTERN.test(url) ? currentCeremonyId() : null
 
         let response: Response
         try {
@@ -84,15 +79,14 @@ export function installNativeAuthCapture(): void {
                     .catch(() => '')
                 reportPasskeyHttpFailure(passkeyPath, response.status, body)
             }
-            // Only persist a verify token when the ceremony that issued the
-            // request is STILL the active one: a response landing after its
-            // ceremony timed out already told the user "failed" and must not
-            // leave a half-authenticated session — even if a retry ceremony
-            // is running by then (TASK-21782).
-            if (response.ok && VERIFY_URL_PATTERN.test(url) && isCeremonyStillActive(issuingCeremonyId)) {
+            // The token is only STASHED here; guardPasskeyCeremony persists it
+            // when the owning ceremony resolves and discards it on failure —
+            // so a verify landing after its ceremony was reported "failed"
+            // can never leave a half-authenticated session (TASK-21782).
+            if (response.ok && VERIFY_URL_PATTERN.test(url)) {
                 const body = await response.clone().json()
                 if (body && typeof body.token === 'string' && body.token) {
-                    setAuthToken(body.token)
+                    stashCeremonyVerifyToken(body.token)
                 }
             }
         } catch {

--- a/src/utils/native-webauthn.ts
+++ b/src/utils/native-webauthn.ts
@@ -3,6 +3,8 @@
 
 import { keccak256, type Hex, type SignableMessage, encodeAbiParameters } from 'viem'
 import { bytesToBigInt, hexToBytes } from 'viem'
+import { isCapacitor } from './capacitor'
+import { raceCeremonyTimeout, waitForPasskeyShim } from './passkeyCeremony.utils'
 // @noble/curves/p256 was the public path in v1.9.7; v2 removed it. Pin documented in package.json.
 import { p256 } from '@noble/curves/p256'
 
@@ -172,10 +174,16 @@ export function createNativeSignMessageCallback(rpId: string, pinnedCredentialId
             timeout: 60000,
         }
 
-        // uses navigator.credentials.get() which is shimmed by @capgo/capacitor-passkey
-        const cred = (await navigator.credentials.get({
-            publicKey: assertionOptions,
-        })) as PublicKeyCredential
+        // uses navigator.credentials.get() which is shimmed by @capgo/capacitor-passkey.
+        // Same guard class as login (TASK-21782): a signature racing the async
+        // shim install would run the webview's raw WebAuthn, which silently
+        // hangs in Capacitor — gate on the shim and bound the ceremony.
+        if (isCapacitor()) await waitForPasskeyShim()
+        const cred = (await raceCeremonyTimeout(
+            navigator.credentials.get({
+                publicKey: assertionOptions,
+            })
+        )) as PublicKeyCredential
 
         if (!cred || !cred.response) {
             throw new Error('native signing failed — no credential returned')

--- a/src/utils/passkeyCeremony.utils.ts
+++ b/src/utils/passkeyCeremony.utils.ts
@@ -80,12 +80,17 @@ export const waitForPasskeyShim = async (timeoutMs: number = SHIM_WAIT_TIMEOUT_M
     }
 }
 
-// Ceremony-in-flight tracking. native-auth-capture only persists a
-// /passkeys/*/verify token while a ceremony is active, so a verify response
-// landing AFTER a timeout already told the user "failed" cannot leave a
-// half-authenticated session behind.
-let activeCeremonies = 0
-export const isPasskeyCeremonyActive = (): boolean => activeCeremonies > 0
+// Ceremony-in-flight tracking. native-auth-capture binds each
+// /passkeys/*/verify request to the ceremony that was active when the
+// request was ISSUED, and persists its token only if that same ceremony is
+// still active when the response lands. A verify response arriving after
+// its ceremony timed out is dropped — even when the user has already
+// started a NEW ceremony (a bare "any ceremony active" check would re-open
+// the window and store the stale token).
+let ceremonySeq = 0
+let activeCeremonyId: number | null = null
+export const currentCeremonyId = (): number | null => activeCeremonyId
+export const isCeremonyStillActive = (id: number | null): boolean => id !== null && id === activeCeremonyId
 
 /**
  * Races `promise` against a `CeremonyTimeoutError`. On timeout the original
@@ -111,10 +116,12 @@ export const raceCeremonyTimeout = <T>(promise: Promise<T>, ms: number = CEREMON
 export const guardPasskeyCeremony = async <T>(startCeremony: () => Promise<T>): Promise<T> => {
     const native = isCapacitor()
     if (native) await waitForPasskeyShim()
-    activeCeremonies++
+    const ceremonyId = ++ceremonySeq
+    activeCeremonyId = ceremonyId
     try {
         return native ? await raceCeremonyTimeout(startCeremony()) : await startCeremony()
     } finally {
-        activeCeremonies = Math.max(0, activeCeremonies - 1)
+        // only clear our own registration — a newer ceremony may have taken over
+        if (activeCeremonyId === ceremonyId) activeCeremonyId = null
     }
 }

--- a/src/utils/passkeyCeremony.utils.ts
+++ b/src/utils/passkeyCeremony.utils.ts
@@ -1,0 +1,62 @@
+/**
+ * Guards for the passkey login ceremony (TASK-21782).
+ *
+ * The zerodev `toWebAuthnKey()` call can pend forever on native Android —
+ * a tap that races the async `autoShimWebAuthn` install runs the webview's
+ * raw WebAuthn (broken in Capacitor), and the Credential Manager callback
+ * can silently never fire. Without a timeout, `isLoggingIn` stays true and
+ * the Log In button is dead until the app is killed.
+ */
+
+// WebAuthn UI sheets time out on their own around 60s; racing shorter would
+// cancel a ceremony the user is legitimately still completing.
+export const CEREMONY_TIMEOUT_MS = 60_000
+
+// The shim install is a dynamic import + native plugin call — normally
+// sub-second. 3s covers a slow cold start without stalling a real tap.
+export const SHIM_WAIT_TIMEOUT_MS = 3_000
+const SHIM_POLL_INTERVAL_MS = 100
+
+export class CeremonyTimeoutError extends Error {
+    constructor(ms: number) {
+        super(`passkey ceremony did not settle within ${ms}ms`)
+        this.name = 'CeremonyTimeoutError'
+    }
+}
+
+export class PasskeyShimNotReadyError extends Error {
+    constructor(ms: number) {
+        super(`native passkey shim not installed after ${ms}ms`)
+        this.name = 'PasskeyShimNotReadyError'
+    }
+}
+
+export const isPasskeyShimInstalled = (): boolean =>
+    (globalThis as typeof globalThis & { __capgoPasskeyShimInstalled?: unknown }).__capgoPasskeyShimInstalled === true
+
+/**
+ * Resolves once the capgo passkey shim has patched `navigator.credentials`;
+ * rejects with `PasskeyShimNotReadyError` if it hasn't after `timeoutMs`.
+ * Rejecting (instead of proceeding) is deliberate: the un-shimmed webview
+ * WebAuthn call is exactly the silent-hang this file exists to prevent.
+ */
+export const waitForPasskeyShim = async (timeoutMs: number = SHIM_WAIT_TIMEOUT_MS): Promise<void> => {
+    const deadline = Date.now() + timeoutMs
+    while (!isPasskeyShimInstalled()) {
+        if (Date.now() >= deadline) throw new PasskeyShimNotReadyError(timeoutMs)
+        await new Promise((resolve) => setTimeout(resolve, SHIM_POLL_INTERVAL_MS))
+    }
+}
+
+/**
+ * Races `promise` against a `CeremonyTimeoutError`. On timeout the original
+ * promise keeps running but its result is discarded by the caller's `await`,
+ * so a late ceremony success can never log the user in after we gave up.
+ */
+export const raceCeremonyTimeout = <T>(promise: Promise<T>, ms: number = CEREMONY_TIMEOUT_MS): Promise<T> => {
+    let timer: ReturnType<typeof setTimeout>
+    const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new CeremonyTimeoutError(ms)), ms)
+    })
+    return Promise.race([promise, timeout]).finally(() => clearTimeout(timer)) as Promise<T>
+}

--- a/src/utils/passkeyCeremony.utils.ts
+++ b/src/utils/passkeyCeremony.utils.ts
@@ -130,9 +130,14 @@ let stashedVerifyToken: string | null = null
 export const currentCeremonyId = (): number | null => activeCeremonyId
 export const isCeremonyStillActive = (id: number | null): boolean => id !== null && id === activeCeremonyId
 
-/** Called by native-auth-capture; ignored unless a guarded ceremony is active. */
-export const stashCeremonyVerifyToken = (token: string): void => {
-    if (activeCeremonyId !== null) stashedVerifyToken = token
+/**
+ * Called by native-auth-capture with the ceremony id captured when the verify
+ * REQUEST was issued. Accepted only while that same ceremony is still the
+ * active one — a request issued before the current window opened (e.g. a
+ * timed-out ceremony's late verify) cannot enter the retry's stash.
+ */
+export const stashCeremonyVerifyToken = (token: string, issuingCeremonyId: number | null): void => {
+    if (isCeremonyStillActive(issuingCeremonyId)) stashedVerifyToken = token
 }
 
 /**

--- a/src/utils/passkeyCeremony.utils.ts
+++ b/src/utils/passkeyCeremony.utils.ts
@@ -1,15 +1,19 @@
+import { isCapacitor } from '@/utils/capacitor'
+
 /**
- * Guards for the passkey login ceremony (TASK-21782).
+ * Guards for the passkey ceremony (TASK-21782).
  *
  * The zerodev `toWebAuthnKey()` call can pend forever on native Android —
  * a tap that races the async `autoShimWebAuthn` install runs the webview's
  * raw WebAuthn (broken in Capacitor), and the Credential Manager callback
- * can silently never fire. Without a timeout, `isLoggingIn` stays true and
- * the Log In button is dead until the app is killed.
+ * can silently never fire. Without a timeout, `isLoggingIn`/`isRegistering`
+ * stays true and the button is dead until the app is killed.
  */
 
 // WebAuthn UI sheets time out on their own around 60s; racing shorter would
-// cancel a ceremony the user is legitimately still completing.
+// cancel a ceremony the user is legitimately still completing. Native-only:
+// on web, cross-device (QR/hybrid) and security-key ceremonies routinely run
+// minutes, and the silent-hang this defends against is a Capacitor defect.
 export const CEREMONY_TIMEOUT_MS = 60_000
 
 // The shim install is a dynamic import + native plugin call — normally
@@ -31,27 +35,63 @@ export class PasskeyShimNotReadyError extends Error {
     }
 }
 
-export const isPasskeyShimInstalled = (): boolean =>
-    (globalThis as typeof globalThis & { __capgoPasskeyShimInstalled?: unknown }).__capgoPasskeyShimInstalled === true
+export class PasskeyShimFailedError extends Error {
+    constructor() {
+        super('native passkey shim install failed — restart required')
+        this.name = 'PasskeyShimFailedError'
+    }
+}
+
+/** True for the pre-ceremony / timeout guard errors thrown by this module. */
+export const isCeremonyGuardError = (err: unknown): err is Error =>
+    err instanceof Error &&
+    (err.name === 'CeremonyTimeoutError' ||
+        err.name === 'PasskeyShimNotReadyError' ||
+        err.name === 'PasskeyShimFailedError')
+
+type ShimGlobals = typeof globalThis & {
+    __capgoPasskeyShimInstalled?: unknown
+    __capgoPasskeyShimFailed?: unknown
+}
+
+export const isPasskeyShimInstalled = (): boolean => (globalThis as ShimGlobals).__capgoPasskeyShimInstalled === true
+
+// Set by PeanutProvider when the shim install chain rejects — lets a login
+// tap fail immediately with honest "restart" copy instead of burning the
+// poll window on an install that will never arrive.
+export const markPasskeyShimFailed = (): void => {
+    ;(globalThis as ShimGlobals).__capgoPasskeyShimFailed = true
+}
+const hasPasskeyShimFailed = (): boolean => (globalThis as ShimGlobals).__capgoPasskeyShimFailed === true
 
 /**
  * Resolves once the capgo passkey shim has patched `navigator.credentials`;
- * rejects with `PasskeyShimNotReadyError` if it hasn't after `timeoutMs`.
+ * rejects with `PasskeyShimFailedError` when the install is known-dead, or
+ * `PasskeyShimNotReadyError` if it hasn't landed after `timeoutMs`.
  * Rejecting (instead of proceeding) is deliberate: the un-shimmed webview
  * WebAuthn call is exactly the silent-hang this file exists to prevent.
  */
 export const waitForPasskeyShim = async (timeoutMs: number = SHIM_WAIT_TIMEOUT_MS): Promise<void> => {
     const deadline = Date.now() + timeoutMs
     while (!isPasskeyShimInstalled()) {
+        if (hasPasskeyShimFailed()) throw new PasskeyShimFailedError()
         if (Date.now() >= deadline) throw new PasskeyShimNotReadyError(timeoutMs)
         await new Promise((resolve) => setTimeout(resolve, SHIM_POLL_INTERVAL_MS))
     }
 }
 
+// Ceremony-in-flight tracking. native-auth-capture only persists a
+// /passkeys/*/verify token while a ceremony is active, so a verify response
+// landing AFTER a timeout already told the user "failed" cannot leave a
+// half-authenticated session behind.
+let activeCeremonies = 0
+export const isPasskeyCeremonyActive = (): boolean => activeCeremonies > 0
+
 /**
  * Races `promise` against a `CeremonyTimeoutError`. On timeout the original
  * promise keeps running but its result is discarded by the caller's `await`,
- * so a late ceremony success can never log the user in after we gave up.
+ * and the ceremony-active window has closed, so a late success can neither
+ * log the user in nor store its token.
  */
 export const raceCeremonyTimeout = <T>(promise: Promise<T>, ms: number = CEREMONY_TIMEOUT_MS): Promise<T> => {
     let timer: ReturnType<typeof setTimeout>
@@ -59,4 +99,22 @@ export const raceCeremonyTimeout = <T>(promise: Promise<T>, ms: number = CEREMON
         timer = setTimeout(() => reject(new CeremonyTimeoutError(ms)), ms)
     })
     return Promise.race([promise, timeout]).finally(() => clearTimeout(timer)) as Promise<T>
+}
+
+/**
+ * The one wrapper both login and register ceremonies route through: on
+ * Capacitor, gate on the shim actually being installed and bound the
+ * ceremony to CEREMONY_TIMEOUT_MS; on web, run it untouched (hybrid/QR
+ * ceremonies legitimately run for minutes). Tracks the active window for
+ * native-auth-capture either way.
+ */
+export const guardPasskeyCeremony = async <T>(startCeremony: () => Promise<T>): Promise<T> => {
+    const native = isCapacitor()
+    if (native) await waitForPasskeyShim()
+    activeCeremonies++
+    try {
+        return native ? await raceCeremonyTimeout(startCeremony()) : await startCeremony()
+    } finally {
+        activeCeremonies = Math.max(0, activeCeremonies - 1)
+    }
 }

--- a/src/utils/passkeyCeremony.utils.ts
+++ b/src/utils/passkeyCeremony.utils.ts
@@ -1,4 +1,6 @@
+import { captureException } from '@sentry/nextjs'
 import { isCapacitor } from '@/utils/capacitor'
+import { setAuthToken } from '@/utils/auth-token'
 
 /**
  * Guards for the passkey ceremony (TASK-21782).
@@ -11,10 +13,14 @@ import { isCapacitor } from '@/utils/capacitor'
  */
 
 // WebAuthn UI sheets time out on their own around 60s; racing shorter would
-// cancel a ceremony the user is legitimately still completing. Native-only:
-// on web, cross-device (QR/hybrid) and security-key ceremonies routinely run
-// minutes, and the silent-hang this defends against is a Capacitor defect.
+// cancel a ceremony the user is legitimately still completing.
 export const CEREMONY_TIMEOUT_MS = 60_000
+
+// Web cross-device (QR/hybrid) and security-key ceremonies legitimately run
+// minutes, so the web bound is generous — it exists only so a ceremony the
+// browser never settles can't leave isLoggingIn true (and the landing
+// buttons dead) forever.
+export const WEB_CEREMONY_TIMEOUT_MS = 300_000
 
 // The shim install is a dynamic import + native plugin call — normally
 // sub-second. 3s covers a slow cold start without stalling a real tap.
@@ -42,12 +48,43 @@ export class PasskeyShimFailedError extends Error {
     }
 }
 
+export class CeremonyConflictError extends Error {
+    constructor() {
+        super('another passkey ceremony is already in progress')
+        this.name = 'CeremonyConflictError'
+    }
+}
+
 /** True for the pre-ceremony / timeout guard errors thrown by this module. */
 export const isCeremonyGuardError = (err: unknown): err is Error =>
     err instanceof Error &&
     (err.name === 'CeremonyTimeoutError' ||
         err.name === 'PasskeyShimNotReadyError' ||
-        err.name === 'PasskeyShimFailedError')
+        err.name === 'PasskeyShimFailedError' ||
+        err.name === 'CeremonyConflictError')
+
+const GUARD_ERROR_TAG: Record<string, string> = {
+    CeremonyTimeoutError: 'ceremony_timeout',
+    PasskeyShimNotReadyError: 'shim_not_ready',
+    PasskeyShimFailedError: 'shim_failed',
+    CeremonyConflictError: 'ceremony_conflict',
+}
+
+/**
+ * One Sentry capture for guard errors from both the login and register catch
+ * paths — the tag is derived from the error class, so a new guard error can't
+ * silently collapse into the wrong bucket in one copy of a hand-rolled ternary.
+ */
+export const captureCeremonyGuardError = (
+    err: Error,
+    flow: 'login' | 'register',
+    extra?: Record<string, unknown>
+): void => {
+    captureException(err, {
+        tags: { error_type: `${flow}_${GUARD_ERROR_TAG[err.name] ?? 'ceremony_guard'}` },
+        extra: { shimInstalled: isPasskeyShimInstalled(), isCapacitor: isCapacitor(), ...extra },
+    })
+}
 
 type ShimGlobals = typeof globalThis & {
     __capgoPasskeyShimInstalled?: unknown
@@ -80,17 +117,23 @@ export const waitForPasskeyShim = async (timeoutMs: number = SHIM_WAIT_TIMEOUT_M
     }
 }
 
-// Ceremony-in-flight tracking. native-auth-capture binds each
-// /passkeys/*/verify request to the ceremony that was active when the
-// request was ISSUED, and persists its token only if that same ceremony is
-// still active when the response lands. A verify response arriving after
-// its ceremony timed out is dropped — even when the user has already
-// started a NEW ceremony (a bare "any ceremony active" check would re-open
-// the window and store the stale token).
+// Ceremony-in-flight tracking. Ceremonies are serialized (guardPasskeyCeremony
+// rejects a second concurrent one), so the single active window always has one
+// owner. native-auth-capture STASHES a /passkeys/*/verify token while a
+// ceremony is active; the token is persisted only when the owning ceremony
+// RESOLVES — a verify response from a ceremony that timed out or was told
+// "failed" can never end up persisted (the guard discards the stash on
+// failure), even when it lands while a retry ceremony is running.
 let ceremonySeq = 0
 let activeCeremonyId: number | null = null
+let stashedVerifyToken: string | null = null
 export const currentCeremonyId = (): number | null => activeCeremonyId
 export const isCeremonyStillActive = (id: number | null): boolean => id !== null && id === activeCeremonyId
+
+/** Called by native-auth-capture; ignored unless a guarded ceremony is active. */
+export const stashCeremonyVerifyToken = (token: string): void => {
+    if (activeCeremonyId !== null) stashedVerifyToken = token
+}
 
 /**
  * Races `promise` against a `CeremonyTimeoutError`. On timeout the original
@@ -109,19 +152,35 @@ export const raceCeremonyTimeout = <T>(promise: Promise<T>, ms: number = CEREMON
 /**
  * The one wrapper both login and register ceremonies route through: on
  * Capacitor, gate on the shim actually being installed and bound the
- * ceremony to CEREMONY_TIMEOUT_MS; on web, run it untouched (hybrid/QR
- * ceremonies legitimately run for minutes). Tracks the active window for
- * native-auth-capture either way.
+ * ceremony to CEREMONY_TIMEOUT_MS; on web, use the generous
+ * WEB_CEREMONY_TIMEOUT_MS bound (hybrid/QR ceremonies legitimately run for
+ * minutes, but an abandoned one must not wedge the UI forever).
+ *
+ * Ceremonies are mutually exclusive: overlapping windows would make verify
+ * tokens unattributable (the fetch layer can't tell whose fetch it sees), so
+ * a second concurrent ceremony fails fast with CeremonyConflictError instead
+ * of evicting the first's window. The stashed verify token is committed only
+ * when the ceremony resolves, so a ceremony reported as failed can never
+ * leave a persisted token behind.
  */
 export const guardPasskeyCeremony = async <T>(startCeremony: () => Promise<T>): Promise<T> => {
     const native = isCapacitor()
+    if (activeCeremonyId !== null) throw new CeremonyConflictError()
     if (native) await waitForPasskeyShim()
+    // re-check: another ceremony may have claimed the window during the wait
+    if (activeCeremonyId !== null) throw new CeremonyConflictError()
     const ceremonyId = ++ceremonySeq
     activeCeremonyId = ceremonyId
+    stashedVerifyToken = null
     try {
-        return native ? await raceCeremonyTimeout(startCeremony()) : await startCeremony()
+        const result = await raceCeremonyTimeout(
+            startCeremony(),
+            native ? CEREMONY_TIMEOUT_MS : WEB_CEREMONY_TIMEOUT_MS
+        )
+        if (stashedVerifyToken !== null) setAuthToken(stashedVerifyToken)
+        return result
     } finally {
-        // only clear our own registration — a newer ceremony may have taken over
         if (activeCeremonyId === ceremonyId) activeCeremonyId = null
+        stashedVerifyToken = null
     }
 }

--- a/src/utils/webauthn.utils.ts
+++ b/src/utils/webauthn.utils.ts
@@ -27,11 +27,13 @@ export enum WebAuthnErrorName {
     NotSupported = 'NotSupportedError',
 }
 
-export type PasskeyErrorClassification = { code: string; message: string }
+export type PasskeyErrorClassification = { code: PasskeyErrorCode; message: string }
 
 // Curated copy keyed by code. Never surface raw error.message / server bodies to
 // the user (those go to Sentry only); these strings are the only thing shown.
-const PASSKEY_LOGIN_MESSAGES: Record<string, string> = {
+// Keys are the closed set of classification codes — `PasskeyErrorCode` below —
+// so a new code can't silently fall into the wrong handler branch downstream.
+const PASSKEY_LOGIN_MESSAGES = {
     LOGIN_CANCELED: 'Login was cancelled, or no passkey was found on this device. Try again, or create a wallet.',
     PASSKEY_INTERRUPTED: 'Something interrupted the passkey prompt. Please try again.',
     PASSKEY_UNSUPPORTED:
@@ -39,10 +41,13 @@ const PASSKEY_LOGIN_MESSAGES: Record<string, string> = {
     PASSKEY_STATE: 'There was a problem with the passkey on this device. Restart the app and try again.',
     PASSKEY_ORIGIN: 'This app isn’t authorized for passkeys on peanut.me. Please update to the latest version.',
     NETWORK: 'Couldn’t reach Peanut’s servers. Check your connection and try again.',
-    CEREMONY_TIMEOUT: 'Login is taking longer than it should. Please try again.',
+    // flow-neutral wording — classifyPasskeyError also serves the signup ceremony
+    CEREMONY_TIMEOUT: 'This is taking longer than it should. Please try again.',
     PASSKEY_NOT_READY: 'The app is still getting ready for passkeys. Wait a moment and try again.',
     LOGIN_ERROR: 'We couldn’t verify your passkey. Please try again, or contact support if it keeps happening.',
-}
+} as const satisfies Record<string, string>
+
+export type PasskeyErrorCode = keyof typeof PASSKEY_LOGIN_MESSAGES
 
 function isNetworkError(error: Error): boolean {
     if (error.name === 'TypeError' && /fetch|network/i.test(error.message)) return true
@@ -57,7 +62,7 @@ function isNetworkError(error: Error): boolean {
  */
 export function classifyPasskeyError(error: unknown): PasskeyErrorClassification {
     const err = error instanceof Error ? error : new Error(String(error))
-    let code = 'LOGIN_ERROR'
+    let code: PasskeyErrorCode = 'LOGIN_ERROR'
     // iOS surfaces ceremony failures as a bare Error whose message carries the
     // ASAuthorizationError code, not a DOMException name: 1001 = user canceled,
     // 1004 = failed (typically no usable passkey on this device). Both mean
@@ -87,6 +92,11 @@ export function classifyPasskeyError(error: unknown): PasskeyErrorClassification
             break
         case 'PasskeyShimNotReadyError':
             code = 'PASSKEY_NOT_READY'
+            break
+        // install known-dead — only an app restart re-runs it, so send the
+        // restart copy instead of the transient "wait a moment" one
+        case 'PasskeyShimFailedError':
+            code = 'PASSKEY_STATE'
             break
         default:
             if (isNetworkError(err)) code = 'NETWORK'

--- a/src/utils/webauthn.utils.ts
+++ b/src/utils/webauthn.utils.ts
@@ -39,6 +39,8 @@ const PASSKEY_LOGIN_MESSAGES: Record<string, string> = {
     PASSKEY_STATE: 'There was a problem with the passkey on this device. Restart the app and try again.',
     PASSKEY_ORIGIN: 'This app isn’t authorized for passkeys on peanut.me. Please update to the latest version.',
     NETWORK: 'Couldn’t reach Peanut’s servers. Check your connection and try again.',
+    CEREMONY_TIMEOUT: 'Login is taking longer than it should. Please try again.',
+    PASSKEY_NOT_READY: 'The app is still getting ready for passkeys. Wait a moment and try again.',
     LOGIN_ERROR: 'We couldn’t verify your passkey. Please try again, or contact support if it keeps happening.',
 }
 
@@ -78,6 +80,13 @@ export function classifyPasskeyError(error: unknown): PasskeyErrorClassification
             break
         case 'SecurityError':
             code = 'PASSKEY_ORIGIN'
+            break
+        // ceremony guards from passkeyCeremony.utils (TASK-21782)
+        case 'CeremonyTimeoutError':
+            code = 'CEREMONY_TIMEOUT'
+            break
+        case 'PasskeyShimNotReadyError':
+            code = 'PASSKEY_NOT_READY'
             break
         default:
             if (isNetworkError(err)) code = 'NETWORK'

--- a/src/utils/webauthn.utils.ts
+++ b/src/utils/webauthn.utils.ts
@@ -90,6 +90,9 @@ export function classifyPasskeyError(error: unknown): PasskeyErrorClassification
         case 'CeremonyTimeoutError':
             code = 'CEREMONY_TIMEOUT'
             break
+        case 'CeremonyConflictError':
+            code = 'PASSKEY_INTERRUPTED'
+            break
         case 'PasskeyShimNotReadyError':
             code = 'PASSKEY_NOT_READY'
             break


### PR DESCRIPTION
## Summary

Intermittent native-Android login wedge (TASK-21782): zerodev's `toWebAuthnKey()` has no timeout, so a ceremony that never settles — a tap racing the async `autoShimWebAuthn` install (raw webview WebAuthn silently hangs in Capacitor), or an Android Credential Manager callback that never fires — leaves `isLoggingIn` true forever. The Log In button is disabled while loading, so the user cannot retry without killing the app. RCA with the full event timeline: `mono/ops/mobile-login-stuck-loading-task-21782.md`.

- **`guardPasskeyCeremony()`** — the one wrapper **both login and register** ceremonies route through: on Capacitor, gate on the capgo shim actually being installed, then bound the ceremony to **60s**; on web, run untouched. A late ceremony result is discarded, and its verify token is not persisted (see below), so a post-timeout success can neither log the user in nor leave stray state.
- **Shim failure honesty**: shim-install failures (including the previously-uncaught dynamic `import()` rejection) mark a known-dead flag — a login tap then fails immediately with "restart the app" copy instead of polling 3s toward "wait a moment" advice that could never come true.
- **Half-auth prevention**: `native-auth-capture` only persists a `/passkeys/*/verify` token while a ceremony is in flight, so a verify response landing after the user was already told "failed" cannot create a half-authenticated session.
- **Discriminating telemetry**: Sentry `login_ceremony_timeout` / `login_shim_not_ready` (+ register equivalents) with `shimInstalled` + `elapsedMs` — tells us *where* native ceremonies hang (the RCA had zero signal).
- **Closed error-code union**: `PasskeyErrorCode` is keyed off the copy map, so a future classification code can't silently fall into the `clearAuthState` branch.
- **Disable Sign Up while a login ceremony is pending** — mid-ceremony taps navigated the setup flow to the waitlist step ("Peanut is invite-only" flash in Konrad's recording).
- **Telemetry fix**: the `login` capture no longer labels the native app `isPwa: true`; uses `isNativeBridge()` so capacitor-flavored *web* builds keep real PWA semantics.

## Task

Notion TASK-21782 — [Investigate intermittent mobile login redirect loop](https://app.notion.com/p/peanutprotocol/Investigate-intermittent-mobile-login-redirect-loop-3c6838117579811a85f8e72528692a16)

## Design notes / accepted trade-offs

- **Timeout is native-only.** Web cross-device (QR/hybrid) and security-key ceremonies legitimately run for minutes; the silent hang this defends against is a Capacitor defect. (/code-review finding, applied.)
- **A post-timeout retry may start a second ceremony while the first is still pending natively.** Deliberate: reusing the in-flight promise would re-wedge the retry on a hung-dead first call — the exact failure being fixed. If the first ceremony is alive, Android Credential Manager rejects the concurrent request cleanly; the late verify response is ignored by the capture guard.
- **`usePWAStatus` keeps returning true on native** — layouts depend on that "standalone shell" meaning; only the analytics call site reinterprets it.
- Follow-up (not this PR): unify the repo's four hand-rolled `Promise.race`-vs-`setTimeout` sites behind one `withTimeout` util (divergent resolve/reject semantics make it non-mechanical).

## Risks / breaking changes

- No backend changes. No cross-repo deploy order.
- A native user who dawdles >60s in the OS sheet gets a "try again" toast; the guard discards the late result and its token, so no half-authed state is possible.
- Signup path now shares the guard: a hung register ceremony surfaces as a retryable error (previously: silent forever-spinner with zero telemetry). `SetupPasskey` keys on `err.name`, which the guard errors preserve.
- Native needs this via OTA: after merge to `main`, include in the next sync into `mobile-release` / OTA tag.

## QA

- `npm test` — 270 suites green; `src/utils/__tests__/passkeyCeremony.utils.test.ts` (15 tests) covers timeout, late-result discard, shim polling/failed-fast, ceremony-active token window, and the native/web guard split.
- Manual (sandbox): web Log In flow unchanged. Simulate the wedge by blocking the passkey server request — spinner clears after 60s with a retry toast instead of hanging forever.

Screenshots: N/A (no visible change — only a transient disabled state and error toasts on paths that previously hung forever).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented the Sign Up button from being used while login is in progress.
  - Improved passkey reliability across web and mobile app environments.
  - Added safeguards for passkey readiness, setup failures, concurrent attempts, and ceremonies that take too long.
  - Prevented expired or unsuccessful ceremonies from storing verification data.
  - Preserved authentication state when passkey setup times out or is unavailable.
  - Added clearer timeout, readiness, and retry guidance, including routing to login when appropriate.
- **Analytics**
  - Improved login tracking across web and mobile app environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->