### PR TITLE
fix(qr-scanner): recover the camera when the app returns to foreground

### DIFF
--- a/src/components/Global/QRScanner/__tests__/useQRScanner.test.ts
+++ b/src/components/Global/QRScanner/__tests__/useQRScanner.test.ts
@@ -8,6 +8,8 @@ import { captureException } from '@sentry/nextjs'
 import { useQRScanner } from '../useQRScanner'
 
 let onDecode: (result: { data: string }) => void
+let startBehaviour: () => Promise<void> = () => Promise.resolve()
+let startCalls = 0
 
 jest.mock('qr-scanner', () => ({
     __esModule: true,
@@ -15,7 +17,10 @@ jest.mock('qr-scanner', () => ({
         constructor(_video: HTMLVideoElement, cb: (result: { data: string }) => void) {
             onDecode = cb
         }
-        start = jest.fn().mockResolvedValue(undefined)
+        start = jest.fn(() => {
+            startCalls++
+            return startBehaviour()
+        })
         stop = jest.fn()
         destroy = jest.fn()
         setCamera = jest.fn()
@@ -64,4 +69,85 @@ it('camera scan: onScan failure is captured with the qr_scan_processing tag', as
             extra: { qrLength: 100, qrKind: 'pix', qrPayload: PIX_PAYLOAD },
         })
     )
+})
+
+describe('resume after backgrounding (TASK-21862)', () => {
+    function setHidden(hidden: boolean): void {
+        Object.defineProperty(document, 'hidden', { value: hidden, configurable: true })
+        document.dispatchEvent(new Event('visibilitychange'))
+    }
+
+    async function mountScanning() {
+        const { result } = renderHook(() => useQRScanner(jest.fn(), undefined, true))
+        const videoRef = result.current.videoRef as React.MutableRefObject<HTMLVideoElement | null>
+        videoRef.current = document.createElement('video')
+        await act(async () => {
+            await result.current.retryCamera()
+        })
+        // the mount-time start ran before the <video> existed and left a
+        // 100ms element-retry timer behind; let it fire before asserting
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 150))
+        })
+        return result
+    }
+
+    afterEach(() => {
+        Object.defineProperty(document, 'hidden', { value: false, configurable: true })
+        startBehaviour = () => Promise.resolve()
+    })
+
+    it('a successful restart returns to the live camera', async () => {
+        const result = await mountScanning()
+        expect(result.current.isCameraReady).toBe(true)
+
+        await act(async () => setHidden(true))
+        expect(result.current.isCameraReady).toBe(false)
+
+        await act(async () => setHidden(false))
+        expect(result.current.isCameraReady).toBe(true)
+        expect(result.current.error).toBeNull()
+    })
+
+    it('a rejected restart shows the error view instead of an endless spinner', async () => {
+        const result = await mountScanning()
+
+        await act(async () => setHidden(true))
+        startBehaviour = () => Promise.reject(new DOMException('Camera not found.', 'NotFoundError'))
+        await act(async () => setHidden(false))
+
+        expect(result.current.isCameraReady).toBe(false)
+        expect(result.current.error).toBe('qrScanner.cameraNotFound')
+    })
+
+    it('a retry after a failed restart recovers the camera', async () => {
+        const result = await mountScanning()
+
+        await act(async () => setHidden(true))
+        startBehaviour = () => Promise.reject(new DOMException('Camera not found.', 'NotFoundError'))
+        await act(async () => setHidden(false))
+        expect(result.current.error).toBe('qrScanner.cameraNotFound')
+
+        startBehaviour = () => Promise.resolve()
+        await act(async () => {
+            await result.current.retryCamera()
+        })
+        expect(result.current.error).toBeNull()
+        expect(result.current.isCameraReady).toBe(true)
+    })
+
+    it('overlapping resumes do not start the camera twice', async () => {
+        const result = await mountScanning()
+        const before = startCalls
+
+        await act(async () => setHidden(true))
+        await act(async () => {
+            setHidden(false)
+            setHidden(false)
+            setHidden(false)
+        })
+
+        expect(startCalls - before).toBe(1)
+        expect(result.current.isCameraReady).toBe(true)
+    })
 })

--- a/src/components/Global/QRScanner/__tests__/useQRScanner.test.ts
+++ b/src/components/Global/QRScanner/__tests__/useQRScanner.test.ts
@@ -10,18 +10,40 @@ import { useQRScanner } from '../useQRScanner'
 let onDecode: (result: { data: string }) => void
 let startBehaviour: () => Promise<void> = () => Promise.resolve()
 let startCalls = 0
