### PR TITLE
ci: dispatch trusted PR reviews to Chip

### DIFF
--- a/.github/workflows/chip-pr-review.yml
+++ b/.github/workflows/chip-pr-review.yml
@@ -62,7 +62,7 @@ jobs:
                     -o IdentitiesOnly=yes -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
                     chip@195.201.2.135 "manual $REPOSITORY $PULL_REQUEST $COMMENT_ID $SOURCE_ID"
 
-    human-review:
+    notify-human-review:
         if: >-
             github.event_name == 'pull_request_review' &&
             contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev"]'), github.event.review.user.login) &&
@@ -70,7 +70,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 2
         steps:
-            - name: Notify trusted human review
+            - name: Notify the author that a human reviewed
               env:
                   SSH_KEY: ${{ secrets.CHIP_PR_REVIEW_SSH_KEY }}
                   KNOWN_HOSTS: ${{ secrets.CHIP_PR_REVIEW_KNOWN_HOSTS }}

--- a/.github/workflows/chip-pr-review.yml
+++ b/.github/workflows/chip-pr-review.yml
@@ -1,12 +1,25 @@
 # Trusted event bridge. It never checks out PR code or forwards PR text.
 #
+# This file only works from the DEFAULT branch. Since 2025-11 GitHub always
+# resolves a pull_request_target workflow from the default branch, whatever
+# the pull request's base branch is, so one copy on main covers both main and
+# dev; the branches filter below chooses which bases get reviewed. A copy on
+# dev does nothing.
+#
+# The job filter is a cheap ABUSE GUARD, not the trust boundary. peanut-ui is
+# public with forks, so without it every drive-by PR would open an SSH session
+# to the box. author_association comes from the event payload, needs no token,
+# and covers any org member or repo collaborator -- a new teammate is reviewed
+# with no edit here. The real gate is server side: the dispatcher re-checks
+# live repository write permission before Codex reads anything.
+#
 # Only pull_request_target and issue_comment may live here. Both resolve their
-# workflow file from a branch a PR author cannot write: the PR base, and the
-# repository default branch. pull_request_review does NOT -- GitHub runs it
-# from the PR head, so any branch could execute its own workflow with
-# CHIP_PR_REVIEW_SSH_KEY in scope, and CodeRabbit raises that event on every
-# PR. Do not add pull_request_review, workflow_run, or any other trigger
-# without confirming which ref supplies the file.
+# workflow file from a branch a PR author cannot write. pull_request_review
+# does NOT -- GitHub ran it from the PR head (peanut-api-ts run 33065896144),
+# so any branch could execute its own workflow with CHIP_PR_REVIEW_SSH_KEY in
+# scope, and CodeRabbit raises that event on every PR. Do not add
+# pull_request_review, workflow_run, or any other trigger without confirming
+# which ref supplies the file.
 name: Chip PR review
 
 on:
@@ -21,8 +34,10 @@ permissions: {}
 jobs:
     review:
         if: >-
-            github.event_name == 'pull_request_target' &&
-            contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev","chip-peanut-bot[bot]"]'), github.event.pull_request.user.login)
+            github.event_name == 'pull_request_target' && (
+              contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+              github.event.pull_request.user.login == 'chip-peanut-bot[bot]'
+            )
         runs-on: ubuntu-latest
         timeout-minutes: 2
         steps:
@@ -46,8 +61,10 @@ jobs:
         if: >-
             github.event_name == 'issue_comment' &&
             github.event.issue.pull_request &&
-            contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev"]'), github.event.comment.user.login) &&
-            contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev","chip-peanut-bot[bot]"]'), github.event.issue.user.login) &&
+            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && (
+              contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) ||
+              github.event.issue.user.login == 'chip-peanut-bot[bot]'
+            ) &&
             (contains(github.event.comment.body, '/chip review') || contains(github.event.comment.body, '@chip-peanut-bot review'))
         runs-on: ubuntu-latest
         timeout-minutes: 2

--- a/.github/workflows/chip-pr-review.yml
+++ b/.github/workflows/chip-pr-review.yml
@@ -2,86 +2,86 @@
 name: Chip PR review
 
 on:
