### PR TITLE
fix: three production bugs the fixture work surfaced

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,6 +201,7 @@
         ],
         "moduleNameMapper": {
             "\\.(svg|png|jpg|jpeg|gif|webp)$": "<rootDir>/src/utils/__mocks__/static-image.ts",
+            "\\.css$": "jest-transform-stub",
             "^@/config/wagmi\\.config$": "<rootDir>/src/utils/__mocks__/wagmi-config.ts",
             "^wagmi/chains$": "<rootDir>/src/utils/__mocks__/wagmi.ts",
             "^next/cache$": "<rootDir>/src/utils/__mocks__/next-cache.ts",

--- a/src/__tests__/dev-routes-gate.test.ts
+++ b/src/__tests__/dev-routes-gate.test.ts
@@ -31,11 +31,8 @@ const ORIGINAL_BASE_URL = process.env.NEXT_PUBLIC_BASE_URL
 async function loadProdBuild() {
     process.env.NEXT_PUBLIC_BASE_URL = 'https://peanut.me'
     jest.resetModules()
-    const [{ proxy, config }, { isBlockedDevRoute }] = await Promise.all([
-        import('@/proxy'),
-        import('@/constants/dev-tools.consts'),
-    ])
-    return { proxy, config, isBlockedDevRoute }
+    const { proxy, config } = await import('@/proxy')
+    return { proxy, config }
 }
 
 afterAll(() => {
@@ -51,14 +48,13 @@ describe('dev routes on peanut.me', () => {
     })
 
     it('404s every dev page except the three allowed ones', async () => {
-        const { proxy, isBlockedDevRoute } = await loadProdBuild()
+        const { proxy } = await loadProdBuild()
 
-        const answering = DEV_ROUTES.filter((route) => {
-            if (isBlockedDevRoute(route)) {
-                return proxy(new NextRequest(`https://peanut.me${route}`))?.status !== 404
-            }
-            return true
-        })
+        // every route goes through the proxy — so the allowlist is asserted
+        // to actually answer, not just skipped by the filter
+        const answering = DEV_ROUTES.filter(
+            (route) => proxy(new NextRequest(`https://peanut.me${route}`))?.status !== 404
+        )
 
         expect(answering.sort()).toEqual(ALLOWED_ON_PROD)
     })

--- a/src/__tests__/dev-routes-gate.test.ts
+++ b/src/__tests__/dev-routes-gate.test.ts
@@ -1,0 +1,71 @@
+/** @jest-environment node */
+import fs from 'fs'
+import path from 'path'
+import { NextRequest } from 'next/server'
+
+// Walk the app router and collect the route every page.tsx produces. Route
+// groups — the `(name)` folders — add no path segment.
+function routesUnder(dir: string, base = ''): string[] {
+    const routes: string[] = []
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (entry.isDirectory()) {
+            const segment = entry.name.startsWith('(') ? base : `${base}/${entry.name}`
+            routes.push(...routesUnder(path.join(dir, entry.name), segment))
+        } else if (entry.name === 'page.tsx') {
+            routes.push(base || '/')
+        }
+    }
+    return routes
+}
+
+const DEV_ROUTES = routesUnder(path.join(process.cwd(), 'src/app')).filter((route) => route.startsWith('/dev'))
+
+// Only these three answer on peanut.me. Widening this list is a deliberate act:
+// full-graph and payment-graph are the event visualisations, safe-area reads
+// device insets on the production native build.
+const ALLOWED_ON_PROD = ['/dev/full-graph', '/dev/payment-graph', '/dev/safe-area']
+
+const ORIGINAL_BASE_URL = process.env.NEXT_PUBLIC_BASE_URL
+
+// The gate reads env at module load, so re-import it as a peanut.me build.
+async function loadProdBuild() {
+    process.env.NEXT_PUBLIC_BASE_URL = 'https://peanut.me'
+    jest.resetModules()
+    const [{ proxy, config }, { isBlockedDevRoute }] = await Promise.all([
+        import('@/proxy'),
+        import('@/constants/dev-tools.consts'),
+    ])
+    return { proxy, config, isBlockedDevRoute }
+}
+
+afterAll(() => {
+    process.env.NEXT_PUBLIC_BASE_URL = ORIGINAL_BASE_URL
+    jest.resetModules()
+})
+
+describe('dev routes on peanut.me', () => {
+    it('finds the dev pages on disk', () => {
+        // guards the walker itself — an empty list would make everything below pass
+        expect(DEV_ROUTES.length).toBeGreaterThan(20)
+        expect(DEV_ROUTES).toEqual(expect.arrayContaining(['/dev', '/dev/debug', '/dev/ds', ...ALLOWED_ON_PROD]))
+    })
+
+    it('404s every dev page except the three allowed ones', async () => {
+        const { proxy, isBlockedDevRoute } = await loadProdBuild()
+
+        const answering = DEV_ROUTES.filter((route) => {
+            if (isBlockedDevRoute(route)) {
+                return proxy(new NextRequest(`https://peanut.me${route}`))?.status !== 404
+            }
+            return true
+        })
+
+        expect(answering.sort()).toEqual(ALLOWED_ON_PROD)
+    })
+
+    it('keeps /dev in the proxy matcher', async () => {
+        const { config } = await loadProdBuild()
+
+        expect(config.matcher).toContain('/dev/:path*')
+    })
+})

--- a/src/app/(mobile-ui)/__tests__/layout-backend-error.test.tsx
+++ b/src/app/(mobile-ui)/__tests__/layout-backend-error.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * (mobile-ui) layout — what happens when there is no user.
+ *
+ * Two different states end with `user === null`: the backend is down, and the
+ * person is not signed in. Only the second one may reach /setup. The user query
+ * throws for a 5xx and returns null for a 401, so `userFetchError` is the signal
+ * that tells them apart.
+ */
+import React from 'react'
+import { render, screen, act } from '@testing-library/react'
+
+const mockRouterReplace = jest.fn()
+
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ replace: mockRouterReplace, push: jest.fn(), back: jest.fn(), prefetch: jest.fn() }),
+    usePathname: () => '/home',
+}))
+
+const mockUseAuth = jest.fn()
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => mockUseAuth(),
+}))
+
+jest.mock('@/hooks/useNetworkStatus', () => ({
+    useNetworkStatus: () => ({ isOnline: true, isInitialized: true }),
+}))
+jest.mock('@/hooks/useAccountSetupRedirect', () => ({
+    useAccountSetupRedirect: () => ({ needsRedirect: false, isCheckingAccount: false }),
+}))
+jest.mock('@/hooks/usePullToRefresh', () => ({ usePullToRefresh: jest.fn() }))
+jest.mock('@/hooks/useNativePlugins', () => ({ useNativePlugins: jest.fn() }))
+jest.mock('@/hooks/useKeepWebBypass', () => ({ useKeepWebBypass: () => false }))
+jest.mock('@/hooks/useMigrationFlag', () => ({ useMigrationFlag: () => false }))
+jest.mock('@/hooks/useSafeBack', () => ({}))
+jest.mock('@/redux/hooks', () => ({ useSetupStore: () => ({ showIosPwaInstallScreen: false }) }))
+jest.mock('@/utils/demo', () => ({ isDemoMode: () => false, enableDemoMode: jest.fn() }))
+jest.mock('@/utils/migration.utils', () => ({ shouldShowSunsetBlock: () => false }))
+
+// Child screens are stubbed: this spec is about which one the layout picks.
+jest.mock('@/components/Global/BackendErrorScreen', () => ({
+    __esModule: true,
+    default: () => <div data-testid="backend-error-screen" />,
+}))
+jest.mock('@/components/Global/OfflineScreen', () => ({ __esModule: true, default: () => <div /> }))
+jest.mock('@/components/Global/Loading', () => ({ __esModule: true, default: () => <div data-testid="loading" /> }))
+jest.mock('@/components/Global/AppShell', () => ({
+    AppShell: ({ children }: { children: React.ReactNode }) => <div data-testid="app-shell">{children}</div>,
+}))
+jest.mock('@/components/Global/BottomNav', () => ({ BottomNav: () => <div /> }))
+jest.mock('@/components/Global/Banner', () => ({ Banner: () => <div /> }))
+jest.mock('@/components/Global/GuestLoginModal', () => ({ __esModule: true, default: () => <div /> }))
+jest.mock('@/components/Global/ReConsentModal', () => ({ __esModule: true, default: () => <div /> }))
+jest.mock('@/components/Global/SupportDrawer', () => ({ __esModule: true, default: () => <div /> }))
+jest.mock('@/components/Global/SupportDeepLink', () => ({ __esModule: true, default: () => <div /> }))
+jest.mock('@/components/Global/QRScannerOverlay', () => ({ __esModule: true, default: () => <div /> }))
+jest.mock('@/components/Global/SecurityVerificationOverlay', () => ({ __esModule: true, default: () => <div /> }))
+jest.mock('@/components/ForceIOSPWAInstall', () => ({ __esModule: true, default: () => <div /> }))
+jest.mock('@/components/Invites/JoinWaitlistPage', () => ({ __esModule: true, default: () => <div /> }))
+jest.mock('@/components/Migration/SunsetScreen', () => ({ __esModule: true, default: () => <div /> }))
+
+import Layout from '../layout'
+
+const CACHED_USER = {
+    user: { userId: 'u1', username: 'probe', hasAppAccess: true },
+    accounts: [],
+} as any
+
+const authState = (over: Record<string, unknown> = {}) => ({
+    user: null,
+    isFetchingUser: false,
+    userFetchError: null,
+    logoutUser: jest.fn(),
+    isLoggingOut: false,
+    ...over,
+})
+
+const renderLayout = () =>
+    render(
+        <Layout>
+            <div data-testid="page" />
+        </Layout>
+    )
+
+const rerenderLayout = (rerender: (ui: React.ReactElement) => void) =>
+    rerender(
+        <Layout>
+            <div data-testid="page" />
+        </Layout>
+    )
+
+describe('(mobile-ui) layout — no user', () => {
+    beforeEach(() => {
+        jest.useFakeTimers()
+        mockRouterReplace.mockClear()
+    })
+
+    afterEach(() => {
+        // drop, never fire: the logged-out fallback calls window.location.replace,
+        // which jsdom cannot do.
+        jest.clearAllTimers()
+        jest.useRealTimers()
+    })
+
+    it('backend down: shows the error screen and never sends the user to /setup', () => {
+        mockUseAuth.mockReturnValue(authState({ userFetchError: new Error('backend error fetching user') }))
+
+        renderLayout()
+
+        expect(screen.getByTestId('backend-error-screen')).toBeInTheDocument()
+        expect(mockRouterReplace).not.toHaveBeenCalled()
+
+        // the redirect arms a 3s hard-nav fallback. it must never have been armed.
+        expect(jest.getTimerCount()).toBe(0)
+        act(() => {
+            jest.advanceTimersByTime(5000)
+        })
+        expect(screen.getByTestId('backend-error-screen')).toBeInTheDocument()
+        expect(mockRouterReplace).not.toHaveBeenCalled()
+    })
+
+    it('logged out: still reaches /setup', () => {
+        mockUseAuth.mockReturnValue(authState())
+
+        renderLayout()
+
+        expect(screen.queryByTestId('backend-error-screen')).not.toBeInTheDocument()
+        expect(mockRouterReplace).toHaveBeenCalledWith('/setup')
+    })
+
+    it('error after the redirect is armed: the 3s hard-nav fallback is dropped', () => {
+        mockUseAuth.mockReturnValue(authState())
+        const { rerender } = renderLayout()
+        expect(jest.getTimerCount()).toBe(1)
+
+        mockUseAuth.mockReturnValue(authState({ userFetchError: new Error('backend error fetching user') }))
+        act(() => rerenderLayout(rerender))
+
+        expect(screen.getByTestId('backend-error-screen')).toBeInTheDocument()
+        expect(jest.getTimerCount()).toBe(0)
+    })
+
+    it('refetch blip over cached data: keeps the app, no error screen, no redirect', () => {
+        mockUseAuth.mockReturnValue(authState({ user: CACHED_USER, userFetchError: new Error('blip') }))
+
+        renderLayout()
+
+        expect(screen.queryByTestId('backend-error-screen')).not.toBeInTheDocument()
+        expect(screen.getByTestId('app-shell')).toBeInTheDocument()
+        expect(mockRouterReplace).not.toHaveBeenCalled()
+    })
+})

