### PR TITLE
ci: gate main-targeted PRs on human authorship too

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -428,6 +428,110 @@ jobs:
                           });
                       }
 
+    # Human-only authorship gate. Every commit on the PR must be authored by a
+    # repo collaborator's own GitHub account — no `*[bot]` authors (claude[bot],
+    # github-actions[bot], …) and no emails that GitHub cannot map to an
+    # account. Policy set 2026-08-24: AI is a tool, not an owner; every commit
+    # has a human who is accountable for it. Cloud coding sessions that commit
+    # as claude[bot] are exactly what this blocks. Content-publish PRs pass:
+    # update-content.yml authors and signs its commit as a human account.
+    #
+    # No allowlist to maintain: "has write access to this repo" IS the team
+    # roster, and GitHub org/repo access management keeps it current. The
+    # per-user permission endpoint works with the default GITHUB_TOKEN.
+    human-authors:
+        name: human-authors
+        if: github.event_name == 'pull_request'
+        runs-on: ubuntu-latest
+        # The workflow-level permissions block drops pull-requests, and the
+        # commit-listing endpoint 403s without it.
+        permissions:
+            pull-requests: read
+        steps:
+            - name: Verify every commit is authored by a team member
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const memberCache = new Map();
+                      async function hasWriteAccess(login) {
+                        if (memberCache.has(login)) return memberCache.get(login);
+                        let ok = false;
+                        try {
+                          const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            username: login,
+                          });
+                          ok = ['admin', 'maintain', 'write'].includes(data.permission);
+                        } catch (e) {
+                          ok = false;
+                        }
+                        memberCache.set(login, ok);
+                        return ok;
+                      }
+                      // A commit already reachable from `main` or `dev` is permanent: every ref
+                      // carries non_fast_forward + required_signatures with no bypass actors, so it
+                      // can never be rewritten. Judging it a second time only wedges the back-merge
+                      // that carries it — the PR goes red with no branch shape that can clear it.
+                      // Gate new work; the PR that first proposed the commit is where this bites.
+                      const landedCache = new Map();
+                      async function alreadyLanded(sha) {
+                        if (landedCache.has(sha)) return landedCache.get(sha);
+                        let landed = false;
+                        for (const branch of ['main', 'dev']) {
+                          try {
+                            const { data } = await github.rest.repos.compareCommitsWithBasehead({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              basehead: `${branch}...${sha}`,
+                            });
+                            if (data.status === 'identical' || data.status === 'behind') {
+                              landed = true;
+                              break;
+                            }
+                          } catch (e) {
+                            // Missing branch or unrelated history — not an exemption.
+                          }
+                        }
+                        landedCache.set(sha, landed);
+                        return landed;
+                      }
+                      const commits = await github.paginate(github.rest.pulls.listCommits, {
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        pull_number: context.payload.pull_request.number,
+                        per_page: 100,
+                      });
+                      const bad = [];
+                      const landed = [];
+                      for (const c of commits) {
+                        const sha = c.sha.slice(0, 7);
+                        const login = c.author && c.author.login;
+                        const email = (c.commit.author && c.commit.author.email) || 'unknown';
+                        let problem = null;
+                        if (!login) {
+                          problem = `author email <${email}> is not linked to a GitHub account — commit from your own account (git config user.email must be an email verified on your GitHub profile)`;
+                        } else if (login.endsWith('[bot]')) {
+                          problem = `authored by ${login} — bot-authored commits are not allowed; commit as yourself`;
+                        } else if (!(await hasWriteAccess(login))) {
+                          problem = `authored by ${login}, who has no write access to this repo`;
+                        }
+                        if (!problem) continue;
+                        if (await alreadyLanded(c.sha)) {
+                          landed.push(`${sha}: ${problem}`);
+                          continue;
+                        }
+                        bad.push(`${sha}: ${problem}`);
+                      }
+                      if (landed.length) {
+                        core.warning(`Already merged to main/dev, so not judged again:\n${landed.join('\n')}`);
+                      }
+                      if (bad.length) {
+                        core.setFailed(`Commits must be authored by a team member:\n${bad.join('\n')}`);
+                      } else {
+                        console.log(`✅ All ${commits.length} commits are authored by team members`);
+                      }
+
     # Single umbrella check that aggregates all required test/quality jobs.
     # Branch protection on `dev`/`main` requires only `ci-success` instead of
     # listing every individual job — keeps the ruleset stable as jobs are
@@ -439,7 +543,7 @@ jobs:
     ci-success:
         name: ci-success
         if: always()
-        needs: [format, eslint, typecheck, unit, e2e, report]
+        needs: [format, eslint, typecheck, unit, e2e, report, human-authors]
         runs-on: ubuntu-latest
         steps:
             - name: Verify all required jobs passed
@@ -453,6 +557,7 @@ jobs:
                       echo "  unit:      ${{ needs.unit.result }}"
                       echo "  e2e:       ${{ needs.e2e.result }}"
                       echo "  report:    ${{ needs.report.result }}"
+                      echo "  human-authors: ${{ needs['human-authors'].result }}"
                       exit 1
                   fi
                   echo "✅ All required jobs passed"


### PR DESCRIPTION
## Why

`human-authors` was added on `dev` and has not reached `main` yet, so **every PR based on `main` runs without it**. That is not a theoretical gap — it is exactly how the current mess happened:

- #2823 (base `main`) carried `aa6db97` — `chore: retrigger OTA build`, an empty commit authored by `chip-peanut-bot[bot]`. Ungated, so it merged.
- `aa6db97` is now an ancestor of `main` and can never be rewritten (`non_fast_forward` + `required_signatures` on `refs/heads/**`, zero bypass actors).
- Every back-merge lists it, so [#2830](https://github.com/peanutprotocol/peanut-ui/pull/2830) is red and unmergeable. [#2839](https://github.com/peanutprotocol/peanut-ui/pull/2839) fixes that end (stop re-judging commits that already landed); **this PR closes the door it came through**.

## What

The same job, with the same script as `dev` has after #2839 — byte-identical text in the same position, so the next `dev` → `main` release merges it as the same change rather than a conflict. Added to `ci-success.needs` so it actually gates.

## Effect on open `main` PRs

I checked every one. Only [#2829](https://github.com/peanutprotocol/peanut-ui/pull/2829) fails: its single commit `4d393a7` is authored by `chip-peanut-bot[bot]`. That is the gate doing its job — the fix is to re-commit that one-line change from a human account. Everything else (#2833, #2835, #2836) is human-authored and unaffected.

The content pipeline is unaffected: `update-content.yml` commits as `Hugo Montenegro <h@hugomontenegro.com>`, a real account, so content-publish PRs pass and merge-on-green keeps working.

Depends on nothing — but merge #2839 first if you want the two files to converge cleanly.