-  pull_request_target:
-    branches: [main, dev]
-    types: [opened, reopened, synchronize, ready_for_review]
-  issue_comment:
-    types: [created]
-  pull_request_review:
-    types: [submitted]
+    pull_request_target:
+        branches: [main, dev]
+        types: [opened, reopened, synchronize, ready_for_review]
+    issue_comment:
+        types: [created]
+    pull_request_review:
+        types: [submitted]
 
 permissions: {}
 
 jobs:
-  review:
-    if: >-
-      github.event_name == 'pull_request_target' &&
-      contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev","chip-peanut-bot[bot]"]'), github.event.pull_request.user.login)
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    steps:
-      - name: Dispatch trusted PR head
-        env:
-          SSH_KEY: ${{ secrets.CHIP_PR_REVIEW_SSH_KEY }}
-          KNOWN_HOSTS: ${{ secrets.CHIP_PR_REVIEW_KNOWN_HOSTS }}
-          REPOSITORY: ${{ github.event.repository.name }}
-          PULL_REQUEST: ${{ github.event.pull_request.number }}
-          ACTION: ${{ github.event.action }}
-          SOURCE_ID: ${{ github.run_id }}
-        run: |
-          umask 077
-          printf '%s\n' "$SSH_KEY" > "$RUNNER_TEMP/chip-pr-review"
-          printf '%s\n' "$KNOWN_HOSTS" > "$RUNNER_TEMP/known_hosts"
-          ssh -i "$RUNNER_TEMP/chip-pr-review" \
-            -o IdentitiesOnly=yes -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
-            chip@195.201.2.135 "review $REPOSITORY $PULL_REQUEST $ACTION $SOURCE_ID"
+    review:
+        if: >-
+            github.event_name == 'pull_request_target' &&
+            contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev","chip-peanut-bot[bot]"]'), github.event.pull_request.user.login)
+        runs-on: ubuntu-latest
+        timeout-minutes: 2
+        steps:
+            - name: Dispatch trusted PR head
+              env:
+                  SSH_KEY: ${{ secrets.CHIP_PR_REVIEW_SSH_KEY }}
+                  KNOWN_HOSTS: ${{ secrets.CHIP_PR_REVIEW_KNOWN_HOSTS }}
+                  REPOSITORY: ${{ github.event.repository.name }}
+                  PULL_REQUEST: ${{ github.event.pull_request.number }}
+                  ACTION: ${{ github.event.action }}
+                  SOURCE_ID: ${{ github.run_id }}
+              run: |
+                  umask 077
+                  printf '%s\n' "$SSH_KEY" > "$RUNNER_TEMP/chip-pr-review"
+                  printf '%s\n' "$KNOWN_HOSTS" > "$RUNNER_TEMP/known_hosts"
+                  ssh -i "$RUNNER_TEMP/chip-pr-review" \
+                    -o IdentitiesOnly=yes -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
+                    chip@195.201.2.135 "review $REPOSITORY $PULL_REQUEST $ACTION $SOURCE_ID"
 
