### PR TITLE
fix(sentry): give stackless console events a stack and stop issue explosion

### DIFF
--- a/sentry.utils.test.ts
+++ b/sentry.utils.test.ts
@@ -1,5 +1,5 @@
 import type { ErrorEvent } from '@sentry/nextjs'
-import { shouldIgnoreError } from './sentry.utils'
+import { beforeSendHandler, shouldIgnoreError } from './sentry.utils'
 import { criticalFlowTags } from '@/utils/sentry-critical-flow'
 
 function eventWith(partial: {
@@ -50,5 +50,38 @@ describe('shouldIgnoreError — critical-flow captures', () => {
 
     it('still ignores user cancellations, tagged or not', () => {
         expect(shouldIgnoreError(eventWith({ type: 'Error', value: 'User rejected the request', tags }))).toBe(true)
+    })
+})
+
+describe('beforeSendHandler — OneSignal op-failure fingerprint', () => {
+    const opEvent = (message: string): ErrorEvent => ({ message }) as unknown as ErrorEvent
+
+    it('collapses per-device op failures onto one fingerprint', () => {
+        const a = opEvent('Op failed (no retry): [{"name":"update-subscription","onesignalId":"5b1ff00c"}]')
+        const b = opEvent('Op failed (no retry): [{"name":"update-subscription","onesignalId":"e064b640"}]')
+
+        beforeSendHandler(a)
+        beforeSendHandler(b)
+
+        expect(a.fingerprint).toEqual(['onesignal-op-failed', 'update-subscription'])
+        expect(a.fingerprint).toEqual(b.fingerprint)
+    })
+
+    it('keeps different op names apart', () => {
+        const paused = opEvent('Op failed, pausing: [{"name":"login-user","onesignalId":"576b81d2"}]')
+        beforeSendHandler(paused)
+        expect(paused.fingerprint).toEqual(['onesignal-op-failed', 'login-user'])
+    })
+
+    it('leaves unrelated events unfingerprinted', () => {
+        const other = opEvent('Something else failed entirely')
+        beforeSendHandler(other)
+        expect(other.fingerprint).toBeUndefined()
+    })
+})
+
+describe('shouldIgnoreError — OneSignal worker-messenger noise', () => {
+    it('ignores the no-service-worker postMessage warning', () => {
+        expect(shouldIgnoreError(eventWith({ message: '[WM] No SW registration for postMessage' }))).toBe(true)
     })
 })

--- a/sentry.utils.ts
+++ b/sentry.utils.ts
@@ -58,7 +58,32 @@ const IGNORED_ERRORS = {
         // which is always true on capacitor://localhost — it then proceeds and the
         // camera works. Pure noise on native (PEANUT-UI-R1M).
         'The camera stream is only accessible if the page is transferred via https',
+        // OneSignal's worker messenger console.errors this whenever it wants to
+        // talk to a service worker that isn't registered yet — on first load, and
+        // on every native launch where the SW never registers at all. It retries,
+        // and nothing user-visible depends on it.
+        '[WM] No SW registration for postMessage',
     ],
+}
+
+/**
+ * OneSignal's op queue console.errors a failed operation with the whole op
+ * payload inlined, and that payload carries a per-device `onesignalId`. Since
+ * captureConsoleIntegration groups a stackless message event by its text, every
+ * device minted its OWN Sentry issue — unbounded issue creation for what is one
+ * failure mode.
+ *
+ * These are not dropped: push-subscription writes failing is worth watching
+ * (iOS push was silently dead for months on a mis-provisioned APNs key), so
+ * they collapse onto one issue per op name instead, where the rate is legible.
+ */
+const ONESIGNAL_OP_FAILURE = /^Op failed[^:]*:\s*\[?\s*\{\s*"name"\s*:\s*"([^"]+)"/
+
+function collapseNoisyFingerprint(event: ErrorEvent): void {
+    const opName = event.message?.match(ONESIGNAL_OP_FAILURE)?.[1]
+    if (opName) {
+        event.fingerprint = ['onesignal-op-failed', opName]
+    }
 }
 
 /**
@@ -339,6 +364,7 @@ export function beforeSendHandler(event: ErrorEvent): ErrorEvent | null {
     if (shouldIgnoreError(event)) {
         return null
     }
+    collapseNoisyFingerprint(event)
     cleanSensitiveHeaders(event)
     return event
 }

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -41,6 +41,7 @@ import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { useTranslations } from 'next-intl'
 import { resolveSettledTxHash } from '@/utils/settled-tx-hash.utils'
+import { toError } from '@/utils/to-error'
 
 export default function WithdrawCryptoPage() {
     const router = useRouter()
@@ -496,7 +497,7 @@ export default function WithdrawCryptoPage() {
                 method_type: 'crypto',
             })
         } catch (err) {
-            console.error('Withdrawal execution failed:', err)
+            console.error('Withdrawal execution failed:', toError(err))
             const errMsg = toFriendlyError(err)
             posthog.capture(ANALYTICS_EVENTS.WITHDRAW_FAILED, {
                 method_type: 'crypto',

--- a/src/components/Global/QRScanner/useQRScanner.ts
+++ b/src/components/Global/QRScanner/useQRScanner.ts
@@ -6,6 +6,7 @@ import { useDeviceType, DeviceType } from '@/hooks/useGetDeviceType'
 import { isCapacitor } from '@/utils/capacitor'
 import { ensureNativeCameraPermission } from '@/utils/camera-permission'
 import { reportQrScanError } from './utils'
+import { toError } from '@/utils/to-error'
 
 // ============================================================================
 // Configuration
@@ -325,7 +326,7 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
             } catch (err) {
                 clearTimeout(startTimeoutId)
                 cleanup()
-                console.error('Error accessing camera:', err)
+                console.error('Error accessing camera:', toError(err))
 
                 const errName = err instanceof Error ? err.name : ''
                 const shouldRetry =
@@ -372,7 +373,7 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
             setFacingMode(newFacingMode)
             if (isScanningRef.current) setIsCameraReady(true)
         } catch (err) {
-            console.error('Error switching camera:', err)
+            console.error('Error switching camera:', toError(err))
             setError(t('qrScanner.cameraSwitchFailed'))
         } finally {
             isSwitchingCameraRef.current = false

--- a/src/components/Kyc/SumsubKycWrapper.tsx
+++ b/src/components/Kyc/SumsubKycWrapper.tsx
@@ -106,7 +106,7 @@ const SumsubWebSdkModal = ({
 
         const handleLoaded = () => setSdkLoaded(true)
         const handleError = () => {
-            console.error('[sumsub] failed to load websdk script')
+            console.error(new Error('[sumsub] failed to load websdk script'))
             setSdkLoadError(true)
         }
 

--- a/src/components/Setup/Views/SetupPasskey.tsx
+++ b/src/components/Setup/Views/SetupPasskey.tsx
@@ -109,7 +109,8 @@ const SetupPasskey = () => {
             // success - useEffect below will handle navigation
         } catch (error) {
             const err = error as Error
-            console.error('[SetupPasskey] registration failed:', err.name, err.message)
+            // the Error itself, not its name/message — captureConsole only attaches a stack when an arg is an Error
+            console.error('[SetupPasskey] registration failed:', err)
             posthog.capture(ANALYTICS_EVENTS.SIGNUP_PASSKEY_FAILED, {
                 device_type: deviceType,
                 error_name: err.name,

--- a/src/hooks/wallet/useSendMoney.ts
+++ b/src/hooks/wallet/useSendMoney.ts
@@ -9,6 +9,7 @@ import { useRainCardOverview, RAIN_CARD_OVERVIEW_QUERY_KEY } from '../useRainCar
 import { rainCentsToUsdcUnits } from '@/utils/balance.utils'
 import { useTranslations } from 'next-intl'
 import { notifyHaptic } from '@/utils/haptics'
+import { toError } from '@/utils/to-error'
 import type { RainCollateralKind } from '@/services/rain'
 import { useSpendBundle } from './useSpendBundle'
 import { InsufficientSpendableError, SessionKeyGrantRequiredError, type SpendStrategy } from './spendPreflight'
@@ -125,7 +126,7 @@ export const useSendMoney = ({ address }: UseSendMoneyOptions) => {
             // pre-tap cached value.
             queryClient.invalidateQueries({ queryKey: ['balance', address] })
 
-            console.error('[useSendMoney] Transaction failed, rolled back balance:', error)
+            console.error('[useSendMoney] Transaction failed, rolled back balance:', toError(error))
 
             if (error instanceof InsufficientSpendableError) {
                 // Passed the display gate but couldn't route yet — useSpendBundle has

--- a/src/utils/__tests__/sentry-fingerprint-url.test.ts
+++ b/src/utils/__tests__/sentry-fingerprint-url.test.ts
@@ -1,0 +1,53 @@
+import { sanitizeUrl } from '@/utils/sentry.utils'
+
+describe('sanitizeUrl — fetch-failure fingerprints', () => {
+    it('collapses the enum values of a query param onto one fingerprint', () => {
+        const iban = sanitizeUrl('https://api.peanut.me/bridge/exchange-rate?accountType=iban')
+        const clabe = sanitizeUrl('https://api.peanut.me/bridge/exchange-rate?accountType=clabe')
+        const gb = sanitizeUrl('https://api.peanut.me/bridge/exchange-rate?accountType=gb')
+
+        expect(iban).toBe(clabe)
+        expect(clabe).toBe(gb)
+    })
+
+    it('normalizes every value in a multi-param query', () => {
+        expect(sanitizeUrl('https://api.peanut.me/manteca/prices?asset=USDC&against=ARS')).toBe(
+            'https://api.peanut.me/manteca/prices?asset={value}&against={value}'
+        )
+    })
+
+    /*
+     * The numeric pass ran before this change, so its output has to stay
+     * byte-identical — otherwise every already-correct fingerprint forks a new
+     * Sentry issue on deploy and the existing history is orphaned.
+     */
+    it('leaves numeric query values on their existing {id} fingerprint', () => {
+        expect(sanitizeUrl('https://api.peanut.me/users/history?limit=50')).toBe(
+            'https://api.peanut.me/users/history?limit={id}'
+        )
+        expect(sanitizeUrl('https://api.peanut.me/users/history?limit=50')).toBe(
+            sanitizeUrl('https://api.peanut.me/users/history?limit=5')
+        )
+    })
+
+    it('still normalizes ids and uuids in the path', () => {
+        expect(sanitizeUrl('https://api.peanut.me/rain/cards/123')).toBe('https://api.peanut.me/rain/cards/{id}')
+        expect(sanitizeUrl('https://api.peanut.me/rain/cards/3f2b1a0c-4d5e-6f70-8912-a3b4c5d6e7f8/pin')).toBe(
+            'https://api.peanut.me/rain/cards/{uuid}/pin'
+        )
+    })
+
+    it('keeps different param names apart', () => {
+        expect(sanitizeUrl('https://api.peanut.me/x?a=1')).not.toBe(sanitizeUrl('https://api.peanut.me/x?b=1'))
+    })
+
+    it('leaves a query-less url untouched', () => {
+        expect(sanitizeUrl('https://api.peanut.me/users/limits')).toBe('https://api.peanut.me/users/limits')
+    })
+
+    it('mixes numeric and non-numeric values in one query', () => {
+        expect(sanitizeUrl('https://api.peanut.me/tokens/price?address=0xaf88d065&chainId=42161')).toBe(
+            'https://api.peanut.me/tokens/price?address={value}&chainId={id}'
+        )
+    })
+})

