### PR TITLE
ci(release): couple native releases to the production OTA lane

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -113,22 +113,61 @@ jobs:
                       echo "NEXT_PUBLIC_ONESIGNAL_DEBUG=true" >> .env.production.local
                   fi
 
+            - name: Resolve release versionName
+              id: version
+              env:
+                  INPUT_VERSION: ${{ github.event.inputs.versionName || '' }}
+              run: |
+                  # versionName: manual dispatch input wins; else the tag name minus
+                  # its leading 'v' (v1.0.10 -> 1.0.10); else package.json (the same
+                  # fallback build.gradle uses). Resolved once, up front, so the OTA
+                  # floor check and the bundle publish below see the exact version
+                  # the binary ships with. Keep in lockstep with ios-release.yml.
+                  VERSION_NAME="$INPUT_VERSION"
+                  if [ -z "$VERSION_NAME" ] && [ "$GITHUB_REF_TYPE" = "tag" ]; then
+                      VERSION_NAME="${GITHUB_REF_NAME#v}"
+                  fi
+                  if [ -z "$VERSION_NAME" ]; then
+                      VERSION_NAME="$(node -p "require('./package.json').version")"
+                  fi
+                  echo "name=$VERSION_NAME" >> "$GITHUB_OUTPUT"
+                  echo "Release versionName: $VERSION_NAME"
+
+            # A binary whose versionName is ahead of the newest production OTA bundle
+            # makes Capgo's disable_auto_update_under_native rule reject every bundle
+            # on those devices — OTA goes silently dead for the whole fleet while CI
+            # stays green (TASK-21793: 102 devices, a month of refused updates). Read
+            # the floor before the long build; the publish step after the store
+            # upload closes the gap this detects. Keep in lockstep with
+            # ios-release.yml.
+            - name: Check production OTA floor
+              id: ota_floor
+              env:
+                  CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
+                  VERSION_NAME: ${{ steps.version.outputs.name }}
+              run: |
+                  CURRENT="$(npx @capgo/cli@latest channel currentBundle production \
+                    --apikey "$CAPGO_API_KEY" --quiet | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' | tail -n1 || true)"
+                  if [ -z "$CURRENT" ]; then
+                      echo "::error::cannot read the production channel's current bundle from Capgo — refusing to ship a binary that may strand the fleet's OTA path" >&2
+                      exit 1
+                  fi
+                  NEEDS_OTA="$(node scripts/semver-newer.mjs "$VERSION_NAME" "$CURRENT")"
+                  echo "needs_ota=$NEEDS_OTA" >> "$GITHUB_OUTPUT"
+                  if [ "$NEEDS_OTA" = "true" ]; then
+                      echo "versionName $VERSION_NAME is ahead of production bundle $CURRENT — a matching bundle ships after the store upload"
+                  else
+                      echo "versionName $VERSION_NAME is covered by production bundle $CURRENT"
+                  fi
+
             - name: Build signed AAB
               env:
                   # native sentry sdk dsn — read by android/app/build.gradle into a
                   # manifest placeholder. same project dsn the js layer bakes into
                   # the static export above; no new secret needed.
                   SENTRY_DSN_ANDROID: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+                  ANDROID_VERSION_NAME: ${{ steps.version.outputs.name }}
               run: |
-                  # versionName: manual dispatch input wins; else the tag name minus
-                  # its leading 'v' (v1.0.10 -> 1.0.10); else build.gradle's
-                  # package.json fallback. Keeps the Play versionName in lockstep
-                  # with the release tag without a manual package.json bump.
-                  VERSION_NAME="${{ github.event.inputs.versionName }}"
-                  if [ -z "$VERSION_NAME" ] && [ "$GITHUB_REF_TYPE" = "tag" ]; then
-                      VERSION_NAME="${GITHUB_REF_NAME#v}"
-                  fi
-                  export ANDROID_VERSION_NAME="$VERSION_NAME"
                   # Monotonic (run_number always increases). +10000 clears legacy
                   # codes already on Play from earlier manual/local uploads (small
                   # console codes plus git-commit-count builds up to ~8600).
