### PR TITLE
ci: require human-authored commits on every PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -436,9 +436,9 @@ jobs:
     # as claude[bot] are exactly what this blocks. Content-publish PRs pass:
     # update-content.yml authors and signs its commit as a human account.
     #
-    # No allowlist to maintain: the collaborator list IS the team roster, and
-    # GitHub org/repo access management keeps it current. Listing collaborators
-    # needs only the metadata read that GITHUB_TOKEN always carries.
+    # No allowlist to maintain: "has write access to this repo" IS the team
+    # roster, and GitHub org/repo access management keeps it current. The
+    # per-user permission endpoint works with the default GITHUB_TOKEN.
     human-authors:
         name: human-authors
         if: github.event_name == 'pull_request'
@@ -452,16 +452,22 @@ jobs:
               uses: actions/github-script@v7
               with:
                   script: |
-                      const collaborators = await github.paginate(github.rest.repos.listCollaborators, {
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        affiliation: 'all',
-                        per_page: 100,
-                      });
-                      const ALLOWED = new Set(collaborators.map((c) => c.login));
-                      if (ALLOWED.size === 0) {
-                        core.setFailed('Collaborator list came back empty — cannot verify authorship');
-                        return;
+                      const memberCache = new Map();
+                      async function hasWriteAccess(login) {
+                        if (memberCache.has(login)) return memberCache.get(login);
+                        let ok = false;
+                        try {
+                          const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            username: login,
+                          });
+                          ok = ['admin', 'maintain', 'write'].includes(data.permission);
+                        } catch (e) {
+                          ok = false;
+                        }
+                        memberCache.set(login, ok);
+                        return ok;
                       }
                       const commits = await github.paginate(github.rest.pulls.listCommits, {
                         owner: context.repo.owner,
@@ -478,8 +484,8 @@ jobs:
                           bad.push(`${sha}: author email <${email}> is not linked to a GitHub account — commit from your own account (git config user.email must be an email verified on your GitHub profile)`);
                         } else if (login.endsWith('[bot]')) {
                           bad.push(`${sha}: authored by ${login} — bot-authored commits are not allowed; commit as yourself`);
-                        } else if (!ALLOWED.has(login)) {
-                          bad.push(`${sha}: authored by ${login}, who is not a collaborator on this repo`);
+                        } else if (!(await hasWriteAccess(login))) {
+                          bad.push(`${sha}: authored by ${login}, who has no write access to this repo`);
                         }
                       }
                       if (bad.length) {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -428,6 +428,57 @@ jobs:
                           });
                       }
 
+    # Human-only authorship gate. Every commit on the PR must be authored by a
+    # team member's own GitHub account — no `*[bot]` authors (claude[bot],
+    # github-actions[bot], …) and no emails that GitHub cannot map to an
+    # account. Policy set 2026-08-24: AI is a tool, not an owner; every commit
+    # has a human who is accountable for it. Cloud coding sessions that commit
+    # as claude[bot] are exactly what this blocks. Content-publish PRs pass:
+    # update-content.yml authors and signs its commit as a human account.
+    #
+    # To add a teammate: add their GitHub login to ALLOWED below (one line).
+    human-authors:
+        name: human-authors
+        if: github.event_name == 'pull_request'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Verify every commit is authored by a team member
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const ALLOWED = new Set([
+                        'Hugo0',
+                        '0xkkonrad',
+                        'abalinda',
+                        'innolope-dev',
+                        'jjramirezn',
+                        'kushagrasarathe',
+                      ]);
+                      const commits = await github.paginate(github.rest.pulls.listCommits, {
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        pull_number: context.payload.pull_request.number,
+                        per_page: 100,
+                      });
+                      const bad = [];
+                      for (const c of commits) {
+                        const sha = c.sha.slice(0, 7);
+                        const login = c.author && c.author.login;
+                        const email = (c.commit.author && c.commit.author.email) || 'unknown';
+                        if (!login) {
+                          bad.push(`${sha}: author email <${email}> is not linked to a GitHub account — commit from your own account (git config user.email must be an email verified on your GitHub profile)`);
+                        } else if (login.endsWith('[bot]')) {
+                          bad.push(`${sha}: authored by ${login} — bot-authored commits are not allowed; commit as yourself`);
+                        } else if (!ALLOWED.has(login)) {
+                          bad.push(`${sha}: authored by ${login}, who is not in the team allowlist in .github/workflows/tests.yml`);
+                        }
+                      }
+                      if (bad.length) {
+                        core.setFailed(`Commits must be authored by a team member:\n${bad.join('\n')}`);
+                      } else {
+                        console.log(`✅ All ${commits.length} commits are authored by team members`);
+                      }
+
     # Single umbrella check that aggregates all required test/quality jobs.
     # Branch protection on `dev`/`main` requires only `ci-success` instead of
     # listing every individual job — keeps the ruleset stable as jobs are
