### PR TITLE
ci: CODEOWNERS on workflows so the human-authors gate cannot be silently removed

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Workflow files gate the human-authors policy. A PR that edits them needs a
+# code-owner review, so the gate cannot be removed by a PR nobody reads.
+/.github/workflows/ @Hugo0


### PR DESCRIPTION
Follow-up to #2805 (the CODEOWNERS commit landed on the branch after the merge).

**Summary:** 3-line CODEOWNERS: any PR editing .github/workflows/ needs a code-owner (Hugo) review. Closes the hole where a PR could delete the human-authors job and still merge green with 0 approvals on dev.

**Risk:** none at runtime — only binds once code-owner review is required on the dev ruleset (org Staging ruleset flip, pending).

**QA:** file syntax is the standard CODEOWNERS pattern; enforced by GitHub, no CI change.