@@ -145,6 +184,42 @@ jobs:
                   status: completed
                   # Staged production rollout: set status: inProgress + userFraction: 0.1,
                   # then promote in Play Console once crash/error rates look clean.
+
+            # The binary that just shipped is ahead of every production OTA bundle, so
+            # its devices would refuse all existing bundles. Publish the exact JS baked
+            # into this binary (native:release leaves it in out/) under the binary's own
+            # version — the lanes can no longer drift apart. A failure here is the floor
+            # guard firing: the job goes red instead of the fleet going silently dark.
+            # Upload flags in lockstep with capgo-deploy.yml; ios-release.yml publishes
+            # the same version from the same tag, which --version-exists-ok turns into a
+            # verified no-op.
+            - name: Publish matching production OTA bundle
+              if: steps.ota_floor.outputs.needs_ota == 'true'
+              env:
+                  CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
+                  CAPGO_PRIVATE_KEY: ${{ secrets.CAPGO_PRIVATE_KEY }}
+                  VERSION: ${{ steps.version.outputs.name }}
+              run: |
+                  if [ ! -f out/index.html ]; then
+                      echo "::error::out/ is missing its static export — cannot publish the matching OTA bundle, and without it every device on the $VERSION binary refuses OTA updates" >&2
+                      exit 1
+                  fi
+                  npx @capgo/cli@latest bundle upload \
+                    --channel production \
+                    --apikey "$CAPGO_API_KEY" \
+                    --key-data-v2 "$CAPGO_PRIVATE_KEY" \
+                    --path ./out \
+                    --bundle "$VERSION" \
+                    --auto-min-update-version \
+                    --version-exists-ok \
+                    --comment "${GITHUB_SHA:0:7} — auto-published with the $VERSION native release"
+                  CURRENT="$(npx @capgo/cli@latest channel currentBundle production \
+                    --apikey "$CAPGO_API_KEY" --quiet | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' | tail -n1 || true)"
+                  if [ "$CURRENT" != "$VERSION" ]; then
+                      echo "::error::production channel serves '${CURRENT:-<none>}', expected $VERSION — devices on the $VERSION binary have no OTA path" >&2
+                      exit 1
+                  fi
+                  echo "Production channel now serves $VERSION"
 
             - name: Upload AAB as build artifact
               if: always()

--- a/.github/workflows/capgo-deploy.yml
+++ b/.github/workflows/capgo-deploy.yml
@@ -7,6 +7,13 @@ on:
     # is the separate, deliberate act that says "ship this JS to everyone", and the
     # tag is a permanent record of exactly which commit went out.
     #
+    # One deliberate exception to "tags only": a NATIVE release whose versionName
+    # is ahead of the newest production bundle auto-publishes a matching bundle
+    # from its own commit (see android-release.yml / ios-release.yml). Without
+    # that, Capgo's disable_auto_update_under_native rule makes every device on
+    # the new binary refuse all existing bundles — OTA silently dead for the
+    # fleet while CI stays green (TASK-21793).
+    #
     #   git tag ota-1.0.48 && git push origin ota-1.0.48
     #
     # The bundle version is taken from the tag (ota-1.0.48 -> 1.0.48), so each

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -65,6 +65,54 @@ jobs:
             - name: Install dependencies
               run: pnpm install
 