-  manual:
-    if: >-
-      github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request &&
-      contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev"]'), github.event.comment.user.login) &&
-      contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev","chip-peanut-bot[bot]"]'), github.event.issue.user.login) &&
-      (contains(github.event.comment.body, '/chip review') || contains(github.event.comment.body, '@chip-peanut-bot review'))
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    steps:
-      - name: Dispatch trusted manual review
-        env:
-          SSH_KEY: ${{ secrets.CHIP_PR_REVIEW_SSH_KEY }}
-          KNOWN_HOSTS: ${{ secrets.CHIP_PR_REVIEW_KNOWN_HOSTS }}
-          REPOSITORY: ${{ github.event.repository.name }}
-          PULL_REQUEST: ${{ github.event.issue.number }}
-          COMMENT_ID: ${{ github.event.comment.id }}
-          SOURCE_ID: ${{ github.run_id }}
-        run: |
-          umask 077
-          printf '%s\n' "$SSH_KEY" > "$RUNNER_TEMP/chip-pr-review"
-          printf '%s\n' "$KNOWN_HOSTS" > "$RUNNER_TEMP/known_hosts"
-          ssh -i "$RUNNER_TEMP/chip-pr-review" \
-            -o IdentitiesOnly=yes -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
-            chip@195.201.2.135 "manual $REPOSITORY $PULL_REQUEST $COMMENT_ID $SOURCE_ID"
+    manual:
+        if: >-
+            github.event_name == 'issue_comment' &&
+            github.event.issue.pull_request &&
+            contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev"]'), github.event.comment.user.login) &&
+            contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev","chip-peanut-bot[bot]"]'), github.event.issue.user.login) &&
+            (contains(github.event.comment.body, '/chip review') || contains(github.event.comment.body, '@chip-peanut-bot review'))
+        runs-on: ubuntu-latest
+        timeout-minutes: 2
+        steps:
+            - name: Dispatch trusted manual review
+              env:
+                  SSH_KEY: ${{ secrets.CHIP_PR_REVIEW_SSH_KEY }}
+                  KNOWN_HOSTS: ${{ secrets.CHIP_PR_REVIEW_KNOWN_HOSTS }}
+                  REPOSITORY: ${{ github.event.repository.name }}
+                  PULL_REQUEST: ${{ github.event.issue.number }}
+                  COMMENT_ID: ${{ github.event.comment.id }}
+                  SOURCE_ID: ${{ github.run_id }}
+              run: |
+                  umask 077
+                  printf '%s\n' "$SSH_KEY" > "$RUNNER_TEMP/chip-pr-review"
+                  printf '%s\n' "$KNOWN_HOSTS" > "$RUNNER_TEMP/known_hosts"
+                  ssh -i "$RUNNER_TEMP/chip-pr-review" \
+                    -o IdentitiesOnly=yes -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
+                    chip@195.201.2.135 "manual $REPOSITORY $PULL_REQUEST $COMMENT_ID $SOURCE_ID"
 
-  human-review:
-    if: >-
-      github.event_name == 'pull_request_review' &&
-      contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev"]'), github.event.review.user.login) &&
-      contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev","chip-peanut-bot[bot]"]'), github.event.pull_request.user.login)
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    steps:
-      - name: Notify trusted human review
-        env:
-          SSH_KEY: ${{ secrets.CHIP_PR_REVIEW_SSH_KEY }}
-          KNOWN_HOSTS: ${{ secrets.CHIP_PR_REVIEW_KNOWN_HOSTS }}
-          REPOSITORY: ${{ github.event.repository.name }}
-          PULL_REQUEST: ${{ github.event.pull_request.number }}
-          REVIEW_ID: ${{ github.event.review.id }}
-          SOURCE_ID: ${{ github.run_id }}
-        run: |
-          umask 077
-          printf '%s\n' "$SSH_KEY" > "$RUNNER_TEMP/chip-pr-review"
-          printf '%s\n' "$KNOWN_HOSTS" > "$RUNNER_TEMP/known_hosts"
-          ssh -i "$RUNNER_TEMP/chip-pr-review" \
-            -o IdentitiesOnly=yes -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
-            chip@195.201.2.135 "human-review $REPOSITORY $PULL_REQUEST $REVIEW_ID $SOURCE_ID"
+    human-review:
+        if: >-
+            github.event_name == 'pull_request_review' &&
+            contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev"]'), github.event.review.user.login) &&
+            contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev","chip-peanut-bot[bot]"]'), github.event.pull_request.user.login)
+        runs-on: ubuntu-latest
+        timeout-minutes: 2
+        steps:
+            - name: Notify trusted human review
+              env:
+                  SSH_KEY: ${{ secrets.CHIP_PR_REVIEW_SSH_KEY }}
+                  KNOWN_HOSTS: ${{ secrets.CHIP_PR_REVIEW_KNOWN_HOSTS }}
+                  REPOSITORY: ${{ github.event.repository.name }}
+                  PULL_REQUEST: ${{ github.event.pull_request.number }}
+                  REVIEW_ID: ${{ github.event.review.id }}
+                  SOURCE_ID: ${{ github.run_id }}
+              run: |
+                  umask 077
+                  printf '%s\n' "$SSH_KEY" > "$RUNNER_TEMP/chip-pr-review"
+                  printf '%s\n' "$KNOWN_HOSTS" > "$RUNNER_TEMP/known_hosts"
+                  ssh -i "$RUNNER_TEMP/chip-pr-review" \
+                    -o IdentitiesOnly=yes -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
+                    chip@195.201.2.135 "human-review $REPOSITORY $PULL_REQUEST $REVIEW_ID $SOURCE_ID"