--- a/src/utils/__tests__/to-error.test.ts
+++ b/src/utils/__tests__/to-error.test.ts
@@ -1,0 +1,47 @@
+import { toError } from '@/utils/to-error'
+
+describe('toError', () => {
+    it('passes an Error through untouched', () => {
+        const err = new TypeError('boom')
+        expect(toError(err)).toBe(err)
+    })
+
+    it('preserves a DOMException subclass identity', () => {
+        const err = new DOMException('denied', 'NotAllowedError')
+        expect(toError(err)).toBe(err)
+    })
+
+    // qr-scanner rejects with bare strings
+    it('wraps a thrown string', () => {
+        expect(toError('Camera not found.').message).toBe('Camera not found.')
+    })
+
+    /*
+     * The case that motivated the helper: a plain object stringifies to
+     * '[object Object]', so the payload was lost from the Sentry title as well
+     * as the stack.
+     */
+    it('serializes a plain object instead of stringifying it', () => {
+        expect(toError({ code: 'INSUFFICIENT_FUNDS', chainId: 42161 }).message).toBe(
+            '{"code":"INSUFFICIENT_FUNDS","chainId":42161}'
+        )
+    })
+
+    it('falls back to String() on a circular object', () => {
+        const circular: Record<string, unknown> = { a: 1 }
+        circular.self = circular
+        expect(toError(circular).message).toBe('[object Object]')
+    })
+
+    it('handles null and undefined', () => {
+        expect(toError(null).message).toBe('null')
+        expect(toError(undefined).message).toBe('undefined')
+    })
+
+    it('always returns something captureConsole will attach a stack to', () => {
+        for (const value of ['s', 42, null, undefined, { a: 1 }, new Error('e')]) {
+            expect(toError(value)).toBeInstanceOf(Error)
+            expect(toError(value).stack).toBeTruthy()
+        }
+    })
+})