+            - name: Resolve release versionName
+              id: version
+              env:
+                  INPUT_VERSION: ${{ github.event.inputs.versionName || '' }}
+              run: |
+                  # versionName: manual dispatch input wins; else the tag name minus
+                  # its leading 'v' (v1.0.31 -> 1.0.31); else package.json — the same
+                  # precedence the archive step always used. Resolved once, up front,
+                  # so the OTA floor check and the bundle publish below see the exact
+                  # version the binary ships with. Keep in lockstep with
+                  # android-release.yml.
+                  VERSION_NAME="$INPUT_VERSION"
+                  if [ -z "$VERSION_NAME" ] && [ "$GITHUB_REF_TYPE" = "tag" ]; then
+                      VERSION_NAME="${GITHUB_REF_NAME#v}"
+                  fi
+                  if [ -z "$VERSION_NAME" ]; then
+                      VERSION_NAME="$(node -p "require('./package.json').version")"
+                  fi
+                  echo "name=$VERSION_NAME" >> "$GITHUB_OUTPUT"
+                  echo "Release versionName: $VERSION_NAME"
+
+            # A binary whose versionName is ahead of the newest production OTA bundle
+            # makes Capgo's disable_auto_update_under_native rule reject every bundle
+            # on those devices — OTA goes silently dead for the whole fleet while CI
+            # stays green (TASK-21793: 102 devices, a month of refused updates). Read
+            # the floor before the long build; the publish step after the store
+            # upload closes the gap this detects. Keep in lockstep with
+            # android-release.yml.
+            - name: Check production OTA floor
+              id: ota_floor
+              env:
+                  CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
+                  VERSION_NAME: ${{ steps.version.outputs.name }}
+              run: |
+                  CURRENT="$(npx @capgo/cli@latest channel currentBundle production \
+                    --apikey "$CAPGO_API_KEY" --quiet | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' | tail -n1 || true)"
+                  if [ -z "$CURRENT" ]; then
+                      echo "::error::cannot read the production channel's current bundle from Capgo — refusing to ship a binary that may strand the fleet's OTA path" >&2
+                      exit 1
+                  fi
+                  NEEDS_OTA="$(node scripts/semver-newer.mjs "$VERSION_NAME" "$CURRENT")"
+                  echo "needs_ota=$NEEDS_OTA" >> "$GITHUB_OUTPUT"
+                  if [ "$NEEDS_OTA" = "true" ]; then
+                      echo "versionName $VERSION_NAME is ahead of production bundle $CURRENT — a matching bundle ships after the store upload"
+                  else
+                      echo "versionName $VERSION_NAME is covered by production bundle $CURRENT"
+                  fi
+
             - name: Verify SumSub Cordova plugin materialized
               # `cap sync ios` silently drops a Cordova plugin (exit 0, no folder)
               # when node_modules isn't fully materialized, and the archive then
@@ -147,23 +195,18 @@ jobs:
                   # Monotonic, always-increments-even-on-rerun. TestFlight requires each
                   # upload's build number to exceed the last.
                   IOS_BUILD_NUMBER: ${{ github.run_number }}
-                  IOS_VERSION_INPUT: ${{ github.event.inputs.versionName || '' }}
-                  IOS_TAG_NAME: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+                  IOS_VERSION_NAME: ${{ steps.version.outputs.name }}
               run: |
-                  # MARKETING_VERSION: explicit versionName input wins, else the pushed
-                  # tag (v1.0.31 -> 1.0.31), else package.json — the same precedence
+                  # MARKETING_VERSION comes from the "Resolve release versionName"
+                  # step (input > tag > package.json — the same precedence
                   # android-release.yml uses, so the two platforms cannot report
-                  # different versions for one release. The project.pbxproj value is
+                  # different versions for one release). The project.pbxproj value is
                   # itself stamped from package.json by scripts/native-ios-postsync.js
                   # during the build step above, so this is belt-and-braces rather than
                   # the only thing standing between us and the old hand-maintained 1.0.
                   # CURRENT_PROJECT_VERSION is always the CI run number.
                   # Info.plist reads both via $(...) build settings.
-                  IOS_VERSION_NAME="$IOS_VERSION_INPUT"
-                  if [ -z "$IOS_VERSION_NAME" ] && [ -n "$IOS_TAG_NAME" ]; then IOS_VERSION_NAME="${IOS_TAG_NAME#v}"; fi
-                  if [ -z "$IOS_VERSION_NAME" ]; then IOS_VERSION_NAME="$(node -p "require('./package.json').version")"; fi
-                  MARKETING_ARG=()
-                  if [ -n "$IOS_VERSION_NAME" ]; then MARKETING_ARG=("MARKETING_VERSION=$IOS_VERSION_NAME"); fi
+                  MARKETING_ARG=("MARKETING_VERSION=$IOS_VERSION_NAME")
 
                   cat > /tmp/ExportOptions.plist <<EOF
                   <?xml version="1.0" encoding="UTF-8"?>
