### PR TITLE
ci: dispatch trusted PR reviews to Chip on dev

### DIFF
--- a/.github/workflows/chip-pr-review.yml
+++ b/.github/workflows/chip-pr-review.yml
@@ -1,4 +1,12 @@
 # Trusted event bridge. It never checks out PR code or forwards PR text.
+#
+# Only pull_request_target and issue_comment may live here. Both resolve their
+# workflow file from a branch a PR author cannot write: the PR base, and the
+# repository default branch. pull_request_review does NOT -- GitHub runs it
+# from the PR head, so any branch could execute its own workflow with
+# CHIP_PR_REVIEW_SSH_KEY in scope, and CodeRabbit raises that event on every
+# PR. Do not add pull_request_review, workflow_run, or any other trigger
+# without confirming which ref supplies the file.
 name: Chip PR review
 
 on:
@@ -7,8 +15,6 @@ on:
         types: [opened, reopened, synchronize, ready_for_review]
     issue_comment:
         types: [created]
-    pull_request_review:
-        types: [submitted]
 
 permissions: {}
 
@@ -61,27 +67,3 @@ jobs:
                   ssh -i "$RUNNER_TEMP/chip-pr-review" \
                     -o IdentitiesOnly=yes -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
                     chip@195.201.2.135 "manual $REPOSITORY $PULL_REQUEST $COMMENT_ID $SOURCE_ID"
-
-    notify-human-review:
-        if: >-
-            github.event_name == 'pull_request_review' &&
-            contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev"]'), github.event.review.user.login) &&
-            contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev","chip-peanut-bot[bot]"]'), github.event.pull_request.user.login)
-        runs-on: ubuntu-latest
-        timeout-minutes: 2
-        steps:
-            - name: Notify the author that a human reviewed
-              env:
-                  SSH_KEY: ${{ secrets.CHIP_PR_REVIEW_SSH_KEY }}
-                  KNOWN_HOSTS: ${{ secrets.CHIP_PR_REVIEW_KNOWN_HOSTS }}
-                  REPOSITORY: ${{ github.event.repository.name }}
-                  PULL_REQUEST: ${{ github.event.pull_request.number }}
-                  REVIEW_ID: ${{ github.event.review.id }}
-                  SOURCE_ID: ${{ github.run_id }}
-              run: |
-                  umask 077
-                  printf '%s\n' "$SSH_KEY" > "$RUNNER_TEMP/chip-pr-review"
-                  printf '%s\n' "$KNOWN_HOSTS" > "$RUNNER_TEMP/known_hosts"
-                  ssh -i "$RUNNER_TEMP/chip-pr-review" \
-                    -o IdentitiesOnly=yes -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
-                    chip@195.201.2.135 "human-review $REPOSITORY $PULL_REQUEST $REVIEW_ID $SOURCE_ID"