--- a/src/app/(mobile-ui)/dev/layout.tsx
+++ b/src/app/(mobile-ui)/dev/layout.tsx
@@ -2,26 +2,16 @@
 
 import { usePathname } from 'next/navigation'
 import { notFound } from 'next/navigation'
-import { BASE_URL } from '@/constants/general.consts'
+import { DEV_ROUTES_ENABLED, isBlockedDevRoute } from '@/constants/dev-tools.consts'
 
-// Routes allowed on peanut.me (production). All /dev routes are available elsewhere
-// (localhost, staging, Vercel preview deploys).
-// safe-area is read-only diagnostics and has to run on the production native build,
-// which is where the devices with the reported oversized inset actually are
-const PRODUCTION_ALLOWED_ROUTES = ['/dev/full-graph', '/dev/payment-graph', '/dev/safe-area']
-
-const IS_PROD_DOMAIN = BASE_URL === 'https://peanut.me'
-
+// Second layer, for the native app only. That build is a static export, so
+// proxy.ts never runs and this is the sole gate there. On the web the proxy
+// answers 404 first — a notFound() inside this route group still returns 200.
 export default function DevLayout({ children }: { children: React.ReactNode }) {
     const pathname = usePathname()
 
-    // On peanut.me, only allow specific routes (full-graph, payment-graph)
-    // On staging, Vercel previews, and localhost, all /dev routes are accessible
-    if (IS_PROD_DOMAIN) {
-        const isAllowedInProd = PRODUCTION_ALLOWED_ROUTES.some((route) => pathname?.startsWith(route))
-        if (!isAllowedInProd) {
-            notFound()
-        }
+    if (!DEV_ROUTES_ENABLED && isBlockedDevRoute(pathname ?? '')) {
+        notFound()
     }
 
     return <>{children}</>

--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -112,7 +112,19 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
         // (reliable on the first render after the hard-nav); persist it so later
         // navigations that drop the hash stay in demo mode.
         if (isDemoMode()) enableDemoMode()
-        if (!isPublicPath && isReady && !isFetchingUser && !user && !isRedirecting.current && !isDemoMode()) {
+        // no user has two causes. the user query returns null for a 401, and throws
+        // for a 5xx or a network failure. so an error here means the backend is
+        // down, not that the person is logged out. leave them on the error screen
+        // below — a bounce to signup reads as "you are logged out" during an outage.
+        if (
+            !isPublicPath &&
+            isReady &&
+            !isFetchingUser &&
+            !user &&
+            !userFetchError &&
+            !isRedirecting.current &&
+            !isDemoMode()
+        ) {
             isRedirecting.current = true
             router.replace('/setup')
             // Hard-nav fallback if the soft nav silently fails; re-check at fire time.
@@ -122,7 +134,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
             return () => clearTimeout(fallback)
         }
         return undefined
-    }, [user, isFetchingUser, isReady, isPublicPath, router])
+    }, [user, isFetchingUser, isReady, isPublicPath, userFetchError, router])
 
     // redirect logged-in users without peanut wallet account to complete setup
     const { needsRedirect, isCheckingAccount } = useAccountSetupRedirect()

