### PR TITLE
fix(qr-scanner): keep the start attempt alive while camera permission is pending

### DIFF
--- a/src/components/Global/QRScanner/__tests__/useQRScanner.test.ts
+++ b/src/components/Global/QRScanner/__tests__/useQRScanner.test.ts
@@ -10,6 +10,7 @@ import { useQRScanner } from '../useQRScanner'
 let onDecode: (result: { data: string }) => void
 let startBehaviour: () => Promise<void> = () => Promise.resolve()
 let startCalls = 0
+let destroyCalls = 0
 let attachStream = true
 let lastOptions: { preferredCamera?: unknown } = {}
 
@@ -44,7 +45,9 @@ jest.mock('qr-scanner', () => ({
             this.active = false
             this.video.srcObject = null
         })
-        destroy = jest.fn()
+        destroy = jest.fn(() => {
+            destroyCalls++
+        })
         setCamera = jest.fn()
         setInversionMode = jest.fn()
     },
@@ -53,11 +56,15 @@ jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }))
 jest.mock('@/components/0_Bruddle/Toast', () => ({
     useToast: () => ({ error: jest.fn(), info: jest.fn() }),
 }))
+// jest hoists these factories, so the switches they read must be `mock`-prefixed
+let mockDeviceType = 'web'
+let mockCapacitor = false
 jest.mock('@/hooks/useGetDeviceType', () => ({
-    useDeviceType: () => ({ deviceType: 'web' }),
+    useDeviceType: () => ({ deviceType: mockDeviceType }),
     DeviceType: { IOS: 'ios' },
 }))
-jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => false }))
+jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => mockCapacitor }))
+jest.mock('@/utils/camera-permission', () => ({ ensureNativeCameraPermission: jest.fn(async () => true) }))
 jest.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }))
 
 // jsdom implements neither, and the hook's cleanup calls both on unmount