--- a/.github/workflows/chip-pr-review.yml
+++ b/.github/workflows/chip-pr-review.yml
@@ -1,0 +1,87 @@
+# Trusted event bridge. It never checks out PR code or forwards PR text.
+name: Chip PR review
+
+on:
+    pull_request_target:
+        branches: [main, dev]
+        types: [opened, reopened, synchronize, ready_for_review]
+    issue_comment:
+        types: [created]
+    pull_request_review:
+        types: [submitted]
+
+permissions: {}
+
+jobs:
+    review:
+        if: >-
+            github.event_name == 'pull_request_target' &&
+            contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev","chip-peanut-bot[bot]"]'), github.event.pull_request.user.login)
+        runs-on: ubuntu-latest
+        timeout-minutes: 2
+        steps:
+            - name: Dispatch trusted PR head
+              env:
+                  SSH_KEY: ${{ secrets.CHIP_PR_REVIEW_SSH_KEY }}
+                  KNOWN_HOSTS: ${{ secrets.CHIP_PR_REVIEW_KNOWN_HOSTS }}
+                  REPOSITORY: ${{ github.event.repository.name }}
+                  PULL_REQUEST: ${{ github.event.pull_request.number }}
+                  ACTION: ${{ github.event.action }}
+                  SOURCE_ID: ${{ github.run_id }}
+              run: |
+                  umask 077
+                  printf '%s\n' "$SSH_KEY" > "$RUNNER_TEMP/chip-pr-review"
+                  printf '%s\n' "$KNOWN_HOSTS" > "$RUNNER_TEMP/known_hosts"
+                  ssh -i "$RUNNER_TEMP/chip-pr-review" \
+                    -o IdentitiesOnly=yes -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
+                    chip@195.201.2.135 "review $REPOSITORY $PULL_REQUEST $ACTION $SOURCE_ID"
+
+    manual:
+        if: >-
+            github.event_name == 'issue_comment' &&
+            github.event.issue.pull_request &&
+            contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev"]'), github.event.comment.user.login) &&
+            contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev","chip-peanut-bot[bot]"]'), github.event.issue.user.login) &&
+            (contains(github.event.comment.body, '/chip review') || contains(github.event.comment.body, '@chip-peanut-bot review'))
+        runs-on: ubuntu-latest
+        timeout-minutes: 2
+        steps:
+            - name: Dispatch trusted manual review
+              env:
+                  SSH_KEY: ${{ secrets.CHIP_PR_REVIEW_SSH_KEY }}
+                  KNOWN_HOSTS: ${{ secrets.CHIP_PR_REVIEW_KNOWN_HOSTS }}
+                  REPOSITORY: ${{ github.event.repository.name }}
+                  PULL_REQUEST: ${{ github.event.issue.number }}
+                  COMMENT_ID: ${{ github.event.comment.id }}
+                  SOURCE_ID: ${{ github.run_id }}
+              run: |
+                  umask 077
+                  printf '%s\n' "$SSH_KEY" > "$RUNNER_TEMP/chip-pr-review"
+                  printf '%s\n' "$KNOWN_HOSTS" > "$RUNNER_TEMP/known_hosts"
+                  ssh -i "$RUNNER_TEMP/chip-pr-review" \
+                    -o IdentitiesOnly=yes -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
+                    chip@195.201.2.135 "manual $REPOSITORY $PULL_REQUEST $COMMENT_ID $SOURCE_ID"
+
+    notify-human-review:
+        if: >-
+            github.event_name == 'pull_request_review' &&
+            contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev"]'), github.event.review.user.login) &&
+            contains(fromJSON('["Hugo0","jjramirezn","kushagrasarathe","abalinda","0xkkonrad","innolope-dev","chip-peanut-bot[bot]"]'), github.event.pull_request.user.login)
+        runs-on: ubuntu-latest
+        timeout-minutes: 2
+        steps:
+            - name: Notify the author that a human reviewed
+              env:
+                  SSH_KEY: ${{ secrets.CHIP_PR_REVIEW_SSH_KEY }}
+                  KNOWN_HOSTS: ${{ secrets.CHIP_PR_REVIEW_KNOWN_HOSTS }}
+                  REPOSITORY: ${{ github.event.repository.name }}
+                  PULL_REQUEST: ${{ github.event.pull_request.number }}
+                  REVIEW_ID: ${{ github.event.review.id }}
+                  SOURCE_ID: ${{ github.run_id }}
+              run: |
+                  umask 077
+                  printf '%s\n' "$SSH_KEY" > "$RUNNER_TEMP/chip-pr-review"
+                  printf '%s\n' "$KNOWN_HOSTS" > "$RUNNER_TEMP/known_hosts"
+                  ssh -i "$RUNNER_TEMP/chip-pr-review" \
+                    -o IdentitiesOnly=yes -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
+                    chip@195.201.2.135 "human-review $REPOSITORY $PULL_REQUEST $REVIEW_ID $SOURCE_ID"


### PR DESCRIPTION
## Summary

`pull_request_target` reads its workflow from the **base branch** of the PR. The copy going to `main` therefore only covers `main`-targeted PRs. Nearly all work targets `dev`, so `dev` needs the same bridge or it gets no AI review at all.

Identical to the canonical file in mono (`ops/schedulers/pr-review/chip-pr-review.yml`), verified by `PR_REVIEW_CHECK_DEPLOYED=1 node --test`.

## Why this is safe

- `permissions: {}` — the job holds no GitHub token.
- It never checks out PR code and never forwards PR title, body, or comment text. Only the repository name, PR number and event ids cross the SSH bridge.
- The dispatcher on chip re-verifies the author against an explicit allowlist **and** live repository permission before any review starts.
- Chip never approves. On `dev` it always comments, so it cannot block a green merge.

## Task

Follow-up to the Chip PR review rollout.

https://claude.ai/code/session_01TYXiBavHf8unVNbn2pbhg6