### PR TITLE
fix(ci): bake NEXT_PUBLIC_* into Capgo OTA bundles (native QR scan/paste dead on ota-1.0.54/1.0.55)

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,5 @@
 NEXT_PUBLIC_BASE_URL='https://peanut.example.org'
+# Wallet code now asserts these are baked rather than letting `undefined` reach viem
+# (see assertZeroDevRpcUrls) — a suite that touches the kernel client needs them set.
+NEXT_PUBLIC_ZERO_DEV_BUNDLER_URL='https://bundler.peanut.example.org/v1'
+NEXT_PUBLIC_ZERO_DEV_PAYMASTER_URL='https://paymaster.peanut.example.org/v1'

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -90,8 +90,9 @@ jobs:
               run: |
                   # NEXT_PUBLIC_* values are baked into the static export at build time.
                   # rpId MUST be peanut.me (passkeys + assetlinks/AASA).
-                  # Keep this block identical to ios-release.yml. CAPACITOR_BUILD /
-                  # IS_NATIVE_BUILD / GIT_COMMIT_HASH are auto-baked by next.config.native.js.
+                  # Keep this block identical to ios-release.yml / android-release.yml /
+                  # capgo-deploy.yml. CAPACITOR_BUILD / IS_NATIVE_BUILD / GIT_COMMIT_HASH
+                  # are auto-baked by next.config.native.js.
                   cat > .env.production.local <<EOF
                   NEXT_PUBLIC_BASE_URL=https://peanut.me
                   NEXT_PUBLIC_PEANUT_API_URL=${{ vars.NEXT_PUBLIC_PEANUT_API_URL }}

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -93,7 +93,9 @@ jobs:
                   # Keep this block identical to ios-release.yml / android-release.yml /
                   # capgo-deploy.yml. CAPACITOR_BUILD / IS_NATIVE_BUILD / GIT_COMMIT_HASH
                   # are auto-baked by next.config.native.js.
-                  cat > .env.production.local <<EOF
+                  # Delimiter is quoted: a secret holding $ or a backtick must land in the
+                  # file verbatim, not be expanded — or executed — by the shell.
+                  cat > .env.production.local <<'EOF'
                   NEXT_PUBLIC_BASE_URL=https://peanut.me
                   NEXT_PUBLIC_PEANUT_API_URL=${{ vars.NEXT_PUBLIC_PEANUT_API_URL }}
                   NEXT_PUBLIC_NATIVE_RP_ID=peanut.me

--- a/.github/workflows/capgo-deploy.yml
+++ b/.github/workflows/capgo-deploy.yml
@@ -79,6 +79,35 @@ jobs:
             - name: Install dependencies
               run: pnpm install
 
+            # Keep this block identical to ios-release.yml / android-release.yml /
+            # capgo-deploy.yml. It was missing here since the lane was created, so every
+            # production OTA bundle shipped with all NEXT_PUBLIC_* undefined: recognizeQr
+            # threw on BASE_URL and Sentry/PostHog never initialised — mono
+            # `ops/native-ota-envless-bundle-rca.md`. native-build.js now fails in CI when
+            # the file is missing.
+            - name: Bake production NEXT_PUBLIC_* into the static export
+              run: |
+                  # NEXT_PUBLIC_* values are baked into the static export at build time.
+                  # rpId MUST be peanut.me (passkeys + assetlinks/AASA). CAPACITOR_BUILD /
+                  # IS_NATIVE_BUILD / GIT_COMMIT_HASH are auto-baked by next.config.native.js.
+                  cat > .env.production.local <<EOF
+                  NEXT_PUBLIC_BASE_URL=https://peanut.me
+                  NEXT_PUBLIC_PEANUT_API_URL=${{ vars.NEXT_PUBLIC_PEANUT_API_URL }}
+                  NEXT_PUBLIC_NATIVE_RP_ID=peanut.me
+                  NEXT_PUBLIC_ZERO_DEV_BUNDLER_URL=${{ secrets.NEXT_PUBLIC_ZERO_DEV_BUNDLER_URL }}
+                  NEXT_PUBLIC_ZERO_DEV_PAYMASTER_URL=${{ secrets.NEXT_PUBLIC_ZERO_DEV_PAYMASTER_URL }}
+                  NEXT_PUBLIC_ZERO_DEV_PASSKEY_PROJECT_ID=${{ secrets.NEXT_PUBLIC_ZERO_DEV_PASSKEY_PROJECT_ID }}
+                  NEXT_PUBLIC_ZERO_DEV_RECOVERY_BUNDLER_URL=${{ secrets.NEXT_PUBLIC_ZERO_DEV_RECOVERY_BUNDLER_URL }}
+                  NEXT_PUBLIC_JUSTANAME_ENS_DOMAIN=peanut.me
+                  NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+                  NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
+                  NEXT_PUBLIC_POSTHOG_HOST=${{ vars.NEXT_PUBLIC_POSTHOG_HOST }}
+                  NEXT_PUBLIC_GA_KEY=${{ vars.NEXT_PUBLIC_GA_KEY }}
+                  NEXT_PUBLIC_ONESIGNAL_APP_ID=${{ secrets.NEXT_PUBLIC_ONESIGNAL_APP_ID }}
+                  NEXT_PUBLIC_SAFARI_WEB_ID=${{ vars.NEXT_PUBLIC_SAFARI_WEB_ID }}
+                  NEXT_PUBLIC_ONESIGNAL_WEBHOOK=${{ vars.NEXT_PUBLIC_ONESIGNAL_WEBHOOK }}
+                  EOF
+
             - name: Build native static export
               run: node scripts/native-build.js
 

--- a/.github/workflows/capgo-deploy.yml
+++ b/.github/workflows/capgo-deploy.yml
@@ -90,7 +90,9 @@ jobs:
                   # NEXT_PUBLIC_* values are baked into the static export at build time.
                   # rpId MUST be peanut.me (passkeys + assetlinks/AASA). CAPACITOR_BUILD /
                   # IS_NATIVE_BUILD / GIT_COMMIT_HASH are auto-baked by next.config.native.js.
-                  cat > .env.production.local <<EOF
+                  # Delimiter is quoted: a secret holding $ or a backtick must land in the
+                  # file verbatim, not be expanded — or executed — by the shell.
+                  cat > .env.production.local <<'EOF'
                   NEXT_PUBLIC_BASE_URL=https://peanut.me
                   NEXT_PUBLIC_PEANUT_API_URL=${{ vars.NEXT_PUBLIC_PEANUT_API_URL }}
                   NEXT_PUBLIC_NATIVE_RP_ID=peanut.me

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -83,8 +83,9 @@ jobs:
               run: |
                   # NEXT_PUBLIC_* values are baked into the static export at build time.
                   # rpId MUST be peanut.me (passkeys + assetlinks/AASA).