--- a/src/app/(mobile-ui)/rewards/__tests__/points-error-state.test.tsx
+++ b/src/app/(mobile-ui)/rewards/__tests__/points-error-state.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+type QueryResult = { data?: unknown; isPending?: boolean; isLoading?: boolean; isError?: boolean; error?: unknown }
+
+const mockQueryResults: Record<string, QueryResult> = {}
+
+jest.mock('@tanstack/react-query', () => ({
+    useQuery: ({ queryKey }: { queryKey: unknown[] }) =>
+        mockQueryResults[String(queryKey[0])] ?? {
+            data: undefined,
+            isPending: false,
+            isLoading: false,
+            isError: false,
+        },
+}))
+
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn() }) }))
+jest.mock('next/image', () => () => null)
+jest.mock('posthog-js', () => ({ capture: jest.fn() }))
+jest.mock('framer-motion', () => ({ useInView: () => false }))
+jest.mock('@/i18n/app/useAppTranslations', () => ({ useAppTranslations: () => (key: string) => key }))
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => ({ user: { user: { userId: 'user-1', username: 'alice' } }, fetchUser: jest.fn() }),
+}))
+jest.mock('@/hooks/useSafeBack', () => ({ useSafeBack: () => jest.fn() }))
+jest.mock('@/hooks/useCountUp', () => ({ useCountUp: (value: number) => value }))
+jest.mock('@/services/invites', () => ({ invitesApi: { getInvites: jest.fn() } }))
+jest.mock('@/services/points', () => ({
+    pointsApi: { getTierInfo: jest.fn(), getUserInvitesGraph: jest.fn(), getCashStatus: jest.fn() },
+}))
+jest.mock('@/utils/capacitor', () => ({ isIOSNative: () => false }))
+jest.mock('@/utils/format.utils', () => ({ shortenPoints: (n: number) => ({ number: String(n), suffix: '' }) }))
+jest.mock('@/utils/native-routes', () => ({ profileUrl: (u: string) => `/${u}` }))
+jest.mock('@/utils/general.utils', () => ({ getInitialsFromName: () => 'A' }))
+jest.mock('@/components/Global/Card/card.utils', () => ({ getCardPosition: () => 'single' }))
+jest.mock('@/components/0_Bruddle/PageContainer', () => {
+    return function MockPageContainer(p: { children?: React.ReactNode }) {
+        return <div>{p.children}</div>
+    }
+})
+jest.mock('@/components/0_Bruddle/Button', () => ({
+    Button: (p: { children?: React.ReactNode }) => <button>{p.children}</button>,
+}))
+jest.mock('@/components/Global/Card', () => {
+    return function MockCard(p: { children?: React.ReactNode }) {
+        return <div>{p.children}</div>
+    }
+})
+jest.mock('@/components/Global/Icons/Icon', () => ({ Icon: () => null }))
+jest.mock('@/components/Global/NavHeader', () => () => null)
+jest.mock('@/components/Global/NavigationArrow', () => () => null)
+jest.mock('@/components/Global/InvitesGraph', () => () => null)
+jest.mock('@/components/Global/InviteFriendsModal', () => () => null)
+jest.mock('@/components/Points/InviteePointsBadge', () => () => null)
+jest.mock('@/components/TransactionDetails/TransactionAvatarBadge', () => () => null)
+jest.mock('@/components/UserHeader', () => ({ VerifiedUserLabel: () => null }))
+jest.mock('@/components/Global/Loading', () => {
+    return function MockLoading() {
+        return <div data-testid="loading" />
+    }
+})
+// EmptyState is shared: the page uses it for the points failure AND, further
+// down, for "no invites yet". Key the stub on the title so a test can name the
+// one it means — a bare testid matches both.
+jest.mock('@/components/Global/EmptyStates/EmptyState', () => {
+    return function MockEmptyState(p: { title?: string }) {
+        return <div data-testid={`empty-state-${p.title}`}>{p.title}</div>
+    }
+})
+
+import RewardsPage from '../page'
+
+// Flag combinations as react-query 5.8.4 actually reports them. A disabled query
+// is pending but NOT loading, which is what separates "not started" from
+// "settled with nothing in it".
+const NOT_STARTED = { data: undefined, isPending: true, isLoading: false, isError: false }
+const IN_FLIGHT = { data: undefined, isPending: true, isLoading: true, isError: false }
+
+// pointsApi.getTierInfo catches its own failures and resolves with data: null,
+// so a failed GET /points looks like a settled query with nothing in it.
+const TIER_INFO_FAILED = { data: { success: false, data: null }, isPending: false, isLoading: false, isError: false }
+const TIER_INFO_OK = {
+    data: { success: true, data: { totalPoints: 150, currentTier: 1, nextTierThreshold: 500, pointsToNextTier: 350 } },
+    isPending: false,
+    isLoading: false,
+    isError: false,
+}
+
+describe('RewardsPage when the points total fails to load', () => {
+    beforeEach(() => {
+        for (const key of Object.keys(mockQueryResults)) delete mockQueryResults[key]
+        mockQueryResults.invites = { data: { invitees: [] }, isPending: false, isLoading: false, isError: false }
+    })
+
+    it('shows the loader while both queries wait on the user, not the error state', () => {
+        // Both queries are `enabled: !!user?.user.userId`, so on a cold load they
+        // are disabled: pending, never started, no data.
+        mockQueryResults.invites = NOT_STARTED
+        mockQueryResults.tierInfo = NOT_STARTED
+
+        render(<RewardsPage />)
+
+        expect(screen.getByTestId('loading')).toBeInTheDocument()
+        expect(screen.queryByTestId('empty-state-loadPointsFailed')).not.toBeInTheDocument()
+    })
+
+    it('shows the error state instead of spinning forever', () => {
+        mockQueryResults.tierInfo = TIER_INFO_FAILED
+
+        render(<RewardsPage />)
+
+        expect(screen.getByTestId('empty-state-loadPointsFailed')).toBeInTheDocument()
+        expect(screen.queryByTestId('loading')).not.toBeInTheDocument()
+    })
+
+    it('still shows the loader while the points total is in flight', () => {
+        mockQueryResults.tierInfo = IN_FLIGHT
+
+        render(<RewardsPage />)
+
+        expect(screen.getByTestId('loading')).toBeInTheDocument()
+        expect(screen.queryByTestId('empty-state-loadPointsFailed')).not.toBeInTheDocument()
+    })
+
+    it('renders the points total when the request succeeds', () => {
+        mockQueryResults.tierInfo = TIER_INFO_OK
+
+        const { container } = render(<RewardsPage />)
+
+        expect(container).toHaveTextContent('150 pointsLabel')
+        expect(screen.queryByTestId('empty-state-loadPointsFailed')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('loading')).not.toBeInTheDocument()
+    })
+})