@@ -221,5 +228,188 @@ describe('resume after backgrounding (TASK-21862)', () => {
 
         // a MouseEvent here becomes qr-scanner's deviceId {exact: ...}
         expect(lastOptions.preferredCamera).toBe('environment')
+    })
+})
+
+describe('permission still pending at the deadline (TASK-21927)', () => {
+    const IOS_CAMERA_DELAY_MS = 200
+    const VIDEO_ELEMENT_RETRY_DELAY_MS = 100
+    const CAMERA_START_TIMEOUT_MS = 5000
+
+    type VideoRef = React.MutableRefObject<HTMLVideoElement | null>
+
+    let settleStart: { resolve: () => void; reject: (err: unknown) => void }
+
+    function setHidden(hidden: boolean): void {
+        Object.defineProperty(document, 'hidden', { value: hidden, configurable: true })
+        document.dispatchEvent(new Event('visibilitychange'))
+    }
+
+    /*
+     * Mounts an iOS scanner whose getUserMedia is still outstanding. The video
+     * element retry (100ms) and the iOS hardware-settle delay (200ms) both have
+     * to drain before the library's start() is even called.
+     */
+    async function mountPendingStart() {
+        startBehaviour = () =>
+            new Promise<void>((resolve, reject) => {
+                settleStart = { resolve, reject }
+            })
+        const { result } = renderHook(() => useQRScanner(jest.fn(), undefined, true))
+        const videoRef = result.current.videoRef as VideoRef
+        videoRef.current = document.createElement('video')
+        await act(async () => {
+            jest.advanceTimersByTime(VIDEO_ELEMENT_RETRY_DELAY_MS)
+        })
+        await act(async () => {
+            jest.advanceTimersByTime(IOS_CAMERA_DELAY_MS)
+        })
+        return { result, videoRef }
+    }
+
+    // The permission modal owns the whole screen, so React unmounts the <video>
+    // the pending scanner is bound to — and remounts a fresh one the moment the
+    // modal clears. That swap is why recovery has to restart the camera.
+    const unmountVideo = (videoRef: VideoRef) => {
+        videoRef.current = null
+    }
+    const remountVideo = (videoRef: VideoRef) => {
+        videoRef.current = document.createElement('video')
+    }
+
+    async function drainRebuild(videoRef: VideoRef) {
+        remountVideo(videoRef)
+        await act(async () => {
+            jest.advanceTimersByTime(VIDEO_ELEMENT_RETRY_DELAY_MS)
+        })
+        await act(async () => {
+            jest.advanceTimersByTime(IOS_CAMERA_DELAY_MS)
+        })
+    }
+
+    beforeEach(() => {
+        jest.useFakeTimers()
+        mockDeviceType = 'ios'
+        startCalls = 0
+        destroyCalls = 0
+        attachStream = true
+    })
+
+    afterEach(() => {
+        jest.useRealTimers()
+        Object.defineProperty(document, 'hidden', { value: false, configurable: true })
+        mockDeviceType = 'web'
+        mockCapacitor = false
+        startBehaviour = () => Promise.resolve()
+        attachStream = true
+    })
+
+    it('the deadline shows the permission modal without ending the attempt', async () => {
+        const { result } = await mountPendingStart()
+        const teardowns = destroyCalls
+
+        await act(async () => {
+            jest.advanceTimersByTime(CAMERA_START_TIMEOUT_MS)
+        })
+
+        expect(result.current.isPermissionDenied).toBe(true)
+        expect(result.current.error).toBe('qrScanner.cameraPermissionDenied')
+        // the pre-fix deadline destroyed the scanner here, throwing away a grant
+        // that was still one tap away
+        expect(destroyCalls).toBe(teardowns)
+    })
+
+    it('a grant that lands after the deadline brings the camera up on its own', async () => {
+        const { result, videoRef } = await mountPendingStart()
+
+        await act(async () => {
+            jest.advanceTimersByTime(CAMERA_START_TIMEOUT_MS)
+        })
+        expect(result.current.isPermissionDenied).toBe(true)
+        unmountVideo(videoRef)
+
+        // the user finally taps Allow, 5s late — the production specimen took 2m43s
+        startBehaviour = () => Promise.resolve()
+        await act(async () => {
+            settleStart.resolve()
+        })
+        await drainRebuild(videoRef)
+
+        expect(result.current.isPermissionDenied).toBe(false)
+        expect(result.current.error).toBeNull()
+        expect(result.current.isCameraReady).toBe(true)
+    })
+
+    it('a grant that lands while backgrounded is picked up on the way back', async () => {
+        const { result, videoRef } = await mountPendingStart()
+
+        await act(async () => {
+            jest.advanceTimersByTime(CAMERA_START_TIMEOUT_MS)
+        })
+        unmountVideo(videoRef)
+        await act(async () => setHidden(true))
+
+        startBehaviour = () => Promise.resolve()
+        await act(async () => {
+            settleStart.resolve()
+        })
+        // rebuilding on a hidden document resolves without a stream, so the
+        // modal has to stay up until the visibility listener takes over
+        expect(result.current.isPermissionDenied).toBe(true)
+        expect(result.current.isCameraReady).toBe(false)
+
+        await act(async () => setHidden(false))
+        await drainRebuild(videoRef)
+
+        expect(result.current.isPermissionDenied).toBe(false)
+        expect(result.current.isCameraReady).toBe(true)
+    })
+
+    it('a denial that lands after the deadline stays on the permission modal', async () => {
+        const { result, videoRef } = await mountPendingStart()
+
+        await act(async () => {
+            jest.advanceTimersByTime(CAMERA_START_TIMEOUT_MS)
+        })
+        unmountVideo(videoRef)
+        await act(async () => {
+            settleStart.reject(new DOMException('Permission denied', 'NotAllowedError'))
+        })
+
+        expect(result.current.isPermissionDenied).toBe(true)
+        expect(result.current.error).toBe('qrScanner.cameraPermissionDenied')
+        expect(result.current.isCameraReady).toBe(false)
+    })
+
+    it('a hardware failure that lands after the deadline reports the hardware error', async () => {
+        const { result, videoRef } = await mountPendingStart()
+
+        await act(async () => {
+            jest.advanceTimersByTime(CAMERA_START_TIMEOUT_MS)
+        })
+        unmountVideo(videoRef)
+        await act(async () => {
+            settleStart.reject(new DOMException('Camera not found.', 'NotFoundError'))
+        })
+
+        expect(result.current.isPermissionDenied).toBe(false)
+        expect(result.current.error).toBe('qrScanner.cameraNotFound')
+    })
+
+    it('native keeps waiting on the OS dialog with no deadline at all', async () => {
+        mockCapacitor = true
+        const { result } = await mountPendingStart()
+
+        await act(async () => {
+            jest.advanceTimersByTime(CAMERA_START_TIMEOUT_MS * 4)
+        })
+        // the OS owns this prompt and answers it cleanly, so nothing may pre-empt it
+        expect(result.current.isPermissionDenied).toBe(false)
+        expect(result.current.error).toBeNull()
+
+        await act(async () => {
+            settleStart.resolve()
+        })
+        expect(result.current.isCameraReady).toBe(true)
     })
 })

