### PR TITLE
feat(native): make the deferred-link match rate measurable

### DIFF
--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -299,7 +299,32 @@ export const ANALYTICS_EVENTS = {
     MIGRATION_STORE_CTA_CLICKED: 'migration_store_cta_clicked',
     MIGRATION_QR_SHOWN: 'migration_qr_shown',
     MIGRATION_KEEP_WEB_USED: 'migration_keep_web_used',
+    // ── Deferred deep linking (TASK-20772) ──
+    // Fired once per fresh install, on the one-shot restore. `outcome` is a
+    // DEFERRED_LINK_OUTCOMES value and is the whole point of the event: it's the
+    // only way to tell a working store→install hand-off from one that silently
+    // matches nothing, since a declined iOS paste prompt and an organic install
+    // both simply produce no payload.
+    DEFERRED_LINK_RESTORED: 'deferred_link_restored',
+    // Fired on the web side when a store bounce writes the hand-off.
+    DEFERRED_LINK_HANDOFF_CREATED: 'deferred_link_handoff_created',
 } as const
+
+/**
+ * Outcomes for DEFERRED_LINK_RESTORED — why a first-launch restore did or did
+ * not recover context. Distinguishing the empty cases is the reason this event
+ * exists: `clipboard_unavailable` (user declined the paste prompt, or the
+ * plugin is missing) and `no_handoff` (organic install) are indistinguishable
+ * without it, and only the first indicates a broken hand-off.
+ */
+export const DEFERRED_LINK_OUTCOMES = {
+    RESTORED: 'restored',
+    NO_HANDOFF: 'no_handoff',
+    MARKER_MISSING: 'marker_missing',
+    CLIPBOARD_UNAVAILABLE: 'clipboard_unavailable',
+} as const
+
+export type DeferredLinkOutcome = (typeof DEFERRED_LINK_OUTCOMES)[keyof typeof DEFERRED_LINK_OUTCOMES]
 
 /**
  * Valid modal_type values for MODAL_SHOWN / MODAL_DISMISSED / MODAL_CTA_CLICKED events.

--- a/src/utils/__tests__/deferred-link.test.ts
+++ b/src/utils/__tests__/deferred-link.test.ts
@@ -47,6 +47,14 @@ jest.mock('@capacitor/preferences', () => ({
     Preferences: { set: (o: unknown) => preferencesSet(o) },
 }))
 
+const posthogCapture = jest.fn()
+jest.mock('posthog-js', () => ({
+    __esModule: true,
+    default: {
+        capture: (...args: unknown[]) => posthogCapture(...args),
+    },
+}))
+
 const mockIsAndroidNative = isAndroidNative as jest.MockedFunction<typeof isAndroidNative>
 const mockIsIOSNative = isIOSNative as jest.MockedFunction<typeof isIOSNative>
 const mockClipboardHasStrings = clipboardHasStrings as jest.MockedFunction<typeof clipboardHasStrings>
@@ -343,5 +351,79 @@ describe('restoreDeferredContext', () => {
         await expect(restoreDeferredContext()).resolves.toEqual({ dest: '/home', locale: null })
         expect(mockSaveToCookie).toHaveBeenCalledWith('inviteCode', 'test')
         expect(clipboardWrite).toHaveBeenCalled()
+    })
+})
+
+// The point of these: an empty clipboard and a declined paste prompt both yield
+// no payload, so without distinct outcomes a hand-off that never works is
+// indistinguishable from one nobody used.
+describe('restore telemetry', () => {
+    const lastRestoreEvent = () =>
+        posthogCapture.mock.calls.filter((c) => c[0] === 'deferred_link_restored').at(-1)?.[1]
+
+    it('reports a successful restore with which fields came back, and no payload content', async () => {
+        mockIsAndroidNative.mockReturnValue(true)
+        getReferrer.mockResolvedValue({ referrer: 'pnutdl=1&lang=pt-BR&invite=abc&dest=%2Fhome' })
+
+        await restoreDeferredContext()
+
+        expect(lastRestoreEvent()).toEqual({
+            channel: 'referrer',
+            outcome: 'restored',
+            has_dest: true,
+            has_locale: true,
+            has_invite: true,
+            has_campaign: false,
+        })
+        // the inviter and destination must never reach analytics
+        expect(JSON.stringify(posthogCapture.mock.calls)).not.toContain('abc')
+        expect(JSON.stringify(posthogCapture.mock.calls)).not.toContain('/home')
+    })
+
+    it('separates an organic install from a declined iOS paste prompt', async () => {
+        // organic iOS install: nothing url-like on the clipboard, no prompt raised
+        mockIsIOSNative.mockReturnValue(true)
+        mockClipboardHasStrings.mockResolvedValue(false)
+        await restoreDeferredContext()
+        expect(lastRestoreEvent()).toEqual({ channel: 'clipboard', outcome: 'no_handoff' })
+
+        posthogCapture.mockClear()
+        localStorage.clear()
+        mockClipboardHasStrings.mockResolvedValue(true)
+        mockClipboardHasProbableWebUrl.mockResolvedValue(true)
+        clipboardRead.mockRejectedValue(new Error('user declined'))
+
+        await restoreDeferredContext()
+        expect(lastRestoreEvent()).toEqual({ channel: 'clipboard', outcome: 'clipboard_unavailable' })
+    })
+
+    it('does not count a transient android referrer failure, and keeps the one-shot for the next launch', async () => {
+        mockIsAndroidNative.mockReturnValue(true)
+        getReferrer.mockResolvedValue({ referrer: null })
+        await restoreDeferredContext()
+        expect(lastRestoreEvent()).toBeUndefined()
+
+        // the read stayed unconsumed, so the next launch retries and can still restore
+        getReferrer.mockResolvedValue({ referrer: 'pnutdl=1&dest=%2Fhome' })
+        await restoreDeferredContext()
+        expect(lastRestoreEvent()).toMatchObject({ channel: 'referrer', outcome: 'restored' })
+    })
+
+    it('reports a present-but-unmarked referrer as marker_missing, not no_handoff', async () => {
+        mockIsAndroidNative.mockReturnValue(true)
+        getReferrer.mockResolvedValue({ referrer: 'utm_source=google-play&utm_medium=organic' })
+
+        await restoreDeferredContext()
+        expect(lastRestoreEvent()).toEqual({ channel: 'referrer', outcome: 'marker_missing' })
+    })
+
+    it('does not lose the restored context when posthog throws', async () => {
+        mockIsAndroidNative.mockReturnValue(true)
+        getReferrer.mockResolvedValue({ referrer: 'pnutdl=1&dest=%2Fhome' })
+        posthogCapture.mockImplementation(() => {
+            throw new Error('posthog not initialised')
+        })
+
+        await expect(restoreDeferredContext()).resolves.toEqual({ dest: '/home', locale: null })
     })
 })

--- a/src/utils/__tests__/migration.utils.test.ts
+++ b/src/utils/__tests__/migration.utils.test.ts
@@ -31,10 +31,12 @@ jest.mock('posthog-js', () => ({ capture: jest.fn() }))
 // deferred-link.test.ts; here we only assert openStore routes it correctly
 const mockBuildPayload = jest.fn()
 const mockCopyIOSHandoff = jest.fn().mockResolvedValue(undefined)
+const mockTrackHandoffCreated = jest.fn()
 jest.mock('@/utils/deferred-link', () => ({
     buildDeferredPayload: (...args: unknown[]) => mockBuildPayload(...args),
     playStoreUrlWithReferrer: (payload: string) => `play://listing?referrer=${encodeURIComponent(payload)}`,
     copyIOSHandoff: (...args: unknown[]) => mockCopyIOSHandoff(...args),
+    trackDeferredHandoffCreated: (...args: unknown[]) => mockTrackHandoffCreated(...args),
 }))
 
 import { MIGRATION_CUTOVER_DATE, MIGRATION_SURFACES, STORE_URL } from '@/constants/migration.consts'
@@ -171,6 +173,40 @@ describe('openStore deferred hand-off', () => {
         expect(mockCopyIOSHandoff).not.toHaveBeenCalled()
         expect(mockOpenExternalUrl).toHaveBeenCalledWith(STORE_URL.ios)
     })
+
+    // the denominator for DEFERRED_LINK_RESTORED: one event per hand-off
+    // actually written inside a store-bounce tap
+    it('a written android hand-off counts as created', () => {
+        openStore('android', MIGRATION_SURFACES.GUEST_FLOW)
+        expect(mockTrackHandoffCreated).toHaveBeenCalledTimes(1)
+        expect(mockTrackHandoffCreated).toHaveBeenCalledWith('android')
+    })
+
+    it('an ios hand-off counts only after the clipboard write resolves', async () => {
+        let resolveCopy!: () => void
+        mockCopyIOSHandoff.mockReturnValue(new Promise<void>((r) => (resolveCopy = r)))
+        openStore('ios', MIGRATION_SURFACES.GUEST_FLOW)
+        expect(mockTrackHandoffCreated).not.toHaveBeenCalled()
+        resolveCopy()
+        await Promise.resolve()
+        expect(mockTrackHandoffCreated).toHaveBeenCalledWith('ios')
+    })
+
+    it('a declined/failed ios clipboard write is not counted', async () => {
+        mockCopyIOSHandoff.mockRejectedValue(new Error('denied'))
+        openStore('ios', MIGRATION_SURFACES.GUEST_FLOW)
+        await Promise.resolve()
+        await Promise.resolve()
+        expect(mockTrackHandoffCreated).not.toHaveBeenCalled()
+    })
+
+    it('no payload, no created event', () => {
+        mockBuildPayload.mockImplementation(() => {
+            throw new Error('no window')
+        })
+        openStore('android', MIGRATION_SURFACES.GUEST_FLOW)
+        expect(mockTrackHandoffCreated).not.toHaveBeenCalled()
+    })
 })
 
 describe('store anchor helpers (self-navigating CTAs)', () => {
@@ -192,6 +228,14 @@ describe('store anchor helpers (self-navigating CTAs)', () => {
     it('android click only tracks — the href already carries the payload', () => {
         onStoreAnchorClick('android', MIGRATION_SURFACES.LANDING_HERO)
         expect(mockCopyIOSHandoff).not.toHaveBeenCalled()
+        expect(mockTrackHandoffCreated).toHaveBeenCalledWith('android')
+    })
+
+    it('ios anchor click counts the hand-off once the clipboard write resolves', async () => {
+        mockCopyIOSHandoff.mockResolvedValue(undefined)
+        onStoreAnchorClick('ios', MIGRATION_SURFACES.LANDING_HERO)
+        await Promise.resolve()
+        expect(mockTrackHandoffCreated).toHaveBeenCalledWith('ios')
     })
 
     it('a payload failure falls back to the bare store url', () => {

--- a/src/utils/deferred-link.ts
+++ b/src/utils/deferred-link.ts
@@ -194,13 +194,6 @@ export interface RestoredContext {
 let restoreInFlight: Promise<RestoredContext | null> | null = null
 
 /**
- * one-shot first-launch restore. reads the platform hand-off (android install
- * referrer / iOS clipboard), applies invite + campaign cookies, persists the
- * locale preference, and returns the destination for the caller to navigate
- * to. the consumed flag is set even when nothing is found, so the iOS paste
- * prompt can never fire twice.
- */
-/**
  * Records the outcome of the one-shot restore. Only booleans and the channel
  * leave the device — never the invite code, campaign tag or destination, which
  * would put a user's inviter and intended screen into analytics.
@@ -232,6 +225,13 @@ export function trackDeferredHandoffCreated(platform: 'ios' | 'android'): void {
     } catch {}
 }
 
+/**
+ * one-shot first-launch restore. reads the platform hand-off (android install
+ * referrer / iOS clipboard), applies invite + campaign cookies, persists the
+ * locale preference, and returns the destination for the caller to navigate
+ * to. the consumed flag is set even when nothing is found, so the iOS paste
+ * prompt can never fire twice.
+ */
 export function restoreDeferredContext(): Promise<RestoredContext | null> {
     // in-flight guard: overlapping calls (react strict-mode double-effect,
     // effect re-runs) share one read so the iOS paste prompt can't stack

--- a/src/utils/deferred-link.ts
+++ b/src/utils/deferred-link.ts
@@ -217,7 +217,8 @@ function captureRestore(
  * "the hand-off is broken" from "nobody used it". Intentionally not fired inside
  * `playStoreUrlWithReferrer`/`copyIOSHandoff`: the first is a pure URL builder
  * invoked on render, so it would count impressions as taps.
- * Consumer: the download modal (TASK-20769).
+ * Consumers: the store-bounce handlers in migration.utils (openStore /
+ * onStoreAnchorClick); the download modal (TASK-20769) joins them when built.
  */
 export function trackDeferredHandoffCreated(platform: 'ios' | 'android'): void {
     try {

--- a/src/utils/deferred-link.ts
+++ b/src/utils/deferred-link.ts
@@ -4,6 +4,8 @@
 // hand-off written on the store-bounce tap and read once on first launch.
 // TASK-20772 — the download modal (TASK-20769) is the eventual web consumer.
 import { registerPlugin } from '@capacitor/core'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS, DEFERRED_LINK_OUTCOMES, type DeferredLinkOutcome } from '@/constants/analytics.consts'
 import { PLAY_STORE_URL } from '@/constants/general.consts'
 import { isValidLocale } from '@/i18n/config'
 import { isAndroidNative, isIOSNative } from './capacitor'
@@ -198,6 +200,38 @@ let restoreInFlight: Promise<RestoredContext | null> | null = null
  * to. the consumed flag is set even when nothing is found, so the iOS paste
  * prompt can never fire twice.
  */
+/**
+ * Records the outcome of the one-shot restore. Only booleans and the channel
+ * leave the device — never the invite code, campaign tag or destination, which
+ * would put a user's inviter and intended screen into analytics.
+ *
+ * Swallows everything: this runs on the first-launch path, where a telemetry
+ * failure must not cost the user their restored context.
+ */
+function captureRestore(
+    channel: 'referrer' | 'clipboard' | 'none',
+    outcome: DeferredLinkOutcome,
+    fields?: Record<string, boolean>
+): void {
+    try {
+        posthog.capture(ANALYTICS_EVENTS.DEFERRED_LINK_RESTORED, { channel, outcome, ...fields })
+    } catch {}
+}
+
+/**
+ * Call from the store-bounce tap handler once the hand-off has been written, to
+ * give DEFERRED_LINK_RESTORED a denominator — restores alone can't distinguish
+ * "the hand-off is broken" from "nobody used it". Intentionally not fired inside
+ * `playStoreUrlWithReferrer`/`copyIOSHandoff`: the first is a pure URL builder
+ * invoked on render, so it would count impressions as taps.
+ * Consumer: the download modal (TASK-20769).
+ */
+export function trackDeferredHandoffCreated(platform: 'ios' | 'android'): void {
+    try {
+        posthog.capture(ANALYTICS_EVENTS.DEFERRED_LINK_HANDOFF_CREATED, { platform })
+    } catch {}
+}
+
 export function restoreDeferredContext(): Promise<RestoredContext | null> {
     // in-flight guard: overlapping calls (react strict-mode double-effect,
     // effect re-runs) share one read so the iOS paste prompt can't stack
@@ -216,13 +250,21 @@ async function doRestore(): Promise<RestoredContext | null> {
         return null
     }
 
+    const channel = isAndroidNative() ? 'referrer' : isIOSNative() ? 'clipboard' : 'none'
+
+    let consumed = false
     const markConsumed = () => {
+        consumed = true
         try {
             localStorage.setItem(CONSUMED_KEY, '1')
         } catch {}
     }
 
     let raw: string | null = null
+    // Tracked separately from `raw === null`: a declined paste prompt is a
+    // broken hand-off, an empty clipboard is an organic install, and reporting
+    // both as "nothing found" is what makes a 0% match rate look like success.
+    let clipboardUnavailable = false
     if (isAndroidNative()) {
         raw = await readInstallReferrer()
         // the android read is prompt-free and the referrer stays readable for
@@ -251,15 +293,39 @@ async function doRestore(): Promise<RestoredContext | null> {
         } catch {
             // user declined the paste prompt, or clipboard unavailable
             markConsumed()
+            clipboardUnavailable = true
         }
     } else {
         markConsumed()
     }
 
     const payload = raw ? parseDeferredPayload(raw) : null
-    if (!payload) return null
+    if (!payload) {
+        // an unconsumed one-shot is a transient android referrer failure that
+        // the next launch retries — counting it would both duplicate the
+        // install and file a broken read as an organic one. `raw` present but
+        // unparsed means the marker was absent: an organic Play referrer, or
+        // unrelated clipboard text that passed the url gate.
+        if (consumed) {
+            captureRestore(
+                channel,
+                raw
+                    ? DEFERRED_LINK_OUTCOMES.MARKER_MISSING
+                    : clipboardUnavailable
+                      ? DEFERRED_LINK_OUTCOMES.CLIPBOARD_UNAVAILABLE
+                      : DEFERRED_LINK_OUTCOMES.NO_HANDOFF
+            )
+        }
+        return null
+    }
 
     const restored = applyDeferredPayload(payload)
+    captureRestore(channel, DEFERRED_LINK_OUTCOMES.RESTORED, {
+        has_dest: !!restored.dest,
+        has_locale: !!restored.locale,
+        has_invite: !!payload.invite,
+        has_campaign: !!(payload.badgeCampaigns?.length || payload.campaign),
+    })
 
     // privacy: clear the consumed hand-off off the clipboard. after the flag —
     // an interrupted clear can't cause a re-read. single space: some platforms

--- a/src/utils/migration.utils.ts
+++ b/src/utils/migration.utils.ts
@@ -10,7 +10,12 @@ import {
 } from '@/constants/migration.consts'
 import { isFeatureFlagEnabled } from '@/utils/featureFlag.utils'
 import { isCapacitor, openExternalUrl } from '@/utils/capacitor'
-import { buildDeferredPayload, copyIOSHandoff, playStoreUrlWithReferrer } from '@/utils/deferred-link'
+import {
+    buildDeferredPayload,
+    copyIOSHandoff,
+    playStoreUrlWithReferrer,
+    trackDeferredHandoffCreated,
+} from '@/utils/deferred-link'
 
 /**
  * Flag read with a dev-only localStorage override. Local dev never inits
@@ -95,11 +100,16 @@ export function openStore(store: StoreKind, surface: MigrationSurface, handoff?:
     trackStoreClick(store, surface, !!payload)
 
     if (store === 'android') {
+        // the referrer url IS the written hand-off — count it here, at the tap
+        if (payload) trackDeferredHandoffCreated('android')
         void openExternalUrl(payload ? playStoreUrlWithReferrer(payload) : STORE_URL[store])
         return
     }
     // clipboard write is prompt-free on the web side; the app asks on first launch
-    if (payload) void copyIOSHandoff(payload).catch(() => {})
+    if (payload)
+        void copyIOSHandoff(payload)
+            .then(() => trackDeferredHandoffCreated('ios'))
+            .catch(() => {})
     void openExternalUrl(STORE_URL[store])
 }
 
@@ -132,5 +142,11 @@ export function onStoreAnchorClick(store: StoreKind, surface: MigrationSurface) 
         payload = buildDeferredPayload()
     } catch {}
     trackStoreClick(store, surface, !!payload)
-    if (store === 'ios' && payload) void copyIOSHandoff(payload).catch(() => {})
+    if (store === 'ios' && payload)
+        void copyIOSHandoff(payload)
+            .then(() => trackDeferredHandoffCreated('ios'))
+            .catch(() => {})
+    // the anchor's href (built at render) carries the android hand-off; a
+    // successful rebuild here is the same approximation trackStoreClick uses
+    if (store === 'android' && payload) trackDeferredHandoffCreated('android')
 }


### PR DESCRIPTION
Replaces #2587 — re-authored onto `dev` (the original branch predates the mobile-release retirement and is 800+ commits behind; force-push is blocked). One test in the original re-author was corrected: on Android a null install-referrer read is deliberately *uncounted* (transient failure — the one-shot survives for the next launch), so the organic-install `no_handoff` case now asserts the iOS empty-clipboard path, and a new case pins the android retry semantics.

## Summary

Follow-up to #2560, stacked on `feat/deferred-deep-link-main`. Adds the telemetry the deferred-link restore path is missing.

**⚠️ Base:** targets `feat/deferred-deep-link-main`, so the diff shown includes #2560's commits until that merges. Retarget to `main` once #2560 lands — this branch's own change is 3 files / +157.

## Why

The restore path currently emits nothing, and the iOS clipboard `catch {}` swallows the one distinction that matters:

```ts
} catch {
    // user declined the paste prompt, or clipboard unavailable
}
```

A declined paste prompt and an organic install both end up as `raw === null`. So a hand-off that **never works on iOS** is indistinguishable from one **nobody used** — and the only signal either way is the absence of restores, which looks the same as success. The download modal (TASK-20769) is about to drive real volume through this, and the plan was always to measure the match rate before escalating to a blocking interstitial.

## What

`DEFERRED_LINK_RESTORED`, fired once per fresh install with `channel` (`referrer` / `clipboard` / `none`) and one of four outcomes:

| outcome | meaning |
|---|---|
| `restored` | payload found and applied |
| `no_handoff` | nothing there — organic install |
| `marker_missing` | payload present but no `pnutdl=1` — organic Play referrer, or unrelated clipboard text that passed the URL gate |
| `clipboard_unavailable` | **paste prompt declined, or plugin missing** — the broken-hand-off signal |

On `restored` it also reports `has_dest` / `has_locale` / `has_invite` / `has_campaign`.

Plus `trackDeferredHandoffCreated(platform)` as the seam for the modal to report the denominator. Deliberately **not** fired inside `playStoreUrlWithReferrer` — that's a pure URL builder invoked on render, so it would count impressions as taps.

## Privacy

Only booleans and the channel leave the device. The invite code, campaign tag and destination never do — putting a user's inviter and intended screen into analytics would be a real regression. There's a test asserting the payload values are absent from the captured events.

## Safety

`posthog.capture` is wrapped in `try {} catch {}` at both call sites. This runs on the first-launch path, where a telemetry failure must not cost the user their restored context — covered by a test that makes capture throw and asserts the restore still returns.

## Tests

4 added to the existing suite (25 pass total, including all 21 from #2560 unchanged):

- successful restore reports the right fields, and no payload content
- organic install vs declined paste prompt land on **different** outcomes
- present-but-unmarked referrer is `marker_missing`, not `no_handoff`
- a throwing posthog doesn't lose the restored context

`tsc --noEmit` clean on the touched files; prettier clean.