-                  # Keep this block identical to android-release.yml. CAPACITOR_BUILD /
-                  # IS_NATIVE_BUILD / GIT_COMMIT_HASH are auto-baked by next.config.native.js.
+                  # Keep this block identical to ios-release.yml / android-release.yml /
+                  # capgo-deploy.yml. CAPACITOR_BUILD / IS_NATIVE_BUILD / GIT_COMMIT_HASH
+                  # are auto-baked by next.config.native.js.
                   cat > .env.production.local <<EOF
                   NEXT_PUBLIC_BASE_URL=https://peanut.me
                   NEXT_PUBLIC_PEANUT_API_URL=${{ vars.NEXT_PUBLIC_PEANUT_API_URL }}

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -86,7 +86,9 @@ jobs:
                   # Keep this block identical to ios-release.yml / android-release.yml /
                   # capgo-deploy.yml. CAPACITOR_BUILD / IS_NATIVE_BUILD / GIT_COMMIT_HASH
                   # are auto-baked by next.config.native.js.
-                  cat > .env.production.local <<EOF
+                  # Delimiter is quoted: a secret holding $ or a backtick must land in the
+                  # file verbatim, not be expanded — or executed — by the shell.
+                  cat > .env.production.local <<'EOF'
                   NEXT_PUBLIC_BASE_URL=https://peanut.me
                   NEXT_PUBLIC_PEANUT_API_URL=${{ vars.NEXT_PUBLIC_PEANUT_API_URL }}
                   NEXT_PUBLIC_NATIVE_RP_ID=peanut.me

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
         "@types/validator": "^13.12.2",
         "@typescript-eslint/eslint-plugin": "^8.59.1",
         "@typescript-eslint/parser": "^8.59.1",
+        "dotenv": "^16.6.1",
         "eslint": "^9.39.4",
         "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import-x": "^4.16.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,6 +331,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.59.1
         version: 8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      dotenv:
+        specifier: ^16.6.1
+        version: 16.6.1
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@1.21.7)

--- a/scripts/__tests__/native-env-check.test.js
+++ b/scripts/__tests__/native-env-check.test.js
@@ -1,0 +1,49 @@
+const fs = require('fs')
+const path = require('path')
+const Module = require('module')
+
+const SCRIPT_PATH = path.join(__dirname, '..', 'native-build.js')
+
+// native-build.js is a script, not a module: it calls main() at import time and
+// exports nothing. Load the real source with that call stripped so the env check
+// can be asserted against the list the build actually enforces.
+function loadScriptInternals() {
+    const source = fs.readFileSync(SCRIPT_PATH, 'utf-8')
+    const withoutEntrypoint = source.replace(/\nmain\(\)\s*$/, '\n')
+    expect(withoutEntrypoint).not.toBe(source)
+
+    const exposed = withoutEntrypoint + '\nmodule.exports = { missingNativeEnv, REQUIRED_NATIVE_ENV }\n'
+
+    const mod = new Module(SCRIPT_PATH, null)
+    mod.filename = SCRIPT_PATH
+    mod.paths = Module._nodeModulePaths(path.dirname(SCRIPT_PATH))
+    mod._compile(exposed, SCRIPT_PATH)
+    return mod.exports
+}
+
+const { missingNativeEnv, REQUIRED_NATIVE_ENV } = loadScriptInternals()
+
+describe('missingNativeEnv', () => {
+    it('reports nothing when every required key has a value', () => {
+        const env = REQUIRED_NATIVE_ENV.map((key) => `${key}=value-for-${key}`).join('\n')
+        expect(missingNativeEnv(env)).toEqual([])
+    })
+
+    // An empty value bakes `''` into the bundle, which is as dead as an absent key.
+    it('reports both an empty value and an absent key', () => {
+        const env = REQUIRED_NATIVE_ENV.filter((key) => key !== 'NEXT_PUBLIC_SENTRY_DSN')
+            .map((key) => (key === 'NEXT_PUBLIC_BASE_URL' ? `${key}=` : `${key}=set`))
+            .join('\n')
+        expect(missingNativeEnv(env).sort()).toEqual(['NEXT_PUBLIC_BASE_URL', 'NEXT_PUBLIC_SENTRY_DSN'])
+    })
+
+    it('ignores comments and blank lines, so a commented-out key still counts as missing', () => {
+        const env = [
+            '# written by capgo-deploy.yml',
+            '',
+            ...REQUIRED_NATIVE_ENV.map((key) => (key === 'NEXT_PUBLIC_POSTHOG_KEY' ? `# ${key}=set` : `${key}=set`)),
+            '',
+        ].join('\n')
+        expect(missingNativeEnv(env)).toEqual(['NEXT_PUBLIC_POSTHOG_KEY'])
+    })
+})

--- a/scripts/__tests__/native-env-check.test.js
+++ b/scripts/__tests__/native-env-check.test.js
@@ -48,6 +48,29 @@ describe('missingNativeEnv', () => {
         expect(missingNativeEnv(env).sort()).toEqual(['NEXT_PUBLIC_BASE_URL', 'NEXT_PUBLIC_SENTRY_DSN'])
     })
 
