### PR TITLE
ci: stop double-running Tests on every PR commit

### DIFF
--- a/.github/workflows/content-publish-automerge.yml
+++ b/.github/workflows/content-publish-automerge.yml
@@ -134,9 +134,10 @@ jobs:
                   # on; the run conclusion also folds in advisory jobs (e2e). Gate on
                   # exactly what the ruleset gates on.
                   #
-                  # `Tests` runs on both `push` and `pull_request`, so a commit usually
-                  # carries TWO ci-success check runs. Require at least one and ALL of
-                  # them green — a single red run must block the merge.
+                  # `Tests` runs on `pull_request` (and `push` for dev/main), so a
+                  # commit can carry more than one ci-success check run. Require at
+                  # least one and ALL of them green — a single red run must block the
+                  # merge.
                   RUNS="repos/$REPO/commits/$SHA/check-runs?per_page=100"
                   TOTAL=$(gh api "$RUNS" --jq '[.check_runs[] | select(.name=="ci-success")] | length' || echo 0)
                   GREEN=$(gh api "$RUNS" --jq '[.check_runs[] | select(.name=="ci-success" and .conclusion=="success")] | length' || echo 0)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,13 @@
 name: Tests
 
 on:
+    # push is post-merge signal only. `['**']` double-ran the whole suite on
+    # every PR commit (push + pull_request runs on the same SHA, in different
+    # concurrency groups, so neither cancelled the other).
+    # content-publish-automerge's merge-on-green requires "at least one and
+    # ALL green" ci-success check runs per SHA, so one run per SHA satisfies it.
     push:
-        branches: ['**']
+        branches: [main, dev]
     pull_request:
         branches: [main, dev, develop]
     workflow_dispatch:


### PR DESCRIPTION
## What

Restrict the `Tests` workflow's `push` trigger from `branches: ['**']` to `branches: [main, dev]` (post-merge signal only). Also updates the now-stale comment in `content-publish-automerge.yml` that described the two-runs-per-SHA behavior.

## Why

Every PR commit currently runs the **entire suite twice**: the `push` and `pull_request` events fire on the same SHA but land in different concurrency groups (`pull_request.number` vs `ref`), so neither cancels the other. The run list shows push/PR pairs seconds apart, each ~2 min across 7 jobs — roughly half of this repo's Tests compute is duplicate work. The `pull_request` run is the better of the two: it tests the merge commit against the base.

## Safety check on content publishes

`content-publish-automerge`'s `merge-on-green` path triggers on **any** completed `Tests` run (including `pull_request`-event runs) and its gate requires *"at least one and ALL green"* `ci-success` check runs per SHA — one run per SHA satisfies it. No other workflow consumes push-triggered Tests runs (checked `workflow_run` references across `.github/workflows/`).