@@ -233,6 +276,42 @@ jobs:
                   # token expires mid-wait (401 NOT_AUTHORIZED). The build is
                   # already in App Store Connect by then, so skip the wait.
                   wait-for-processing: 'false'
+
+            # The binary that just shipped is ahead of every production OTA bundle, so
+            # its devices would refuse all existing bundles. Publish the exact JS baked
+            # into this binary (the build step leaves it in out/) under the binary's own
+            # version — the lanes can no longer drift apart. A failure here is the floor
+            # guard firing: the job goes red instead of the fleet going silently dark.
+            # Upload flags in lockstep with capgo-deploy.yml; android-release.yml
+            # publishes the same version from the same tag, which --version-exists-ok
+            # turns into a verified no-op.
+            - name: Publish matching production OTA bundle
+              if: steps.ota_floor.outputs.needs_ota == 'true'
+              env:
+                  CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
+                  CAPGO_PRIVATE_KEY: ${{ secrets.CAPGO_PRIVATE_KEY }}
+                  VERSION: ${{ steps.version.outputs.name }}
+              run: |
+                  if [ ! -f out/index.html ]; then
+                      echo "::error::out/ is missing its static export — cannot publish the matching OTA bundle, and without it every device on the $VERSION binary refuses OTA updates" >&2
+                      exit 1
+                  fi
+                  npx @capgo/cli@latest bundle upload \
+                    --channel production \
+                    --apikey "$CAPGO_API_KEY" \
+                    --key-data-v2 "$CAPGO_PRIVATE_KEY" \
+                    --path ./out \
+                    --bundle "$VERSION" \
+                    --auto-min-update-version \
+                    --version-exists-ok \
+                    --comment "${GITHUB_SHA:0:7} — auto-published with the $VERSION native release"
+                  CURRENT="$(npx @capgo/cli@latest channel currentBundle production \
+                    --apikey "$CAPGO_API_KEY" --quiet | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' | tail -n1 || true)"
+                  if [ "$CURRENT" != "$VERSION" ]; then
+                      echo "::error::production channel serves '${CURRENT:-<none>}', expected $VERSION — devices on the $VERSION binary have no OTA path" >&2
+                      exit 1
+                  fi
+                  echo "Production channel now serves $VERSION"
 
             - name: Upload IPA as build artifact
               if: always()

--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -244,6 +244,16 @@ must be unique, and re-tagging is cheaper than a package.json bump.
 Not `v*`: that prefix belongs to `ios-release.yml` / `android-release.yml` for native
 store builds, and the two must not trigger each other.
 
+One deliberate exception to "opt-in per release": a **native release auto-publishes a
+matching production bundle** when its versionName is ahead of the newest production
+bundle. Capgo refuses on-device any bundle sorting below the installed native version
+(`disable_auto_update_under_native`), so a binary that outruns the bundles strands its
+whole fleet with green CI — that was TASK-21793 (102 devices refused OTA for a month
+because internal builds shipped 1.0.53 while the newest bundle was 1.0.51). The release
+workflows check the floor before building (`scripts/semver-newer.mjs` against
+`channel currentBundle production`) and, after the store upload, publish the release's
+own `out/` under the binary's versionName, then assert the channel serves it.
+
 - **The `production` channel** must exist in the Capgo dashboard and be bound to the prod
   app. It does — bundle 1.0.48 shipped to it on 2026-08-06.
 - **No second approver yet.** The job declares the `Production` environment, but that