--- a/src/utils/sentry-init.ts
+++ b/src/utils/sentry-init.ts
@@ -45,6 +45,21 @@ export function initSentry(): void {
             tracesSampleRate: 0.1,
             debug: false,
 
+            /*
+             * captureConsoleIntegration only calls captureException when one of the
+             * console args is an Error instance; otherwise it calls captureMessage,
+             * which carries no stack at all. That is how ~3.4% of our exception
+             * volume arrived unattributable — a message, no frames, no way to tell
+             * which of several call sites produced it. This synthesizes a stack at
+             * the capture point for every message event, including the deliberate
+             * captureMessage calls in fetchWithSentry and native-auth-capture.
+             *
+             * Note it lands on `threads`, not `exception.values`, so PostHog's
+             * mirror still reports these as an empty exception list; only passing a
+             * real Error at the call site clears that.
+             */
+            attachStacktrace: true,
+
             beforeSend: beforeSendHandler,
 
             integrations: [

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -396,15 +396,31 @@ const sanitizeHeaders = (headers: RequestInit['headers']): Record<string, unknow
 }
 
 // Sanitize URL for fingerprinting by replacing IDs with placeholders
-const sanitizeUrl = (url: string) => {
+export const sanitizeUrl = (url: string) => {
     return (
         url
             // Replace numeric IDs in path
             .replace(/\/\d+(?=\/|$)/g, '/{id}')
             // Replace UUIDs in path
             .replace(/\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?=\/|$)/gi, '/{uuid}')
-            // Replace numeric IDs in query params
-            .replace(/([?&][^=&]*=)\d+/g, '$1{id}')
+            // Replace numeric IDs in query params. Anchored to the end of the
+            // value: unanchored, this ate the leading 0 of an 0x-prefixed
+            // address and left `{id}xaf88d065`, so every wallet still got its
+            // own fingerprint AND the value was unreadable.
+            .replace(/([?&][^=&]*=)\d+(?=&|$)/g, '$1{id}')
+            /*
+             * Then every remaining query value. Normalizing only the numeric ones
+             * left each enum value of a param as its own Sentry issue: one 429 on
+             * /bridge/exchange-rate was three issues (accountType=iban / clabe / gb,
+             * PEANUT-UI-SGN / SQ4 / SSA) for a single upstream fault. The param
+             * names still separate genuinely different calls, and the raw URL stays
+             * on the event as `extra.url`.
+             *
+             * The lookahead skips values the numeric pass already replaced, so
+             * fingerprints that were correct before this change keep grouping into
+             * their existing issue instead of forking a new one.
+             */
+            .replace(/([?&][^=&]*=)(?!\{id\})[^&]*/g, '$1{value}')
     )
 }
 

--- a/src/utils/to-error.ts
+++ b/src/utils/to-error.ts
@@ -1,0 +1,26 @@
+/**
+ * Normalize an unknown thrown value into an Error.
+ *
+ * `catch (err)` gives back `unknown`, and plenty of what we catch is not an
+ * Error: qr-scanner rejects with bare strings, viem and several SDKs reject
+ * with plain objects. Logging those directly costs us twice —
+ * `captureConsoleIntegration` only attaches a stack when one of the console
+ * args is an Error instance, and a non-Error object stringifies to the
+ * useless `[object Object]`, so the payload is gone as well as the frames.
+ *
+ * Non-Error objects are serialized rather than stringified, so the shape
+ * survives into the Sentry title instead of collapsing.
+ */
+export function toError(value: unknown): Error {
+    if (value instanceof Error) return value
+
+    if (typeof value === 'object' && value !== null) {
+        try {
+            return new Error(JSON.stringify(value))
+        } catch {
+            // circular or non-serializable — fall through to String()
+        }
+    }
+
+    return new Error(String(value))
+}


### PR DESCRIPTION
## What

Started from [this PostHog view](https://eu.posthog.com/project/138913/activity/explore) — `$exception` events where `$cymbal_errors` is set. That property is PostHog's flag for *"empty exception list"*: the event arrived with a message but no `exception.values`, so no type and no stack.

**Those events were reaching Sentry fine.** The problem is the shape they arrived in, and how they grouped. 433 events / 255 people over 7d (~3.4% of exception volume).

## Why they were stackless

`captureConsoleIntegration` only calls `captureException` when one of the console args **is an `Error` instance**; otherwise it calls `captureMessage`, which carries no stack at all ([`captureconsole.js`](https://github.com/getsentry/sentry-javascript/blob/8.55.0/packages/core/src/integrations/captureconsole.ts)). Every event on that page was either a `console.error` whose args held no `Error`, or one of our deliberate `captureMessage` calls.

## Changes

**1. `attachStacktrace: true`** — synthesizes a stack for every message event, including `fetchWithSentry` / `native-auth-capture`, and third-party console noise where we can't touch the call site. One line, covers all 433.

**2. Call sites that destroyed their payload** — a stack can't recover an error the call site already threw away:

| Site | Was |
|---|---|
| `SetupPasskey.tsx` | passed `err.name, err.message` instead of `err` — largest family, ~126/wk |
| `useQRScanner.ts` ×2 | qr-scanner rejects with bare strings (`'Camera not found.'`) |
| `SumsubKycWrapper.tsx` | no `Error` object at all |
| `withdraw/crypto/page.tsx` | logged `[object Object]` — money-moving flow |
| `useSendMoney.ts` | logged `[object Object]` — money-moving flow |

Adds `utils/to-error.ts`, replacing what were already three ad-hoc copies of the same normalization. It JSON-serializes plain objects so the shape survives into the title instead of collapsing.

Passkey filtering is unchanged — the `AbortError` / `not allowed by the user` variants still match, via exception type rather than message.

**3. `sanitizeUrl` fingerprint gap** — it normalized numeric query values but not the rest, so one upstream 429 was three separate issues:

| Issue | Title | Events (7d) |
|---|---|---|
| PEANUT-UI-SGN | `exchange-rate?accountType=iban` | 273 |
| PEANUT-UI-SQ4 | `exchange-rate?accountType=clabe` | 151 |
| PEANUT-UI-SSA | `exchange-rate?accountType=gb` | 131 |

Now normalizes every value. A lookahead skips values the numeric pass already replaced, so fingerprints that were *already* correct keep their existing issue rather than forking a new one on deploy.

While adding tests for this I found a pre-existing bug: the numeric rule was unanchored, so `?address=0xaf88d065` had its leading `0` replaced and became `{id}xaf88d065` — every wallet still got its own fingerprint *and* the value was unreadable. Anchored with `(?=&|$)`.

**4. OneSignal issue explosion** — its op-failure message inlines a per-device `onesignalId`, so every device minted its own Sentry issue. These are **fingerprinted, not dropped**: push-subscription writes failing is exactly the signal that was missing while iOS push was dead on a mis-provisioned APNs key. Collapsed onto one issue per op name. The worker messenger's no-service-worker warning is pure noise and is ignored.

## Note

`attachStacktrace` lands on `threads`, not `exception.values`, so PostHog's mirror will still flag the remaining third-party ones as an empty exception list. That flag only clears where we now pass a real `Error`. Sentry is fully fixed; the PostHog view shrinks but won't empty out.

## Testing

- New: `to-error.test.ts` (8 cases), `sentry-fingerprint-url.test.ts` (7 cases, incl. the no-refingerprint regression guard)
- Extended `sentry.utils.test.ts` with the OneSignal fingerprint + ignore cases
- 94 sentry/`toError` tests and 272 tests across the touched components pass; prettier and eslint clean

## Overlap

Touches `sentry.utils.ts`, as does #2735 (chained-error matching + Capgo noise). No textual conflict — different regions, and `collapseNoisyFingerprint` composes with its `shouldIgnoreError` changes — but whichever lands second deserves a re-read.