### PR TITLE
hotfix: re-enable Manteca (revert 2026-08-24 kill-switch)

### DIFF
--- a/src/config/underMaintenance.config.ts
+++ b/src/config/underMaintenance.config.ts
@@ -93,7 +93,7 @@ const DISABLE_XCHAIN_WITHDRAW_GLOBALLY = false
 const underMaintenanceConfig: MaintenanceConfig = {
     enableFullMaintenance: false, // set to true to redirect all pages to /maintenance
     enableMaintenanceBanner: false, // set to true to show maintenance banner on all pages
-    disabledPaymentProviders: ['MANTECA'], // Manteca outage 2026-08-24 — QR payments (MP AR + PIX BR) disabled. Empty the array to restore.
+    disabledPaymentProviders: [], // set to ['MANTECA'] to disable Manteca QR payments (last used: 2026-08-24 outage)
     /**
      * Cross-chain withdraw is force-disabled in the iOS app, on top of the global
      * kill-switch. Getter, not a constant: the platform is only knowable once the
@@ -109,7 +109,7 @@ const underMaintenanceConfig: MaintenanceConfig = {
     disableCardLaunchCTA: false, // kill-switch for the in-app "shhh" card CTA (funnel card step + activated home splash). Set true to mute it (dial down in-app load); /card flow + /shhhhh + waitlist stay reachable regardless.
     disableLandingCardFold: false, // set to true to hide the landing-page card fold (black door fold + the closed-beta strip under it)
     pixBrazilOnrampMaintenance: false, // BRL deposits restored via dynamic PIX QR (2026-07-02). Set true if the onramp degrades again.
-    disabledMantecaCurrencies: ['ARS', 'BRL'], // Manteca outage 2026-08-24 — add-money + withdraw blocked for both geos. Empty the array to restore.
+    disabledMantecaCurrencies: [], // Manteca restored after the 2026-08-24 outage (ARS + BRL live). Add a currency here to block it during a future outage.
 }
 
 // shared user-facing copy for cross-chain disabled paths — keep wording aligned with TokenSelector banner


### PR DESCRIPTION
Reverts the maintenance kill-switch flip from #2807 — both arrays back to empty:

- `disabledPaymentProviders: []` — QR payments (Mercado Pago AR + PIX BR) live again
- `disabledMantecaCurrencies: []` — ARS + BRL add-money and withdraw live again

`npm run typecheck` clean. (The `add-money-states` unit-test failure noted in #2807 is pre-existing on main, unrelated.)