+    // The three ways a per-key regex used to disagree with dotenv — each one passed
+    // the check while the bundle baked something else.
+
+    // dotenv keeps the LAST assignment, so a trailing `KEY=` wins over an earlier value.
+    it('judges a repeated key by its last assignment', () => {
+        const env = [...REQUIRED_NATIVE_ENV.map((key) => `${key}=set`), 'NEXT_PUBLIC_SENTRY_DSN='].join('\n')
+        expect(missingNativeEnv(env)).toEqual(['NEXT_PUBLIC_SENTRY_DSN'])
+    })
+
+    // dotenv strips an unquoted trailing comment, so `KEY= # todo` bakes '' — not '# todo'.
+    it('strips an inline comment before judging the value', () => {
+        const env = REQUIRED_NATIVE_ENV.map((key) =>
+            key === 'NEXT_PUBLIC_BASE_URL' ? `${key}= # todo` : `${key}=set # baked by CI`
+        ).join('\n')
+        expect(missingNativeEnv(env)).toEqual(['NEXT_PUBLIC_BASE_URL'])
+    })
+
+    // dotenv accepts `export KEY=value`, so a source-able local file must not fail the check.
+    it('accepts an export prefix', () => {
+        const env = REQUIRED_NATIVE_ENV.map((key) => `export ${key}=set`).join('\n')
+        expect(missingNativeEnv(env)).toEqual([])
+    })
+
     it('ignores comments and blank lines, so a commented-out key still counts as missing', () => {
         const env = [
             '# written by capgo-deploy.yml',

--- a/scripts/__tests__/native-env-check.test.js
+++ b/scripts/__tests__/native-env-check.test.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const os = require('os')
 const path = require('path')
 const Module = require('module')
 
@@ -12,7 +13,8 @@ function loadScriptInternals() {
     const withoutEntrypoint = source.replace(/\nmain\(\)\s*$/, '\n')
     expect(withoutEntrypoint).not.toBe(source)
 
-    const exposed = withoutEntrypoint + '\nmodule.exports = { missingNativeEnv, REQUIRED_NATIVE_ENV }\n'
+    const exposed =
+        withoutEntrypoint + '\nmodule.exports = { missingNativeEnv, unbakedNativeEnv, REQUIRED_NATIVE_ENV }\n'
 
     const mod = new Module(SCRIPT_PATH, null)
     mod.filename = SCRIPT_PATH
@@ -21,7 +23,7 @@ function loadScriptInternals() {
     return mod.exports
 }
 
-const { missingNativeEnv, REQUIRED_NATIVE_ENV } = loadScriptInternals()
+const { missingNativeEnv, unbakedNativeEnv, REQUIRED_NATIVE_ENV } = loadScriptInternals()
 
 describe('missingNativeEnv', () => {
     it('reports nothing when every required key has a value', () => {
@@ -79,5 +81,38 @@ describe('missingNativeEnv', () => {
             '',
         ].join('\n')
         expect(missingNativeEnv(env)).toEqual(['NEXT_PUBLIC_POSTHOG_KEY'])
+    })
+})
+
+// The pre-build check can only see the file. This one reads the export, so a value the
+// file carried but the bundle never inlined — the outage one step further down the lane
+// — is caught before the bundle ships.
+describe('unbakedNativeEnv', () => {
+    const values = Object.fromEntries(REQUIRED_NATIVE_ENV.map((key) => [key, `value-for-${key}`]))
+
+    function bundleOf(keys) {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'native-out-'))
+        fs.mkdirSync(path.join(dir, 'chunks'))
+        fs.writeFileSync(path.join(dir, 'chunks', 'app.js'), keys.map((key) => `"${values[key]}"`).join(';'))
+        // a value hiding in a non-.js asset must not count: only .js ships as code
+        fs.writeFileSync(path.join(dir, 'index.html'), REQUIRED_NATIVE_ENV.map((key) => values[key]).join(' '))
+        return dir
+    }
+
+    it('reports nothing when every required value is inlined somewhere in out/', () => {
+        expect(unbakedNativeEnv(values, bundleOf(REQUIRED_NATIVE_ENV))).toEqual([])
+    })
+
+    it('reports a value the export never inlined', () => {
+        const partial = REQUIRED_NATIVE_ENV.filter((key) => key !== 'NEXT_PUBLIC_SENTRY_DSN')
+        expect(unbakedNativeEnv(values, bundleOf(partial))).toEqual(['NEXT_PUBLIC_SENTRY_DSN'])
+    })
+
+    // The pre-build check has already thrown on these in CI; locally it only warns, and
+    // a key with no value is not evidence of a broken export.
+    it('skips a key that had no value to look for', () => {
+        const withHole = { ...values, NEXT_PUBLIC_POSTHOG_KEY: '' }
+        const partial = REQUIRED_NATIVE_ENV.filter((key) => key !== 'NEXT_PUBLIC_POSTHOG_KEY')
+        expect(unbakedNativeEnv(withHole, bundleOf(partial))).toEqual([])
     })
 })

--- a/scripts/__tests__/native-env-check.test.js
+++ b/scripts/__tests__/native-env-check.test.js
@@ -37,6 +37,17 @@ describe('missingNativeEnv', () => {
         expect(missingNativeEnv(env).sort()).toEqual(['NEXT_PUBLIC_BASE_URL', 'NEXT_PUBLIC_SENTRY_DSN'])
     })
 
+    // dotenv unwraps matching quotes: `KEY=""` and `KEY='  '` bake '' just like `KEY=`
+    it('treats a quoted-empty or quoted-whitespace value as missing, and a quoted value as set', () => {
+        const withQuotes = (key) => {
+            if (key === 'NEXT_PUBLIC_BASE_URL') return `${key}=""`
+            if (key === 'NEXT_PUBLIC_SENTRY_DSN') return `${key}='   '`
+            return `${key}="set"`
+        }
+        const env = REQUIRED_NATIVE_ENV.map(withQuotes).join('\n')
+        expect(missingNativeEnv(env).sort()).toEqual(['NEXT_PUBLIC_BASE_URL', 'NEXT_PUBLIC_SENTRY_DSN'])
+    })
+
     it('ignores comments and blank lines, so a commented-out key still counts as missing', () => {
         const env = [
             '# written by capgo-deploy.yml',

--- a/scripts/native-build.js
+++ b/scripts/native-build.js
@@ -477,6 +477,30 @@ function restoreModifiedFiles() {
     }
 }
 
+// Every NEXT_PUBLIC_* is inlined into the static export at build time, so a missing
+// or half-written .env.production.local ships a bundle where each one is `undefined`.
+// The Capgo OTA lane did exactly that for four months and nothing could report it —
+// Sentry and PostHog were among the undefined keys (mono
+// `ops/native-ota-envless-bundle-rca.md`). In CI that has to fail the build, not warn.
+const REQUIRED_NATIVE_ENV = [
+    'NEXT_PUBLIC_NATIVE_RP_ID',
+    'NEXT_PUBLIC_BASE_URL',
+    'NEXT_PUBLIC_PEANUT_API_URL',
+    'NEXT_PUBLIC_SENTRY_DSN',
+    'NEXT_PUBLIC_POSTHOG_KEY',
+    'NEXT_PUBLIC_ZERO_DEV_BUNDLER_URL',
+    'NEXT_PUBLIC_ZERO_DEV_PAYMASTER_URL',
+]
+
+// A key is missing when it has no line of its own, or its line carries no value
+// (`KEY=`). Anchoring per line also skips comments and blank lines.
+function missingNativeEnv(envContent) {
+    return REQUIRED_NATIVE_ENV.filter((key) => {
+        const match = envContent.match(new RegExp(`^${key}=(.*)$`, 'm'))
+        return !match || !match[1].trim()
+    })
+}
+
 async function main() {
     let buildSucceeded = false
 
@@ -491,6 +515,7 @@ async function main() {
         }
 
         // validate required env vars for native build
+        const strict = Boolean(process.env.CI)
         const envFile = path.join(__dirname, '..', '.env.production.local')
         if (fs.existsSync(envFile)) {
             const envContent = fs.readFileSync(envFile, 'utf-8')
@@ -508,6 +533,17 @@ async function main() {
             } else {
                 console.log('✅ NEXT_PUBLIC_ONESIGNAL_APP_ID is set')
             }
+
+            const missing = missingNativeEnv(envContent)
+            if (missing.length) {
+                const message = `.env.production.local has no value for: ${missing.join(', ')}`
+                if (strict) throw new Error(message)
+                console.warn(`⚠️  ${message}`)
+            }
+        } else if (strict) {
+            throw new Error(
+                '.env.production.local not found — CI must write it before native-build.js (see capgo-deploy.yml / ios-release.yml / android-release.yml)'
+            )
         } else {
             console.warn('⚠️  .env.production.local not found — using default rpId (peanut.me)')
         }

--- a/scripts/native-build.js
+++ b/scripts/native-build.js
@@ -490,15 +490,19 @@ const REQUIRED_NATIVE_ENV = [
     'NEXT_PUBLIC_POSTHOG_KEY',
     'NEXT_PUBLIC_ZERO_DEV_BUNDLER_URL',
     'NEXT_PUBLIC_ZERO_DEV_PAYMASTER_URL',
+    // the native OneSignal adapter throws at init without it — push dead on every device
+    'NEXT_PUBLIC_ONESIGNAL_APP_ID',
 ]
 
-// A key is missing when it has no line of its own, or its line carries no value
-// (`KEY=`). Anchoring per line also skips comments and blank lines.
+// Value of a `KEY=value` line, or '' when the key has no line of its own or the
+// line carries no value (`KEY=`). Anchoring per line also skips comments.
+function nativeEnvValue(envContent, key) {
+    const match = envContent.match(new RegExp(`^${key}=(.*)$`, 'm'))
+    return match ? match[1].trim() : ''
+}
+
 function missingNativeEnv(envContent) {
-    return REQUIRED_NATIVE_ENV.filter((key) => {
-        const match = envContent.match(new RegExp(`^${key}=(.*)$`, 'm'))
-        return !match || !match[1].trim()
-    })
+    return REQUIRED_NATIVE_ENV.filter((key) => !nativeEnvValue(envContent, key))
 }
 
 async function main() {
@@ -519,26 +523,21 @@ async function main() {
         const envFile = path.join(__dirname, '..', '.env.production.local')
         if (fs.existsSync(envFile)) {
             const envContent = fs.readFileSync(envFile, 'utf-8')
-            const rpIdMatch = envContent.match(/NEXT_PUBLIC_NATIVE_RP_ID=(.+)/)
-            if (!rpIdMatch || !rpIdMatch[1].trim()) {
-                throw new Error('NEXT_PUBLIC_NATIVE_RP_ID is not set in .env.production.local — passkeys will fail')
-            }
-            console.log(`✅ NEXT_PUBLIC_NATIVE_RP_ID=${rpIdMatch[1].trim()}`)
-
-            // app id is inlined into the bundle at build time; without it the native
-            // OneSignal SDK can't initialize and push notifications silently no-op.
-            const appIdMatch = envContent.match(/NEXT_PUBLIC_ONESIGNAL_APP_ID=(.+)/)
-            if (!appIdMatch || !appIdMatch[1].trim()) {
-                console.warn('⚠️  NEXT_PUBLIC_ONESIGNAL_APP_ID is not set — native push notifications will be disabled')
-            } else {
-                console.log('✅ NEXT_PUBLIC_ONESIGNAL_APP_ID is set')
-            }
-
             const missing = missingNativeEnv(envContent)
             if (missing.length) {
                 const message = `.env.production.local has no value for: ${missing.join(', ')}`
-                if (strict) throw new Error(message)
+                // rpId is fatal everywhere (passkeys break); the rest fail closed in CI only
+                if (strict || missing.includes('NEXT_PUBLIC_NATIVE_RP_ID')) throw new Error(message)
                 console.warn(`⚠️  ${message}`)
+            }
+            for (const key of REQUIRED_NATIVE_ENV) {
+                if (missing.includes(key)) continue
+                // rpId is printed in full — it must read peanut.me (passkeys + assetlinks/AASA)
+                console.log(
+                    key === 'NEXT_PUBLIC_NATIVE_RP_ID'
+                        ? `✅ ${key}=${nativeEnvValue(envContent, key)}`
+                        : `✅ ${key} is set`
+                )
             }
         } else if (strict) {
             throw new Error(

--- a/scripts/native-build.js
+++ b/scripts/native-build.js
@@ -8,6 +8,7 @@
  */
 
 const { execSync } = require('child_process')
+const dotenv = require('dotenv')
 const fs = require('fs')
 const path = require('path')
 
@@ -494,21 +495,20 @@ const REQUIRED_NATIVE_ENV = [
     'NEXT_PUBLIC_ONESIGNAL_APP_ID',
 ]
 
-// Value of a `KEY=value` line, or '' when the key has no line of its own or the
-// line carries no value (`KEY=`, `KEY=""`, `KEY='  '` — dotenv unwraps matching
-// quotes, so a quoted-empty value bakes '' exactly like a bare one). Anchoring
-// per line also skips comments.
-function nativeEnvValue(envContent, key) {
-    const match = envContent.match(new RegExp(`^${key}=(.*)$`, 'm'))
-    if (!match) return ''
-    return match[1]
-        .trim()
-        .replace(/^(["'])(.*)\1$/, '$2')
-        .trim()
+// Read the file with the same parser that bakes it: Next loads .env.production.local
+// through @next/env, which is dotenv. A per-key regex disagrees with dotenv in ways
+// that all end in a bundle the check called healthy — a repeated key (dotenv keeps
+// the LAST, so a trailing `KEY=` wins), an inline `# comment` (dotenv strips it, so
+// `KEY= # todo` bakes ''), and an `export ` prefix (dotenv accepts it).
+// Trimmed because a quoted-whitespace value (`KEY='  '`) is as dead as an empty one.
+function nativeEnvValues(envContent) {
+    const parsed = dotenv.parse(envContent)
+    return Object.fromEntries(Object.entries(parsed).map(([key, value]) => [key, value.trim()]))
 }
 
 function missingNativeEnv(envContent) {
-    return REQUIRED_NATIVE_ENV.filter((key) => !nativeEnvValue(envContent, key))
+    const values = nativeEnvValues(envContent)
+    return REQUIRED_NATIVE_ENV.filter((key) => !values[key])
 }
 
 async function main() {
@@ -529,6 +529,7 @@ async function main() {
         const envFile = path.join(__dirname, '..', '.env.production.local')
         if (fs.existsSync(envFile)) {
             const envContent = fs.readFileSync(envFile, 'utf-8')
+            const envValues = nativeEnvValues(envContent)
             const missing = missingNativeEnv(envContent)
             if (missing.length) {
                 const message = `.env.production.local has no value for: ${missing.join(', ')}`
@@ -539,11 +540,7 @@ async function main() {
             for (const key of REQUIRED_NATIVE_ENV) {
                 if (missing.includes(key)) continue
                 // rpId is printed in full — it must read peanut.me (passkeys + assetlinks/AASA)
-                console.log(
-                    key === 'NEXT_PUBLIC_NATIVE_RP_ID'
-                        ? `✅ ${key}=${nativeEnvValue(envContent, key)}`
-                        : `✅ ${key} is set`
-                )
+                console.log(key === 'NEXT_PUBLIC_NATIVE_RP_ID' ? `✅ ${key}=${envValues[key]}` : `✅ ${key} is set`)
             }
         } else if (strict) {
             throw new Error(

--- a/scripts/native-build.js
+++ b/scripts/native-build.js
@@ -511,6 +511,33 @@ function missingNativeEnv(envContent) {
     return REQUIRED_NATIVE_ENV.filter((key) => !values[key])
 }
 
+// The pre-build check proves the file carried values; this proves Next inlined them.
+// Only .js is scanned: a real native build puts every required value there and nowhere
+// else. NEXT_PUBLIC_ZERO_DEV_PASSKEY_PROJECT_ID and NEXT_PUBLIC_GA_KEY reach no shipped
+// module at all, which is why neither is on the required list — adding a key here that
+// the native build drops would red-build the release lane, so measure before adding one.
+function collectJsFiles(dir, found = []) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name)
+        if (entry.isDirectory()) collectJsFiles(full, found)
+        else if (entry.name.endsWith('.js')) found.push(full)
+    }
+    return found
+}
+
+function unbakedNativeEnv(envValues, outDir) {
+    const wanted = REQUIRED_NATIVE_ENV.filter((key) => envValues[key])
+    const baked = new Set()
+    for (const file of collectJsFiles(outDir)) {
+        const content = fs.readFileSync(file, 'utf-8')
+        for (const key of wanted) {
+            if (!baked.has(key) && content.includes(envValues[key])) baked.add(key)
+        }
+        if (baked.size === wanted.length) break
+    }
+    return wanted.filter((key) => !baked.has(key))
+}
+
 async function main() {
     let buildSucceeded = false
 
@@ -527,9 +554,11 @@ async function main() {
         // validate required env vars for native build
         const strict = Boolean(process.env.CI)
         const envFile = path.join(__dirname, '..', '.env.production.local')
+        let bakedEnv = null
         if (fs.existsSync(envFile)) {
             const envContent = fs.readFileSync(envFile, 'utf-8')
             const envValues = nativeEnvValues(envContent)
+            bakedEnv = envValues
             const missing = missingNativeEnv(envContent)
             if (missing.length) {
                 const message = `.env.production.local has no value for: ${missing.join(', ')}`
@@ -604,6 +633,17 @@ async function main() {
         }
 
         pruneExportedAssets()
+
+        // A value present in the file but absent from out/ means the export never saw
+        // it — the exact shape of the OTA outage, just one step further down the lane.
+        if (bakedEnv) {
+            const outDir = path.join(__dirname, '..', 'out')
+            const unbaked = unbakedNativeEnv(bakedEnv, outDir)
+            if (unbaked.length) {
+                throw new Error(`built bundle has no trace of: ${unbaked.join(', ')} — the export did not inline them`)
+            }
+            console.log(`✅ all ${REQUIRED_NATIVE_ENV.length} required NEXT_PUBLIC_* found in the exported bundle`)
+        }
 
         buildSucceeded = true
         console.log('\n✅ Native build completed successfully!')

--- a/scripts/native-build.js
+++ b/scripts/native-build.js
@@ -495,10 +495,16 @@ const REQUIRED_NATIVE_ENV = [
 ]
 
 // Value of a `KEY=value` line, or '' when the key has no line of its own or the
-// line carries no value (`KEY=`). Anchoring per line also skips comments.
+// line carries no value (`KEY=`, `KEY=""`, `KEY='  '` — dotenv unwraps matching
+// quotes, so a quoted-empty value bakes '' exactly like a bare one). Anchoring
+// per line also skips comments.
 function nativeEnvValue(envContent, key) {
     const match = envContent.match(new RegExp(`^${key}=(.*)$`, 'm'))
-    return match ? match[1].trim() : ''
+    if (!match) return ''
+    return match[1]
+        .trim()
+        .replace(/^(["'])(.*)\1$/, '$2')
+        .trim()
 }
 
 function missingNativeEnv(envContent) {

--- a/src/components/Create/useCreateLink.tsx
+++ b/src/components/Create/useCreateLink.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { getNextDepositIndex } from '@/app/actions/claimLinks'
+import { BASE_URL } from '@/constants/general.consts'
 import { loadingStateContext } from '@/context/loadingStates.context'
 import { saveToLocalStorage } from '@/utils/general.utils'
 import { generateKeysFromString, getLinkFromParams } from '@/utils/peanut-link.utils'
@@ -104,7 +105,7 @@ export const useCreateLink = () => {
                 contractVersion,
                 depositIdx,
                 password,
-                `${process.env.NEXT_PUBLIC_BASE_URL!}/claim`,
+                `${BASE_URL}/claim`,
                 undefined
             )
             return {

--- a/src/components/Global/DirectSendQR/__tests__/recognizeQr.test.ts
+++ b/src/components/Global/DirectSendQR/__tests__/recognizeQr.test.ts
@@ -642,7 +642,9 @@ describe('recognizeQr', () => {
         const original = process.env.NEXT_PUBLIC_BASE_URL
 
         afterEach(() => {
-            process.env.NEXT_PUBLIC_BASE_URL = original
+            // assigning undefined would store the string "undefined" and defeat the fallback
+            if (original === undefined) delete process.env.NEXT_PUBLIC_BASE_URL
+            else process.env.NEXT_PUBLIC_BASE_URL = original
         })
 
         it('still recognizes a Pix payload and a peanut.me URL', () => {

--- a/src/components/Global/DirectSendQR/__tests__/recognizeQr.test.ts
+++ b/src/components/Global/DirectSendQR/__tests__/recognizeQr.test.ts
@@ -632,4 +632,32 @@ describe('recognizeQr', () => {
             expect(recognizeQr('ar.com.globalgetnet')).toBe(EQrType.ENS_NAME)
         })
     })
+
+    // ota-1.0.54 and ota-1.0.55 shipped with every NEXT_PUBLIC_* undefined. The old
+    // local `BASE_URL = process.env.NEXT_PUBLIC_BASE_URL!` was read on the first line
+    // of recognizeQr, so every payload threw a TypeError before any match ran — mono
+    // `ops/native-ota-envless-bundle-rca.md`. BASE_URL now comes from
+    // @/constants/general.consts, which falls back to https://peanut.me.
+    describe('with no NEXT_PUBLIC_BASE_URL (env-less native bundle)', () => {
+        const original = process.env.NEXT_PUBLIC_BASE_URL
+
+        afterEach(() => {
+            process.env.NEXT_PUBLIC_BASE_URL = original
+        })
+
+        it('still recognizes a Pix payload and a peanut.me URL', () => {
+            delete process.env.NEXT_PUBLIC_BASE_URL
+
+            jest.isolateModules(() => {
+                // isolateModules is sync-only, so this has to be require() rather than import
+                const scoped = require('../utils')
+                expect(
+                    scoped.recognizeQr(
+                        '00020126580014br.gov.bcb.pix0136123e4567-e12b-12d1-a456-4266554400005204000053039865802BR5913Fulano de Tal6008BRASILIA62070503***63041D3D'
+                    )
+                ).toBe(EQrType.PIX)
+                expect(scoped.recognizeQr('https://peanut.me/claim?x=1')).toBe(EQrType.PEANUT_URL)
+            })
+        })
+    })
 })

--- a/src/components/Global/DirectSendQR/utils.ts
+++ b/src/components/Global/DirectSendQR/utils.ts
@@ -1,4 +1,4 @@
-import { ENS_NAME_REGEX } from '@/constants/general.consts'
+import { BASE_URL, ENS_NAME_REGEX } from '@/constants/general.consts'
 import { getTokenSymbol, getTokenDecimals } from '@/utils/general.utils'
 import { validatePixKey, isPixEmvcoQr, isPixRecurringCode } from '@/utils/withdraw.utils'
 import { isAddress, formatUnits } from 'viem'
@@ -85,8 +85,6 @@ const REGEXES_BY_TYPE: { [key in QrType]?: RegExp } = {
     [EQrType.URL]:
         /^(https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)$/,
 }
-
-export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL!
 
 export function recognizeQr(data: string): QrType | null {
     // Normalize the data for comparison (remove protocol and www)

--- a/src/constants/zerodev.consts.ts
+++ b/src/constants/zerodev.consts.ts
@@ -10,6 +10,21 @@ import { isCapacitor } from '@/utils/capacitor'
 export const BUNDLER_URL = process.env.NEXT_PUBLIC_ZERO_DEV_BUNDLER_URL!
 export const PAYMASTER_URL = process.env.NEXT_PUBLIC_ZERO_DEV_PAYMASTER_URL!
 
+// The `!` above is a build-time promise, and an env-less bundle breaks it: both read
+// `undefined`, viem's http() takes that as "use the chain's public RPC", and a public
+// RPC has no ERC-4337 methods — so every userOp failed with an error naming neither
+// ZeroDev nor the missing variable. Assert at the transports instead of at module load,
+// which would white-screen the whole app over a wallet-only misconfiguration.
+export function assertZeroDevRpcUrls(bundlerUrl?: string, paymasterUrl?: string) {
+    const missing = [
+        !bundlerUrl && 'NEXT_PUBLIC_ZERO_DEV_BUNDLER_URL',
+        !paymasterUrl && 'NEXT_PUBLIC_ZERO_DEV_PAYMASTER_URL',
+    ].filter(Boolean)
+    if (missing.length) {
+        throw new Error(`ZeroDev RPC is not configured — ${missing.join(' and ')} missing from this bundle`)
+    }
+}
+
 // Timeout for the ZeroDev bundler + paymaster RPC transports. viem's http()
 // default is 10s, which intermittently trips a `TimeoutError` on
 // `zd_sponsorUserOperation` during ZeroDev paymaster latency spikes — silently

--- a/src/context/kernelClient.context.tsx
+++ b/src/context/kernelClient.context.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { HARNESS_ENABLED } from '@/constants/harness.consts'
 import {
+    assertZeroDevRpcUrls,
     PEANUT_WALLET_CHAIN,
     USER_OP_ENTRY_POINT,
     ZERODEV_KERNEL_VERSION,
@@ -124,6 +125,7 @@ export const createHarnessEcdsaKernelClient = async <C extends Chain>(
     privateKey: `0x${string}`,
     { bundlerUrl, paymasterUrl }: { bundlerUrl: string; paymasterUrl: string }
 ): Promise<GenericSmartAccountClient<C>> => {
+    assertZeroDevRpcUrls(bundlerUrl, paymasterUrl)
     const signer = privateKeyToAccount(privateKey)
     const validator = await signerToEcdsaValidator(publicClient, {
         signer,
@@ -201,6 +203,7 @@ export const createKernelClientForChain = async <C extends Chain>(
     console.log(`Creating new kernel client for chain ${chain.name}...`)
 
     const { bundlerUrl, paymasterUrl } = options
+    assertZeroDevRpcUrls(bundlerUrl, paymasterUrl)
 
     let kernelAccount: Awaited<ReturnType<typeof createKernelAccount>>
     // The v0.0.3 PATCHED validator this account migrates *to* — the same

--- a/src/services/onesignal/web.adapter.ts
+++ b/src/services/onesignal/web.adapter.ts
@@ -44,11 +44,11 @@ export const webOneSignalAdapter: OneSignalAdapter = {
         initPromise = (async () => {
             const appId = process.env.NEXT_PUBLIC_ONESIGNAL_APP_ID
             const safariWebId = process.env.NEXT_PUBLIC_SAFARI_WEB_ID
-            const webhookUrl = process.env.NEXT_PUBLIC_ONESIGNAL_WEBHOOK!
+            const webhookUrl = process.env.NEXT_PUBLIC_ONESIGNAL_WEBHOOK
 
-            if (!appId || !safariWebId) {
+            if (!appId || !safariWebId || !webhookUrl) {
                 throw new Error(
-                    'OneSignal configuration missing: NEXT_PUBLIC_ONESIGNAL_APP_ID and NEXT_PUBLIC_SAFARI_WEB_ID are required'
+                    'OneSignal configuration missing: NEXT_PUBLIC_ONESIGNAL_APP_ID, NEXT_PUBLIC_SAFARI_WEB_ID and NEXT_PUBLIC_ONESIGNAL_WEBHOOK are required'
                 )
             }
 

--- a/src/utils/ephemeralSpendKey.ts
+++ b/src/utils/ephemeralSpendKey.ts
@@ -23,6 +23,7 @@ import {
 } from '@zerodev/sdk'
 import { getEntryPoint, KERNEL_V3_1 } from '@zerodev/sdk/constants'
 import {
+    assertZeroDevRpcUrls,
     BUNDLER_URL,
     PAYMASTER_URL,
     PEANUT_WALLET_CHAIN,
@@ -194,6 +195,7 @@ export async function createEphemeralSpendSession(args: {
     patchedSudoValidator: KernelValidator
 }): Promise<EphemeralSpendSession> {
     const { publicClient, chain, scope, patchedSudoValidator } = args
+    assertZeroDevRpcUrls(BUNDLER_URL, PAYMASTER_URL)
 
     try {
         let privateKey: Hex | null = generatePrivateKey()


### PR DESCRIPTION
## Summary

`.github/workflows/capgo-deploy.yml` ran `node scripts/native-build.js` without first writing `.env.production.local`. `ios-release.yml` and `android-release.yml` write that file (every production `NEXT_PUBLIC_*`) right before the same build step; the OTA lane never did, since the lane was created on 2026-04-22.

So every production OTA bundle was built with each `process.env.NEXT_PUBLIC_*` set to `undefined`:

- `src/components/Global/DirectSendQR/utils.ts` declared `export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL!`, and `recognizeQr()` read `BASE_URL.toLowerCase()` on its first line. Every payload — Pix, Mercado Pago, EVM, paste — threw a `TypeError` before any match ran, and the catch-all showed "Erro ao processar o código QR".
- `NEXT_PUBLIC_SENTRY_DSN` and `NEXT_PUBLIC_POSTHOG_KEY` were also undefined, so Sentry and PostHog never initialised. The error catcher ran; the SDKs were absent. That is why the failure left no trace anywhere.

`ota-1.0.54` and `ota-1.0.55` are the first two OTAs devices ever applied, so this surfaced only this week.

Note the shape, because it is what the guards below are built around: **the store binary is fine** — both native lanes bake env correctly — and **every OTA that lands on top of it is not**. The app works on install and breaks the first time an OTA applies.

Full RCA: mono `ops/native-ota-envless-bundle-rca.md`.

## What this PR does

**Closes the hole**

1. `capgo-deploy.yml` gets the `.env.production.local` step, identical to the one in the two store lanes.
2. All three lanes write that file with a **quoted** heredoc delimiter. Unquoted, a secret value containing `$` or a backtick was expanded — and command-substituted — by the shell before reaching the file. Demonstrated locally: a value of ``https://ex.io/p$roject/`id -un`/x`` reached the file as `https://ex.io/p/<output of id -un>/x` — `$roject` silently dropped, and the backticks executed on the runner. `${{ }}` is interpolated by the runner before bash sees the script, so it still substitutes.

**Two guards, one per stage**

3. **Before the build**, `native-build.js` fails closed under `CI`: a missing file, or a required key with no value, throws instead of warning. Locally it still warns, so `pnpm native:build` on a dev machine is unchanged (rpId stays fatal everywhere — passkeys break without it).
4. **After the build**, it scans `out/` for each required value and fails if one left no trace. The first guard can only see the file; this one proves next actually inlined it. In `native-build.js` rather than the workflow, so all three lanes get it.

The file is read with **dotenv**, the parser `@next/env` uses to bake it, rather than a per-key regex. A regex disagrees with dotenv in three ways that each end in a bundle the check called healthy:

| `.env.production.local` contains | a per-key regex says | what next bakes |
|---|---|---|
| `KEY=value` then later `KEY=` | present ✅ | `""` (dotenv keeps the **last**) |
| `KEY= # todo` | present, value `# todo` | `""` (dotenv strips inline comments) |
| `export KEY=value` | **missing** ❌ | `"value"` (dotenv accepts `export `) |

**Stops the remaining silent-undefined reads**

5. `DirectSendQR/utils.ts` drops its duplicate `BASE_URL` and imports the one from `@/constants/general.consts`, which falls back to `https://peanut.me`. Nothing imported the local copy.
6. `useCreateLink` built the claim URL from `process.env.NEXT_PUBLIC_BASE_URL!` — in an env-less bundle that handed users links reading `undefined/claim`, with nothing thrown. Now the same `general.consts` `BASE_URL`.
7. `BUNDLER_URL` / `PAYMASTER_URL` read `undefined`, and viem's `http()` takes that as "use the chain's public RPC" — which has no ERC-4337 methods, so every userOp failed with an error naming neither ZeroDev nor the missing variable. `assertZeroDevRpcUrls()` now runs at the three functions that build the transports.
8. The OneSignal web adapter already threw on a missing app id and safari id; the webhook url had a `!` and was left out of that check. It joins it.

## Task

TASK-21900 — https://app.notion.com/3c883811757981ff876fc1bcdf1e88c3

## Risks / breaking changes

- Every future `ota-*` tag now ships a bundle with env baked. Sentry, PostHog and ZeroDev go live on OTA for the first time — expect native events and errors to appear that were previously dark.
- The `dev` → staging lane in the same workflow gets the same production values. That is not a redirect: `NEXT_PUBLIC_BASE_URL` and `NEXT_PUBLIC_PEANUT_API_URL` already resolved to their production defaults through code fallbacks in the env-less bundle.
- Either guard turns a lane that forgets the env file into a red build. Intended — that is the whole point.
- **`assertZeroDevRpcUrls()` adds a throw to the wallet path.** It is deliberately at the three transport-building functions and *not* at module load: a wallet-only misconfiguration must not white-screen the app, and it must not break a local or preview build on import. In `createEphemeralSpendSession` it sits above the `try`, because that `catch` rewraps everything into `EphemeralKeyPreflightError` and would otherwise rebury the message as a `cause`. It cannot fire when the env is baked, which after this PR is enforced twice.
- `.env.test` gains the two ZeroDev URLs, so a suite that reaches the kernel client keeps testing what it meant to instead of failing on the new guard.
- `dotenv` is added as a devDependency, pinned `^16.6.1` rather than the newest 17.4.2. `parse()` is byte-identical between the two, 16.6.1 is already in the lockfile (so the entry dedupes to 3 lines), and `jest.setup.ts`'s existing `require('dotenv')` — until now an undeclared dependency — keeps resolving to the version it already resolved to, instead of gaining dotenv 17's per-suite log line.
- No runtime change on web: `general.consts` `BASE_URL` is the value the web bundle already used.
- No cross-repo impact. No API change.

## QA

- **CI**: the `capgo-deploy` run log must show `✅ NEXT_PUBLIC_NATIVE_RP_ID=peanut.me`, `✅ <KEY> is set` for the other seven, and `✅ all 8 required NEXT_PUBLIC_* found in the exported bundle`. Both OTA runs to date showed `⚠️  .env.production.local not found`.
- **Device**: after a human tags `ota-1.0.56`, kill and reopen the app twice (launch 1 downloads, launch 2 applies), then scan a Pix QR — it must resolve. Sentry `environment:native release:<7-char sha>` canaries appearing is the proof the bundle is live and not dark.
- **Unit**: `scripts/__tests__/native-env-check.test.js` covers the required-key check (all present, empty value, absent key, quoted-empty, commented-out, repeated key, inline comment, `export ` prefix) and the bundle scan (all inlined, one absent, a key with no value to look for, a value hiding in a non-`.js` asset). The three parser cases each fail against the pre-review implementation. The case in `recognizeQr.test.ts` deletes `NEXT_PUBLIC_BASE_URL`, reloads the module, and asserts a Pix payload and a `peanut.me` URL still resolve — it fails with the exact production `TypeError` against the pre-fix file.
- Local gate: `prettier --check`, `tsc --noEmit`, `eslint` on the changed files, and the 18 suites covering the wallet, withdraw, send-link, request and add-money paths the new guards sit in — all pass. Full `unit` job green in CI.

### Measured, not assumed

- **Parity with the real parser.** The check and `@next/env@16.2.3`'s own `loadEnvConfig` agree on all six env-file shapes, including the three in the table above.
- **What actually gets inlined.** A full native build with sentinel values, run on **both `main` and `dev`**, puts all 8 required values in `out/**/*.js` and nowhere else — which is why only `.js` is scanned. `NEXT_PUBLIC_ZERO_DEV_PASSKEY_PROJECT_ID` and `NEXT_PUBLIC_GA_KEY` reach no shipped module at all, which is why neither is on the required list. Adding a key to that list without measuring it first would red-build the release lane, so the comment beside it says so.
- **Cost of the scan**: ~100ms over the 51 MB / 408-file bundle. Against a deliberately drifted env it reported exactly the two drifted keys.

## Screenshots

N/A (no visible change).

## Design notes / accepted trade-offs

The env block is still duplicated across three workflows on purpose. The durable dedupe is one reusable `workflow_call` job (or a composite action) with `secrets: inherit`, and that is deferred to a follow-up on `dev` — #2806 rewrote the ios/android release lanes and #2825 rewrites all three again, so doing it here guarantees a back-merge conflict on exactly these files. The two guards in `native-build.js` are what make the duplication safe meanwhile: a lane that drifts breaks its own build instead of shipping a dark bundle.

**Still not a durable fix on its own.** This PR closes the exact hole and makes a misbuilt bundle fail its own build twice over. It does not make OTA releases safe in general. Follow-up, planned right behind this one:
- App refuses a misbuilt bundle at runtime: gate `CapacitorUpdater.notifyAppReady()` on a self-check (baked env present + `/healthz`), so Capgo auto-rolls back within 15s on every device.
- One source for the native env (`workflow_call` build job with `secrets: inherit`) and a required-key list derived from code, not hand-kept.
- Telemetry that cannot be stripped by env: public DSN / PostHog key as code defaults, `x-peanut-client` bundle header on native API calls, Sentry tags `capgo_bundle` / `native_version`, alert on native canary users/day dropping.
- Bundle ↔ shell fingerprint check in `capgo-deploy.yml`, staged rollout, and a post-OTA "did the new release phone home" check.

## Rollout

1. Merge this to `main`.
2. A human tags `ota-1.0.56` on the merge commit and pushes the tag. The workflow runs from the tagged commit, so the fix has to be on it.
3. Check the run log and Capgo, then verify on device.
4. Back-merge `main` → `dev`.

**Order matters against #2825.** That PR replaces tag-driven releases with a "Release OTA" `workflow_dispatch` pinned to `dev`, resolving `<major>.<build>.<ota>` instead of taking the number from the tag. Run against the repo's real tag list today, its resolver refuses both paths — `ota` errors with *"no v1.\<build\>.0 tag exists yet — cut a native release before an OTA"* (only `v1.0.0` exists), and the break-glass tag `ota-1.0.56` fails validation with *"has build 0 — build numbers start at 1"*. So if #2825 lands first, this hotfix cannot ship as an OTA without first cutting a full `1.1.0` native store release. Ship steps 1–3 before merging #2825.

The two branches otherwise compose cleanly: trial-merged, they auto-merge on all three workflows, with the env step landing inside #2825's restructured `deploy` job right before `native-build.js` and the quoted delimiters surviving in all three files.

**On the back-merge (step 4).** `src/config/peanut.config.tsx` conflicts between `main` and `dev` today, with or without this PR — this PR adds zero new conflicts. It needs a real hand-merge (`dev` has the `AppStateProviders` dynamic-import + marketing-route split, `main` has the passkey-ceremony shim + native canary; both belong in the result). Do not resolve it by copying one side's hunk wholesale — git will not recognise it as the same change and silently duplicates the block, which `merge-tree` reports as exit 0. Signatures are clear: 0 unsigned commits in `origin/dev..origin/main` and GitHub reports all 24 as `verified: true`, so the merge will not hit `GH013` — provided the branch is cut from that day's `origin/dev`.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved QR code recognition for Peanut payment payloads and URLs when the native app’s base URL configuration is unavailable.
  - Preserved special characters in production secrets during native and over-the-air deployments.
  - Native builds now detect missing or unbundled production configuration earlier.

- **Reliability**
  - Added validation for required blockchain bundler and paymaster settings.
  - Improved deployment checks for API, authentication, analytics, monitoring, and notification configuration.
  - Added notification webhook validation to improve release readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