--- a/scripts/__tests__/semver-newer.test.js
+++ b/scripts/__tests__/semver-newer.test.js
@@ -1,0 +1,57 @@
+const { spawnSync } = require('child_process')
+const path = require('path')
+
+const SCRIPT_PATH = path.join(__dirname, '..', 'semver-newer.mjs')
+
+// The script is a CI entrypoint: its contract is stdout + exit code, so run it
+// the way the release workflows do instead of reaching into its internals.
+function run(...args) {
+    return spawnSync(process.execPath, [SCRIPT_PATH, ...args], { encoding: 'utf-8' })
+}
+
+describe('semver-newer', () => {
+    it.each([
+        ['1.0.54', '1.0.51', 'true'],
+        ['1.0.51', '1.0.54', 'false'],
+        ['1.0.54', '1.0.54', 'false'],
+        ['1.1.0', '1.0.9999', 'true'],
+        ['2.0.0', '1.9.9', 'true'],
+        // numeric, not lexicographic: 10 > 9
+        ['1.0.10', '1.0.9', 'true'],
+    ])('%s above %s → %s', (candidate, baseline, expected) => {
+        const result = run(candidate, baseline)
+
+        expect(result.status).toBe(0)
+        expect(result.stdout.trim()).toBe(expected)
+    })
+
+    // The case sort -V gets backwards, and the reason this script exists: a
+    // prerelease sorts BELOW its plain version, so a 1.0.54 binary refuses a
+    // 1.0.54-hotfix1 bundle (disable_auto_update_under_native).
+    it.each([
+        ['1.0.54', '1.0.54-hotfix1', 'true'],
+        ['1.0.54-hotfix1', '1.0.54', 'false'],
+        ['1.0.54-hotfix2', '1.0.54-hotfix1', 'true'],
+        ['1.0.54-hotfix1.2', '1.0.54-hotfix1', 'true'],
+        // numeric prerelease identifiers compare numerically per semver §11
+        ['1.0.54-2', '1.0.54-10', 'false'],
+        // numeric identifiers sort below alphanumeric ones
+        ['1.0.54-alpha', '1.0.54-2', 'true'],
+    ])('%s above %s → %s (prerelease ordering)', (candidate, baseline, expected) => {
+        const result = run(candidate, baseline)
+
+        expect(result.status).toBe(0)
+        expect(result.stdout.trim()).toBe(expected)
+    })
+
+    it.each([['not-a-version', '1.0.54'], ['1.0.54', ''], ['1.0.54'], ['1.0', '1.0.54']])(
+        'fails loudly on unusable input %p %p',
+        (...args) => {
+            const result = run(...args.filter((a) => a !== undefined))
+
+            expect(result.status).toBe(1)
+            expect(result.stdout).toBe('')
+            expect(result.stderr).toContain('semver-newer')
+        }
+    )
+})

--- a/scripts/semver-newer.mjs
+++ b/scripts/semver-newer.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// Prints "true" when <candidate> sorts strictly above <baseline> in semver
+// order, "false" otherwise. Exits 1 on unusable input so a caller under
+// `set -e` dies instead of misreading an error as "false".
+//
+// Usage: node scripts/semver-newer.mjs <candidate> <baseline>
+//
+// Why prerelease-aware ordering matters here: Capgo compares a device's native
+// version against bundle versions with full semver semantics, and its
+// disable_auto_update_under_native rule rejects any bundle sorting below the
+// binary. 1.0.54-hotfix1 sorts BELOW 1.0.54 — `sort -V` gets exactly that case
+// backwards, which is the difference between "fleet is covered" and every
+// device silently refusing updates (TASK-21793).
+
+const SEMVER = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/
+
+const [candidate, baseline] = process.argv.slice(2)
+
+try {
+    process.stdout.write(`${compare(parse(candidate, 'candidate'), parse(baseline, 'baseline')) > 0}\n`)
+} catch (err) {
+    console.error(`✗ semver-newer: ${err.message}`)
+    process.exit(1)
+}
+
+function parse(version, label) {
+    const match = SEMVER.exec(version ?? '')
+    if (!match) throw new Error(`${label} must be X.Y.Z or X.Y.Z-<prerelease>, got "${version}"`)
+    const [, major, minor, patch, prerelease] = match
+    return { numbers: [Number(major), Number(minor), Number(patch)], prerelease: prerelease?.split('.') }
+}
+
+function compare(a, b) {
+    for (let i = 0; i < 3; i++) {
+        if (a.numbers[i] !== b.numbers[i]) return a.numbers[i] - b.numbers[i]
+    }
+    if (!a.prerelease && !b.prerelease) return 0
+    if (!a.prerelease) return 1
+    if (!b.prerelease) return -1
+    const len = Math.max(a.prerelease.length, b.prerelease.length)
+    for (let i = 0; i < len; i++) {
+        const [x, y] = [a.prerelease[i], b.prerelease[i]]
+        if (x === undefined) return -1
+        if (y === undefined) return 1
+        const [xNum, yNum] = [/^\d+$/.test(x), /^\d+$/.test(y)]
+        if (xNum && yNum) {
+            if (Number(x) !== Number(y)) return Number(x) - Number(y)
+        } else if (xNum !== yNum) {
+            return xNum ? -1 : 1
+        } else if (x !== y) {
+            return x < y ? -1 : 1
+        }
+    }
+    return 0
+}