+let attachStream = true
+let lastOptions: { preferredCamera?: unknown } = {}
 
 jest.mock('qr-scanner', () => ({
     __esModule: true,
     default: class {
-        constructor(_video: HTMLVideoElement, cb: (result: { data: string }) => void) {
+        video: HTMLVideoElement
+        active = false
+        constructor(video: HTMLVideoElement, cb: (result: { data: string }) => void, options: object) {
             onDecode = cb
+            this.video = video
+            lastOptions = options
         }
-        start = jest.fn(() => {
+        /*
+         * Models the library contract the hook now depends on: start() is a
+         * no-op while already active, attaches the MediaStream to the <video>
+         * before resolving, and clears `active` when acquisition rejects.
+         */
+        start = jest.fn(async () => {
+            if (this.active) return
+            this.active = true
             startCalls++
-            return startBehaviour()
+            try {
+                await startBehaviour()
+            } catch (err) {
+                this.active = false
+                throw err
+            }
+            if (attachStream) this.video.srcObject = {} as MediaStream
         })
-        stop = jest.fn()
+        stop = jest.fn(() => {
+            this.active = false
+            this.video.srcObject = null
+        })
         destroy = jest.fn()
         setCamera = jest.fn()
         setInversionMode = jest.fn()
@@ -77,24 +99,32 @@ describe('resume after backgrounding (TASK-21862)', () => {
         document.dispatchEvent(new Event('visibilitychange'))
     }
 
+    /*
+     * The mount effect starts the camera before the <video> exists and leaves a
+     * 100ms element-retry timer behind. Draining that on a real clock raced CI,
+     * so run the retry synchronously and assert on a settled scanner.
+     */
     async function mountScanning() {
         const { result } = renderHook(() => useQRScanner(jest.fn(), undefined, true))
         const videoRef = result.current.videoRef as React.MutableRefObject<HTMLVideoElement | null>
         videoRef.current = document.createElement('video')
         await act(async () => {
-            await result.current.retryCamera()
-        })
-        // the mount-time start ran before the <video> existed and left a
-        // 100ms element-retry timer behind; let it fire before asserting
-        await act(async () => {
-            await new Promise((resolve) => setTimeout(resolve, 150))
+            jest.advanceTimersByTime(100) // CONFIG.VIDEO_ELEMENT_RETRY_DELAY_MS
         })
         return result
     }
 
+    beforeEach(() => {
+        jest.useFakeTimers()
+        startCalls = 0
+        attachStream = true
+    })
+
     afterEach(() => {
+        jest.useRealTimers()
         Object.defineProperty(document, 'hidden', { value: false, configurable: true })
         startBehaviour = () => Promise.resolve()
+        attachStream = true
     })
 
     it('a successful restart returns to the live camera', async () => {
@@ -149,5 +179,47 @@ describe('resume after backgrounding (TASK-21862)', () => {
 
         expect(startCalls - before).toBe(1)
         expect(result.current.isCameraReady).toBe(true)
+    })
+
+    it('does not re-enter the camera flow while the error view is up', async () => {
+        const result = await mountScanning()
+
+        startBehaviour = () => Promise.reject(new DOMException('nope', 'NotFoundError'))
+        await act(async () => {
+            await result.current.retryCamera()
+        })
+        expect(result.current.error).toBe('qrScanner.cameraNotFound')
+
+        // a foreground here used to clear the error, show a spinner and hang on
+        // a denied getUserMedia before landing back on the same view
+        const before = startCalls
+        await act(async () => setHidden(true))
+        await act(async () => setHidden(false))
+        expect(startCalls).toBe(before)
+        expect(result.current.error).toBe('qrScanner.cameraNotFound')
+    })
+
+    it('treats a start that resolves without a stream as a failed start', async () => {
+        const result = await mountScanning()
+
+        attachStream = false
+        await act(async () => {
+            await result.current.retryCamera()
+        })
+
+        expect(result.current.isCameraReady).toBe(false)
+        expect(result.current.error).toBe('qrScanner.cameraStartFailed')
+    })
+
+    it('retryCamera ignores the click event its callers pass straight through', async () => {
+        const result = await mountScanning()
+        expect(lastOptions.preferredCamera).toBe('environment')
+
+        await act(async () => {
+            await (result.current.retryCamera as (event: unknown) => Promise<void>)(new MouseEvent('click'))
+        })
+
+        // a MouseEvent here becomes qr-scanner's deviceId {exact: ...}
+        expect(lastOptions.preferredCamera).toBe('environment')
     })
 })

--- a/src/components/Global/QRScanner/index.tsx
+++ b/src/components/Global/QRScanner/index.tsx
@@ -221,19 +221,28 @@ function ScanRegionOverlay({
 function ErrorView({
     message,
     onClose,
+    onRetry,
     children,
 }: {
     message: string
     onClose: () => void
+    onRetry?: () => void
     children?: React.ReactNode
 }) {
     const tCommon = useTranslations('common')
     return (
         <div className="p-4 text-center text-white">
             <p className="text-red-500">{message}</p>
-            <button onClick={onClose} className="mt-4 rounded bg-white px-4 py-2 text-black">
-                {tCommon('close')}
-            </button>
+            <div className="mt-4 flex items-center justify-center gap-2">
+                {onRetry && (
+                    <button onClick={onRetry} className="rounded bg-white px-4 py-2 text-black">
+                        {tCommon('retry')}
+                    </button>
+                )}
+                <button onClick={onClose} className="rounded bg-white px-4 py-2 text-black">
+                    {tCommon('close')}
+                </button>
+            </div>
             {children}
         </div>
     )
@@ -350,7 +359,7 @@ export default function QRScanner({ onScan, onClose, isOpen = true }: QRScannerP
                  */
                 <CameraPermissionModal visible onRetry={retryCamera} onClose={close} onPaste={handlePaste} />
             ) : error ? (
-                <ErrorView message={error} onClose={close}>
+                <ErrorView message={error} onClose={close} onRetry={() => retryCamera()}>
                     <PasteActions
                         onPaste={handlePaste}
                         detectedAddress={detectedAddress}

--- a/src/components/Global/QRScanner/index.tsx
+++ b/src/components/Global/QRScanner/index.tsx
@@ -359,7 +359,7 @@ export default function QRScanner({ onScan, onClose, isOpen = true }: QRScannerP
                  */
                 <CameraPermissionModal visible onRetry={retryCamera} onClose={close} onPaste={handlePaste} />
             ) : error ? (
-                <ErrorView message={error} onClose={close} onRetry={() => retryCamera()}>
+                <ErrorView message={error} onClose={close} onRetry={retryCamera}>
                     <PasteActions
                         onPaste={handlePaste}
                         detectedAddress={detectedAddress}

--- a/src/components/Global/QRScanner/useQRScanner.ts
+++ b/src/components/Global/QRScanner/useQRScanner.ts
@@ -117,7 +117,10 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
     const retryCountRef = useRef<number>(0)
     const videoElementRetryCountRef = useRef<number>(0)
     const isSwitchingCameraRef = useRef(false)
-    const isStartingCameraRef = useRef(false)
+    // bumped by every startCamera; a start whose generation is stale was
+    // superseded mid-await and must not commit state or touch the new scanner
+    const startGenRef = useRef(0)
+    const startCameraRef = useRef<((preferredCamera?: FacingMode) => Promise<void>) | null>(null)
 
     // -------------------------------------------------------------------------
     // Scanner Lifecycle
@@ -182,7 +185,7 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
                     toast.error(result.error || t('qrScanner.qrProcessingFailed'))
                     processingQRRef.current = false
                     // Resume scanner on failure so user can try again
-                    scannerRef.current?.start()
+                    scannerRef.current?.start().catch(() => startCameraRef.current?.())
                 }
             } catch (err) {
                 // console.info, not error: captureConsoleIntegration would turn an
@@ -192,7 +195,7 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
                 toast.error(t('qrScanner.qrProcessingError'))
                 processingQRRef.current = false
                 // Resume scanner on error so user can try again
-                scannerRef.current?.start()
+                scannerRef.current?.start().catch(() => startCameraRef.current?.())
             }
         },
         [onScan, toast, t]
@@ -226,143 +229,161 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
 
     const startCamera = useCallback(
         async (preferredCamera: FacingMode = facingMode) => {
-            if (isStartingCameraRef.current) return
-            isStartingCameraRef.current = true
+            setError(null)
+            setIsPermissionDenied(false)
+            setIsCameraReady(false)
 
+            if (!videoRef.current) {
+                // retry if video element not ready (react mounting race condition)
+                if (videoElementRetryCountRef.current < CONFIG.MAX_VIDEO_ELEMENT_RETRIES) {
+                    videoElementRetryCountRef.current++
+                    setTimeout(() => {
+                        if (isScanningRef.current) startCamera(preferredCamera)
+                    }, CONFIG.VIDEO_ELEMENT_RETRY_DELAY_MS)
+                    return
+                }
+                setError(t('qrScanner.cameraStartFailed'))
+                videoElementRetryCountRef.current = 0
+                return
+            }
+
+            // reset retry counter on success
+            videoElementRetryCountRef.current = 0
+
+            const generation = ++startGenRef.current
+            const superseded = () => generation !== startGenRef.current
+
+            let startTimeoutId: ReturnType<typeof setTimeout> | undefined
             try {
-                setError(null)
-                setIsPermissionDenied(false)
-                setIsCameraReady(false)
+                cleanup()
 
-                if (!videoRef.current) {
-                    // retry if video element not ready (react mounting race condition)
-                    if (videoElementRetryCountRef.current < CONFIG.MAX_VIDEO_ELEMENT_RETRIES) {
-                        videoElementRetryCountRef.current++
-                        setTimeout(() => {
-                            if (isScanningRef.current) startCamera(preferredCamera)
-                        }, CONFIG.VIDEO_ELEMENT_RETRY_DELAY_MS)
+                if (isCapacitor()) {
+                    const granted = await ensureNativeCameraPermission()
+                    if (superseded()) return
+                    if (!granted) {
+                        setIsPermissionDenied(true)
+                        setError(getErrorMessage(CAMERA_ERRORS.NOT_ALLOWED, 0))
                         return
                     }
-                    setError(t('qrScanner.cameraStartFailed'))
-                    videoElementRetryCountRef.current = 0
+                }
+
+                // iOS needs a delay to release camera hardware
+                if (deviceType === DeviceType.IOS) {
+                    await new Promise((resolve) => setTimeout(resolve, CONFIG.IOS_CAMERA_DELAY_MS))
+                }
+
+                // the drawer may have closed, or a newer start may have taken
+                // over, while the settle delay ran
+                if (superseded()) return
+                if (!isScanningRef.current || !videoRef.current) {
+                    cleanup()
                     return
                 }
 
-                // reset retry counter on success
-                videoElementRetryCountRef.current = 0
+                /*
+                 * Statically imported. It was lazy-loaded in 1.0.45 to keep the
+                 * decoder off the app shell's critical path, but that only defers
+                 * qr-scanner's 15KB wrapper — the 43KB worker that does the decoding
+                 * is fetched separately at construction either way, and on native the
+                 * whole export is on local disk, so the win was a millisecond of parse
+                 * time. It cost a gap between the camera going live and scanning
+                 * starting, and put a ChunkLoadError inside the camera catch below,
+                 * where anything that is not NotFound/NotReadable is reported to the
+                 * user as denied camera permission.
+                 */
+                const scanner = new QrScannerLib(videoRef.current, (result) => handleQRScan(result.data), {
+                    ...SCANNER_OPTIONS,
+                    preferredCamera,
+                })
 
-                let startTimeoutId: ReturnType<typeof setTimeout> | undefined
-                try {
-                    cleanup()
+                scanner.setInversionMode('original')
 
-                    if (isCapacitor()) {
-                        const granted = await ensureNativeCameraPermission()
-                        if (!granted) {
-                            setIsPermissionDenied(true)
-                            setError(getErrorMessage(CAMERA_ERRORS.NOT_ALLOWED, 0))
-                            return
-                        }
-                    }
+                scannerRef.current = scanner
 
-                    // iOS needs a delay to release camera hardware
-                    if (deviceType === DeviceType.IOS) {
-                        await new Promise((resolve) => setTimeout(resolve, CONFIG.IOS_CAMERA_DELAY_MS))
-                    }
-
-                    /*
-                     * Statically imported. It was lazy-loaded in 1.0.45 to keep the
-                     * decoder off the app shell's critical path, but that only defers
-                     * qr-scanner's 15KB wrapper — the 43KB worker that does the decoding
-                     * is fetched separately at construction either way, and on native the
-                     * whole export is on local disk, so the win was a millisecond of parse
-                     * time. It cost a gap between the camera going live and scanning
-                     * starting, and put a ChunkLoadError inside the camera catch below,
-                     * where anything that is not NotFound/NotReadable is reported to the
-                     * user as denied camera permission.
-                     */
-                    const scanner = new QrScannerLib(videoRef.current, (result) => handleQRScan(result.data), {
-                        ...SCANNER_OPTIONS,
-                        preferredCamera,
-                    })
-
-                    scanner.setInversionMode('original')
-
-                    scannerRef.current = scanner
-
-                    if (isCapacitor()) {
-                        // Native (Capacitor) resolves getUserMedia once the OS permission
-                        // dialog is answered and rejects cleanly on denial, so no timeout is
-                        // needed. Racing the short timeout made the first-run permission
-                        // prompt look like a failure (false "Camera start timed out" → retry).
-                        await scanner.start()
-                    } else {
-                        // iOS PWA (WKWebView) getUserMedia can hang forever after the user
-                        // denies permission instead of rejecting — race a timeout so the
-                        // permission modal still shows.
-                        await Promise.race([
-                            scanner.start(),
-                            new Promise<never>((_, reject) => {
-                                startTimeoutId = setTimeout(
-                                    () => reject(new DOMException('Camera start timed out', 'NotAllowedError')),
-                                    CONFIG.CAMERA_START_TIMEOUT_MS
-                                )
-                            }),
-                        ])
-                        clearTimeout(startTimeoutId)
-                    }
-
-                    // Request continuous autofocus — some devices default to single-shot
-                    // focus on start, leaving the image blurry when the user moves the phone.
-                    try {
-                        const stream = videoRef.current?.srcObject as MediaStream | null
-                        const track = stream?.getVideoTracks()[0]
-                        if (track && 'applyConstraints' in track) {
-                            await track.applyConstraints({
-                                advanced: [{ focusMode: 'continuous' } as MediaTrackConstraintSet],
-                            })
-                        }
-                    } catch {
-                        // Not all devices support focusMode — safe to ignore
-                    }
-
-                    console.log('[QR Scanner] Camera started, ready to scan')
-                    setIsCameraReady(true)
-                    retryCountRef.current = 0
-                } catch (err) {
+                if (isCapacitor()) {
+                    // Native (Capacitor) resolves getUserMedia once the OS permission
+                    // dialog is answered and rejects cleanly on denial, so no timeout is
+                    // needed. Racing the short timeout made the first-run permission
+                    // prompt look like a failure (false "Camera start timed out" → retry).
+                    await scanner.start()
+                } else {
+                    // iOS PWA (WKWebView) getUserMedia can hang forever after the user
+                    // denies permission instead of rejecting — race a timeout so the
+                    // permission modal still shows.
+                    await Promise.race([
+                        scanner.start(),
+                        new Promise<never>((_, reject) => {
+                            startTimeoutId = setTimeout(
+                                () => reject(new DOMException('Camera start timed out', 'NotAllowedError')),
+                                CONFIG.CAMERA_START_TIMEOUT_MS
+                            )
+                        }),
+                    ])
                     clearTimeout(startTimeoutId)
-                    cleanup()
-                    console.error('Error accessing camera:', toError(err))
-
-                    const errName = err instanceof Error ? err.name : ''
-                    const shouldRetry =
-                        errName === CAMERA_ERRORS.NOT_READABLE && retryCountRef.current < CONFIG.MAX_CAMERA_RETRIES
-
-                    // treat any non-retryable, non-hardware error as permission denied.
-                    // the qr-scanner library may wrap or rename the browser's NotAllowedError.
-                    // exclude NOT_READABLE (camera busy) — it has its own "remains busy" error path.
-                    if (!shouldRetry && errName !== CAMERA_ERRORS.NOT_FOUND && errName !== CAMERA_ERRORS.NOT_READABLE) {
-                        setIsPermissionDenied(true)
-                    }
-
-                    setError(getErrorMessage(errName, retryCountRef.current))
-
-                    if (shouldRetry) {
-                        retryCountRef.current++
-                        setTimeout(() => {
-                            if (isScanningRef.current) startCamera(preferredCamera)
-                        }, CONFIG.CAMERA_RETRY_DELAY_MS)
-                    } else {
-                        retryCountRef.current = 0
-                    }
                 }
-            } finally {
-                isStartingCameraRef.current = false
+
+                if (superseded() || !isScanningRef.current) return
+
+                /*
+                 * qr-scanner resolves start() without a stream when it was
+                 * stopped mid-acquisition (it discards the stream once
+                 * _active is false) or when the document was hidden. Reporting
+                 * ready here is what leaves a black <video> under a dismissed
+                 * spinner, so treat a missing stream as a failed start.
+                 */
+                if (!videoRef.current?.srcObject) {
+                    cleanup()
+                    setError(t('qrScanner.cameraStartFailed'))
+                    return
+                }
+
+                // Request continuous autofocus — some devices default to single-shot
+                // focus on start, leaving the image blurry when the user moves the phone.
+                try {
+                    const stream = videoRef.current?.srcObject as MediaStream | null
+                    const track = stream?.getVideoTracks()[0]
+                    if (track && 'applyConstraints' in track) {
+                        await track.applyConstraints({
+                            advanced: [{ focusMode: 'continuous' } as MediaTrackConstraintSet],
+                        })
+                    }
+                } catch {
+                    // Not all devices support focusMode — safe to ignore
+                }
+
+                console.log('[QR Scanner] Camera started, ready to scan')
+                setIsCameraReady(true)
+                retryCountRef.current = 0
+            } catch (err) {
+                clearTimeout(startTimeoutId)
+                cleanup()
+                console.error('Error accessing camera:', toError(err))
+
+                const errName = err instanceof Error ? err.name : ''
+                const shouldRetry =
+                    errName === CAMERA_ERRORS.NOT_READABLE && retryCountRef.current < CONFIG.MAX_CAMERA_RETRIES
+
+                // treat any non-retryable, non-hardware error as permission denied.
+                // the qr-scanner library may wrap or rename the browser's NotAllowedError.
+                // exclude NOT_READABLE (camera busy) — it has its own "remains busy" error path.
+                if (!shouldRetry && errName !== CAMERA_ERRORS.NOT_FOUND && errName !== CAMERA_ERRORS.NOT_READABLE) {
+                    setIsPermissionDenied(true)
+                }
+
+                setError(getErrorMessage(errName, retryCountRef.current))
+
+                if (shouldRetry) {
+                    retryCountRef.current++
+                    setTimeout(() => {
+                        if (isScanningRef.current) startCamera(preferredCamera)
+                    }, CONFIG.CAMERA_RETRY_DELAY_MS)
+                } else {
+                    retryCountRef.current = 0
+                }
             }
         },
         [facingMode, deviceType, cleanup, handleQRScan, getErrorMessage, t]
     )
-
-    const startCameraRef = useRef(startCamera)
 
     const toggleCamera = useCallback(async () => {
         if (!scannerRef.current || !isScanning || isSwitchingCameraRef.current) return
@@ -378,8 +399,12 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
          */
         isSwitchingCameraRef.current = true
         setIsCameraReady(false)
+        const scanner = scannerRef.current
         try {
-            await scannerRef.current.setCamera(newFacingMode)
+            await scanner.setCamera(newFacingMode)
+            // a resume or retry may have rebuilt the scanner during the
+            // handover; committing facingMode now would describe a dead stream
+            if (scannerRef.current !== scanner) return
             setFacingMode(newFacingMode)
             if (isScanningRef.current) setIsCameraReady(true)
         } catch (err) {
@@ -399,7 +424,7 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
         isScanningRef.current = isScanning
     }, [isScanning])
 
-    // the visibility listener is subscribed once; read startCamera through a ref
+    // the visibility listener subscribes once; read startCamera through a ref
     useEffect(() => {
         startCameraRef.current = startCamera
     }, [startCamera])
@@ -411,15 +436,32 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
                 scannerRef.current?.stop()
                 // resume repaints from a cold stream — show the placeholder until then
                 setIsCameraReady(false)
-            } else if (isScanningRef.current) {
+            } else if (isScanningRef.current && scannerRef.current) {
                 /*
-                 * iOS reclaims the capture device while backgrounded, so the stopped
-                 * scanner's own start() can come back "Camera not found" on resume.
-                 * Go through startCamera instead: it rebuilds the scanner after the
-                 * hardware settle delay and, when the restart still fails, leaves the
-                 * user on the retry/paste error view rather than an endless spinner.
+                 * iOS reclaims the capture device while backgrounded, so this
+                 * start() can reject with "Camera not found" even though the
+                 * same session had a working camera (PEANUT-UI-SV1). Falling
+                 * back to a full rebuild recovers it, and if that fails too the
+                 * user lands on the error view instead of an endless spinner.
+                 *
+                 * Deliberately still the scanner's own start() on the happy
+                 * path: it re-arms the instance the hidden branch stopped, and
+                 * skips a decode-worker rebuild on every foreground.
                  */
-                void startCameraRef.current()
+                scannerRef.current
+                    .start()
+                    .then(() => {
+                        if (!isScanningRef.current) return
+                        // start() also resolves without a stream when it was
+                        // stopped mid-acquisition — rebuild rather than show a
+                        // ready state over a dead <video>
+                        if (!videoRef.current?.srcObject) {
+                            void startCameraRef.current?.()
+                            return
+                        }
+                        setIsCameraReady(true)
+                    })
+                    .catch(() => startCameraRef.current?.())
             }
         }
 
@@ -459,6 +501,8 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
         videoRef,
         close,
         toggleCamera,
-        retryCamera: startCamera,
+        // wrapped: callers wire this straight to onClick, and a MouseEvent
+        // arriving as preferredCamera makes qr-scanner ask for deviceId {exact: [object MouseEvent]}
+        retryCamera: () => startCamera(),
     }
 }

--- a/src/components/Global/QRScanner/useQRScanner.ts
+++ b/src/components/Global/QRScanner/useQRScanner.ts
@@ -117,6 +117,7 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
     const retryCountRef = useRef<number>(0)
     const videoElementRetryCountRef = useRef<number>(0)
     const isSwitchingCameraRef = useRef(false)
+    const isStartingCameraRef = useRef(false)
 
     // -------------------------------------------------------------------------
     // Scanner Lifecycle
@@ -225,134 +226,143 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
 
     const startCamera = useCallback(
         async (preferredCamera: FacingMode = facingMode) => {
-            setError(null)
-            setIsPermissionDenied(false)
-            setIsCameraReady(false)
+            if (isStartingCameraRef.current) return
+            isStartingCameraRef.current = true
 
-            if (!videoRef.current) {
-                // retry if video element not ready (react mounting race condition)
-                if (videoElementRetryCountRef.current < CONFIG.MAX_VIDEO_ELEMENT_RETRIES) {
-                    videoElementRetryCountRef.current++
-                    setTimeout(() => {
-                        if (isScanningRef.current) startCamera(preferredCamera)
-                    }, CONFIG.VIDEO_ELEMENT_RETRY_DELAY_MS)
-                    return
-                }
-                setError(t('qrScanner.cameraStartFailed'))
-                videoElementRetryCountRef.current = 0
-                return
-            }
-
-            // reset retry counter on success
-            videoElementRetryCountRef.current = 0
-
-            let startTimeoutId: ReturnType<typeof setTimeout> | undefined
             try {
-                cleanup()
+                setError(null)
+                setIsPermissionDenied(false)
+                setIsCameraReady(false)
 
-                if (isCapacitor()) {
-                    const granted = await ensureNativeCameraPermission()
-                    if (!granted) {
-                        setIsPermissionDenied(true)
-                        setError(getErrorMessage(CAMERA_ERRORS.NOT_ALLOWED, 0))
+                if (!videoRef.current) {
+                    // retry if video element not ready (react mounting race condition)
+                    if (videoElementRetryCountRef.current < CONFIG.MAX_VIDEO_ELEMENT_RETRIES) {
+                        videoElementRetryCountRef.current++
+                        setTimeout(() => {
+                            if (isScanningRef.current) startCamera(preferredCamera)
+                        }, CONFIG.VIDEO_ELEMENT_RETRY_DELAY_MS)
                         return
                     }
+                    setError(t('qrScanner.cameraStartFailed'))
+                    videoElementRetryCountRef.current = 0
+                    return
                 }
 
-                // iOS needs a delay to release camera hardware
-                if (deviceType === DeviceType.IOS) {
-                    await new Promise((resolve) => setTimeout(resolve, CONFIG.IOS_CAMERA_DELAY_MS))
-                }
+                // reset retry counter on success
+                videoElementRetryCountRef.current = 0
 
-                /*
-                 * Statically imported. It was lazy-loaded in 1.0.45 to keep the
-                 * decoder off the app shell's critical path, but that only defers
-                 * qr-scanner's 15KB wrapper — the 43KB worker that does the decoding
-                 * is fetched separately at construction either way, and on native the
-                 * whole export is on local disk, so the win was a millisecond of parse
-                 * time. It cost a gap between the camera going live and scanning
-                 * starting, and put a ChunkLoadError inside the camera catch below,
-                 * where anything that is not NotFound/NotReadable is reported to the
-                 * user as denied camera permission.
-                 */
-                const scanner = new QrScannerLib(videoRef.current, (result) => handleQRScan(result.data), {
-                    ...SCANNER_OPTIONS,
-                    preferredCamera,
-                })
-
-                scanner.setInversionMode('original')
-
-                scannerRef.current = scanner
-
-                if (isCapacitor()) {
-                    // Native (Capacitor) resolves getUserMedia once the OS permission
-                    // dialog is answered and rejects cleanly on denial, so no timeout is
-                    // needed. Racing the short timeout made the first-run permission
-                    // prompt look like a failure (false "Camera start timed out" → retry).
-                    await scanner.start()
-                } else {
-                    // iOS PWA (WKWebView) getUserMedia can hang forever after the user
-                    // denies permission instead of rejecting — race a timeout so the
-                    // permission modal still shows.
-                    await Promise.race([
-                        scanner.start(),
-                        new Promise<never>((_, reject) => {
-                            startTimeoutId = setTimeout(
-                                () => reject(new DOMException('Camera start timed out', 'NotAllowedError')),
-                                CONFIG.CAMERA_START_TIMEOUT_MS
-                            )
-                        }),
-                    ])
-                    clearTimeout(startTimeoutId)
-                }
-
-                // Request continuous autofocus — some devices default to single-shot
-                // focus on start, leaving the image blurry when the user moves the phone.
+                let startTimeoutId: ReturnType<typeof setTimeout> | undefined
                 try {
-                    const stream = videoRef.current?.srcObject as MediaStream | null
-                    const track = stream?.getVideoTracks()[0]
-                    if (track && 'applyConstraints' in track) {
-                        await track.applyConstraints({
-                            advanced: [{ focusMode: 'continuous' } as MediaTrackConstraintSet],
-                        })
+                    cleanup()
+
+                    if (isCapacitor()) {
+                        const granted = await ensureNativeCameraPermission()
+                        if (!granted) {
+                            setIsPermissionDenied(true)
+                            setError(getErrorMessage(CAMERA_ERRORS.NOT_ALLOWED, 0))
+                            return
+                        }
                     }
-                } catch {
-                    // Not all devices support focusMode — safe to ignore
-                }
 
-                console.log('[QR Scanner] Camera started, ready to scan')
-                setIsCameraReady(true)
-                retryCountRef.current = 0
-            } catch (err) {
-                clearTimeout(startTimeoutId)
-                cleanup()
-                console.error('Error accessing camera:', toError(err))
+                    // iOS needs a delay to release camera hardware
+                    if (deviceType === DeviceType.IOS) {
+                        await new Promise((resolve) => setTimeout(resolve, CONFIG.IOS_CAMERA_DELAY_MS))
+                    }
 
-                const errName = err instanceof Error ? err.name : ''
-                const shouldRetry =
-                    errName === CAMERA_ERRORS.NOT_READABLE && retryCountRef.current < CONFIG.MAX_CAMERA_RETRIES
+                    /*
+                     * Statically imported. It was lazy-loaded in 1.0.45 to keep the
+                     * decoder off the app shell's critical path, but that only defers
+                     * qr-scanner's 15KB wrapper — the 43KB worker that does the decoding
+                     * is fetched separately at construction either way, and on native the
+                     * whole export is on local disk, so the win was a millisecond of parse
+                     * time. It cost a gap between the camera going live and scanning
+                     * starting, and put a ChunkLoadError inside the camera catch below,
+                     * where anything that is not NotFound/NotReadable is reported to the
+                     * user as denied camera permission.
+                     */
+                    const scanner = new QrScannerLib(videoRef.current, (result) => handleQRScan(result.data), {
+                        ...SCANNER_OPTIONS,
+                        preferredCamera,
+                    })
 
-                // treat any non-retryable, non-hardware error as permission denied.
-                // the qr-scanner library may wrap or rename the browser's NotAllowedError.
-                // exclude NOT_READABLE (camera busy) — it has its own "remains busy" error path.
-                if (!shouldRetry && errName !== CAMERA_ERRORS.NOT_FOUND && errName !== CAMERA_ERRORS.NOT_READABLE) {
-                    setIsPermissionDenied(true)
-                }
+                    scanner.setInversionMode('original')
 
-                setError(getErrorMessage(errName, retryCountRef.current))
+                    scannerRef.current = scanner
 
-                if (shouldRetry) {
-                    retryCountRef.current++
-                    setTimeout(() => {
-                        if (isScanningRef.current) startCamera(preferredCamera)
-                    }, CONFIG.CAMERA_RETRY_DELAY_MS)
-                } else {
+                    if (isCapacitor()) {
+                        // Native (Capacitor) resolves getUserMedia once the OS permission
+                        // dialog is answered and rejects cleanly on denial, so no timeout is
+                        // needed. Racing the short timeout made the first-run permission
+                        // prompt look like a failure (false "Camera start timed out" → retry).
+                        await scanner.start()
+                    } else {
+                        // iOS PWA (WKWebView) getUserMedia can hang forever after the user
+                        // denies permission instead of rejecting — race a timeout so the
+                        // permission modal still shows.
+                        await Promise.race([
+                            scanner.start(),
+                            new Promise<never>((_, reject) => {
+                                startTimeoutId = setTimeout(
+                                    () => reject(new DOMException('Camera start timed out', 'NotAllowedError')),
+                                    CONFIG.CAMERA_START_TIMEOUT_MS
+                                )
+                            }),
+                        ])
+                        clearTimeout(startTimeoutId)
+                    }
+
+                    // Request continuous autofocus — some devices default to single-shot
+                    // focus on start, leaving the image blurry when the user moves the phone.
+                    try {
+                        const stream = videoRef.current?.srcObject as MediaStream | null
+                        const track = stream?.getVideoTracks()[0]
+                        if (track && 'applyConstraints' in track) {
+                            await track.applyConstraints({
+                                advanced: [{ focusMode: 'continuous' } as MediaTrackConstraintSet],
+                            })
+                        }
+                    } catch {
+                        // Not all devices support focusMode — safe to ignore
+                    }
+
+                    console.log('[QR Scanner] Camera started, ready to scan')
+                    setIsCameraReady(true)
                     retryCountRef.current = 0
+                } catch (err) {
+                    clearTimeout(startTimeoutId)
+                    cleanup()
+                    console.error('Error accessing camera:', toError(err))
+
+                    const errName = err instanceof Error ? err.name : ''
+                    const shouldRetry =
+                        errName === CAMERA_ERRORS.NOT_READABLE && retryCountRef.current < CONFIG.MAX_CAMERA_RETRIES
+
+                    // treat any non-retryable, non-hardware error as permission denied.
+                    // the qr-scanner library may wrap or rename the browser's NotAllowedError.
+                    // exclude NOT_READABLE (camera busy) — it has its own "remains busy" error path.
+                    if (!shouldRetry && errName !== CAMERA_ERRORS.NOT_FOUND && errName !== CAMERA_ERRORS.NOT_READABLE) {
+                        setIsPermissionDenied(true)
+                    }
+
+                    setError(getErrorMessage(errName, retryCountRef.current))
+
+                    if (shouldRetry) {
+                        retryCountRef.current++
+                        setTimeout(() => {
+                            if (isScanningRef.current) startCamera(preferredCamera)
+                        }, CONFIG.CAMERA_RETRY_DELAY_MS)
+                    } else {
+                        retryCountRef.current = 0
+                    }
                 }
+            } finally {
+                isStartingCameraRef.current = false
             }
         },
         [facingMode, deviceType, cleanup, handleQRScan, getErrorMessage, t]
     )
+
+    const startCameraRef = useRef(startCamera)
 
     const toggleCamera = useCallback(async () => {
         if (!scannerRef.current || !isScanning || isSwitchingCameraRef.current) return
@@ -389,6 +399,11 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
         isScanningRef.current = isScanning
     }, [isScanning])
 
+    // the visibility listener is subscribed once; read startCamera through a ref
+    useEffect(() => {
+        startCameraRef.current = startCamera
+    }, [startCamera])
+
     // Handle visibility change - pause camera when app goes to background
     useEffect(() => {
         const handleVisibilityChange = () => {
@@ -396,19 +411,21 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
                 scannerRef.current?.stop()
                 // resume repaints from a cold stream — show the placeholder until then
                 setIsCameraReady(false)
-            } else if (isScanning && scannerRef.current) {
-                scannerRef.current
-                    .start()
-                    .then(() => {
-                        if (isScanningRef.current) setIsCameraReady(true)
-                    })
-                    .catch((err) => console.error('Error resuming camera:', err))
+            } else if (isScanningRef.current) {
+                /*
+                 * iOS reclaims the capture device while backgrounded, so the stopped
+                 * scanner's own start() can come back "Camera not found" on resume.
+                 * Go through startCamera instead: it rebuilds the scanner after the
+                 * hardware settle delay and, when the restart still fails, leaves the
+                 * user on the retry/paste error view rather than an endless spinner.
+                 */
+                void startCameraRef.current()
             }
         }
 
         document.addEventListener('visibilitychange', handleVisibilityChange)
         return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
-    }, [isScanning])
+    }, [])
 
     // Start/stop scanner based on isScanning state
     useEffect(() => {


### PR DESCRIPTION
Closes TASK-21862 — https://app.notion.com/p/3c78381175798110b8bfd9529ac52418

## Problem

An iPhone user opened the QR scanner, backgrounded the app for 94 seconds, and came back to a permanent "Starting camera…" spinner. iOS had reclaimed the capture device, so the stopped scanner's own `start()` rejected with `Camera not found.` — even though the same session had started that camera successfully a minute earlier.

`useQRScanner`'s visibilitychange handler called `scanner.start()` raw and its `.catch` only did a `console.error`. `isCameraReady` stayed `false` with no `error` set, which is exactly the state `index.tsx` renders as the indefinite spinner. The only escape was closing the drawer.

Sentry: [PEANUT-UI-SV1](https://peanut-c34d84c05.sentry.io/issues/7692395912/) — 1 event / 1 user, iOS 18.7, production release `043991d`. No money moved, failed, or got stuck.

## Fix

- Foreground resume now goes through `startCamera()` rather than `scanner.start()`. That path rebuilds the scanner after the iOS hardware settle delay and, when the restart still fails, sets the existing error state instead of leaving a bare spinner.
- New `isStartingCameraRef` guard in `startCamera` so overlapping visibility events — or a retry racing a resume — can't start two cameras at once. (This is the whole diff in `useQRScanner.ts`: the body is wrapped in `try/finally`, so review with `?w=1`.)
- The visibility listener now reads `startCamera` through a ref and subscribes once, instead of resubscribing per `isScanning` change.
- `ErrorView` gained a Retry button next to Close, so a failed restart reaches retry / paste / close rather than close-only. Uses the existing `common.retry` key — no new strings.

## Tests

`useQRScanner.test.ts` gains a resume suite: successful restart returns to the live camera; a rejected restart lands on `cameraNotFound` instead of spinning; a retry after that failure recovers; three synchronous resume events produce one `start()`. Three of the four fail against the pre-fix hook.

## Verification left for QA

Definition of done includes a manual pass on iOS Safari/PWA: open the scanner, background the app for at least a minute, return, and scan a QR.