### PR TITLE
ci: fix a folded-scalar newline that disabled the Chip bridge

### DIFF
--- a/.github/workflows/chip-pr-review.yml
+++ b/.github/workflows/chip-pr-review.yml
@@ -34,10 +34,9 @@ permissions: {}
 jobs:
     review:
         if: >-
-            github.event_name == 'pull_request_target' && (
-              contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
-              github.event.pull_request.user.login == 'chip-peanut-bot[bot]'
-            )
+            github.event_name == 'pull_request_target' &&
+            (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+            || github.event.pull_request.user.login == 'chip-peanut-bot[bot]')
         runs-on: ubuntu-latest
         timeout-minutes: 2
         steps:
@@ -61,10 +60,9 @@ jobs:
         if: >-
             github.event_name == 'issue_comment' &&
             github.event.issue.pull_request &&
-            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && (
-              contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) ||
-              github.event.issue.user.login == 'chip-peanut-bot[bot]'
-            ) &&
+            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+            (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+            || github.event.issue.user.login == 'chip-peanut-bot[bot]') &&
             (contains(github.event.comment.body, '/chip review') || contains(github.event.comment.body, '@chip-peanut-bot review'))
         runs-on: ubuntu-latest
         timeout-minutes: 2


### PR DESCRIPTION
## Summary

The first live `pull_request_target` events fired and concluded **skipped** for a `MEMBER` author the filter names explicitly.

YAML folds a `>-` block into one line only for lines sitting at the block indentation. The continuation lines were indented two spaces further, so YAML kept their newlines and GitHub evaluated an expression containing raw newlines — which is false.

## Why it was invisible

A false condition reports the job as `skipped`. That is exactly what a correctly filtered drive-by PR reports, so the bridge looked healthy while reviewing nothing.

No unit test could see it — every string the tests assert on was present and correct. Only opening a real PR surfaced it. `ops/schedulers/pr-review/test.mjs` now walks each `if: >-` block and fails on any line indented past the fold; verified by reintroducing the fault.

https://claude.ai/code/session_01TYXiBavHf8unVNbn2pbhg6