### PR DESCRIPTION
TASK-21793. Follow-up to #2795 (which fixed the silent-no-op bug class for the dev→staging lane and predicted this incident in its own PR body).

## The incident

Internal store builds shipped with versionName **1.0.53** while the newest production OTA bundle was **1.0.51**. Capgo's `disable_auto_update_under_native` rule rejects any bundle sorting below the installed native version, so every device on the new binaries refused all existing bundles — OTA silently dead for the whole beta fleet (102 devices / 1,002 refusal events in 30 days; 26 devices stuck on July-29 JS), with green CI throughout. The immediate remediation (`ota-1.0.54` on the 08-21 build commit) already shipped; this PR makes the failure class impossible to repeat silently.

## Changes

- **`android-release.yml` / `ios-release.yml`** — three new pieces, kept in lockstep across the two platforms:
    - *Resolve release versionName* up front (input > tag > package.json, the same precedence both workflows already used inline), so every later step sees the exact version the binary ships with.
    - *Check production OTA floor* before the long build: read `channel currentBundle production` from Capgo and compare against the versionName with `scripts/semver-newer.mjs`. Unreadable channel or unparseable version fails the job — a binary that may strand the fleet does not ship on a guess.
    - *Publish matching production OTA bundle* after the store upload, only when the binary would leapfrog the newest bundle: upload the release's own `out/` (the exact JS baked into the binary) under the binary's versionName, then assert the channel actually serves it. The lanes can no longer drift apart; a failed publish turns the job red instead of the fleet going dark. Both platforms publishing the same version from the same tag is a verified no-op via `--version-exists-ok`.
- **`scripts/semver-newer.mjs`** — prerelease-aware "sorts strictly above" comparison. `sort -V` gets the case that matters here backwards: `1.0.54-hotfix1` sorts *below* `1.0.54` in semver (and in Capgo's on-device check), *above* it in GNU version sort. Fails loudly on unusable input so a `bash -e` step dies rather than misreading an error as "false".
- **`capgo-deploy.yml` / `docs/NATIVE-RELEASE.md`** — the "production OTA fires on an `ota-*` tag and nothing else" design notes now document this one deliberate exception.

## Task items covered elsewhere

- *Post-upload assertion on the production `ota-*` lane*: already live — #2795's "Verify channel serves the new bundle" step merged unconditional (no channel guard), so it ran on the `ota-1.0.54` remediation deploy. No change needed.
- *Sentry alert on `disable_auto_update_under_native`* and the *Capgo channel update-policy check* are ops-side, tracked in TASK-21793.

## Verification

- 16 new jest tests for `semver-newer.mjs` (plain/prerelease ordering incl. numeric identifiers, loud failure on unusable input); full `scripts/__tests__` suite green (35 tests).
- The floor-check step simulated under `bash -e` for all four paths: ahead → publish, covered → skip, unreadable channel → red, unparseable version → red.
- All three workflows parse; `prettier --check` clean on every touched file.
