### PR TITLE
fix(native): route every link entry and exit through a path the app can render

### DIFF
--- a/scripts/native-build.js
+++ b/scripts/native-build.js
@@ -70,11 +70,31 @@ const P0_TRANSFORMS = [
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { hasNativeSession } from '@/utils/auth-token'
+import { deepLinkToNativePath } from '@/utils/native-routes'
+import { hasDeepLinkNavigated, markDeepLinkNavigated } from '@/utils/deep-link-state'
 import { isDemoMode } from '@/utils/demo'
 
 export default function RootRedirect() {
     const router = useRouter()
     useEffect(() => {
+        /*
+         * This is the only page that can answer a full-document load on either
+         * platform (iOS has no SPA fallback; Android's findPageHtml is shadowed
+         * by Capacitor's html5mode) — a load at a non-root path boots here with
+         * the original URL still in location. Recover it through the deep-link
+         * mapper instead of dumping the user at /home.
+         */
+        const { pathname, search, hash } = window.location
+        if (pathname !== '/' && pathname !== '/index.html') {
+            const target = deepLinkToNativePath(pathname + search + hash)
+            if (target) {
+                markDeepLinkNavigated()
+                router.replace(target)
+                return
+            }
+        }
+        // An App Link / push tap may have navigated already — don't clobber it.
+        if (hasDeepLinkNavigated()) return
         // Demo has no JWT — without the isDemoMode() check a demo user who hits
         // the root (e.g. bounced from a web-only route) lands on /setup, whose
         // landing screen disables demo and dumps them at Log In.
@@ -91,7 +111,8 @@ export default function RootRedirect() {
          */
         let cancelled = false
         hasNativeSession().then((has) => {
-            if (!cancelled) router.replace(has ? '/home' : '/setup')
+            if (cancelled || hasDeepLinkNavigated()) return
+            router.replace(has ? '/home' : '/setup')
         })
         return () => {
             cancelled = true

--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -23,6 +23,7 @@ import { Banner } from '@/components/Global/Banner'
 import { useSetupStore } from '@/redux/hooks'
 import ForceIOSPWAInstall from '@/components/ForceIOSPWAInstall'
 import { isPublicRoute } from '@/constants/routes'
+import { saveRedirectUrl } from '@/utils/general.utils'
 import { IS_DEV } from '@/constants/general.consts'
 import { HARNESS_ENABLED } from '@/constants/harness.consts'
 import { usePullToRefresh } from '@/hooks/usePullToRefresh'
@@ -112,6 +113,11 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
         if (isDemoMode()) enableDemoMode()
         if (!isPublicPath && isReady && !isFetchingUser && !user && !isRedirecting.current && !isDemoMode()) {
             isRedirecting.current = true
+            // Keep the target: a logged-out tap on a protected deep link
+            // (/pay-request, /card, /receipt, every push) used to be dropped
+            // here and land on /home after login. useLogin/useAccountSetup
+            // consume this via consumePostAuthRedirect.
+            saveRedirectUrl()
             router.replace('/setup')
             // Hard-nav fallback if the soft nav silently fails; re-check at fire time.
             const fallback = setTimeout(() => {

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -255,7 +255,17 @@ function MantecaBankWithdrawFlow() {
      */
     const handleOnboardingError = useCallback(
         (error: string): boolean => {
-            const onboardingErrorPatterns = ['fund origin', 'profile incomplete', 'onboarding required']
+            // 'manteca kyc' / 'manteca_kyc_required' cover the API's
+            // MANTECA_KYC_REQUIRED responses ("User needs to do manteca KYC
+            // first") — the service layer strips the `code` field, so the text
+            // is all this screen ever sees.
+            const onboardingErrorPatterns = [
+                'fund origin',
+                'profile incomplete',
+                'onboarding required',
+                'manteca kyc',
+                'manteca_kyc_required',
+            ]
             const normalizedError = error.toLowerCase()
             const isOnboardingError = onboardingErrorPatterns.some((pattern) => normalizedError.includes(pattern))
             if (!isOnboardingError) return false

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -152,7 +152,6 @@ function MantecaBankWithdrawFlow() {
     // intent is passed at call time: handleInitiateKyc('LATAM')
     const sumsubFlow = useMultiPhaseKycFlow({})
     const [showKycModal, setShowKycModal] = useState(false)
-    const [isRedirectingToOnboarding, setIsRedirectingToOnboarding] = useState(false)
 
     // Get method and country from URL parameters
     const selectedMethodType = searchParams.get('method') // mercadopago, pix, bank-transfer, etc.
@@ -246,39 +245,22 @@ function MantecaBankWithdrawFlow() {
     }
 
     /**
-     * Detect Manteca onboarding-incomplete errors and redirect user to complete their profile.
-     * Returns true if the error was handled (caller should return early).
+     * Detect Manteca onboarding-incomplete errors and surface an actionable
+     * message. Returns true if the error was handled (caller should return early).
      *
-     * INTENTIONAL FALLBACK — NOT a primary code path. The KYC 2.0 architecture
-     * (engineering/projects/kyc-2.0/final-plan.md) centralizes all data
-     * collection in Sumsub and submits to Manteca via the API (`submitToManteca`
-     * in peanut-api-ts). The Manteca hosted onboarding widget is dead-by-design
-     * — but we keep this last-resort redirect for the long tail of users who
-     * land in an incomplete Manteca state (partial provisioning, undelivered
-     * initial-onboarding API call). Without this escape hatch they'd be stuck
-     * at withdraw time with no actionable error.
-     *
-     * Right fix: root-cause why `submitToManteca` sometimes leaves users
-     * half-onboarded, fix that, delete this fallback + `/manteca/initiate-onboarding`
-     * route + `mantecaApi.initiateOnboarding` client. Tracked separately.
+     * This used to redirect into the Manteca hosted onboarding widget — a
+     * KYC-2.0-era dead end (Sumsub owns data collection; `submitToManteca` in
+     * peanut-api-ts owns submission) with 0 triggers in 90 days. The widget
+     * redirect and its `/manteca/initiate-onboarding` backend route are gone.
      */
     const handleOnboardingError = useCallback(
-        async (error: string): Promise<boolean> => {
+        (error: string): boolean => {
             const onboardingErrorPatterns = ['fund origin', 'profile incomplete', 'onboarding required']
             const normalizedError = error.toLowerCase()
             const isOnboardingError = onboardingErrorPatterns.some((pattern) => normalizedError.includes(pattern))
             if (!isOnboardingError) return false
 
-            setIsRedirectingToOnboarding(true)
-            try {
-                const result = await mantecaApi.initiateOnboarding({
-                    returnUrl: window.location.href,
-                })
-                window.location.href = result.url
-            } catch {
-                setErrorMessage(t('errors.completeAccountSetup'))
-                setIsRedirectingToOnboarding(false)
-            }
+            setErrorMessage(t('errors.completeAccountSetup'))
             return true
         },
         [t]
@@ -323,7 +305,7 @@ function MantecaBankWithdrawFlow() {
             })
 
             if (result.error) {
-                if (await handleOnboardingError(result.error)) return
+                if (handleOnboardingError(result.error)) return
                 setErrorMessage(result.error)
                 return
             }
@@ -460,7 +442,7 @@ function MantecaBankWithdrawFlow() {
                 if (handleStaleSession(result.message ?? result.error)) return
 
                 // handle onboarding-incomplete errors by redirecting to complete profile
-                if (await handleOnboardingError(result.message ?? result.error)) return
+                if (handleOnboardingError(result.message ?? result.error)) return
 
                 // handle third-party account error with user-friendly message
                 if (result.error === 'TAX_ID_MISMATCH' || result.error === 'CUIT_MISMATCH') {
@@ -865,18 +847,13 @@ function MantecaBankWithdrawFlow() {
                                 !isCompleteBankDetails ||
                                 isDestinationAddressChanging ||
                                 !isDestinationAddressValid ||
-                                isLockingPrice ||
-                                isRedirectingToOnboarding
+                                isLockingPrice
                             }
-                            loading={isDestinationAddressChanging || isLockingPrice || isRedirectingToOnboarding}
+                            loading={isDestinationAddressChanging || isLockingPrice}
                             className="w-full"
                             shadowSize="4"
                         >
-                            {isRedirectingToOnboarding
-                                ? t('manteca.redirecting')
-                                : isLockingPrice
-                                  ? t('manteca.lockingRate')
-                                  : t('review')}
+                            {isLockingPrice ? t('manteca.lockingRate') : t('review')}
                         </Button>
 
                         {(errorMessage || sumsubFlow.error) && (

--- a/src/components/Global/AddressLink/index.tsx
+++ b/src/components/Global/AddressLink/index.tsx
@@ -1,6 +1,8 @@
 import { printableAddress, isCryptoAddress } from '@/utils/general.utils'
 import { normalizeEnsName } from '@/utils/ens-name.utils'
 import { usePrimaryNameServer } from '@/hooks/usePrimaryNameServer'
+import { isCapacitor } from '@/utils/capacitor'
+import { recipientPayUrl } from '@/utils/native-routes'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
@@ -35,11 +37,17 @@ const AddressLink = ({ address, className = '', isLink = true }: AddressLinkProp
         }
     }, [address, ensName])
 
-    // Create a simple URL - all identifiers go to /{identifier}
-    const url = `/${urlAddress}`
+    // All identifiers go to the recipient route — /{identifier} on web,
+    // /send?recipient= on native (the catch-all is pruned there, and _blank
+    // is a dead tap in the WebView).
+    const url = recipientPayUrl(urlAddress)
 
     return isLink ? (
-        <Link className={twMerge('cursor-pointer text-xs text-grey-1 underline', className)} href={url} target="_blank">
+        <Link
+            className={twMerge('cursor-pointer text-xs text-grey-1 underline', className)}
+            href={url}
+            target={isCapacitor() ? undefined : '_blank'}
+        >
             {displayAddress}
         </Link>
     ) : (

--- a/src/components/Global/InvitesGraph/index.tsx
+++ b/src/components/Global/InvitesGraph/index.tsx
@@ -1568,10 +1568,14 @@ export default function InvitesGraph(props: InvitesGraphProps) {
 
                 if (node.externalType === 'WALLET') {
                     // Wallet → Arbiscan
-                    openExternalUrl(`https://arbiscan.io/address/${externalId}`)
+                    openExternalUrl(`https://arbiscan.io/address/${externalId}`).catch((e) =>
+                        console.warn('failed to open explorer link:', e)
+                    )
                 } else if (node.externalType === 'MERCHANT') {
                     // Merchant → Google search
-                    openExternalUrl(`https://www.google.com/search?q=${encodeURIComponent(node.label)}`)
+                    openExternalUrl(`https://www.google.com/search?q=${encodeURIComponent(node.label)}`).catch((e) =>
+                        console.warn('failed to open search link:', e)
+                    )
                 }
                 // BANK → Do nothing (no useful URL for IBAN/CLABE/ACH)
                 return

--- a/src/components/Global/InvitesGraph/index.tsx
+++ b/src/components/Global/InvitesGraph/index.tsx
@@ -33,7 +33,10 @@
 import { useTranslations } from 'next-intl'
 import { useState, useCallback, useMemo, useRef, useEffect } from 'react'
 import dynamic from 'next/dynamic'
+import { useRouter } from 'next/navigation'
 import { Button } from '@/components/0_Bruddle/Button'
+import { openExternalUrl } from '@/utils/capacitor'
+import { profileUrl } from '@/utils/native-routes'
 import { Icon } from '@/components/Global/Icons/Icon'
 import { pointsApi } from '@/services/points'
 import { inferBankAccountType } from '@/utils/bridge.utils'
@@ -191,6 +194,7 @@ const DEFAULT_TOP_NODES = 5000
 
 export default function InvitesGraph(props: InvitesGraphProps) {
     const t = useTranslations('global')
+    const router = useRouter()
     const {
         width,
         height,
@@ -1564,25 +1568,26 @@ export default function InvitesGraph(props: InvitesGraphProps) {
 
                 if (node.externalType === 'WALLET') {
                     // Wallet → Arbiscan
-                    window.open(`https://arbiscan.io/address/${externalId}`, '_blank')
+                    openExternalUrl(`https://arbiscan.io/address/${externalId}`)
                 } else if (node.externalType === 'MERCHANT') {
                     // Merchant → Google search
-                    window.open(`https://www.google.com/search?q=${encodeURIComponent(node.label)}`, '_blank')
+                    openExternalUrl(`https://www.google.com/search?q=${encodeURIComponent(node.label)}`)
                 }
                 // BANK → Do nothing (no useful URL for IBAN/CLABE/ACH)
                 return
             }
 
-            // User mode: Navigate to user profile in new tab
+            // User node → profile. window.open('/<user>','_blank') was dead on
+            // iOS (no popup support) and a full app reset on Android.
             if (isMinimal && node.username) {
-                window.open(`/${node.username}`, '_blank')
+                router.push(profileUrl(node.username))
                 return
             }
 
             // Full/Payment mode: User node → Select (camera follows)
             setSelectedUserId(node.id)
         },
-        [isMinimal]
+        [isMinimal, router]
     )
 
     // Right-click selects the node (camera follows)

--- a/src/components/Global/QRScannerOverlay/index.tsx
+++ b/src/components/Global/QRScannerOverlay/index.tsx
@@ -119,14 +119,24 @@ function DirectSendContent({ redirectTo, setIsModalOpen }: ModalContentProps) {
 function ExternalUrlContent({ redirectTo, setIsModalOpen }: ModalContentProps) {
     const t = useTranslations('global')
     const tCommon = useTranslations('common')
+    const toast = useToast()
     return (
         <div className="flex flex-col justify-center p-6">
             <span className="text-sm">{t('qrScannerOverlay.externalUrlIntro')}</span>
             <span className="text-sm">{t('qrScannerOverlay.externalUrlTrust')}</span>
             <div className="flex items-center justify-center gap-2">
                 <Button
-                    onClick={() => {
-                        if (redirectTo) openExternalUrl(redirectTo)
+                    onClick={async () => {
+                        if (redirectTo) {
+                            // scheme-less QR payloads ("example.com/x") make
+                            // Browser.open throw — the tap died silently.
+                            const url = /^[a-z][a-z0-9+.-]*:/i.test(redirectTo) ? redirectTo : `https://${redirectTo}`
+                            try {
+                                await openExternalUrl(url)
+                            } catch {
+                                toast.error(tCommon('somethingWentWrong'))
+                            }
+                        }
                         setTimeout(() => {
                             setIsModalOpen(false)
                         }, 750)
@@ -289,7 +299,10 @@ export default function QRScannerOverlay() {
                             const lookup = await response.json()
 
                             if (lookup.claimed && lookup.redirectUrl) {
-                                redirectUrl = lookup.redirectUrl
+                                // The server sends an absolute peanut.me URL —
+                                // pushed raw it left the app (Safari on iOS, a
+                                // /setup bounce on Android). Map it in-app.
+                                redirectUrl = deepLinkToNativePath(lookup.redirectUrl) ?? qrClaimUrl(redirectQrCode)
                             } else {
                                 redirectUrl = qrClaimUrl(redirectQrCode)
                             }

--- a/src/components/LandingPage/LandingPageCapacitorGate.tsx
+++ b/src/components/LandingPage/LandingPageCapacitorGate.tsx
@@ -11,6 +11,7 @@ import { useEffect, type ReactNode } from 'react'
 import { useRouter } from 'next/navigation'
 import { hasNativeSession } from '@/utils/auth-token'
 import { isCapacitor } from '@/utils/capacitor'
+import { hasDeepLinkNavigated } from '@/utils/deep-link-state'
 import { isDemoMode } from '@/utils/demo'
 
 export function LandingPageCapacitorGate({ children }: { children: ReactNode }) {
@@ -18,6 +19,10 @@ export function LandingPageCapacitorGate({ children }: { children: ReactNode }) 
 
     useEffect(() => {
         if (isCapacitor()) {
+            // A deep link already navigated this boot — replacing to /home now
+            // would discard that pending push and eat the tap (a cold-start App
+            // Link races this gate on both platforms).
+            if (hasDeepLinkNavigated()) return
             // Demo mode has no session but is valid — send it to the app.
             if (isDemoMode()) {
                 router.replace('/home')
@@ -27,6 +32,7 @@ export function LandingPageCapacitorGate({ children }: { children: ReactNode }) 
             // legacy cookie-jar fallback). /home's layout still validates via
             // /users/me and bounces dead sessions.
             hasNativeSession().then((hasSession) => {
+                if (hasDeepLinkNavigated()) return
                 router.replace(hasSession ? '/home' : '/setup')
             })
         }

--- a/src/components/Profile/components/PublicProfile.tsx
+++ b/src/components/Profile/components/PublicProfile.tsx
@@ -16,6 +16,7 @@ import { useState, useEffect, useMemo, useRef } from 'react'
 import { invitesApi } from '@/services/invites'
 import { usersApi } from '@/services/users'
 import { useRouter } from 'next/navigation'
+import { isCapacitor } from '@/utils/capacitor'
 import { requestUrl } from '@/utils/native-routes'
 import Card from '@/components/Global/Card'
 import { checkIfInternalNavigation, saveToCookie, toInviteCode } from '@/utils/general.utils'
@@ -110,8 +111,12 @@ const PublicProfile: React.FC<PublicProfileProps> = ({ username, isLoggedIn = fa
                 link_type: resolvedToOwner ? 'invite_code' : 'none',
             })
             if (intercepted) return
-            // Unresolvable and mismatched codes still navigate — /invite owns the messaging.
-            router.push(`/invite?code=${code}`)
+            // Unresolvable and mismatched codes still navigate — /invite owns the
+            // messaging. Native strips /invite; /setup?step=signup is its stand-in
+            // (the cookie above already carries the code, and ONLY when it resolved
+            // to the owner — don't route through inviteFlowUrl, which writes it
+            // unconditionally and would revert the resolvedToOwner guard).
+            router.push(isCapacitor() ? '/setup?step=signup' : `/invite?code=${code}`)
         } finally {
             setIsJoining(false)
         }

--- a/src/components/Request/Pay/Pay.tsx
+++ b/src/components/Request/Pay/Pay.tsx
@@ -7,7 +7,7 @@ import { getRequestLink } from '@/utils/general.utils'
 import { useRouter } from 'next/navigation'
 import { chargesApi } from '@/services/charges'
 import { isCapacitor } from '@/utils/capacitor'
-import { requestPotUrl } from '@/utils/native-routes'
+import { chargePayUrl } from '@/utils/native-routes'
 
 export const PayRequestLink = () => {
     const searchParams = useSearchParams()
@@ -17,7 +17,9 @@ export const PayRequestLink = () => {
         try {
             const charge = await chargesApi.get(uuid)
             if (isCapacitor()) {
-                router.push(requestPotUrl(uuid))
+                // uuid is a CHARGE id (chargesApi just resolved it) — the
+                // request-pot dispatch treated it as a pot id and 404'd.
+                router.push(chargePayUrl(uuid))
             } else {
                 const link = getRequestLink({
                     ...charge.requestLink,

--- a/src/hooks/__tests__/useNativeAppLinks.test.tsx
+++ b/src/hooks/__tests__/useNativeAppLinks.test.tsx
@@ -5,6 +5,7 @@
 import { renderHook, waitFor } from '@testing-library/react'
 import { useNativeAppLinks } from '../useNativeAppLinks'
 import { restoreDeferredContext } from '@/utils/deferred-link'
+import { resetDeepLinkStateForTests } from '@/utils/deep-link-state'
 import { getOneSignalAdapter } from '@/services/onesignal'
 
 const push = jest.fn()
@@ -44,6 +45,10 @@ const mockRestore = restoreDeferredContext as jest.MockedFunction<typeof restore
 beforeEach(() => {
     jest.clearAllMocks()
     launchUrl = undefined
+    // Module state + the launch-url guard outlive a test: without these resets
+    // an earlier test's navigation suppresses the next test's launch dispatch.
+    resetDeepLinkStateForTests()
+    sessionStorage.clear()
 })
 
 describe('useNativeAppLinks deferred restore wiring', () => {

--- a/src/hooks/__tests__/useNativeAppLinks.test.tsx
+++ b/src/hooks/__tests__/useNativeAppLinks.test.tsx
@@ -17,6 +17,9 @@ jest.mock('@sentry/nextjs', () => ({ captureMessage: jest.fn() }))
 jest.mock('@/utils/capacitor', () => ({
     isCapacitor: jest.fn(() => true),
     getPlatform: jest.fn(() => 'android-native'),
+    openExternalUrl: jest.fn(() => Promise.resolve()),
+    closeInAppBrowser: jest.fn(() => Promise.resolve()),
+    markInAppBrowserClosed: jest.fn(),
 }))
 
 jest.mock('@/services/onesignal', () => ({

--- a/src/hooks/__tests__/useNativeAppLinks.test.tsx
+++ b/src/hooks/__tests__/useNativeAppLinks.test.tsx
@@ -5,7 +5,7 @@
 import { renderHook, waitFor } from '@testing-library/react'
 import { useNativeAppLinks } from '../useNativeAppLinks'
 import { restoreDeferredContext } from '@/utils/deferred-link'
-import { resetDeepLinkStateForTests } from '@/utils/deep-link-state'
+import { markDeepLinkNavigated, resetDeepLinkStateForTests } from '@/utils/deep-link-state'
 import { getOneSignalAdapter } from '@/services/onesignal'
 
 const push = jest.fn()
@@ -106,5 +106,35 @@ describe('useNativeAppLinks deferred restore wiring', () => {
         const mockAdapter = getOneSignalAdapter as jest.MockedFunction<typeof getOneSignalAdapter>
         await waitFor(() => expect(mockAdapter).toHaveBeenCalled())
         expect(push).not.toHaveBeenCalled()
+    })
+})
+
+describe('launch-url replay guard', () => {
+    it('stamps the launch url even when RootRedirect already routed it, so a webview reload cannot replay it', async () => {
+        launchUrl = 'https://peanut.me/claim?i=abc'
+        // RootRedirect recovered the same URL from location on the full-document load
+        markDeepLinkNavigated()
+
+        const first = renderHook(() => useNativeAppLinks())
+        await waitFor(() => expect(getOneSignalAdapter).toHaveBeenCalled())
+        expect(push).not.toHaveBeenCalled()
+        first.unmount()
+
+        // logout / hard-nav fallback: same process, fresh module state,
+        // getLaunchUrl still returns the original URL
+        resetDeepLinkStateForTests()
+        jest.clearAllMocks()
+
+        renderHook(() => useNativeAppLinks())
+        await waitFor(() => expect(getOneSignalAdapter).toHaveBeenCalled())
+        expect(push).not.toHaveBeenCalled()
+    })
+
+    it('still dispatches a launch url that nothing has handled', async () => {
+        launchUrl = 'https://peanut.me/claim?i=unhandled'
+
+        renderHook(() => useNativeAppLinks())
+
+        await waitFor(() => expect(push).toHaveBeenCalledWith('/claim?i=unhandled'))
     })
 })

--- a/src/hooks/useNativeAppLinks.ts
+++ b/src/hooks/useNativeAppLinks.ts
@@ -7,7 +7,7 @@ import posthog from 'posthog-js'
 import { captureMessage } from '@/utils/sentry-lazy'
 import { isCapacitor, openExternalUrl, closeInAppBrowser, markInAppBrowserClosed } from '@/utils/capacitor'
 import { deepLinkToNativePath } from '@/utils/native-routes'
-import { markDeepLinkNavigated } from '@/utils/deep-link-state'
+import { hasDeepLinkNavigated, markDeepLinkNavigated } from '@/utils/deep-link-state'
 import { sanitizeRedirectURL, saveToCookie } from '@/utils/cookie-url.utils'
 import { toInviteCode } from '@/utils/invite-code.utils'
 import { getOneSignalAdapter } from '@/services/onesignal'
@@ -124,13 +124,18 @@ export function useNativeAppLinks() {
             // this push on cold start and must yield to it.
             anyDeepLinkNavigated = true
             markDeepLinkNavigated()
-            // A deep link arriving while our in-app browser sheet is up (the
-            // Persona/Bridge KYC return leg) must dismiss it or the nav happens
-            // underneath a full-screen browser. Fire-and-forget: close is fast
-            // and the push must not wait on it.
-            void closeInAppBrowser()
-            router.push(safe)
-            captureLink(source, url, safe, 'navigated')
+            /*
+             * A deep link arriving while our in-app browser sheet is up (the
+             * Persona/Bridge KYC return leg) must dismiss it or the nav happens
+             * underneath a full-screen browser. Sequence the push after the
+             * close, but cap the wait: a wedged Browser.close (the silent-
+             * native-failure class) must degrade to navigating behind the
+             * sheet, never to an eaten tap.
+             */
+            void Promise.race([closeInAppBrowser(), new Promise((r) => setTimeout(r, 500))]).finally(() => {
+                router.push(safe)
+                captureLink(source, url, safe, 'navigated')
+            })
             return true
         }
 
@@ -165,8 +170,11 @@ export function useNativeAppLinks() {
                 // process, so it is dispatched at most once per launch URL —
                 // without the sessionStorage guard every webview reload (logout,
                 // hard-nav fallback) replayed a stale claim/pay link.
+                // hasDeepLinkNavigated(): RootRedirect may already have routed
+                // this same launch URL (a full-document load recovers it from
+                // location) — dispatching it again would double-navigate.
                 const launch = await App.getLaunchUrl()
-                if (launch?.url) {
+                if (launch?.url && !hasDeepLinkNavigated()) {
                     let alreadyHandled = false
                     try {
                         alreadyHandled = sessionStorage.getItem(HANDLED_LAUNCH_URL_KEY) === launch.url

--- a/src/hooks/useNativeAppLinks.ts
+++ b/src/hooks/useNativeAppLinks.ts
@@ -3,9 +3,11 @@
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { focusManager } from '@tanstack/react-query'
+import posthog from 'posthog-js'
 import { captureMessage } from '@/utils/sentry-lazy'
-import { isCapacitor } from '@/utils/capacitor'
+import { isCapacitor, openExternalUrl, closeInAppBrowser, markInAppBrowserClosed } from '@/utils/capacitor'
 import { deepLinkToNativePath } from '@/utils/native-routes'
+import { markDeepLinkNavigated } from '@/utils/deep-link-state'
 import { sanitizeRedirectURL, saveToCookie } from '@/utils/cookie-url.utils'
 import { toInviteCode } from '@/utils/invite-code.utils'
 import { getOneSignalAdapter } from '@/services/onesignal'
@@ -23,6 +25,18 @@ import { getOneSignalAdapter } from '@/services/onesignal'
 let appListenersFailureCaptured = false
 let clickListenerFailureCaptured = false
 
+// Cold-start URL guard: getLaunchUrl returns the ORIGINAL launch URL for the
+// whole native process, so every webview reload (logout, hard-nav fallback)
+// used to replay a stale claim/pay link. sessionStorage survives reloads but
+// dies with the process — exactly the lifetime of "this launch URL was handled".
+const HANDLED_LAUNCH_URL_KEY = 'peanut:handledLaunchUrl'
+
+// Double-delivery guard: the same URL can reach openDeepLink twice in one boot
+// (explicit getLaunchUrl dispatch + the bridge's own cold-start appUrlOpen
+// replay). One navigation is correct; the second is a duplicate history entry.
+let lastDispatchedUrl: string | null = null
+let lastDispatchedAt = 0
+
 export function useNativeAppLinks() {
     const router = useRouter()
 
@@ -39,17 +53,58 @@ export function useNativeAppLinks() {
         }
 
         // true once ANY deep link actually navigated (cold start, warm start,
-        // push tap) — the deferred-restore dest yields only to a navigation
-        // that really happened, not to a launch url that was rejected.
+        // push tap) — the deferred-restore dest and the landing-page boot
+        // redirect yield only to a navigation that really happened, not to a
+        // launch url that was rejected. Module state (deep-link-state.ts) so
+        // LandingPageCapacitorGate can read it without a render dependency.
         let anyDeepLinkNavigated = false
 
-        const openDeepLink = (url?: string | null): boolean => {
+        // Until this instrumentation, no deep link left any trace unless it
+        // threw — "links don't work" was undiagnosable from telemetry.
+        const captureLink = (source: string, raw: string, mapped: string | null, outcome: string) =>
+            posthog.capture('native_link_received', {
+                source,
+                raw,
+                mapped,
+                outcome,
+                dropped: outcome === 'dropped',
+            })
+
+        const openDeepLink = (url?: string | null, source = 'app_url'): boolean => {
             if (!url) return false
+            // Same URL twice in one boot = cold-start double delivery
+            // (getLaunchUrl + the bridge's appUrlOpen replay) — one nav is right.
+            if (url === lastDispatchedUrl && Date.now() - lastDispatchedAt < 3000) return true
             const target = deepLinkToNativePath(url)
-            if (!target) return false
+            if (!target) {
+                /*
+                 * A peanut.me path with no native stand-in (blog, help, legal,
+                 * locale pages…) opens the real web page in the in-app browser
+                 * instead of silently eating the tap. Off-domain URLs stay with
+                 * the caller — the push handler hands those to the system
+                 * browser itself. The bare origin is excluded: it maps to the
+                 * marketing landing, which is noise for someone already in the app.
+                 */
+                try {
+                    const parsed = new URL(url, 'https://peanut.me')
+                    const isAppHost = /^(.+\.)?peanut\.me$/.test(parsed.hostname)
+                    if (isAppHost && (parsed.pathname !== '/' || parsed.search)) {
+                        lastDispatchedUrl = url
+                        lastDispatchedAt = Date.now()
+                        openExternalUrl(parsed.href).catch((e) => console.warn('failed to open web-only link:', e))
+                        captureLink(source, url, null, 'in_app_browser')
+                        return true
+                    }
+                } catch {}
+                captureLink(source, url, null, 'dropped')
+                return false
+            }
             // same-origin guard: only ever navigate to an in-app relative path
             const safe = sanitizeRedirectURL(target)
-            if (!safe) return false
+            if (!safe) {
+                captureLink(source, url, target, 'dropped')
+                return false
+            }
             // /invite is rewritten to /setup by the mapper (the landing page is
             // pruned from the native export) — carry the code via the SESSION
             // invite cookie, same semantics as the deferred-link restore: it
@@ -63,8 +118,19 @@ export function useNativeAppLinks() {
                     if (code) saveToCookie('inviteCode', code)
                 }
             } catch {}
-            router.push(safe)
+            lastDispatchedUrl = url
+            lastDispatchedAt = Date.now()
+            // Flag first (synchronously): the landing gate's /home replace races
+            // this push on cold start and must yield to it.
             anyDeepLinkNavigated = true
+            markDeepLinkNavigated()
+            // A deep link arriving while our in-app browser sheet is up (the
+            // Persona/Bridge KYC return leg) must dismiss it or the nav happens
+            // underneath a full-screen browser. Fire-and-forget: close is fast
+            // and the push must not wait on it.
+            void closeInAppBrowser()
+            router.push(safe)
+            captureLink(source, url, safe, 'navigated')
             return true
         }
 
@@ -95,10 +161,33 @@ export function useNativeAppLinks() {
                 track(() => backListener.remove())
 
                 // App Links: cold start (getLaunchUrl) + warm start (appUrlOpen).
+                // getLaunchUrl returns the original launch URL for the whole
+                // process, so it is dispatched at most once per launch URL —
+                // without the sessionStorage guard every webview reload (logout,
+                // hard-nav fallback) replayed a stale claim/pay link.
                 const launch = await App.getLaunchUrl()
-                openDeepLink(launch?.url)
-                const urlListener = await App.addListener('appUrlOpen', ({ url }: { url: string }) => openDeepLink(url))
+                if (launch?.url) {
+                    let alreadyHandled = false
+                    try {
+                        alreadyHandled = sessionStorage.getItem(HANDLED_LAUNCH_URL_KEY) === launch.url
+                        if (!alreadyHandled) sessionStorage.setItem(HANDLED_LAUNCH_URL_KEY, launch.url)
+                    } catch {}
+                    if (!alreadyHandled) openDeepLink(launch.url, 'launch_url')
+                }
+                const urlListener = await App.addListener('appUrlOpen', ({ url }: { url: string }) =>
+                    openDeepLink(url, 'app_url_open')
+                )
                 track(() => urlListener.remove())
+
+                // Keep the in-app-browser flag honest when the user dismisses
+                // the sheet themselves.
+                import('@capacitor/browser')
+                    .then(({ Browser }) =>
+                        Browser.addListener('browserFinished', () => markInAppBrowserClosed()).then((l) =>
+                            track(() => l.remove())
+                        )
+                    )
+                    .catch(() => {})
 
                 // deferred deep link (store-install hand-off). deliberately NOT
                 // awaited: the iOS clipboard read can sit on the system paste
@@ -110,14 +199,22 @@ export function useNativeAppLinks() {
                     .then((restored) => {
                         if (!restored?.dest) return
                         // a deep link that actually navigated wins the landing
-                        if (anyDeepLinkNavigated) return
+                        if (anyDeepLinkNavigated) {
+                            captureLink('deferred', restored.dest, restored.dest, 'yielded')
+                            return
+                        }
                         // a restore that resolves late (paste prompt left up for
                         // minutes, sluggish referrer service) must not teleport a
                         // user who is already tapping through onboarding — only
                         // navigate while this still reads as "the app just opened".
                         // cookies + locale above are applied regardless.
-                        if (Date.now() - restoreStartedAt > 10_000) return
+                        if (Date.now() - restoreStartedAt > 10_000) {
+                            captureLink('deferred', restored.dest, restored.dest, 'expired')
+                            return
+                        }
+                        markDeepLinkNavigated()
                         router.push(restored.dest)
+                        captureLink('deferred', restored.dest, restored.dest, 'navigated')
                     })
                     .catch((e) => console.warn('deferred link restore failed:', e))
             } catch (e) {
@@ -146,14 +243,19 @@ export function useNativeAppLinks() {
                         const link = typeof target === 'string' ? target : deepLink
                         // Off-domain https links (operator sends) can't route in-app;
                         // with launch URLs suppressed, hand them to the system browser
-                        // rather than silently swallowing the tap.
-                        if (link && !deepLinkToNativePath(link) && /^https:\/\//i.test(link)) {
-                            import('@capacitor/browser')
-                                .then(({ Browser }) => Browser.open({ url: link }))
-                                .catch((e) => console.warn('failed to open external push link:', e))
+                        // rather than silently swallowing the tap. peanut.me links
+                        // always go through openDeepLink — it opens web-only paths
+                        // in the in-app browser itself.
+                        if (
+                            link &&
+                            /^https:\/\//i.test(link) &&
+                            !/^https:\/\/([^/]*\.)?peanut\.me(\/|\?|#|$)/i.test(link)
+                        ) {
+                            openExternalUrl(link).catch((e) => console.warn('failed to open external push link:', e))
+                            captureLink('push', link, null, 'external_browser')
                             return
                         }
-                        openDeepLink(link)
+                        openDeepLink(link, 'push')
                     })
                 )
             } catch (e) {
@@ -171,6 +273,24 @@ export function useNativeAppLinks() {
         }
 
         init()
+
+        /*
+         * Raw `<a target="_blank">` anchors with external hrefs (card terms,
+         * passkey help, block explorers, attachments) hand the URL to the OS on
+         * Android and are a silent no-op on iOS. Intercept at capture phase and
+         * route through the in-app browser. Only the navigation is prevented —
+         * propagation continues, so React handlers on the anchor still run.
+         */
+        const onDocumentClick = (e: MouseEvent) => {
+            const anchor = (e.target as Element | null)?.closest?.('a[target="_blank"]')
+            if (!anchor) return
+            const href = anchor.getAttribute('href')
+            if (!href || !/^https?:\/\//i.test(href)) return
+            e.preventDefault()
+            openExternalUrl(href).catch((err) => console.warn('failed to open external link:', err))
+        }
+        document.addEventListener('click', onDocumentClick, true)
+        cleanups.push(() => document.removeEventListener('click', onDocumentClick, true))
 
         return () => {
             disposed = true

--- a/src/hooks/useNativeAppLinks.ts
+++ b/src/hooks/useNativeAppLinks.ts
@@ -174,13 +174,17 @@ export function useNativeAppLinks() {
                 // this same launch URL (a full-document load recovers it from
                 // location) — dispatching it again would double-navigate.
                 const launch = await App.getLaunchUrl()
-                if (launch?.url && !hasDeepLinkNavigated()) {
+                if (launch?.url) {
+                    // Stamp BEFORE the hasDeepLinkNavigated() check: on the
+                    // RootRedirect path the URL is already handled, and skipping
+                    // the stamp let the next reload (module state gone,
+                    // getLaunchUrl unchanged) replay it.
                     let alreadyHandled = false
                     try {
                         alreadyHandled = sessionStorage.getItem(HANDLED_LAUNCH_URL_KEY) === launch.url
                         if (!alreadyHandled) sessionStorage.setItem(HANDLED_LAUNCH_URL_KEY, launch.url)
                     } catch {}
-                    if (!alreadyHandled) openDeepLink(launch.url, 'launch_url')
+                    if (!alreadyHandled && !hasDeepLinkNavigated()) openDeepLink(launch.url, 'launch_url')
                 }
                 const urlListener = await App.addListener('appUrlOpen', ({ url }: { url: string }) =>
                     openDeepLink(url, 'app_url_open')

--- a/src/services/manteca.ts
+++ b/src/services/manteca.ts
@@ -219,24 +219,6 @@ export const mantecaApi = {
 
         return response.json()
     },
-    initiateOnboarding: async (params: {
-        returnUrl: string
-        failureUrl?: string
-        exchange?: string
-    }): Promise<{ url: string }> => {
-        const response = await serverFetch('/manteca/initiate-onboarding', {
-            method: 'POST',
-            body: jsonStringify(params),
-        })
-
-        if (!response.ok) {
-            const errorData = await response.json().catch(() => ({}))
-            throw new Error(errorData.message || `Failed to get onboarding URL`)
-        }
-
-        return response.json()
-    },
-
     deposit: async (
         params: CreateMantecaOnrampParams
     ): Promise<{ data?: MantecaDepositResponseData; error?: string }> => {

--- a/src/types/api.generated.ts
+++ b/src/types/api.generated.ts
@@ -5971,53 +5971,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/manteca/initiate-onboarding": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Initiate Manteca onboarding
-         * @description Creates an onboarding widget URL for the current user using userId as userExternalId and returns the URL
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header: {
-                    Authorization: string;
-                };
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        returnUrl: string;
-                        failureUrl?: string;
-                        exchange?: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/manteca/prices": {
         parameters: {
             query?: never;

--- a/src/types/api.openapi.json
+++ b/src/types/api.openapi.json
@@ -10108,54 +10108,6 @@
                 }
             }
         },
-        "/manteca/initiate-onboarding": {
-            "post": {
-                "summary": "Initiate Manteca onboarding",
-                "tags": [
-                    "manteca"
-                ],
-                "description": "Creates an onboarding widget URL for the current user using userId as userExternalId and returns the URL",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "returnUrl": {
-                                        "type": "string"
-                                    },
-                                    "failureUrl": {
-                                        "type": "string"
-                                    },
-                                    "exchange": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "returnUrl"
-                                ]
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "parameters": [
-                    {
-                        "schema": {
-                            "type": "string"
-                        },
-                        "in": "header",
-                        "name": "Authorization",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Default Response"
-                    }
-                }
-            }
-        },
         "/manteca/prices": {
             "get": {
                 "parameters": [

--- a/src/utils/__tests__/native-routes.test.ts
+++ b/src/utils/__tests__/native-routes.test.ts
@@ -132,9 +132,9 @@ describe('native-routes', () => {
                 expect(rewriteMethodPath('/withdraw/crypto')).toBe('/withdraw/crypto')
             })
 
-            it('should rewrite /add-money/crypto as dynamic (no static exception for add-money)', () => {
-                // note: add-money does NOT have a static route exception for crypto
-                expect(rewriteMethodPath('/add-money/crypto')).toBe('/add-money?country=crypto')
+            it('should not rewrite /add-money/crypto or /add-money/us (static routes)', () => {
+                expect(rewriteMethodPath('/add-money/crypto')).toBe('/add-money/crypto')
+                expect(rewriteMethodPath('/add-money/us')).toBe('/add-money/us')
             })
 
             it('should append extraParams to rewritten add-money path', () => {
@@ -494,6 +494,133 @@ describe('native-routes', () => {
                     '/claim?c=42161&v=v4.2&i=99#p=s3cr3t'
                 )
             })
+        })
+    })
+
+    // 2026-08 native-links review coverage: the "My QR" payload, the legacy
+    // /request/pay shape, bare-origin push links, static add-money subroutes,
+    // and web-only roots.
+    describe('deepLinkToNativePath — review additions', () => {
+        describe('capacitor mode', () => {
+            beforeEach(() => {
+                mockIsCapacitor.mockReturnValue(true)
+            })
+
+            it('maps /pay/<user> — the "My QR" payload — onto the send dispatcher', () => {
+                expect(deepLinkToNativePath('https://peanut.me/pay/alice')).toBe('/send?recipient=alice')
+            })
+
+            it('maps legacy /request/pay?id=<chargeUuid> as a CHARGE, not user "pay"', () => {
+                expect(deepLinkToNativePath('https://peanut.me/request/pay?id=charge-123')).toBe(
+                    '/pay-request?chargeId=charge-123'
+                )
+            })
+
+            it('still maps /request/<user> to the request screen', () => {
+                expect(deepLinkToNativePath('https://peanut.me/request/alice')).toBe('/request?recipient=alice')
+            })
+
+            it('maps the bare-origin shapes legacy pushes and inbox rows carry', () => {
+                expect(deepLinkToNativePath('https://peanut.me?id=req-123')).toBe('/pay-request?id=req-123')
+                expect(deepLinkToNativePath('https://peanut.me/?chargeId=charge-123')).toBe(
+                    '/pay-request?chargeId=charge-123'
+                )
+            })
+
+            it('drops the truly bare origin', () => {
+                expect(deepLinkToNativePath('https://peanut.me')).toBeNull()
+            })
+
+            it('keeps the static add-money subroutes instead of rewriting them to ?country=', () => {
+                expect(deepLinkToNativePath('/add-money/crypto')).toBe('/add-money/crypto')
+                expect(deepLinkToNativePath('/add-money/us')).toBe('/add-money/us')
+            })
+
+            it('returns null for web-only roots so the caller opens them in the in-app browser', () => {
+                expect(deepLinkToNativePath('https://peanut.me/help')).toBeNull()
+                expect(deepLinkToNativePath('https://peanut.me/blog/some-post')).toBeNull()
+                expect(deepLinkToNativePath('https://peanut.me/terms')).toBeNull()
+                expect(deepLinkToNativePath('https://peanut.me/es-419/pricing')).toBeNull()
+                expect(deepLinkToNativePath('https://peanut.me/foodie')).toBeNull()
+            })
+
+            it('keeps roots the native export ships', () => {
+                expect(deepLinkToNativePath('https://peanut.me/home')).toBe('/home')
+                expect(deepLinkToNativePath('https://peanut.me/card')).toBe('/card')
+                expect(deepLinkToNativePath('https://peanut.me/pay-request?chargeId=x')).toBe('/pay-request?chargeId=x')
+            })
+        })
+
+        describe('web mode', () => {
+            beforeEach(() => {
+                mockIsCapacitor.mockReturnValue(false)
+            })
+
+            it('maps /pay/<user> to the send route (mirror of the web page redirect)', () => {
+                expect(deepLinkToNativePath('https://peanut.me/pay/alice')).toBe('/send/alice')
+            })
+
+            it('maps legacy /request/pay?id= to pay-request on web too', () => {
+                expect(deepLinkToNativePath('https://peanut.me/request/pay?id=charge-123')).toBe(
+                    '/pay-request?chargeId=charge-123'
+                )
+            })
+
+            it('keeps web-only roots as-is', () => {
+                expect(deepLinkToNativePath('https://peanut.me/help')).toBe('/help')
+            })
+
+            it('maps the bare-origin id shape to pay-request', () => {
+                expect(deepLinkToNativePath('https://peanut.me?id=req-123')).toBe('/pay-request?id=req-123')
+            })
+        })
+    })
+
+    /*
+     * AASA drift guard: every path root claimed for the app in
+     * public/.well-known/apple-app-site-association must map to a native page
+     * (directly or via a rewrite). A root added to the AASA without a mapper
+     * branch ships an App Link that cold-boots the app to /home — the exact
+     * class of bug the 2026-08 native-links review closed. The Android
+     * intent-filter list mirrors the AASA, so this guards both platforms.
+     */
+    describe('AASA path list maps into the native export', () => {
+        beforeEach(() => {
+            mockIsCapacitor.mockReturnValue(true)
+        })
+
+        // extension-less JSON — require() won't parse it
+        const { readFileSync } = require('fs')
+        const { join } = require('path')
+        const aasa = JSON.parse(
+            readFileSync(join(process.cwd(), 'public/.well-known/apple-app-site-association'), 'utf8')
+        )
+        const roots = new Set<string>(
+            aasa.applinks.details
+                .flatMap((d: { paths: string[] }) => d.paths)
+                .map((p: string) => p.split('/').filter(Boolean)[0])
+                .filter(Boolean)
+        )
+
+        // A representative deep link per claimed root — dynamic roots get a
+        // realistic sample; static roots are tested bare.
+        const SAMPLE_BY_ROOT: Record<string, string> = {
+            claim: '/claim?c=42161&v=v4.2&i=99#p=pw',
+            pay: '/pay/alice',
+            'pay-request': '/pay-request?chargeId=x',
+            send: '/send/alice',
+            request: '/request/alice',
+            qr: '/qr/CODE123',
+            'add-money': '/add-money/belgium/bank',
+            withdraw: '/withdraw/be/bank',
+            receipt: '/receipt/intent-1?kind=ONRAMP',
+            profile: '/profile',
+            invite: '/invite?code=alice',
+        }
+
+        it.each([...roots])('claimed root %s resolves to a native path', (root) => {
+            const sample = SAMPLE_BY_ROOT[root] ?? `/${root}`
+            expect(deepLinkToNativePath(`https://peanut.me${sample}`)).not.toBeNull()
         })
     })
 })

--- a/src/utils/capacitor.ts
+++ b/src/utils/capacitor.ts
@@ -141,11 +141,38 @@ export function getNativeRpId(): string {
  * - on web: window.open with _blank
  * - in capacitor: uses @capacitor/browser plugin
  */
+/*
+ * Whether OUR in-app browser sheet is (probably) up — set on every
+ * openExternalUrl, cleared by browserFinished (wired in useNativeAppLinks) and
+ * by closeInAppBrowser. Lets a deep link that arrives while the sheet is open
+ * (the Persona/Bridge KYC return leg) close it before navigating, instead of
+ * routing underneath a full-screen browser.
+ */
+let inAppBrowserOpen = false
+
+export function markInAppBrowserClosed(): void {
+    inAppBrowserOpen = false
+}
+
+export async function closeInAppBrowser(): Promise<void> {
+    if (!inAppBrowserOpen || !isCapacitor()) return
+    inAppBrowserOpen = false
+    try {
+        const { Browser } = await import('@capacitor/browser')
+        await Browser.close()
+    } catch {
+        // Browser.close rejects when the sheet is already gone — fine.
+    }
+}
+
 export async function openExternalUrl(url: string): Promise<void> {
     if (isCapacitor()) {
         const { Browser } = await import('@capacitor/browser')
+        inAppBrowserOpen = true
         await Browser.open({ url })
-    } else {
-        window.open(url, '_blank')
+    } else if (!window.open(url, '_blank')) {
+        // WhatsApp/Instagram in-app browsers block window.open — the guest
+        // store bounce was a silent dead tap there. Navigate in place instead.
+        window.location.assign(url)
     }
 }

--- a/src/utils/deep-link-state.ts
+++ b/src/utils/deep-link-state.ts
@@ -15,3 +15,8 @@ export function markDeepLinkNavigated(): void {
 export function hasDeepLinkNavigated(): boolean {
     return deepLinkNavigated
 }
+
+// Module state outlives a jest test; production code must never call this.
+export function resetDeepLinkStateForTests(): void {
+    deepLinkNavigated = false
+}

--- a/src/utils/deep-link-state.ts
+++ b/src/utils/deep-link-state.ts
@@ -1,0 +1,17 @@
+/*
+ * Module-level deep-link dispatch state, shared between useNativeAppLinks (the
+ * writer) and LandingPageCapacitorGate (the reader). Set SYNCHRONOUSLY at
+ * dispatch: the gate's /home|/setup replace races the deep-link push on cold
+ * start, and Next discards the pending push the moment the replace lands — the
+ * flag lets the gate yield to a navigation that already happened.
+ */
+
+let deepLinkNavigated = false
+
+export function markDeepLinkNavigated(): void {
+    deepLinkNavigated = true
+}
+
+export function hasDeepLinkNavigated(): boolean {
+    return deepLinkNavigated
+}

--- a/src/utils/native-routes.ts
+++ b/src/utils/native-routes.ts
@@ -114,8 +114,39 @@ function mapDeepLinkPath(parsed: URL): string | null {
     const extraParams = parsed.search.replace(/^\?/, '')
     const segments = path.split('/').filter(Boolean)
 
+    /*
+     * Bare origin (`https://peanut.me?id=X` / `?chargeId=X`) — the shape legacy
+     * withdraw pushes and their stored inbox rows carry. Without this branch the
+     * tap landed on the marketing page (web) or was dropped (native); the params
+     * are the same two /pay-request dispatches the recipient branch below uses.
+     */
+    if (segments.length === 0) {
+        const chargeId = parsed.searchParams.get('chargeId')
+        if (chargeId) return chargePayUrl(chargeId, parsed.searchParams.get('context') ?? undefined)
+        const requestId = parsed.searchParams.get('id')
+        if (requestId) return requestPotUrl(requestId)
+        return isCapacitor() ? null : appendParams(path, extraParams)
+    }
+
     if (segments[0] === 'send' && segments[1]) {
         return appendParams(sendUrl(decodeURIComponent(segments.slice(1).join('/'))), extraParams)
+    }
+    // `/pay/<recipient>` — every user's "My QR" payload. The web page is a pure
+    // client redirect to sendUrl(recipient) and is stripped from the native
+    // export, so both platforms funnel straight to the send dispatcher here.
+    if (segments[0] === 'pay' && segments[1]) {
+        return appendParams(sendUrl(decodeURIComponent(segments.slice(1).join('/'))), extraParams)
+    }
+    /*
+     * Legacy `/request/pay?id=<chargeUuid>` — printed into old shared links.
+     * `id` here is a CHARGE uuid, so it must dispatch as chargePayUrl; falling
+     * through to the request branch reads "request money from user 'pay'", and
+     * the page's own native fallback treats the uuid as a request pot and 404s.
+     */
+    if (segments[0] === 'request' && segments[1] === 'pay' && segments.length === 2) {
+        const chargeId = parsed.searchParams.get('id') ?? parsed.searchParams.get('chargeId')
+        if (chargeId) return chargePayUrl(chargeId)
+        return appendParams(path, extraParams)
     }
     if (segments[0] === 'request' && segments[1]) {
         return appendParams(requestUrl(decodeURIComponent(segments.slice(1).join('/'))), extraParams)
@@ -184,8 +215,55 @@ function mapDeepLinkPath(parsed: URL): string | null {
         return null
     }
 
+    /*
+     * Reserved roots that the native export does not ship (marketing, blog,
+     * legal, locale prefixes, redirect slugs…) must return null rather than
+     * pass through: the passthrough cold-boots the app to / and reads as a
+     * dropped tap. null tells openDeepLink to show the real page in the
+     * in-app browser instead. Web keeps the passthrough — every reserved
+     * root is a real page there.
+     */
+    if (isCapacitor() && !NATIVE_EXPORT_ROOTS.has(segments[0].toLowerCase())) {
+        return null
+    }
+
     return appendParams(path, extraParams)
 }
+
+/*
+ * Route roots that exist in the native static export — src/app/(mobile-ui)/* +
+ * /setup, minus what scripts/native-build.js disables. The AASA drift test in
+ * __tests__/native-routes.test.ts walks the App Links path list against this
+ * mapper, so a root claimed for the app but missing here fails CI instead of
+ * shipping a dead deep link.
+ */
+const NATIVE_EXPORT_ROOTS = new Set([
+    'add-money',
+    'badges',
+    'card',
+    'card-payment',
+    'card-recovery',
+    'claim',
+    'fix-card-signature',
+    'history',
+    'home',
+    'limits',
+    'notifications',
+    'pay-request',
+    'points',
+    'profile',
+    'qr',
+    'qr-pay',
+    'receipt',
+    'recover-funds',
+    'recover-wallet',
+    'request',
+    'rewards',
+    'send',
+    'settings',
+    'setup',
+    'withdraw',
+])
 
 function appendParams(base: string, params: string): string {
     if (!params) return base
@@ -206,6 +284,10 @@ export function rewriteMethodPath(path: string, extraParams?: string): string {
     if (addMoneyMatch) {
         const country = addMoneyMatch[1]
         const subView = addMoneyMatch[2] // bank, manteca, etc.
+        // static routes, not [country] — same carve-out as withdraw below
+        if (country === 'crypto' || country === 'us') {
+            return extraParams ? `${path}${path.includes('?') ? '&' : '?'}${extraParams}` : path
+        }
         let url = `/add-money?country=${country}`
         if (subView) url += `&view=${subView}`
         if (extraParams) url += `&${extraParams}`


### PR DESCRIPTION
## What

The OTA half of the native-links review ([full review](https://claude.ai/code/artifact/d84c1cbb-e5de-4172-8f22-017d6fdc0978), consolidating its PR-2…PR-5): every inbound link path (App Link, push tap, QR scan, deferred restore), the boot/auth redirect, and the outbound call sites that left the app.

### Inbound — `deepLinkToNativePath` (one file, eleven findings)
- **`/pay/<user>`** — every user's own **"My QR" payload** — now maps to the send dispatcher. It had no mapper branch and no native page: scanning someone's QR opened the app on /home. (P1)
- **Legacy `/request/pay?id=<chargeUuid>`** dispatches as a charge. It used to read as "request money from user *pay*", and even a passthrough would 404: the page's own native fallback treats the uuid as a request pot (also fixed).
- **Bare-origin `?id=` / `?chargeId=`** — the shape legacy withdraw pushes and their 1,379 stored inbox rows carry — maps to /pay-request, repairing already-stored rows.
- **`/add-money/crypto` and `/add-money/us`** stay on their static routes instead of being rewritten to `?country=`.
- **Web-only roots return null** (help, blog, legal, locale pages, redirect slugs); `openDeepLink` then opens the real page in the in-app browser instead of silently eating the tap.
- **AASA drift test**: walks the App Links path list in `apple-app-site-association` and asserts every claimed root resolves through the mapper — the three hand-maintained lists can't silently drift again.

### Boot and auth keep the target
- **RootRedirect** (native-build transform) recovers `location.pathname+search+hash` on a full-document load and routes it through the mapper. This is the only page that can answer a full-document load on either platform (iOS has no SPA fallback; Android's findPageHtml is shadowed by html5mode) — no Swift router needed.
- **The (mobile-ui) auth gate calls `saveRedirectUrl()` before bouncing to /setup** — a logged-out tap on any protected deep link (/pay-request, /card, /receipt, every push target) now lands on its target after login instead of /home. `useLogin`/`useAccountSetup` already consume it. (P1)
- **LandingPageCapacitorGate yields** to a deep link that already navigated (flag set synchronously at dispatch).

### Hook hardening — `useNativeAppLinks`
- **`getLaunchUrl` dispatched once per launch URL** (sessionStorage guard — dies with the process, survives webview reloads): logout / hard-nav fallback used to replay stale claim/pay links. A same-URL double delivery within one boot is deduped. Deliberately NOT deleting the getLaunchUrl dispatch: cold-start delivery must not bet on appUrlOpen retention semantics.
- **Telemetry**: `posthog.capture('native_link_received', {source, raw, mapped, outcome, dropped})` on every dispatch path (launch, warm, push, deferred). Until now no deep link left any trace unless it threw.
- **Capture-phase click interceptor** (native only): raw `a[target=_blank]` anchors with external hrefs (card terms, passkey help, explorers, attachments) route through the in-app browser — `_blank` is a dead tap on iOS and an OS hand-off on Android.
- **`Browser.close()` before navigating** when a deep link arrives while the in-app browser sheet is up (Persona/Bridge KYC return leg; pairs with the api-ts `redirect_uri` change).

### Outbound call sites
| file | change |
|---|---|
| InvitesGraph | `router.push(profileUrl(username))` instead of `window.open('/<user>','_blank')` (dead on iOS, full app reset on Android); explorer/search nodes via `openExternalUrl` |
| AddressLink | `recipientPayUrl` + `target=_blank` only on web |
| PublicProfile guest CTA | `/setup?step=signup` on native — keeps the `resolvedToOwner` cookie guard (deliberately not `inviteFlowUrl`, which writes the cookie unconditionally) |
| QRScannerOverlay | claimed-QR redirect maps through the deep-link mapper (server sends an absolute URL → Safari/iOS, /setup bounce/Android); scheme-less URLs get `https://`; open failures toast |
| utils/capacitor.ts | web `window.open` fallback to `location.assign` — WhatsApp/Instagram in-app browsers block window.open |
| withdraw/manteca | hosted-onboarding widget fallback deleted (0 triggers in 90d; backend route deleted in the api-ts PR); onboarding errors surface an actionable message |

## Counterpart
peanut-api-ts PR (same review, emitter half): withdraw/kyc/charge push links, reserved usernames, Bridge redirect_uri, Manteca onboarding route deletion.

## Ships as
One OTA via the **Release OTA** lane (#2825's scheme once it lands). The AASA/binary changes (review PR-7) are deliberately NOT here — the AASA widening must wait until this OTA is applied in the field (gate on `native_link_received` telemetry).

## Verified
- `tsc --noEmit` clean; prettier run on all touched files; eslint: 0 errors (remaining warnings pre-existing).
- `native-routes.test.ts` 117 tests (new: /pay, /request/pay, bare-origin, static add-money subroutes, web-only-root nulls, AASA drift walk) — one stale test updated: it asserted /add-money/crypto gets dynamically rewritten, which is the exact bug this fixes (the static page exists).
- `useNativeAppLinks.test.tsx`, `PublicProfile.test.tsx`, `post-auth-redirect-consumers.test.tsx`, `peanut-url-routing.test.tsx`, `ClientProviders.test.tsx` green.
- RootRedirect transform syntax-checked standalone.

On-device (with the OTA): scan your own My QR → send screen; tap `/request/pay?id=` → pay screen; log out, tap a receipt push, log in → receipt; tap an invites-graph node → profile; `native_link_received` events with `dropped:false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved native deep-link handling for payments, profiles, requests, and add-money routes.
  - Preserved deep-link destinations through sign-in and setup flows.
  - Added smoother in-app browser handling for external links and push notifications.
  - QR codes now support scheme-less URLs and route supported payment links directly in the app.
  - Native profile, invite, and payment links now use platform-appropriate destinations.

- **Bug Fixes**
  - Prevented duplicate or conflicting redirects during app launch.
  - Improved fallback navigation when external links cannot open normally.
  - Simplified unsupported Manteca onboarding error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->