--- a/src/app/(mobile-ui)/rewards/page.tsx
+++ b/src/app/(mobile-ui)/rewards/page.tsx
@@ -116,7 +116,12 @@ const PointsPage = () => {
     // query never reports an error. Past the guard above the request has settled,
     // so missing data means it failed.
     if (isInvitesError || isTierInfoError || !tierInfo?.data) {
-        console.error('Error loading points data:', invitesError ?? tierInfoError)
+        // in the swallowed-error path both error objects are null — log the
+        // settled response so the branch never prints a contentless "null"
+        console.error(
+            'Error loading points data:',
+            invitesError ?? tierInfoError ?? { tierInfoSettledWithoutData: tierInfo }
+        )
 
         return (
             <div className="mx-auto space-y-3 mt-6 w-full md:max-w-2xl">

--- a/src/app/(mobile-ui)/rewards/page.tsx
+++ b/src/app/(mobile-ui)/rewards/page.tsx
@@ -53,7 +53,7 @@ const PointsPage = () => {
     }
     const {
         data: invites,
-        isLoading,
+        isPending: isInvitesPending,
         isError: isInvitesError,
         error: invitesError,
     } = useQuery({
@@ -64,7 +64,7 @@ const PointsPage = () => {
 
     const {
         data: tierInfo,
-        isLoading: isTierInfoLoading,
+        isPending: isTierInfoPending,
         isError: isTierInfoError,
         error: tierInfoError,
     } = useQuery({
@@ -105,11 +105,17 @@ const PointsPage = () => {
         fetchUser()
     }, [])
 
-    if (isLoading || isTierInfoLoading || !tierInfo?.data) {
+    // isPending, not isLoading: both queries wait on `user`, and a disabled query
+    // reports isLoading false. isLoading would send the first paint to the error
+    // state below, before either request has even started.
+    if (isInvitesPending || isTierInfoPending) {
         return <Loading variant="mascot" />
     }
 
-    if (isInvitesError || isTierInfoError) {
+    // getTierInfo catches its own failures and resolves with `data: null`, so the
+    // query never reports an error. Past the guard above the request has settled,
+    // so missing data means it failed.
+    if (isInvitesError || isTierInfoError || !tierInfo?.data) {
         console.error('Error loading points data:', invitesError ?? tierInfoError)
 
         return (

--- a/src/app/dev/layout.tsx
+++ b/src/app/dev/layout.tsx
@@ -4,10 +4,10 @@ import { usePathname } from 'next/navigation'
 import { notFound } from 'next/navigation'
 import { shouldBlockDevRoute } from '@/constants/dev-tools.consts'
 
-// Second layer, for the native app only. That build is a static export, so
-// proxy.ts never runs and this layout is the gate for this route group —
-// src/app/dev/layout.tsx does the same for the other group. On the web the
-// proxy answers 404 first; a notFound() inside this route group returns 200.
+// Second layer, for the native app only — the twin of
+// src/app/(mobile-ui)/dev/layout.tsx. That build is a static export, so
+// proxy.ts never runs; without this layout the pages in this group
+// (kyc-flows, loading-words) answer in the production native app.
 export default function DevLayout({ children }: { children: React.ReactNode }) {
     const pathname = usePathname()
 

--- a/src/constants/dev-tools.consts.ts
+++ b/src/constants/dev-tools.consts.ts
@@ -7,3 +7,23 @@
 // page that renders without an agent in the panes is a dead harness.
 export const DEV_TOOLS_ENABLED =
     process.env.NODE_ENV === 'development' || process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview'
+
+// Where the /dev pages may answer. peanut.me is the only host that blocks them;
+// localhost, staging and vercel previews keep every tool. A build with no
+// NEXT_PUBLIC_BASE_URL reads as peanut.me, so the gate fails closed.
+// Cannot import BASE_URL from general.consts — that module pulls in viem and
+// proxy.ts runs on the edge.
+export const DEV_ROUTES_ENABLED =
+    DEV_TOOLS_ENABLED || (process.env.NEXT_PUBLIC_BASE_URL || 'https://peanut.me') !== 'https://peanut.me'
+
+// The /dev routes that stay reachable on peanut.me. full-graph and payment-graph
+// are the activity visualisations shown at events. safe-area reads device insets
+// and must run on the production native build, where the bad insets are.
+const PROD_ALLOWED_DEV_ROUTES = ['/dev/full-graph', '/dev/payment-graph', '/dev/safe-area']
+
+// True for any /dev path that must not answer on peanut.me. One check for both
+// route groups — `src/app/dev/*` and `src/app/(mobile-ui)/dev/*`.
+export function isBlockedDevRoute(pathname: string): boolean {
+    if (pathname !== '/dev' && !pathname.startsWith('/dev/')) return false
+    return !PROD_ALLOWED_DEV_ROUTES.some((route) => pathname === route || pathname.startsWith(`${route}/`))
+}

--- a/src/constants/dev-tools.consts.ts
+++ b/src/constants/dev-tools.consts.ts
@@ -27,3 +27,11 @@ export function isBlockedDevRoute(pathname: string): boolean {
     if (pathname !== '/dev' && !pathname.startsWith('/dev/')) return false
     return !PROD_ALLOWED_DEV_ROUTES.some((route) => pathname === route || pathname.startsWith(`${route}/`))
 }
+
+// The one call every gate makes — proxy.ts on the web, the two dev layouts on
+// the native static export. The flag and the predicate are only meaningful
+// together; a call site that uses isBlockedDevRoute alone would 404 dev
+// tooling on staging and previews.
+export function shouldBlockDevRoute(pathname: string): boolean {
+    return !DEV_ROUTES_ENABLED && isBlockedDevRoute(pathname)
+}

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -125,9 +125,10 @@ export const PUBLIC_ROUTES_REGEX = /^\/(request\/pay|claim|pay\/.+|support|invit
 /**
  * Regex for dev-only public routes: ALL /dev pages (index + every tool/preview).
  * Only matched when IS_DEV is true (build-time NODE_ENV==='development'), so this
- * never applies on prod/preview builds. /dev is also independently notFound()'d on
- * peanut.me by dev/layout.tsx (except full-graph/payment-graph), so dev tooling is
- * doubly walled off from prod — this just removes the login-redirect friction locally.
+ * never applies on prod/preview builds. On peanut.me the /dev pages are blocked
+ * by shouldBlockDevRoute — proxy.ts answers a real 404 on the web, and the two
+ * dev layouts notFound() on the native static export — except the allowlist in
+ * dev-tools.consts.ts. This regex just removes login-redirect friction locally.
  */
 export const DEV_ONLY_PUBLIC_ROUTES_REGEX = /^\/dev(\/|$)/
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,7 +4,7 @@
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import maintenanceConfig from '@/config/underMaintenance.config'
-import { DEV_ROUTES_ENABLED, isBlockedDevRoute } from '@/constants/dev-tools.consts'
+import { shouldBlockDevRoute } from '@/constants/dev-tools.consts'
 import { LOCALE_COOKIE, toAppLocale, toMarketingLocale, withCountry } from '@/i18n/localeBridge'
 import { DEFAULT_LOCALE, type Locale } from '@/i18n/types'
 
@@ -15,7 +15,7 @@ export function proxy(request: NextRequest) {
     // (mobile-ui)/dev/layout.tsx renders the not-found UI but still returns 200,
     // so the real 404 has to come from here. This also covers the pages under
     // `src/app/dev/*`, which have no layout gate at all.
-    if (!DEV_ROUTES_ENABLED && isBlockedDevRoute(pathname)) {
+    if (shouldBlockDevRoute(pathname)) {
         return new NextResponse(null, { status: 404 })
     }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,17 +4,20 @@
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import maintenanceConfig from '@/config/underMaintenance.config'
+import { DEV_ROUTES_ENABLED, isBlockedDevRoute } from '@/constants/dev-tools.consts'
 import { LOCALE_COOKIE, toAppLocale, toMarketingLocale, withCountry } from '@/i18n/localeBridge'
 import { DEFAULT_LOCALE, type Locale } from '@/i18n/types'
 
 export function proxy(request: NextRequest) {
     const { pathname } = request.nextUrl
 
-    // /dev/ routes are now accessible in production for testing
-    // Uncomment below to block /dev/ routes in production if needed
-    // if (process.env.NODE_ENV === 'production' && pathname.startsWith('/dev/')) {
-    //     return new NextResponse(null, { status: 404 })
-    // }
+    // Internal dev tooling must not answer on peanut.me. The client gate in
+    // (mobile-ui)/dev/layout.tsx renders the not-found UI but still returns 200,
+    // so the real 404 has to come from here. This also covers the pages under
+    // `src/app/dev/*`, which have no layout gate at all.
+    if (!DEV_ROUTES_ENABLED && isBlockedDevRoute(pathname)) {
+        return new NextResponse(null, { status: 404 })
+    }
 
     // check if full maintenance mode is enabled
     if (maintenanceConfig.enableFullMaintenance) {


### PR DESCRIPTION
## Summary

Three production bugs, found while building the fixture harness in #2819. None was caught by a test, by Sentry, or by review — each surfaced from looking at a real screen or a real log.

Kept apart from #2819 on purpose: that PR is tooling with no production behaviour, this one is ~130 lines that change what users see. If one of these is wrong during launch week, reverting it should not mean reverting a harness.

**Base: `feat/design-system`** (PR #2813).

## 1. Internal dev tooling answered 200 on peanut.me

The intent to block `/dev` on production has been in the tree since February (`6830d7f3e`). It was written in the wrong place, so it never worked.

`(mobile-ui)/dev/layout.tsx` called `notFound()` for everything outside a small allowlist. **Inside a route group that renders the not-found UI and still answers 200**, so peanut.me served the page and its chunks to anyone who asked.

Worse, the pages under `src/app/dev/` sit outside that group and had **no gate at all**. `/dev/kyc-flows` rendered internal KYC flow diagrams to anonymous visitors on production.

The check now runs in the proxy, which sees both route groups, returns a real status, and covers routes nobody has written yet. Measured on a production build: **17 dev routes went 200 → 404**; `full-graph`, `payment-graph` and `safe-area` stayed 200. The allowlist is the one the layout already had — nothing added, nothing removed.

The host decides, not the build. Blocking on the dev-and-preview flag alone would have taken `/dev` off **staging**, which `6830d7f3e` enabled deliberately. peanut.me is the only host that blocks, and a build with no base URL reads as peanut.me, so the gate fails closed. The layout keeps its check because the native build is a static export with no proxy.

A test walks `src/app` for every `page.tsx`, so a dev page added tomorrow is covered without anyone remembering.

## 2. A backend outage sent signed-in users to the signup flow

`(mobile-ui)/layout.tsx` renders `BackendErrorScreen` when the user fetch fails. An effect earlier in the same file matched the same state with no error guard, called `router.replace('/setup')`, and armed a 3-second hard-nav fallback behind it.

Instrumented first paints, before:

```
+3128ms   error screen paints
+7054ms   → /setup        ← the fallback fires
```

During an outage that reads as "you have been logged out", which is the worst thing to tell someone whose money is behind the login.

"No user" has two causes and the data already told them apart: the user query **returns null** for a 401 and **throws** for a 5xx. One condition. After: the screen holds past 11 seconds and the URL never moves. A logged-out visitor still reaches `/setup` on identical timing.

Jest could not import the layout at all — no CSS mapper — so this had never been testable. One line added; `jest-transform-stub` was already a dependency.

## 3. A failed points fetch spun forever

`/rewards` sat on the mascot loader with no way out when `GET /points` failed. The error branch below the loader was unreachable for that path.

`pointsApi.getTierInfo` catches its own failure and resolves with `data: null`, so react-query never reports an error and never retries. The loading guard read `!tierInfo?.data`, which stays true forever once the call has failed. The invites call throws properly, which is why the error branch looked live in review.

The guards now split three states instead of two. A disabled query reports `isLoading` false while both queries wait on `user`, so `isLoading` cannot tell "not started" from "settled and empty". `isPending` can.

The screen was only correct before because a parent covers for it, using a different predicate than the queries use. It is now correct on its own terms.

## Verified

- `typecheck` clean · `npx jest` **304 suites, 3639 tests** · `prettier` clean · `ds-lint --check` no metric increased
- Each fix has one focused spec, and each spec was **proven to fail against the unfixed code** before it passed — including against the original buggy version, not only against a strawman
- Production builds served and probed for 1 and 2; first-paint instrumentation for 2, because a screenshot after settle cannot see a redirect that fires at 7 seconds

## Found and deliberately not fixed

- **Points failures never reach Sentry.** History's error branch calls `captureException`; rewards only `console.error`s, and `getTierInfo` swallows before even that. This is why bug 3 survived
- A failed invites call still blanks the whole rewards screen instead of dropping one section
- `isRedirecting.current` never resets, so a later legitimate redirect in the same mount is suppressed
- The `/dev` chunks still reach production bundles. The proxy blocks the routes, not the JavaScript — that needs a build rule over every `/dev` route
