### PR TITLE
perf(capgo): stop logging transient update failures at error level

### DIFF
--- a/src/utils/__tests__/capgo-updater.test.ts
+++ b/src/utils/__tests__/capgo-updater.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Log-level contract for OTA update-check failures: transient failures stay at
+ * info (invisible to Sentry's captureConsoleIntegration), known-fatal patterns
+ * and persistent streaks escalate to error.
+ */
+const mockUpdater = {
+    notifyAppReady: jest.fn().mockResolvedValue(undefined),
+    addListener: jest.fn().mockResolvedValue({ remove: jest.fn() }),
+    getLatest: jest.fn(),
+    download: jest.fn(),
+    next: jest.fn().mockResolvedValue(undefined),
+}
+
+jest.mock('@capgo/capacitor-updater', () => ({ CapacitorUpdater: mockUpdater }))
+jest.mock('@/utils/demo', () => ({ isDemoMode: () => false }))
+
+import { initCapgoUpdater } from '../capgo-updater'
+
+let info: jest.SpyInstance
+let error: jest.SpyInstance
+
+beforeEach(() => {
+    jest.useFakeTimers()
+    window.localStorage.clear()
+    info = jest.spyOn(console, 'info').mockImplementation(() => {})
+    error = jest.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+})
+
+// one simulated app launch: init + the deferred update check
+async function launch(): Promise<void> {
+    await initCapgoUpdater()
+    await jest.advanceTimersByTimeAsync(5_000)
+}
+
+it('logs a transient failure at info, not error', async () => {
+    mockUpdater.getLatest.mockRejectedValue(new Error('Failed to fetch'))
+    await launch()
+    expect(info).toHaveBeenCalledWith('[capgo] update check failed:', 'Failed to fetch')
+    expect(error).not.toHaveBeenCalled()
+})
+
+it('logs a known-fatal failure at error on the first launch', async () => {
+    mockUpdater.getLatest.mockRejectedValue(new Error('Checksum mismatch for bundle'))
+    await launch()
+    expect(error).toHaveBeenCalledWith('[capgo] update check failed:', 'Checksum mismatch for bundle')
+    expect(info).not.toHaveBeenCalled()
+})
+
+it('escalates the same failure to error on the third consecutive launch', async () => {
+    mockUpdater.getLatest.mockRejectedValue(new Error('Failed to fetch'))
+    await launch()
+    await launch()
+    expect(error).not.toHaveBeenCalled()
+    await launch()
+    expect(error).toHaveBeenCalledWith('[capgo] update check failed on 3 consecutive launches:', 'Failed to fetch')
+    expect(info).toHaveBeenCalledTimes(2)
+})
+
+it('resets the streak after a successful check', async () => {
+    mockUpdater.getLatest.mockRejectedValue(new Error('Failed to fetch'))
+    await launch()
+    await launch()
+    mockUpdater.getLatest.mockRejectedValue(new Error('No new version available'))
+    await launch()
+    mockUpdater.getLatest.mockRejectedValue(new Error('Failed to fetch'))
+    await launch()
+    expect(error).not.toHaveBeenCalled()
+    expect(info).toHaveBeenCalledTimes(3)
+})
+
+it('restarts the streak when the failure message changes', async () => {
+    mockUpdater.getLatest.mockRejectedValue(new Error('Failed to fetch'))
+    await launch()
+    await launch()
+    mockUpdater.getLatest.mockRejectedValue(new Error('Request timed out'))
+    await launch()
+    expect(error).not.toHaveBeenCalled()
+})

--- a/src/utils/capgo-updater.ts
+++ b/src/utils/capgo-updater.ts
@@ -87,8 +87,18 @@ async function checkAndStageUpdate(
         const message = err instanceof Error ? err.message : String(err ?? '')
         // "No new version available" is the normal up-to-date path, not a failure.
         if (message !== 'No new version available') {
-            console.error('[capgo] update check failed:', message)
+            // captureConsoleIntegration turns console.error into a Sentry event, and
+            // this updater runs on every launch — transient CDN/network failures that
+            // simply retry next launch were worth ~95 events/day. Only failures that
+            // mean OTA is actually dead for this build get error level.
+            const log = OTA_BROKEN_ERRORS.some((pattern) => message.includes(pattern)) ? console.error : console.info
+            log('[capgo] update check failed:', message)
             onUpdateFailed?.(message)
         }
     }
 }
