### PR TITLE
fix(startup): survive a null or throwing localStorage

### DIFF
--- a/src/config/wagmi.config.tsx
+++ b/src/config/wagmi.config.tsx
@@ -1,6 +1,7 @@
 'use client'
-import { WagmiProvider, cookieToInitialState, createConfig, http, type Config } from 'wagmi'
+import { WagmiProvider, cookieToInitialState, createConfig, createStorage, http, type Config } from 'wagmi'
 import { arbitrum, bsc, celo, gnosis, linea, mainnet, optimism, polygon, scroll, worldchain } from 'wagmi/chains'
+import { resilientWebStorage } from '@/utils/safe-storage'
 
 // Base intentionally absent: WAGMI's `http()` (no URL) defaults to mainnet.base.org,
 // which IP-rate-limits us with 403s and pollutes the console. We don't use Base for
@@ -11,6 +12,10 @@ export const networks = [arbitrum, mainnet, optimism, polygon, gnosis, scroll, b
 export const wagmiConfig = createConfig({
     chains: [arbitrum, mainnet, optimism, polygon, gnosis, scroll, bsc, linea, worldchain, celo],
     ssr: true,
+    // wagmi's default storage touches window.localStorage unguarded, and this
+    // createConfig runs at module scope — a document that throws SecurityError
+    // on that property takes the app shell down before it renders.
+    storage: createStorage({ storage: resilientWebStorage }),
     transports: {
         [arbitrum.id]: http(),
         [mainnet.id]: http(),

--- a/src/i18n/app/__tests__/locale-store.test.ts
+++ b/src/i18n/app/__tests__/locale-store.test.ts
@@ -36,6 +36,17 @@ function setNavigatorLanguage(value: string): void {
     Object.defineProperty(navigator, 'language', { value, configurable: true })
 }
 
+const realLocalStorage = Object.getOwnPropertyDescriptor(window, 'localStorage')!
+
+function stubLocalStorage(get: () => Storage | null): void {
+    Object.defineProperty(window, 'localStorage', { get, configurable: true })
+}
+
+afterEach(() => {
+    Object.defineProperty(window, 'localStorage', realLocalStorage)
+    window.localStorage.clear()
+})
+
 type LocaleStore = typeof import('../locale-store')
 
 function freshStore(): LocaleStore {
@@ -144,5 +155,32 @@ describe('emitDeviceContextToAnalytics', () => {
         // guard is set only on success, so the next call retries instead of no-op
         await store.emitDeviceContextToAnalytics()
         expect(store.currentDeviceContext()).toEqual({ device_language: 'en-us', platform: 'web' })
+    })
+})
+
+describe('localeReady', () => {
+    it('falls back to the browser language when localStorage is null', async () => {
+        // some Android in-app browsers (Sentry PEANUT-UI-STC) expose it as null,
+        // which `typeof localStorage !== 'undefined'` happily waves through
+        stubLocalStorage(() => null)
+        setNavigatorLanguage('pt-BR')
+        const store = freshStore()
+        await expect(store.localeReady()).resolves.toBe('pt-BR')
+    })
+
+    it('still prefers a stored locale over the browser language', async () => {
+        window.localStorage.setItem('app-locale', 'pt-BR')
+        setNavigatorLanguage('en-US')
+        const store = freshStore()
+        await expect(store.localeReady()).resolves.toBe('pt-BR')
+    })
+
+    it('memoizes a usable locale rather than a rejection every later awaiter would inherit', async () => {
+        stubLocalStorage(() => null)
+        setNavigatorLanguage('es-419')
+        const store = freshStore()
+        const first = store.localeReady()
+        expect(store.localeReady()).toBe(first)
+        await expect(first).resolves.toBe('es-419')
     })
 })

--- a/src/i18n/app/locale-store.ts
+++ b/src/i18n/app/locale-store.ts
@@ -6,6 +6,7 @@
 import Cookies from 'js-cookie'
 import posthog from 'posthog-js'
 import { getPlatform, isCapacitor } from '@/utils/capacitor'
+import { readStoredValue, writeStoredValue } from '@/utils/safe-storage'
 import { resolveLocale, type AppLocale } from './config'
 
 const LOCALE_KEY = 'app-locale'
@@ -112,15 +113,19 @@ async function resolveStartupLocale(): Promise<AppLocale> {
         // shares the memoized bridge call with the analytics emit
         return resolveLocale(await rawDeviceTag())
     }
-    const stored =
-        Cookies.get(LOCALE_KEY) ?? (typeof localStorage !== 'undefined' ? localStorage.getItem(LOCALE_KEY) : null)
+    const stored = Cookies.get(LOCALE_KEY) ?? readStoredValue(LOCALE_KEY)
     if (stored) return resolveLocale(stored)
     return navigatorLocale()
 }
 
-/** Resolves the startup locale once; memoized for the session. */
+/**
+ * Resolves the startup locale once; memoized for the session. The catch is
+ * what makes memoizing safe: a rejected promise cached here would leave every
+ * later awaiter — AppIntlProvider included — hanging on a failure it has no
+ * handler for.
+ */
 export function localeReady(): Promise<AppLocale> {
-    if (!resolution) resolution = resolveStartupLocale()
+    if (!resolution) resolution = resolveStartupLocale().catch(() => navigatorLocale())
     return resolution
 }
 
@@ -132,11 +137,8 @@ export function persistLocale(locale: AppLocale): void {
         return
     }
     Cookies.set(LOCALE_KEY, locale, { expires: 365, path: '/' })
-    try {
-        localStorage.setItem(LOCALE_KEY, locale)
-    } catch {
-        // storage may be unavailable (private mode); cookie is authoritative
-    }
+    // storage may be unavailable (private mode); cookie is authoritative
+    writeStoredValue(LOCALE_KEY, locale)
 }
 
 let markApplied: (() => void) | null = null

--- a/src/utils/__tests__/safe-storage.test.ts
+++ b/src/utils/__tests__/safe-storage.test.ts
@@ -1,0 +1,63 @@
+/**
+ * The failure this guards (Sentry PEANUT-UI-STC / PEANUT-UI-STF) is not a
+ * throwing getItem — it is `window.localStorage` itself being null or throwing
+ * SecurityError in restricted Android in-app browsers, which took out startup
+ * locale detection and wagmi's module-scope createConfig.
+ */
+import { readStoredValue, removeStoredValue, resilientWebStorage, webStorage, writeStoredValue } from '../safe-storage'
+
+const realStorage = Object.getOwnPropertyDescriptor(window, 'localStorage')!
+
+function stubLocalStorage(get: () => Storage | null): void {
+    Object.defineProperty(window, 'localStorage', { get, configurable: true })
+}
+
+afterEach(() => {
+    Object.defineProperty(window, 'localStorage', realStorage)
+})
+
+it('reads and writes through a healthy localStorage', () => {
+    writeStoredValue('k', 'v')
+    expect(readStoredValue('k')).toBe('v')
+    removeStoredValue('k')
+    expect(readStoredValue('k')).toBeNull()
+})
+
+it('treats a null localStorage as empty instead of dereferencing it', () => {
+    stubLocalStorage(() => null)
+    expect(readStoredValue('k')).toBeNull()
+    expect(() => writeStoredValue('k', 'v')).not.toThrow()
+    expect(() => removeStoredValue('k')).not.toThrow()
+})
+
+it('survives a localStorage property getter that throws SecurityError', () => {
+    const hostile = {
+        get localStorage(): Storage {
+            throw new DOMException('The operation is insecure.', 'SecurityError')
+        },
+    }
+    expect(webStorage(hostile)).toBeNull()
+})
+
+it('treats a host without localStorage (SSR) as empty', () => {
+    expect(webStorage({})).toBeNull()
+})
+
+it('survives storage methods that throw once reached', () => {
+    const throwing = {
+        getItem: () => {
+            throw new DOMException('denied', 'SecurityError')
+        },
+        setItem: () => {
+            throw new DOMException('QuotaExceeded', 'QuotaExceededError')
+        },
+        removeItem: () => {
+            throw new DOMException('denied', 'SecurityError')
+        },
+    } as unknown as Storage
+    stubLocalStorage(() => throwing)
+
+    expect(resilientWebStorage.getItem('k')).toBeNull()
+    expect(() => resilientWebStorage.setItem('k', 'v')).not.toThrow()
+    expect(() => resilientWebStorage.removeItem('k')).not.toThrow()
+})

--- a/src/utils/safe-storage.ts
+++ b/src/utils/safe-storage.ts
@@ -1,0 +1,65 @@
+/*
+ * Restricted documents — Android in-app browsers, Chrome with site data
+ * blocked — expose `localStorage` as null or throw SecurityError from the
+ * property getter itself, so even reaching for it has to be guarded. Every
+ * caller degrades to "no stored value" rather than throwing.
+ */
+
+type WebStorageLike = {
+    getItem(key: string): string | null
+    setItem(key: string, value: string): void
+    removeItem(key: string): void
+}
+
+type StorageHost = { localStorage?: WebStorageLike | null }
+
+// `host` is a test seam: jest's jsdom global swallows throwing property
+// getters, so the SecurityError path is only reachable with an explicit host.
+export function webStorage(host: StorageHost = globalThis): WebStorageLike | null {
+    try {
+        return host.localStorage ?? null
+    } catch {
+        return null
+    }
+}
+
+export function readStoredValue(key: string): string | null {
+    const storage = webStorage()
+    if (!storage) return null
+    try {
+        return storage.getItem(key)
+    } catch {
+        return null
+    }
+}
+
+export function writeStoredValue(key: string, value: string): void {
+    const storage = webStorage()
+    if (!storage) return
+    try {
+        storage.setItem(key, value)
+    } catch {
+        // quota exceeded or storage disabled mid-session
+    }
+}
+
+export function removeStoredValue(key: string): void {
+    const storage = webStorage()
+    if (!storage) return
+    try {
+        storage.removeItem(key)
+    } catch {
+        // storage disabled mid-session
+    }
+}
+
+/**
+ * Drop-in for wagmi's `getDefaultStorage()`, which reads `window.localStorage`
+ * unguarded and leaves only `setItem` in a try/catch — enough for `createConfig`
+ * at module scope to throw and take the whole app shell down.
+ */
+export const resilientWebStorage: WebStorageLike = {
+    getItem: readStoredValue,
+    setItem: writeStoredValue,
+    removeItem: removeStoredValue,
+}


### PR DESCRIPTION
Closes TASK-21835 — https://app.notion.com/p/3c68381175798174b75effb4b74fb0fd

## Problem

Restricted documents — Android in-app browsers (Twitter's, Samsung), Chrome with site data blocked — expose `window.localStorage` as `null`, or throw `SecurityError` from the property getter itself. Two startup paths reached for it unguarded:

**Locale detection ([PEANUT-UI-STC](https://peanut-c34d84c05.sentry.io/issues/7690378127/))** — `resolveStartupLocale` checked `typeof localStorage !== 'undefined'`, and `typeof null === 'object'`, so a null storage sailed through the guard and `getItem` threw. `localeReady()` then memoized the rejected promise, and `AppIntlProvider` awaits it with no rejection handler — so a supported-language visitor stayed in English for the whole session and `app_locale` analytics never fired.

**Wagmi config ([PEANUT-UI-STF](https://peanut-c34d84c05.sentry.io/issues/7690983802/))** — `@wagmi/core@2.19.0`'s `getDefaultStorage()` reads `window.localStorage` with no try/catch, and only wraps `setItem`. Our `createConfig` runs at module scope, so a throwing getter took the app shell down before first render.

Both are 1 anonymous production actor each, 0 transaction attempts, $0 exposure.

## Fix

New `src/utils/safe-storage.ts` guards the property access *and* every storage method, degrading to "no stored value":

- `locale-store` reads and writes through it, so a hostile storage falls through to the browser-language default. `localeReady()` also catches now — memoizing a rejection is what turned a one-off read failure into a session-long wedge.
- `wagmi.config` passes `createStorage({ storage: resilientWebStorage })` instead of relying on wagmi's default. Key prefix is unchanged (`wagmi`), so existing persisted connector state still loads.

## Tests

`safe-storage.test.ts` covers the healthy round-trip, a null `localStorage`, a getter that throws `SecurityError`, a host with no `localStorage` at all (SSR), and storage methods that throw once reached. `locale-store.test.ts` gains a `localeReady` suite: browser-language fallback under a null storage, stored-locale precedence, and the memoization now caching a usable locale rather than a rejection. The null-storage and memoization cases fail against the pre-fix module.

One note on the `webStorage(host)` seam: jest's jsdom global swallows throwing property getters and yields `undefined`, so the `SecurityError` branch is unreachable through `window` and needs an explicit host object to exercise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved app startup reliability when browser storage is unavailable, blocked, or throws errors.
  - Added graceful fallback to the browser’s language when saved locale data cannot be accessed.
  - Preserved locale preferences more reliably without allowing storage failures to interrupt the app.
- **Tests**
  - Added coverage for unavailable, restricted, and error-prone browser storage scenarios.
  - Added tests for locale fallback, saved-locale precedence, and startup resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->