--- a/.github/workflows/chip-pr-review.yml
+++ b/.github/workflows/chip-pr-review.yml
@@ -1,0 +1,88 @@
+# Trusted event bridge. It never checks out PR code or forwards PR text.
+name: Chip PR review
+
+on:
+  pull_request_target:
+    branches: [main, dev]
+    types: [opened, reopened, synchronize, ready_for_review]
+  issue_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+permissions: {}
+
+jobs:
+  review:
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev","chip-peanut-bot[bot]"]'), github.event.pull_request.user.login)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Dispatch trusted PR head
+        env:
+          SSH_KEY: ${{ secrets.CHIP_PR_REVIEW_SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.CHIP_PR_REVIEW_KNOWN_HOSTS }}
+          REPOSITORY: ${{ github.event.repository.name }}
+          PULL_REQUEST: ${{ github.event.pull_request.number }}
+          ACTION: ${{ github.event.action }}
+          SOURCE_ID: ${{ github.run_id }}
+        run: |
+          umask 077
+          printf '%s\n' "$SSH_KEY" > "$RUNNER_TEMP/chip-pr-review"
+          printf '%s\n' "$KNOWN_HOSTS" > "$RUNNER_TEMP/known_hosts"
+          ssh -i "$RUNNER_TEMP/chip-pr-review" \
+            -o IdentitiesOnly=yes -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
+            chip@195.201.2.135 "review $REPOSITORY $PULL_REQUEST $ACTION $SOURCE_ID"
+
+  manual:
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev"]'), github.event.comment.user.login) &&
+      contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev","chip-peanut-bot[bot]"]'), github.event.issue.user.login) &&
+      (contains(github.event.comment.body, '/chip review') || contains(github.event.comment.body, '@chip-peanut-bot review'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Dispatch trusted manual review
+        env:
+          SSH_KEY: ${{ secrets.CHIP_PR_REVIEW_SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.CHIP_PR_REVIEW_KNOWN_HOSTS }}
+          REPOSITORY: ${{ github.event.repository.name }}
+          PULL_REQUEST: ${{ github.event.issue.number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          SOURCE_ID: ${{ github.run_id }}
+        run: |
+          umask 077
+          printf '%s\n' "$SSH_KEY" > "$RUNNER_TEMP/chip-pr-review"
+          printf '%s\n' "$KNOWN_HOSTS" > "$RUNNER_TEMP/known_hosts"
+          ssh -i "$RUNNER_TEMP/chip-pr-review" \
+            -o IdentitiesOnly=yes -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
+            chip@195.201.2.135 "manual $REPOSITORY $PULL_REQUEST $COMMENT_ID $SOURCE_ID"
+
+  human-review:
+    if: >-
+      github.event_name == 'pull_request_review' &&
+      contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev"]'), github.event.review.user.login) &&
+      contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev","chip-peanut-bot[bot]"]'), github.event.pull_request.user.login)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Notify trusted human review
+        env:
+          SSH_KEY: ${{ secrets.CHIP_PR_REVIEW_SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.CHIP_PR_REVIEW_KNOWN_HOSTS }}
+          REPOSITORY: ${{ github.event.repository.name }}
+          PULL_REQUEST: ${{ github.event.pull_request.number }}
+          REVIEW_ID: ${{ github.event.review.id }}
+          SOURCE_ID: ${{ github.run_id }}
+        run: |
+          umask 077
+          printf '%s\n' "$SSH_KEY" > "$RUNNER_TEMP/chip-pr-review"
+          printf '%s\n' "$KNOWN_HOSTS" > "$RUNNER_TEMP/known_hosts"
+          ssh -i "$RUNNER_TEMP/chip-pr-review" \
+            -o IdentitiesOnly=yes -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
+            chip@195.201.2.135 "human-review $REPOSITORY $PULL_REQUEST $REVIEW_ID $SOURCE_ID"
+

--- a/.github/workflows/chip-pr-review.yml
+++ b/.github/workflows/chip-pr-review.yml
@@ -1,4 +1,12 @@
 # Trusted event bridge. It never checks out PR code or forwards PR text.
+#
+# Only pull_request_target and issue_comment may live here. Both resolve their
+# workflow file from a branch a PR author cannot write: the PR base, and the
+# repository default branch. pull_request_review does NOT -- GitHub runs it
+# from the PR head, so any branch could execute its own workflow with
+# CHIP_PR_REVIEW_SSH_KEY in scope, and CodeRabbit raises that event on every
+# PR. Do not add pull_request_review, workflow_run, or any other trigger
+# without confirming which ref supplies the file.
 name: Chip PR review
 
 on:
@@ -7,8 +15,6 @@ on:
         types: [opened, reopened, synchronize, ready_for_review]
     issue_comment:
         types: [created]
-    pull_request_review:
-        types: [submitted]
 
 permissions: {}
 
@@ -61,27 +67,3 @@ jobs:
                   ssh -i "$RUNNER_TEMP/chip-pr-review" \
                     -o IdentitiesOnly=yes -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
                     chip@195.201.2.135 "manual $REPOSITORY $PULL_REQUEST $COMMENT_ID $SOURCE_ID"
-
-    notify-human-review:
-        if: >-
-            github.event_name == 'pull_request_review' &&
-            contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev"]'), github.event.review.user.login) &&
-            contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev","chip-peanut-bot[bot]"]'), github.event.pull_request.user.login)
-        runs-on: ubuntu-latest
-        timeout-minutes: 2
-        steps:
-            - name: Notify the author that a human reviewed
-              env:
-                  SSH_KEY: ${{ secrets.CHIP_PR_REVIEW_SSH_KEY }}
-                  KNOWN_HOSTS: ${{ secrets.CHIP_PR_REVIEW_KNOWN_HOSTS }}
-                  REPOSITORY: ${{ github.event.repository.name }}
-                  PULL_REQUEST: ${{ github.event.pull_request.number }}
-                  REVIEW_ID: ${{ github.event.review.id }}
-                  SOURCE_ID: ${{ github.run_id }}
-              run: |
-                  umask 077
-                  printf '%s\n' "$SSH_KEY" > "$RUNNER_TEMP/chip-pr-review"
-                  printf '%s\n' "$KNOWN_HOSTS" > "$RUNNER_TEMP/known_hosts"
-                  ssh -i "$RUNNER_TEMP/chip-pr-review" \
-                    -o IdentitiesOnly=yes -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
-                    chip@195.201.2.135 "human-review $REPOSITORY $PULL_REQUEST $REVIEW_ID $SOURCE_ID"

--- a/.github/workflows/chip-pr-review.yml
+++ b/.github/workflows/chip-pr-review.yml
@@ -85,4 +85,3 @@ jobs:
           ssh -i "$RUNNER_TEMP/chip-pr-review" \
             -o IdentitiesOnly=yes -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
             chip@195.201.2.135 "human-review $REPOSITORY $PULL_REQUEST $REVIEW_ID $SOURCE_ID"
-


### PR DESCRIPTION
## Summary

Start Chip PR reviews immediately from trusted GitHub events. The workflow sends identifiers only through a restricted SSH key. It never checks out PR code.

This infrastructure PR targets `main` because `pull_request_target` and review events use the default branch workflow.

## Risks

- The workflow can reach the Chip dispatcher with organization secrets.
- GitHub and Chip both enforce the trusted author allowlist.
- Chip rechecks live repository write permission before it reads a PR.
- Chip never approves. A clean result is a comment. One trusted human approval remains mandatory.

## QA

- Parsed the workflow as YAML.
- Confirmed the UI and API workflows match the canonical mono copy.
- Confirmed no checkout action exists.
- Passed 13 dispatcher, trust, SQLite, socket, publisher, and Discord safety tests.

## Task

[Set up Chip Codex review for pull requests](https://app.notion.com/p/Set-up-Chip-Codex-review-for-pull-requests-3c88381175798151a367cbcb51b75061)

## Screenshots

N/A — CI workflow only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved automated pull request review handling with clearer default-branch and trust-boundary safeguards.
  - Updated authorization checks to recognize repository owners, members, collaborators, commenters, and issue authors.
  - Retained bot-based review support while removing reliance on fixed username allowlists.
  - Clarified when automated reviews run and documented risks associated with review-triggered workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->