--- a/src/components/Global/QRScanner/__tests__/useQRScanner.test.ts
+++ b/src/components/Global/QRScanner/__tests__/useQRScanner.test.ts
@@ -372,7 +372,14 @@ describe('permission still pending at the deadline (TASK-21927)', () => {
         expect(result.current.isCameraReady).toBe(true)
     })
 
-    it('a denial that lands after the deadline stays on the permission modal', async () => {
+    /*
+     * The rejection value is qr-scanner's real one, not a DOMException:
+     * _getCameraStream swallows every getUserMedia DOMException in a bare catch
+     * and then throws the bare string 'Camera not found.', whatever actually
+     * went wrong. Anything richer here would be testing a contract the pinned
+     * library never honours.
+     */
+    it('a failure that lands after the deadline leaves the user on the permission modal', async () => {
         const { result, videoRef } = await mountPendingStart()
 
         await act(async () => {
@@ -380,27 +387,12 @@ describe('permission still pending at the deadline (TASK-21927)', () => {
         })
         unmountVideo(videoRef)
         await act(async () => {
-            settleStart.reject(new DOMException('Permission denied', 'NotAllowedError'))
+            settleStart.reject('Camera not found.')
         })
 
         expect(result.current.isPermissionDenied).toBe(true)
         expect(result.current.error).toBe('qrScanner.cameraPermissionDenied')
         expect(result.current.isCameraReady).toBe(false)
-    })
-
-    it('a hardware failure that lands after the deadline reports the hardware error', async () => {
-        const { result, videoRef } = await mountPendingStart()
-
-        await act(async () => {
-            jest.advanceTimersByTime(CAMERA_START_TIMEOUT_MS)
-        })
-        unmountVideo(videoRef)
-        await act(async () => {
-            settleStart.reject(new DOMException('Camera not found.', 'NotFoundError'))
-        })
-
-        expect(result.current.isPermissionDenied).toBe(false)
-        expect(result.current.error).toBe('qrScanner.cameraNotFound')
     })
 
     it('native keeps waiting on the OS dialog with no deadline at all', async () => {

--- a/src/components/Global/QRScanner/__tests__/useQRScanner.test.ts
+++ b/src/components/Global/QRScanner/__tests__/useQRScanner.test.ts
@@ -73,6 +73,13 @@ HTMLMediaElement.prototype.load = jest.fn()
 
 const PIX_PAYLOAD = '00020101021226' + '0014br.gov.bcb.pix' + 'y'.repeat(68)
 
+// Every mount schedules a 100ms element-retry before the <video> exists. Left on
+// a real clock it outlives its own test and fires startCamera into whichever
+// test is running 100ms later, inflating the module-level startCalls there — a
+// ~4% flake in "does not re-enter the camera flow while the error view is up".
+beforeEach(() => jest.useFakeTimers())
+afterEach(() => jest.useRealTimers())
+
 it('camera scan: onScan failure is captured with the qr_scan_processing tag', async () => {
     const error = new Error('routing exploded')
     const onScan = jest.fn().mockRejectedValue(error)
@@ -83,7 +90,7 @@ it('camera scan: onScan failure is captured with the qr_scan_processing tag', as
     const videoRef = result.current.videoRef as React.MutableRefObject<HTMLVideoElement | null>
     videoRef.current = document.createElement('video')
     await act(async () => {
-        await result.current.retryCamera()
+        jest.advanceTimersByTime(100) // CONFIG.VIDEO_ELEMENT_RETRY_DELAY_MS
     })
 
     await act(async () => {

--- a/src/components/Global/QRScanner/useQRScanner.ts
+++ b/src/components/Global/QRScanner/useQRScanner.ts
@@ -83,6 +83,25 @@ const SCANNER_OPTIONS = {
 let lastScan: { data: string; timestamp: number } | null = null
 const SCAN_DEBOUNCE_MS = 1000
 
+/**
+ * Waits on a start attempt without taking ownership of it: 'started' when the
+ * camera came up in time, 'pending' when the deadline won and the attempt is
+ * still outstanding. Rejects with whatever start() rejected with.
+ */
+async function raceStartDeadline(started: Promise<void>): Promise<'started' | 'pending'> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+    try {
+        return await Promise.race([
+            started.then(() => 'started' as const),
+            new Promise<'pending'>((resolve) => {
+                timeoutId = setTimeout(resolve, CONFIG.CAMERA_START_TIMEOUT_MS, 'pending')
+            }),
+        ])
+    } finally {
+        clearTimeout(timeoutId)
+    }
+}
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -295,7 +314,6 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
             const generation = ++startGenRef.current
             const superseded = () => generation !== startGenRef.current
 
-            let startTimeoutId: ReturnType<typeof setTimeout> | undefined
             try {
                 cleanup()
 
@@ -360,14 +378,7 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
                      * adoptPendingStart and lets the permission modal cover the wait.
                      */
                     const started = scanner.start()
-                    const outcome = await Promise.race([
-                        started.then(() => 'started' as const),
-                        new Promise<'pending'>((resolve) => {
-                            startTimeoutId = setTimeout(resolve, CONFIG.CAMERA_START_TIMEOUT_MS, 'pending')
-                        }),
-                    ])
-                    clearTimeout(startTimeoutId)
-                    if (outcome === 'pending') {
+                    if ((await raceStartDeadline(started)) === 'pending') {
                         adoptPendingStart(started, superseded, preferredCamera)
                         return
                     }
@@ -406,7 +417,6 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
                 setIsCameraReady(true)
                 retryCountRef.current = 0
             } catch (err) {
-                clearTimeout(startTimeoutId)
                 cleanup()
                 console.error('Error accessing camera:', toError(err))
 

--- a/src/components/Global/QRScanner/useQRScanner.ts
+++ b/src/components/Global/QRScanner/useQRScanner.ts
@@ -273,13 +273,18 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
                     if (document.hidden) return
                     void startCameraRef.current?.(preferredCamera)
                 })
-                .catch((err: unknown) => {
+                .catch(() => {
+                    /*
+                     * No classification is possible here. qr-scanner 1.4.2
+                     * swallows every getUserMedia DOMException in _getCameraStream
+                     * and rejects start() with the bare string 'Camera not found.',
+                     * so denial, missing hardware and a busy camera are one
+                     * indistinguishable failure by the time it reaches us. The
+                     * modal is already up and is the one state that offers both
+                     * retry and paste, so leave the user on it.
+                     */
                     if (stale()) return
                     cleanup()
-                    const errName = err instanceof Error ? err.name : ''
-                    const isHardware = errName === CAMERA_ERRORS.NOT_FOUND || errName === CAMERA_ERRORS.NOT_READABLE
-                    setIsPermissionDenied(!isHardware)
-                    setError(getErrorMessage(errName, retryCountRef.current))
                 })
 
             setIsPermissionDenied(true)

--- a/src/components/Global/QRScanner/useQRScanner.ts
+++ b/src/components/Global/QRScanner/useQRScanner.ts
@@ -16,8 +16,9 @@ const CONFIG = {
     CAMERA_RETRY_DELAY_MS: 1000,
     MAX_CAMERA_RETRIES: 3,
     IOS_CAMERA_DELAY_MS: 200,
-    // in iOS PWA (WKWebView), getUserMedia can hang forever after denial
-    // instead of rejecting. timeout ensures the permission modal still shows.
+    // How long a web/PWA start() may run before the permission modal takes over
+    // the screen. Not an expiry: the attempt keeps running behind the modal, so
+    // this is only how long the user waits for actionable UI.
     CAMERA_START_TIMEOUT_MS: 5000,
     /*
      * A ceiling, not a fixed rate. qr-scanner drives its loop from
@@ -227,6 +228,47 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
         [t]
     )
 
+    /*
+     * Owns a getUserMedia call that outlived its deadline. The permission modal
+     * goes up so the user is never stranded on a spinner (and keeps the retry
+     * and paste fallbacks), while the attempt keeps running underneath: a user
+     * who was still reading the OS prompt gets the camera the moment they
+     * allow it. The scanner is deliberately NOT torn down here — destroying it
+     * is what threw the pending grant away.
+     *
+     * Recovery restarts rather than adopting the resolved stream: the modal
+     * unmounts the <video> the pending scanner is bound to, so the element the
+     * user would see is a fresh one that needs its own start.
+     */
+    const adoptPendingStart = useCallback(
+        (started: Promise<void>, superseded: () => boolean, preferredCamera: FacingMode) => {
+            const stale = () => superseded() || !isScanningRef.current
+
+            started
+                .then(() => {
+                    if (stale()) return
+                    // qr-scanner resolves start() without a stream while the
+                    // document is hidden, so a rebuild here would swap the
+                    // modal for a false "camera start failed" — the visibility
+                    // listener already owns recovery on the way back
+                    if (document.hidden) return
+                    void startCameraRef.current?.(preferredCamera)
+                })
+                .catch((err: unknown) => {
+                    if (stale()) return
+                    cleanup()
+                    const errName = err instanceof Error ? err.name : ''
+                    const isHardware = errName === CAMERA_ERRORS.NOT_FOUND || errName === CAMERA_ERRORS.NOT_READABLE
+                    setIsPermissionDenied(!isHardware)
+                    setError(getErrorMessage(errName, retryCountRef.current))
+                })
+
+            setIsPermissionDenied(true)
+            setError(getErrorMessage(CAMERA_ERRORS.NOT_ALLOWED, 0))
+        },
+        [cleanup, getErrorMessage]
+    )
+
     const startCamera = useCallback(
         async (preferredCamera: FacingMode = facingMode) => {
             setError(null)
@@ -307,19 +349,28 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
                     // prompt look like a failure (false "Camera start timed out" → retry).
                     await scanner.start()
                 } else {
-                    // iOS PWA (WKWebView) getUserMedia can hang forever after the user
-                    // denies permission instead of rejecting — race a timeout so the
-                    // permission modal still shows.
-                    await Promise.race([
-                        scanner.start(),
-                        new Promise<never>((_, reject) => {
-                            startTimeoutId = setTimeout(
-                                () => reject(new DOMException('Camera start timed out', 'NotAllowedError')),
-                                CONFIG.CAMERA_START_TIMEOUT_MS
-                            )
+                    /*
+                     * iOS PWA (WKWebView) getUserMedia can hang forever after the user
+                     * denies permission instead of rejecting, so a deadline is still
+                     * what puts the permission modal on screen. But that hang is
+                     * indistinguishable from a prompt the user simply has not answered
+                     * yet, and rejecting at five seconds tore down a camera that
+                     * arrived moments later (TASK-21927). So the deadline no longer
+                     * ends the attempt: it hands the still-pending start() to
+                     * adoptPendingStart and lets the permission modal cover the wait.
+                     */
+                    const started = scanner.start()
+                    const outcome = await Promise.race([
+                        started.then(() => 'started' as const),
+                        new Promise<'pending'>((resolve) => {
+                            startTimeoutId = setTimeout(resolve, CONFIG.CAMERA_START_TIMEOUT_MS, 'pending')
                         }),
                     ])
                     clearTimeout(startTimeoutId)
+                    if (outcome === 'pending') {
+                        adoptPendingStart(started, superseded, preferredCamera)
+                        return
+                    }
                 }
 
                 if (superseded() || !isScanningRef.current) return
@@ -382,7 +433,7 @@ export function useQRScanner(onScan: QRScanHandler, onClose: (() => void) | unde
                 }
             }
         },
-        [facingMode, deviceType, cleanup, handleQRScan, getErrorMessage, t]
+        [facingMode, deviceType, cleanup, handleQRScan, getErrorMessage, adoptPendingStart, t]
     )
 
     const toggleCamera = useCallback(async () => {


### PR DESCRIPTION
Closes TASK-21927.

## The bug

The web/PWA camera path races `getUserMedia` against a hard 5-second deadline and, on expiry, destroys the scanner and shows permission-denied.

That deadline exists for a real reason: in an iOS PWA (WKWebView) `getUserMedia` can hang forever after a denial instead of rejecting, and without a deadline the user is stranded on a spinner. But a hang after denial is indistinguishable from a prompt the user simply has not answered yet — so the same timeout also tore down cameras that were one tap away.

- 30-day production class: **251 events across 178 users**.
- Monitor specimen (2026-08-26): one iOS PWA user hit `NotAllowedError: Camera start timed out` at 18:19:27Z, then scanned four QR codes from 18:22:10Z. `$0` moved, lost, held or stuck — it is a UX failure, not a money one.

## The fix

The deadline no longer ends the attempt.

- At 5s the permission modal still goes up, so nobody stares at a spinner and the **retry and paste fallbacks stay reachable** — unchanged from today.
- The pending `start()` keeps running underneath instead of being destroyed. When permission settles in the user's favour the camera comes up on its own.
- Recovery **restarts** rather than adopting the resolved stream: the modal unmounts the `<video>` the pending scanner is bound to, so the element the user would see is a fresh one that needs its own start.
- A late rejection now reports the real error (`NotFoundError` / `NotReadableError`) instead of a blanket "permission denied".
- A grant that lands while the app is backgrounded is left to the existing visibility listener — rebuilding on a hidden document resolves without a stream, which would have swapped the modal for a false "camera start failed".

## Native: nothing changes

The Capacitor branch never had a deadline. On native, `ensureNativeCameraPermission()` settles the OS dialog *before* `getUserMedia`, and `getUserMedia` then rejects cleanly on denial — the short timeout was removed from that path earlier precisely because it made the first-run prompt look like a failure. This PR does not touch it, and a test pins it: `native keeps waiting on the OS dialog with no deadline at all` fails if a deadline is ever introduced there.

## Tests

Six new cases in `useQRScanner.test.ts` under an iOS device profile, modelling the `<video>` unmount/remount the permission modal causes. Four of them fail on `dev` and pass here; the other two are the no-regression pins and pass both ways.

| case | on `dev` | here |
|---|---|---|
| the deadline shows the permission modal without ending the attempt | ✗ | ✓ |
| a grant that lands after the deadline brings the camera up on its own | ✗ | ✓ |
| a grant that lands while backgrounded is picked up on the way back | ✗ | ✓ |
| a hardware failure that lands after the deadline reports the hardware error | ✗ | ✓ |
| a denial that lands after the deadline stays on the permission modal | ✓ | ✓ |
| native keeps waiting on the OS dialog with no deadline at all | ✓ | ✓ |

The 5 existing TASK-21862 resume/backgrounding tests pass unchanged.

## Two follow-ups in the second commit (no behaviour change)

**Extracted the deadline race.** The complexity bot flagged `startCamera` at CC 23 / SLOC 99 once the fix grew it. `raceStartDeadline` now owns the race *and* the timeout handle, so the outer `startTimeoutId` and its `clearTimeout` in the catch are gone — the function is back under where it started.

**De-flaked the suite.** While verifying, I hit a ~4% failure in `does not re-enter the camera flow while the error view is up` (expects 2 starts, sees 3). It is **pre-existing** — reproducible on `dev` at 1/25, so it is not from this change, but it is in the file I am touching. Cause: every mount schedules a 100ms element-retry before the `<video>` exists, and the file's first test left that one on a real clock; it outlived its own test and fired `startCamera` into whichever test was running 100ms later, inflating the module-level `startCalls` there. Fake timers are now installed file-wide and that test drains its own retry, as the describes already did. 40 consecutive runs clean.

## Local verification

`src/components/Global` jest suite green (339 tests), prettier clean, eslint clean on the touched files, typecheck shows no new errors (only the pre-existing SVG `TS2307` noise).

CodeRabbit replied **"Review rate limited"** and reviewed nothing — not re-requested.