### PR TITLE
hotfix(seo): crawl-allow /invite?invited_by= like /invite?code=

### DIFF
--- a/src/constants/__tests__/seo-route-policy.test.ts
+++ b/src/constants/__tests__/seo-route-policy.test.ts
@@ -74,12 +74,15 @@ describe('SEO route policy', () => {
         expect(receivesNoindexHeader(route)).toBe(false)
     })
 
-    it.each(['/home', '/home/activity', '/invite?code=abc&lid=campaign', '/api/og?type=send&username=alice&amount=10'])(
-        'renders a noindex header for %s through Next route matching',
-        async (route) => {
-            await expect(renderedRobotsHeader(route)).resolves.toBe('noindex, nofollow')
-        }
-    )
+    it.each([
+        '/home',
+        '/home/activity',
+        '/invite?code=abc&lid=campaign',
+        '/invite?invited_by=abc',
+        '/api/og?type=send&username=alice&amount=10',
+    ])('renders a noindex header for %s through Next route matching', async (route) => {
+        await expect(renderedRobotsHeader(route)).resolves.toBe('noindex, nofollow')
+    })
 
     it.each(['/lp', '/api/og/marketing?title=Peanut', '/m/stain', '/en/pay-with/pix'])(
         'does not render a noindex header for %s through Next route matching',
@@ -107,6 +110,7 @@ describe('SEO route policy', () => {
             '/setup$',
             '/invite$',
             '/invite?code=',
+            '/invite?invited_by=',
         ])
     })
 })

--- a/src/constants/seo-route-policy.js
+++ b/src/constants/seo-route-policy.js
@@ -77,7 +77,8 @@ const ROBOTS_DISALLOWED_PATHS = Object.freeze([
     '/withdraw',
 ])
 
-// GSC shows these exact shells (or their invite query variants) in Google's
+// GSC shows these exact shells (or their invite query variants — ?invited_by=
+// is what peanut-ui emits since ui#2828, ?code= the legacy alias) in Google's
 // index. They need a narrow crawl exception so search engines can observe and
 // refresh the X-Robots-Tag. Descendant transaction/profile URLs remain
 // blocked. Keep the exceptions while these routes exist; only remove one once
@@ -89,6 +90,7 @@ const GOOGLE_DEINDEX_CRAWL_ALLOW_PATHS = Object.freeze([
     '/setup$',
     '/invite$',
     '/invite?code=',
+    '/invite?invited_by=',
 ])
 
 const NOINDEX_HEADER = Object.freeze({ key: 'X-Robots-Tag', value: 'noindex, nofollow' })


### PR DESCRIPTION
## What

Adds `/invite?invited_by=` to `GOOGLE_DEINDEX_CRAWL_ALLOW_PATHS` next to `/invite?code=`, with tests.

## Why

peanut-ui emits `/invite?invited_by=<username>` once #2828 lands (`?code=` stays a permanent read alias). This policy is main-only, so #2828 can't touch it. Without it, prod robots.txt is `Allow: /invite?code=` / `Disallow: /invite`: the new URL shape is crawl-blocked, Google can't read its `X-Robots-Tag: noindex`, and shared links get indexed as URL-only entries — the problem this exception was added for.

`X-Robots-Tag` itself already covers both shapes (prefix-based; checked on prod).

## Tests

`seo-route-policy.test.ts` + `robots.test.ts` green locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated search engine handling for invite links using the `invited_by` query parameter.
  * Invite links with valid tracking parameters can now be crawled appropriately, while protected routes remain excluded from indexing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->