### PR TITLE
fix(native): stop the Android splash handoff crashing on a resumed launch

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -73,6 +73,16 @@ const config: CapacitorConfig = {
              * effect on the next store release, not via OTA.
              */
             launchAutoHide: false,
+            /*
+             * 0 disables the plugin's fade-out, which is what stops it calling
+             * setOnExitAnimationListener. That listener makes Android hand the
+             * system starting window over to our process, and a background/
+             * resume mid-launch leaves the handoff with a released leash —
+             * SurfaceControl.Transaction.hide(null) crashes the app on the next
+             * frame (PEANUT-UI-SVN). Without it the system tears its own splash
+             * down. Android-only key; iOS ignores it.
+             */
+            launchFadeOutDuration: 0,
         },
     },
 }

--- a/src/hooks/__tests__/useSplashGate.test.tsx
+++ b/src/hooks/__tests__/useSplashGate.test.tsx
@@ -61,6 +61,38 @@ describe('useSplashGate', () => {
         expect(removeListener).toHaveBeenCalledTimes(1)
     })
 
+    // The listener has to be live before the state is read: appStateChange is
+    // never replayed, so a resume in that gap would park the splash forever
+    // (splashHidden is already set, so the hard timeout cannot retry).
+    it('does not miss a resume that lands while the state read is in flight', async () => {
+        const { App } = jest.requireMock('@capacitor/app')
+        let releaseState!: (state: { isActive: boolean }) => void
+        App.getState.mockImplementationOnce(
+            () => new Promise<{ isActive: boolean }>((resolve) => (releaseState = resolve))
+        )
+
+        renderHook(() => useSplashGate())
+
+        await waitFor(() => expect(emitState).toBeDefined())
+        await act(async () => {
+            emitState!({ isActive: true })
+            releaseState({ isActive: false })
+        })
+
+        await waitFor(() => expect(hide).toHaveBeenCalledTimes(1))
+        expect(removeListener).toHaveBeenCalledTimes(1)
+    })
+
+    it('gives up on the wait when the listener cannot be registered', async () => {
+        isActive = false
+        const { App } = jest.requireMock('@capacitor/app')
+        App.addListener.mockRejectedValueOnce(new Error('not implemented'))
+
+        renderHook(() => useSplashGate())
+
+        await waitFor(() => expect(hide).toHaveBeenCalledTimes(1))
+    })
+
     it('still hides when the app plugin is unavailable', async () => {
         const { App } = jest.requireMock('@capacitor/app')
         App.getState.mockRejectedValueOnce(new Error('not implemented'))

--- a/src/hooks/__tests__/useSplashGate.test.tsx
+++ b/src/hooks/__tests__/useSplashGate.test.tsx
@@ -14,7 +14,7 @@ const hide = jest.fn(() => Promise.resolve())
 jest.mock('@capacitor/splash-screen', () => ({ SplashScreen: { hide: () => hide() } }))
 
 let isActive = true
-const removeListener = jest.fn()
+const removeListener = jest.fn(() => Promise.resolve())
 let emitState: ((state: { isActive: boolean }) => void) | undefined
 jest.mock('@capacitor/app', () => ({
     App: {
@@ -26,11 +26,18 @@ jest.mock('@capacitor/app', () => ({
     },
 }))
 
+let warn: jest.SpyInstance
+
 beforeEach(() => {
     jest.clearAllMocks()
     resetSplashGateForTests()
     isActive = true
     emitState = undefined
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+    warn.mockRestore()
 })
 
 describe('useSplashGate', () => {
@@ -38,6 +45,7 @@ describe('useSplashGate', () => {
         renderHook(() => useSplashGate())
 
         await waitFor(() => expect(hide).toHaveBeenCalledTimes(1))
+        expect(warn).not.toHaveBeenCalled()
     })
 
     it('defers the hide while the app is backgrounded and fires it on resume', async () => {
@@ -59,6 +67,7 @@ describe('useSplashGate', () => {
         })
         await waitFor(() => expect(hide).toHaveBeenCalledTimes(1))
         expect(removeListener).toHaveBeenCalledTimes(1)
+        expect(warn).not.toHaveBeenCalled()
     })
 
     // The listener has to be live before the state is read: appStateChange is
@@ -81,6 +90,7 @@ describe('useSplashGate', () => {
 
         await waitFor(() => expect(hide).toHaveBeenCalledTimes(1))
         expect(removeListener).toHaveBeenCalledTimes(1)
+        expect(warn).not.toHaveBeenCalled()
     })
 
     it('gives up on the wait when the listener cannot be registered', async () => {

--- a/src/hooks/__tests__/useSplashGate.test.tsx
+++ b/src/hooks/__tests__/useSplashGate.test.tsx
@@ -1,0 +1,72 @@
+// PEANUT-UI-SVN: hiding the splash while the activity is backgrounded runs the
+// Android splash teardown against a window that is released by the time the app
+// resumes and draws, crashing the process. The hide must park until active.
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useSplashGate, resetSplashGateForTests } from '../useSplashGate'
+
+jest.mock('next/navigation', () => ({ usePathname: () => '/home' }))
+
+jest.mock('@/utils/capacitor', () => ({ isCapacitor: jest.fn(() => true) }))
+
+jest.mock('@/i18n/app/locale-store', () => ({ localeApplied: jest.fn(() => Promise.resolve()) }))
+
+const hide = jest.fn(() => Promise.resolve())
+jest.mock('@capacitor/splash-screen', () => ({ SplashScreen: { hide: () => hide() } }))
+
+let isActive = true
+const removeListener = jest.fn()
+let emitState: ((state: { isActive: boolean }) => void) | undefined
+jest.mock('@capacitor/app', () => ({
+    App: {
+        getState: jest.fn(() => Promise.resolve({ isActive })),
+        addListener: jest.fn((_event: string, cb: (state: { isActive: boolean }) => void) => {
+            emitState = cb
+            return Promise.resolve({ remove: removeListener })
+        }),
+    },
+}))
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    resetSplashGateForTests()
+    isActive = true
+    emitState = undefined
+})
+
+describe('useSplashGate', () => {
+    it('hides the splash once the locale is painted', async () => {
+        renderHook(() => useSplashGate())
+
+        await waitFor(() => expect(hide).toHaveBeenCalledTimes(1))
+    })
+
+    it('defers the hide while the app is backgrounded and fires it on resume', async () => {
+        isActive = false
+
+        renderHook(() => useSplashGate())
+
+        await waitFor(() => expect(emitState).toBeDefined())
+        expect(hide).not.toHaveBeenCalled()
+
+        // a second background event must not release the parked hide
+        await act(async () => {
+            emitState!({ isActive: false })
+        })
+        expect(hide).not.toHaveBeenCalled()
+
+        await act(async () => {
+            emitState!({ isActive: true })
+        })
+        await waitFor(() => expect(hide).toHaveBeenCalledTimes(1))
+        expect(removeListener).toHaveBeenCalledTimes(1)
+    })
+
+    it('still hides when the app plugin is unavailable', async () => {
+        const { App } = jest.requireMock('@capacitor/app')
+        App.getState.mockRejectedValueOnce(new Error('not implemented'))
+
+        renderHook(() => useSplashGate())
+
+        await waitFor(() => expect(hide).toHaveBeenCalledTimes(1))
+    })
+})

--- a/src/hooks/useSplashGate.ts
+++ b/src/hooks/useSplashGate.ts
@@ -23,15 +23,45 @@ import { localeApplied } from '@/i18n/app/locale-store'
 let splashHidden = false
 let hardTimeoutArmed = false
 
+/*
+ * hide() unblocks the first frame, and on Android that frame is what runs the
+ * system splash-screen teardown. Running it while the activity is backgrounded
+ * hands the teardown a window that is gone by the time the app resumes and
+ * actually draws, which crashed the process (PEANUT-UI-SVN, one Android 13
+ * cold start backgrounded ~2s in and resumed 15s later). Park until the app is
+ * foregrounded; a splash nobody can see is not worth a crash.
+ */
+async function whenActive(): Promise<void> {
+    const { App } = await import('@capacitor/app')
+    if ((await App.getState()).isActive) return
+    await new Promise<void>((resolve) => {
+        const handle = App.addListener('appStateChange', ({ isActive }: { isActive: boolean }) => {
+            if (!isActive) return
+            void handle.then((listener) => listener.remove())
+            resolve()
+        })
+    })
+}
+
 async function hideSplash() {
     if (splashHidden) return
     splashHidden = true
+    try {
+        await whenActive()
+    } catch (e) {
+        console.warn('failed to read native app state:', e)
+    }
     try {
         const { SplashScreen } = await import('@capacitor/splash-screen')
         await SplashScreen.hide()
     } catch (e) {
         console.warn('failed to hide splash screen:', e)
     }
+}
+
+export function resetSplashGateForTests() {
+    splashHidden = false
+    hardTimeoutArmed = false
 }
 
 export function useSplashGate() {

--- a/src/hooks/useSplashGate.ts
+++ b/src/hooks/useSplashGate.ts
@@ -33,14 +33,24 @@ let hardTimeoutArmed = false
  */
 async function whenActive(): Promise<void> {
     const { App } = await import('@capacitor/app')
-    if ((await App.getState()).isActive) return
-    await new Promise<void>((resolve) => {
-        const handle = App.addListener('appStateChange', ({ isActive }: { isActive: boolean }) => {
-            if (!isActive) return
-            void handle.then((listener) => listener.remove())
-            resolve()
-        })
+
+    let resumed!: () => void
+    const nextResume = new Promise<void>((resolve) => {
+        resumed = resolve
     })
+
+    // Listener first, state read second: appStateChange is never replayed, so a
+    // resume landing between a false read and the registration would park the
+    // splash for the rest of the launch.
+    const listener = await App.addListener('appStateChange', ({ isActive }: { isActive: boolean }) => {
+        if (isActive) resumed()
+    })
+    try {
+        if ((await App.getState()).isActive) return
+        await nextResume
+    } finally {
+        await listener.remove().catch(() => {})
+    }
 }
 
 async function hideSplash() {
@@ -59,12 +69,12 @@ async function hideSplash() {
     }
 }
 
-export function resetSplashGateForTests() {
+export function resetSplashGateForTests(): void {
     splashHidden = false
     hardTimeoutArmed = false
 }
 
-export function useSplashGate() {
+export function useSplashGate(): void {
     const pathname = usePathname()
 
     useEffect(() => {


### PR DESCRIPTION
Notion: TASK-21935 · Sentry: [PEANUT-UI-SVN](https://peanut-c34d84c05.sentry.io/issues/PEANUT-UI-SVN)

## The issue is real, and reproducible from the config

One fatal event on `me.peanut.wallet@1.0.53+10047` (Realme RMX3286, Android 13). Cold start 09:29:01Z → backgrounded ~2s in → resumed 09:29:16Z → crash 112 ms later, on the first frame after resume:

```
ViewRootImpl.draw
  ViewTreeObserver.dispatchOnDraw
    ActivityThread$1.onDraw
      ActivityThread.syncTransferSplashscreenViewTransaction
        SurfaceControl$Transaction.hide  → checkNotReleased() on null
```

`ActivityThread$1.onDraw` → `syncTransferSplashscreenViewTransaction` is the **splash-view handoff** path: the system only transfers its starting window into the app process when the app has registered a `SplashScreen.OnExitAnimationListener`. Otherwise the system tears its own starting window down and this code never runs.

We register one. `@capacitor/splash-screen`'s Android 12 path does:

```java
if (config.getLaunchFadeOutDuration() > 0) {
    windowSplashScreen.setOnExitAnimationListener(...)   // ← the handoff
}
```

`launchFadeOutDuration` defaults to **200** and `capacitor.config.ts` never set it, so the listener was always registered. The `> 0` guard is upstream's own mitigation for this exact crash ([capacitor-plugins#1856](https://github.com/ionic-team/capacitor-plugins/issues/1856) / [#2083](https://github.com/ionic-team/capacitor-plugins/pull/2083)) — we shipped the plugin version that has it but never turned it on.

Timeline fits exactly: `hide()` (or the 3s hard timeout in `useSplashGate`) fired while backgrounded and removed the pre-draw gate; the activity couldn't draw; on resume 13s later the first frame ran the handoff against a leash the system had long since released.

## Changes

**`capacitor.config.ts` — `launchFadeOutDuration: 0`.** The structural fix: no exit-animation listener, no handoff, the crashing frame is unreachable. Android-only key (iOS never reads it). The visual cost is the plugin's 200ms fade; the system's own splash exit transition replaces it, and `backgroundColor` already matches the app shell.

**`useSplashGate.ts` — park `hide()` until the app is active.** Belt-and-braces, and the half that ships via OTA rather than waiting on a store release. `App.getState()`; if backgrounded, wait for the next `appStateChange` with `isActive: true`, then hide. A failing/absent App plugin falls through and hides immediately, so the splash can't wedge.

## Test

`src/hooks/__tests__/useSplashGate.test.tsx` — hides on the happy path, defers while backgrounded and fires on resume (verified failing with the deferral removed), and still hides when the App plugin rejects.

## Rollout

`launchFadeOutDuration` is baked in at `cap sync`, so it lands with the next store release, not via OTA. Ordering is safe either way here: the JS half is independently correct, and per the existing `launchAutoHide` note JS-first is always the safe direction.

Not covered: on-device regression on Realme/Oppo/OnePlus-class hardware (DoD item 3) — worth running against the next TestFlight/Play build, since the failure is device- and timing-specific and no local emulator reproduces it reliably.