### PR TITLE
fix(startup): keep a signal when locale resolution falls back

### DIFF
--- a/src/config/__tests__/wagmi-storage.test.ts
+++ b/src/config/__tests__/wagmi-storage.test.ts
@@ -1,0 +1,44 @@
+/**
+ * jest's moduleNameMapper stubs `@/config/wagmi.config` for the whole suite, so
+ * nothing otherwise loads the real module. Required by relative path here (the
+ * mapper pattern is anchored to the alias) to pin the one thing that keeps the
+ * app shell alive in restricted documents: createConfig must be handed our
+ * guarded storage, never wagmi's default, whose getDefaultStorage() reads
+ * window.localStorage unguarded at module scope (PEANUT-UI-STF).
+ */
+import { resilientWebStorage } from '@/utils/safe-storage'
+
+const createConfig = jest.fn(() => ({}))
+const createStorage = jest.fn(() => ({ key: 'wagmi' }))
+
+// mocking 'wagmi' shadows 'wagmi/chains' too, so the chains live here as well
+jest.mock('wagmi', () => {
+    const chain = (id: number) => ({ id })
+    return {
+        __esModule: true,
+        createConfig: (...args: unknown[]) => createConfig(...(args as [])),
+        createStorage: (...args: unknown[]) => createStorage(...(args as [])),
+        http: () => ({}),
+        WagmiProvider: () => null,
+        cookieToInitialState: () => undefined,
+        arbitrum: chain(42161),
+        bsc: chain(56),
+        celo: chain(42220),
+        gnosis: chain(100),
+        linea: chain(59144),
+        mainnet: chain(1),
+        optimism: chain(10),
+        polygon: chain(137),
+        scroll: chain(534352),
+        worldchain: chain(480),
+    }
+})
+
+it('builds the wagmi config with the guarded storage adapter', () => {
+    require('../wagmi.config')
+
+    expect(createStorage).toHaveBeenCalledWith({ storage: resilientWebStorage })
+
+    const [parameters] = createConfig.mock.calls[0] as unknown as [{ storage?: unknown }]
+    expect(parameters.storage).toBe(createStorage.mock.results[0].value)
+})

--- a/src/i18n/app/__tests__/locale-store.test.ts
+++ b/src/i18n/app/__tests__/locale-store.test.ts
@@ -18,6 +18,17 @@ jest.mock('posthog-js', () => ({
     },
 }))
 
+// module-level so it applies to every isolateModules registry freshStore builds
+const mockCookiesGet = jest.fn()
+
+jest.mock('js-cookie', () => ({
+    __esModule: true,
+    default: {
+        get: (...args: unknown[]) => mockCookiesGet(...args),
+        set: jest.fn(),
+    },
+}))
+
 const mockIsCapacitor = jest.fn()
 const mockGetPlatform = jest.fn()
 
@@ -173,6 +184,21 @@ describe('localeReady', () => {
         setNavigatorLanguage('en-US')
         const store = freshStore()
         await expect(store.localeReady()).resolves.toBe('pt-BR')
+    })
+
+    it('warns when resolution fails so the fallback is not silent', async () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+        // document.cookie throws in a sandboxed/opaque-origin document
+        mockCookiesGet.mockImplementation(() => {
+            throw new DOMException('The operation is insecure.', 'SecurityError')
+        })
+        setNavigatorLanguage('pt-BR')
+
+        const store = freshStore()
+        await expect(store.localeReady()).resolves.toBe('pt-BR')
+        expect(warn).toHaveBeenCalled()
+
+        warn.mockRestore()
     })
 
     it('memoizes a usable locale rather than a rejection every later awaiter would inherit', async () => {

--- a/src/i18n/app/locale-store.ts
+++ b/src/i18n/app/locale-store.ts
@@ -125,7 +125,14 @@ async function resolveStartupLocale(): Promise<AppLocale> {
  * handler for.
  */
 export function localeReady(): Promise<AppLocale> {
-    if (!resolution) resolution = resolveStartupLocale().catch(() => navigatorLocale())
+    if (!resolution)
+        resolution = resolveStartupLocale().catch((err) => {
+            // the unhandled rejection was the only signal that startup locale
+            // resolution had failed (PEANUT-UI-STC); neither caller handles it,
+            // so warn to keep captureConsoleIntegration reporting the next one
+            console.warn('Startup locale resolution failed; falling back to the browser language', err)
+            return navigatorLocale()
+        })
     return resolution
 }
 
@@ -136,7 +143,13 @@ export function persistLocale(locale: AppLocale): void {
             .catch(() => {})
         return
     }
-    Cookies.set(LOCALE_KEY, locale, { expires: 365, path: '/' })
+    try {
+        // document.cookie throws in a sandboxed/opaque-origin document, and this
+        // runs straight off a LocaleSwitcher onClick with no handler upstream
+        Cookies.set(LOCALE_KEY, locale, { expires: 365, path: '/' })
+    } catch {
+        // storage below is the only remaining mirror
+    }
     // storage may be unavailable (private mode); cookie is authoritative
     writeStoredValue(LOCALE_KEY, locale)
 }


### PR DESCRIPTION
Follow-up to [#2822](https://github.com/peanutprotocol/peanut-ui/pull/2822) (TASK-21835), which merged before these came up in review.

## 1. `localeReady`'s catch was silent

#2822 added `.catch(() => navigatorLocale())` so a failed read can't wedge the session. But neither caller attaches a handler — `IntlCore.tsx:56` and `LocaleSync.tsx:26` both use a bare `.then` — so the unhandled rejection *was* the signal, and it is how PEANUT-UI-STC was found in the first place. After the catch, a future failure would silently drop every affected user to their browser language, record the wrong `app_locale`, and produce no Sentry event.

Now warns before falling back. `captureConsoleIntegration` is already enabled, so the next one reports without the memoized-rejection wedge coming back.

## 2. `persistLocale`'s `Cookies.set` was still unguarded

The sandboxed / opaque-origin documents that make `localStorage` throw do the same for `document.cookie`. On the read side `resolveStartupLocale` would throw at `Cookies.get` before reaching `readStoredValue`, but `localeReady`'s catch absorbs that. `persistLocale` had no such net and `LocaleSwitcher.tsx:86` calls it straight from an `onClick`, so a language switch threw out of the event handler instead of degrading. Pre-existing, but it was the last unguarded storage access in the function #2822 rewrote.

## 3. The wagmi wiring had no test

`package.json` maps `^@/config/wagmi\.config$` to a stub for the entire suite and nothing required it by relative path, so the real `createConfig` never ran under jest — meaning the half of #2822 that fixes the app-shell crash (PEANUT-UI-STF) was unverified. A wagmi upgrade that reshuffles options, or a refactor dropping `storage:` as redundant, would have left CI green while module-scope `window.localStorage` access returned.

Added `src/config/__tests__/wagmi-storage.test.ts`, which requires the module by relative path (the mapper pattern is anchored to the alias, so it doesn't intercept). Deleting the `storage:` line now fails the suite — verified.

Two notes on the test, since both cost a false start: `jest.mock('wagmi', …)` also shadows `wagmi/chains`, so the chain stubs live in that same factory rather than the shared `__mocks__/wagmi.ts`; and it deliberately does not use `jest.isolateModules`, which would hand `wagmi.config` a different `safe-storage` instance and break the identity assertion.

Local: 205 tests pass across `src/i18n`, `src/config` and `safe-storage`; eslint, prettier and typecheck clean.