@@ -439,7 +490,7 @@ jobs:
     ci-success:
         name: ci-success
         if: always()
-        needs: [format, eslint, typecheck, unit, e2e, report]
+        needs: [format, eslint, typecheck, unit, e2e, report, human-authors]
         runs-on: ubuntu-latest
         steps:
             - name: Verify all required jobs passed
@@ -453,6 +504,7 @@ jobs:
                       echo "  unit:      ${{ needs.unit.result }}"
                       echo "  e2e:       ${{ needs.e2e.result }}"
                       echo "  report:    ${{ needs.report.result }}"
+                      echo "  human-authors: ${{ needs['human-authors'].result }}"
                       exit 1
                   fi
                   echo "✅ All required jobs passed"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -429,14 +429,16 @@ jobs:
                       }
 
     # Human-only authorship gate. Every commit on the PR must be authored by a
-    # team member's own GitHub account — no `*[bot]` authors (claude[bot],
+    # repo collaborator's own GitHub account — no `*[bot]` authors (claude[bot],
     # github-actions[bot], …) and no emails that GitHub cannot map to an
     # account. Policy set 2026-08-24: AI is a tool, not an owner; every commit
     # has a human who is accountable for it. Cloud coding sessions that commit
     # as claude[bot] are exactly what this blocks. Content-publish PRs pass:
     # update-content.yml authors and signs its commit as a human account.
     #
-    # To add a teammate: add their GitHub login to ALLOWED below (one line).
+    # No allowlist to maintain: the collaborator list IS the team roster, and
+    # GitHub org/repo access management keeps it current. Listing collaborators
+    # needs only the metadata read that GITHUB_TOKEN always carries.
     human-authors:
         name: human-authors
         if: github.event_name == 'pull_request'
@@ -450,14 +452,17 @@ jobs:
               uses: actions/github-script@v7
               with:
                   script: |
-                      const ALLOWED = new Set([
-                        'Hugo0',
-                        '0xkkonrad',
-                        'abalinda',
-                        'innolope-dev',
-                        'jjramirezn',
-                        'kushagrasarathe',
-                      ]);
+                      const collaborators = await github.paginate(github.rest.repos.listCollaborators, {
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        affiliation: 'all',
+                        per_page: 100,
+                      });
+                      const ALLOWED = new Set(collaborators.map((c) => c.login));
+                      if (ALLOWED.size === 0) {
+                        core.setFailed('Collaborator list came back empty — cannot verify authorship');
+                        return;
+                      }
                       const commits = await github.paginate(github.rest.pulls.listCommits, {
                         owner: context.repo.owner,
                         repo: context.repo.repo,
@@ -474,7 +479,7 @@ jobs:
                         } else if (login.endsWith('[bot]')) {
                           bad.push(`${sha}: authored by ${login} — bot-authored commits are not allowed; commit as yourself`);
                         } else if (!ALLOWED.has(login)) {
-                          bad.push(`${sha}: authored by ${login}, who is not in the team allowlist in .github/workflows/tests.yml`);
+                          bad.push(`${sha}: authored by ${login}, who is not a collaborator on this repo`);
                         }
                       }
                       if (bad.length) {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -441,6 +441,10 @@ jobs:
         name: human-authors
         if: github.event_name == 'pull_request'
         runs-on: ubuntu-latest
+        # The workflow-level permissions block drops pull-requests, and the
+        # commit-listing endpoint 403s without it.
+        permissions:
+            pull-requests: read
         steps:
             - name: Verify every commit is authored by a team member
               uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
Adds a required `human-authors` job to the Tests workflow. Every commit on a PR must be authored by a team member's own GitHub account. The job fails on:
- any `*[bot]` author (claude[bot] from cloud sessions, github-actions[bot], …)
- any author email GitHub cannot map to an account
- any GitHub account not in the team allowlist

Policy from Discord 2026-08-24: AI is a tool, not an owner — every commit has an accountable human.

## Mechanics
- Gated via `ci-success.needs`, so the existing dev/main ruleset makes it blocking with no ruleset change.
- Runs only on `pull_request` events; on branch pushes the job is skipped, which `ci-success` treats as neutral (unchanged behavior).
- Content-publish auto-merge PRs pass: `update-content.yml` authors and signs its commit as a human account (Hugo0).
- To onboard a teammate: add their GitHub login to `ALLOWED` (one line).

## Risks
- None to runtime code. If someone commits with an email not verified on their GitHub profile, their PR fails with a message telling them exactly that — intended behavior, it forces attributable commits.

## QA
- This PR checks itself: the new job runs on this PR's own commits (authored by Hugo0).