### PR TITLE
fix(claim): stop rendering a failed optimistic claim as a success

### DIFF
--- a/src/components/Claim/Link/Onchain/Success.view.tsx
+++ b/src/components/Claim/Link/Onchain/Success.view.tsx
@@ -12,7 +12,7 @@ import { formatTokenAmount, getTokenDetails, shortenStringLong } from '@/utils/g
 import { useRecipientDisplay } from '@/hooks/useRecipientDisplay'
 import { useQueryClient } from '@tanstack/react-query'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { Hash } from 'viem'
 import { formatUnits } from 'viem'
 import * as _consts from '../../Claim.consts'
@@ -21,6 +21,10 @@ import { PeanutCheering } from '@/assets/mascot'
 import Image from 'next/image'
 import { useAppHaptic } from '@/hooks/useAppHaptic'
 import { useTranslations } from 'next-intl'
+import ErrorAlert from '@/components/Global/ErrorAlert'
+import { useFriendlyError } from '@/hooks/useFriendlyError'
+import { useSafeBack } from '@/hooks/useSafeBack'
+import { API_ERROR_CODES } from '@/services/api-error'
 import { badgeCampaignForLegacyWire } from '@/components/Invites/badge-campaign-context'
 
 export const SuccessClaimLinkView = ({
@@ -28,8 +32,15 @@ export const SuccessClaimLinkView = ({
     setTransactionHash,
     claimLinkData,
     tokenPrice,
+    onCustom,
 }: _consts.IClaimScreenProps) => {
     const t = useTranslations('claim')
+    const tCommon = useTranslations('common')
+    const toFriendlyError = useFriendlyError()
+    const goBack = useSafeBack('/home')
+    // The optimistic claim path lands here before the broadcast is known to
+    // have succeeded, so a failure can only arrive through the poll below.
+    const [claimFailure, setClaimFailure] = useState<{ code: string | null } | null>(null)
     const { user: authUser } = useUserStore()
     const { fetchUser } = useAuth()
     const router = useRouter()
@@ -51,7 +62,7 @@ export const SuccessClaimLinkView = ({
     }, [queryClient])
 
     useEffect(() => {
-        if (!!transactionHash) return
+        if (!!transactionHash || claimFailure) return
 
         const fetchClaimData = async () => {
             try {
@@ -79,11 +90,13 @@ export const SuccessClaimLinkView = ({
 
                     return true
                 } else if (link.status === ESendLinkStatus.FAILED) {
-                    // Claim failed after optimistic return - show error to user
+                    // The API rolled the claim back, so the success card below
+                    // would be a lie. `claimFailureCode` is the only channel
+                    // this path has: CHAIN_INFRA_UNAVAILABLE means the failure
+                    // was provably pre-submission, so the link is claimable
+                    // again and offering a retry is honest advice.
                     console.error('Claim failed:', link.events?.[link.events.length - 1]?.reason || 'Unknown error')
-                    // TODO: Show error UI to user instead of silent failure
-                    // For now, setting txHash to 'FAILED' to stop showing loading state
-                    setTransactionHash('FAILED')
+                    setClaimFailure({ code: link.claimFailureCode ?? null })
                     return true
                 }
                 return false
@@ -105,7 +118,7 @@ export const SuccessClaimLinkView = ({
 
         // Clean up the interval when component unmounts or transactionHash changes
         return () => clearInterval(intervalId)
-    }, [transactionHash, claimLinkData.link, queryClient, fetchUser])
+    }, [transactionHash, claimFailure, claimLinkData.link, queryClient, fetchUser])
 
     const tokenDetails = useMemo(() => {
         if (!claimLinkData) return null
@@ -174,6 +187,37 @@ export const SuccessClaimLinkView = ({
         // trigger haptic on mount
         triggerHaptic()
     }, [triggerHaptic])
+
+    if (claimFailure) {
+        const isRetryable = claimFailure.code === API_ERROR_CODES.CHAIN_INFRA_UNAVAILABLE
+        return (
+            <div className="flex min-h-[inherit] flex-col justify-between gap-8">
+                <div className="md:hidden">
+                    <NavHeader icon="cancel" title={navHeaderTitle} onPrev={goBack} />
+                </div>
+                <div className="relative z-10 my-auto flex h-full flex-col justify-center space-y-4">
+                    <ErrorAlert description={toFriendlyError({ code: claimFailure.code })} />
+                    {isRetryable && (
+                        <Button
+                            shadowSize="4"
+                            className="w-full"
+                            onClick={() => {
+                                // the link was rolled back, so INITIAL offers
+                                // the claim again rather than a spent link
+                                setTransactionHash(undefined)
+                                onCustom('INITIAL')
+                            }}
+                        >
+                            {tCommon('tryAgain')}
+                        </Button>
+                    )}
+                    <Button variant="stroke" className="w-full" onClick={() => router.push('/home')}>
+                        {t('backToHome')}
+                    </Button>
+                </div>
+            </div>
+        )
+    }
 
     return (
         <div className="flex min-h-[inherit] flex-col justify-between gap-8">

--- a/src/components/Claim/Link/Onchain/Success.view.tsx
+++ b/src/components/Claim/Link/Onchain/Success.view.tsx
@@ -22,6 +22,7 @@ import Image from 'next/image'
 import { useAppHaptic } from '@/hooks/useAppHaptic'
 import { useTranslations } from 'next-intl'
 import ErrorAlert from '@/components/Global/ErrorAlert'
+import PeanutLoading from '@/components/Global/PeanutLoading'
 import { useFriendlyError } from '@/hooks/useFriendlyError'
 import { useSafeBack } from '@/hooks/useSafeBack'
 import { API_ERROR_CODES } from '@/services/api-error'
@@ -184,9 +185,27 @@ export const SuccessClaimLinkView = ({
     }
 
     useEffect(() => {
-        // trigger haptic on mount
+        // success feedback belongs to a confirmed claim, not to arriving here —
+        // the optimistic path mounts this view before the broadcast is known
+        if (!transactionHash) return
         triggerHaptic()
-    }, [triggerHaptic])
+    }, [transactionHash, triggerHaptic])
+
+    // The optimistic 202 lands here with no hash and no outcome yet. Rendering
+    // the success card now would claim money that has not moved — and would
+    // keep claiming it for as long as the poll is slow or failing.
+    if (!transactionHash && !claimFailure) {
+        return (
+            <div className="flex min-h-[inherit] flex-col justify-between gap-8">
+                <div className="md:hidden">
+                    <NavHeader icon="cancel" title={navHeaderTitle} onPrev={goBack} />
+                </div>
+                <div className="relative z-10 my-auto flex h-full flex-col justify-center">
+                    <PeanutLoading message={tCommon('status.processing')} />
+                </div>
+            </div>
+        )
+    }
 
     if (claimFailure) {
         const isRetryable = claimFailure.code === API_ERROR_CODES.CHAIN_INFRA_UNAVAILABLE

--- a/src/components/Claim/__tests__/claim-success-poll-failure.test.tsx
+++ b/src/components/Claim/__tests__/claim-success-poll-failure.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * SUCCESS view — what the poller renders when the optimistic claim failed.
+ *
+ * A Peanut Wallet P2P claim sends `optimisticReturn: true`, so POST /claim
+ * answers 202 before it broadcasts and this view is already mounted when the
+ * broadcast fails. Nothing in the response can carry the outcome; the only
+ * channel is the polled SendLink, and until `claimFailureCode` existed the
+ * view stopped its spinner with a sentinel 'FAILED' hash and left the success
+ * card on screen — a claim that never happened, rendered as money received.
+ */
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { IntlWrapper } from '@/test-utils/intl'
+
+const mockRouterPush = jest.fn()
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ push: mockRouterPush, replace: jest.fn(), prefetch: jest.fn(), back: jest.fn() }),
+    useSearchParams: () => new URLSearchParams(),
+}))
+
+jest.mock('next/image', () => ({
+    __esModule: true,
+    default: (props: any) => {
+        const { priority, fill, unoptimized, ...rest } = props
+        return <img {...rest} />
+    },
+}))
+
+const mockSendLinksApi = { get: jest.fn() }
+jest.mock('@/services/sendLinks', () => ({
+    ESendLinkStatus: {
+        creating: 'creating',
+        completed: 'completed',
+        CLAIMING: 'CLAIMING',
+        CLAIMED: 'CLAIMED',
+        CANCELLED: 'CANCELLED',
+        FAILED: 'FAILED',
+    },
+    sendLinksApi: mockSendLinksApi,
+}))
+
+jest.mock('@/context/authContext', () => ({ useAuth: () => ({ fetchUser: jest.fn() }) }))
+jest.mock('@/context/ClaimBankFlowContext', () => ({
+    useClaimBankFlow: () => ({ offrampDetails: null, claimType: 'claim', bankDetails: null }),
+}))
+jest.mock('@/redux/hooks', () => ({ useUserStore: () => ({ user: null }) }))
+jest.mock('@/hooks/useRecipientDisplay', () => ({
+    useRecipientDisplay: () => ({ displayName: 'alice' }),
+}))
+jest.mock('@/hooks/useAppHaptic', () => ({ useAppHaptic: () => ({ triggerHaptic: jest.fn() }) }))
+jest.mock('@/utils/general.utils', () => ({
+    formatTokenAmount: (n: number) => String(n),
+    getTokenDetails: () => ({ symbol: 'USDC', decimals: 6 }),
+    shortenStringLong: (s: string) => s,
+}))
+jest.mock('@/components/Global/SoundPlayer', () => ({ SoundPlayer: () => null }))
+jest.mock('@/components/Global/NavHeader', () => ({ __esModule: true, default: () => null }))
+jest.mock('@/components/Global/CreateAccountButton', () => ({
+    __esModule: true,
+    default: () => <button>create account</button>,
+}))
+jest.mock('@/components/Global/PeanutActionDetailsCard', () => ({
+    __esModule: true,
+    default: (props: any) => <div data-testid="success-card">{props.title}</div>,
+}))
+jest.mock('@/components/Invites/badge-campaign-context', () => ({
+    badgeCampaignForLegacyWire: () => undefined,
+}))
+
+import { SuccessClaimLinkView } from '../Link/Onchain/Success.view'
+
+const claimLinkData = {
+    link: 'https://peanut.to/claim#?c=42161&v=v4.3&i=7&p=secret',
+    pubKey: '0xpub',
+    chainId: '42161',
+    amount: 5_000_000n,
+    tokenAddress: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+    tokenDecimals: 6,
+    tokenSymbol: 'USDC',
+    senderAddress: '0xsender',
+    sender: null,
+} as any
+
+const renderView = (onCustom = jest.fn()) => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+    render(
+        <IntlWrapper>
+            <QueryClientProvider client={client}>
+                <SuccessClaimLinkView
+                    {...({
+                        transactionHash: undefined,
+                        setTransactionHash: jest.fn(),
+                        claimLinkData,
+                        tokenPrice: 1,
+                        onCustom,
+                    } as any)}
+                />
+            </QueryClientProvider>
+        </IntlWrapper>
+    )
+    return { onCustom }
+}
+
+describe('SUCCESS view — polled claim failure', () => {
+    beforeEach(() => {
+        mockSendLinksApi.get.mockReset()
+        mockRouterPush.mockReset()
+    })
+
+    test('a retryable failure replaces the success card with the retry copy and a way back', async () => {
+        mockSendLinksApi.get.mockResolvedValue({
+            status: 'FAILED',
+            claimFailureCode: 'CHAIN_INFRA_UNAVAILABLE',
+            events: [],
+        })
+
+        const { onCustom } = renderView()
+
+        expect(await screen.findByText(/network is busy/i)).toBeInTheDocument()
+        // the money-received card must be gone — nothing was claimed
+        expect(screen.queryByTestId('success-card')).not.toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button', { name: /try again/i }))
+        expect(onCustom).toHaveBeenCalledWith('INITIAL')
+    })
+
+    test('a failure with no code gets the generic copy and no retry button', async () => {
+        mockSendLinksApi.get.mockResolvedValue({ status: 'FAILED', claimFailureCode: null, events: [] })
+
+        renderView()
+
+        expect(await screen.findByText(/contact support/i)).toBeInTheDocument()
+        expect(screen.queryByTestId('success-card')).not.toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument()
+    })
+
+    test('a confirmed claim still renders the success card', async () => {
+        mockSendLinksApi.get.mockResolvedValue({
+            status: 'CLAIMED',
+            claim: { txHash: '0xabc' },
+            events: [],
+        })
+
+        renderView()
+
+        await waitFor(() => expect(screen.getByTestId('success-card')).toBeInTheDocument())
+        expect(screen.queryByText(/network is busy/i)).not.toBeInTheDocument()
+    })
+})

--- a/src/components/Claim/__tests__/claim-success-poll-failure.test.tsx
+++ b/src/components/Claim/__tests__/claim-success-poll-failure.test.tsx
@@ -13,6 +13,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { IntlWrapper } from '@/test-utils/intl'
 
+const mockTriggerHaptic = jest.fn()
 const mockRouterPush = jest.fn()
 jest.mock('next/navigation', () => ({
     useRouter: () => ({ push: mockRouterPush, replace: jest.fn(), prefetch: jest.fn(), back: jest.fn() }),
@@ -48,13 +49,23 @@ jest.mock('@/redux/hooks', () => ({ useUserStore: () => ({ user: null }) }))
 jest.mock('@/hooks/useRecipientDisplay', () => ({
     useRecipientDisplay: () => ({ displayName: 'alice' }),
 }))
-jest.mock('@/hooks/useAppHaptic', () => ({ useAppHaptic: () => ({ triggerHaptic: jest.fn() }) }))
+jest.mock('@/hooks/useAppHaptic', () => ({ useAppHaptic: () => ({ triggerHaptic: mockTriggerHaptic }) }))
 jest.mock('@/utils/general.utils', () => ({
     formatTokenAmount: (n: number) => String(n),
     getTokenDetails: () => ({ symbol: 'USDC', decimals: 6 }),
     shortenStringLong: (s: string) => s,
 }))
-jest.mock('@/components/Global/SoundPlayer', () => ({ SoundPlayer: () => null }))
+const mockSoundPlayed = jest.fn()
+jest.mock('@/components/Global/SoundPlayer', () => ({
+    SoundPlayer: (props: any) => {
+        mockSoundPlayed(props.sound)
+        return null
+    },
+}))
+jest.mock('@/components/Global/PeanutLoading', () => ({
+    __esModule: true,
+    default: (props: any) => <div data-testid="peanut-loading">{props.message}</div>,
+}))
 jest.mock('@/components/Global/NavHeader', () => ({ __esModule: true, default: () => null }))
 jest.mock('@/components/Global/CreateAccountButton', () => ({
     __esModule: true,
@@ -82,20 +93,30 @@ const claimLinkData = {
     sender: null,
 } as any
 
-const renderView = (onCustom = jest.fn()) => {
+const renderView = (onCustom = jest.fn(), initialHash?: string) => {
     const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+
+    // the real parent owns `transactionHash`, so the poll's setter has to
+    // rebind the prop — a jest.fn() here would leave the view stuck pending
+    const Harness = () => {
+        const [transactionHash, setTransactionHash] = React.useState<string | undefined>(initialHash)
+        return (
+            <SuccessClaimLinkView
+                {...({
+                    transactionHash,
+                    setTransactionHash,
+                    claimLinkData,
+                    tokenPrice: 1,
+                    onCustom,
+                } as any)}
+            />
+        )
+    }
+
     render(
         <IntlWrapper>
             <QueryClientProvider client={client}>
-                <SuccessClaimLinkView
-                    {...({
-                        transactionHash: undefined,
-                        setTransactionHash: jest.fn(),
-                        claimLinkData,
-                        tokenPrice: 1,
-                        onCustom,
-                    } as any)}
-                />
+                <Harness />
             </QueryClientProvider>
         </IntlWrapper>
     )
@@ -106,6 +127,8 @@ describe('SUCCESS view — polled claim failure', () => {
     beforeEach(() => {
         mockSendLinksApi.get.mockReset()
         mockRouterPush.mockReset()
+        mockSoundPlayed.mockReset()
+        mockTriggerHaptic.mockReset()
     })
 
     test('a retryable failure replaces the success card with the retry copy and a way back', async () => {
@@ -146,5 +169,45 @@ describe('SUCCESS view — polled claim failure', () => {
 
         await waitFor(() => expect(screen.getByTestId('success-card')).toBeInTheDocument())
         expect(screen.queryByText(/network is busy/i)).not.toBeInTheDocument()
+    })
+})
+
+describe('SUCCESS view — before the poll resolves', () => {
+    beforeEach(() => {
+        mockSendLinksApi.get.mockReset()
+        mockSoundPlayed.mockReset()
+        mockTriggerHaptic.mockReset()
+    })
+
+    test('a claim with no outcome yet shows processing — no success card, sound or haptic', async () => {
+        // a poll that never settles: the optimistic 202 has landed, nothing else
+        mockSendLinksApi.get.mockReturnValue(new Promise(() => {}))
+
+        renderView()
+
+        expect(await screen.findByTestId('peanut-loading')).toBeInTheDocument()
+        expect(screen.queryByTestId('success-card')).not.toBeInTheDocument()
+        expect(mockSoundPlayed).not.toHaveBeenCalled()
+        expect(mockTriggerHaptic).not.toHaveBeenCalled()
+    })
+
+    test('a poll that keeps erroring stays in processing rather than claiming success', async () => {
+        mockSendLinksApi.get.mockRejectedValue(new Error('network down'))
+
+        renderView()
+
+        await waitFor(() => expect(mockSendLinksApi.get).toHaveBeenCalled())
+        expect(screen.getByTestId('peanut-loading')).toBeInTheDocument()
+        expect(screen.queryByTestId('success-card')).not.toBeInTheDocument()
+    })
+
+    test('a synchronous claim arrives with its hash and renders success immediately', () => {
+        mockSendLinksApi.get.mockReturnValue(new Promise(() => {}))
+
+        renderView(jest.fn(), '0xabc')
+
+        expect(screen.getByTestId('success-card')).toBeInTheDocument()
+        expect(mockSoundPlayed).toHaveBeenCalledWith('success')
+        expect(mockTriggerHaptic).toHaveBeenCalled()
     })
 })

--- a/src/services/services.types.ts
+++ b/src/services/services.types.ts
@@ -338,6 +338,10 @@ export type SendLink = {
     textContent?: string
     fileUrl?: string
     status: SendLinkStatus
+    /** Machine-readable reason the last claim attempt failed. The optimistic
+     *  claim path is answered 202 before the broadcast, so this is the only
+     *  thing a poller can read to tell a retryable outage from a dead end. */
+    claimFailureCode?: string | null
     createdAt: Date
     senderAddress: string
     amount: bigint


### PR DESCRIPTION
Frontend half of [peanut-api-ts#1408](https://github.com/peanutprotocol/peanut-api-ts/pull/1408). Closes the gap that PR's review surfaced: the retryable-claim classification it added could never reach the flow that actually needs it.

## The gap

`Initial.view.tsx` sends `optimisticReturn: true` for every regular P2P claim, so `POST /claim` answers **202 before it broadcasts**. When the broadcast then fails, the response is already gone — no status code, no error body, nothing for `useClaimLink` to catch. The SUCCESS view is mounted by then, and its poll did this:

```ts
} else if (link.status === ESendLinkStatus.FAILED) {
    // TODO: Show error UI to user instead of silent failure
    // For now, setting txHash to 'FAILED' to stop showing loading state
    setTransactionHash('FAILED')
```

`transactionHash` is not rendered anywhere in that view, so the sentinel only stopped the poll — and the success card stayed on screen. A claim that never happened rendered as **"You claimed $X"**, with a fake hash in flow state.

The API's 503 `CHAIN_INFRA_UNAVAILABLE` branch still serves the two synchronous callers (external-wallet `Confirm.view`, bank off-ramp `BankFlowManager`), which is where the reported incident came from — PEANUT-UI-SJ5 throws inside `if (!response.ok)`, unreachable on a 202. This PR covers the optimistic path those two don't.

## The fix

api-ts#1408 now persists `SendLink.claimFailureCode` on rollback and projects it from `GET /send-links/:pubKey` (and evicts the 30s create-cache that sits in front of that endpoint, or the poll would read straight past it). This side reads it:

- **`CHAIN_INFRA_UNAVAILABLE`** — provably pre-submission, and the API rolled the link back, so it is claimable again: show the existing `networkBusyTimeout` copy plus a **Try again** button that returns to `INITIAL`.
- **anything else / no code** — terminal: generic `genericSupport` copy, no retry button, no false promise.
- The success card renders only on a confirmed claim.

No new i18n keys — both messages already ship in every locale via `useFriendlyError`, which is the same mapping #2777 added for the synchronous path.

## Testing

`src/components/Claim/__tests__/claim-success-poll-failure.test.tsx` pins all three outcomes, verified to fail against the sentinel-hash behavior (2 of 3 red when reverted). Claim suites + `friendly-error.utils` green (56 tests); typecheck and eslint clean on the touched files.

## Deploy ordering

Safe either way, but the copy only differs once api-ts#1408 is out: `claimFailureCode` is absent until then, which takes the terminal branch — still strictly better than today's false success.
