### PR TITLE
ci: keep a passer-by from dispatching a manual Chip review

### DIFF
--- a/.github/workflows/chip-pr-review.yml
+++ b/.github/workflows/chip-pr-review.yml
@@ -67,7 +67,7 @@ jobs:
         if: >-
             github.event_name == 'issue_comment' &&
             github.event.issue.pull_request &&
-            !contains(fromJSON('["NONE","MANNEQUIN"]'), github.event.comment.author_association) &&
+            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.comment.author_association) &&
             (contains(github.event.comment.body, '/chip review') || contains(github.event.comment.body, '@chip-peanut-bot review'))
         runs-on: ubuntu-latest
         timeout-minutes: 2

--- a/.github/workflows/chip-pr-review.yml
+++ b/.github/workflows/chip-pr-review.yml
@@ -67,6 +67,7 @@ jobs:
         if: >-
             github.event_name == 'issue_comment' &&
             github.event.issue.pull_request &&
+            !contains(fromJSON('["NONE","MANNEQUIN"]'), github.event.comment.author_association) &&
             (contains(github.event.comment.body, '/chip review') || contains(github.event.comment.body, '@chip-peanut-bot review'))
         runs-on: ubuntu-latest
         timeout-minutes: 2


### PR DESCRIPTION
## Summary

Follow-up to #1443 / #2846.

Dropping the association gate on the manual job left `/chip review` open to anyone on the public repo: type it and an SSH session opens, three GitHub calls run, and the dispatcher then refuses. Cheap per attempt, free to repeat.

It now excludes `NONE` and `MANNEQUIN` — the two values that mean pure stranger.

It deliberately still admits `CONTRIBUTOR`, because that is what an org admin with **private** org membership reads as. That is the exact trap that silently skipped their reviews earlier today, so the guard must never be used to decide trust.

Live repository write permission still decides that, server side.

https://claude.ai/code/session_01TYXiBavHf8unVNbn2pbhg6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted manual pull request reviews to comments from approved repository contributors, improving review workflow security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->