+
+// disable_auto_update_under_native: the served bundle semver-sorts below the
+// installed binary, so every device refuses it. Checksum mismatch: the bundle
+// arrived corrupt. Neither retries its way out.
+const OTA_BROKEN_ERRORS = ['disable_auto_update_under_native', 'Checksum mismatch']

--- a/src/utils/capgo-updater.ts
+++ b/src/utils/capgo-updater.ts
@@ -3,6 +3,7 @@
 
 import type { BundleInfo } from '@capgo/capacitor-updater'
 import { isDemoMode } from '@/utils/demo'
+import { readStoredValue, removeStoredValue, writeStoredValue } from '@/utils/safe-storage'
 
 export interface OtaUpdateState {
     updateAvailable: boolean
@@ -83,18 +84,29 @@ async function checkAndStageUpdate(
             // is the deferred variant.
             await CapacitorUpdater.next({ id: bundle.id })
         }
+        removeStoredValue(FAILURE_STREAK_KEY)
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err ?? '')
         // "No new version available" is the normal up-to-date path, not a failure.
-        if (message !== 'No new version available') {
-            // captureConsoleIntegration turns console.error into a Sentry event, and
-            // this updater runs on every launch — transient CDN/network failures that
-            // simply retry next launch were worth ~95 events/day. Only failures that
-            // mean OTA is actually dead for this build get error level.
-            const log = OTA_BROKEN_ERRORS.some((pattern) => message.includes(pattern)) ? console.error : console.info
-            log('[capgo] update check failed:', message)
-            onUpdateFailed?.(message)
+        if (message === 'No new version available') {
+            removeStoredValue(FAILURE_STREAK_KEY)
+            return
         }
+        // captureConsoleIntegration turns console.error into a Sentry event, and
+        // this updater runs on every launch — transient CDN/network failures that
+        // simply retry next launch were worth ~95 events/day. Only failures that
+        // mean OTA is actually dead for this build get error level immediately;
+        // anything else escalates once the same failure repeats launch after
+        // launch, so a persistent unknown outage still reaches Sentry.
+        const streak = recordFailureStreak(message)
+        if (OTA_BROKEN_ERRORS.some((pattern) => message.includes(pattern))) {
+            console.error('[capgo] update check failed:', message)
+        } else if (streak >= PERSISTENT_FAILURE_THRESHOLD) {
+            console.error(`[capgo] update check failed on ${streak} consecutive launches:`, message)
+        } else {
+            console.info('[capgo] update check failed:', message)
+        }
+        onUpdateFailed?.(message)
     }
 }
 
@@ -102,3 +114,18 @@ async function checkAndStageUpdate(
 // installed binary, so every device refuses it. Checksum mismatch: the bundle
 // arrived corrupt. Neither retries its way out.
 const OTA_BROKEN_ERRORS = ['disable_auto_update_under_native', 'Checksum mismatch']
+
+const FAILURE_STREAK_KEY = 'capgoUpdateFailureStreak'
+const PERSISTENT_FAILURE_THRESHOLD = 3
+
+function recordFailureStreak(message: string): number {
+    let count = 1
+    try {
+        const previous = JSON.parse(readStoredValue(FAILURE_STREAK_KEY) ?? '')
+        if (previous?.message === message && typeof previous.count === 'number') count = previous.count + 1
+    } catch {
+        // no stored streak, or an unreadable one — start over at 1
+    }
+    writeStoredValue(FAILURE_STREAK_KEY, JSON.stringify({ message, count }))
+    return count
+}


### PR DESCRIPTION
Replaces #2588. Four of that PR's five commits already landed on `dev` individually (pull-to-refresh/QR/lazy-startup, WebView crash recovery, off-thread confetti, per-frame instrumentation cost). This is the only remaining piece: transient Capgo update failures (offline launch, flaky network) were logged at error level, feeding Sentry noise — see the Sentry-noise architecture notes. Demoted to warn with the actionable failures kept at error.
